### PR TITLE
[TLX-main] Fix dot_precheck to allow for tlx.buffered_tensor (copying #247)

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1557,7 +1557,7 @@ class TritonSemantic(Generic[TensorTy]):
             acc_handle = self.builder.create_splat(ret_ty.to_ir(self.builder), _0)
         else:
             acc_handle = acc.handle
-            assert acc.type == ret_ty
+            assert acc.type.shape == ret_ty.shape and acc.type.element_ty == ret_ty.element_ty, "acc must have same shape and dtype as output"
     
         # max_num_imprecise_acc only applies to fp8 -> fp32 dot on sm_90
         if max_num_imprecise_acc is None:


### PR DESCRIPTION
Cherry-pick #247 requires non-trivial merge conflict fix in pre-check. 
Manually applies the one-line fix as a new PR.
<img width="1184" height="499" alt="image" src="https://github.com/user-attachments/assets/0c03fbaa-b636-4754-b2ec-151f0d02a577" />
