### PR TITLE
[TLX] Skip scalars in layout propagation

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -85,8 +85,13 @@ public:
     if (failed(solver.initializeAndRun(op)))
       return signalPassFailure();
 
+    auto isScalar = [](Operation *op) {
+      return op->getResults().size() == 1 &&
+             op->getResultTypes()[0].isIntOrIndexOrFloat();
+    };
+
     funcOp.walk([&](mlir::Operation *op) {
-      if (isa<tlx::RequireLayoutOp>(op))
+      if (isa<tlx::RequireLayoutOp>(op) || isScalar(op))
         return WalkResult::advance();
 
       for (auto [i, result] : llvm::enumerate(op->getResults())) {


### PR DESCRIPTION
Scalar ops like `%c0_i32 = arith.constant 0 : i32` are used for indexing and should be skipped during layout propagation.