### PR TITLE
[TLX] Add tlx.local_store

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ While this approach places more responsibility on the user, it reduces the compi
     Loads the buffer from local memory into a distributed tensor.
 
 
+- `tlx.local_store(buffer, distributed_tensor)`
+
+    Store a distributed tensor into a buffer in local memory.
+
 - `buffer = tlx.local_trans(buffer, dims)`
 
     Permutes the dimensions of a tensor.
-
 
 
 ### Async memory access

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -123,6 +123,13 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
         return srcEncoding != nullptr;
       });
 
+  addDynamicallyLegalOp<triton::gpu::LocalStoreOp>(
+      [&](triton::gpu::LocalStoreOp op) -> bool {
+        Attribute srcEncoding =
+            dyn_cast<RankedTensorType>(op.getSrc().getType()).getEncoding();
+        return srcEncoding != nullptr;
+      });
+
   addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) -> bool {
     for (auto arg : funcOp.getArguments()) {
       if (auto tensor = dyn_cast<RankedTensorType>(arg.getType())) {

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -621,6 +621,7 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
       GenericOpPattern<triton::CallOp>,
       GenericOpPattern<ReturnOp>,
       GenericOpPattern<triton::gpu::AsyncCopyGlobalToLocalOp>,
+      GenericOpPattern<triton::gpu::LocalStoreOp>,
       TritonFuncOpPattern>(typeConverter, context);
 }
 // Proton patterns

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -38,6 +38,10 @@ void init_triton_tlx_ir(py::module &&m) {
              return self.create<ttg::LocalLoadOp>(newType, subView,
                                                   asyncToken.value_or(Value()));
            })
+      .def("create_local_store",
+           [](TritonOpBuilder &self, Value &dst, Value &regValues) -> void {
+             self.create<ttg::LocalStoreOp>(regValues, dst);
+           })
       .def("make_swizzled_shared_encoding_attr",
            [](TritonOpBuilder &self, unsigned vectorSize, unsigned perPhase,
               unsigned maxPhase, std::vector<unsigned> order,

--- a/third_party/tlx/language/__init__.py
+++ b/third_party/tlx/language/__init__.py
@@ -14,6 +14,8 @@ __all__ = [
     "buffered_tensor",  # type
     "local_alloc",
     "local_view",
+    "local_load",
+    "local_store",
     "async_load",
     "async_load_commit_group",
     "async_load_wait_group",

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -158,6 +158,16 @@ def local_load(
     """
     return tl.tensor(_builder.create_local_load(src.handle, token.handle if token else None), src.type)
 
+@tl.builtin
+def local_store(
+    dst: tlx.buffered_tensor,
+    src: tl.tensor,
+    _builder=None,
+) -> tl.tensor:
+    """
+    Store a distributed tensor into a buffer in local memory.
+    """
+    return tl.tensor(_builder.create_local_store(dst.handle, src.handle), tl.void)
 
 @tl.builtin
 def local_trans(input: tlx.buffered_tensor, dims: Tuple[int] = (1, 0), _builder=None) -> tlx.buffered_tensor:


### PR DESCRIPTION
Add the frontend API, and legalization changes to make sure layout
encoding is valid when TritonGPU conversion pass finishes. Will do
similar legalization changes for local_load in a following commit.

Currently, for the kernel locat_load_store in the test, .ttir looks like
this:

```
module {
  tt.func public @local_load_store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0), %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0), %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0), %arg3: i32 {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0)) attributes {noinline = false} {
    %c2_i32 = arith.constant 2 : i32 loc(#loc1)
    %c1_i32 = arith.constant 1 : i32 loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %c64_i32 = arith.constant 64 : i32 loc(#loc1)
    %0 = tt.get_program_id x : i32 loc(#loc2)
    %1 = arith.muli %0, %c64_i32 : i32 loc(#loc3)
    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32> loc(#loc4)
    %3 = tt.splat %1 : i32 -> tensor<64xi32> loc(#loc5)
    %4 = arith.addi %3, %2 : tensor<64xi32> loc(#loc5)
    %5 = tt.splat %arg3 : i32 -> tensor<64xi32> loc(#loc6)
    %6 = arith.cmpi slt, %4, %5 : tensor<64xi32> loc(#loc6)
    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>> loc(#loc7)
    %8 = tt.addptr %7, %4 : tensor<64x!tt.ptr<f32>>, tensor<64xi32> loc(#loc7)
    %9 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>> loc(#loc8)
    %10 = tt.addptr %9, %4 : tensor<64x!tt.ptr<f32>>, tensor<64xi32> loc(#loc8)
    %11 = ttg.local_alloc : () -> !ttg.memdesc<4x64xf32, #shared, #smem, mutable> loc(#loc9)
    %12 = ttg.memdesc_subview %11[%c0_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc10)
    %13 = ttg.memdesc_subview %11[%c1_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc11)
    %14 = ttg.memdesc_subview %11[%c2_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc12)
    %15 = ttg.async_copy_global_to_local %8, %12 mask %6 : tensor<64x!tt.ptr<f32>> -> <64xf32, #shared, #smem, mutable> loc(#loc13)
    %16 = ttg.async_copy_global_to_local %10, %13 mask %6 : tensor<64x!tt.ptr<f32>> -> <64xf32, #shared, #smem, mutable> loc(#loc14)
    %17 = ttg.async_commit_group  loc(#loc15)
    %18 = ttg.async_wait  {num = 0 : i32} loc(#loc16)
    %19 = ttg.local_load %12 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32> loc(#loc17)
    %20 = ttg.local_load %13 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32> loc(#loc18)
    %21 = arith.addf %19, %20 : tensor<64xf32> loc(#loc19)
    ttg.local_store %21, %14 : tensor<64xf32> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc20)
    %22 = ttg.local_load %14 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32> loc(#loc21)
    %23 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>> loc(#loc22)
    %24 = tt.addptr %23, %4 : tensor<64x!tt.ptr<f32>>, tensor<64xi32> loc(#loc22)
    tt.store %24, %22, %6 : tensor<64x!tt.ptr<f32>> loc(#loc23)
    tt.return loc(#loc24)
  } loc(#loc)
} loc(#loc)
```

.ttgir looks like this:

```
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @local_load_store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0), %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0), %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0), %arg3: i32 {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":127:0)) attributes {noinline = false} {
    %c64_i32 = arith.constant 64 : i32 loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %c1_i32 = arith.constant 1 : i32 loc(#loc1)
    %c2_i32 = arith.constant 2 : i32 loc(#loc1)
    %0 = tt.get_program_id x : i32 loc(#loc2)
    %1 = arith.muli %0, %c64_i32 : i32 loc(#loc3)
    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked> loc(#loc4)
    %3 = tt.splat %1 : i32 -> tensor<64xi32, #blocked> loc(#loc5)
    %4 = arith.addi %3, %2 : tensor<64xi32, #blocked> loc(#loc5)
    %5 = tt.splat %arg3 : i32 -> tensor<64xi32, #blocked> loc(#loc6)
    %6 = arith.cmpi slt, %4, %5 : tensor<64xi32, #blocked> loc(#loc6)
    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked> loc(#loc7)
    %8 = tt.addptr %7, %4 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked> loc(#loc7)
    %9 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked> loc(#loc8)
    %10 = tt.addptr %9, %4 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked> loc(#loc8)
    %11 = ttg.local_alloc : () -> !ttg.memdesc<4x64xf32, #shared, #smem, mutable> loc(#loc9)
    %12 = ttg.memdesc_subview %11[%c0_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc10)
    %13 = ttg.memdesc_subview %11[%c1_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc11)
    %14 = ttg.memdesc_subview %11[%c2_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc12)
    %15 = ttg.async_copy_global_to_local %8, %12 mask %6 : tensor<64x!tt.ptr<f32>, #blocked> -> <64xf32, #shared, #smem, mutable> loc(#loc13)
    %16 = ttg.async_copy_global_to_local %10, %13 mask %6 : tensor<64x!tt.ptr<f32>, #blocked> -> <64xf32, #shared, #smem, mutable> loc(#loc14)
    %17 = ttg.async_commit_group  loc(#loc15)
    %18 = ttg.async_wait  {num = 0 : i32} loc(#loc16)
    %19 = ttg.local_load %12 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32, #blocked> loc(#loc17)
    %20 = ttg.local_load %13 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32, #blocked> loc(#loc17)
    %21 = arith.addf %19, %20 : tensor<64xf32, #blocked> loc(#loc17)
    ttg.local_store %21, %14 : tensor<64xf32, #blocked> -> !ttg.memdesc<64xf32, #shared, #smem, mutable> loc(#loc18)
    %22 = ttg.local_load %14 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32, #blocked> loc(#loc19)
    %23 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked> loc(#loc20)
    %24 = tt.addptr %23, %4 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked> loc(#loc20)
    tt.store %24, %22, %6 : tensor<64x!tt.ptr<f32>, #blocked> loc(#loc19)
    tt.return loc(#loc21)
  } loc(#loc)
} loc(#loc)
```

The TTGIR right after convert-triton-to-tritongpu pass is like this:

```
bin/triton-opt  --pass-pipeline="builtin.module(convert-triton-to-tritongpu{enable-
source-remat=false num-ctas=1 num-warps=4 target=cuda:100
threads-per-warp=32})" ...
```

```
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @local_load_store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
    %c2_i32 = arith.constant 2 : i32
    %c1_i32 = arith.constant 1 : i32
    %c0_i32 = arith.constant 0 : i32
    %c64_i32 = arith.constant 64 : i32
    %0 = tt.get_program_id x : i32
    %1 = arith.muli %0, %c64_i32 : i32
    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
    %3 = tt.splat %1 : i32 -> tensor<64xi32, #blocked>
    %4 = arith.addi %3, %2 : tensor<64xi32, #blocked>
    %5 = tt.splat %arg3 : i32 -> tensor<64xi32, #blocked>
    %6 = arith.cmpi slt, %4, %5 : tensor<64xi32, #blocked>
    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
    %8 = tt.addptr %7, %4 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
    %9 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
    %10 = tt.addptr %9, %4 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
    %11 = ttg.local_alloc : () -> !ttg.memdesc<4x64xf32, #shared, #smem, mutable>
    %12 = ttg.memdesc_subview %11[%c0_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
    %13 = ttg.memdesc_subview %11[%c1_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
    %14 = ttg.memdesc_subview %11[%c2_i32, %c0_i32] : !ttg.memdesc<4x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
    %15 = ttg.async_copy_global_to_local %8, %12 mask %6 : tensor<64x!tt.ptr<f32>, #blocked> -> <64xf32, #shared, #smem, mutable>
    %16 = ttg.async_copy_global_to_local %10, %13 mask %6 : tensor<64x!tt.ptr<f32>, #blocked> -> <64xf32, #shared, #smem, mutable>
    %17 = ttg.async_commit_group
    %18 = ttg.async_wait  {num = 0 : i32}
    %19 = ttg.local_load %12 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32>
    %20 = ttg.convert_layout %19 : tensor<64xf32> -> tensor<64xf32, #blocked>
    %21 = ttg.local_load %13 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32>
    %22 = ttg.convert_layout %21 : tensor<64xf32> -> tensor<64xf32, #blocked>
    %23 = arith.addf %20, %22 : tensor<64xf32, #blocked>
    ttg.local_store %23, %14 : tensor<64xf32, #blocked> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
    %24 = ttg.local_load %14 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32>
    %25 = ttg.convert_layout %24 : tensor<64xf32> -> tensor<64xf32, #blocked>
    %26 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
    %27 = tt.addptr %26, %4 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
    tt.store %27, %25, %6 : tensor<64x!tt.ptr<f32>, #blocked>
    tt.return
  }
}
```