### PR TITLE
[TLX] cluster launch control

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -288,6 +288,45 @@ def TTNG_NamedBarrierWaitOp : TTNG_Op<"wait_barrier_named", []> {
   let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
 }
 
+def TTNG_AsyncCLCTryCancelOp : TTNG_Op<"async_clc_try_cancel", []> {
+  let summary = "Requests cancellation of cluster which is not launched yet";
+
+  let description = [{
+    Requests atomically cancelling the launch of a cluster that has not started running yet.
+
+    This lowers using PTX instruction
+    clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
+
+    It asynchronously writes an opaque response (16-byte CLC response) to shared memory. The completion of the asynchronous operation is tracked using the mbarrier object in `alloc`.
+
+    https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-try-cancel
+  }];
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$mbarAlloc,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$clcResAlloc
+  );
+
+  let assemblyFormat = "$mbarAlloc`,` $clcResAlloc attr-dict `:` type(operands)";
+}
+
+def TTNG_AsyncCLCQueryCancelOp : TTNG_Op<"async_clc_query_cancel", []> {
+  let summary = "Extract CTA ID from CLC response";
+
+  let description = [{
+    Extract CTA ID from CLC response stored at the SMEM address pointed
+    and return (xctaid, yctaid, zctaid).
+
+    https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-query-cancel
+  }];
+
+  let arguments = (ins TT_PtrType:$responseAddr);
+
+  let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = "$responseAddr attr-dict `:` type($responseAddr) `->` type($result)";
+}
+
 def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local"> {
   let summary = "copy data based on descriptor from global memory to local memory asynchronously";
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -320,11 +320,26 @@ def TTNG_AsyncCLCQueryCancelOp : TTNG_Op<"async_clc_query_cancel", []> {
     https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-query-cancel
   }];
 
-  let arguments = (ins TT_PtrType:$responseAddr);
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$clcResAlloc,
+    I32:$valid,
+    I32:$ctaId
+    // Variadic<I32>:$ctaId
+    // TT_Tensor:$ctaIdY,
+    // TT_Tensor:$ctaIdZ
+    // I32:$valid,
+    // I32:$ctaIdX,
+    // I32:$ctaIdY,
+    // I32:$ctaIdZ
+    // TODO. use Variadic<I32>?
+  );
 
-  let results = (outs TT_Tensor:$result);
+  // let results = (outs I32:$result);
 
-  let assemblyFormat = "$responseAddr attr-dict `:` type($responseAddr) `->` type($result)";
+  // let assemblyFormat = "$clcResAlloc attr-dict `:` type($clcResAlloc) `->` type($result)";
+  // let assemblyFormat = "$clcResAlloc attr-dict `:` type($clcResAlloc)";
+  // let assemblyFormat = "$clcResAlloc`,` $valid`,` $ctaIdX`,` $ctaIdY`,` $ctaIdZ attr-dict `:` type(operands)";
+  let assemblyFormat = "$clcResAlloc`,` $valid`,` $ctaId attr-dict `:` type(operands)";
 }
 
 def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local"> {

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -315,7 +315,7 @@ def TTNG_AsyncCLCQueryCancelOp : TTNG_Op<"async_clc_query_cancel", []> {
 
   let description = [{
     Extract CTA ID from CLC response stored at the SMEM address pointed
-    and return (xctaid, yctaid, zctaid).
+    and store results to (valid, xctaid, yctaid, zctaid).
 
     https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-query-cancel
   }];
@@ -323,23 +323,12 @@ def TTNG_AsyncCLCQueryCancelOp : TTNG_Op<"async_clc_query_cancel", []> {
   let arguments = (ins
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$clcResAlloc,
     I32:$valid,
-    I32:$ctaId
-    // Variadic<I32>:$ctaId
-    // TT_Tensor:$ctaIdY,
-    // TT_Tensor:$ctaIdZ
-    // I32:$valid,
-    // I32:$ctaIdX,
-    // I32:$ctaIdY,
-    // I32:$ctaIdZ
-    // TODO. use Variadic<I32>?
+    I32:$ctaIdX,
+    I32:$ctaIdY,
+    I32:$ctaIdZ
   );
 
-  // let results = (outs I32:$result);
-
-  // let assemblyFormat = "$clcResAlloc attr-dict `:` type($clcResAlloc) `->` type($result)";
-  // let assemblyFormat = "$clcResAlloc attr-dict `:` type($clcResAlloc)";
-  // let assemblyFormat = "$clcResAlloc`,` $valid`,` $ctaIdX`,` $ctaIdY`,` $ctaIdZ attr-dict `:` type(operands)";
-  let assemblyFormat = "$clcResAlloc`,` $valid`,` $ctaId attr-dict `:` type(operands)";
+  let assemblyFormat = "$clcResAlloc`,` $valid`,` $ctaIdX`,` $ctaIdY`,` $ctaIdZ attr-dict `:` type(operands)";
 }
 
 def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local"> {

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1617,43 +1617,6 @@ def test_cluster_launch_control(BLOCK_SIZE, device):
         cta_id = -1
         tlx.clc_query(clc_response, valid, cta_id)
 
-            # if ctaid is NOT valid, exit
-            # if response[0] == 0:
-            #     return
-            # else:
-            #     ctaid = response[1]
-
-            #     offsets = ctaid + tl.range(0, BLOCK_SIZE)
-            #     mask = offsets < n_elements
-
-            #     x = tl.load(x_ptr + offsets, mask=mask)
-            #     y = tl.load(y_ptr + offsets, mask=mask)
-            #     output = x + y
-            #     tl.store(z_ptr + offsets, output, mask=mask)
-
-
-        # block_start = pid * BLOCK_SIZE
-        # with tlx.async_tasks():
-        #     with tlx.async_task("default"):
-        #         offsets = block_start + tl.arange(0, BLOCK_SIZE)
-        #         mask = offsets < n_elements
-        #         x = tl.load(x_ptr + offsets, mask=mask)
-        #         y = tl.load(y_ptr + offsets, mask=mask)
-        #         output = x + y
-        #         tl.store(z_ptr + offsets, output, mask=mask)
-        #     with tlx.async_task(num_warps=1, registers=100, replicate=2):
-        #         offsets = block_start + tl.arange(0, BLOCK_SIZE)
-        #         mask = offsets < n_elements
-        #         a = tl.load(a_ptr + offsets, mask=mask)
-        #         b = tl.load(b_ptr + offsets, mask=mask)
-        #         replica_id = tlx.async_task_replica_id()
-        #         # This no-op is just to test that replica_id
-        #         # is correctly passed to the kernel
-        #         a1 = a + replica_id
-        #         b1 = b - replica_id
-        #         output = a1 + b1
-        #         tl.store(c_ptr + offsets, output, mask=mask)
-
     torch.manual_seed(0)
     # number of kernels to launch in a non-persistent mode
     size = 100000

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1636,4 +1636,4 @@ def test_cluster_launch_control(BLOCK_SIZE, device):
     assert re.search((r'clusterlaunchcontrol.query_cancel.is_canceled.pred.b128'), ptx, flags=re.DOTALL)
     assert re.search((r'clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128'), ptx, flags=re.DOTALL)
 
-    torch.testing.assert_close(output, x+y, check_dtype=False)
+    torch.testing.assert_close(output, x + y, check_dtype=False)

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1574,3 +1574,120 @@ def test_async_dots_blackwell_tmem(device):
 
     ref_out = ((a @ b) * 0.5) @ c
     torch.testing.assert_close(d, ref_out)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+@pytest.mark.parametrize("BLOCK_SIZE", [(256)])
+def test_cluster_launch_control(BLOCK_SIZE, device):
+
+    @triton.jit
+    def add2_clc(
+        x_ptr,
+        y_ptr,
+        z_ptr,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        # CTA ID of the first work load
+        ctaid = tl.program_id(axis=0)
+        block_start = ctaid * BLOCK_SIZE
+
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = tl.load(y_ptr + offsets, mask=mask)
+        output = x + y
+        tl.store(z_ptr + offsets, output, mask=mask)
+
+        bars = tlx.alloc_barriers(num_barriers=1)
+        clc_mbar = tlx.local_view(bars, 0)
+
+        responses = tlx.alloc_clc_responses(num_responses=1)
+        clc_response = tlx.local_view(responses, 0)
+
+        # while True:
+
+        # CLC issue and wait
+        tlx.clc_issue(clc_response, clc_mbar)
+
+        # mbar completion and extract CTA ID
+        # response = tl.full([1, 1,1,1], -1, tl.int32)
+        # tlx.barrier_wait(cta_id, clc_mbar)
+
+            # if ctaid is NOT valid, exit
+            # if response[0] == 0:
+            #     return
+            # else:
+            #     ctaid = response[1]
+
+            #     offsets = ctaid + tl.range(0, BLOCK_SIZE)
+            #     mask = offsets < n_elements
+
+            #     x = tl.load(x_ptr + offsets, mask=mask)
+            #     y = tl.load(y_ptr + offsets, mask=mask)
+            #     output = x + y
+            #     tl.store(z_ptr + offsets, output, mask=mask)
+
+
+        # block_start = pid * BLOCK_SIZE
+        # with tlx.async_tasks():
+        #     with tlx.async_task("default"):
+        #         offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        #         mask = offsets < n_elements
+        #         x = tl.load(x_ptr + offsets, mask=mask)
+        #         y = tl.load(y_ptr + offsets, mask=mask)
+        #         output = x + y
+        #         tl.store(z_ptr + offsets, output, mask=mask)
+        #     with tlx.async_task(num_warps=1, registers=100, replicate=2):
+        #         offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        #         mask = offsets < n_elements
+        #         a = tl.load(a_ptr + offsets, mask=mask)
+        #         b = tl.load(b_ptr + offsets, mask=mask)
+        #         replica_id = tlx.async_task_replica_id()
+        #         # This no-op is just to test that replica_id
+        #         # is correctly passed to the kernel
+        #         a1 = a + replica_id
+        #         b1 = b - replica_id
+        #         output = a1 + b1
+        #         tl.store(c_ptr + offsets, output, mask=mask)
+
+    torch.manual_seed(0)
+    # number of kernels to launch in a non-persistent mode
+    size = 100000
+    x = torch.rand(size, device=device)
+    y = torch.rand(size, device=device)
+
+    output = torch.empty_like(x)
+    n_elements = output.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
+    kernel = add2_clc[grid](x, y, output, n_elements, BLOCK_SIZE=BLOCK_SIZE, launch_cluster=True)
+    # ttgir = kernel.asm["ttgir"]
+
+    # pattern_ws = (r'ttg.warp_specialize(.*) attributes {requestedRegisters = array<i32: 100, 100>}')
+    # assert re.search(pattern_ws, ttgir, flags=re.DOTALL)
+    # pattern_p0 = (r'partition0(.*) num_warps\(1\)')
+    # assert re.search(pattern_p0, ttgir, flags=re.DOTALL)
+    # pattern_p1 = (r'partition1(.*) num_warps\(1\)')
+    # assert re.search(pattern_p1, ttgir, flags=re.DOTALL)
+
+    # Check that the replica_id is correctly passed to non-default regions
+    # TTIR/TTGIR should be something like:
+    #  partition0(...) {
+    #   %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32, #blocked>
+    #   ...
+    #   %13 = arith.addf %9, %cst
+    #   ...}
+    #  partition1(...) {
+    #   %cst = arith.constant dense<1.000000e+00> : tensor<1024xf32, #blocked>
+    #   ...
+    #   %13 = arith.addf %9, %cst
+    #   %14 = arith.subf %12, %cst
+    #   ...}
+    # pattern_cst = (r'cst = arith.constant dense\<.*\>')
+    # found = re.findall(pattern_cst, ttgir)
+    # assert len(found) == 2, "Expected 2 cst by calling `tlx.async_task_replica_id()` in two regions"
+    # assert found[0] != found[1], "Two matches MUST be different"
+    # assert "dense<0.0" in found[0] and "dense<1.0" in found[1], "Expected 0.0 and 1.0 as replica_id"
+
+    torch.testing.assert_close(output, x+y, check_dtype=False)

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1615,8 +1615,8 @@ def test_cluster_launch_control(BLOCK_SIZE, device):
         # CLC parse CTA ID from response
         valid = 0
         cta_id_x = -1
-        cta_id_y = -1
-        cta_id_z = -1
+        cta_id_y = -2
+        cta_id_z = -3
         tlx.clc_query(clc_response, valid, cta_id_x, cta_id_y, cta_id_z)
 
     torch.manual_seed(0)

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -89,6 +89,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.wait_barrier_named %c9_i32, %c256_i32 : i32, i32
     tt.return
   }
+
+  // CHECK-LABEL: async_clc_try_cancel
+  tt.func @async_clc_try_cancel(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
+    %c9_i32 = arith.constant 9 : i32
+    %c256_i32 = arith.constant 256 : i32
+    // CHECK-NEXT: [[CLC_RESPONSE:%.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
+    // CHECK-NEXT: "clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 $0, $1;", "r,r" [[CLC_RESPONSE]], [[BAR_ID]]
+    ttng.async_clc_try_cancel %c9_i32, %c256_i32 : i32, i32
+    tt.return
+  }
 }
 
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -48,6 +48,7 @@ class HIPOptions:
     allowed_dot_input_precisions: Tuple[str] = ("ieee", )
     enable_fp_fusion: bool = True
     launch_cooperative_grid: bool = False
+    launch_cluster: bool = False # No-op placeholder
     matrix_instr_nonkdim: int = 0
     kpack: int = 1
     allow_flush_denorm: bool = False

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -48,7 +48,7 @@ class HIPOptions:
     allowed_dot_input_precisions: Tuple[str] = ("ieee", )
     enable_fp_fusion: bool = True
     launch_cooperative_grid: bool = False
-    launch_cluster: bool = False # No-op placeholder
+    launch_cluster: bool = False  # No-op placeholder
     matrix_instr_nonkdim: int = 0
     kpack: int = 1
     allow_flush_denorm: bool = False

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -117,6 +117,7 @@ class CUDAOptions:
     ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttgir|llir|ptx})
     enable_fp_fusion: bool = True
     launch_cooperative_grid: bool = False
+    launch_cluster: bool = False # Blackwell cluster launcher
     launch_pdl: bool = False
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -117,7 +117,7 @@ class CUDAOptions:
     ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttgir|llir|ptx})
     enable_fp_fusion: bool = True
     launch_cooperative_grid: bool = False
-    launch_cluster: bool = False # Blackwell cluster launcher
+    launch_cluster: bool = False  # Blackwell cluster launcher
     launch_pdl: bool = False
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -356,11 +356,11 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas
       launchAttr[num_attrs] = clusterAttr;
       ++num_attrs;
 
-      // CUlaunchAttribute clusterSchedulingAttr = {{}};
-      // clusterSchedulingAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
-      // clusterSchedulingAttr.value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
-      // launchAttr[num_attrs] = clusterSchedulingAttr;
-      // ++num_attrs;
+      CUlaunchAttribute clusterSchedulingAttr = {{}};
+      clusterSchedulingAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+      clusterSchedulingAttr.value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+      launchAttr[num_attrs] = clusterSchedulingAttr;
+      ++num_attrs;
     }}
 
     config.numAttrs = num_attrs;

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -716,8 +716,8 @@ class CudaLauncher(object):
         global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
         profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
                                            _allocation._profile_allocator)
-        self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_cluster, self.launch_pdl,
-                    global_scratch, profile_scratch, *args)
+        self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_cluster,
+                    self.launch_pdl, global_scratch, profile_scratch, *args)
 
 
 class CudaDriver(GPUDriver):

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -342,7 +342,7 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas
       ++num_attrs;
     }}
 
-    if (launch_cluster || num_ctas != 1) {{
+    if (launch_cluster !=0 || num_ctas != 1) {{
       CUlaunchAttribute clusterAttr = {{}};
       clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
       clusterAttr.value.clusterDim.x = clusterDimX;
@@ -351,11 +351,11 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas
       launchAttr[num_attrs] = clusterAttr;
       ++num_attrs;
 
-      CUlaunchAttribute clusterSchedulingAttr = {{}};
-      clusterSchedulingAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
-      clusterSchedulingAttr.value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
-      launchAttr[num_attrs] = clusterSchedulingAttr;
-      ++num_attrs;
+      // CUlaunchAttribute clusterSchedulingAttr = {{}};
+      // clusterSchedulingAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+      // clusterSchedulingAttr.value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+      // launchAttr[num_attrs] = clusterSchedulingAttr;
+      // ++num_attrs;
     }}
 
     config.numAttrs = num_attrs;

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -662,7 +662,6 @@ def wrap_handle_tensordesc(launcher, tensordesc_meta):
         raw_kernel_args = args[len(_BASE_ARGS_FORMAT):]
         tensordesc_idx = 0
         final_args = []
-        import pdb; pdb.set_trace()
         for i, arg in enumerate(raw_kernel_args):
             if isinstance(arg, (TensorDescriptor, GluonTensorDescriptor)):
                 meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -364,12 +364,6 @@ struct AsyncCLCQueryCancelOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
-    // Value valid, xctaid, yctaid, zctaid;
-
-    // TritonLLVMOpBuilder b(op.getLoc(), rewriter);
-    // Value id = getThreadId(rewriter, op.getLoc());
-    // Value valid = b.icmp_eq(id, b.i32_val(0));
-
     std::string ptx = R"(
     {
       .reg .pred p1;
@@ -386,28 +380,13 @@ struct AsyncCLCQueryCancelOpConversion
         ptxBuilder.newOperand(adaptor.getClcResAlloc(), "r"),
         ptxBuilder.newOperand(adaptor.getValid(), "r"), // 1-bit pred
         ptxBuilder.newOperand(adaptor.getCtaId(), "r"), // 32-bit pred
-        // ptxBuilder.newOperand(adaptor.getCtaId()[1], "r"), // 32-bit pred
-        // ptxBuilder.newOperand(adaptor.getCtaId()[2], "r"), // 32-bit pred
+        // TODO. add CTA ID y/z
     };
 
     auto queryOp = *ptxBuilder.create<>(ptx);
     queryOp(operands, /*onlyAttachMLIRArgs=*/true);
     auto voidTy = void_ty(getContext());
     ptxBuilder.launch(rewriter, op.getLoc(), voidTy);
-
-    // SmallVector<Value> resultVals;
-    // resultVals.reserve(4);
-    // resultVals.push_back(valid); // 0 or 1
-    // resultVals.push_back(xctaid);
-    // resultVals.push_back(yctaid);
-    // resultVals.push_back(zctaid);
-    // auto typeConverter = getTypeConverter();
-    // auto resultTy = cast<RankedTensorType>(op.getType());
-    // Value ret =
-    //    packLLElements(loc, typeConverter, resultVals, rewriter, resultTy);
-    // Value ret = 100;
-
-    // rewriter.replaceOp(op, valid);
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -378,7 +378,9 @@ struct AsyncCLCQueryCancelOpConversion
     PTXBuilder ptxBuilder;
     SmallVector<PTXBuilder::Operand *, 5> operands = {
         ptxBuilder.newOperand(adaptor.getClcResAlloc(), "r"),
-        ptxBuilder.newOperand(adaptor.getValid(), "r"), // 32-bit pred (1-bit will fail PTX compiling)
+        ptxBuilder.newOperand(
+            adaptor.getValid(),
+            "r"), // 32-bit pred (1-bit will fail PTX compiling)
         ptxBuilder.newOperand(adaptor.getCtaIdX(), "r"), // 32-bit pred
         ptxBuilder.newOperand(adaptor.getCtaIdY(), "r"), // 32-bit pred
         ptxBuilder.newOperand(adaptor.getCtaIdZ(), "r"), // 32-bit pred

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -371,16 +371,17 @@ struct AsyncCLCQueryCancelOpConversion
       ld.shared.b128 clc_result, [$0];
       clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 p1, clc_result;
       selp.u32 $1, 1, 0, p1;
-      @p1 clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 {$2, _, _, _}, clc_result;
+      @p1 clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 {$2, $3, $4, _}, clc_result;
     }
     )";
 
     PTXBuilder ptxBuilder;
     SmallVector<PTXBuilder::Operand *, 5> operands = {
         ptxBuilder.newOperand(adaptor.getClcResAlloc(), "r"),
-        ptxBuilder.newOperand(adaptor.getValid(), "r"), // 1-bit pred
-        ptxBuilder.newOperand(adaptor.getCtaId(), "r"), // 32-bit pred
-        // TODO. add CTA ID y/z
+        ptxBuilder.newOperand(adaptor.getValid(), "r"), // 32-bit pred (1-bit will fail PTX compiling)
+        ptxBuilder.newOperand(adaptor.getCtaIdX(), "r"), // 32-bit pred
+        ptxBuilder.newOperand(adaptor.getCtaIdY(), "r"), // 32-bit pred
+        ptxBuilder.newOperand(adaptor.getCtaIdZ(), "r"), // 32-bit pred
     };
 
     auto queryOp = *ptxBuilder.create<>(ptx);

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -438,11 +438,13 @@ void init_triton_tlx_ir(py::module &&m) {
                return self.create<ttg::LocalAllocOp>(memDesc);
            })
       .def("create_alloc_clc_responses",
-           [](TritonOpBuilder &self, int numResponses, Attribute clcResEncoding) -> mlir::Value {
+           [](TritonOpBuilder &self, int numResponses,
+              Attribute clcResEncoding) -> mlir::Value {
              auto context = self.getBuilder().getContext();
              auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
              auto memDescType = ttg::MemDescType::get(
-                 {numResponses}, self.getBuilder().getIntegerType(128, /*signed=*/false),
+                 {numResponses},
+                 self.getBuilder().getIntegerType(128, /*signed=*/false),
                  clcResEncoding, memorySpace, /*mutableMemory=*/true);
 
              mlir::Value bufferViews =
@@ -455,9 +457,10 @@ void init_triton_tlx_ir(py::module &&m) {
              self.create<ttng::AsyncCLCTryCancelOp>(mbar, responseAddr);
            })
       .def("clc_query",
-           [](TritonOpBuilder &self,
-              Value responseAddr, Value valid, Value ctaIdX, Value ctaIdY, Value ctaIdZ) -> void {
-             self.create<ttng::AsyncCLCQueryCancelOp>(responseAddr, valid, ctaIdX, ctaIdY, ctaIdZ);
+           [](TritonOpBuilder &self, Value responseAddr, Value valid,
+              Value ctaIdX, Value ctaIdY, Value ctaIdZ) -> void {
+             self.create<ttng::AsyncCLCQueryCancelOp>(responseAddr, valid,
+                                                      ctaIdX, ctaIdY, ctaIdZ);
            })
       .def("create_async_TMA_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &coord,

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -437,6 +437,54 @@ void init_triton_tlx_ir(py::module &&m) {
              else
                return self.create<ttg::LocalAllocOp>(memDesc);
            })
+      .def("create_alloc_clc_responses",
+           [](TritonOpBuilder &self, int numResponses, Attribute clcResEncoding) -> mlir::Value {
+             auto context = self.getBuilder().getContext();
+             auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
+             auto memDescType = ttg::MemDescType::get(
+                 {numResponses}, self.getBuilder().getIntegerType(128, /*signed=*/false),
+                 clcResEncoding, memorySpace, /*mutableMemory=*/true);
+
+             mlir::Value bufferViews =
+                 self.create<ttg::LocalAllocOp>(memDescType);
+
+             return bufferViews;
+           })
+      .def("clc_issue",
+           [](TritonOpBuilder &self, Value responseAddr, Value mbar) -> void {
+             self.create<ttng::AsyncCLCTryCancelOp>(mbar, responseAddr);
+           })
+      .def("clc_query",
+           [](TritonOpBuilder &self, Value cta_id,
+              Value response_addr) -> Value {
+             auto retType = cast<RankedTensorType>(cta_id.getType());
+             return self.create<ttng::AsyncCLCQueryCancelOp>(retType,
+                                                             response_addr);
+           })
+      .def("create_alloc_clc_responses",
+           [](TritonOpBuilder &self, int numResponses, Attribute clcResEncoding) -> mlir::Value {
+             auto context = self.getBuilder().getContext();
+             auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
+             auto memDescType = ttg::MemDescType::get(
+                 {numResponses}, self.getBuilder().getIntegerType(128, /*signed=*/false),
+                 clcResEncoding, memorySpace, /*mutableMemory=*/true);
+
+             mlir::Value bufferViews =
+                 self.create<ttg::LocalAllocOp>(memDescType);
+
+             return bufferViews;
+           })
+      .def("clc_issue",
+           [](TritonOpBuilder &self, Value responseAddr, Value mbar) -> void {
+             self.create<ttng::AsyncCLCTryCancelOp>(mbar, responseAddr);
+           })
+      .def("clc_query",
+           [](TritonOpBuilder &self, Value cta_id,
+              Value response_addr) -> Value {
+             auto retType = cast<RankedTensorType>(cta_id.getType());
+             return self.create<ttng::AsyncCLCQueryCancelOp>(retType,
+                                                             response_addr);
+           })
       .def("create_async_TMA_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &coord,
               Value mbarrier, Value pred, Value result,

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -456,8 +456,8 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("clc_query",
            [](TritonOpBuilder &self,
-              Value responseAddr, Value valid, Value ctaId) -> void {
-             self.create<ttng::AsyncCLCQueryCancelOp>(responseAddr, valid, ctaId);
+              Value responseAddr, Value valid, Value ctaIdX, Value ctaIdY, Value ctaIdZ) -> void {
+             self.create<ttng::AsyncCLCQueryCancelOp>(responseAddr, valid, ctaIdX, ctaIdY, ctaIdZ);
            })
       .def("create_async_TMA_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &coord,

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -455,35 +455,9 @@ void init_triton_tlx_ir(py::module &&m) {
              self.create<ttng::AsyncCLCTryCancelOp>(mbar, responseAddr);
            })
       .def("clc_query",
-           [](TritonOpBuilder &self, Value cta_id,
-              Value response_addr) -> Value {
-             auto retType = cast<RankedTensorType>(cta_id.getType());
-             return self.create<ttng::AsyncCLCQueryCancelOp>(retType,
-                                                             response_addr);
-           })
-      .def("create_alloc_clc_responses",
-           [](TritonOpBuilder &self, int numResponses, Attribute clcResEncoding) -> mlir::Value {
-             auto context = self.getBuilder().getContext();
-             auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
-             auto memDescType = ttg::MemDescType::get(
-                 {numResponses}, self.getBuilder().getIntegerType(128, /*signed=*/false),
-                 clcResEncoding, memorySpace, /*mutableMemory=*/true);
-
-             mlir::Value bufferViews =
-                 self.create<ttg::LocalAllocOp>(memDescType);
-
-             return bufferViews;
-           })
-      .def("clc_issue",
-           [](TritonOpBuilder &self, Value responseAddr, Value mbar) -> void {
-             self.create<ttng::AsyncCLCTryCancelOp>(mbar, responseAddr);
-           })
-      .def("clc_query",
-           [](TritonOpBuilder &self, Value cta_id,
-              Value response_addr) -> Value {
-             auto retType = cast<RankedTensorType>(cta_id.getType());
-             return self.create<ttng::AsyncCLCQueryCancelOp>(retType,
-                                                             response_addr);
+           [](TritonOpBuilder &self,
+              Value responseAddr, Value valid, Value ctaId) -> void {
+             self.create<ttng::AsyncCLCQueryCancelOp>(responseAddr, valid, ctaId);
            })
       .def("create_async_TMA_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &coord,

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -23,12 +23,19 @@ from .utility import (
     async_task_replica_id,
     dtype_of,
 )
+from .dynamic_launch import (
+    alloc_clc_responses,
+    clc_issue,
+    clc_query,
+)
 
 from . import compiler
 
 __all__ = [
+    # async_tasks
     "async_tasks",
     "async_task",
+    # types
     "layout_encoding",
     "shared_layout_encoding",
     "swizzled_shared_layout_encoding",
@@ -40,6 +47,7 @@ __all__ = [
     "mbarrier",
     "mbarrier_type",
     "async_token",
+    # mem_ops
     "local_alloc",
     "local_view",
     "subslice",
@@ -54,16 +62,23 @@ __all__ = [
     "async_descriptor_store",
     "async_descriptor_store_wait",
     "fence_async_shared",
+    # barriers
     "alloc_barriers",
     "barrier_expect_bytes",
     "barrier_wait",
     "barrier_arrive",
     "named_barrier_wait",
     "named_barrier_arrive",
+    # mma_ops
     "async_dot",
     "async_dot_wait",
     "tcgen05_commit",
+    # utility
     "thread_id",
     "async_task_replica_id",
     "dtype_of",
+    # dynamic launcher ops
+    "alloc_clc_responses",
+    "clc_issue",
+    "clc_query",
 ]

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -30,26 +30,25 @@ def alloc_clc_responses(
 
 @tl.builtin
 def clc_issue(
-    clc_response_addr: tlx.buffered_tensor,
+    clc_response_addr: tlx.clc_response,
     barrier: tlx.mbarrier,
     _semantic=None,
 ):
-    """
-    Issue async `clusterlaunchcontrol.try_cancel` request for
-    CTA ID of available cluster
-    """
+    # Issue async `clusterlaunchcontrol.try_cancel` request for
+    # CTA ID of available cluster
     return _semantic.builder.clc_issue(clc_response_addr.handle, barrier.handle)
 
 
 @tl.builtin
 def clc_query(
-    cta_id: tl.tensor,
-    clc_response_addr: tlx.buffered_tensor,
+    clc_response_addr: tlx.clc_response,
+    valid, cta_id,
     _semantic=None,
-) -> tl.base_value:
-    """
-    Extract CTA ID from CLC response
-
-    Return success/fail of PTX instruction
-    """
-    return _semantic.builder.clc_query(cta_id, clc_response_addr)
+):
+    # Extract CTA ID from CLC response
+    # Return success/fail of PTX instruction
+    return _semantic.builder.clc_query(
+        clc_response_addr.handle,
+        valid.handle,
+        cta_id.handle,
+    )

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -32,6 +32,8 @@ def clc_issue(
 ):
     # Issue async `clusterlaunchcontrol.try_cancel` request for
     # CTA ID of available cluster
+    assert type(clc_response_addr) == tlx.clc_response
+
     return _semantic.builder.clc_issue(clc_response_addr.handle, barrier.handle)
 
 
@@ -46,6 +48,8 @@ def clc_query(
 ):
     # Extract CTA ID from CLC response
     # Return success/fail of PTX instruction
+    assert type(clc_response_addr) == tlx.clc_response
+
     return _semantic.builder.clc_query(
         clc_response_addr.handle,
         valid.handle,

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -42,7 +42,7 @@ def clc_issue(
 @tl.builtin
 def clc_query(
     clc_response_addr: tlx.clc_response,
-    valid, cta_id,
+    valid, cta_id_x, cta_id_y, cta_id_z,
     _semantic=None,
 ):
     # Extract CTA ID from CLC response
@@ -50,5 +50,7 @@ def clc_query(
     return _semantic.builder.clc_query(
         clc_response_addr.handle,
         valid.handle,
-        cta_id.handle,
+        cta_id_x.handle,
+        cta_id_y.handle,
+        cta_id_z.handle,
     )

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -4,6 +4,7 @@ from . import types as tlx
 
 # Blackwell-only
 
+
 @tl.builtin
 def alloc_clc_responses(
     num_responses: tl.constexpr,
@@ -19,13 +20,8 @@ def alloc_clc_responses(
         layout.numCTASplit,
         layout.numCTAOrder,
     )
-    return tlx.clc_response(
-        _semantic.builder.create_alloc_clc_responses(
-            num_responses.value,
-            layout_handle),
-        num_responses,
-        layout,
-        _semantic)
+    return tlx.clc_response(_semantic.builder.create_alloc_clc_responses(num_responses.value, layout_handle),
+                            num_responses, layout, _semantic)
 
 
 @tl.builtin
@@ -42,7 +38,10 @@ def clc_issue(
 @tl.builtin
 def clc_query(
     clc_response_addr: tlx.clc_response,
-    valid, cta_id_x, cta_id_y, cta_id_z,
+    valid,
+    cta_id_x,
+    cta_id_y,
+    cta_id_z,
     _semantic=None,
 ):
     # Extract CTA ID from CLC response

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -32,7 +32,7 @@ def clc_issue(
 ):
     # Issue async `clusterlaunchcontrol.try_cancel` request for
     # CTA ID of available cluster
-    assert type(clc_response_addr) == tlx.clc_response
+    assert isinstance(clc_response_addr, tlx.clc_response)
 
     return _semantic.builder.clc_issue(clc_response_addr.handle, barrier.handle)
 
@@ -48,7 +48,7 @@ def clc_query(
 ):
     # Extract CTA ID from CLC response
     # Return success/fail of PTX instruction
-    assert type(clc_response_addr) == tlx.clc_response
+    assert isinstance(clc_response_addr, tlx.clc_response)
 
     return _semantic.builder.clc_query(
         clc_response_addr.handle,

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -1,0 +1,55 @@
+import triton.language.core as tl
+
+from . import types as tlx
+
+# Blackwell-only
+
+@tl.builtin
+def alloc_clc_responses(
+    num_responses: tl.constexpr,
+    _semantic=None,
+) -> tlx.clc_response:
+    layout = tlx.swizzled_shared_layout_encoding.make_default(rank=1)
+    layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
+        layout.vectorSize,
+        layout.perPhase,
+        layout.maxPhase,
+        layout.order,
+        layout.numCTAsPerCGA,
+        layout.numCTASplit,
+        layout.numCTAOrder,
+    )
+    return tlx.clc_response(
+        _semantic.builder.create_alloc_clc_responses(
+            num_responses.value,
+            layout_handle),
+        num_responses,
+        layout,
+        _semantic)
+
+
+@tl.builtin
+def clc_issue(
+    clc_response_addr: tlx.buffered_tensor,
+    barrier: tlx.mbarrier,
+    _semantic=None,
+):
+    """
+    Issue async `clusterlaunchcontrol.try_cancel` request for
+    CTA ID of available cluster
+    """
+    return _semantic.builder.clc_issue(clc_response_addr.handle, barrier.handle)
+
+
+@tl.builtin
+def clc_query(
+    cta_id: tl.tensor,
+    clc_response_addr: tlx.buffered_tensor,
+    _semantic=None,
+) -> tl.base_value:
+    """
+    Extract CTA ID from CLC response
+
+    Return success/fail of PTX instruction
+    """
+    return _semantic.builder.clc_query(cta_id, clc_response_addr)

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -131,12 +131,21 @@ def local_view(
     ...
 
 
+@overload
+def local_view(
+    local_allocated_buffers: tlx.clc_response,
+    buffer_idx: int,
+    _builder=None,
+) -> tlx.clc_response:
+    ...
+
+
 @tl.builtin
 def local_view(
-    local_allocated_buffers: tlx.buffered_tensor | tlx.mbarrier,
+    local_allocated_buffers: tlx.buffered_tensor | tlx.mbarrier | tlx.clc_response,
     buffer_idx: int,
     _semantic=None,
-) -> tlx.buffered_tensor | tlx.mbarrier:
+) -> tlx.buffered_tensor | tlx.mbarrier | tlx.clc_response:
     """
     Returns a subview of the buffer.
     """
@@ -144,6 +153,8 @@ def local_view(
     view_handle = _semantic.builder.create_memdesc_subview(local_allocated_buffers.handle, buffer_idx)
     if isinstance(local_allocated_buffers, tlx.mbarrier):
         return tlx.mbarrier(view_handle, 0, local_allocated_buffers.type.layout)
+    elif isinstance(local_allocated_buffers, tlx.clc_response):
+        return tlx.clc_response(view_handle, 0, local_allocated_buffers.type.layout)
     else:
         return tlx.buffered_tensor(
             view_handle,

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -329,7 +329,8 @@ class clc_response(tl.base_value):
     Define a CLC response object
     """
 
-    def __init__(self, handle, num: int, layout: Optional[swizzled_shared_layout_encoding], semantic: TritonSemantic = None):
+    def __init__(self, handle, num: int, layout: Optional[swizzled_shared_layout_encoding],
+                 semantic: TritonSemantic = None):
         self.handle = handle
         self.type = clc_response_type(num, layout, semantic)
         self.num = num
@@ -358,7 +359,7 @@ class clc_response_type(buffered_tensor_type):
         return value, cursor + 1
 
     def to_ir(self, builder: ir.builder) -> None:
-        builder=semantic.builder
+        builder = self.semantic.builder
         if self.num >= 1:
             shape = [self.num]
         else:


### PR DESCRIPTION
This PR introduces Blackwell CLC to TLX exposing 3 APIs to users:
1. `responses = tlx.alloc_clc_responses(num_responses=1)`: allocate a 16-byte wide SMEM address storing a 16-byte opaque object for CLC)
2. `tlx.clc_issue(clc_response, clc_mbar)`: issue clc.try_cancel async for next available CTA wrapped by a mbarrier
3. `tlx.clc_query(clc_response, valid, cta_id)`: get CTA ID from the CLC response

`pytest python/test/unit/language/test_tlx.py::test_cluster_launch_control`

Reference: https://docs.nvidia.com/cutlass/media/docs/cpp/blackwell_cluster_launch_control.html#blackwell-warp-specialized-persistent-kernel

Generated PTX:
```
	// begin inline asm
	clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [%r12], [%r7];
	// end inline asm
...
    {
      .reg .pred p1;
      .reg .b128 clc_result;
      ld.shared.b128 clc_result, [%r12];
      clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 p1, clc_result;
      selp.u32 %r13, 1, 0, p1;
      @p1 clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 {%r14, %r14, %r14, _}, clc_result;
    }
```
CLC PTX from cutlass:
```
{
clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [%r85], [%r16];
}
...
{
.reg .pred p1;
.reg .b128 clc_result;
ld.shared.b128 clc_result, [%r99];
clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 p1, clc_result;
selp.u32 %r98, 1, 0, p1;
@p1 clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 {%r95, %r96, %r97, _}, clc_result;
}
```
