### PR TITLE
Support multi-staged buffers

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -1397,6 +1397,13 @@ void reuseBuffers(SmallVector<Operation *> &taskTopOps,
 
 // Go through a list of operations under one scope.
 // prevAccum can be null if there is an outer loop for the reuse loops.
+//
+// opsUsingNumBuffers - ops that use buffers with a specific stage. For a
+// enclosing region such as forOp, if none of its inner ops use buffers with a
+// specific stage, we don't need to add an argument to the forOp.
+//
+// bufferArgIndices - map from forOp to a map from numBuffers to the index of
+// the argument for numBuffers.
 Value updateAccumLoopCount(
     SmallVector<Operation *> &opList, unsigned numBuffers,
     SmallVector<Operation *> &taskTopOps, Operation *commonOuterLoop,

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
@@ -438,10 +438,10 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 
 // Verify that we can reuse buffers between two for loops
 // CHECK-LABEL: @_attn_bwd_ws
-// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 0 : i32} : () -> !tt.memdesc<2x64x128xbf16
-// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 1 : i32} : () -> !tt.memdesc<2x64x128xbf16
-// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 0 : i32} : () -> !tt.memdesc<2x64x128xbf16
-// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 1 : i32} : () -> !tt.memdesc<2x64x128xbf16
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 0 : i32} : () -> !tt.memdesc<1x64x128xbf16
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 1 : i32} : () -> !tt.memdesc<1x64x128xbf16
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 0 : i32} : () -> !tt.memdesc<1x64x128xbf16
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 1 : i32} : () -> !tt.memdesc<1x64x128xbf16
 
 // CHECK: %[[TID:.*]] = triton_nvidia_gpu.get_async_task_id : i32
 // CHECK: %[[ZERO:.*]] = arith.constant 0 : i32


### PR DESCRIPTION
Supporting different number of WS buffers in a kernel like below:  


```
@triton.autotune(
    [triton.Config(
            {"BLOCK_M": 64, "BLOCK_K": 32},
            num_stages=2,
            num_warps=4,
            num_consumer_groups=2,
            num_buffers_warp_spec=3,
        )],
)
@triton.jit
def kernel(
    for pid in tl.range(tl.program_id(0), total_tiles, tl.num_programs(0), num_stages=2):
```

