### PR TITLE
[TLX] Add requested registers to tlx.async_task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ docs/sg_execution_times.rst
 .vscode
 .vs
 
+# Symlink after pip install
+python/triton/tlx
+
 # Vim
 *.swp
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1733,10 +1733,14 @@ void init_triton_ir(py::module &&m) {
       // Warp specialize ops
       .def("create_warp_specialize_op",
            [](TritonOpBuilder &self, std::vector<int> partitionNumWarps,
-              int numPartitionRegions) -> ttg::WarpSpecializeOp {
+              std::vector<int> requestedRegisters, int numPartitionRegions) -> ttg::WarpSpecializeOp {
              ArrayRef<Type> dummyTypes;
-             return self.create<ttg::WarpSpecializeOp>(
-                 dummyTypes, partitionNumWarps, numPartitionRegions);
+              auto wsOp = self.create<ttg::WarpSpecializeOp>(
+                  dummyTypes, partitionNumWarps, numPartitionRegions);
+
+                wsOp.setRequestedRegisters(requestedRegisters);
+
+                return wsOp;
            })
       .def("create_warp_yield_op",
            [](TritonOpBuilder &self) -> ttg::WarpYieldOp {

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -35,7 +35,7 @@ def test_async_tasks(BLOCK_SIZE, device):
                 y = tl.load(y_ptr + offsets, mask=mask)
                 output = x + y
                 tl.store(z_ptr + offsets, output, mask=mask)
-            with tlx.async_task(num_warps=4):
+            with tlx.async_task(num_warps=4, registers=100):
                 offsets = block_start + tl.arange(0, BLOCK_SIZE)
                 mask = offsets < n_elements
                 a = tl.load(a_ptr + offsets, mask=mask)
@@ -60,6 +60,7 @@ def test_async_tasks(BLOCK_SIZE, device):
     kernel = add2_warp_specialized_kernel[grid](x, y, output1, a, b, output2, n_elements, BLOCK_SIZE)
     ttgir = kernel.asm["ttgir"]
     assert "ttg.warp_specialize" in ttgir
+    assert "requestedRegisters" in ttgir
 
     ref_out1, ref_out2 = dual_add(x, y, a, b)
     torch.testing.assert_close(output1, ref_out1, check_dtype=False)

--- a/python/triton/tlx
+++ b/python/triton/tlx
@@ -1,0 +1,1 @@
+/data/users/daohang/fbtriton/third_party/tlx

--- a/python/triton/tlx
+++ b/python/triton/tlx
@@ -1,1 +1,0 @@
-/data/users/daohang/fbtriton/third_party/tlx

--- a/third_party/tlx/language/async_task.py
+++ b/third_party/tlx/language/async_task.py
@@ -13,6 +13,7 @@ class async_task:
         self.is_explict = False
         self.task_ids = None
         self.num_warps = None
+        self.num_regs = None
         if args:
             assert len(args) == 1
             if isinstance(args[0], core.constexpr) and args[0] == "default":
@@ -23,6 +24,7 @@ class async_task:
         else:
             self.is_explict = True
             self.num_warps = core._unwrap_if_constexpr(kwargs.get("num_warps", None))
+            self.num_regs = core._unwrap_if_constexpr(kwargs.get("registers", None))
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Instead of defining a new build function in td, I notice `setRequestedRegisters` is already available in generated code `build/cmake.linux-x86_64-cpython-3.11/include/triton/Dialect/TritonGPU/IR/Ops.h.inc` so I invoke it in TLX frontend.

Testplan:
`pytest python/test/unit/language/test_tlx.py::test_async_tasks`

TTGIR
```
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @add2_warp_specialized_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg2: !tt.ptr<f32> {tt.divisibility =
 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":1
8:0), %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg6: i32 {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0)) attributes {noinline = false} {
    %c1024_i32 = arith.constant 1024 : i32 loc(#loc1)
    %0 = tt.get_program_id x : i32 loc(#loc2)
    %1 = arith.muli %0, %c1024_i32 : i32 loc(#loc3)
    ttg.warp_specialize(%arg3, %arg4, %1, %arg5, %arg6) attributes {requestedRegisters = array<i32: 100>}
    default {
      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked> loc(#loc5)
      %3 = tt.splat %1 : i32 -> tensor<1024xi32, #blocked> loc(#loc6)
      %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked> loc(#loc6)
      %5 = tt.splat %arg6 : i32 -> tensor<1024xi32, #blocked> loc(#loc7)
      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked> loc(#loc7)
      %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc8)
      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc8)
      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc9)
      %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc10)
      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc10)
      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc11)
      %13 = arith.addf %9, %12 : tensor<1024xf32, #blocked> loc(#loc12)
      %14 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc13)
      %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc13)
      tt.store %15, %13, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc14)
      ttg.warp_yield loc(#loc15)
    }
    partition0(%arg7: !tt.ptr<f32> loc(unknown), %arg8: !tt.ptr<f32> loc(unknown), %arg9: i32 loc(unknown), %arg10: !tt.ptr<f32> loc(unknown), %arg11: i32 loc(unknown)) num_warps(4) {
      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked> loc(#loc16)
      %3 = tt.splat %arg9 : i32 -> tensor<1024xi32, #blocked> loc(#loc17)
      %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked> loc(#loc17)
      %5 = tt.splat %arg11 : i32 -> tensor<1024xi32, #blocked> loc(#loc18)
      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked> loc(#loc18)
      %7 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc19)
      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc19)
      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc20)
      %10 = tt.splat %arg8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc21)
      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc21)
      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc22)
      %13 = arith.addf %9, %12 : tensor<1024xf32, #blocked> loc(#loc23)
      %14 = tt.splat %arg10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc24)
      %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc24)
      tt.store %15, %13, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc25)
      ttg.warp_return loc(#loc26)
    } : (!tt.ptr<f32>, !tt.ptr<f32>, i32, !tt.ptr<f32>, i32) -> () loc(#loc4)
    tt.return loc(#loc27)
  } loc(#loc)
} loc(#loc)
```