### PR TITLE
[TLX-main] Bug fix in layout encoding

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1048,11 +1048,11 @@ class TritonSemantic(Generic[TensorTy]):
         if is_bool:
             elt_ty = tl.int8
             ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
-            ptr = cast(ptr, ptr_ty, self.builder)
+            ptr = self.cast(ptr, ptr_ty, self.builder)
     
         # Cast `other` into `elt_ty` type
         if other is not None:
-            other = cast(other, elt_ty, self.builder)
+            other = self.cast(other, elt_ty, self.builder)
     
         # Create loaded result type `dst_ty`
         if ptr.type.is_block():

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -66,8 +66,9 @@ public:
   void runOnFuncOp(triton::FuncOp funcOp) {
     // We can terminate early if we don't have a layout constraint.
     WalkResult walkResult = funcOp.walk([&](mlir::Operation *op) {
-      if (isa<tlx::RequireLayoutOp>(op))
-        return WalkResult::interrupt();
+      if (auto requireLayoutOp = dyn_cast<tlx::RequireLayoutOp>(op))
+        if (isa<gpu::MemDescType>(requireLayoutOp.getType()))
+          return WalkResult::interrupt();
       return WalkResult::advance();
     });
     if (!walkResult.wasInterrupted())
@@ -111,6 +112,7 @@ public:
       }
       return WalkResult::advance();
     });
+    return;
   }
 
   void runOnOperation() override {

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -57,24 +57,11 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
     full_shape = [unwrapped_num] + unwrapped_shape
     dtype = tl._unwrap_if_constexpr(dtype)
     elem_type = dtype.to_ir(_semantic.builder)
-    if storage == tlx.storage_kind.smem:
-        # if layout is given by user, continue to create layout_handle
-        # otherwise, create default NVMMA for 2D tensor and swizzled_shared for others, then continue to create layout_handle
-        if isinstance(layout, tlx.nv_mma_shared_layout_encoding) or (layout is None and len(shape) == 2):
-            layout = layout if layout else tlx.nv_mma_shared_layout_encoding.make_default(shape, dtype)
-            layout_handle = _semantic.builder.make_nv_mma_shared_encoding_attr(
-                    [int(x) for x in layout.shape],
-                    layout.order,
-                    layout.elemType.to_ir(_semantic.builder),
-                    layout.numCTAsPerCGA,
-                    layout.numCTASplit,
-                    layout.numCTAOrder,
-                    layout.fp4Padded,
-                )
-        elif isinstance(layout, tlx.swizzled_shared_layout_encoding) or (layout is None and len(shape) == 1):
-            # layout = layout if layout else tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
-            layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
-            layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
+    if layout is None:
+        if storage == tlx.storage_kind.smem:
+            if len(shape) == 1:
+                layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
+                layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
                     layout.vectorSize,
                     layout.perPhase,
                     layout.maxPhase,
@@ -83,11 +70,20 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
                     layout.numCTASplit,
                     layout.numCTAOrder,
                 )
-    elif storage == tlx.storage_kind.tmem:
-        # if layout is given by user, continue to create layout_handle
-        # otherwise, create default tmem layout and continue to create layout_handle
-        layout = layout if layout else tlx.tensor_memory_layout_encoding.make_default(shape)
-        layout_handle = _semantic.builder.make_tensor_memory_encoding_attr(
+            else:
+                layout = tlx.nv_mma_shared_layout_encoding.make_default(shape, dtype)
+                layout_handle = _semantic.builder.make_nv_mma_shared_encoding_attr(
+                    [int(x) for x in layout.shape],
+                    layout.order,
+                    layout.elemType.to_ir(_semantic.builder),
+                    layout.numCTAsPerCGA,
+                    layout.numCTASplit,
+                    layout.numCTAOrder,
+                    layout.fp4Padded,
+                )
+        else:
+            layout = tlx.tensor_memory_layout_encoding.make_default(shape)
+            layout_handle = _semantic.builder.make_tensor_memory_encoding_attr(
                 layout.blockM,
                 layout.blockN,
                 layout.unpacked,
@@ -95,50 +91,7 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
                 layout.CTASplitN,
             )
     else:
-        raise NotImplementedError("Unsupported storage kind: " + str(storage))
-
-    # if layout is None:
-    #     if storage == tlx.storage_kind.smem:
-    #         if len(shape) == 2:
-    #             layout = tlx.nv_mma_shared_layout_encoding(
-    #                     shape=shape, 
-    #                     order=[1, 0], 
-    #                     elemType=dtype,
-    #                     numCTAsPerCGA=[1, 1], 
-    #                     numCTASplit=[1, 1], 
-    #                     numCTAOrder=[1, 1],
-    #                     fp4Padded=False)
-    #             layout_handle = _semantic.builder.make_nv_mma_shared_encoding_attr(
-    #                 [int(x) for x in layout.shape],
-    #                 layout.order,
-    #                 layout.elemType.to_ir(_semantic.builder),
-    #                 layout.numCTAsPerCGA,
-    #                 layout.numCTASplit,
-    #                 layout.numCTAOrder,
-    #                 layout.fp4Padded,
-    #             )
-    #         else:
-    #             layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
-    #             layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
-    #                 layout.vectorSize,
-    #                 layout.perPhase,
-    #                 layout.maxPhase,
-    #                 layout.order,
-    #                 layout.numCTAsPerCGA,
-    #                 layout.numCTASplit,
-    #                 layout.numCTAOrder,
-    #             )
-    #     else:
-    #         layout = tlx.tensor_memory_layout_encoding.make_default(shape)
-    #         layout_handle = _semantic.builder.make_tensor_memory_encoding_attr(
-    #             layout.blockM,
-    #             layout.blockN,
-    #             layout.unpacked,
-    #             layout.CTASplitM,
-    #             layout.CTASplitN,
-    #         )
-    # else:
-    #     raise NotImplementedError("User-specified layout encoding not yet implemented.")
+        raise NotImplementedError("User-specified layout encoding not yet implemented.")
 
     if storage == tlx.storage_kind.smem:
         tensor_handle = _semantic.builder.create_local_alloc(full_shape, elem_type, layout_handle)

--- a/third_party/tlx/language/types.py
+++ b/third_party/tlx/language/types.py
@@ -105,6 +105,25 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
         self.numCTASplit = numCTASplit
         self.numCTAOrder = numCTAOrder
         self.fp4Padded = fp4Padded
+    
+
+    """
+    Make a default NVMMA shared layout encoding.
+    """
+
+    @classmethod
+    def make_default(cls, shape, dtype):
+        rank = len(shape)
+        return cls(
+            shape=shape, 
+            order=list(reversed(range(rank))),  # e.g, [1, 0] as a row-major order, 
+            elemType=dtype,
+            numCTAsPerCGA=[1] * rank, 
+            numCTASplit=[1] * rank, 
+            numCTAOrder=[1] * rank,
+            fp4Padded=False
+        )
+
 
     """
     Create a new layout that is a permutation of the given layout.

--- a/third_party/tlx/tutorials/pipelined-gemm.py
+++ b/third_party/tlx/tutorials/pipelined-gemm.py
@@ -74,9 +74,8 @@ def matmul_kernel_pipelined_hopper(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stri
     b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
 
     # allocate NUM_STAGES buffers
-    buffers_A = tlx.local_alloc(shape=(BLOCK_SIZE_M, BLOCK_SIZE_K), dtype=tlx.dtype_of(a_ptr), num=NUM_STAGES, layout=tlx.swizzled_shared_layout_encoding.make_default(rank=2))
-    buffers_B = tlx.local_alloc(shape=(BLOCK_SIZE_K, BLOCK_SIZE_N), dtype=tlx.dtype_of(b_ptr), num=NUM_STAGES, layout=tlx.swizzled_shared_layout_encoding.make_default(rank=2))
-
+    buffers_A = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_STAGES)
+    buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_STAGES)
     # prefetch (pipelining) for NUM_STAGES - 1 buffers
     for i in tl.range(0, NUM_STAGES - 1, loop_unroll_factor=NUM_STAGES - 1):
         a = tlx.local_view(buffers_A, i)

--- a/third_party/tlx/tutorials/pipelined-gemm.py
+++ b/third_party/tlx/tutorials/pipelined-gemm.py
@@ -76,6 +76,7 @@ def matmul_kernel_pipelined_hopper(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stri
     # allocate NUM_STAGES buffers
     buffers_A = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_STAGES)
     buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_STAGES)
+
     # prefetch (pipelining) for NUM_STAGES - 1 buffers
     for i in tl.range(0, NUM_STAGES - 1, loop_unroll_factor=NUM_STAGES - 1):
         a = tlx.local_view(buffers_A, i)

--- a/third_party/tlx/tutorials/pipelined-gemm.py
+++ b/third_party/tlx/tutorials/pipelined-gemm.py
@@ -74,8 +74,8 @@ def matmul_kernel_pipelined_hopper(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stri
     b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
 
     # allocate NUM_STAGES buffers
-    buffers_A = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_STAGES)
-    buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_STAGES)
+    buffers_A = tlx.local_alloc(shape=(BLOCK_SIZE_M, BLOCK_SIZE_K), dtype=tlx.dtype_of(a_ptr), num=NUM_STAGES, layout=tlx.swizzled_shared_layout_encoding.make_default(rank=2))
+    buffers_B = tlx.local_alloc(shape=(BLOCK_SIZE_K, BLOCK_SIZE_N), dtype=tlx.dtype_of(b_ptr), num=NUM_STAGES, layout=tlx.swizzled_shared_layout_encoding.make_default(rank=2))
 
     # prefetch (pipelining) for NUM_STAGES - 1 buffers
     for i in tl.range(0, NUM_STAGES - 1, loop_unroll_factor=NUM_STAGES - 1):


### PR DESCRIPTION
A previous hacky patch creates NVMMA layout encoding by default to make WGMMA work in our WS kernels
https://github.com/facebookexperimental/triton/commit/c4d476f6cce272df09b3d4d01a4f966a9ed9265f 

It failed two tests:
- pytest python/test/unit/language/test_tlx.py::test_local_load where `tlx.local_alloc` creates 1-D buffer not for WGMMA
- python third_party/tlx/tutorials/pipelined-gemm.py where 2D SMEM buffer is created and used by WGMMA but not in WS

The reason why we overlooked this is discussed at https://fb.workplace.com/groups/385893200869952/permalink/724909593634976/. We should revisit how TLX changes are picked up by Triton cache key generation. A VERY IMPORTANT takeaway is to use `TRITON_ALWAYS_COMPILE=1` each time you run a test to avoid incorrect cache hit.

Back to this PR:
Before a more robust layout propagation fix added in data flow analysis, we modified our hacky logic to make things work first.