### PR TITLE
[TLX] Enable legalizing WarpSpecializeOp during TTIR->TTGIR

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -92,7 +92,6 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
     MLIRContext &context, TritonGPUTypeConverter &typeConverter)
     : ConversionTarget(context) {
   // TODO: we should also verify ops of TritonGPUDialect
-  addLegalDialect<triton::gpu::TritonGPUDialect>();
 
   // Some ops from SCF are illegal
   addIllegalOp<scf::ExecuteRegionOp, scf::ParallelOp, scf::ReduceOp,
@@ -101,6 +100,7 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
   addDynamicallyLegalDialect<arith::ArithDialect, math::MathDialect,
                              triton::TritonDialect, cf::ControlFlowDialect,
                              scf::SCFDialect, ub::UBDialect,
+                             triton::gpu::TritonGPUDialect,
                              triton::nvidia_gpu::TritonNvidiaGPUDialect>(
       [&](Operation *op) {
         bool hasLegalRegions = true;

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -587,6 +587,52 @@ public:
   }
 };
 
+class TritonWarpSpecializePattern
+    : public OpConversionPattern<WarpSpecializeOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(WarpSpecializeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> newResultTypes;
+    for (auto type : op.getResultTypes()) {
+      Type newType = typeConverter->convertType(type);
+      if (!newType)
+        return rewriter.notifyMatchFailure(op, "not a 1:1 type conversion");
+      newResultTypes.push_back(newType);
+    }
+
+    auto newOp = rewriter.create<WarpSpecializeOp>(
+        op.getLoc(), newResultTypes, op.getPartitionNumWarps(),
+        op.getPartitionRegions().size());
+
+    // Update the operands and types.
+    newOp->setOperands(adaptor.getOperands());
+
+    rewriter.inlineRegionBefore(op.getDefaultRegion(), newOp.getDefaultRegion(),
+                                newOp.getDefaultRegion().end());
+    // Retype region arguments
+    if (failed(rewriter.convertRegionTypes(&newOp.getDefaultRegion(),
+                                           *getTypeConverter()))) {
+      return rewriter.notifyMatchFailure(op, "could not convert body types");
+    }
+
+    for (unsigned i = 0; i < op.getPartitionRegions().size(); ++i) {
+      auto *oldRegion = op.getPartitionRegions()[i];
+      auto *newRegion = newOp.getPartitionRegions()[i];
+      rewriter.inlineRegionBefore(*oldRegion, *newRegion, newRegion->end());
+      // Retype region arguments
+      if (failed(rewriter.convertRegionTypes(newRegion, *getTypeConverter()))) {
+        return rewriter.notifyMatchFailure(op, "could not convert body types");
+      }
+    }
+
+    rewriter.replaceOp(op, newOp.getResults());
+    return success();
+  }
+};
+
 void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
                             RewritePatternSet &patterns, unsigned numCTAs) {
   MLIRContext *context = patterns.getContext();
@@ -607,7 +653,7 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
       GenericOpPattern<triton::ReduceReturnOp>, TritonScanPattern,
       GenericOpPattern<triton::ScanReturnOp>,
       GenericOpPattern<triton::MakeRangeOp>, TritonExpandDimsPattern,
-      TritonTransPattern, TritonDotPattern,
+      TritonTransPattern, TritonDotPattern, TritonWarpSpecializePattern,
       GatherScatterOpPattern<DescriptorGatherOp>,
       GatherScatterOpPattern<DescriptorScatterOp>,
       GatherScatterOpPattern<triton::nvidia_gpu::AsyncTMAGatherOp>,

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -618,9 +618,8 @@ public:
       return rewriter.notifyMatchFailure(op, "could not convert body types");
     }
 
-    for (unsigned i = 0; i < op.getPartitionRegions().size(); ++i) {
-      auto *oldRegion = op.getPartitionRegions()[i];
-      auto *newRegion = newOp.getPartitionRegions()[i];
+    for (auto [oldRegion, newRegion] : llvm::zip_equal(
+             op.getPartitionRegions(), newOp.getPartitionRegions())) {
       rewriter.inlineRegionBefore(*oldRegion, *newRegion, newRegion->end());
       // Retype region arguments
       if (failed(rewriter.convertRegionTypes(newRegion, *getTypeConverter()))) {

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -195,5 +195,22 @@ tt.func @partition_axis_info(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
   } : (!tt.ptr<i32>) -> ()
   tt.return
 }
+}
 
+// -----
+
+// CHECK-LABEL: @legalize_warp_specialize
+tt.func @legalize_warp_specialize(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
+  ttg.warp_specialize(%arg0)
+  default {
+    ttg.warp_yield
+  }
+  partition0(%arg2: !tt.ptr<i32>) num_warps(2) {
+    // CHECK: tt.splat {{.*}} : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #blocked>
+    // CHECK: tt.load {{.*}} : tensor<256x!tt.ptr<i32>, #blocked>
+    %splatted = tt.splat %arg2 : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>>
+    %input = tt.load %splatted : tensor<256x!tt.ptr<i32>>
+    ttg.warp_return
+  } : (!tt.ptr<i32>) -> ()
+  tt.return
 }

--- a/third_party/tlx/tutorials/vector-add2.py
+++ b/third_party/tlx/tutorials/vector-add2.py
@@ -1,0 +1,180 @@
+"""
+Vector Addition
+===============
+
+Performs two independent elementwise additions in parallel:
+
+out1 = x + y
+out2 = a + b
+
+Each addition is applied across corresponding elements of input vectors, producing
+two output vectors of the same shape.
+"""
+
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.tlx.language as tlx
+
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+@triton.jit
+def add2_kernel(
+    x_ptr,
+    y_ptr,
+    z_ptr,
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    a = tl.load(a_ptr + offsets, mask=mask)
+    b = tl.load(b_ptr + offsets, mask=mask)
+    output1 = x + y
+    output2 = a + b
+    tl.store(z_ptr + offsets, output1, mask=mask)
+    tl.store(c_ptr + offsets, output2, mask=mask)
+
+
+def add2(x: torch.Tensor, y: torch.Tensor, a: torch.Tensor, b: torch.Tensor):
+    output1 = torch.empty_like(x)
+    output2 = torch.empty_like(a)
+    assert x.device == DEVICE and y.device == DEVICE and output1.device == DEVICE
+    n_elements = output1.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    add2_kernel[grid](x, y, output1, a, b, output2, n_elements, BLOCK_SIZE=1024)
+    return output1, output2
+
+
+@triton.jit
+def add2_warp_specailized_kernel(
+    x_ptr,
+    y_ptr,
+    z_ptr,
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    with tlx.async_tasks():
+        with tlx.async_task("default"):
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            y = tl.load(y_ptr + offsets, mask=mask)
+            output = x + y
+            tl.store(z_ptr + offsets, output, mask=mask)
+        with tlx.async_task(num_warps=4):
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            a = tl.load(a_ptr + offsets, mask=mask)
+            b = tl.load(b_ptr + offsets, mask=mask)
+            output = a + b
+            tl.store(c_ptr + offsets, output, mask=mask)
+
+
+def add2_warp_specailized(x: torch.Tensor, y: torch.Tensor, a: torch.Tensor, b: torch.Tensor):
+    output1 = torch.empty_like(x)
+    output2 = torch.empty_like(a)
+    assert x.device == DEVICE and y.device == DEVICE and output1.device == DEVICE
+    n_elements = output1.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    add2_warp_specailized_kernel[grid](x, y, output1, a, b, output2, n_elements, BLOCK_SIZE=1024)
+    return output1, output2
+
+
+def dual_add(x, y, a, b):
+    return x + y, a + b
+
+torch.manual_seed(0)
+size = 98432
+x = torch.rand(size, device=DEVICE)
+y = torch.rand(size, device=DEVICE)
+a = torch.rand(size, device=DEVICE)
+b = torch.rand(size, device=DEVICE)
+output_torch_1, output_torch_2 = dual_add(x, y, a, b)
+output_triton_1, output_triton_2 = add2(x, y, a, b)
+output_triton_ws_1, output_triton_ws_2 = add2_warp_specailized(x, y, a, b)
+
+print(
+    f"The maximum difference between torch and triton is "
+    f"{torch.max(torch.abs(output_torch_1 - output_triton_1))}"
+)
+print(
+    f"The maximum difference between torch and triton is "
+    f"{torch.max(torch.abs(output_torch_2 - output_triton_2))}"
+)
+print(
+    f"The maximum difference between torch and triton is "
+    f"{torch.max(torch.abs(output_torch_1 - output_triton_ws_1))}"
+)
+print(
+    f"The maximum difference between torch and triton is "
+    f"{torch.max(torch.abs(output_torch_2 - output_triton_ws_2))}"
+)
+# %%
+# Seems like we're good to go!
+
+# %%
+# Benchmark
+# ---------
+#
+# We can now benchmark our custom op on vectors of increasing sizes to get a sense of how it does relative to PyTorch.
+# To make things easier, Triton has a set of built-in utilities that allow us to concisely plot the performance of our custom ops.
+# for different problem sizes.
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["size"],  # Argument names to use as an x-axis for the plot.
+        x_vals=[
+            2**i for i in range(12, 28, 1)
+        ],  # Different possible values for `x_name`.
+        x_log=True,  # x axis is logarithmic.
+        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot.
+        line_vals=["triton", "triton_ws", "torch"],  # Possible values for `line_arg`.
+        line_names=["Triton", "Triton_WS", "Torch"],  # Label name for the lines.
+        styles=[("blue", "-"), ("green", "-"), ("red", "-")],  # Line styles.
+        ylabel="GB/s",  # Label name for the y-axis.
+        plot_name="vector-add-performance",  # Name for the plot. Used also as a file name for saving the plot.
+        args={},  # Values for function arguments not in `x_names` and `y_name`.
+    )
+)
+def benchmark(size, provider):
+    x = torch.rand(size, device=DEVICE, dtype=torch.float32)
+    y = torch.rand(size, device=DEVICE, dtype=torch.float32)
+    a = torch.rand(size, device=DEVICE, dtype=torch.float32)
+    b = torch.rand(size, device=DEVICE, dtype=torch.float32)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == "torch":
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: dual_add(x, y, a ,b), quantiles=quantiles)
+    if provider == "triton":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: add2(x, y, a, b), quantiles=quantiles
+        )
+    if provider == "triton_ws":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: add2_warp_specailized(x, y, a, b), quantiles=quantiles
+        )
+    gbps = lambda ms: 3 * x.numel() * x.element_size() * 1e-9 / (ms * 1e-3)
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+# %%
+# We can now run the decorated function above. Pass `print_data=True` to see the performance number, `show_plots=True` to plot them, and/or
+# `save_path='/path/to/results/' to save them to disk along with raw CSV data:
+benchmark.run(print_data=True, show_plots=True)


### PR DESCRIPTION
Also added a tutorial 
```

@triton.jit
def add2_warp_specailized_kernel(
    x_ptr,
    y_ptr,
    z_ptr,
    a_ptr,
    b_ptr,
    c_ptr,
    n_elements,
    BLOCK_SIZE: tl.constexpr,
):
    pid = tl.program_id(axis=0)
    block_start = pid * BLOCK_SIZE
    with tlx.async_tasks():
        with tlx.async_task("default"):
            offsets = block_start + tl.arange(0, BLOCK_SIZE)
            mask = offsets < n_elements
            x = tl.load(x_ptr + offsets, mask=mask)
            y = tl.load(y_ptr + offsets, mask=mask)
            output = x + y
            tl.store(z_ptr + offsets, output, mask=mask)
        with tlx.async_task(num_warps=4):
            offsets = block_start + tl.arange(0, BLOCK_SIZE)
            mask = offsets < n_elements
            a = tl.load(a_ptr + offsets, mask=mask)
            b = tl.load(b_ptr + offsets, mask=mask)
            output = a + b
            tl.store(c_ptr + offsets, output, mask=mask)
```

   vector-add-performance (gbps):
```
           size       Triton    Triton_WS        Torch
0        4096.0     7.958549     8.302703     5.774436
1        8192.0    15.515152    16.340425    11.420074
2       16384.0    30.266009    32.167539    22.341818
3       32768.0    58.794257    63.015384    43.420495
4       65536.0   111.709090   116.473930    84.453607
5      131072.0   196.607991   201.442627   151.236923
6      262144.0   333.233892   336.657521   259.377306
7      524288.0   506.721668   513.336807   414.784810
8     1048576.0   693.502633   700.919758   593.981894
9     2097152.0   855.282203   838.413661   768.750741
10    4194304.0   969.109046   957.895223   908.644701
11    8388608.0  1042.667577  1042.322092  1003.742146
12   16777216.0  1074.360676  1077.488613  1048.401297
13   33554432.0  1104.151616  1112.842646  1097.889542
14   67108864.0  1117.264523  1127.349584  1123.524402
15  134217728.0  1123.838039  1134.822544  1132.702826
```