### PR TITLE
Use OptimizePartitionWarps to set warp and reg counts

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -67,17 +67,6 @@ struct AllocateWarpGroups
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
-    // HACK: tracked by T239590507
-    mod.walk([&](WarpSpecializeOp op) {
-      SmallVector<int32_t> partitionNumWarps(op.getPartitionNumWarps());
-      // if we have 5 partitions, try to set to [0, 1, 2] to 1.
-      if (partitionNumWarps.size() == 5) {
-        partitionNumWarps[0] = 1;
-        partitionNumWarps[1] = 1;
-        partitionNumWarps[2] = 1;
-      }
-      op.setPartitionNumWarps(partitionNumWarps);
-    });
     // First determine the maximum number of extra warps.
     int maxExtraWarps = 0;
     mod.walk([&](WarpSpecializeOp op) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -199,8 +199,9 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
     region->walk([minWarps = &minWarps](Operation *op) {
       // Some instructions have critical throughput if have low register usage.
       // Make sure there are enough warps for these ops to execute quickly.
-      if (isa<ttng::AsyncTMAGatherOp, ttng::AsyncTMAScatterOp,
-              ttng::AsyncTMACopyGlobalToLocalOp>(op))
+      // TODO: Should we keep a minimum of 2 warps for
+      // AsyncTMACopyGlobalToLocalOp under certain conditions?
+      if (isa<ttng::AsyncTMAGatherOp, ttng::AsyncTMAScatterOp>(op))
         *minWarps = 2;
       // TMEM ops require at least 4 warps to be able to read all lanes.
       else if (isa<ttng::TMEMLoadOp, ttng::TMEMStoreOp, ttng::TMEMAllocOp>(op))
@@ -256,7 +257,7 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
        llvm::zip(wsOp.getPartitionRegions(), partitionNumWarps,
                  wsOp.getPartitionNumWarps(), maxTensorRegs, estRegUsage)) {
     // "Guess" the register usage for each partition.
-    estRegs = tensorRegs ? 88 : 24;
+    estRegs = tensorRegs ? 192 : 24;
 
     // Layouts need to be reassigned if the number of warps changed and there
     // are tensor computations.

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -94,6 +94,8 @@ void init_triton_passes_ttgpuir(py::module &&m) {
                      createTritonInstrumentConcurrencySanitizer);
   ADD_PASS_WRAPPER_0("add_partition_scheduling",
                      createTritonGPUPartitionScheduling);
+  ADD_PASS_WRAPPER_0("add_optimize_partition_warps",
+                     createTritonGPUOptimizePartitionWarps);
 }
 
 void init_triton_passes_convert(py::module &&m) {

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -313,6 +313,10 @@ class CUDABackend(BaseBackend):
         passes.common.add_symbol_dce(pm)
         if capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
+        # Optimize the number of warps and registers after TMA lowering, so
+        # that any local loads eliminated by TMA lowering do not inflate them.
+        if capability // 10 >= 10:
+            passes.ttgpuir.add_optimize_partition_warps(pm)
         nvidia.passes.ttnvgpuir.add_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_lower_mma(pm)
         passes.common.add_sccp(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -450,7 +450,6 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
   }
 
   unsigned idx = 1;
-  SmallVector<int32_t> estRegUsage;
   for (Region *region : wsOp.getPartitionRegions()) {
     AsyncTaskId asyncTaskId = nTaskIds[idx];
     OpBuilderWithAsyncTaskIds taskBuilder(context);
@@ -465,17 +464,7 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
       SpecializeOp(op, mapping, taskBuilder, asyncTaskId);
     }
     taskBuilder.create<ttg::WarpReturnOp>(loc);
-    auto regAlloc =
-        scanRegUsage(partitionBlock, asyncTaskId, requestedRegisters);
-    // HACK: first partition has idx of 2
-    if (idx == 2 || idx == 3 || idx == 4)
-      estRegUsage.push_back(24);
-    else
-      estRegUsage.push_back(192);
   }
-
-  // The default region doesn't request registers.
-  wsOp.setRequestedRegisters(estRegUsage);
 
   // The capture set is the same for every partition region, so now find the
   // captures and thread them in to the regions.


### PR DESCRIPTION
Instead of using manual hacks to set the warp and reg counts during WS, let OptimizePartitionWarps compute them.

The heuristics in OptimizePartitionWarps are slightly modified to get the desired result for FlashAttention, but the implementation mostly works as-is, including updating the layouts of tensors after the number of warps is modified.

This produces the same llir and PTX for the Blackwell FA benchmark as we currently do, but eliminates the existing hacks.
