### PR TITLE
[TLX-3.5] Fix pytest python/triton_kernels/tests/test_matmul.py::test_op

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1056,7 +1056,7 @@ class CodeGenerator(ast.NodeVisitor):
         # if tl.constexpr: skip to avoid false alarm such as \
         # Loop-carried variable "i" has initial type constexpr_type[0] but is re-assigned to constexpr_type[1] in loop
         # if tl.tensor or buffered_tensor(tl.base_value): assert type persists
-        if not _is_constexpr(loop_val):
+        if not _is_constexpr(loop_val) and hasattr(loop_val, 'type'):
             assert loop_val.type == live_val.type, \
             f'Loop-carried variable {name} has initial type {live_val.type} '\
             f'but is re-assigned to {loop_val.type} in loop! '\

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1052,11 +1052,10 @@ class CodeGenerator(ast.NodeVisitor):
         assert _is_triton_value(loop_val), f'cannot reassign constexpr {name} in the loop'
         assert _is_triton_value(live_val), f'cannot reassign constexpr {name} in the loop'
         assert type(loop_val) is type(live_val), f'Loop carried variable {name} changed type'
-        if hasattr(loop_val, 'type'):
-            assert loop_val.type == live_val.type, \
-                f'Loop-carried variable "{name}" has initial type {live_val.type} '\
-                f'but is re-assigned to {loop_val.type} in loop! '\
-                f'Please make sure that the type stays consistent.'
+        assert not _is_triton_tensor(loop_val) or loop_val.type == live_val.type, \
+            f'Loop-carried variable {name} has initial type {live_val.type} '\
+            f'but is re-assigned to {loop_val.type} in loop! '\
+            f'Please make sure that the type stays consistent.'
 
     def visit_withitem(self, node):
         return self.visit(node.context_expr)
@@ -1064,7 +1063,7 @@ class CodeGenerator(ast.NodeVisitor):
     def visit_With(self, node):
         assert len(node.items) == 1
         context = node.items[0].context_expr
-        # Facebook begins 
+        # Facebook begins
         # In upstream repo, `with` statements are lowered by constructing context managers
         # and it will require non-trivial changes in TLX dispatcher for async_task
         # which will be done later

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1579,8 +1579,7 @@ class TritonSemantic(Generic[TensorTy]):
         # max_num_imprecise_acc only applies to fp8 -> fp32 dot on sm_90
         if max_num_imprecise_acc is None:
             if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
-                # All combinations of supported fp8 x fp8 are permitted
-                pass
+                max_num_imprecise_acc = self.builder.options.max_num_imprecise_acc_default
             else:
                 max_num_imprecise_acc = 0
         else:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1051,11 +1051,11 @@ class TritonSemantic(Generic[TensorTy]):
         if is_bool:
             elt_ty = tl.int8
             ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
-            ptr = self.cast(ptr, ptr_ty, self.builder)
+            ptr = self.cast(ptr, ptr_ty)
 
         # Cast `other` into `elt_ty` type
         if other is not None:
-            other = self.cast(other, elt_ty, self.builder)
+            other = self.cast(other, elt_ty)
 
         # Create loaded result type `dst_ty`
         if ptr.type.is_block():
@@ -1077,7 +1077,7 @@ class TritonSemantic(Generic[TensorTy]):
                 self.builder.create_masked_load(ptr.handle, mask.handle, other.handle if other else None, cache, eviction,
                                            is_volatile), dst_ty)
         if ptr.type.scalar == tl.int1:
-            ret = cast(ret, tl.int1, self.builder)
+            ret = cast(ret, tl.int1)
         return ret
 
     def load(self, ptr: TensorTy, mask: Optional[TensorTy], other: Optional[TensorTy], boundary_check: Tuple,


### PR DESCRIPTION
1. ValueError: Invalid rounding mode: <triton._C.libtriton.ir.builder object at 0x7fb740b150d0>. Supported rounding modes are 'rtne' and 'rtz'. Simple fix in `self.cast` function signature in semantics by cross-verifying between `git difftool 2ac060b8b 330c88bb3 -- python/triton/language/semantic.py`. But we need to factor out our own changes on dot_precheck so that future merge conflicts can be handled automatically in semantics.py

2. AssertionError: Loop-carried variable "i" has initial type constexpr_type[0] but is re-assigned to constexpr_type[1] in loop! Please make sure that the type stays consistent.

3. Fix create_dot(): incompatible function arguments

`pytest python/triton_kernels/tests/test_matmul.py::test_op`