### PR TITLE
[racer] Replace tlx.local_view(x, y) with x[y] across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ While this approach places more responsibility on the user, it reduces the compi
 
     Allocate `NUM_BUFFERS` of buffers in the tensor memory per thread block, each with size size. The memory layout is inferred from its consumers.
 
-- `buffer = tlx.local_view(buffers, buffer_idx)`
+- `buffer = buffers[ buffer_idx]`
 
     Return a subview of the buffer indexed by `buffer_idx` from `buffers`.
 

--- a/third_party/tlx/tutorials/amd-gemm-pipelined.py
+++ b/third_party/tlx/tutorials/amd-gemm-pipelined.py
@@ -1,5 +1,4 @@
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
@@ -10,10 +9,21 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 def get_hip_autotune_config_full():
     configs = [
-        triton.Config({
-            'BLOCK_SIZE_M': block_m, 'BLOCK_SIZE_N': block_n, 'BLOCK_SIZE_K': block_k, 'GROUP_SIZE_M': group_size_m,
-            'NUM_STAGES': num_stages
-        } | {'kpack': kpack, 'matrix_instr_nonkdim': mat_dim_non_k, 'waves_per_eu': waves_per_eu}, num_warps=num_warps)
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": block_m,
+                "BLOCK_SIZE_N": block_n,
+                "BLOCK_SIZE_K": block_k,
+                "GROUP_SIZE_M": group_size_m,
+                "NUM_STAGES": num_stages,
+            }
+            | {
+                "kpack": kpack,
+                "matrix_instr_nonkdim": mat_dim_non_k,
+                "waves_per_eu": waves_per_eu,
+            },
+            num_warps=num_warps,
+        )
         for block_m in [32, 64, 128, 256]
         for block_n in [32, 64, 128, 256]
         for block_k in [32, 64, 128]
@@ -57,7 +67,6 @@ def is_invalid_config(config, N, M, K, mfma):
 
 
 def prune_configs(configs, named_args, **kwargs):
-
     pruned_configs = []
     M = named_args["M"]
     N = named_args["N"]
@@ -87,29 +96,80 @@ def prune_configs(configs, named_args, **kwargs):
         if GROUP_SIZE_M * BLOCK_SIZE_M >= M and GROUP_SIZE_M != 1:
             continue
         # out of shared memory resource
-        LDS = (BLOCK_SIZE_K * BLOCK_SIZE_M * elemBytes_a + BLOCK_SIZE_K * BLOCK_SIZE_N * elemBytes_b)
+        LDS = (
+            BLOCK_SIZE_K * BLOCK_SIZE_M * elemBytes_a
+            + BLOCK_SIZE_K * BLOCK_SIZE_N * elemBytes_b
+        )
         if LDS > 65536:
             continue
         pruned_configs.append(config)
 
     print(f"{len(configs)=} {len(pruned_configs)=} for {M=} {N=} {K=}")
     if len(pruned_configs) == 0:
-        raise RuntimeError("No valid configs left after pruning! Consider autotuning further with TritonBench")
+        raise RuntimeError(
+            "No valid configs left after pruning! Consider autotuning further with TritonBench"
+        )
     return pruned_configs
 
 
 full_tune = False
 hip_configs = [
-    triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 2, 'NUM_STAGES': 2}
-                  | {'kpack': 2, 'matrix_instr_nonkdim': 16, 'waves_per_eu': 0}, num_warps=4),
-    triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 1, 'NUM_STAGES': 2}
-                  | {'kpack': 2, 'matrix_instr_nonkdim': 16, 'waves_per_eu': 4}, num_warps=4),
-    triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 4, 'NUM_STAGES': 2}
-                  | {'kpack': 2, 'matrix_instr_nonkdim': 16, 'waves_per_eu': 2}, num_warps=4),
-    triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 4, 'NUM_STAGES': 2}
-                  | {'kpack': 1, 'matrix_instr_nonkdim': 16, 'waves_per_eu': 0}, num_warps=8),
-    triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 6, 'NUM_STAGES': 2}
-                  | {'matrix_instr_nonkdim': 16, 'waves_per_eu': 0}, num_warps=8, num_stages=2)
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 32,
+            "BLOCK_SIZE_N": 32,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 2,
+            "NUM_STAGES": 2,
+        }
+        | {"kpack": 2, "matrix_instr_nonkdim": 16, "waves_per_eu": 0},
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 32,
+            "BLOCK_SIZE_N": 32,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 1,
+            "NUM_STAGES": 2,
+        }
+        | {"kpack": 2, "matrix_instr_nonkdim": 16, "waves_per_eu": 4},
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 4,
+            "NUM_STAGES": 2,
+        }
+        | {"kpack": 2, "matrix_instr_nonkdim": 16, "waves_per_eu": 2},
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 4,
+            "NUM_STAGES": 2,
+        }
+        | {"kpack": 1, "matrix_instr_nonkdim": 16, "waves_per_eu": 0},
+        num_warps=8,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 256,
+            "BLOCK_SIZE_N": 256,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 6,
+            "NUM_STAGES": 2,
+        }
+        | {"matrix_instr_nonkdim": 16, "waves_per_eu": 0},
+        num_warps=8,
+        num_stages=2,
+    ),
 ]
 
 configs = get_hip_autotune_config_full() if full_tune else hip_configs
@@ -120,16 +180,28 @@ configs = get_hip_autotune_config_full() if full_tune else hip_configs
         "early_config_prune": prune_configs,
     },
     configs=configs,
-    key=['M', 'N', 'K'],
+    key=["M", "N", "K"],
 )
 @triton.jit
-def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak,  #
-                                  stride_bk, stride_bn,  #
-                                  stride_cm, stride_cn, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
-                                  BLOCK_SIZE_K: tl.constexpr,  #
-                                  GROUP_SIZE_M: tl.constexpr,  #
-                                  NUM_STAGES: tl.constexpr  #
-                                  ):
+def matmul_kernel_pipelined_mi300(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  #
+    GROUP_SIZE_M: tl.constexpr,  #
+    NUM_STAGES: tl.constexpr,  #
+):
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
@@ -161,13 +233,17 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
     # In general, when using tl.load + local_store
     # num buffers = pipeline-stage(local-store) - pipeline-stage(local-load)
     NUM_BUFFERS = NUM_STAGES - 1
-    buffers_A = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_STAGES - 1)
-    buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_STAGES - 1)
+    buffers_A = tlx.local_alloc(
+        (BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_STAGES - 1
+    )
+    buffers_B = tlx.local_alloc(
+        (BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_STAGES - 1
+    )
 
     # Pipeline Prologue. (NUM_STAGES - 1) iterations
     for i in tl.range(0, NUM_STAGES - 1, loop_unroll_factor=NUM_STAGES - 1):
-        a_smem_view = tlx.local_view(buffers_A, i)
-        b_smem_view = tlx.local_view(buffers_B, i)
+        a_smem_view = buffers_A[i]
+        b_smem_view = buffers_B[i]
         a_load_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - i * BLOCK_SIZE_K)
         b_load_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - i * BLOCK_SIZE_K)
         tlx.local_store(a_smem_view, a_load_reg)
@@ -181,15 +257,15 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
     # Disable auto-pipelining with num_stages=0
     for k in tl.range(NUM_STAGES - 1, K_ITERS, num_stages=0):
         # prefetch data for k into regs, this is NUM_STAGES - 1 ahead of the k in the following tl.dot
-        a_k_smem_view = tlx.local_view(buffers_A, k % NUM_BUFFERS)
-        b_k_smem_view = tlx.local_view(buffers_B, k % NUM_BUFFERS)
+        a_k_smem_view = buffers_A[k % NUM_BUFFERS]
+        b_k_smem_view = buffers_B[k % NUM_BUFFERS]
         a_load_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K)
         b_load_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K)
 
         # do compute on data fetched ahead by NUM_STAGES - 1
         buf = (k - NUM_STAGES - 1) % NUM_BUFFERS
-        a_k_prev_shmem = tlx.local_view(buffers_A, buf)
-        b_k_prev_shmem = tlx.local_view(buffers_B, buf)
+        a_k_prev_shmem = buffers_A[buf]
+        b_k_prev_shmem = buffers_B[buf]
         a_k_prev_reg = tlx.local_load(a_k_prev_shmem)
         b_k_prev_reg = tlx.local_load(b_k_prev_shmem)
         acc = tl.dot(a_k_prev_reg, b_k_prev_reg, acc)
@@ -201,11 +277,13 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
     # Epilogue
-    for k in tl.range(K_ITERS - (NUM_STAGES - 1), K_ITERS, loop_unroll_factor=NUM_STAGES - 1):
+    for k in tl.range(
+        K_ITERS - (NUM_STAGES - 1), K_ITERS, loop_unroll_factor=NUM_STAGES - 1
+    ):
         # do compute on data fetched ahead by NUM_STAGES - 1 in Main Loop
         buf = k % NUM_BUFFERS
-        a_k_prev_shmem = tlx.local_view(buffers_A, buf)
-        b_k_prev_shmem = tlx.local_view(buffers_B, buf)
+        a_k_prev_shmem = buffers_A[buf]
+        b_k_prev_shmem = buffers_B[buf]
         a_k_prev_reg = tlx.local_load(a_k_prev_shmem)
         b_k_prev_reg = tlx.local_load(b_k_prev_shmem)
         acc = tl.dot(a_k_prev_reg, b_k_prev_reg, acc)
@@ -227,13 +305,22 @@ def matmul(a, b):
     # Allocates output.
     c = torch.empty((M, N), device=a.device, dtype=torch.float16)
     # 1D launch kernel where each block gets its own program.
-    grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    )
     matmul_kernel_pipelined_mi300[grid](
-        a, b, c,  #
-        M, N, K,  #
-        a.stride(0), a.stride(1),  #
-        b.stride(0), b.stride(1),  #
-        c.stride(0), c.stride(1),  #
+        a,
+        b,
+        c,  #
+        M,
+        N,
+        K,  #
+        a.stride(0),
+        a.stride(1),  #
+        b.stride(0),
+        b.stride(1),  #
+        c.stride(0),
+        c.stride(1),  #
     )
     return c
 
@@ -263,7 +350,7 @@ TORCH_HAS_FP8 = False
 # We can now compare the performance of our kernel against that of cuBLAS or rocBLAS. Here we focus on square matrices,
 # but feel free to arrange this script as you wish to benchmark any other matrix shape.
 
-ref_lib = 'cuBLAS' if is_cuda() else 'rocBLAS'
+ref_lib = "cuBLAS" if is_cuda() else "rocBLAS"
 
 configs = []
 for fp8_inputs in [False, True]:
@@ -272,18 +359,29 @@ for fp8_inputs in [False, True]:
     configs.append(
         triton.testing.Benchmark(
             x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-            x_vals=[256, 512, 1024, 2048, 4096],  # Different possible values for `x_name`
+            x_vals=[
+                256,
+                512,
+                1024,
+                2048,
+                4096,
+            ],  # Different possible values for `x_name`
             line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
             # Possible values for `line_arg`
             # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
-            line_vals=["triton"] if fp8_inputs else [ref_lib.lower(), "triton"],  # Label name for the lines
+            line_vals=["triton"]
+            if fp8_inputs
+            else [ref_lib.lower(), "triton"],  # Label name for the lines
             line_names=["Triton"] if fp8_inputs else [ref_lib, "Triton"],  # Line styles
             styles=[("green", "-"), ("blue", "-")],
             ylabel="TFLOPS",  # Label name for the y-axis
-            plot_name="matmul-performance-" +
-            ("fp16" if not fp8_inputs else "fp8"),  # Name for the plot, used also as a file name for saving the plot.
+            plot_name="matmul-performance-"
+            + (
+                "fp16" if not fp8_inputs else "fp8"
+            ),  # Name for the plot, used also as a file name for saving the plot.
             args={"fp8_inputs": fp8_inputs},
-        ))
+        )
+    )
 
 
 @triton.testing.perf_report(configs)
@@ -296,9 +394,13 @@ def benchmark(M, N, K, provider, fp8_inputs):
         b = b.to(torch.float8_e5m2)
     quantiles = [0.5, 0.2, 0.8]
     if provider == ref_lib.lower():
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles, rep=1000)
-    if provider == 'triton':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles, rep=1000)
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: torch.matmul(a, b), quantiles=quantiles, rep=1000
+        )
+    if provider == "triton":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: matmul(a, b), quantiles=quantiles, rep=1000
+        )
     perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
     return perf(ms), perf(max_ms), perf(min_ms)
 

--- a/third_party/tlx/tutorials/blackwell-fa-ws-persistent_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-persistent_test.py
@@ -1,11 +1,10 @@
 import pytest
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.tools.tensor_descriptor import TensorDescriptor
 from triton._internal_testing import is_blackwell
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -31,9 +30,17 @@ def _host_descriptor_pre_hook(nargs):
 configs = [
     triton.Config(
         {
-            'BLOCK_M': 256, 'BLOCK_N': 128, 'NUM_BUFFERS_Q': 1, 'NUM_BUFFERS_KV': 3, 'NUM_BUFFERS_QK': 1,
-            'NUM_MMA_GROUPS': 2
-        }, num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
+            "BLOCK_M": 256,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS_Q": 1,
+            "NUM_BUFFERS_KV": 3,
+            "NUM_BUFFERS_QK": 1,
+            "NUM_MMA_GROUPS": 2,
+        },
+        num_stages=0,
+        num_warps=4,
+        pre_hook=_host_descriptor_pre_hook,
+    ),
 ]
 
 
@@ -59,17 +66,25 @@ def _compute_offsets(tile_idx, n_tile_num, H, N_CTX, BLOCK_M):
 
 @triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
 @triton.jit
-def _attn_fwd_ws(sm_scale, M,  #
-                 Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                 HEAD_DIM: tl.constexpr,  #
-                 BLOCK_M: tl.constexpr,  #
-                 BLOCK_N: tl.constexpr,  #
-                 FP8_OUTPUT: tl.constexpr,  #
-                 NUM_BUFFERS_Q: tl.constexpr,  #
-                 NUM_BUFFERS_KV: tl.constexpr,  #
-                 NUM_BUFFERS_QK: tl.constexpr,  #
-                 NUM_MMA_GROUPS: tl.constexpr,  #
-                 ):
+def _attn_fwd_ws(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    NUM_BUFFERS_Q: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,  #
+    NUM_BUFFERS_QK: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+):
     tl.static_assert(BLOCK_N <= HEAD_DIM)
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
@@ -91,8 +106,12 @@ def _attn_fwd_ws(sm_scale, M,  #
     tile_idx = prog_id
 
     # allocate SMEM buffers and barriers
-    q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS * NUM_BUFFERS_Q)
-    kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
+    q_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS * NUM_BUFFERS_Q
+    )
+    kv_tiles = tlx.local_alloc(
+        (BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV
+    )
 
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_Q)
     q_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_Q)
@@ -100,19 +119,43 @@ def _attn_fwd_ws(sm_scale, M,  #
     kv_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
 
     # allocate TMEM buffers and barriers
-    qk_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem)
+    qk_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem
+    )
     # Shared buffer for QK, P and Alpha, l, and m.
     # Alpha/l/m lives in the lower half of qk_buf, and P lives in the upper half.
-    p_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_v), NUM_MMA_GROUPS * 2,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
-    alpha_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                                  tlx.storage_kind.tmem, reuse=qk_tiles)
-    l_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
-    m_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
+    p_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM),
+        tlx.dtype_of(desc_v),
+        NUM_MMA_GROUPS * 2,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    alpha_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    l_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    m_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
 
-    acc_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem)
+    acc_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem
+    )
 
     qk_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
     qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
@@ -132,10 +175,13 @@ def _attn_fwd_ws(sm_scale, M,  #
             for i in range(0, tiles_per_sm):
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
                 for _ in tl.range(lo, hi, BLOCK_N):
                     _, phase = _get_bufidx_phase(accum_cnt, 1)
-                    for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
+                    for cid in tl.range(
+                        0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS
+                    ):
                         # -- update output accumulator --
                         tlx.barrier_wait(alpha_fulls[cid], phase)
                         # Use alpha[0] for cid=0, and alpha[HEAD_DIM] for cid=1
@@ -148,7 +194,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                     accum_cnt += 1
 
                 _, phase = _get_bufidx_phase(i, 1)
-                for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
+                for cid in tl.range(
+                    0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS
+                ):
                     # epilogue
                     tlx.barrier_wait(l_fulls[cid], phase)
                     # Use l[1]/l[1+HEAD_DIM] and m[2][2 + HEAD_DIM]
@@ -157,7 +205,11 @@ def _attn_fwd_ws(sm_scale, M,  #
                     tlx.barrier_arrive(qk_empties[cid])
                     m = tlx.local_load(m_tiles[cid * HEAD_DIM + 2])
                     m += tl.math.log2(l)
-                    offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                    offs_m = (
+                        start_m * BLOCK_M
+                        + cid * BLOCK_M_SPLIT
+                        + tl.arange(0, BLOCK_M_SPLIT)
+                    )
                     m_ptrs = M + off_hz * N_CTX + offs_m
                     tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
 
@@ -175,7 +227,8 @@ def _attn_fwd_ws(sm_scale, M,  #
             for i in range(0, tiles_per_sm):
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
                 # initialize pointer to m and l
                 m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
                 l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
@@ -229,7 +282,9 @@ def _attn_fwd_ws(sm_scale, M,  #
 
             for j in range(0, tiles_per_sm):
                 # initialize offsets
-                _, _, lo, hi, _, _ = _compute_offsets(tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                _, _, lo, hi, _, _ = _compute_offsets(
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
 
                 # wait for the Q buffer to be populated by the producer
                 q_bufIdx, q_phase = _get_bufidx_phase(j, NUM_BUFFERS_Q)
@@ -241,7 +296,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                 # loop over k, v and update accumulator
                 for i in tl.range(lo, hi, BLOCK_N):
                     k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                    v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+                    v_bufIdx, v_phase = _get_bufidx_phase(
+                        accum_cnt_kv + 1, NUM_BUFFERS_KV
+                    )
 
                     # -- compute q @ k ----
                     # wait for the K buffer to be populated by the producer
@@ -303,40 +360,52 @@ def _attn_fwd_ws(sm_scale, M,  #
             accum_cnt_kv = 0
             for i in range(0, tiles_per_sm):
                 # initialize offsets
-                _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
 
                 # load q: it will stay in SRAM throughout
                 q_bufIdx, q_phase = _get_bufidx_phase(i, NUM_BUFFERS_Q)
                 tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-                tlx.barrier_expect_bytes(q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
+                tlx.barrier_expect_bytes(
+                    q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM
+                )  # float16
                 qo_offset_y_split = qo_offset_y
-                tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx])
+                tlx.async_descriptor_load(
+                    desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx]
+                )
 
                 q_bufIdx += NUM_BUFFERS_Q
                 tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-                tlx.barrier_expect_bytes(q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
+                tlx.barrier_expect_bytes(
+                    q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM
+                )  # float16
                 qo_offset_y_split = qo_offset_y + BLOCK_M_SPLIT
-                tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx])
+                tlx.async_descriptor_load(
+                    desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx]
+                )
 
                 # loop over loading k, v
                 for _ in tl.range(lo, hi, BLOCK_N):
                     k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
                     # wait for the K buffer to be released by the consumer
-                    k_empty = tlx.local_view(kv_empties, k_bufIdx)
+                    k_empty = kv_empties[k_bufIdx]
                     tlx.barrier_wait(k_empty, k_phase ^ 1)
                     # load K
-                    k_full = tlx.local_view(kv_fulls, k_bufIdx)
-                    k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+                    k_full = kv_fulls[k_bufIdx]
+                    k_tile = kv_tiles[k_bufIdx]
                     tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                     tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
-                    v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+                    v_bufIdx, v_phase = _get_bufidx_phase(
+                        accum_cnt_kv + 1, NUM_BUFFERS_KV
+                    )
                     # wait for the V buffer to be released by the consumer
-                    v_empty = tlx.local_view(kv_empties, v_bufIdx)
+                    v_empty = kv_empties[v_bufIdx]
                     tlx.barrier_wait(v_empty, v_phase ^ 1)
                     # load V
-                    v_full = tlx.local_view(kv_fulls, v_bufIdx)
-                    v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+                    v_full = kv_fulls[v_bufIdx]
+                    v_tile = kv_tiles[v_bufIdx]
                     tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                     tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -347,7 +416,6 @@ def _attn_fwd_ws(sm_scale, M,  #
 
 
 class _attention(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, sm_scale):
         # shape constraints
@@ -359,18 +427,45 @@ class _attention(torch.autograd.Function):
         o = torch.empty_like(q)
         extra_kern_args = {}
 
-        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        M = torch.empty(
+            (q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32
+        )
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
         dummy_block = [1, 1]
-        desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+        desc_q = TensorDescriptor(
+            q,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
         if q.dtype == torch.float8_e5m2:
-            desc_v = TensorDescriptor(v, shape=[HEAD_DIM_K, y_dim], strides=[q.shape[2], 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[HEAD_DIM_K, y_dim],
+                strides=[q.shape[2], 1],
+                block_shape=dummy_block,
+            )
         else:
-            desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[y_dim, HEAD_DIM_K],
+                strides=[HEAD_DIM_K, 1],
+                block_shape=dummy_block,
+            )
+        desc_k = TensorDescriptor(
+            k,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
+        desc_o = TensorDescriptor(
+            o,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
 
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -391,13 +486,19 @@ class _attention(torch.autograd.Function):
 
         ctx.grid = grid
         _attn_fwd_ws[grid](
-            sm_scale, M,  #
-            q.shape[0], q.shape[1],  #
-            desc_q, desc_k, desc_v, desc_o,  #
+            sm_scale,
+            M,  #
+            q.shape[0],
+            q.shape[1],  #
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,  #
             N_CTX=q.shape[2],  #
             HEAD_DIM=HEAD_DIM_K,  #
             FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-            **extra_kern_args)
+            **extra_kern_args,
+        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
@@ -422,9 +523,21 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
     if mode == "bwd":
         pytest.skip("Backward pass not supported.")
     torch.manual_seed(20)
-    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    q = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    v = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
     sm_scale = 0.5
     # reference implementation
     ref_dtype = dtype
@@ -453,8 +566,10 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
 
 
 try:
-    from flash_attn.flash_attn_interface import \
-        flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func,
+    )
+
     HAS_FLASH = True
 except BaseException:
     HAS_FLASH = False
@@ -480,7 +595,8 @@ configs.append(
             "HEAD_DIM": HEAD_DIM,
             "mode": "fwd",
         },
-    ))
+    )
+)
 
 
 @triton.testing.perf_report(configs)
@@ -488,9 +604,15 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
     assert mode in ["fwd", "bwd"]
     dtype = torch.float16
     if "triton" in provider:
-        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        q = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        k = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        v = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
         if mode == "fwd" and "fp8" in provider:
             q = q.to(torch.float8_e5m2)
             k = k.to(torch.float8_e5m2)
@@ -506,7 +628,12 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
         ms = triton.testing.do_bench(fn)
 
     if provider == "flash":
-        qkv = torch.randn((BATCH, N_CTX, 3, H, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        qkv = torch.randn(
+            (BATCH, N_CTX, 3, H, HEAD_DIM),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
         fn = lambda: flash_attn_func(qkv)
         if mode == "bwd":
             o = fn()

--- a/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
@@ -1,11 +1,10 @@
 import pytest
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.tools.tensor_descriptor import TensorDescriptor
 from triton._internal_testing import is_blackwell
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -31,8 +30,13 @@ def _host_descriptor_pre_hook(nargs):
 configs = [
     triton.Config(
         {
-            'BLOCK_M': 256, 'BLOCK_N': 128, 'NUM_BUFFERS_Q': 1, 'NUM_BUFFERS_KV': 3, 'NUM_BUFFERS_QK': 1,
-            'NUM_MMA_GROUPS': 2, 'NUM_MMA_SLICES': 2
+            "BLOCK_M": 256,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS_Q": 1,
+            "NUM_BUFFERS_KV": 3,
+            "NUM_BUFFERS_QK": 1,
+            "NUM_MMA_GROUPS": 2,
+            "NUM_MMA_SLICES": 2,
         },
         num_stages=0,
         num_warps=4,
@@ -105,7 +109,7 @@ def _compute_offsets(tile_idx, n_tile_num, H, N_CTX, BLOCK_M):
 @triton.jit
 def _split_n(x, SPLIT_FACTOR: tl.constexpr):
     if SPLIT_FACTOR == 1:
-        return (x, )
+        return (x,)
     else:
         x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
         return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
@@ -116,26 +120,34 @@ def _join_n(xs):
     if len(xs) == 1:
         return xs[0]
     else:
-        x0 = _join_n(xs[:len(xs) // 2])
-        x1 = _join_n(xs[len(xs) // 2:])
+        x0 = _join_n(xs[: len(xs) // 2])
+        x1 = _join_n(xs[len(xs) // 2 :])
         x = tl.join(x0, x1).permute(0, 2, 1).reshape([x0.shape[0], x0.shape[1] * 2])
         return x
 
 
 @triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
 @triton.jit
-def _attn_fwd_ws(sm_scale, M,  #
-                 Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                 HEAD_DIM: tl.constexpr,  #
-                 BLOCK_M: tl.constexpr,  #
-                 BLOCK_N: tl.constexpr,  #
-                 FP8_OUTPUT: tl.constexpr,  #
-                 NUM_BUFFERS_Q: tl.constexpr,  #
-                 NUM_BUFFERS_KV: tl.constexpr,  #
-                 NUM_BUFFERS_QK: tl.constexpr,  #
-                 NUM_MMA_GROUPS: tl.constexpr,  #
-                 NUM_MMA_SLICES: tl.constexpr,  #
-                 ):
+def _attn_fwd_ws(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    NUM_BUFFERS_Q: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,  #
+    NUM_BUFFERS_QK: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+    NUM_MMA_SLICES: tl.constexpr,  #
+):
     tl.static_assert(BLOCK_N <= HEAD_DIM)
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
@@ -158,9 +170,15 @@ def _attn_fwd_ws(sm_scale, M,  #
     tile_idx = prog_id
 
     # allocate SMEM buffers and barriers
-    q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS * NUM_BUFFERS_Q)
-    kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
-    o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_MMA_GROUPS)
+    q_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS * NUM_BUFFERS_Q
+    )
+    kv_tiles = tlx.local_alloc(
+        (BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV
+    )
+    o_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_MMA_GROUPS
+    )
 
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_Q)
     q_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_Q)
@@ -170,7 +188,9 @@ def _attn_fwd_ws(sm_scale, M,  #
     o_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
 
     # allocate TMEM buffers and barriers
-    qk_tiles = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem)
+    qk_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, BLOCK_N), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem
+    )
     # Shared buffer for QK, P and Alpha, l, and m.
     # A single QK buffer is split evenly:
     #   - First half  : stores P
@@ -180,16 +200,38 @@ def _attn_fwd_ws(sm_scale, M,  #
     #  Alpha : |BLK_M/2*1*fp32|
     #     l :                 |BLK_M/2*1*fp32|
     #     m :                                |BLK_M/2*1*fp32|
-    p_tiles = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N // NUM_MMA_SLICES), tlx.dtype_of(desc_v),
-                              NUM_MMA_GROUPS * NUM_MMA_SLICES * 2, tlx.storage_kind.tmem, reuse=qk_tiles)
-    alpha_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                                  tlx.storage_kind.tmem, reuse=qk_tiles)
-    l_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
-    m_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
+    p_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, BLOCK_N // NUM_MMA_SLICES),
+        tlx.dtype_of(desc_v),
+        NUM_MMA_GROUPS * NUM_MMA_SLICES * 2,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    alpha_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    l_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    m_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
 
-    acc_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem)
+    acc_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem
+    )
 
     qk_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
     qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
@@ -209,7 +251,8 @@ def _attn_fwd_ws(sm_scale, M,  #
             for i in range(0, tiles_per_sm):
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
                 for _ in tl.range(lo, hi, BLOCK_N):
                     _, phase = _get_bufidx_phase(accum_cnt, 1)
                     for cid in tl.static_range(0, NUM_MMA_GROUPS):
@@ -241,7 +284,11 @@ def _attn_fwd_ws(sm_scale, M,  #
                     tlx.barrier_arrive(qk_empties[cid])
                     m = tlx.local_load(m_tiles[cid * HEAD_DIM + 2])
                     m += tl.math.log2(l)
-                    offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                    offs_m = (
+                        start_m * BLOCK_M
+                        + cid * BLOCK_M_SPLIT
+                        + tl.arange(0, BLOCK_M_SPLIT)
+                    )
                     m_ptrs = M + off_hz * N_CTX + offs_m
                     tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
 
@@ -273,7 +320,8 @@ def _attn_fwd_ws(sm_scale, M,  #
             for i in range(0, tiles_per_sm):
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
                 # initialize pointer to m and l
                 m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
                 l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
@@ -304,11 +352,15 @@ def _attn_fwd_ws(sm_scale, M,  #
                         # prepare p for the v dot
                         # Use p[NUM_MMA_SLICES + slice_id] for cid=0, and
                         # p[NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id] for cid=1
-                        p_bufIdx = cid * NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id
+                        p_bufIdx = (
+                            cid * NUM_MMA_GROUPS * NUM_MMA_SLICES
+                            + NUM_MMA_SLICES
+                            + slice_id
+                        )
                         p_i = tl.math.exp2(qks[slice_id])
                         tlx.local_store(p_tiles[p_bufIdx], p_i.to(tlx.dtype_of(desc_v)))
                         tlx.barrier_arrive(p_fulls[slice_id + cid * NUM_MMA_SLICES])
-                        ps = ps + (p_i, )
+                        ps = ps + (p_i,)
 
                     p = _join_n(ps)
                     l_ij = tl.sum(p, 1)
@@ -331,7 +383,9 @@ def _attn_fwd_ws(sm_scale, M,  #
 
             for j in range(0, tiles_per_sm):
                 # initialize offsets
-                _, _, lo, hi, _, _ = _compute_offsets(tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                _, _, lo, hi, _, _ = _compute_offsets(
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
 
                 q_bufIdx, q_phase = _get_bufidx_phase(j, NUM_BUFFERS_Q)
                 k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
@@ -397,7 +451,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                     accum_cnt_qk += 1
                     accum_cnt_kv += 2
                     k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                    v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+                    v_bufIdx, v_phase = _get_bufidx_phase(
+                        accum_cnt_kv + 1, NUM_BUFFERS_KV
+                    )
 
                     # -- compute q0 @ k ----
                     # wait for the K buffer to be populated by the producer
@@ -416,15 +472,25 @@ def _attn_fwd_ws(sm_scale, M,  #
                     # -- compute p1 @ v from the previous iteration----
                     tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
                     for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                        tlx.barrier_wait(p_fulls[slice_id + 1 * NUM_MMA_SLICES], qk_phase_prev)
+                        tlx.barrier_wait(
+                            p_fulls[slice_id + 1 * NUM_MMA_SLICES], qk_phase_prev
+                        )
                         kv_slice = tlx.local_slice(
                             kv_tiles[v_bufIdx_prev],
                             [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
                             [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM],
                         )
-                        p_bufIdx = 1 * NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id
+                        p_bufIdx = (
+                            1 * NUM_MMA_GROUPS * NUM_MMA_SLICES
+                            + NUM_MMA_SLICES
+                            + slice_id
+                        )
                         use_acc = acc1_init if slice_id == 0 else True
-                        mBarriers = [kv_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+                        mBarriers = (
+                            [kv_empties[v_bufIdx_prev]]
+                            if slice_id == NUM_MMA_SLICES - 1
+                            else []
+                        )
                         tlx.async_dot(
                             p_tiles[p_bufIdx],
                             kv_slice,
@@ -450,7 +516,9 @@ def _attn_fwd_ws(sm_scale, M,  #
 
                     tlx.barrier_wait(acc_fulls[0], qk_phase)
                     for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                        tlx.barrier_wait(p_fulls[slice_id + 0 * NUM_MMA_SLICES], qk_phase)
+                        tlx.barrier_wait(
+                            p_fulls[slice_id + 0 * NUM_MMA_SLICES], qk_phase
+                        )
                         # Use p[1] for cid=0, and p[3] for cid=1
                         kv_slice = tlx.local_slice(
                             kv_tiles[v_bufIdx],
@@ -479,9 +547,15 @@ def _attn_fwd_ws(sm_scale, M,  #
                         [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
                         [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM],
                     )
-                    p_bufIdx = 1 * NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id
+                    p_bufIdx = (
+                        1 * NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id
+                    )
                     use_acc = acc1_init if slice_id == 0 else True
-                    mBarriers = [acc_empties[1], kv_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+                    mBarriers = (
+                        [acc_empties[1], kv_empties[v_bufIdx]]
+                        if slice_id == NUM_MMA_SLICES - 1
+                        else []
+                    )
                     tlx.async_dot(
                         p_tiles[p_bufIdx],
                         kv_slice,
@@ -499,41 +573,51 @@ def _attn_fwd_ws(sm_scale, M,  #
             accum_cnt_kv = 0
             for i in range(0, tiles_per_sm):
                 # initialize offsets
-                _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
 
                 # load q0
                 q_bufIdx, q_phase = _get_bufidx_phase(i, NUM_BUFFERS_Q)
                 tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-                tlx.barrier_expect_bytes(q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
+                tlx.barrier_expect_bytes(
+                    q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM
+                )  # float16
                 qo_offset_y_split = qo_offset_y
-                tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx])
+                tlx.async_descriptor_load(
+                    desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx]
+                )
 
                 # loop over loading k, v
                 k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
                 # wait for the K buffer to be released by the consumer
-                k_empty = tlx.local_view(kv_empties, k_bufIdx)
+                k_empty = kv_empties[k_bufIdx]
                 tlx.barrier_wait(k_empty, k_phase ^ 1)
 
                 # load K
-                k_full = tlx.local_view(kv_fulls, k_bufIdx)
-                k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+                k_full = kv_fulls[k_bufIdx]
+                k_tile = kv_tiles[k_bufIdx]
                 tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
                 # load q1
                 q_bufIdx += NUM_BUFFERS_Q
                 tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-                tlx.barrier_expect_bytes(q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
+                tlx.barrier_expect_bytes(
+                    q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * HEAD_DIM
+                )  # float16
                 qo_offset_y_split = qo_offset_y + BLOCK_M_SPLIT
-                tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx])
+                tlx.async_descriptor_load(
+                    desc_q, q_tiles[q_bufIdx], [qo_offset_y_split, 0], q_fulls[q_bufIdx]
+                )
 
                 v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
                 # wait for the V buffer to be released by the consumer
-                v_empty = tlx.local_view(kv_empties, v_bufIdx)
+                v_empty = kv_empties[v_bufIdx]
                 tlx.barrier_wait(v_empty, v_phase ^ 1)
                 # load V
-                v_full = tlx.local_view(kv_fulls, v_bufIdx)
-                v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+                v_full = kv_fulls[v_bufIdx]
+                v_tile = kv_tiles[v_bufIdx]
                 tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -543,21 +627,23 @@ def _attn_fwd_ws(sm_scale, M,  #
                 for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N):
                     k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
                     # wait for the K buffer to be released by the consumer
-                    k_empty = tlx.local_view(kv_empties, k_bufIdx)
+                    k_empty = kv_empties[k_bufIdx]
                     tlx.barrier_wait(k_empty, k_phase ^ 1)
                     # load K
-                    k_full = tlx.local_view(kv_fulls, k_bufIdx)
-                    k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+                    k_full = kv_fulls[k_bufIdx]
+                    k_tile = kv_tiles[k_bufIdx]
                     tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                     tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
-                    v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+                    v_bufIdx, v_phase = _get_bufidx_phase(
+                        accum_cnt_kv + 1, NUM_BUFFERS_KV
+                    )
                     # wait for the V buffer to be released by the consumer
-                    v_empty = tlx.local_view(kv_empties, v_bufIdx)
+                    v_empty = kv_empties[v_bufIdx]
                     tlx.barrier_wait(v_empty, v_phase ^ 1)
                     # load V
-                    v_full = tlx.local_view(kv_fulls, v_bufIdx)
-                    v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+                    v_full = kv_fulls[v_bufIdx]
+                    v_tile = kv_tiles[v_bufIdx]
                     tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                     tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -571,13 +657,17 @@ def _attn_fwd_ws(sm_scale, M,  #
             # initialize offsets
             for i in range(0, tiles_per_sm):
                 # initialize offsets
-                _, _, _, _, qo_offset_y, _ = _compute_offsets(tile_idx, n_tile_num, H, N_CTX, BLOCK_M)
+                _, _, _, _, qo_offset_y, _ = _compute_offsets(
+                    tile_idx, n_tile_num, H, N_CTX, BLOCK_M
+                )
                 _, phase = _get_bufidx_phase(i, 1)
                 for cid in tl.static_range(0, NUM_MMA_GROUPS):
                     tlx.barrier_wait(o_fulls[cid], phase)
                     tlx.fence_async_shared()
                     qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
-                    tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                    tlx.async_descriptor_store(
+                        desc_o, o_tiles[cid], [qo_offset_y_split, 0]
+                    )
                     tlx.async_descriptor_store_wait(0)
                     tlx.barrier_arrive(o_empties[cid])
 
@@ -585,7 +675,6 @@ def _attn_fwd_ws(sm_scale, M,  #
 
 
 class _attention(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, sm_scale):
         # shape constraints
@@ -597,18 +686,45 @@ class _attention(torch.autograd.Function):
         o = torch.empty_like(q)
         extra_kern_args = {}
 
-        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        M = torch.empty(
+            (q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32
+        )
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
         dummy_block = [1, 1]
-        desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+        desc_q = TensorDescriptor(
+            q,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
         if q.dtype == torch.float8_e5m2:
-            desc_v = TensorDescriptor(v, shape=[HEAD_DIM_K, y_dim], strides=[q.shape[2], 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[HEAD_DIM_K, y_dim],
+                strides=[q.shape[2], 1],
+                block_shape=dummy_block,
+            )
         else:
-            desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[y_dim, HEAD_DIM_K],
+                strides=[HEAD_DIM_K, 1],
+                block_shape=dummy_block,
+            )
+        desc_k = TensorDescriptor(
+            k,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
+        desc_o = TensorDescriptor(
+            o,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
 
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -629,13 +745,19 @@ class _attention(torch.autograd.Function):
 
         ctx.grid = grid
         _attn_fwd_ws[grid](
-            sm_scale, M,  #
-            q.shape[0], q.shape[1],  #
-            desc_q, desc_k, desc_v, desc_o,  #
+            sm_scale,
+            M,  #
+            q.shape[0],
+            q.shape[1],  #
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,  #
             N_CTX=q.shape[2],  #
             HEAD_DIM=HEAD_DIM_K,  #
             FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-            **extra_kern_args)
+            **extra_kern_args,
+        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
@@ -660,9 +782,21 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
     if mode == "bwd":
         pytest.skip("Backward pass not supported.")
     torch.manual_seed(20)
-    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    q = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    v = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
     sm_scale = 0.5
     # reference implementation
     ref_dtype = dtype
@@ -691,8 +825,10 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
 
 
 try:
-    from flash_attn.flash_attn_interface import \
-        flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func,
+    )
+
     HAS_FLASH = True
 except BaseException:
     HAS_FLASH = False
@@ -718,7 +854,8 @@ configs.append(
             "HEAD_DIM": HEAD_DIM,
             "mode": "fwd",
         },
-    ))
+    )
+)
 
 
 @triton.testing.perf_report(configs)
@@ -726,9 +863,15 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
     assert mode in ["fwd", "bwd"]
     dtype = torch.float16
     if "triton" in provider:
-        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        q = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        k = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        v = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
         if mode == "fwd" and "fp8" in provider:
             q = q.to(torch.float8_e5m2)
             k = k.to(torch.float8_e5m2)
@@ -744,7 +887,12 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
         ms = triton.testing.do_bench(fn)
 
     if provider == "flash":
-        qkv = torch.randn((BATCH, N_CTX, 3, H, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        qkv = torch.randn(
+            (BATCH, N_CTX, 3, H, HEAD_DIM),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
         fn = lambda: flash_attn_func(qkv)
         if mode == "bwd":
             o = fn()

--- a/third_party/tlx/tutorials/blackwell-fa-ws-pipelined_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-pipelined_test.py
@@ -1,11 +1,10 @@
 import pytest
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.tools.tensor_descriptor import TensorDescriptor
 from triton._internal_testing import is_blackwell
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -31,8 +30,18 @@ def _host_descriptor_pre_hook(nargs):
 configs = [
     # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'NUM_BUFFERS_KV': 3, 'NUM_BUFFERS_QK': 1, 'NUM_MMA_GROUPS': 1},
     #               num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
-    triton.Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'NUM_BUFFERS_KV': 3, 'NUM_BUFFERS_QK': 1, 'NUM_MMA_GROUPS': 2},
-                  num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
+    triton.Config(
+        {
+            "BLOCK_M": 256,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS_KV": 3,
+            "NUM_BUFFERS_QK": 1,
+            "NUM_MMA_GROUPS": 2,
+        },
+        num_stages=0,
+        num_warps=4,
+        pre_hook=_host_descriptor_pre_hook,
+    ),
 ]
 
 
@@ -58,16 +67,24 @@ def _compute_offsets(H, N_CTX, BLOCK_M):
 
 @triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
 @triton.jit
-def _attn_fwd_ws(sm_scale, M,  #
-                 Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                 HEAD_DIM: tl.constexpr,  #
-                 BLOCK_M: tl.constexpr,  #
-                 BLOCK_N: tl.constexpr,  #
-                 FP8_OUTPUT: tl.constexpr,  #
-                 NUM_BUFFERS_KV: tl.constexpr,  #
-                 NUM_BUFFERS_QK: tl.constexpr,  #
-                 NUM_MMA_GROUPS: tl.constexpr,  #
-                 ):
+def _attn_fwd_ws(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,  #
+    NUM_BUFFERS_QK: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+):
     tl.static_assert(BLOCK_N <= HEAD_DIM)
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
@@ -75,29 +92,61 @@ def _attn_fwd_ws(sm_scale, M,  #
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
 
     # allocate SMEM buffers and barriers
-    q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS)
-    kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
+    q_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS
+    )
+    kv_tiles = tlx.local_alloc(
+        (BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV
+    )
 
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
     kv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     kv_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
 
     # allocate TMEM buffers and barriers
-    qk_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                               tlx.storage_kind.tmem)
+    qk_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM),
+        tl.float32,
+        NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+    )
     # Shared buffer for QK, P and Alpha, l, and m.
     # Alpha/l/m lives in the lower half of qk_buf, and P lives in the upper half.
-    p_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_v), NUM_MMA_GROUPS * NUM_BUFFERS_QK * 2,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
-    alpha_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                                  tlx.storage_kind.tmem, reuse=qk_tiles)
-    l_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
-    m_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
+    p_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM),
+        tlx.dtype_of(desc_v),
+        NUM_MMA_GROUPS * NUM_BUFFERS_QK * 2,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    alpha_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    l_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    m_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
 
-    acc_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                                tlx.storage_kind.tmem)
+    acc_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM),
+        tl.float32,
+        NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+    )
 
     qk_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_QK)
     p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_QK)
@@ -112,20 +161,26 @@ def _attn_fwd_ws(sm_scale, M,  #
         # correction group
         with tlx.async_task("default"):
             # initialize offsets
-            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(H, N_CTX, BLOCK_M)
+            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                H, N_CTX, BLOCK_M
+            )
             accum_cnt = 0
             buf_idx = 0
             phase = 0
 
             for _ in tl.range(lo, hi, BLOCK_N):
                 buf_idx, phase = _get_bufidx_phase(accum_cnt, NUM_BUFFERS_QK)
-                for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
+                for cid in tl.range(
+                    0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS
+                ):
                     buf_idx_2 = buf_idx + cid * NUM_BUFFERS_QK
 
                     # -- update output accumulator --
                     tlx.barrier_wait(alpha_fulls[buf_idx_2], phase)
                     # Use alpha[0] for cid=0, and alpha[HEAD_DIM * NUM_BUFFERS_QK] for cid=1
-                    alpha_1 = tlx.local_load(alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK])
+                    alpha_1 = tlx.local_load(
+                        alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK]
+                    )
                     tlx.barrier_arrive(alpha_empties[buf_idx_2])
 
                     acc = tlx.local_load(acc_tiles[buf_idx_2])
@@ -142,7 +197,11 @@ def _attn_fwd_ws(sm_scale, M,  #
                 l = tlx.local_load(l_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK + 1])
                 m = tlx.local_load(m_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK + 2])
                 m += tl.math.log2(l)
-                offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                offs_m = (
+                    start_m * BLOCK_M
+                    + cid * BLOCK_M_SPLIT
+                    + tl.arange(0, BLOCK_M_SPLIT)
+                )
                 m_ptrs = M + off_hz * N_CTX + offs_m
                 tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
 
@@ -155,7 +214,9 @@ def _attn_fwd_ws(sm_scale, M,  #
         # softmax groups
         with tlx.async_task(num_warps=4, registers=152, replicate=NUM_MMA_GROUPS):
             # initialize offsets
-            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(H, N_CTX, BLOCK_M)
+            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                H, N_CTX, BLOCK_M
+            )
             # initialize pointer to m and l
             m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
             l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
@@ -179,7 +240,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                 alpha = tl.math.exp2(m_i - m_ij)
                 tlx.barrier_wait(alpha_empties[qk_bufIdx], qk_phase ^ 1)
                 # Use alpha[0] for cid=0, and alpha[HEAD_DIM * NUM_BUFFERS_QK] for cid=1
-                tlx.local_store(alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK], alpha[:, None])
+                tlx.local_store(
+                    alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK], alpha[:, None]
+                )
                 tlx.barrier_arrive(alpha_fulls[qk_bufIdx])
 
                 qk = qk * qk_scale - m_ij[:, None]
@@ -324,38 +387,48 @@ def _attn_fwd_ws(sm_scale, M,  #
         # load
         with tlx.async_task(num_warps=1, registers=24):
             # initialize offsets
-            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(H, N_CTX, BLOCK_M)
+            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                H, N_CTX, BLOCK_M
+            )
 
             # load q0
-            tlx.barrier_expect_bytes(q_fulls[0], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
+            tlx.barrier_expect_bytes(
+                q_fulls[0], 2 * BLOCK_M_SPLIT * HEAD_DIM
+            )  # float16
             qo_offset_y_split = qo_offset_y
-            tlx.async_descriptor_load(desc_q, q_tiles[0], [qo_offset_y_split, 0], q_fulls[0])
+            tlx.async_descriptor_load(
+                desc_q, q_tiles[0], [qo_offset_y_split, 0], q_fulls[0]
+            )
 
             # loop over loading k, v
             accum_cnt_kv = 0
             k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
             # wait for the K buffer to be released by the consumer
-            k_empty = tlx.local_view(kv_empties, k_bufIdx)
+            k_empty = kv_empties[k_bufIdx]
             tlx.barrier_wait(k_empty, k_phase ^ 1)
 
             # load K
-            k_full = tlx.local_view(kv_fulls, k_bufIdx)
-            k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+            k_full = kv_fulls[k_bufIdx]
+            k_tile = kv_tiles[k_bufIdx]
             tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
             tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
             # load q1
-            tlx.barrier_expect_bytes(q_fulls[1], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
+            tlx.barrier_expect_bytes(
+                q_fulls[1], 2 * BLOCK_M_SPLIT * HEAD_DIM
+            )  # float16
             qo_offset_y_split = qo_offset_y + BLOCK_M_SPLIT
-            tlx.async_descriptor_load(desc_q, q_tiles[1], [qo_offset_y_split, 0], q_fulls[1])
+            tlx.async_descriptor_load(
+                desc_q, q_tiles[1], [qo_offset_y_split, 0], q_fulls[1]
+            )
 
             v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
             # wait for the V buffer to be released by the consumer
-            v_empty = tlx.local_view(kv_empties, v_bufIdx)
+            v_empty = kv_empties[v_bufIdx]
             tlx.barrier_wait(v_empty, v_phase ^ 1)
             # load V
-            v_full = tlx.local_view(kv_fulls, v_bufIdx)
-            v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+            v_full = kv_fulls[v_bufIdx]
+            v_tile = kv_tiles[v_bufIdx]
             tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
             tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -365,21 +438,21 @@ def _attn_fwd_ws(sm_scale, M,  #
             for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N):
                 k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
                 # wait for the K buffer to be released by the consumer
-                k_empty = tlx.local_view(kv_empties, k_bufIdx)
+                k_empty = kv_empties[k_bufIdx]
                 tlx.barrier_wait(k_empty, k_phase ^ 1)
                 # load K
-                k_full = tlx.local_view(kv_fulls, k_bufIdx)
-                k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+                k_full = kv_fulls[k_bufIdx]
+                k_tile = kv_tiles[k_bufIdx]
                 tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
                 v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
                 # wait for the V buffer to be released by the consumer
-                v_empty = tlx.local_view(kv_empties, v_bufIdx)
+                v_empty = kv_empties[v_bufIdx]
                 tlx.barrier_wait(v_empty, v_phase ^ 1)
                 # load V
-                v_full = tlx.local_view(kv_fulls, v_bufIdx)
-                v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+                v_full = kv_fulls[v_bufIdx]
+                v_tile = kv_tiles[v_bufIdx]
                 tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -388,7 +461,6 @@ def _attn_fwd_ws(sm_scale, M,  #
 
 
 class _attention(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, sm_scale):
         # shape constraints
@@ -400,18 +472,45 @@ class _attention(torch.autograd.Function):
         o = torch.empty_like(q)
         extra_kern_args = {}
 
-        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        M = torch.empty(
+            (q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32
+        )
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
         dummy_block = [1, 1]
-        desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+        desc_q = TensorDescriptor(
+            q,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
         if q.dtype == torch.float8_e5m2:
-            desc_v = TensorDescriptor(v, shape=[HEAD_DIM_K, y_dim], strides=[q.shape[2], 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[HEAD_DIM_K, y_dim],
+                strides=[q.shape[2], 1],
+                block_shape=dummy_block,
+            )
         else:
-            desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[y_dim, HEAD_DIM_K],
+                strides=[HEAD_DIM_K, 1],
+                block_shape=dummy_block,
+            )
+        desc_k = TensorDescriptor(
+            k,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
+        desc_o = TensorDescriptor(
+            o,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
 
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -419,17 +518,27 @@ class _attention(torch.autograd.Function):
         triton.set_allocator(alloc_fn)
 
         def grid(META):
-            return (triton.cdiv(q.shape[2], META["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
+            return (
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
 
         ctx.grid = grid
         _attn_fwd_ws[grid](
-            sm_scale, M,  #
-            q.shape[0], q.shape[1],  #
-            desc_q, desc_k, desc_v, desc_o,  #
+            sm_scale,
+            M,  #
+            q.shape[0],
+            q.shape[1],  #
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,  #
             N_CTX=q.shape[2],  #
             HEAD_DIM=HEAD_DIM_K,  #
             FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-            **extra_kern_args)
+            **extra_kern_args,
+        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
@@ -454,9 +563,21 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
     if mode == "bwd":
         pytest.skip("Backward pass not supported.")
     torch.manual_seed(20)
-    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    q = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    v = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
     sm_scale = 0.5
     # reference implementation
     ref_dtype = dtype
@@ -485,8 +606,10 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
 
 
 try:
-    from flash_attn.flash_attn_interface import \
-        flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func,
+    )
+
     HAS_FLASH = True
 except BaseException:
     HAS_FLASH = False
@@ -511,7 +634,8 @@ configs.append(
             "HEAD_DIM": HEAD_DIM,
             "mode": "fwd",
         },
-    ))
+    )
+)
 
 
 @triton.testing.perf_report(configs)
@@ -519,9 +643,15 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
     assert mode in ["fwd", "bwd"]
     dtype = torch.float16
     if "triton" in provider:
-        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        q = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        k = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        v = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
         if mode == "fwd" and "fp8" in provider:
             q = q.to(torch.float8_e5m2)
             k = k.to(torch.float8_e5m2)
@@ -537,7 +667,12 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
         ms = triton.testing.do_bench(fn)
 
     if provider == "flash":
-        qkv = torch.randn((BATCH, N_CTX, 3, H, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        qkv = torch.randn(
+            (BATCH, N_CTX, 3, H, HEAD_DIM),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
         fn = lambda: flash_attn_func(qkv)
         if mode == "bwd":
             o = fn()

--- a/third_party/tlx/tutorials/blackwell-fa-ws_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws_test.py
@@ -1,11 +1,10 @@
 import pytest
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.tools.tensor_descriptor import TensorDescriptor
 from triton._internal_testing import is_blackwell
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -31,8 +30,18 @@ def _host_descriptor_pre_hook(nargs):
 configs = [
     # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'NUM_BUFFERS_KV': 3, 'NUM_BUFFERS_QK': 1, 'NUM_MMA_GROUPS': 1},
     #               num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
-    triton.Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'NUM_BUFFERS_KV': 3, 'NUM_BUFFERS_QK': 1, 'NUM_MMA_GROUPS': 2},
-                  num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
+    triton.Config(
+        {
+            "BLOCK_M": 256,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS_KV": 3,
+            "NUM_BUFFERS_QK": 1,
+            "NUM_MMA_GROUPS": 2,
+        },
+        num_stages=0,
+        num_warps=4,
+        pre_hook=_host_descriptor_pre_hook,
+    ),
 ]
 
 
@@ -58,43 +67,83 @@ def _compute_offsets(H, N_CTX, BLOCK_M):
 
 @triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
 @triton.jit
-def _attn_fwd_ws(sm_scale, M,  #
-                 Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                 HEAD_DIM: tl.constexpr,  #
-                 BLOCK_M: tl.constexpr,  #
-                 BLOCK_N: tl.constexpr,  #
-                 FP8_OUTPUT: tl.constexpr,  #
-                 NUM_BUFFERS_KV: tl.constexpr,  #
-                 NUM_BUFFERS_QK: tl.constexpr,  #
-                 NUM_MMA_GROUPS: tl.constexpr,  #
-                 ):
+def _attn_fwd_ws(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,  #
+    NUM_BUFFERS_QK: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+):
     tl.static_assert(BLOCK_N <= HEAD_DIM)
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
 
     # allocate SMEM buffers and barriers
-    q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS)
-    kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
+    q_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS
+    )
+    kv_tiles = tlx.local_alloc(
+        (BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV
+    )
 
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
     kv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     kv_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
 
     # allocate TMEM buffers and barriers
-    qk_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                               tlx.storage_kind.tmem)
+    qk_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM),
+        tl.float32,
+        NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+    )
     # Shared buffer for QK, P and Alpha, l, and m.
     # Alpha/l/m lives in the lower half of qk_buf, and P lives in the upper half.
-    p_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_v), NUM_MMA_GROUPS * NUM_BUFFERS_QK * 2,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
-    alpha_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                                  tlx.storage_kind.tmem, reuse=qk_tiles)
-    l_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
-    m_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                              tlx.storage_kind.tmem, reuse=qk_tiles)
+    p_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM),
+        tlx.dtype_of(desc_v),
+        NUM_MMA_GROUPS * NUM_BUFFERS_QK * 2,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    alpha_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    l_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    m_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        HEAD_DIM * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
 
-    acc_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-                                tlx.storage_kind.tmem)
+    acc_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM),
+        tl.float32,
+        NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        tlx.storage_kind.tmem,
+    )
 
     qk_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_QK)
     p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_QK)
@@ -109,20 +158,26 @@ def _attn_fwd_ws(sm_scale, M,  #
         # correction group
         with tlx.async_task("default"):
             # initialize offsets
-            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(H, N_CTX, BLOCK_M)
+            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                H, N_CTX, BLOCK_M
+            )
             accum_cnt = 0
             buf_idx = 0
             phase = 0
 
             for _ in tl.range(lo, hi, BLOCK_N):
                 buf_idx, phase = _get_bufidx_phase(accum_cnt, NUM_BUFFERS_QK)
-                for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
+                for cid in tl.range(
+                    0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS
+                ):
                     buf_idx_2 = buf_idx + cid * NUM_BUFFERS_QK
 
                     # -- update output accumulator --
                     tlx.barrier_wait(alpha_fulls[buf_idx_2], phase)
                     # Use alpha[0] for cid=0, and alpha[HEAD_DIM * NUM_BUFFERS_QK] for cid=1
-                    alpha_1 = tlx.local_load(alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK])
+                    alpha_1 = tlx.local_load(
+                        alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK]
+                    )
                     tlx.barrier_arrive(alpha_empties[buf_idx_2])
 
                     acc = tlx.local_load(acc_tiles[buf_idx_2])
@@ -139,7 +194,11 @@ def _attn_fwd_ws(sm_scale, M,  #
                 l = tlx.local_load(l_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK + 1])
                 m = tlx.local_load(m_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK + 2])
                 m += tl.math.log2(l)
-                offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                offs_m = (
+                    start_m * BLOCK_M
+                    + cid * BLOCK_M_SPLIT
+                    + tl.arange(0, BLOCK_M_SPLIT)
+                )
                 m_ptrs = M + off_hz * N_CTX + offs_m
                 tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
 
@@ -154,7 +213,9 @@ def _attn_fwd_ws(sm_scale, M,  #
         # softmax groups
         with tlx.async_task(num_warps=4, registers=152, replicate=NUM_MMA_GROUPS):
             # initialize offsets
-            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(H, N_CTX, BLOCK_M)
+            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                H, N_CTX, BLOCK_M
+            )
             # initialize pointer to m and l
             m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
             l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
@@ -178,7 +239,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                 alpha = tl.math.exp2(m_i - m_ij)
                 tlx.barrier_wait(alpha_empties[qk_bufIdx], qk_phase ^ 1)
                 # Use alpha[0] for cid=0, and alpha[HEAD_DIM * NUM_BUFFERS_QK] for cid=1
-                tlx.local_store(alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK], alpha[:, None])
+                tlx.local_store(
+                    alpha_tiles[cid * HEAD_DIM * NUM_BUFFERS_QK], alpha[:, None]
+                )
                 tlx.barrier_arrive(alpha_fulls[qk_bufIdx])
 
                 qk = qk * qk_scale - m_ij[:, None]
@@ -223,7 +286,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                 tlx.barrier_wait(kv_fulls[k_bufIdx], k_phase)
                 k_tile = tlx.local_trans(kv_tiles[k_bufIdx])
                 qk_bufIdx, qk_phase = _get_bufidx_phase(accum_cnt_qk, NUM_BUFFERS_QK)
-                for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
+                for cid in tl.range(
+                    0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS
+                ):
                     qk_bufIdx_2 = qk_bufIdx + cid * NUM_BUFFERS_QK
                     if cid == NUM_MMA_GROUPS - 1:
                         tlx.async_dot(
@@ -245,7 +310,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                 # -- compute p @ v ----
                 # wait for the V buffer to be populated by the producer
                 tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
-                for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
+                for cid in tl.range(
+                    0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS
+                ):
                     qk_bufIdx_2 = qk_bufIdx + cid * NUM_BUFFERS_QK
                     tlx.barrier_wait(p_fulls[qk_bufIdx_2], qk_phase)
                     tlx.barrier_wait(acc_fulls[qk_bufIdx_2], qk_phase)
@@ -274,34 +341,40 @@ def _attn_fwd_ws(sm_scale, M,  #
         # load
         with tlx.async_task(num_warps=1, registers=24):
             # initialize offsets
-            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(H, N_CTX, BLOCK_M)
+            start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                H, N_CTX, BLOCK_M
+            )
 
             # load q: it will stay in SRAM throughout
             for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
-                tlx.barrier_expect_bytes(q_fulls[cid], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
+                tlx.barrier_expect_bytes(
+                    q_fulls[cid], 2 * BLOCK_M_SPLIT * HEAD_DIM
+                )  # float16
                 qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
-                tlx.async_descriptor_load(desc_q, q_tiles[cid], [qo_offset_y_split, 0], q_fulls[cid])
+                tlx.async_descriptor_load(
+                    desc_q, q_tiles[cid], [qo_offset_y_split, 0], q_fulls[cid]
+                )
 
             # loop over loading k, v
             accum_cnt_kv = 0
             for _ in tl.range(lo, hi, BLOCK_N):
                 k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
                 # wait for the K buffer to be released by the consumer
-                k_empty = tlx.local_view(kv_empties, k_bufIdx)
+                k_empty = kv_empties[k_bufIdx]
                 tlx.barrier_wait(k_empty, k_phase ^ 1)
                 # load K
-                k_full = tlx.local_view(kv_fulls, k_bufIdx)
-                k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+                k_full = kv_fulls[k_bufIdx]
+                k_tile = kv_tiles[k_bufIdx]
                 tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
                 v_bufIdx, v_phase = _get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
                 # wait for the V buffer to be released by the consumer
-                v_empty = tlx.local_view(kv_empties, v_bufIdx)
+                v_empty = kv_empties[v_bufIdx]
                 tlx.barrier_wait(v_empty, v_phase ^ 1)
                 # load V
-                v_full = tlx.local_view(kv_fulls, v_bufIdx)
-                v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+                v_full = kv_fulls[v_bufIdx]
+                v_tile = kv_tiles[v_bufIdx]
                 tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -310,7 +383,6 @@ def _attn_fwd_ws(sm_scale, M,  #
 
 
 class _attention(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, sm_scale):
         # shape constraints
@@ -322,18 +394,45 @@ class _attention(torch.autograd.Function):
         o = torch.empty_like(q)
         extra_kern_args = {}
 
-        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        M = torch.empty(
+            (q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32
+        )
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
         dummy_block = [1, 1]
-        desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+        desc_q = TensorDescriptor(
+            q,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
         if q.dtype == torch.float8_e5m2:
-            desc_v = TensorDescriptor(v, shape=[HEAD_DIM_K, y_dim], strides=[q.shape[2], 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[HEAD_DIM_K, y_dim],
+                strides=[q.shape[2], 1],
+                block_shape=dummy_block,
+            )
         else:
-            desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[y_dim, HEAD_DIM_K],
+                strides=[HEAD_DIM_K, 1],
+                block_shape=dummy_block,
+            )
+        desc_k = TensorDescriptor(
+            k,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
+        desc_o = TensorDescriptor(
+            o,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
 
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -341,17 +440,27 @@ class _attention(torch.autograd.Function):
         triton.set_allocator(alloc_fn)
 
         def grid(META):
-            return (triton.cdiv(q.shape[2], META["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
+            return (
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
 
         ctx.grid = grid
         _attn_fwd_ws[grid](
-            sm_scale, M,  #
-            q.shape[0], q.shape[1],  #
-            desc_q, desc_k, desc_v, desc_o,  #
+            sm_scale,
+            M,  #
+            q.shape[0],
+            q.shape[1],  #
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,  #
             N_CTX=q.shape[2],  #
             HEAD_DIM=HEAD_DIM_K,  #
             FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-            **extra_kern_args)
+            **extra_kern_args,
+        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
@@ -376,9 +485,21 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
     if mode == "bwd":
         pytest.skip("Backward pass not supported.")
     torch.manual_seed(20)
-    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    q = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    v = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
     sm_scale = 0.5
     # reference implementation
     ref_dtype = dtype
@@ -407,8 +528,10 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
 
 
 try:
-    from flash_attn.flash_attn_interface import \
-        flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func,
+    )
+
     HAS_FLASH = True
 except BaseException:
     HAS_FLASH = False
@@ -433,7 +556,8 @@ configs.append(
             "HEAD_DIM": HEAD_DIM,
             "mode": "fwd",
         },
-    ))
+    )
+)
 
 
 @triton.testing.perf_report(configs)
@@ -441,9 +565,15 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
     assert mode in ["fwd", "bwd"]
     dtype = torch.float16
     if "triton" in provider:
-        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        q = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        k = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        v = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
         if mode == "fwd" and "fp8" in provider:
             q = q.to(torch.float8_e5m2)
             k = k.to(torch.float8_e5m2)
@@ -459,7 +589,12 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
         ms = triton.testing.do_bench(fn)
 
     if provider == "flash":
-        qkv = torch.randn((BATCH, N_CTX, 3, H, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        qkv = torch.randn(
+            (BATCH, N_CTX, 3, H, HEAD_DIM),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
         fn = lambda: flash_attn_func(qkv)
         if mode == "bwd":
             o = fn()

--- a/third_party/tlx/tutorials/blackwell-gemm-pipelined.py
+++ b/third_party/tlx/tutorials/blackwell-gemm-pipelined.py
@@ -1,8 +1,7 @@
-import pytest
 from typing import Optional
 
+import pytest
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
@@ -13,11 +12,19 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 def get_cuda_autotune_config():
     return [
-        triton.Config({'BLOCK_SIZE_M': BM, 'BLOCK_SIZE_N': BN, "BLOCK_SIZE_K" : BK, "GROUP_SIZE_M" : 8, "NUM_STAGES" : s}) \
-        for BM in [128] \
-        for BN in [128, 256] \
-        for BK in [64,128] \
-        for s in ([2,4])
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": BM,
+                "BLOCK_SIZE_N": BN,
+                "BLOCK_SIZE_K": BK,
+                "GROUP_SIZE_M": 8,
+                "NUM_STAGES": s,
+            }
+        )
+        for BM in [128]
+        for BN in [128, 256]
+        for BK in [64, 128]
+        for s in ([2, 4])
     ]
 
 
@@ -29,16 +36,28 @@ def alloc_fn(size: int, align: int, stream: Optional[int]):
 
 @triton.autotune(
     configs=get_cuda_autotune_config(),
-    key=['M', 'N', 'K'],
+    key=["M", "N", "K"],
 )
 @triton.jit
-def matmul_kernel_tma_pipelined_blackwell(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak,  #
-                                          stride_bk, stride_bn,  #
-                                          stride_cm, stride_cn, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
-                                          BLOCK_SIZE_K: tl.constexpr,  #
-                                          GROUP_SIZE_M: tl.constexpr,  #
-                                          NUM_STAGES: tl.constexpr  #
-                                          ):
+def matmul_kernel_tma_pipelined_blackwell(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  #
+    GROUP_SIZE_M: tl.constexpr,  #
+    NUM_STAGES: tl.constexpr,  #
+):
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
@@ -79,40 +98,48 @@ def matmul_kernel_tma_pipelined_blackwell(a_ptr, b_ptr, c_ptr, M, N, K, stride_a
 
     # prefetch (pipelining) for NUM_STAGES - 1 buffers
     for i in tl.range(0, NUM_STAGES - 1, loop_unroll_factor=NUM_STAGES - 1):
-        a = tlx.local_view(buffers_A, i)
-        b = tlx.local_view(buffers_B, i)
-        load_bar = tlx.local_view(load_bars, i)
-        tlx.barrier_expect_bytes(load_bar, 2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K)  # float16
-        tlx.async_descriptor_load(desc_a, a, [pid_m * BLOCK_SIZE_M, i * BLOCK_SIZE_K], load_bar)
-        tlx.async_descriptor_load(desc_b, b, [i * BLOCK_SIZE_K, pid_n * BLOCK_SIZE_N], load_bar)
+        a = buffers_A[i]
+        b = buffers_B[i]
+        load_bar = load_bars[i]
+        tlx.barrier_expect_bytes(
+            load_bar, 2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K
+        )  # float16
+        tlx.async_descriptor_load(
+            desc_a, a, [pid_m * BLOCK_SIZE_M, i * BLOCK_SIZE_K], load_bar
+        )
+        tlx.async_descriptor_load(
+            desc_b, b, [i * BLOCK_SIZE_K, pid_n * BLOCK_SIZE_N], load_bar
+        )
 
     # main K loop
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     # init accumulator to 0 (in TMEM)
-    buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
-    acc_tmem = tlx.local_view(buffers, 0)
+    buffers = tlx.local_alloc(
+        (BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem
+    )
+    acc_tmem = buffers[0]
     tlx.local_store(acc_tmem, accumulator)
 
     num_iter = tl.cdiv(K, BLOCK_SIZE_K)
     for k in range(0, num_iter):
         # identify the buffer index for the current iteration
         buf = k % NUM_STAGES
-        a_k = tlx.local_view(buffers_A, buf)
-        b_k = tlx.local_view(buffers_B, buf)
+        a_k = buffers_A[buf]
+        b_k = buffers_B[buf]
 
         # wait for buffers to be ready at `phase`
-        load_bar = tlx.local_view(load_bars, buf)
+        load_bar = load_bars[buf]
         tlx.barrier_wait(load_bar, phase)
 
         # issue the async mma "with `phase`"
-        dot_bar = tlx.local_view(dot_bars, buf)
+        dot_bar = dot_bars[buf]
         # mmav5 can take A and B from SMEM, and accumulate result into TMEM
         tlx.async_dot(a_k, b_k, acc_tmem, mBarriers=[dot_bar], out_dtype=tl.float32)
 
         # prefetch for i-th iteration, i.e, NUM_STAGES - 1 ahead
         i = k + NUM_STAGES - 1
         # wait for the previous iteration's MMA using the buffer to complete
-        prev_dot_bar = tlx.local_view(dot_bars, i % NUM_STAGES)
+        prev_dot_bar = dot_bars[i % NUM_STAGES]
         # if the previous MMA was issued in previous round of the buffers/barrier use, `phase` was flipped in last iteration,
         # meaning the previous MMA was issued "with `phase ^ 1`"
         prev_phase = phase ^ 1 if (i % NUM_STAGES == NUM_STAGES - 1) else phase
@@ -120,21 +147,27 @@ def matmul_kernel_tma_pipelined_blackwell(a_ptr, b_ptr, c_ptr, M, N, K, stride_a
         tlx.barrier_wait(prev_dot_bar, prev_phase)
 
         if i < num_iter:
-            a_next = tlx.local_view(buffers_A, i % NUM_STAGES)
-            b_next = tlx.local_view(buffers_B, i % NUM_STAGES)
-            next_load_bar = tlx.local_view(load_bars, i % NUM_STAGES)
+            a_next = buffers_A[i % NUM_STAGES]
+            b_next = buffers_B[i % NUM_STAGES]
+            next_load_bar = load_bars[i % NUM_STAGES]
             # prefetch
             # if i % NUM_STAGES == NUM_STAGES - 1, we are prefetching for the buffer with current `phase`
             # otherwise, we are prefetching for the buffer with next phase (`phase ^ 1`)
-            tlx.barrier_expect_bytes(next_load_bar, 2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K)  # float16
-            tlx.async_descriptor_load(desc_a, a_next, [pid_m * BLOCK_SIZE_M, i * BLOCK_SIZE_K], next_load_bar)
-            tlx.async_descriptor_load(desc_b, b_next, [i * BLOCK_SIZE_K, pid_n * BLOCK_SIZE_N], next_load_bar)
+            tlx.barrier_expect_bytes(
+                next_load_bar, 2 * (BLOCK_SIZE_M + BLOCK_SIZE_N) * BLOCK_SIZE_K
+            )  # float16
+            tlx.async_descriptor_load(
+                desc_a, a_next, [pid_m * BLOCK_SIZE_M, i * BLOCK_SIZE_K], next_load_bar
+            )
+            tlx.async_descriptor_load(
+                desc_b, b_next, [i * BLOCK_SIZE_K, pid_n * BLOCK_SIZE_N], next_load_bar
+            )
 
         phase = phase if (buf < NUM_STAGES - 1) else phase ^ 1
 
     # wait for last mma to complete
     i = num_iter - 1
-    prev_dot_bar = tlx.local_view(dot_bars, i % NUM_STAGES)
+    prev_dot_bar = dot_bars[i % NUM_STAGES]
     prev_phase = phase ^ 1 if (i % NUM_STAGES == NUM_STAGES - 1) else phase
     tlx.barrier_wait(prev_dot_bar, prev_phase)
 
@@ -143,10 +176,14 @@ def matmul_kernel_tma_pipelined_blackwell(a_ptr, b_ptr, c_ptr, M, N, K, stride_a
     c = result.to(tl.float16)
 
     # store the result to SMEM to prepare for TMA store (TMEM -> GMEM)
-    c_buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float16, tl.constexpr(1))
-    c_smem = tlx.local_view(c_buffers, 0)
+    c_buffers = tlx.local_alloc(
+        (BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float16, tl.constexpr(1)
+    )
+    c_smem = c_buffers[0]
     tlx.local_store(c_smem, c)
-    tlx.async_descriptor_store(desc_c, c_smem, [pid_m * BLOCK_SIZE_M, pid_n * BLOCK_SIZE_N])
+    tlx.async_descriptor_store(
+        desc_c, c_smem, [pid_m * BLOCK_SIZE_M, pid_n * BLOCK_SIZE_N]
+    )
 
 
 def matmul(a, b):
@@ -162,13 +199,22 @@ def matmul(a, b):
     triton.set_allocator(alloc_fn)
 
     # 1D launch kernel where each block gets its own program.
-    grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    )
     matmul_kernel_tma_pipelined_blackwell[grid](
-        a, b, c,  #
-        M, N, K,  #
-        a.stride(0), a.stride(1),  #
-        b.stride(0), b.stride(1),  #
-        c.stride(0), c.stride(1),  #
+        a,
+        b,
+        c,  #
+        M,
+        N,
+        K,  #
+        a.stride(0),
+        a.stride(1),  #
+        b.stride(0),
+        b.stride(1),  #
+        c.stride(0),
+        c.stride(1),  #
     )
     return c
 
@@ -190,13 +236,15 @@ def test_op():
     torch.allclose(triton_output, torch_output, atol=1e-2, rtol=rtol)
 
 
-ref_lib = 'cuBLAS'
+ref_lib = "cuBLAS"
 
 configs = []
 configs.append(
     triton.testing.Benchmark(
         x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
+        x_vals=[
+            128 * i for i in range(2, 33)
+        ],  # Different possible values for `x_name`
         line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
         # Possible values for `line_arg`
         # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
@@ -204,9 +252,11 @@ configs.append(
         line_names=[ref_lib, "Triton"],  # Line styles
         styles=[("green", "-"), ("blue", "-")],
         ylabel="TFLOPS",  # Label name for the y-axis
-        plot_name="matmul-performance-" + ("fp16"),  # Name for the plot, used also as a file name for saving the plot.
+        plot_name="matmul-performance-"
+        + ("fp16"),  # Name for the plot, used also as a file name for saving the plot.
         args={},
-    ))
+    )
+)
 
 
 @triton.testing.perf_report(configs)
@@ -215,9 +265,13 @@ def benchmark(M, N, K, provider):
     b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
     quantiles = [0.5, 0.2, 0.8]
     if provider == ref_lib.lower():
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
-    if provider == 'triton':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: torch.matmul(a, b), quantiles=quantiles
+        )
+    if provider == "triton":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: matmul(a, b), quantiles=quantiles
+        )
     perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
     return perf(ms), perf(max_ms), perf(min_ms)
 

--- a/third_party/tlx/tutorials/hopper-fa-ws-pipelined_test.py
+++ b/third_party/tlx/tutorials/hopper-fa-ws-pipelined_test.py
@@ -1,11 +1,10 @@
 import pytest
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.tools.tensor_descriptor import TensorDescriptor
 from triton._internal_testing import is_hopper
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -29,38 +28,72 @@ def _host_descriptor_pre_hook(nargs):
 
 
 configs = [
-    triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'NUM_BUFFERS': 2, 'NUM_MMA_WARPS': 4, 'NUM_MMA_GROUPS': 1},
-                  num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
-    triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'NUM_BUFFERS': 2, 'NUM_MMA_WARPS': 8, 'NUM_MMA_GROUPS': 2},
-                  num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
+    triton.Config(
+        {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS": 2,
+            "NUM_MMA_WARPS": 4,
+            "NUM_MMA_GROUPS": 1,
+        },
+        num_stages=0,
+        num_warps=4,
+        pre_hook=_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS": 2,
+            "NUM_MMA_WARPS": 8,
+            "NUM_MMA_GROUPS": 2,
+        },
+        num_stages=0,
+        num_warps=4,
+        pre_hook=_host_descriptor_pre_hook,
+    ),
 ]
 
 
 @triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
 @triton.jit
-def _attn_fwd_ws_pipelined(sm_scale, M,  #
-                           Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                           HEAD_DIM: tl.constexpr,  #
-                           BLOCK_M: tl.constexpr,  #
-                           BLOCK_N: tl.constexpr,  #
-                           FP8_OUTPUT: tl.constexpr,  #
-                           NUM_BUFFERS: tl.constexpr,  #
-                           NUM_MMA_WARPS: tl.constexpr,  #
-                           NUM_MMA_GROUPS: tl.constexpr,  #
-                           ):
+def _attn_fwd_ws_pipelined(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    NUM_BUFFERS: tl.constexpr,  #
+    NUM_MMA_WARPS: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+):
     tl.static_assert(BLOCK_N <= HEAD_DIM)
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
 
     # allocate buffers
-    q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS)
+    q_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS
+    )
     k_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS)
     v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_v), NUM_BUFFERS)
 
     # allocate barriers
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=1)
-    k_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS)
+    k_empties = tlx.alloc_barriers(
+        num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS
+    )
     k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=1)
-    v_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS)
+    v_empties = tlx.alloc_barriers(
+        num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS
+    )
     v_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=1)
 
     with tlx.async_tasks():
@@ -78,11 +111,15 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
 
             # load q: it will stay in SRAM throughout
             for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
-                q_full = tlx.local_view(q_fulls, cid)
-                tlx.barrier_expect_bytes(q_full, 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
-                q_tile = tlx.local_view(q_tiles, cid)
+                q_full = q_fulls[cid]
+                tlx.barrier_expect_bytes(
+                    q_full, 2 * BLOCK_M_SPLIT * HEAD_DIM
+                )  # float16
+                q_tile = q_tiles[cid]
                 qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
-                tlx.async_descriptor_load(desc_q, q_tile, [qo_offset_y_split, 0], q_full)
+                tlx.async_descriptor_load(
+                    desc_q, q_tile, [qo_offset_y_split, 0], q_full
+                )
 
             # loop over loading k, v
             kv_phase = 0
@@ -93,20 +130,20 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
                 kv_phase = kv_phase ^ (buf_id == 0)
 
                 # wait for the K buffer to be released by the consumer
-                k_empty = tlx.local_view(k_empties, buf_id)
+                k_empty = k_empties[buf_id]
                 tlx.barrier_wait(k_empty, kv_phase)
                 # load K
-                k_full = tlx.local_view(k_fulls, buf_id)
-                k_tile = tlx.local_view(k_tiles, buf_id)
+                k_full = k_fulls[buf_id]
+                k_tile = k_tiles[buf_id]
                 tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
                 # wait for the V buffer to be released by the consumer
-                v_empty = tlx.local_view(v_empties, buf_id)
+                v_empty = v_empties[buf_id]
                 tlx.barrier_wait(v_empty, kv_phase)
                 # load V
-                v_full = tlx.local_view(v_fulls, buf_id)
-                v_tile = tlx.local_view(v_tiles, buf_id)
+                v_full = v_fulls[buf_id]
+                v_tile = v_tiles[buf_id]
                 tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -114,7 +151,11 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
                 acc_cnt += 1
 
         # consumer group
-        with tlx.async_task(num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS, registers=232, replicate=NUM_MMA_GROUPS):
+        with tlx.async_task(
+            num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS,
+            registers=232,
+            replicate=NUM_MMA_GROUPS,
+        ):
             # initialize pointer to m and l
             m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
             l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
@@ -126,9 +167,9 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
 
             # wait for the Q buffer to be populated by the producer
             cid = tlx.async_task_replica_id()
-            q_full = tlx.local_view(q_fulls, cid)
+            q_full = q_fulls[cid]
             tlx.barrier_wait(q_full, 0)
-            q_tile = tlx.local_view(q_tiles, cid)
+            q_tile = q_tiles[cid]
 
             lo, hi = 0, N_CTX
             k_phase = 0
@@ -137,9 +178,9 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
             v_buf_id = 0
 
             # wait for the K[0] buffer to be populated by the producer
-            k_full = tlx.local_view(k_fulls, k_buf_id)
+            k_full = k_fulls[k_buf_id]
             tlx.barrier_wait(k_full, k_phase)
-            k_tile = tlx.local_view(k_tiles, k_buf_id)
+            k_tile = k_tiles[k_buf_id]
 
             # -- compute qk[0] ----
             k_tile = tlx.local_trans(k_tile)
@@ -147,7 +188,7 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
             # wait for the MMA using to complete
             qk = tlx.async_dot_wait(0, qk)
             # release the K buffer
-            k_empty = tlx.local_view(k_empties, k_buf_id)
+            k_empty = k_empties[k_buf_id]
             tlx.barrier_arrive(k_empty, 1)
 
             # -- compute m_i and l_i ----
@@ -170,9 +211,9 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
                 k_phase = k_phase ^ (k_buf_id == 0)
 
                 # wait for the K buffer to be populated by the producer
-                k_full = tlx.local_view(k_fulls, k_buf_id)
+                k_full = k_fulls[k_buf_id]
                 tlx.barrier_wait(k_full, k_phase)
-                k_tile = tlx.local_view(k_tiles, k_buf_id)
+                k_tile = k_tiles[k_buf_id]
 
                 # compute qk for the current iteration
                 k_tile = tlx.local_trans(k_tile)
@@ -182,9 +223,9 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
                 # wait for the previous V buffer to be populated by the producer
                 v_buf_id = (acc_cnt - 1) % NUM_BUFFERS
                 v_phase = v_phase ^ (v_buf_id == 0)
-                v_full = tlx.local_view(v_fulls, v_buf_id)
+                v_full = v_fulls[v_buf_id]
                 tlx.barrier_wait(v_full, v_phase)
-                v_tile = tlx.local_view(v_tiles, v_buf_id)
+                v_tile = v_tiles[v_buf_id]
                 # prepare p and v for the dot
                 p = p.to(tlx.dtype_of(desc_k))
                 acc = tlx.async_dot(p, v_tile, acc)
@@ -192,7 +233,7 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
                 # wait for the current qk MMA to complete
                 qk = tlx.async_dot_wait(1, qk)
                 # release the K buffer
-                k_empty = tlx.local_view(k_empties, k_buf_id)
+                k_empty = k_empties[k_buf_id]
                 tlx.barrier_arrive(k_empty, 1)
 
                 # -- compute m_i and l_i ----
@@ -210,7 +251,7 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
                 # wait for the previous pv MMA to complete
                 acc = tlx.async_dot_wait(0, acc)
                 # release the V buffer
-                v_empty = tlx.local_view(v_empties, v_buf_id)
+                v_empty = v_empties[v_buf_id]
                 tlx.barrier_arrive(v_empty, 1)
                 acc = acc * alpha[:, None]
                 acc_cnt += 1
@@ -219,16 +260,16 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
             # wait for the V buffer to be populated by the producer
             v_buf_id = (acc_cnt - 1) % NUM_BUFFERS
             v_phase = v_phase ^ (v_buf_id == 0)
-            v_full = tlx.local_view(v_fulls, v_buf_id)
+            v_full = v_fulls[v_buf_id]
             tlx.barrier_wait(v_full, v_phase)
-            v_tile = tlx.local_view(v_tiles, v_buf_id)
+            v_tile = v_tiles[v_buf_id]
             # prepare p and v for the dot
             p = p.to(tlx.dtype_of(desc_k))
             acc = tlx.async_dot(p, v_tile, acc)
             # wait for the MMA using to complete
             acc = tlx.async_dot_wait(0, acc)
             # release the V buffer
-            v_empty = tlx.local_view(v_empties, v_buf_id)
+            v_empty = v_empties[v_buf_id]
             tlx.barrier_arrive(v_empty, 1)
 
             # epilogue
@@ -241,14 +282,15 @@ def _attn_fwd_ws_pipelined(sm_scale, M,  #
             qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
             m_i += tl.math.log2(l_i)
             acc = acc / l_i[:, None]
-            offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+            offs_m = (
+                start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+            )
             m_ptrs = M + off_hz * N_CTX + offs_m
             tl.store(m_ptrs, m_i)
             desc_o.store([qo_offset_y_split, 0], acc.to(tlx.dtype_of(desc_o)))
 
 
 class _attention(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, sm_scale):
         # shape constraints
@@ -260,18 +302,45 @@ class _attention(torch.autograd.Function):
         o = torch.empty_like(q)
         extra_kern_args = {}
 
-        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        M = torch.empty(
+            (q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32
+        )
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
         dummy_block = [1, 1]
-        desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+        desc_q = TensorDescriptor(
+            q,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
         if q.dtype == torch.float8_e5m2:
-            desc_v = TensorDescriptor(v, shape=[HEAD_DIM_K, y_dim], strides=[q.shape[2], 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[HEAD_DIM_K, y_dim],
+                strides=[q.shape[2], 1],
+                block_shape=dummy_block,
+            )
         else:
-            desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[y_dim, HEAD_DIM_K],
+                strides=[HEAD_DIM_K, 1],
+                block_shape=dummy_block,
+            )
+        desc_k = TensorDescriptor(
+            k,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
+        desc_o = TensorDescriptor(
+            o,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
 
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -279,17 +348,27 @@ class _attention(torch.autograd.Function):
         triton.set_allocator(alloc_fn)
 
         def grid(META):
-            return (triton.cdiv(q.shape[2], META["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
+            return (
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
 
         ctx.grid = grid
         _attn_fwd_ws_pipelined[grid](
-            sm_scale, M,  #
-            q.shape[0], q.shape[1],  #
-            desc_q, desc_k, desc_v, desc_o,  #
+            sm_scale,
+            M,  #
+            q.shape[0],
+            q.shape[1],  #
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,  #
             N_CTX=q.shape[2],  #
             HEAD_DIM=HEAD_DIM_K,  #
             FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-            **extra_kern_args)
+            **extra_kern_args,
+        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
@@ -314,9 +393,21 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
     if mode == "bwd":
         pytest.skip("Backward pass not supported.")
     torch.manual_seed(20)
-    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    q = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    v = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
     sm_scale = 0.5
     # reference implementation
     ref_dtype = dtype
@@ -350,8 +441,10 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
 
 
 try:
-    from flash_attn.flash_attn_interface import \
-        flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func,
+    )
+
     HAS_FLASH = True
 except BaseException:
     HAS_FLASH = False
@@ -376,7 +469,8 @@ configs.append(
             "HEAD_DIM": HEAD_DIM,
             "mode": "fwd",
         },
-    ))
+    )
+)
 
 
 @triton.testing.perf_report(configs)
@@ -384,9 +478,15 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
     assert mode in ["fwd", "bwd"]
     dtype = torch.float16
     if "triton" in provider:
-        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        q = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        k = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        v = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
         if mode == "fwd" and "fp8" in provider:
             q = q.to(torch.float8_e5m2)
             k = k.to(torch.float8_e5m2)
@@ -402,7 +502,12 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
         ms = triton.testing.do_bench(fn)
 
     if provider == "flash":
-        qkv = torch.randn((BATCH, N_CTX, 3, H, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        qkv = torch.randn(
+            (BATCH, N_CTX, 3, H, HEAD_DIM),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
         fn = lambda: flash_attn_func(qkv)
         if mode == "bwd":
             o = fn()

--- a/third_party/tlx/tutorials/hopper-fa-ws_test.py
+++ b/third_party/tlx/tutorials/hopper-fa-ws_test.py
@@ -1,11 +1,10 @@
 import pytest
 import torch
-
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.tools.tensor_descriptor import TensorDescriptor
 from triton._internal_testing import is_hopper
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -29,38 +28,72 @@ def _host_descriptor_pre_hook(nargs):
 
 
 configs = [
-    triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'NUM_BUFFERS': 2, 'NUM_MMA_WARPS': 4, 'NUM_MMA_GROUPS': 1},
-                  num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
-    triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'NUM_BUFFERS': 2, 'NUM_MMA_WARPS': 8, 'NUM_MMA_GROUPS': 2},
-                  num_stages=0, num_warps=4, pre_hook=_host_descriptor_pre_hook),
+    triton.Config(
+        {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS": 2,
+            "NUM_MMA_WARPS": 4,
+            "NUM_MMA_GROUPS": 1,
+        },
+        num_stages=0,
+        num_warps=4,
+        pre_hook=_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "NUM_BUFFERS": 2,
+            "NUM_MMA_WARPS": 8,
+            "NUM_MMA_GROUPS": 2,
+        },
+        num_stages=0,
+        num_warps=4,
+        pre_hook=_host_descriptor_pre_hook,
+    ),
 ]
 
 
 @triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
 @triton.jit
-def _attn_fwd_ws(sm_scale, M,  #
-                 Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                 HEAD_DIM: tl.constexpr,  #
-                 BLOCK_M: tl.constexpr,  #
-                 BLOCK_N: tl.constexpr,  #
-                 FP8_OUTPUT: tl.constexpr,  #
-                 NUM_BUFFERS: tl.constexpr,  #
-                 NUM_MMA_WARPS: tl.constexpr,  #
-                 NUM_MMA_GROUPS: tl.constexpr,  #
-                 ):
+def _attn_fwd_ws(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    NUM_BUFFERS: tl.constexpr,  #
+    NUM_MMA_WARPS: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+):
     tl.static_assert(BLOCK_N <= HEAD_DIM)
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
 
     # allocate buffers
-    q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS)
+    q_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS
+    )
     k_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS)
     v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_v), NUM_BUFFERS)
 
     # allocate barriers
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=1)
-    k_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS)
+    k_empties = tlx.alloc_barriers(
+        num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS
+    )
     k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=1)
-    v_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS)
+    v_empties = tlx.alloc_barriers(
+        num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS
+    )
     v_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=1)
 
     with tlx.async_tasks():
@@ -78,11 +111,15 @@ def _attn_fwd_ws(sm_scale, M,  #
 
             # load q: it will stay in SRAM throughout
             for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
-                q_full = tlx.local_view(q_fulls, cid)
-                tlx.barrier_expect_bytes(q_full, 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
-                q_tile = tlx.local_view(q_tiles, cid)
+                q_full = q_fulls[cid]
+                tlx.barrier_expect_bytes(
+                    q_full, 2 * BLOCK_M_SPLIT * HEAD_DIM
+                )  # float16
+                q_tile = q_tiles[cid]
                 qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
-                tlx.async_descriptor_load(desc_q, q_tile, [qo_offset_y_split, 0], q_full)
+                tlx.async_descriptor_load(
+                    desc_q, q_tile, [qo_offset_y_split, 0], q_full
+                )
 
             # loop over loading k, v
             kv_phase = 0
@@ -93,20 +130,20 @@ def _attn_fwd_ws(sm_scale, M,  #
                 kv_phase = kv_phase ^ (buf_id == 0)
 
                 # wait for the K buffer to be released by the consumer
-                k_empty = tlx.local_view(k_empties, buf_id)
+                k_empty = k_empties[buf_id]
                 tlx.barrier_wait(k_empty, kv_phase)
                 # load K
-                k_full = tlx.local_view(k_fulls, buf_id)
-                k_tile = tlx.local_view(k_tiles, buf_id)
+                k_full = k_fulls[buf_id]
+                k_tile = k_tiles[buf_id]
                 tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_k, k_tile, [kv_offset_y, 0], k_full)
 
                 # wait for the V buffer to be released by the consumer
-                v_empty = tlx.local_view(v_empties, buf_id)
+                v_empty = v_empties[buf_id]
                 tlx.barrier_wait(v_empty, kv_phase)
                 # load V
-                v_full = tlx.local_view(v_fulls, buf_id)
-                v_tile = tlx.local_view(v_tiles, buf_id)
+                v_full = v_fulls[buf_id]
+                v_tile = v_tiles[buf_id]
                 tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * HEAD_DIM)  # float16
                 tlx.async_descriptor_load(desc_v, v_tile, [kv_offset_y, 0], v_full)
 
@@ -114,7 +151,11 @@ def _attn_fwd_ws(sm_scale, M,  #
                 acc_cnt += 1
 
         # consumer group
-        with tlx.async_task(num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS, registers=232, replicate=NUM_MMA_GROUPS):
+        with tlx.async_task(
+            num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS,
+            registers=232,
+            replicate=NUM_MMA_GROUPS,
+        ):
             # initialize pointer to m and l
             m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
             l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
@@ -126,9 +167,9 @@ def _attn_fwd_ws(sm_scale, M,  #
 
             # wait for the Q buffer to be populated by the producer
             cid = tlx.async_task_replica_id()
-            q_full = tlx.local_view(q_fulls, cid)
+            q_full = q_fulls[cid]
             tlx.barrier_wait(q_full, 0)
-            q_tile = tlx.local_view(q_tiles, cid)
+            q_tile = q_tiles[cid]
 
             lo, hi = 0, N_CTX
             kv_phase = 1
@@ -141,9 +182,9 @@ def _attn_fwd_ws(sm_scale, M,  #
                 kv_phase = kv_phase ^ (buf_id == 0)
 
                 # wait for the K buffer to be populated by the producer
-                k_full = tlx.local_view(k_fulls, buf_id)
+                k_full = k_fulls[buf_id]
                 tlx.barrier_wait(k_full, kv_phase)
-                k_tile = tlx.local_view(k_tiles, buf_id)
+                k_tile = k_tiles[buf_id]
 
                 # -- compute qk ----
                 k_tile = tlx.local_trans(k_tile)
@@ -151,7 +192,7 @@ def _attn_fwd_ws(sm_scale, M,  #
                 # wait for the MMA using to complete
                 qk = tlx.async_dot_wait(0, qk)
                 # release the K buffer
-                k_empty = tlx.local_view(k_empties, buf_id)
+                k_empty = k_empties[buf_id]
                 tlx.barrier_arrive(k_empty, 1)
 
                 m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
@@ -166,14 +207,14 @@ def _attn_fwd_ws(sm_scale, M,  #
                 p = p.to(tlx.dtype_of(desc_k))
 
                 # wait for the V buffer to be populated by the producer
-                v_full = tlx.local_view(v_fulls, buf_id)
+                v_full = v_fulls[buf_id]
                 tlx.barrier_wait(v_full, kv_phase)
-                v_tile = tlx.local_view(v_tiles, buf_id)
+                v_tile = v_tiles[buf_id]
                 acc = tlx.async_dot(p, v_tile, acc)
                 # wait for the MMA using to complete
                 acc = tlx.async_dot_wait(0, acc)
                 # release the V buffer
-                v_empty = tlx.local_view(v_empties, buf_id)
+                v_empty = v_empties[buf_id]
                 tlx.barrier_arrive(v_empty, 1)
 
                 # update m_i and l_i
@@ -192,14 +233,15 @@ def _attn_fwd_ws(sm_scale, M,  #
             qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
             m_i += tl.math.log2(l_i)
             acc = acc / l_i[:, None]
-            offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+            offs_m = (
+                start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+            )
             m_ptrs = M + off_hz * N_CTX + offs_m
             tl.store(m_ptrs, m_i)
             desc_o.store([qo_offset_y_split, 0], acc.to(tlx.dtype_of(desc_o)))
 
 
 class _attention(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, sm_scale):
         # shape constraints
@@ -211,18 +253,45 @@ class _attention(torch.autograd.Function):
         o = torch.empty_like(q)
         extra_kern_args = {}
 
-        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        M = torch.empty(
+            (q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32
+        )
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
         dummy_block = [1, 1]
-        desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+        desc_q = TensorDescriptor(
+            q,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
         if q.dtype == torch.float8_e5m2:
-            desc_v = TensorDescriptor(v, shape=[HEAD_DIM_K, y_dim], strides=[q.shape[2], 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[HEAD_DIM_K, y_dim],
+                strides=[q.shape[2], 1],
+                block_shape=dummy_block,
+            )
         else:
-            desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-        desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(
+                v,
+                shape=[y_dim, HEAD_DIM_K],
+                strides=[HEAD_DIM_K, 1],
+                block_shape=dummy_block,
+            )
+        desc_k = TensorDescriptor(
+            k,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
+        desc_o = TensorDescriptor(
+            o,
+            shape=[y_dim, HEAD_DIM_K],
+            strides=[HEAD_DIM_K, 1],
+            block_shape=dummy_block,
+        )
 
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -230,17 +299,27 @@ class _attention(torch.autograd.Function):
         triton.set_allocator(alloc_fn)
 
         def grid(META):
-            return (triton.cdiv(q.shape[2], META["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
+            return (
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
 
         ctx.grid = grid
         _attn_fwd_ws[grid](
-            sm_scale, M,  #
-            q.shape[0], q.shape[1],  #
-            desc_q, desc_k, desc_v, desc_o,  #
+            sm_scale,
+            M,  #
+            q.shape[0],
+            q.shape[1],  #
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,  #
             N_CTX=q.shape[2],  #
             HEAD_DIM=HEAD_DIM_K,  #
             FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-            **extra_kern_args)
+            **extra_kern_args,
+        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
@@ -265,9 +344,21 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
     if mode == "bwd":
         pytest.skip("Backward pass not supported.")
     torch.manual_seed(20)
-    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    q = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
+    v = (
+        torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE)
+        .normal_(mean=0.0, std=0.5)
+        .requires_grad_()
+    )
     sm_scale = 0.5
     # reference implementation
     ref_dtype = dtype
@@ -301,8 +392,10 @@ def test_op(Z, H, N_CTX, HEAD_DIM, mode, provider, dtype=torch.float16):
 
 
 try:
-    from flash_attn.flash_attn_interface import \
-        flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func,
+    )
+
     HAS_FLASH = True
 except BaseException:
     HAS_FLASH = False
@@ -327,7 +420,8 @@ configs.append(
             "HEAD_DIM": HEAD_DIM,
             "mode": "fwd",
         },
-    ))
+    )
+)
 
 
 @triton.testing.perf_report(configs)
@@ -335,9 +429,15 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
     assert mode in ["fwd", "bwd"]
     dtype = torch.float16
     if "triton" in provider:
-        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
-        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        q = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        k = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
+        v = torch.randn(
+            (BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True
+        )
         if mode == "fwd" and "fp8" in provider:
             q = q.to(torch.float8_e5m2)
             k = k.to(torch.float8_e5m2)
@@ -353,7 +453,12 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
         ms = triton.testing.do_bench(fn)
 
     if provider == "flash":
-        qkv = torch.randn((BATCH, N_CTX, 3, H, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        qkv = torch.randn(
+            (BATCH, N_CTX, 3, H, HEAD_DIM),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
         fn = lambda: flash_attn_func(qkv)
         if mode == "bwd":
             o = fn()


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**Commandeer this diff (recommended) or land with accept2ship tag.**

**This diff was generated by Racer AI agent on behalf of [Daohang Shi](https://www.internalfb.com/profile/view/100002092355226) for T243138289. If the diff quality is poor, consider contacting the user to provide clearer instructions on the task.**

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.
- **For M10N reviewers:** as you review AI-generated diffs, we ask you to give them the same priority as human-generated diffs, and take action in a timely manner by either accepting, rejecting, or resigning as a reviewer. For diffs that don't meet the quality bar (e.g. code doesn't compile, not readable or introduces functionality regressions), we ask that you use the following hashtags to provide clear signals to improve our tools - `#monlowqualitydiff` `#monwrongreviewerdiff`

## Summary:
This diff implements a codemod to replace all instances of `tlx.local_view(x, y)` with the direct indexing syntax `x[y]` across the fbsource repository. This is part of the TLX frontend migration to simplify the API and make it more consistent with standard Python indexing.

**Scope**: 870 replacements across 34 Python files

**Key changes**:
- Replaced `tlx.local_view(tensor, index)` → `tensor[index]` 
- Updated files in fbcode/ads_mkl/, fbcode/deeplearning/, fbcode/pytorch/, fbcode/scripts/, and third-party/triton/
- All replacements maintain functional equivalence while simplifying the code

**Implementation approach**:
- Used perl regex for simple single-line cases (844 instances)
- Used perl slurp mode for multi-line cases (26 instances)
- Manually verified and fixed edge cases with nested parentheses
- Applied pyfmt formatting and arc lint to all modified files
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=b035cbf7-b455-11f0-a66f-0e9af46531d1&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=b035cbf7-b455-11f0-a66f-0e9af46531d1&tab=Trace)

Differential Revision: D85720409


