### PR TITLE
[TLX] WS-GEMM kernel with two consumers

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -97,8 +97,7 @@ public:
       for (auto [i, result] : llvm::enumerate(op->getResults())) {
         auto *lattice = solver.lookupState<LayoutEncodingLattice>(result);
         if (!lattice)
-          continue;
-        // llvm_unreachable("Lattice not found.");
+          llvm_unreachable("Lattice not found.");
         if (lattice->getValue().isUninitialized())
           continue;
         if (auto origType = dyn_cast<gpu::MemDescType>(result.getType())) {

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -67,22 +67,15 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
     elem_type = dtype.to_ir(_builder)
     if layout is None:
         if storage == tlx.storage_kind.smem:
-            layout = tlx.nv_mma_shared_layout_encoding(
-                    shape=shape, 
-                    order=[1, 0], 
-                    elemType=dtype,
-                    numCTAsPerCGA=[1, 1], 
-                    numCTASplit=[1, 1], 
-                    numCTAOrder=[1, 1],
-                    fp4Padded=False)
-            layout_handle = _builder.make_nv_mma_shared_encoding_attr(
-                [int(x) for x in layout.shape],
+            layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
+            layout_handle = _builder.make_swizzled_shared_encoding_attr(
+                layout.vectorSize,
+                layout.perPhase,
+                layout.maxPhase,
                 layout.order,
-                layout.elemType.to_ir(_builder),
                 layout.numCTAsPerCGA,
                 layout.numCTASplit,
                 layout.numCTAOrder,
-                layout.fp4Padded,
             )
         else:
             layout = tlx.tensor_memory_layout_encoding.make_default(shape)


### PR DESCRIPTION
Fresh PR on top of trunk (deprecating two older PRs (https://github.com/facebookexperimental/triton/pull/168 and https://github.com/facebookexperimental/triton/pull/203) )

![image](https://github.com/user-attachments/assets/53d075c1-6c84-455d-88cf-d4e15857c79e)

![image](https://github.com/user-attachments/assets/6e00218e-db6f-4458-a8df-b83f3bc4b30f)

![image](https://github.com/user-attachments/assets/fe41fa9f-727d-4306-b5fe-e8ec48c2f30a)

Best perf numbers so far (85% of cuBLAS)
```
✅ Triton and Torch match
matmul-performance-fp16:
         M       N       K      cuBLAS      Triton
0    256.0   256.0   256.0    4.969554    2.995932
1    384.0   384.0   384.0   15.869704    8.982091
2    512.0   512.0   512.0   34.952534   19.284157
3    640.0   640.0   640.0   60.907061   33.165993
4    768.0   768.0   768.0   98.991442   52.526073
5    896.0   896.0   896.0  140.055128   77.379855
6   1024.0  1024.0  1024.0  199.728763  107.546260
7   1152.0  1152.0  1152.0  243.133560  142.401624
8   1280.0  1280.0  1280.0  291.271116  182.044442
9   1408.0  1408.0  1408.0  365.737598  224.237577
10  1536.0  1536.0  1536.0  429.776883  244.065097
11  1664.0  1664.0  1664.0  440.313754  289.995152
12  1792.0  1792.0  1792.0  424.629956  337.710405
13  1920.0  1920.0  1920.0  516.785047  385.673931
14  2048.0  2048.0  2048.0  597.186792  441.869043
15  2176.0  2176.0  2176.0  582.766260  308.260753
16  2304.0  2304.0  2304.0  505.563433  341.865784
17  2432.0  2432.0  2432.0  593.806371  376.632946
18  2560.0  2560.0  2560.0  572.054559  409.920263
19  2688.0  2688.0  2688.0  577.202959  443.823673
20  2816.0  2816.0  2816.0  590.378432  470.234046
21  2944.0  2944.0  2944.0  563.915474  384.927101
22  3072.0  3072.0  3072.0  606.202530  415.011281
23  3200.0  3200.0  3200.0  611.525849  436.673787
24  3328.0  3328.0  3328.0  549.289838  465.774666
25  3456.0  3456.0  3456.0  579.360002  484.304536
26  3584.0  3584.0  3584.0  608.564394  511.064392
27  3712.0  3712.0  3712.0  540.716355  442.482529
28  3840.0  3840.0  3840.0  584.852732  466.632911
29  3968.0  3968.0  3968.0  583.497585  489.503038
30  4096.0  4096.0  4096.0  613.785959  518.340234
```
