### PR TITLE
[TLX] tlx.thread_id support

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1914,6 +1914,17 @@ void init_triton_ir(py::module &&m) {
              // Return mlir::Value
              return bufferViews;
            })
+      .def("create_thread_id",
+           [](TritonOpBuilder &self, unsigned axis) -> mlir::Value {
+             static constexpr mlir::gpu::Dimension dims[] = {
+                 mlir::gpu::Dimension::x, mlir::gpu::Dimension::y,
+                 mlir::gpu::Dimension::z};
+             Value threadId = self.create<::mlir::gpu::ThreadIdOp>(
+                 self.getBuilder().getIndexType(), dims[axis]);
+             threadId = self.create<arith::IndexCastOp>(
+                 self.getBuilder().getI32Type(), threadId);
+             return threadId;
+           })
       // Proton Ops
       .def("create_proton_record",
            [](TritonOpBuilder &self, bool isStart, int32_t regionId) -> void {

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -136,10 +136,6 @@ def test_local_alloc_index(BLOCK_SIZE, device):
     # TODO(Arda): Once we have the loads, add checks here
 
 
-@pytest.mark.skipif(
-    not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
-    reason="Requires compute capability >= 9 for NV",
-)
 def test_thread_id(device):
 
     @triton.jit

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -134,3 +134,32 @@ def test_local_alloc_index(BLOCK_SIZE, device):
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
     kernel = local_alloc_index[grid](x, y, n_elements, BLOCK_SIZE)
     # TODO(Arda): Once we have the loads, add checks here
+
+
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
+    reason="Requires compute capability >= 9 for NV",
+)
+def test_thread_id(device):
+
+    @triton.jit
+    def store_from_thread_0_kernel(output_ptr, value, n_elements, axis : tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        tid = tlx.thread_id(axis)
+        if tid == 0:
+            tl.store(output_ptr + offsets, value, mask=mask)
+
+    output = torch.zeros(32, dtype=torch.int32, device='cuda')
+    n_elements = output.numel()
+    value = 42
+    store_from_thread_0_kernel[(1,)](output, value, n_elements, 0, 32, num_warps=1)
+    torch.cuda.synchronize()
+    expected_output = torch.zeros(32, dtype=torch.int32, device='cuda')
+    expected_output[0] = value
+    torch.testing.assert_close(output, expected_output)

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -2,13 +2,15 @@ from .async_task import async_task, async_tasks
 from .types import buffered_tensor, mbarriers
 from .mem_ops import *
 from .barrier import alloc_barriers
+from .utility import *
 
 __all__ = [
+    "alloc_barriers",
     "async_task",
     "async_tasks",
     "buffered_tensor",
     "local_alloc",
     "local_view",
     "mbarriers",
-    "alloc_barriers",
+    "thread_id"
 ]

--- a/third_party/tlx/language/utility.py
+++ b/third_party/tlx/language/utility.py
@@ -1,0 +1,17 @@
+import triton.language.core as tl
+
+from . import types as tlx
+
+
+@tl.builtin
+def thread_id(axis, _builder=None):
+    """
+    Returns the id of the current thread instance along the given :code:`axis`.
+
+    :param axis: The axis of the 3D launch grid. Must be 0, 1 or 2.
+    :type axis: int
+    """
+    axis = tl._constexpr_to_value(axis)
+    if axis not in (0, 1, 2):
+        raise ValueError(f"thread_id axis must be 0, 1, or 2 but got {axis}")
+    return tl.tensor(_builder.create_thread_id(axis), tl.int32)


### PR DESCRIPTION
A `threadId` op allows users to write thread-specialization code which could ease debugging.

