### PR TITLE
[TLX] Require dot operand encoding for register operand for WGMMA 

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -409,63 +409,84 @@ def test_local_trans(device):
     reason="Requires compute capability == 9 for NV",
 )
 def test_async_dot(device):
-    """
-    Define a unit test with similar schema with tl.dot
+
     @triton.jit
-    def ref_kernel(X, stride_xm, stride_xk, Y, stride_yk, stride_yn, Z, stride_zm, stride_zn,
-               BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, INPUT_PRECISION: tl.constexpr, out_dtype: tl.constexpr = tl.float32):
+    def wgmma_kernel_A_smem(X, stride_xm, stride_xk, Y, stride_yk, stride_yn, Z, stride_zm, stride_zn,
+               BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
         off_m = tl.arange(0, BLOCK_M)
         off_n = tl.arange(0, BLOCK_N)
         off_k = tl.arange(0, BLOCK_K)
-        Xs = X + off_m[:, None] * stride_xm + off_k[None, :] * stride_xk
-        Ys = Y + off_k[:, None] * stride_yk + off_n[None, :] * stride_yn
-        Zs = Z + off_m[:, None] * stride_zm + off_n[None, :] * stride_zn
-        x = tl.load(Xs)
-        y = tl.load(Ys)
-        z = tl.dot(x, y, input_precision=INPUT_PRECISION, out_dtype=out_dtype)
-        tl.store(Zs, z)
-    """
+
+        a_ptrs = X + (off_m[:, None] * stride_xm + off_k[None, :] * stride_xk)
+        b_ptrs = Y + (off_k[:, None] * stride_yk + off_n[None, :] * stride_yn)
+
+        buf_alloc_a = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(X), 1)
+        buf_alloc_b = tlx.local_alloc((BLOCK_K, BLOCK_N), tlx.dtype_of(Y), 1)
+        a_tile = tlx.local_view(buf_alloc_a, 0)
+        b_tile = tlx.local_view(buf_alloc_b, 0)
+
+        tlx.async_load(a_ptrs, a_tile)
+        tlx.async_load(b_ptrs, b_tile)
+
+        # wait for buffers to be ready
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(tl.constexpr(0))
+
+        c = tlx.async_dot(a_tile, b_tile)
+        c = tlx.async_dot_wait(tl.constexpr(0), c)
+        c = c.to(tlx.dtype_of(Z))
+        c_ptrs = Z + stride_zm * off_m[:, None] + stride_zn * off_n[None, :]
+        tl.store(c_ptrs, c)
+
 
     @triton.jit
-    def tgt_kernel(X, stride_xm, stride_xk, Y, stride_yk, stride_yn, Z, stride_zm, stride_zn, BLOCK_M: tl.constexpr,
-                   BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, INPUT_PRECISION: tl.constexpr, out_dtype: tl.constexpr,
-                   COL_INPUT: tl.constexpr, COL_OTHER: tl.constexpr):
+    def wgmma_kernel_A_reg(X, stride_xm, stride_xk, Y, stride_yk, stride_yn, Z, stride_zm, stride_zn,
+               BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
         off_m = tl.arange(0, BLOCK_M)
         off_n = tl.arange(0, BLOCK_N)
+        off_k = tl.arange(0, BLOCK_K)
 
-        buf_alloc_x = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float32, 1)
-        buf_alloc_y = tlx.local_alloc((BLOCK_K, BLOCK_N), tl.float32, 1)
-        a_smem = tlx.local_view(buf_alloc_x, 0)
-        b_smem = tlx.local_view(buf_alloc_y, 0)
+        a_ptrs = X + (off_m[:, None] * stride_xm + off_k[None, :] * stride_xk)
+        b_ptrs = Y + (off_k[:, None] * stride_yk + off_n[None, :] * stride_yn)
 
-        Zs = Z + off_m[:, None] * stride_zm + off_n[None, :] * stride_zn
+        buf_alloc_b = tlx.local_alloc((BLOCK_K, BLOCK_N), tlx.dtype_of(Y), 1)
+        b_tile = tlx.local_view(buf_alloc_b, 0)
 
-        # TODO. initialize values or async load
+        a_tile = tl.load(a_ptrs)
+        tlx.async_load(b_ptrs, b_tile)
 
-        z = tlx.async_dot(a_smem, b_smem, input_precision=INPUT_PRECISION, out_dtype=out_dtype)
-        z = tlx.async_dot_wait(tl.constexpr(0), z)
-        tl.store(Zs, z)
+        # wait for buffers to be ready
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(tl.constexpr(0))
 
-    M, N, K = (64, 64, 64)
-    x = torch.ones((M, K), device=device, dtype=torch.float32)
-    y = torch.ones((K, N), device=device, dtype=torch.float32)
-    z = torch.empty_like(x, device=device, dtype=torch.float32)
+        c = tlx.async_dot(a_tile, b_tile)
+        c = tlx.async_dot_wait(tl.constexpr(0), c)
+        c = c.to(tlx.dtype_of(Z))
+        c_ptrs = Z + stride_zm * off_m[:, None] + stride_zn * off_n[None, :]
+        tl.store(c_ptrs, c)
 
-    kern_kwargs = {
-        'BLOCK_M': M, 'BLOCK_K': K, 'BLOCK_N': N, 'INPUT_PRECISION': "tf32", 'out_dtype': tl.float32, 'COL_INPUT': 0,
-        'COL_OTHER': 1
-    }
-    with pytest.raises(RuntimeError) as _:
-        _ = tgt_kernel[(1, 1)](x, x.stride(0), x.stride(1), y, y.stride(0), y.stride(1), z, z.stride(0), z.stride(1),
-                               **kern_kwargs)
+    torch.manual_seed(0)
+    M, N, K = (64, 64, 32)
+    x = torch.randn((M, K), device=device, dtype=torch.float16)
+    y = torch.randn((K, N), device=device, dtype=torch.float16)
+    z = torch.zeros((M, N), device=device, dtype=torch.float16)
 
-    # TODO. assert "ttng.warp_group_dot" in pgm["ttir"] but not accessible due to thrown RuntimeError
-    # Following snippet can be found in the printed TTIR.
-    # %49 = "tlx.require_layout"(%10) : (!ttg.memdesc<64x64xf32, #shared, #smem, mutable>) -> !ttg.memdesc<64x64xf32, #shared1, #smem, mutable>
-    # %50 = "tlx.require_layout"(%13) : (!ttg.memdesc<64x64xf32, #shared, #smem, mutable>) -> !ttg.memdesc<64x64xf32, #shared2, #smem, mutable>
-    # %51 = "ttg.convert_layout"(%3) : (tensor<64x64xf32>) -> tensor<64x64xf32, #mma>
-    # "ttng.fence_async_shared"() <{bCluster = false}> : () -> ()
-    # %52 = "ttng.warp_group_dot"(%49, %50, %51) <{inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 0 : i32}> : (!ttg.memdesc<64x64xf32, #shared1, #smem, mutable>, !ttg.memdesc<64x64xf32, #shared2, #smem, mutable>, tensor<64x64xf32, #mma>) -> tensor<64x64xf32, #mma>
+    # test smem
+    kern_kwargs = {'BLOCK_M': M, 'BLOCK_K': K, 'BLOCK_N': N}
+    kernel = wgmma_kernel_A_smem[(1, 1)](x, x.stride(0), x.stride(1), y, y.stride(0), y.stride(1), z, z.stride(0),
+                                       z.stride(1), **kern_kwargs)
+    ttgir = kernel.asm["ttgir"]
+    assert ttgir.count("ttg.async_copy_global_to_local") == 2
+    z_ref = torch.matmul(x, y)
+    torch.testing.assert_close(z, z_ref)
+
+    # test reg
+    kern_kwargs = {'BLOCK_M': M, 'BLOCK_K': K, 'BLOCK_N': N}
+    kernel = wgmma_kernel_A_reg[(1, 1)](x, x.stride(0), x.stride(1), y, y.stride(0), y.stride(1), z, z.stride(0),
+                                       z.stride(1), **kern_kwargs)
+    ttgir = kernel.asm["ttgir"]
+    assert ttgir.count("ttg.async_copy_global_to_local") == 1
+    torch.testing.assert_close(z, z_ref)
 
 
 @pytest.mark.skipif(

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -124,6 +124,15 @@ void init_triton_tlx_ir(py::module &&m) {
                  context, versionMajor, versionMinor, warpsPerCTA, CTALayout,
                  instrShape));
            })
+      .def("make_dot_operand_encoding_attr",
+           [](TritonOpBuilder &self, Value opnd, unsigned opIdx,
+              Attribute parentEnc) -> Attribute {
+             auto context = self.getBuilder().getContext();
+             auto eltType =
+                 cast<RankedTensorType>(opnd.getType()).getElementType();
+             return ttg::DotOperandEncodingAttr::get(context, opIdx, parentEnc,
+                                                     eltType);
+           })
       .def("make_default_tmem_compatible_tensor_layout_encoding",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
               Type elementType, int moduleNumWarps, int threadsPerWarp,


### PR DESCRIPTION
When the `A` operand of wgmma is in registers, the specific dot operand encoding is required.