### PR TITLE
[WIP] [AutoWS] Enable outer loop scheduling 

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.cpp
@@ -245,6 +245,16 @@ static std::optional<int> tryGetMaxStage(scf::ForOp &forOp) {
         .getValue()
         .getSExtValue();
   }
+  forOp.getBodyRegion().walk([&](scf::ForOp nestedFor) {
+    auto nestedMaxStage = tryGetMaxStage(nestedFor);
+    if (!nestedMaxStage.has_value())
+      return;
+    else if (!maxStage.has_value())
+      maxStage = nestedMaxStage.value();
+    else
+      maxStage = std::max(maxStage.value(), nestedMaxStage.value());
+  });
+
   return maxStage;
 }
 


### PR DESCRIPTION
Adds the initial logic to allow nested loop traversal with loop scheduling. This is currently only enabled for the tt.warp_specialize case to reuse an existing schedule. 

Example current output IR: [P1959941582](https://www.internalfb.com/phabricator/paste/view/P1959941582)