### PR TITLE
Fix lit tests

### DIFF
--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -764,12 +764,12 @@ tt.func @implicit_and_explicit_capture_liveness() {
 }
 
 // expected-remark @below {{explicit_capture_liveness}}
-// expected-remark @below {{size = 33}}
-// expected-remark @below {{offset = 32, size = 1}}
+// expected-remark @below {{size = 45}}
+// expected-remark @below {{offset = 44, size = 1}}
 tt.func @explicit_capture_liveness() {
   // expected-remark @below {{offset = 0, size = 16}}
   %0 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #A_SHARED, #smem, mutable>
-  // expected-remark @below {{offset = 16, size = 12}}
+  // expected-remark @below {{offset = 32, size = 12}}
   ttg.warp_specialize(%0)
   default {
     // expected-remark @below {{offset = 16, size = 16}}

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -74,7 +74,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %c256_i32 = arith.constant 256 : i32
     // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
     // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
-    // CHECK-NEXT: "bar.arrive $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    // CHECK-NEXT: nvvm.barrier.arrive id = [[BAR_ID]] number_of_threads = [[NUM_THRADS]]
     ttng.arrive_barrier_named %c9_i32, %c256_i32 : i32, i32
     tt.return
   }
@@ -85,7 +85,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %c256_i32 = arith.constant 256 : i32
     // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
     // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
-    // CHECK-NEXT: "bar.sync $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    // CHECK-NEXT: nvvm.barrier id = [[BAR_ID]] number_of_threads = [[NUM_THRADS]]
     ttng.wait_barrier_named %c9_i32, %c256_i32 : i32, i32
     tt.return
   }


### PR DESCRIPTION
1. Some inline PTX operations were switched to NVVM intrinsics in cfe3dd079865d9f23cc6d7854de707636892cacf
2. Extending the live ranges of allocations in changes the allocation offsets (63df6d4d710929f530efa5418699ae5ceb34d818)