### PR TITLE
[AutoWS] Extend InterleaveTMEM to look past ArriveBarriers

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -326,7 +326,7 @@ void hoistArriveBarriersInBlock(
 
   SmallVector<ArriveBarrierOp> arrives;
   // Collect the Arrives for a block in program order.
-  for (auto it = block.rbegin(), e = block.rend(); it != e; ++it) {
+  for (auto it = block.begin(), e = block.end(); it != e; ++it) {
     Operation *op = &*it;
     if (auto arrive = dyn_cast<ArriveBarrierOp>(op)) {
       if (arriveMap.count(arrive)) {
@@ -380,7 +380,7 @@ void hoistArriveBarriers(
     DenseMap<ArriveBarrierOp, DenseSet<Operation *>> &arriveMap) {
   for (mlir::Region &region : op->getRegions()) {
     for (mlir::Block &block : region) {
-      sinkArriveBarriersInBlock(block, arriveMap);
+      hoistArriveBarriersInBlock(block, arriveMap);
     }
   }
 }


### PR DESCRIPTION
Upstream Triton already contains a pass that attempts to reorder TMEM operations closer to their desired use + store to enable subtiling, but these operations are slightly too conservative regarding a BarrierArriveOp. In particular, the existing code correctly determines that it cannot move the load past a BarrierArrive. However, it doesn't check if its safe to move the BarrierArrive. This PR extends that pass by allowing moving the BarrierArrive for the purpose of reordering TMEM instructions and then attempt to restore the old location as much as possible.

Here is the general approach:
1. Attempt to sink the ArriveBarrierOp as deeply as possible. In general you can safely move an ArriveBarrierOp deeper into the same basic block until you reach some operation that waits/commits on a barrier. As a simple proof, you could always reach that point in the code without the other warp/op having waited on the barrier, so it must be valid to delay the arrive until then.
2. Continue with the previous algorithm. The load can now be pushed deeper without the arrive.
3. "Hoist" the ArriveOp back to its original location. Conceptually we retain which memory operations previously came after the arrive and move up the basic block until we reach a memory operation that didn't use to come before it. In general this means we may include additional memory operations (that's the point of moving the store up), but it will be the minimum number and it will always be correct.

There are some additional details to simplify the code and avoid unnecessary code movement, but they are not crucial to the underlying summary. Here is a diff of the IR from just this pass: https://www.internalfb.com/intern/diffing/?paste_number=1992597588. As you can see this results in proper subtiling as desired.