### PR TITLE
[Cherry-pick][CONFLICTS] Remove setuptools requirement from setup.py (#7983)

### DIFF
--- a/python/test/backend/test_device_backend.py
+++ b/python/test/backend/test_device_backend.py
@@ -15,6 +15,7 @@ import triton.language as tl
 
 import pytest
 
+<<<<<<< HEAD
 with pytest.raises(ImportError):
     # Facebook.
     # Following two imports should hit ImportError because functions
@@ -31,6 +32,17 @@ with pytest.raises(ImportError):
         suffix = sysconfig.get_config_var('EXT_SUFFIX')
         so = os.path.join(srcdir, '{name}{suffix}'.format(name=name, suffix=suffix))
         cc = os.environ.get("CC")
+=======
+def build_for_backend(name, src, srcdir):
+    suffix = sysconfig.get_config_var('EXT_SUFFIX')
+    so = os.path.join(srcdir, '{name}{suffix}'.format(name=name, suffix=suffix))
+    cc = os.environ.get("CC")
+    if cc is None:
+        # TODO: support more things here.
+        clang = shutil.which("clang")
+        gcc = shutil.which("gcc")
+        cc = gcc if gcc is not None else clang
+>>>>>>> 2ac060b8b (Remove setuptools requirement from setup.py (#7983))
         if cc is None:
             # TODO: support more things here.
             clang = shutil.which("clang")


### PR DESCRIPTION
⚠️ **MERGE CONFLICTS DETECTED** ⚠️

This cherry-pick contains merge conflicts that require manual resolution.

Original Commit: 2ac060b8b955cf4c6412458bea9df554342c1b1a
Original Author: Anatoly Myachev
Original Date: 2025-08-27 12:58:40 +0200

**Action Required:**
1. Check out this branch locally
2. Resolve the merge conflicts in the affected files
3. Commit the resolved changes
4. Update this PR

Original commit message:
```
Remove setuptools requirement from setup.py (#7983)

Closes #7192

Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
The conflicts have been committed with conflict markers for easier resolution.
