### PR TITLE
[WS] fix taskId when removeLayoutConv creates convert_layout for

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -528,8 +528,6 @@ Value LayoutPropagation::getValueAs(Value value, Attribute encoding) {
                                          tensorType.getElementType(), encoding);
     Value converted = rewriter.create<ConvertLayoutOp>(value.getLoc(), tmpType,
                                                        rewrittenValue);
-    if (value.getDefiningOp())
-      converted.getDefiningOp()->setAttrs(value.getDefiningOp()->getAttrs());
     // TODO: we could cache the conversion.
     return converted;
   }

--- a/lib/Dialect/TritonGPU/Transforms/TaskIdPropagate.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/TaskIdPropagate.cpp
@@ -283,7 +283,8 @@ void backwardPropagateTaskIds(Operation *op,
     }
 
     auto op = value.getDefiningOp();
-    addAsyncTaskIds(op, asyncTasks);
+    if (!anchors.count(op))
+      addAsyncTaskIds(op, asyncTasks);
 
     // Handle for loops.
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {

--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -745,6 +745,9 @@ void groupChannels(
     if (dst1->getBlock() != dst2->getBlock() || !dst1->hasOneUse() ||
         !dst2->hasOneUse())
       return false;
+    // Check taskIds on dstOps.
+    if (getAsyncTaskIds(dst1) != getAsyncTaskIds(dst2))
+      return false;
     Operation *dst1User = *(dst1->getUsers().begin());
     Operation *dst2User = *(dst2->getUsers().begin());
     return dst1User == dst2User && dst1User->getBlock() == dst1->getBlock();


### PR DESCRIPTION
a loadOp

Summary:
As an example:
```
%13 = triton_gpu.convert_layout %12 # %12 is output of TMA load, with
taskId of 0
%15 = scf.for %arg6 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg7 = %13)
  %23 = triton_gpu.convert_layout %arg7 : tensor<64x64xbf16, #mma>
```
During removeLayoutConversion, we should not assigne taskId of 0 to the created convert_layout.
Right before CodePartition:
```
%15 = triton_gpu.convert_layout %13 {async_task_id = dense<[0, 1]>
%16 = triton_gpu.convert_layout %14 {async_task_id = dense<[0, 2]>
scf.for %arg6 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg7 = %15, %arg8 = %16)
  %28 = triton_gpu.convert_layout %arg7 {async_task_id = dense<1>
  %29 = triton_gpu.convert_layout %arg8 {async_task_id = dense<2>
```
We should not combine the above two channels since the destination ops have different taskIds.
