### PR TITLE
[Cherry-pick] Add `llc` to the lit tool configuration (#7992)

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -59,6 +59,7 @@ tools = [
     'triton-opt',
     'triton-llvm-opt',
     'mlir-translate',
+    'llc',
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
 ]
 


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: a06e9026ecc2b19b2609f36522b6d48fb8af1154
Original Author: Stella Stamenova
Original Date: 2025-08-28 12:40:49 -0700

Original commit message:
```
Add `llc` to the lit tool configuration (#7992)

The triton lit tests leverage several llvm & mlir tools such as opt,
mlir-translate and llc. These are generally configured to come directly
from the llvm build that triton is using, but llc is not. This means
that right now the llc version on the system will be used instead and if
it doesn't match the rest of the tools, we can end up with failures. An
example failure is using an older version than the llvm build and
missing features (such as `ptx83`). To fix this issue, configure lit to
use the `llc` directly from the llvm build.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
