### PR TITLE
[WS] Deduplicate tl.async_task

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2910,10 +2910,7 @@ class async_task:
     Context manager to run code fragments asynchronously.
     """
     def __init__(self, task_ids, _builder=None):
-        unique_task_ids = set()
-        for tid in task_ids:
-            unique_task_ids.add(_constexpr_to_value(tid))
-        self.task_ids = list(unique_task_ids)
+        self.task_ids = list({_constexpr_to_value(tid) for tid in task_ids})
         self.builder = _builder
 
     def __enter__(self):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2910,7 +2910,10 @@ class async_task:
     Context manager to run code fragments asynchronously.
     """
     def __init__(self, task_ids, _builder=None):
-        self.task_ids = task_ids
+        unique_task_ids = set()
+        for tid in task_ids:
+            unique_task_ids.add(_constexpr_to_value(tid))
+        self.task_ids = list(unique_task_ids)
         self.builder = _builder
 
     def __enter__(self):


### PR DESCRIPTION
Also support specifying task_id with `const_expr` values, such as

```
@triton.jit
def kernel(ptr, CONSUMER_TASK: tl.constexpr):
    with tl.async_task([CONSUMER_TASK]):
            tl.store(...)
```

Also deduplcating task ids specified with  tl.async_task, e.g

```
        with tl.async_task([1, NUM_CONSUMER_GROUPS]):
            tl.store(...)
```

