### PR TITLE
[TLX] loop carry check

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -924,10 +924,11 @@ class CodeGenerator(ast.NodeVisitor):
         assert _is_triton_value(loop_val), f'cannot reassign constxpr {name} in the loop'
         assert _is_triton_value(live_val), f'cannot reasign constexpr {name} in the loop'
         assert type(loop_val) is type(live_val), f'Loop carried variable {name} changed type'
-        assert not _is_triton_tensor(loop_val) or loop_val.type == live_val.type, \
-            f'Loop-carried variable {name} has initial type {live_val.type} '\
-            f'but is re-assigned to {loop_val.type} in loop! '\
-            f'Please make sure that the type stays consistent.'
+        if hasattr(loop_val, 'type'):
+            assert loop_val.type == live_val.type, \
+                f'Loop-carried variable "{name}" has initial type {live_val.type} '\
+                f'but is re-assigned to {loop_val.type} in loop! '\
+                f'Please make sure that the type stays consistent.'
 
     def visit_withitem(self, node):
         return self.visit(node.context_expr)


### PR DESCRIPTION
With TLX the kernel is going to be more verbose and it's easier to accidentally shadow a variable in a loop.

The current check for this behavior does not understand types like `tensor_descriptor` or `tlx.buffered_tensor`. If the type is not `triton.tensor` it will be allowed.

This PR tightens the check.

Without this PR, the issue will surface only at building ttir and it's a lot harder to narrow down the issue on a non trivial kernel:

```
python/test/unit/language/test_tlx.py::test_loop_carry_var_check /data/users/pchen7e4/triton/python/test/unit/language/test_tlx.py:1292:22: error: 'scf.for' op 0-th region iter_arg and 0-th yielded value have different type: '!ttg.memdesc<2x16x16xi16, #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory, mutable>' != '!ttg.memdesc<16x16xi16, #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory, mutable>'
```

With this PR the error message is a lot more friendly:
```
AssertionError: Loop-carried variable "x" has initial type buffered_tensor_<int16, ['16', '16'], nv_mma_shared_layout_encoding, 2> but is re-assigned to buffered_tensor_<int16, ['16', '16'], nv_mma_shared_layout_encoding, 0> in loop! Please make sure that the type stays consistent.
```