### PR TITLE
[autoWS] correctly set up getBufferIdxAndPhase for buffer reuse

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -234,7 +234,7 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
                           unsigned numBuffers,
                           const DenseSet<Operation *> &regionsWithChannels,
                           Value &bufferIdx, Value &phase, ReuseConfig *config,
-                          int reuseGroupIdx);
+                          int reuseGroupIdx, Channel *ch);
 
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
                                  Value barrierAlloc, Value bufferIdx);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1380,7 +1380,7 @@ DenseMap<Channel *, Value> createBufferPost(
         // Goes through channels here. Make sure the channel is not partilly
         // mutated.
         getBufferIdxAndPhase(builder, user, numBuffers, regionsWithChannels,
-                             bufferIdx, _phase, config, reuseGrp);
+                             bufferIdx, _phase, config, reuseGrp, channel);
       } else {
         bufferIdx = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
             user->getLoc(), 0, 32);
@@ -1929,9 +1929,10 @@ void insertAsyncComm(
         LDBG("call getBufferIdxAndPhase2 ");
         headProducer->dump();
       });
-      getBufferIdxAndPhase(
-          builder, headProducer, kv.second.front()->getNumBuffers(),
-          regionsWithChannels, bufferIdx, phase, config, reuseGrp);
+      getBufferIdxAndPhase(builder, headProducer,
+                           kv.second.front()->getNumBuffers(),
+                           regionsWithChannels, bufferIdx, phase, config,
+                           reuseGrp, masterChannel);
     } else {
       // Producer is not in a ForOp, create phase and bufferIdx here.
       bufferIdx = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -473,7 +473,7 @@ void insertAsyncCopy(
       });
       getBufferIdxAndPhase(builder, srcOp, kv.getFirst()->getNumBuffers(),
                            regionsWithChannels, bufferIdx, phase, config,
-                           reuseGrp);
+                           reuseGrp, kv.getFirst());
     } else {
       // Producer is not in a ForOp, create phase and bufferIdx here which will
       // be used by both producer and consumers.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -65,7 +65,8 @@ void processProducerCommitOp(OpBuilder &builder, ttnvws::ProducerCommitOp op,
   ttng::ArriveBarrierOp arriveOp;
 
   assert(loadType != ttnvws::TokenLoadType::AsyncLoadOp);
-  arriveOp = builder.create<ttng::ArriveBarrierOp>(loc, bufferFull, fullCnt);
+  arriveOp =
+      builder.create<ttng::ArriveBarrierOp>(loc, bufferFull, 1); // fullCnt);
 
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
@@ -87,7 +88,7 @@ void processConsumerReleaseOp(OpBuilder &builder, ttnvws::ConsumerReleaseOp op,
                               unsigned emptyCnt) {
   auto loc = op.getLoc();
   auto arriveOp =
-      builder.create<ttng::ArriveBarrierOp>(loc, bufferEmpty, emptyCnt);
+      builder.create<ttng::ArriveBarrierOp>(loc, bufferEmpty, 1); // emptyCnt);
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
 }
@@ -177,12 +178,12 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
       // EmptyView is used for ConsumerRelease and ProducerAcquire.
       // FullView is for ConsumerWait and ProducerCommit.
       builder.create<ttng::InitBarrierOp>(loc, barrierFullView,
-                                          bufferFullCount);
+                                          1); // bufferFullCount);
 
       Value barrierEmptyView = builder.create<ttg::MemDescIndexOp>(
           loc, singleBarrierMemDescType, bufferEmptyArray, idx);
       builder.create<ttng::InitBarrierOp>(loc, barrierEmptyView,
-                                          bufferEmptyCount);
+                                          1); // bufferEmptyCount);
     }
 
     assert(numCTAs == 1 && "remote CTA is not supported yet");


### PR DESCRIPTION
set up reuseGrp correctly in getBufferIdxAndPhase
For example, for k,v buffer reuse, accumCnt for v should be incremented based on accumCnt for k.
Also set init_barrier to 1 and barrier arrive count to 1.