### PR TITLE
NameLoc support for barriers and buffers added by AutoWS

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -18,6 +18,10 @@ namespace mlir {
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+std::string Channel::getChannelName() const {
+  return getChannelNameFromProducerConsumers(relation.first, relation.second);
+}
+
 // Check to see if op is enclosed under ifOp.
 bool enclosing(scf::IfOp ifOp, Operation *op) {
   return ifOp->isProperAncestor(op);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -62,6 +62,9 @@ public:
   virtual Operation *getDstOpLast() { return nullptr; }
   virtual void getDstOps(SmallVector<Operation *> &dsts) {}
 
+  // Get a string identifier for this channel
+  std::string getChannelName() const;
+
   Relation relation; // producer task Id, a list of consumer task Ids
   Operation *op;
   unsigned operandIdx;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
@@ -100,4 +100,66 @@ void copyLoopScheduleInfo(Operation *newOp, Operation *oldOp) {
     newOp->setAttr(tt::kLoopClusterAttrName,
                    oldOp->getAttr(tt::kLoopClusterAttrName));
 }
+
+// Barrier naming utilities for creating descriptive NameLocs
+std::string getChannelNameFromProducerConsumers(int producerId,
+                                                ArrayRef<int> consumerIds) {
+  std::string name = "ch_prod" + std::to_string(producerId);
+  for (int consumerId : consumerIds) {
+    name += "_cons" + std::to_string(consumerId);
+  }
+  return name;
+}
+
+std::string getBarrierName(llvm::StringRef barrierType,
+                           llvm::StringRef bufferType,
+                           llvm::StringRef channelName) {
+  return (barrierType + "_" + bufferType + "_" + channelName).str();
+}
+
+std::string getInitBarrierName(llvm::StringRef bufferType, unsigned bufferIdx) {
+  return ("init_barrier_" + bufferType + "_buf" + std::to_string(bufferIdx))
+      .str();
+}
+
+// NameLoc creation utilities for barriers
+Location createBarrierNameLoc(OpBuilder &builder, Operation *op,
+                              llvm::StringRef barrierType,
+                              llvm::StringRef bufferType) {
+  auto loc = op->getLoc();
+
+  std::string channelName = "unknown";
+  if (auto attr = op->getAttrOfType<StringAttr>("channel_name")) {
+    channelName = attr.getValue().str();
+  }
+  std::string barrierName =
+      getBarrierName(barrierType, bufferType, channelName);
+  return mlir::NameLoc::get(builder.getStringAttr(barrierName), loc);
+}
+
+Location createInitBarrierNameLoc(OpBuilder &builder, Location baseLoc,
+                                  llvm::StringRef bufferType,
+                                  unsigned bufferIdx) {
+  std::string barrierName = getInitBarrierName(bufferType, bufferIdx);
+  return mlir::NameLoc::get(builder.getStringAttr(barrierName), baseLoc);
+}
+
+// Buffer naming utilities for creating descriptive NameLocs
+std::string getBufferName(llvm::StringRef bufferType,
+                          llvm::StringRef channelName, unsigned numBuffers) {
+  std::string name = bufferType.str() + "_" + channelName.str();
+
+  // Add number of buffers for pipelining
+  name += "_nbuf" + std::to_string(numBuffers);
+
+  return name;
+}
+
+Location createBufferNameLoc(OpBuilder &builder, Location baseLoc,
+                             llvm::StringRef bufferType,
+                             llvm::StringRef channelName, unsigned numBuffers) {
+  std::string bufferName = getBufferName(bufferType, channelName, numBuffers);
+  return mlir::NameLoc::get(builder.getStringAttr(bufferName), baseLoc);
+}
+
 } // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.h
@@ -132,5 +132,28 @@ private:
 // where the dependency exists without a direct "user".
 void copyLoopScheduleInfo(Operation *newOp, Operation *oldOp);
 
+// Barrier naming utilities for creating descriptive NameLocs
+std::string getChannelNameFromProducerConsumers(int producerId,
+                                                ArrayRef<int> consumerIds);
+std::string getBarrierName(llvm::StringRef barrierType,
+                           llvm::StringRef bufferType,
+                           llvm::StringRef channelName);
+std::string getInitBarrierName(llvm::StringRef bufferType, unsigned bufferIdx);
+
+// NameLoc creation utilities for barriers
+Location createBarrierNameLoc(OpBuilder &builder, Operation *op,
+                              llvm::StringRef barrierType,
+                              llvm::StringRef bufferType);
+Location createInitBarrierNameLoc(OpBuilder &builder, Location baseLoc,
+                                  llvm::StringRef bufferType,
+                                  unsigned bufferIdx);
+
+// Buffer naming utilities for creating descriptive NameLocs
+std::string getBufferName(llvm::StringRef bufferType,
+                          llvm::StringRef channelName, unsigned numBuffers);
+Location createBufferNameLoc(OpBuilder &builder, Location baseLoc,
+                             llvm::StringRef bufferType,
+                             llvm::StringRef channelName, unsigned numBuffers);
+
 } // namespace mlir
 #endif // NV_DIALECT_HOPPER_TRANSFORMS_UTILITY_H_

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -49,11 +49,14 @@ Value getMBarrierPhaseBit(OpBuilder &builder, Operation *op,
 
 void processProducerAcquireOp(OpBuilder &builder, ttnvws::ProducerAcquireOp op,
                               Value bufferEmpty) {
-  auto loc = op.getLoc();
+  auto namedLoc =
+      createBarrierNameLoc(builder, op, "producer_acquire", "empty");
+
   Value phase = getMBarrierPhaseBit(builder, op, true);
   auto i32Ty = builder.getIntegerType(32);
-  phase = builder.create<arith::ExtUIOp>(loc, i32Ty, phase);
-  auto waitOp = builder.create<ttng::WaitBarrierOp>(loc, bufferEmpty, phase);
+  phase = builder.create<arith::ExtUIOp>(namedLoc, i32Ty, phase);
+  auto waitOp =
+      builder.create<ttng::WaitBarrierOp>(namedLoc, bufferEmpty, phase);
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
   copyLoopScheduleInfo(waitOp, op);
@@ -62,12 +65,13 @@ void processProducerAcquireOp(OpBuilder &builder, ttnvws::ProducerAcquireOp op,
 void processProducerCommitOp(OpBuilder &builder, ttnvws::ProducerCommitOp op,
                              Value bufferFull, ttnvws::TokenLoadType loadType,
                              unsigned fullCnt) {
-  auto loc = op.getLoc();
+  auto namedLoc = createBarrierNameLoc(builder, op, "producer_commit", "full");
+
   ttng::ArriveBarrierOp arriveOp;
 
   assert(loadType != ttnvws::TokenLoadType::AsyncLoadOp);
-  arriveOp =
-      builder.create<ttng::ArriveBarrierOp>(loc, bufferFull, 1); // fullCnt);
+  arriveOp = builder.create<ttng::ArriveBarrierOp>(namedLoc, bufferFull,
+                                                   1); // fullCnt);
 
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
@@ -76,11 +80,13 @@ void processProducerCommitOp(OpBuilder &builder, ttnvws::ProducerCommitOp op,
 
 void processConsumerWaitOp(OpBuilder &builder, ttnvws::ConsumerWaitOp op,
                            Value bufferFull) {
-  auto loc = op.getLoc();
+  auto namedLoc = createBarrierNameLoc(builder, op, "consumer_wait", "full");
+
   Value phase = getMBarrierPhaseBit(builder, op, false);
   auto i32Ty = builder.getIntegerType(32);
-  phase = builder.create<arith::ExtUIOp>(loc, i32Ty, phase);
-  auto waitOp = builder.create<ttng::WaitBarrierOp>(loc, bufferFull, phase);
+  phase = builder.create<arith::ExtUIOp>(namedLoc, i32Ty, phase);
+  auto waitOp =
+      builder.create<ttng::WaitBarrierOp>(namedLoc, bufferFull, phase);
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
   copyLoopScheduleInfo(waitOp, op);
@@ -89,9 +95,11 @@ void processConsumerWaitOp(OpBuilder &builder, ttnvws::ConsumerWaitOp op,
 void processConsumerReleaseOp(OpBuilder &builder, ttnvws::ConsumerReleaseOp op,
                               Value bufferEmpty, int numCTAs,
                               unsigned emptyCnt) {
-  auto loc = op.getLoc();
-  auto arriveOp =
-      builder.create<ttng::ArriveBarrierOp>(loc, bufferEmpty, 1); // emptyCnt);
+  auto namedLoc =
+      createBarrierNameLoc(builder, op, "consumer_release", "empty");
+
+  auto arriveOp = builder.create<ttng::ArriveBarrierOp>(namedLoc, bufferEmpty,
+                                                        1); // emptyCnt);
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
   copyLoopScheduleInfo(arriveOp, op);
@@ -181,12 +189,15 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
           loc, singleBarrierMemDescType, bufferFullArray, idx);
       // EmptyView is used for ConsumerRelease and ProducerAcquire.
       // FullView is for ConsumerWait and ProducerCommit.
-      builder.create<ttng::InitBarrierOp>(loc, barrierFullView,
+      auto fullLoc = createInitBarrierNameLoc(builder, loc, "full", i);
+      builder.create<ttng::InitBarrierOp>(fullLoc, barrierFullView,
                                           1); // bufferFullCount);
 
       Value barrierEmptyView = builder.create<ttg::MemDescIndexOp>(
           loc, singleBarrierMemDescType, bufferEmptyArray, idx);
-      builder.create<ttng::InitBarrierOp>(loc, barrierEmptyView,
+
+      auto emptyLoc = createInitBarrierNameLoc(builder, loc, "empty", i);
+      builder.create<ttng::InitBarrierOp>(emptyLoc, barrierEmptyView,
                                           1); // bufferEmptyCount);
     }
 


### PR DESCRIPTION
# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
