### PR TITLE
[TLX] Refactor tlx.async_dot implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v0.9.1
     hooks:
       - id: ruff
-        files: '(^python|^third_party/proton|^third_party/amd|^third_party/nvidia|^test)/.*'
+        files: '(^python|^third_party/proton|^third_party/amd|^third_party/nvidia|^third_party/tlx|^test)/.*'
         args: ["--fix", "--exit-non-zero-on-fix"]
         exclude: |
           (?x)(

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -443,8 +443,7 @@ def test_async_dot(device):
 
         # TODO. initialize values or async load
 
-        z = tlx.async_dot(a_smem, b_smem, input_precision=INPUT_PRECISION, out_dtype=out_dtype, col_input=COL_INPUT,
-                          col_other=COL_OTHER)
+        z = tlx.async_dot(a_smem, b_smem, input_precision=INPUT_PRECISION, out_dtype=out_dtype)
         z = tlx.async_dot_wait(tl.constexpr(0), z)
         tl.store(Zs, z)
 
@@ -510,14 +509,14 @@ def test_async_dot_blackwell(device):
         tlx.local_store(acc_tmem, acc_init, tlx.storage_kind.tmem)
 
         # no barrier, tcgen5 mma synchronous semantic, compiler auto inserts barrier and wait
-        tlx.async_dot(a_smem, b_smem, acc_tmem, mmav5=True, mBarrier=None, input_precision=INPUT_PRECISION,
-                      out_dtype=out_dtype, col_input=COL_INPUT, col_other=COL_OTHER)
+        tlx.async_dot(a_smem, b_smem, acc_tmem, mBarrier=None, input_precision=INPUT_PRECISION,
+                      out_dtype=out_dtype)
 
         # given barrier, tcgen5 mma asynchronous semantic, need to explicitly wait for the barrier
         bars = tlx.alloc_barriers(tl.constexpr(1))
         bar = tlx.local_view(bars, 0)
-        tlx.async_dot(a_smem, b_smem, acc_tmem, mmav5=True, mBarrier=bar, input_precision=INPUT_PRECISION,
-                      out_dtype=out_dtype, col_input=COL_INPUT, col_other=COL_OTHER)
+        tlx.async_dot(a_smem, b_smem, acc_tmem, mBarrier=bar, input_precision=INPUT_PRECISION,
+                      out_dtype=out_dtype)
         tlx.barrier_wait(bar, tl.constexpr(0))
 
         # now result == a*b + a*b
@@ -758,8 +757,7 @@ def test_descriptor_load(device):
     grid = lambda meta: (triton.cdiv(M, BLOCK_SIZE_M), triton.cdiv(N, BLOCK_SIZE_N))
 
     # TODO: remove exception handling once layout propagation is implemented
-    with pytest.raises(RuntimeError) as _:
-        kernel = descriptor_load_kernel[grid](x, y, M, N, BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N)
-        assert kernel.asm["ttgir"].count("ttng.async_tma_copy_global_to_local") == 1
-        assert kernel.asm["ttgir"].count("ttng.async_tma_copy_local_to_global") == 1
-        torch.testing.assert_close(x, y)
+    kernel = descriptor_load_kernel[grid](x, y, M, N, BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N)
+    assert kernel.asm["ttgir"].count("ttng.async_tma_copy_global_to_local") == 1
+    assert kernel.asm["ttgir"].count("ttng.async_tma_copy_local_to_global") == 1
+    torch.testing.assert_close(x, y)

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -250,9 +250,7 @@ def async_descriptor_load(
     assert isinstance(desc, tl.tensor_descriptor_base)
     ndim = len(desc.block_shape)
     assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
-
-    # Requires a row-major layout for TMA only supports continuous memory access
-    result_handle = require_nv_mma_shared_layout(result, [1, 0], _builder)
+    result_handle = require_nv_mma_shared_layout(result, _builder)
     offsets = _convert_to_ir_values(_builder, offsets, require_i64=False)
     cache = _str_to_load_cache_modifier(cache_modifier)
     eviction = _str_to_eviction_policy(eviction_policy)
@@ -269,8 +267,6 @@ def async_descriptor_store(
     assert isinstance(desc, tl.tensor_descriptor_base)
     ndim = len(desc.block_shape)
     assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
-
-    # Requires a row-major layout for TMA only supports continuous memory access
-    source_handle = require_nv_mma_shared_layout(source, [1, 0], _builder)
+    source_handle = require_nv_mma_shared_layout(source, _builder)
     offsets = _convert_to_ir_values(_builder, offsets, require_i64=False)
     _builder.create_async_TMA_store(desc.handle, offsets, source_handle)

--- a/third_party/tlx/language/mma_ops.py
+++ b/third_party/tlx/language/mma_ops.py
@@ -6,37 +6,34 @@ from . import types as tlx
 from .utility import cuda_parse_arch
 
 
-def require_nv_mma_shared_layout(x: tlx.buffered_tensor, order, _builder=None):
-    if not isinstance(x.layout, tlx.nv_mma_shared_layout_encoding):
-        # TODO. why do we need this class object?
-        layout = tlx.nv_mma_shared_layout_encoding(shape=x.shape, order=order, elemType=x.dtype, numCTAsPerCGA=[1, 1],
+def require_nv_mma_shared_layout(x: tlx.buffered_tensor, _builder=None):
+    assert isinstance(x.layout, tlx.shared_layout_encoding), "input must be a shared tensor"
+    if isinstance(x.layout, tlx.swizzled_shared_layout_encoding):
+        layout = tlx.nv_mma_shared_layout_encoding(shape=x.shape, order=x.layout.order, elemType=x.dtype, numCTAsPerCGA=[1, 1],
                                                    numCTASplit=[1, 1], numCTAOrder=[1, 1], fp4Padded=False)
-
-    layout_handle = _builder.make_nv_mma_shared_encoding_attr(
-        [int(x) for x in layout.shape],
-        layout.order,
-        layout.elemType.to_ir(_builder),
-        layout.numCTAsPerCGA,
-        layout.numCTASplit,
-        layout.numCTAOrder,
-        layout.fp4Padded,
-    )
-    return _builder.create_require_layout(x.handle, layout_handle)
+        layout_handle = _builder.make_nv_mma_shared_encoding_attr(
+            [int(x) for x in layout.shape],
+            layout.order,
+            layout.elemType.to_ir(_builder),
+            layout.numCTAsPerCGA,
+            layout.numCTASplit,
+            layout.numCTAOrder,
+            layout.fp4Padded,
+        )
+        return _builder.create_require_layout(x.handle, layout_handle)
+    else:
+        assert isinstance(x.layout, tlx.nv_mma_shared_layout_encoding), "input must be a shared mma tensor"
+        return x.handle
 
 
 # async dot signature needs to be close to tl.dot as much as possible
 @tl.builtin
 def async_dot(
-    input: tlx.buffered_tensor,
-    other: tlx.buffered_tensor,
-    acc=None,  # tl.tensor,
-    mmav5: bool = False,
+    A: tlx.buffered_tensor | tl.tensor,
+    B: tlx.buffered_tensor,
+    acc: tlx.buffered_tensor | tl.tensor | None = None,
     mBarrier=None,
     input_precision=None,
-    allow_tf32=None,
-    max_num_imprecise_acc=None,
-    col_input=0,
-    col_other=0,
     out_dtype=tl.float32,
     _builder=None,
 ) -> tl.tensor:
@@ -63,28 +60,35 @@ def async_dot(
     """
 
     # Perform dot_precheck shared by tl.dot
-    (input, other, acc_handle, input_precision, max_num_imprecise_acc,
-     ret_ty) = semantic.dot_precheck(input, other, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype,
-                                     _builder)
+    (A, B, acc_handle, input_precision, max_num_imprecise_acc,
+     ret_ty) = semantic.dot_precheck(A, B, acc, input_precision, None, None, out_dtype, _builder)
+
+    assert A.shape[0] >= 64, "M must be at least 64"
+    assert A.shape[1] >= 16, "K must be at least 16"
+    assert B.shape[1] >= 32, "N must be at least 32"
+
+    cuda_compute_capability = int(cuda_parse_arch(_builder.options.arch))
+    version = 5 if cuda_compute_capability >= 100 else 3
 
     # TODO. batched dot is not supported yet
-    input = require_nv_mma_shared_layout(input, [0, 1] if col_input else [1, 0], _builder)
-    other = require_nv_mma_shared_layout(other, [0, 1] if col_other else [1, 0], _builder)
+    if isinstance(A, tlx.buffered_tensor) and A.storage == tlx.storage_kind.smem:
+        A_handle = require_nv_mma_shared_layout(A, _builder)
+    else :
+        # Registers or TMEM buffer do not need mma shared layout
+        A_handle = A.handle
 
-    if mmav5:
-        assert int(cuda_parse_arch(_builder.options.arch)) >= 100, "mmav5 is only supported on Blackwell and above"
-        output = _builder.create_tcgen5_dot(input, other, acc.handle, mBarrier.handle if mBarrier else None)
+    B_handle = require_nv_mma_shared_layout(B, _builder)
+
+    if version == 5:
+        assert isinstance(A, tlx.buffered_tensor) , "input must be a buffered tensor"
+        output = _builder.create_tcgen5_dot(A_handle, B_handle, acc.handle, mBarrier.handle if mBarrier else None)
         return tlx.async_token(output)
-
-    acc = _builder.create_require_layout(acc_handle, _builder.make_nv_mma_encoding_attr())
-
-    _builder.create_fence_async_shared()
-
-    output = _builder.create_warp_group_dot(input, other, acc, input_precision, max_num_imprecise_acc, True)
-
-    # Release the mma layout for the output to conform to what the user expects
-    output = _builder.create_release_layout(output)
-    return tl.tensor(output, ret_ty)
+    else :
+        acc = _builder.create_require_layout(acc_handle, _builder.make_nv_mma_encoding_attr(A_handle, acc_handle, version, 0, _builder.options.num_warps))
+        output = _builder.create_warp_group_dot(A_handle, B_handle, acc, input_precision, max_num_imprecise_acc, True)
+        # Release the mma layout for the output to conform to what the user expects
+        output = _builder.create_release_layout(output)
+        return tl.tensor(output, ret_ty)
 
 
 @tl.builtin


### PR DESCRIPTION
Refactoring tlx.async_dot implementation:
- Removing some unused parameters
- Removing the `mmav5` flag, instead computing it on the fly
- Tweaking layout requiring logics.