### PR TITLE
[TLX] Add tlx.barrier_expect plus some minor formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,314 +1,228 @@
-<div align="center">
-  <img src="https://lh5.googleusercontent.com/wzQKEsTFkrgNQO9JjhGH5wFvslJr1saLtLaJ_a6Fp_gNENpvt3VG7BmztwngU9hFJaU4CPwGiw1opQtDvTkLrxWRbO_a12Q-pdESWHgtmheIHcPbOL5ZMC4TSiJVe5ty1w=w3517" alt="Triton logo">
-</div>
+# TLX - Triton Low-level Language Extensions
 
-| **`Documentation`** | **`Nightly Wheels`** |
-|-------------------- | -------------------- |
-| [![Documentation](https://github.com/triton-lang/triton/actions/workflows/documentation.yml/badge.svg)](https://triton-lang.org/) | [![Wheels](https://github.com/triton-lang/triton/actions/workflows/wheels.yml/badge.svg)](https://github.com/triton-lang/triton/actions/workflows/wheels.yml) |
+## Introduction
 
-# Triton
+TLX (Triton Low-level Language Extensions) is a low-level, warp-aware, hardware-near extension of the Triton DSL. It offers intrinsics and warp-specialized operations for fine-grained GPU control, hardware-oriented primitives for advanced kernel development, and explicit constructs for GPU memory, computation, and asynchronous control flow. TLX is designed for expert users pushing Triton closer to the metal.
 
-This is the development repository of Triton, a language and compiler for writing highly efficient custom Deep-Learning primitives. The aim of Triton is to provide an open-source environment to write fast code at higher productivity than CUDA, but also with higher flexibility than other existing DSLs.
+Primarily targeting NVIDIA GPUs (for now), TLX extends Triton to support:
 
-The foundations of this project are described in the following MAPL2019 publication: [Triton: An Intermediate Language and Compiler for Tiled Neural Network Computations](http://www.eecs.harvard.edu/~htk/publication/2019-mapl-tillet-kung-cox.pdf). Please consider citing this work if you use Triton!
+- Hardware-specific intrinsics (e.g., wgmma, async_copy, barrier)
+- Shared and local memory allocation
+- Instruction-level scheduling and control
+- Cross-warpgroup synchronization
 
-The [official documentation](https://triton-lang.org) contains installation instructions and tutorials.  See also these third-party [Triton puzzles](https://github.com/srush/Triton-Puzzles), which can all be run using the Triton interpreter -- no GPU required.
 
-# Quick Installation
+While this approach places more responsibility on the user, it reduces the compiler's role as a performance bottleneck. Although it may introduce divergence across hardware platforms, it empowers users to perform deeper, architecture-specific optimizations without relying solely on compiler heuristics.
 
-You can install the latest stable release of Triton from pip:
 
-```shell
-pip install triton
+## Preview of the DSL Extension
+
+### Local buffer allocation
+
+- `buffers = tlx.local_alloc(shape, dtype, num_buffers)`
+
+    Allocate number_buffers buffers in local memory per thread block, each of size size. The memory layout is inferred from its consumers.. 
+
+
+- `buffers = tlx.tmem_alloc(size, NUM_STAGES)`
+
+    Allocate number_buffers of buffers in the tensor memory per thread block, each with size size.
+
+### Async memory access
+
+- `buffer = tlx.async_descriptor_load(memdesc, [offsets], barrier)`
+
+   Load a chunk of data from global memory into a local memory buffer. The global address, strides, and buffer size are defined by the memory descriptor. A barrier object is provided and signaled upon completion of the operation.
+
+
+
+### Async tensor core operations
+
+- `acc = tlx.async_dot(a[i], b[i], acc)`
+- `acc = tlx.async_dot(a_reg, b[i], acc)`
+- `acc[i] = tlx.async_dot(a[i], b[i], acc[i], barrier)`
+
+
+### Barrier operations
+
+- `barriers = tlx.alloc_barrier(num_barriers, expected_count)`
+
+    Allocate a specified number of barrier objects in the local memory.
+
+- `tlx.barrier_wait(bar, phase)`
+
+- `tlx.barrier_arrive(bar)`
+
+- `tlx.barrier_expect_bytes(bar, bytes)`
+
+
+### Warp Specialization operations
+
+- `tlx.async_tasks` and `tlx.async_task`
+
 ```
-
-Binary wheels are available for CPython 3.9-3.13.
-
-# Enabling Blackwell Support
-
-The main branch now features support for NVIDIA Blackwell GPUs using 5th
-generation tensor cores. To enable this, you will need two additional steps:
-
-1. Build a pre-release PyTorch from source with CUDA 12.8
-2. Build triton from the latest source
-
-
-First, to build pytorch you need to have CUDA 12.8 installed locally. If not,
-follow the [instructions for your platform](https://developer.nvidia.com/cuda-downloads)
-```bash
-# Clone and checkout pytorch 2.6 release candidate
-git clone https://github.com/pytorch/pytorch
-cd pytorch
-git checkout v2.6.0-rc9
-git submodule sync
-git submodule update --init --recursive -j 8
-
-# Install build dependencies (assumes you already have a system compiler)
-pip install -r requirements.txt
-pip install mkl-static mkl-include wheel
-
-# Build PyTorch (will take a long time)
-export CUDA_HOME=/usr/local/cuda-12.8
-export CUDA_PATH=$CUDA_HOME
-export TORCH_CUDA_ARCH_LIST=Blackwell
-python setup.py develop
-
-# Optional, package build into a wheel to install on other machines.
-python setup.py bdist_wheel
-ls dist  # Wheel should be output in this directory
+    with tlx.async_tasks
+        with tlx.asycn_task(default)
+            ...
+        with tlx.asycn_task(num_warps = 4)
+            ...
 ```
+`tlx.async_tasks` opens a multi-tasking region where independent asynchronous tasks can be declared. Each task executes in parallel using a dedicated subset of warps within the thread block..
 
-Note that if you use the domain libraries (`torchvision`, `torchtext`,
-`torchaudio`, etc.) these will need to be built from source as well, otherwise
-their custom PyTorch extensions will not work.
+`tlx.async_task(default)` defines the default task, also known as the trunk. It uses the available warps not explicitly reserved by other tasks. . 
 
-Finally, follow the instructions below to install triton from source.
+`tlx.async_task(num_warps=4)` defines a warp-specialized asynchronous task that explicitly reserves 4 warps in addition to those used by the trunk task..
 
-# Install from source
 
-```shell
-git clone https://github.com/triton-lang/triton.git
-cd triton
 
-pip install -r python/requirements.txt # build-time dependencies
-pip install -e .
+
+
+
+## Preview of Kernels Implemented with TLX
+
+### Warp-Specialized GEMM on NVIDIA Hopper
+
 ```
+@triton.jit
+def matmul_kernel_tma_ws_cooperative_hopper(
+   a_desc, b_desc, c_desc, M, N, K,
+   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, 
+   NUM_STAGES: tl.constexpr, NUM_WARPS: tl.constexpr, dtype: tl.constexpr
+):
+    # allocate NUM_STAGES buffers
+    dtype_size = tlx.sizeof(dtype)
+    a = tlx.local_alloc(BLOCK_M // 2 * BLOCK_K * dtype_size, NUM_STAGES * 2)
+    b = tlx.local_alloc(BLOCK_N * BLOCK_K * dtype_size, NUM_STAGES)
 
-Or with a virtualenv:
+    # allocate barriers
+    barEmptyA = tlx.alloc_barrier(NUM_STAGES * 2, NUM_WARPS * 4)
+    barFullA = tlx.alloc_barrier(NUM_STAGES * 2, NUM_WARPS * 4)
+    barEmptyB = tlx.alloc_barrier(NUM_STAGES, 128)
+    barFullB = tlx.alloc_barrier(NUM_STAGES, 128)
 
-```shell
-git clone https://github.com/triton-lang/triton.git
-cd triton
+    with tlx.async_tasks():
+        # producer group 
+        with tl.async_task(num_warps = 4, registers=40)
+            pid = tl.program_id(axis=0)
+            num_pid_m = tl.cdiv(M, BLOCK_M)
+            num_pid_n = tl.cdiv(N, BLOCK_N)
+            pid_m = pid // num_pid_m 
+            pid_n = pid % num_pid_n 
+            offs_am = pid_m * BLOCK_M
+            offs_bn = pid_n * BLOCK_N
+            phase = 1
+            for k in range(0, tl.cdiv(K, BLOCK_K)):
+                # locate the buffer index that current iteration should access
+                buf = k % NUM_STAGES       
+                offs_k = k * BLOCK_K
 
-python -m venv .venv --prompt triton
-source .venv/bin/activate
+                # wait for the A buffer to be released by the consumer 1
+                tlx.barrier_wait(barEmptyA[buf], phase)
+                tlx.barrier_expect_bytes(barFullA[buf], BLOCK_M // 2 * BLOCK_K * dtype_size)
+                a[buf] = tlx.async_descriptor_load(a_desc, [offs_am, offs_k], barFullA[buf])
 
-pip install -r python/requirements.txt # build-time dependencies
-pip install -e .
-```
+                # wait for the B buffer to be released by both consumers
+                tlx.barrier_wait(barEmptyB[buf], phase)
+                tlx.barrier_expect_bytes(barFullB[buf], BLOCK_N * BLOCK_K * dtype_size)
+                b[buf] = tlx.async_descriptor_load(b_desc, [offs_bn, offs_k], barFullB[buf])
 
-# Building with a custom LLVM
+                # wait for the A buffer to be released by the consumer 2
+                buf2 = buf + NUM_STAGES
+                tlx.barrier_wait(barEmptyA[buf2], phase)
+                tlx.barrier_expect_bytes(barFullA[buf2], BLOCK_M // 2 * BLOCK_K * dtype_size)
+                a[buf2] = tlx.async_descriptor_load(a_desc, [offs_am + BLOCK_M // 2, offs_k], barFullA[buf2])
+                
+                # buffers in a row share the same phase
+                phase = (buf < NUM_STAGES - 1) ? phase : phase ^ 1
 
-Triton uses LLVM to generate code for GPUs and CPUs.  Normally, the Triton build
-downloads a prebuilt LLVM, but you can also build LLVM from source and use that.
-
-LLVM does not have a stable API, so the Triton build will not work at an
-arbitrary LLVM version.
-
-1. Find the version of LLVM that Triton builds against.  Check
-`cmake/llvm-hash.txt` to see the current version. For example, if it says:
-       49af6502c6dcb4a7f7520178bd14df396f78240c
-
-   This means that the version of Triton you have builds against
-   [LLVM](https://github.com/llvm/llvm-project) 49af6502.
-
-2. `git checkout` LLVM at this revision.  Optionally, make additional
-   modifications to LLVM.
-
-3. [Build LLVM](https://llvm.org/docs/CMake.html).  For example, you might run
-
-       $ cd $HOME/llvm-project  # your clone of LLVM.
-       $ mkdir build
-       $ cd build
-       $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON ../llvm -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld" -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU"
-       $ ninja
-
-4. Grab a snack, this will take a while.
-
-5. Build Triton as above, but set the following environment variables.
-
-       # Modify as appropriate to point to your LLVM build.
-       $ export LLVM_BUILD_DIR=$HOME/llvm-project/build
-
-       $ cd <triton install>
-       $ LLVM_INCLUDE_DIRS=$LLVM_BUILD_DIR/include \
-         LLVM_LIBRARY_DIR=$LLVM_BUILD_DIR/lib \
-         LLVM_SYSPATH=$LLVM_BUILD_DIR \
-         pip install -e .
-
-# Tips for building
-
-- Set `TRITON_BUILD_WITH_CLANG_LLD=true` as an environment variable to use clang
-  and lld.  lld in particular results in faster builds.
-
-- Set `TRITON_BUILD_WITH_CCACHE=true` to build with ccache.
-
-- Set `TRITON_HOME=/some/path` to change the location of the `.triton`
-  directory where Triton's cache is located and downloads are stored
-  during the build. By default, this is the user's home directory. It
-  can be changed anytime.
-
-- If you're running out of memory when building Triton, specify the `MAX_JOBS`
-  environment variable (to the `pip install -e .` command) to limit the
-  number of jobs.
-
-- Pass `--no-build-isolation` to `pip install` to make nop builds faster.
-  Without this, every invocation of `pip install` uses a different symlink to
-  cmake, and this forces ninja to rebuild most of the `.a` files.
-
-- vscode intellisense has some difficulty figuring out how to build Triton's C++
-  (probably because, in our build, users don't invoke cmake directly, but
-  instead use setup.py).  Teach vscode how to compile Triton as follows.
-
-    - Do a local build. Run command `pip install -e .`
-    - Get the full path to the `compile_commands.json` file produced by the build:
-      `find ./build -name 'compile_commands.json' | xargs readlink -f`.
-      You might get a full path similar to `/Users/{username}/triton/build/cmake.macosx-11.1-arm64-cpython-3.12/compile_commands.json`
-    - In vscode, install the
-      [C/C++
-      extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools),
-      then open the command palette (`Shift + Command + P` on Mac, or `Shift +
-      Ctrl + P` on Windows/Linux) and open `C/C++: Edit Configurations (UI)`.
-    - Open "Advanced Settings" and paste the full path to
-      `compile_commands.json` into the "Compile Commands" textbox.
-
-# Running tests
-
-There currently isn't a turnkey way to run all the Triton tests, but you can
-follow the following recipe.
-
-```shell
-# One-time setup.  Note this will reinstall local Triton because torch
-# overwrites it with the public version.
-$ make dev-install
-
-# To run all tests (requires a GPU)
-$ make test
-
-# Or, to run tests without a gpu
-$ make test-nogpu
-```
-
-# Tips for hacking
-
-For detailed instructions on how to debug Triton's frontend, please refer to this [tutorial](https://triton-lang.org/main/programming-guide/chapter-3/debugging.html). The following includes additional tips for hacking on Triton's backend.
-
-**Configuration knobs**
-
-See [`python/triton/knobs.py`](python/triton/knobs.py) for the full list of configuration knobs. You can set those knobs directly in python or use environment variables to control them. Below are some of the environment variables you can specify (see `knobs.py` for the full list):
-
-- `MLIR_ENABLE_DUMP=1` dumps the IR before every MLIR pass Triton runs, for all
-   kernels. Use `MLIR_ENABLE_DUMP=kernelName` to dump for a specific kernel only.
-  - Triton cache can interfere with the dump. In cases where `MLIR_ENABLE_DUMP=1` does not work, try cleaning your triton cache: `rm -r ~/.triton/cache/*`
-- `MLIR_DUMP_PATH` specifies where `MLIR_ENABLE_DUMP` will dump to. If unset will dump to stderr.
-- `LLVM_IR_ENABLE_DUMP=1` dumps the IR before every pass run over the LLVM IR.
-- `TRITON_REPRODUCER_PATH=<reproducer_path>` will generate an MLIR reproducer file
-  at `<reproducer_path>` before each MLIR compiler stage. If any of the stages fail,
-  `<reproducer_path>` will be a local MLIR reproducer captured right before the failing pass.
-- `TRITON_INTERPRET=1` uses the Triton interpreter instead of running on the
-  GPU.  You can insert Python breakpoints in your kernel code!
-- `TRITON_ENABLE_LLVM_DEBUG=1` passes `-debug` to LLVM, printing a lot of
-  debugging information to stdout.  If this is too noisy, run with just
-  `TRITON_LLVM_DEBUG_ONLY` instead to limit the output.
-
-  An alternative way to reduce output noisiness is running with
-  `LLVM_IR_ENABLE_DUMP=1`, extract the IR before the LLVM pass of interest, and
-  then run LLVM's `opt` standalone, perhaps passing `-debug-only=foo` on the
-  command line.
-- `TRITON_LLVM_DEBUG_ONLY=<comma-separated>` is the equivalent of LLVM's
-  `-debug-only` command-line option. This limits the LLVM debug output to
-  specific pass or component names (which are specified using `#define
-  DEBUG_TYPE` throughout LLVM and Triton) in order to allow the debug output to
-  be less noisy. `TRITON_LLVM_DEBUG_ONLY` allows for one or more comma
-  separated values to be specified (eg
-  `TRITON_LLVM_DEBUG_ONLY="tritongpu-remove-layout-conversions"` or
-  `TRITON_LLVM_DEBUG_ONLY="tritongpu-remove-layout-conversions,regalloc"`).
-- `TRITON_ENABLE_ASAN=1` invokes the LLVM address sanitizer for
-  memory leak and out of bounds access detection. Currently only supported on the AMD
-  backend. This must be run using the ASAN libraries documented [here](https://rocm.docs.amd.com/projects/llvm-project/en/latest/conceptual/using-gpu-sanitizer.html).
-
-  When enabling the address sanitizer it is recommended to disable various memory caching strategies
-  both within the ROCm stack and PyTorch. This will give the address sanitizer the best chance at finding the
-  memory fault where it originates. See this [test](https://github.com/triton-lang/triton/blob/main/third_party/amd/python/test/test_address_sanitizer.py) for more details.
-
-- `USE_IR_LOC={ttir,ttgir}` reparses the IR such that the location information
-  will be the line number of the IR file with that particular extension,
-  instead of line number of the python file. This can provide a direct mapping
-  from the IR to llir/ptx. When used with performance tools, it can provide a
-  breakdown on IR instructions.
-- `TRITON_PRINT_AUTOTUNING=1` prints out the best autotuning config and total time
-  spent for each kernel after autotuning is complete.
-- `DISABLE_LLVM_OPT` will disable llvm optimizations for make_llir and make_ptx
-  if its value is true when parsing as Bool. Otherwise, it will be parsed as a list
-  of flags to disable llvm optimizations. One usage case is
-  `DISABLE_LLVM_OPT="disable-lsr"`
-  Loop strength reduction is known to cause up to 10% performance changes for
-  certain kernels with register pressure.
-- `TRITON_ALWAYS_COMPILE=1` forces to compile kernels regardless of cache hit.
-- `MLIR_ENABLE_TIMING` dumps the timing information for each MLIR pass.
-- `LLVM_ENABLE_TIMING` dumps the timing information for each LLVM pass.
-- `TRITON_DEFAULT_FP_FUSION` overrides the default behavior of allowing fp fusion (mul+add->fma).
-- `MLIR_ENABLE_DIAGNOSTICS=<comma-separated>` controls diagnostic emission in MLIR.
-  Options are: `warnings`, `remarks`, `stacktraces`, `operations`.
-  Use comma-separated values to customize output. For example,
-  `MLIR_ENABLE_DIAGNOSTICS=remarks,operations` enables remarks and IR operations,
-  while `MLIR_ENABLE_DIAGNOSTICS=warnings,stacktraces` enables warnings with
-  stacktraces. By default, only errors are shown. Setting `warnings` includes
-  errors and warnings; `remarks` includes errors, warnings, and remarks.
-- `MLIR_ENABLE_REMARK` is deprecated. Please use `MLIR_ENABLE_DIAGNOSTICS=remarks`.
-- `TRITON_KERNEL_DUMP` enables the dumping of the IR from each compilation stage and the final ptx/amdgcn.
-- `TRITON_DUMP_DIR` specifies the directory to save the dumped IR and ptx/amdgcn when `TRITON_KERNEL_DUMP` is set to 1.
-- `TRITON_KERNEL_OVERRIDE` enables the override of the compiled kernel with a user-specified IR/ptx/amdgcn at the beginning of each compilation stage.
-- `TRITON_OVERRIDE_DIR` specifies the directory from which to load the IR/ptx/amdgcn files when `TRITON_KERNEL_OVERRIDE` is set to 1.
-- `TRITON_F32_DEFAULT` sets the default input precision of `tl.dot` when using 32-bit floats, which can be either `ieee`, `tf32`, or `tf32x3`.
-- `TRITON_FRONT_END_DEBUGGING=1` disables exception wrapping when an error occurs in the compiler frontend, allowing the full stack trace to be seen.
-
-N.B. Some of these environment variables don't have a knob in `knobs.py`-- those are only relevant to the C++ layer(s), hence they don't exist in the python layer.
-
-**Kernel Override Steps**
-
-```bash
-export TRITON_ALWAYS_COMPILE=1
-export TRITON_KERNEL_DUMP=1
-export TRITON_DUMP_DIR=<dump_dir>
-export TRITON_KERNEL_OVERRIDE=1
-export TRITON_OVERRIDE_DIR=<override_dir>
-# Step 1: Run the kernel once to dump kernel's IRs and ptx/amdgcn in $TRITON_DUMP_DIR
-# Step 2: Copy $TRITON_DUMP_DIR/<kernel_hash> to $TRITON_OVERRIDE_DIR
-# Step 3: Delete the stages that you do not want to override and modify the stage you do want to override
-# Step 4: Run the kernel again to see the overridden result
+        # Two consumer groups 
+        with tl.async_task(num_warps = 4, registers=232, replicate=2)
+            phase = 0
+            for k in range(0, tl.cdiv(K, BLOCK_K)):
+                # locate the buffer index that current iteration should access
+                buf = k % NUM_STAGES     
+                phase = (buf > 0) ? phase : phase ^ 1  
+                bufA = buf + NUM_STAGES * duplicate
+                # wait for the buffer to be produced by the consumer
+                tlx.barrier_wait(barFullA[bufA], phase)
+                tlx.barrier_wait(barFullB[buf], phase)
+                acc = tlx.async_dot(a[bufA], b[buf], acc)
+                # wait for current mma to complete
+                tlx.async_dot_wait(0)
+                # release buffers
+                tlx.barrier_arrive(barEmptyA[bufA])
+                tlx.barrier_arrive(barEmptyB[buf])
+            c = acc.to(dtype)
+            tlx.async_descriptor_store(c_desc, [offs_am + duplicate * BLOCK_M // 2, offs_bn], c)
 ```
 
 
-# Changelog
+### Warp-Specialized GEMM on NVIDIA Blackwell
 
-Version 2.0 is out! New features include:
+```
+@triton.jit
+def matmul_kernel_tma_ws_blackwell(
+    a_desc, b_desc, c_desc, M, N, K,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, 
+    NUM_STAGES: tl.constexpr, NUM_WARPS: tl.constexpr, dtype: tl.constexpr
+):
+    # allocate NUM_STAGES buffers
+    dtype_size = tlx.sizeof(dtype)
+    a = tlx.local_alloc(BLOCK_M * BLOCK_K * dtype_size, NUM_STAGES)
+    b = tlx.local_alloc(BLOCK_N * BLOCK_K * dtype_size, NUM_STAGES)
+    acc = tlx.tmem_alloc(BLOCK_M * BLOCK_N, 1)
 
-- Many, many bug fixes
-- Performance improvements
-- Backend rewritten to use MLIR
-- Support for kernels that contain back-to-back matmuls (e.g., flash attention)
+    # allocate barriers
+    barSmemFull = tlx.alloc_barrier(NUM_STAGES, NUM_WARPS * 4)
+    barSmemEmpty = tlx.alloc_barrier(NUM_STAGES, 32)
+    barTmemFull = tlx.alloc_barrier(1, 32)
 
-# Contributing
+    with tlx.async_tasks():
+        # producer group 
+        with tlx.async_task("default"):
+            pid = tl.program_id(axis=0)
+            num_pid_m = tl.cdiv(M, BLOCK_M)
+            num_pid_n = tl.cdiv(N, BLOCK_N)
+            pid_m = pid // num_pid_m 
+            pid_n = pid % num_pid_n 
+            offs_am = pid_m * BLOCK_M
+            offs_bn = pid_n * BLOCK_N
+            phase = 0
+            for k in range(0, tl.cdiv(K, BLOCK_K)):
+                # locate the buffer index that current iteration should access
+                buf = k % NUM_STAGES       
+                offs_k = k * BLOCK_K
+                # wait for the buffer to be released by the consumer
+                tlx.barrier_wait(barSmemEmpty[buf], phase ^ 1)
+                tlx.barrier_expect_bytes(barSmemFull[buf], (BLOCK_M + BLOCK_N) * BLOCK_K) * dtype_size)
+                a[buf] = tlx.async_descriptor_load(a_desc, [offs_am, offs_k], barSmemFull[buf])
+                b[buf] = tlx.async_descriptor_load(b_desc, [offs_bn, offs_k], barSmemFull[buf])
+                # buffers in a row share the same phase
+                phase = (buf < NUM_STAGES - 1) ? phase : phase ^ 1
 
-Community contributions are more than welcome, whether it be to fix bugs or to add new features at [github](https://github.com/triton-lang/triton/). For more detailed instructions, please visit our [contributor's guide](CONTRIBUTING.md).
+        # mma group 
+        with tl.async_task(num_warps = 1)
+            phase = 0
+            buf = 0
+            last_phase = 0
+            for k in range(0, tl.cdiv(K, BLOCK_K)):
+                # locate the buffer index that current iteration should access
+                buf = k % NUM_STAGES       
+                # wait for the buffer to be produced by the consumer
+                tlx.barrier_wait(barSmemFull[buf], phase)
+                # release buffers on completion by setting barSmemEmpty 
+                acc[0] = tlx.async_dot(a[buf], b[buf].T, acc[0], barSmemEmpty[buf])
+                last_phase = phase
+                phase = (buf < NUM_STAGES - 1) ? phase : phase ^ 1
+            # wait for the last mma to complete  
+            tlx.barrier_wait(barSmemEmpty[buf], last_phase)
+            tlx.barrier_arrive(barTmemFull[0])
 
-# Compatibility
-
-Supported Platforms:
-
-- Linux
-
-Supported Hardware:
-
-- NVIDIA GPUs (Compute Capability 8.0+)
-- AMD GPUs (ROCm 6.2+)
-- Under development: CPUs
-
-# Development Container (Dev Container)
-
-**Dev Containers** for the Triton project are available from
-the [triton-dev-containers repository](https://github.com/redhat-et/triton-dev-containers)
-
-### Key Benefits:
-- **Consistency**: All developers can work with the same development
-  environment, ensuring uniform behavior across different systems.
-- **Isolation**: The container prevents potential conflicts with software
-  installed on your local machine.
-- **Portability**: Easily share the development environment with team members,
-  minimizing onboarding time and setup issues.
-
-### How to Use the Dev Container:
-
-For detailed instructions on how to use the dev containers please see
-the [dev container user guide](https://github.com/redhat-et/triton-dev-containers/blob/main/.devcontainer/devcontainer.md)
+        # epilog group
+        with tl.async_task(num_warps = 4)
+            phase = 0
+            tl.barrier_wait(barTmemFull[0], phase)
+            c = tlx.tmem_load(acc[0])
+            c = c.to(dtype)
+            tlx.async_descriptor_store(c_desc, [offs_am, offs_bn], c)
+```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ While this approach places more responsibility on the user, it reduces the compi
 
 - `tlx.barrier_expect_bytes(bar, bytes)`
 
+    Signal a barrier of an expected number of bytes to be copied.
+
 
 ### Warp Specialization operations
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ While this approach places more responsibility on the user, it reduces the compi
 
 - `tlx.barrier_expect_bytes(bar, bytes)`
 
-    Signal a barrier of an expected number of bytes to be copied.
-
 
 ### Warp Specialization operations
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ While this approach places more responsibility on the user, it reduces the compi
 
 - `buffers = tlx.local_alloc(shape, dtype, num_buffers)`
 
-    Allocate number_buffers buffers in local memory per thread block, each of size size. The memory layout is inferred from its consumers..
+    Allocate number_buffers buffers in local memory per thread block, each of size size. The memory layout is inferred from its consumers.. 
 
 
 - `buffers = tlx.tmem_alloc(size, NUM_STAGES)`
@@ -71,7 +71,7 @@ While this approach places more responsibility on the user, it reduces the compi
 ```
 `tlx.async_tasks` opens a multi-tasking region where independent asynchronous tasks can be declared. Each task executes in parallel using a dedicated subset of warps within the thread block..
 
-`tlx.async_task(default)` defines the default task, also known as the trunk. It uses the available warps not explicitly reserved by other tasks. .
+`tlx.async_task(default)` defines the default task, also known as the trunk. It uses the available warps not explicitly reserved by other tasks. . 
 
 `tlx.async_task(num_warps=4)` defines a warp-specialized asynchronous task that explicitly reserves 4 warps in addition to those used by the trunk task..
 
@@ -88,7 +88,7 @@ While this approach places more responsibility on the user, it reduces the compi
 @triton.jit
 def matmul_kernel_tma_ws_cooperative_hopper(
    a_desc, b_desc, c_desc, M, N, K,
-   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, 
    NUM_STAGES: tl.constexpr, NUM_WARPS: tl.constexpr, dtype: tl.constexpr
 ):
     # allocate NUM_STAGES buffers
@@ -103,19 +103,19 @@ def matmul_kernel_tma_ws_cooperative_hopper(
     barFullB = tlx.alloc_barrier(NUM_STAGES, 128)
 
     with tlx.async_tasks():
-        # producer group
+        # producer group 
         with tl.async_task(num_warps = 4, registers=40)
             pid = tl.program_id(axis=0)
             num_pid_m = tl.cdiv(M, BLOCK_M)
             num_pid_n = tl.cdiv(N, BLOCK_N)
-            pid_m = pid // num_pid_m
-            pid_n = pid % num_pid_n
+            pid_m = pid // num_pid_m 
+            pid_n = pid % num_pid_n 
             offs_am = pid_m * BLOCK_M
             offs_bn = pid_n * BLOCK_N
             phase = 1
             for k in range(0, tl.cdiv(K, BLOCK_K)):
                 # locate the buffer index that current iteration should access
-                buf = k % NUM_STAGES
+                buf = k % NUM_STAGES       
                 offs_k = k * BLOCK_K
 
                 # wait for the A buffer to be released by the consumer 1
@@ -133,17 +133,17 @@ def matmul_kernel_tma_ws_cooperative_hopper(
                 tlx.barrier_wait(barEmptyA[buf2], phase)
                 tlx.barrier_expect_bytes(barFullA[buf2], BLOCK_M // 2 * BLOCK_K * dtype_size)
                 a[buf2] = tlx.async_descriptor_load(a_desc, [offs_am + BLOCK_M // 2, offs_k], barFullA[buf2])
-
+                
                 # buffers in a row share the same phase
                 phase = (buf < NUM_STAGES - 1) ? phase : phase ^ 1
 
-        # Two consumer groups
+        # Two consumer groups 
         with tl.async_task(num_warps = 4, registers=232, replicate=2)
             phase = 0
             for k in range(0, tl.cdiv(K, BLOCK_K)):
                 # locate the buffer index that current iteration should access
-                buf = k % NUM_STAGES
-                phase = (buf > 0) ? phase : phase ^ 1
+                buf = k % NUM_STAGES     
+                phase = (buf > 0) ? phase : phase ^ 1  
                 bufA = buf + NUM_STAGES * duplicate
                 # wait for the buffer to be produced by the consumer
                 tlx.barrier_wait(barFullA[bufA], phase)
@@ -165,7 +165,7 @@ def matmul_kernel_tma_ws_cooperative_hopper(
 @triton.jit
 def matmul_kernel_tma_ws_blackwell(
     a_desc, b_desc, c_desc, M, N, K,
-    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, 
     NUM_STAGES: tl.constexpr, NUM_WARPS: tl.constexpr, dtype: tl.constexpr
 ):
     # allocate NUM_STAGES buffers
@@ -180,19 +180,19 @@ def matmul_kernel_tma_ws_blackwell(
     barTmemFull = tlx.alloc_barrier(1, 32)
 
     with tlx.async_tasks():
-        # producer group
+        # producer group 
         with tlx.async_task("default"):
             pid = tl.program_id(axis=0)
             num_pid_m = tl.cdiv(M, BLOCK_M)
             num_pid_n = tl.cdiv(N, BLOCK_N)
-            pid_m = pid // num_pid_m
-            pid_n = pid % num_pid_n
+            pid_m = pid // num_pid_m 
+            pid_n = pid % num_pid_n 
             offs_am = pid_m * BLOCK_M
             offs_bn = pid_n * BLOCK_N
             phase = 0
             for k in range(0, tl.cdiv(K, BLOCK_K)):
                 # locate the buffer index that current iteration should access
-                buf = k % NUM_STAGES
+                buf = k % NUM_STAGES       
                 offs_k = k * BLOCK_K
                 # wait for the buffer to be released by the consumer
                 tlx.barrier_wait(barSmemEmpty[buf], phase ^ 1)
@@ -202,21 +202,21 @@ def matmul_kernel_tma_ws_blackwell(
                 # buffers in a row share the same phase
                 phase = (buf < NUM_STAGES - 1) ? phase : phase ^ 1
 
-        # mma group
+        # mma group 
         with tl.async_task(num_warps = 1)
             phase = 0
             buf = 0
             last_phase = 0
             for k in range(0, tl.cdiv(K, BLOCK_K)):
                 # locate the buffer index that current iteration should access
-                buf = k % NUM_STAGES
+                buf = k % NUM_STAGES       
                 # wait for the buffer to be produced by the consumer
                 tlx.barrier_wait(barSmemFull[buf], phase)
-                # release buffers on completion by setting barSmemEmpty
+                # release buffers on completion by setting barSmemEmpty 
                 acc[0] = tlx.async_dot(a[buf], b[buf].T, acc[0], barSmemEmpty[buf])
                 last_phase = phase
                 phase = (buf < NUM_STAGES - 1) ? phase : phase ^ 1
-            # wait for the last mma to complete
+            # wait for the last mma to complete  
             tlx.barrier_wait(barSmemEmpty[buf], last_phase)
             tlx.barrier_arrive(barTmemFull[0])
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -613,11 +613,6 @@ void init_triton_ir(py::module &&m) {
           ret::reference);
   py::class_<ttg::WarpYieldOp, OpState>(m, "WarpYieldOp", py::module_local());
   py::class_<ttg::WarpReturnOp, OpState>(m, "WarpReturnOp", py::module_local());
-  py::class_<ttng::InitBarrierOp, OpState>(m, "InitBarrierOp",
-                                           py::module_local());
-  py::class_<ttng::InvalBarrierOp, OpState>(m, "InvalBarrierOp",
-                                            py::module_local());
-
   py::class_<scf::ConditionOp, OpState>(m, "ConditionOp", py::module_local());
 
   py::class_<Operation, std::unique_ptr<Operation, py::nodelete>>(

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1916,6 +1916,15 @@ void init_triton_ir(py::module &&m) {
             Value pred = self.create<arith::ConstantIntOp>(1, 1);
             self.create<ttng::BarrierExpectOp>(mbarrerLoc, expectBytes, pred);
           })
+      .def("create_barrier_wait",
+           [](TritonOpBuilder &self, Value mbarrerLoc, Value phase) -> void {
+             self.create<ttng::WaitBarrierOp>(mbarrerLoc, phase);
+           })
+      .def(
+          "barrier_arrive",
+          [](TritonOpBuilder &self, Value mbarrerLoc, int arriveCount) -> void {
+            self.create<ttng::ArriveBarrierOp>(mbarrerLoc, arriveCount);
+          })
       // Proton Ops
       .def("create_proton_record",
            [](TritonOpBuilder &self, bool isStart, int32_t regionId) -> void {

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -84,7 +84,7 @@ def test_alloc_barriers(BLOCK_SIZE, device):
 
         bars = tlx.alloc_barriers(num_barriers=10, arrive_count=2)
         
-        tlx.barrier_expect(tlx.local_view(bars, 0), 128)
+        tlx.barrier_expect_bytes(tlx.local_view(bars, 0), 128)
 
     torch.manual_seed(0)
     size = 98432

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -81,16 +81,10 @@ def test_alloc_barriers(BLOCK_SIZE, device):
         BLOCK_SIZE: tl.constexpr,
     ):
         pid = tl.program_id(axis=0)
-        block_start = pid * BLOCK_SIZE
 
-        bars = tlx.alloc_barriers(10, 2)
-
-        offsets = block_start + tl.arange(0, BLOCK_SIZE)
-        mask = offsets < n_elements
-        x = tl.load(x_ptr + offsets, mask=mask)
-        y = tl.load(y_ptr + offsets, mask=mask)
-        output = x + y
-        tl.store(z_ptr + offsets, output, mask=mask)
+        bars = tlx.alloc_barriers(num_barriers=10, arrive_count=2)
+        
+        tlx.barrier_expect(tlx.local_view(bars, 0), 128)
 
     torch.manual_seed(0)
     size = 98432
@@ -102,9 +96,8 @@ def test_alloc_barriers(BLOCK_SIZE, device):
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
     kernel = add_with_mbarrier[grid](x, y, output, n_elements, BLOCK_SIZE)
 
-    torch.testing.assert_close(output, x + y, check_dtype=False)
-
     assert kernel.asm["ttgir"].count("ttng.init_barrier") == 10
+    assert kernel.asm["ttgir"].count("ttng.barrier_expect") == 1
 
 
 @pytest.mark.skipif(

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -107,6 +107,11 @@ def test_alloc_barriers(BLOCK_SIZE, device):
     assert kernel.asm["ttgir"].count("ttng.init_barrier") == 10
 
 
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
+    reason="Requires compute capability >= 9 for NV",
+)
+@pytest.mark.parametrize("BLOCK_SIZE", [(1024)])
 def test_local_alloc_index(BLOCK_SIZE, device):
 
     @triton.jit
@@ -129,6 +134,3 @@ def test_local_alloc_index(BLOCK_SIZE, device):
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
     kernel = local_alloc_index[grid](x, y, n_elements, BLOCK_SIZE)
     # TODO(Arda): Once we have the loads, add checks here
-
-
-test_local_alloc_index(BLOCK_SIZE=256, device='cuda')

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -55,7 +55,7 @@ def test_async_tasks(BLOCK_SIZE, device):
     output1 = torch.empty_like(x)
     output2 = torch.empty_like(a)
     n_elements = output1.numel()
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     kernel = add2_warp_specialized_kernel[grid](x, y, output1, a, b, output2, n_elements, BLOCK_SIZE)
     ttgir = kernel.asm["ttgir"]
     assert "ttg.warp_specialize" in ttgir
@@ -83,7 +83,7 @@ def test_alloc_barriers(BLOCK_SIZE, device):
         pid = tl.program_id(axis=0)
 
         bars = tlx.alloc_barriers(num_barriers=10, arrive_count=2)
-
+        
         tlx.barrier_expect(tlx.local_view(bars, 0), 128)
 
     torch.manual_seed(0)
@@ -117,6 +117,7 @@ def test_local_alloc_index(BLOCK_SIZE, device):
         buffers = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(2))
         buffer0 = tlx.local_view(buffers, 0)
         buffer1 = tlx.local_view(buffers, 1)
+
 
     torch.manual_seed(0)
     size = 256

--- a/python/triton/tlx
+++ b/python/triton/tlx
@@ -1,0 +1,1 @@
+/data/users/daohang/fbtriton/third_party/tlx

--- a/python/triton/tlx
+++ b/python/triton/tlx
@@ -1,1 +1,0 @@
-/data/users/daohang/fbtriton/third_party/tlx

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -1,7 +1,7 @@
 from .async_task import async_task, async_tasks
 from .types import buffered_tensor
 from .mem_ops import *
-from .barrier import alloc_barriers
+from .barrier import *
 
 __all__ = [
     "async_task",
@@ -10,4 +10,5 @@ __all__ = [
     "local_alloc",
     "local_view",
     "alloc_barriers",
+    "barrier_expect",
 ]

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -1,5 +1,5 @@
 from .async_task import async_task, async_tasks
-from .types import buffered_tensor
+from .types import * 
 from .mem_ops import *
 from .barrier import *
 
@@ -7,6 +7,7 @@ __all__ = [
     "async_task",
     "async_tasks",
     "buffered_tensor",
+    "mbarriers",
     "local_alloc",
     "local_view",
     "alloc_barriers",

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -1,5 +1,5 @@
 from .async_task import async_task, async_tasks
-from .types import buffered_tensor, mbarriers
+from .types import buffered_tensor
 from .mem_ops import *
 from .barrier import alloc_barriers
 
@@ -9,6 +9,5 @@ __all__ = [
     "buffered_tensor",
     "local_alloc",
     "local_view",
-    "mbarriers",
     "alloc_barriers",
 ]

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -8,7 +8,7 @@ def alloc_barriers(
     num_barriers: tl.constexpr,
     arrive_count: tl.constexpr,
     _builder=None,
-) -> tlx.mbarrier:
+) -> tlx.mbarriers:
     """
     Allocates buffer in shared memory and initialize mbarriers with arrive_counts.
 
@@ -16,7 +16,7 @@ def alloc_barriers(
     - `num_barriers`: The number of barriers to allocate.
     - `arrive_counts`: The number of threads that need to arrive at the barrier before it can be released.
     """
-    return tlx.mbarrier(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
+    return tlx.mbarriers(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
 
 @tl.builtin
 def barrier_expect_bytes(

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -16,7 +16,7 @@ def alloc_barriers(
     - `num_barriers`: The number of barriers to allocate.
     - `arrive_counts`: The number of threads that need to arrive at the barrier before it can be released.
     """
-    return tlx.buffered_tensor(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
+    return tlx.mbarrier(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
 
 @tl.builtin
 def barrier_expect(

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -20,7 +20,7 @@ def alloc_barriers(
 
 @tl.builtin
 def barrier_expect_bytes(
-    bar: tlx.buffered_tensor,
+    bar: tlx.mbarriers,
     size: tl.constexpr,
     _builder=None,
 ) -> None:

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -18,7 +18,6 @@ def alloc_barriers(
     """
     return tlx.buffered_tensor(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
 
-
 @tl.builtin
 def barrier_expect(
     bar: tlx.buffered_tensor,
@@ -26,7 +25,7 @@ def barrier_expect(
     _builder=None,
 ) -> None:
     """
-    Signal a barrier of an expected number of bytes to be copied
+    Signal a barrier of an expected number of bytes to be copied 
 
     Input:
     - `bars`: The mbarriers to wait on.

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -11,9 +11,26 @@ def alloc_barriers(
 ) -> tlx.buffered_tensor:
     """
     Allocates buffer in shared memory and initialize mbarriers with arrive_counts.
-    
-    Input: 
+
+    Input:
     - `num_barriers`: The number of barriers to allocate.
     - `arrive_counts`: The number of threads that need to arrive at the barrier before it can be released.
     """
     return tlx.buffered_tensor(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
+
+@tl.builtin
+def barrier_expect(
+    bar: tlx.buffered_tensor,
+    size: tl.constexpr,
+    _builder=None,
+) -> None:
+    """
+    Signal a barrier of an expected number of bytes to be copied 
+
+    Input:
+    - `bars`: The mbarriers to wait on.
+    - `idx`: The index of the barrier to wait on.
+    """
+
+    # TODO. add validator logics
+    _builder.create_barrier_expect(bar.handle, size.value)

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -8,7 +8,7 @@ def alloc_barriers(
     num_barriers: tl.constexpr,
     arrive_count: tl.constexpr,
     _builder=None,
-) -> tlx.mbarriers:
+) -> tlx.buffered_tensor:
     """
     Allocates buffer in shared memory and initialize mbarriers with arrive_counts.
     
@@ -16,4 +16,4 @@ def alloc_barriers(
     - `num_barriers`: The number of barriers to allocate.
     - `arrive_counts`: The number of threads that need to arrive at the barrier before it can be released.
     """
-    return tlx.mbarriers(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
+    return tlx.buffered_tensor(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -30,3 +30,30 @@ def barrier_expect_bytes(
 
     # TODO. add validator logics
     _builder.create_barrier_expect(bar.handle, size.value)
+
+
+@tl.builtin
+def barrier_wait(
+    bar: tlx.buffered_tensor,
+    phase: tl.constexpr,
+    _builder=None,
+) -> None:
+    """
+    Signal a barrier of an expected number of bytes to be copied 
+    """
+
+    # TODO. add validator logics
+    _builder.create_barrier_wait(bar.handle, phase.value)
+
+@tl.builtin
+def barrier_arrive(
+    bar: tlx.buffered_tensor,
+    arrive_count: tl.constexpr,
+    _builder=None,
+) -> None:
+    """
+    Perform the arrive operation on an mbarrier 
+    """
+
+    # TODO. add validator logics
+    _builder.create_barrier_arrive(bar.handle, arrive_count.value)

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -19,17 +19,13 @@ def alloc_barriers(
     return tlx.mbarrier(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
 
 @tl.builtin
-def barrier_expect(
+def barrier_expect_bytes(
     bar: tlx.buffered_tensor,
     size: tl.constexpr,
     _builder=None,
 ) -> None:
     """
     Signal a barrier of an expected number of bytes to be copied 
-
-    Input:
-    - `bars`: The mbarriers to wait on.
-    - `idx`: The index of the barrier to wait on.
     """
 
     # TODO. add validator logics

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -8,7 +8,7 @@ def alloc_barriers(
     num_barriers: tl.constexpr,
     arrive_count: tl.constexpr,
     _builder=None,
-) -> tlx.buffered_tensor:
+) -> tlx.mbarrier:
     """
     Allocates buffer in shared memory and initialize mbarriers with arrive_counts.
 

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -30,30 +30,3 @@ def barrier_expect_bytes(
 
     # TODO. add validator logics
     _builder.create_barrier_expect(bar.handle, size.value)
-
-
-@tl.builtin
-def barrier_wait(
-    bar: tlx.buffered_tensor,
-    phase: tl.constexpr,
-    _builder=None,
-) -> None:
-    """
-    Signal a barrier of an expected number of bytes to be copied 
-    """
-
-    # TODO. add validator logics
-    _builder.create_barrier_wait(bar.handle, phase.value)
-
-@tl.builtin
-def barrier_arrive(
-    bar: tlx.buffered_tensor,
-    arrive_count: tl.constexpr,
-    _builder=None,
-) -> None:
-    """
-    Perform the arrive operation on an mbarrier 
-    """
-
-    # TODO. add validator logics
-    _builder.create_barrier_arrive(bar.handle, arrive_count.value)

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -27,25 +27,3 @@ class buffered_tensor(tl.base_value):
         super().__init__()
         # IR handle
         self.handle = handle
-
-
-# class mbarriers(tl.tensor):
-class mbarriers(tl.base_value):
-    """
-    A symbolic type representing an array of mbarriers (each mbarrier is 8-byte)
-    with 1D tensor in uint64 dtype stored in shared memory.
-
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-size-alignment
-
-    Examples:
-        bars = tlx.alloc_barriers(num=4)
-
-    Attributes:
-        handle: The backing IR value representing the buffer allocation.
-    """
-
-    def __init__(self, handle):
-        """Not called by user code."""
-        super().__init__()
-        # IR handle
-        self.handle = handle

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -27,3 +27,12 @@ class buffered_tensor(tl.base_value):
         super().__init__()
         # IR handle
         self.handle = handle
+
+
+class mbarrier(buffered_tensor):
+    """
+    Define mbarrier type derived from buffered_tensor to support barrier specific operations/validations
+    """
+    def __init__(self, handle):
+        super().__init__(handle)
+        pass

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -29,7 +29,7 @@ class buffered_tensor(tl.base_value):
         self.handle = handle
 
 
-class mbarrier(buffered_tensor):
+class mbarriers(buffered_tensor):
     """
     Define mbarrier type derived from buffered_tensor to support barrier specific operations/validations
     """


### PR DESCRIPTION
This PR adds new op `tlx.barrier_expect` with a few minor changes included as below:
1. combine `tlx.mbarriers` with `tlx.buffered_tensor`
2. minor fix in `create_memdesc_subview` because barrier alloc must be a descriptor of 1xi64 type

Going forward:
1. add a few more barrier ops (wait/arrives) in separate PRs for easier review
2. finish a complete GEMM showcase with tlx primitives
3. add validator logics in ops