### PR TITLE
[autoWS] Fix local buffer layout to favor TMA store

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1030,16 +1030,14 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
             for (auto *user : op->getUsers()) {
               // Do not reuse the current order for TMA store desc. Subsequent
               // codegen for TMA store does not handle mismatching order well.
-              if (isa<tt::DescriptorStoreOp>(user)) {
-                tmaStore = dyn_cast<tt::DescriptorStoreOp>(user);
+              if ((tmaStore = dyn_cast<tt::DescriptorStoreOp>(user))) {
                 return false;
               }
             }
           }
           // Do not reuse the current order for TMA store desc. Subsequent
           // codegen for TMA store does not handle mismatching order well.
-          if (isa<tt::DescriptorStoreOp>(op)) {
-            tmaStore = dyn_cast<tt::DescriptorStoreOp>(op);
+          if ((tmaStore = dyn_cast<tt::DescriptorStoreOp>(op))) {
             return false;
           }
           return isa<mlir::triton::DotOpInterface>(op);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1022,15 +1022,27 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
   } else {
     auto originTaskIds = builder.getAsyncTaskIds();
     builder.setAsyncTaskIdsFromOp(srcOp);
+    tt::DescriptorStoreOp tmaStore;
     bool requireMMASharedEncoding =
-        llvm::any_of(actualConsumers, [](Operation *op) {
+        llvm::any_of(actualConsumers, [&](Operation *op) {
           // convert_layout
           if (isa<ttg::ConvertLayoutOp>(op)) {
-            for (auto *user : op->getUsers())
-              if (isa<tt::DescriptorStoreOp>(user))
-                return true;
+            for (auto *user : op->getUsers()) {
+              // Do not reuse the current order for TMA store desc. Subsequent
+              // codegen for TMA store does not handle mismatching order well.
+              if (isa<tt::DescriptorStoreOp>(user)) {
+                tmaStore = dyn_cast<tt::DescriptorStoreOp>(user);
+                return false;
+              }
+            }
           }
-          return isa<mlir::triton::DotOpInterface, tt::DescriptorStoreOp>(op);
+          // Do not reuse the current order for TMA store desc. Subsequent
+          // codegen for TMA store does not handle mismatching order well.
+          if (isa<tt::DescriptorStoreOp>(op)) {
+            tmaStore = dyn_cast<tt::DescriptorStoreOp>(op);
+            return false;
+          }
+          return isa<mlir::triton::DotOpInterface>(op);
         });
 
     // Get shape, layout and type of a slice
@@ -1040,6 +1052,9 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
       sharedLayout = ttg::NVMMASharedEncodingAttr::get(
           context, sliceShape, order, CTALayout, elemType,
           /*fp4Padded*/ false);
+    } else if (tmaStore) {
+      sharedLayout = ttng::getEncodingFromDescriptor(tmaStore, tensorType,
+                                                     tmaStore.getDesc());
     } else if (auto tmaLoad = dyn_cast<tt::DescriptorLoadOp>(srcOp)) {
       sharedLayout = ttng::getEncodingFromDescriptor(tmaLoad, tmaLoad.getType(),
                                                      tmaLoad.getDesc());


### PR DESCRIPTION
For column-major tensors that'll be stored out in row-major way by TMA store, if they are in different tasks, we currently create a column-major smem buffer. The producer populates in a natural way and the consumer converts it to row-major in registers before throwing it to TMA store. This will end up a pattern where the convert layout is folded into the TMA store, e.g,

```
#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
        ttng.async_tma_copy_local_to_global %desc_o_29[%qo_offset_y_42, %c0_i32_35] %103 : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<128x128xf16, #shared2, #smem, mutable> loc(#loc129)

```

Unfortunately, the TMA store lowering does not handle mismatches smem layout well. It basically ignores the incoming buffer layout thus outputs wrong values.

A workaround is to always create row-major smem buffer to match whatever the TMA store comes in with.