### PR TITLE
[Cherry-pick] [NVIDIA] Add native MXFP FP8 scaled_dot for SM120 (#7918)

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -49,7 +49,12 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
       /*retType=*/"::mlir::Value",
       /*methodName=*/"getB",
       /*args=*/(ins)>,
-  InterfaceMethod<
+    InterfaceMethod<
+      /*desc=*/"Get the output tensor",
+      /*retType=*/"::mlir::Value",
+      /*methodName=*/"getD",
+      /*args=*/(ins)>,
+    InterfaceMethod<
       /*desc=*/"Verify the dimensions of the A and B DotOp operands.",
       /*retType=*/"bool",
       /*methodName=*/"verifyDims",
@@ -64,6 +69,7 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
         auto aTy = cast<ShapedType>($_op.getA().getType());
         auto bTy = cast<ShapedType>($_op.getB().getType());
         auto cTy = cast<ShapedType>($_op->getOperand(2).getType());
+        auto dTy = cast<ShapedType>($_op.getD().getType());
         auto aShape = aTy.getShape();
         auto bShape = bTy.getShape();
         auto cShape = cTy.getShape();

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -19,6 +19,7 @@ class AMDRotatingSharedEncodingAttr;
 class AMDMfmaEncodingAttr;
 class TensorOrMemDesc;
 class MemDescType;
+class CTALayoutAttr;
 
 // - BlockedEncodingAttrs have the following input dimensions.
 //
@@ -125,6 +126,13 @@ LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          unsigned mfmaMDim,
                                          ArrayRef<unsigned> tilesPerWarp,
                                          ArrayRef<unsigned> warpsPerCTA);
+
+LinearLayout getSM120DotScaledScaleLayout(MLIRContext *ctx, int dotOperandIdx,
+                                          ArrayRef<int64_t> dotOperandShape,
+                                          ArrayRef<unsigned> tilesPerWarp,
+                                          ArrayRef<unsigned> warpsPerCTA,
+                                          unsigned instrM, unsigned instrN,
+                                          CTALayoutAttr ctaLayoutAttr);
 
 // Create LinearLayout for nvidia mma tile.
 LinearLayout nvidiaMmaTile(MLIRContext *ctx, ArrayRef<unsigned> tileShape,

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -127,8 +127,8 @@ def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, 
     precision = "tf32" if dtype_src_str == "tensorfloat32" else "ieee"
     dtype_src_str = "float32" if dtype_src_str == "tensorfloat32" else dtype_src_str
     if dtype_src_str == "float8e5":
-        a = torch.randint(20, 40, (M, K), dtype=torch.int8, device=device).view(torch.float8_e5m2)
-        b = torch.randint(20, 40, (K, N), dtype=torch.int8, device=device).view(torch.float8_e5m2)
+        a = torch.randint(20, 40, (M, K), dtype=torch.uint8, device=device).view(torch.float8_e5m2)
+        b = torch.randint(20, 40, (K, N), dtype=torch.uint8, device=device).view(torch.float8_e5m2)
         A = f8_to_f16(a, dtype_src_str)
         B = f8_to_f16(b, dtype_src_str)
     else:
@@ -369,8 +369,8 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     a_f16 = f8_to_f16(a, dtype_src_str)
     b = torch.randint(20, 40, (K, N), dtype=torch.uint8, device=device).view(torch.float8_e5m2)
     b_f16 = f8_to_f16(b, dtype_src_str)
-    a_scale = torch.randint(130, (M, K // 32), dtype=torch.uint8, device=device)
-    b_scale = torch.randint(130, (N, K // 32), dtype=torch.uint8, device=device)
+    a_scale = torch.randint(64, 130, (M, K // 32), dtype=torch.uint8, device=device)
+    b_scale = torch.randint(64, 130, (N, K // 32), dtype=torch.uint8, device=device)
 
     dtype_dst = getattr(torch, dtype_dst_str)
     output = torch.empty((M, N), dtype=dtype_dst, device=device)
@@ -378,9 +378,10 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     kernel_kwargs = {}
     if is_hip():
         kernel_kwargs["matrix_instr_nonkdim"] = nonKDim
-    mxfp_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1), b.stride(0),
-                      b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES=NUM_STAGES,
-                      **kernel_kwargs, num_warps=NUM_WARPS)
+
+    out = mxfp_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1),
+                            b.stride(0), b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K,
+                            NUM_STAGES=NUM_STAGES, **kernel_kwargs, num_warps=NUM_WARPS)
     a_scale_f32 = fp8e8m0_to_float32(a_scale)
     b_scale_f32 = fp8e8m0_to_float32(b_scale)
     a_scale_f32 = a_scale_f32.repeat_interleave(32, dim=1)
@@ -393,9 +394,12 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     b = b_f16 * b_scale_f32
     ref_out = torch.matmul(a, b).to(torch.float32)
     output = output.to(torch.float32)
-    atol = 0.0001
-    rtol = 0.0001
-    torch.testing.assert_close(ref_out, output, atol=atol, rtol=rtol)
+    atol = 1e-2 * math.sqrt(K / 32)
+    torch.testing.assert_close(ref_out, output, atol=atol, rtol=0)
+
+    if is_cuda() and torch.cuda.get_device_capability()[0] == 12:
+        ptx = out.asm["ptx"]
+        assert "mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X" in ptx
 
 
 def _knob_promote_lhs_to_tmem(monkeypatch):

--- a/test/Conversion/tritongpu_to_llvm_sm120.mlir
+++ b/test/Conversion/tritongpu_to_llvm_sm120.mlir
@@ -1,0 +1,30 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-accelerate-matmul --allocate-shared-memory-nv='compute-capability=120' --convert-triton-gpu-to-llvm='compute-capability=120' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [1, 4], instrShape = [16, 8]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_mmav2_dot_scaled
+  // CHECK: mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X
+  tt.func public @sm120_mmav2_dot_scaled(
+    %a: tensor<128x32xf8E5M2, #blocked_k>,
+    %sa: tensor<128x2xi8, #blocked>,
+    %b: tensor<32x128xf8E5M2, #blocked>,
+    %sb: tensor<128x2xi8, #blocked>,
+    %out: !tt.ptr<f32>
+  ){
+    %c = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %a_d = ttg.convert_layout %a : tensor<128x32xf8E5M2, #blocked_k> -> tensor<128x32xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %b_d = ttg.convert_layout %b : tensor<32x128xf8E5M2, #blocked> -> tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %d = tt.dot_scaled %a_d scale %sa, %b_d scale %sb, %c lhs = e5m2 rhs = e5m2 {fastMath = false}
+      : tensor<128x32xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<128x2xi8, #blocked>
+        * tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>, tensor<128x2xi8, #blocked>
+        -> tensor<128x128xf32, #blocked>
+    %out_splat = tt.splat %out : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked>
+    %out_ptrs = tt.broadcast %out_splat : tensor<128x1x!tt.ptr<f32>, #blocked> -> tensor<128x128x!tt.ptr<f32>, #blocked>
+    %zero = arith.constant dense<0> : tensor<128x128xi1, #blocked>
+    tt.store %out_ptrs, %d, %zero : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -667,3 +667,83 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return %19 : tensor<128x128xf32, #blocked>
   }
 }
+
+// -----
+
+// Verify that for SM_120 with FP8 inputs, tt.dot_scaled is preserved and
+// scales are converted to linear layout for hardware acceleration.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_dot_scaled_basic
+  tt.func public @sm120_dot_scaled_basic(
+    %a: tensor<128x32xi8, #blocked_k>,
+    %scale_a: tensor<128x2xi8, #blocked>,
+    %b: tensor<32x128xi8, #blocked>,
+    %scale_b: tensor<128x2xi8, #blocked>
+  ) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK-DAG: tt.dot_scaled
+    // CHECK-DAG: #linear
+    // CHECK-DAG: #linear1
+    // CHECK-NOT: ttng.tc_gen5_mma_scaled
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e4m3 {fastMath = false}
+      : tensor<128x32xi8, #blocked_k>, tensor<128x2xi8, #blocked>
+        * tensor<32x128xi8, #blocked>, tensor<128x2xi8, #blocked>
+        -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// Verify that for SM_120 with FP4 inputs, tt.dot_scaled is decomposed into:
+// 1. ttg.fp4_to_fp for unpacking FP4 values
+// 2. Scale application with arith.mulf
+// 3. Regular tt.dot operation with MMA encoding
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked2_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_dot_scaled_fp4_fallback
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: ttg.fp4_to_fp
+  // CHECK: tt.dot
+  // CHECK: #mma
+  tt.func public @sm120_dot_scaled_fp4_fallback(
+    %a: tensor<128x32xi8, #blocked2_k>,
+    %scale_a: tensor<128x2xi8, #blocked2>,
+    %b: tensor<32x128xi8, #blocked2>,
+    %scale_b: tensor<128x2xi8, #blocked2>
+  ) -> tensor<128x128xf32, #blocked2> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked2>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e2m1 {fastMath = false}
+      : tensor<128x32xi8, #blocked2_k>, tensor<128x2xi8, #blocked2>
+        * tensor<32x128xi8, #blocked2>, tensor<128x2xi8, #blocked2>
+        -> tensor<128x128xf32, #blocked2>
+    tt.return %d : tensor<128x128xf32, #blocked2>
+  }
+}
+
+// -----
+
+// Verify that for SM_100 (Blackwell), tt.dot_scaled uses the specialized
+// MMAv5 path with tensor memory and tc_gen5_mma_scaled instruction.
+
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked3_1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3_2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm100_dot_scaled_mma_v5
+  // CHECK: ttng.tc_gen5_mma_scaled
+  // CHECK-NOT: tt.dot_scaled
+  tt.func public @sm100_dot_scaled_mma_v5(%a: tensor<128x64xi8, #blocked3_2>, %scale_a: tensor<128x2xi8, #blocked3_1>, %b: tensor<64x128xi8, #blocked3>, %scale_b: tensor<128x2xi8, #blocked3_1>) -> tensor<128x128xf32, #blocked3> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked3>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<128x64xi8, #blocked3_2>, tensor<128x2xi8, #blocked3_1> * tensor<64x128xi8, #blocked3>, tensor<128x2xi8, #blocked3_1> -> tensor<128x128xf32, #blocked3>
+    tt.return %d : tensor<128x128xf32, #blocked3>
+  }
+}

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3607,6 +3607,96 @@ TEST_F(LinearLayoutConversionsTest, TensorMemory_CTASplit) {
                 LinearLayout::identity1D(2, kCol, d1));
 }
 
+// Tests for SM120 DotScaled Scale Layout
+TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_AScale_Basic) {
+  // Test basic A-scale (per-row) layout for SM120
+  // dotOperandIdx = 0 (A-scale), shape = [128, 32], tilesPerWarp = [1, 1],
+  // warpsPerCTA = [4, 1], instrM = 16, instrN = 8
+  auto layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/0, /*dotOperandShape=*/{128, 32},
+      /*tilesPerWarp=*/{1, 1}, /*warpsPerCTA=*/{4, 1},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+
+  auto ll = LinearLayout(
+      {{S("register"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {64, 0}}},
+       {S("lane"), {{8, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+       {S("warp"), {{16, 0}, {32, 0}}},
+       {S("block"), {}}},
+      {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+}
+
+TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_BScale_Basic) {
+  // Test basic B-scale (per-col) layout for SM120
+  // dotOperandIdx = 1 (B-scale), shape = [32, 128], tilesPerWarp = [1, 1],
+  // warpsPerCTA = [1, 4], instrM = 16, instrN = 8
+  auto layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/1, /*dotOperandShape=*/{32, 128},
+      /*tilesPerWarp=*/{1, 1}, /*warpsPerCTA=*/{1, 4},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+  auto ll = LinearLayout(
+      {{S("register"),
+        {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {0, 32}, {0, 64}}},
+       {S("lane"), {{0, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+       {S("warp"), {{8, 0}, {16, 0}}},
+       {S("block"), {}}},
+      {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+}
+
+TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_MultiWarp) {
+  // Test with multiple warps configuration
+  // A-scale with 2x2 warp layout
+  auto layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/0, /*dotOperandShape=*/{256, 64},
+      /*tilesPerWarp=*/{2, 1}, /*warpsPerCTA=*/{2, 2},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+  auto ll = LinearLayout({{S("register"),
+                           {{32, 0},
+                            {0, 1},
+                            {0, 2},
+                            {0, 4},
+                            {0, 8},
+                            {0, 16},
+                            {0, 32},
+                            {64, 0},
+                            {128, 0}}},
+                          {S("lane"), {{8, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+                          {S("warp"), {{0, 0}, {16, 0}}},
+                          {S("block"), {}}},
+                         {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+
+  layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/1, /*dotOperandShape=*/{256, 64},
+      /*tilesPerWarp=*/{2, 1}, /*warpsPerCTA=*/{2, 2},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+  ll = LinearLayout({{S("register"),
+                      {{0, 1},
+                       {0, 2},
+                       {0, 4},
+                       {0, 8},
+                       {0, 16},
+                       {0, 32},
+                       {16, 0},
+                       {32, 0},
+                       {64, 0},
+                       {128, 0}}},
+                     {S("lane"), {{0, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+                     {S("warp"), {{8, 0}, {0, 0}}},
+                     {S("block"), {}}},
+                    {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+}
+
 } // anonymous namespace
 } // namespace mlir::triton::gpu
 


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: 001ec4b253348744054b910ca2b4bb07c8bba7c1
Original Author: Hyunsung Lee
Original Date: 2025-08-30 04:42:23 +0900

Original commit message:
```
[NVIDIA] Add native MXFP FP8 scaled_dot for SM120 (#7918)

### Summary
- Replace decomposition fallback by implementing native MXFP FP8
(E4M3/E5M2) MMA for SM120 to reduce latency and improve throughput on
SM120.
- Support 1X mode (see
https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-block-scaling
for further information.)


### Future directions
- mxfp4 x mxfp4 support (scale_vec 2X)
- mxfp8 x mxfp4

 
### Benchmark 
E2E vLLM Benchmark: Llama3-8B-Instruct - in_len=1024 out_len=1024
batch_size=128 (5090 RTX)
(Thanks to @mobicham, he conducted this benchmark)
```
fp8 x fp8 = 42.83 sec 
mxfp8 x mxfp8 (using native dot) = 44.45 sec
mxfp8 x mxfp8 (main using emulation) = 76.44 sec
```


<!---
The core Triton is a small number of people, and we receive many PRs
(thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the
following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]`
with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a
comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
- [x] The `lit` tests I have added follow these [best
practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
including the "tests should be minimal" section. (Usually running Python
code
    and using the instructions it generates is not minimal.)
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
