### PR TITLE
[TLX] Add buffer indexing

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1856,9 +1856,7 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_memdesc_subview",
            [](TritonOpBuilder &self, Value localAlloc,
-              std::vector<Value> &bufferIdx) -> mlir::Value {
-             assert(bufferIdx.size() == 1 &&
-                    "tlx.get_buffer can index only one dimension.");
+              Value bufferIdx) -> mlir::Value {
              auto localAllocType = cast<ttg::MemDescType>(localAlloc.getType());
              auto localAllocShape = localAllocType.getShape();
              auto context = self.getBuilder().getContext();
@@ -1872,12 +1870,13 @@ void init_triton_ir(py::module &&m) {
              Type memDescType = ttg::MemDescType::get(
                  localAllocShape.drop_front(), localAllocType.getElementType(),
                  encoding, sharedMemorySpace,
-                 /*mutableMemory=*/true);
+                 /*mutableMemory=*/localAllocType.getMutableMemory());
              return self.create<ttg::MemDescSubviewOp>(memDescType, localAlloc,
                                                        bufferIdx);
            })
       .def("create_alloc_barriers",
-           [](TritonOpBuilder &self, int num_barriers, int arrive_count) -> mlir::Value {
+           [](TritonOpBuilder &self, int num_barriers,
+              int arrive_count) -> mlir::Value {
              auto context = self.getBuilder().getContext();
              auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
              auto barrierCTALayout = CTALayoutAttr::get(

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1854,6 +1854,28 @@ void init_triton_ir(py::module &&m) {
                                                   memorySpace);
              return self.create<ttg::LocalAllocOp>(memDesc);
            })
+      .def("create_memdesc_subview",
+           [](TritonOpBuilder &self, Value localAlloc,
+              std::vector<Value> &bufferIdx) -> mlir::Value {
+             assert(bufferIdx.size() == 1 &&
+                    "tlx.get_buffer can index only one dimension.");
+             auto localAllocType = cast<ttg::MemDescType>(localAlloc.getType());
+             auto localAllocShape = localAllocType.getShape();
+             auto context = self.getBuilder().getContext();
+             auto ctaLayout =
+                 ttg::CTALayoutAttr::get(context, /*CTAsPerCGA=*/{1},
+                                         /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+             auto encoding = ttg::SwizzledSharedEncodingAttr::get(
+                 context, 1, 1, 1, {0}, ctaLayout);
+             Attribute sharedMemorySpace =
+                 triton::gpu::SharedMemorySpaceAttr::get(context);
+             Type memDescType = ttg::MemDescType::get(
+                 localAllocShape.drop_front(), localAllocType.getElementType(),
+                 encoding, sharedMemorySpace,
+                 /*mutableMemory=*/true);
+             return self.create<ttg::MemDescSubviewOp>(memDescType, localAlloc,
+                                                       bufferIdx);
+           })
       .def("create_alloc_barriers",
            [](TritonOpBuilder &self, int num_barriers, int arrive_count) -> mlir::Value {
              auto context = self.getBuilder().getContext();

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -116,10 +116,9 @@ def test_local_alloc_index(BLOCK_SIZE, device):
         n_elements,
         BLOCK_SIZE: tl.constexpr,
     ):
-        # pid = tl.program_id(axis=0)
         buffers = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(2))
-        buffer0 = tlx.get_buffer(buffers, [0])
-        buffer1 = tlx.get_buffer(buffers, [1])
+        buffer0 = tlx.local_view(buffers, 0)
+        buffer1 = tlx.local_view(buffers, 1)
 
 
     torch.manual_seed(0)

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -105,3 +105,31 @@ def test_alloc_barriers(BLOCK_SIZE, device):
     torch.testing.assert_close(output, x + y, check_dtype=False)
 
     assert kernel.asm["ttgir"].count("ttng.init_barrier") == 10
+
+
+def test_local_alloc_index(BLOCK_SIZE, device):
+
+    @triton.jit
+    def local_alloc_index(
+        x_ptr,
+        y_ptr,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        # pid = tl.program_id(axis=0)
+        buffers = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(2))
+        buffer0 = tlx.get_buffer(buffers, [0])
+        buffer1 = tlx.get_buffer(buffers, [1])
+
+
+    torch.manual_seed(0)
+    size = 256
+    x = torch.rand(size, device=device)
+    y = torch.rand(size, device=device)
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
+    kernel = local_alloc_index[grid](x, y, n_elements, BLOCK_SIZE)
+    # TODO(Arda): Once we have the loads, add checks here
+
+
+test_local_alloc_index(BLOCK_SIZE=256, device='cuda')

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
     "async_tasks",
     "buffered_tensor",
     "local_alloc",
-    "get_buffer",
+    "local_view",
     "mbarriers",
     "alloc_barriers",
 ]

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -1,6 +1,6 @@
 from .async_task import async_task, async_tasks
 from .types import buffered_tensor, mbarriers
-from .mem_ops import local_alloc
+from .mem_ops import *
 from .barrier import alloc_barriers
 
 __all__ = [
@@ -8,6 +8,7 @@ __all__ = [
     "async_tasks",
     "buffered_tensor",
     "local_alloc",
+    "get_buffer",
     "mbarriers",
     "alloc_barriers",
 ]

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -1,5 +1,5 @@
 import triton.language.core as tl
-from triton.language.semantic import _convert_to_ir_values
+from triton.language.semantic import _convert_elem_to_ir_value
 
 from . import types as tlx
 
@@ -23,7 +23,7 @@ def local_alloc(
 
 
 @tl.builtin
-def get_buffer(
+def local_view(
     local_allocated_buffers: tlx.buffered_tensor,
     buffer_idx: int,
     _builder=None,
@@ -31,5 +31,5 @@ def get_buffer(
     """
     Returns a subview of the buffer.
     """
-    buffer_idx = _convert_to_ir_values(_builder, buffer_idx, require_i64=False)
+    buffer_idx = _convert_elem_to_ir_value(_builder, buffer_idx, require_i64=False)
     return tlx.buffered_tensor(_builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx), )

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -1,4 +1,5 @@
 import triton.language.core as tl
+from triton.language.semantic import _convert_to_ir_values
 
 from . import types as tlx
 
@@ -19,3 +20,16 @@ def local_alloc(
     dtype = tl._constexpr_to_value(dtype)
     elem_type = dtype.to_ir(_builder)
     return tlx.buffered_tensor(_builder.create_local_alloc(full_shape, elem_type), )
+
+
+@tl.builtin
+def get_buffer(
+    local_allocated_buffers: tlx.buffered_tensor,
+    buffer_idx: int,
+    _builder=None,
+) -> tlx.buffered_tensor:
+    """
+    Returns a subview of the buffer.
+    """
+    buffer_idx = _convert_to_ir_values(_builder, buffer_idx, require_i64=False)
+    return tlx.buffered_tensor(_builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx), )

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -7,8 +7,8 @@ class buffered_tensor(tl.base_value):
     such as shared memory (SMEM) or local memory (TMEM).
 
     This type is to model data that is not stored in global memory or registers
-    but instead resides in hardware-close memory spaces with specialized allocation
-    , access, or swizzling patterns.
+    but instead resides in hardware-close memory spaces with specialized
+    allocation, access, or swizzling patterns.
 
     Unlike regular `tl.tensor`, which models values computed by operations,
     `buffered_tensor` reflects a memory-backed buffer that may be explicitly


### PR DESCRIPTION
This PR adds buffer indexing capability.

For the `local_alloc_index` kernel in `test_tlx.py`, IR looks like below:

```mlir
#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
#smem = #ttg.shared_memory
"builtin.module"() ({
  "tt.func"() <{arg_attrs = [{tt.divisibility = 16 : i32}, {tt.divisibility = 16 : i32}, {tt.divisibility = 16 : i32}], function_type = (!tt.ptr<f32>, !tt.ptr<f32>, i32) -> (), sym_name = "local_alloc_index", sym_visibility = "public"}> ({
  ^bb0(%arg0: !tt.ptr<f32> loc(unknown), %arg1: !tt.ptr<f32> loc(unknown), %arg2: i32 loc(unknown)):
    %0 = "ttg.local_alloc"() : () -> !ttg.memdesc<2x256x256xf32, #shared, #smem> 
    %1 = "arith.constant"() <{value = 0 : i32}> : () -> i32 
    %2 = "ttg.memdesc_subview"(%0, %1) : (!ttg.memdesc<2x256x256xf32, #shared, #smem>, i32) -> !ttg.memdesc<256x256xf32, #shared, #smem, mutable> 
    %3 = "arith.constant"() <{value = 1 : i32}> : () -> i32 
    %4 = "ttg.memdesc_subview"(%0, %3) : (!ttg.memdesc<2x256x256xf32, #shared, #smem>, i32) -> !ttg.memdesc<256x256xf32, #shared, #smem, mutable> 
    "tt.return"() : () -> () 
  }) {noinline = false} : () -> () 
}) : () -> ()
```



Once the load ops are implemented, test will be updated with actual checks. Now it is just a placeholder.