### PR TITLE
[TLX] Replacing tlx.local_view with []

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -148,6 +148,7 @@ def test_local_load(BLOCK_SIZE, device):
     assert kernel.asm["ttgir"].count("ttg.local_load") == 2
     torch.testing.assert_close(x + y, output)
 
+
 # Tests tl.load->tlx_local_store->tlx_local_load
 # This is a smem load/store test variant that does not use
 # async_load, so this test can be run on platforms where
@@ -168,7 +169,7 @@ def test_load_store_smem_with_tl_load(BLOCK_SIZE, device):
         offsets = block_start + tl.arange(0, BLOCK_SIZE)
         mask = offsets < n_elements
 
-        smem_buffers = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 3)
+        smem_buffers = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 3)
         x_smem = tlx.local_view(smem_buffers, 0)
         y_smem = tlx.local_view(smem_buffers, 1)
 
@@ -189,13 +190,14 @@ def test_load_store_smem_with_tl_load(BLOCK_SIZE, device):
     y = torch.rand(size, dtype=torch.float32, device=device)
     output = torch.empty_like(x)
     n_elements = x.numel()
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
     kernel = smem_reg_store_load[grid](x, y, output, n_elements, BLOCK_SIZE)
     assert kernel.asm["ttgir"].count("ttg.local_alloc") == 1
     assert kernel.asm["ttgir"].count("ttg.memdesc_subview") == 2
     assert kernel.asm["ttgir"].count("ttg.local_load") == 2
     assert kernel.asm["ttgir"].count("ttg.local_store") == 2
     torch.testing.assert_close(x + y, output)
+
 
 @pytest.mark.skipif(
     not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
@@ -1372,6 +1374,7 @@ def _global_tmem_func(
 
     tl.store(x_ptr_offsets, b)
 
+
 @pytest.mark.skipif(
     not is_cuda() or torch.cuda.get_device_capability()[0] < 10,
     reason="Requires compute capability >= 10 for NV",
@@ -1404,12 +1407,14 @@ def test_tmem_op_func(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
 def math_kernel(x):
     return x * 0.5 * (1 + (0.7978845608 * x * (1.0 + 0.044715 * x * x)))
 
+
 @pytest.mark.parametrize("BLOCK_SIZE", [(64)])
 def test_inline_tmem(BLOCK_SIZE, device):
+
     @triton.jit
     def kernel(y_ptr, BLOCK_SIZE: tl.constexpr):
         buffers = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(4), tlx.storage_kind.tmem)
-        buffer0 = tlx.local_view(buffers, 0)
+        buffer0 = buffers[0]
         x = tlx.local_load(buffer0)
         pid = tl.program_id(axis=0)
         offsets_i = tl.arange(0, BLOCK_SIZE)[:, None]
@@ -1417,7 +1422,6 @@ def test_inline_tmem(BLOCK_SIZE, device):
         offsets = offsets_i * BLOCK_SIZE + offsets_j
         y = math_kernel(x)
         tl.store(y_ptr + offsets, y)
-
 
     y = torch.rand((64, 64), dtype=torch.float32, device=device)
     grid = lambda meta: (1, )

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -29,7 +29,7 @@ def alloc_barriers(
         layout.numCTAOrder,
     )
     return tlx.mbarrier(_builder.create_alloc_barriers(num_barriers.value, arrive_count.value, layout_handle),
-                        num_barriers, layout)
+                        num_barriers, layout, _builder)
 
 
 @tl.builtin
@@ -70,7 +70,8 @@ def barrier_wait(
     if isinstance(phase, tl.tensor):
         _builder.create_barrier_wait(bar.handle, phase.handle, pred_handle)
     elif isinstance(phase, tl.constexpr):
-        _builder.create_barrier_wait(bar.handle, _convert_elem_to_ir_value(_builder, phase.value, require_i64=False), pred_handle)
+        _builder.create_barrier_wait(bar.handle, _convert_elem_to_ir_value(_builder, phase.value, require_i64=False),
+                                     pred_handle)
     else:
         raise RuntimeError(f"`phase` is in type {type(phase)} (must be either `tl.tensor` or `tl.constexpr`)")
 

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -106,14 +106,7 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
     else:
         tensor_handle = _builder.create_tmem_alloc(full_shape, elem_type, layout_handle)
 
-    return tlx.buffered_tensor(
-        tensor_handle,
-        dtype,
-        unwrapped_shape,
-        unwrapped_num,
-        storage,
-        layout,
-    )
+    return tlx.buffered_tensor(tensor_handle, dtype, unwrapped_shape, unwrapped_num, storage, layout, _builder)
 
 
 # overload declarations just to make linter happy
@@ -147,7 +140,7 @@ def local_view(
     buffer_idx = _convert_elem_to_ir_value(_builder, buffer_idx, require_i64=False)
     view_handle = _builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx)
     if isinstance(local_allocated_buffers, tlx.mbarrier):
-        return tlx.mbarrier(view_handle, 1, local_allocated_buffers.type.layout)
+        return tlx.mbarrier(view_handle, 0, local_allocated_buffers.type.layout)
     else:
         return tlx.buffered_tensor(
             view_handle,
@@ -157,6 +150,14 @@ def local_view(
             local_allocated_buffers.type.storage,
             local_allocated_buffers.type.layout,
         )
+
+
+def _buffered_tensor_getitem(self, buffer_idx, _builder=None):
+    return local_view(self, buffer_idx, _builder=self.type.builder)
+
+
+tlx.buffered_tensor.__getitem__ = _buffered_tensor_getitem
+tlx.mbarrier.__getitem__ = _buffered_tensor_getitem
 
 
 @tl.builtin
@@ -271,7 +272,7 @@ def local_load(
         output = _builder.create_release_layout(load_handle)
         return tl.tensor(output, block_type)
     else:
-        output =_builder.create_local_load(src.handle, token.handle if token else None)
+        output = _builder.create_local_load(src.handle, token.handle if token else None)
         return tl.tensor(output, block_type)
 
 

--- a/third_party/tlx/tutorials/gemm-WS-blackwell.py
+++ b/third_party/tlx/tutorials/gemm-WS-blackwell.py
@@ -106,17 +106,13 @@ def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M
                 for k in range(0, k_tiles):
                     # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
                     buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
-                    a = tlx.local_view(buffers_A, buf)
-                    b = tlx.local_view(buffers_B, buf)
-                    smem_full_bar = tlx.local_view(smem_full_bars, buf)
-                    smem_empty_bar = tlx.local_view(smem_empty_bars, buf)
                     # wait for previous phase(round) of dot for this buf
-                    tlx.barrier_wait(smem_empty_bar, load_phase ^ 1)
+                    tlx.barrier_wait(smem_empty_bars[buf], load_phase ^ 1)
                     # buffer is now ready to be used again
                     offs_k = k * BLOCK_SIZE_K
-                    tlx.barrier_expect_bytes(smem_full_bar, 2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K)  # float16
-                    tlx.async_descriptor_load(a_desc, a, [offs_am, offs_k], smem_full_bar)
-                    tlx.async_descriptor_load(b_desc, b, [offs_k, offs_bn], smem_full_bar)
+                    tlx.barrier_expect_bytes(smem_full_bars[buf], 2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K)  # float16
+                    tlx.async_descriptor_load(a_desc, buffers_A[buf], [offs_am, offs_k], smem_full_bars[buf])
+                    tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_k, offs_bn], smem_full_bars[buf])
                     # flip phase at the end of a round
                     load_phase = load_phase ^ (buf == NUM_SMEM_BUFFERS - 1)
                 processed_k_iters += k_tiles
@@ -141,10 +137,8 @@ def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M
                 offs_bn = pid_n * BLOCK_SIZE_N
 
                 # init accumulator to 0 (in TMEM), block until the buffer is ready
-                acc_tmem = tlx.local_view(tmem_buffers, cur_tmem_buf)
                 # wait epilogue consumer to be done with the buffer before reusing it
-                tmem_empty_bar = tlx.local_view(tmem_empty_bars, cur_tmem_buf)
-                tlx.barrier_wait(tmem_empty_bar, tmem_write_phase)
+                tlx.barrier_wait(tmem_empty_bars[cur_tmem_buf], tmem_write_phase)
                 # flip phase at the end of a round of using TMEM barriers
                 tmem_write_phase = tmem_write_phase ^ (cur_tmem_buf == NUM_TMEM_BUFFERS - 1)
 
@@ -152,27 +146,21 @@ def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M
                 for k in range(0, k_tiles):
                     # processed_k_iters + k means we use the immediate next buffer slot of tile_id x when we start tile_id x+1
                     buf = (processed_k_iters + k) % NUM_SMEM_BUFFERS
-                    a = tlx.local_view(buffers_A, buf)
-                    b = tlx.local_view(buffers_B, buf)
-                    smem_full_bar = tlx.local_view(smem_full_bars, buf)
-                    smem_empty_bar = tlx.local_view(smem_empty_bars, buf)
                     # wait for current phase(round) of load for this buf
-                    tlx.barrier_wait(smem_full_bar, dot_phase)
+                    tlx.barrier_wait(smem_full_bars[buf], dot_phase)
                     # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
-                    tlx.async_dot(a, b, acc_tmem, use_acc=k > 0, mBarriers=[smem_empty_bar], out_dtype=tl.float32)
+                    tlx.async_dot(buffers_A[buf], buffers_B[buf], tmem_buffers[cur_tmem_buf], use_acc=k > 0, mBarriers=[smem_empty_bars[buf]], out_dtype=tl.float32)
                     # flip phase at the end of a round
                     dot_phase = dot_phase ^ (buf == NUM_SMEM_BUFFERS - 1)
 
                 # wait for last mma to complete
                 last_buf = (processed_k_iters + k_tiles - 1) % NUM_SMEM_BUFFERS
-                last_smem_empty_bar = tlx.local_view(smem_empty_bars, last_buf)
                 # in case phase was flipped, we should use the phase value when dot op was issued
                 last_dot_phase = dot_phase ^ (last_buf == NUM_SMEM_BUFFERS - 1)
-                tlx.barrier_wait(last_smem_empty_bar, last_dot_phase)
+                tlx.barrier_wait(smem_empty_bars[last_buf], last_dot_phase)
 
                 # done filling this buffer, signal epilogue consumer
-                tmem_full_bar = tlx.local_view(tmem_full_bars, cur_tmem_buf)
-                tlx.barrier_arrive(tmem_full_bar, 1)
+                tlx.barrier_arrive(tmem_full_bars[cur_tmem_buf], 1)
 
                 # possibly enter next iteration (next tile) without waiting for epilogue
                 cur_tmem_buf = (cur_tmem_buf + 1) % NUM_TMEM_BUFFERS
@@ -196,13 +184,12 @@ def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M
                 offs_am = pid_m * BLOCK_SIZE_M
                 offs_bn = pid_n * BLOCK_SIZE_N
 
-                tmem_full_bar = tlx.local_view(tmem_full_bars, cur_tmem_buf)
-                tlx.barrier_wait(tmem_full_bar, tmem_read_phase)
+                tlx.barrier_wait(tmem_full_bars[cur_tmem_buf], tmem_read_phase)
                 # flip phase at the end of a round of using TMEM barriers
                 tmem_read_phase = tmem_read_phase ^ (cur_tmem_buf == NUM_TMEM_BUFFERS - 1)
 
                 # load the result from TMEM to registers
-                acc_tmem = tlx.local_view(tmem_buffers, cur_tmem_buf)
+                acc_tmem = tmem_buffers[cur_tmem_buf]
 
                 if EPILOGUE_SUBTILE:
                     # We load/store the result half by half to reduce SMEM pressure
@@ -221,8 +208,7 @@ def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M
                     c_desc.store([offs_am, offs_bn], c)
 
                 # done storing this buffer, signal MMA consumer to resume writing to it
-                tmem_empty_bar = tlx.local_view(tmem_empty_bars, cur_tmem_buf)
-                tlx.barrier_arrive(tmem_empty_bar, 1)
+                tlx.barrier_arrive(tmem_empty_bars[cur_tmem_buf], 1)
 
                 cur_tmem_buf = (cur_tmem_buf + 1) % NUM_TMEM_BUFFERS
 


### PR DESCRIPTION
Optionally indexing op `[]` can be used to replace `tlx.local_view`.