### PR TITLE
Backport changes to resolve do_bench/cpu related isuses

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -35,6 +35,26 @@ def test_kwargs(use_cuda_graph: bool, device: str):
     assert len(_kernel.cache) == 2
 
 
+def test_no_do_bench(device: str):
+    M, N = 1024, 16
+    src = torch.randn(M * N, device=device)
+    dst = torch.empty(M * N, device=device)
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE_M': 32}), triton.Config(kwargs={'BLOCK_SIZE_M': 128})]
+
+    @triton.autotune(configs=configs, key=["M"])
+    @triton.jit
+    def _kernel(dst, src, stride_m: tl.constexpr, M, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_M: tl.constexpr):
+        offsets_m = tl.program_id(0) * stride_m + tl.arange(0, BLOCK_SIZE_M)
+        offsets_n = tl.arange(0, BLOCK_SIZE_N)
+        x = tl.load(src + offsets_m[:, None] * BLOCK_SIZE_N + offsets_n[None, :])
+        tl.store(dst + offsets_m[:, None] * BLOCK_SIZE_N + offsets_n[None, :], x)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE_M']), )
+    _kernel[grid](dst, src, N, M, N)
+    assert len(_kernel.cache) == 1
+
+
 @pytest.mark.parametrize('pass_kwargs_to_kernel', [False, True])
 def test_restore(pass_kwargs_to_kernel, device):
     N = 1024

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1387,7 +1387,10 @@ class CodeGenerator(ast.NodeVisitor):
 
 
 def ast_to_ttir(fn, src, context, options, codegen_fns, module_map):
-    arg_types = list(map(str_to_ty, src.signature.values()))
+    arg_types = [None] * len(fn.arg_names)
+    for k, v in src.signature.items():
+        idx = fn.arg_names.index(k)
+        arg_types[idx] = str_to_ty(v)
     prototype = ASTFunction([], arg_types, src.constants, src.attrs)
     file_name, begin_line = get_jit_fn_file_line(fn)
     # query function representation

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -515,7 +515,7 @@ class HIPDriver(GPUDriver):
     def is_active():
         try:
             import torch
-            return torch.version.hip is not None
+            return torch.cuda.is_available() and (torch.version.hip is not None)
         except ImportError:
             return False
 


### PR DESCRIPTION
Backports the changes from the following commits:
- https://github.com/triton-lang/triton/commit/ba2d7f5276bb48d516245be10317c4b6896944b2
- https://github.com/triton-lang/triton/commit/3bd4a58ae718f7383737b05bd8a6531f7a76d9c6
- https://github.com/triton-lang/triton/commit/1e914b7584ba5781a7f1399d3ef6975d6327cedb

These were resolved in Beta/Trunk testing to fix issues related to building Triton on CPUs and either defining or importing kernels. 