### PR TITLE
[Cherry-pick] [Blackwell] Verify `tcgen05.mma` operand dtypes (#8015)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -261,10 +262,77 @@ static void printToken(OpAsmPrinter &p, Operation *op, Value dep, Type token) {
   p << ']';
 }
 
+namespace {
+enum class MMADTypeKind { tf32, f16, f8f6f4, i8 };
+} // namespace
+
+static std::string strMMADTypeKind(MMADTypeKind kind) {
+  switch (kind) {
+  case MMADTypeKind::tf32:
+    return "tf32";
+  case MMADTypeKind::f16:
+    return "f16";
+  case MMADTypeKind::f8f6f4:
+    return "f8f6f4";
+  case MMADTypeKind::i8:
+    return "i8";
+  }
+}
+
+static std::optional<std::pair<MMADTypeKind, SmallVector<Type>>>
+getMMAv5DTypeKindAndAcc(Type t) {
+  MLIRContext *ctx = t.getContext();
+  if (t.isF32()) {
+    return {{MMADTypeKind::tf32, {Float32Type::get(ctx)}}};
+  }
+  if (t.isF16() || t.isBF16()) {
+    return {
+        {MMADTypeKind::f16, {Float16Type::get(ctx), Float32Type::get(ctx)}}};
+  }
+  // TODO: float6 and explicit float4 types are not supported yet.
+  // TODO: tcgen05.mma supports ui8/si8 -> s32 MMA, but Triton does not.
+  // FIXME: i8 is used to represent float4 types.
+  if (isa<Float8E4M3FNType, Float8E5M2Type>(t) || t.isInteger(8)) {
+    return {
+        {MMADTypeKind::f8f6f4, {Float16Type::get(ctx), Float32Type::get(ctx)}}};
+  }
+  return std::nullopt;
+}
+
+static LogicalResult verifyMMADType(Operation *op, Type a, Type b, Type d) {
+  auto akind = getMMAv5DTypeKindAndAcc(a);
+  auto bkind = getMMAv5DTypeKindAndAcc(b);
+  if (!akind)
+    return op->emitOpError("unsupported LHS operand dtype: ") << a;
+  if (!bkind)
+    return op->emitOpError("unsupported RHS operand dtype: ") << b;
+  if (akind->first != bkind->first) {
+    return op->emitOpError(
+               "LHS and RHS operand dtypes kinds don't match: LHS kind is ")
+           << strMMADTypeKind(akind->first) << " but RHS kind is "
+           << strMMADTypeKind(bkind->first);
+  }
+  if (!llvm::is_contained(akind->second, d)) {
+    InFlightDiagnostic diag =
+        op->emitOpError("unsupported accumulator dtype for operand kind ")
+        << strMMADTypeKind(akind->first) << ", accumulator dtype is " << d
+        << " but must be one of [";
+    llvm::interleaveComma(akind->second, diag, [&](Type t) { diag << t; });
+    diag << "]";
+    return diag;
+  }
+  return success();
+}
+
 LogicalResult TCGen5MMAOp::verify() {
   if (!getIsAsync() && !getBarriers().empty()) {
     return emitOpError("The op is synchronous but a barrier is present.");
   }
+  Type atype = getA().getType().getElementType();
+  Type btype = getB().getType().getElementType();
+  Type dtype = getD().getType().getElementType();
+  if (failed(verifyMMADType(*this, atype, btype, dtype)))
+    return failure();
   return success();
 }
 
@@ -335,6 +403,12 @@ LogicalResult TCGen5MMAScaledOp::verify() {
   if (!getIsAsync() && !getBarriers().empty()) {
     return emitOpError("The op is synchronous but a barrier is present.");
   }
+  Type atype = getA().getType().getElementType();
+  Type btype = getB().getType().getElementType();
+  Type dtype = getD().getType().getElementType();
+  if (failed(verifyMMADType(*this, atype, btype, dtype)))
+    return failure();
+  return success();
   return success();
 }
 

--- a/test/NVWS/lower_warp_group.mlir
+++ b/test/NVWS/lower_warp_group.mlir
@@ -15,7 +15,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   //       CHECK-NEXT:   ttng.tc_gen5_mma
   tt.func @warp_group(%a: !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
                   %b: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
-                  %c: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory, mutable>,
+                  %c: !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory, mutable>,
                   %accUse: i1,
                   %pred: i1,
                   %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
@@ -25,7 +25,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       ttng.tc_gen5_mma %a, %b, %c, %accUse, %pred, %barrier[%false] {is_async} :
         !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
          !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
-         !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory, mutable>,
+         !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory, mutable>,
          !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
         nvws.warp_group.return
       }
@@ -48,7 +48,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   //       CHECK-NEXT:   ttng.tc_gen5_mma
   tt.func @warp_default(%a: !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
                   %b: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
-                  %c: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory, mutable>,
+                  %c: !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory, mutable>,
                   %accUse: i1,
                   %pred: i1,
                   %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
@@ -58,7 +58,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       ttng.tc_gen5_mma %a, %b, %c, %accUse, %pred, %barrier[%false] {is_async} :
          !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
          !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
-         !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory, mutable>,
+         !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory, mutable>,
          !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
         nvws.warp_group.return
       }

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -16,7 +16,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   //       CHECK:   ttng.tc_gen5_mma
   tt.func @tcgen5(%a: !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
                   %b: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
-                  %c: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory, mutable>,
+                  %c: !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory, mutable>,
                   %accUse: i1,
                   %pred: i1,
                   %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
@@ -24,13 +24,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.tc_gen5_mma %a, %b, %c, %accUse, %pred, %barrier[%barrierPred] {is_async} :
        !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
        !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
-       !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory, mutable>,
+       !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory, mutable>,
        !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
 
     ttng.tc_gen5_mma %a, %b, %c, %accUse, %pred:
        !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
        !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
-       !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory, mutable>
+       !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory, mutable>
     tt.return
   }
 

--- a/test/TritonNvidiaGPU/test_promotion_to_tensor_memory.mlir
+++ b/test/TritonNvidiaGPU/test_promotion_to_tensor_memory.mlir
@@ -12,7 +12,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: @no_tmem_promotion
   tt.func public @no_tmem_promotion(
     %lhs: tensor<128x32xf16, #blocked1>,
-    %rhs: tensor<32x256xf32, #blocked2>
+    %rhs: tensor<32x256xf16, #blocked2>
   ) {
     %true = arith.constant true
     %cst = arith.constant dense<0.0> : tensor<128x256xf32, #blocked>
@@ -22,11 +22,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
       !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
     // CHECK-NOT: ttng.tmem_alloc %[[ARG0:.*]] : (tensor<128x32xf32, #[[BLOCKED:blocked[0-9]*]]>) -> !ttg.memdesc<128x32xf32, #[[TMEM:tmem[0-9]*]]
     %lhs_shared = ttg.local_alloc %lhs : (tensor<128x32xf16, #blocked1>) -> !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory>
-    %rhs_shared = ttg.local_alloc %rhs : (tensor<32x256xf32, #blocked2>) -> !ttg.memdesc<32x256xf32, #shared1, #ttg.shared_memory>
+    %rhs_shared = ttg.local_alloc %rhs : (tensor<32x256xf16, #blocked2>) -> !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>
 
     ttng.tc_gen5_mma %lhs_shared, %rhs_shared, %tmem, %true, %true :
        !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory>,
-       !ttg.memdesc<32x256xf32, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>,
        !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
 
     tt.return
@@ -47,7 +47,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: @promote_lhs_to_tmem
   tt.func public @promote_lhs_to_tmem(
     %lhs: tensor<128x32xf16, #blocked3>,
-    %rhs: tensor<32x256xf32, #blocked2>
+    %rhs: tensor<32x256xf16, #blocked2>
   ) {
     %true = arith.constant true
     %cst = arith.constant dense<0.0> : tensor<128x256xf32, #blocked>
@@ -57,11 +57,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
       !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_alloc %[[ARG0:.*]] : (tensor<128x32xf16, #[[BLOCKED:blocked[0-9]*]]>) -> !ttg.memdesc<128x32xf16, #[[TMEM:tmem[0-9]*]]
     %lhs_shared = ttg.local_alloc %lhs : (tensor<128x32xf16, #blocked3>) -> !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory>
-    %rhs_shared = ttg.local_alloc %rhs : (tensor<32x256xf32, #blocked2>) -> !ttg.memdesc<32x256xf32, #shared1, #ttg.shared_memory>
+    %rhs_shared = ttg.local_alloc %rhs : (tensor<32x256xf16, #blocked2>) -> !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>
 
     ttng.tc_gen5_mma %lhs_shared, %rhs_shared, %tmem, %true, %true :
        !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory>,
-       !ttg.memdesc<32x256xf32, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>,
        !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
 
     tt.return


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: 62f8bfc75743face0cdc595d6c5a1067f8a72835
Original Author: Jeff Niu
Original Date: 2025-08-29 16:01:43 -0700

Original commit message:
```
[Blackwell] Verify `tcgen05.mma` operand dtypes (#8015)

@aeng-openai ran into a weird error when mixing float16 and float8
operands. Add a verifier to prevent that.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
