### PR TITLE
[TLX] Do not overwrite unpacked for fp32 types during layout propagation

### DIFF
--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -139,6 +139,34 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     return success();
   }
 
+  // Reinterpret to fp32 type requires the tensor to be unpacked
+  if (auto reinterpretOp = dyn_cast<ttg::MemDescReinterpretOp>(op)) {
+    auto resultLattice = results[0];
+    LayoutEncoding resultLayoutEncoding = resultLattice->getValue();
+    if (!resultLayoutEncoding.isUninitialized()) {
+      if (auto tmemEncoding = dyn_cast<ttng::TensorMemoryEncodingAttr>(
+              resultLattice->getValue().getLayoutEncoding())) {
+        auto srcTy = cast<ttg::MemDescType>(reinterpretOp.getSrc().getType());
+        auto srcEncoding =
+            dyn_cast<ttng::TensorMemoryEncodingAttr>(srcTy.getEncoding());
+        auto bitwidth = srcTy.getElementType().getIntOrFloatBitWidth();
+        bool unpacked = bitwidth > 16 ? srcEncoding.getUnpacked()
+                                      : tmemEncoding.getUnpacked();
+        auto newTmemEncoding = ttng::TensorMemoryEncodingAttr::get(
+            tmemEncoding.getContext(), srcEncoding.getBlockM(),
+            srcEncoding.getBlockN(), unpacked, tmemEncoding.getCTASplitM(),
+            tmemEncoding.getCTASplitN());
+        const auto updatedResultLayoutEncoding =
+            LayoutEncoding(newTmemEncoding);
+        auto operandLattice = operands[0];
+        ChangeResult changed =
+            operandLattice->meet(updatedResultLayoutEncoding);
+        propagateIfChanged(operandLattice, changed);
+      }
+    }
+    return success();
+  }
+
   if (auto requireLayoutOp = dyn_cast<triton::tlx::RequireLayoutOp>(op)) {
     // Skip the layout propagation for registers. require_layout ops on tensor
     // types will be rewritten into convert_layout ops, and following passes
@@ -173,12 +201,11 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     return success();
   }
 
-  auto isScalar = [](Type type) { return type.isIntOrIndexOrFloat(); };
   // Propagate from results to the operands
   for (const auto resultLattice : results) {
     for (auto [i, operandLattice] : llvm::enumerate(operands)) {
       // Don't propagate if the operand is a scalar
-      if (isScalar(op->getOpOperand(i).get().getType()))
+      if (!isa<ttg::MemDescType>(op->getOpOperand(i).get().getType()))
         continue;
       ChangeResult changed = operandLattice->meet(resultLattice->getValue());
       propagateIfChanged(operandLattice, changed);
@@ -236,9 +263,8 @@ LogicalResult LayoutForwardPropagation::visitOperation(
            ttng::TMEMSubSliceOp>(op))
     return success();
 
-  auto isScalar = [](Type type) { return type.isIntOrIndexOrFloat(); };
   for (const auto [operandIdx, operandLattice] : llvm::enumerate(operands)) {
-    if (isScalar(op->getOperand(operandIdx).getType()))
+    if (!isa<ttg::MemDescType>(op->getOperand(operandIdx).getType()))
       continue;
     LayoutEncoding operandLayoutEncoding = operandLattice->getValue();
 


### PR DESCRIPTION
Also restricting layout propagation to memdesc only.

```
python third_party/tlx/tutorials/blackwell-gdpa.py

B=1024 max_M=1000 D=384 H=3 sparsity=0.5
GDPA TLX WS: 1.2268870290120442 ms
```