### PR TITLE
[TLX] IR release_layout op

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/CMakeLists.txt
+++ b/lib/Conversion/TritonToTritonGPU/CMakeLists.txt
@@ -13,4 +13,5 @@ add_triton_library(TritonToTritonGPU
     TritonIR
     ProtonIR
     TritonGPUIR
+    TLXIR
 )

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Support/LLVM.h"
+#include "third_party/tlx/dialect/include/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -116,7 +117,9 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
   });
 
   addDynamicallyLegalOp<triton::gpu::AsyncCopyGlobalToLocalOp,
-                        triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp>(
+                        triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp,
+                        triton::tlx::RequireLayoutOp,
+                        triton::tlx::ReleaseLayoutOp>(
       [&](Operation *op) -> bool {
         // make sure every RankedTensorType operand has encoding
         for (auto operandType : op->getOperandTypes()) {

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -31,4 +31,17 @@ def TLX_RequireLayoutOp : TLX_Op<"require_layout",
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 }
 
+def TLX_ReleaseLayoutOp : TLX_Op<"release_layout",
+                                 [SameOperandsAndResultShape,
+                                  SameOperandsAndResultElementType,
+                                  Pure]> {
+  let summary = "release specific layout for a register buffer";
+
+  let arguments = (ins TT_Tensor:$src);
+
+  let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+}
+
 #endif

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -29,6 +29,17 @@ void init_triton_tlx_ir(py::module &&m) {
                 throw std::runtime_error("Unsupported type");
               }
             })
+      .def("create_release_layout",
+           [](TritonOpBuilder &self, Value &v) -> Value {
+             if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
+               assert(type.getEncoding() && "Expect layout encoding");
+               auto newType = RankedTensorType::get(type.getShape(),
+                                                    type.getElementType());
+               return self.create<tlx::ReleaseLayoutOp>(newType, v);
+             } else {
+               throw std::runtime_error("Unsupported type");
+             }
+           })
       .def("create_local_load",
            [](TritonOpBuilder &self, Value subView,
               std::optional<Value> asyncToken) -> mlir::Value {

--- a/third_party/tlx/language/mma_ops.py
+++ b/third_party/tlx/language/mma_ops.py
@@ -71,5 +71,9 @@ def async_dot(
     acc = _builder.create_require_layout(acc_handle, _builder.make_nv_mma_encoding_attr())
 
     _builder.create_fence_async_shared()
-    return tl.tensor(_builder.create_warp_group_dot(input, other, acc, input_precision, max_num_imprecise_acc, True),
-                     ret_ty)
+
+    output = _builder.create_warp_group_dot(input, other, acc, input_precision, max_num_imprecise_acc, True)
+
+    # Release the mma layout for the output to conform to what the user expects
+    output = _builder.create_release_layout(output)
+    return tl.tensor(output, ret_ty)


### PR DESCRIPTION
Introducing a new IR op `tlx.release_layout` to downcast the layout of `async_dot` output to none to favor TTIR legalization. The TTGIR for a gemm kernel now looks like

```
tt.func public @tgt_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("test_tlx.py":354:0), %arg1: i32 {tt.divisibility = 16 : i32} loc("test_tlx.py":354:0), %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("test_tlx.py":354:0), %arg3: i32 {tt.divisibility = 16 : i32} loc("test_tlx.py":354:0), %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("test_tlx.py":354:0), %arg5: i32 {tt.divisibility = 16 : i32} loc("test_tlx.py":354:0)) attributes {noinline = false} {
    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked> loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked1> loc(#loc2)
    %1 = ttg.local_alloc : () -> !ttg.memdesc<1x64x64xf32, #shared, #smem, mutable> loc(#loc3)
    %2 = ttg.local_alloc : () -> !ttg.memdesc<1x64x64xf32, #shared, #smem, mutable> loc(#loc4)
    %3 = ttg.memdesc_subview %1[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable> loc(#loc5)
    %4 = ttg.memdesc_subview %2[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable> loc(#loc6)
    %5 = ttg.convert_layout %0 : tensor<64xi32, #blocked1> -> tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked2}>> loc(#loc7)
    %6 = tt.expand_dims %5 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked2}>> -> tensor<64x1xi32, #blocked2> loc(#loc7)
    %7 = ttg.convert_layout %6 : tensor<64x1xi32, #blocked2> -> tensor<64x1xi32, #blocked3> loc(#loc8)
    %8 = tt.splat %arg5 : i32 -> tensor<64x1xi32, #blocked3> loc(#loc8)
    %9 = arith.muli %7, %8 : tensor<64x1xi32, #blocked3> loc(#loc8)
    %10 = tt.splat %arg4 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>, #blocked3> loc(#loc9)
    %11 = tt.addptr %10, %9 : tensor<64x1x!tt.ptr<f32>, #blocked3>, tensor<64x1xi32, #blocked3> loc(#loc9)
    %12 = ttg.convert_layout %0 : tensor<64xi32, #blocked1> -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked4}>> loc(#loc10)
    %13 = tt.expand_dims %12 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked4}>> -> tensor<1x64xi32, #blocked4> loc(#loc10)
    %14 = ttg.convert_layout %13 : tensor<1x64xi32, #blocked4> -> tensor<1x64xi32, #blocked> loc(#loc11)
    %15 = tt.broadcast %11 : tensor<64x1x!tt.ptr<f32>, #blocked3> -> tensor<64x64x!tt.ptr<f32>, #blocked3> loc(#loc11)
    %16 = ttg.convert_layout %15 : tensor<64x64x!tt.ptr<f32>, #blocked3> -> tensor<64x64x!tt.ptr<f32>, #blocked> loc(#loc11)
    %17 = tt.broadcast %14 : tensor<1x64xi32, #blocked> -> tensor<64x64xi32, #blocked> loc(#loc11)
    %18 = tt.addptr %16, %17 : tensor<64x64x!tt.ptr<f32>, #blocked>, tensor<64x64xi32, #blocked> loc(#loc11)
    %19 = tlx.require_layout %3 : !ttg.memdesc<64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared1, #smem, mutable> loc(#loc12)
    %20 = tlx.require_layout %4 : !ttg.memdesc<64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared2, #smem, mutable> loc(#loc12)
    %21 = tlx.require_layout %cst : tensor<64x64xf32, #blocked> -> tensor<64x64xf32, #mma> loc(#loc12)
    ttng.fence_async_shared {bCluster = false} loc(#loc12)
    %22 = ttng.warp_group_dot %19, %20, %21 {inputPrecision = 0 : i32, isAsync = true} : !ttg.memdesc<64x64xf32, #shared1, #smem, mutable> * !ttg.memdesc<64x64xf32, #shared2, #smem, mutable> -> tensor<64x64xf32, #mma> loc(#loc12)
    %23 = tlx.release_layout %22 : tensor<64x64xf32, #mma> -> tensor<64x64xf32, #blocked> loc(#loc12)
    tt.store %18, %23 : tensor<64x64x!tt.ptr<f32>, #blocked> loc(#loc13)
    tt.return loc(#loc14)
  } loc(#loc)
```

A subsequent layout propagation pass should 
 - backward prop `tlx.require_layout`
 - forward prop `tlx.release_layout` or change it to `ttg.convert_layout`