### PR TITLE
Create one region for multiple taskIds that perform gen5 dot

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -37,7 +37,14 @@ namespace mlir {
 
 Operation *SpecializeOp(Operation *op, IRMapping &mapping,
                         OpBuilderWithAsyncTaskIds &builder,
-                        AsyncTaskId asyncTaskId);
+                        SmallVector<AsyncTaskId> taskList);
+
+static bool hasAsyncTaskId(Operation *op, SmallVector<AsyncTaskId> &taskList) {
+  for (auto tId : taskList)
+    if (hasAsyncTaskId(op, tId))
+      return true;
+  return false;
+}
 
 unsigned scanRegUsage(Block *block, AsyncTaskId asyncTaskId,
                       unsigned requestedRegisters) {
@@ -47,8 +54,8 @@ unsigned scanRegUsage(Block *block, AsyncTaskId asyncTaskId,
 }
 
 // Collect argument indices that are used by the specific taskId.
-static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
-                                                     int asyncTaskId) {
+static SmallVector<unsigned>
+collectBlockArgsForTask(scf::ForOp forOp, SmallVector<AsyncTaskId> taskList) {
 
   // Collect argument indices that can be reached along the definition chain.
   SetVector<unsigned> argIndices;
@@ -56,7 +63,7 @@ static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
       [&](scf::ForOp nestedForOp, Value arg, unsigned argIdx) {
         for (auto user : arg.getUsers()) {
           // Skip ops that are not in the same async task
-          if (!hasAsyncTaskId(user, asyncTaskId))
+          if (!hasAsyncTaskId(user, taskList))
             continue;
 
           if (isa<scf::YieldOp>(user)) {
@@ -67,7 +74,7 @@ static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
                 auto initArg =
                     nestedForOp.getInitArgs()[blockArg.getArgNumber() - 1];
                 if (Operation *def = initArg.getDefiningOp()) {
-                  if (hasAsyncTaskId(def, asyncTaskId)) {
+                  if (hasAsyncTaskId(def, taskList)) {
                     argIndices.insert(argIdx);
                     return;
                   }
@@ -88,7 +95,7 @@ static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
               auto initArg =
                   nestedForOp.getInitArgs()[blockArg.getArgNumber() - 1];
               if (Operation *def = initArg.getDefiningOp()) {
-                if (hasAsyncTaskId(def, asyncTaskId)) {
+                if (hasAsyncTaskId(def, taskList)) {
                   argIndices.insert(argIdx);
                   return;
                 }
@@ -146,7 +153,7 @@ static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
 
 Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
                           OpBuilderWithAsyncTaskIds &builder,
-                          AsyncTaskId asyncTaskId) {
+                          SmallVector<AsyncTaskId> taskList) {
   LLVM_DEBUG({
     LDBG("specialize ifOp ");
     ifOp.dump();
@@ -163,7 +170,7 @@ Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
     for (Value yieldV : ifOp.thenYield().getOperands()) {
       // Check the defining op for the corresponding result.
       if (Operation *def = yieldV.getDefiningOp()) {
-        bool hasTaskId = hasAsyncTaskId(def, asyncTaskId);
+        bool hasTaskId = hasAsyncTaskId(def, taskList);
         if (hasTaskId) {
           keptResultVec.push_back(resultIdx);
         }
@@ -176,7 +183,7 @@ Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
           // track initial value
           auto initArg = forOp.getInitArgs()[bbArg.getArgNumber() - 1];
           if (Operation *def = initArg.getDefiningOp()) {
-            if (hasAsyncTaskId(def, asyncTaskId))
+            if (hasAsyncTaskId(def, taskList))
               keptResultVec.push_back(resultIdx);
           } else {
             llvm_unreachable("Initial value should have a defining op");
@@ -198,12 +205,12 @@ Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
       ifOp.elseBlock());
 
   OpBuilderWithAsyncTaskIds ifBuilder(ifOp.getContext());
-  ifBuilder.setAsynTaskIdsFromArray({asyncTaskId});
+  ifBuilder.setAsynTaskIdsFromArray(taskList);
 
   // Handle thenRegion of this IfOp.
   ifBuilder.setInsertionPointToEnd(newIfOp.thenBlock());
   for (Operation &thenOp : ifOp.thenBlock()->getOperations()) {
-    SpecializeOp(&thenOp, mapping, ifBuilder, asyncTaskId);
+    SpecializeOp(&thenOp, mapping, ifBuilder, taskList);
   }
 
   // Update yields
@@ -224,7 +231,7 @@ Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
   if (ifOp.elseBlock()) {
     ifBuilder.setInsertionPointToEnd(newIfOp.elseBlock());
     for (Operation &elseOp : ifOp.elseBlock()->getOperations()) {
-      SpecializeOp(&elseOp, mapping, ifBuilder, asyncTaskId);
+      SpecializeOp(&elseOp, mapping, ifBuilder, taskList);
     }
     if (keptResultVec.size() < ifOp->getResultTypes().size()) {
       SmallVector<Value> elseYieldOperands;
@@ -245,9 +252,9 @@ Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
 
 Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
                            OpBuilderWithAsyncTaskIds &builder,
-                           AsyncTaskId asyncTaskId) {
+                           SmallVector<AsyncTaskId> taskList) {
   // Create newForOp for each task Id.
-  auto usedArgs = collectBlockArgsForTask(forOp, asyncTaskId);
+  auto usedArgs = collectBlockArgsForTask(forOp, taskList);
 
   // Prepare newLoopArgs.
   SmallVector<Value> newLoopArgs;
@@ -279,10 +286,10 @@ Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
 
   // Recursively clone all operations with this asyncTaskId to newForOp.
   OpBuilderWithAsyncTaskIds forBuilder(forOp.getContext());
-  forBuilder.setAsynTaskIdsFromArray({asyncTaskId});
+  forBuilder.setAsynTaskIdsFromArray(taskList);
   forBuilder.setInsertionPointToStart(newForOp.getBody());
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    SpecializeOp(&op, mapping, forBuilder, asyncTaskId);
+    SpecializeOp(&op, mapping, forBuilder, taskList);
   }
 
   // Create YieldOp for newForOp.
@@ -296,14 +303,14 @@ Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
     auto initialYield =
         llvm::cast<scf::YieldOp>(newForOp.getBody()->getTerminator());
     if (newYieldOperands.size() == 0) {
-      setAsyncTaskIds(initialYield, {asyncTaskId});
+      setAsyncTaskIds(initialYield, taskList);
       createNewYield = false;
     }
   }
   if (createNewYield) {
     auto newYieldOp =
         forBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
-    setAsyncTaskIds(newYieldOp, {asyncTaskId});
+    setAsyncTaskIds(newYieldOp, taskList);
   }
 
   // Replace results of forOp with results of newForOp.
@@ -318,29 +325,29 @@ Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
 
 Operation *SpecializeOp(Operation *op, IRMapping &mapping,
                         OpBuilderWithAsyncTaskIds &builder,
-                        AsyncTaskId asyncTaskId) {
+                        SmallVector<AsyncTaskId> taskList) {
   auto taskIds = getAsyncTaskIds(op);
   // yieldOp are sometimes implict, meaning they do not necessarily have a task
   // id, but they should be shared by all async tasks.
-  if (!hasAsyncTaskId(op, asyncTaskId) && !isa<scf::YieldOp>(op))
+  if (!hasAsyncTaskId(op, taskList) && !isa<scf::YieldOp>(op))
     return nullptr;
 
   if (op->getNumRegions() == 0) {
     Operation *newOp = builder.clone(*op, mapping);
-    setAsyncTaskIds(newOp, asyncTaskId);
+    setAsyncTaskIds(newOp, taskList);
     for (unsigned i = 0; i < op->getNumResults(); ++i)
       mapping.map(op->getResult(i), newOp->getResult(i));
     return newOp;
   } else {
     if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-      return SpecializeIfOp(ifOp, mapping, builder, asyncTaskId);
+      return SpecializeIfOp(ifOp, mapping, builder, taskList);
     } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-      return SpecializeForOp(forOp, mapping, builder, asyncTaskId);
+      return SpecializeForOp(forOp, mapping, builder, taskList);
     } else if (auto reduceOp = dyn_cast<triton::ReduceOp>(op)) {
       Operation *newOp = builder.clone(*op, mapping);
       // recursively set async task ids for child ops
       newOp->walk(
-          [&](Operation *childOp) { setAsyncTaskIds(childOp, asyncTaskId); });
+          [&](Operation *childOp) { setAsyncTaskIds(childOp, taskList); });
       for (unsigned i = 0; i < op->getNumResults(); ++i)
         mapping.map(op->getResult(i), newOp->getResult(i));
       return newOp;
@@ -350,6 +357,98 @@ Operation *SpecializeOp(Operation *op, IRMapping &mapping,
   }
 
   return nullptr;
+}
+
+static void isOpMMaTask(Operation *op, AsyncTaskId asyncTaskId,
+                        bool &hasGen5MMa, bool &hasOtherTensorOp) {
+  hasGen5MMa = false;
+  hasOtherTensorOp = false;
+  if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+    for (Operation &op2 : forOp.getBody()->without_terminator()) {
+      bool hasGen5MMaTmp;
+      isOpMMaTask(&op2, asyncTaskId, hasGen5MMaTmp, hasOtherTensorOp);
+      if (hasGen5MMaTmp)
+        hasGen5MMa = true;
+    }
+    return;
+  }
+  if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    for (Operation &thenOp : ifOp.thenBlock()->getOperations()) {
+      bool hasGen5MMaTmp;
+      isOpMMaTask(&thenOp, asyncTaskId, hasGen5MMaTmp, hasOtherTensorOp);
+      if (hasGen5MMaTmp)
+        hasGen5MMa = true;
+    }
+
+    if (ifOp.elseBlock()) {
+      for (Operation &elseOp : ifOp.elseBlock()->getOperations()) {
+        bool hasGen5MMaTmp;
+        isOpMMaTask(&elseOp, asyncTaskId, hasGen5MMaTmp, hasOtherTensorOp);
+        if (hasGen5MMaTmp)
+          hasGen5MMa = true;
+      }
+    }
+    return;
+  }
+  if (dyn_cast<triton::MakeRangeOp>(op) || isa<arith::ConstantOp>(op))
+    return;
+  if (!hasAsyncTaskId(op, asyncTaskId))
+    return;
+  if (isa<triton::nvidia_gpu::TCGen5MMAOp>(op)) {
+    hasGen5MMa = true;
+    return;
+  }
+
+  for (int i = 0; i < op->getNumResults(); ++i) {
+    if (auto tensorType =
+            dyn_cast<RankedTensorType>(op->getResult(i).getType())) {
+      LLVM_DEBUG({
+        LDBG("groupTasksToRegion: hit a tensor type for task " << asyncTaskId);
+        op->dump();
+      });
+      hasOtherTensorOp = true;
+      break;
+    }
+  }
+}
+
+static void groupTasksToRegion(
+    triton::FuncOp funcOp, SmallVector<Operation *> &opList,
+    DenseMap<AsyncTaskId, SmallVector<AsyncTaskId>> &tasksToRegion,
+    DenseMap<AsyncTaskId, unsigned> &numWarpsForTask) {
+  // By default each taskId has its own group.
+  DenseSet<AsyncTaskId> mmaTasks;
+  // Assume a single region for mma tasks, the key taskId is mmaTaskId.
+  AsyncTaskId mmaTaskId;
+  for (AsyncTaskId asyncTaskId : getNestedAsyncTaskIds(funcOp)) {
+    // Mark a task as MMA only.
+    bool hasGen5MMa = false;
+    bool hasOtherTensorOp = false;
+    for (Operation *op : opList) {
+      bool hasGen5MMaTmp;
+      isOpMMaTask(op, asyncTaskId, hasGen5MMaTmp, hasOtherTensorOp);
+      if (hasGen5MMaTmp)
+        hasGen5MMa = true;
+      if (hasOtherTensorOp)
+        break;
+    }
+    if (!hasOtherTensorOp && hasGen5MMa) {
+      if (mmaTasks.empty())
+        mmaTaskId = asyncTaskId;
+      mmaTasks.insert(asyncTaskId);
+      LDBG("groupTasksToRegion: task " << asyncTaskId << " is gen5 mma task");
+    }
+  }
+  // Merge all mmaTasks in one group.
+  for (AsyncTaskId asyncTaskId : getNestedAsyncTaskIds(funcOp)) {
+    if (!mmaTasks.count(asyncTaskId)) {
+      tasksToRegion[asyncTaskId].push_back(asyncTaskId);
+      numWarpsForTask[asyncTaskId] = 4; // FIXME: hard-code to 4
+    } else {
+      tasksToRegion[mmaTaskId].push_back(asyncTaskId);
+      numWarpsForTask[asyncTaskId] = 1;
+    }
+  }
 }
 
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
@@ -385,19 +484,31 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
   auto returnOp = llvm::cast<triton::ReturnOp>(lastBlock->getTerminator());
   builder.setInsertionPoint(returnOp);
 
-  // Instead of a new IfOp for each task, we create one partitionRegion.
-  auto nTaskIds = getNestedAsyncTaskIds(funcOp);
+  // Simple heuristics to merge tasks to one region.
+  DenseMap<AsyncTaskId, SmallVector<AsyncTaskId>> tasksToRegion;
+  DenseMap<AsyncTaskId, unsigned> numWarpsForTask; // task to number of warps
+  groupTasksToRegion(funcOp, opList, tasksToRegion, numWarpsForTask);
+  // List of taskIds in sorted order.
+  SmallVector<AsyncTaskId> keySorted;
+  for (auto &kv : tasksToRegion) {
+    keySorted.push_back(kv.first);
+  }
+  std::sort(keySorted.begin(), keySorted.end());
+
+  // For New Lowering.
+  // Instead of a new IfOp for each task region, we create one partitionRegion.
   SmallVector<int32_t> partitionNumWarps;
-  for (AsyncTaskId asyncTaskId : nTaskIds) {
-    if (asyncTaskId == 0)
-      continue;
-    partitionNumWarps.push_back(4);
+  for (AsyncTaskId keyId : keySorted) {
+    if (keyId == 0) {
+      continue; // the default region
+    }
+    partitionNumWarps.push_back(numWarpsForTask[keyId]);
   }
   ArrayRef<Type> dummyTypes;
   ImplicitLocOpBuilder impB(opList[0]->getLoc(), opList[0]);
   impB.setInsertionPoint(returnOp);
   auto wsOp = impB.create<ttg::WarpSpecializeOp>(dummyTypes, partitionNumWarps,
-                                                 nTaskIds.size() - 1);
+                                                 keySorted.size() - 1);
 
   // Clone all operations into the corresponding if blocks. If the operation
   // has multiple taskIds, it will be cloned for multiple if blocks.
@@ -405,14 +516,14 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
   // body with the right asyncTaskId, instead of cloning the IfOp.
   // Handle producer WG.
   {
-    AsyncTaskId asyncTaskId = nTaskIds[0];
     OpBuilderWithAsyncTaskIds taskBuilder(context);
-    taskBuilder.setAsynTaskIdsFromArray({asyncTaskId});
+    auto &taskList = tasksToRegion[keySorted[0]];
+    taskBuilder.setAsynTaskIdsFromArray(taskList);
     Block *defaultBlock = impB.createBlock(&wsOp.getDefaultRegion());
     taskBuilder.setInsertionPointToStart(defaultBlock);
     IRMapping mapping;
     for (Operation *op : opList) {
-      SpecializeOp(op, mapping, taskBuilder, asyncTaskId);
+      SpecializeOp(op, mapping, taskBuilder, taskList);
     }
     SmallVector<Value> opnds;
     taskBuilder.create<ttg::WarpYieldOp>(loc, opnds);
@@ -420,22 +531,24 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
 
   unsigned idx = 1;
   SmallVector<int32_t> estRegUsage;
+  // keySorted[0] is in default region.
   for (Region *region : wsOp.getPartitionRegions()) {
-    AsyncTaskId asyncTaskId = nTaskIds[idx];
+    // List of taksIds for this region.
+    auto &taskList = tasksToRegion[keySorted[idx]];
     OpBuilderWithAsyncTaskIds taskBuilder(context);
-    taskBuilder.setAsynTaskIdsFromArray({asyncTaskId});
-    LDBG("region idx " << idx << " " << nTaskIds.size());
+    taskBuilder.setAsynTaskIdsFromArray(taskList);
+
     ++idx;
     Block *partitionBlock = impB.createBlock(region);
     taskBuilder.setInsertionPointToStart(partitionBlock);
 
     IRMapping mapping;
     for (Operation *op : opList) {
-      SpecializeOp(op, mapping, taskBuilder, asyncTaskId);
+      SpecializeOp(op, mapping, taskBuilder, taskList);
     }
     taskBuilder.create<ttg::WarpReturnOp>(loc);
     auto regAlloc =
-        scanRegUsage(partitionBlock, asyncTaskId, requestedRegisters);
+        scanRegUsage(partitionBlock, taskList[0], requestedRegisters);
     estRegUsage.push_back(regAlloc);
   }
 


### PR DESCRIPTION
Summary: Also support one warp for the gen5 region

Rebased from https://github.com/facebookexperimental/triton/pull/91