### PR TITLE
[Cherry-pick][CONFLICTS] [AMD][Gluon] support inline when amdgpu ops in the callee (#8041)

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -783,3 +783,57 @@ def test_tmem_copy_no_scales(M, N, BLOCK_N, num_warps, swizzle):
 
     tmem_copy_no_scales[(1, )](input, output, M, N, BLOCK_N, swizzle, num_warps=num_warps)
     assert (output == input).all()
+<<<<<<< HEAD
+=======
+
+
+@gluon.jit
+def early_return_kernel(x):
+    if x.sum(0).sum(0):
+        return x
+    x = x + x
+    return x
+
+
+def test_2d_tensor_early_return():
+    warp_size = ttgl.constexpr(THREADS_PER_WARP)
+
+    @gluon.jit
+    def kernel(N, out):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, warp_size], [1, 4], [1, 0])
+        BLOCK: ttgl.constexpr = 32
+
+        x0 = ttgl.arange(0, BLOCK, layout=ttgl.SliceLayout(1, layout))
+        x1 = ttgl.arange(0, BLOCK, layout=ttgl.SliceLayout(0, layout))
+        x = x0[:, None] * x1[None, :]
+        for i in range(N):
+            x += early_return_kernel(x)
+        ttgl.store(out, x.sum(0).sum(0))
+
+    out = torch.empty(1, dtype=torch.int32, device="cuda")
+    compiled_kernel = kernel.warmup(N=100, out=out, grid=(1, ))
+    assert compiled_kernel.asm["llir"].count("define") == 1
+
+
+@pytest.mark.skipif(not is_hip_cdna3() and not is_hip_cdna4(), reason="Requires CDNA3 or CDNA4")
+def test_inline_with_amdgpu_dialect():
+
+    @gluon.jit
+    def buffer_load(x, offsets):
+        return ttgl.amd.cdna3.buffer_load(ptr=x, offsets=offsets)
+
+    @gluon.jit
+    def kernel(x, y):
+        layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[64], warps_per_cta=[4],
+                                                    order=[0])
+        offsets = ttgl.arange(0, 64, layout=layout)
+
+        a = buffer_load(x, offsets)
+        ttgl.amd.cdna3.buffer_store(stored_value=a, ptr=y, offsets=offsets)
+
+    input = torch.arange(64, device="cuda").to(torch.int32)
+    output = torch.empty_like(input)
+
+    compiled_kernel = kernel.warmup(input, output, grid=(1, ))
+    assert compiled_kernel.asm["ttgir"].count("tt.func private") == 0
+>>>>>>> 33b282355 ([AMD][Gluon] support inline when amdgpu ops in the callee (#8041))

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "third_party/amd/include/Utils/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Interfaces.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -49,6 +50,8 @@ void mlir::triton::amdgpu::TritonAMDGPUDialect::initialize() {
 #define GET_OP_LIST
 #include "Dialect/TritonAMDGPU/IR/Ops.cpp.inc"
       >();
+
+  addInterfaces<TritonInlinerInterface>();
 }
 
 #include "Dialect/TritonAMDGPU/IR/TritonAMDGPUEnums.cpp.inc"


### PR DESCRIPTION
⚠️ **MERGE CONFLICTS DETECTED** ⚠️

This cherry-pick contains merge conflicts that require manual resolution.

Original Commit: 33b282355f00a269154a2f1a18eafab8e10e11a8
Original Author: Zeng Wu
Original Date: 2025-09-05 21:36:24 -0700

**Action Required:**
1. Check out this branch locally
2. Resolve the merge conflicts in the affected files
3. Commit the resolved changes
4. Update this PR

Original commit message:
```
[AMD][Gluon] support inline when amdgpu ops in the callee (#8041)

Before this change, when there are amdgpu ops in the kernel
as callee, inlining will fail.
A`gluon-inline` pass runs after ttgir is generated by the
frontend, so `run_parser` in test_frontend will not trigger it.
Therefore, a runtime testing using `warmup` is added.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
The conflicts have been committed with conflict markers for easier resolution.
