### PR TITLE
Fix a failure when creating more than 2 regions

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -115,7 +115,8 @@ void init_gluon_ir(py::module &&m) {
       .def(
           "get_partition_region",
           [](ttg::WarpSpecializeOp self, unsigned idx) -> Region & {
-            if (idx >= self.getNumRegions())
+            auto numPartitions = self.getPartitionRegions().size();
+            if (idx >= numPartitions)
               throw pybind11::index_error("Op region index out of range");
             return *self.getPartitionRegions()[idx];
           },


### PR DESCRIPTION
Summary: getNumRegions() returns 2, even though getPartitionRegions().size() is more than 2.
Without the fix, we will hit "Op region index out of range".
