### PR TITLE
fix an issue with two consumers when output of ForOp is used

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -224,7 +224,7 @@ Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
   for (unsigned i = 0; i < usedArgs.size(); ++i) {
     auto oldResult = forOp.getResult(usedArgs[i]);
     auto newResult = newForOp.getResult(i);
-    mapping.map(oldResult, newResult); //p->getResult(i), newOp->getResult(i));
+    mapping.map(oldResult, newResult);
   }
 
   return newForOp;

--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -224,9 +224,7 @@ Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
   for (unsigned i = 0; i < usedArgs.size(); ++i) {
     auto oldResult = forOp.getResult(usedArgs[i]);
     auto newResult = newForOp.getResult(i);
-    oldResult.replaceUsesWithIf(newResult, [&](OpOperand &operand) -> bool {
-      return hasAsyncTaskId(operand.getOwner(), asyncTaskId);
-    });
+    mapping.map(oldResult, newResult); //p->getResult(i), newOp->getResult(i));
   }
 
   return newForOp;


### PR DESCRIPTION
Summary: For an example with
IfOp
  o = forOp
  mulf that uses o

Prior to the change:
IfOp
  o1 = forOp
  mulf that uses o1
IfOp
  o2 = forOp
  mulf that uses o1

After:
IfOp
  o1 = forOp
  use o1
IfOp
  o2 = forOp
  use o2

We should not replace use of o with output of the specialized forOp while handling the first taskId, that will make handling of the next taskId incorrect. Instead of we update the mapping that is private to each taskId.
