### PR TITLE
[TLX] Adjust register requirement for Blackwell FA fwd

### DIFF
--- a/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
@@ -325,7 +325,7 @@ def _attn_fwd_ws(sm_scale, M,  #
                 tile_idx += num_progs
 
             # mma group
-        with tlx.async_task(num_warps=1, registers=80):
+        with tlx.async_task(num_warps=1, registers=24):
             accum_cnt_kv = 0
             accum_cnt_qk = 0
 
@@ -495,7 +495,7 @@ def _attn_fwd_ws(sm_scale, M,  #
                 tile_idx += num_progs
 
         # load
-        with tlx.async_task(num_warps=1, registers=80):
+        with tlx.async_task(num_warps=1, registers=24):
             accum_cnt_kv = 0
             for i in range(0, tiles_per_sm):
                 # initialize offsets
@@ -567,7 +567,7 @@ def _attn_fwd_ws(sm_scale, M,  #
                 tile_idx += num_progs
 
         # epilog group
-        with tlx.async_task(num_warps=1, registers=80):
+        with tlx.async_task(num_warps=1, registers=24):
             # initialize offsets
             for i in range(0, tiles_per_sm):
                 # initialize offsets


### PR DESCRIPTION
Getting fewer register spills and slightly better perf:

`python run.py --op blackwell_attentions --only tlx_blackwell_ws_pipelined_persistent_fwd  --seq-len 8191 --batch 4 --n-heads 48 --d-head 128 --metrics tflops --rep 3000 --sleep 1.0`

Before:
```

  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    tlx_blackwell_ws_pipelined_persistent_fwd-tflops
----------------------------------------------------  --------------------------------------------------
                        (4, 48, 48, 8191, 8191, 128)                                             924.471

```

After:

```

 (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    tlx_blackwell_ws_pipelined_persistent_fwd-tflops
----------------------------------------------------  --------------------------------------------------
                        (4, 48, 48, 8191, 8191, 128)                                             949.553
```
