### PR TITLE
WarpSpec] improve allocation for smem

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -186,6 +186,7 @@ private:
     size_t size;
     size_t alignment;
     size_t offset;
+    SetVector<int> regionIds;
 
     bool operator==(const BufferT &other) const { return id == other.id; }
     bool operator<(const BufferT &other) const { return id < other.id; }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -488,7 +488,7 @@ private:
     LDBG("Dump bufferRange ---------");
     for (auto bufferIter : bufferRange) {
       LLVM_DEBUG({
-        llvm::dbgs() << "-- " << bufferIter.first->size << " " << bufferIter.first->offset < " regions ";
+        llvm::dbgs() << "-- " << bufferIter.first->size << " " << bufferIter.first->offset << " regions ";
         for (auto tId : bufferIter.first->regionIds) {
           llvm::dbgs() << tId << " ";
         }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -575,6 +575,8 @@ private:
     auto inDifferentRegion = [&](BufferT *A, BufferT *B) {
       auto tA = A->regionIds;
       auto tB = B->regionIds;
+      if (tA.empty() || tB.empty())
+        return true;
       for (auto t1 : tA) {
         for (auto t2 : tB) {
           if (t1 != t2)


### PR DESCRIPTION
Summary: Attempt to teach Allocation analysis to be aware of warpspec regions. Add a list of regions to each buffer, also teach interference graph to be ware of regions. Currently it makes convert_layout within one consumer to be able to overlap.

Test Plan: Run JFA bwd
