### PR TITLE
[TLX] Fix UB from wrong live range assumption of barriers

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -1228,6 +1228,7 @@ def test_barrier_live_range(device):
         bars3 = tlx.alloc_barriers(num_barriers=tl.constexpr(1), arrive_count=3)
         tlx.barrier_arrive(bars3[0])
 
+        # bars1 and bars2 should both be live here
         tlx.barrier_arrive(bars1[0])
 
     torch.manual_seed(0)

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -75,7 +75,10 @@ public:
       return WalkResult::advance();
     });
 
-    // Insert InvalBarrierOp before returnOp of entry funcOp
+    // todo: consider removing all the inval op that's located right before
+    // return in a later pass to save a few cycles.
+    // Insert InvalBarrierOp before returnOp of
+    // entry funcOp
     funcOp.walk([&](triton::ReturnOp op) {
       OpBuilder builder(op); // Insert *before* returnOp
       Location loc = op.getLoc();


### PR DESCRIPTION
If you have a pattern like this:
```
alloc barrierA
init barrierA

alloc barrierB
init barrierB
...
only use barrierB
```
the SMEM allocation pass will assume barrierA is dead when allocating barrierB so it will try to reuse the same buffer location. However, this means we'll have `mbarrier.init` on the same memory location twice without a `mbarrier.inval` in between. This is undefined behavior as explicitly stated in PTX doc: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-init

>The behavior of performing an mbarrier.init operation on a memory location containing a valid mbarrier object is undefined; invalidate the mbarrier object using mbarrier.inval first, before repurposing the memory location for any other purpose, including another mbarrier object.

TLX opens up the API of barrier alloc (bundled with init) but not barrier inval. This PR fixes it by automatically inserting corresponding `mbarrier.inval` Ops before return Op in Fixup pass. Since Fixup pass is very early, the only possibility of having barrier init op there is user calling TLX API so we can safely insert inval ops.

Included test passing: `pytest -vs python/test/unit/language/test_tlx.py::test_barrier_live_range`.

# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
all passing
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
all passing except AMD one (expected on a B200 machine)
```
