### PR TITLE
[WS] Support cross-dimension split-K data partition

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -617,13 +617,11 @@ void rewriteRematerializedOps(triton::FuncOp &funcOp,
   // For each rematerialized op, create a new op and replace its user with it.
   for (auto opDim : partitionScheme.rematerializedOps) {
     auto oldOp = opDim.first;
-    partitionScheme.opPartitionDims.erase(oldOp);
-    partitionScheme.ops.remove(oldOp);
     builder.setInsertionPoint(oldOp);
     builder.setAsyncTaskIdsFromOp(oldOp);
 
     // Skip the first dim which will be using the original op.
-    for (unsigned i = 0; i < opDim.second.size(); i++) {
+    for (unsigned i = 1; i < opDim.second.size(); i++) {
       unsigned dim = opDim.second[i];
       LLVM_DEBUG({
         LDBG("rewriting op along dim " << dim << ":");

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_data_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_data_partition.mlir
@@ -134,3 +134,137 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     tt.return
   }
 }
+
+// -----
+
+// CHECK-LABEL: @cross_dim_partition
+// CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
+// CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
+// CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<128x128xbf16
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : tensor<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : tensor<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+#shared1 = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @cross_dim_partition(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg7: f32, %arg8: i32, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32) attributes {noinline = false} {
+    %cst = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} dense<0.000000e+00> : tensor<128x128xf32, #mma>
+    %c0_i32 = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} 0 : i32
+    %c16384_i32 = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} 16384 : i32
+    %cst_0 = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} dense<true> : tensor<128x128xi1, #blocked>
+    %c1_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 1 : i32
+    %c128_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 128 : i32
+    %c256_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 256 : i32
+    %c384_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 384 : i32
+    %c2_i64 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 2 : i64
+    %c64_i32 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 64 : i32
+    %c512_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 512 : i32
+    %c4_i64 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 4 : i64
+    %cst_1 = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} dense<128> : tensor<1x128xi32, #blocked>
+    %0 = tt.get_program_id x {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %1 = tt.get_program_id y {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %2 = arith.divsi %1, %arg8 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %3 = arith.remsi %1, %arg8 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %4 = tt.addptr %arg1, %2 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i32>, i32
+    %5 = tt.load %4 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i32>
+    %6 = tt.addptr %4, %c1_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i32>, i32
+    %7 = tt.load %6 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i32>
+    %8 = arith.subi %7, %5 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %9 = arith.minsi %8, %arg10 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %10 = arith.muli %2, %c512_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %11 = tt.addptr %arg6, %10 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i8>, i32
+    %12 = tt.addptr %11, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8>, i32
+    %13 = tt.addptr %11, %c256_i32 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8>, i32
+    %14 = tt.addptr %11, %c384_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i8>, i32
+    %15 = arith.muli %arg8, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+    %16 = arith.extsi %15 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+    %17 = arith.muli %16, %c2_i64 {async_task_id = dense<0> : vector<1xi32>} : i64
+    %18 = arith.shrsi %17, %c4_i64 {async_task_id = dense<0> : vector<1xi32>} : i64
+    tt.experimental_tensormap_create %11, %arg0, [%c64_i32, %c64_i32], [%15, %7], [%18], [%c1_i32, %c1_i32] {async_task_id = dense<0> : vector<1xi32>, elem_type = 1 : i32, fill_mode = 0 : i32, interleave_layout = 0 : i32, swizzle_mode = 3 : i32} : (!tt.ptr<i8>, !tt.ptr<bf16>, i32, i32, i32, i32, i64, i32, i32) -> ()
+    %19 = arith.muli %arg9, %c256_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+    tt.experimental_tensormap_create %12, %arg2, [%c64_i32, %c128_i32], [%15, %19], [%18], [%c1_i32, %c1_i32] {async_task_id = dense<0> : vector<1xi32>, elem_type = 1 : i32, fill_mode = 0 : i32, interleave_layout = 0 : i32, swizzle_mode = 3 : i32} : (!tt.ptr<i8>, !tt.ptr<bf16>, i32, i32, i32, i32, i64, i32, i32) -> ()
+    tt.experimental_tensormap_create %13, %arg3, [%c64_i32, %c64_i32], [%15, %7], [%18], [%c1_i32, %c1_i32] {async_task_id = dense<0> : vector<1xi32>, elem_type = 1 : i32, fill_mode = 0 : i32, interleave_layout = 0 : i32, swizzle_mode = 3 : i32} : (!tt.ptr<i8>, !tt.ptr<bf16>, i32, i32, i32, i32, i64, i32, i32) -> ()
+    tt.experimental_tensormap_create %14, %arg5, [%c64_i32, %c64_i32], [%15, %7], [%18], [%c1_i32, %c1_i32] {async_task_id = dense<0> : vector<1xi32>, elem_type = 1 : i32, fill_mode = 0 : i32, interleave_layout = 0 : i32, swizzle_mode = 3 : i32} : (!tt.ptr<i8>, !tt.ptr<bf16>, i32, i32, i32, i32, i64, i32, i32) -> ()
+    %20 = arith.muli %0, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %21 = arith.cmpi slt, %20, %9 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    scf.if %21 {
+      %22 = arith.muli %0, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %23 = arith.addi %5, %22 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %24 = arith.muli %3, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %25 = tt.experimental_descriptor_load %11[%23, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
+      %26 = triton_gpu.local_alloc %25 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      %27 = arith.muli %2, %c256_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %28 = tt.experimental_descriptor_load %12[%27, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
+      %29 = triton_gpu.local_alloc %28 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      %30 = triton_nvidia_gpu.warp_group_dot %26, %29, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
+      %31 = arith.truncf %30 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> to tensor<128x128xbf16, #mma>
+      %32 = triton_gpu.local_alloc %31 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #mma>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      %33 = tt.experimental_descriptor_load %13[%23, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
+      %34 = triton_gpu.local_alloc %33 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      %35 = tt.trans %34 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
+      %36 = triton_nvidia_gpu.warp_group_dot %35, %32, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
+      %37 = triton_gpu.convert_layout %36 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> -> tensor<128x128xf32, #blocked>
+      %38 = arith.truncf %37 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+      %39 = arith.muli %27, %arg8 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+      %40 = arith.muli %39, %c128_i32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+      %41 = tt.addptr %arg4, %40 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<bf16>, i32
+      %42 = arith.muli %arg8, %c16384_i32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+      %43 = tt.addptr %41, %42 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<bf16>, i32
+      %44 = arith.muli %3, %c128_i32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+      %45 = tt.addptr %43, %44 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<bf16>, i32
+      %46 = tt.make_range {async_task_id = dense<[1, 2]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %47 = tt.expand_dims %46 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xi32, #blocked>
+      %48 = tt.splat %arg8 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<1x128xi32, #blocked>
+      %49 = arith.muli %47, %48 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128xi32, #blocked>
+      %50 = arith.muli %49, %cst_1 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128xi32, #blocked>
+      %51 = tt.splat %45 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<bf16> -> tensor<1x128x!tt.ptr<bf16>, #blocked>
+      %52 = tt.addptr %51, %50 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128x!tt.ptr<bf16>, #blocked>, tensor<1x128xi32, #blocked>
+      %53 = tt.make_range {async_task_id = dense<[1, 2]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %54 = tt.expand_dims %53 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+      %55 = tt.broadcast %52 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128x!tt.ptr<bf16>, #blocked> -> tensor<128x128x!tt.ptr<bf16>, #blocked>
+      %56 = tt.broadcast %54 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x1xi32, #blocked> -> tensor<128x128xi32, #blocked>
+      %57 = tt.addptr %55, %56 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128x!tt.ptr<bf16>, #blocked>, tensor<128x128xi32, #blocked>
+      %58 = tt.atomic_rmw fadd, relaxed, gpu, %57, %38, %cst_0 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128x!tt.ptr<bf16>, #blocked>, tensor<128x128xbf16, #blocked>, tensor<128x128xi1, #blocked>) -> tensor<128x128xbf16, #blocked>
+      %59 = arith.addi %27, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %60 = tt.experimental_descriptor_load %12[%59, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
+      %61 = triton_gpu.local_alloc %60 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      %62 = tt.trans %61 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
+      %63 = triton_nvidia_gpu.warp_group_dot %34, %62, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
+      %64 = arith.truncf %63 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> to tensor<128x128xbf16, #mma>
+      %65 = tt.experimental_descriptor_load %12[%27, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
+      %66 = triton_gpu.local_alloc %65 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      %67 = tt.trans %66 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
+      %68 = triton_gpu.convert_layout %64 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xbf16, #mma> -> tensor<128x128xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+      %69 = triton_nvidia_gpu.warp_group_dot %68, %67, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : tensor<128x128xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
+      %70 = triton_gpu.convert_layout %69 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> -> tensor<128x128xf32, #blocked1>
+      %71 = arith.truncf %70 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #blocked1> to tensor<128x128xbf16, #blocked1>
+      %72 = arith.muli %0, %c128_i32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+      %73 = arith.addi %5, %72 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+      %74 = arith.muli %3, %c128_i32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+      tt.experimental_descriptor_store %14[%73, %74], %71 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<i8>, tensor<128x128xbf16, #blocked1>
+      %75 = triton_gpu.local_alloc %64 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #mma>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      %76 = tt.trans %75 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
+      %77 = triton_nvidia_gpu.warp_group_dot %76, %26, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
+      %78 = triton_gpu.convert_layout %77 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> -> tensor<128x128xf32, #blocked>
+      %79 = arith.truncf %78 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+      %80 = tt.addptr %41, %c0_i32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<bf16>, i32
+      %81 = tt.addptr %80, %44 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<bf16>, i32
+      %82 = tt.splat %81 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<bf16> -> tensor<1x128x!tt.ptr<bf16>, #blocked>
+      %83 = tt.addptr %82, %50 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128x!tt.ptr<bf16>, #blocked>, tensor<1x128xi32, #blocked>
+      %84 = tt.broadcast %83 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128x!tt.ptr<bf16>, #blocked> -> tensor<128x128x!tt.ptr<bf16>, #blocked>
+      %85 = tt.addptr %84, %56 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128x!tt.ptr<bf16>, #blocked>, tensor<128x128xi32, #blocked>
+      %86 = tt.atomic_rmw fadd, relaxed, gpu, %85, %79, %cst_0 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128x!tt.ptr<bf16>, #blocked>, tensor<128x128xbf16, #blocked>, tensor<128x128xi1, #blocked>) -> tensor<128x128xbf16, #blocked>
+    } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_data_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_data_partition.mlir
@@ -138,19 +138,6 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 // -----
 
 // CHECK-LABEL: @cross_dim_partition
-// CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
-// CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
-// CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<128x128xbf16
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : tensor<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : tensor<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
-// CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
-
 #blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
@@ -201,17 +188,26 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
       %22 = arith.muli %0, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
       %23 = arith.addi %5, %22 {async_task_id = dense<0> : vector<1xi32>} : i32
       %24 = arith.muli %3, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      // CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
+      // CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
       %25 = tt.experimental_descriptor_load %11[%23, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
       %26 = triton_gpu.local_alloc %25 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
       %27 = arith.muli %2, %c256_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      // CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<128x128xbf16
       %28 = tt.experimental_descriptor_load %12[%27, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
       %29 = triton_gpu.local_alloc %28 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
       %30 = triton_nvidia_gpu.warp_group_dot %26, %29, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
       %31 = arith.truncf %30 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> to tensor<128x128xbf16, #mma>
       %32 = triton_gpu.local_alloc %31 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #mma>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
+      // CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
+      // CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<64x128xbf16
       %33 = tt.experimental_descriptor_load %13[%23, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
       %34 = triton_gpu.local_alloc %33 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
       %35 = tt.trans %34 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
       %36 = triton_nvidia_gpu.warp_group_dot %35, %32, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
       %37 = triton_gpu.convert_layout %36 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> -> tensor<128x128xf32, #blocked>
       %38 = arith.truncf %37 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
@@ -236,15 +232,21 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
       %57 = tt.addptr %55, %56 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128x!tt.ptr<bf16>, #blocked>, tensor<128x128xi32, #blocked>
       %58 = tt.atomic_rmw fadd, relaxed, gpu, %57, %38, %cst_0 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128x!tt.ptr<bf16>, #blocked>, tensor<128x128xbf16, #blocked>, tensor<128x128xi1, #blocked>) -> tensor<128x128xbf16, #blocked>
       %59 = arith.addi %27, %c128_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      // CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<128x128xbf16
       %60 = tt.experimental_descriptor_load %12[%59, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
       %61 = triton_gpu.local_alloc %60 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
       %62 = tt.trans %61 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
       %63 = triton_nvidia_gpu.warp_group_dot %34, %62, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
       %64 = arith.truncf %63 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> to tensor<128x128xbf16, #mma>
+      // CHECK: tt.experimental_descriptor_load {{.*}} -> tensor<128x128xbf16
       %65 = tt.experimental_descriptor_load %12[%27, %24] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8> -> tensor<128x128xbf16, #blocked1>
       %66 = triton_gpu.local_alloc %65 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #blocked1>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
       %67 = tt.trans %66 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
       %68 = triton_gpu.convert_layout %64 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xbf16, #mma> -> tensor<128x128xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : tensor<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : tensor<64x128xbf16, {{.*}} * !tt.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
       %69 = triton_nvidia_gpu.warp_group_dot %68, %67, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : tensor<128x128xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
       %70 = triton_gpu.convert_layout %69 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> -> tensor<128x128xf32, #blocked1>
       %71 = arith.truncf %70 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #blocked1> to tensor<128x128xbf16, #blocked1>
@@ -254,6 +256,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
       tt.experimental_descriptor_store %14[%73, %74], %71 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<i8>, tensor<128x128xbf16, #blocked1>
       %75 = triton_gpu.local_alloc %64 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x128xbf16, #mma>) -> !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory>
       %76 = tt.trans %75 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory>
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
+      // CHECK: triton_nvidia_gpu.warp_group_dot {{.*}} : !tt.memdesc<128x64xbf16, {{.*}} * !tt.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
       %77 = triton_nvidia_gpu.warp_group_dot %76, %26, %cst {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x128xbf16, #shared1, #triton_gpu.shared_memory> * !tt.memdesc<128x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
       %78 = triton_gpu.convert_layout %77 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #mma> -> tensor<128x128xf32, #blocked>
       %79 = arith.truncf %78 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>


### PR DESCRIPTION
Previously we only support data partition an operation along a fixed dimension, i.e, either M- or N-dim for a 2D tensor operation. Now I'm extending it to supporting partition an op along multiple dimensions. A specific use case is to partition along a chain of dot operations. E.g.,

```
o = tl.dot(o, w)
grad_o = tl.dot(grad_o, tl.trans(w))
grad_w = tl.dot(tl.trans(grad_o), o)
tl.atomic_add(grad_w)
```

Partitioning the first dot along `M` would lead to partitioning the third dot along `K`. Partitioning the first do along `N` would result in partitioning the second dot along `K`. Either way would cause a cross-dimension partition (K-partition) for the two operands of some dot and it is only valid when the immediate result of the K-partitioned dot is stored out through an atomic_add. The PR supports that and for the above example, it would result in the following partition

```
o1 = tl.dot(o/2, w)
o2 = tl.dot(o/2, w)
grad_o1 = tl.dot(grad_o, tl.trans(w/2))
grad_o2 = tl.dot(grad_o, tl.trans(w/2))
grad_w1 = tl.dot(tl.trans(grad_o1), o1)
grad_w2 = tl.dot(tl.trans(grad_o2), o2)
tl.atomic_add(grad_w1)
tl.atomic_add(grad_w2)
```

The split-K partition of a dot results in M-partition for its `A` operand and N-partition for its `B` operand, but no partition is needed for the acc and output operand. This may cause a conflict with partitioning other ops where any operand needs to be partitioned in a different way. In that case I'm introducing the concept of rematerialization, which enables to recompute inexpensive ops, such as `LocalAllocOp` or `arith::ConstantOp`. For the former, a `LocalAllocOp` op won't be partitioned and a `MemDescSubviewOp` can be created for arbitrary partition.




