### PR TITLE
Add a fix pass to rewrite the incorrect bar.sync 0 in WS

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -49,6 +49,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerConvertNVGPUToLLVMPass();
   mlir::triton::registerDecomposeUnsupportedNVIDIAConversions();
   mlir::registerLLVMDIScope();
+  mlir::triton::registerFixWSBarrierPass();
 
   // TritonAMDGPUToLLVM passes
   mlir::triton::registerConvertTritonAMDGPUToLLVM();

--- a/test/TritonNvidiaGPU/WarpSpecialization/fix_ws_barrier.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/fix_ws_barrier.mlir
@@ -1,0 +1,92 @@
+// RUN: triton-opt %s -split-input-file --fix-ws-barrier | FileCheck %s
+
+// CHECK-LABEL: @no_rewrite_barrier
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warp-groups-per-cta" = 2 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.shared = 171056 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  llvm.func @no_rewrite_barrier(%arg0: !llvm.ptr<1> {tt.divisibility = 16 : i32}) attributes {noinline = false, nvvm.kernel = 1 : ui1, nvvm.reqntid = array<i32: 256>} {
+    // CHECK: nvvm.barrier0
+    // CHECK: nvvm.barrier0
+    nvvm.barrier0
+    nvvm.barrier0
+    llvm.br ^bb1
+  ^bb1:
+    llvm.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @mixed_control_flow
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warp-groups-per-cta" = 2 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.shared = 171056 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  llvm.func @mixed_control_flow(%arg0: !llvm.ptr<1> {tt.divisibility = 16 : i32}) attributes {noinline = false, nvvm.kernel = 1 : ui1, nvvm.reqntid = array<i32: 256>} {
+    // CHECK: nvvm.barrier0
+    // CHECK: nvvm.barrier0
+    // CHECK: bar.sync 0x1, 0x80;
+    // CHECK: bar.sync 0x2, 0x80;
+    nvvm.barrier0
+    nvvm.barrier0
+    %1 = llvm.mlir.constant(1 : i1) : i1
+    llvm.br ^bb1
+  ^bb1:
+    nvvm.barrier0
+    llvm.cond_br %1, ^bb2, ^bb3
+  ^bb2:
+    nvvm.barrier0
+    llvm.br ^bb3
+  ^bb3:
+    llvm.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @no_warp_specialize
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.shared = 171056 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  llvm.func @no_warp_specialize(%arg0: !llvm.ptr<1> {tt.divisibility = 16 : i32}) attributes {noinline = false, nvvm.kernel = 1 : ui1, nvvm.reqntid = array<i32: 256>} {
+    // CHECK: nvvm.barrier0
+    // CHECK: nvvm.barrier0
+    // CHECK: nvvm.barrier0
+    // CHECK: nvvm.barrier0
+    nvvm.barrier0
+    nvvm.barrier0
+    %1 = llvm.mlir.constant(1 : i1) : i1
+    llvm.br ^bb1
+  ^bb1:
+    nvvm.barrier0
+    llvm.cond_br %1, ^bb2, ^bb3
+  ^bb2:
+    nvvm.barrier0
+    llvm.br ^bb3
+  ^bb3:
+    llvm.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @reuse_barrier_id
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warp-groups-per-cta" = 2 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.shared = 171056 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  llvm.func @reuse_barrier_id(%arg0: !llvm.ptr<1> {tt.divisibility = 16 : i32}) attributes {noinline = false, nvvm.kernel = 1 : ui1, nvvm.reqntid = array<i32: 256>} {
+    // CHECK: nvvm.barrier0
+    // CHECK: nvvm.barrier0
+    // CHECK: bar.sync 0x2, 0x80;
+    // CHECK: bar.sync 0x2, 0x80;
+    // CHECK: bar.sync 0x3, 0x80;
+    // CHECK: bar.sync 0x4, 0x80;
+    // CHECK: bar.sync 0x1, 0x80;
+    nvvm.barrier0
+    nvvm.barrier0
+    %1 = llvm.mlir.constant(1 : i1) : i1
+    llvm.br ^bb1
+  ^bb1:
+    nvvm.barrier0
+    %2 = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "bar.sync 0x2, 0x80;", ""  : () -> !llvm.void
+    %3 = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "bar.sync 0x3, 0x80;", ""  : () -> !llvm.void
+    %4 = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "bar.sync 0x4, 0x80;", ""  : () -> !llvm.void
+    llvm.cond_br %1, ^bb2, ^bb3
+  ^bb2:
+    nvvm.barrier0
+    llvm.br ^bb3
+  ^bb3:
+    llvm.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -281,6 +281,7 @@ class CUDABackend(BaseBackend):
         nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version)
         nvidia.passes.ttnvgpuir.add_nvgpu_to_llvm(pm)
         passes.convert.add_arith_to_llvmir(pm)
+        nvidia.passes.ttgpuir.add_fix_ws_barrier(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h
@@ -29,6 +29,8 @@ createConvertTritonGPUToLLVMPass(int32_t computeCapability);
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonGPUToLLVMPass(int32_t computeCapability, int32_t ptxVersion);
 
+std::unique_ptr<OperationPass<ModuleOp>> createFixWSBarrierPass();
+
 #define GEN_PASS_REGISTRATION
 #include "nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h.inc"
 

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.td
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.td
@@ -36,4 +36,11 @@ def ConvertTritonGPUToLLVM : Pass<"convert-triton-gpu-to-llvm", "mlir::ModuleOp"
     ];
 }
 
+def FixWSBarrier : Pass<"fix-ws-barrier", "mlir::ModuleOp"> {
+    let summary = "Fix the barrier usage in LLVM due to warp specialization";
+    let constructor = "mlir::triton::createFixWSBarrierPass()";
+    let dependentDialects = ["mlir::LLVM::LLVMDialect",
+                             "mlir::NVVM::NVVMDialect"];
+}
+
 #endif

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
@@ -20,6 +20,7 @@ add_triton_library(TritonNVIDIAGPUToLLVM
     UpcastMXFPToLLVM.cpp
     TargetInfo.cpp
     RegReallocOpToLLVM.cpp
+    FixWSBarrier.cpp
 
     DEPENDS
     TritonNVIDIAGPUConversionPassIncGen

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/FixWSBarrier.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/FixWSBarrier.cpp
@@ -1,0 +1,121 @@
+#include "TritonNVIDIAGPUToLLVM/Passes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/SmallSet.h"
+
+#include "Utility.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_FIXWSBARRIER
+#include "TritonNVIDIAGPUToLLVM/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+namespace {
+
+using namespace mlir;
+using namespace triton;
+using namespace triton::gpu;
+
+struct FixWSBarrier
+    : public mlir::triton::impl::FixWSBarrierBase<FixWSBarrier> {
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+
+    if (!mod->hasAttr("triton_gpu.num-warp-groups-per-cta"))
+      return;
+
+    Operation *kernelFunc;
+    int numKernel = 0;
+    for (auto func : mod.getOps<LLVM::LLVMFuncOp>()) {
+      // We filter the libdevice functions
+      if (!func.getName().starts_with("__nv")) {
+        kernelFunc = func;
+        numKernel++;
+      }
+    }
+
+    // This warp specialization fix pass now only supports: all functions should
+    // be inlined.
+    if (numKernel != 1)
+      return;
+
+    assert(kernelFunc->getAttrOfType<mlir::IntegerAttr>("nvvm.kernel")
+               .getValue()
+               .getZExtValue() == 1);
+
+    llvm::DenseMap<Block *, int> barIdReuse;
+    llvm::SmallVector<llvm::StringRef> operands;
+    llvm::SmallSet<int, 16> allocBarId;
+
+    // Helper function to setup metadata for used barrier id
+    auto processEachBarSync = [&](StringRef instruction, Block *block) {
+      auto operandsStr = instruction.substr(instruction.find("bar.sync ") + 9);
+      operandsStr = operandsStr.rtrim(";");
+      operands.clear();
+      operandsStr.split(operands, ',');
+      int barId = -1;
+      operands[0].trim().getAsInteger(0, barId);
+      int threadCount = -1;
+      operands[1].trim().getAsInteger(0, threadCount);
+      if (threadCount == 128) {
+        allocBarId.insert(barId);
+        if (!barIdReuse.count(block)) {
+          barIdReuse[block] = barId;
+        }
+      }
+    };
+
+    // Scan through the kernel function to find the used barrier id
+    for (Block &block : kernelFunc->getRegion(0).getBlocks()) {
+      for (LLVM::InlineAsmOp asmop : block.getOps<LLVM::InlineAsmOp>()) {
+        StringRef instruction = asmop.getAsmString();
+        if (instruction.starts_with("bar.sync")) {
+          processEachBarSync(instruction, &block);
+        }
+      }
+    }
+
+    int curBarId = 1;
+    OpBuilder builder(mod.getContext());
+    for (Block &block : kernelFunc->getRegion(0).getBlocks()) {
+      // We allow bar.sync 0 in the entry block. No warp specialization happens
+      // yet in the entry block. For the rest, we need to rewrite the bar.sync 0
+      // with a goal to reuse the barrier id.
+      if (!block.isEntryBlock()) {
+        for (NVVM::Barrier0Op barrier :
+             llvm::make_early_inc_range(block.getOps<NVVM::Barrier0Op>())) {
+          builder.setInsertionPoint(barrier);
+          if (barIdReuse.count(&block))
+            barSync(builder, barrier, barIdReuse[&block], 128);
+          else {
+            while (allocBarId.count(curBarId))
+              curBarId++;
+
+            if (curBarId > 15)
+              llvm::report_fatal_error(
+                  "Too many barriers, at most 16 barriers");
+
+            barSync(builder, barrier, curBarId, 128);
+            allocBarId.insert(curBarId);
+            barIdReuse[&block] = curBarId;
+            curBarId++;
+          }
+          barrier->erase();
+        }
+      }
+    }
+  }
+};
+} // namespace
+
+namespace mlir::triton {
+std::unique_ptr<OperationPass<ModuleOp>> createFixWSBarrierPass() {
+  return std::make_unique<FixWSBarrier>();
+}
+
+} // namespace mlir::triton

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -26,6 +26,9 @@ void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
   m.def("add_decompose_unsupported_conversions", [](mlir::PassManager &pm) {
     pm.addPass(NVIDIA::createDecomposeUnsupportedConversionsPass());
   });
+  m.def("add_fix_ws_barrier", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::createFixWSBarrierPass());
+  });
 }
 
 void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {


### PR DESCRIPTION
This PR adds a pass to rewrite the incorrect bar.sync 0 in WS. It keeps all the `nvvm.barrier0` in the entry block, which has all kinds of WS init code. These `bar.sync 0` are desired as part of the initialization and the WS hasn't started yet. In each control flow path, we rewrite any `bar.sync 0` to `bar.sync BARID, 128`. We have a hard-coded warp group size as 4 warps (128 threads). Here BARID is the barrier id, which we try to reuse as much as possible (BARID must < 16). After we merge to OAI's WS backend, this pass could be dropped. A similar approach based on `PartitionedRegion` has been implemented there.
