### PR TITLE
[TLX] Bug fix of async_task taking default requested registers

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1733,14 +1733,15 @@ void init_triton_ir(py::module &&m) {
       // Warp specialize ops
       .def("create_warp_specialize_op",
            [](TritonOpBuilder &self, std::vector<int> partitionNumWarps,
-              std::vector<int> requestedRegisters, int numPartitionRegions) -> ttg::WarpSpecializeOp {
+              std::optional<std::vector<int>> requestedRegisters,
+              int numPartitionRegions) -> ttg::WarpSpecializeOp {
              ArrayRef<Type> dummyTypes;
-              auto wsOp = self.create<ttg::WarpSpecializeOp>(
-                  dummyTypes, partitionNumWarps, numPartitionRegions);
+             auto wsOp = self.create<ttg::WarpSpecializeOp>(
+                 dummyTypes, partitionNumWarps, numPartitionRegions);
 
-                wsOp.setRequestedRegisters(requestedRegisters);
+             wsOp.setRequestedRegisters(requestedRegisters);
 
-                return wsOp;
+             return wsOp;
            })
       .def("create_warp_yield_op",
            [](TritonOpBuilder &self) -> ttg::WarpYieldOp {

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -70,7 +70,8 @@ def visit_withAsyncTasks(self, node):
 
         # Create tasks body block
         self._set_insertion_point_and_loc(ip, last_loc)
-        ws_op = self.builder.create_warp_specialize_op(taskNumWarps, taskNumRegs, sum(taskReplica))
+        ws_op = self.builder.create_warp_specialize_op(taskNumWarps, taskNumRegs if len(taskNumRegs) > 0 else None,
+                                                       sum(taskReplica))
 
         # Add captures
         captures = sorted(v for v in (liveins.keys() & self.used_vars) if not _is_constexpr(liveins[v]))

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -68,6 +68,9 @@ def visit_withAsyncTasks(self, node):
         assert num_default == 1, "Default task must be one and only one"
         block.erase()
 
+        assert len(taskNumRegs) in [0,
+                                    len(taskNumWarps)], "Registers are set for either ALL or NONE of non-default tasks"
+
         # Create tasks body block
         self._set_insertion_point_and_loc(ip, last_loc)
         ws_op = self.builder.create_warp_specialize_op(taskNumWarps, taskNumRegs if len(taskNumRegs) > 0 else None,


### PR DESCRIPTION
With `registers` left default in `tlx.async_task`, we were passing an empty list to following code while we actually need it to go to the else-branch. This PR fixes it by passing None instead of empty list. Verifying by `pytest python/test/unit/language/test_tlx.py`
```
void WarpSpecializeOp::setRequestedRegisters(::std::optional<::llvm::ArrayRef<int32_t>> attrValue) {
    auto &odsProp = getProperties().requestedRegisters;
    if (attrValue)
      odsProp = ::mlir::Builder((*this)->getContext()).getDenseI32ArrayAttr(*attrValue);
    else
      odsProp = nullptr;
}
```