### PR TITLE
Fix propagation of task IDs to parent ops

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
@@ -76,9 +76,12 @@ int doTaskIdPropagate(triton::FuncOp &funcOp) {
     if (!taskIds.isUninitialized() &&
         (isa<arith::ConstantOp>(op) || !op->hasAttr("async_task_id"))) {
       op->setAttr("async_task_id", taskIds.getTaskIds());
-      labelParentOps(op);
     }
   });
+  // The parent operations must have the union of their children's operations.
+  // We do this in a separate walk to avoid having a parent operation treated
+  // like an anchor op and skipped by the first walk.
+  funcOp.walk([&](mlir::Operation *op) { labelParentOps(op); });
   return 0;
 }
 


### PR DESCRIPTION
A parent op must always have the union of the task IDs of the operations that it contains. However, we currently skip propagating the ID to the parent if the child operation happens to be an anchor op.

In addition, because `labelParentOps` itself sets `async_task_ids` on the parent operations, it can cause the parent operation to appear like an anchor op when we actually visit it, causing us to skip it.

To address these, add a second walk where we unconditionally propagate task IDs to parent ops.