### PR TITLE
[AutoWS] Update Barrier stage info from optimizeTMALoads

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -366,6 +366,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
       loc, builder.getI32Type(), phase);
   auto wait = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
       loc, consBarrier, phase);
+  copyLoopScheduleInfo(wait, headConsumerSameLevel);
 
   // Convert all the consumers to local_load
   for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {


### PR DESCRIPTION
Adds a missing stage information. This is responsible for these barriers weren't properly predicated. This is not necessarily complete as their may be additional barriers, but this was a reason for a lack of barrier predication.