### PR TITLE
[TLX] Introducing shared memory layout encoding

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1835,16 +1835,21 @@ void init_triton_ir(py::module &&m) {
              ArrayRef<Type> dummyTypes;
              return self.create<ttg::WarpReturnOp>();
            })
+      .def("make_swizzled_shared_encoding_attr",
+           [](TritonOpBuilder &self, unsigned vectorSize, unsigned perPhase,
+              unsigned maxPhase, std::vector<unsigned> order,
+              unsigned CTAsPerCGA, unsigned CTASplitNum, unsigned CTAOrder) {
+             auto context = self.getBuilder().getContext();
+             auto CTALayout = ttg::CTALayoutAttr::get(context, CTAsPerCGA,
+                                                      CTASplitNum, CTAOrder);
+             return mlir::cast<Attribute>(ttg::SwizzledSharedEncodingAttr::get(
+                 context, vectorSize, perPhase, maxPhase, order, CTALayout));
+           })
       .def("create_local_alloc",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
-              Type &elementType) -> mlir::Value {
+              Type &elementType, Attribute &encoding) -> mlir::Value {
              auto context = self.getBuilder().getContext();
              auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
-             auto CTALayout =
-                 ttg::CTALayoutAttr::get(context, /*CTAsPerCGA=*/{1},
-                                         /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
-             auto encoding = ttg::SwizzledSharedEncodingAttr::get(
-                 context, 1, 1, 1, {0}, CTALayout);
              auto memDesc =
                  ttg::MemDescType::get(shape, elementType, encoding,
                                        memorySpace, /*mutableMemory=*/true);
@@ -1856,23 +1861,19 @@ void init_triton_ir(py::module &&m) {
              auto localAllocType = cast<ttg::MemDescType>(localAlloc.getType());
              auto localAllocShape = localAllocType.getShape();
              auto context = self.getBuilder().getContext();
-             auto ctaLayout =
-                 ttg::CTALayoutAttr::get(context, /*CTAsPerCGA=*/{1},
-                                         /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
-             auto encoding = ttg::SwizzledSharedEncodingAttr::get(
-                 context, 1, 1, 1, {0}, ctaLayout);
              Attribute sharedMemorySpace =
                  triton::gpu::SharedMemorySpaceAttr::get(context);
              Type memDescType;
              if (localAllocShape.size() == 1) {
                memDescType = ttg::MemDescType::get(
-                   {1}, localAllocType.getElementType(), encoding,
-                   sharedMemorySpace,
+                   {1}, localAllocType.getElementType(),
+                   localAllocType.getEncoding(), sharedMemorySpace,
                    /*mutableMemory=*/localAllocType.getMutableMemory());
              } else {
                memDescType = ttg::MemDescType::get(
                    localAllocShape.drop_front(),
-                   localAllocType.getElementType(), encoding, sharedMemorySpace,
+                   localAllocType.getElementType(),
+                   localAllocType.getEncoding(), sharedMemorySpace,
                    /*mutableMemory=*/localAllocType.getMutableMemory());
              }
              Value zero = self.create<arith::ConstantIntOp>(0, 32);

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -83,7 +83,7 @@ def test_alloc_barriers(BLOCK_SIZE, device):
         pid = tl.program_id(axis=0)
 
         bars = tlx.alloc_barriers(num_barriers=10, arrive_count=2)
-        
+
         tlx.barrier_expect_bytes(tlx.local_view(bars, 0), 128)
 
     torch.manual_seed(0)
@@ -104,7 +104,7 @@ def test_alloc_barriers(BLOCK_SIZE, device):
     not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
     reason="Requires compute capability >= 9 for NV",
 )
-@pytest.mark.parametrize("BLOCK_SIZE", [(1024)])
+@pytest.mark.parametrize("BLOCK_SIZE", [(64)])
 def test_local_alloc_index(BLOCK_SIZE, device):
 
     @triton.jit

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -2,13 +2,14 @@ import triton.language.core as tl
 from triton.language.semantic import _convert_elem_to_ir_value
 
 from . import types as tlx
-
+from typing import Optional
 
 @tl.builtin
 def local_alloc(
     shape: tuple,
     dtype: tl.dtype,
     num: tl.constexpr,
+    layout: Optional[tlx.shared_layout_encoding] = None,
     _builder=None,
 ) -> tlx.buffered_tensor:
     """
@@ -19,7 +20,21 @@ def local_alloc(
     full_shape = [unwrapped_num] + unwrapped_shape
     dtype = tl._constexpr_to_value(dtype)
     elem_type = dtype.to_ir(_builder)
-    return tlx.buffered_tensor(_builder.create_local_alloc(full_shape, elem_type), )
+    block_type = tl.block_type(dtype, full_shape)
+    if layout is None:
+        layout = tlx.swizzled_shared_layout_encoding.make_default(rank = len(shape))
+        layout_handle = _builder.make_swizzled_shared_encoding_attr(
+            layout.vectorSize,
+            layout.perPhase,
+            layout.maxPhase,
+            layout.order,
+            layout.numCTAsPerCGA,
+            layout.numCTASplit,
+            layout.numCTAOrder,
+        )
+    else:
+        raise NotImplementedError("User-specified layout encoding not yet implemented.")
+    return tlx.buffered_tensor(_builder.create_local_alloc(full_shape, elem_type, layout_handle), block_type, layout)
 
 
 @tl.builtin
@@ -32,4 +47,9 @@ def local_view(
     Returns a subview of the buffer.
     """
     buffer_idx = _convert_elem_to_ir_value(_builder, buffer_idx, require_i64=False)
-    return tlx.buffered_tensor(_builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx), )
+    buffer_type = local_allocated_buffers.type
+    # A subview of a one-dimensional buffer is still one-dimensional.
+    view_shape = buffer_type.shape[1:] if len(buffer_type.shape) > 1 else buffer_type.shape
+    view_type = tl.block_type(buffer_type.element_ty, view_shape)
+    layout = local_allocated_buffers.layout
+    return tlx.buffered_tensor(_builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx), view_type, layout)

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -1,10 +1,57 @@
 import triton.language.core as tl
+from typing import Optional
+
+
+class layout_encoding:
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+
+class shared_layout_encoding(layout_encoding):
+    def __init__(self):
+        super().__init__()
+        pass
+
+
+class swizzled_shared_layout_encoding(shared_layout_encoding):
+    def __init__(self, vectorSize, perPhase, maxPhase, order, numCTAs, numCTAsPerCGA, numCTASplit, numCTAOrder):
+        super().__init__()
+        self.vectorSize = vectorSize
+        self.perPhase = perPhase
+        self.maxPhase = maxPhase
+        self.order = order
+        self.numCTAs = numCTAs
+        self.numCTAsPerCGA = numCTAsPerCGA
+        self.numCTASplit = numCTASplit
+        self.numCTAOrder = numCTAOrder
+
+    """
+    Make a default non-swizzled shared layout encoding.
+    """
+    @classmethod
+    def make_default(cls, rank=2):
+        return cls(
+            vectorSize=1,
+            perPhase=1,
+            maxPhase=1,
+            order=list(range(rank)),
+            numCTAs=1,
+            numCTAsPerCGA=1,
+            numCTASplit=1,
+            numCTAOrder=1,
+        )
+
+    def build(self, builder):
+        pass
 
 
 class buffered_tensor(tl.base_value):
     """
     A symbolic type representing a tensor allocated in a manually managed buffer
-    such as shared memory (SMEM) or local memory (TMEM).
+    such as shared memory (SMEM).
 
     This type is to model data that is not stored in global memory or registers
     but instead resides in hardware-close memory spaces with specialized
@@ -22,11 +69,18 @@ class buffered_tensor(tl.base_value):
         handle: The backing IR value representing the buffer allocation.
     """
 
-    def __init__(self, handle):
+    def __init__(self, handle, type: tl.dtype, layout: Optional[shared_layout_encoding] = None):
         """Not called by user code."""
         super().__init__()
         # IR handle
         self.handle = handle
+        # Block shape
+        self.shape = type.shape if type.is_block() else ()
+        self.type = type  # Tensor type (can be block_type)
+        # Following the practice in pytorch, dtype is scalar type
+        self.dtype = type.scalar
+        # Layout encoding
+        self.layout = layout
 
 
 class mbarriers(buffered_tensor):
@@ -34,5 +88,8 @@ class mbarriers(buffered_tensor):
     Define mbarrier type derived from buffered_tensor to support barrier specific operations/validations
     """
     def __init__(self, handle):
-        super().__init__(handle)
+        # Temporarily use 1, as the shape must be a power of 2.
+        # TODO: use the actual barrier count to compute shape for precise boundary checks.
+        block_type = tl.block_type(tl.int64, [1])
+        super().__init__(handle, block_type)
         pass

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -32,7 +32,7 @@ class swizzled_shared_layout_encoding(shared_layout_encoding):
     Make a default non-swizzled shared layout encoding.
     """
     @classmethod
-    def make_default(cls, rank=2):
+    def make_default(cls, rank):
         return cls(
             vectorSize=1,
             perPhase=1,


### PR DESCRIPTION
Introducing shared memory layout encoding during buffer allocation. User can optionally specify the explicit encoding (not implemented yet), otherwise the compiler enforces a non-swizzled layout for the buffer.

When the buffer is used in a different layout, e.g, a non-swizzled buffer is used for dot operands, layout conversion will be needed. Assigning layout information to `tlx.buffered_tensor` ensures a strong type system that can identify the need of such layout conversion.