### PR TITLE
[AutoWS] Prevent assigning different element types to share a buffer reuse

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -317,10 +317,6 @@ public:
         if (idTypes.count(bufferId) == 0) {
           idTypes[bufferId] = elemType;
         }
-        if (idTypes[bufferId] != elemType) {
-          ++bufferId;
-          idTypes[bufferId] = elemType;
-        }
         owner->setAttr(
             "buffer.id",
             IntegerAttr::get(IntegerType::get(owner->getContext(), 32),


### PR DESCRIPTION
Fixes one of the issues with N_CTX=128 and SEQ_LEN=128 with a constant N_CTX. The setup attempts to assign two buffers are "shared", but they different element types (bf16 vs f32). There are additional issues, but this appears to be an isolated unsafe code feature.