### PR TITLE
[CodePartition] Insert synchronization ops after asycn copy creation.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -2069,6 +2069,7 @@ void insertAsyncComm(
       auto pcOp = copyOpMap.find(c)->second;
       producerOps.insert(pcOp.first);
       consumerOps.insert(pcOp.second);
+      consumerOps.insert(c->getDstOp());
     }
 
     // Find head producer
@@ -2278,10 +2279,8 @@ void insertAsyncCopy(
     }
 
     for (auto &channel : kv.second) {
-      copyOpMap[channel] = {producerConsumerOps.first, channel->getDstOp()};
+      copyOpMap[channel] = producerConsumerOps;
     }
-
-    copyOpMap[domininatingChannel] = producerConsumerOps;
   }
 }
 

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
@@ -325,13 +325,13 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 // CHECK: scf.if %[[#WG1]]
 // CHECK: triton_nvidia_gpu.reg_alloc 232
 // CHECK: scf.for
-// CHECK: triton_nvidia_gpu.producer_acquire
 // CHECK: scf.for
 // CHECK: triton_nvidia_gpu.wait_barrier
 // CHECK: triton_gpu.local_load
 // CHECK: triton_gpu.local_load
 // CHECK: triton_nvidia_gpu.warp_group_dot
 // CHECK: triton_nvidia_gpu.consumer_release
+// CHECK: triton_nvidia_gpu.producer_acquire
 // CHECK: triton_gpu.local_store
 // CHECK: triton_nvidia_gpu.producer_commit
 // CHECK: %c2_i32 = arith.constant 2 : i32
@@ -340,8 +340,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 // CHECK: triton_nvidia_gpu.reg_alloc 232
 // CHECK: scf.for
 // CHECK: scf.for
-// CHECK: triton_gpu.local_load
 // CHECK: triton_nvidia_gpu.consumer_wait
+// CHECK: triton_gpu.local_load
 // CHECK: triton_nvidia_gpu.consumer_release
 // CHECK: tt.experimental_descriptor_store
 


### PR DESCRIPTION
Summary:

With arbitary data channel the producer ops could be a non-load op, which mean it doesn't necessarily write to SMEM. A `local_store` op will be created to support the data channel, and in that case the producer acquire primitive should precede the `local_store` op instead of the original producer op. This change enables that by creating the async copy before inserting synchronization primitives. A map is set up to track the created async copy and the original data channel.
