### PR TITLE
[TLX] Support named barrier for Pingpong schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Examples
 
     Perform the arrive operation on an mbarrier
 
+- `tlx.named_barrier_wait(bar_id, num_threads)`
+
+    Wait until `num_threads` threads have reached the specified named mbarrier phase.
+
+- `tlx.named_barrier_arrive(bar_id, num_threads)`
+
+    Signal arrival at a named mbarrier with the given thread count.
+
 - `tlx.barrier_expect_bytes(bar, bytes)`
 
   Signal a barrier of an expected number of bytes to be copied.

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -262,6 +262,22 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier"> {
   let hasVerifier = 1;
 }
 
+def TTNG_NamedBarrierArriveOp : TTNG_Op<"arrive_barrier_named", []> {
+  let summary = "named barrier arrive";
+
+  let arguments = (ins I32:$bar, I32: $numThreads);
+
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
+}
+
+def TTNG_NamedBarrierWaitOp : TTNG_Op<"wait_barrier_named", []> {
+  let summary = "named barrier wait";
+
+  let arguments = (ins I32:$bar, I32: $numThreads);
+
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
+}
+
 def TTNG_TensorDescToTMAPtrOp : TTNG_Op<"tensor_desc_to_tma_ptr", [Pure]> {
   let summary = "Convert tensor descriptor to pointer to tma descriptor";
 

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -929,6 +929,73 @@ def test_wait_arrive_ws(BLOCK_SIZE, device):
     not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
     reason="Requires compute capability >= 9 for NV",
 )
+@pytest.mark.parametrize("BLOCK_SIZE", [(1024)])
+# def test_mbarriers(BLOCK_SIZE, device):
+def test_named_wait_arrive(BLOCK_SIZE, device):
+
+    @triton.jit
+    def add2_warp_specialized_pingpong_kernel(
+        x_ptr,
+        y_ptr,
+        z_ptr,
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        with tlx.async_tasks():
+            with tlx.async_task("default"):
+                tlx.named_barrier_wait(9, 256)
+                tlx.named_barrier_arrive(10, 256)
+                offsets = block_start + tl.arange(0, BLOCK_SIZE)
+                mask = offsets < n_elements
+                x = tl.load(x_ptr + offsets, mask=mask)
+                y = tl.load(y_ptr + offsets, mask=mask)
+                output = x + y
+                tl.store(z_ptr + offsets, output, mask=mask)
+            with tlx.async_task(num_warps=4, registers=100):
+                tlx.named_barrier_arrive(9, 256)
+                tlx.named_barrier_wait(10, 256)
+                offsets = block_start + tl.arange(0, BLOCK_SIZE)
+                mask = offsets < n_elements
+                a = tl.load(a_ptr + offsets, mask=mask)
+                b = tl.load(b_ptr + offsets, mask=mask)
+                output = a + b
+                tl.store(c_ptr + offsets, output, mask=mask)
+
+
+    def dual_add(x, y, a, b):
+        return x + y, a + b
+
+    torch.manual_seed(0)
+    size = 98432
+    x = torch.rand(size, device=device)
+    y = torch.rand(size, device=device)
+    a = torch.rand(size, device=device)
+    b = torch.rand(size, device=device)
+
+    output1 = torch.empty_like(x)
+    output2 = torch.empty_like(a)
+    n_elements = output1.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
+    kernel = add2_warp_specialized_pingpong_kernel[grid](x, y, output1, a, b, output2, n_elements, BLOCK_SIZE)
+    ttgir = kernel.asm["ttgir"]
+    assert ttgir.count("ttng.wait_barrier_named %c9_i32, %c256_i32") == 1
+    assert ttgir.count("ttng.arrive_barrier_named %c10_i32, %c256_i32") == 1
+    assert ttgir.count("ttng.arrive_barrier_named %c9_i32_1, %c256_i32") == 1
+    assert ttgir.count("ttng.wait_barrier_named %c10_i32_0, %c256_i32") == 1
+
+    ref_out1, ref_out2 = dual_add(x, y, a, b)
+    torch.testing.assert_close(output1, ref_out1, check_dtype=False)
+    torch.testing.assert_close(output2, ref_out2, check_dtype=False)
+
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
+    reason="Requires compute capability >= 9 for NV",
+)
 def test_descriptor_load(device):
 
     def alloc_fn(size: int, align: int, stream: Optional[int]):

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -45,6 +45,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.arrive_barrier %alloc, 2, %pred : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
+
+  // CHECK-LABEL: arrive_barrier_named
+  tt.func @arrive_barrier_named(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
+    %c9_i32 = arith.constant 9 : i32
+    %c256_i32 = arith.constant 256 : i32
+    // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
+    // CHECK-NEXT: "bar.arrive $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    ttng.arrive_barrier_named %c9_i32, %c256_i32 : i32, i32
+    tt.return
+  }
+
+  // CHECK-LABEL: wait_barrier_named
+  tt.func @wait_barrier_named(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
+    %c9_i32 = arith.constant 9 : i32
+    %c256_i32 = arith.constant 256 : i32
+    // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
+    // CHECK-NEXT: "bar.sync $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    ttng.wait_barrier_named %c9_i32, %c256_i32 : i32, i32
+    tt.return
+  }
 }
 
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -217,6 +217,59 @@ struct ArriveBarrierOpConversion
     return success();
   }
 };
+
+struct NamedBarrierArriveOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::NamedBarrierArriveOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::NamedBarrierArriveOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::NamedBarrierArriveOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    std::string ptxAsm = "bar.arrive $0, $1;";
+
+    PTXBuilder ptxBuilder;
+    SmallVector<PTXBuilder::Operand *, 2> operands = {
+        ptxBuilder.newOperand(adaptor.getBar(), "r"),
+        ptxBuilder.newOperand(adaptor.getNumThreads(), "r")};
+
+    auto arriveOp = *ptxBuilder.create<>(ptxAsm);
+    arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
+    auto voidTy = void_ty(getContext());
+    ptxBuilder.launch(rewriter, op.getLoc(), voidTy);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct NamedBarrierWaitOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::NamedBarrierWaitOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::NamedBarrierWaitOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::NamedBarrierWaitOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    std::string ptxAsm = "bar.sync $0, $1;";
+
+    PTXBuilder ptxBuilder;
+    SmallVector<PTXBuilder::Operand *, 2> operands = {
+        ptxBuilder.newOperand(adaptor.getBar(), "r"),
+        ptxBuilder.newOperand(adaptor.getNumThreads(), "r")};
+
+    auto waitOp = *ptxBuilder.create<>(ptxAsm);
+    waitOp(operands, /*onlyAttachMLIRArgs=*/true);
+    auto voidTy = void_ty(getContext());
+    ptxBuilder.launch(rewriter, op.getLoc(), voidTy);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
 } // namespace
 
 void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
@@ -228,4 +281,6 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit);
   patterns.add<BarrierExpectConversion>(typeConverter, benefit);
   patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
+  patterns.add<NamedBarrierArriveOpConversion>(typeConverter, benefit);
+  patterns.add<NamedBarrierWaitOpConversion>(typeConverter, benefit);
 }

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -220,6 +220,14 @@ void init_triton_tlx_ir(py::module &&m) {
              }
              return outputs;
            })
+      .def("create_named_barrier_wait",
+           [](TritonOpBuilder &self, Value barrier, Value numThreads) -> void {
+             self.create<ttng::NamedBarrierWaitOp>(barrier, numThreads);
+           })
+      .def("create_named_barrier_arrive",
+           [](TritonOpBuilder &self, Value barrier, Value numThreads) -> void {
+             self.create<ttng::NamedBarrierArriveOp>(barrier, numThreads);
+           })
       .def("create_tmem_alloc",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
               Type &elementType, Attribute &encoding) -> mlir::Value {

--- a/third_party/tlx/language/barrier.py
+++ b/third_party/tlx/language/barrier.py
@@ -68,3 +68,40 @@ def barrier_arrive(
 
     # TODO. add validator logics
     _builder.create_barrier_arrive(bar.handle, arrive_count.value)
+
+
+@tl.builtin
+def named_barrier_wait(
+    bar: int,
+    arrive_count: int,
+    _builder=None,
+) -> None:
+    """
+    Wait until `arrive_count` threads have reached the specified named mbarrier phase.
+
+    Arguments:
+        bar (tl.constexpr): Identifier for the named barrier (e.g. from a buffer view).
+        count (tl.constexpr): Number of threads arriving at the barrier.
+    """
+
+    bar_handle = _convert_elem_to_ir_value(_builder, bar, require_i64=False)
+    arrive_count_handle = _convert_elem_to_ir_value(_builder, arrive_count, require_i64=False)
+    _builder.create_named_barrier_wait(bar_handle, arrive_count_handle)
+
+
+@tl.builtin
+def named_barrier_arrive(
+    bar: tl.constexpr,
+    arrive_count: tl.constexpr,
+    _builder=None,
+) -> None:
+    """
+    Signal arrival at a named mbarrier with the given thread count.
+
+    Arguments:
+        bar (tl.constexpr): Identifier for the named barrier (e.g. from a buffer view).
+        count (tl.constexpr): Number of threads arriving at the barrier.
+    """
+    bar_handle = _convert_elem_to_ir_value(_builder, bar, require_i64=False)
+    arrive_count_handle = _convert_elem_to_ir_value(_builder, arrive_count, require_i64=False)
+    _builder.create_named_barrier_arrive(bar_handle, arrive_count_handle)


### PR DESCRIPTION
Adding `tlx.named_barrier_wait` and `tlx.named_barrier_arrive` to supporting Pingpong schedule. Two ttgir ops are introduced correspondingly. Also adding WS+pipelined+Pingpong FA kernel.

```
After:
fused-attention-ws-pipelined-pingpong-batch4-head32-d128:
     N_CTX  Triton [FP16]
0   1024.0     488.167798
1   2048.0     576.562504
2   4096.0     603.177504
3   8192.0     619.294642
4  16384.0     614.810779

Before:
fused-attention-ws-pipelined-batch4-head32-d128:
     N_CTX  Triton [FP16]
0   1024.0     478.080941
1   2048.0     556.157572
2   4096.0     527.902147
3   8192.0     595.027327
4  16384.0     600.218371
```

