### PR TITLE
Exposing latency on the load

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1269,7 +1269,8 @@ def TT_DescriptorLoadOp : TT_Op<"descriptor_load"> {
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
     Variadic<I32>:$indices,
     DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
+    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
+    OptionalAttr<I32Attr>:$tt_latency
   );
 
   let results = (outs TT_Tensor:$result);

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1475,12 +1475,17 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_descriptor_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &indices,
-              CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> Value {
+              CacheModifier cacheModifier, EvictionPolicy evictionPolicy,
+              std::optional<int> latency) -> Value {
              auto descTy = cast<triton::TensorDescType>(desc.getType());
              auto resTy = descTy.getBlockType();
-             return self.create<DescriptorLoadOp>(
-                 resTy, desc, indices, cacheModifier, evictionPolicy);
+             IntegerAttr latencyAttr = nullptr;
+             if (latency.has_value())
+               latencyAttr =
+                   self.getBuilder().getI32IntegerAttr(latency.value());
+             return self.create<DescriptorLoadOp>(resTy, desc, indices,
+                                                  cacheModifier, evictionPolicy,
+                                                  latencyAttr);
            })
       .def("create_descriptor_gather",
            [](TritonOpBuilder &self, Value desc, Value x_indices, Value y_index,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1332,14 +1332,14 @@ class tensor_descriptor_base(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, offsets: Sequence[constexpr | tensor], _builder=None) -> tensor:
+    def load(self, offsets: List[tensor], latency=None, _builder=None) -> tensor:
         """Load a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be filled with zeros.
 
         :note: Offset must be a multiple of 16-bytes
         """
-        return semantic.descriptor_load(self, offsets, "", "", _builder)
+        return semantic.descriptor_load(self, offsets, "", "", latency, _builder)
 
     @builtin
     def store(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1332,7 +1332,7 @@ class tensor_descriptor_base(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, offsets: List[tensor], latency=None, _builder=None) -> tensor:
+    def load(self, offsets: Sequence[constexpr | tensor], latency=None, _builder=None) -> tensor:
         """Load a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be filled with zeros.

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1147,7 +1147,7 @@ def load(ptr: tl.tensor, mask: Optional[tl.tensor], other: Optional[tl.tensor], 
         return _load_legacy(ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile, builder)
 
 
-def descriptor_load(desc: tl.tensor_descriptor_base, offsets, cache_modifier: str, eviction_policy: str,
+def descriptor_load(desc: tl.tensor_descriptor_base, offsets, cache_modifier: str, eviction_policy: str, latency: Optional[int],
                     builder: ir.builder) -> tl.tensor:
     assert isinstance(desc, tl.tensor_descriptor_base)
     ndim = len(desc.block_shape)
@@ -1155,7 +1155,7 @@ def descriptor_load(desc: tl.tensor_descriptor_base, offsets, cache_modifier: st
 
     offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
     x = builder.create_descriptor_load(desc.handle, offsets, _str_to_load_cache_modifier(cache_modifier),
-                                       _str_to_eviction_policy(eviction_policy))
+                                       _str_to_eviction_policy(eviction_policy), latency)
     return tl.tensor(x, desc.block_type)
 
 


### PR DESCRIPTION
Adding a latency variable in the load op which can be used in the future for latency described pipelining & scheduling.
Added an optional int in the load op and modified related functions.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x ] This PR does not need a test because no functionality has been added so far, only exposed an optional variable.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
