### PR TITLE
[Cherry-pick] [BACKEND] Fix matrix descriptor for no-swizzle case (#8027)

### DIFF
--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -157,8 +157,8 @@ def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, 
         atol = 0.06
         rtol = 0.06
     else:
-        atol = 0.01
-        rtol = 0.01
+        atol = 0.001
+        rtol = 0.001
     torch.testing.assert_close(ref_out, output, atol=atol, rtol=rtol)
     # Make sure the mma is pipelined by checking if in the TTGIR we see two mmav5
     # operations. (Pipeliner will add additional mma operation by peeling the prologue.)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -103,8 +103,12 @@ static Value createDescriptor(ConversionPatternRewriter &rewriter, Location loc,
     llvm::report_fatal_error("Unsupported swizzling size.");
   }
   if (swizzling == 0) {
-    desc.leadDimensionBaseOffset = 16 >> 4; // 16 bytes.
-    desc.strideDimensionBaseOffset = (8 * 16) >> 4;
+    // Because the descriptor normalizes spacing to 128-bit units, the
+    // normalized per-element stride is 16 bytes and LBO is defined as 8×that,
+    // i.e. 128 bytes.
+    desc.leadDimensionBaseOffset = 128 >> 4;
+    // Offset from first row to second row 16x16 bytes.
+    desc.strideDimensionBaseOffset = 256 >> 4;
   } else {
     desc.leadDimensionBaseOffset = (swizzling * stride) >> 4;
     desc.strideDimensionBaseOffset = swizzling >> 1;


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: 1c2e9bb563ca61672dd72d4fc2bb802fd1d1c781
Original Author: Thomas Raoux
Original Date: 2025-09-02 00:07:03 -0700

Original commit message:
```
[BACKEND] Fix matrix descriptor for no-swizzle case (#8027)

Also tighten the precision check to catch subtle fp8 precision diff
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
