### PR TITLE
[AutoWS] Enable loop scheduling on the inner of loop(s) of persistent FA after WS

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -20,6 +20,10 @@ void lowerLoops(ModuleOp moduleOp);
 
 bool hasGpuBarriers(scf::ForOp forOp);
 bool isSafeToPipeline(scf::ForOp forOp);
+// Do any preprocessing on the loop information for a given module.
+void doLoopSchedulePreprocessing(ModuleOp moduleOp, Builder &builder);
+// TODO: Remove me and move to pass structure.
+void scheduleLoops(ModuleOp moduleOp);
 llvm::MapVector<Operation *, std::pair<int, Operation *>>
 loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
                           triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -274,10 +274,9 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
     // If the `scf.if` op itself is a latency op, skip it.
     if (opLatency.contains(ifOp))
       continue;
-    // Ensure this does not create scheduling conflicts by ensuring the
-    // forward slice of the `scf.if` does not contain ops that are already
-    // scheduled, as this will cause the `scf.if` to be scheduled after its
-    // dependents.
+    // Ensure this does not create scheduling conflicts by ensuring the forward
+    // slice of the `scf.if` does not contain ops that are already scheduled, as
+    // this will cause the `scf.if` to be scheduled after its dependents.
     SetVector<Operation *> slice;
     getForwardSlice(ifOp, &slice);
     if (llvm::any_of(slice, [&](Operation *op) { return opToStage.count(op); }))
@@ -316,9 +315,9 @@ CoarseSchedule getInitialSchedule(scf::ForOp forOp,
                  ttng::WaitBarrierOp, ttng::ArriveBarrierOp>(op);
     };
 
-    // If there are no latency ops or all latency ops are in the same stage,
-    // we don't need to pipeline the loop. Return a new schedule with
-    // everything assigned to the same stage.
+    // If there are no latency ops or all latency ops are in the same stage, we
+    // don't need to pipeline the loop. Return a new schedule with everything
+    // assigned to the same stage.
     DenseSet<int> latencyStages;
     auto ops = forOp.getBody()->without_terminator();
     for (Operation &op : llvm::make_filter_range(ops, isLatencyOp)) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -4,7 +4,9 @@
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
@@ -132,6 +134,19 @@ public:
             << moduleOp << "\n\n\n";
       }
     }
+    triton::gpu::doLoopSchedulePreprocessing(moduleOp, builder);
+    if (dumpIntermediateSteps) {
+      llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
+                      "doLoopSchedulePreprocessing\n"
+                   << moduleOp << "\n\n\n";
+    }
+    triton::gpu::scheduleLoops(moduleOp);
+    if (dumpIntermediateSteps) {
+      llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
+                      "doLoopSchedule\n"
+                   << moduleOp << "\n\n\n";
+    }
+
     doTokenLowering(funcOp, numWarpGroups - 1);
     if (!ForBlackWell) {
       // Clear num_stages to disable SWP.


### PR DESCRIPTION
The existing structure of loop scheduling will fail to run on the second pass of any persistent kernels because it fails to meet the loop scheduling preconditions.

In particular, the loop scheduler requires the following details to update the schedule from the existing one:

1. It must be an inner loop
2. It must have the tt.warp_specialize attribute
3. It must have the tt.max_stage defined (indicates the scheduler already ran).

At this stage our outer loop satisfies condition 2 and the inner loop satisfies conditions 1 and 3. This adds a preprocessing step to update the inner loop to contain the `tt.warp_specialize` attribute so loop scheduling can proceed and adds loop scheduling to the main loop (before token lowering).

You can see the output of running `triton-opt --nvgpu-warp-specialization test/Hopper/WarpSpecialization/fa_code_partition.mlir` [here](https://www.internalfb.com/phabricator/paste/view/P1962287472). At this time it just takes the entirety of each inner loop and schedules it the same inner stage.

The next step will be to enable the actual pipelining to match our diagram.