### PR TITLE
[TLX] Fix NVMMA shared layout for 2cta

### DIFF
--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -79,15 +79,18 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
                     layout.numCTAOrder,
                 )
             else:
-                layout = tlx.nv_mma_shared_layout_encoding.make_default(shape, dtype)
+                layout = tlx.nv_mma_shared_layout_encoding.make_default(shape, dtype, _builder.options.num_ctas,
+                                                                        _builder.options.num_warps,
+                                                                        32  # threads_per_warp
+                                                                        )
                 layout_handle = _builder.make_nv_mma_shared_encoding_attr(
                     [int(x) for x in layout.shape],
                     layout.order,
                     layout.elemType.to_ir(_builder),
-                    layout.numCTAsPerCGA,
-                    layout.numCTASplit,
-                    layout.numCTAOrder,
                     layout.fp4Padded,
+                    layout.numCTAs,
+                    layout.moduleNumWarps,
+                    layout.threadsPerWarp,
                 )
         else:
             layout = tlx.tensor_memory_layout_encoding.make_default(shape)
@@ -271,7 +274,7 @@ def local_load(
         output = _builder.create_release_layout(load_handle)
         return tl.tensor(output, block_type)
     else:
-        output =_builder.create_local_load(src.handle, token.handle if token else None)
+        output = _builder.create_local_load(src.handle, token.handle if token else None)
         return tl.tensor(output, block_type)
 
 

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -9,16 +9,16 @@ def require_nv_mma_shared_layout(x: tlx.buffered_tensor, _builder=None):
     assert isinstance(x.type.layout, tlx.shared_layout_encoding), "input must be a shared tensor"
     if isinstance(x.type.layout, tlx.swizzled_shared_layout_encoding):
         layout = tlx.nv_mma_shared_layout_encoding(shape=x.shape, order=x.type.layout.order, elemType=x.dtype,
-                                                   numCTAsPerCGA=[1, 1], numCTASplit=[1, 1], numCTAOrder=[1, 1],
-                                                   fp4Padded=False)
+                                                   fp4Padded=False, numCTAs=_builder.options.num_ctas,
+                                                   moduleNumWarps=_builder.options.num_warps, threadsPerWarp=32)
         layout_handle = _builder.make_nv_mma_shared_encoding_attr(
             [int(x) for x in layout.shape],
             layout.order,
             layout.elemType.to_ir(_builder),
-            layout.numCTAsPerCGA,
-            layout.numCTASplit,
-            layout.numCTAOrder,
             layout.fp4Padded,
+            layout.numCTAs,
+            layout.moduleNumWarps,
+            layout.threadsPerWarp,
         )
         return _builder.create_require_layout(x.handle, layout_handle)
     else:


### PR DESCRIPTION
When giving an initial NVMMA shared layout to buffered tensor, we should respect the CTA layout instead of always forcing 1 cta mode.

The construction of `ttg::CTALayoutAttr` is much easier on C++ side with existing builders from tablegen def so we defer it until we are about to create `NVMMASharedEncodingAttr`. We construct CTALayou from default `BlockedEncodingAttr`, like deriving a shared layout from a distributed tensor.

`pytest -vs python/test/unit/language/test_tlx.py` all passing.

