### PR TITLE
Njriasan/tmem support memdesc index

### DIFF
--- a/test/Hopper/WarpSpecialization/1D_tmem.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem.mlir
@@ -240,3 +240,40 @@ module attributes {ttg.maxnreg = 168 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-w
     tt.return
   }
 }
+
+// CHECK the ability to reuse result, as specified tmem.start_buffer to
+// reuse the same buffer via a reinterpret.
+// CHECK-LABEL: @_dummy_repro
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = true, elementBitWidth = 32, CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 520 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @_dummy_repro(%in_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %in_desc_0: i32, %in_desc_1: i64, %out_desc: !tt.tensordesc<tensor<128x1xf32, #shared1>>, %out_desc_2: i32, %out_desc_3: i32, %out_desc_4: i64, %out_desc_5: i64) attributes {noinline = false, ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32} {
+    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %cst = arith.constant dense<3.000000e+00> : tensor<128xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %pid = tt.get_program_id x : i32
+    %alpha = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    %alpha_6 = ttg.local_alloc {allocation.offset = 512 : i32} : () -> !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.init_barrier %alpha_6, 1 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.barrier_expect %alpha_6, 512, %true : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %in_desc[%pid] %alpha, %alpha_6, %true : !tt.tensordesc<tensor<128xf32, #shared>>, !ttg.memdesc<1xi64, #shared2, #smem, mutable> -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    ttng.wait_barrier %alpha_6, %c0_i32 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.inval_barrier %alpha_6 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    %alpha_7 = ttg.local_load %alpha : !ttg.memdesc<128xf32, #shared, #smem, mutable> -> tensor<128xf32, #blocked>
+    %alpha_i = arith.mulf %alpha_7, %cst : tensor<128xf32, #blocked>
+    %0 = ttg.convert_layout %alpha_i {tmem.start = 0 : i32, ttg.partition = 0 : i32} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32, ttg.partition = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xf32, #blocked1>
+    %2 = ttg.local_alloc %1 {allocation.offset = 0 : i32} : (tensor<128x1xf32, #blocked1>) -> !ttg.memdesc<128x1xf32, #shared1, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %out_desc[%pid, %c0_i32] %2 : !tt.tensordesc<tensor<128x1xf32, #shared1>>, !ttg.memdesc<128x1xf32, #shared1, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/1D_tmem.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem.mlir
@@ -288,3 +288,53 @@ module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scr
     tt.return
   }
 }
+
+// -----
+
+// CHECK the ability to reuse result with an intermediate.
+// memdesc_index.
+// CHECK-LABEL: @_dummy_memdesc_index_repro
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = true, elementBitWidth = 32, CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 520 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @_dummy_memdesc_index_repro(%in_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %in_desc_0: i32, %in_desc_1: i64, %out_desc: !tt.tensordesc<tensor<128x1xf32, #shared1>>, %out_desc_2: i32, %out_desc_3: i32, %out_desc_4: i64, %out_desc_5: i64) attributes {noinline = false, ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32} {
+    %result, %token = ttng.tmem_alloc  : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: ttg.memdesc_index
+    %mem_179 = ttg.memdesc_index %result[%c0_i32] {tmem.start_buffer = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 1x128x128>
+    // CHECK: ttng.tmem_subslice
+    // CHECK: ttg.memdesc_reinterpret
+    %cst = arith.constant dense<3.000000e+00> : tensor<128xf32, #blocked>
+    %true = arith.constant true
+    %pid = tt.get_program_id x : i32
+    %alpha = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    %alpha_6 = ttg.local_alloc {allocation.offset = 512 : i32} : () -> !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.init_barrier %alpha_6, 1 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.barrier_expect %alpha_6, 512, %true : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %in_desc[%pid] %alpha, %alpha_6, %true : !tt.tensordesc<tensor<128xf32, #shared>>, !ttg.memdesc<1xi64, #shared2, #smem, mutable> -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    ttng.wait_barrier %alpha_6, %c0_i32 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.inval_barrier %alpha_6 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    %alpha_7 = ttg.local_load %alpha : !ttg.memdesc<128xf32, #shared, #smem, mutable> -> tensor<128xf32, #blocked>
+    %alpha_i = arith.mulf %alpha_7, %cst : tensor<128xf32, #blocked>
+    // CHECK-NOT: tmem.start
+    %0 = ttg.convert_layout %alpha_i {tmem.start = 0 : i32, ttg.partition = 0 : i32} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    // CHECK: tt.expand_dims
+    // CHECK: ttng.tmem_store
+    // CHECK: ttng.tmem_load
+    // CHECK: tt.reshape
+    // CHECK: ttg.convert_layout
+    // CHECK: tt.expand_dims
+    %1 = tt.expand_dims %0 {axis = 1 : i32, ttg.partition = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xf32, #blocked1>
+    %2 = ttg.local_alloc %1 {allocation.offset = 0 : i32} : (tensor<128x1xf32, #blocked1>) -> !ttg.memdesc<128x1xf32, #shared1, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %out_desc[%pid, %c0_i32] %2 : !tt.tensordesc<tensor<128x1xf32, #shared1>>, !ttg.memdesc<128x1xf32, #shared1, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/1D_tmem.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem.mlir
@@ -241,6 +241,8 @@ module attributes {ttg.maxnreg = 168 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-w
   }
 }
 
+// -----
+
 // CHECK the ability to reuse result, as specified tmem.start_buffer to
 // reuse the same buffer via a reinterpret.
 // CHECK-LABEL: @_dummy_repro
@@ -273,7 +275,6 @@ module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scr
     // CHECK-NOT: tmem.start
     %0 = ttg.convert_layout %alpha_i {tmem.start = 0 : i32, ttg.partition = 0 : i32} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
     // CHECK: tt.expand_dims
-    // CHECK: ttg.convert_layout
     // CHECK: ttng.tmem_store
     // CHECK: ttng.tmem_load
     // CHECK: tt.reshape

--- a/test/Hopper/WarpSpecialization/1D_tmem.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem.mlir
@@ -254,7 +254,7 @@ module attributes {ttg.maxnreg = 168 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-w
 #smem = #ttg.shared_memory
 module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 520 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
   tt.func public @_dummy_repro(%in_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %in_desc_0: i32, %in_desc_1: i64, %out_desc: !tt.tensordesc<tensor<128x1xf32, #shared1>>, %out_desc_2: i32, %out_desc_3: i32, %out_desc_4: i64, %out_desc_5: i64) attributes {noinline = false, ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32} {
-    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result, %token = ttng.tmem_alloc {tmem.start_buffer = 0 : i32}  : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     %cst = arith.constant dense<3.000000e+00> : tensor<128xf32, #blocked>
     %c0_i32 = arith.constant 0 : i32
     %true = arith.constant true

--- a/test/Hopper/WarpSpecialization/1D_tmem.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem.mlir
@@ -255,6 +255,8 @@ module attributes {ttg.maxnreg = 168 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-w
 module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 520 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
   tt.func public @_dummy_repro(%in_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %in_desc_0: i32, %in_desc_1: i64, %out_desc: !tt.tensordesc<tensor<128x1xf32, #shared1>>, %out_desc_2: i32, %out_desc_3: i32, %out_desc_4: i64, %out_desc_5: i64) attributes {noinline = false, ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32} {
     %result, %token = ttng.tmem_alloc {tmem.start_buffer = 0 : i32}  : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    // CHECK: ttng.tmem_subslice
+    // CHECK: ttg.memdesc_reinterpret
     %cst = arith.constant dense<3.000000e+00> : tensor<128xf32, #blocked>
     %c0_i32 = arith.constant 0 : i32
     %true = arith.constant true
@@ -268,7 +270,15 @@ module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scr
     ttng.inval_barrier %alpha_6 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
     %alpha_7 = ttg.local_load %alpha : !ttg.memdesc<128xf32, #shared, #smem, mutable> -> tensor<128xf32, #blocked>
     %alpha_i = arith.mulf %alpha_7, %cst : tensor<128xf32, #blocked>
+    // CHECK-NOT: tmem.start
     %0 = ttg.convert_layout %alpha_i {tmem.start = 0 : i32, ttg.partition = 0 : i32} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    // CHECK: tt.expand_dims
+    // CHECK: ttg.convert_layout
+    // CHECK: ttng.tmem_store
+    // CHECK: ttng.tmem_load
+    // CHECK: tt.reshape
+    // CHECK: ttg.convert_layout
+    // CHECK: tt.expand_dims
     %1 = tt.expand_dims %0 {axis = 1 : i32, ttg.partition = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xf32, #blocked1>
     %2 = ttg.local_alloc %1 {allocation.offset = 0 : i32} : (tensor<128x1xf32, #blocked1>) -> !ttg.memdesc<128x1xf32, #shared1, #smem>
     ttng.fence_async_shared {bCluster = false}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -174,12 +174,16 @@ void generate1DAllocations(OpBuilder &builder, Operation *producer) {
 
 ttg::MemDescReinterpretOp
 sliceAndReinterpretTMEMBuffer(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
-                              int offset) {
+                              int offset, size_t blockN) {
   auto allocType = allocOp.getType();
   auto shape = allocType.getShape();
+  auto oldBlockN = shape[1];
+  assert(oldBlockN >= blockN && "Invalid blockN size");
+  assert(oldBlockN % blockN == 0 && "Invalid blockN divisibility");
+  assert((offset + blockN) <= oldBlockN && "Invalid offset");
   auto tmemDesc = createTMEMDesc(builder, allocType, shape[0], 1);
   auto subSlice = builder.create<ttng::TMEMSubSliceOp>(allocOp->getLoc(),
-                                                       allocOp, offset, 1);
+                                                       allocOp, offset, blockN);
   return builder.create<ttg::MemDescReinterpretOp>(allocOp->getLoc(), tmemDesc,
                                                    subSlice);
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -1,3 +1,4 @@
+#include "TMEMUtils.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Pass/PassManager.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
@@ -190,6 +191,12 @@ void generate1DAllocations(OpBuilder &builder, Operation *producer) {
   }
   // Delete tmem.start
   producer->removeAttr("tmem.start");
+}
+
+ttg::MemDescReinterpretOp
+reinterpretTMEMBufferDroppingDim(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
+                                 size_t dim) {
+  return nullptr;
 }
 
 #define GEN_PASS_DEF_NVGPUTEST1DTMEMALLOC

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -167,11 +167,11 @@ void generate1DAllocations(OpBuilder &builder, Operation *producer,
   if (producerTMEMStart < allocOps.size()) {
     auto allocOp = allocOps[producerTMEMStart];
     auto allocShape = allocOp.getType().getShape();
-    if (allocShape[1] != 1) {
+    if (allocShape[allocShape.size() - 1] != 1) {
       builder.setInsertionPointAfter(allocOp);
       // Hardcode allocShape[0] / 2 for testing.
-      allocOpBuffer =
-          sliceAndReinterpretTMEMBuffer(builder, allocOp, allocShape[0] / 2, 1);
+      allocOpBuffer = sliceAndReinterpretTMEMBuffer(
+          builder, allocOp, allocShape[allocShape.size() - 2] / 2, 1);
     } else {
       allocOpBuffer = allocOp;
     }
@@ -199,11 +199,11 @@ sliceAndReinterpretTMEMBuffer(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
   auto shape = allocType.getShape();
   auto oldBlockN = shape[1];
   // TODO(njriasan): Support 1x128x128?
-  assert(shape.size() == 2 && "Invalid shape");
   assert(oldBlockN >= blockN && "Invalid blockN size");
   assert(oldBlockN % blockN == 0 && "Invalid blockN divisibility");
   assert((offset + blockN) <= oldBlockN && "Invalid offset");
-  auto tmemDesc = createTMEMDesc(builder, allocType, shape[0], 1);
+  auto tmemDesc =
+      createTMEMDesc(builder, allocType, shape[shape.size() - 2], 1);
   auto subSlice = builder.create<ttng::TMEMSubSliceOp>(allocOp->getLoc(),
                                                        allocOp, offset, blockN);
   return builder.create<ttg::MemDescReinterpretOp>(allocOp->getLoc(), tmemDesc,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -77,6 +77,9 @@ private:
     // Expand from 1D -> 2D
     auto oldRetType = getResultTensorType(producer, 1);
     builder.setInsertionPointAfter(producer);
+    // TODO(njriasan): This only works because
+    // producer->getResult(0) already has a ttg.slice attribute.
+    // We will probably need to update this to work more generally.
     auto expandDims = builder.create<tt::ExpandDimsOp>(
         producer->getLoc(), producer->getResult(0), 1);
     copyAttrs(producer, expandDims);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
@@ -8,11 +8,10 @@ namespace ttg = mlir::triton::gpu;
 namespace ttng = ::mlir::triton::nvidia_gpu;
 namespace mlir {
 // Generate code to reintepret the ttng::TMEMAllocOp by converting
-// the provided dimension to 1. For example, this could interpret
-// a [128, 128] TMEMAllocOp as [128, 1] with dim=1.
+// the N dimension to 1 at the specified offset.
 ttg::MemDescReinterpretOp
-reinterpretTMEMBufferDroppingDim(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
-                                 size_t dim);
+sliceAndReinterpretTMEMBuffer(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
+                              int offset);
 } // namespace mlir
 
 #endif // NV_DIALECT_HOPPER_TRANSFORMS_TMEMUTILS_H_

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
@@ -15,7 +15,7 @@ sliceAndReinterpretTMEMBuffer(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
 // Create a TMEM descriptor that is sufficient for the given
 // TMEM Allocation Operator.
 ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,
-                                size_t blockM, size_t blockN);
+                                int64_t blockM, int64_t blockN);
 
 } // namespace mlir
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
@@ -5,13 +5,13 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 namespace ttg = mlir::triton::gpu;
-namespace ttng = ::mlir::triton::nvidia_gpu;
 namespace mlir {
-// Generate code to reintepret the ttng::TMEMAllocOp by converting
+// Generate code to reintepret a TMEM buffer operation by converting
 // the N dimension to the given value that must be less the current size.
-ttg::MemDescReinterpretOp
-sliceAndReinterpretTMEMBuffer(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
-                              int offset, size_t blockN);
+ttg::MemDescReinterpretOp sliceAndReinterpretTMEMBuffer(OpBuilder &builder,
+                                                        Operation *allocOp,
+                                                        int offset,
+                                                        size_t blockN);
 // Create a TMEM descriptor that is sufficient for the given
 // TMEM Allocation Operator.
 ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
@@ -12,6 +12,11 @@ namespace mlir {
 ttg::MemDescReinterpretOp
 sliceAndReinterpretTMEMBuffer(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
                               int offset);
+// Create a TMEM descriptor that is sufficient for the given
+// TMEM Allocation Operator.
+ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,
+                                size_t blockM, size_t blockN);
+
 } // namespace mlir
 
 #endif // NV_DIALECT_HOPPER_TRANSFORMS_TMEMUTILS_H_

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
@@ -8,10 +8,10 @@ namespace ttg = mlir::triton::gpu;
 namespace ttng = ::mlir::triton::nvidia_gpu;
 namespace mlir {
 // Generate code to reintepret the ttng::TMEMAllocOp by converting
-// the N dimension to 1 at the specified offset.
+// the N dimension to the given value that must be less the current size.
 ttg::MemDescReinterpretOp
 sliceAndReinterpretTMEMBuffer(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
-                              int offset);
+                              int offset, size_t blockN);
 // Create a TMEM descriptor that is sufficient for the given
 // TMEM Allocation Operator.
 ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMUtils.h
@@ -1,0 +1,18 @@
+#ifndef NV_DIALECT_HOPPER_TRANSFORMS_TMEMUTILS_H_
+#define NV_DIALECT_HOPPER_TRANSFORMS_TMEMUTILS_H_
+
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+namespace ttg = mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace mlir {
+// Generate code to reintepret the ttng::TMEMAllocOp by converting
+// the provided dimension to 1. For example, this could interpret
+// a [128, 128] TMEMAllocOp as [128, 1] with dim=1.
+ttg::MemDescReinterpretOp
+reinterpretTMEMBufferDroppingDim(OpBuilder &builder, ttng::TMEMAllocOp allocOp,
+                                 size_t dim);
+} // namespace mlir
+
+#endif // NV_DIALECT_HOPPER_TRANSFORMS_TMEMUTILS_H_


### PR DESCRIPTION
Depends on #356. Extends the TMEM helper to actually match the OAI Gluon use case, which uses `ttg.memdesc_index`. This is the new alloc operation info:

```
%result, %token = ttng.tmem_alloc  : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
%mem_179 = ttg.memdesc_index %result[%c0_i32] {tmem.start_buffer = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 1x128x128>
```

which generates this IR for the reinterpret:

```
%1 = ttng.tmem_subslice %0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128>
%2 = ttg.memdesc_reinterpret %1 : !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>
```

This now exactly matches the example from the task.