### PR TITLE
[AutoWS] Fix Stage/Cluster info for ProducerAcquire

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1523,8 +1523,10 @@ desyncTCGen5MMAOp(OpBuilderWithAsyncTaskIds &builder, ttng::TCGen5MMAOp mmaOp,
   }
   phase = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
       loc, builder.getI32Type(), phase);
-  return builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
+  auto waitOp = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
       loc, producerBarrier, phase);
+  copyLoopScheduleInfo(waitOp, producerOrConsumer);
+  return waitOp;
 
   LLVM_DEBUG({
     LDBG("desync: create wait_barrier for producer ");

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -355,6 +355,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(
         loc, tmaLoad.getDesc(), tmaLoad.getIndices(), prodBarrier,
         pipelineBuffer, pred);
+    copyLoopScheduleInfo(copy, tmaLoad);
   }
 
   // Create a wait_barrier before the first consumer.


### PR DESCRIPTION
Adds the remaining loop/stage info for the producer acquire. This was placing the barrier in the wrong stage otherwise.