### PR TITLE
[TLX] Disable automatic warp spec for TLX

### DIFF
--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -92,3 +92,79 @@ module {
     tt.return
   }
 }
+
+
+// -----
+
+// CHECK: module attributes {
+// CHECK-SAME: tlx.has_warp_spec_ops = true
+// CHECK-NOT: tlx.has_explicit_local_mem_access
+// CHECK-NOT: tlx.has_tlx_ops
+module attributes {tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @add2_warp_specialized_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} , %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} , %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32} , %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32} , %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32} , %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32} , %arg6: i32 {tt.divisibility = 16 : i32} ) attributes {noinline = false} {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    ttg.warp_specialize(%arg3, %arg4, %1, %arg5, %arg6) attributes {requestedRegisters = array<i32: 100, 100>}
+    default {
+      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+      %3 = tt.splat %1 : i32 -> tensor<1024xi32>
+      %4 = arith.addi %3, %2 : tensor<1024xi32>
+      %5 = tt.splat %arg6 : i32 -> tensor<1024xi32>
+      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32>
+      %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>>
+      %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>>
+      %13 = arith.addf %9, %12 : tensor<1024xf32>
+      %14 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      tt.store %15, %13, %6 : tensor<1024x!tt.ptr<f32>>
+      ttg.warp_yield
+    }
+    partition0(%arg7: !tt.ptr<f32> , %arg8: !tt.ptr<f32> , %arg9: i32 , %arg10: !tt.ptr<f32> , %arg11: i32 ) num_warps(4) {
+      %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32>
+      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+      %3 = tt.splat %arg9 : i32 -> tensor<1024xi32>
+      %4 = arith.addi %3, %2 : tensor<1024xi32>
+      %5 = tt.splat %arg11 : i32 -> tensor<1024xi32>
+      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32>
+      %7 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>>
+      %10 = tt.splat %arg8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>>
+      %13 = arith.addf %9, %cst : tensor<1024xf32>
+      %14 = arith.addf %13, %12 : tensor<1024xf32>
+      %15 = tt.splat %arg10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %16 = tt.addptr %15, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      tt.store %16, %14, %6 : tensor<1024x!tt.ptr<f32>>
+      ttg.warp_return
+    }
+    partition1(%arg7: !tt.ptr<f32> , %arg8: !tt.ptr<f32> , %arg9: i32 , %arg10: !tt.ptr<f32> , %arg11: i32 ) num_warps(4) {
+      %cst = arith.constant dense<1.000000e+00> : tensor<1024xf32>
+      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+      %3 = tt.splat %arg9 : i32 -> tensor<1024xi32>
+      %4 = arith.addi %3, %2 : tensor<1024xi32>
+      %5 = tt.splat %arg11 : i32 -> tensor<1024xi32>
+      %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32>
+      %7 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      %9 = tt.load %8, %6 : tensor<1024x!tt.ptr<f32>>
+      %10 = tt.splat %arg8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      %12 = tt.load %11, %6 : tensor<1024x!tt.ptr<f32>>
+      %13 = arith.addf %9, %cst : tensor<1024xf32>
+      %14 = arith.subf %12, %cst : tensor<1024xf32>
+      %15 = arith.addf %13, %14 : tensor<1024xf32>
+      %16 = tt.splat %arg10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %17 = tt.addptr %16, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      tt.store %17, %15, %6 : tensor<1024x!tt.ptr<f32>>
+      ttg.warp_return
+    } : (!tt.ptr<f32>, !tt.ptr<f32>, i32, !tt.ptr<f32>, i32) -> ()
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -21,6 +21,7 @@ namespace tlx {
 constexpr static char AttrHasExplicitLocalMemAccessName[] =
     "tlx.has_explicit_local_mem_access";
 constexpr static char AttrHasTLXOpsName[] = "tlx.has_tlx_ops";
+constexpr static char AttrHasWarpSpecOpsName[] = "tlx.has_warp_spec_ops";
 } // namespace tlx
 } // namespace triton
 } // namespace mlir


### PR DESCRIPTION
If the kernel has manual WS calls via TLX, we mark it on the module op as an attribute and leverage that to disable automatic ws pass (for Blackwell)

Testing: lit test and `pytest -vs python/test/unit/language/test_tlx.py` (test_async_tasks was failing and now passing)