### PR TITLE
[TLX] async_dot_wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ While this approach places more responsibility on the user, it reduces the compi
 - `acc = tlx.async_dot(a_reg, b[i], acc)`
 - `acc[i] = tlx.async_dot(a[i], b[i], acc[i], barrier)`
 
+- `acc = tlx.async_dot_wait(tl.constexpr(0), acc)`
+
+    Wait for completion of prior asynchronous dot operations.
+
+Examples
+```
+    acc = tlx.async_dot(a_smem, b_smem)
+    acc = tlx.async_dot_wait(tl.constexpr(0), acc)
+    tl.store(C_ptrs, acc)
+```
 
 ### Barrier operations
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ While this approach places more responsibility on the user, it reduces the compi
 - `acc = tlx.async_dot(a_reg, b[i], acc)`
 - `acc[i] = tlx.async_dot(a[i], b[i], acc[i], barrier)`
 
-- `acc = tlx.async_dot_wait(tl.constexpr(0), acc)`
+- `acc = tlx.async_dot_wait(pendings, acc)`
 
-    Wait for completion of prior asynchronous dot operations.
+    Wait for completion of prior asynchronous dot operations. The pendings argument indicates the number of in-flight operations not completed.
 
 Examples
 ```

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -10,6 +10,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 using namespace mlir;
 using namespace mlir::triton::gpu;
@@ -116,10 +117,10 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
     return false;
   });
 
-  addDynamicallyLegalOp<triton::gpu::AsyncCopyGlobalToLocalOp,
-                        triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp,
-                        triton::tlx::RequireLayoutOp,
-                        triton::tlx::ReleaseLayoutOp>(
+  addDynamicallyLegalOp<
+      triton::gpu::AsyncCopyGlobalToLocalOp, triton::gpu::LocalLoadOp,
+      triton::gpu::LocalStoreOp, triton::nvidia_gpu::WarpGroupDotWaitOp,
+      triton::tlx::RequireLayoutOp, triton::tlx::ReleaseLayoutOp>(
       [&](Operation *op) -> bool {
         // make sure every RankedTensorType operand has encoding
         for (auto operandType : op->getOperandTypes()) {

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -11,6 +11,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 namespace mlir::triton {
 #define GEN_PASS_DEF_CONVERTTRITONTOTRITONGPU
@@ -624,6 +625,7 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
       GenericOpPattern<triton::gpu::AsyncCopyGlobalToLocalOp>,
       GenericOpPattern<triton::gpu::LocalStoreOp>,
       GenericOpPattern<triton::gpu::LocalLoadOp>,
+      GenericOpPattern<triton::nvidia_gpu::WarpGroupDotWaitOp>,
       TritonFuncOpPattern>(typeConverter, context);
 }
 // Proton patterns

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -376,6 +376,7 @@ def test_async_dot(device):
 
         z = tlx.async_dot(a_smem, b_smem, input_precision=INPUT_PRECISION, out_dtype=out_dtype, col_input=COL_INPUT,
                           col_other=COL_OTHER)
+        z = tlx.async_dot_wait(tl.constexpr(0), z)
         tl.store(Zs, z)
 
     M, N, K = (64, 64, 64)

--- a/third_party/tlx/language/mma_ops.py
+++ b/third_party/tlx/language/mma_ops.py
@@ -77,3 +77,18 @@ def async_dot(
     # Release the mma layout for the output to conform to what the user expects
     output = _builder.create_release_layout(output)
     return tl.tensor(output, ret_ty)
+
+
+@tl.builtin
+def async_dot_wait(
+    pendings: tl.constexpr,
+    inp: tl.tensor,
+    _builder=None,
+) -> tl.tensor:
+    """
+    Wait for completion of prior asynchronous dot operations.
+    Each input must be the tensors corresponding to the async dot ops that we're
+    waiting on.
+    """
+    pendings = tl._unwrap_if_constexpr(pendings)
+    return tl.tensor(_builder.create_warp_group_dot_wait([inp.handle], pendings)[0], inp.type)


### PR DESCRIPTION
`acc = tlx.async_dot_wait(tl.constexpr(0), acc)`

    Wait for completion of prior asynchronous dot operations.

Examples:
```
    acc = tlx.async_dot(a_smem, b_smem)
    acc = tlx.async_dot_wait(tl.constexpr(0), acc)
    tl.store(C_ptrs, acc)
```


Generated TTIR:


```
   %28 = tlx.require_layout %4 : !ttg.memdesc<64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared1, #smem, mutable> loc(#loc13)
    %29 = tlx.require_layout %5 : !ttg.memdesc<64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared2, #smem, mutable> loc(#loc13)
    %30 = tlx.require_layout %cst_11 : tensor<64x64xf32> -> tensor<64x64xf32, #mma> loc(#loc13)
    ttng.fence_async_shared {bCluster = false} loc(#loc13)
    %31 = ttng.warp_group_dot %28, %29, %30 {inputPrecision = 0 : i32, isAsync = true} : !ttg.memdesc<64x64xf32, #shared1, #smem, mutable> * !ttg.memdesc<64x64xf32, #shared2, #smem, mutable> -> tensor<64x64xf32, #mma> loc(#loc13)
    %32 = ttng.warp_group_dot_wait %31 {pendings = 0 : i32} : tensor<64x64xf32, #mma> loc(#loc14)
    %33 = tlx.release_layout %32 : tensor<64x64xf32, #mma> -> tensor<64x64xf32> loc(#loc13)
    tt.store %27, %33 : tensor<64x64x!tt.ptr<f32>> loc(#loc15)
```