### PR TITLE
[TLX] introduce tlx.local_alloc

### DIFF
--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -1,7 +1,10 @@
-
-from .async_task import (async_task, async_tasks)
+from .async_task import async_task, async_tasks
+from .types import buffered_tensor
+from .mem_ops import local_alloc
 
 __all__ = [
     "async_task",
     "async_tasks",
+    "buffered_tensor",
+    "local_alloc",
 ]

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -1,0 +1,23 @@
+import triton.language.core as tl
+
+from . import types as tlx
+
+
+@tl.builtin
+def local_alloc(
+    shape: tuple,
+    dtype: tl.dtype,
+    num: tl.constexpr,
+    _builder=None,
+) -> tlx.buffered_tensor:
+    """
+    Allocates buffer in shared memory and return a view of the buffer.
+    """
+    unwrapped_shape = [tl._constexpr_to_value(dim) for dim in shape]
+    unwrapped_num = tl._constexpr_to_value(num)
+    full_shape = [unwrapped_num] + unwrapped_shape
+    dtype = tl._constexpr_to_value(dtype)
+    elem_type = dtype.to_ir(_builder)
+    return tlx.buffered_tensor(
+        _builder.create_local_alloc(full_shape, elem_type),
+    )

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -1,0 +1,29 @@
+import triton.language.core as tl
+
+
+class buffered_tensor(tl.base_value):
+    """
+    A symbolic type representing a tensor allocated in a manually managed buffer
+    such as shared memory (SMEM) or local memory (TMEM).
+
+    This type is to model data that is not stored in global memory or registers
+    but instead resides in hardware-close memory spaces with specialized allocation
+    , access, or swizzling patterns.
+
+    Unlike regular `tl.tensor`, which models values computed by operations,
+    `buffered_tensor` reflects a memory-backed buffer that may be explicitly
+    allocated and reused across program regions. It is primarily used with
+    low-level intrinsics such as `tlx.local_alloc()`.
+
+    Examples:
+        a = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, num=4)
+
+    Attributes:
+        handle: The backing IR value representing the buffer allocation.
+    """
+
+    def __init__(self, handle):
+        """Not called by user code."""
+        super().__init__()
+        # IR handle
+        self.handle = handle


### PR DESCRIPTION
Introducing `tlx.local_alloc` which can be used to allocate a number of shared memory buffers.

For example, to allocate `NUM_BUFFERS` number of `float16` buffers, each has `BLOCK_MxBLOCK_K` shape:

  `  buffers = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, NUM_BUFFERS)`

where `BLOCK_M`, `BLOCK_K`, `NUM_BUFFERS` are all of `tl.constexpr` type.

The op will be translated to the following-like TTGIR op:

`    %0 = "ttg.local_alloc"() : () -> !ttg.memdesc<4x128x128xf16, #shared, #smem> 
`

For now users have no control of specifying the swizzling mode for the buffers. The compiler will automatically figure that out based on how they are consumed, in a separate PR.