### PR TITLE
[AutoWS] Add an assert that all latency ops have a corresponding stage/cluster and propagate missing barrier info

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -553,6 +553,8 @@ CoarseSchedule getInitialSchedule(scf::ForOp forOp,
       // FIXME: This should assert all latency ops have an assigned stage.
       if (schedule.count(&op))
         latencyStages.insert(schedule[&op].first);
+      else
+        assert(false);
     }
     if (latencyStages.size() <= 1) {
       CoarseSchedule normalized(/*numStages=*/1);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -561,7 +561,8 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
 }
 
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
-                                 Value barrierAlloc, Value bufferIdx) {
+                                 Value barrierAlloc, Value bufferIdx,
+                                 Operation *op) {
   auto context = barrierAlloc.getContext();
   Attribute sharedMemorySpace =
       triton::gpu::SharedMemorySpaceAttr::get(context);
@@ -572,8 +573,10 @@ Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
       /*mutableMemory=*/true);
 
   // Create barrierForTMA from barrierAlloc.
-  return builder.createWithAsyncTaskIds<ttg::MemDescIndexOp>(
+  auto output = builder.createWithAsyncTaskIds<ttg::MemDescIndexOp>(
       barrierAlloc.getLoc(), barrierTy, barrierAlloc, bufferIdx);
+  copyLoopScheduleInfo(output, op);
+  return output;
 }
 
 static void setTmemChannelAttr(Operation *op, int channelId,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -428,28 +428,38 @@ unsigned getReuseAccumArgIdx(Operation *regionOp,
 // Compute and return the buffer index and phase for a given accumulate count.
 std::pair<Value, Value> getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder,
                                              Location loc, Value accumCnt,
-                                             unsigned numBuffers) {
+                                             unsigned numBuffers,
+                                             Operation *op) {
   Value numBuffersVal =
       builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, numBuffers, 32);
+  copyLoopScheduleInfo(numBuffersVal.getDefiningOp(), op);
   numBuffersVal = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
       loc, builder.getI64Type(), numBuffersVal);
+  copyLoopScheduleInfo(numBuffersVal.getDefiningOp(), op);
   // Calculate accumCnt / numBuffers
   // initBufferIdx = accumCnt - accumCnt / numBuffers * numBuffers
   // initPhase = (accumCnt / numBuffers) & 1
   Value bufferIdx = builder.createWithAsyncTaskIds<arith::DivUIOp>(
       loc, accumCnt, numBuffersVal);
-  Value initBufferIdx = builder.createWithAsyncTaskIds<arith::SubIOp>(
-      loc, accumCnt,
-      builder.createWithAsyncTaskIds<arith::MulIOp>(loc, bufferIdx,
-                                                    numBuffersVal));
+  copyLoopScheduleInfo(bufferIdx.getDefiningOp(), op);
+  auto mulOp = builder.createWithAsyncTaskIds<arith::MulIOp>(loc, bufferIdx,
+                                                             numBuffersVal);
+  copyLoopScheduleInfo(mulOp, op);
+  Value initBufferIdx =
+      builder.createWithAsyncTaskIds<arith::SubIOp>(loc, accumCnt, mulOp);
+  copyLoopScheduleInfo(initBufferIdx.getDefiningOp(), op);
   initBufferIdx = builder.createWithAsyncTaskIds<arith::TruncIOp>(
       loc, builder.getI32Type(), initBufferIdx);
+  copyLoopScheduleInfo(initBufferIdx.getDefiningOp(), op);
 
   Value one = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 64);
+  copyLoopScheduleInfo(one.getDefiningOp(), op);
   bufferIdx =
       builder.createWithAsyncTaskIds<arith::AndIOp>(loc, bufferIdx, one);
+  copyLoopScheduleInfo(bufferIdx.getDefiningOp(), op);
   Value initPhase = builder.createWithAsyncTaskIds<arith::TruncIOp>(
       loc, builder.getI1Type(), bufferIdx);
+  copyLoopScheduleInfo(initPhase.getDefiningOp(), op);
   return {initBufferIdx, initPhase};
 }
 
@@ -511,7 +521,7 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
       getAccumCount(builder, op, regionsWithChannels, config, reuseGroupIdx);
   if (reuseGroupIdx < 0) {
     std::tie(bufferIdx, phase) =
-        getBufferIdxAndPhase(builder, op->getLoc(), accumCnt, numBuffers);
+        getBufferIdxAndPhase(builder, op->getLoc(), accumCnt, numBuffers, op);
     return;
   }
   // op is a user of the channel. accumCnt is the corresponding argument of the
@@ -534,18 +544,20 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
   assert(theIdx >= 0);
   if (theIdx == 0) {
     std::tie(bufferIdx, phase) =
-        getBufferIdxAndPhase(builder, op->getLoc(), accumCnt, numBuffers);
+        getBufferIdxAndPhase(builder, op->getLoc(), accumCnt, numBuffers, op);
     return;
   }
   // Increment accumCnt if there are multiple channels in the reuseGroup in this
   // region.
   Value idxVal = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
       op->getLoc(), theIdx, 64);
+  copyLoopScheduleInfo(idxVal.getDefiningOp(), op);
   Value addRes = builder.createWithAsyncTaskIds<arith::AddIOp>(
       op->getLoc(), accumCnt, idxVal);
+  copyLoopScheduleInfo(addRes.getDefiningOp(), op);
 
   std::tie(bufferIdx, phase) =
-      getBufferIdxAndPhase(builder, op->getLoc(), addRes, numBuffers);
+      getBufferIdxAndPhase(builder, op->getLoc(), addRes, numBuffers, op);
 }
 
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -229,7 +229,8 @@ Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
                     ReuseConfig *config, int reuseGroupIdx);
 std::pair<Value, Value> getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder,
                                              Location loc, Value accumCnt,
-                                             unsigned numBuffers);
+                                             unsigned numBuffers,
+                                             Operation *op);
 void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
                           unsigned numBuffers,
                           const DenseSet<Operation *> &regionsWithChannels,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -238,7 +238,8 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
                           int reuseGroupIdx, Channel *ch);
 
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
-                                 Value barrierAlloc, Value bufferIdx);
+                                 Value barrierAlloc, Value bufferIdx,
+                                 Operation *op);
 
 Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             SmallVector<tt::DescriptorLoadOp> &tmaLoads,


### PR DESCRIPTION
Adds an assert that all latency ops have stage info and forces the propagation in places to fix accuracy.