### PR TITLE
[TLX] Add a pass to attach metadata to ttir module

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -22,6 +22,7 @@
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
 #include "nvidia/include/NVGPUToLLVM/Passes.h"
 #include "nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h"
+#include "tlx/dialect/include/Transforms/Passes.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 #include "triton/Target/LLVMIR/Passes.h"
@@ -90,6 +91,9 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
 
   // NVGPU transform passes
   mlir::registerNVHopperTransformsPasses();
+
+  // TLX passes
+  mlir::triton::tlx::registerPasses();
 
   registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
                   mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect,

--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -1,0 +1,23 @@
+
+// RUN: triton-opt -pass-pipeline='builtin.module(triton-tlx-attach-metadata{num-warps=8 target=cuda:90 num-ctas=2 threads-per-warp=32})' %s| FileCheck %s
+
+// CHECK: module attributes {
+// CHECK-SAME: "ttg.num-ctas" = 2
+// CHECK-SAME: "ttg.num-warps" = 8
+// CHECK-SAME: ttg.target = "cuda:90"
+// CHECK-SAME: "ttg.threads-per-warp" = 32
+module {
+    tt.func @add_kernel(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tt.splat %c1_i32 : i32 -> tensor<256xi32>
+    %1 = tt.splat %cst : f32 -> tensor<256xf32>
+    %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
+        %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
+        %4 = arith.addf %arg4, %3 : tensor<256xf32>
+        %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+        scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
+    } {tt.loop_unroll_factor = 2 : i32}
+    tt.return
+    }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1,5 +1,5 @@
 from triton.backends.compiler import BaseBackend, GPUTarget
-from triton._C.libtriton import ir, passes, llvm, nvidia
+from triton._C.libtriton import ir, passes, llvm, nvidia, tlx
 from triton import knobs
 from triton.runtime.errors import PTXASError
 
@@ -208,6 +208,7 @@ class CUDABackend(BaseBackend):
     def make_ttir(mod, metadata, opt, capability):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
+        tlx.tlx_passes.add_triton_tlx_attach_metadata(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
         passes.common.add_inliner(pm)
         passes.ttir.add_rewrite_tensor_pointer(pm)
         if capability // 10 < 9:

--- a/third_party/tlx/dialect/include/CMakeLists.txt
+++ b/third_party/tlx/dialect/include/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/third_party/tlx/dialect/include/Transforms/CMakeLists.txt
+++ b/third_party/tlx/dialect/include/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(TritonTLXTransformsIncGen)

--- a/third_party/tlx/dialect/include/Transforms/Passes.h
+++ b/third_party/tlx/dialect/include/Transforms/Passes.h
@@ -1,0 +1,15 @@
+#ifndef TRITON_TLX_PASSES_H
+#define TRITON_TLX_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::triton::tlx {
+
+#define GEN_PASS_DECL
+#include "tlx/dialect/include/Transforms/Passes.h.inc"
+#define GEN_PASS_REGISTRATION
+#include "tlx/dialect/include/Transforms/Passes.h.inc"
+
+} // namespace mlir::triton::tlx
+
+#endif

--- a/third_party/tlx/dialect/include/Transforms/Passes.td
+++ b/third_party/tlx/dialect/include/Transforms/Passes.td
@@ -1,0 +1,31 @@
+#ifndef TRITON_TLX_PASSES
+#define TRITON_TLX_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def TritonTLXAttachMetadata : Pass</*cli-arg*/"triton-tlx-attach-metadata", /*Op*/"mlir::ModuleOp"> {
+  let summary = "Attach metadata to the module";
+  let description = [{
+    The pass attaches metadata to the TritonDialect module to help make TritonGPU or TritonNvidiaGPU integrate
+    better into frontend DSL and TritonDialect.
+  }];
+
+  let dependentDialects = ["mlir::triton::TritonDialect"];
+
+  let options = [
+      Option<"target", "target",
+            "std::string", /*default*/"\"\"",
+            "the GPU target, e.g., cuda:80, hip:gfx942">,
+      Option<"numWarps", "num-warps",
+             "int32_t", /*default*/"4",
+             "number of warps">,
+      Option<"threadsPerWarp", "threads-per-warp",
+             "int32_t", /*default*/"32",
+             "number of threads per warp">,
+      Option<"numCTAs", "num-ctas",
+             "int32_t", /*default*/"1",
+             "number of ctas in a cga">,
+   ];
+}
+
+#endif // TRITON_TLX_PASSES

--- a/third_party/tlx/dialect/lib/CMakeLists.txt
+++ b/third_party/tlx/dialect/lib/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/third_party/tlx/dialect/lib/Transforms/AttachMetadata.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/AttachMetadata.cpp
@@ -1,0 +1,37 @@
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "tlx/dialect/include/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir::triton::tlx {
+
+#define GEN_PASS_DEF_TRITONTLXATTACHMETADATA
+#include "tlx/dialect/include/Transforms/Passes.h.inc"
+
+#define DEBUG_TYPE "tlx-attach-metadata"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+class TritonTLXAttachMetadataPass
+    : public impl::TritonTLXAttachMetadataBase<TritonTLXAttachMetadataPass> {
+  using impl::TritonTLXAttachMetadataBase<
+      TritonTLXAttachMetadataPass>::TritonTLXAttachMetadataBase;
+
+public:
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+
+    Builder b(&getContext());
+    mod->setAttr(ttg::AttrNumWarpsName, b.getI32IntegerAttr(numWarps));
+    mod->setAttr(ttg::AttrNumThreadsPerWarp,
+                 b.getI32IntegerAttr(threadsPerWarp));
+    mod->setAttr(ttg::AttrNumCTAsName, b.getI32IntegerAttr(numCTAs));
+    mod->setAttr(ttg::AttrTargetName, b.getStringAttr(this->target.getValue()));
+  }
+};
+
+} // namespace mlir::triton::tlx

--- a/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_triton_library(TritonTLXTransforms
+  AttachMetadata.cpp
+
+  DEPENDS
+  TritonTLXTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  TritonGPUIR
+  TLXIR
+)

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -2,6 +2,7 @@
 #include "ir.h" // TritonOpBuilder
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
+#include "tlx/dialect/include/Transforms/Passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 namespace py = pybind11;
@@ -9,6 +10,7 @@ using namespace ir;
 using namespace mlir;
 namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
+namespace tlx = triton::tlx;
 
 void init_triton_tlx_ir(py::module &&m) {
   auto *builder_cls = ir::getBuilderClass();
@@ -168,7 +170,9 @@ void init_triton_tlx_ir(py::module &&m) {
 }
 
 void init_triton_tlx_passes(py::module &&m) {
-  // TODO: add TLX passes
+  ADD_PASS_OPTION_WRAPPER_4("add_triton_tlx_attach_metadata",
+                            tlx::createTritonTLXAttachMetadata, std::string,
+                            int32_t, int32_t, int32_t);
 }
 
 void init_triton_tlx(py::module &&m) {


### PR DESCRIPTION
This is to make sure some TTGIR/TLX ops can be verified properly in TTIR.

Testing:
- `make test-lit`
- `pytest -vs python/test/unit/language/test_tlx.py`
- Verify the produced TTIR with the input in `test/TLX/attach-metadata.mlir`:

```
bin/triton-opt -pass-pipeline='builtin.module(triton-tlx-attach-metadata{num-warps=8 target=cuda:90 num-ctas=2 threads-per-warp=32})' test/TLX/attach-metadata.mlir
module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
  tt.func @add_kernel(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
    %c1_i32 = arith.constant 1 : i32
    %cst = arith.constant 0.000000e+00 : f32
    %0 = tt.splat %c1_i32 : i32 -> tensor<256xi32>
    %1 = tt.splat %cst : f32 -> tensor<256xf32>
    %2:2 = scf.for %arg2 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg3 = %1, %arg4 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
      %3 = tt.load %arg4 : tensor<256x!tt.ptr<f32>>
      %4 = arith.addf %arg3, %3 : tensor<256xf32>
      %5 = tt.addptr %arg4, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
      scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
    } {tt.loop_unroll_factor = 2 : i32}
    tt.return
  }
}
```
