### PR TITLE
[TLX] Allow local_reinterpret to change shapes

### DIFF
--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -330,12 +330,26 @@ void init_triton_tlx_ir(py::module &&m) {
               std::vector<int64_t> newShape) -> mlir::Value {
              auto oldType = cast<ttg::MemDescType>(src.getType());
              assert(oldType && "Expect MemDescType for src");
-             // TODO: assert encoding should be compatible for oldType and
-             // newType. Performance loss should be acceptable but not
-             // correctness.
+             auto encoding = oldType.getEncoding();
+             if (!oldType.getShape().equals(newShape)) {
+               // Only accept unswizzled encoding for now.
+               if (auto mmaEncoding =
+                       dyn_cast<ttg::NVMMASharedEncodingAttr>(encoding)) {
+                 if (mmaEncoding.getSwizzlingByteWidth() != 0)
+                   llvm_unreachable("Only accept unswizzled encoding");
+               } else if (auto swizzledEncoding =
+                              dyn_cast<ttg::SwizzledSharedEncodingAttr>(
+                                  encoding)) {
+                 if (!(swizzledEncoding.getVec() == 1 &&
+                       swizzledEncoding.getPerPhase() == 1 &&
+                       swizzledEncoding.getMaxPhase() == 1))
+                   llvm_unreachable("Only accept unswizzled encoding");
+               }
+             }
+
              auto newType = ttg::MemDescType::get(
-                 newShape, newElementType, oldType.getEncoding(),
-                 oldType.getMemorySpace(), oldType.getMutableMemory());
+                 newShape, newElementType, encoding, oldType.getMemorySpace(),
+                 oldType.getMutableMemory());
              return self.create<ttg::MemDescReinterpretOp>(newType, src);
            })
       .def("create_async_TMA_load",

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -330,7 +330,9 @@ void init_triton_tlx_ir(py::module &&m) {
               std::vector<int64_t> newShape) -> mlir::Value {
              auto oldType = cast<ttg::MemDescType>(src.getType());
              assert(oldType && "Expect MemDescType for src");
-
+             // TODO: assert encoding should be compatible for oldType and
+             // newType. Performance loss should be acceptable but not
+             // correctness.
              auto newType = ttg::MemDescType::get(
                  newShape, newElementType, oldType.getEncoding(),
                  oldType.getMemorySpace(), oldType.getMutableMemory());

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -288,19 +288,20 @@ def local_trans(input: tlx.buffered_tensor, dims: Tuple[int] = (1, 0), _semantic
 
 
 @tl.builtin
-def local_reinterpret(src: tlx.buffered_tensor, dtype: tl.dtype, _semantic=None) -> tlx.buffered_tensor:
+def local_reinterpret(src: tlx.buffered_tensor, dtype: tl.dtype, shape: list[tl.constexpr] = None,
+                      _semantic=None) -> tlx.buffered_tensor:
     """
-        Reinterpret the dtype of a buffered tensor. Currently only support TMEM.
+        Reinterpret the dtype and shape of a buffered tensor. Layout is preserved.
     """
-    assert isinstance(src, tlx.buffered_tensor) and src.type.storage == tlx.storage_kind.tmem and isinstance(
-        src.type.layout, tlx.tensor_memory_layout_encoding), "TLX local_reinterpret only supports TMEM"
+    if shape is None:
+        shape = src.type.shape
 
     reinterpreted_value_handle = _semantic.builder.create_memdesc_reinterpret(src.handle,
-                                                                              dtype.to_ir(_semantic.builder), src.shape)
+                                                                              dtype.to_ir(_semantic.builder), shape)
     return tlx.buffered_tensor(
         reinterpreted_value_handle,
         dtype,
-        src.shape,
+        shape,
         src.type.storage,
         src.type.layout,
     )

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -295,6 +295,10 @@ def local_reinterpret(src: tlx.buffered_tensor, dtype: tl.dtype, shape: list[tl.
     """
     if shape is None:
         shape = src.type.shape
+    else:
+        assert isinstance(
+            src, tlx.buffered_tensor
+        ) and src.type.storage == tlx.storage_kind.smem, "TLX local_reinterpret with reshaping only supports SMEM"
 
     reinterpreted_value_handle = _semantic.builder.create_memdesc_reinterpret(src.handle,
                                                                               dtype.to_ir(_semantic.builder), shape)


### PR DESCRIPTION
This is to support preloading a tensor to SMEM and use it piece-by-piece later on. An example use case of the feature is:


```
        desc_in = tl.make_tensor_descriptor(
            input_ptr,
            shape=[1, M * N],
            strides=[M * N, 1],
            block_shape=[1, BLOCK_SIZE_M * BLOCK_SIZE_N],
        )

        buffers_in = tlx.local_alloc((1, BLOCK_SIZE_N), tl.int16, BLOCK_SIZE_M)
        buffer_in = tlx.local_view(buffers_in, 0)
        reinterpreted = tlx.local_reinterpret(buffer_in, tl.int16, [1, BLOCK_SIZE_M * BLOCK_SIZE_N])
        tlx.async_descriptor_load(desc_in, reinterpreted, [0, off_m * N + off_n], bar)

         for k in range(0, BLOCK_SIZE_M):
               buffer_in = tlx.local_view(buffers_in, k)
               ....
```

Without using the `local_reinterpret` the  `async_descriptor_load` would get the wrong shape.

