### PR TITLE
[AutoWS] Propagate tl.assume to all partitions

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1,5 +1,5 @@
 from triton.backends.compiler import BaseBackend, GPUTarget, Language
-from triton._C.libtriton import ir, passes, llvm, nvidia, amd
+from triton._C.libtriton import ir, passes, llvm, nvidia
 from triton import knobs
 from triton.runtime.errors import PTXASError
 
@@ -294,7 +294,6 @@ class CUDABackend(BaseBackend):
                 # use Meta's WS internally which supports both hopper and blackwell
                 passes.ttgpuir.add_partition_scheduling(pm)
                 nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, dump_enabled)
-                amd.passes.ttgpuir.add_fold_true_cmpi(pm)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             # hoist again and allow hoisting out of if statements

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1,5 +1,5 @@
 from triton.backends.compiler import BaseBackend, GPUTarget, Language
-from triton._C.libtriton import ir, passes, llvm, nvidia
+from triton._C.libtriton import ir, passes, llvm, nvidia, amd
 from triton import knobs
 from triton.runtime.errors import PTXASError
 
@@ -294,6 +294,7 @@ class CUDABackend(BaseBackend):
                 # use Meta's WS internally which supports both hopper and blackwell
                 passes.ttgpuir.add_partition_scheduling(pm)
                 nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, dump_enabled)
+                amd.passes.ttgpuir.add_fold_true_cmpi(pm)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             # hoist again and allow hoisting out of if statements

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskPartition.cpp
@@ -112,8 +112,10 @@ void doTaskPartition(triton::FuncOp &funcOp, unsigned numWarpGroups) {
   // Annoate the program with task ids
   SmallVector<AsyncTaskId, 1> producerTaskIds{0};
   SmallVector<AsyncTaskId, 2> consumerTaskIds;
+  SmallVector<AsyncTaskId> allTaskIds{0};
   for (unsigned i = 0; i < numWarpGroups - 1; ++i) {
     consumerTaskIds.push_back(i + producerTaskIds.size());
+    allTaskIds.push_back(i + producerTaskIds.size());
   }
 
   for (auto op : producerOps) {


### PR DESCRIPTION
Propagates the context of tl.assume to every partition. Results in worse performance on main with `tl.assume(N_CTX > 0)` in the main persistent kernel.