### PR TITLE
Move tlx.fence_async_shared before tlx.async_descriptor_store in test_tlx unit test

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1317,9 +1317,9 @@ def test_descriptor_load(device):
 
         tlx.async_descriptor_load(desc_in, buffer, [off_m, off_n], bar)
         tlx.barrier_wait(bar=bar, phase=0)
+        tlx.fence_async_shared()
         tlx.async_descriptor_store(desc_out, buffer, [off_m, off_n])
         tlx.async_descriptor_store_wait(0)
-        tlx.fence_async_shared()
 
     triton.set_allocator(alloc_fn)
     M, N = 128, 128


### PR DESCRIPTION
Summary:
Synced with htyu regarding this change.

**Context**
The `tlx.fence_async_shared` hints the compiler not to reorder shared
memory operations (e.g., `async_dot`) across this line. Without this, subsequent
operations (such as `async_descriptor_store`) may access buffers before they are
ready.

**Issue Illustration**
In D83073728, the `fence_async_shared` was placed after `async_descriptor_store`, 
causing it to access incomplete results from async_dot and leading to inaccuracies.

```
# mma
out = tlx.async_dot(buffer_x, z_smem)
out = tlx.async_dot_wait(tl.constexpr(0), out)

# store out tma result
tlx.local_store(out_smem, out.to(tlx.dtype_of(out_desc)))
tlx.async_descriptor_store(out_desc, out_smem, [row_offset, 0])
tlx.async_descriptor_store_wait(0)
tlx.fence_async_shared()
```
Placing the fence before async_descriptor_store resolves the issue.

**The Diff**
This change demonstrates the correct usage of TLX TMA store for future reference.

Differential Revision: D83119457


