### PR TITLE
[DataPartition] Support per-op partition dimension

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -339,13 +339,6 @@ bool computePartitionScheme(triton::FuncOp &funcOp,
   int numWarps =
       TritonGPUDialect::getNumWarps(funcOp->getParentOfType<ModuleOp>());
   for (auto dotOp : dots) {
-    // // Validate the partition scheme that is already computed for the dot
-    // if (partitionScheme.opPartitionDims.contains(dotOp)) {
-    //   unsigned partitionDim = partitionScheme.opPartitionDims[dotOp];
-    //   // TODO: validate the partition scheme
-    //   continue;
-    // }
-
     // partition along M first, otherwise along N
     RankedTensorType dotType = dotOp.getType();
     LLVM_DEBUG({


### PR DESCRIPTION
When in the presense of `tl.trans`, the original partition dimension could flip. I'm extending data partition to support per-op partition dimension. This requires a DFS-based partition scheme computation instead of a BFS one.

I'm also extending partition computation to be iterative, i.e, when a paricular partition either along M or N dimension fails, it automatically tries partition along the other dimension.