### PR TITLE
[TLX] Tensor memory allocation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ While this approach places more responsibility on the user, it reduces the compi
 
 ### Local buffer allocation
 
-- `buffers = tlx.local_alloc(shape, dtype, num_buffers)`
+- `buffers = tlx.local_alloc(shape, dtype, NUM_BUFFERS)`
 
-    Allocate number_buffers buffers in local memory per thread block, each of size size. The memory layout is inferred from its consumers..
+    Allocate `NUM_BUFFERS` buffers in local memory per thread block, each of size size. The memory layout is inferred from its consumers.
 
 
-- `buffers = tlx.tmem_alloc(size, NUM_STAGES)`
+- `buffers = tlx.local_alloc(shape, dtype, NUM_BUFFERS, tlx.storage_kind.tmem)`
 
-    Allocate number_buffers of buffers in the tensor memory per thread block, each with size size.
+    Allocate `NUM_BUFFERS` of buffers in the tensor memory per thread block, each with size size. The memory layout is inferred from its consumers.
 
 ### Async memory access
 

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -106,6 +106,31 @@ def test_local_alloc_index(BLOCK_SIZE, device):
     # TODO(Arda): Once we have the stores, add numerical checks here
 
 
+
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability()[0] < 10,
+    reason="Requires compute capability >= 10 for NV",
+)
+@pytest.mark.parametrize("BLOCK_SIZE", [(64)])
+def test_tmem_alloc_index(BLOCK_SIZE, device):
+
+    @triton.jit
+    def kernel(
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        buffers = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(2), tlx.storage_kind.tmem)
+        buffer0 = tlx.local_view(buffers, 0)
+        buffer1 = tlx.local_view(buffers, 1)
+
+
+    grid = lambda meta: (1, )
+    kerenl_info = kernel[grid](BLOCK_SIZE)
+    # TODO: check numerics once tmem load/store is ready
+    kerenl_info.asm["ttgir"]
+    assert kerenl_info.asm["ttgir"].count("kernel") == 1
+
+
+
 def test_thread_id(device):
 
     @triton.jit

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -2,27 +2,46 @@
 #include "ir.h" // TritonOpBuilder
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 namespace py = pybind11;
 using namespace ir;
 using namespace mlir;
 namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
 
 void init_triton_tlx_ir(py::module &&m) {
   auto *builder_cls = ir::getBuilderClass();
-  builder_cls->def(
-      "create_require_layout",
-      [](TritonOpBuilder &self, Value &v, Attribute &encoding) -> Value {
-        Type newType;
-        if (auto type = dyn_cast<ttg::MemDescType>(v.getType())) {
-          newType = ttg::MemDescType::get(
-              type.getShape(), type.getElementType(), encoding,
-              type.getMemorySpace(), type.getMutableMemory());
-        } else {
-          throw std::runtime_error("Unsupported type");
-        }
-        return self.create<tlx::RequireLayoutOp>(newType, v);
-      });
+  builder_cls
+      ->def("create_require_layout",
+            [](TritonOpBuilder &self, Value &v, Attribute &encoding) -> Value {
+              Type newType;
+              if (auto type = dyn_cast<ttg::MemDescType>(v.getType())) {
+                newType = ttg::MemDescType::get(
+                    type.getShape(), type.getElementType(), encoding,
+                    type.getMemorySpace(), type.getMutableMemory());
+              } else {
+                throw std::runtime_error("Unsupported type");
+              }
+              return self.create<tlx::RequireLayoutOp>(newType, v);
+            })
+      .def("make_tensor_memory_encoding_attr",
+           [](TritonOpBuilder &self, unsigned blockM, unsigned blockN,
+              bool unpacked, unsigned CTASplitM, unsigned CTASplitN) {
+             auto context = self.getBuilder().getContext();
+             return mlir::cast<Attribute>(ttng::TensorMemoryEncodingAttr::get(
+                 context, blockM, blockN, unpacked, CTASplitM, CTASplitN));
+           })
+      .def("create_tmem_alloc",
+           [](TritonOpBuilder &self, std::vector<int64_t> shape,
+              Type &elementType, Attribute &encoding) -> mlir::Value {
+             auto context = self.getBuilder().getContext();
+             auto memorySpace = ttng::TensorMemorySpaceAttr::get(context);
+             auto memDesc =
+                 ttg::MemDescType::get(shape, elementType, encoding,
+                                       memorySpace, /*mutableMemory=*/true);
+             return self.create<ttng::TMEMAllocOp>(memDesc, nullptr);
+           });
 }
 
 void init_triton_tlx_passes(py::module &&m) {

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -8,17 +8,21 @@ __all__ = [
     # warp specialization ops
     "async_task",
     "async_tasks",
+
     # local buffer ops
     "buffered_tensor", # type
     "local_alloc",
     "local_view",
     "async_load",
+    "storage_kind",  # type
+
     # barrier ops
     "mbarriers", # type
     "alloc_barriers",
     "barrier_expect_bytes",
     "barrier_wait",
     "barrier_arrive",
+
     # debugging ops
     "thread_id"
 ]

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import triton.language.core as tl
 from triton.language.semantic import (
     _convert_elem_to_ir_value,
@@ -7,6 +6,7 @@ from triton.language.semantic import (
 )
 
 from . import types as tlx
+from . utility import cuda_parse_arch
 from typing import Optional
 
 
@@ -15,12 +15,17 @@ def local_alloc(
     shape: tuple,
     dtype: tl.dtype,
     num: tl.constexpr,
+    storage: tlx.storage_kind = tlx.storage_kind.smem,
     layout: Optional[tlx.shared_layout_encoding] = None,
     _builder=None,
 ) -> tlx.buffered_tensor:
     """
     Allocates buffer in shared memory and return a view of the buffer.
     """
+    if storage == tlx.storage_kind.tmem:
+        capability = int(cuda_parse_arch(_builder.options.arch))
+        assert capability >= 100, "tmem is only available on Blackwell"
+
     unwrapped_shape = [tl._unwrap_if_constexpr(dim) for dim in shape]
     unwrapped_num = tl._unwrap_if_constexpr(num)
     full_shape = [unwrapped_num] + unwrapped_shape
@@ -28,21 +33,38 @@ def local_alloc(
     elem_type = dtype.to_ir(_builder)
     block_type = tl.block_type(dtype, full_shape)
     if layout is None:
-        layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
-        layout_handle = _builder.make_swizzled_shared_encoding_attr(
-            layout.vectorSize,
-            layout.perPhase,
-            layout.maxPhase,
-            layout.order,
-            layout.numCTAsPerCGA,
-            layout.numCTASplit,
-            layout.numCTAOrder,
-        )
+        if storage == tlx.storage_kind.smem:
+            layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
+            layout_handle = _builder.make_swizzled_shared_encoding_attr(
+                layout.vectorSize,
+                layout.perPhase,
+                layout.maxPhase,
+                layout.order,
+                layout.numCTAsPerCGA,
+                layout.numCTASplit,
+                layout.numCTAOrder,
+            )
+        else:
+            layout = tlx.tensor_memory_layout_encoding.make_default(shape)
+            layout_handle = _builder.make_tensor_memory_encoding_attr(
+                layout.blockM,
+                layout.blockN,
+                layout.unpacked,
+                layout.CTASplitM,
+                layout.CTASplitN,
+            )
     else:
         raise NotImplementedError("User-specified layout encoding not yet implemented.")
+
+    if storage == tlx.storage_kind.smem:
+        tensor_handle = _builder.create_local_alloc(full_shape, elem_type, layout_handle)
+    else:
+        tensor_handle = _builder.create_tmem_alloc(full_shape, elem_type, layout_handle)
+
     return tlx.buffered_tensor(
-        _builder.create_local_alloc(full_shape, elem_type, layout_handle),
+        tensor_handle,
         block_type,
+        storage,
         layout,
     )
 

--- a/third_party/tlx/language/utility.py
+++ b/third_party/tlx/language/utility.py
@@ -1,6 +1,15 @@
 import triton.language.core as tl
 
 from . import types as tlx
+import re
+
+
+def cuda_parse_arch(arch):
+    pattern = r"^sm(\d+)$"
+    match = re.fullmatch(pattern, arch)
+    if not match:
+        raise ValueError(f"TRITON_OVERRIDE_ARCH must have the form {pattern}")
+    return int(match.group(1))
 
 @tl.builtin
 def thread_id(axis, _builder=None):


### PR DESCRIPTION
Extending  `tlx.local_alloc` to handle tensor memory allocation on Blackwell:

- `buffers = tlx.local_alloc(shape, dtype, num_buffers)`  # to allocate buffer on shared memory
- `buffers = tlx.local_alloc(shape, dtype, num_buffers, tlx.storage_kind.smem)`  # to allocate buffer on shared memory
- `buffers = tlx.local_alloc(shape, dtype, num_buffers, tlx.storage_kind.tmem)`  # to allocate buffer on tensor memory