### PR TITLE
[Cherry-pick] Add support for 5 triton backends instead of 4 (#7990)

### DIFF
--- a/python/src/main.cc
+++ b/python/src/main.cc
@@ -8,11 +8,12 @@ namespace py = pybind11;
 #define FOR_EACH_2(MACRO, X, ...) MACRO(X) FOR_EACH_1(MACRO, __VA_ARGS__)
 #define FOR_EACH_3(MACRO, X, ...) MACRO(X) FOR_EACH_2(MACRO, __VA_ARGS__)
 #define FOR_EACH_4(MACRO, X, ...) MACRO(X) FOR_EACH_3(MACRO, __VA_ARGS__)
+#define FOR_EACH_5(MACRO, X, ...) MACRO(X) FOR_EACH_4(MACRO, __VA_ARGS__)
 
 #define FOR_EACH_NARG(...) FOR_EACH_NARG_(__VA_ARGS__, FOR_EACH_RSEQ_N())
 #define FOR_EACH_NARG_(...) FOR_EACH_ARG_N(__VA_ARGS__)
-#define FOR_EACH_ARG_N(_1, _2, _3, _4, N, ...) N
-#define FOR_EACH_RSEQ_N() 4, 3, 2, 1, 0
+#define FOR_EACH_ARG_N(_1, _2, _3, _4, _5, N, ...) N
+#define FOR_EACH_RSEQ_N() 5, 4, 3, 2, 1, 0
 
 #define CONCATENATE(x, y) CONCATENATE1(x, y)
 #define CONCATENATE1(x, y) x##y


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: a12b048b60a1625df4f359104e339e9db53dbb2f
Original Author: Stella Stamenova
Original Date: 2025-08-27 13:57:44 -0700

Original commit message:
```
Add support for 5 triton backends instead of 4 (#7990)

This change adds support for one more element in the `FOR_EACH_P` macro
(and therefore its dependencies) - in particular, currently the macro
supports 4 elements and after this change, it will support 5.

The macro is only used in one place currently - to iterate over the
supported backends, for example:

```
FOR_EACH_P(DECLARE_BACKEND, TRITON_BACKENDS_TUPLE)
```

With the addition of gluon, the default number of backends is now 3
(gluon, cuda, amd) which only leaves "room" for one more backend. So if
one wanted to add `triton-shared`, that would be the limit of backends
they can support unless they explicitly drop one of the defaults. By
bumping the number here, triton can support the defaults + 2 more
backends which is the behavior from before the addition of gluon.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
