### PR TITLE
[TLX] Warp-specialized grouped GEMM kernel for blackwell

### DIFF
--- a/third_party/tlx/tutorials/blackwell-grouped-gemm.py
+++ b/third_party/tlx/tutorials/blackwell-grouped-gemm.py
@@ -543,7 +543,6 @@ def grouped_matmul_tlx_kernel(
                         offs_am = tile_m_idx * BLOCK_SIZE_M
                         offs_bn = tile_n_idx * BLOCK_SIZE_N
 
-                        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
                         for kk in range(0, tl.cdiv(k, BLOCK_SIZE_K)):
                             buf, phase = _get_bufidx_phase(accum_cnt, NUM_SMEM_BUFFERS)
                             tlx.barrier_wait(smem_empty_bars[buf], phase ^ 1)


### PR DESCRIPTION
```
group-gemm-performance:
        N    cuBLAS    Triton  Triton + TMA       TLX
0   128.0  0.036288  0.015488      0.021536  0.021504
1   256.0  0.036928  0.017536      0.021696  0.021632
2   512.0  0.037632  0.048256      0.023616  0.023712
3  1024.0  0.053856  0.230464      0.035968  0.034720
/home/hoy/triton-fb/python/triton/testing.py:370: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
  plt.show()
group-gemm-performance-m-8192-k-8192:
        M    cuBLAS     Triton  Triton + TMA       TLX
0   128.0  0.170816   2.002416      0.164608  0.154688
1   256.0  0.198544   3.768896      0.283680  0.238592
2   512.0  0.305856   7.363552      0.512416  0.418720
3  1024.0  0.605056  13.958176      0.828432  0.691904
```