### PR TITLE
[TLX] Fix broken LITs after rebasing to 3.5

### DIFF
--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -77,8 +77,8 @@ module {
     %9 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>>
     %10 = tt.addptr %9, %4 : tensor<64x!tt.ptr<f32>>, tensor<64xi32>
     %11 = ttg.local_alloc : () -> !ttg.memdesc<2x64xf32, #shared, #smem, mutable>
-    %12 = ttg.memdesc_subview %11[%c0_i32, %c0_i32] : !ttg.memdesc<2x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
-    %13 = ttg.memdesc_subview %11[%c1_i32, %c0_i32] : !ttg.memdesc<2x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
+    %12 = ttg.memdesc_index %11[%c0_i32] : !ttg.memdesc<2x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
+    %13 = ttg.memdesc_index %11[%c1_i32] : !ttg.memdesc<2x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
     %14 = ttg.async_copy_global_to_local %8, %12 mask %6 : tensor<64x!tt.ptr<f32>> -> <64xf32, #shared, #smem, mutable>
     %15 = ttg.async_copy_global_to_local %10, %13 mask %6 : tensor<64x!tt.ptr<f32>> -> <64xf32, #shared, #smem, mutable>
     ttg.async_commit_group

--- a/test/TLX/insert-require-layout.mlir
+++ b/test/TLX/insert-require-layout.mlir
@@ -14,10 +14,10 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %25 = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable>
     %c0_i32 = arith.constant 0 : i32
     %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
-    // CHECK: %[[mem_desc1:.*]] = ttg.memdesc_subview %{{.*}}
-    %26 = ttg.memdesc_subview %24[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
-    // CHECK: %[[mem_desc2:.*]] = ttg.memdesc_subview %{{.*}}
-    %27 = ttg.memdesc_subview %25[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
+    // CHECK: %[[mem_desc1:.*]] = ttg.memdesc_index %{{.*}}
+    %26 = ttg.memdesc_index %24[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
+    // CHECK: %[[mem_desc2:.*]] = ttg.memdesc_index %{{.*}}
+    %27 = ttg.memdesc_index %25[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
     %28 = tt.load %arg1 : tensor<64x32x!tt.ptr<f16>, #blocked>
     %29 = tt.load %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked>
     ttg.local_store %28, %26 : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -121,6 +121,7 @@ tt.func public @tma_load_while(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, 
 
   tt.return
 }
+}
 
 // -----
 
@@ -140,16 +141,14 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
     %0 = ttg.local_alloc : () -> !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>
     %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable>
-    %2 = ttg.memdesc_subview %1[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %2 = ttg.memdesc_index %1[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    %3 = ttg.memdesc_subview %1[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %3 = ttg.memdesc_index %1[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttg.warp_specialize(%arg5, %result)
     default {
-      %4 = ttg.memdesc_subview %0[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
-      // CHECK: tensor_desc_to_tma_ptr{{.*}}!tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
-      %5 = ttng.tensor_desc_to_tma_ptr %arg0 : !tt.tensordesc<tensor<128x64xf16>> to !tt.ptr<i8>
-      ttng.async_tma_copy_global_to_local %5[%c0_i32, %c0_i32] %4, %2, %true : !tt.ptr<i8>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %4 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %4, %2, %true : !tt.tensordesc<tensor<128x64xf16>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
       ttg.warp_yield
     }
     // CHECK: %arg10: !tt.tensordesc<tensor<128x64xf16, #[[SHARED]]>>
@@ -157,7 +156,7 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
       %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
       %true_0 = arith.constant true
       %c0_i32_1 = arith.constant 0 : i32
-      %4 = ttg.memdesc_subview %arg11[%c0_i32_1, %c0_i32_1, %c0_i32_1] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %4 = ttg.memdesc_index %arg11[%c0_i32_1] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttng.tmem_store %cst, %4, %true_0 : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttg.warp_return
     }
@@ -190,13 +189,13 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
     %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable>
-    %2 = ttg.memdesc_subview %1[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %2 = ttg.memdesc_index %1[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    %3 = ttg.memdesc_subview %1[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %3 = ttg.memdesc_index %1[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttg.warp_specialize(%0, %arg5, %result)
     default {
-      %4 = ttg.memdesc_subview %result[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %4 = ttg.memdesc_index %result[%c0_i32] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttng.tmem_store %cst, %4, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttg.warp_yield
     }
@@ -205,17 +204,15 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
       %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
       %true_1 = arith.constant true
       %c0_i32_2 = arith.constant 0 : i32
-      %4 = ttg.memdesc_subview %arg12[%c0_i32_2, %c0_i32_2, %c0_i32_2] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %4 = ttg.memdesc_index %arg12[%c0_i32_2] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttng.tmem_store %cst_0, %4, %true_1 : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       ttg.warp_return
     }
     // CHECK: %arg11: !tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
     partition1(%arg10: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg11: !tt.tensordesc<tensor<128x128xf16>>, %arg12: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(4) {
       %c0_i32_0 = arith.constant 0 : i32
-      %4 = ttg.memdesc_subview %arg10[%c0_i32_0, %c0_i32_0, %c0_i32_0] : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
-      // CHECK: tensor_desc_to_tma_ptr{{.*}}!tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
-      %5 = ttng.tensor_desc_to_tma_ptr %arg11 : !tt.tensordesc<tensor<128x128xf16>> to !tt.ptr<i8>
-      ttng.async_tma_copy_local_to_global %5[%c0_i32_0, %c0_i32_0] %4 : !tt.ptr<i8>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %4 = ttg.memdesc_index %arg10[%c0_i32_0] : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      ttng.async_tma_copy_local_to_global %arg11[%c0_i32_0, %c0_i32_0] %4 : !tt.tensordesc<tensor<128x128xf16>>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
       ttg.warp_return
     // CHECK: !tt.tensordesc<tensor<128x128xf16, #[[SHARED]]>>
     } : (!ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !tt.tensordesc<tensor<128x128xf16>>, !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -88,12 +88,12 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, 
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK-DAG: #[[BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-// CHECK-DAG: #[[NVMMA_32:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+// CHECK-DAG: #[[NVMMA_32:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
 tt.func public @tma_load_while(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: i32 {tt.divisibility = 16 : i32}, %arg3: tensor<32xi32, #blocked>, %cond: i1) {
     %c1_i32 = arith.constant 1 : i32
     %c8_i32 = arith.constant 8 : i32

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -259,7 +259,7 @@ LogicalResult LayoutForwardPropagation::visitOperation(
     Operation *op, ArrayRef<const LayoutEncodingLattice *> operands,
     ArrayRef<LayoutEncodingLattice *> results) {
 
-  if (!isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
+  if (!isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp, ttg::MemDescReinterpretOp,
            ttng::TMEMSubSliceOp>(op))
     return success();
 

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -379,7 +379,7 @@ void init_triton_tlx_ir(py::module &&m) {
                      useD.has_value() ? useD.value() : predTrue /*useD*/,
                      pred.has_value() ? pred.value() : predTrue /*pred */,
                      false /* two_ctas*/, ValueRange(mBarriers),
-                     ValueRange(barrierPreds))
+                     ValueRange(barrierPreds), true /* is_async */)
                  .getToken();
            })
       .def("create_tcgen05_commit",


### PR DESCRIPTION
1. memdesc_subview => memdesc_index
2. deprecate tensor_desc_to_tma_ptr
3. introduce `{is_async}` to `ttng.tc_gen5_mma`