### PR TITLE
Patch download file with chmod 777

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -140,6 +140,14 @@ def get_env_with_keys(key: list):
             return os.environ[k]
     return ""
 
+def set_permissions(directory):
+    try:
+        subprocess.run(["chmod", "-R", "777", directory], check=True)
+        print(f"Permissions set to 777 for {directory}")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to set permissions: {e}")
+
+
 
 def is_offline_build() -> bool:
     """
@@ -312,7 +320,7 @@ def get_thirdparty_packages(packages: list):
         if p.sym_name is not None:
             sym_link_path = os.path.join(package_root_dir, p.sym_name)
             update_symlink(sym_link_path, package_dir)
-
+        set_permissions(package_root_dir)
     return thirdparty_cmake_args
 
 


### PR DESCRIPTION
Summary:
Currently we are having permission issue when run with root.
```
[55/283] Building Passes.h.inc...
  FAILED: [code=126] third_party/amd/include/TritonAMDGPUTransforms/Passes.h.inc $SRC_DIR/python/build/cmake.linux-x86_64-cpython-3.10/third_party/amd/include/TritonAMDGPUTransforms/Passes.h.inc
  cd $SRC_DIR/python/build/cmake.linux-x86_64-cpython-3.10 && /tmp/triton/.triton/llvm/llvm-a66376b0-ubuntu-x64/bin/mlir-tblgen -gen-pass-decls -name TritonAMDGPU -I $SRC_DIR/third_party/amd/include/TritonAMDGPUTransforms -I$SRC_DIR/include -I$SRC_DIR/. -I/tmp/triton/.triton/llvm/llvm-a66376b0-ubuntu-x64/include -I/tmp/triton/.triton/llvm/llvm-a66376b0-ubuntu-x64/include -I$SRC_DIR/include -I$SRC_DIR/python/build/cmake.linux-x86_64-cpython-3.10/include -I$SRC_DIR/third_party -I$SRC_DIR/python/build/cmake.linux-x86_64-cpython-3.10/third_party -I$SRC_DIR/python/src -I$SRC_DIR/third_party/amd/include -I$SRC_DIR/python/build/cmake.linux-x86_64-cpython-3.10/third_party/amd/include $SRC_DIR/third_party/amd/include/TritonAMDGPUTransforms/Passes.td --write-if-changed -o third_party/amd/include/TritonAMDGPUTransforms/Passes.h.inc -d third_party/amd/include/TritonAMDGPUTransforms/Passes.h.inc.d
````
After chmoding this we are can build with root
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `This is CD`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
