### PR TITLE
[TLX] Add replicates to tlx.async_task 

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -35,7 +35,7 @@ def test_async_tasks(BLOCK_SIZE, device):
                 y = tl.load(y_ptr + offsets, mask=mask)
                 output = x + y
                 tl.store(z_ptr + offsets, output, mask=mask)
-            with tlx.async_task(num_warps=4, registers=100):
+            with tlx.async_task(num_warps=4, registers=100, replicate=2):
                 offsets = block_start + tl.arange(0, BLOCK_SIZE)
                 mask = offsets < n_elements
                 a = tl.load(a_ptr + offsets, mask=mask)

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -59,8 +59,11 @@ def test_async_tasks(BLOCK_SIZE, device):
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
     kernel = add2_warp_specialized_kernel[grid](x, y, output1, a, b, output2, n_elements, BLOCK_SIZE)
     ttgir = kernel.asm["ttgir"]
+    # TODO. more comprehensive regex check for finer granularity
     assert "ttg.warp_specialize" in ttgir
     assert "requestedRegisters" in ttgir
+    assert "partition0" in ttgir
+    assert "partition1" in ttgir
 
     ref_out1, ref_out2 = dual_add(x, y, a, b)
     torch.testing.assert_close(output1, ref_out1, check_dtype=False)

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -79,7 +79,6 @@ def visit_withAsyncTasks(self, node):
             ws_op.append_operand(val.handle)
 
         index = 1
-        self.is_isolated_region = True
 
         for stmt in stmts:
             assert _is_async_task(self, stmt)

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -56,7 +56,7 @@ def visit_withAsyncTasks(self, node):
                 num_default += 1
             else:
                 assert task.replicate is not None, "Replicate must be non-None for non-default task"
-                taskReplica.append(task.replicate) 
+                taskReplica.append(task.replicate)
 
                 # Get used vars to be captured
                 taskNumWarps.extend([task.num_warps] * task.replicate)

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -45,6 +45,8 @@ def visit_withAsyncTasks(self, node):
         # Count the number of sub tasks and caculate captures
         taskNumWarps = []
         taskNumRegs = []
+        taskReplica = []
+
         num_default = 0
         for stmt in stmts:
             assert _is_async_task(self, stmt)
@@ -53,10 +55,13 @@ def visit_withAsyncTasks(self, node):
             if task.is_default:
                 num_default += 1
             else:
+                assert task.replicate is not None, "Replicate must be non-None for non-default task"
+                taskReplica.append(task.replicate) 
+
                 # Get used vars to be captured
-                taskNumWarps.append(task.num_warps)
+                taskNumWarps.extend([task.num_warps] * task.replicate)
                 if task.num_regs:
-                    taskNumRegs.append(task.num_regs)
+                    taskNumRegs.extend([task.num_regs] * task.replicate)
                 with enter_sub_region(self):
                     self.visit(stmt)
 
@@ -65,7 +70,7 @@ def visit_withAsyncTasks(self, node):
 
         # Create tasks body block
         self._set_insertion_point_and_loc(ip, last_loc)
-        ws_op = self.builder.create_warp_specialize_op(taskNumWarps, taskNumRegs, len(stmts) - 1)
+        ws_op = self.builder.create_warp_specialize_op(taskNumWarps, taskNumRegs, sum(taskReplica))
 
         # Add captures
         captures = sorted(v for v in (liveins.keys() & self.used_vars) if not _is_constexpr(liveins[v]))
@@ -89,11 +94,10 @@ def visit_withAsyncTasks(self, node):
 
                 self.builder.create_warp_yield_op()
             else:
-                task_body = ws_op.get_partition_region(index - 1)
-                index += 1
+                for i in range(task.replicate):
+                    task_body = ws_op.get_partition_region(index - 1)
+                    index += 1
 
-                replicate = task.replicate
-                for i in range(replicate):
                     block = self.builder.create_block_with_parent(task_body, [])
                     self.builder.set_insertion_point_to_start(block)
                     self.visit(stmt)

--- a/third_party/tlx/language/async_task.py
+++ b/third_party/tlx/language/async_task.py
@@ -26,7 +26,7 @@ class async_task:
             self.is_explict = True
             self.num_warps = core._unwrap_if_constexpr(kwargs.get("num_warps", None))
             self.num_regs = core._unwrap_if_constexpr(kwargs.get("registers", None))
-            self.replicate= core._unwrap_if_constexpr(kwargs.get("replicate", 1))
+            self.replicate = core._unwrap_if_constexpr(kwargs.get("replicate", 1))
 
     def __enter__(self):
         return self

--- a/third_party/tlx/language/async_task.py
+++ b/third_party/tlx/language/async_task.py
@@ -14,6 +14,7 @@ class async_task:
         self.task_ids = None
         self.num_warps = None
         self.num_regs = None
+        self.replicate = None
         if args:
             assert len(args) == 1
             if isinstance(args[0], core.constexpr) and args[0] == "default":
@@ -25,6 +26,7 @@ class async_task:
             self.is_explict = True
             self.num_warps = core._unwrap_if_constexpr(kwargs.get("num_warps", None))
             self.num_regs = core._unwrap_if_constexpr(kwargs.get("registers", None))
+            self.replicate= core._unwrap_if_constexpr(kwargs.get("replicate", 1))
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This PR allows users set replicates for each async task. 

NOTE. Pre-commit run includes 3 unrelated formatting changes in test_tlx.

~~TODO. I will expose replicate_id to the captures of each partition.~~ => In another PR

Test plan.
`with tlx.async_task(num_warps=4, registers=100, replicate=2):` can produce TTIR as below (expected).
```
module {
  tt.func public @add2_warp_specialized_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0), %arg6: i32 {tt.divisibility = 16 : i32} loc("/data/users/daohang/fbtriton/python/test/unit/language/test_tlx.py":18:0)) attributes {noinline = false} {
    %c1024_i32 = arith.constant 1024 : i32 loc(#loc1)
    %0 = tt.get_program_id x : i32 loc(#loc2)
    %1 = arith.muli %0, %c1024_i32 : i32 loc(#loc3)
    ttg.warp_specialize(%arg3, %arg4, %1, %arg5, %arg6) attributes {requestedRegisters = array<i32: 100, 100>}
    default {
      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32> loc(#loc5)
      %3 = tt.splat %1 : i32 -> tensor<1024xi32> loc(#loc6)
      %4 = arith.addi %3, %2 : tensor<1024xi32> loc(#loc6)
      %5 = tt.splat %arg6 : i32 -> tensor<1024xi32> loc(#loc7)
      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32> loc(#loc7)
      %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc8)
      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc8)
      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc9)
      %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc10)
      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc10)
      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc11)
      %13 = arith.addf %9, %12 : tensor<1024xf32> loc(#loc12)
      %14 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc13)
      %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc13)
      tt.store %15, %13, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc14)
      ttg.warp_yield loc(#loc15)
    }
    partition0(%arg7: !tt.ptr<f32> loc(unknown), %arg8: !tt.ptr<f32> loc(unknown), %arg9: i32 loc(unknown), %arg10: !tt.ptr<f32> loc(unknown), %arg11: i32 loc(unknown)) num_warps(4) {
      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32> loc(#loc16)
      %3 = tt.splat %arg9 : i32 -> tensor<1024xi32> loc(#loc17)
      %4 = arith.addi %3, %2 : tensor<1024xi32> loc(#loc17)
      %5 = tt.splat %arg11 : i32 -> tensor<1024xi32> loc(#loc18)
      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32> loc(#loc18)
      %7 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc19)
      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc19)
      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc20)
      %10 = tt.splat %arg8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc21)
      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc21)
      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc22)
      %13 = arith.addf %9, %12 : tensor<1024xf32> loc(#loc23)
      %14 = tt.splat %arg10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc24)
      %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc24)
      tt.store %15, %13, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc25)
      ttg.warp_return loc(#loc26)
    }
    partition1(%arg7: !tt.ptr<f32> loc(unknown), %arg8: !tt.ptr<f32> loc(unknown), %arg9: i32 loc(unknown), %arg10: !tt.ptr<f32> loc(unknown), %arg11: i32 loc(unknown)) num_warps(4) {
      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32> loc(#loc16)
      %3 = tt.splat %arg9 : i32 -> tensor<1024xi32> loc(#loc17)
      %4 = arith.addi %3, %2 : tensor<1024xi32> loc(#loc17)
      %5 = tt.splat %arg11 : i32 -> tensor<1024xi32> loc(#loc18)
      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32> loc(#loc18)
      %7 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc19)
      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc19)
      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc20)
      %10 = tt.splat %arg8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc21)
      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc21)
      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc22)
      %13 = arith.addf %9, %12 : tensor<1024xf32> loc(#loc23)
      %14 = tt.splat %arg10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>> loc(#loc24)
      %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32> loc(#loc24)
      tt.store %15, %13, %6 : tensor<1024x!tt.ptr<f32>> loc(#loc25)
      ttg.warp_return loc(#loc26)
    } : (!tt.ptr<f32>, !tt.ptr<f32>, i32, !tt.ptr<f32>, i32) -> () loc(#loc4)
    tt.return loc(#loc27)
  } loc(#loc)
```