### PR TITLE
Fix ENUM issue with -werror

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -26,12 +26,17 @@ static inline std::string to_string(DataChannelKind k) {
   switch (k) {
   case DataChannelKind::SMEM:
     return "smem";
+  case mlir::DataChannelKind::SMEMPost:
+    return "smemPost";
   case DataChannelKind::TMEM:
     return "tmem";
+  case mlir::DataChannelKind::TMEMPost:
+    return "tmemPost";
   case DataChannelKind::REG:
     return "reg";
+  default:
+    return "Unknown";
   }
-  return "Unknown";
 }
 
 struct Channel {


### PR DESCRIPTION
Fixes a missing enum option issue that would break compilation when running `make dev-install-llvm`