### PR TITLE
[TLX] Fix layout prop generating empty lattice value issue

### DIFF
--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -41,7 +41,8 @@ void LayoutEncoding::print(raw_ostream &os) const {
 
 LayoutEncoding LayoutEncoding::join(const LayoutEncoding &lhs,
                                     const LayoutEncoding &rhs) {
-  return LayoutEncoding::getUnknownLayout();
+  assert(lhs == rhs && "Conflicting layouts");
+  return lhs;
 }
 
 LayoutEncoding LayoutEncoding::meet(const LayoutEncoding &lhs,


### PR DESCRIPTION
The dataflow join operator is used to merge lattice values from different control paths. It's used to handle multiple WS regions, and should not result in a new lattice value if the original ones are uninitialized.