### PR TITLE
[WS][Blackwell] Use mma inline barrier for consumer release

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -92,6 +92,16 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    unsigned loopCnt = 0;
+    getOperation()->walk([&](scf::ForOp forOp) {
+      // Bail out for loops with num_stage <= 1.
+      if (getNumStagesOrDefault(forOp) > 1)
+        loopCnt++;
+    });
+
+    if (loopCnt == 0)
+      return;
+
     // Go over the interesting ops and assign latencies (based on the
     // numStages) to the them, trying to populate the allowed stages. This
     // step will be at some point extracted to separate pass that will be run

--- a/python/gemmbench/gemmbench.py
+++ b/python/gemmbench/gemmbench.py
@@ -74,9 +74,9 @@ impl_map = {fn.__name__: fn for fn in test_impls}
 
 def test():
     torch.manual_seed(0)
-    m = 128
-    n = 128
-    k = 64
+    m = 8192
+    n = 8192
+    k = 8192
     a = torch.randn((m, k), device="cuda", dtype=torch.float16)
     b = torch.randn((k, n), device="cuda", dtype=torch.float16)
     torch_output = torch.matmul(a, b)

--- a/python/gemmbench/impls/matmul_persistent_tma_ws.py
+++ b/python/gemmbench/impls/matmul_persistent_tma_ws.py
@@ -102,7 +102,7 @@ class TmaAutoTuneHelper:
                 "BLOCK_SIZE_K": 64,
                 "GROUP_SIZE_M": 8,
             },
-            num_stages=2,
+            num_stages=1,
             num_warps=4,
             num_consumer_groups=1,
             num_buffers_warp_spec=3,

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
@@ -18,8 +18,8 @@
 // CHECK: ttng.consumer_wait
 // CHECK: ttg.local_load
 // CHECK: ttg.local_load
-// CHECK: tt.dot
 // CHECK: ttng.consumer_release
+// CHECK: tt.dot
 
 
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -845,6 +845,91 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       tt.store %127, %133, %113 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>
       tt.store %128, %134, %114 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>
     } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @matmul_persistent_tma_ws_tcgen05_kernel
+// CHECK: %[[#TASKID:]] = ttng.get_async_task_id : i32
+// CHECK: %[[C0:.+]] = arith.constant 0 : i32
+// CHECK: %[[#WG0:]] = arith.cmpi eq, %[[#TASKID]], %[[C0]] : i32
+// CHECK: scf.if %[[#WG0]]
+// CHECK: ttng.reg_dealloc 40
+// CHECK: scf.for
+// CHECK: ttng.wait_barrier
+// CHECK: ttng.async_tma_copy_global_to_local
+// CHECK: ttng.async_tma_copy_global_to_local
+// CHECK: %[[C1:.+]] = arith.constant 1 : i32
+// CHECK: %[[#WG1:]] = arith.cmpi eq, %[[#TASKID]], %[[C1]] : i32
+// CHECK: scf.if %[[#WG1]]
+// CHECK: ttng.reg_alloc 232
+// CHECK: ttng.wait_barrier
+// CHECK: ttng.tc_gen5_mma
+// CHECK: ttng.wait_barrier
+// CHECK: ttng.tmem_load
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, unpacked = true>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_persistent_tma_ws_tcgen05_kernel(%arg0: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg1: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg2: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %true = arith.constant {async_task_id = dense<1> : vector<1xi32>} true
+    %c127_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 127 : i32
+    %c8_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 8 : i32
+    %c128_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 128 : i32
+    %c256_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 256 : i32
+    %c0_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 0 : i32
+    %c64_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 64 : i32
+    %c1_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 1 : i32
+    %c255_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 255 : i32
+    %c63_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 63 : i32
+    %cst = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    %0 = arith.addi %arg3, %c127_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %1 = arith.divsi %0, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %2 = arith.addi %arg4, %c255_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %3 = arith.divsi %2, %c256_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %4 = arith.muli %1, %3 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %5 = tt.get_program_id x {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %6 = tt.get_num_programs x {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %7 = arith.muli %3, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %8 = arith.addi %arg5, %c63_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %9 = arith.divsi %8, %c64_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %10 = tt.reinterpret_tensor_descriptor %arg0 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> to !tt.tensordesc<tensor<128x64xf16>>
+    %11 = tt.reinterpret_tensor_descriptor %arg1 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> to !tt.tensordesc<tensor<256x64xf16>>
+    %12 = tt.reinterpret_tensor_descriptor %arg2 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<i8, 0> to !tt.tensordesc<tensor<128x256xf16>>
+    scf.for %arg6 = %5 to %4 step %6  : i32 {
+      %13 = arith.divsi %arg6, %7 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %14 = arith.muli %13, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %15 = arith.subi %1, %14 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %16 = arith.minsi %15, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %17 = arith.remsi %arg6, %7 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %18 = arith.remsi %17, %16 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %19 = arith.addi %14, %18 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %20 = arith.divsi %17, %16 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %21 = arith.muli %19, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %22 = arith.muli %20, %c256_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %23 = ttng.tmem_alloc %cst {async_task_id = dense<1> : vector<1xi32>} : (tensor<128x256xf32, #blocked>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+      %24:2 = scf.for %arg7 = %c0_i32 to %9 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %c0_i32) -> (tensor<128x256xf32, #blocked>, i32)  : i32 {
+        %28 = tt.experimental_descriptor_load %10[%21, %arg9] {async_task_id = dense<0> : vector<1xi32>} : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked1>
+        %29 = ttg.local_alloc %28 {async_task_id = dense<1> : vector<1xi32>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %30 = tt.experimental_descriptor_load %11[%22, %arg9] {async_task_id = dense<0> : vector<1xi32>} : !tt.tensordesc<tensor<256x64xf16>> -> tensor<256x64xf16, #blocked1>
+        %31 = ttg.local_alloc %30 {async_task_id = dense<1> : vector<1xi32>} : (tensor<256x64xf16, #blocked1>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+        %32 = ttg.memdesc_trans %31 {async_task_id = dense<1> : vector<1xi32>, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem> -> !ttg.memdesc<64x256xf16, #shared1, #smem>
+        ttng.tc_gen5_mma %29, %32, %23, %true, %true {async_task_id = dense<1> : vector<1xi32>} : (!ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x256xf16, #shared1, #smem>, !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+        %33 = arith.addi %arg9, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+        scf.yield {async_task_id = dense<[0, 1]> : vector<2xi32>} %arg8, %33 : tensor<128x256xf32, #blocked>, i32
+      } {async_task_id = dense<[0, 1]> : vector<2xi32>}
+      %25 = ttng.tmem_load %23 {async_task_id = dense<1> : vector<1xi32>} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
+      %26 = arith.truncf %25 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x256xf32, #blocked> to tensor<128x256xf16, #blocked>
+      %27 = ttg.convert_layout %26 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x256xf16, #blocked> -> tensor<128x256xf16, #blocked2>
+      tt.experimental_descriptor_store %12[%21, %22], %27 {async_task_id = dense<1> : vector<1xi32>} : !tt.tensordesc<tensor<128x256xf16>>, tensor<128x256xf16, #blocked2>
+    } {async_task_id = dense<[0, 1]> : vector<2xi32>}
     tt.return
   }
 }

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -282,6 +282,7 @@ class CUDABackend(BaseBackend):
             passes.common.add_canonicalizer(pm)
             passes.common.add_licm(pm)
             passes.ttgpuir.add_optimize_accumulator_init(pm)
+            nvidia.passes.ttnvgpuir.add_keep_acc_in_tmem(pm)
             passes.ttgpuir.add_ws_task_partition(pm, opt.num_consumer_groups)
             passes.ttgpuir.add_taskid_propagate(pm, opt.num_consumer_groups)
             passes.ttgpuir.add_ws_data_partition(pm, opt.num_consumer_groups)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -282,7 +282,8 @@ class CUDABackend(BaseBackend):
             passes.common.add_canonicalizer(pm)
             passes.common.add_licm(pm)
             passes.ttgpuir.add_optimize_accumulator_init(pm)
-            nvidia.passes.ttnvgpuir.add_keep_acc_in_tmem(pm)
+            if opt.num_consumer_groups > 0:
+                nvidia.passes.ttnvgpuir.add_keep_acc_in_tmem(pm)
             passes.ttgpuir.add_ws_task_partition(pm, opt.num_consumer_groups)
             passes.ttgpuir.add_taskid_propagate(pm, opt.num_consumer_groups)
             passes.ttgpuir.add_ws_data_partition(pm, opt.num_consumer_groups)


### PR DESCRIPTION
The tcgen05 mma instruction can update an inline barrier object on this completion. The implementation of consumer release can leverage that efficiently.

The most performant WS gemm kernel now is with two workgroups:


```
Barrier p[3],c[3];

# Producer
if warp_id == [0,3]:  
  for k in range(0, tl.cdiv(K, BLOCK_K), phase=1, idx=0):
     ProducerAcquire(c[idx], phase)
     a[idx] = tl._experimental_descriptor_load(a_ptrs, p[idx])
     b[idx] = tl._experimental_descriptor_load(b_ptrs, p[idx])     
     a_ptrs += BLOCK_K * stride_ak
     b_ptrs += BLOCK_K * stride_bk
     phase = (idx < 2) ? phase : phase ^ 1 
     idx = (idx + 1) % 3     

# Consumer 1
if warp_id == [4,7]:  
  c1 = tl.zeros((BLOCK_M / 2, BLOCK_N))
  for k in range(0, tl.cdiv(K, BLOCK_K), phase=0, idx=0):
      ConsumerWait(p[idx], phase)
      c1 += tl.dot(a1[idx], b[idx], c[idx])
      phase = (idx < 2) ? phase : phase ^ 1
      idx = (idx + 1) % 3
  c_ptrs = c_ptr + stride_cm …
  tl.store(c_ptrs, c1)
```



Perf:

```
$ python python/tutorials/09-persistent-matmul.py
TMA benchmarks will be running with experimental grid constant TMA descriptor.
M=32, N=32, K=32 verification naive vs: torch: ✅ cublas: ✅ persistent: ✅ TMA persistent: ✅ Tensor descriptor persistent: ✅ TMA persistent with warp specialization: ✅
M=8192, N=8192, K=512 verification naive vs: torch: ✅ cublas: ✅ persistent: ✅ TMA persistent: ✅ Tensor descriptor persistent: ✅ TMA persistent with warp specialization: ✅
526.416 2219.217 ROOT
├─ nan 0.022 _ZN2at6native18elementwise_kernelILi128ELi4EZNS0_22gpu_kernel_impl_nocastIZZZNS0_23direct_copy_kernel_cudaERNS_18TensorIteratorBaseEENKUlvE1_clEvENKUlvE8_clEvEUlN3c104HalfEE_EEvS4_RKT_EUliE_EEviT1_
├─ nan 0.028 _ZN2at6native54_GLOBAL__N__bbfa638d_21_DistributionNormal_cu_0c5b6e8543distribution_elementwise_grid_stride_kernelIfLi4EZNS0_9templates4cuda20normal_and_transformIN3c104HalfEfPNS_17CUDAGeneratorImplEZZZNS4_13normal_kernelIS9_EEvRKNS_10TensorBaseEddT_ENKUlvE_clEvENKUlvE1_clEvEUlfE_EEvRNS_18TensorIteratorBaseET1_T2_EUlP24curandStatePhilox4_32_10E0_ZNS1_27distribution_nullary_kernelIS7_f6float4S9_SO_SH_EEvSJ_SL_RKT3_T4_EUlifE_EEvlNS_15PhiloxCudaStateESK_SL_
├─ 661.964 1141.926 cublas [M=8192, N=8192, K=512]
│  └─ nan 1141.926 nvjet_hsh_256x256_64x4_2x1_2cta_v_bz_TNT
├─ 458.316 149.939 matmul_kernel [M=8192, N=8192, K=512]
├─ 240.990 285.155 matmul_kernel_descriptor_persistent [M=8192, N=8192, K=512]
├─ 423.985 162.080 matmul_kernel_persistent [M=8192, N=8192, K=512]
├─ 241.947 284.027 matmul_kernel_tma_persistent [M=8192, N=8192, K=512]
├─ 667.826 102.900 matmul_persistent_tma_ws_cooperative_kernel [M=8192, N=8192, K=512]
└─ 737.805 93.140 torch [M=8192, N=8192, K=512]
   └─ nan 93.140 nvjet_hsh_256x256_64x4_2x1_2cta_v_bz_TNT
```