### PR TITLE
[AutoWS] Fix incorrect return in getAccumArgIdx logic

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -319,8 +319,8 @@ unsigned getAccumArgIdx(scf::ForOp parentForOp, Operation *ctrlOp,
       if (needAccumCntForReuse(parentForOp.getOperation(),
                                config->getGroup(idx)))
         ++cnts;
-      return cnts;
     }
+    return cnts;
   }
   // Walk parentForOp in preorder.
   unsigned preOrderId = 0, ctrlId = 0;


### PR DESCRIPTION
Within `getAccumArgIdx` the reuse path attempts to iterate over every prior index to update the count. However, the return is placed inside the body of the for loop, so the loop will only ever execute for a single iteration (and the behavior will be never enter the loop `reuseGroupIdx == 0`.

This moves the return statement after the for loop, which seems like the desired behavior of the loop. Note: This is a bug spotted by static analysis while validating the LoopScheduling related changes, not based on running code.