### PR TITLE
[TLX] async_task_replica_id

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -41,7 +41,12 @@ def test_async_tasks(BLOCK_SIZE, device):
                 mask = offsets < n_elements
                 a = tl.load(a_ptr + offsets, mask=mask)
                 b = tl.load(b_ptr + offsets, mask=mask)
-                output = a + b
+                replica_id = tlx.async_task_replica_id()
+                # This no-op is just to test that replica_id
+                # is correctly passed to the kernel
+                a1 = a + replica_id
+                b1 = b - replica_id
+                output = a1 + b1
                 tl.store(c_ptr + offsets, output, mask=mask)
 
     def dual_add(x, y, a, b):
@@ -67,6 +72,25 @@ def test_async_tasks(BLOCK_SIZE, device):
     assert re.search(pattern_p0, ttgir, flags=re.DOTALL)
     pattern_p1 = (r'partition1(.*) num_warps\(4\)')
     assert re.search(pattern_p1, ttgir, flags=re.DOTALL)
+
+    # Check that the replica_id is correctly passed to the kernel
+    # TTIR/TTGIR should be something like:
+    #  partition0(...) {
+    #   %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32, #blocked>
+    #   ...
+    #   %13 = arith.addf %9, %cst
+    #   ...}
+    #  partition1(...) {
+    #   %cst = arith.constant dense<1.000000e+00> : tensor<1024xf32, #blocked>
+    #   ...
+    #   %13 = arith.addf %9, %cst
+    #   %14 = arith.subf %12, %cst
+    #   ...}
+    pattern_cst = (r'cst = arith.constant dense\<.*\>')
+    found = re.findall(pattern_cst, ttgir)
+    assert len(found) == 2, "Expected 2 cst by calling `tlx.async_task_replica_id()` in two regions"
+    assert found[0] != found[1], "Two matches MUST be different"
+    assert "dense<0.0" in found[0] and "dense<1.0" in found[1], "Expected 0.0 and 1.0 as replica_id"
 
     ref_out1, ref_out2 = dual_add(x, y, a, b)
     torch.testing.assert_close(output1, ref_out1, check_dtype=False)

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -73,7 +73,7 @@ def test_async_tasks(BLOCK_SIZE, device):
     pattern_p1 = (r'partition1(.*) num_warps\(4\)')
     assert re.search(pattern_p1, ttgir, flags=re.DOTALL)
 
-    # Check that the replica_id is correctly passed to the kernel
+    # Check that the replica_id is correctly passed to non-default regions
     # TTIR/TTGIR should be something like:
     #  partition0(...) {
     #   %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32, #blocked>

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -2,7 +2,6 @@
 
 import ast
 from typing import List
-# import os
 import triton.tlx.language as tlx  # Make sure async_task(s) are exposed via tlx.__init__.py
 
 

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -86,7 +86,7 @@ def visit_withAsyncTasks(self, node):
                     with enter_sub_region(self):
                         self.visit(stmt)
 
-            region_replica_id_stack.pop()  # reset
+            region_replica_id_stack.pop()  # revert adding dummy placeholder
 
         assert num_default == 1, "Default task must be one and only one"
         block.erase()

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -1,6 +1,7 @@
 # third_party/tlx/codegen/async.py
 
 import ast
+import os
 import triton.tlx.language as tlx  # Make sure async_task(s) are exposed via tlx.__init__.py
 
 
@@ -98,6 +99,7 @@ def visit_withAsyncTasks(self, node):
                 self.builder.create_warp_yield_op()
             else:
                 for i in range(task.replicate):
+                    os.environ["TLX_ASYNC_TASK_REPLICA_ID"] = str(i)
                     task_body = ws_op.get_partition_region(index - 1)
                     index += 1
 

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -3,6 +3,22 @@
 import ast
 from typing import List
 import triton.tlx.language as tlx  # Make sure async_task(s) are exposed via tlx.__init__.py
+from contextlib import contextmanager
+
+# TLX allows users to specify the replicate number when definine
+# a non-default partition region. We use a stack to keep track of
+# replica_id of the region being compiled.
+region_replica_id_stack: List[int] = []
+
+
+@contextmanager
+def tlx_enter_sub_region():
+    global region_replica_id_stack
+    replica_id_stack_backup = region_replica_id_stack.copy()
+    try:
+        yield
+    finally:
+        assert region_replica_id_stack == replica_id_stack_backup
 
 
 def _is_async_task(self, node) -> bool:
@@ -30,12 +46,7 @@ def visit_withAsyncTask(self, node):
     self.visit_compound_statement(node.body)
 
 
-# TLX allows users to specify the replicate number when definine
-# a non-default partition region. We use a stack to keep track of
-# replica_id of the region being compiled.
-region_replica_id_stack: List[int] = []
-
-
+@tlx_enter_sub_region()
 def visit_withAsyncTasks(self, node):
     from triton.compiler.code_generator import (enter_sub_region, _is_list_like, _is_constexpr)
     with enter_sub_region(self) as sr:
@@ -46,34 +57,36 @@ def visit_withAsyncTasks(self, node):
         if not _is_list_like(stmts):
             stmts = [stmts]
 
-        # dry visit task body
-        block = self.builder.create_block()
-        self.builder.set_insertion_point_to_start(block)
-        # Count the number of sub tasks and caculate captures
-        taskNumWarps = []
-        taskNumRegs = []
-        taskReplica = []
-        global region_replica_id_stack
-        region_replica_id_stack.append(-1)  # dummy replica ID in dry visit
+        with tlx_enter_sub_region():  # dry visit async task body
+            block = self.builder.create_block()
+            self.builder.set_insertion_point_to_start(block)
+            # Count the number of sub tasks and caculate captures
+            taskNumWarps = []
+            taskNumRegs = []
+            taskReplica = []
 
-        num_default = 0
-        for stmt in stmts:
-            assert _is_async_task(self, stmt)
-            task = _get_async_task(self, stmt)
-            assert task.is_explict
-            if task.is_default:
-                num_default += 1
-            else:
-                assert task.replicate is not None, "Replicate must be non-None for non-default task"
-                taskReplica.append(task.replicate)
+            global region_replica_id_stack
+            region_replica_id_stack.append(-1)  # dummy placeholder
 
-                # Get used vars to be captured
-                taskNumWarps.extend([task.num_warps] * task.replicate)
-                if task.num_regs:
-                    taskNumRegs.extend([task.num_regs] * task.replicate)
-                self.visit(stmt)
+            num_default = 0
+            for stmt in stmts:
+                assert _is_async_task(self, stmt)
+                task = _get_async_task(self, stmt)
+                assert task.is_explict
+                if task.is_default:
+                    num_default += 1
+                else:
+                    assert task.replicate is not None, "Replicate must be non-None for non-default task"
+                    taskReplica.append(task.replicate)
 
-        region_replica_id_stack = []  # reset
+                    # Get used vars to be captured
+                    taskNumWarps.extend([task.num_warps] * task.replicate)
+                    if task.num_regs:
+                        taskNumRegs.extend([task.num_regs] * task.replicate)
+                    with enter_sub_region(self):
+                        self.visit(stmt)
+
+            region_replica_id_stack.pop()  # reset
 
         assert num_default == 1, "Default task must be one and only one"
         block.erase()

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -165,10 +165,6 @@ void init_triton_tlx_ir(py::module &&m) {
              self.create<ttng::AsyncTMACopyLocalToGlobalOp>(tmaPtr, coord,
                                                             source);
            });
-  // .def("async_task_replica_id", [](TritonOpBuilder &self) -> mlir::Value {
-  //   auto context = self.getBuilder().getContext();
-  //   return 0;
-  // });
 }
 
 void init_triton_tlx_passes(py::module &&m) {

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -165,6 +165,10 @@ void init_triton_tlx_ir(py::module &&m) {
              self.create<ttng::AsyncTMACopyLocalToGlobalOp>(tmaPtr, coord,
                                                             source);
            });
+  // .def("async_task_replica_id", [](TritonOpBuilder &self) -> mlir::Value {
+  //   auto context = self.getBuilder().getContext();
+  //   return 0;
+  // });
 }
 
 void init_triton_tlx_passes(py::module &&m) {

--- a/third_party/tlx/language/utility.py
+++ b/third_party/tlx/language/utility.py
@@ -2,6 +2,7 @@ import triton.language.core as tl
 
 from . import types as tlx
 import re
+import os
 
 
 def cuda_parse_arch(arch):
@@ -24,3 +25,7 @@ def thread_id(axis, _builder=None):
     if axis not in (0, 1, 2):
         raise ValueError(f"thread_id axis must be 0, 1, or 2 but got {axis}")
     return tl.tensor(_builder.create_thread_id(axis), tl.int32)
+
+@tl.builtin
+def async_task_replica_id(_builder=None):
+    return tl.constexpr(int(os.environ.get("TLX_ASYNC_TASK_REPLICA_ID", 0)))

--- a/third_party/tlx/language/utility.py
+++ b/third_party/tlx/language/utility.py
@@ -26,6 +26,7 @@ def thread_id(axis, _builder=None):
         raise ValueError(f"thread_id axis must be 0, 1, or 2 but got {axis}")
     return tl.tensor(_builder.create_thread_id(axis), tl.int32)
 
+
 @tl.builtin
 def async_task_replica_id(_builder=None):
     return tl.constexpr(int(os.environ.get("TLX_ASYNC_TASK_REPLICA_ID", 0)))

--- a/third_party/tlx/language/utility.py
+++ b/third_party/tlx/language/utility.py
@@ -29,4 +29,7 @@ def thread_id(axis, _builder=None):
 
 @tl.builtin
 def async_task_replica_id(_builder=None):
-    return tl.constexpr(int(os.environ.get("TLX_ASYNC_TASK_REPLICA_ID", 0)))
+    from triton.tlx.compiler.code_generator import region_replica_id_stack
+    assert len(region_replica_id_stack
+               ) > 0, "async_task_replica_id must be called inside an async region where the stack must be non-empty"
+    return tl.constexpr(region_replica_id_stack[-1])

--- a/third_party/tlx/language/utility.py
+++ b/third_party/tlx/language/utility.py
@@ -2,7 +2,6 @@ import triton.language.core as tl
 
 from . import types as tlx
 import re
-import os
 
 
 def cuda_parse_arch(arch):


### PR DESCRIPTION
Expose replica_id to frontend. Potential use case will be handling staged WS in GEMM (see example in README.md).

This PR implements it via env vars and verifies with a comprehensive unit test (see details in UT in-code comments) while alternative approaches of appending context variables are also discussed.

Since current version doesn't have issues shown by unit tests, we can revisit the alternative approach when there's a need in the future.

```
    partition0(%arg7: !tt.ptr<f32> loc(unknown), %arg8: !tt.ptr<f32> loc(unknown), %arg9: i32 loc(unknown), %arg10: !tt.ptr<f32> loc(unknown), %arg11: i32 loc(unknown)) num_warps(4) {
      %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32, #blocked> loc(#loc1)
      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked> loc(#loc16)
      %3 = tt.splat %arg9 : i32 -> tensor<1024xi32, #blocked> loc(#loc17)
      %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked> loc(#loc17)
      %5 = tt.splat %arg11 : i32 -> tensor<1024xi32, #blocked> loc(#loc18)
      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked> loc(#loc18)
      %7 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc19)
      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc19)
      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc20)
      %10 = tt.splat %arg8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc21)
      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc21)
      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc22)
      %13 = arith.addf %9, %cst : tensor<1024xf32, #blocked> loc(#loc23)
      %14 = arith.addf %13, %12 : tensor<1024xf32, #blocked> loc(#loc24)
      %15 = tt.splat %arg10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc25)
      %16 = tt.addptr %15, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc25)
      tt.store %16, %14, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc26)
      ttg.warp_return loc(#loc27)
    }
    partition1(%arg7: !tt.ptr<f32> loc(unknown), %arg8: !tt.ptr<f32> loc(unknown), %arg9: i32 loc(unknown), %arg10: !tt.ptr<f32> loc(unknown), %arg11: i32 loc(unknown)) num_warps(4) {
      %cst = arith.constant dense<1.000000e+00> : tensor<1024xf32, #blocked> loc(#loc1)
      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked> loc(#loc16)
      %3 = tt.splat %arg9 : i32 -> tensor<1024xi32, #blocked> loc(#loc17)
      %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked> loc(#loc17)
      %5 = tt.splat %arg11 : i32 -> tensor<1024xi32, #blocked> loc(#loc18)
      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked> loc(#loc18)
      %7 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc19)
      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc19)
      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc20)
      %10 = tt.splat %arg8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc21)
      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc21)
      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc22)
      %13 = arith.addf %9, %cst : tensor<1024xf32, #blocked> loc(#loc23)
      %14 = arith.subf %12, %cst : tensor<1024xf32, #blocked> loc(#loc28)
      %15 = arith.addf %13, %14 : tensor<1024xf32, #blocked> loc(#loc24)
      %16 = tt.splat %arg10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc25)
      %17 = tt.addptr %16, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked> loc(#loc25)
      tt.store %17, %15, %6 : tensor<1024x!tt.ptr<f32>, #blocked> loc(#loc26)
      ttg.warp_return loc(#loc27)
    } : (!tt.ptr<f32>, !tt.ptr<f32>, i32, !tt.ptr<f32>, i32) -> () loc(#loc4)
```