### PR TITLE
[AutoWS] Prune pipelining for Partitions with a single stage

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -159,7 +159,7 @@ public:
   auto begin() const { return opToStageAndCluster.begin(); }
 
   // Set <stage, cluster> based on CoarseSchedule.
-  void serialize(scf::ForOp &forOp) const;
+  void serialize(scf::ForOp &forOp, bool keepExistingMaxStage = true) const;
   // Create a CoarseSchedule based on forOp's <stage, cluster>.
   LogicalResult deSerialize(scf::ForOp &forOp);
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -60,7 +60,7 @@ class AssignLoadLatencies {
 public:
   AssignLoadLatencies(scf::ForOp forOp, int numStages,
                       DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), numStages(numStages), opLatency(opLatency) {};
+      : forOp(forOp), numStages(numStages), opLatency(opLatency){};
 
   void run() {
     bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
@@ -151,7 +151,7 @@ public:
 class AssignMMALatencies {
 public:
   AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), opLatency(opLatency) {};
+      : forOp(forOp), opLatency(opLatency){};
 
   void run() {
     DenseMap<Operation *, int> mmaSelfLatency;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -60,7 +60,7 @@ class AssignLoadLatencies {
 public:
   AssignLoadLatencies(scf::ForOp forOp, int numStages,
                       DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), numStages(numStages), opLatency(opLatency){};
+      : forOp(forOp), numStages(numStages), opLatency(opLatency) {};
 
   void run() {
     bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
@@ -151,7 +151,7 @@ public:
 class AssignMMALatencies {
 public:
   AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), opLatency(opLatency){};
+      : forOp(forOp), opLatency(opLatency) {};
 
   void run() {
     DenseMap<Operation *, int> mmaSelfLatency;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.cpp
@@ -249,15 +249,17 @@ static std::optional<int> tryGetMaxStage(scf::ForOp &forOp) {
 }
 
 // Set <stage, cluster> based on CoarseSchedule.
-void tt::CoarseSchedule::serialize(scf::ForOp &forOp) const {
+void tt::CoarseSchedule::serialize(scf::ForOp &forOp,
+                                   bool keepExistingMaxStage) const {
   for (auto [op, stage, cluster] : getOpsInOrder(forOp)) {
     setStageCluster(op, stage, *cluster);
   }
 
   Builder b(forOp.getContext());
   int maxStages = numStages - 1;
-  if (auto maxStageAttr = tryGetMaxStage(forOp))
-    maxStages = std::max(maxStages, *maxStageAttr);
+  if (keepExistingMaxStage)
+    if (auto maxStageAttr = tryGetMaxStage(forOp))
+      maxStages = std::max(maxStages, *maxStageAttr);
   forOp->setAttr(mlir::triton::kScheduledMaxStageAttrName,
                  b.getI32IntegerAttr(maxStages));
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -655,7 +655,7 @@ void scheduleLoop(scf::ForOp forOp, const DenseMap<Operation *, int> &opLatency,
   });
 
   // Write the schedule to the IR
-  schedule.serialize(forOp);
+  schedule.serialize(forOp, false);
 }
 } // namespace
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -97,6 +97,10 @@ static void expandLoops(ModuleOp moduleOp) {
     if (failed(schedule.deSerialize(forOp))) {
       continue;
     }
+    // Skip pipelining when we have a single stage.
+    if (schedule.getNumStages() == 1) {
+      continue;
+    }
 
     std::vector<std::pair<Operation *, unsigned>> finalSchedule =
         schedule.createFinalSchedule(forOp);


### PR DESCRIPTION
The pipelining steps will still execute for partitions with a single stage. This will result in unnecessary epilogue generation, hurting performance. Here is an example with the producer epilogue in DP FA:

Before: [P1979886251](https://www.internalfb.com/phabricator/paste/view/P1979886251)
After: [P1979906182](https://www.internalfb.com/phabricator/paste/view/P1979906182)