### PR TITLE
[TLX] Fixing issues for tl.async_task(replicate=2)

### DIFF
--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -110,13 +110,13 @@ def visit_withAsyncTasks(self, node):
         for stmt in stmts:
             assert _is_async_task(self, stmt)
             task = _get_async_task(self, stmt)
-
             if task.is_default:
                 task_body = ws_op.get_default_region()
 
                 block = self.builder.create_block_with_parent(task_body, [])
                 self.builder.set_insertion_point_to_start(block)
-                self.visit(stmt)
+                with enter_sub_region(self):
+                    self.visit(stmt)
 
                 self.builder.create_warp_yield_op()
             else:
@@ -128,7 +128,8 @@ def visit_withAsyncTasks(self, node):
 
                     block = self.builder.create_block_with_parent(task_body, [])
                     self.builder.set_insertion_point_to_start(block)
-                    self.visit(stmt)
+                    with enter_sub_region(self):
+                        self.visit(stmt)
 
                     for name in captures:
                         val = liveins[name]

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -1,5 +1,5 @@
 import triton.language.core as tl
-from typing import Optional, Self
+from typing import Optional, Self, List
 import enum
 from abc import abstractmethod
 
@@ -146,6 +146,9 @@ class buffered_tensor(tl.base_value):
         self.storage = storage
         # Layout encoding
         self.layout = layout
+
+    def _flatten_ir(self, handles) -> None:
+        handles.append(self.handle)
 
     def make_permute(self, handle, dims) -> Self:
         permuted_type = tl.block_type(self.type.scalar, [self.shape[d] for d in dims])


### PR DESCRIPTION
Fixing two issues related to  `tl.async_task(replicate=2)`

- scoping each compilation of the task region; otherwise their live-ins and scoped vars would be mixed
- implement `_flatten_ir` for buffered tensors