### PR TITLE
[autoWS] Use mma layout for buffers for TMA store via convert_layout

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1035,6 +1035,12 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
     builder.setAsyncTaskIdsFromOp(srcOp);
     bool requireMMASharedEncoding =
         llvm::any_of(actualConsumers, [](Operation *op) {
+          // convert_layout
+          if (isa<ttg::ConvertLayoutOp>(op)) {
+            for (auto *user : op->getUsers())
+              if (isa<tt::DescriptorStoreOp>(user))
+                return true;
+          }
           return isa<mlir::triton::DotOpInterface, tt::DescriptorStoreOp>(op);
         });
 


### PR DESCRIPTION
Summary: When there is a convert_layout prior to TMA store, look through it.
We now have truncf in one partition, convert_layout in another partition followed by TMA store.
