### PR TITLE
[TLX] enable test cases for tmem load/store

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -252,21 +252,20 @@ def test_tmem_load_store(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
         # b == a == tensor of 1.0
         tl.store(x_ptr_offsets, b + 2)
 
-    x = torch.rand((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=torch.float32, device=device)  # noqa: F841
-    grid = lambda meta: (1, )  # noqa: F841
-    # TODO: uncomment below once layout propagation is ready
-    # kerenl_info = tmem_load_store_kernel[grid](x, x.stride(0), x.stride(1), BLOCK_SIZE_M, BLOCK_SIZE_N)
+    x = torch.rand((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=torch.float32, device=device)
+    grid = lambda meta: (1, )
+    kerenl_info = tmem_load_store_kernel[grid](x, x.stride(0), x.stride(1), BLOCK_SIZE_M, BLOCK_SIZE_N)
 
-    # assert kerenl_info.asm["ttir"].count("ttng.tmem_store") == 1
-    # assert kerenl_info.asm["ttir"].count("ttng.tmem_load") == 1
+    assert kerenl_info.asm["ttir"].count("ttng.tmem_store") == 1
+    assert kerenl_info.asm["ttir"].count("ttng.tmem_load") == 1
 
-    # assert kerenl_info.asm["ttgir"].count("kernel") == 1
-    # assert kerenl_info.asm["ttgir"].count("ttng.tmem_alloc") == 1
-    # assert kerenl_info.asm["ttgir"].count("ttng.tmem_store") == 1
-    # assert kerenl_info.asm["ttgir"].count("ttng.tmem_load") == 1
+    assert kerenl_info.asm["ttgir"].count("kernel") == 1
+    assert kerenl_info.asm["ttgir"].count("ttng.tmem_alloc") == 1
+    assert kerenl_info.asm["ttgir"].count("ttng.tmem_store") == 1
+    assert kerenl_info.asm["ttgir"].count("ttng.tmem_load") == 1
 
-    # ref_out = torch.ones_like(x) + 2
-    # torch.testing.assert_close(x, ref_out)
+    ref_out = torch.ones_like(x) + 2
+    torch.testing.assert_close(x, ref_out)
 
 
 def test_thread_id(device):


### PR DESCRIPTION
We now have require/release layout op so it's all working: 

```
pytest -vs python/test/unit/language/test_tlx.py::test_tmem_load_store
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.11.13, pytest-8.3.4, pluggy-1.5.0 -- /data/users/pchen7e4/miniconda3/bin/python
cachedir: .pytest_cache
rootdir: /data/users/pchen7e4/triton
configfile: pyproject.toml
plugins: xdist-3.7.0, forked-1.6.0, typeguard-4.3.0
collected 3 items                                                                                                                                                                                             

python/test/unit/language/test_tlx.py::test_tmem_load_store[64-64] PASSED
python/test/unit/language/test_tlx.py::test_tmem_load_store[64-8] PASSED
python/test/unit/language/test_tlx.py::test_tmem_load_store[128-16] PASSED
```

.ttgir (for the (128, 16) test case)
```mlir
#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
#loc = loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":235:0)
#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, unpacked = true>
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @tmem_load_store_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":235:0), %arg1: i32 {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":235:0)) attributes {noinline = false} {
    %cst = arith.constant dense<2.000000e+00> : tensor<128x16xf32, #blocked> loc(#loc1)
    %true = arith.constant true loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %cst_0 = arith.constant dense<1.000000e+00> : tensor<128x16xf32, #blocked> loc(#loc1)
    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> loc(#loc2)
    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xi32, #blocked1> loc(#loc2)
    %2 = tt.splat %arg1 : i32 -> tensor<128x1xi32, #blocked1> loc(#loc3)
    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked1> loc(#loc3)
    %4 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> loc(#loc4)
    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x16xi32, #blocked1> loc(#loc4)
    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked1> -> tensor<128x16xi32, #blocked1> loc(#loc5)
    %7 = tt.broadcast %5 : tensor<1x16xi32, #blocked1> -> tensor<128x16xi32, #blocked1> loc(#loc5)
    %8 = arith.addi %6, %7 : tensor<128x16xi32, #blocked1> loc(#loc5)
    %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x16x!tt.ptr<f32>, #blocked1> loc(#loc6)
    %10 = tt.addptr %9, %8 : tensor<128x16x!tt.ptr<f32>, #blocked1>, tensor<128x16xi32, #blocked1> loc(#loc6)
    %result = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x16xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc7)
    %11 = ttg.memdesc_subview %result[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x128x16xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc8)
    ttng.tmem_store %cst_0, %11, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc9)
    %result_1 = ttng.tmem_load %11 : !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked> loc(#loc10)
    %12 = arith.addf %result_1, %cst : tensor<128x16xf32, #blocked> loc(#loc11)
    %13 = ttg.convert_layout %12 : tensor<128x16xf32, #blocked> -> tensor<128x16xf32, #blocked1> loc(#loc12)
    tt.store %10, %13 : tensor<128x16x!tt.ptr<f32>, #blocked1> loc(#loc12)
    tt.return loc(#loc13)
  } loc(#loc)
} loc(#loc)
```