### PR TITLE
[TLX] Skip tensors in layout propagation

### DIFF
--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -62,7 +62,7 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     ArrayRef<const LayoutEncodingLattice *> results) {
   if (auto requireLayoutOp = dyn_cast<triton::tlx::RequireLayoutOp>(op)) {
 
-    // skips the layout propagation for registers. require_layout ops on tensor
+    // Skip the layout propagation for registers. require_layout ops on tensor
     // types will be rewritten into convert_layout ops, and following passes
     // will handle them.
     if (isa<RankedTensorType>(requireLayoutOp.getType()))

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -61,6 +61,10 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     Operation *op, ArrayRef<LayoutEncodingLattice *> operands,
     ArrayRef<const LayoutEncodingLattice *> results) {
   if (auto requireLayoutOp = dyn_cast<triton::tlx::RequireLayoutOp>(op)) {
+
+    if (isa<RankedTensorType>(requireLayoutOp.getType()))
+      return success();
+
     Attribute layout = requireLayoutOp.getType().getEncoding();
     const auto layoutLattice = LayoutEncoding(layout);
     for (auto operandLattice : operands) {

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -62,6 +62,9 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     ArrayRef<const LayoutEncodingLattice *> results) {
   if (auto requireLayoutOp = dyn_cast<triton::tlx::RequireLayoutOp>(op)) {
 
+    // skips the layout propagation for registers. require_layout ops on tensor
+    // types will be rewritten into convert_layout ops, and following passes
+    // will handle them.
     if (isa<RankedTensorType>(requireLayoutOp.getType()))
       return success();
 


### PR DESCRIPTION
This change skips the layout propagation for registers. `require_layout` ops on tensor types will be rewritten into `convert_layout` ops, and following passes will handle them.