### PR TITLE
[TLX] Fix tmem local_load return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,12 @@ While this approach places more responsibility on the user, it reduces the compi
 
 - `distributed_tensor = tlx.local_load(buffer, optional_token)`
 
-    Loads the buffer from local memory into a distributed tensor.
-
-
-- `distributed_tensor = tlx.local_load(buffer, optional_token, tlx.storage_kind.tmem)`
-
-    Loads the buffer from tensor memory into a distributed tensor.
+    Loads the buffer from local memory or tensor memory into a distributed tensor.
 
 
 - `tlx.local_store(buffer, distributed_tensor)`
 
-    Store a distributed tensor into a buffer in local memory.
-
-
-- `tlx.local_store(buffer, distributed_tensor, tlx.storage_kind.tmem)`
-
-    Store a distributed tensor into a buffer in tensor memory.
+    Store a distributed tensor into a buffer in local memory or tensor memory.
 
 - `buffer = tlx.local_trans(buffer, dims)`
 

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1422,5 +1422,4 @@ def test_inline_tmem(BLOCK_SIZE, device):
     y = torch.rand((64, 64), dtype=torch.float32, device=device)
     grid = lambda meta: (1, )
     kerenl_info = kernel[grid](y, BLOCK_SIZE)
-    # TODO: check numerics once tmem load/store is ready
     assert kerenl_info.asm["ttir"].count("store") == 1

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1409,13 +1409,13 @@ def test_inline_tmem(BLOCK_SIZE, device):
     @triton.jit
     def kernel(y_ptr, BLOCK_SIZE: tl.constexpr):
         buffers = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(4), tlx.storage_kind.tmem)
-        buffer0 = tlx.local_view(buffers, 0)  # noqa: F841
-        x = tlx.local_load(buffer0)  # noqa: F841
+        buffer0 = tlx.local_view(buffers, 0)
+        x = tlx.local_load(buffer0)
         pid = tl.program_id(axis=0)
         offsets_i = tl.arange(0, BLOCK_SIZE)[:, None]
         offsets_j = tl.arange(0, BLOCK_SIZE)[None, :]
         offsets = offsets_i * BLOCK_SIZE + offsets_j
-        y = math_kernel(x)  # noqa: F841
+        y = math_kernel(x)
         tl.store(y_ptr + offsets, y)
 
 

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -296,8 +296,8 @@ def test_tmem_load_store(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
 
         buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
         buffer1 = tlx.local_view(buffers, 0)
-        tlx.local_store(buffer1, a, tlx.storage_kind.tmem)
-        b = tlx.local_load(buffer1, tlx.storage_kind.tmem)
+        tlx.local_store(buffer1, a)
+        b = tlx.local_load(buffer1)
         # b == a == tensor of 1.0
         tl.store(x_ptr_offsets, b + 2)
 
@@ -346,17 +346,17 @@ def test_tmem_subslice(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
 
         buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
         buffer1 = tlx.local_view(buffers, 0)
-        tlx.local_store(buffer1, a, tlx.storage_kind.tmem)
+        tlx.local_store(buffer1, a)
 
         subslice1 = tlx.subslice(buffer1, 0, BLOCK_SIZE_N // 4)
         subslice2 = tlx.subslice(buffer1, BLOCK_SIZE_N // 4, BLOCK_SIZE_N // 4)
         subslice3 = tlx.subslice(buffer1, BLOCK_SIZE_N // 2, BLOCK_SIZE_N // 4)
         subslice4 = tlx.subslice(buffer1, 3 * BLOCK_SIZE_N // 4, BLOCK_SIZE_N // 4)
 
-        b1 = tlx.local_load(subslice1, tlx.storage_kind.tmem)
-        b2 = tlx.local_load(subslice2, tlx.storage_kind.tmem)
-        b3 = tlx.local_load(subslice3, tlx.storage_kind.tmem)
-        b4 = tlx.local_load(subslice4, tlx.storage_kind.tmem)
+        b1 = tlx.local_load(subslice1)
+        b2 = tlx.local_load(subslice2)
+        b3 = tlx.local_load(subslice3)
+        b4 = tlx.local_load(subslice4)
         # b == a == tensor of 1.0
         tl.store(x_ptr_offsets1, b1 + 2)
         tl.store(x_ptr_offsets2, b2 + 2)
@@ -553,8 +553,8 @@ def test_local_reinterpret(device):
         tlx.async_load_wait_group(tl.constexpr(0))
 
         x32_reg = tlx.local_load(smem_buffer_32_0)
-        tlx.local_store(tmem_buffer_0, x32_reg, tlx.storage_kind.tmem)
-        x32_reg_from_tmem = tlx.local_load(tmem_buffer_0, tlx.storage_kind.tmem)
+        tlx.local_store(tmem_buffer_0, x32_reg)
+        x32_reg_from_tmem = tlx.local_load(tmem_buffer_0)
         tl.store(y32_ptr + output_offset, x32_reg_from_tmem)
 
         # x16 GMEM -> x16 SMEM -> x16 Reg -> x16 TMEM -> x16 Reg -> y16 GMEM
@@ -568,8 +568,8 @@ def test_local_reinterpret(device):
         reinterpreted = tlx.local_reinterpret(tmem_buffer_0, tl.float16)
 
         x16_reg = tlx.local_load(smem_buffer_16_0)
-        tlx.local_store(reinterpreted, x16_reg, tlx.storage_kind.tmem)
-        x16_reg_from_tmem = tlx.local_load(reinterpreted, tlx.storage_kind.tmem)
+        tlx.local_store(reinterpreted, x16_reg)
+        x16_reg_from_tmem = tlx.local_load(reinterpreted)
         tl.store(y16_ptr + output_offset, x16_reg_from_tmem)
 
     torch.manual_seed(0)
@@ -706,7 +706,7 @@ def test_async_dot_blackwell(device):
 
         buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
         acc_tmem = tlx.local_view(buffers, 0)
-        tlx.local_store(acc_tmem, acc_init, tlx.storage_kind.tmem)
+        tlx.local_store(acc_tmem, acc_init)
 
         # no barrier, tcgen5 mma synchronous semantic, compiler auto inserts barrier and wait
         tlx.async_dot(a_smem, b_smem, acc_tmem, mBarriers=[], out_dtype=OUT_DTYPE)
@@ -718,7 +718,7 @@ def test_async_dot_blackwell(device):
         tlx.barrier_wait(bar, tl.constexpr(0))
 
         # now result == a*b + a*b
-        result = tlx.local_load(acc_tmem, tlx.storage_kind.tmem)
+        result = tlx.local_load(acc_tmem)
 
         c = result.to(tl.float16)
         c_ptrs = c_ptr + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
@@ -785,18 +785,18 @@ def test_async_dot_blackwell_not_use_d(device):
 
         # fill tmem d with 1
         acc_init = tl.full((BLOCK_M, BLOCK_N), 1, dtype=tl.float32)
-        tlx.local_store(acc_tmem, acc_init, tlx.storage_kind.tmem)
+        tlx.local_store(acc_tmem, acc_init)
         # do not use d (so that we get A*B instead of A*B+1)
         tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=False, mBarriers=[], out_dtype=OUT_DTYPE)
 
         # c1 = A*B
-        c1 = tlx.local_load(acc_tmem, tlx.storage_kind.tmem).to(tl.float16)
+        c1 = tlx.local_load(acc_tmem).to(tl.float16)
         c_ptrs = c_ptr1 + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
         tl.store(c_ptrs, c1)
 
         # now use d, so c2 = A*B + c1 = A*B + A*B
         tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=pid < 1000, mBarriers=[], out_dtype=OUT_DTYPE)
-        c2 = tlx.local_load(acc_tmem, tlx.storage_kind.tmem).to(tl.float16)
+        c2 = tlx.local_load(acc_tmem).to(tl.float16)
         c_ptrs = c_ptr2 + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
         tl.store(c_ptrs, c2)
 
@@ -858,7 +858,7 @@ def test_tcgen05_commit(device):
 
         # fill tmem d with 0
         acc_init = tl.full((BLOCK_M, BLOCK_N), 0, dtype=tl.float32)
-        tlx.local_store(acc_tmem, acc_init, tlx.storage_kind.tmem)
+        tlx.local_store(acc_tmem, acc_init)
 
         # issue multiple mma ops
         bars = tlx.alloc_barriers(tl.constexpr(NUM_DOT))
@@ -874,7 +874,7 @@ def test_tcgen05_commit(device):
         tlx.barrier_wait(bar_final, tl.constexpr(0))
 
         # c1 = A*B
-        c1 = tlx.local_load(acc_tmem, tlx.storage_kind.tmem).to(tl.float16)
+        c1 = tlx.local_load(acc_tmem).to(tl.float16)
         c_ptrs = c_ptr1 + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
         tl.store(c_ptrs, c1)
 
@@ -938,7 +938,7 @@ def test_async_dot_blackwell_tmem_A(device):
         acc_init = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
         acc_buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
         acc_tmem = tlx.local_view(acc_buffers, 0)
-        tlx.local_store(acc_tmem, acc_init, tlx.storage_kind.tmem)
+        tlx.local_store(acc_tmem, acc_init)
 
         # async load a and b into SMEM
         buf_alloc_a = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, tl.constexpr(1))
@@ -956,12 +956,12 @@ def test_async_dot_blackwell_tmem_A(device):
         # store A to TMEM
         buffers_a = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, tl.constexpr(1), tlx.storage_kind.tmem)
         a_tmem = tlx.local_view(buffers_a, 0)
-        tlx.local_store(a_tmem, a_reg, tlx.storage_kind.tmem)
+        tlx.local_store(a_tmem, a_reg)
 
         # acc_tmem = acc_tmem + a_tmem * b_smem
         tlx.async_dot(a_tmem, b_smem, acc_tmem, mBarriers=[], out_dtype=OUT_DTYPE)
         # load result from TMEM to Reg
-        result = tlx.local_load(acc_tmem, tlx.storage_kind.tmem)
+        result = tlx.local_load(acc_tmem)
 
         c = result.to(tl.float16)
         c_ptrs = c_ptr + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
@@ -1367,11 +1367,10 @@ def _global_tmem_func(
 
     ones = tl.full((BLOCK_SIZE_M, BLOCK_SIZE_N), 1.0, tl.float32)
     buffer1 = tlx.local_view(buffers, 0)
-    tlx.local_store(buffer1, ones, tlx.storage_kind.tmem)
-    b = tlx.local_load(buffer1, tlx.storage_kind.tmem)
+    tlx.local_store(buffer1, ones)
+    b = tlx.local_load(buffer1)
 
     tl.store(x_ptr_offsets, b)
-
 
 @pytest.mark.skipif(
     not is_cuda() or torch.cuda.get_device_capability()[0] < 10,
@@ -1399,3 +1398,29 @@ def test_tmem_op_func(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
 
     ref_out = torch.ones_like(x)
     torch.testing.assert_close(x, ref_out)
+
+
+@triton.jit
+def math_kernel(x):
+    return x * 0.5 * (1 + (0.7978845608 * x * (1.0 + 0.044715 * x * x)))
+
+@pytest.mark.parametrize("BLOCK_SIZE", [(64)])
+def test_inline_tmem(BLOCK_SIZE, device):
+    @triton.jit
+    def kernel(y_ptr, BLOCK_SIZE: tl.constexpr):
+        buffers = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(4), tlx.storage_kind.tmem)
+        buffer0 = tlx.local_view(buffers, 0)  # noqa: F841
+        x = tlx.local_load(buffer0)  # noqa: F841
+        pid = tl.program_id(axis=0)
+        offsets_i = tl.arange(0, BLOCK_SIZE)[:, None]
+        offsets_j = tl.arange(0, BLOCK_SIZE)[None, :]
+        offsets = offsets_i * BLOCK_SIZE + offsets_j
+        y = math_kernel(x)  # noqa: F841
+        tl.store(y_ptr + offsets, y)
+
+
+    y = torch.rand((64, 64), dtype=torch.float32, device=device)
+    grid = lambda meta: (1, )
+    kerenl_info = kernel[grid](y, BLOCK_SIZE)
+    # TODO: check numerics once tmem load/store is ready
+    assert kerenl_info.asm["ttir"].count("store") == 1

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -1,4 +1,3 @@
-from torch import storage
 import triton.language.core as tl
 from triton.language.semantic import (
     _convert_elem_to_ir_value,

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -1,3 +1,4 @@
+from torch import storage
 import triton.language.core as tl
 from triton.language.semantic import (
     _convert_elem_to_ir_value,
@@ -255,34 +256,36 @@ def async_load_wait_group(
 @tl.builtin
 def local_load(
     src: tlx.buffered_tensor,
-    storage: tlx.storage_kind = tlx.storage_kind.smem,
     token: tlx.async_token = None,
     _builder=None,
 ) -> tl.tensor:
     """
     Loads buffer from local or tensor memory into a distributed tensor.
     """
+    block_type = tl.block_type(src.type.element_ty, src.type.shape)
+    storage = src.type.storage
     if storage == tlx.storage_kind.tmem:
         _assert_blackwell_for_tmem(_builder.options.arch)
         tmem_compatible_layout_encoding = _create_tmem_compatible_tensor_layout_encoding(_builder, src)
         load_handle = _builder.create_tmem_load(src.handle, tmem_compatible_layout_encoding,
                                                 token.handle if token else None)
         output = _builder.create_release_layout(load_handle)
-        return tl.tensor(output, src.type)
+        return tl.tensor(output, block_type)
+    else:
+        output =_builder.create_local_load(src.handle, token.handle if token else None)
+        return tl.tensor(output, block_type)
 
-    block_type = tl.block_type(src.type.element_ty, src.type.shape)
-    return tl.tensor(_builder.create_local_load(src.handle, token.handle if token else None), block_type)
 
 @tl.builtin
 def local_store(
     dst: tlx.buffered_tensor,
     src: tl.tensor,
-    storage: tlx.storage_kind = tlx.storage_kind.smem,
     _builder=None,
 ) -> tl.tensor:
     """
     Store a distributed tensor into a buffer in local or tensor memory.
     """
+    storage = dst.type.storage
     if storage == tlx.storage_kind.tmem:
         _assert_blackwell_for_tmem(_builder.options.arch)
         tmem_compatible_layout_encoding = _create_tmem_compatible_tensor_layout_encoding(_builder, dst)

--- a/third_party/tlx/tutorials/gemm-WS-blackwell.py
+++ b/third_party/tlx/tutorials/gemm-WS-blackwell.py
@@ -207,16 +207,16 @@ def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M
                 if EPILOGUE_SUBTILE:
                     # We load/store the result half by half to reduce SMEM pressure
                     acc_tmem_subslice1 = tlx.subslice(acc_tmem, 0, BLOCK_SIZE_N // 2)
-                    result = tlx.local_load(acc_tmem_subslice1, tlx.storage_kind.tmem)
+                    result = tlx.local_load(acc_tmem_subslice1)
                     c = result.to(tl.float16)
                     c_desc.store([offs_am, offs_bn], c)
 
                     acc_tmem_subslice2 = tlx.subslice(acc_tmem, BLOCK_SIZE_N // 2, BLOCK_SIZE_N // 2)
-                    result = tlx.local_load(acc_tmem_subslice2, tlx.storage_kind.tmem)
+                    result = tlx.local_load(acc_tmem_subslice2)
                     c = result.to(tl.float16)
                     c_desc.store([offs_am, offs_bn + BLOCK_SIZE_N // 2], c)
                 else:
-                    result = tlx.local_load(acc_tmem, tlx.storage_kind.tmem)
+                    result = tlx.local_load(acc_tmem)
                     c = result.to(tl.float16)
                     c_desc.store([offs_am, offs_bn], c)
 

--- a/third_party/tlx/tutorials/pipelined-gemm-blackwell-tma.py
+++ b/third_party/tlx/tutorials/pipelined-gemm-blackwell-tma.py
@@ -89,7 +89,7 @@ def matmul_kernel_tma_pipelined_blackwell(a_ptr, b_ptr, c_ptr, M, N, K, stride_a
     # init accumulator to 0 (in TMEM)
     buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
     acc_tmem = tlx.local_view(buffers, 0)
-    tlx.local_store(acc_tmem, accumulator, tlx.storage_kind.tmem)
+    tlx.local_store(acc_tmem, accumulator)
 
     num_iter = tl.cdiv(K, BLOCK_SIZE_K)
     for k in range(0, num_iter):
@@ -137,7 +137,7 @@ def matmul_kernel_tma_pipelined_blackwell(a_ptr, b_ptr, c_ptr, M, N, K, stride_a
     tlx.barrier_wait(prev_dot_bar, prev_phase)
 
     # load the result from TMEM to registers
-    result = tlx.local_load(acc_tmem, tlx.storage_kind.tmem)
+    result = tlx.local_load(acc_tmem)
     c = result.to(tl.float16)
 
     # store the result to SMEM to prepare for TMA store (TMEM -> GMEM)


### PR DESCRIPTION
Fixing the return type of tmem local_load to be based on block_type instead of buffered_tensor type.

Also retiring storage specification for `tlx.local_load` and `tlx.local_store` as it can be inferred from the mem desc.