### PR TITLE
Clean up taskIds in createTMEMCopy

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -2840,7 +2840,9 @@ ttng::WaitBarrierOp desyncTCGen5MMAOp(
       consumerBarrier =
           getBarrierForPipelineStage(builder, barrierAlloc, bufferIdx);
     } else {
-      // mmaOp can be in a different task from headProducer.
+      // mmaOp can be in a different task from headProducer. Even if user and
+      // mma are in the same block and they share the same barrier, but the
+      // phases should be offset by 1.
       auto loc = user->getLoc();
       Value _1_1b =
           builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);


### PR DESCRIPTION
So subview/bufferIdx has the correct taskIds. It also handles the case where tmem_alloc doesn't have a srcValue.

For TMEM channel feeding into operand A of gen5 dotOp, we set up TokenLoadType correctly.
