### PR TITLE
[TLX][AMD] Add barrier support

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -81,6 +81,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUStreamPipeline();
   mlir::registerTritonAMDGPUCanonicalizePointers();
   mlir::registerTritonAMDGPUConvertToBufferOps();
+  mlir::registerTritonAMDGPULowerBarrierOps();
   mlir::registerTritonAMDGPUInThreadTranspose();
   mlir::registerTritonAMDGPUCoalesceAsyncCopy();
   mlir::registerTritonAMDGPUUpdateAsyncWaitCount();

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -4,7 +4,7 @@ import torch
 import re
 import triton
 import triton.language as tl
-from triton._internal_testing import is_cuda
+from triton._internal_testing import is_cuda, is_hip
 import triton.language.extra.tlx as tlx
 from typing import Optional
 import traceback
@@ -1094,6 +1094,7 @@ def tlx_square_non_ws(
     z_ptr,
     n_elements,
     BLOCK_SIZE: tl.constexpr,
+    EXPECTED_ARRIVAL_COUNT:tl.constexpr,
 ):
     """
     Test pairs of arrive/wait using different phases
@@ -1122,8 +1123,8 @@ def tlx_square_non_ws(
     mask = offsets < n_elements
 
     # mbarrier ops
-
-    bars = tlx.alloc_barriers(num_barriers=1)  # create
+    
+    bars = tlx.alloc_barriers(num_barriers=1, arrive_count=EXPECTED_ARRIVAL_COUNT)  # create
     bar = tlx.local_view(bars, 0)
 
     x = tl.load(x_ptr + offsets, mask=mask)  # Do something
@@ -1151,13 +1152,14 @@ def tlx_square_ws(
     z_ptr,
     n_elements,
     BLOCK_SIZE: tl.constexpr,
+    EXPECTED_ARRIVAL_COUNT:tl.constexpr,
 ):
     # prologue
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 
     # mbarrier ops
-    bars = tlx.alloc_barriers(num_barriers=2)  # create
+    bars = tlx.alloc_barriers(num_barriers=2, arrive_count=EXPECTED_ARRIVAL_COUNT)  # create
     b0 = tlx.local_view(bars, 0)
     b1 = tlx.local_view(bars, 1)
 
@@ -1185,7 +1187,7 @@ def tlx_square_ws(
             tlx.barrier_arrive(bar=b0)  # Wait
 
 
-def run_tlx_square(func, BLOCK_SIZE, device):
+def run_tlx_square(func, BLOCK_SIZE, device, expected_arrival_count=1):
 
     # prepare inputs
     torch.manual_seed(0)
@@ -1198,28 +1200,26 @@ def run_tlx_square(func, BLOCK_SIZE, device):
 
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
 
-    kernel = func[grid](x, z, n_elements, BLOCK_SIZE)
+    kernel = func[grid](x, z, n_elements, BLOCK_SIZE, expected_arrival_count)
 
     z_ref = x * x
 
     torch.testing.assert_close(z, z_ref, check_dtype=False)
     return kernel
 
-
-# Unit test for arrive/wait
-@pytest.mark.skipif(
-    not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
-    reason="Requires compute capability >= 9 for NV",
-)
 @pytest.mark.parametrize("BLOCK_SIZE", [(1024)])
 # def test_mbarriers(BLOCK_SIZE, device):
 def test_wait_arrive_non_ws(BLOCK_SIZE, device):
-    kernel = run_tlx_square(tlx_square_non_ws, BLOCK_SIZE, device)
-
+    expected_arrival_count = 4 if is_hip() else 1
+    kernel = run_tlx_square(tlx_square_non_ws, BLOCK_SIZE, device, expected_arrival_count=expected_arrival_count)
     # ASSERT in ttgir
     ttgir = kernel.asm["ttgir"]
-    assert (ttgir.count("ttng.init_barrier") == 1) and (ttgir.count("ttng.wait_barrier") == 3) and (
-        ttgir.count("ttng.barrier_expect") == 0) and (ttgir.count("ttng.arrive_barrier") == 3), f"TTGIR {ttgir}"
+    if is_hip():
+        assert (ttgir.count("amdgpu.init_barrier") == 1) and (ttgir.count("amdgpu.read_barrier_phase") == 3) and (
+          ttgir.count("amdgpu.arrive_barrier") == 3), f"TTGIR {ttgir}"
+    else:    
+        assert (ttgir.count("ttng.init_barrier") == 1) and (ttgir.count("ttng.wait_barrier") == 3) and (
+          ttgir.count("ttng.barrier_expect") == 0) and (ttgir.count("ttng.arrive_barrier") == 3), f"TTGIR {ttgir}"
 
 
 @pytest.mark.skipif(

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -221,7 +221,8 @@ class HIPBackend(BaseBackend):
         passes.ttgpuir.add_coalesce(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
-        
+        amd.passes.ttgpuir.add_lower_barrier_ops(pm)
+
         # Maintain the order of the following three passes
         # for graphs with tlx.local_load -> tt.dot,
         # dot op specifics from add_accelerate_matmul are required

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/CMakeLists.txt
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/CMakeLists.txt
@@ -16,3 +16,4 @@ mlir_tablegen(TritonAMDGPUEnums.cpp.inc -gen-enum-defs)
 mlir_tablegen(TritonAMDGPUAttrDefs.h.inc -gen-attrdef-decls)
 mlir_tablegen(TritonAMDGPUAttrDefs.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(TritonAMDGPUAttrDefsIncGen)
+

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -493,5 +493,63 @@ def InThreadTransposeOp : TT_AMDGPU_Op<"in_thread_transpose", [Pure]> {
                                  mlir::triton::gpu::BlockedEncodingAttr srcEncoding);
   }];
 }
+//===----------------------------------------------------------------------===//
+// ArriveBarrierOp
+//===----------------------------------------------------------------------===//
+def ArriveBarrierOp : TT_AMDGPU_Op<"arrive_barrier",  [MemoryEffects<[MemWrite<SharedMemory>, MemRead<SharedMemory>]>]> {
+  let summary = "barrier arrive";
 
+  let description = [{
+    This operation defines the arriving action for a named barrier.
+    `count` is the number by which the arrival count of the barrier is decremented
+    'expectedCount' is the expected arrival count of the barrier.
+     The count of the barrier is set to this value after all threads have arrived
+  }];
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
+    I32Attr:$count,
+    I32Attr:$expectedCount
+  );
+
+  let assemblyFormat = [{
+    $alloc `,` $count `,` $expectedCount attr-dict `:` qualified(type($alloc))
+  }];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// InitBarrierOp
+//===----------------------------------------------------------------------===//
+def InitBarrierOp : TT_AMDGPU_Op<"init_barrier", [MemoryEffects<[MemWrite<SharedMemory>]>]> {
+  let summary = "Initialize a barrier in the given shared memory allocation.";
+  let description = [{
+      Initializes a shared memory allocation with mbarrier information.
+      `alloc` is a descriptor to the shared memory allocation. `count` is the
+      number of arrives expected by the barrier.
+
+  }];
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$alloc,
+    I32Attr:$count
+  );
+  let assemblyFormat = "$alloc `,` $count attr-dict `:` qualified(type($alloc))";
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// ReadBarrierPhaseOp
+//===----------------------------------------------------------------------===//
+def ReadBarrierPhaseOp : TT_AMDGPU_Op<"read_barrier_phase",  [MemoryEffects<[MemRead<SharedMemory>]>]> {
+  let summary = "Read phase";
+
+  let description = [{ Read barrier phase}];
+
+  let arguments = (ins 
+                   Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$alloc
+                  );
+  let results = (outs I32:$result);
+  //let assemblyFormat = "operands attr-dict `:` type($result)";
+}
 #endif

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -126,6 +126,14 @@ def TritonAMDGPUReorderInstructions: Pass<"tritonamdgpu-reorder-instructions", "
   let dependentDialects = [];
 }
 
+def TritonAMDGPULowerBarrierOps: Pass<"tritonamdgpu-lower-barrier-ops", "mlir::ModuleOp"> {
+  let summary = "Lower barrier ops";
+
+  let description = "This pass lowers TTNG barrier ops to AMDGPU Barrier ops";
+
+  let dependentDialects = ["mlir::ROCDL::ROCDLDialect, mlir::triton::amdgpu::TritonAMDGPUDialect"];
+}
+
 def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "mlir::ModuleOp"> {
   let summary = "Convert memory operations to buffer operations";
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -394,4 +394,30 @@ LogicalResult ConcatOp::verify() {
 
   return success();
 }
+
+static LogicalResult
+verifyBarrierType(Operation *op, mlir::triton::gpu::MemDescType barrierType) {
+  if (!barrierType.getElementType().isInteger(64) ||
+      barrierType.getShape() != ArrayRef<int64_t>({1}))
+    return op->emitOpError(
+        "barrier allocation must be a descriptor of 1xi64 type");
+  return success();
+}
+
+// -- InitBarrierOp --
+LogicalResult InitBarrierOp::verify() {
+  if (failed(verifyBarrierType(*this, getAlloc().getType())))
+    return failure();
+  return success();
+}
+
+// -- ArriveBarrierOp --
+LogicalResult ArriveBarrierOp::verify() {
+  if (failed(verifyBarrierType(*this, getAlloc().getType())))
+    return failure();
+  if (getCount() < 1)
+    return emitOpError("count must be greater than or equal to 1");
+  return success();
+}
+
 } // namespace mlir::triton::amdgpu

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpConversion.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpConversion.cpp
@@ -1,0 +1,192 @@
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "Utility.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Pass/PassManager.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+
+
+using namespace mlir;
+// using ::mlir::triton::gpu::SharedEncodingAttr;
+
+namespace ttg = mlir::triton::gpu;
+namespace tt = mlir::triton;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+
+namespace {
+
+Value getBarrierField(triton::TritonLLVMOpBuilder builder, SharedMemoryObject barrierSmemObj, int fieldIndex) {
+  OpBuilder b = *builder.builder;
+  auto i32ty = b.getIntegerType(32);
+  auto baseAddr = barrierSmemObj.getBase();
+  return builder.gep(baseAddr.getType(), i32ty, baseAddr, builder.i32_val(fieldIndex));
+}
+
+Value getPhaseBaseAddress(TritonLLVMOpBuilder builder, SharedMemoryObject barrierSmemObj) {
+ return getBarrierField(builder, barrierSmemObj, 1);
+}
+
+Value getCountBaseAddress(TritonLLVMOpBuilder builder, SharedMemoryObject barrierSmemObj) {
+ return getBarrierField(builder, barrierSmemObj, 0);
+}
+
+struct InitBarrierOpConversion
+  : public ConvertOpToLLVMPattern<triton::amdgpu::InitBarrierOp> {
+using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+LogicalResult
+matchAndRewrite(triton::amdgpu::InitBarrierOp op, OpAdaptor adaptor,
+                ConversionPatternRewriter &rewriter) const override {
+  
+  Location loc = op.getLoc();
+  MLIRContext *ctx = rewriter.getContext();
+
+  auto barrierSmemObj = LLVM::getSharedMemoryObjectFromStruct(
+        op.getLoc(), adaptor.getAlloc(), typeConverter->convertType(
+        op.getAlloc().getType().getElementType()), rewriter);
+  int count = op.getCount();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto countBaseAddr = getCountBaseAddress(b, barrierSmemObj);
+  auto phaseBaseAddr = getPhaseBaseAddress(b, barrierSmemObj);
+
+  // Set countVal to count -1 because we use DS_DEC_RTN which does count -= 1 and 
+  // wraps around when post dec value reaches -1. 
+  // For example, initializing count to 2 will allow 3 arrives
+  // (2->1->0->-1) before the value gets reset to 2
+  Value countVal = b.i32_val(count - 1);
+  Value phaseVal = b.i32_val(0);
+  b.store(countVal, countBaseAddr);
+  b.store(phaseVal, phaseBaseAddr);
+  rewriter.eraseOp(op);
+  return success();
+}
+
+};
+
+struct ArriveBarrierOpConversion
+  : public ConvertOpToLLVMPattern<triton::amdgpu::ArriveBarrierOp> {
+using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+LogicalResult
+matchAndRewrite(triton::amdgpu::ArriveBarrierOp op, OpAdaptor adaptor,
+                ConversionPatternRewriter &rewriter) const override {
+  
+  Location loc = op.getLoc();
+  auto barrierSmemObj = LLVM::getSharedMemoryObjectFromStruct(
+        op.getLoc(), adaptor.getAlloc(), typeConverter->convertType(
+        op.getAlloc().getType().getElementType()), rewriter);
+  
+  // TODO: Support decCount > 1 with DS_SUB_RTN_U32 and 
+  // reset barrier arrival count to expected count with DS_WRITE_B32 when 
+  // phase flip condition is met
+  int decCount = op.getCount();
+  assert(decCount == 1 && "Only support decCount == 1 for now");
+
+  // Calulate the address of phase from the base address
+  // of the barrier smem object
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto countBaseAddr = getCountBaseAddress(b, barrierSmemObj);
+  auto phaseBaseAddr = getPhaseBaseAddress(b, barrierSmemObj);
+  
+  // Decrement the arrival count 
+  // Arrival count will be reset to resetVal if 
+  // preDecrementCountVal == 0
+  auto resetVal = b.i32_val(op.getExpectedCount() - 1);
+  GCNBuilder gcnBuilder;
+  auto &dec_rtn = *gcnBuilder.create("ds_dec_rtn_u32");
+  auto retVal = gcnBuilder.newOperand("=v");
+  auto countBaseAddrArg = gcnBuilder.newOperand(countBaseAddr, "v");
+  auto resetValArg = gcnBuilder.newOperand(resetVal, "v");
+  dec_rtn(retVal, countBaseAddrArg, resetValArg);
+  auto &wait_cnt = *gcnBuilder.create("s_waitcnt lgkmcnt(0)");
+  wait_cnt();
+  auto preDecrementCountVal =
+  gcnBuilder.launch(rewriter, loc, i32_ty, true /*hasSideEffects*/);
+
+  // If barrier's count is 0 before the decrement, then
+  // sufficient threads have arrived and we can flip the phase
+  MLIRContext *ctx = rewriter.getContext();
+  Value zero = b.i32_val(0);
+  Value allArrived = b.icmp_eq(preDecrementCountVal, zero);
+
+  Block *currentBlock = rewriter.getInsertionBlock();
+  Block *afterPhaseFlipBlock =
+      rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+  Block *phaseFlipBlock = rewriter.createBlock(afterPhaseFlipBlock);
+  rewriter.setInsertionPointToEnd(currentBlock);
+
+  rewriter.create<LLVM::CondBrOp>(loc, allArrived, phaseFlipBlock,
+                                  afterPhaseFlipBlock);
+
+  rewriter.setInsertionPointToStart(phaseFlipBlock);
+  GCNBuilder phaseFlipBuilder;
+  auto &xor_phase = *phaseFlipBuilder.create("ds_xor_b32");
+  auto baseAddrArg = phaseFlipBuilder.newOperand(phaseBaseAddr, "v");
+  Value one = b.i32_val(1);
+  auto oneArg = phaseFlipBuilder.newOperand(one, "v");
+  xor_phase(baseAddrArg, oneArg);
+
+  // Wakeup the wavefronts that are sleeping in the 
+  // barrier spin wait loop
+  auto &s_wakeup = *phaseFlipBuilder.create("s_wakeup");
+  s_wakeup();
+  auto xor_op = phaseFlipBuilder.launch(rewriter, loc, void_ty(ctx),
+                                    true /*hasSideEffects*/);
+
+  auto br = rewriter.create<LLVM::BrOp>(loc, afterPhaseFlipBlock);
+
+  rewriter.eraseOp(op);
+  return success();
+}
+};
+
+struct ReadBarrierPhaseOpConversion
+  : public ConvertOpToLLVMPattern<triton::amdgpu::ReadBarrierPhaseOp> {
+using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+LogicalResult
+matchAndRewrite(triton::amdgpu::ReadBarrierPhaseOp op, OpAdaptor adaptor,
+                ConversionPatternRewriter &rewriter) const override {
+  
+  Location loc = op.getLoc();
+  auto barrierSmemObj = LLVM::getSharedMemoryObjectFromStruct(
+        op.getLoc(), adaptor.getAlloc(), typeConverter->convertType(
+        op.getAlloc().getType().getElementType()), rewriter);
+
+  auto countBaseAddr = barrierSmemObj.getBase();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto phaseBaseAddr = getPhaseBaseAddress(b, barrierSmemObj);
+  
+  auto res = b.load(i32_ty, phaseBaseAddr);
+
+  GCNBuilder phaseReadBuilder;
+  MLIRContext *ctx = rewriter.getContext();
+  auto &wait_cnt = *phaseReadBuilder.create("s_waitcnt lgkmcnt(0)");
+  wait_cnt();
+  phaseReadBuilder.launch(rewriter, loc, void_ty(ctx),
+                                    true /*hasSideEffects*/);
+  rewriter.replaceOp(op, res);
+  return success();
+  }
+};
+
+} // namespace
+
+namespace mlir::triton::AMD {
+void populateBarrierOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                       const TargetInfo &targetInfo,
+                                       RewritePatternSet &patterns,
+                                       ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                                       PatternBenefit benefit) {
+ patterns.add<InitBarrierOpConversion>(typeConverter, benefit);
+ patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
+ patterns.add<ReadBarrierPhaseOpConversion>(typeConverter, benefit);
+}
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonAMDGPUToLLVM
     AtomicRMWOpsEmitter.cpp
+    BarrierOpConversion.cpp
     BufferOpsEmitter.cpp
     ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
     ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -31,6 +31,13 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        ModuleAxisInfoAnalysis &axisInfoAnalysis,
                                        PatternBenefit benefit);
 
+void populateBarrierOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                       const TargetInfo &targetInfo,
+                                       RewritePatternSet &patterns,
+                                       ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                                       PatternBenefit benefit);
+
+
 void populateSPMDOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                  RewritePatternSet &patterns,
                                  PatternBenefit benefit);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -172,6 +172,8 @@ struct ConvertTritonAMDGPUToLLVM
     AMD::populateElementwiseOpToLLVMPatterns(typeConverter, patterns, ftz,
                                              axisInfoAnalysis, allocation,
                                              targetInfo, AMDBenefit);
+    AMD::populateBarrierOpToLLVMPatterns(typeConverter, targetInfo, patterns,
+                                           axisInfoAnalysis, AMDBenefit);
     AMD::populateLoadStoreOpToLLVMPatterns(typeConverter, targetInfo, patterns,
                                            axisInfoAnalysis, AMDBenefit);
     populatePatterns7(mlir::triton::populateReduceOpToLLVMPatterns,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonAMDGPUTransforms
   CanonicalizePointers.cpp
   CoalesceAsyncCopy.cpp
   ConvertToBufferOps.cpp
+  LowerBarrierOps.cpp
   OptimizeEpilogue.cpp
   HoistLayoutConversions.cpp
   ReorderInstructions.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerBarrierOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerBarrierOps.cpp
@@ -1,0 +1,179 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "mlir/Pass/PassManager.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+
+
+
+namespace ttg = mlir::triton::gpu;
+namespace tt = mlir::triton;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "tritonamdgpu-lower-barrier-ops"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONAMDGPULOWERBARRIEROPS
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+namespace {
+
+static const int THREADS_PER_WAVE = 64;
+static const int WAVES_PER_TASK = 4;
+
+void lowerArriveBarrierOps(ModuleOp m, const std::map<mlir::triton::gpu::LocalAllocOp, int> &localAllocToBarrierExpectedCount) {
+  SmallVector<Operation *> eraseOps;
+  auto cond = Value();
+  m.walk([&](ttng::ArriveBarrierOp op) {
+    LDBG("Lowering ArriveBarrierOp: " << op << "\n");
+    auto loc = op.getLoc();
+    OpBuilder builder(op);
+    if (!cond) {
+      auto ctx = op.getContext();
+      // Create if condition for the arrive
+      auto i32ty = builder.getIntegerType(32);
+      auto threadId = builder.create<ROCDL::ThreadIdXOp>(loc, i32ty);
+      auto threadsPerWave =
+          builder.create<arith::ConstantIntOp>(loc, THREADS_PER_WAVE, 32);
+      auto mod = builder.create<arith::RemSIOp>(loc, threadId, threadsPerWave);
+      auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+      cond =
+          builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, mod, zero);
+    }
+    auto ifOp = builder.create<scf::IfOp>(loc, cond);
+    auto thenBuilder = ifOp.getThenBodyBuilder();
+    if (auto defOp = dyn_cast<triton::gpu::MemDescSubviewOp>(op.getAlloc().getDefiningOp())) {
+      if (auto srcOp = dyn_cast<triton::gpu::LocalAllocOp>(defOp.getSrc().getDefiningOp())) {
+        auto it = localAllocToBarrierExpectedCount.find(srcOp);
+        if (it != localAllocToBarrierExpectedCount.end()) {
+          auto expectedCount = it->second;
+          auto incrementCount = op.getCount();
+          LDBG("srcOp: " << srcOp << " inc: " << incrementCount << "expected: " << expectedCount << "\n");
+          thenBuilder.create<triton::amdgpu::ArriveBarrierOp>(loc, op.getAlloc(), incrementCount, expectedCount);
+        } else {
+          assert(false && "Cannot find LocalAlllocOp for ArriveBarrierOp");
+        }
+      } 
+    } else {
+      assert(false && "ArriveBarrierOp not connected to LocalAllocOp");
+    }
+    eraseOps.push_back(op);
+  });
+  for (auto op : eraseOps) { op->erase(); }
+}
+
+void lowerWaitBarrierOps(ModuleOp m) {
+  SmallVector<Operation *> eraseOps;
+  m.walk([&](ttng::WaitBarrierOp op) {
+    LDBG("Lowering WaitBarrierOp: " << op << "\n");
+    auto loc = op.getLoc();
+    OpBuilder builder(op);
+    auto waitPhase = op.getPhase();
+    auto whileOp = builder.create<scf::WhileOp>(loc, TypeRange{}, ValueRange{});
+    // Spin Wait
+    // while - Before block
+    Block *beforeBlock = builder.createBlock(&whileOp.getBefore());
+    builder.setInsertionPointToEnd(beforeBlock);
+    auto i32ty = builder.getIntegerType(32);
+    // TODO: Lower this to a LocalLoad
+    Value barrierPhase = builder.create<triton::amdgpu::ReadBarrierPhaseOp>(loc, i32ty, op.getAlloc());
+    Value phaseCond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                  barrierPhase, waitPhase);
+    builder.create<scf::ConditionOp>(loc, phaseCond, ValueRange{});
+     // while - after block
+    Block *afterBlock = builder.createBlock(&whileOp.getAfter());
+    builder.setInsertionPointToEnd(afterBlock);
+    auto five = builder.create<arith::ConstantIntOp>(loc, 5, 32);
+    auto sleepInstrinsic = "llvm.amdgcn.s.sleep";
+    auto sleepOp = LLVM::createLLVMIntrinsicCallOp(builder, loc, sleepInstrinsic, TypeRange{}, ValueRange{five});
+    builder.create<scf::YieldOp>(loc,  ValueRange{});
+    builder.setInsertionPointAfter(whileOp);
+  
+    const char *asmStr = "s_wakeup";
+    const char *constraints = "";
+    auto asmDialectAttr = LLVM::AsmDialectAttr::get(builder.getContext(),
+                                                      LLVM::AsmDialect::AD_ATT);
+    builder.create<LLVM::InlineAsmOp>(
+        loc,
+        /*resultTypes=*/TypeRange(), /*operands=*/ValueRange(),
+        /*asm_string=*/asmStr, constraints, /*has_side_effects=*/true,
+        /*is_align_stack=*/false, /*asm_dialect=*/asmDialectAttr,
+        /*operand_attrs=*/ArrayAttr());// end spin wait
+    eraseOps.push_back(op);
+  });
+  for (auto op : eraseOps) { op->erase();}
+}
+
+void lowerInitBarrierOps(ModuleOp m, std::map<mlir::triton::gpu::LocalAllocOp, int> &localAllocToBarrierExpectedCount) {
+  SmallVector<Operation *> eraseOps;
+  auto cond = Value();
+  m.walk([&](ttng::InitBarrierOp op) {
+    LDBG("Lowering InitBarrierOp: " << op << "\n");
+    auto loc = op.getLoc();
+    OpBuilder builder(op);
+    if (!cond) {
+      auto ctx = op.getContext();
+      // Create if tid == 0 condition for the arrive
+      auto i32ty = builder.getIntegerType(32);
+      auto threadId = builder.create<ROCDL::ThreadIdXOp>(loc, i32ty);
+      auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+      cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                               threadId, zero);
+    }
+    auto ifOp = builder.create<scf::IfOp>(loc, cond);
+    auto thenBuilder = ifOp.getThenBodyBuilder();
+    thenBuilder.create<triton::amdgpu::InitBarrierOp>(loc, op.getAlloc(), op.getCount());
+    if (auto defOp = dyn_cast<triton::gpu::MemDescSubviewOp>(op.getAlloc().getDefiningOp())) {
+      if (auto srcOp = dyn_cast<triton::gpu::LocalAllocOp>(defOp.getSrc().getDefiningOp())) {
+        LDBG("srcOp: " << srcOp << " count: " << op.getCount() << "\n");
+        localAllocToBarrierExpectedCount[srcOp] = op.getCount();
+      } 
+    } else {
+      assert(false && "InitBarrierOp not connected to LocalAllocOp");
+    }
+    eraseOps.push_back(op);
+  });
+  for (auto op : eraseOps) { op->erase(); }
+}
+
+} // anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// Pass definition
+//===----------------------------------------------------------------------===//
+
+struct TritonAMDGPULowerBarrierOpsPass
+    : public impl::TritonAMDGPULowerBarrierOpsBase<
+          TritonAMDGPULowerBarrierOpsPass> {
+public:
+  using impl::TritonAMDGPULowerBarrierOpsBase<
+      TritonAMDGPULowerBarrierOpsPass>::TritonAMDGPULowerBarrierOpsBase;
+
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    // Barrier arrive needs expected_arrival_count so it can be reset at phase flip
+    // This map saves the expected_arrival_count while processing InitBarrierOp
+    std::map<mlir::triton::gpu::LocalAllocOp, int> localAllocToBarrierExpectedCount;
+    lowerInitBarrierOps(m, localAllocToBarrierExpectedCount);
+    for (auto [op, count] : localAllocToBarrierExpectedCount) {
+      llvm::errs() << "localAllocToBarrierExpectedCount " << op << " " << count << "\n";
+    }
+    lowerArriveBarrierOps(m, localAllocToBarrierExpectedCount);
+    lowerWaitBarrierOps(m);  
+  }
+};
+
+} // namespace mlir

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -28,6 +28,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/TargetParser/TargetParser.h"
 #include <pybind11/pybind11.h>
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include <stdexcept>
 
 namespace py = pybind11;
@@ -74,6 +75,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                             const std::string &);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",
                      mlir::createTritonAMDGPUReorderInstructions);
+  ADD_PASS_WRAPPER_0("add_lower_barrier_ops",
+                     mlir::createTritonAMDGPULowerBarrierOps);                   
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi", mlir::createTritonAMDFoldTrueCmpI);
   ADD_PASS_OPTION_WRAPPER_1("add_block_pingpong",
                             mlir::createTritonAMDGPUBlockPingpong, int32_t);
@@ -123,6 +126,10 @@ void init_triton_amd(py::module &&m) {
   m.def("load_dialects", [](mlir::MLIRContext &context) {
     mlir::DialectRegistry registry;
     registry.insert<mlir::triton::amdgpu::TritonAMDGPUDialect>();
+    // tlx barrier calls lower to ttng ops
+    // Without this registration, ttng op creation in triton_tlx.cc will fail
+    // TODO: Fix this after we have ttg barrier ops
+    registry.insert<mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect>();
     // registry.insert<mlir::ROCDL::ROCDLDialect>();
     mlir::registerROCDLDialectTranslation(registry);
     context.appendDialectRegistry(registry);

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -3,6 +3,7 @@ import triton.language.core as tl
 from triton.language.semantic import _convert_elem_to_ir_value
 
 from . import types as tlx
+from .utility import is_hip
 
 
 @tl.builtin
@@ -18,6 +19,7 @@ def alloc_barriers(
     - `num_barriers`: The number of barriers to allocate.
     - `arrive_counts`: The number of threads that need to arrive at the barrier before it can be released.
     """
+         
     layout = tlx.swizzled_shared_layout_encoding.make_default(rank=1)
     layout_handle = _builder.make_swizzled_shared_encoding_attr(
         layout.vectorSize,
@@ -85,6 +87,8 @@ def barrier_arrive(
     """
     Perform the arrive operation on an mbarrier
     """
+
+    assert arrive_count.value == 1 or not is_hip(), "AMD backend currently only supports arrive_count == 1"
 
     # TODO. add validator logics
     _builder.create_barrier_arrive(bar.handle, arrive_count.value)

--- a/third_party/tlx/language/tlx/utility.py
+++ b/third_party/tlx/language/tlx/utility.py
@@ -2,8 +2,14 @@ import triton.language.core as tl
 
 from . import types as tlx
 import re
+import triton.runtime.driver as driver
 
 
+
+def is_hip():
+    target = driver.active.get_current_target()
+    return target.backend == 'hip'
+    
 def cuda_parse_arch(arch):
     pattern = r"^sm(\d+)$"
     match = re.fullmatch(pattern, arch)


### PR DESCRIPTION
AMD lowering for 
- tlx.alloc_barriers
- tlx.barrier_arrive 
- tlx.barrier_wait

**Alloc**
The implementation uses the 1xi64 tlx barrier as a 2xi32 struct for count and phase i.e {uint32_t count, uint32_t phase} 
phase can be 0/1.

**Init**
The barrier is initialized in tid 0
_count_ is initialized to the expected arrival count
_phase_ is initialized to 0

**Arrive**
Arrive is only executed on the first thread in a warp. 
Arrive decrements the arrival count until the phase-flip condition is met i.e. count becomes 0.
The warps that arrives last at the barrier, flips the phase and resets the count of the barrier to the init value.

**Wait**
Waiting warps spin-wait until barrier phase is not equal to the _phase_ input param.

**Testing**
python -m pytest /home/kmanivannan/fb-triton/python/test/unit/language/test_tlx.py -k test_wait_arrive_non_ws
