### PR TITLE
Show memory allocation details in IR

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h
@@ -12,6 +12,10 @@ namespace mlir::triton::gpu {
 void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
                                        ModuleAllocation &allocation);
 
+/// Add shared memory access annotations to all operations that use shared
+/// memory Only adds annotations when MLIR_ENABLE_DUMP=1 is set.
+void addSharedMemoryAnnotations(ModuleOp mod);
+
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_CONVERSION_TRITON_GPU_TO_LLVM_ALLOCATE_UTILITY_H_

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -1,6 +1,106 @@
 #include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
+#include "triton/Analysis/Allocation.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include <cstdlib>
+#include <string>
 
 namespace mlir::triton::gpu {
+
+// Helper function to compute allocation size from MemDescType
+inline size_t computeAllocationSize(MemDescType memdescTy) {
+  auto elemTy = memdescTy.getElementType();
+  auto shape = memdescTy.getShape();
+  size_t elemSize = elemTy.getIntOrFloatBitWidth() / 8;
+  size_t totalElements = 1;
+  for (auto dim : shape) {
+    totalElements *= dim;
+  }
+  return totalElements * elemSize;
+}
+
+// Helper function to add allocation information as IR annotations
+void addAllocationAnnotations(Operation *op) {
+  MLIRContext *ctx = op->getContext();
+  IntegerAttr offsetAttr;
+  MemDescType memdescTy;
+
+  // Try to get allocation.offset from the operation itself
+  if (auto attr = op->getAttrOfType<IntegerAttr>("allocation.offset")) {
+    offsetAttr = attr;
+    // Find MemDescType from result or operands
+    for (auto result : op->getResults()) {
+      if (auto ty = dyn_cast<MemDescType>(result.getType())) {
+        memdescTy = ty;
+        break;
+      }
+    }
+    if (!memdescTy) {
+      for (auto operand : op->getOperands()) {
+        if (auto ty = dyn_cast<MemDescType>(operand.getType())) {
+          memdescTy = ty;
+          break;
+        }
+      }
+    }
+  } else {
+    // Try to find it through operands
+    for (auto operand : op->getOperands()) {
+      if (auto definingOp = operand.getDefiningOp()) {
+        if (auto allocOp = dyn_cast<triton::gpu::LocalAllocOp>(definingOp)) {
+          if (auto attr =
+                  allocOp->getAttrOfType<IntegerAttr>("allocation.offset")) {
+            offsetAttr = attr;
+            memdescTy = cast<MemDescType>(allocOp.getType());
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (!offsetAttr || !memdescTy) {
+    return;
+  }
+
+  auto offset = offsetAttr.getInt();
+  size_t totalSize = computeAllocationSize(memdescTy);
+  auto elemTy = memdescTy.getElementType();
+  auto shape = memdescTy.getShape();
+  size_t elemSize = elemTy.getIntOrFloatBitWidth() / 8;
+  size_t totalElements = totalSize / elemSize;
+
+  // Add annotations
+  op->setAttr("shared_memory.access_offset",
+              IntegerAttr::get(IntegerType::get(ctx, 64), offset));
+  op->setAttr("shared_memory.access_size_bytes",
+              IntegerAttr::get(IntegerType::get(ctx, 64), totalSize));
+  op->setAttr("shared_memory.access_element_count",
+              IntegerAttr::get(IntegerType::get(ctx, 64), totalElements));
+  op->setAttr("shared_memory.access_element_size_bytes",
+              IntegerAttr::get(IntegerType::get(ctx, 32), elemSize));
+}
+
+// Function to add shared memory access annotations to all operations that use
+// shared memory
+void addSharedMemoryAnnotations(ModuleOp mod) {
+  // Check if MLIR_ENABLE_DUMP env is set to 1
+  static bool dumpEnabled = []() {
+    if (const char *env = std::getenv("MLIR_ENABLE_DUMP")) {
+      return std::string(env) == "1";
+    }
+    return false;
+  }();
+  if (!dumpEnabled) {
+    return;
+  }
+
+  mod.walk([&](Operation *op) {
+    if (isa<triton::gpu::LocalStoreOp, triton::gpu::LocalLoadOp,
+            triton::gpu::MemDescSubsliceOp, triton::gpu::MemDescIndexOp>(op)) {
+      addAllocationAnnotations(op);
+    }
+  });
+}
 
 void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
                                        ModuleAllocation &allocation) {

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -65,12 +65,6 @@ void addAllocationAnnotations(Operation *op) {
 
   auto offset = offsetAttr.getInt();
   size_t totalSize = computeAllocationSize(memdescTy);
-  auto elemTy = memdescTy.getElementType();
-  auto shape = memdescTy.getShape();
-  size_t elemSize = elemTy.getIntOrFloatBitWidth() / 8;
-  size_t totalElements = totalSize / elemSize;
-
-  // Add annotations
   op->setAttr("shared_memory.offset",
               IntegerAttr::get(IntegerType::get(ctx, 64), offset));
   op->setAttr("shared_memory.size_bytes",

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
@@ -36,6 +36,9 @@ struct AllocateSharedMemoryNv
         mod, mlir::triton::nvidia_gpu::getNvidiaAllocationAnalysisScratchSizeFn(
                  targetInfo));
     mlir::triton::gpu::attachAllocationSizeAndOffsetAttr(mod, allocation);
+
+    // Add shared memory annotations to operations that use shared memory
+    mlir::triton::gpu::addSharedMemoryAnnotations(mod);
   }
 };
 } // namespace


### PR DESCRIPTION
We often debug allocation issues (e.g., smem corruption) and barriers by looking at corresponding allocations in ttgir. This PR shows memory allocation details at the operations that use the allocation.
* The details include offset, size, element bytes+count;
* Currently tracks these operations: LocalStoreOp, LocalLoadOp, MemDescSubsliceOp, MemDescIndexOp;
* Only runs when MLIR_ENABLE_DUMP=1.

Example IR output for `MLIR_ENABLE_DUMP=1 TRITON_ALWAYS_COMPILE=1 python3 python/tutorials/06-fused-attention.py` (indented for readability) with autoWS:
```
%1 = ttg.memdesc_index %0[%c0_i32]
{shared_memory.element_count = 3 : i64,
 shared_memory.element_size_bytes = 8 : i32, 
 shared_memory.offset = 147712 : i64, 
 shared_memory.size_bytes = 24 : i64}
 : !ttg.memdesc<3x1xi64, #shared, #smem, mutable> -> 
!ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
```
without the changes:
```
%1 = ttg.memdesc_index %0[%c0_i32]
 : !ttg.memdesc<3x1xi64, #shared, #smem, mutable> ->
 !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
```

# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
