### PR TITLE
[Cherry-pick] Fix `NvidiaTool.from_path` when tool cannot be found (#7985)

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -181,13 +181,11 @@ class NvidiaTool:
     def from_path(path: str) -> Optional[NvidiaTool]:
         try:
             result = subprocess.check_output([path, "--version"], stderr=subprocess.STDOUT)
-            if result is None:
-                return None
             version = re.search(r".*release (\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
             if version is None:
                 return None
             return NvidiaTool(path, version.group(1))
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return None
 
 


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: a531c0ccc153904305eadc9fc29d1ef515cac996
Original Author: Anatoly Myachev
Original Date: 2025-08-28 21:20:32 +0200

Original commit message:
```
Fix `NvidiaTool.from_path` when tool cannot be found (#7985)

Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
