### PR TITLE
[TLX] propagate mem space to func calls properly

### DIFF
--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -338,9 +338,17 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("get_memdesc_type",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
-              Type &elementType, Attribute &encoding) -> Type {
+              Type &elementType, Attribute &encoding,
+              std::string storage) -> Type {
              auto context = self.getBuilder().getContext();
-             auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
+             Attribute memorySpace;
+             if (storage == "tmem")
+               memorySpace = ttng::TensorMemorySpaceAttr::get(context);
+             else if (storage == "smem") {
+               memorySpace = ttg::SharedMemorySpaceAttr::get(context);
+             } else {
+               llvm_unreachable("Unknown storage type");
+             }
              return ttg::MemDescType::get(shape, elementType, encoding,
                                           memorySpace, /*mutableMemory=*/true);
            })

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -132,7 +132,6 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
         self.numCTAOrder = numCTAOrder
         self.fp4Padded = fp4Padded
 
-
     """
     Make a default NVMMA shared layout encoding.
     """
@@ -143,7 +142,6 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
         return cls(shape=shape, order=list(reversed(range(rank))),  # e.g, [1, 0] as a row-major order
                    elemType=elemType, numCTAsPerCGA=[1] * rank, numCTASplit=[1] * rank, numCTAOrder=[1] * rank,
                    fp4Padded=False)
-
 
     """
     Create a new layout that is a permutation of the given layout.
@@ -254,12 +252,13 @@ class buffered_tensor_type(tl.block_type):
 
     def to_ir(self, builder: ir.builder) -> None:
         shape = self.shape
-        if self.num > 1:
+        if self.num >= 1:
             shape = [self.num] + list(shape)
         return builder.get_memdesc_type(
             shape,
             self.element_ty.to_ir(builder),
             self.layout.to_ir(builder),
+            self.storage.value,
         )
 
     def _flatten_ir(self, handles) -> None:
@@ -297,7 +296,7 @@ class mbarrier_type(buffered_tensor_type):
         return value, cursor + 1
 
     def to_ir(self, builder: ir.builder) -> None:
-        if self.num > 1:
+        if self.num >= 1:
             shape = [self.num]
         else:
             shape = self.shape
@@ -305,6 +304,7 @@ class mbarrier_type(buffered_tensor_type):
             shape,
             self.element_ty.to_ir(builder),
             self.layout.to_ir(builder),
+            self.storage.value,
         )
 
 


### PR DESCRIPTION
When building a func call, we need to give the arg the right mem space attr instead of always forcing SMEM.

`pytest -vs python/test/unit/language/test_tlx.py` all passing.