### PR TITLE
[Cherry-pick] [Dialect] Make warp specialization require at least 4 warps (#8005)

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -908,6 +908,12 @@ LogicalResult WarpSpecializeOp::verify() {
         "cannot be nested inside another `ttg.warp_specialize` op");
   }
 
+  std::optional<int> numWarps = maybeLookupNumWarps(*this);
+  if (numWarps && *numWarps % 4 != 0) {
+    return mlir::emitError(getLoc()) << "warp-specialized kernels requires "
+                                        "num_warps to be a multiple of 4";
+  }
+
   return success();
 }
 


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: cfc0a9d14506028c79383822df98e6a8da9c17cb
Original Author: Jeff Niu
Original Date: 2025-08-29 09:45:18 -0700

Original commit message:
```
[Dialect] Make warp specialization require at least 4 warps (#8005)

The warpgroup allocator makes fairly strong assumptions that the default
number of warps is at least 4. Untangling this is non-trivial (see #7940
which is WIP to fix this). For now, just add an error message to prevent
the compiler from crashing and confusing users.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
