### PR TITLE
[TLX] Introducing Triton low-level language extension

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -465,7 +465,11 @@ void init_triton_ir(py::module &&m) {
       .def("get_parent_region", &Region::getParentRegion, ret::reference)
       .def("size", [](Region &self) { return self.getBlocks().size(); })
       .def("empty", &Region::empty)
-      .def("id", [](Region &self) { return (uint64_t)&self; });
+      .def("id", [](Region &self) { return (uint64_t)&self; })
+      .def("add_argument", [](Region &self, Type ty) -> BlockArgument {
+        auto loc = UnknownLoc::get(ty.getContext());
+        return self.addArgument(ty, loc);
+      });
 
   py::class_<Block>(m, "block", py::module_local())
       .def("arg",
@@ -596,7 +600,17 @@ void init_triton_ir(py::module &&m) {
       .def("get_before", &scf::WhileOp::getBefore, ret::reference)
       .def("get_after", &scf::WhileOp::getAfter, ret::reference);
   py::class_<ttg::WarpSpecializeOp, OpState>(m, "WarpSpecializeOp",
-                                             py::module_local());
+                                             py::module_local())
+      .def("get_default_region", &ttg::WarpSpecializeOp::getDefaultRegion,
+           ret::reference)
+      .def(
+          "get_partition_region",
+          [](ttg::WarpSpecializeOp self, unsigned idx) -> Region & {
+            if (idx >= self.getNumRegions())
+              throw pybind11::index_error("Op region index out of range");
+            return *self.getPartitionRegions()[idx];
+          },
+          ret::reference);
   py::class_<ttg::WarpYieldOp, OpState>(m, "WarpYieldOp", py::module_local());
   py::class_<ttg::WarpReturnOp, OpState>(m, "WarpReturnOp", py::module_local());
   py::class_<scf::ConditionOp, OpState>(m, "ConditionOp", py::module_local());

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -595,6 +595,10 @@ void init_triton_ir(py::module &&m) {
   py::class_<scf::WhileOp, OpState>(m, "WhileOp", py::module_local())
       .def("get_before", &scf::WhileOp::getBefore, ret::reference)
       .def("get_after", &scf::WhileOp::getAfter, ret::reference);
+  py::class_<ttg::WarpSpecializeOp, OpState>(m, "WarpSpecializeOp",
+                                             py::module_local());
+  py::class_<ttg::WarpYieldOp, OpState>(m, "WarpYieldOp", py::module_local());
+  py::class_<ttg::WarpReturnOp, OpState>(m, "WarpReturnOp", py::module_local());
   py::class_<scf::ConditionOp, OpState>(m, "ConditionOp", py::module_local());
 
   py::class_<Operation, std::unique_ptr<Operation, py::nodelete>>(
@@ -1803,6 +1807,24 @@ void init_triton_ir(py::module &&m) {
       .def("create_proton_record",
            [](TritonOpBuilder &self, bool isStart, int32_t regionId) -> void {
              self.create<mlir::triton::proton::RecordOp>(isStart, regionId);
+           })
+      // Warp specialize ops
+      .def("create_warp_specialize_op",
+           [](TritonOpBuilder &self, std::vector<int> partitionNumWarps,
+              int numPartitionRegions) -> ttg::WarpSpecializeOp {
+             ArrayRef<Type> dummyTypes;
+             return self.create<ttg::WarpSpecializeOp>(
+                 dummyTypes, partitionNumWarps, numPartitionRegions);
+           })
+      .def("create_warp_yield_op",
+           [](TritonOpBuilder &self) -> ttg::WarpYieldOp {
+             ArrayRef<Type> dummyTypes;
+             return self.create<ttg::WarpYieldOp>(ValueRange{});
+           })
+      .def("create_warp_return_op",
+           [](TritonOpBuilder &self) -> ttg::WarpReturnOp {
+             ArrayRef<Type> dummyTypes;
+             return self.create<ttg::WarpReturnOp>();
            });
 
   py::class_<PassManager>(m, "pass_manager", py::module_local())

--- a/python/triton/tlx
+++ b/python/triton/tlx
@@ -1,0 +1,1 @@
+/home/hoy/triton-fb/third_party/tlx

--- a/setup.py
+++ b/setup.py
@@ -639,6 +639,8 @@ def get_packages():
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         yield "triton.profiler"
 
+    yield "triton/tlx"
+
 
 def add_link_to_backends(external_only):
     for backend in backends:
@@ -673,10 +675,17 @@ def add_link_to_proton():
     update_symlink(proton_install_dir, proton_dir)
 
 
+def add_link_to_tlx():
+    src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "third_party", "tlx"))
+    install_dir = os.path.join(os.path.dirname(__file__), "triton", "tlx")
+    update_symlink(install_dir, src_dir)
+
+
 def add_links(external_only):
     add_link_to_backends(external_only=external_only)
     if not external_only and check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         add_link_to_proton()
+    add_link_to_tlx()
 
 
 class plugin_bdist_wheel(bdist_wheel):

--- a/third_party/tlx/README.md
+++ b/third_party/tlx/README.md
@@ -1,0 +1,5 @@
+# TLX - Triton Low-level Extensions
+
+## Introduction
+
+TLX (Triton Low-level Language Extensions) is a low-level, warp-aware, hardware-near extension of the Triton DSL. It provides intrinsics and warp-specialized operations for fine-grained GPU control, hardware-oriented primitives for advanced kernel development, and explicit constructs for GPU memory, compute, and asynchronous control flow, designed for power users pushing Triton to the metal.

--- a/third_party/tlx/__init__.py
+++ b/third_party/tlx/__init__.py
@@ -1,0 +1,2 @@
+from . import compiler
+from . import language

--- a/third_party/tlx/compiler/__init__.py
+++ b/third_party/tlx/compiler/__init__.py
@@ -1,0 +1,7 @@
+
+from .code_generator import (visit_withAsyncTask, visit_withAsyncTasks)
+
+__all__ = [
+    "visit_withAsyncTask",
+    "visit_withAsyncTasks",
+]

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -1,0 +1,70 @@
+# third_party/tlx/codegen/async.py
+
+import ast
+import triton.tlx.language as tlx  # Make sure async_task(s) are exposed via tlx.__init__.py
+
+
+def _is_async_task(self, node) -> bool:
+    if isinstance(node, ast.With):
+        context = node.items[0].context_expr
+        if isinstance(context, ast.Call):
+            withitemClass = self.visit(context.func)
+            if withitemClass == tlx.async_task:
+                return True
+    return False
+
+
+def _get_async_task(self, node):
+    context = node.items[0].context_expr
+    # Parse positional args (e.g., [0])
+    args = [self.visit(arg) for arg in context.args]
+    # Extract keyword arguments as (key, value AST nodes)
+    kwargs = {kw.arg: self.visit(kw.value) for kw in context.keywords}
+    with tlx.async_task(*args, _builder=self.builder, **kwargs) as task:
+        return task
+
+
+def visit_withAsyncTask(self, node):
+    task = _get_async_task(self, node)
+    # Visit the body of the `with` region
+    self.visit_compound_statement(node.body)
+
+
+def visit_withAsyncTasks(self, node):
+    from triton.compiler.code_generator import enter_sub_region, _is_list_like
+  # ⏳ defer import
+    with enter_sub_region(self) as sr:
+        stmts = node.body
+        # Ensure that stmts is iterable
+        if not _is_list_like(stmts):
+            stmts = [stmts]
+
+        # Count the number of sub tasks
+        taskNumWarps = []
+        for stmt in stmts:
+            assert _is_async_task(self, stmt)
+            task = _get_async_task(self, stmt)
+            assert task.explict
+            taskNumWarps.append(task.num_warps)
+
+        # create tasks body block
+        ws_op = self.builder.create_warp_specialize_op(taskNumWarps, len(stmts) - 1)
+
+        for index, stmt in enumerate(stmts):
+            assert _is_async_task(self, stmt)
+            # create a WarpSpecializePartitionsOp for the task
+            task_body = ws_op.get_region(index)
+            partitionBlock = self.builder.create_block_with_parent(task_body, [])
+            self.builder.set_insertion_point_to_start(partitionBlock)
+            self.visit(stmt)
+            if index == 0:
+                self.builder.create_warp_yield_op()
+            else:
+                self.builder.create_warp_return_op()
+
+
+        # Capture live-ins
+        # liveins
+        # wsOp->insertOperands(wsOp.getNumOperands(), capture);
+        # replace_all_uses_with
+        # replaceAllUsesInRegionWith

--- a/third_party/tlx/compiler/dispatch.py
+++ b/third_party/tlx/compiler/dispatch.py
@@ -1,0 +1,10 @@
+
+import ast
+import triton.tlx.language as tlx
+from triton.tlx.compiler import visit_withAsyncTask, visit_withAsyncTasks
+
+# Dispatch table
+TLX_WITH_DISPATCH = {
+    tlx.async_tasks: visit_withAsyncTasks,
+    tlx.async_task: visit_withAsyncTask,
+}

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -1,0 +1,7 @@
+
+from .async_task import (async_task, async_tasks)
+
+__all__ = [
+    "async_task",
+    "async_tasks",
+]

--- a/third_party/tlx/language/async_task.py
+++ b/third_party/tlx/language/async_task.py
@@ -1,0 +1,45 @@
+from triton.language import core
+
+
+class async_task:
+    """
+    Context manager to run code fragments asynchronously.
+    """
+    def __init__(self, *args, _builder=None, **kwargs):
+        self.builder = _builder
+        # Handle the optional positional argument like [0]
+        if args:
+            self.task_ids = list({core._constexpr_to_value(tid) for tid in args[0]})
+            self.num_warps = None
+            self.explict = False
+        else:
+            self.task_ids = None
+            self.num_warps = core._constexpr_to_value(kwargs.get("num_warps", None))
+            self.explict = True
+
+    def __enter__(self):
+        if not self.explict:
+            self.builder.set_async_task_ids(self.task_ids)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.builder.unset_async_task_ids()
+
+
+class async_tasks:
+    """
+    Context manager to run code fragments asynchronously.
+    """
+    def __init__(self, _builder=None):
+        # Support both: async_task([0]) and async_task(warp_id=4, num_warps=4)
+        if args and isinstance(args[0], list):
+            self.task_ids = list({core._constexpr_to_value(tid) for tid in task_ids})
+            self.start_warp_id = None
+            self.num_warps = None
+            self.explict = False
+        else:
+            self.task_ids = None
+            self.start_warp_id = kwargs.get("warp_id", None)
+            self.num_warps = kwargs.get("num_warps", None)
+            self.explict = True
+        self.builder = _builder

--- a/third_party/tlx/language/async_task.py
+++ b/third_party/tlx/language/async_task.py
@@ -8,17 +8,23 @@ class async_task:
     def __init__(self, *args, _builder=None, **kwargs):
         self.builder = _builder
         # Handle the optional positional argument like [0]
+        self.is_default = False
+        self.is_explict = False
+        self.task_ids = None
+        self.num_warps = None
         if args:
-            self.task_ids = list({core._constexpr_to_value(tid) for tid in args[0]})
-            self.num_warps = None
-            self.explict = False
+            assert len(args) == 1
+            if isinstance(args[0], core.constexpr) and args[0] == "default":
+                self.is_explict = True
+                self.is_default = True
+            else:
+                self.task_ids = list({core._constexpr_to_value(tid) for tid in args[0]})
         else:
-            self.task_ids = None
+            self.is_explict = True
             self.num_warps = core._constexpr_to_value(kwargs.get("num_warps", None))
-            self.explict = True
 
     def __enter__(self):
-        if not self.explict:
+        if not self.is_explict:
             self.builder.set_async_task_ids(self.task_ids)
         return self
 
@@ -27,19 +33,11 @@ class async_task:
 
 
 class async_tasks:
-    """
-    Context manager to run code fragments asynchronously.
-    """
-    def __init__(self, _builder=None):
-        # Support both: async_task([0]) and async_task(warp_id=4, num_warps=4)
-        if args and isinstance(args[0], list):
-            self.task_ids = list({core._constexpr_to_value(tid) for tid in task_ids})
-            self.start_warp_id = None
-            self.num_warps = None
-            self.explict = False
-        else:
-            self.task_ids = None
-            self.start_warp_id = kwargs.get("warp_id", None)
-            self.num_warps = kwargs.get("num_warps", None)
-            self.explict = True
-        self.builder = _builder
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass

--- a/third_party/tlx/language/async_task.py
+++ b/third_party/tlx/language/async_task.py
@@ -24,12 +24,10 @@ class async_task:
             self.num_warps = core._constexpr_to_value(kwargs.get("num_warps", None))
 
     def __enter__(self):
-        if not self.is_explict:
-            self.builder.set_async_task_ids(self.task_ids)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.builder.unset_async_task_ids()
+        pass
 
 
 class async_tasks:


### PR DESCRIPTION
TLX (Triton Low-level Language Extensions) is a low-level, warp-aware, hardware-near extension of the Triton DSL. It provides intrinsics and warp-specialized operations for fine-grained GPU control, hardware-oriented primitives for advanced kernel development, and explicit constructs for GPU memory, compute, and asynchronous control flow, designed for power users pushing Triton to the metal.

This PR adds scaffolding for TLS and introduces async task related ops for warp specialization support through explicit async task programming

```
@triton.jit
def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
    pid = tl.program_id(axis=0)
    block_start = pid * BLOCK_SIZE
    offsets = block_start + tl.arange(0, BLOCK_SIZE)
    mask = offsets < n_elements

    # allocate NUM_STAGES buffers
    x_buf = tlx.local_alloc(BLOCK_SIZE, 1)
    y_buf = tlx.local_alloc(BLOCK_SIZE, 1)

   # allocate barriers
    bar = tlx.alloc_barrier(1)

    with tlx.async_tasks():
        with tlx.async_task("default"):
            x_buf = tlx.async_load(x_ptr + offsets, mask=mask)
            y_buf = tlx.async_load(y_ptr + offsets, mask=mask)
            tlx.barrier_arrive(bar)
        with tlx.async_task(num_warps = 4):
            tlx.barrier_wait(bar)
            x = tlx.local_load(x_buf)
            y = tlx.local_load(y_buf)
            output = x + y
            tl.store(output_ptr + offsets, output, mask=mask)
```


This PR adds initial codegen support for `tlx.async_tasks` and `tlx.async_task`, which are translated to `ttg.warp_specialize` structure.

```
ttg.warp_specialize"() <{partitionNumWarps = array<i32: 4>}> ({
      ttg.warp_yield"() : () -> () loc(#loc14)
    }, {
      "ttg.warp_specialize.partitions"() : () -> () loc(#loc6)
    }) : () -> () loc(#loc6)
```


