### PR TITLE
[TLX-3.5] Run core triton UTs in run_all.sh

### DIFF
--- a/third_party/tlx/run_all.sh
+++ b/third_party/tlx/run_all.sh
@@ -40,7 +40,28 @@ if [ "$(ask)" == "yes" ]; then
 fi
 
 
-# Run unit tests
+# Run core triton unit tests
+ask() {
+    retval=""
+    while true; do
+        read -p "Run core Triton python unit tests? {y|n}" yn
+        case $yn in
+            [Yy]* ) retval="yes"; break;;
+            [Nn]* ) retval="no"; break;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+    echo "$retval"
+}
+if [ "$(ask)" == "yes" ]; then
+    echo "Running core Triton python unit tests"
+    pytest python/test/unit/language/test_conversions.py
+    pytest python/test/unit/language/test_standard.py
+    pytest python/test/unit/language/test_block_pointer.py
+fi
+
+
+# Run TLX unit tests
 ask() {
     retval=""
     while true; do
@@ -54,7 +75,7 @@ ask() {
     echo "$retval"
 }
 if [ "$(ask)" == "yes" ]; then
-    echo "Running TLX tutorial kernels"
+    echo "Running TLX Unit Tests"
     pytest python/test/unit/language/test_tlx.py
 fi
 


### PR DESCRIPTION
We recently found TLX branch breaks a bunch of core Triton unit tests, which should have been detected much earlier.
Until we set up OSS CI in Github actions, let's do a best practice by running core Triton UTs in TLX commits.

I'm adding a few pytests which passes completely for now. `test_core.py` still fails a few. 