### PR TITLE
[TLX] Reduce the inference with the software pipeliner

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -33,12 +33,13 @@ namespace gpu {
 #define GEN_PASS_DEF_TRITONGPUPIPELINE
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
-static void pipelineWgmma(ModuleOp moduleOp) {
+static void pipelineWgmma(ModuleOp moduleOp, unsigned numStages) {
   SmallVector<scf::ForOp> loops;
   moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
 
   for (scf::ForOp forOp : loops) {
-    mlir::triton::asyncLaunchDots(forOp);
+    if (getNumStagesOrDefault(forOp, numStages) >= 1)
+      mlir::triton::asyncLaunchDots(forOp);
   }
 }
 
@@ -244,7 +245,7 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
     // Cleanup the IR from the pipeline attributes.
     removeAttributes(moduleOp);
 
-    pipelineWgmma(moduleOp);
+    pipelineWgmma(moduleOp, numStages);
 
     // schedule the waits
     mlir::triton::updateWaits(getOperation());

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -111,8 +111,12 @@ static int minNumInterleavedCommitOps(Operation *waitOp) {
     return 0;
   };
 
+  // For AsyncWaitOp ops that do not come with a token to track the specific
+  // copy group, respect the original pending number. Such case is most likely
+  // from user code. The compiler should not generate a non-zero pending number
+  // if it does not know exactly which group to track.
   if (waitOp->getNumOperands() != 1)
-    return 0;
+    return cast<ttg::AsyncWaitOp>(waitOp).getNum();
   Value val = waitOp->getOperand(0);
   // If the value resides in a region other than the region of the wait op, then
   // the wait op must be in some nested region. Measure the number of commits


### PR DESCRIPTION
For an AsyncWaitOp op that does not come in with a valid token, the pipeliner could kick in optimizing its pending wait count to 0. This is problematic if the original op has a different pending count, even for loops with num_stages=0. I'm disabling the optimization. 

An upstreaming of the change is : https://github.com/triton-lang/triton/pull/7317 . As discussed there, there seems to be some fundamental problems to get existing optimizations working or bailing out for user-optimized code, but I think we should try to fixes those and see how far we can go. This patch is an attempt.

Also backporting Manman's previous work to disable WGMMA pipelining for loops with num_stages==0

```

python3 third_party/tlx/tutorials/pipelined-gemm.py

✅ Triton and Torch match

matmul-performance-fp16:
         M       N       K      cuBLAS      Triton
0    256.0   256.0   256.0    4.519724    3.266592
1    384.0   384.0   384.0   13.456061    9.885319
2    512.0   512.0   512.0   28.244472   21.236982
3    640.0   640.0   640.0   44.043010   37.751153
4    768.0   768.0   768.0   78.643199   59.603266
5    896.0   896.0   896.0  114.981317   87.466332
6   1024.0  1024.0  1024.0  157.903207  120.916877
7   1152.0  1152.0  1152.0  187.723954  159.252472
8   1280.0  1280.0  1280.0  243.176265  202.897842
9   1408.0  1408.0  1408.0  299.754003  256.177431
10  1536.0  1536.0  1536.0  283.115527  308.993749
11  1664.0  1664.0  1664.0  339.982512  373.011897
12  1792.0  1792.0  1792.0  399.180434  434.899109
13  1920.0  1920.0  1920.0  444.144571  490.430155
14  2048.0  2048.0  2048.0  551.202155  566.917546
15  2176.0  2176.0  2176.0  463.611767  369.877508
16  2304.0  2304.0  2304.0  498.963376  414.090962
17  2432.0  2432.0  2432.0  544.532313  450.412234
18  2560.0  2560.0  2560.0  519.869115  496.484845
19  2688.0  2688.0  2688.0  554.779639  520.522195
20  2816.0  2816.0  2816.0  596.943795  576.955205
21  2944.0  2944.0  2944.0  525.627224  431.597575
22  3072.0  3072.0  3072.0  562.714065  462.347389
23  3200.0  3200.0  3200.0  554.037607  492.366884
24  3328.0  3328.0  3328.0  537.123237  530.322621
25  3456.0  3456.0  3456.0  553.446355  561.455989
26  3584.0  3584.0  3584.0  577.827593  575.400968
27  3712.0  3712.0  3712.0  535.687482  498.085855
28  3840.0  3840.0  3840.0  566.049894  529.544225
29  3968.0  3968.0  3968.0  537.735448  561.675207
30  4096.0  4096.0  4096.0  570.305058  594.130222
```