### PR TITLE
Extens live range for smem space of warp_specialize arguments

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -420,10 +420,16 @@ private:
           continue;
         }
 
-        // Any scratch memory's live range is the current operation's live
-        // range.
-        bufferRange.insert(
-            {buffer, Interval(operationId.at(op), operationId.at(op) + 1)});
+        if (op && isa<mlir::triton::gpu::WarpSpecializeOp>(op)) {
+          bufferRange.insert(
+              {buffer, Interval((size_t)0, (size_t)operationId.size())});
+        } else {
+
+          // Any scratch memory's live range is the current operation's live
+          // range.
+          bufferRange.insert(
+              {buffer, Interval(operationId.at(op), operationId.at(op) + 1)});
+        }
         LLVM_DEBUG({
           llvm::dbgs() << "-- buffer " << buffer->id << "; value: ";
           op->dump();
@@ -459,10 +465,16 @@ private:
     // Analyze liveness of explicit buffers
     Liveness liveness(operation);
     auto getValueLivenessRange = [&](Value value) {
+      Operation *defOp = value.getDefiningOp();
       auto liveOperations = liveness.resolveLiveness(value);
       auto minId = std::numeric_limits<size_t>::max();
       auto maxId = std::numeric_limits<size_t>::min();
       llvm::for_each(liveOperations, [&](Operation *liveOp) {
+        if (defOp && isa<mlir::triton::gpu::WarpSpecializeOp>(defOp)) {
+          minId = 0;
+          maxId = operationId.size();
+          return;
+        }
         if (operationId[liveOp] < minId) {
           minId = operationId[liveOp];
         }


### PR DESCRIPTION
Summary: llvm backend can move barriers around so can't guanrantee that the smem space for warp_specialize arguments has a short live range.
