### PR TITLE
[Blackwell][WS] Improve data partitioning to handle tmem_load/alloc

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -145,12 +145,13 @@ struct CanonicalizeConvertFromAlloc
 
   mlir::LogicalResult
   matchAndRewrite(triton::gpu::LocalAllocOp op,
-                  PatternRewriter &rewriter) const override {
+                  PatternRewriter &baseRewriter) const override {
     if (!op.getSrc())
       return failure();
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
     if (!convert)
       return failure();
+    PatternRewriterWithAsyncTaskIds rewriter(baseRewriter, op);
     rewriter.replaceOpWithNewOp<triton::gpu::LocalAllocOp>(
         op, op->getResult(0).getType(), convert.getSrc());
     return mlir::success();
@@ -164,10 +165,11 @@ struct CanonicalizeConvertFromLocalStore
 
   mlir::LogicalResult
   matchAndRewrite(triton::gpu::LocalStoreOp op,
-                  PatternRewriter &rewriter) const override {
+                  PatternRewriter &baseRewriter) const override {
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
     if (!convert)
       return failure();
+    PatternRewriterWithAsyncTaskIds rewriter(baseRewriter, op);
     rewriter.replaceOpWithNewOp<triton::gpu::LocalStoreOp>(op, convert.getSrc(),
                                                            op.getDst());
     return mlir::success();
@@ -286,7 +288,8 @@ struct CanonicalizeConvertFromConvert
 
     // cvt(cvt(x, type1), type2) -> cvt(x, type2)
     if (auto cvt = dyn_cast<ConvertLayoutOp>(arg)) {
-      rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
+      PatternRewriterWithAsyncTaskIds rewriterTask(rewriter, cvt);
+      rewriterTask.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
           op, op->getResultTypes().front(), cvt.getSrc());
       return success();
     }

--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -389,10 +389,25 @@ Operation *sliceOp(Operation *op, int offset,
                                    type.getShape().end()};
         int sliceSize = shape[dim] / numOfPartitions;
         shape[dim] = sliceSize;
-        auto newType =
-            MemDescType::get(shape, type.getElementType(), type.getEncoding(),
-                             type.getMemorySpace(), type.getMutableMemory());
-        newV.setType(newType);
+        // change encoding for ttng.tensor_memory_encoding to match gen5.
+        if (auto tmem = dyn_cast<nvidia_gpu::TensorMemoryEncodingAttr>(
+                type.getEncoding())) {
+          Attribute accEncoding =
+              triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
+                  builder.getContext(),
+                  dim == 0 ? tmem.getBlockM() / 2 : tmem.getBlockM(),
+                  dim == 1 ? tmem.getBlockN() / 2 : tmem.getBlockN(),
+                  tmem.getUnpacked(), tmem.getCTASplitM(), tmem.getCTASplitN());
+          auto newType =
+              MemDescType::get(shape, type.getElementType(), accEncoding,
+                               type.getMemorySpace(), type.getMutableMemory());
+          newV.setType(newType);
+        } else {
+          auto newType =
+              MemDescType::get(shape, type.getElementType(), type.getEncoding(),
+                               type.getMemorySpace(), type.getMutableMemory());
+          newV.setType(newType);
+        }
       } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
         SmallVector<int64_t> shape{type.getShape().begin(),
                                    type.getShape().end()};
@@ -422,12 +437,103 @@ Operation *sliceOp(Operation *op, int offset,
   // slice operands first
   Operation *newOp;
   if (op->hasTrait<OpTrait::Elementwise>() ||
-      isa<ConvertLayoutOp, BroadcastOp, SplatOp, ExpandDimsOp, LocalAllocOp,
-          nvidia_gpu::TMEMAllocOp, nvidia_gpu::TMEMLoadOp>(op)) {
+      isa<ConvertLayoutOp, BroadcastOp, SplatOp, ExpandDimsOp, LocalAllocOp>(
+          op)) {
     for (Value operand : op->getOperands())
       sliceOp(operand, offset, builder, mappings, reverseMappings,
               partitionScheme);
     newOp = cloneAndSetResultType(op);
+  } else if (auto tmemLdOp = dyn_cast<nvidia_gpu::TMEMLoadOp>(op)) {
+    for (Value operand : op->getOperands())
+      sliceOp(operand, offset, builder, mappings, reverseMappings,
+              partitionScheme);
+    auto srcTy = mappings.lookupOrNull(tmemLdOp.getSrc()).getType();
+    auto type = cast<MemDescType>(srcTy);
+    auto tmem = cast<nvidia_gpu::TensorMemoryEncodingAttr>(type.getEncoding());
+
+    RankedTensorType oldRetType = tmemLdOp.getType();
+    auto retShapePerCTA = getShapePerCTA(oldRetType);
+    int numWarps =
+        TritonGPUDialect::getNumWarps(op->getParentOfType<ModuleOp>());
+    auto CTALayout = getCTALayout(oldRetType.getEncoding());
+    builder.setInsertionPoint(op);
+    Attribute newDistributedEncoding = nvidia_gpu::getTmemCompatibleLayout(
+        tmem.getBlockM(), tmem.getBlockN(), retShapePerCTA, numWarps,
+        CTALayout);
+
+    SmallVector<int64_t> shape{oldRetType.getShape().begin(),
+                               oldRetType.getShape().end()};
+    int sliceSize = shape[dim] / numOfPartitions;
+    shape[dim] = sliceSize;
+    auto newAccType = RankedTensorType::get(shape, oldRetType.getElementType(),
+                                            newDistributedEncoding);
+    auto ld = builder.createWithAsyncTaskIds<triton::nvidia_gpu::TMEMLoadOp>(
+        op->getLoc(), newAccType, mappings.lookupOrNull(tmemLdOp.getSrc()));
+
+    auto newType = RankedTensorType::get(shape, oldRetType.getElementType(),
+                                         oldRetType.getEncoding());
+    auto cvtOp = builder.createWithAsyncTaskIds<ConvertLayoutOp>(op->getLoc(),
+                                                                 newType, ld);
+    auto v = tmemLdOp->getResult(0);
+    auto newV = cvtOp->getResult(0);
+    mappings.map(v, newV);
+    reverseMappings.map(newV, v);
+    newOp = cvtOp;
+  } else if (auto tmemAllocOp = dyn_cast<nvidia_gpu::TMEMAllocOp>(op)) {
+    for (Value operand : op->getOperands())
+      sliceOp(operand, offset, builder, mappings, reverseMappings,
+              partitionScheme);
+    // Check for src.
+    if (tmemAllocOp.getSrc()) {
+      // src is blocked layout. apply convert layout on src
+      auto srcTy = cast<RankedTensorType>(
+          mappings.lookupOrNull(tmemAllocOp.getSrc()).getType());
+
+      // convert from srcTy to a compatible blocked layout.
+      auto retShapePerCTA = getShapePerCTA(srcTy);
+      int numWarps =
+          TritonGPUDialect::getNumWarps(op->getParentOfType<ModuleOp>());
+      auto CTALayout = getCTALayout(srcTy.getEncoding());
+      builder.setInsertionPoint(op);
+
+      // calculate new tmem type.
+      auto retType = cast<MemDescType>(tmemAllocOp.getType());
+      SmallVector<int64_t> shape{retType.getShape().begin(),
+                                 retType.getShape().end()};
+      int sliceSize = shape[dim] / numOfPartitions;
+      shape[dim] = sliceSize;
+      auto tmem =
+          cast<nvidia_gpu::TensorMemoryEncodingAttr>(retType.getEncoding());
+      auto accEncoding = triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
+          builder.getContext(),
+          dim == 0 ? tmem.getBlockM() / 2 : tmem.getBlockM(),
+          dim == 1 ? tmem.getBlockN() / 2 : tmem.getBlockN(),
+          tmem.getUnpacked(), tmem.getCTASplitM(), tmem.getCTASplitN());
+      auto newType = MemDescType::get(shape, retType.getElementType(),
+                                      accEncoding, retType.getMemorySpace(),
+                                      retType.getMutableMemory());
+
+      Attribute newDistributedEncoding = nvidia_gpu::getTmemCompatibleLayout(
+          accEncoding.getBlockM(), accEncoding.getBlockN(), retShapePerCTA,
+          numWarps, CTALayout);
+      auto newAccType = RankedTensorType::get(
+          srcTy.getShape(), srcTy.getElementType(), newDistributedEncoding);
+      auto cvtOp = builder.createWithAsyncTaskIds<ConvertLayoutOp>(
+          op->getLoc(), newAccType,
+          mappings.lookupOrNull(tmemAllocOp.getSrc()));
+
+      // replace tmemAllocOp with alloc, where the src is cvtOp.
+      auto alloc =
+          builder.createWithAsyncTaskIds<triton::nvidia_gpu::TMEMAllocOp>(
+              op->getLoc(), newType, cvtOp);
+
+      auto v = tmemAllocOp->getResult(0);
+      auto newV = alloc->getResult(0);
+      mappings.map(v, newV);
+      reverseMappings.map(newV, v);
+      newOp = alloc;
+    } else
+      newOp = cloneAndSetResultType(op);
   } else if (auto constOp = dyn_cast<arith::ConstantOp>(op)) {
     builder.setInsertionPoint(op);
     auto valAttr = cast<DenseElementsAttr>(constOp.getValueAttr());
@@ -730,6 +836,7 @@ void partitionTasks(triton::FuncOp &funcOp, int numConsumerGroups) {
   // clean up
 
   SmallVector<Operation *> opsToDelete;
+  OpBuilderWithAsyncTaskIds builder(funcOp.getContext());
   for (auto op : partitionScheme.ops) {
     if (isa<scf::YieldOp>(op))
       continue;
@@ -756,6 +863,42 @@ void partitionTasks(triton::FuncOp &funcOp, int numConsumerGroups) {
     partitionScheme.ops.remove(op);
     op->erase();
   }
+
+  // Collect original operations
+  SmallVector<scf::ForOp> orderedForOps;
+  funcOp.walk([&](Operation *op) {
+    if (auto forOp = dyn_cast<scf::ForOp>(op))
+      orderedForOps.push_back(forOp);
+  });
+  for (auto &forOp : orderedForOps) {
+    SmallVector<Operation *> opList;
+    forOp.walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+      if (!isa<scf::YieldOp>(subOp) && subOp != forOp.getOperation() &&
+          partitionScheme.ops.count(subOp))
+        opList.push_back(subOp);
+    });
+    Block &block = *forOp.getBody();
+    for (auto it = opList.rbegin(); it != opList.rend(); ++it) {
+      Operation *op = *it;
+      LLVM_DEBUG({
+        LDBG("erasing op ");
+        op->dump();
+      });
+      // Update YieldOpnd if op feeds into Yield.
+      for (unsigned i = 0; i < op->getNumResults(); ++i) {
+        for (OpOperand &yieldOpOperand : op->getResult(i).getUses()) {
+          if (auto yieldOp =
+                  dyn_cast<scf::YieldOp>(yieldOpOperand.getOwner())) {
+            auto operandNumber = yieldOpOperand.getOperandNumber();
+            BlockArgument arg = block.getArgument(operandNumber + 1);
+            yieldOp.setOperand(operandNumber, arg);
+          }
+        }
+      }
+      op->erase();
+    }
+  }
+
   LLVM_DEBUG({
     LDBG("prior to clean up:");
     funcOp.dump();

--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -457,10 +457,15 @@ Operation *sliceOp(Operation *op, int offset,
         TritonGPUDialect::getNumWarps(op->getParentOfType<ModuleOp>());
     auto CTALayout = getCTALayout(oldRetType.getEncoding());
     builder.setInsertionPoint(op);
+    // The source op is already sliced at this point, so srcTy, type, tmem is
+    // sliced. We use getTmemCompatibleLayout to get a block layout that is for
+    // the sliced tmem here.
     Attribute newDistributedEncoding = nvidia_gpu::getTmemCompatibleLayout(
         tmem.getBlockM(), tmem.getBlockN(), retShapePerCTA, numWarps,
         CTALayout);
 
+    // oldRetType is the desired output, we slice it and convert from the
+    // compatible layout to the sliced desired output.
     SmallVector<int64_t> shape{oldRetType.getShape().begin(),
                                oldRetType.getShape().end()};
     int sliceSize = shape[dim] / numOfPartitions;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -26,7 +26,8 @@ using namespace triton::nvidia_gpu;
 static void
 lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
              function_ref<void(Value, Value, Value, Value)> createLoad,
-             PatternRewriter &rewriter) {
+             PatternRewriterWithAsyncTaskIds &rewriter,
+             PatternRewriter &baseRewriter) {
   MLIRContext *ctx = op->getContext();
   Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
   auto loc = op->getLoc();
@@ -49,7 +50,7 @@ lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
   auto barrierEncoding = SharedEncodingAttr::get(tensorType.getContext(), 1, 1,
                                                  1, {0}, barrierCTALayout);
   MemDescType barrierMemDescType =
-      MemDescType::get({1}, rewriter.getI64Type(), barrierEncoding,
+      MemDescType::get({1}, baseRewriter.getI64Type(), barrierEncoding,
                        sharedMemorySpace, /*mutableMemory=*/true);
   Value barrierAlloc = rewriter.create<LocalAllocOp>(loc, barrierMemDescType);
   rewriter.create<InitBarrierOp>(loc, barrierAlloc, 1);
@@ -79,7 +80,8 @@ public:
       rewriter.create<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(
           op.getLoc(), tmaPtr, op.getIndices(), barrierAlloc, alloc, pred);
     };
-    lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, baseRewriter);
+    lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter,
+                 baseRewriter);
     return success();
   }
 };
@@ -89,14 +91,16 @@ struct TMAGatherLowering
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(ExperimentalDescriptorGatherOp op,
-                                PatternRewriter &rewriter) const override {
+                                PatternRewriter &baseRewriter) const override {
+    PatternRewriterWithAsyncTaskIds rewriter(baseRewriter, op);
     auto createLoad = [&](Value tmaPtr, Value barrierAlloc, Value alloc,
                           Value pred) {
       rewriter.create<triton::nvidia_gpu::AsyncTMAGatherOp>(
           op.getLoc(), tmaPtr, op.getXOffsets(), op.getYOffset(), barrierAlloc,
           alloc, pred);
     };
-    lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
+    lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter,
+                 baseRewriter);
     return success();
   }
 };
@@ -104,7 +108,8 @@ struct TMAGatherLowering
 static void lowerTMAStore(Operation *op, mlir::TypedValue<RankedTensorType> src,
                           Value desc,
                           function_ref<void(Value, Value)> createStore,
-                          PatternRewriter &rewriter) {
+                          PatternRewriterWithAsyncTaskIds &rewriter,
+                          PatternRewriter &baseRewriter) {
   MLIRContext *ctx = op->getContext();
   Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
   auto loc = op->getLoc();
@@ -127,7 +132,7 @@ static void lowerTMAStore(Operation *op, mlir::TypedValue<RankedTensorType> src,
       rewriter.create<triton::nvidia_gpu::TensorDescToTMAPtrOp>(loc, desc);
   createStore(tmaPtr, alloc);
   rewriter.create<triton::nvidia_gpu::TMAStoreWaitOp>(loc, 0);
-  rewriter.eraseOp(op);
+  baseRewriter.eraseOp(op);
 }
 
 struct TMAStoreLowering
@@ -135,12 +140,14 @@ struct TMAStoreLowering
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(ExperimentalDescriptorStoreOp op,
-                                PatternRewriter &rewriter) const override {
+                                PatternRewriter &baseRewriter) const override {
+    PatternRewriterWithAsyncTaskIds rewriter(baseRewriter, op);
     auto createStore = [&](Value tmaPtr, Value alloc) {
       rewriter.create<triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp>(
           op.getLoc(), tmaPtr, op.getIndices(), alloc);
     };
-    lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);
+    lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter,
+                  baseRewriter);
     return success();
   }
 };
@@ -150,12 +157,14 @@ struct TMAScatterLowering
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(ExperimentalDescriptorScatterOp op,
-                                PatternRewriter &rewriter) const override {
+                                PatternRewriter &baseRewriter) const override {
+    PatternRewriterWithAsyncTaskIds rewriter(baseRewriter, op);
     auto createStore = [&](Value tmaPtr, Value alloc) {
       rewriter.create<triton::nvidia_gpu::AsyncTMAScatterOp>(
           op.getLoc(), tmaPtr, op.getXOffsets(), op.getYOffset(), alloc);
     };
-    lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);
+    lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter,
+                  baseRewriter);
     return success();
   }
 };


### PR DESCRIPTION
tmem_load, tmem_alloc can have side effects so we can no longer depend on populateForOpDeadArgumentElimination/ForOp cleanup to remove the original ops that should be replaced with the sliced versions. We removed the original ops by walking through the function op and erasing ops in partitionScheme.ops.

Also this patch tries to correctly handle the slicing of tmem_load/alloc: an extra convert_layout is added to convert the blocked layout that is used by tmem_load/alloc to be compatible with the sliced tmem.

There are a few places where we need to keep attributes. These changes exist in the ws branch but in a different file.