### PR TITLE
[autoWS] add minRegAutoWS and maxRegAutoWS to autotune configs

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -45,6 +45,8 @@ constexpr static char AttrNumWarpsName[] = "ttg.num-warps";
 constexpr static char AttrNumCTAsName[] = "ttg.num-ctas";
 constexpr static char AttrTargetName[] = "ttg.target";
 constexpr static char AttrNumThreadsPerWarp[] = "ttg.threads-per-warp";
+constexpr static char AttrMinRegAutoWSName[] = "ttg.min_reg_auto_ws";
+constexpr static char AttrMaxRegAutoWSName[] = "ttg.max_reg_auto_ws";
 
 // Find the contextual number of warps on which this operation is executed.
 int lookupNumWarps(Operation *op);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -252,12 +252,24 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
     }
   } while (changed);
 
+  // Read the attribute from the module
+  ModuleOp mod = axisInfo.getModuleOp();
+  int minRegAutoWS = 42;  // default value
+  if (auto attr = mod->getAttrOfType<IntegerAttr>(AttrMinRegAutoWSName)) {
+      minRegAutoWS = attr.getInt();
+  }
+  int maxRegAutoWS = 168;  // default value
+  if (auto attr = mod->getAttrOfType<IntegerAttr>(AttrMaxRegAutoWSName)) {
+      maxRegAutoWS = attr.getInt();
+  }
+
   SmallVector<int32_t> estRegUsage(partitionNumWarps.size());
   for (auto [partition, newNumWarps, prevNumWarps, tensorRegs, estRegs] :
        llvm::zip(wsOp.getPartitionRegions(), partitionNumWarps,
                  wsOp.getPartitionNumWarps(), maxTensorRegs, estRegUsage)) {
+
     // "Guess" the register usage for each partition.
-    estRegs = tensorRegs ? 168 : 24;
+    estRegs = tensorRegs ? maxRegAutoWS : minRegAutoWS;
 
     // Layouts need to be reassigned if the number of warps changed and there
     // are tensor computations.

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -254,7 +254,7 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
 
   // Read the attribute from the module
   ModuleOp mod = axisInfo.getModuleOp();
-  int minRegAutoWS = 42;  // default value
+  int minRegAutoWS = 24;  // default value
   if (auto attr = mod->getAttrOfType<IntegerAttr>(AttrMinRegAutoWSName)) {
       minRegAutoWS = attr.getInt();
   }

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -434,6 +434,8 @@ class JITHookCompileInfo(TypedDict):
     num_warps: int
     num_ctas: int
     num_stages: int
+    minRegAutoWS: int
+    maxRegAutoWS: int
     enable_fp_fusion: bool
     launch_cooperative_grid: bool
     extern_libs: tuple[tuple[str, str], ...]

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -315,7 +315,7 @@ class Config:
     :ivar ir_override: filename of a user-defined IR (*.{ttgir|llir|ptx|amdgcn}).
     """
 
-    def __init__(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, maxnreg=None, pre_hook=None, ir_override=None):
+    def __init__(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, maxnreg=None, pre_hook=None, ir_override=None, minRegAutoWS=None, maxRegAutoWS=None):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas
@@ -323,6 +323,8 @@ class Config:
         self.maxnreg = maxnreg
         self.pre_hook = pre_hook
         self.ir_override = ir_override
+        self.minRegAutoWS = minRegAutoWS
+        self.maxRegAutoWS = maxRegAutoWS
 
     def __setstate__(self, state):
         self.kwargs = state.get("kwargs", {})
@@ -332,6 +334,8 @@ class Config:
         self.maxnreg = state.get("maxnreg", None)
         self.pre_hook = state.get("pre_hook", None)
         self.ir_override = state.get("ir_override", None)
+        self.minRegAutoWS = state.get("minRegAutoWS", None)
+        self.maxRegAutoWS = state.get("maxRegAutoWS", None)
 
     def all_kwargs(self):
         return {
@@ -343,6 +347,8 @@ class Config:
                     ("num_stages", self.num_stages),
                     ("maxnreg", self.maxnreg),
                     ("ir_override", self.ir_override),
+                    ("minRegAutoWS", self.minRegAutoWS),
+                    ("maxRegAutoWS", self.maxRegAutoWS),
                 ) if v is not None
             }
         }
@@ -355,6 +361,8 @@ class Config:
         res.append(f"num_ctas: {self.num_ctas}")
         res.append(f"num_stages: {self.num_stages}")
         res.append(f"maxnreg: {self.maxnreg}")
+        res.append(f"minRegAutoWS: {self.minRegAutoWS}")
+        res.append(f"maxRegAutoWS: {self.maxRegAutoWS}")
         return ", ".join(res)
 
     def __hash__(self):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -631,7 +631,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         name = self.fn.__qualname__
         module = self.fn.__module__
         arg_reprs = ", ".join([f"{param.name}: {ty}" for param, ty in zip(self.params, key[1])])
-        repr = f"{name}[num_warps={options.num_warps}, num_ctas={options.num_ctas}, num_stages={options.num_stages}, enable_fp_fusion={options.enable_fp_fusion}, launch_cooperative_grid={options.launch_cooperative_grid}]({arg_reprs})"
+        repr = f"{name}[num_warps={options.num_warps}, num_ctas={options.num_ctas}, num_stages={options.num_stages}, minRegAutoWS={options.minRegAutoWS}, maxRegAutoWS={options.maxRegAutoWS}, enable_fp_fusion={options.enable_fp_fusion}, launch_cooperative_grid={options.launch_cooperative_grid}]({arg_reprs})"
         full_name = get_full_name(self.fn)
 
         specialization_data = serialize_specialization_data(full_name, signature, constants, configs[0], options, key)
@@ -643,6 +643,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
             'num_warps': options.num_warps,
             'num_ctas': options.num_ctas,
             'num_stages': options.num_stages,
+            'minRegAutoWS': options.minRegAutoWS,
+            'maxRegAutoWS': options.maxRegAutoWS,
             'enable_fp_fusion': options.enable_fp_fusion,
             'launch_cooperative_grid': options.launch_cooperative_grid,
             'extern_libs': options.extern_libs,

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -108,7 +108,7 @@ class CUDAOptions:
     num_ctas: int = 1
     num_stages: int = 3
     warp_size: int = 32
-    minRegAutoWS: int = 42
+    minRegAutoWS: int = 24
     maxRegAutoWS: int = 152
     # maxnreg corresponds to the ptx parameter .maxnreg, which controls the
     # maximum number of 32-bit registers used by one thread.

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -108,6 +108,8 @@ class CUDAOptions:
     num_ctas: int = 1
     num_stages: int = 3
     warp_size: int = 32
+    minRegAutoWS: int = 42
+    maxRegAutoWS: int = 152
     # maxnreg corresponds to the ptx parameter .maxnreg, which controls the
     # maximum number of 32-bit registers used by one thread.
     maxnreg: Optional[int] = None
@@ -247,6 +249,14 @@ class CUDABackend(BaseBackend):
         # Set maxnreg on all kernels, if it was provided.
         if opt.maxnreg is not None:
             mod.set_attr("ttg.maxnreg", ir.builder(mod.context).get_int32_attr(opt.maxnreg))
+
+        # Add minRegAutoWS attribute (you need to add this)
+        if opt.minRegAutoWS is not None:
+            mod.set_attr("ttg.min_reg_auto_ws", ir.builder(mod.context).get_int32_attr(opt.minRegAutoWS))
+
+        # Add maxRegAutoWS attribute (you need to add this)
+        if opt.maxRegAutoWS is not None:
+            mod.set_attr("ttg.max_reg_auto_ws", ir.builder(mod.context).get_int32_attr(opt.maxRegAutoWS))
 
         cluster_info = nvidia.ClusterInfo()
         if opt.cluster_dims is not None:


### PR DESCRIPTION
# PR description
This PR exposes minRegAutoWS and maxRegAutoWS to autotune configs. In the generated ttgir, you'll see `ttg.max_reg_auto_ws` and `ttg.min_reg_auto_ws` attributes in the moduleOp.

This PR takes the user input config parameter of minRegAutoWS and maxRegAutoWS, and use them for the pass OptimizePartitionWarps at TritonGPU dialect level.

**Test plan**: 
Please see the use example in tritonbench commit: https://github.com/meta-pytorch/tritonbench/pull/530
In `tritonbench/tritonbench/kernels/blackwell_triton_fused_attention_dp.py`, add `minRegAutoWS` and `maxRegAutoWS` in `triton.Configs`, and run
```
CUDA_VISIBLE_DEVICES=6 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python [run.py](http://run.py/) --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --metrics tflops --rep 3000 --sleep 1.0 --only triton_tutorial_flash_dp_persistent_blackwell
```

# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

Note that ruff complains an error not from my modifications:
```
python/tutorials/fused-attention-ws.py:24:5: F811 Redefinition of unused `is_blackwell` from line 7
   |
24 | def is_blackwell():
   |     ^^^^^^^^^^^^ F811
25 |     return is_cuda() and torch.cuda.get_device_capability()[0] == 10
   |
   = help: Remove definition: `is_blackwell`
```

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

Test plan: 
In `tritonbench/tritonbench/kernels/blackwell_triton_fused_attention_dp.py`, add `minRegAutoWS` and `maxRegAutoWS` in `triton.Configs`, and run
```
CUDA_VISIBLE_DEVICES=6 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python [run.py](http://run.py/) --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --metrics tflops --rep 3000 --sleep 1.0 --only triton_tutorial_flash_dp_persistent_blackwell
```

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
