### PR TITLE
[TLX] Hacky fix in layout propagation to unblock

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -97,7 +97,8 @@ public:
       for (auto [i, result] : llvm::enumerate(op->getResults())) {
         auto *lattice = solver.lookupState<LayoutEncodingLattice>(result);
         if (!lattice)
-          llvm_unreachable("Lattice not found.");
+          continue;
+        // llvm_unreachable("Lattice not found.");
         if (lattice->getValue().isUninitialized())
           continue;
         if (auto origType = dyn_cast<gpu::MemDescType>(result.getType())) {

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -67,15 +67,22 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
     elem_type = dtype.to_ir(_builder)
     if layout is None:
         if storage == tlx.storage_kind.smem:
-            layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
-            layout_handle = _builder.make_swizzled_shared_encoding_attr(
-                layout.vectorSize,
-                layout.perPhase,
-                layout.maxPhase,
+            layout = tlx.nv_mma_shared_layout_encoding(
+                    shape=shape, 
+                    order=[1, 0], 
+                    elemType=dtype,
+                    numCTAsPerCGA=[1, 1], 
+                    numCTASplit=[1, 1], 
+                    numCTAOrder=[1, 1],
+                    fp4Padded=False)
+            layout_handle = _builder.make_nv_mma_shared_encoding_attr(
+                [int(x) for x in layout.shape],
                 layout.order,
+                layout.elemType.to_ir(_builder),
                 layout.numCTAsPerCGA,
                 layout.numCTASplit,
                 layout.numCTAOrder,
+                layout.fp4Padded,
             )
         else:
             layout = tlx.tensor_memory_layout_encoding.make_default(shape)

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -105,6 +105,14 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
         self.numCTAOrder = numCTAOrder
         self.fp4Padded = fp4Padded
 
+    """
+    Create a new layout that is a permutation of the given layout.
+    """
+
+    def make_permute(self, dims) -> Self:
+        permuted_order = tuple(self.order[d] for d in dims)
+        return nv_mma_shared_layout_encoding(self.shape, permuted_order, self.elemType, self.numCTAsPerCGA, self.numCTASplit, self.numCTAOrder, self.fp4Padded)
+
 
 class storage_kind(enum.Enum):
     smem = "smem"


### PR DESCRIPTION
This PR contains some hacky patches in layout propagation to unblock TLX kernels. 

`python third_party/tlx/tutorials/gemm-WS-hopper.py`

`python -m pytest third_party/tlx/tutorials/flash-attention-WS-pipelined-hopper.py`