### PR TITLE
[autoWS] fix barrier insertion for a channel loop associated with acc

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1948,6 +1948,68 @@ void insertAsyncComm(
       tOps.insert(headProducer);
       tmaHeadProducer = getFirstOpInBlock(tOps);
     }
+
+    auto withSameTask = [&](Operation *A, Operation *B) -> bool {
+      auto aTasks = getAsyncTaskIds(A);
+      auto bTasks = getAsyncTaskIds(B);
+      if (aTasks.size() != bTasks.size())
+        return false;
+      for (unsigned i = 0; i < aTasks.size(); ++i)
+        if (aTasks[i] != bTasks[i])
+          return false;
+      return true;
+    };
+    // Return the backward channel if found.
+    // Assume chF is a forward channel where producer and consumer are in the
+    // same block.
+    auto isForwardOfChannelLoop = [&](Channel *chF) -> Channel * {
+      if (chF->channelKind != DataChannelKind::TMEMPost)
+        return nullptr;
+      ttng::TmemDataChannelPost *tmemChannel =
+          static_cast<ttng::TmemDataChannelPost *>(chF);
+      if (!tmemChannel->isOperandD)
+        return nullptr;
+      // Check for a cycle, a channel from chF->getDstOp to an op prior to
+      // chF->getSrcOp and all users are in the same block.
+      for (auto *ch : orderedChannels) {
+        if (ch == chF)
+          continue;
+        if (withSameTask(ch->getDstOp(), chF->getSrcOp()) &&
+            ch->getAllocOp() == chF->getAllocOp() &&
+            ch->getSrcOp() == chF->getDstOp() &&
+            chF->getSrcOp()->getBlock() == ch->getSrcOp()->getBlock() &&
+            chF->getSrcOp()->getBlock() == ch->getDstOp()->getBlock()) {
+          if (appearsBefore(ch->getDstOp(), chF->getSrcOp()))
+            return ch;
+        }
+      }
+      return nullptr;
+    };
+    // Assume chB is a backward channel where producer and consumer are in the
+    // same block.
+    auto isBackwardOfChannelLoop = [&](Channel *chB) -> bool {
+      if (chB->channelKind != DataChannelKind::TMEMPost)
+        return false;
+      ttng::TmemDataChannelPost *tmemChannel =
+          static_cast<ttng::TmemDataChannelPost *>(chB);
+      if (!tmemChannel->isOperandD)
+        return false;
+      // Check for a cycle, a channel from an op after chB->getDstOp to
+      // chB->getSrcOp and all users are in the same block.
+      for (auto *ch : orderedChannels) {
+        if (ch == chB)
+          continue;
+        if (withSameTask(ch->getSrcOp(), chB->getDstOp()) &&
+            ch->getAllocOp() == chB->getAllocOp() &&
+            ch->getDstOp() == chB->getSrcOp() &&
+            chB->getSrcOp()->getBlock() == ch->getSrcOp()->getBlock() &&
+            chB->getSrcOp()->getBlock() == ch->getDstOp()->getBlock()) {
+          if (appearsBefore(chB->getDstOp(), ch->getSrcOp()))
+            return true;
+        }
+      }
+      return false;
+    };
     Operation *nestedInsertionTarget = nullptr;
     // Check to see if producer and consumer are in the same block.
     bool producerInNestedRegion = false, consumerInNestedRegion = false;
@@ -1970,11 +2032,35 @@ void insertAsyncComm(
     } else {
       // Check to see if consumer appears later than producer (loop-carried).
       if (!appearsBefore(headProducer, headConsumer)) {
-        LDBG("FIXME consumer before producer for channel "
+        // We will combine this channel with the other channel associated with
+        // the same value (gen5 operandD).
+        // -- Both channels are in the same block
+        // -- One channel is a forward edge, the other is a back edge.
+        // When handling the forward edge, we put a consumer release with gen5
+        // and a consumer wait prior to gen5, we also put a producer acquire
+        // before the srcOp of the channel and a producer commit after the
+        // srcOp. Instead, we need to move the producer acquire to be prior to
+        // the dstOp of the backward channel. We will have:
+        //   tmem_load(dstOp of channel B) ...
+        //   tmem_store(srcOp of channel F) ...
+        //   gen5(srcOp of channel B, dstOp of channel F)
+        // We should emit:
+        //   producer_acquire
+        //   tmem_load(dstOp of channel B) ...
+        //   tmem_store(srcOp of channel F)
+        //   producer_commit ...
+        //   consumer_wait (gen5 partition)
+        //   gen5 consumer_release (srcOp of channel B, dstOp of channel F)
+        assert(isBackwardOfChannelLoop(masterChannel));
+        LDBG("Skip consumer before producer for channel "
              << masterChannel->uniqID);
-        continue; // FIXME: skip this channel for now.
+        continue;
       }
     }
+    Operation *producerAcquireForChannelLoop = nullptr;
+    auto *bwdCh = isForwardOfChannelLoop(masterChannel);
+    if (bwdCh)
+      producerAcquireForChannelLoop = bwdCh->getDstOp();
     int reuseGrp = channelInReuseGroup(masterChannel, config);
     if (nestedInsertionTarget) {
       // If the producer is nested we need to pull the buffer + index
@@ -1997,6 +2083,8 @@ void insertAsyncComm(
       // headProducer can be local_store but bufferIdx will be used
       // by tmaLoad as well.
       builder.setInsertionPoint(tmaHeadProducer);
+      if (producerAcquireForChannelLoop)
+        builder.setInsertionPoint(producerAcquireForChannelLoop);
       LLVM_DEBUG({
         LDBG("call getBufferIdxAndPhase2 ");
         headProducer->dump();
@@ -2098,6 +2186,14 @@ void insertAsyncComm(
         Operation *producerAcquirePoint = headProducer;
         if (isProducerTMA(masterChannel, isPost))
           producerAcquirePoint = tmaHeadProducer;
+        if (producerAcquireForChannelLoop) {
+          LLVM_DEBUG({
+            LDBG("move producer acquire for inline barrier "
+                 << masterChannel->uniqID << " ");
+            producerAcquireForChannelLoop->dump();
+          });
+          producerAcquirePoint = producerAcquireForChannelLoop;
+        }
         bool addCompletionBarrier = nestedInsertionTarget == nullptr;
         if (!addCompletionBarrier) {
           // We need to place the commit after the for loop.
@@ -2125,7 +2221,11 @@ void insertAsyncComm(
         auto producerAcquirePoint =
             getSameLevelOp(headConsumer, tmaHeadProducer); // tmaHeadProducer;
         builder.setAsynTaskIdsFromArray(masterChannel->relation.first);
-        builder.setInsertionPoint(producerAcquirePoint);
+        if (producerAcquireForChannelLoop) {
+          builder.setInsertionPoint(producerAcquireForChannelLoop);
+        } else {
+          builder.setInsertionPoint(producerAcquirePoint);
+        }
         auto acquireOp =
             builder.createWithAsyncTaskIds<ttnvws::ProducerAcquireOp>(
                 headProducer->getLoc(), token.second, bufferIdx, phase);


### PR DESCRIPTION
Summary: We try to recognize a channel loop with all users in the same block around an alloc for operand D of gen5 mma which is used as inout.

For a code pattern of:
  tmem_load(dstOp of channel B) ...
  tmem_store(srcOp of channel F) ...
  gen5(srcOp of channel B, dstOp of channel F)
We should emit:
  producer_acquire
  tmem_load(dstOp of channel B) ...
  tmem_store(srcOp of channel F)
  producer_commit ...
  consumer_wait (gen5 partition)
  gen5 consumer_release (srcOp of channel B, dstOp of channel F)
After code partitioning:
  gen5 partition:
    consumer_wait
    gen5 consumer_release
  the other partition:
    producer_acquire
    tmem_load
    ...
    tmem_store
    producer_commit
