### PR TITLE
[TLX] Blackwell WS GEMM tutorial kernel

### DIFF
--- a/third_party/tlx/tutorials/gemm-WS-blackwell.py
+++ b/third_party/tlx/tutorials/gemm-WS-blackwell.py
@@ -24,7 +24,7 @@ def get_cuda_autotune_config():
             num_warps=4,
             num_stages=1,
             pre_hook=matmul_tma_set_block_size_hook,
-        ) for BM in [128] for BN in [128, 256] for BK in [64, 128] for s in ([2, 3, 4]) for subtile in [True, False]
+        ) for BM in [128] for BN in [128, 256] for BK in [64, 128] for s in ([2, 3, 4]) for subtile in [True]
     ]
 
 
@@ -167,7 +167,7 @@ def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M
                 cur_tmem_buf = (cur_tmem_buf + 1) % 2
                 processed_k_iters += k_tiles
 
-        with tlx.async_task(num_warps=4, num_regs=232):
+        with tlx.async_task(num_warps=4, num_regs=232):  # epilogue consumer
             tmem_phase_first = 0
             tmem_phase_second = 0
             cur_tmem_buf = 0
@@ -260,7 +260,7 @@ configs = []
 configs.append(
     triton.testing.Benchmark(
         x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-        x_vals=[128 * i for i in range(2, 34)],  # Different possible values for `x_name`
+        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
         line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
         # Possible values for `line_arg`
         # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.

--- a/third_party/tlx/tutorials/gemm-WS-blackwell.py
+++ b/third_party/tlx/tutorials/gemm-WS-blackwell.py
@@ -1,0 +1,290 @@
+# TLX GEMM kernel optimized for Blackwell Warp Specialization
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.tlx.language as tlx
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+def get_cuda_autotune_config():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": BM,
+                "BLOCK_SIZE_N": BN,
+                "BLOCK_SIZE_K": BK,
+                "GROUP_SIZE_M": 8,
+                "NUM_SMEM_BUFFERS": s,
+                "EPILOGUE_SUBTILE": subtile,
+            },
+            num_warps=4,
+            num_stages=1,
+            pre_hook=matmul_tma_set_block_size_hook,
+        ) for BM in [128] for BN in [128, 256] for BK in [64, 128] for s in ([2, 3, 4]) for subtile in [True, False]
+    ]
+
+
+def matmul_tma_set_block_size_hook(nargs):
+    BLOCK_M = nargs["BLOCK_SIZE_M"]
+    BLOCK_N = nargs["BLOCK_SIZE_N"]
+    BLOCK_K = nargs["BLOCK_SIZE_K"]
+    nargs["a_desc"].block_shape = [BLOCK_M, BLOCK_K]
+    nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N]
+    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", False)
+    if EPILOGUE_SUBTILE:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N // 2]
+    else:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N]
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.autotune(
+    configs=get_cuda_autotune_config(),
+    key=["M", "N", "K"],
+)
+@triton.jit
+def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M: tl.constexpr,
+                                   BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,  #
+                                   GROUP_SIZE_M: tl.constexpr,  #
+                                   NUM_SMEM_BUFFERS: tl.constexpr,  #
+                                   NUM_SMS: tl.constexpr,  #
+                                   EPILOGUE_SUBTILE: tl.constexpr,  #
+                                   ):
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    num_tiles = num_pid_m * num_pid_n
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+
+    # allocate NUM_SMEM_BUFFERS buffers
+    buffers_A = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tl.float16, NUM_SMEM_BUFFERS)
+    buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tl.float16, NUM_SMEM_BUFFERS)
+    # allocate barriers
+    smem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS, arrive_count=1)
+    smem_full_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS, arrive_count=1)
+
+    # use TMEM buffer with 2 slots
+    tmem_buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float32, tl.constexpr(2), tlx.storage_kind.tmem)
+    tmem_full_bars = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
+    tmem_empty_bars = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
+    # initialize the phases. These phase flags flip when a round of dot or load is done for SMEM buffers
+    dot_phase = 0  # the current phase of dot op
+    load_phase = 0  # the current phase of TMA load
+
+    with tlx.async_tasks():
+        with tlx.async_task("default"):  # producer, TMA load
+            # we virtually "flatten" the two layer loop as if we're performing tma loads on
+            # one big list of data
+            processed_k_iters = 0
+            for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+                offs_am = pid_m * BLOCK_SIZE_M
+                offs_bn = pid_n * BLOCK_SIZE_N
+
+                for k in range(0, k_tiles):
+                    # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
+                    buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
+                    a = tlx.local_view(buffers_A, buf)
+                    b = tlx.local_view(buffers_B, buf)
+                    smem_full_bar = tlx.local_view(smem_full_bars, buf)
+                    smem_empty_bar = tlx.local_view(smem_empty_bars, buf)
+                    # wait for previous phase(round) of dot for this buf
+                    tlx.barrier_wait(smem_empty_bar, load_phase ^ 1)
+                    # buffer is now ready to be used again
+                    offs_k = k * BLOCK_SIZE_K
+                    tlx.barrier_expect_bytes(smem_full_bar, 2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K)  # float16
+                    tlx.async_descriptor_load(a_desc, a, [offs_am, offs_k], smem_full_bar)
+                    tlx.async_descriptor_load(b_desc, b, [offs_k, offs_bn], smem_full_bar)
+                    # flip phase at the end of a round
+                    load_phase = (load_phase if (buf < NUM_SMEM_BUFFERS - 1) else load_phase ^ 1)
+                processed_k_iters += k_tiles
+        with tlx.async_task(num_warps=4, num_regs=232):  # MMA consumer
+            tmem_phase_first = 1
+            tmem_phase_second = 1
+            cur_tmem_buf = 0
+
+            processed_k_iters = 0
+            for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+                offs_am = pid_m * BLOCK_SIZE_M
+                offs_bn = pid_n * BLOCK_SIZE_N
+
+                # init accumulator to 0 (in TMEM), block until the buffer is ready
+                zeros = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+                acc_tmem = tlx.local_view(tmem_buffers, cur_tmem_buf)
+                # wait epilogue consumer to be done with the buffer before reusing it
+                tmem_empty_bar = tlx.local_view(tmem_empty_bars, cur_tmem_buf)
+                if cur_tmem_buf == 0:
+                    tlx.barrier_wait(tmem_empty_bar, tmem_phase_first)
+                    tmem_phase_first = tmem_phase_first ^ 1  # flip for next use
+                else:
+                    tlx.barrier_wait(tmem_empty_bar, tmem_phase_second)
+                    tmem_phase_second = tmem_phase_second ^ 1  # flip for next use
+
+                tlx.local_store(acc_tmem, zeros, tlx.storage_kind.tmem)
+
+                # now iterate along K to compute result for the block
+                for k in range(0, k_tiles):
+                    # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
+                    buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
+                    a = tlx.local_view(buffers_A, buf)
+                    b = tlx.local_view(buffers_B, buf)
+                    smem_full_bar = tlx.local_view(smem_full_bars, buf)
+                    smem_empty_bar = tlx.local_view(smem_empty_bars, buf)
+                    # wait for current phase(round) of load for this buf
+                    tlx.barrier_wait(smem_full_bar, dot_phase)
+                    # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
+                    tlx.async_dot(a, b, acc_tmem, mBarrier=smem_empty_bar, out_dtype=tl.float32)
+                    # flip phase at the end of a round
+                    dot_phase = (dot_phase if (buf < NUM_SMEM_BUFFERS - 1) else dot_phase ^ 1)
+
+                # wait for last mma to complete
+                last_buf = (processed_k_iters + k_tiles - 1) % NUM_SMEM_BUFFERS
+                last_smem_empty_bar = tlx.local_view(smem_empty_bars, last_buf)
+                # in case phase was flipped, we should use the phase value when dot op was issued
+                last_dot_phase = (dot_phase ^ 1 if (last_buf == NUM_SMEM_BUFFERS - 1) else dot_phase)
+                tlx.barrier_wait(last_smem_empty_bar, last_dot_phase)
+
+                # done filling this buffer, signal epilogue consumer
+                tmem_full_bar = tlx.local_view(tmem_full_bars, cur_tmem_buf)
+                tlx.barrier_arrive(tmem_full_bar, 1)
+
+                # possibly enter next iteration (next tile) without waiting for epilogue
+                cur_tmem_buf = (cur_tmem_buf + 1) % 2
+                processed_k_iters += k_tiles
+
+        with tlx.async_task(num_warps=4, num_regs=232):
+            tmem_phase_first = 0
+            tmem_phase_second = 0
+            cur_tmem_buf = 0
+
+            for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+                offs_am = pid_m * BLOCK_SIZE_M
+                offs_bn = pid_n * BLOCK_SIZE_N
+
+                tmem_full_bar = tlx.local_view(tmem_full_bars, cur_tmem_buf)
+                if cur_tmem_buf == 0:
+                    tlx.barrier_wait(tmem_full_bar, tmem_phase_first)
+                    tmem_phase_first = tmem_phase_first ^ 1
+                else:
+                    tlx.barrier_wait(tmem_full_bar, tmem_phase_second)
+                    tmem_phase_second = tmem_phase_second ^ 1
+                # tlx.barrier_wait(tmem_full_bar, tmem_phases[cur_tmem_buf])
+
+                # load the result from TMEM to registers
+                acc_tmem = tlx.local_view(tmem_buffers, cur_tmem_buf)
+
+                if EPILOGUE_SUBTILE:
+                    # We load/store the result half by half to reduce SMEM pressure
+                    acc_tmem_subslice1 = tlx.subslice(acc_tmem, 0, BLOCK_SIZE_N // 2)
+                    result = tlx.local_load(acc_tmem_subslice1, tlx.storage_kind.tmem)
+                    c = result.to(tl.float16)
+                    c_desc.store([offs_am, offs_bn], c)
+
+                    acc_tmem_subslice2 = tlx.subslice(acc_tmem, BLOCK_SIZE_N // 2, BLOCK_SIZE_N // 2)
+                    result = tlx.local_load(acc_tmem_subslice2, tlx.storage_kind.tmem)
+                    c = result.to(tl.float16)
+                    c_desc.store([offs_am, offs_bn + BLOCK_SIZE_N // 2], c)
+                else:
+                    result = tlx.local_load(acc_tmem, tlx.storage_kind.tmem)
+                    c = result.to(tl.float16)
+                    c_desc.store([offs_am, offs_bn], c)
+
+                # done storing this buffer, signal MMA consumer to resume writing to it
+                tmem_empty_bar = tlx.local_view(tmem_empty_bars, cur_tmem_buf)
+                tlx.barrier_arrive(tmem_empty_bar, 1)
+
+                cur_tmem_buf = (cur_tmem_buf + 1) % 2
+
+
+def matmul(a, b):
+    # Check constraints.
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+    M, K = a.shape
+    K, N = b.shape
+    # Allocates output.
+    c = torch.empty((M, N), device=a.device, dtype=torch.float16)
+
+    # A dummy block value that will be overwritten when we have the real block size
+    dummy_block = [1, 1]
+    a_desc = TensorDescriptor(a, a.shape, a.stride(), dummy_block)
+    b_desc = TensorDescriptor(b, b.shape, b.stride(), dummy_block)
+    c_desc = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    # Persistent kernel to have thread block resident in SM as long as possible
+    grid = lambda META: (min(
+        NUM_SMS,
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    ), )
+    matmul_kernel_tma_ws_blackwell[grid](
+        a_desc, b_desc, c_desc,  #
+        M, N, K,  #
+        NUM_SMS=NUM_SMS,  #
+    )
+    return c
+
+
+torch.manual_seed(0)
+M, N, K = 8192, 8192, 8192
+a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+torch_output = torch.matmul(a, b)
+triton_output = matmul(a, b)
+print(f"torch_output_with_fp16_inputs={torch_output}")
+print(f"triton_output_with_fp16_inputs={triton_output}")
+rtol = 0
+torch.testing.assert_close(triton_output, torch_output, atol=1e-2, rtol=rtol)
+print("✅ Triton and Torch match")
+
+ref_lib = "cuBLAS"
+
+configs = []
+configs.append(
+    triton.testing.Benchmark(
+        x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
+        x_vals=[128 * i for i in range(2, 34)],  # Different possible values for `x_name`
+        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
+        # Possible values for `line_arg`
+        # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
+        line_vals=[ref_lib.lower(), "triton"],  # Label name for the lines
+        line_names=[ref_lib, "Triton"],  # Line styles
+        styles=[("green", "-"), ("blue", "-")],
+        ylabel="TFLOPS",  # Label name for the y-axis
+        plot_name="matmul-performance-" + ("fp16"),  # Name for the plot, used also as a file name for saving the plot.
+        args={},
+    ))
+
+
+@triton.testing.perf_report(configs)
+def benchmark(M, N, K, provider):
+    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == ref_lib.lower():
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
+    if provider == "triton":
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles)
+    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+print("Running benchmarks...")
+benchmark.run(show_plots=True, print_data=True)


### PR DESCRIPTION
Optimization techniques applied:
- Warp Specializations: 1 producer group loading data async with TMA, 1 MMA consumer group issuing async MMA operations, 1 epilogue consumer group storing result from TMEM to GMEM
- Persistent kernel: each program processes more than 1 tile and stay in the same SM for as long as possible. This hides latency of epilogue consumer group's store operation
- TMA load/store: with host side descriptor initialization
- Epilogue sub-tiling: have the epilogue group store results half by half to reduce SMEM pressure

Performance:
```bash
Locking GPU 5 power cap to 750 W
Locking GPU 5 frequency cap to 1965 Hz
...
✅ Triton and Torch match
Running benchmarks...
matmul-performance-fp16:
         M       N       K       cuBLAS       Triton
0    256.0   256.0   256.0     4.619278     1.436405
1    384.0   384.0   384.0    12.330815     4.712309
2    512.0   512.0   512.0    29.127110    11.452025
3    640.0   640.0   640.0    56.888887    22.291156
4    768.0   768.0   768.0    98.303997    37.399672
5    896.0   896.0   896.0   154.493799    56.126962
6   1024.0  1024.0  1024.0   190.650180    83.676888
7   1152.0  1152.0  1152.0   270.684094   114.983742
8   1280.0  1280.0  1280.0   371.308771   157.538463
9   1408.0  1408.0  1408.0   419.367389   216.179476
10  1536.0  1536.0  1536.0   544.452929   273.541559
11  1664.0  1664.0  1664.0   528.376468   346.528508
12  1792.0  1792.0  1792.0   663.582236   432.285543
13  1920.0  1920.0  1920.0   727.578980   531.054023
14  2048.0  2048.0  2048.0   804.903898   671.088657
15  2176.0  2176.0  2176.0   876.131603   744.458647
16  2304.0  2304.0  2304.0  1038.603107   682.510610
17  2432.0  2432.0  2432.0   968.774597   758.669107
18  2560.0  2560.0  2560.0   997.693653   839.532450
19  2688.0  2688.0  2688.0  1026.084317   923.788278
20  2816.0  2816.0  2816.0  1063.761188   965.183059
21  2944.0  2944.0  2944.0  1107.467361  1014.473947
22  3072.0  3072.0  3072.0  1155.573589   929.199681
23  3200.0  3200.0  3200.0  1081.880625   851.913509
24  3328.0  3328.0  3328.0  1146.986087   959.084751
25  3456.0  3456.0  3456.0  1165.788556  1022.548669
26  3584.0  3584.0  3584.0  1110.495026  1107.716095
27  3712.0  3712.0  3712.0   979.085776  1051.550956
28  3840.0  3840.0  3840.0  1074.197622  1013.588416
29  3968.0  3968.0  3968.0  1079.260882  1060.501317
30  4096.0  4096.0  4096.0  1108.235676  1108.664784
```

The perf number fluctuates in each bench run, but we always get close to cublas on large input, and almost always outperform cublas on some inputs.