### PR TITLE
[CodePartition] Place lowered TMA op nearby original op

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -1901,6 +1901,7 @@ optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
   // Convert all the producers to async_tma_copy_global_to_local
   Operation *copy = nullptr;
   for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {
+    builder.setInsertionPoint(tmaLoad);
     auto pipelineBuffer = getBufferForPipelineStage(builder, tmaLoad.getType(),
                                                     buffer, bufferIdx, true);
     copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(


### PR DESCRIPTION
Placing lowered TMA op nearby the original op to avoid messing up with the dependencies.