### PR TITLE
[TLX] Remove token for Blackwell dot

### DIFF
--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -279,42 +279,16 @@ void init_triton_tlx_ir(py::module &&m) {
       .def("create_tcgen5_dot",
            [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
               mlir::Value &d, std::optional<Value> useD,
-              std::optional<Value> pred,
-              std::vector<Value> mBarriers) -> mlir::Value {
-             // try to find the TMEMAllocOp that created d
-             ttng::TMEMAllocOp tmemAllocOp;
-             auto value = d;
-             while (true) {
-               if ((tmemAllocOp = value.getDefiningOp<ttng::TMEMAllocOp>())) {
-                 break;
-               }
-               // TODO: find the defining op properly - the defining op is not
-               // necessarily MemDescSubviewOp
-               auto definingOp = value.getDefiningOp();
-               if (auto subviewOp =
-                       dyn_cast<ttg::MemDescSubviewOp>(definingOp)) {
-                 value = subviewOp.getSrc();
-               } else {
-                 auto requireLayoutOp =
-                     value.getDefiningOp<tlx::RequireLayoutOp>();
-                 assert(requireLayoutOp &&
-                        "Failed to find TMEMAllocOp defining the "
-                        "accumulator TMEM passed to dot op.");
-                 value = requireLayoutOp.getSrc();
-               }
-             }
-
+              std::optional<Value> pred, std::vector<Value> mBarriers) -> void {
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
              std::vector<Value> barrierPreds(mBarriers.size(), predTrue);
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
-             return self
-                 .create<ttng::TCGen5MMAOp>(
-                     tokType, a, b, d, tmemAllocOp.getToken(),
-                     useD.has_value() ? useD.value() : predTrue /*useD*/,
-                     pred.has_value() ? pred.value() : predTrue /*pred */,
-                     false /* two_ctas*/, ValueRange(mBarriers),
-                     ValueRange(barrierPreds))
-                 .getToken();
+             self.create<ttng::TCGen5MMAOp>(
+                 tokType, a, b, d, Value(),
+                 useD.has_value() ? useD.value() : predTrue /*useD*/,
+                 pred.has_value() ? pred.value() : predTrue /*pred */,
+                 false /* two_ctas*/, ValueRange(mBarriers),
+                 ValueRange(barrierPreds));
            })
       .def("create_tcgen05_commit",
            [](TritonOpBuilder &self, Value &barrier) -> void {

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -121,7 +121,7 @@ def async_dot(
             else:
                 use_acc_handle = _builder.get_int1(use_acc.value)
         output = _builder.create_tcgen5_dot(A_handle, B_handle, acc.handle, use_acc_handle, pred, handles)
-        return tlx.async_token(output)
+        return tl.tensor(output, tl.void)
     else:
         mma_layout = _builder.make_nv_mma_encoding_attr(A_handle, acc_handle, version, 0, _builder.options.num_warps)
         acc = _builder.create_require_layout(acc_handle, mma_layout)


### PR DESCRIPTION
Token was used for dep analysis in some passes but now since TLX opens up things users could manually manage those ops. There's currently no usecase for exposing the token here so removing it from TLX API.

In particular, a pass that would require a token is `HoistTMEMAlloc` and it was disabled when we have tlx ops called in kernel https://github.com/facebookexperimental/triton/pull/198

`pytest -vs python/test/unit/language/test_tlx.py` all passing.