### PR TITLE
Update bufferIdx correctly to handle IfOp under ForOp

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -91,6 +91,11 @@ static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
         // Skip control flow ops that are shared by all async tasks
         continue;
       }
+      // If use is the initial value of ForOp argument.
+      if (auto userFor = dyn_cast<scf::ForOp>(user)) {
+        argIndices.insert(argIdx);
+        return;
+      }
 
       // Found a real user, the arg is needed
       if (user->getNumRegions() == 0) {

--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -1336,7 +1336,7 @@ scf::ForOp createNewLoop(scf::ForOp forOp, int numBuffers,
     // Increment by 1.
     builder.setInsertionPoint(yieldOp);
     Value one =
-        builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 32);
+        builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 64);
     Value nextCntIdx = builder.createWithAsyncTaskIds<arith::AddIOp>(
         loc, tmpAccumLoopCount, one);
     yieldOp->insertOperands(yieldOp.getNumOperands(),

--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -548,16 +548,16 @@ scf::IfOp rewriteIfOp(scf::IfOp ifOp, unsigned numBuffers,
   ifBuilder.setInsertionPoint(newIfOp.thenYield());
 
   auto parentForOp = newIfOp->getParentOfType<scf::ForOp>();
-  unsigned tSize;
+  unsigned tSize, parentTCnts = 0;
   SmallVector<Operation *> preOrderOpsOfParent;
   if (parentForOp) {
     tSize = parentForOp.getBody()->getArguments().size();
     getAccumCntsPreOrder(parentForOp.getOperation(), opsWithChannels,
                          opsWithBufferReuse, preOrderOpsOfParent);
+    parentTCnts =
+        getAccumCnts(parentForOp.getOperation(), opsWithChannels,
+                     opsWithBufferReuse); // preOrderOpsOfParent.size();
   }
-  auto parentTCnts =
-      getAccumCnts(parentForOp.getOperation(), opsWithChannels,
-                   opsWithBufferReuse); // preOrderOpsOfParent.size();
   LDBG("rewrite ifOp: parentFor " << parentTCnts << " accumCnts");
 
 #if 0


### PR DESCRIPTION
Summary:
For the case of
```
ForOp
  IfOp
    ForOp
      Channel
```
We need to create AccumLoopCount for the channel through the outer ForOp. Prior to the fix, bufIdx argument of the outer loop increases by one for each iteration, which can cause deadlock when the IfOp is not executed for some iterations.

The fix is to add AccumIf argument for the outer ForOp:
```
ForOp accumIf, bufIdx
  IfOp
    ForOp
      Channel uses (idx, phase) based on accumIf
    accumIf += 1
```
Modify createNewLoop to handle the general case instead of depending on
    bool hasParallelReuse, bool isOuterOfReuse.