### PR TITLE
[Cherry-pick] [BACKEND] Turn on bit 46 for descriptors in mmav5 (#8032)

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -454,13 +454,13 @@ void convertDotImpl(const LLVMTypeConverter &typeConverter,
                                                      interleaved, transA);
   } else {
     auto allocShapeA = getAllocShape(aTensorTy, 1);
-    aLoader = std::make_unique<DotOpMmaV3SmemLoader>(
+    aLoader = std::make_unique<DotOpMmaV5SmemLoader>(
         a, baseA, shapeA, allocShapeA, zero, 1, transA, aOperandShape,
         op.numBitsPerElementA, rewriter, loc);
   }
 
   auto allocShapeB = getAllocShape(bTensorTy, 0);
-  DotOpMmaV3SmemLoader bLoader = DotOpMmaV3SmemLoader(
+  DotOpMmaV5SmemLoader bLoader = DotOpMmaV5SmemLoader(
       b, baseB, shapeB, allocShapeB, zero, 1, transB, {mmaSizeN, mmaSizeK},
       op.numBitsPerElementB, rewriter, loc);
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -1016,7 +1016,7 @@ static void copySharedToTmem(ConversionPatternRewriter &rewriter, Location loc,
   auto createCopy = [&](int repM, int repN) {
     Value zero = b.i32_val(0);
     SmallVector<int64_t> shape(op.getSrc().getType().getShape());
-    DotOpMmaV3SmemLoader smemLoader = DotOpMmaV3SmemLoader(
+    DotOpMmaV5SmemLoader smemLoader = DotOpMmaV5SmemLoader(
         op.getSrc(), baseSrc, shape, op.getSrc().getType().getAllocShape(),
         zero, 1, /*trans=*/false, {128, 8},
         op.getSrc().getType().getElementType().getIntOrFloatBitWidth(),


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: fca399fd8f227069d9bf68b31f50691664dd81dd
Original Author: Mario Lezcano Casado
Original Date: 2025-09-08 17:23:09 +0100

Original commit message:
```
[BACKEND] Turn on bit 46 for descriptors in mmav5 (#8032)

Following
https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-shared-memory-descriptor
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
