### PR TITLE
[TLX] Include compiler and language path in triton cache key

### DIFF
--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -301,6 +301,12 @@ def triton_key():
     for lib in pkgutil.walk_packages([language_path], prefix="triton.language."):
         with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
             contents += [hashlib.sha256(f.read()).hexdigest()]
+    # third-party TLX
+    from pathlib import Path
+    tlx_path = str(Path(TRITON_PATH).parent.parent / "third_party" / "tlx" / "language")
+    for lib in pkgutil.walk_packages([tlx_path], prefix="tlx."):
+        with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
+            contents += [hashlib.sha256(f.read()).hexdigest()]
     return f'{__version__}' + '-'.join(contents)
 
 

--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -303,10 +303,11 @@ def triton_key():
             contents += [hashlib.sha256(f.read()).hexdigest()]
     # third-party TLX
     from pathlib import Path
-    tlx_path = str(Path(TRITON_PATH).parent.parent / "third_party" / "tlx" / "language")
-    for lib in pkgutil.walk_packages([tlx_path], prefix="tlx."):
-        with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
-            contents += [hashlib.sha256(f.read()).hexdigest()]
+    for tlx_sub_folder in ["language", "compiler"]:
+        tlx_path = str(Path(TRITON_PATH).parent.parent / "third_party" / "tlx" / tlx_sub_folder)
+        for lib in pkgutil.walk_packages([tlx_path], prefix="tlx."):
+            with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
+                contents += [hashlib.sha256(f.read()).hexdigest()]
     return f'{__version__}' + '-'.join(contents)
 
 


### PR DESCRIPTION
Fix issues https://fb.workplace.com/groups/385893200869952/permalink/724909593634976/
Test plan: 
- delete `/tmp/triton_cache_daohang/` entirely
- run a good unit test
- introduce bad code changes and run the same unit test
