### PR TITLE
[TLX] Refactor types to support inlining

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -119,7 +119,7 @@ def test_local_load(BLOCK_SIZE, device):
         x_ptr_offsets = x_ptr + offsets
         y_ptr_offsets = y_ptr + offsets
 
-        buffers = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 2)
+        buffers = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 3)
         buffer0 = tlx.local_view(buffers, 0)
         buffer1 = tlx.local_view(buffers, 1)
         tlx.async_load(x_ptr_offsets, buffer0, mask=mask)

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -270,8 +270,8 @@ def local_load(
         output = _builder.create_release_layout(load_handle)
         return tl.tensor(output, src.type)
 
-    return tl.tensor(_builder.create_local_load(src.handle, token.handle if token else None), src.type)
-
+    block_type = tl.block_type(src.type.element_ty, src.type.shape)
+    return tl.tensor(_builder.create_local_load(src.handle, token.handle if token else None), block_type)
 
 @tl.builtin
 def local_store(

--- a/third_party/tlx/language/mem_ops.py
+++ b/third_party/tlx/language/mem_ops.py
@@ -40,7 +40,7 @@ def local_alloc(
     storage: tlx.storage_kind = tlx.storage_kind.smem,
     layout: Optional[tlx.shared_layout_encoding] = None,
     _builder=None,
-) -> tlx.buffered_tensors:
+) -> tlx.buffered_tensor:
     """
     Allocates buffer in shared memory and return a view of the buffer.
     """
@@ -106,21 +106,20 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
     else:
         tensor_handle = _builder.create_tmem_alloc(full_shape, elem_type, layout_handle)
 
-    base_tensor = tlx.buffered_tensor(
+    return tlx.buffered_tensor(
         tensor_handle,
         dtype,
         unwrapped_shape,
+        unwrapped_num,
         storage,
         layout,
     )
-
-    return tlx.buffered_tensors(base_tensor, num)
 
 
 # overload declarations just to make linter happy
 @overload
 def local_view(
-    local_allocated_buffers: tlx.buffered_tensors,
+    local_allocated_buffers: tlx.buffered_tensor,
     buffer_idx: int,
     _builder=None,
 ) -> tlx.buffered_tensor:
@@ -129,7 +128,7 @@ def local_view(
 
 @overload
 def local_view(
-    local_allocated_buffers: tlx.mbarriers,
+    local_allocated_buffers: tlx.mbarrier,
     buffer_idx: int,
     _builder=None,
 ) -> tlx.mbarrier:
@@ -138,7 +137,7 @@ def local_view(
 
 @tl.builtin
 def local_view(
-    local_allocated_buffers: tlx.buffered_tensors | tlx.mbarriers,
+    local_allocated_buffers: tlx.buffered_tensor | tlx.mbarrier,
     buffer_idx: int,
     _builder=None,
 ) -> tlx.buffered_tensor | tlx.mbarrier:
@@ -146,18 +145,17 @@ def local_view(
     Returns a subview of the buffer.
     """
     buffer_idx = _convert_elem_to_ir_value(_builder, buffer_idx, require_i64=False)
-    base_tensor = local_allocated_buffers.base_tensor
-    view_shape = base_tensor.type.shape
-    view_handle = _builder.create_memdesc_subview(base_tensor.handle, buffer_idx)
-    if isinstance(local_allocated_buffers, tlx.mbarriers):
-        return tlx.mbarrier(view_handle, )
+    view_handle = _builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx)
+    if isinstance(local_allocated_buffers, tlx.mbarrier):
+        return tlx.mbarrier(view_handle, 1, local_allocated_buffers.type.layout)
     else:
         return tlx.buffered_tensor(
             view_handle,
-            base_tensor.type.scalar,
-            view_shape,
-            base_tensor.type.storage,
-            base_tensor.type.layout,
+            local_allocated_buffers.type.scalar,
+            local_allocated_buffers.shape,
+            0,
+            local_allocated_buffers.type.storage,
+            local_allocated_buffers.type.layout,
         )
 
 
@@ -184,6 +182,7 @@ def subslice(
         _builder.create_tmem_subslice(local_allocated_buffer.handle, offset, size),
         local_allocated_buffer.type.element_ty,
         subslice_shape,
+        local_allocated_buffer.type.num,
         local_allocated_buffer.type.storage,
         local_allocated_buffer.type.layout,
     )
@@ -332,6 +331,7 @@ def local_reinterpret(src: tlx.buffered_tensor, dtype: tl.dtype, shape: list[tl.
         reinterpreted_value_handle,
         dtype,
         shape,
+        src.type.num,
         src.type.storage,
         src.type.layout,
     )
@@ -359,7 +359,8 @@ def async_descriptor_load(
         pred_handle = _builder.get_int1(True)
     else:
         pred_handle = pred.handle
-    _builder.create_async_TMA_load(desc.handle, offsets, barrier.handle, pred_handle, result_handle, cache, eviction, False)
+    _builder.create_async_TMA_load(desc.handle, offsets, barrier.handle, pred_handle, result_handle, cache, eviction,
+                                   False)
 
 
 @tl.builtin


### PR DESCRIPTION
Adding `to_ir`, `_flatten_ir_types` and `mangle` implementation to `buffered_tensor` so that it can be used for function calls. Also unifying `buffered_tensor` an `buffered_tensors`.