### PR TITLE
[TLX] Fix num buffers cannot be power of 2 issue

### DIFF
--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -18,7 +18,8 @@ def alloc_barriers(
     - `num_barriers`: The number of barriers to allocate.
     - `arrive_counts`: The number of threads that need to arrive at the barrier before it can be released.
     """
-    return tlx.mbarriers(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value), )
+    base_barrier = tlx.mbarrier(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value))
+    return tlx.mbarriers(base_barrier, num_barriers)
 
 
 @tl.builtin

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -40,7 +40,7 @@ def local_alloc(
     storage: tlx.storage_kind = tlx.storage_kind.smem,
     layout: Optional[tlx.shared_layout_encoding] = None,
     _builder=None,
-) -> tlx.buffered_tensor:
+) -> tlx.buffered_tensors:
     """
     Allocates buffer in shared memory and return a view of the buffer.
     """
@@ -52,7 +52,6 @@ def local_alloc(
     full_shape = [unwrapped_num] + unwrapped_shape
     dtype = tl._unwrap_if_constexpr(dtype)
     elem_type = dtype.to_ir(_builder)
-    block_type = tl.block_type(dtype, full_shape)
     if layout is None:
         if storage == tlx.storage_kind.smem:
             layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
@@ -82,34 +81,42 @@ def local_alloc(
     else:
         tensor_handle = _builder.create_tmem_alloc(full_shape, elem_type, layout_handle)
 
-    return tlx.buffered_tensor(
+    block_type = tl.block_type(dtype, unwrapped_shape)
+    base_tensor = tlx.buffered_tensor(
         tensor_handle,
         block_type,
         storage,
         layout,
     )
 
+    return tlx.buffered_tensors(base_tensor, num)
+
 
 @tl.builtin
 def local_view(
-    local_allocated_buffers: tlx.buffered_tensor,
+    local_allocated_buffers: tlx.buffered_tensors | tlx.mbarriers,
     buffer_idx: int,
     _builder=None,
-) -> tlx.buffered_tensor:
+) -> tlx.buffered_tensor | tlx.mbarrier:
     """
     Returns a subview of the buffer.
     """
     buffer_idx = _convert_elem_to_ir_value(_builder, buffer_idx, require_i64=False)
-    buffer_type = local_allocated_buffers.type
-    # A subview of a one-dimensional buffer is still one-dimensional.
-    view_shape = (buffer_type.shape[1:] if len(buffer_type.shape) > 1 else buffer_type.shape)
-    view_type = tl.block_type(buffer_type.element_ty, view_shape)
-    return tlx.buffered_tensor(
-        _builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx),
-        view_type,
-        local_allocated_buffers.storage,
-        local_allocated_buffers.layout,
-    )
+    base_tensor = local_allocated_buffers.base_tensor
+    view_shape = base_tensor.shape
+    view_type = tl.block_type(base_tensor.type.element_ty, view_shape)
+    view_handle = _builder.create_memdesc_subview(base_tensor.handle, buffer_idx)
+    if isinstance(local_allocated_buffers, tlx.mbarriers):
+        return tlx.mbarrier(
+            view_handle,
+        )
+    else:
+        return tlx.buffered_tensor(
+            view_handle,
+            view_type,
+            base_tensor.storage,
+            base_tensor.layout,
+        )
 
 
 @tl.builtin

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -157,17 +157,34 @@ class buffered_tensor(tl.base_value):
         )
 
 
-class mbarriers(buffered_tensor):
+class buffered_tensors(tl.base_value):
     """
-    Define mbarrier type derived from buffered_tensor to support barrier specific operations/validations
+    Define a list of buffered_tensor
+    """
+
+    def __init__(self, base_tensor : buffered_tensor, num : tl.constexpr):
+        self.base_tensor = base_tensor
+        self.num = num
+
+
+class mbarrier(buffered_tensor):
+    """
+    Define a mbarrier object
     """
 
     def __init__(self, handle):
-        # Temporarily use 1, as the shape must be a power of 2.
-        # TODO: use the actual barrier count to compute shape for precise boundary checks.
         block_type = tl.block_type(tl.int64, [1])
         super().__init__(handle, block_type, storage_kind.smem)
         pass
+
+class mbarriers(tl.base_value):
+    """
+    Define a list of mbarrier
+    """
+
+    def __init__(self, base_barrier : mbarrier, num : tl.constexpr):
+        self.base_tensor = base_barrier
+        self.num = num
 
 
 class async_token(tl.base_value):


### PR DESCRIPTION
`tlx.buffered_tensor` requires every dimension of the tensor to be power of 2 due to the underlying use of `tl.block_type`.. This doesn't work with buffer allocation with arbitrary number of buffers such as

 ` buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.int16, 3)`

To fix that, I'm introducing `tlx.buffered_tensors` as a wrapper of the `tlx.buffered_tensor` type. So for the above example, the `buffers` object will have  `tlx.buffered_tensors` type, with an underlying `tlx.buffered_tensor` type for the `[BLOCK_SIZE_M, BLOCK_SIZE_N]` tensor.

Similar change is made for mbarriers.