### PR TITLE
[TLX] Fix barrier mistyping

### DIFF
--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -24,7 +24,7 @@ def alloc_barriers(
 
 @tl.builtin
 def barrier_expect_bytes(
-    bar: tlx.mbarriers,
+    bar: tlx.mbarrier,
     size: tl.constexpr,
     _builder=None,
 ) -> None:

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -260,7 +260,7 @@ def async_descriptor_load(
     desc: tl.tensor_descriptor_base,
     result: tlx.buffered_tensor,
     offsets: list[tl.tensor],
-    barrier: tlx.mbarriers,
+    barrier: tlx.mbarrier,
     cache_modifier: str = "",
     eviction_policy: str = "",
     _builder=None,

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -166,6 +166,7 @@ class buffered_tensors(tl.base_value):
     def __init__(self, base_tensor: buffered_tensor, num: tl.constexpr):
         self.base_tensor = base_tensor
         self.num = num
+        self.handle = base_tensor.handle
 
 
 class mbarrier(buffered_tensor):
@@ -187,6 +188,7 @@ class mbarriers(tl.base_value):
     def __init__(self, base_barrier: mbarrier, num: tl.constexpr):
         self.base_tensor = base_barrier
         self.num = num
+        self.handle = base_barrier.handle
 
 
 class async_token(tl.base_value):


### PR DESCRIPTION
Cleanup some mistyping. Also creating a `handle` field for `tlx. mbarriers` and `tlx.buffered_tensors` for transparent handing in WS region when those objects are captured. Every captured object is expected to have a handle field.