### PR TITLE
[CodePartition] Optimize the placement of consumer releases 

### DIFF
--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
@@ -342,8 +342,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 // CHECK: scf.for
 // CHECK: triton_gpu.local_load
 // CHECK: triton_nvidia_gpu.consumer_wait
-// CHECK: tt.experimental_descriptor_store
 // CHECK: triton_nvidia_gpu.consumer_release
+// CHECK: tt.experimental_descriptor_store
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>


### PR DESCRIPTION
Fix the inefficient placement of consumer releases when producer and consumer are not in the same scope. For example, given

```
Q = tl.load
for (..) 
   K = tl.load
   QK = dot(Q, K)
   ...
tl.store
```

Previously the consumer release corresponding to `Q` was placed after the store. With the current fix the release would go right after the for loop.


 `TORCH_CUDA_ARCH_LIST=9.0a python run.py --op flash_attention --only triton_tutorial_flash_v2_tma_ws,triton_tutorial_flash_v2_tma_ws_persistent,triton_tutorial_flash_v2 --num-inputs 1 --seq-len 10 --metrics tflops --batch 1024 --n-heads 4 --d-head 128 --cudagraph`

Before:

  ```
(Batch, Heads, SeqLen, Dhead)    triton_tutorial_flash_v2_tma_ws-tflops    triton_tutorial_flash_v2_tma_ws_persistent-tflops    triton_tutorial_flash_v2-tflops
-------------------------------  ----------------------------------------  ---------------------------------------------------  ---------------------------------
           (1024, 4, 1024, 128)                                   393.141                                              400.046                            366.498

```
```

After:
  (Batch, Heads, SeqLen, Dhead)    triton_tutorial_flash_v2_tma_ws-tflops    triton_tutorial_flash_v2_tma_ws_persistent-tflops    triton_tutorial_flash_v2-tflops
-------------------------------  ----------------------------------------  ---------------------------------------------------  ---------------------------------
           (1024, 4, 1024, 128)                                    396.43                                              422.847                            363.753

```