### PR TITLE
[AutoWS] [DO-NOT-MERGE] Hack to setup correct LoopSchedule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ dev-install: dev-install-requires dev-install-triton
 .PHONY: dev-install-llvm
 .NOPARALLEL: dev-install-llvm
 dev-install-llvm:
-	LLVM_BUILD_PATH=$(LLVM_BUILD_PATH) scripts/build-llvm-project.sh
+# 	LLVM_BUILD_PATH=$(LLVM_BUILD_PATH) scripts/build-llvm-project.sh
 	TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_BUILD_WITH_CCACHE=0 \
 		LLVM_INCLUDE_DIRS=$(LLVM_BUILD_PATH)/include \
 		LLVM_LIBRARY_DIR=$(LLVM_BUILD_PATH)/lib \

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -77,7 +77,7 @@ public:
     int maxIndirectionLevel = 0;
     for (auto &[loadOp, info] : loadOpToIndLevel)
       maxIndirectionLevel = std::max(maxIndirectionLevel, info.first);
-    unsigned loadLatency = (numStages - 1) / (maxIndirectionLevel + 1);
+    unsigned loadLatency = 1;
 
     for (auto [loadOp, dist] : loadOpToIndLevel) {
       opLatency[loadOp] = loadLatency;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -60,7 +60,7 @@ class AssignLoadLatencies {
 public:
   AssignLoadLatencies(scf::ForOp forOp, int numStages,
                       DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), numStages(numStages), opLatency(opLatency) {};
+      : forOp(forOp), numStages(numStages), opLatency(opLatency){};
 
   void run() {
     bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
@@ -77,7 +77,7 @@ public:
     int maxIndirectionLevel = 0;
     for (auto &[loadOp, info] : loadOpToIndLevel)
       maxIndirectionLevel = std::max(maxIndirectionLevel, info.first);
-    unsigned loadLatency = 1;
+    unsigned loadLatency = (numStages - 1) / (maxIndirectionLevel + 1);
 
     for (auto [loadOp, dist] : loadOpToIndLevel) {
       opLatency[loadOp] = loadLatency;
@@ -151,7 +151,7 @@ public:
 class AssignMMALatencies {
 public:
   AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), opLatency(opLatency) {};
+      : forOp(forOp), opLatency(opLatency){};
 
   void run() {
     DenseMap<Operation *, int> mmaSelfLatency;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -79,8 +79,13 @@ public:
       maxIndirectionLevel = std::max(maxIndirectionLevel, info.first);
     unsigned loadLatency = (numStages - 1) / (maxIndirectionLevel + 1);
 
+    int index = 0;
+
     for (auto [loadOp, dist] : loadOpToIndLevel) {
-      opLatency[loadOp] = loadLatency;
+      opLatency[loadOp] = loadLatency - index;
+      if (index == 0) {
+        index += 1;
+      }
     }
   }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -200,6 +200,7 @@ public:
             else
               opLatency[&op] += 1;
           }
+          opLatency[&op] = 0;
         }
       }
     }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -248,8 +248,8 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
   }
 
   // FB Change: Set a budget based on the distance.
-  const size_t dotHeuristic = 2;
-  const bool useMMAHeurstic = dotCount > (dotHeuristic + 1);
+  const size_t dotHeuristic = 3;
+  const bool useMMAHeurstic = dotCount > dotHeuristic;
   size_t dotIndex = 0;
 
   // Assign stage to each op reachable from a latency op

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -252,7 +252,7 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
       lat = opLatency.lookup(op);
     // If an op has no users (maxDist == -1) but has latency, we include its
     // latency otherwise it contributes 0 to the distance.
-    int d = lat + (maxDist < 0 ? 0 : maxDist);
+    int d = std::min(lat + (maxDist < 0 ? 0 : maxDist), 2);
     distance[op] = d;
     return d;
   };

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -248,8 +248,8 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
   }
 
   // FB Change: Set a budget based on the distance.
-  const size_t dotHeuristic = 3;
-  const bool useMMAHeurstic = dotCount > dotHeuristic;
+  const size_t dotHeuristic = 2;
+  const bool useMMAHeurstic = dotCount > (dotHeuristic + 1);
   size_t dotIndex = 0;
 
   // Assign stage to each op reachable from a latency op

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -257,7 +257,7 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
        llvm::zip(wsOp.getPartitionRegions(), partitionNumWarps,
                  wsOp.getPartitionNumWarps(), maxTensorRegs, estRegUsage)) {
     // "Guess" the register usage for each partition.
-    estRegs = tensorRegs ? 192 : 24;
+    estRegs = tensorRegs ? 152 : 24;
 
     // Layouts need to be reassigned if the number of warps changed and there
     // are tensor computations.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -174,16 +174,6 @@ public:
                       "doLoopSchedule\n"
                    << moduleOp << "\n\n\n";
     }
-    // Note: Removing this reveals the
-    // Result has an invalid layout: #ttg.blocked<{sizePerThread = [1, 1],
-    // threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>.
-    if (false) { //! ForBlackWell) {
-      // Clear num_stages to disable SWP.
-      funcOp->walk([&](scf::ForOp forOp) {
-        forOp->setAttr(mlir::triton::kNumStagesAttrName,
-                       builder.getI32IntegerAttr(0));
-      });
-    }
   }
 
   void runOnOperation() override {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -174,7 +174,10 @@ public:
                       "doLoopSchedule\n"
                    << moduleOp << "\n\n\n";
     }
-    if (true) { //! ForBlackWell) {
+    // Note: Removing this reveals the
+    // Result has an invalid layout: #ttg.blocked<{sizePerThread = [1, 1],
+    // threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>.
+    if (false) { //! ForBlackWell) {
       // Clear num_stages to disable SWP.
       funcOp->walk([&](scf::ForOp forOp) {
         forOp->setAttr(mlir::triton::kNumStagesAttrName,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1523,8 +1523,10 @@ desyncTCGen5MMAOp(OpBuilderWithAsyncTaskIds &builder, ttng::TCGen5MMAOp mmaOp,
   }
   phase = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
       loc, builder.getI32Type(), phase);
-  return builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
+  auto waitOp = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
       loc, producerBarrier, phase);
+  copyLoopScheduleInfo(waitOp, producerOrConsumer);
+  return waitOp;
 
   LLVM_DEBUG({
     LDBG("desync: create wait_barrier for producer ");

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -355,6 +355,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(
         loc, tmaLoad.getDesc(), tmaLoad.getIndices(), prodBarrier,
         pipelineBuffer, pred);
+    copyLoopScheduleInfo(copy, tmaLoad);
   }
 
   // Create a wait_barrier before the first consumer.


### PR DESCRIPTION
Hack to setup the correct loop schedule for e2e testing: [P1971654641](https://www.internalfb.com/phabricator/paste/view/P1971654641).

General structure: 
- dot(q0, k) -> cluster 0, stage 1
- dot(q1, k) -> cluster 3, stage 1
- dot(p0, v) -> cluster 3, stage 1
- dot(p1, v) -> cluster 1, stage 2

Since we will renormalize later after WS, this should map to our expected cluster. Note there should be no need to separate `dot(q1, k)` and  `dot(p0, v)` into separate clusters since these will just be ordered.
