### PR TITLE
[TLX] Introduce local allocation aliasing for local buffer reuse

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -120,27 +120,27 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
   addDynamicallyLegalOp<
       triton::gpu::AsyncCopyGlobalToLocalOp, triton::gpu::LocalLoadOp,
       triton::gpu::LocalStoreOp, triton::nvidia_gpu::WarpGroupDotWaitOp,
-      triton::tlx::RequireLayoutOp, triton::tlx::ReleaseLayoutOp>(
-      [&](Operation *op) -> bool {
-        // make sure every RankedTensorType operand has encoding
-        for (auto operandType : op->getOperandTypes()) {
-          if (auto rankedTensorType = dyn_cast<RankedTensorType>(operandType)) {
-            if (rankedTensorType.getEncoding() == nullptr) {
-              return false;
-            }
-          }
+      triton::tlx::RequireLayoutOp, triton::tlx::ReleaseLayoutOp,
+      triton::tlx::LocalAliasOp>([&](Operation *op) -> bool {
+    // make sure every RankedTensorType operand has encoding
+    for (auto operandType : op->getOperandTypes()) {
+      if (auto rankedTensorType = dyn_cast<RankedTensorType>(operandType)) {
+        if (rankedTensorType.getEncoding() == nullptr) {
+          return false;
         }
+      }
+    }
 
-        // make sure result type has encoding if it is RankedTensorType
-        for (auto resultType : op->getResultTypes()) {
-          if (auto rankedTensorType = dyn_cast<RankedTensorType>(resultType)) {
-            if (rankedTensorType.getEncoding() == nullptr) {
-              return false;
-            }
-          }
+    // make sure result type has encoding if it is RankedTensorType
+    for (auto resultType : op->getResultTypes()) {
+      if (auto rankedTensorType = dyn_cast<RankedTensorType>(resultType)) {
+        if (rankedTensorType.getEncoding() == nullptr) {
+          return false;
         }
-        return true;
-      });
+      }
+    }
+    return true;
+  });
 
   addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) -> bool {
     for (auto arg : funcOp.getArguments()) {

--- a/test/TLX/rewrite-local-alias.mlir
+++ b/test/TLX/rewrite-local-alias.mlir
@@ -1,0 +1,66 @@
+// RUN: triton-opt -split-input-file --tlx-rewrite-local-alias %s| FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, unpacked = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, unpacked = false>
+
+// CHECK-DAG: #[[$SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+// CHECK-DAG: #[[$SHARED1:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+// CHECK-DAG: #[[$TMEM:.*]] = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, unpacked = true>
+// CHECK-DAG: #[[$TMEM1:.*]] = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, unpacked = false>
+
+module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tcgen5_fa_kernel
+  tt.func public @tcgen5_fa_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    // CHECK: %[[$LOCAL_ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<1x64x16xf16, #[[$SHARED]], #smem, mutable>
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<1x16x32xf16, #shared1, #smem, mutable>
+
+    // CHECK-NOT: tlx.local_alias
+    // CHECK: ttg.memdesc_reinterpret %[[$LOCAL_ALLOC]] : !ttg.memdesc<1x64x16xf16, #[[$SHARED]], #smem, mutable> -> !ttg.memdesc<1x32x32xf16, #[[$SHARED1]], #smem, mutable>
+    %2 = tlx.local_alias %0 : !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<1x32x32xf16, #shared1, #smem, mutable>
+
+    // CHECK: %[[$TMEM_ALLOC:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable>
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // CHECK-NOT: tlx.local_alias
+    // CHECK: ttg.memdesc_reinterpret %[[$TMEM_ALLOC]] : !ttg.memdesc<1x64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x32xf16, #[[$TMEM1]], #ttng.tensor_memory, mutable>
+    %result_0 = tlx.local_alias %result : !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable>
+    %result_1 = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttg.warp_specialize(%0, %result, %1, %2, %result_1, %result_0)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg8: !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable>, %arg9: !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>, %arg10: !ttg.memdesc<1x16x32xf16, #shared1, #smem, mutable>, %arg11: !ttg.memdesc<1x32x32xf16, #shared1, #smem, mutable>, %arg12: !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>, %arg13: !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable>) num_warps(1) {
+      %true = arith.constant true
+      %false = arith.constant false
+      %c0_i32 = arith.constant 0 : i32
+      %3 = ttg.memdesc_index %arg8[%c0_i32] : !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x16xf16, #shared, #smem, mutable>
+      %4 = ttg.memdesc_index %arg10[%c0_i32] : !ttg.memdesc<1x16x32xf16, #shared1, #smem, mutable> -> !ttg.memdesc<16x32xf16, #shared1, #smem, mutable>
+      %5 = ttg.memdesc_index %arg9[%c0_i32] : !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+      %6 = ttng.tc_gen5_mma %3, %4, %5[], %false, %true : !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, !ttg.memdesc<16x32xf16, #shared1, #smem, mutable>, !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+      %7 = ttg.memdesc_index %arg13[%c0_i32] : !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf16, #tmem1, #ttng.tensor_memory, mutable>
+      %8 = ttg.memdesc_index %arg11[%c0_i32] : !ttg.memdesc<1x32x32xf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf16, #shared1, #smem, mutable>
+      %9 = ttg.memdesc_index %arg12[%c0_i32] : !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+      %10 = ttng.tc_gen5_mma %7, %8, %9[], %false, %true : !ttg.memdesc<64x32xf16, #tmem1, #ttng.tensor_memory, mutable>, !ttg.memdesc<32x32xf16, #shared1, #smem, mutable>, !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    }
+    partition1(%arg8: !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable>, %arg9: !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>, %arg10: !ttg.memdesc<1x16x32xf16, #shared1, #smem, mutable>, %arg11: !ttg.memdesc<1x32x32xf16, #shared1, #smem, mutable>, %arg12: !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>, %arg13: !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable>) num_warps(4) {
+      %true = arith.constant true
+      %c0_i32 = arith.constant 0 : i32
+      %3 = ttg.memdesc_index %arg9[%c0_i32] : !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+      %result_2 = ttng.tmem_load %3 : !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x32xf32, #blocked>
+      %4 = ttg.convert_layout %result_2 : tensor<64x32xf32, #blocked> -> tensor<64x32xf32, #blocked1>
+      %5 = arith.truncf %4 : tensor<64x32xf32, #blocked1> to tensor<64x32xf16, #blocked1>
+      %6 = ttg.memdesc_index %arg13[%c0_i32] : !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf16, #tmem1, #ttng.tensor_memory, mutable>
+      %7 = ttg.convert_layout %5 : tensor<64x32xf16, #blocked1> -> tensor<64x32xf16, #blocked>
+      ttng.tmem_store %7, %6, %true : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #tmem1, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<1x64x16xf16, #shared, #smem, mutable>, !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x16x32xf16, #shared1, #smem, mutable>, !ttg.memdesc<1x32x32xf16, #shared1, #smem, mutable>, !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable>) -> ()
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -218,11 +218,12 @@ class HIPBackend(BaseBackend):
         # Maintain the order of the following three passes
         # for graphs with tlx.local_load -> tt.dot,
         # dot op specifics from add_accelerate_matmul are required
-        # to create the require_layout before tlx.local_local. 
+        # to create the require_layout before tlx.local_local.
         # This layout will then be propagated to the tlx.local_alloc
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         tlx.tlx_passes.add_tlx_insert_require_layout(pm)
         tlx.tlx_passes.add_tlx_propagate_layout(pm)
+        tlx.tlx_passes.add_tlx_rewrite_local_alias(pm)
 
         passes.ttgpuir.add_remove_layout_conversions(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -260,6 +260,7 @@ class CUDABackend(BaseBackend):
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         tlx.tlx_passes.add_tlx_propagate_layout(pm)
+        tlx.tlx_passes.add_tlx_rewrite_local_alias(pm)
         if capability // 10 >= 8:
             passes.ttgpuir.add_f32_dot_tc(pm)
         # TODO(Qingyi): Move PlanCTAPass to the front of CoalescePass

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -9,6 +9,7 @@
 
 #include "tlx/dialect/include/IR/Dialect.h.inc"
 #include "tlx/dialect/include/IR/OpsEnums.h.inc"
+#include "tlx/dialect/include/IR/Traits.h"
 #define GET_ATTRDEF_CLASSES
 #include "tlx/dialect/include/IR/TLXAttrDefs.h.inc"
 

--- a/third_party/tlx/dialect/include/IR/TLXInterfaces.td
+++ b/third_party/tlx/dialect/include/IR/TLXInterfaces.td
@@ -1,0 +1,9 @@
+#ifndef TLX_INTERFACES
+#define TLX_INTERFACES
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
+def SameOperandAndResultMemorySpace : NativeOpTrait<"SameOperandAndResultMemorySpace">;
+
+#endif // TLX_INTERFACES

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -13,6 +13,7 @@ include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypeInterfaces.td"
 include "TLXDialect.td"
+include "TLXInterfaces.td"
 
 
 class TLX_Op<string mnemonic, list<Trait> traits = []> :
@@ -42,6 +43,18 @@ def TLX_ReleaseLayoutOp : TLX_Op<"release_layout",
   let arguments = (ins TT_Tensor:$src);
 
   let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+}
+
+def TLX_LocalAliasOp : TLX_Op<"local_alias",
+                                 [SameOperandAndResultMemorySpace,
+                                  Pure]> {
+  let summary = "Create an alias of a local memory buffer";
+
+  let arguments = (ins TTG_TensorOrMemDesc:$src);
+
+  let results = (outs TTG_TensorOrMemDesc:$result);
 
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 }

--- a/third_party/tlx/dialect/include/IR/Traits.h
+++ b/third_party/tlx/dialect/include/IR/Traits.h
@@ -1,0 +1,35 @@
+#ifndef TRITON_DIALECT_TLX_IR_TRAITS_H_
+
+#define TRITON_DIALECT_TLX_IR_TRAITS_H_
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Support/LogicalResult.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+
+namespace mlir {
+namespace OpTrait {
+
+// These functions are out-of-line implementations of the methods in the
+// corresponding trait classes. This avoids them being template
+// instantiated/duplicated.
+namespace impl {
+
+LogicalResult
+verifySameOperandAndResultMemorySpace(Operation *op);
+
+} // namespace impl
+
+template <typename ConcreteType>
+class SameOperandAndResultMemorySpace
+    : public TraitBase<ConcreteType, SameOperandAndResultMemorySpace> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return impl::verifySameOperandAndResultMemorySpace(op);
+  }
+};
+} // namespace OpTrait
+} // namespace mlir
+
+#endif

--- a/third_party/tlx/dialect/include/Transforms/Passes.td
+++ b/third_party/tlx/dialect/include/Transforms/Passes.td
@@ -53,4 +53,15 @@ def TLXInsertRequireLayout : Pass<"tlx-insert-require-layout", "mlir::ModuleOp">
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
 
 }
+
+def TLXRewriteLocalAlias : Pass<"tlx-rewrite-local-alias", "mlir::ModuleOp"> {
+  let summary = "Replace tlx::LocalAliasOp with the aliased local mem_desc";
+
+  let description = [{
+    This pass replaces a tlx::LocalAliasOp op with the original aliased mem_desc.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
+
+}
 #endif // TRITON_TLX_PASSES

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -105,7 +105,7 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     Operation *op, ArrayRef<LayoutEncodingLattice *> operands,
     ArrayRef<const LayoutEncodingLattice *> results) {
   LDBG("Visiting operation " << *op << "\n");
-  if (isa<tlx::ReleaseLayoutOp>(op))
+  if (isa<tlx::ReleaseLayoutOp, tlx::LocalAliasOp>(op))
     return success();
 
   if (isa<RegionBranchOpInterface, ttg::WarpSpecializePartitionsOp>(op))

--- a/third_party/tlx/dialect/lib/IR/CMakeLists.txt
+++ b/third_party/tlx/dialect/lib/IR/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TLXIR
   Dialect.cpp
   Ops.cpp
+  Traits.cpp
 
   DEPENDS
   TLXTableGen

--- a/third_party/tlx/dialect/lib/IR/Traits.cpp
+++ b/third_party/tlx/dialect/lib/IR/Traits.cpp
@@ -1,0 +1,38 @@
+#include "tlx/dialect/include/IR/Traits.h"
+
+#include "mlir/IR/TypeUtilities.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace mlir;
+namespace ttg = ::mlir::triton::gpu;
+
+LogicalResult
+OpTrait::impl::verifySameOperandAndResultMemorySpace(Operation *op) {
+  if (failed(verifyAtLeastNOperands(op, 1)) ||
+      failed(verifyAtLeastNResults(op, 1)))
+    return failure();
+
+  // Only mem descs can have memory spaces.
+  auto operandType =
+      dyn_cast<ttg::MemDescType>(op->getOperand(0).getType());
+
+  auto resultType =
+      dyn_cast<ttg::MemDescType>(op->getResult(0).getType());
+
+  if (operandType && resultType) {
+    if (operandType.getMemorySpace() != resultType.getMemorySpace()) {
+      op->emitOpError()
+          << "requires the same memory space for all operands and results";
+      return failure();
+    }
+    return success();
+  } else {
+    op->emitOpError()
+        << "requires the MemDescType for all operands and results";
+    return failure();
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonTLXTransforms
   Fixup.cpp
   PropagateLayout.cpp
   InsertRequireLayout.cpp
+  RewriteLocalAlias.cpp
 
   DEPENDS
   TritonTLXTransformsIncGen

--- a/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
@@ -1,0 +1,211 @@
+#include "IR/Dialect.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Transforms/Passes.h"
+
+#define DEBUG_TYPE "tlx-rewrite-local-alias"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace ttg = ::mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+
+namespace mlir {
+namespace triton {
+namespace tlx {
+
+#define GEN_PASS_DEF_TLXREWRITELOCALALIAS
+
+#include "tlx/dialect/include/Transforms/Passes.h.inc"
+
+LogicalResult rewriteLocalAlias(ModuleOp m) {
+  // Build a closure of all local_alloc and local_alias ops that share the same
+  // physical memory
+  LDBG("rewriteLocalAlias\n");
+
+  // Forward map: alloc op -> alias ops
+  DenseMap<Operation*, SmallVector<tlx::LocalAliasOp, 4>> aliasClasses;
+  // Reverse map: alias op -> base alloc op
+  DenseMap<tlx::LocalAliasOp, Operation *> aliasToAlloc;
+
+  // Collect alias ops and bucket them by their base local alloc.
+  WalkResult result = m.walk([&](Operation *op) -> WalkResult {
+    if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op)) {
+      assert(aliasClasses.count(op) == 0 && "Duplicate alloc op");
+      aliasClasses[op] = {};
+    } else if (auto aliasOp = dyn_cast<tlx::LocalAliasOp>(op)) {
+      auto alias = aliasOp.getSrc();
+      auto srcOp = alias.getDefiningOp();
+      if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(srcOp)) {
+        assert(aliasClasses.count(srcOp) && "Base alloc op not in map");
+        aliasClasses[srcOp].push_back(aliasOp);
+        aliasToAlloc[aliasOp] = srcOp;
+      } else if (auto srcAliasOp = dyn_cast<tlx::LocalAliasOp>(srcOp)) {
+        srcOp = aliasToAlloc[srcAliasOp];
+        assert(srcOp && "Alias op must refer to a local alloc");
+        assert(aliasClasses.count(srcOp) && "Base alloc not in map");
+        aliasClasses[srcOp].push_back(aliasOp);
+        aliasToAlloc[aliasOp] = srcOp;
+      } else {
+        op->emitError(
+            "LocalAliasOp must refer to a local_alloc or local_alias op");
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+
+  if (result.wasInterrupted()) {
+    return failure();
+  }
+
+  LLVM_DEBUG({
+    LDBG("Alias classes");
+    for (auto &kv : aliasClasses) {
+      Operation *allocOp = kv.first;
+      auto &aliases = kv.second;
+      DBGS() << "  Base alloc: ";
+      allocOp->dump();
+      for (auto alias : aliases) {
+        DBGS() << "     aliases: ";
+        alias->dump();
+      }
+      llvm::dbgs() << "\n";
+    }
+  });
+
+  if (aliasToAlloc.empty()) {
+    LDBG("No LocalAliasOp");
+    return success();
+  }
+
+  // Compute the max shape of an alias class
+  DenseMap<Operation *, ttg::MemDescType> allocToMaxStorageType;
+  for (auto &kv : aliasClasses) {
+    auto allocOp = kv.first;
+    auto &aliases = kv.second;
+    auto allocType =
+        dyn_cast<ttg::MemDescType>(allocOp->getResult(0).getType());
+    auto maxStorageType = allocType;
+    auto maxStorageSize =
+        allocType.getNumElements() * allocType.getElementTypeBitWidth();
+    for (tlx::LocalAliasOp alias : aliases) {
+      auto aliasType = dyn_cast<ttg::MemDescType>(alias.getResult().getType());
+      auto aliasStorageSize =
+          aliasType.getNumElements() * aliasType.getElementTypeBitWidth();
+      if (aliasStorageSize > maxStorageSize) {
+        maxStorageType = aliasType;
+        maxStorageSize = aliasStorageSize;
+      }
+    }
+    allocToMaxStorageType[allocOp] = maxStorageType;
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n\n";
+    LDBG("Max storage type for each alloc op");
+    for (auto &kv : allocToMaxStorageType) {
+      auto allocOp = kv.first;
+      auto maxStorageType = kv.second;
+      DBGS() << "  alloc: ";
+      allocOp->dump();
+      DBGS() << "     max storage type: ";
+      maxStorageType.dump();
+      llvm::dbgs() << "\n";
+    }
+  });
+
+  // Create a new local_alloc op for each alias class if the max storage type
+  // isn't the same as the base alloc type
+  DenseMap<Operation *, Operation *> allocToNewAlloc;
+  OpBuilder builder(m.getContext());
+  for (auto &kv : aliasClasses) {
+    Operation *baseAllocOp = kv.first;
+    auto baseAllocType =
+        dyn_cast<ttg::MemDescType>(baseAllocOp->getResult(0).getType());
+
+    ttg::MemDescType maxType = allocToMaxStorageType[baseAllocOp];
+    if (maxType != baseAllocType) {
+      // Need a new alloc with the larger type.
+      builder.setInsertionPoint(baseAllocOp);
+      auto newAllocOp =
+          builder.create<ttg::LocalAllocOp>(baseAllocOp->getLoc(), maxType);
+      // Save mapping so we can rewrite uses later.
+      allocToNewAlloc[baseAllocOp] = newAllocOp;
+    }
+  }
+
+  // Rewrite uses of local_alias ops to use the new local_alloc op.
+  for (auto &kv : aliasClasses) {
+    // Replace the base alloc op with the new one if it exists.
+    Operation *baseAllocOp = kv.first;
+    if (allocToNewAlloc.count(baseAllocOp)) {
+      auto newAllocOp = allocToNewAlloc[baseAllocOp];
+      if (newAllocOp) {
+        // Create a memdesc reinterpret op to convert the new alloc to the base
+        // alloc
+        LLVM_DEBUG({
+          llvm::dbgs() << "\n";
+          DBGS() << "Rewrite base alloc: ";
+          baseAllocOp->dump();
+          DBGS() << "  to: ";
+          newAllocOp->dump();
+        });
+
+        builder.setInsertionPoint(baseAllocOp);
+        auto newAllocType =
+            dyn_cast<ttg::MemDescType>(newAllocOp->getResult(0).getType());
+        auto baseAllocType =
+            dyn_cast<ttg::MemDescType>(baseAllocOp->getResult(0).getType());
+        auto newAllocToBaseAllocOp = builder.create<ttg::MemDescReinterpretOp>(
+            baseAllocOp->getLoc(), baseAllocType, newAllocOp->getResult(0));
+        baseAllocOp->getResult(0).replaceAllUsesWith(
+            newAllocToBaseAllocOp.getResult());
+        baseAllocOp->erase();
+        baseAllocOp = newAllocOp;
+      }
+    }
+
+    // Rewrite all alias ops in the class to use the new/base alloc op.
+    auto &aliases = kv.second;
+    for (tlx::LocalAliasOp aliasOp : aliases) {
+      LLVM_DEBUG({
+        llvm::dbgs() << "\n";
+        DBGS() << "Rewrite alias: ";
+        aliasOp->dump();
+      });
+      builder.setInsertionPoint(aliasOp);
+      auto aliasType = aliasOp.getResult().getType();
+      auto baseAllocToAliasOp = builder.create<ttg::MemDescReinterpretOp>(
+          baseAllocOp->getLoc(), aliasType, baseAllocOp->getResult(0));
+      aliasOp.getResult().replaceAllUsesWith(baseAllocToAliasOp.getResult());
+      aliasOp->erase();
+    }
+  }
+
+  return success();
+}
+
+struct TLXRewriteLocalAliasPass
+    : public impl::TLXRewriteLocalAliasBase<TLXRewriteLocalAliasPass> {
+public:
+  using impl::TLXRewriteLocalAliasBase<
+      TLXRewriteLocalAliasPass>::TLXRewriteLocalAliasBase;
+
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    if (failed(tlx::rewriteLocalAlias(m))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace tlx
+} // namespace triton
+} // namespace mlir

--- a/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
@@ -148,29 +148,27 @@ LogicalResult rewriteLocalAlias(ModuleOp m) {
     Operation *baseAllocOp = kv.first;
     if (allocToNewAlloc.count(baseAllocOp)) {
       auto newAllocOp = allocToNewAlloc[baseAllocOp];
-      if (newAllocOp) {
-        // Create a memdesc reinterpret op to convert the new alloc to the base
-        // alloc
-        LLVM_DEBUG({
-          llvm::dbgs() << "\n";
-          DBGS() << "Rewrite base alloc: ";
-          baseAllocOp->dump();
-          DBGS() << "  to: ";
-          newAllocOp->dump();
-        });
+      // Create a memdesc reinterpret op to convert the new alloc to the base
+      // alloc
+      LLVM_DEBUG({
+        llvm::dbgs() << "\n";
+        DBGS() << "Rewrite base alloc: ";
+        baseAllocOp->dump();
+        DBGS() << "  to: ";
+        newAllocOp->dump();
+      });
 
-        builder.setInsertionPoint(baseAllocOp);
-        auto newAllocType =
-            dyn_cast<ttg::MemDescType>(newAllocOp->getResult(0).getType());
-        auto baseAllocType =
-            dyn_cast<ttg::MemDescType>(baseAllocOp->getResult(0).getType());
-        auto newAllocToBaseAllocOp = builder.create<ttg::MemDescReinterpretOp>(
-            baseAllocOp->getLoc(), baseAllocType, newAllocOp->getResult(0));
-        baseAllocOp->getResult(0).replaceAllUsesWith(
-            newAllocToBaseAllocOp.getResult());
-        baseAllocOp->erase();
-        baseAllocOp = newAllocOp;
-      }
+      builder.setInsertionPoint(baseAllocOp);
+      auto newAllocType =
+          dyn_cast<ttg::MemDescType>(newAllocOp->getResult(0).getType());
+      auto baseAllocType =
+          dyn_cast<ttg::MemDescType>(baseAllocOp->getResult(0).getType());
+      auto newAllocToBaseAllocOp = builder.create<ttg::MemDescReinterpretOp>(
+          baseAllocOp->getLoc(), baseAllocType, newAllocOp->getResult(0));
+      baseAllocOp->getResult(0).replaceAllUsesWith(
+          newAllocToBaseAllocOp.getResult());
+      baseAllocOp->erase();
+      baseAllocOp = newAllocOp;
     }
 
     // Rewrite all alias ops in the class to use the new/base alloc op.

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -167,8 +167,6 @@ void init_triton_tlx_ir(py::module &&m) {
                     "Integer type not supported.");
 
              Block *parentBlock = self.getBuilder().getInsertionBlock();
-             mlir::Operation *parentOp = parentBlock->getParentOp();
-             auto moduleOp = parentOp->getParentOfType<ModuleOp>();
              int numWarps =
                  ttg::maybeLookupNumWarps(parentBlock).value_or(moduleNumWarps);
              assert((numWarps == 4 || numWarps == 8) &&

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -41,21 +41,21 @@ void init_triton_tlx_ir(py::module &&m) {
             return self.create<ttg::MemDescIndexOp>(memDescType, localAlloc, bufferIdx);
           })
       .def("create_require_layout",
-            [](TritonOpBuilder &self, Value &v, Attribute &encoding) -> Value {
-              Type newType;
-              if (auto type = dyn_cast<ttg::MemDescType>(v.getType())) {
-                newType = ttg::MemDescType::get(
-                    type.getShape(), type.getElementType(), encoding,
-                    type.getMemorySpace(), type.getMutableMemory());
-                return self.create<tlx::RequireLayoutOp>(newType, v);
-              } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
-                newType = RankedTensorType::get(
-                    type.getShape(), type.getElementType(), encoding);
-                return self.create<tlx::RequireLayoutOp>(newType, v);
-              } else {
-                throw std::runtime_error("Unsupported type");
-              }
-            })
+           [](TritonOpBuilder &self, Value &v, Attribute &encoding) -> Value {
+             Type newType;
+             if (auto type = dyn_cast<ttg::MemDescType>(v.getType())) {
+               newType = ttg::MemDescType::get(
+                   type.getShape(), type.getElementType(), encoding,
+                   type.getMemorySpace(), type.getMutableMemory());
+               return self.create<tlx::RequireLayoutOp>(newType, v);
+             } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
+               newType = RankedTensorType::get(type.getShape(),
+                                               type.getElementType(), encoding);
+               return self.create<tlx::RequireLayoutOp>(newType, v);
+             } else {
+               throw std::runtime_error("Unsupported type");
+             }
+           })
       .def("create_release_layout",
            [](TritonOpBuilder &self, Value &v) -> Value {
              if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
@@ -167,6 +167,8 @@ void init_triton_tlx_ir(py::module &&m) {
                     "Integer type not supported.");
 
              Block *parentBlock = self.getBuilder().getInsertionBlock();
+             mlir::Operation *parentOp = parentBlock->getParentOp();
+             auto moduleOp = parentOp->getParentOfType<ModuleOp>();
              int numWarps =
                  ttg::maybeLookupNumWarps(parentBlock).value_or(moduleNumWarps);
              assert((numWarps == 4 || numWarps == 8) &&
@@ -264,9 +266,8 @@ void init_triton_tlx_ir(py::module &&m) {
                // Obtain the single buffer view
                Value idx = self.getBuilder().create<arith::ConstantIntOp>(
                    bufferViews.getLoc(), i, 32);
-               mlir::Value buf =
-                   self.create<ttg::MemDescIndexOp>(
-                       singleBarrierMemDescType, bufferViews, idx);
+               mlir::Value buf = self.create<ttg::MemDescIndexOp>(
+                   singleBarrierMemDescType, bufferViews, idx);
 
                // Initialize mbarrier at buf view
                self.create<ttng::InitBarrierOp>(buf,
@@ -302,13 +303,17 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("create_tmem_alloc",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
-              Type &elementType, Attribute &encoding) -> mlir::Value {
+              Type &elementType, Attribute &encoding,
+              std::optional<Value> alias) -> mlir::Value {
              auto context = self.getBuilder().getContext();
              auto memorySpace = ttng::TensorMemorySpaceAttr::get(context);
              auto memDesc =
                  ttg::MemDescType::get(shape, elementType, encoding,
                                        memorySpace, /*mutableMemory=*/true);
-             return self.create<ttng::TMEMAllocOp>(memDesc, nullptr);
+             if (alias)
+               return self.create<tlx::LocalAliasOp>(memDesc, *alias);
+             else
+               return self.create<ttng::TMEMAllocOp>(memDesc, nullptr);
            })
       .def("create_tmem_load",
            [](TritonOpBuilder &self, Value subView, Attribute &layoutEncoding,
@@ -357,8 +362,7 @@ void init_triton_tlx_ir(py::module &&m) {
                }
                // TODO: find the defining op properly
                auto definingOp = value.getDefiningOp();
-               if (auto subviewOp =
-                       dyn_cast<ttg::MemDescIndexOp>(definingOp)) {
+               if (auto subviewOp = dyn_cast<ttg::MemDescIndexOp>(definingOp)) {
                  value = subviewOp.getSrc();
                } else {
                  auto requireLayoutOp =
@@ -446,13 +450,17 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("create_local_alloc",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
-              Type &elementType, Attribute &encoding) -> mlir::Value {
+              Type &elementType, Attribute &encoding,
+              std::optional<Value> alias) -> mlir::Value {
              auto context = self.getBuilder().getContext();
              auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
              auto memDesc =
                  ttg::MemDescType::get(shape, elementType, encoding,
                                        memorySpace, /*mutableMemory=*/true);
-             return self.create<ttg::LocalAllocOp>(memDesc);
+             if (alias)
+               return self.create<tlx::LocalAliasOp>(memDesc, *alias);
+             else
+               return self.create<ttg::LocalAllocOp>(memDesc);
            })
       .def("create_async_TMA_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &coord,
@@ -474,6 +482,8 @@ void init_triton_tlx_ir(py::module &&m) {
 void init_triton_tlx_passes(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_tlx_propagate_layout", tlx::createTlxPropagateLayout);
   ADD_PASS_WRAPPER_0("add_tlx_insert_require_layout", tlx::createTLXInsertRequireLayout);
+  ADD_PASS_WRAPPER_0("add_tlx_rewrite_local_alias",
+                     tlx::createTLXRewriteLocalAlias);
   ADD_PASS_OPTION_WRAPPER_4("add_triton_tlx_fixup", tlx::createTritonTLXFixup,
                             std::string, int32_t, int32_t, int32_t);
 }

--- a/third_party/tlx/tutorials/blackwell-gdpa.py
+++ b/third_party/tlx/tutorials/blackwell-gdpa.py
@@ -390,6 +390,12 @@ def gdpa_kernel_tma_ws_blackwell(
     qk1_buf = tlx.local_alloc(
         (BLOCK_M // 2, HEAD_DIM), tl.float32, 1, tlx.storage_kind.tmem
     )
+    p0_buf = tlx.local_alloc(
+        (BLOCK_M // 2, HEAD_DIM), dtype, 1, tlx.storage_kind.tmem, reuse=qk0_buf
+    )
+    p1_buf = tlx.local_alloc(
+        (BLOCK_M // 2, HEAD_DIM), dtype, 1, tlx.storage_kind.tmem, reuse=qk1_buf
+    )
     o0_buf = tlx.local_alloc(
         (BLOCK_M // 2, HEAD_DIM), tl.float32, 1, tlx.storage_kind.tmem
     )
@@ -484,14 +490,15 @@ def gdpa_kernel_tma_ws_blackwell(
                         # p0 = fast_gelu(qk0)
                         p0 = _fma_f32x2(qk0, tanh_approx_fp32(inner0), qk0)
                         p0 = p0.to(dtype)
-                        p0_view = tlx.local_reinterpret(qk_view_1st, dtype)
-                        tlx.local_store(p0_view, p0)
+                        p0_view = tlx.local_view(p0_buf, bufIdx)
+                        p0_view_1st = tlx.subslice(p0_view, 0, HEAD_DIM // 2)
+                        tlx.local_store(p0_view_1st, p0)
 
                         # p1 = fast_gelu(qk1)
                         p1 = _fma_f32x2(qk1, tanh_approx_fp32(inner1), qk1)
                         p1 = p1.to(dtype)
-                        p1_view = tlx.local_reinterpret(qk_view_2nd, dtype)
-                        tlx.local_store(p1_view, p1)
+                        p0_view_2nd = tlx.subslice(p0_view, HEAD_DIM // 2, HEAD_DIM // 2)
+                        tlx.local_store(p0_view_2nd, p1)
 
                         # p and qk reuse tmem space, single producer commit for p via consumer_release_qk
                         consumer_release_qk_view = tlx.local_view(producer_qk0, bufIdx)
@@ -601,14 +608,15 @@ def gdpa_kernel_tma_ws_blackwell(
                         # p0 = fast_gelu(qk0)
                         p0 = _fma_f32x2(qk0, tanh_approx_fp32(inner0), qk0)
                         p0 = p0.to(dtype)
-                        p0_view = tlx.local_reinterpret(qk_view_1st, dtype)
-                        tlx.local_store(p0_view, p0)
+                        p1_view = tlx.local_view(p1_buf, bufIdx)
+                        p1_view_1st = tlx.subslice(p1_view, 0, HEAD_DIM // 2)
+                        tlx.local_store(p1_view_1st, p0)
 
                         # p1 = fast_gelu(qk1)
                         p1 = _fma_f32x2(qk1, tanh_approx_fp32(inner1), qk1)
                         p1 = p1.to(dtype)
-                        p1_view = tlx.local_reinterpret(qk_view_2nd, dtype)
-                        tlx.local_store(p1_view, p1)
+                        p1_view_2nd = tlx.subslice(p1_view, HEAD_DIM // 2, HEAD_DIM // 2)
+                        tlx.local_store(p1_view_2nd, p1)
 
                         # p and qk reuse tmem space, single producer commit for p via consumer_release_qk
                         consumer_release_qk_view = tlx.local_view(producer_qk1, bufIdx)
@@ -780,8 +788,7 @@ def gdpa_kernel_tma_ws_blackwell(
                         consumer_p0_view, phase_p
                     )  # consumer wait for p0 due to reuse of p0 and qk0
                     # reinterpret qk0 as p0
-                    qk_view = tlx.local_view(qk0_buf, bufIdx_p)
-                    p0_view = tlx.local_reinterpret(qk_view, dtype)
+                    p0_view = tlx.local_view(p0_buf, bufIdx_p)
 
                     bufIdx_o, phase_o = _get_bufidx_phase(accum_cnt_o, NUM_BUFFERS_O)
                     producer_commit_o0_view = tlx.local_view(
@@ -873,8 +880,7 @@ def gdpa_kernel_tma_ws_blackwell(
                             consumer_release_kv, bufIdx_v
                         )
                         # reinterpret as p1
-                        qk_view = tlx.local_view(qk1_buf, bufIdx_qk1)
-                        p1_view = tlx.local_reinterpret(qk_view, dtype)
+                        p1_view = tlx.local_view(p1_buf, bufIdx_qk1)
                         tlx.async_dot(  # p1 . v from previous iteration
                             p1_view,
                             v_view,
@@ -932,9 +938,6 @@ def gdpa_kernel_tma_ws_blackwell(
                         tlx.barrier_wait(
                             consumer_p0_view, phase_qk
                         )  # consumer wait for p0 use producer_qk0 due to reuse
-                        # reinterpret as p0
-                        qk_view = tlx.local_view(qk0_buf, bufIdx_qk)
-                        p0_view = tlx.local_reinterpret(qk_view, dtype)
 
                         v_view = tlx.local_view(kv_buf, bufIdx_v)
                         bufIdx_o, phase_o = _get_bufidx_phase(
@@ -945,7 +948,7 @@ def gdpa_kernel_tma_ws_blackwell(
                         )
                         o0_view = tlx.local_view(o0_buf, bufIdx_o)
                         tlx.async_dot(
-                            p0_view,
+                            p0_buf[bufIdx_qk],
                             v_view,
                             o0_view,
                             use_acc=True,
@@ -983,8 +986,6 @@ def gdpa_kernel_tma_ws_blackwell(
                     tlx.barrier_wait(
                         consumer_p1_view, phase_qk1
                     )  # consumer wait for p1 due to reuse of p1 and qk1
-                    qk_view = tlx.local_view(qk1_buf, bufIdx_qk1)
-                    p1_view = tlx.local_reinterpret(qk_view, dtype)
 
                     accum_cnt_qk1 += 1
                     # release p0, p1 via producer_commit_qk0, qk1 barriers
@@ -1005,7 +1006,7 @@ def gdpa_kernel_tma_ws_blackwell(
                     )
                     o1_view = tlx.local_view(o1_buf, bufIdx_o)
                     tlx.async_dot(  # p1 . v in last iteration
-                        p1_view,
+                        p1_buf[bufIdx_qk1],
                         v_view,
                         o1_view,
                         use_acc=not first,


### PR DESCRIPTION
With this PR users now can create two separate logic local memory buffers and alias them so they eventually share the same physical buffers. This allows a different separate memory layout is attached to each logic buffer

User can specify such memory aliasing through the `reuse` operand of `tlx.local_alloc`

     
```
        a_tiles = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, tl.constexpr(1))
        c_tiles = tlx.local_alloc((BLOCK_N, BLOCK_N), tl.float16, tl.constexpr(1), reuse=a_tiles)

```

In this case, `c_tiles` and `a_tiles` two logically-separate but physically-shared buffers. The size of the physical buffer is the max size of them. The underlying layout propagation pass will atomically figure out a memory layout for each logical buffer separately. 




