### PR TITLE
Fix merging TMA store with SMEM buffer

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1801,6 +1801,26 @@ void insertAsyncComm(
             consumerOps.insert(t);
             actualConsumerOps.insert(t);
           }
+
+          // If the consumer is subsequently used to perform a TMA store, we
+          // would like to skip actually loading the value and just directly
+          // copy it from SMEM to global memory. To make this possible, the TMA
+          // store should be treated as a consumer of the channel, so that the
+          // consumer release barrier is placed after the TMA store is
+          // completed. Note that this is best effort, if we miss the TMA store,
+          // the result will incur a performance hit, but still be correct.
+          if (llvm::isa<ttg::LocalLoadOp>(dst)) {
+            for (auto user : dst->getUsers()) {
+              // Advance past any layout conversions, because we will be storing
+              // directly from memory anyway.
+              while (llvm::isa<ttg::ConvertLayoutOp>(user) && user->hasOneUse())
+                user = *user->getUsers().begin();
+              if (llvm::isa<tt::DescriptorStoreOp>(user)) {
+                consumerOps.insert(user);
+                actualConsumerOps.insert(user);
+              }
+            }
+          }
         }
       } else {
         consumerOps.insert(c->getDstOp());


### PR DESCRIPTION
TMALowering currently incorrectly allows a TMA store to reuse an existing allocation even if the contents of that allocation may have changed. For example, our WS implementation currently generates the following sequence:

```
%acc = local_load
%barr = memdesc_index
arrive_barrier %barr
descriptor_store %acc
```

which gets transformed into:

```
%barr = memdesc_index
arrive_barrier %barr
async_tma_copy_local_to_global
```

Here, the TMA operation now reads from the allocation after we have executed the "consumer release" barrier.

To address this, track TMA stores when inserting barriers and ensure that the consumer release is inserted after the TMA store. This allows us to make the optimisation in TMALowering simple and safe.