### PR TITLE
[TLX] Store invalidWSOp WarpSpecializeOp as instead of pointer

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -27,21 +27,20 @@ public:
   // validate the module and error early for unsupported cases
   LogicalResult verifyModule(ModuleOp &mod) {
     // ws should not capture RankedTensorType
-    ttg::WarpSpecializeOp *invalidWSOp = nullptr;
+    ttg::WarpSpecializeOp invalidWSOp = nullptr;
     auto result = mod.walk([&](ttg::WarpSpecializeOp op) {
       for (auto argType : op.getOperandTypes()) {
         if (isa<RankedTensorType>(argType)) {
-          invalidWSOp = &op;
+          invalidWSOp = op;
           return WalkResult::interrupt();
         }
       }
       return WalkResult::advance();
     });
     if (result.wasInterrupted()) {
-      return invalidWSOp->emitError()
-             << "WarpSpecializeOp should not capture "
-                "RankedTensorType. Try moving tensor "
-                "computation into specific async task.";
+      return invalidWSOp.emitError() << "WarpSpecializeOp should not capture "
+                                        "RankedTensorType. Try moving tensor "
+                                        "computation into specific async task.";
     }
     return success();
   }


### PR DESCRIPTION
In default build mode (non debug), the `emitError` call will seg fault. This fixes the issue.

Tested by:
- `make test-lit`
- `python third_party/tlx/tutorials/blackwell-gemm-ws.py`

with both `DEBUG=1` or default build.