### PR TITLE
[Cherry-pick] [proton] Add missing #include. (#8008)

### DIFF
--- a/third_party/proton/csrc/include/Utility/String.h
+++ b/third_party/proton/csrc/include/Utility/String.h
@@ -2,6 +2,7 @@
 #define PROTON_UTILITY_STRING_H_
 
 #include <string>
+#include <vector>
 
 namespace proton {
 


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: 35695e67ba4bd2f6efa531f904077c700cc7a8ba
Original Author: Christian Sigg
Original Date: 2025-08-29 14:18:20 +0200

Original commit message:
```
[proton] Add missing #include. (#8008)
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
