### PR TITLE
[WS] Add FpToFpOp to WSDataPartition pass

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -388,8 +388,8 @@ Operation *sliceOp(Operation *op, int offset,
   // slice operands first
   Operation *newOp;
   if (op->hasTrait<OpTrait::Elementwise>() ||
-      isa<ConvertLayoutOp, BroadcastOp, SplatOp, ExpandDimsOp, LocalAllocOp>(
-          op)) {
+      isa<ConvertLayoutOp, BroadcastOp, SplatOp, ExpandDimsOp, LocalAllocOp,
+          FpToFpOp>(op)) {
     for (Value operand : op->getOperands())
       sliceOp(operand, offset, builder, mappings, reverseMappings,
               partitionScheme);


### PR DESCRIPTION
Adding `FpToFpOp` to `WSDataPartition` pass. Currently `TritonGPUWSDataPartition` pass fails since the `sliceOp` is missing support for `FpToFpOp` and results in "Unsupported Op type" error.

Sample failing IR:

```
[tritongpu-warp-spec-data-partition]: slicing:
%58 = "tt.fp_to_fp"(%52) <{rounding = 1 : i32}> {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xf32, #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>) -> tensor<128x128xf8E5M2, #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
[tritongpu-warp-spec-data-partition]:

unsupported op type
```

Verified the pass succeeds after adding `FpToFpOp` using `triton-opt`

Test command used:
```
triton/python/build/cmake.linux-x86_64-cpython-3.11/bin/triton-opt --tritongpu-warp-spec-data-partition=num-consumer-groups=2  --debug-only=tritongpu-warp-spec-data-partition ~/sample.ttir
```

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] This PR does not need a test because `tested using triton-opt for failing IR`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
