### PR TITLE
[TLX] memdesc reinterpret

### DIFF
--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -275,15 +275,16 @@ void init_triton_tlx_ir(py::module &&m) {
                }
                // TODO: find the defining op properly - the defining op is not
                // necessarily MemDescSubviewOp
-               auto defineingOp = value.getDefiningOp();
+               auto definingOp = value.getDefiningOp();
                if (auto subviewOp =
-                       dyn_cast<ttg::MemDescSubviewOp>(defineingOp)) {
+                       dyn_cast<ttg::MemDescSubviewOp>(definingOp)) {
                  value = subviewOp.getSrc();
                } else {
                  auto requireLayoutOp =
                      value.getDefiningOp<tlx::RequireLayoutOp>();
-                 assert(subviewOp && "Failed to find TMEMAllocOp defining the "
-                                     "accumulator TMEM passed to dot op.");
+                 assert(requireLayoutOp &&
+                        "Failed to find TMEMAllocOp defining the "
+                        "accumulator TMEM passed to dot op.");
                  value = requireLayoutOp.getSrc();
                }
              }

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -7,6 +7,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Casting.h"
 
 namespace py = pybind11;
 using namespace ir;
@@ -274,10 +275,17 @@ void init_triton_tlx_ir(py::module &&m) {
                }
                // TODO: find the defining op properly - the defining op is not
                // necessarily MemDescSubviewOp
-               auto subviewOp = value.getDefiningOp<ttg::MemDescSubviewOp>();
-               assert(subviewOp && "Failed to find TMEMAllocOp defining the "
-                                   "accumulator TMEM passed to dot op.");
-               value = subviewOp.getSrc();
+               auto defineingOp = value.getDefiningOp();
+               if (auto subviewOp =
+                       dyn_cast<ttg::MemDescSubviewOp>(defineingOp)) {
+                 value = subviewOp.getSrc();
+               } else {
+                 auto requireLayoutOp =
+                     value.getDefiningOp<tlx::RequireLayoutOp>();
+                 assert(subviewOp && "Failed to find TMEMAllocOp defining the "
+                                     "accumulator TMEM passed to dot op.");
+                 value = requireLayoutOp.getSrc();
+               }
              }
 
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
@@ -307,6 +315,17 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value &arg,
               std::vector<int32_t> order) -> mlir::Value {
              return self.create<ttg::MemDescTransOp>(arg, order);
+           })
+      .def("create_memdesc_reinterpret",
+           [](TritonOpBuilder &self, Value &src, Type &newElementType,
+              std::vector<int64_t> newShape) -> mlir::Value {
+             auto oldType = cast<ttg::MemDescType>(src.getType());
+             assert(oldType && "Expect MemDescType for src");
+
+             auto newType = ttg::MemDescType::get(
+                 newShape, newElementType, oldType.getEncoding(),
+                 oldType.getMemorySpace(), oldType.getMutableMemory());
+             return self.create<ttg::MemDescReinterpretOp>(newType, src);
            })
       .def("create_async_TMA_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &coord,

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -295,17 +295,16 @@ def local_reinterpret(src: tlx.buffered_tensor, dtype: tl.dtype, _builder=None) 
     """
         Reinterpret the dtype of a buffered tensor. Currently only support TMEM.
     """
-    assert isinstance(src, tlx.buffered_tensor) and src.storage == tlx.storage_kind.tmem and isinstance(
-        src.layout, tlx.tensor_memory_layout_encoding), "TLX local_reinterpret only supports TMEM"
-
-    block_type = tl.block_type(dtype, src.shape)
+    assert isinstance(src, tlx.buffered_tensor) and src.type.storage == tlx.storage_kind.tmem and isinstance(
+        src.type.layout, tlx.tensor_memory_layout_encoding), "TLX local_reinterpret only supports TMEM"
 
     reinterpreted_value_handle = _builder.create_memdesc_reinterpret(src.handle, dtype.to_ir(_builder), src.shape)
     return tlx.buffered_tensor(
         reinterpreted_value_handle,
-        block_type,
-        src.storage,
-        src.layout,
+        dtype,
+        src.shape,
+        src.type.storage,
+        src.type.layout,
     )
 
 

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -291,6 +291,25 @@ def local_trans(input: tlx.buffered_tensor, dims: Tuple[int] = (1, 0), _builder=
 
 
 @tl.builtin
+def local_reinterpret(src: tlx.buffered_tensor, dtype: tl.dtype, _builder=None) -> tlx.buffered_tensor:
+    """
+        Reinterpret the dtype of a buffered tensor. Currently only support TMEM.
+    """
+    assert isinstance(src, tlx.buffered_tensor) and src.storage == tlx.storage_kind.tmem and isinstance(
+        src.layout, tlx.tensor_memory_layout_encoding), "TLX local_reinterpret only supports TMEM"
+
+    block_type = tl.block_type(dtype, src.shape)
+
+    reinterpreted_value_handle = _builder.create_memdesc_reinterpret(src.handle, dtype.to_ir(_builder), src.shape)
+    return tlx.buffered_tensor(
+        reinterpreted_value_handle,
+        block_type,
+        src.storage,
+        src.layout,
+    )
+
+
+@tl.builtin
 def async_descriptor_load(
     desc: tl.tensor_descriptor_base,
     result: tlx.buffered_tensor,

--- a/third_party/tlx/language/mma_ops.py
+++ b/third_party/tlx/language/mma_ops.py
@@ -31,6 +31,23 @@ def require_dot_operand_layout(opnd: tl.tensor, opIdx, parent_layout, _builder=N
     return _builder.create_require_layout(opnd.handle, layout_handle)
 
 
+def require_tmem_layout_unpacked(src: tlx.buffered_tensor, unpacked: bool, _builder=None):
+    assert isinstance(src, tlx.buffered_tensor) and src.storage == tlx.storage_kind.tmem and isinstance(
+        src.layout, tlx.tensor_memory_layout_encoding), "input must be a TMEM tensor"
+    old_layout = src.layout
+    if old_layout.unpacked != unpacked:
+        layout_handle = _builder.make_tensor_memory_encoding_attr(
+            old_layout.blockM,
+            old_layout.blockN,
+            unpacked,
+            old_layout.CTASplitM,
+            old_layout.CTASplitN,
+        )
+        return _builder.create_require_layout(src.handle, layout_handle)
+    # if the layout is already correct, return the original handle
+    return src.handle
+
+
 # async dot signature needs to be close to tl.dot as much as possible
 @tl.builtin
 def async_dot(
@@ -82,26 +99,16 @@ def async_dot(
         assert cuda_compute_capability < 100, "register operand is not supported on Blackwell"
         A_handle = A.handle
     else:
-        assert isinstance(A, tlx.buffered_tensor) and A.type.storage == tlx.storage_kind.tmem and isinstance(
-            A.type.layout, tlx.tensor_memory_layout_encoding), "input must be a TMEM tensor"
-        if A.type.layout.unpacked:
-            layout_handle = _builder.make_tensor_memory_encoding_attr(
-                A.type.layout.blockM,
-                A.type.layout.blockN,
-                False,  # unpacked == False
-                A.type.layout.CTASplitM,
-                A.type.layout.CTASplitN,
-            )
-            A_handle = _builder.create_require_layout(A.handle, layout_handle)
-        else:
-            # A already has `unpacked` set to False, no need for a require_layout
-            A_handle = A.handle
+        # set unpacked to False for A
+        A_handle = require_tmem_layout_unpacked(A, False, _builder)
 
     B_handle = require_nv_mma_shared_layout(B, _builder)
 
     if version == 5:
         assert isinstance(A, tlx.buffered_tensor), "input must be a buffered tensor"
-        output = _builder.create_tcgen5_dot(A_handle, B_handle, acc.handle, mBarrier.handle if mBarrier else None)
+        # D needs to have `unpacked` set to True, see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-packing-formats
+        acc_handle = require_tmem_layout_unpacked(acc, True, _builder)
+        output = _builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, mBarrier.handle if mBarrier else None)
         return tlx.async_token(output)
     else:
         mma_layout = _builder.make_nv_mma_encoding_attr(A_handle, acc_handle, version, 0, _builder.options.num_warps)

--- a/third_party/tlx/language/mma_ops.py
+++ b/third_party/tlx/language/mma_ops.py
@@ -32,9 +32,9 @@ def require_dot_operand_layout(opnd: tl.tensor, opIdx, parent_layout, _builder=N
 
 
 def require_tmem_layout_unpacked(src: tlx.buffered_tensor, unpacked: bool, _builder=None):
-    assert isinstance(src, tlx.buffered_tensor) and src.storage == tlx.storage_kind.tmem and isinstance(
-        src.layout, tlx.tensor_memory_layout_encoding), "input must be a TMEM tensor"
-    old_layout = src.layout
+    assert isinstance(src, tlx.buffered_tensor) and src.type.storage == tlx.storage_kind.tmem and isinstance(
+        src.type.layout, tlx.tensor_memory_layout_encoding), "input must be a TMEM tensor"
+    old_layout = src.type.layout
     if old_layout.unpacked != unpacked:
         layout_handle = _builder.make_tensor_memory_encoding_attr(
             old_layout.blockM,


### PR DESCRIPTION
The only known good use case for now is to reuse TMEM buffer with a different data type so we only expose dtype to frontend.

This PR also:
- Extract `require_tmem_layout_unpacked` to force the tmem layout to have correct `unpacked` value
- Require `D` in MMA to have `unpacked == true` as specified in PTX

We still need temporary hack for layout propagation to get this to work.

```diff
diff --git a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
index 6983ccb4a..15c3db986 100644
--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -4,6 +4,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Support/LLVM.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -60,6 +61,9 @@ LayoutEncoding LayoutEncoding::meet(const LayoutEncoding &lhs,
 LogicalResult LayoutBackwardPropagation::visitOperation(
     Operation *op, ArrayRef<LayoutEncodingLattice *> operands,
     ArrayRef<const LayoutEncodingLattice *> results) {
+  if (isa<triton::gpu::LocalLoadOp>(op)) {
+    return success();
+  }
   if (auto requireLayoutOp = dyn_cast<triton::tlx::RequireLayoutOp>(op)) {
     Attribute layout = requireLayoutOp.getType().getEncoding();
     const auto layoutLattice = LayoutEncoding(layout);
```

We will have the layout propagation not propagate through `MemDescReinterpretOp` to address it properly.

All tests passed with clean cache dir: `pytest -vs python/test/unit/language/test_tlx.py`

.ttgir for new test (layout propagation is ok in this case since there's no require_layout that would back propagate layout to memdesc_reinterpret)

```mlir
#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
#blocked2 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [0, 1]}>
#loc = loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":476:0)
#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
#smem = #ttg.shared_memory
#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, unpacked = true>
module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @local_reinterpret_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":476:0), %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":476:0), %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":476:0), %arg3: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("/data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py":476:0)) attributes {noinline = false} {
    %cst = arith.constant dense<128> : tensor<64x1xi32, #blocked> loc(#loc1)
    %cst_0 = arith.constant dense<128> : tensor<64x1xi32, #blocked1> loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %true = arith.constant true loc(#loc1)
    %c128_i32 = arith.constant 128 : i32 loc(#loc1)
    %c64_i32 = arith.constant 64 : i32 loc(#loc1)
    %0 = tt.get_program_id x : i32 loc(#loc2)
    %1 = tt.get_program_id y : i32 loc(#loc3)
    %2 = arith.muli %0, %c64_i32 : i32 loc(#loc4)
    %3 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> loc(#loc5)
    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> loc(#loc5)
    %5 = tt.splat %2 : i32 -> tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> loc(#loc6)
    %6 = tt.splat %2 : i32 -> tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> loc(#loc6)
    %7 = arith.addi %5, %3 : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> loc(#loc6)
    %8 = arith.addi %6, %4 : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> loc(#loc6)
    %9 = arith.muli %1, %c128_i32 : i32 loc(#loc7)
    %10 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> loc(#loc8)
    %11 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc8)
    %12 = tt.splat %9 : i32 -> tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> loc(#loc9)
    %13 = tt.splat %9 : i32 -> tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc9)
    %14 = arith.addi %12, %10 : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> loc(#loc9)
    %15 = arith.addi %13, %11 : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc9)
    %16 = tt.expand_dims %7 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<64x1xi32, #blocked1> loc(#loc10)
    %17 = tt.expand_dims %8 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked> loc(#loc10)
    %18 = arith.muli %16, %cst_0 : tensor<64x1xi32, #blocked1> loc(#loc11)
    %19 = arith.muli %17, %cst : tensor<64x1xi32, #blocked> loc(#loc11)
    %20 = tt.expand_dims %14 {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xi32, #blocked1> loc(#loc12)
    %21 = tt.expand_dims %15 {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xi32, #blocked> loc(#loc12)
    %22 = tt.broadcast %18 : tensor<64x1xi32, #blocked1> -> tensor<64x128xi32, #blocked1> loc(#loc13)
    %23 = tt.broadcast %19 : tensor<64x1xi32, #blocked> -> tensor<64x128xi32, #blocked> loc(#loc13)
    %24 = tt.broadcast %20 : tensor<1x128xi32, #blocked1> -> tensor<64x128xi32, #blocked1> loc(#loc13)
    %25 = tt.broadcast %21 : tensor<1x128xi32, #blocked> -> tensor<64x128xi32, #blocked> loc(#loc13)
    %26 = arith.addi %22, %24 : tensor<64x128xi32, #blocked1> loc(#loc13)
    %27 = arith.addi %23, %25 : tensor<64x128xi32, #blocked> loc(#loc13)
    %28 = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf32, #shared, #smem, mutable> loc(#loc14)
    %29 = ttg.memdesc_subview %28[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x64x128xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf32, #shared, #smem, mutable> loc(#loc15)
    %30 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked1> loc(#loc16)
    %31 = tt.addptr %30, %26 : tensor<64x128x!tt.ptr<f32>, #blocked1>, tensor<64x128xi32, #blocked1> loc(#loc16)
    %32 = ttg.async_copy_global_to_local %31, %29 : tensor<64x128x!tt.ptr<f32>, #blocked1> -> <64x128xf32, #shared, #smem, mutable> loc(#loc17)
    %result = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc18)
    %33 = ttg.memdesc_subview %result[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x64x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc19)
    %34 = ttg.async_commit_group  loc(#loc20)
    %35 = ttg.async_wait  {num = 0 : i32} loc(#loc21)
    %36 = ttg.local_load %29 : !ttg.memdesc<64x128xf32, #shared, #smem, mutable> -> tensor<64x128xf32, #blocked2> loc(#loc22)
    ttng.tmem_store %36, %33, %true : tensor<64x128xf32, #blocked2> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc22)
    %37 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked1> loc(#loc23)
    %38 = tt.addptr %37, %26 : tensor<64x128x!tt.ptr<f32>, #blocked1>, tensor<64x128xi32, #blocked1> loc(#loc23)
    %result_1 = ttng.tmem_load %33 : !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #blocked2> loc(#loc24)
    %39 = ttg.convert_layout %result_1 : tensor<64x128xf32, #blocked2> -> tensor<64x128xf32, #blocked1> loc(#loc25)
    tt.store %38, %39 : tensor<64x128x!tt.ptr<f32>, #blocked1> loc(#loc25)
    %40 = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> loc(#loc26)
    %41 = ttg.memdesc_subview %40[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc27)
    %42 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blocked> loc(#loc28)
    %43 = tt.addptr %42, %27 : tensor<64x128x!tt.ptr<f16>, #blocked>, tensor<64x128xi32, #blocked> loc(#loc28)
    %44 = ttg.async_copy_global_to_local %43, %41 : tensor<64x128x!tt.ptr<f16>, #blocked> -> <64x128xf16, #shared, #smem, mutable> loc(#loc29)
    %45 = ttg.async_commit_group  loc(#loc30)
    %46 = ttg.async_wait  {num = 0 : i32} loc(#loc31)
    %47 = ttg.memdesc_reinterpret %33 : !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc32)
    %48 = ttg.local_load %41 : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> tensor<64x128xf16, #blocked2> loc(#loc33)
    ttng.tmem_store %48, %47, %true : tensor<64x128xf16, #blocked2> -> !ttg.memdesc<64x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc33)
    %49 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blocked> loc(#loc34)
    %50 = tt.addptr %49, %27 : tensor<64x128x!tt.ptr<f16>, #blocked>, tensor<64x128xi32, #blocked> loc(#loc34)
    %result_2 = ttng.tmem_load %47 : !ttg.memdesc<64x128xf16, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x128xf16, #blocked2> loc(#loc35)
    %51 = ttg.convert_layout %result_2 : tensor<64x128xf16, #blocked2> -> tensor<64x128xf16, #blocked> loc(#loc36)
    tt.store %50, %51 : tensor<64x128x!tt.ptr<f16>, #blocked> loc(#loc36)
    tt.return loc(#loc37)
  } loc(#loc)
} loc(#loc)

```