### PR TITLE
Handle if results that are connected to a block arg

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -317,7 +317,7 @@ Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
       } else {
         assert(isa<BlockArgument>(yieldV) && "Unexpected yield value");
         auto bbArg = cast<BlockArgument>(yieldV);
-        // Find transive defining op for the block arg
+        // Find transitive defining op for the block arg
         Operation *bbAargOwner = bbArg.getOwner()->getParentOp();
         if (auto forOp = dyn_cast<scf::ForOp>(bbAargOwner)) {
           // track initial value

--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -73,9 +73,24 @@ static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
       if (!hasAsyncTaskId(user, asyncTaskId))
         continue;
 
-      // Skip control flow ops that are shared by all async tasks
-      if (isa<scf::YieldOp>(user))
+      if (isa<scf::YieldOp>(user)) {
+        if (auto ifOp = dyn_cast<scf::IfOp>(user->getParentOp())) {
+          // For block arguments, we need to check the initial value as well.
+          if (auto blockArg = dyn_cast<BlockArgument>(arg)) {
+            auto initArg = forOp.getInitArgs()[blockArg.getArgNumber() - 1];
+            if (Operation *def = initArg.getDefiningOp()) {
+              if (hasAsyncTaskId(def, asyncTaskId)) {
+                argIndices.insert(argIdx);
+              }
+            } else {
+              llvm_unreachable("Initial value should have a defining op");
+            }
+          }
+        }
+
+        // Skip control flow ops that are shared by all async tasks
         continue;
+      }
 
       // Found a real user, the arg is needed
       if (user->getNumRegions() == 0) {
@@ -300,7 +315,22 @@ Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
           keptResultVec.push_back(resultIdx);
         }
       } else {
-        keptResultVec.push_back(resultIdx);
+        assert(isa<BlockArgument>(yieldV) && "Unexpected yield value");
+        auto bbArg = cast<BlockArgument>(yieldV);
+        // Find transive defining op for the block arg
+        Operation *bbAargOwner = bbArg.getOwner()->getParentOp();
+        if (auto forOp = dyn_cast<scf::ForOp>(bbAargOwner)) {
+          // track initial value
+          auto initArg = forOp.getInitArgs()[bbArg.getArgNumber() - 1];
+          if (Operation *def = initArg.getDefiningOp()) {
+            if (hasAsyncTaskId(def, asyncTaskId))
+              keptResultVec.push_back(resultIdx);
+          } else {
+            llvm_unreachable("Initial value should have a defining op");
+          }
+        } else {
+          llvm_unreachable("Unexpected block argument owner");
+        }
       }
       ++resultIdx;
     }

--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -60,13 +60,13 @@ void fixTaskId(triton::FuncOp &funcOp) {
       // Do not update loads.
       if (isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp>(defOp))
         continue;
-      // Skip control flow ops.
-      if (isa<scf::YieldOp>(op))
-        continue;
       auto defTaskIds = getAsyncTaskIds(defOp);
       // Make sure defTaskIds cover asyncTaskIds. Call addAsyncTaskIds if
       // necessary.
       if (!oneVecCoversTheOther(defTaskIds, asyncTaskIds)) {
+        // Skip control flow ops.
+        if (isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
+          continue;
         // Const ops with same value but different task ids can be folded.
         if (defOp->getDialect()->getNamespace() == "arith") {
           LLVM_DEBUG({


### PR DESCRIPTION
Handling the nested if in a loop that used one loop arg in its yield, e.g. %arg20 below. `%arg20` and its initial value `%43` should be included in the consumer slice.

```
%43 = arith.mulf %35, %41 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : tensor<128xf32, #blocked> loc(#loc34)

%45:5 = scf.for %arg17 = %c0_i32 to %13 step %c1_i32 iter_args(%arg18 = %c0_i32, %arg19 = %cst_0, %arg20 = %43, %arg21 = %cst_0, %arg22 = %44) -> (i32, tensor<128x128xf32, #mma>, tensor<128xf32, #blocked>, tensor<128x128xf32, #mma>, tensor<128xf32, #blocked>)  : i32 {
        
        %61:2 = scf.if %60 -> (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) {
          scf.yield {async_task_id = dense<[1, 2]> : vector<2xi32>} %arg20, %arg22 : tensor<128xf32, #blocked>, tensor<128xf32, #blocked> loc(#loc1)
        } else {
          ...
          %82 = arith.mulf %76, %80 {async_task_id = dense<1> : vector<1xi32>} : tensor<128xf32, #blocked> loc(#loc47)
          %83 = arith.mulf %77, %81 {async_task_id = dense<2> : vector<1xi32>} : tensor<128xf32, #blocked> loc(#loc47)
          scf.yield {async_task_id = dense<[1, 2]> : vector<2xi32>} %82, %83 : tensor<128xf32, #blocked>, tensor<128xf32, #blocked> loc(#loc48)
        } {async_task_id = dense<[1, 2]> : vector<2xi32>} loc(#loc41)
```

