### PR TITLE
[Cherry-pick][CONFLICTS] [AMD] Introduce Scaled Upcast Ops (#8088)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -420,6 +420,14 @@ def TTG_Fp4ToFpOp : TTG_Op<"fp4_to_fp", [Pure]> {
   let arguments = (ins RankedTensorOf<[I8]>:$src, I32Attr:$axis);
   let results = (outs TT_FloatTensor:$result);
 
+  let extraClassDeclaration = [{
+      static LogicalResult verifyFp4ToFp(
+        mlir::Operation *op,
+        RankedTensorType srcTy,
+        RankedTensorType resTy,
+        unsigned axis);
+  }];
+
   let assemblyFormat = [{
     $src attr-dict `:` type($src) `->` type($result)
   }];

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -376,36 +376,44 @@ void ConvertLayoutOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 LogicalResult Fp4ToFpOp::verify() {
   auto srcTy = cast<RankedTensorType>(getSrc().getType());
   auto resTy = cast<RankedTensorType>(getResult().getType());
-  auto rank = srcTy.getRank();
-
-  if (rank != resTy.getRank())
-    return emitError() << "source rank " << rank << " != result rank "
-                       << resTy.getRank();
-
-  auto srcShape = srcTy.getShape();
-  auto resShape = resTy.getShape();
   auto axis = getAxis();
-
-  if (!(0 <= axis && axis < rank))
-    return emitError() << "axis " << axis << " out of range for rank " << rank;
 
   auto elemType = resTy.getElementType();
   if (!(elemType.isBF16() || elemType.isF16()))
     return emitError() << "only bf16 or f16 is supported for now, got "
                        << elemType;
 
+  return verifyFp4ToFp(*this, srcTy, resTy, axis);
+}
+
+LogicalResult Fp4ToFpOp::verifyFp4ToFp(mlir::Operation *op,
+                                       RankedTensorType srcTy,
+                                       RankedTensorType resTy, unsigned axis) {
+  auto rank = srcTy.getRank();
+
+  if (rank != resTy.getRank())
+    return op->emitError() << "source rank " << rank << " != result rank "
+                           << resTy.getRank();
+
+  auto srcShape = srcTy.getShape();
+  auto resShape = resTy.getShape();
+
+  if (!(0 <= axis && axis < rank))
+    return op->emitError() << "axis " << axis << " out of range for rank "
+                           << rank;
+
   for (int i = 0; i < rank; ++i) {
     if (i == axis) {
       if (resShape[i] != srcShape[i] * 2)
-        return emitError() << "axis " << axis
-                           << " dimension must be 2x source dimension (src="
-                           << srcShape[i] << ", dst=" << resShape[i] << ")";
+        return op->emitError()
+               << "axis " << axis
+               << " dimension must be 2x source dimension (src=" << srcShape[i]
+               << ", dst=" << resShape[i] << ")";
     } else {
       if (resShape[i] != srcShape[i])
-        return emitError() << "dimension " << i
-                           << " mismatch (src=" << srcShape[i]
-                           << ", dst=" << resShape[i] << ", axis=" << axis
-                           << ")";
+        return op->emitError()
+               << "dimension " << i << " mismatch (src=" << srcShape[i]
+               << ", dst=" << resShape[i] << ", axis=" << axis << ")";
     }
   }
   return success();

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -520,6 +520,67 @@ def TTG_UpcastMXFPOp : TT_AMDGPU_Op<"upcast_mxfp", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// ScaledUpcastFp4Op
+//===----------------------------------------------------------------------===//
+
+def ScaledUpcastFp4Op : TT_AMDGPU_Op<"scaled_upcast_fp4", [Pure]> {
+  let summary = "Upcast fp4 and then multiply scale";
+
+  let description = [{
+    Upcast fp4 (e2m1) values packed as i8 values and multiply with the given
+    E8M0 scale encoded as BF16. This maps to `v_cvt_scalef32_*` intrinsics
+    on the AMD CDNA4 architecture.
+
+    The lower 4 bits of the i8s represent the first fp4 element, and the upper
+    4 bits the second fp4 element.
+
+    The `axis` attribute specifies the axis along which the fp4 elements are
+    packed.
+  }];
+
+  let arguments = (ins
+    RankedTensorOf<[I8]>:$input,
+    RankedTensorOf<[BF16]>:$scale,
+    I32Attr:$axis);
+  let results = (outs RankedTensorOf<[AnyTypeOf<[F16, BF16, F32]>]>:$output);
+
+  let assemblyFormat = [{
+    $input `scale` $scale attr-dict
+        `:` type($input) `,` type($scale) `->` type($output)
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// ScaledUpcastFp8Op
+//===----------------------------------------------------------------------===//
+
+def ScaledUpcastFp8Op : TT_AMDGPU_Op<"scaled_upcast_fp8", [
+    Pure,
+    Elementwise,
+    SameOperandsAndResultShape,
+    SameOperandsAndResultEncoding]> {
+  let summary = "Upcast Fp8 and then multiply scale";
+
+  let description = [{
+    Upcast fp8 (e4m3/e5m2) values and multiply with the given E8M0 scale
+    encoded as BF16. This maps to `v_cvt_scalef32_*` intrinsics
+    on the AMD CDNA4 architecture.
+  }];
+
+  let arguments = (ins
+    RankedTensorOf<[AnyTypeOf<[F8E4M3FN, F8E5M2]>]>:$input,
+    RankedTensorOf<[BF16]>:$scale);
+  let results = (outs RankedTensorOf<[AnyTypeOf<[F16, BF16, F32]>]>:$output);
+
+  let assemblyFormat = [{
+    $input `scale` $scale attr-dict
+        `:` type($input) `,` type($scale) `->` type($output)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // InThreadTransposeOp
 //===----------------------------------------------------------------------===//
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/PatternTritonAMDGPUToLLVM.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/PatternTritonAMDGPUToLLVM.h
@@ -15,6 +15,10 @@ void populateConcatOpToLLVMPatterns(mlir::LLVMTypeConverter &typeConverter,
                                     mlir::RewritePatternSet &patterns,
                                     mlir::PatternBenefit benefit);
 
+void populateScaledUpcastOpToLLVMPatterns(
+    mlir::LLVMTypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
+    mlir::PatternBenefit benefit);
+
 } // namespace mlir::triton::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTOLLVM_PATTERNTRITONAMDGPUTOLLVM_H_

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "third_party/amd/include/Utils/Utility.h"
@@ -416,6 +417,19 @@ InThreadTransposeOp::deduceOutputLayout(ArrayRef<int64_t> shape,
 
   LinearLayout transposedLL(bases, SmallVector<StringAttr>(outDimNames));
   return transposedLL;
+}
+
+LogicalResult ScaledUpcastFp4Op::verify() {
+  RankedTensorType inputTy = getInput().getType();
+  RankedTensorType outputTy = getOutput().getType();
+  RankedTensorType scaleTy = getScale().getType();
+  auto axis = getAxis();
+
+  if (outputTy.getShape() != scaleTy.getShape())
+    return emitError() << "scale and output should have the same shape";
+
+  // Reuse Fp4ToFpOp's verifier to check types of input and output
+  return triton::gpu::Fp4ToFpOp::verifyFp4ToFp(*this, inputTy, outputTy, axis);
 }
 
 LogicalResult ConcatOp::verify() {

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonAMDGPUDialectToLLVM
     InThreadTransposeOpToTTG.cpp
     ConcatOpToLLVM.cpp
     Utility.cpp
+    ScaledUpcastToLLVM.cpp
 
     DEPENDS
     TritonAMDGPUIR

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
@@ -1,0 +1,111 @@
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "TritonAMDGPUToLLVM/PatternTritonAMDGPUToLLVM.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+using mlir::LLVM::AMD::upcast4xMxfp8_HW;
+using mlir::LLVM::AMD::upcast8xMxfp4_HW;
+
+namespace {
+struct ScaledUpcastFp4OpPattern
+    : ConvertOpToLLVMPattern<amdgpu::ScaledUpcastFp4Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(amdgpu::ScaledUpcastFp4Op upcastOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = upcastOp.getLoc();
+    auto elemType = upcastOp.getType().getElementType();
+
+    auto inputVals = unpackLLElements(loc, adaptor.getInput(), rewriter);
+    auto scaleVals = unpackLLElements(loc, adaptor.getScale(), rewriter);
+
+    assert(inputVals.size() % 4 == 0);
+    SmallVector<Value> results;
+    results.reserve(inputVals.size() * 2);
+
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    for (int i = 0; i < inputVals.size(); i += 4) {
+      SmallVector<Value, 4> v4i32 =
+          elemType.isF16() ? upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkF16Fp4Op>(
+                                 rewriter, loc, inputVals, i, scaleVals[i * 2],
+                                 /*useShiftedScale=*/true)
+                           : upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkBf16Fp4Op>(
+                                 rewriter, loc, inputVals, i, scaleVals[i * 2],
+                                 /*useShiftedScale=*/true);
+      for (int j = 0; j < 4; j++) {
+        Value elements = b.bitcast(v4i32[j], vec_ty(elemType, 2));
+        results.push_back(b.extract_element(elements, b.i32_val(0)));
+        results.push_back(b.extract_element(elements, b.i32_val(1)));
+      }
+    }
+
+    Value result = packLLElements(loc, getTypeConverter(), results, rewriter,
+                                  upcastOp.getType());
+    rewriter.replaceOp(upcastOp, result);
+    return success();
+  }
+};
+
+struct ScaledUpcastFp8OpPattern
+    : ConvertOpToLLVMPattern<amdgpu::ScaledUpcastFp8Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(amdgpu::ScaledUpcastFp8Op upcastOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = upcastOp.getLoc();
+    auto elemType = upcastOp.getType().getElementType();
+    auto fp8ElemType = upcastOp.getInput().getType().getElementType();
+
+    auto inputVals = unpackLLElements(loc, adaptor.getInput(), rewriter);
+    auto scaleVals = unpackLLElements(loc, adaptor.getScale(), rewriter);
+
+    assert(inputVals.size() % 4 == 0);
+    assert(inputVals.size() == scaleVals.size());
+    SmallVector<Value> results;
+    results.reserve(inputVals.size());
+
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    for (int i = 0; i < inputVals.size(); i += 4) {
+      SmallVector<Value, 2> v2i32 =
+          elemType.isF16()
+              ? (isa<Float8E4M3FNType>(fp8ElemType)
+                     ? upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkF16Fp8Op>(
+                           rewriter, loc, inputVals, i, scaleVals[i],
+                           /*useShiftedScale=*/true)
+                     : upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkF16Bf8Op>(
+                           rewriter, loc, inputVals, i, scaleVals[i],
+                           /*useShiftedScale=*/true))
+              : (isa<Float8E4M3FNType>(fp8ElemType)
+                     ? upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkBf16Fp8Op>(
+                           rewriter, loc, inputVals, i, scaleVals[i],
+                           /*useShiftedScale=*/true)
+                     : upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkBf16Bf8Op>(
+                           rewriter, loc, inputVals, i, scaleVals[i],
+                           /*useShiftedScale=*/true));
+      for (int j = 0; j < 2; j++) {
+        Value elements = b.bitcast(v2i32[j], vec_ty(elemType, 2));
+        results.push_back(b.extract_element(elements, b.i32_val(0)));
+        results.push_back(b.extract_element(elements, b.i32_val(1)));
+      }
+    }
+
+    Value result = packLLElements(loc, getTypeConverter(), results, rewriter,
+                                  upcastOp.getType());
+    rewriter.replaceOp(upcastOp, result);
+    return success();
+  }
+};
+} // anonymous namespace
+
+void mlir::triton::AMD::populateScaledUpcastOpToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit) {
+  patterns.add<ScaledUpcastFp4OpPattern>(typeConverter, benefit);
+  patterns.add<ScaledUpcastFp8OpPattern>(typeConverter, benefit);
+}

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/TritonAMDGPUToLLVMPatterns.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/TritonAMDGPUToLLVMPatterns.cpp
@@ -8,5 +8,6 @@ void populateTritonAMDGPUToLLVMPatterns(LLVMTypeConverter &typeConverter,
   populateExtractSliceOpToLLVMPatterns(typeConverter, patterns, benefit);
   populateInThreadTransposeOpToTTGPatterns(patterns, benefit);
   populateConcatOpToLLVMPatterns(typeConverter, patterns, benefit);
+  populateScaledUpcastOpToLLVMPatterns(typeConverter, patterns, benefit);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Fp4ToFpOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Fp4ToFpOpToLLVM.cpp
@@ -2,18 +2,11 @@
 
 #include "Utility.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
-#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
-#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
-#include "triton/Dialect/Triton/IR/Dialect.h"
-#include "triton/Dialect/TritonGPU/IR/Attributes.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Debug.h"
-#include <array>
 
 using namespace mlir;
 using namespace mlir::triton;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -19,7 +19,6 @@
 #include "third_party/amd/include/Analysis/AxisInfoExt.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Analysis/Allocation.h"
-#include "triton/Analysis/AxisInfo.h"
 #include "triton/Analysis/Membar.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -127,6 +127,73 @@ bool isChainDotTail(mlir::triton::DotOpInterface dotOp);
 // to a wider type: BF16 or FP16
 SmallVector<Value, 4> upcast8xMxfp4_SW(RewriterBase &rewriter, Operation *op,
                                        bool toFp16, Value packedVec);
+<<<<<<< HEAD
+=======
+
+template <typename ConvertOp>
+SmallVector<Value, 4>
+upcast8xMxfp4_HW(RewriterBase &rewriter, Location loc, ArrayRef<Value> xVals,
+                 int idx, Value scale, bool useShiftedScale = false) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value packedVec = b.undef(vec_ty(i8_ty, 4));
+  for (int i : llvm::seq(4))
+    packedVec = b.insert_element(packedVec, xVals[idx + i], b.i32_val(i));
+  packedVec = b.bitcast(packedVec, i32_ty);
+  Type retElemType = bf16_ty;
+  if constexpr (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32PkF16Fp4Op>)
+    retElemType = f16_ty;
+  Type resType = vec_ty(retElemType, 2);
+  // In the DotScaledOp decomposition, the scale has already been left-shifted
+  // by 7 to fit the exponent of bf16. So now we only need to further left-shift
+  // it by 16
+  Value scaleF32;
+  if (useShiftedScale) {
+    scaleF32 = b.bitcast(
+        b.shl(b.zext(i32_ty, b.bitcast(scale, i16_ty)), b.i32_val(16)), f32_ty);
+  } else {
+    scaleF32 = b.bitcast(b.shl(b.zext(i32_ty, scale), b.i32_val(23)), f32_ty);
+  }
+  SmallVector<Value, 4> results;
+  for (int srcSelIndex : llvm::seq(4))
+    results.push_back(rewriter.create<ConvertOp>(loc, resType, packedVec,
+                                                 scaleF32, srcSelIndex));
+  return results;
+}
+
+template <typename ConvertOp>
+SmallVector<Value, 2>
+upcast4xMxfp8_HW(RewriterBase &rewriter, Location loc, ArrayRef<Value> xVals,
+                 int idx, Value scale, bool useShiftedScale = false) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value packedVec = b.undef(vec_ty(i8_ty, 4));
+  for (int i : llvm::seq(4))
+    packedVec = b.insert_element(packedVec, xVals[idx + i], b.i32_val(i));
+  packedVec = b.bitcast(packedVec, i32_ty);
+  Type retElemType = bf16_ty;
+  if constexpr (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32PkF16Fp8Op> ||
+                std::is_same_v<ConvertOp, ROCDL::CvtScaleF32PkF16Bf8Op>)
+    retElemType = f16_ty;
+  Type resType = vec_ty(retElemType, 2);
+  // In the DotScaledOp decomposition, the scale has already been left-shifted
+  // by 7 to fit the exponent of bf16. So now we only need to further left-shift
+  // it by 16
+  Value scaleF32;
+  if (useShiftedScale) {
+    scaleF32 = b.bitcast(
+        b.shl(b.zext(i32_ty, b.bitcast(scale, i16_ty)), b.i32_val(16)), f32_ty);
+  } else {
+    scaleF32 = b.bitcast(b.shl(b.zext(i32_ty, scale), b.i32_val(23)), f32_ty);
+  }
+  SmallVector<Value, 2> results;
+  results.push_back(rewriter.create<ConvertOp>(loc, resType, packedVec,
+                                               scaleF32,
+                                               /*srcLoHiSel=*/false));
+  results.push_back(rewriter.create<ConvertOp>(loc, resType, packedVec,
+                                               scaleF32,
+                                               /*srcLoHiSel=*/true));
+  return results;
+}
+>>>>>>> a25e06d27 ([AMD] Introduce Scaled Upcast Ops (#8088))
 } // namespace mlir::LLVM::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTOLLVM_UTILITY_H_

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -60,6 +60,15 @@ FailureOr<ScaleDotElemType> mlirTypeToScaledElemType(Type type) {
       .Default([](Type) { return failure(); });
 }
 
+// Data types supported by non-native DotScaledOp
+bool isF16F8F4(ScaleDotElemType elemType) {
+  return elemType == ScaleDotElemType::E2M1 ||
+         elemType == ScaleDotElemType::E4M3 ||
+         elemType == ScaleDotElemType::E5M2 ||
+         elemType == ScaleDotElemType::BF16 ||
+         elemType == ScaleDotElemType::FP16;
+}
+
 SmallVector<unsigned, 3>
 warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
              std::pair<int64_t, int64_t> shapePerWarp) {
@@ -622,14 +631,7 @@ public:
 
     ScaleDotElemType aElemType = dotOp.getAElemType();
     ScaleDotElemType bElemType = dotOp.getBElemType();
-    auto supportsTypes = [](ScaleDotElemType elemType) {
-      return elemType == ScaleDotElemType::E2M1 ||
-             elemType == ScaleDotElemType::E4M3 ||
-             elemType == ScaleDotElemType::E5M2 ||
-             elemType == ScaleDotElemType::BF16 ||
-             elemType == ScaleDotElemType::FP16;
-    };
-    if (!supportsTypes(aElemType) || !supportsTypes(bElemType))
+    if (!isF16F8F4(aElemType) || !isF16F8F4(bElemType))
       return rewriter.notifyMatchFailure(dotOp, "NYI: mxfp6 operand");
 
     MLIRContext *ctx = dotOp.getContext();
@@ -1059,7 +1061,7 @@ static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
   return builder.create<triton::FpToFpOp>(loc, tensorPromotedType, operand);
 }
 
-// promote operands of dot op if the existing combination is not natively
+// Promote operands of dot op if the existing combination is not natively
 // supported.
 static void decomposeMixedModeDotOp(ModuleOp mod) {
   mod.walk([](triton::DotOp dotOp) -> void {
@@ -1445,9 +1447,9 @@ struct TritonAMDGPUAccelerateMatmulPass
           context, getMfmaVersion(isaFamily), matrixInstructionSize,
           /*benefit=*/10);
       [[fallthrough]];
-    case ISAFamily::CDNA1:
-    case ISAFamily::CDNA2:
     case ISAFamily::CDNA3:
+    case ISAFamily::CDNA2:
+    case ISAFamily::CDNA1:
       mfmaPatterns.add<::BlockedToMFMA, ::ScaledBlockedToMFMA>(
           context, getMfmaVersion(isaFamily), matrixInstructionSize, kPack,
           /*benefit=*/2);


### PR DESCRIPTION
⚠️ **MERGE CONFLICTS DETECTED** ⚠️

This cherry-pick contains merge conflicts that require manual resolution.

Original Commit: a25e06d275ed2ad890ce60a31b1729aca99fac0f
Original Author: Kyle Wang
Original Date: 2025-09-05 12:42:05 -0700

**Action Required:**
1. Check out this branch locally
2. Resolve the merge conflicts in the affected files
3. Commit the resolved changes
4. Update this PR

Original commit message:
```
[AMD] Introduce Scaled Upcast Ops (#8088)

This PR introduced scaled upcast ops including `ScaledUpcastFp4Op` and
`ScaledUpcastFp8Op`

This is one of a series of PRs to decompose scaled dot on AMD backend.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
The conflicts have been committed with conflict markers for easier resolution.
