### PR TITLE
[TLX] Fix nv_mma_shared_layout_encoding type comparison

### DIFF
--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -163,6 +163,15 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
             self.fp4Padded,
         )
 
+    def __str__(self) -> str:
+        return f"nv_mma_shared_layout_encoding<{self.shape}, {self.order}, {self.elemType}, {self.numCTAsPerCGA}, {self.numCTASplit}, {self.numCTAOrder}, {self.fp4Padded}>"
+
+    def __eq__(self, other) -> bool:
+        return (type(self) is type(other) and self.shape == other.shape and self.order == other.order
+                and self.elemType == other.elemType and self.numCTAsPerCGA == other.numCTAsPerCGA
+                and self.numCTASplit == other.numCTASplit and self.numCTAOrder == other.numCTAOrder
+                and self.fp4Padded == other.fp4Padded)
+
 
 class storage_kind(enum.Enum):
     smem = "smem"


### PR DESCRIPTION
When we compare two `nv_mma_shared_layout_encoding` we should compare all the fields instead of directly comparing two objects.

```
> /data/users/pchen7e4/facebookexperimental/triton/python/triton/compiler/code_generator.py(930)_verify_loop_carried_variable()
-> assert loop_val.type == live_val.type, \
(Pdb) loop_val.type
buffered_tensor_<fp16, ['128', '128'], nv_mma_shared_layout_encoding, 0>
(Pdb) live_val.type
buffered_tensor_<fp16, ['128', '128'], nv_mma_shared_layout_encoding, 0>
(Pdb) live_val.type == loop_val.type
False

(Pdb) live_val.type.shape == loop_val.type.shape
constexpr[True]

(Pdb) live_val.type.layout == loop_val.type.layout
False
```

#225 broke `third_party/tlx/tutorials/flash-attention-WS-pipelined-pingpong-hopper.py` because it does not treat two types equal even if their fields are equal. This diff fixes it by implementing `__eq__` for `nv_mma_shared_layout_encoding`.

```
$ python third_party/tlx/tutorials/flash-attention-WS-pipelined-pingpong-hopper.py
fused-attention-ws-pipelined-pingpong-batch4-head32-d128:
     N_CTX  Triton [FP16]
0   1024.0     503.054936
1   2048.0     620.399683
2   4096.0     635.985442
3   8192.0     676.210406
4  16384.0     699.386532
```

Also now the printed layout is more readable like this

```
(Pdb) live_val.type
buffered_tensor_<fp16, ['128', '128'], nv_mma_shared_layout_encoding<['constexpr[128]', 'constexpr[128]'], (0, 1), fp16, [1, 1], [1, 1], [1, 1], False>, 0>
```