### PR TITLE
[TLX] Throw error early if WS captures RankedTensorType

### DIFF
--- a/test/TLX/tlx-verifier.mlir
+++ b/test/TLX/tlx-verifier.mlir
@@ -1,0 +1,26 @@
+
+// RUN: triton-opt -split-input-file -pass-pipeline='builtin.module(triton-tlx-fixup{num-warps=8 target=cuda:90 num-ctas=2 threads-per-warp=32})' --verify-diagnostics %s
+
+module attributes {tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @legalize_warp_partition(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %3 = tt.splat %1 : i32 -> tensor<1024xi32>
+    // expected-error @+1 {{WarpSpecializeOp should not capture RankedTensorType}}
+    ttg.warp_specialize(%arg3, %3, %arg5)
+    default {
+      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+      %4 = arith.addi %3, %2 : tensor<1024xi32>
+      ttg.warp_yield
+    }
+    partition0(%arg7: !tt.ptr<f32>, %arg8: tensor<1024xi32>, %arg9: !tt.ptr<f32>) num_warps(1) {
+      %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+      %4 = arith.addi %arg8, %2 : tensor<1024xi32>
+      %5 = tt.splat %arg7 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      %8 = tt.splat %arg9 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+      ttg.warp_return
+    } : (!tt.ptr<f32>, tensor<1024xi32>, !tt.ptr<f32>) -> ()
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -6,6 +6,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
@@ -23,8 +24,32 @@ class TritonTLXFixupPass : public impl::TritonTLXFixupBase<TritonTLXFixupPass> {
   using impl::TritonTLXFixupBase<TritonTLXFixupPass>::TritonTLXFixupBase;
 
 public:
+  // validate the module and error early for unsupported cases
+  LogicalResult verifyModule(ModuleOp &mod) {
+    // ws should not capture RankedTensorType
+    ttg::WarpSpecializeOp *invalidWSOp = nullptr;
+    auto result = mod.walk([&](ttg::WarpSpecializeOp op) {
+      for (auto argType : op.getOperandTypes()) {
+        if (isa<RankedTensorType>(argType)) {
+          invalidWSOp = &op;
+          return WalkResult::interrupt();
+        }
+      }
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted()) {
+      return invalidWSOp->emitError() << "WarpSpecializeOp should not capture "
+                                         "RankedTensorType. Try moving tensor "
+                                         "computation into async tasks.";
+    }
+    return success();
+  }
+
   void runOnOperation() override {
     ModuleOp mod = getOperation();
+    if (failed(verifyModule(mod))) {
+      return signalPassFailure();
+    }
 
     // First check if there is any TLX related op in the module. If not, do
     // nothing.

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -38,9 +38,10 @@ public:
       return WalkResult::advance();
     });
     if (result.wasInterrupted()) {
-      return invalidWSOp->emitError() << "WarpSpecializeOp should not capture "
-                                         "RankedTensorType. Try moving tensor "
-                                         "computation into async tasks.";
+      return invalidWSOp->emitError()
+             << "WarpSpecializeOp should not capture "
+                "RankedTensorType. Try moving tensor "
+                "computation into specific async task.";
     }
     return success();
   }


### PR DESCRIPTION
It will be problematic for ttgir conversion. Let's just throw error early and tell the TLX users to move the code into ws regions, which is also better for kernel perf.

Added a lit test. Also tested on blackwell with `./third_party/tlx/run_all.sh`

Run a real tlx kernel with such violations:

```
test_kernel.py:150:9: error: WarpSpecializeOp should not capture RankedTensorType. Try moving tensor computation into specific async task.
    with tlx.async_tasks():
        ^
#blocked = #ttg.blocked< ...
...
```

It's more user friendly than previous error message:

```
error: 'ttg.warp_specialize' op partition region #0 argument #18 has type 'tensor<128xf32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>>' but corresponding capture has type 'tensor<128xf32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>'
    with tlx.async_tasks():
        ^
#blocked = #ttg.blocked ...
```