### PR TITLE
[TLX] fix tensordesc layout propagation

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -15,6 +15,7 @@
 #include <unordered_set>
 
 namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
 
 namespace {
 
@@ -91,6 +92,42 @@ std::optional<UseInfo> getUseInfo(Operation *op) {
     info.shape = expandToRank(shape, rank);
     return info;
   }
+  if (auto load = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    // for now, assume each AsyncTMACopyGlobalToLocalOp is bundled with a
+    // TensorDescToTMAPtrOp
+    auto tensorDescToTMAPtrOp =
+        load.getDescPtr().getDefiningOp<ttng::TensorDescToTMAPtrOp>();
+    if (!tensorDescToTMAPtrOp)
+      llvm::report_fatal_error("AsyncTMACopyGlobalToLocalOp expected to be "
+                               "bundled with a TensorDescToTMAPtrOp");
+    auto desc = tensorDescToTMAPtrOp.getDesc();
+    info.descriptor = desc;
+    info.desiredSharedEncoding = load.getResult().getType().getEncoding();
+    assert(isTMACompatibleEncoding(info.desiredSharedEncoding) &&
+           "expecting TMA compatible encoding");
+    info.ctaLayout = ttg::getCTALayout(info.desiredSharedEncoding);
+    auto shape = load.getResult().getType().getShape();
+    auto rank = desc.getType().getBlockType().getRank();
+    info.shape = expandToRank(shape, rank);
+    return info;
+  }
+  if (auto store = dyn_cast<ttng::AsyncTMACopyLocalToGlobalOp>(op)) {
+    // for now, assume each AsyncTMACopyGlobalToLocalOp is bundled with a
+    // TensorDescToTMAPtrOp
+    auto tensorDescToTMAPtrOp =
+        store.getDescPtr().getDefiningOp<ttng::TensorDescToTMAPtrOp>();
+    if (!tensorDescToTMAPtrOp)
+      llvm::report_fatal_error("AsyncTMACopyGlobalToLocalOp expected to be "
+                               "bundled with a TensorDescToTMAPtrOp");
+    auto desc = tensorDescToTMAPtrOp.getDesc();
+    info.descriptor = desc;
+    auto encoding = store.getSrc().getType().getEncoding();
+    info.ctaLayout = ttg::getCTALayout(encoding);
+    auto shape = store.getSrc().getType().getShape();
+    auto rank = desc.getType().getBlockType().getRank();
+    info.shape = expandToRank(shape, rank);
+    return info;
+  }
   return std::nullopt;
 }
 
@@ -156,15 +193,21 @@ SmallVector<Value> getTiedArgs(Operation *op, int resultIdx) {
     }
     values.push_back(ifOp->getResults()[resultIdx]);
     return values;
-  } else if (auto warpSpecializePartitionsOp =
-                 dyn_cast<mlir::triton::gpu::WarpSpecializePartitionsOp>(op)) {
-    // add arg for every partition
-    SmallVector<Value> values;
-    for (auto &region : warpSpecializePartitionsOp.getPartitionRegions()) {
-      auto &firstBlock = region.getBlocks().front();
+  } else if (auto warpSpecializeOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
+    // add arg for every partition including default partition
+    SmallVector<Value> values = {warpSpecializeOp.getOperands()[resultIdx]};
+    for (auto region : warpSpecializeOp.getPartitionRegions()) {
+      auto &firstBlock = region->getBlocks().front();
       values.push_back(firstBlock.getArguments()[resultIdx]);
     }
     return values;
+  } else if (auto warpSpecializePartitionsOp =
+                 dyn_cast<ttg::WarpSpecializePartitionsOp>(op)) {
+    auto warpSpecializeOp = dyn_cast<ttg::WarpSpecializeOp>(
+        warpSpecializePartitionsOp->getParentOp());
+    assert(warpSpecializeOp && "expected WarpSpecializeOp");
+    // delegate to parent op
+    return getTiedArgs(warpSpecializeOp, resultIdx);
   }
   return {};
 }
@@ -340,6 +383,9 @@ void assignMemoryLayouts(FuncOp &func) {
       } else if (isa<scf::YieldOp>(op)) {
         auto vals = getTiedArgs(op->getParentOp(), use.getOperandNumber());
         updateEncoding(vals, EncodingInfo{});
+      } else if (isa<ttg::WarpSpecializeOp>(op)) {
+        auto vals = getTiedArgs(op, use.getOperandNumber());
+        updateEncoding(vals, EncodingInfo{});
       }
     }
 
@@ -352,8 +398,8 @@ void assignMemoryLayouts(FuncOp &func) {
       }
     } else if (auto blockArg = dyn_cast<BlockArgument>(desc)) {
       auto parentOp = blockArg.getOwner()->getParentOp();
-      if (isa<scf::ForOp, scf::WhileOp,
-              mlir::triton::gpu::WarpSpecializePartitionsOp>(parentOp)) {
+      if (isa<scf::ForOp, scf::WhileOp, ttg::WarpSpecializePartitionsOp>(
+              parentOp)) {
         auto offset = isa<scf::ForOp>(parentOp);
         auto vals = getTiedArgs(parentOp, blockArg.getArgNumber() - offset);
         updateEncoding(vals, EncodingInfo{});

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -94,7 +94,7 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, 
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK: %arg0: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
+  // CHECK: %arg5: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
   tt.func public @ttng_load_seed_from_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
     %true = arith.constant true
     %c1_i32 = arith.constant 1 : i32
@@ -143,7 +143,7 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK: %arg0: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
+  // CHECK: %arg5: !tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
   tt.func public @ttng_store_seed_from_non_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x128xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %true = arith.constant true

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -83,3 +83,102 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, 
   tt.return
 }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+// CHECK-DAG: #[[BLOCKED1:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+// CHECK-DAG: #[[SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: %arg0: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
+  tt.func public @ws_partion_regions_share(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
+    %true = arith.constant true
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    %2 = ttg.memdesc_subview %1[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %3 = ttg.memdesc_subview %1[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.warp_specialize(%arg5, %result)
+    default {
+      %4 = ttg.memdesc_subview %0[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      // CHECK: tensor_desc_to_tma_ptr{{.*}}!tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
+      %5 = ttng.tensor_desc_to_tma_ptr %arg0 : !tt.tensordesc<tensor<128x64xf16>> to !tt.ptr<i8>
+      ttng.async_tma_copy_global_to_local %5[%c0_i32, %c0_i32] %4, %2, %true : !tt.ptr<i8>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      ttg.warp_yield
+    }
+    // CHECK: %arg10: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
+    partition0(%arg10: !tt.tensordesc<tensor<128x64xf16>>, %arg11: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
+      %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+      %true_0 = arith.constant true
+      %c0_i32_1 = arith.constant 0 : i32
+      %4 = ttg.memdesc_subview %arg11[%c0_i32_1, %c0_i32_1, %c0_i32_1] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttng.tmem_store %cst, %4, %true_0 : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    }
+    // CHECK: %arg10: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
+    partition1(%arg10: !tt.tensordesc<tensor<128x64xf16>>, %arg11: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
+      %c0_i32_0 = arith.constant 0 : i32
+      %cst = arith.constant dense<0.000000e+00> : tensor<128x64xf16, #blocked1>
+      // CHECK: tt.descriptor_store %arg10{{.*}}: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>, tensor<128x64xf16, #[[BLOCKED1]]>
+      tt.descriptor_store %arg10[%c0_i32_0, %c0_i32_0], %cst : !tt.tensordesc<tensor<128x64xf16>>, tensor<128x64xf16, #blocked1>
+      ttg.warp_return
+    // CHECK: (!tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
+    } : (!tt.tensordesc<tensor<128x64xf16>>, !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @ws_default_region_share_with_non_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %true = arith.constant true
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    %2 = ttg.memdesc_subview %1[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %3 = ttg.memdesc_subview %1[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.warp_specialize(%arg0, %0, %arg5, %1)
+    default {
+      %4 = ttg.memdesc_subview %result[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttng.tmem_store %cst, %4, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttg.warp_yield
+    }
+    partition0(%arg10: !tt.tensordesc<tensor<128x64xf16>>, %arg11: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>, %arg12: !tt.tensordesc<tensor<128x64xf16>>, %arg13: !ttg.memdesc<2xi64, #shared1, #smem, mutable>) num_warps(4) {
+      %true_0 = arith.constant true
+      %c0_i32_1 = arith.constant 0 : i32
+      %4 = ttg.memdesc_subview %arg11[%c0_i32_1, %c0_i32_1, %c0_i32_1] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %5 = ttg.memdesc_subview %arg13[%c0_i32_1] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+      %6 = ttng.tensor_desc_to_tma_ptr %arg10 : !tt.tensordesc<tensor<128x64xf16>> to !tt.ptr<i8>
+      ttng.async_tma_copy_global_to_local %6[%c0_i32_1, %c0_i32_1] %4, %5, %true_0 : !tt.ptr<i8>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      ttg.warp_return
+    }
+    partition1(%arg10: !tt.tensordesc<tensor<128x64xf16>>, %arg11: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>, %arg12: !tt.tensordesc<tensor<128x64xf16>>, %arg13: !ttg.memdesc<2xi64, #shared1, #smem, mutable>) num_warps(4) {
+      %c0_i32_0 = arith.constant 0 : i32
+      %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x64xf16, #blocked1>
+      tt.descriptor_store %arg12[%c0_i32_0, %c0_i32_0], %cst_1 : !tt.tensordesc<tensor<128x64xf16>>, tensor<128x64xf16, #blocked1>
+      ttg.warp_return
+    } : (!tt.tensordesc<tensor<128x64xf16>>, !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>, !tt.tensordesc<tensor<128x64xf16>>, !ttg.memdesc<2xi64, #shared1, #smem, mutable>) -> ()
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -95,7 +95,7 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, 
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: %arg5: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
-  tt.func public @ttng_load_seed_from_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
+  tt.func public @ttng_load_propagate_to_user(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
     %true = arith.constant true
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
@@ -144,7 +144,7 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: %arg5: !tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
-  tt.func public @ttng_store_seed_from_non_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x128xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
+  tt.func public @ttng_store_propagate_to_def(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x128xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %true = arith.constant true
     %c1_i32 = arith.constant 1 : i32

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -87,7 +87,6 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, 
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
-// CHECK-DAG: #[[BLOCKED1:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 // CHECK-DAG: #[[SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
@@ -138,11 +137,13 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+// CHECK: #[[SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: %arg0: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
   tt.func public @ttng_store_seed_from_non_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x128xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %true = arith.constant true
@@ -161,6 +162,7 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
       ttng.tmem_store %cst, %4, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttg.warp_yield
     }
+    // CHECK: %arg11: !tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
     partition0(%arg10: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg11: !tt.tensordesc<tensor<128x128xf16>>, %arg12: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
       %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
       %true_1 = arith.constant true
@@ -169,12 +171,15 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
       ttng.tmem_store %cst_0, %4, %true_1 : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttg.warp_return
     }
+    // CHECK: %arg11: !tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
     partition1(%arg10: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg11: !tt.tensordesc<tensor<128x128xf16>>, %arg12: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
       %c0_i32_0 = arith.constant 0 : i32
       %4 = ttg.memdesc_subview %arg10[%c0_i32_0, %c0_i32_0, %c0_i32_0] : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      // CHECK: tensor_desc_to_tma_ptr{{.*}}!tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
       %5 = ttng.tensor_desc_to_tma_ptr %arg11 : !tt.tensordesc<tensor<128x128xf16>> to !tt.ptr<i8>
       ttng.async_tma_copy_local_to_global %5[%c0_i32_0, %c0_i32_0] %4 : !tt.ptr<i8>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
       ttg.warp_return
+    // CHECK: !tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
     } : (!ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !tt.tensordesc<tensor<128x128xf16>>, !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
     tt.return
   }

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -96,7 +96,7 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, 
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: %arg0: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
-  tt.func public @ws_partion_regions_share(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
+  tt.func public @ttng_load_seed_from_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
     %true = arith.constant true
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
@@ -128,8 +128,6 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
     partition1(%arg10: !tt.tensordesc<tensor<128x64xf16>>, %arg11: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
       %c0_i32_0 = arith.constant 0 : i32
       %cst = arith.constant dense<0.000000e+00> : tensor<128x64xf16, #blocked1>
-      // CHECK: tt.descriptor_store %arg10{{.*}}: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>, tensor<128x64xf16, #[[BLOCKED1]]>
-      tt.descriptor_store %arg10[%c0_i32_0, %c0_i32_0], %cst : !tt.tensordesc<tensor<128x64xf16>>, tensor<128x64xf16, #blocked1>
       ttg.warp_return
     // CHECK: (!tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
     } : (!tt.tensordesc<tensor<128x64xf16>>, !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
@@ -140,45 +138,44 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @ws_default_region_share_with_non_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
+  tt.func public @ttng_store_seed_from_non_default(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x128xf16>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64) attributes {noinline = false} {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %true = arith.constant true
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
     %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable>
     %2 = ttg.memdesc_subview %1[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %3 = ttg.memdesc_subview %1[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    ttg.warp_specialize(%arg0, %0, %arg5, %1)
+    ttg.warp_specialize(%0, %arg5, %result)
     default {
       %4 = ttg.memdesc_subview %result[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttng.tmem_store %cst, %4, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttg.warp_yield
     }
-    partition0(%arg10: !tt.tensordesc<tensor<128x64xf16>>, %arg11: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>, %arg12: !tt.tensordesc<tensor<128x64xf16>>, %arg13: !ttg.memdesc<2xi64, #shared1, #smem, mutable>) num_warps(4) {
-      %true_0 = arith.constant true
-      %c0_i32_1 = arith.constant 0 : i32
-      %4 = ttg.memdesc_subview %arg11[%c0_i32_1, %c0_i32_1, %c0_i32_1] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
-      %5 = ttg.memdesc_subview %arg13[%c0_i32_1] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-      %6 = ttng.tensor_desc_to_tma_ptr %arg10 : !tt.tensordesc<tensor<128x64xf16>> to !tt.ptr<i8>
-      ttng.async_tma_copy_global_to_local %6[%c0_i32_1, %c0_i32_1] %4, %5, %true_0 : !tt.ptr<i8>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    partition0(%arg10: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg11: !tt.tensordesc<tensor<128x128xf16>>, %arg12: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
+      %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+      %true_1 = arith.constant true
+      %c0_i32_2 = arith.constant 0 : i32
+      %4 = ttg.memdesc_subview %arg12[%c0_i32_2, %c0_i32_2, %c0_i32_2] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttng.tmem_store %cst_0, %4, %true_1 : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttg.warp_return
     }
-    partition1(%arg10: !tt.tensordesc<tensor<128x64xf16>>, %arg11: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>, %arg12: !tt.tensordesc<tensor<128x64xf16>>, %arg13: !ttg.memdesc<2xi64, #shared1, #smem, mutable>) num_warps(4) {
+    partition1(%arg10: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg11: !tt.tensordesc<tensor<128x128xf16>>, %arg12: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
       %c0_i32_0 = arith.constant 0 : i32
-      %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x64xf16, #blocked1>
-      tt.descriptor_store %arg12[%c0_i32_0, %c0_i32_0], %cst_1 : !tt.tensordesc<tensor<128x64xf16>>, tensor<128x64xf16, #blocked1>
+      %4 = ttg.memdesc_subview %arg10[%c0_i32_0, %c0_i32_0, %c0_i32_0] : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %5 = ttng.tensor_desc_to_tma_ptr %arg11 : !tt.tensordesc<tensor<128x128xf16>> to !tt.ptr<i8>
+      ttng.async_tma_copy_local_to_global %5[%c0_i32_0, %c0_i32_0] %4 : !tt.ptr<i8>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
       ttg.warp_return
-    } : (!tt.tensordesc<tensor<128x64xf16>>, !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>, !tt.tensordesc<tensor<128x64xf16>>, !ttg.memdesc<2xi64, #shared1, #smem, mutable>) -> ()
+    } : (!ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !tt.tensordesc<tensor<128x128xf16>>, !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
     tt.return
   }
 }


### PR DESCRIPTION
With TLX, we have two problems:
- We might have WS ops that tensordesc layout propagation pass does not recognize, because WS ops can be created earlier than that pass now
- We might have TTNG TMA load/store ops created earlier than that pass (previously TMA lowering is later so that pass only needs to recognize tt descriptor load/store ops)

This PR fixes it with these changes:
- When seeding tensor desc layout, support `ttng::AsyncTMACopyLocalToGlobalOp` and `ttng::AsyncTMACopyGlobalToLocalOp`. Due to the nature of these ops, we can get "desired shared mem layouts" from the op itself directly (unlike `tt.descriptor_load` that needs to infer that from the users of the result distributed tensor).
- When propagating layouts, always tie args of all regions together. e.g. If we want to change layout of arg 2 of a region, we must change arg 2 of all regions together. We also make the propagation process `WarpSpecializePartitionsOp` when propagating to definitions and process `WarpSpecializeOp` when propagating to users.

I added two test cases here:
- One is propagating from outside to ws ops  (the pass also seeds fallback layout from args of device function boundaries)
- One is propagating from a use inside one non default region to outside

`make test-lit` and `pytest -vs python/test/unit/language/test_tlx.py` all pass. `python third_party/tlx/tutorials/gemm-WS-blackwell.py` now runs through without compilation failures any more.