### PR TITLE
Fix an issue where wrong warp id is used for small TMA store

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1180,10 +1180,10 @@ struct AsyncTMACopyLocalToGlobalOpConversion
     // We clamp the block size and the codegen will emit multiple copy
     // operations.
     for (int copyIdx = 0; copyIdx < numCopies; copyIdx += numWarps) {
+      auto warpOffset = getWarpOffset(op);
       int numWarpsToCopy = std::min(numCopies - copyIdx, numWarps);
       if (numWarpsToCopy == 1)
-        warpID = i32_val(0);
-      auto warpOffset = getWarpOffset(op);
+        warpID = i32_val(warpOffset);
       warpID = sub(warpID, i32_val(warpOffset));
       id = sub(id, i32_val(warpOffset * warpSize));
       Value boxPred =


### PR DESCRIPTION
Small TMA store only needs the first warp to issue the TMA store instruction instead of having all warps issue one. For WS, the first warp should be the first one of the current warp group instead of hardcoded 0. 

Thanks @ggengnv for helping investigate an illegal instruction issue caused by the bug!