### PR TITLE
[WS] Skip task id propogation in absence of dot op

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/TaskIdPropagate.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/TaskIdPropagate.cpp
@@ -411,6 +411,9 @@ public:
         anchorOps.insert(op);
     });
 
+    // If there is no anchorOp, task id propagation is not needed.
+    if (anchorOps.empty())
+      return;
     populateTaskIdsForControlDependencies(anchorOps);
 
     LLVM_DEBUG({


### PR DESCRIPTION

`TaskIdPropagate` pass fails when there is not `dotOp`. 
Currently the `populateTaskIdsForControlDependencies` is called even when `anchorOps` are empty, which is the case for non-warp specialized kernel blocks.

This change bails out of task id propagation when `anchorOps` is empty.
