### PR TITLE
[AutoWS] Support Producer + Consumer Pair where the producer in side a loop and the consumer is outside the loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ dev-install: dev-install-requires dev-install-triton
 .PHONY: dev-install-llvm
 .NOPARALLEL: dev-install-llvm
 dev-install-llvm:
-	LLVM_BUILD_PATH=$(LLVM_BUILD_PATH) scripts/build-llvm-project.sh
 	TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_BUILD_WITH_CCACHE=0 \
 		LLVM_INCLUDE_DIRS=$(LLVM_BUILD_PATH)/include \
 		LLVM_LIBRARY_DIR=$(LLVM_BUILD_PATH)/lib \

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ dev-install: dev-install-requires dev-install-triton
 .PHONY: dev-install-llvm
 .NOPARALLEL: dev-install-llvm
 dev-install-llvm:
+	LLVM_BUILD_PATH=$(LLVM_BUILD_PATH) scripts/build-llvm-project.sh
 	TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_BUILD_WITH_CCACHE=0 \
 		LLVM_INCLUDE_DIRS=$(LLVM_BUILD_PATH)/include \
 		LLVM_LIBRARY_DIR=$(LLVM_BUILD_PATH)/lib \

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1911,22 +1911,15 @@ void insertAsyncComm(
       tOps.insert(headProducer);
       tmaHeadProducer = getFirstOpInBlock(tOps);
     }
-    Operation *insertionPoint = headProducer;
+    bool isProducerNested = false;
     // Check to see if producer and consumer are in the same block.
     if (headProducer->getBlock() != headConsumer->getBlock()) {
       LDBG("different blocks for channel " << masterChannel->uniqID);
       // If producer is inside the loop, consumer is outside.
       int regionCmp = isAinNestedRegion(headProducer, headConsumer);
-      if (regionCmp < 0) { // headProducer is in nested region
-        LDBG("FIXME headProducer is in nested region "
-             << masterChannel->uniqID);
-        // If we are in nested region set the assertion point
-        // to the end of the parent forOp.
-        insertionPoint = headProducer->getParentOp()->getNextNode();
-        if (!insertionPoint) {
-          llvm_unreachable("For Loop without yield statement");
-        }
-      }
+      // headProducer is in nested region
+      // TODO: Is a nested consumer properly supported?
+      isProducerNested = regionCmp < 0;
     } else {
       // Check to see if consumer appears later than producer (loop-carried).
       if (!appearsBefore(headProducer, headConsumer)) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1932,7 +1932,9 @@ void insertAsyncComm(
       if (regionCmp < 0) {
         assert(isa<ttng::TCGen5MMAOp>(headProducer) &&
                "Only TCGen5MMAOp supported");
-        nestedInsertionTarget = getAUnnestedParent(headProducer, headConsumer)
+        nestedInsertionTarget =
+            getAUnnestedParent(headProducer, headConsumer)->getNextNode();
+        assert(nestedInsertionTarget != nullptr && "Malformed IR");
       }
     } else {
       // Check to see if consumer appears later than producer (loop-carried).

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -2294,6 +2294,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
   insertAsyncComm(funcOp, channelsGroupedByConsumers, orderedChannels, tokenMap,
                   barrierAllocMap, bufferMap, copyOpMap, regionsWithChannels,
                   &config, false);
+  funcOp.dump();
   LLVM_DEBUG({
     LDBG("\n\nwith SyncOps");
     funcOp.dump();


### PR DESCRIPTION
Adds support for the pattern in FA between the accumulator and correction epilogue. This creates the following structure for the MMA (we will focus on just the 4th MMA).

Buffer + Phase initialization:
```
  %198 = "arith.constant"() <{value = 1 : i32}> {async_task_id = array<i32: 0, 3>} : () -> i32
  %199 = "arith.extsi"(%198) {async_task_id = array<i32: 0, 3>} : (i32) -> i64
  %200 = "arith.divui"(%arg26, %199) {async_task_id = array<i32: 0, 3>} : (i64, i64) -> i64
  %201 = "arith.muli"(%200, %199) <{overflowFlags = #arith.overflow<none>}> {async_task_id = array<i32: 0, 3>} : (i64, i64) -> i64
  %202 = "arith.subi"(%arg26, %201) <{overflowFlags = #arith.overflow<none>}> {async_task_id = array<i32: 0, 3>} : (i64, i64) -> i64
  %203 = "arith.trunci"(%202) <{overflowFlags = #arith.overflow<none>}> {async_task_id = array<i32: 0, 3>} : (i64) -> i32
  %204 = "arith.constant"() <{value = 1 : i64}> {async_task_id = array<i32: 0, 3>} : () -> i64
  %205 = "arith.andi"(%200, %204) {async_task_id = array<i32: 0, 3>} : (i64, i64) -> i64
  %206 = "arith.trunci"(%205) <{overflowFlags = #arith.overflow<none>}> {async_task_id = array<i32: 0, 3>} : (i64) -> i1
  %207:10 = "scf.for"(...):
    ...
```
Producer acquire (inside for loop and above MMA op)
```
"nvws.producer_acquire"(%53, %203, %206) {async_task_id = array<i32: 3>} : (tensor<1x!nvws.token>, i32, i1) -> ()
... // Other ops like wait on args. Omitted to avoid confusion
%924 = "ttng.tc_gen5_mma"(%917, %897, %907, %887, %81, %81, %918, %920, %922, %919, %921, %923) <{is_async, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1, 3, 3>}> {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 2 : i32, tmem.end = array<i32: 12, 12>, tmem.start = array<i32: 11, 11, 13, 13>, tt.self_latency = 1 : i32} : (!ttg.memdesc<64x128xbf16, #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, unpacked = false>, #ttng.tensor_memory, mutable>, !ttg.memdesc<128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory, mutable>, !ttg.memdesc<64x128xf32, #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, unpacked = true>, #ttng.tensor_memory, mutable>, !ttg.async.token, i1, i1, !ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>, !ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>, !ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>, i1, i1, i1) -> !ttg.async.token
```
Producer commit:
```
   scf.yield ...
)}
// End of for loop
ttng.tc_gen5_commit"(%18) {async_task_id = array<i32: 3>} : (!ttg.memdesc<1x1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>) -> ()
```

Consumer wait + release:
```
...
"ttng.wait_barrier"(%417, %418) <{operandSegmentSizes = array<i32: 1, 1, 0, 0>}> {async_task_id = array<i32: 0>} : (!ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>, i32) -> ()
%419:2 = "ttng.tmem_load"(%416, %207#8) {async_task_id = array<i32: 0>, tmem.end = array<i32: 13, 13>} : (!ttg.memdesc<64x128xf32, #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, unpacked = true>, #ttng.tensor_memory, mutable>, !ttg.async.token) -> (tensor<64x128xf32, #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [0, 1]}>>, !ttg.async.token)
"nvws.consumer_release"(%53, %203) {async_task_id = array<i32: 0>} : (tensor<1x!nvws.token>, i32) -> ()
...
```