### PR TITLE
[AutoWS] Make 1D TMEM logic robust for expand dims

### DIFF
--- a/test/Hopper/WarpSpecialization/1D_tmem.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem.mlir
@@ -288,3 +288,50 @@ module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scr
     tt.return
   }
 }
+
+
+// -----
+
+// CHECK the ability to handle generating
+// CHECK-LABEL: @_dummy_repro_expand_dims
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = true, elementBitWidth = 32, CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 520 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @_dummy_repro_expand_dims(%in_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %in_desc_0: i32, %in_desc_1: i64, %out_desc: !tt.tensordesc<tensor<128x1xf32, #shared1>>, %out_desc_2: i32, %out_desc_3: i32, %out_desc_4: i64, %out_desc_5: i64) attributes {noinline = false, ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32} {
+    %result, %token = ttng.tmem_alloc {tmem.start_buffer = 0 : i32}  : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    // CHECK: ttng.tmem_subslice
+    // CHECK: ttg.memdesc_reinterpret
+    %cst = arith.constant dense<3.000000e+00> : tensor<128xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %pid = tt.get_program_id x : i32
+    %alpha = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    %alpha_6 = ttg.local_alloc {allocation.offset = 512 : i32} : () -> !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.init_barrier %alpha_6, 1 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.barrier_expect %alpha_6, 512, %true : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %in_desc[%pid] %alpha, %alpha_6, %true : !tt.tensordesc<tensor<128xf32, #shared>>, !ttg.memdesc<1xi64, #shared2, #smem, mutable> -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    ttng.wait_barrier %alpha_6, %c0_i32 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    ttng.inval_barrier %alpha_6 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+    %alpha_7 = ttg.local_load %alpha : !ttg.memdesc<128xf32, #shared, #smem, mutable> -> tensor<128xf32, #blocked>
+    %alpha_i = arith.mulf %alpha_7, %cst : tensor<128xf32, #blocked>
+    // CHECK-NOT: tmem.start
+    %0 = ttg.convert_layout %alpha_i {tmem.start = 0 : i32, ttg.partition = 0 : i32} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    // CHECK: tt.expand_dims
+    // CHECK: ttng.tmem_store
+    // CHECK: ttng.tmem_load
+    // CHECK: tt.reshape
+    // CHECK: ttg.convert_layout
+    // CHECK: tt.expand_dims
+    %2 = ttg.local_alloc %alpha_i {allocation.offset = 0 : i32, ttg.partition = 1 : i32} : (tensor<128xf32, #blocked1>) -> !ttg.memdesc<128xf32, #shared1, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %out_desc[%pid] %2 : !tt.tensordesc<tensor<128xf32, #shared1>>, !ttg.memdesc<128xf32, #shared1, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/1D_tmem.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem.mlir
@@ -299,11 +299,10 @@ module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scr
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = true, elementBitWidth = 32, CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 520 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
-  tt.func public @_dummy_repro_expand_dims(%in_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %in_desc_0: i32, %in_desc_1: i64, %out_desc: !tt.tensordesc<tensor<128x1xf32, #shared1>>, %out_desc_2: i32, %out_desc_3: i32, %out_desc_4: i64, %out_desc_5: i64) attributes {noinline = false, ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32} {
+  tt.func public @_dummy_repro_expand_dims(%in_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %in_desc_0: i32, %in_desc_1: i64, %out_desc: !tt.tensordesc<tensor<128xf32, #shared>>, %out_desc_2: i32, %out_desc_3: i32, %out_desc_4: i64, %out_desc_5: i64) attributes {noinline = false, ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32} {
     %result, %token = ttng.tmem_alloc {tmem.start_buffer = 0 : i32}  : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     // CHECK: ttng.tmem_subslice
     // CHECK: ttg.memdesc_reinterpret
@@ -319,18 +318,18 @@ module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scr
     ttng.wait_barrier %alpha_6, %c0_i32 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
     ttng.inval_barrier %alpha_6 : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
     %alpha_7 = ttg.local_load %alpha : !ttg.memdesc<128xf32, #shared, #smem, mutable> -> tensor<128xf32, #blocked>
-    %alpha_i = arith.mulf %alpha_7, %cst : tensor<128xf32, #blocked>
     // CHECK-NOT: tmem.start
-    %0 = ttg.convert_layout %alpha_i {tmem.start = 0 : i32, ttg.partition = 0 : i32} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %alpha_i = arith.mulf %alpha_7, %cst {tmem.start = 0 : i32, ttg.partition = 0 : i32} : tensor<128xf32, #blocked>
+    // CHECK: ttg.convert_layout
     // CHECK: tt.expand_dims
     // CHECK: ttng.tmem_store
     // CHECK: ttng.tmem_load
     // CHECK: tt.reshape
     // CHECK: ttg.convert_layout
-    // CHECK: tt.expand_dims
-    %2 = ttg.local_alloc %alpha_i {allocation.offset = 0 : i32, ttg.partition = 1 : i32} : (tensor<128xf32, #blocked1>) -> !ttg.memdesc<128xf32, #shared1, #smem>
+    // CHECK: ttg.local_alloc
+    %2 = ttg.local_alloc %alpha_i {allocation.offset = 0 : i32, ttg.partition = 1 : i32} : (tensor<128xf32, #blocked>) -> !ttg.memdesc<128xf32, #shared, #smem>
     ttng.fence_async_shared {bCluster = false}
-    ttng.async_tma_copy_local_to_global %out_desc[%pid] %2 : !tt.tensordesc<tensor<128xf32, #shared1>>, !ttg.memdesc<128xf32, #shared1, #smem>
+    ttng.async_tma_copy_local_to_global %out_desc[%pid] %2 : !tt.tensordesc<tensor<128xf32, #shared>>, !ttg.memdesc<128xf32, #shared, #smem>
     ttng.async_tma_store_wait {pendings = 0 : i32}
     tt.return
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -81,11 +81,40 @@ private:
     // Expand from 1D -> 2D
     auto oldRetType = getResultTensorType(producer, 1);
     builder.setInsertionPointAfter(producer);
-    // TODO(njriasan): This only works because
-    // producer->getResult(0) already has a ttg.slice attribute.
-    // We will need to update this to work more generally.
-    auto expandDims = builder.create<tt::ExpandDimsOp>(
-        producer->getLoc(), producer->getResult(0), 1);
+    auto encoding = oldRetType.getEncoding();
+    Value expandDimsInput = producer->getResult(0);
+    unsigned axis = 1;
+    auto context = builder.getContext();
+    // Handle blocked encoding which isn't a slice attribute.
+    if (auto blockedEnc = dyn_cast<ttg::BlockedEncodingAttr>(encoding)) {
+      auto rank = oldRetType.getRank();
+      if (rank == 1) {
+        // create return encoding with rank 2
+        auto retSizePerThread = llvm::to_vector(blockedEnc.getSizePerThread());
+        retSizePerThread.insert(retSizePerThread.begin() + axis, 1);
+        auto retThreadsPerWarp = to_vector(blockedEnc.getThreadsPerWarp());
+        retThreadsPerWarp.insert(retThreadsPerWarp.begin() + axis, 1);
+        auto retWarpsPerCTA = to_vector(blockedEnc.getWarpsPerCTA());
+        retWarpsPerCTA.insert(retWarpsPerCTA.begin() + axis, 1);
+        auto retOrder = {axis, blockedEnc.getOrder()[0]};
+        auto argCTALayout = blockedEnc.getCTALayout();
+        auto retCTAsPerCGA = {argCTALayout.getCTAsPerCGA()[0], axis};
+        auto retCTASplitNum = {argCTALayout.getCTASplitNum()[0], axis};
+        auto retCTAOrder = {axis, argCTALayout.getCTAOrder()[0]};
+        auto retCTALayout = triton::gpu::CTALayoutAttr::get(
+            context, retCTAsPerCGA, retCTASplitNum, retCTAOrder);
+        blockedEnc = triton::gpu::BlockedEncodingAttr::get(
+            context, retSizePerThread, retThreadsPerWarp, retWarpsPerCTA,
+            retOrder, retCTALayout);
+      }
+      auto sliceEnc = ttg::SliceEncodingAttr::get(
+          builder.getContext(), oldRetType.getRank(), blockedEnc);
+      auto sliceType = oldRetType.cloneWithEncoding(sliceEnc);
+      expandDimsInput = builder.create<ttg::ConvertLayoutOp>(
+          expandDimsInput.getLoc(), sliceType, expandDimsInput);
+    }
+    auto expandDims = builder.create<tt::ExpandDimsOp>(producer->getLoc(),
+                                                       expandDimsInput, axis);
     copyAttrs(producer, expandDims);
     setExpandedInput(expandDims);
     Operation *allocOp;


### PR DESCRIPTION
The existing expand dims logic only works because the input was always feeding into another expandDims. To make this robust to other possible 1D changes (or slight variations in the IR where the exact TMEM channel is in a different location) this supports generating the expandDims with any blocked encoding.

Before the expand dims this generates this IR:
```
%7 = ttg.convert_layout %6 : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
```
which creates a new blocked layout and inserts the convert layout.