### PR TITLE
[TLX] TMEM subslice op

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -268,6 +268,68 @@ def test_tmem_load_store(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
     torch.testing.assert_close(x, ref_out)
 
 
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability()[0] < 10,
+    reason="Requires compute capability >= 10 for NV",
+)
+@pytest.mark.parametrize("BLOCK_SIZE_M, BLOCK_SIZE_N", [(128, 64)])
+def test_tmem_subslice(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
+
+    @triton.jit
+    def tmem_subslice_kernel(
+        x_ptr,
+        stride_m,
+        stride_n,
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+    ):
+        offs_m = tl.arange(0, BLOCK_SIZE_M)
+        offs_n1 = tl.arange(0, BLOCK_SIZE_N // 4)
+        offs_n2 = tl.arange(BLOCK_SIZE_N // 4, BLOCK_SIZE_N // 2)
+        offs_n3 = tl.arange(BLOCK_SIZE_N // 2, 3 * BLOCK_SIZE_N // 4)
+        offs_n4 = tl.arange(3 * BLOCK_SIZE_N // 4, BLOCK_SIZE_N)
+        x_ptr_offsets1 = x_ptr + (offs_m[:, None] * stride_m + offs_n1[None, :] * stride_n)
+        x_ptr_offsets2 = x_ptr + (offs_m[:, None] * stride_m + offs_n2[None, :] * stride_n)
+        x_ptr_offsets3 = x_ptr + (offs_m[:, None] * stride_m + offs_n3[None, :] * stride_n)
+        x_ptr_offsets4 = x_ptr + (offs_m[:, None] * stride_m + offs_n4[None, :] * stride_n)
+
+        a = tl.full((BLOCK_SIZE_M, BLOCK_SIZE_N), 1.0, tl.float32)
+
+        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        buffer1 = tlx.local_view(buffers, 0)
+        tlx.local_store(buffer1, a, tlx.storage_kind.tmem)
+
+        subslice1 = tlx.subslice(buffer1, 0, BLOCK_SIZE_N // 4)
+        subslice2 = tlx.subslice(buffer1, BLOCK_SIZE_N // 4, BLOCK_SIZE_N // 4)
+        subslice3 = tlx.subslice(buffer1, BLOCK_SIZE_N // 2, BLOCK_SIZE_N // 4)
+        subslice4 = tlx.subslice(buffer1, 3 * BLOCK_SIZE_N // 4, BLOCK_SIZE_N // 4)
+
+        b1 = tlx.local_load(subslice1, tlx.storage_kind.tmem)
+        b2 = tlx.local_load(subslice2, tlx.storage_kind.tmem)
+        b3 = tlx.local_load(subslice3, tlx.storage_kind.tmem)
+        b4 = tlx.local_load(subslice4, tlx.storage_kind.tmem)
+        # b == a == tensor of 1.0
+        tl.store(x_ptr_offsets1, b1 + 2)
+        tl.store(x_ptr_offsets2, b2 + 2)
+        tl.store(x_ptr_offsets3, b3 + 2)
+        tl.store(x_ptr_offsets4, b4 + 2)
+
+    x = torch.rand((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=torch.float32, device=device)
+    grid = lambda meta: (1, )
+    kerenl_info = tmem_subslice_kernel[grid](x, x.stride(0), x.stride(1), BLOCK_SIZE_M, BLOCK_SIZE_N)
+
+    assert kerenl_info.asm["ttir"].count("ttng.tmem_store") == 1
+    assert kerenl_info.asm["ttir"].count("ttng.tmem_load") == 4
+
+    assert kerenl_info.asm["ttgir"].count("kernel") == 1
+    assert kerenl_info.asm["ttgir"].count("ttng.tmem_alloc") == 1
+    assert kerenl_info.asm["ttgir"].count("ttng.tmem_store") == 1
+    assert kerenl_info.asm["ttgir"].count("ttng.tmem_load") == 4
+
+    ref_out = torch.ones_like(x) + 2
+    torch.testing.assert_close(x, ref_out)
+
+
 def test_thread_id(device):
 
     @triton.jit


### PR DESCRIPTION
Slicing along the innermost dimension from 128xN TMEM.

.ttir
```mlir
#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
#loc = loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":278:0)
#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, unpacked = true>
module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @tmem_subslice_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":278:0), %arg1: i32 {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":278:0)) attributes {noinline = false} {
    %cst = arith.constant dense<2.000000e+00> : tensor<128x16xf32> loc(#loc1)
    %true = arith.constant true loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %cst_0 = arith.constant dense<1.000000e+00> : tensor<128x64xf32> loc(#loc1)
    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32> loc(#loc2)
    %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32> loc(#loc3)
    %2 = tt.make_range {end = 32 : i32, start = 16 : i32} : tensor<16xi32> loc(#loc4)
    %3 = tt.make_range {end = 48 : i32, start = 32 : i32} : tensor<16xi32> loc(#loc5)
    %4 = tt.make_range {end = 64 : i32, start = 48 : i32} : tensor<16xi32> loc(#loc6)
    %5 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32> loc(#loc7)
    %6 = tt.splat %arg1 : i32 -> tensor<128x1xi32> loc(#loc8)
    %7 = arith.muli %5, %6 : tensor<128x1xi32> loc(#loc8)
    %8 = tt.expand_dims %1 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32> loc(#loc9)
    %9 = tt.broadcast %7 : tensor<128x1xi32> -> tensor<128x16xi32> loc(#loc10)
    %10 = tt.broadcast %8 : tensor<1x16xi32> -> tensor<128x16xi32> loc(#loc10)
    %11 = arith.addi %9, %10 : tensor<128x16xi32> loc(#loc10)
    %12 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x16x!tt.ptr<f32>> loc(#loc11)
    %13 = tt.addptr %12, %11 : tensor<128x16x!tt.ptr<f32>>, tensor<128x16xi32> loc(#loc11)
    %14 = tt.expand_dims %2 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32> loc(#loc12)
    %15 = tt.broadcast %14 : tensor<1x16xi32> -> tensor<128x16xi32> loc(#loc13)
    %16 = arith.addi %9, %15 : tensor<128x16xi32> loc(#loc13)
    %17 = tt.addptr %12, %16 : tensor<128x16x!tt.ptr<f32>>, tensor<128x16xi32> loc(#loc14)
    %18 = tt.expand_dims %3 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32> loc(#loc15)
    %19 = tt.broadcast %18 : tensor<1x16xi32> -> tensor<128x16xi32> loc(#loc16)
    %20 = arith.addi %9, %19 : tensor<128x16xi32> loc(#loc16)
    %21 = tt.addptr %12, %20 : tensor<128x16x!tt.ptr<f32>>, tensor<128x16xi32> loc(#loc17)
    %22 = tt.expand_dims %4 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32> loc(#loc18)
    %23 = tt.broadcast %22 : tensor<1x16xi32> -> tensor<128x16xi32> loc(#loc19)
    %24 = arith.addi %9, %23 : tensor<128x16xi32> loc(#loc19)
    %25 = tt.addptr %12, %24 : tensor<128x16x!tt.ptr<f32>>, tensor<128x16xi32> loc(#loc20)
    %result = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc21)
    %26 = ttg.memdesc_subview %result[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc22)
    %27 = tlx.require_layout %cst_0 : tensor<128x64xf32> -> tensor<128x64xf32, #blocked> loc(#loc23)
    ttng.tmem_store %27, %26, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc23)
    %28 = ttng.tmem_subslice %26 {N = 0 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc24)
    %29 = ttng.tmem_subslice %26 {N = 16 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc25)
    %30 = ttng.tmem_subslice %26 {N = 32 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc26)
    %31 = ttng.tmem_subslice %26 {N = 48 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc27)
    %result_1 = ttng.tmem_load %28 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked1> loc(#loc28)
    %32 = tlx.release_layout %result_1 : tensor<128x16xf32, #blocked1> -> tensor<128x16xf32> loc(#loc28)
    %result_2 = ttng.tmem_load %29 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked1> loc(#loc29)
    %33 = tlx.release_layout %result_2 : tensor<128x16xf32, #blocked1> -> tensor<128x16xf32> loc(#loc29)
    %result_3 = ttng.tmem_load %30 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked1> loc(#loc30)
    %34 = tlx.release_layout %result_3 : tensor<128x16xf32, #blocked1> -> tensor<128x16xf32> loc(#loc30)
    %result_4 = ttng.tmem_load %31 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked1> loc(#loc31)
    %35 = tlx.release_layout %result_4 : tensor<128x16xf32, #blocked1> -> tensor<128x16xf32> loc(#loc31)
    %36 = arith.addf %32, %cst : tensor<128x16xf32> loc(#loc32)
    tt.store %13, %36 : tensor<128x16x!tt.ptr<f32>> loc(#loc33)
    %37 = arith.addf %33, %cst : tensor<128x16xf32> loc(#loc34)
    tt.store %17, %37 : tensor<128x16x!tt.ptr<f32>> loc(#loc35)
    %38 = arith.addf %34, %cst : tensor<128x16xf32> loc(#loc36)
    tt.store %21, %38 : tensor<128x16x!tt.ptr<f32>> loc(#loc37)
    %39 = arith.addf %35, %cst : tensor<128x16xf32> loc(#loc38)
    tt.store %25, %39 : tensor<128x16x!tt.ptr<f32>> loc(#loc39)
    tt.return loc(#loc40)
  } loc(#loc)
} loc(#loc)
```

.ttgir
```mlir
#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
#blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
#loc = loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":278:0)
#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, unpacked = true>
module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @tmem_subslice_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":278:0), %arg1: i32 {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":278:0)) attributes {noinline = false} {
    %cst = arith.constant dense<2.000000e+00> : tensor<128x16xf32, #blocked> loc(#loc1)
    %true = arith.constant true loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %cst_0 = arith.constant dense<1.000000e+00> : tensor<128x64xf32, #blocked1> loc(#loc1)
    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>> loc(#loc2)
    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>> -> tensor<128x1xi32, #blocked2> loc(#loc2)
    %2 = tt.splat %arg1 : i32 -> tensor<128x1xi32, #blocked2> loc(#loc3)
    %3 = arith.muli %1, %2 : tensor<128x1xi32, #blocked2> loc(#loc3)
    %4 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> loc(#loc4)
    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> -> tensor<1x16xi32, #blocked2> loc(#loc4)
    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked2> -> tensor<128x16xi32, #blocked2> loc(#loc5)
    %7 = tt.broadcast %5 : tensor<1x16xi32, #blocked2> -> tensor<128x16xi32, #blocked2> loc(#loc5)
    %8 = arith.addi %6, %7 : tensor<128x16xi32, #blocked2> loc(#loc5)
    %9 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x16x!tt.ptr<f32>, #blocked2> loc(#loc6)
    %10 = tt.addptr %9, %8 : tensor<128x16x!tt.ptr<f32>, #blocked2>, tensor<128x16xi32, #blocked2> loc(#loc6)
    %11 = tt.make_range {end = 32 : i32, start = 16 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> loc(#loc7)
    %12 = tt.expand_dims %11 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> -> tensor<1x16xi32, #blocked2> loc(#loc7)
    %13 = tt.broadcast %12 : tensor<1x16xi32, #blocked2> -> tensor<128x16xi32, #blocked2> loc(#loc8)
    %14 = arith.addi %6, %13 : tensor<128x16xi32, #blocked2> loc(#loc8)
    %15 = tt.addptr %9, %14 : tensor<128x16x!tt.ptr<f32>, #blocked2>, tensor<128x16xi32, #blocked2> loc(#loc9)
    %16 = tt.make_range {end = 48 : i32, start = 32 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> loc(#loc10)
    %17 = tt.expand_dims %16 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> -> tensor<1x16xi32, #blocked2> loc(#loc10)
    %18 = tt.broadcast %17 : tensor<1x16xi32, #blocked2> -> tensor<128x16xi32, #blocked2> loc(#loc11)
    %19 = arith.addi %6, %18 : tensor<128x16xi32, #blocked2> loc(#loc11)
    %20 = tt.addptr %9, %19 : tensor<128x16x!tt.ptr<f32>, #blocked2>, tensor<128x16xi32, #blocked2> loc(#loc12)
    %21 = tt.make_range {end = 64 : i32, start = 48 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> loc(#loc13)
    %22 = tt.expand_dims %21 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> -> tensor<1x16xi32, #blocked2> loc(#loc13)
    %23 = tt.broadcast %22 : tensor<1x16xi32, #blocked2> -> tensor<128x16xi32, #blocked2> loc(#loc14)
    %24 = arith.addi %6, %23 : tensor<128x16xi32, #blocked2> loc(#loc14)
    %25 = tt.addptr %9, %24 : tensor<128x16x!tt.ptr<f32>, #blocked2>, tensor<128x16xi32, #blocked2> loc(#loc15)
    %result = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc16)
    %26 = ttg.memdesc_subview %result[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc17)
    ttng.tmem_store %cst_0, %26, %true : tensor<128x64xf32, #blocked1> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc18)
    %27 = ttng.tmem_subslice %26 {N = 0 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc19)
    %28 = ttng.tmem_subslice %26 {N = 16 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc20)
    %29 = ttng.tmem_subslice %26 {N = 32 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc21)
    %30 = ttng.tmem_subslice %26 {N = 48 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc22)
    %result_1 = ttng.tmem_load %27 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked> loc(#loc23)
    %31 = arith.addf %result_1, %cst : tensor<128x16xf32, #blocked> loc(#loc24)
    %32 = ttg.convert_layout %31 : tensor<128x16xf32, #blocked> -> tensor<128x16xf32, #blocked2> loc(#loc25)
    tt.store %10, %32 : tensor<128x16x!tt.ptr<f32>, #blocked2> loc(#loc25)
    %result_2 = ttng.tmem_load %28 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked> loc(#loc26)
    %33 = arith.addf %result_2, %cst : tensor<128x16xf32, #blocked> loc(#loc27)
    %34 = ttg.convert_layout %33 : tensor<128x16xf32, #blocked> -> tensor<128x16xf32, #blocked2> loc(#loc28)
    tt.store %15, %34 : tensor<128x16x!tt.ptr<f32>, #blocked2> loc(#loc28)
    %result_3 = ttng.tmem_load %29 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked> loc(#loc29)
    %35 = arith.addf %result_3, %cst : tensor<128x16xf32, #blocked> loc(#loc30)
    %36 = ttg.convert_layout %35 : tensor<128x16xf32, #blocked> -> tensor<128x16xf32, #blocked2> loc(#loc31)
    tt.store %20, %36 : tensor<128x16x!tt.ptr<f32>, #blocked2> loc(#loc31)
    %result_4 = ttng.tmem_load %30 : !ttg.memdesc<128x16xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked> loc(#loc32)
    %37 = arith.addf %result_4, %cst : tensor<128x16xf32, #blocked> loc(#loc33)
    %38 = ttg.convert_layout %37 : tensor<128x16xf32, #blocked> -> tensor<128x16xf32, #blocked2> loc(#loc34)
    tt.store %25, %38 : tensor<128x16x!tt.ptr<f32>, #blocked2> loc(#loc34)
    tt.return loc(#loc35)
  } loc(#loc)
} loc(#loc)
```