### PR TITLE
[TLX] Add two tutorials for persistent cooperative and pingpong gemm

### DIFF
--- a/third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py
+++ b/third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py
@@ -1,0 +1,316 @@
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from typing import Optional
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+M, N, K = (2176, 2176, 2176)
+
+
+def is_cuda():
+    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+
+
+def is_hip_cdna2():
+    target = triton.runtime.driver.active.get_current_target()
+    return target.backend == 'hip' and target.arch == 'gfx90a'
+
+
+def alloc_fn(size: int, align: int, stream: Optional[int]):
+    assert align == 128
+    assert stream == 0
+    return torch.empty(size, dtype=torch.int8, device=DEVICE)
+
+
+def matmul_tma_set_block_size_hook(nargs):
+    BLOCK_M = nargs["BM"]
+    BLOCK_N = nargs["BN"]
+    BLOCK_K = nargs["BK"]
+    NUM_MMA_GROUPS = nargs["NUM_MMA_GROUPS"]
+    BLOCK_M_SPLIT = BLOCK_M // NUM_MMA_GROUPS
+    nargs["a_desc"].block_shape = [BLOCK_M_SPLIT, BLOCK_K]
+    nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N]
+    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", False)
+    if EPILOGUE_SUBTILE:
+        nargs["c_desc"].block_shape = [BLOCK_M_SPLIT, BLOCK_N // 2]
+    else:
+        nargs["c_desc"].block_shape = [BLOCK_M_SPLIT, BLOCK_N]
+
+
+
+def matmul_get_configs():
+    return [
+        triton.Config({'BM': BM, 'BN': BN, "BK": BK, "GROUP_SIZE_M": 8, "NUM_STAGES": num_stage,
+                "NUM_MMA_WARPS": 8,
+                "NUM_MMA_GROUPS": 2,
+                "EPILOGUE_SUBTILE": True,}, 
+                      num_stages=0, num_warps=4, pre_hook=matmul_tma_set_block_size_hook) \
+        for BM in [256] \
+        for BN in [128] \
+        for BK in [64] \
+        for num_stage in [3, 4]
+    ]
+
+@triton.autotune(
+    # Autotune configs can be reused or adapted
+    configs=matmul_get_configs(),
+    key=["M", "N", "K"],
+    use_cuda_graph=True,
+)
+@triton.jit
+def matmul_kernel_tlx_ws_persistent(
+    a_desc, b_desc, c_desc,
+    M, N, K,
+    NUM_SMS: tl.constexpr, 
+    BM: tl.constexpr,
+    BN: tl.constexpr,
+    BK: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    NUM_MMA_WARPS: tl.constexpr,
+    NUM_MMA_GROUPS: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+):
+    BLOCK_M_SPLIT: tl.constexpr = BM // NUM_MMA_GROUPS
+
+    a = tlx.local_alloc((BLOCK_M_SPLIT, BK), tlx.dtype_of(a_desc), NUM_STAGES * NUM_MMA_GROUPS)
+    b = tlx.local_alloc((BK, BN), tlx.dtype_of(b_desc), NUM_STAGES)
+    bars_empty_a = tlx.alloc_barriers(num_barriers=NUM_STAGES * NUM_MMA_GROUPS, arrive_count=1)
+    bars_full_a = tlx.alloc_barriers(num_barriers=NUM_STAGES * NUM_MMA_GROUPS, arrive_count=1)
+    bars_empty_b = tlx.alloc_barriers(num_barriers=NUM_STAGES, arrive_count=NUM_MMA_GROUPS)
+    bars_full_b = tlx.alloc_barriers(num_barriers=NUM_STAGES, arrive_count=1)
+
+    with tlx.async_tasks():
+        # Producer (async load)
+        with tlx.async_task("default"):
+            start_pid = tl.program_id(axis=0)
+            num_pid_m = tl.cdiv(M, BM)
+            num_pid_n = tl.cdiv(N, BN)
+            num_tiles = num_pid_m * num_pid_n
+            num_pid_in_group = GROUP_SIZE_M * num_pid_n
+            
+            p = 1
+            buf = 0
+            
+            for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * GROUP_SIZE_M
+                group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+                pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+                pid_n = (tile_id % num_pid_in_group) // group_size_m
+                
+                offset_am = pid_m * BM
+                offset_bn = pid_n * BN
+
+                for k in range(0, tl.cdiv(K, BK)):
+                    offset_k = k * BK
+                    
+                    # Async load to a[buf]
+                    empty_a_1st = tlx.local_view(bars_empty_a, buf)
+                    full_a_1st = tlx.local_view(bars_full_a, buf)
+                    tlx.barrier_wait(bar=empty_a_1st, phase=p)
+                    tlx.barrier_expect_bytes(full_a_1st, BLOCK_M_SPLIT * BK * 2)
+                    data_a_1st = tlx.local_view(a, buf)
+                    tlx.async_descriptor_load(a_desc, data_a_1st, [offset_am, offset_k], full_a_1st)
+
+                    # Async load to b[buf]
+                    empty_b = tlx.local_view(bars_empty_b, buf)
+                    full_b = tlx.local_view(bars_full_b, buf)
+                    tlx.barrier_wait(bar=empty_b, phase=p)
+                    tlx.barrier_expect_bytes(full_b, BN * BK * 2)
+                    data_b = tlx.local_view(b, buf)
+                    tlx.async_descriptor_load(b_desc, data_b, [offset_k, offset_bn], full_b)
+
+                    # Async load to a[buf+NUM_STAGES]
+                    empty_a_2nd = tlx.local_view(bars_empty_a, buf + NUM_STAGES)
+                    full_a_2nd = tlx.local_view(bars_full_a, buf + NUM_STAGES)
+                    tlx.barrier_wait(bar=empty_a_2nd, phase=p)
+                    tlx.barrier_expect_bytes(bar=full_a_2nd, size=BLOCK_M_SPLIT * BK * 2)
+                    data_a_2nd = tlx.local_view(a, buf + NUM_STAGES)
+                    tlx.async_descriptor_load(a_desc, data_a_2nd, [offset_am + BLOCK_M_SPLIT, offset_k], full_a_2nd)
+
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+        # Consumers (wgmma + async store)
+        with tlx.async_task(num_warps=4, replicate=2, registers=232):
+            start_pid = tl.program_id(axis=0)
+            num_pid_m = tl.cdiv(M, BM)
+            num_pid_n = tl.cdiv(N, BN)
+            num_tiles = num_pid_m * num_pid_n
+            num_pid_in_group = GROUP_SIZE_M * num_pid_n
+            cid: tl.constexpr = tlx.async_task_replica_id()
+
+            p = 0
+            buf = 0
+            
+            for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * GROUP_SIZE_M
+                group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+                pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+                pid_n = (tile_id % num_pid_in_group) // group_size_m
+                
+                offset_am = pid_m * BM
+                offset_bn = pid_n * BN
+
+                acc = tl.zeros([BM // 2, BN], dtype=tl.float32)
+
+                last_buf = buf
+                full_a = tlx.local_view(bars_full_a, buf + NUM_STAGES * tlx.async_task_replica_id())
+                full_b = tlx.local_view(bars_full_b, buf)
+                tlx.barrier_wait(bar=full_a, phase=p)
+                tlx.barrier_wait(bar=full_b, phase=p)
+
+                data_a = tlx.local_view(a, buf + NUM_STAGES * tlx.async_task_replica_id())
+                data_b = tlx.local_view(b, buf)
+
+                acc = tlx.async_dot(data_a, data_b, acc)
+
+                p = p ^ (buf == (NUM_STAGES - 1))
+                buf = (buf + 1) % NUM_STAGES
+
+                for k in range(1, tl.cdiv(K, BK)):
+                    
+                    full_a = tlx.local_view(bars_full_a, buf + NUM_STAGES * tlx.async_task_replica_id())
+                    full_b = tlx.local_view(bars_full_b, buf)
+                    tlx.barrier_wait(bar=full_a, phase=p)
+                    tlx.barrier_wait(bar=full_b, phase=p)
+
+                    data_a = tlx.local_view(a, buf + NUM_STAGES * tlx.async_task_replica_id())
+                    data_b = tlx.local_view(b, buf)
+
+                    acc = tlx.async_dot(data_a, data_b, acc)
+                    acc = tlx.async_dot_wait(1, acc)
+
+                    empty_a = tlx.local_view(bars_empty_a, last_buf + NUM_STAGES * tlx.async_task_replica_id())
+                    empty_b = tlx.local_view(bars_empty_b, last_buf)
+                    tlx.barrier_arrive(empty_a)
+                    tlx.barrier_arrive(empty_b)
+
+                    last_buf = buf
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+                offset_cm = offset_am + BLOCK_M_SPLIT * tlx.async_task_replica_id()
+
+                acc = tlx.async_dot_wait(0, acc)
+                empty_a = tlx.local_view(bars_empty_a, last_buf + NUM_STAGES * tlx.async_task_replica_id())
+                empty_b = tlx.local_view(bars_empty_b, last_buf)
+                tlx.barrier_arrive(empty_a)
+                tlx.barrier_arrive(empty_b)
+
+                if EPILOGUE_SUBTILE:
+                    acc = tl.reshape(acc, (BLOCK_M_SPLIT, 2, BN // 2))
+                    acc = tl.permute(acc, (0, 2, 1))
+                    acc0, acc1 = tl.split(acc)
+                    c0 = acc0.to(tlx.dtype_of(c_desc))
+                    c_desc.store([offset_cm, offset_bn], c0)
+                    c1 = acc1.to(tlx.dtype_of(c_desc))
+                    c_desc.store([offset_cm, offset_bn + BN // 2], c1)
+                else:
+                    c_desc.store([offset_cm, offset_bn], acc.to(tlx.dtype_of(c_desc)))
+
+def matmul_tlx_ws_persistent(a, b):
+    # Check constraints.
+    assert a.shape[1] == b.shape[0], "Illegal dimensions of input operands"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+
+    (M, N, K) = (a.shape[0], b.shape[1], a.shape[1])
+    c = torch.zeros((M, N), dtype=torch.float16, device=DEVICE)
+
+    NUM_SMS = torch.cuda.get_device_properties(DEVICE).multi_processor_count
+
+    dummy_block = [1, 1]
+    desc_in_1 = TensorDescriptor(a, shape=[M, K], strides=[K, 1], block_shape=dummy_block)
+    desc_in_2 = TensorDescriptor(b, shape=[K, N], strides=[N, 1], block_shape=dummy_block)
+    desc_out = TensorDescriptor(c, shape=[M, N], strides=[N, 1], block_shape=dummy_block)
+
+    def grid(META):
+        num_m_blocks = triton.cdiv(M, META['BM'])
+        num_n_blocks = triton.cdiv(N, META['BN'])
+        total_blocks = num_m_blocks * num_n_blocks
+        return (min(NUM_SMS, total_blocks),)
+
+    matmul_kernel_tlx_ws_persistent[grid](
+        desc_in_1, desc_in_2, desc_out,
+        M, N, K,
+        NUM_SMS=NUM_SMS, 
+    )
+    return c
+
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability()[0] != 9,
+    reason="Requires Hopper GPU",
+)
+def test_op():
+    triton.set_allocator(alloc_fn)
+
+    torch.manual_seed(0)
+
+    a = torch.randn((M, K), dtype=torch.float16, device=DEVICE)
+    b = torch.randn((K, N), dtype=torch.float16, device=DEVICE)
+
+    rtol = 1e-2 if is_hip_cdna2() else 0
+    output = matmul_tlx_ws_persistent(a, b,)
+    output_ref = torch.matmul(a, b)
+
+    torch.allclose(output, output_ref, atol=1e-2, rtol=rtol)
+    
+    print(f"Test passed!")
+
+TORCH_HAS_FP8 = False
+
+ref_lib = 'cuBLAS' if is_cuda() else 'rocBLAS'
+
+# Benchmarking
+configs = []
+for fp8_inputs in [False, True]:
+    if fp8_inputs and (not TORCH_HAS_FP8 or not is_cuda()):
+        continue
+    configs.append(
+        triton.testing.Benchmark(
+            x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
+            x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
+            line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
+            # Possible values for `line_arg`
+            # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
+            line_vals=["triton"] if fp8_inputs else [ref_lib.lower(), "triton"],  # Label name for the lines
+            line_names=["Triton"] if fp8_inputs else [ref_lib, "Triton"],  # Line styles
+            styles=[("green", "-"), ("blue", "-")],
+            ylabel="TFLOPS",  # Label name for the y-axis
+            plot_name="matmul-performance-" +
+            ("fp16" if not fp8_inputs else "fp8"),  # Name for the plot, used also as a file name for saving the plot.
+            args={"fp8_inputs": fp8_inputs},
+        ))
+
+@triton.testing.perf_report(configs)
+def benchmark(M, N, K, provider, fp8_inputs):
+    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+    if TORCH_HAS_FP8 and fp8_inputs:
+        a = a.to(torch.float8_e5m2)
+        b = b.T
+        b = b.to(torch.float8_e5m2)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == ref_lib.lower():
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles, warmup=200, rep=200)
+    if provider == 'triton':
+        _ = matmul_tlx_ws_persistent(a, b) # run to compile
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul_tlx_ws_persistent(a, b), quantiles=quantiles, warmup=200, rep=200)
+    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+if __name__ == "__main__":
+    test_op()
+    if is_cuda() and torch.cuda.get_device_capability()[0] == 9:
+        print("Running benchmarks...")
+        benchmark.run(show_plots=True, print_data=True, diff_col=True)
+    else:
+        print("Skipping benchmarks, no Hopper GPU found.")

--- a/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong,py
+++ b/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong,py
@@ -1,0 +1,314 @@
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from typing import Optional
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+M, N, K = (8192, 8192, 8192)# (2176, 2176, 2176)
+
+
+def is_cuda():
+    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+
+
+def is_hip_cdna2():
+    target = triton.runtime.driver.active.get_current_target()
+    return target.backend == 'hip' and target.arch == 'gfx90a'
+
+
+def alloc_fn(size: int, align: int, stream: Optional[int]):
+    assert align == 128
+    assert stream == 0
+    return torch.empty(size, dtype=torch.int8, device=DEVICE)
+
+
+def matmul_tma_set_block_size_hook(nargs):
+    BLOCK_M = nargs["BM"]
+    BLOCK_N = nargs["BN"]
+    BLOCK_K = nargs["BK"]
+    NUM_MMA_GROUPS = nargs["NUM_MMA_GROUPS"]
+    nargs["a_desc"].block_shape = [BLOCK_M, BLOCK_K]
+    nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N]
+    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", False)
+    if EPILOGUE_SUBTILE:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N // 2]
+    else:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N]
+
+
+
+def matmul_get_configs():
+    return [
+        triton.Config({'BM': BM, 'BN': BN, "BK": BK, "GROUP_SIZE_M": 8, "NUM_STAGES": num_stage,
+                "NUM_MMA_WARPS": 8,
+                "NUM_MMA_GROUPS": 2,
+                "EPILOGUE_SUBTILE": True,}, 
+                      num_stages=0, num_warps=4, pre_hook=matmul_tma_set_block_size_hook) \
+        for BM in [128] \
+        for BN in [128] \
+        for BK in [64] \
+        for num_stage in [4, 5, 6]
+    ]
+
+@triton.autotune(
+    # Autotune configs can be reused or adapted
+    configs=matmul_get_configs(),
+    key=["M", "N", "K"],
+    use_cuda_graph=True,
+)
+@triton.jit
+def matmul_kernel_tlx_ws_persistent(
+    a_desc, b_desc, c_desc,
+    M, N, K,
+    NUM_SMS: tl.constexpr,
+    BM: tl.constexpr,
+    BN: tl.constexpr,
+    BK: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    NUM_MMA_WARPS: tl.constexpr,
+    NUM_MMA_GROUPS: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+):
+    a = tlx.local_alloc((BM, BK), tlx.dtype_of(a_desc), NUM_STAGES)
+    b = tlx.local_alloc((BK, BN), tlx.dtype_of(b_desc), NUM_STAGES)
+
+    # Mainloop Barriers: For producer-consumer synchronization on A and B buffers.
+    # The producer waits on empty, consumers wait on full.
+    mainloop_empty_bar = tlx.alloc_barriers(num_barriers=NUM_STAGES, arrive_count=1)
+    mainloop_full_bar = tlx.alloc_barriers(num_barriers=NUM_STAGES, arrive_count=1)
+
+    pingpong_mma_bar = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    pingpong_epi_bar = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    with tlx.async_tasks():
+        # Producer (async load)
+        with tlx.async_task("default"):
+            start_pid = tl.program_id(axis=0)
+            num_pid_m = tl.cdiv(M, BM)
+            num_pid_n = tl.cdiv(N, BN)
+            num_tiles = num_pid_m * num_pid_n
+            num_pid_in_group = GROUP_SIZE_M * num_pid_n
+            
+            p = 1
+            buf = 0
+            
+            for tile_id in range(start_pid, num_tiles, NUM_SMS):
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * GROUP_SIZE_M
+                group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+                pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+                pid_n = (tile_id % num_pid_in_group) // group_size_m
+                
+                offset_am = pid_m * BM
+                offset_bn = pid_n * BN
+
+                for k in range(0, tl.cdiv(K, BK)):
+                    offset_k = k * BK
+                    
+                    # Async load to a[buf] and b[buf]
+                    empty = tlx.local_view(mainloop_empty_bar, buf)
+                    full = tlx.local_view(mainloop_full_bar, buf)
+                    tlx.barrier_wait(bar=empty, phase=p)
+                    tlx.barrier_expect_bytes(full, BM * BK * 2 + BK * BN * 2) # a and b
+                    data_a = tlx.local_view(a, buf)
+                    tlx.async_descriptor_load(a_desc, data_a, [offset_am, offset_k], full)
+                    data_b = tlx.local_view(b, buf)
+                    tlx.async_descriptor_load(b_desc, data_b, [offset_k, offset_bn], full)
+
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+        # Consumers (wgmma + async store)
+        with tlx.async_task(num_warps=4, replicate=2, registers=232):
+            cid: tl.constexpr = tlx.async_task_replica_id()
+            start_pid = tl.program_id(axis=0) + cid * NUM_SMS
+            num_pid_m = tl.cdiv(M, BM)
+            num_pid_n = tl.cdiv(N, BN)
+            num_tiles = num_pid_m * num_pid_n
+            num_pid_in_group = GROUP_SIZE_M * num_pid_n
+            k_tiles = tl.cdiv(K, BK)
+
+            tile_rank = cid # cta0: 0, 2, 4 cta1; 1, 3, 5
+            phase_mma = 1 - cid
+            phase_epi = 1 - cid
+
+            mma_bar = tlx.local_view(pingpong_mma_bar, 0)
+            epi_bar = tlx.local_view(pingpong_epi_bar, 0)
+
+            for tile_id in range(start_pid, num_tiles, NUM_SMS * 2):
+                total_k_offset = tile_rank * k_tiles
+                tile_rank += 2
+                buf = total_k_offset % NUM_STAGES
+                p = (total_k_offset // NUM_STAGES) % 2
+
+                last_buf = buf
+
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * GROUP_SIZE_M
+                group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+                pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+                pid_n = (tile_id % num_pid_in_group) // group_size_m
+                
+                offset_am = pid_m * BM
+                offset_bn = pid_n * BN
+
+                acc = tl.zeros([BM, BN], dtype=tl.float32)
+
+                # wait ping-pong barrier
+                tlx.barrier_wait(bar=mma_bar, phase=phase_mma)
+
+                # round 0
+                full = tlx.local_view(mainloop_full_bar, buf)
+                tlx.barrier_wait(bar=full, phase=p)
+
+                data_a = tlx.local_view(a, buf)
+                data_b = tlx.local_view(b, buf)
+
+                acc = tlx.async_dot(data_a, data_b, acc)
+
+                p = p ^ (buf == (NUM_STAGES - 1))
+                buf = (buf + 1) % NUM_STAGES
+
+                for k in range(1, k_tiles):                    
+                    full = tlx.local_view(mainloop_full_bar, buf)
+                    tlx.barrier_wait(bar=full, phase=p)
+
+                    data_a = tlx.local_view(a, buf)
+                    data_b = tlx.local_view(b, buf)
+
+                    acc = tlx.async_dot(data_a, data_b, acc)
+
+                    acc = tlx.async_dot_wait(1, acc) # wait for last round
+
+                    empty = tlx.local_view(mainloop_empty_bar, last_buf)
+                    tlx.barrier_arrive(empty)
+
+                    last_buf = buf
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+                tlx.barrier_arrive(mma_bar) # release mma bar
+                acc = tlx.async_dot_wait(0, acc) # wait for last round
+                empty = tlx.local_view(mainloop_empty_bar, last_buf)
+                tlx.barrier_arrive(empty)
+
+                tlx.barrier_wait(bar=epi_bar, phase=phase_epi)
+
+                offset_cm = offset_am
+                if EPILOGUE_SUBTILE:
+                    acc = tl.reshape(acc, (BM, 2, BN // 2))
+                    acc = tl.permute(acc, (0, 2, 1))
+                    acc0, acc1 = tl.split(acc)
+                    c0 = acc0.to(tlx.dtype_of(c_desc))
+                    c_desc.store([offset_cm, offset_bn], c0)
+                    c1 = acc1.to(tlx.dtype_of(c_desc))
+                    c_desc.store([offset_cm, offset_bn + BN // 2], c1)
+                else:
+                    c_desc.store([offset_cm, offset_bn], acc.to(tlx.dtype_of(c_desc)))
+
+                tlx.barrier_arrive(epi_bar)
+
+def matmul_tlx_ws_persistent(a, b, profile=False):
+    # Check constraints.
+    assert a.shape[1] == b.shape[0], "Illegal dimensions of input operands"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+
+    (M, N, K) = (a.shape[0], b.shape[1], a.shape[1])
+    c = torch.zeros((M, N), dtype=torch.float16, device=DEVICE)
+
+    NUM_SMS = torch.cuda.get_device_properties(DEVICE).multi_processor_count
+
+    dummy_block = [1, 1]
+    desc_in_1 = TensorDescriptor(a, shape=[M, K], strides=[K, 1], block_shape=dummy_block)
+    desc_in_2 = TensorDescriptor(b, shape=[K, N], strides=[N, 1], block_shape=dummy_block)
+    desc_out = TensorDescriptor(c, shape=[M, N], strides=[N, 1], block_shape=dummy_block)
+
+    def grid(META):
+        num_m_blocks = triton.cdiv(M, META['BM'])
+        num_n_blocks = triton.cdiv(N, META['BN'])
+        total_blocks = num_m_blocks * num_n_blocks
+        return (min(NUM_SMS, total_blocks),)
+
+    matmul_kernel_tlx_ws_persistent[grid](
+        desc_in_1, desc_in_2, desc_out,
+        M, N, K,
+        NUM_SMS=NUM_SMS,
+    )
+    return c
+
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability()[0] != 9,
+    reason="Requires Hopper GPU",
+)
+def test_op():
+    triton.set_allocator(alloc_fn)
+
+    torch.manual_seed(0)
+
+    a = torch.randn((M, K), dtype=torch.float16, device=DEVICE)
+    b = torch.randn((K, N), dtype=torch.float16, device=DEVICE)
+
+    rtol = 1e-2 if is_hip_cdna2() else 0
+    output = matmul_tlx_ws_persistent(a, b,)
+    output_ref = torch.matmul(a, b)
+
+    torch.allclose(output, output_ref, atol=1e-2, rtol=rtol)
+
+    output = matmul_tlx_ws_persistent(a, b, True)
+    
+    print(f"Test passed!")
+
+TORCH_HAS_FP8 = False
+
+ref_lib = 'cuBLAS' if is_cuda() else 'rocBLAS'
+
+# Benchmarking
+configs = []
+for fp8_inputs in [False, True]:
+    if fp8_inputs and (not TORCH_HAS_FP8 or not is_cuda()):
+        continue
+    configs.append(
+        triton.testing.Benchmark(
+            x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
+            x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
+            line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
+            # Possible values for `line_arg`
+            # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
+            line_vals=["triton"] if fp8_inputs else [ref_lib.lower(), "triton"],  # Label name for the lines
+            line_names=["Triton"] if fp8_inputs else [ref_lib, "Triton"],  # Line styles
+            styles=[("green", "-"), ("blue", "-")],
+            ylabel="TFLOPS",  # Label name for the y-axis
+            plot_name="matmul-performance-" +
+            ("fp16" if not fp8_inputs else "fp8"),  # Name for the plot, used also as a file name for saving the plot.
+            args={"fp8_inputs": fp8_inputs},
+        ))
+
+@triton.testing.perf_report(configs)
+def benchmark(M, N, K, provider, fp8_inputs):
+    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+    if TORCH_HAS_FP8 and fp8_inputs:
+        a = a.to(torch.float8_e5m2)
+        b = b.T
+        b = b.to(torch.float8_e5m2)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == ref_lib.lower():
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles, warmup=200, rep=200)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul_tlx_ws_persistent(a, b), quantiles=quantiles, warmup=200, rep=200)
+    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    return perf(ms), perf(max_ms), perf(min_ms)
+
+
+if __name__ == "__main__":
+    test_op()
+    if is_cuda() and torch.cuda.get_device_capability()[0] == 9:
+        print("Running benchmarks...")
+        benchmark.run(show_plots=True, print_data=True, diff_col=True)
+    else:
+        print("Skipping benchmarks, no Hopper GPU found.")

--- a/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong,py
+++ b/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong,py
@@ -47,12 +47,13 @@ def matmul_get_configs():
         triton.Config({'BM': BM, 'BN': BN, "BK": BK, "GROUP_SIZE_M": 8, "NUM_STAGES": num_stage,
                 "NUM_MMA_WARPS": 8,
                 "NUM_MMA_GROUPS": 2,
-                "EPILOGUE_SUBTILE": True,}, 
+                "EPILOGUE_SUBTILE": True, "USE_NAMED_BARRIER": named_barrier},
                       num_stages=0, num_warps=4, pre_hook=matmul_tma_set_block_size_hook) \
         for BM in [128] \
         for BN in [128] \
         for BK in [64] \
-        for num_stage in [4, 5, 6]
+        for num_stage in [6] \
+        for named_barrier in [True, False]
     ]
 
 @triton.autotune(
@@ -74,6 +75,7 @@ def matmul_kernel_tlx_ws_persistent(
     NUM_MMA_WARPS: tl.constexpr,
     NUM_MMA_GROUPS: tl.constexpr,
     EPILOGUE_SUBTILE: tl.constexpr,
+    USE_NAMED_BARRIER: tl.constexpr,
 ):
     a = tlx.local_alloc((BM, BK), tlx.dtype_of(a_desc), NUM_STAGES)
     b = tlx.local_alloc((BK, BN), tlx.dtype_of(b_desc), NUM_STAGES)
@@ -93,23 +95,23 @@ def matmul_kernel_tlx_ws_persistent(
             num_pid_n = tl.cdiv(N, BN)
             num_tiles = num_pid_m * num_pid_n
             num_pid_in_group = GROUP_SIZE_M * num_pid_n
-            
+
             p = 1
             buf = 0
-            
+
             for tile_id in range(start_pid, num_tiles, NUM_SMS):
                 group_id = tile_id // num_pid_in_group
                 first_pid_m = group_id * GROUP_SIZE_M
                 group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
                 pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
                 pid_n = (tile_id % num_pid_in_group) // group_size_m
-                
+
                 offset_am = pid_m * BM
                 offset_bn = pid_n * BN
 
                 for k in range(0, tl.cdiv(K, BK)):
                     offset_k = k * BK
-                    
+
                     # Async load to a[buf] and b[buf]
                     empty = tlx.local_view(mainloop_empty_bar, buf)
                     full = tlx.local_view(mainloop_full_bar, buf)
@@ -140,6 +142,10 @@ def matmul_kernel_tlx_ws_persistent(
             mma_bar = tlx.local_view(pingpong_mma_bar, 0)
             epi_bar = tlx.local_view(pingpong_epi_bar, 0)
 
+            if cid == 1 and USE_NAMED_BARRIER:
+                # Consumer 1 arrives at barrier 9 to unblock Consumer 0 at the beginning.
+                tlx.named_barrier_arrive(9, 256)
+
             for tile_id in range(start_pid, num_tiles, NUM_SMS * 2):
                 total_k_offset = tile_rank * k_tiles
                 tile_rank += 2
@@ -153,14 +159,20 @@ def matmul_kernel_tlx_ws_persistent(
                 group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
                 pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
                 pid_n = (tile_id % num_pid_in_group) // group_size_m
-                
+
                 offset_am = pid_m * BM
                 offset_bn = pid_n * BN
 
                 acc = tl.zeros([BM, BN], dtype=tl.float32)
 
                 # wait ping-pong barrier
-                tlx.barrier_wait(bar=mma_bar, phase=phase_mma)
+                if USE_NAMED_BARRIER:
+                    if cid == 0:
+                        tlx.named_barrier_wait(9, 256)
+                    else:
+                        tlx.named_barrier_wait(10, 256)
+                else:
+                    tlx.barrier_wait(bar=mma_bar, phase=phase_mma)
 
                 # round 0
                 full = tlx.local_view(mainloop_full_bar, buf)
@@ -174,7 +186,7 @@ def matmul_kernel_tlx_ws_persistent(
                 p = p ^ (buf == (NUM_STAGES - 1))
                 buf = (buf + 1) % NUM_STAGES
 
-                for k in range(1, k_tiles):                    
+                for k in range(1, k_tiles):
                     full = tlx.local_view(mainloop_full_bar, buf)
                     tlx.barrier_wait(bar=full, phase=p)
 
@@ -192,12 +204,22 @@ def matmul_kernel_tlx_ws_persistent(
                     p = p ^ (buf == (NUM_STAGES - 1))
                     buf = (buf + 1) % NUM_STAGES
 
-                tlx.barrier_arrive(mma_bar) # release mma bar
+                if USE_NAMED_BARRIER:
+                    if cid == 0:
+                        # After issuing async_dot, Consumer 0 signals barrier 10 to unblock Consumer 1.
+                        tlx.named_barrier_arrive(10, 256)
+                    else:
+                        # After issuing async_dot, Consumer 1 signals barrier 9 to unblock Consumer 0.
+                        tlx.named_barrier_arrive(9, 256)
+                else:
+                    tlx.barrier_arrive(mma_bar) # release mma bar
+
                 acc = tlx.async_dot_wait(0, acc) # wait for last round
                 empty = tlx.local_view(mainloop_empty_bar, last_buf)
                 tlx.barrier_arrive(empty)
 
-                tlx.barrier_wait(bar=epi_bar, phase=phase_epi)
+                if not USE_NAMED_BARRIER:
+                    tlx.barrier_wait(bar=epi_bar, phase=phase_epi)
 
                 offset_cm = offset_am
                 if EPILOGUE_SUBTILE:
@@ -211,7 +233,8 @@ def matmul_kernel_tlx_ws_persistent(
                 else:
                     c_desc.store([offset_cm, offset_bn], acc.to(tlx.dtype_of(c_desc)))
 
-                tlx.barrier_arrive(epi_bar)
+                if not USE_NAMED_BARRIER:
+                    tlx.barrier_arrive(epi_bar)
 
 def matmul_tlx_ws_persistent(a, b, profile=False):
     # Check constraints.
@@ -260,7 +283,7 @@ def test_op():
     torch.allclose(output, output_ref, atol=1e-2, rtol=rtol)
 
     output = matmul_tlx_ws_persistent(a, b, True)
-    
+
     print(f"Test passed!")
 
 TORCH_HAS_FP8 = False


### PR DESCRIPTION
# Description

This PR introduces two new tutorials for the TLX extension, demonstrating advanced techniques for structuring high-performance GEMM kernels:

1.  **Persistent Cooperative GEMM**: This tutorial demonstrates a cooperative computing pattern where two consumer warp groups collaborate to process a **single GEMM tile simultaneously**. This approach is designed to maximize local data reuse and improve register resource utilization.

2.  **Ping-Pong GEMM**: This tutorial illustrates a software pipelining strategy that interleaves the work of two consumer warp groups across **different GEMM tiles**. It shows how one warp group can execute the main MMA (Matrix Multiply-Accumulate) loop on the current tile while the other group simultaneously processes the epilogue for the previously computed tile. This ping-pong mechanism effectively hides the latency of the epilogue.

These hands-on tutorials provide concrete examples of sophisticated kernel design patterns, enabling advanced users to better optimize their applications with TLX.

# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it only adds some tutorials.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
