### PR TITLE
[Cherry-pick] Advance version 3.4.0->3.5.0 (#8058)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ extensions = [
 autosummary_generate = True
 
 # versioning config
-smv_tag_whitelist = r'^(v3.4.0)$'
+smv_tag_whitelist = r'^(v3.5.0)$'
 smv_branch_whitelist = r'^main$'
 smv_remote_whitelist = None
 smv_released_pattern = r'^tags/.*$'

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.4.0'
+__version__ = '3.5.0'
 
 # ---------------------------------------
 # Note: import order is significant here.

--- a/setup.py
+++ b/setup.py
@@ -785,7 +785,7 @@ def get_git_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.4.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
+TRITON_VERSION = "3.5.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 9)


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: abce3c88f05e8dba40bfacf68acf0ee3869afb5e
Original Author: David Berard
Original Date: 2025-09-05 06:54:26 -0700

Original commit message:
```
Advance version 3.4.0->3.5.0 (#8058)

Related to https://github.com/triton-lang/triton/issues/8012
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
