### PR TITLE
[TLX] Add TTG_SharedClusterMemorySpace attribute

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -5,6 +5,14 @@ include "mlir/IR/AttrTypeBase.td"
 include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUDialect.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 
+def TTG_SharedClusterMemorySpace : AttrDef<TritonNvidiaGPU_Dialect, "SharedClusterMemorySpace"> {
+  let mnemonic = "shared_cluster_memory";
+  let description = [{
+    Attribute to indicate that the memory descriptor points to shared memory. The shared memory could reside in
+    any CTA within a CTA cluster.
+  }];
+}
+
 def TTG_TensorMemorySpace : AttrDef<TritonNvidiaGPU_Dialect, "TensorMemorySpace"> {
   let mnemonic = "tensor_memory";
   let description = [{

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 namespace mlir {
 
@@ -27,7 +28,10 @@ LogicalResult SharedMemoryAliasAnalysis::visitOperation(
   auto result = op->getResult(0);
   // skip ops that return memdesc in a different memory space.
   if (auto memdescTy = dyn_cast<triton::gpu::MemDescType>(result.getType())) {
-    if (!isa_and_nonnull<triton::gpu::SharedMemorySpaceAttr>(
+    // CTA Cluster level SMEM should go through the analysis too, so not
+    // skipping here
+    if (!isa_and_nonnull<triton::gpu::SharedMemorySpaceAttr,
+                         triton::nvidia_gpu::SharedClusterMemorySpaceAttr>(
             memdescTy.getMemorySpace()))
       return success();
   }

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1102,7 +1102,9 @@ static size_t getSharedMemorySize(Type type) {
   if (isa<PointerType, TensorDescType>(type))
     return 8;
   if (auto desc = dyn_cast<MemDescType>(type)) {
-    if (!isa<SharedMemorySpaceAttr>(desc.getMemorySpace()))
+    if (!isa<SharedMemorySpaceAttr,
+             triton::nvidia_gpu::SharedClusterMemorySpaceAttr>(
+            desc.getMemorySpace()))
       return 8;
     return 8 + desc.getRank() * 4;
   }

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -147,10 +147,11 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
                          << ll.getOutDimSize(dims[1]);
     }
   } else if (auto enc = dyn_cast<SharedEncodingTrait>(encoding)) {
-    if (memorySpace != SharedMemorySpaceAttr::get(ctx)) {
-      return emitError()
-             << "memorySpace must be SharedMemorySpace for shared encoding. "
-             << "Got " << memorySpace;
+    if (memorySpace != SharedMemorySpaceAttr::get(ctx) &&
+        memorySpace != nvidia_gpu::SharedClusterMemorySpaceAttr::get(ctx)) {
+      return emitError() << "memorySpace must be SharedMemorySpace or "
+                            "SharedClusterMemorySpace for shared encoding. "
+                         << "Got " << memorySpace;
     }
   } else if (auto enc = dyn_cast<nvidia_gpu::TensorMemoryScalesEncodingAttr>(
                  encoding)) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -156,14 +156,11 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
 
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
                                  Value barrierAlloc, Value bufferIdx) {
-  auto context = barrierAlloc.getContext();
-  Attribute sharedMemorySpace =
-      triton::gpu::SharedMemorySpaceAttr::get(context);
-  ttg::MemDescType barrierTy = ttg::MemDescType::get(
-      {1}, builder.getI64Type(),
-      cast<ttg::MemDescType>(barrierAlloc.getType()).getEncoding(),
-      sharedMemorySpace,
-      /*mutableMemory=*/true);
+  ttg::MemDescType allocType = cast<ttg::MemDescType>(barrierAlloc.getType());
+  ttg::MemDescType barrierTy =
+      ttg::MemDescType::get({1}, builder.getI64Type(), allocType.getEncoding(),
+                            allocType.getMemorySpace(),
+                            /*mutableMemory=*/true);
 
   // Create barrierForTMA from barrierAlloc.
   return builder.createWithAsyncTaskIds<ttg::MemDescIndexOp>(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -545,12 +545,12 @@ static Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance) {
                               /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
   auto barrierEncoding = ttg::SwizzledSharedEncodingAttr::get(
       context, 1, 1, 1, {0}, barrierCTALayout);
-  Type barrierMemDescType = ttg::MemDescType::get(
+  ttg::MemDescType barrierMemDescType = ttg::MemDescType::get(
       {distance, 1}, builder.getI64Type(), barrierEncoding, sharedMemorySpace,
       /*mutableMemory=*/true);
-  Type singleBarrierMemDescType =
-      ttg::MemDescType::get({1}, builder.getI64Type(), barrierEncoding,
-                            sharedMemorySpace, /*mutableMemory=*/true);
+  Type singleBarrierMemDescType = ttg::MemDescType::get(
+      {1}, builder.getI64Type(), barrierEncoding,
+      barrierMemDescType.getMemorySpace(), /*mutableMemory=*/true);
   Value barrierAlloc = builder.create<mlir::triton::gpu::LocalAllocOp>(
       loc, barrierMemDescType, Value());
   for (unsigned i = 0; i < distance; i++) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -62,7 +62,7 @@ createAsyncCopy(const DenseMap<Channel *, Value> &bufferMap, Channel *c,
   auto sliceType = RankedTensorType::get(sliceShape, elemType, sharedLayout);
 
   Attribute sharedMemorySpace =
-      triton::gpu::SharedMemorySpaceAttr::get(context);
+      cast<ttg::MemDescType>(buffer.getType()).getMemorySpace();
   ttg::MemDescType subviewTy =
       ttg::MemDescType::get(sliceType.getShape(), sliceType.getElementType(),
                             sliceType.getEncoding(), sharedMemorySpace,
@@ -117,7 +117,7 @@ createLocalCopy(const DenseMap<Channel *, Value> &bufferMap, Channel *channel,
   auto sliceType = RankedTensorType::get(sliceShape, elemType, sharedLayout);
 
   Attribute sharedMemorySpace =
-      triton::gpu::SharedMemorySpaceAttr::get(context);
+      cast<ttg::MemDescType>(buffer.getType()).getMemorySpace();
   ttg::MemDescType subviewTy =
       ttg::MemDescType::get(sliceType.getShape(), sliceType.getElementType(),
                             sliceType.getEncoding(), sharedMemorySpace,
@@ -187,7 +187,7 @@ Value getBufferForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
   auto sliceType = RankedTensorType::get(sliceShape, elemType, sharedLayout);
 
   Attribute sharedMemorySpace =
-      triton::gpu::SharedMemorySpaceAttr::get(context);
+      cast<ttg::MemDescType>(buffer.getType()).getMemorySpace();
   ttg::MemDescType subviewTy =
       ttg::MemDescType::get(sliceType.getShape(), sliceType.getElementType(),
                             sliceType.getEncoding(), sharedMemorySpace,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -118,13 +118,13 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
                                 /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
     auto barrierEncoding = ttg::SwizzledSharedEncodingAttr::get(
         context, 1, 1, 1, {0}, barrierCTALayout);
-    Type barrierMemDescType = ttg::MemDescType::get(
+    ttg::MemDescType barrierMemDescType = ttg::MemDescType::get(
         {createTokenOp.getNumBuffers(), 1}, builder.getI64Type(),
         barrierEncoding, sharedMemorySpace,
         /*mutableMemory=*/true);
-    Type singleBarrierMemDescType =
-        ttg::MemDescType::get({1}, builder.getI64Type(), barrierEncoding,
-                              sharedMemorySpace, /*mutableMemory=*/true);
+    Type singleBarrierMemDescType = ttg::MemDescType::get(
+        {1}, builder.getI64Type(), barrierEncoding,
+        barrierMemDescType.getMemorySpace(), /*mutableMemory=*/true);
     // These are created prior to warp_specialize.
     Value bufferFullArray = builder.create<mlir::triton::gpu::LocalAllocOp>(
         loc, barrierMemDescType, Value());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -595,6 +595,11 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
   if (isa<triton::gpu::SharedMemorySpaceAttr,
           triton::nvidia_gpu::TensorMemorySpaceAttr>(addressSpace)) {
     spaceId = 3;
+  } else if (isa<triton::nvidia_gpu::SharedClusterMemorySpaceAttr>(
+                 addressSpace)) {
+    // NVPTX backend defines 7 for Shared Cluster memory space:
+    // https://llvm.org/docs/NVPTXUsage.html#address-spaces
+    spaceId = 7;
   } else {
     llvm::report_fatal_error(
         "Only support SharedMemorySpace, TensorMemorySpace for now");

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -276,7 +276,7 @@ void init_triton_tlx_ir(py::module &&m) {
 
              auto singleBarrierMemDescType = ttg::MemDescType::get(
                  {1}, self.getBuilder().getI64Type(), barrierEncoding,
-                 memorySpace, /*mutableMemory=*/true);
+                 barriersMemDescType.getMemorySpace(), /*mutableMemory=*/true);
 
              // Allocate buffer in shared memory
              mlir::Value bufferViews =
@@ -439,6 +439,8 @@ void init_triton_tlx_ir(py::module &&m) {
                memorySpace = ttng::TensorMemorySpaceAttr::get(context);
              else if (storage == "smem") {
                memorySpace = ttg::SharedMemorySpaceAttr::get(context);
+             } else if (storage == "smemCluster") {
+               memorySpace = ttng::SharedClusterMemorySpaceAttr::get(context);
              } else {
                llvm_unreachable("Unknown storage type");
              }

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -178,6 +178,7 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
 class storage_kind(enum.Enum):
     smem = "smem"
     tmem = "tmem"
+    smemCluster = "smemCluster"
 
 
 class buffered_tensor(tl.base_value):


### PR DESCRIPTION
NVPTX defines Shared Cluster memory to be memory space "7", different from "3" for regular Shared memory. https://llvm.org/docs/NVPTXUsage.html#address-spaces. To conform with that,
and to make lowering to `NVVM::mapa` work later, this PR introduces this extra attribute to TTNG.

In this PR I've gone through all references to `SharedMemorySpaceAttr` to make sure `SharedClusterMemorySpaceAttr` is added there as needed. Most of the callsites are for creating LocalAllocOp though, which dictates `SharedMemorySpaceAttr` so no change is needed. Also making a few places future proof by taking source type's memory space attr to dst types, such as MemDescIndex ops.


`make test-lit` all passing.

In the future, this might be split into TLX specific parts and others and contributed to upstream.

This is part of the effort to implement 2cta mode for TLX. See full PR stack in https://github.com/facebookexperimental/triton/issues/636

# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
31 passed, 76 skipped in 24.97s
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
All passing/skipped except AMD one as expected (I'm on B200 GPU)
```
