### PR TITLE
[DataPartition] Fix loop arg partition issue

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -931,12 +931,10 @@ Operation *sliceOp(Operation *op, int offset,
             newInitArgOp->getRegion(parentRegion->getRegionNumber());
         newInitArg = parentRegion->getArgument(argIndex);
       } else {
-        auto initArgOp = initArg.getDefiningOp();
-        unsigned resultIndex = cast<mlir::OpResult>(initArg).getResultNumber();
-        newInitArg = newInitArgOp->getResult(resultIndex);
+        newInitArg = mappings.lookupOrNull(initArg);
       }
 
-      if (newInitArg != initArg) {
+      if (newInitArg) {
         newLoopArgs.append({newInitArg});
         forOp.getBody()->insertArgument(forOp.getBody()->getNumArguments(),
                                         newInitArg.getType(), forOp.getLoc());

--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -935,6 +935,7 @@ Operation *sliceOp(Operation *op, int offset,
       }
 
       if (newInitArg) {
+        assert(newInitArg != initArg && "value not sliced");
         newLoopArgs.append({newInitArg});
         forOp.getBody()->insertArgument(forOp.getBody()->getNumArguments(),
                                         newInitArg.getType(), forOp.getLoc());


### PR DESCRIPTION
For a loop argument of which the initial value is a result of another region, the following mapping could is gonna give the exactly same initial value instead of the sliced value. Switching to mapping lookup as a fix.


```
        auto initArgOp = initArg.getDefiningOp();
        unsigned resultIndex = cast<mlir::OpResult>(initArg).getResultNumber();
        newInitArg = newInitArgOp->getResult(resultIndex);
```

