### PR TITLE
[TLX] Expose full original exceptions during ast visit

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1427,7 +1427,8 @@ class CodeGenerator(ast.NodeVisitor):
                     raise
                 # Wrap the error in a CompilationError which contains the source
                 # of the @jit function.
-                raise CompilationError(self.jit_fn.src, self.cur_node, repr(e)) from None
+                # preserve `e` for more detailed error message
+                raise CompilationError(self.jit_fn.src, self.cur_node, None) from e
 
             # Reset the location to the last one before the visit
             if last_loc:

--- a/third_party/tlx/compiler/code_generator.py
+++ b/third_party/tlx/compiler/code_generator.py
@@ -18,7 +18,7 @@ def tlx_enter_sub_region():
     try:
         yield
     finally:
-        assert region_replica_id_stack == replica_id_stack_backup
+        assert region_replica_id_stack == replica_id_stack_backup, "region_replica_id_stack is not restored"
 
 
 def _is_async_task(self, node) -> bool:


### PR DESCRIPTION
When we accidentally passed wrong type to c++ functions via pybind, there would be a simple `AssertionError()` raised and that alone really didn't tell much:

```
% python third_party/tlx/tutorials/gemm-WS-blackwell.py
Traceback (most recent call last):
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/gemm-WS-blackwell.py", line 268, in <module>
    triton_output = matmul(a, b)
                    ^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/gemm-WS-blackwell.py", line 255, in matmul
    matmul_kernel_tma_ws_blackwell[grid](
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/jit.py", line 374, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 239, in run
    benchmark()
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 228, in benchmark
    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 228, in <dictcomp>
    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 160, in _bench
    return self.do_bench(kernel_call, quantiles=(0.5, 0.2, 0.8))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/testing.py", line 149, in do_bench
    fn()
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 146, in kernel_call
    self.fn.run(
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/jit.py", line 613, in run
    kernel = self.compile(src, target=target, options=options.__dict__)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/compiler/compiler.py", line 339, in compile
    module = src.make_ir(options, codegen_fns, module_map, context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/compiler/compiler.py", line 83, in make_ir
    return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
triton.compiler.errors.CompilationError: at 100:20:
                # now iterate along K to compute result for the block
                for k in range(0, k_tiles):
                    # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
                    buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
                    a = tlx.local_view(buffers_A, buf)
                    b = tlx.local_view(buffers_B, buf)
                    smem_full_bar = tlx.local_view(smem_full_bars, buf)
                    smem_empty_bar = tlx.local_view(smem_empty_bars, buf)
                    # wait for current phase(round) of load for this buf
                    tlx.barrier_wait(smem_full_bar, dot_phase)
                    # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
                    tlx.async_dot(a, b, acc_tmem, mBarriers=[smem_empty_bar], out_dtype=tl.float32)
                    ^
AssertionError()
```

This diff changes the ast visitor to just throw up everything in the original `AssertionError` meaning that we will get to see details about the error (TypeError in this case):

```
% python third_party/tlx/tutorials/gemm-WS-blackwell.py
Traceback (most recent call last):
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/language/core.py", line 42, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/language/mma_ops.py", line 113, in async_dot
    output = _builder.create_tcgen5_dot(A_handle, B_handle, acc.handle, pred, handles)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: create_tcgen5_dot(): incompatible function arguments. The following argument types are supported:
    1. (self: triton._C.libtriton.ir.builder, arg0: triton._C.libtriton.ir.value, arg1: triton._C.libtriton.ir.value, arg2: triton._C.libtriton.ir.value, arg3: Optional[triton._C.libtriton.ir.value]) -> triton._C.libtriton.ir.value

Invoked with: <triton._C.libtriton.ir.builder object at 0x7f46919a4950>, <triton._C.libtriton.ir.value object at 0x7f468ef087b0>, <triton._C.libtriton.ir.value object at 0x7f468ef086b0>, <triton._C.libtriton.ir.value object at 0x7f46919fb970>, None, [<triton._C.libtriton.ir.value object at 0x7f468ef08d30>]

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/compiler/code_generator.py", line 19, in tlx_enter_sub_region
    yield
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/compiler/code_generator.py", line 87, in visit_withAsyncTasks
    self.visit(stmt)
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/compiler/code_generator.py", line 46, in visit_withAsyncTask
    self.visit_compound_statement(node.body)
triton.compiler.errors.CompilationError: at 100:20:
                # now iterate along K to compute result for the block
                for k in range(0, k_tiles):
                    # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
                    buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
                    a = tlx.local_view(buffers_A, buf)
                    b = tlx.local_view(buffers_B, buf)
                    smem_full_bar = tlx.local_view(smem_full_bars, buf)
                    smem_empty_bar = tlx.local_view(smem_empty_bars, buf)
                    # wait for current phase(round) of load for this buf
                    tlx.barrier_wait(smem_full_bar, dot_phase)
                    # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
                    tlx.async_dot(a, b, acc_tmem, mBarriers=[smem_empty_bar], out_dtype=tl.float32)
                    ^

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/compiler/code_generator.py", line 19, in tlx_enter_sub_region
    yield
  File "/data/users/pchen7e4/miniconda3/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/compiler/code_generator.py", line 60, in visit_withAsyncTasks
    with tlx_enter_sub_region():  # dry visit async task body
  File "/data/users/pchen7e4/miniconda3/lib/python3.11/contextlib.py", line 158, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/compiler/code_generator.py", line 21, in tlx_enter_sub_region
    assert region_replica_id_stack == replica_id_stack_backup, "region_replica_id_stack is not restored"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: region_replica_id_stack is not restored

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/users/pchen7e4/miniconda3/lib/python3.11/contextlib.py", line 80, in inner
    with self._recreate_cm():
  File "/data/users/pchen7e4/miniconda3/lib/python3.11/contextlib.py", line 158, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/tlx/compiler/code_generator.py", line 21, in tlx_enter_sub_region
    assert region_replica_id_stack == replica_id_stack_backup, "region_replica_id_stack is not restored"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: region_replica_id_stack is not restored

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/gemm-WS-blackwell.py", line 268, in <module>
    triton_output = matmul(a, b)
                    ^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/gemm-WS-blackwell.py", line 255, in matmul
    matmul_kernel_tma_ws_blackwell[grid](
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/jit.py", line 374, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 239, in run
    benchmark()
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 228, in benchmark
    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 228, in <dictcomp>
    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 160, in _bench
    return self.do_bench(kernel_call, quantiles=(0.5, 0.2, 0.8))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/testing.py", line 149, in do_bench
    fn()
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/autotuner.py", line 146, in kernel_call
    self.fn.run(
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/runtime/jit.py", line 613, in run
    kernel = self.compile(src, target=target, options=options.__dict__)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/compiler/compiler.py", line 339, in compile
    module = src.make_ir(options, codegen_fns, module_map, context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/pchen7e4/triton/third_party/tlx/tutorials/triton/compiler/compiler.py", line 83, in make_ir
    return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
triton.compiler.errors.CompilationError: at 100:20:
                # now iterate along K to compute result for the block
                for k in range(0, k_tiles):
                    # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
                    buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
                    a = tlx.local_view(buffers_A, buf)
                    b = tlx.local_view(buffers_B, buf)
                    smem_full_bar = tlx.local_view(smem_full_bars, buf)
                    smem_empty_bar = tlx.local_view(smem_empty_bars, buf)
                    # wait for current phase(round) of load for this buf
                    tlx.barrier_wait(smem_full_bar, dot_phase)
                    # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
                    tlx.async_dot(a, b, acc_tmem, mBarriers=[smem_empty_bar], out_dtype=tl.float32)
```