### PR TITLE
[TLX] Support both num_regs and registers in async_task

### DIFF
--- a/third_party/tlx/language/tlx/async_task.py
+++ b/third_party/tlx/language/tlx/async_task.py
@@ -20,14 +20,14 @@ class async_task:
             if isinstance(args[0], core.constexpr) and args[0] == "default":
                 self.is_explict = True
                 self.is_default = True
-                self.num_regs = core._unwrap_if_constexpr(kwargs.get("registers", None))
+                self.num_regs = core._unwrap_if_constexpr(kwargs.get("num_regs", kwargs.get("registers", None)))
                 self.replicate = core._unwrap_if_constexpr(kwargs.get("replicate", 1))
             else:
                 self.task_ids = list({core._unwrap_if_constexpr(tid) for tid in args[0]})
         else:
             self.is_explict = True
             self.num_warps = core._unwrap_if_constexpr(kwargs.get("num_warps", None))
-            self.num_regs = core._unwrap_if_constexpr(kwargs.get("registers", None))
+            self.num_regs = core._unwrap_if_constexpr(kwargs.get("num_regs", kwargs.get("registers", None)))
             self.replicate = core._unwrap_if_constexpr(kwargs.get("replicate", 1))
 
     def __enter__(self):


### PR DESCRIPTION
Some kernels accidentally use `num_regs` instead of `registers` to specify register configuration. Let's support both.