### PR TITLE
[TLX] Memory indexing language support

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1712,4 +1712,5 @@ def test_local_index(BLOCK_SIZE, device):
     n_elements = x.numel()
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
     local_index[grid](x, output, n_elements, BLOCK_SIZE)
-    # torch.testing.assert_close(y, output)
+    y = torch.tensor([10., 10., 10., 10.], device='cuda:0')
+    torch.testing.assert_close(y, output)

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -158,12 +158,15 @@ def local_view(
     else:
         # Calculate the correct shape for the subview according to create_memdesc_subview logic
         original_shape = local_allocated_buffers.shape
-        if len(original_shape) == 1:
-            # For 1D tensors, subview creates a single element view with shape [1]
-            new_shape = [1]
+        if local_allocated_buffers.type.num == 0:
+            if len(original_shape) == 1:
+                # For 1D tensors, subview creates a single element view with shape [1]
+                new_shape = [1]
+            else:
+                # For multi-dimensional tensors, drop the first dimension
+                new_shape = original_shape[1:]
         else:
-            # For multi-dimensional tensors, drop the first dimension
-            new_shape = original_shape[1:]
+            new_shape = original_shape
 
         return tlx.buffered_tensor(
             view_handle,


### PR DESCRIPTION
This PR adds support for multi-dimensional indexing in TLX by adding support in view creation.
```
        s = tl.zeros((1, ), dtype=tl.float32)
        for i in range(0, BLOCK_SIZE):
            s += tlx.local_load(buffers[0][i])
```

Prior to this change, the language support was missing (error from Python side of compiler).
[T239903584](https://www.internalfb.com/intern/tasks/?t=239903584)


# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
