### PR TITLE
[FB][Reland #333] Add dbg prints when overriding IR by users

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -332,6 +332,7 @@ def compile(src, target=None, options=None, _env_vars=None):
             # Users can override kernels at scale by setting `ir_override` in autotune config
             # without TRITON_KERNEL_OVERRIDE
             if (ir_override := metadata.get("ir_override", None)) and ir_override.endswith(f".{ext}"):
+                print(f"\nOverriding IR with filename set in triton config {src.constants}: {ir_override}")
                 next_module = parse(ir_override, ext, context)
         elif full_name := fn_override_manager.get_file(ir_filename):
             print(f"\nOverriding kernel with file {full_name}")


### PR DESCRIPTION
Add dbg print requested by internal use case but pushed back when upstreaming
https://github.com/triton-lang/triton/pull/6802/commits/3eaff6f111643482ce7a134715aec05d596f58b7

Re-land https://github.com/facebookexperimental/triton/pull/333 to sidestep sync issues