### PR TITLE
[Cherry-pick][CONFLICTS] [AMD] Redesign stream pipeliner LDS layout selection logic (#8053)

### DIFF
--- a/test/TritonGPU/amd/amd-stream-lds-layout-selection.mlir
+++ b/test/TritonGPU/amd/amd-stream-lds-layout-selection.mlir
@@ -1,0 +1,116 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-stream-pipeline="num_stages=2" -canonicalize | FileCheck %s
+
+// Pick a common shared memory layout with vec = max kWidth of all users.
+// CHECK{LITERAL}: #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 2, maxPhase = 8, order = [0, 1]}>
+// CHECK-NOT: #ttg.swizzled_shared
+// CHECK{LITERAL}: #smem = #ttg.shared_memory
+// CHECK-LABEL: test_lds_layout_selection
+
+// CHECK: %[[ALLOC:.+]] = ttg.local_alloc : () -> !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable>
+// CHECK: %[[MEMDESC_IDX:.+]] = ttg.memdesc_index %[[ALLOC]]
+
+// CHECK: scf.for {{.+}} iter_args({{.*}}, %[[MEMDESC_IDX_ITER:.+]] = %[[MEMDESC_IDX]]) -> ({{.+}})
+//  CHECK: %[[LOAD:.+]] = tt.load {{.+}} : tensor<64x16x!tt.ptr<f16>, #blocked>
+//  CHECK: %[[LOCAL_LOAD_TRANS:.+]] = ttg.local_load %[[MEMDESC_IDX_ITER]] : {{.+}} -> tensor<64x16xf16, #linear>
+//  CHECK: %[[LOCAL_LOAD_DIRECT:.+]] = ttg.local_load %[[MEMDESC_IDX_ITER]] : {{.+}} -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+//  CHECK: tt.dot {{.+}}, %[[LOCAL_LOAD_DIRECT]], {{.+}}
+//  CHECK: %[[TRANS:.+]] = tt.trans %[[LOCAL_LOAD_TRANS]] {{.+}} : {{.+}} -> tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 8}>>
+//  CHECK: tt.dot {{.+}}, %[[TRANS]], {{.+}}
+//  CHECK: %[[MEMDESC_IDX:.+]] = ttg.memdesc_index %[[ALLOC]]
+//  CHECK: ttg.local_store %[[LOAD]], %[[MEMDESC_IDX]]
+//  CHECK: scf.yield
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [32, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 8]], warp = [[0, 0], [0, 0]], block = []}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32], isTransposed = true}>
+#mma1 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16], isTransposed = true}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_lds_layout_selection(
+    %arg0: tensor<64x16x!tt.ptr<f16>, #blocked>,
+    %out0 : tensor<128x16x!tt.ptr<f32>, #blocked>,
+    %out1 : tensor<128x64x!tt.ptr<f32>, #blocked>
+  ) {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %cst_1 = arith.constant dense<0.693147182> : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 4}>>
+    %cst_2 = arith.constant dense<0.581374812> : tensor<128x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %cst_3 = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+
+    %0:2 = scf.for %arg1 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg2 = %cst_0, %arg3 = %cst_3) -> (tensor<128x16xf32, #mma1>, tensor<128x64xf32, #mma>)  : i32 {
+      %1 = tt.load %arg0 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %2 = ttg.convert_layout %1 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #linear>
+      %3 = ttg.convert_layout %1 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 4}>>
+      %4 = tt.dot %cst_1, %3, %arg2 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 4}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 4}>> -> tensor<128x16xf32, #mma1>
+      %5 = tt.trans %2 {order = array<i32: 1, 0>} : tensor<64x16xf16, #linear> -> tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %6 = tt.dot %cst_2, %5, %arg3 : tensor<128x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<128x64xf32, #mma>
+      scf.yield %4, %6 : tensor<128x16xf32, #mma1>, tensor<128x64xf32, #mma>
+    }
+
+    %7 = ttg.convert_layout %0#0 : tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #blocked>
+    %8 = ttg.convert_layout %0#1 : tensor<128x64xf32, #mma> -> tensor<128x64xf32, #blocked>
+    tt.store %out0, %7 : tensor<128x16x!tt.ptr<f32>, #blocked>
+    tt.store %out1, %8 : tensor<128x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+// -----
+
+// Verify that a common shared memory layout is chosen for users with different kWidth and opIdx.
+// CHECK{LITERAL}: #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 2, maxPhase = 8, order = [0, 1]}>
+// CHECK-NOT: #ttg.swizzled_shared
+// CHECK{LITERAL}: #smem = #ttg.shared_memory
+// CHECK-LABEL: test_lds_layout_selection_different_opIdx
+
+// CHECK: %[[ALLOC:.+]] = ttg.local_alloc : () -> !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable>
+// CHECK: %[[MEMDESC_IDX:.+]] = ttg.memdesc_index %[[ALLOC]]
+
+// CHECK: scf.for {{.+}} iter_args({{.*}}, %[[MEMDESC_IDX_ITER:.+]] = %[[MEMDESC_IDX]]) -> ({{.+}})
+//  CHECK: %[[LOAD:.+]] = tt.load {{.+}} : tensor<64x16x!tt.ptr<f16>, #blocked>
+//  CHECK: %[[LOCAL_LOAD_TRANS:.+]] = ttg.local_load %[[MEMDESC_IDX_ITER]] : {{.+}} -> tensor<64x16xf16, #linear>
+//  CHECK: %[[LOCAL_LOAD_DIRECT:.+]] = ttg.local_load %[[MEMDESC_IDX_ITER]] : {{.+}} -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+//  CHECK: tt.dot %[[LOCAL_LOAD_DIRECT]], {{.+}}
+//  CHECK: %[[TRANS:.+]] = tt.trans %[[LOCAL_LOAD_TRANS]] {{.+}} : {{.+}} -> tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 8}>>
+//  CHECK: tt.dot {{.+}}, %[[TRANS]], {{.+}}
+//  CHECK: %[[MEMDESC_IDX:.+]] = ttg.memdesc_index %[[ALLOC]]
+//  CHECK: ttg.local_store %[[LOAD]], %[[MEMDESC_IDX]]
+//  CHECK: scf.yield
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [32, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 8]], warp = [[0, 0], [0, 0]], block = []}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32], isTransposed = true}>
+#mma1 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16], isTransposed = true}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_lds_layout_selection_different_opIdx(
+    %arg0: tensor<64x16x!tt.ptr<f16>, #blocked>,
+    %out0 : tensor<64x64x!tt.ptr<f32>, #blocked>,
+    %out1 : tensor<128x64x!tt.ptr<f32>, #blocked>
+  ) {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma1>
+    %cst_1 = arith.constant dense<0.693147182> : tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 4}>>
+    %cst_2 = arith.constant dense<0.581374812> : tensor<128x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %cst_3 = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+
+    %0:2 = scf.for %arg1 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg2 = %cst_0, %arg3 = %cst_3) -> (tensor<64x64xf32, #mma1>, tensor<128x64xf32, #mma>)  : i32 {
+      %1 = tt.load %arg0 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %2 = ttg.convert_layout %1 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #linear>
+      %3 = ttg.convert_layout %1 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 4}>>
+      %4 = tt.dot %3, %cst_1, %arg2 : tensor<64x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 4}>> * tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 4}>> -> tensor<64x64xf32, #mma1>
+      %5 = tt.trans %2 {order = array<i32: 1, 0>} : tensor<64x16xf16, #linear> -> tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %6 = tt.dot %cst_2, %5, %arg3 : tensor<128x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<128x64xf32, #mma>
+      scf.yield %4, %6 : tensor<64x64xf32, #mma1>, tensor<128x64xf32, #mma>
+    }
+
+    %7 = ttg.convert_layout %0#0 : tensor<64x64xf32, #mma1> -> tensor<64x64xf32, #blocked>
+    %8 = ttg.convert_layout %0#1 : tensor<128x64xf32, #mma> -> tensor<128x64xf32, #blocked>
+    tt.store %out0, %7 : tensor<64x64x!tt.ptr<f32>, #blocked>
+    tt.store %out1, %8 : tensor<128x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-stream-prefetch.mlir
+++ b/test/TritonGPU/amd/amd-stream-prefetch.mlir
@@ -4,14 +4,14 @@
 // RUN: triton-opt %s -tritonamdgpu-stream-pipeline="num_stages=2 local_prefetch=1" -canonicalize | FileCheck %s --check-prefixes=LOCAL_1
 
 // matmul: 128x32 @ 32x128 -> 128x128
-#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-#BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #ALs0 = #ttg.slice<{parent=#AL, dim=0}>
 #BLs0 = #ttg.slice<{parent=#BL, dim=0}>
 #BLs1 = #ttg.slice<{parent=#BL, dim=1}>
-#C = #ttg.nvidia_mma<{versionMajor = 2, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
-#A = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth=2}>
-#B = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth=2}>
+#C = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32], isTransposed = true}>
+#A = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth = 4}>
+#B = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth = 4}>
 
 // An extra register buffer for global loads.
 // GLOBAL_1-LABEL: tt.func @matmul_loop
@@ -74,7 +74,7 @@
 // LOCAL_1: tt.dot
 // LOCAL_1-NOT: tt.dot
 
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
 tt.func @matmul_loop(%lb : index, %ub : index, %step : index,
                   %A : !tt.ptr<f16> {tt.divisibility = 16 : i32},
                   %B : !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<128x128xf32, #C> {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -705,28 +705,6 @@ bool isChainDotHead(tt::DotOpInterface dotOp) {
   return false;
 }
 
-bool hasTransInDefChain(tt::DotOpInterface dotOp, unsigned opIdx) {
-  auto isInSameRegion = [&dotOp](Operation *op) {
-    return op->getParentRegion() == dotOp->getParentRegion();
-  };
-
-  BackwardSliceOptions bwdOpt;
-  bwdOpt.omitBlockArguments = true;
-  bwdOpt.filter = isInSameRegion;
-  SetVector<Operation *> bwdSlices;
-  Operation *dotOperand = (opIdx == 0) ? dotOp.getA().getDefiningOp()
-                                       : dotOp.getB().getDefiningOp();
-
-  if (!dotOperand)
-    return false;
-  (void)getBackwardSlice(dotOperand, &bwdSlices, bwdOpt);
-  if (llvm::find_if(bwdSlices, [](Operation *op) {
-        return isa<tt::TransOp>(op);
-      }) != bwdSlices.end())
-    return true;
-  return false;
-}
-
 bool isChainDotTail(tt::DotOpInterface dotOp) {
   auto isInSameRegion = [&dotOp](Operation *op) {
     return op->getParentRegion() == dotOp->getParentRegion();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -115,10 +115,6 @@ bool isUsedByDotScaledOp(Operation *op);
 // in the same region
 bool isChainDotHead(mlir::triton::DotOpInterface dotOp);
 
-// Check if given operand of this tt.dot is the result of a tt.trans
-// in the same region
-bool hasTransInDefChain(mlir::triton::DotOpInterface dotOp, unsigned opIdx);
-
 // Check if the opA of this tl.dot is the result of another tl.dot
 // in the same region
 bool isChainDotTail(mlir::triton::DotOpInterface dotOp);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -15,7 +15,6 @@
 
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
-using ::mlir::LLVM::AMD::hasTransInDefChain;
 using ::mlir::LLVM::AMD::isChainDotHead;
 using ::mlir::LLVM::AMD::isChainDotTail;
 using ::mlir::LLVM::AMD::scaleDotElemTypeToMLIRType;
@@ -527,18 +526,6 @@ public:
     auto is16BitElemTy = (aElemTy.isF16() || aElemTy.isBF16());
     if (is16BitElemTy && isDotChainTail) {
       kWidth = 4;
-    }
-    // For FA bwd kernel (detected using hasTransInDefChain), depending on
-    // whether the dot is a head or tail in the chain, we adjust the kWidth
-    // accordingly. This will enable us to create the same shared encoding per
-    // pair of tt.dot ops that both use the same tt.load result, one directly
-    // and one via tt.trans, later in the pass pipeline.
-    if (is16BitElemTy && hasTransInDefChain(dotOp, 1u)) {
-      if (isChainDotHead(dotOp)) {
-        kWidth = 4;
-      } else if (isDotChainTail) {
-        kWidth = 8;
-      }
     }
 
     Value newDot;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -184,8 +184,9 @@ StreamCopyChainOps createStreamCopy(tt::LoadOp loadOp, Value alloc,
 }
 
 // Returns the given |inputValue|'s dot user result encoding and updates |opIdx|
-// with which dot operand |inputValue| is fed into if possible.
-ttg::AMDMfmaEncodingAttr getDotEncoding(Value inputValue, unsigned *opIdx) {
+// and |vecSize| with which dot operand |inputValue| is fed into if possible.
+ttg::AMDMfmaEncodingAttr getDotEncoding(Value inputValue, unsigned *opIdx,
+                                        unsigned *vecSize) {
   if (!inputValue.hasOneUse())
     return nullptr;
 
@@ -194,13 +195,17 @@ ttg::AMDMfmaEncodingAttr getDotEncoding(Value inputValue, unsigned *opIdx) {
       user->getBlock() != inputValue.getParentBlock())
     return nullptr;
 
+  LDBG("getDotEncoding user: " << *user);
   if (auto dotOp = dyn_cast<tt::DotOpInterface>(user)) {
     OpOperand &use = *inputValue.getUses().begin();
     *opIdx = use.getOperandNumber();
+    auto operandType = cast<RankedTensorType>(inputValue.getType());
+    *vecSize = ttg::toLinearLayout(operandType).getNumConsecutiveInOut();
     auto dotType = cast<RankedTensorType>(dotOp->getResult(0).getType());
     return dyn_cast<ttg::AMDMfmaEncodingAttr>(dotType.getEncoding());
   }
-  return getDotEncoding(user->getResult(0), opIdx);
+
+  return getDotEncoding(user->getResult(0), opIdx, vecSize);
 }
 
 // Adapted from
@@ -213,7 +218,7 @@ ttg::AMDMfmaEncodingAttr getDotEncoding(Value inputValue, unsigned *opIdx) {
 // needs to be used to be compatible with users' layouts.
 std::optional<ttg::SwizzledSharedEncodingAttr>
 getSharedEncIfAllUsersAreDotEnc(Value loadedValue) {
-  ttg::SwizzledSharedEncodingAttr attr;
+  llvm::SmallVector<ttg::SwizzledSharedEncodingAttr> sharedEncs;
   for (Operation *user : loadedValue.getUsers()) {
     LDBG(" getSharedEncIfAllUsersAreDotEnc current user: " << *user);
     if (user->getNumResults() != 1)
@@ -226,8 +231,11 @@ getSharedEncIfAllUsersAreDotEnc(Value loadedValue) {
       // First time we find a shared encoding in the chain, save it and try to
       // use it if it is compatible with the other users.
       tempAttr = cast<ttg::SwizzledSharedEncodingAttr>(memDesc.getEncoding());
-      if (!getSharedEncIfAllUsersAreDotEnc(userResult).has_value())
+      LDBG("Deduced shared encoding candidate from memDesc: " << tempAttr);
+      if (!getSharedEncIfAllUsersAreDotEnc(userResult).has_value()) {
         return std::nullopt;
+      }
+      sharedEncs.push_back(tempAttr);
     } else {
       if (!(isa<ttg::ConvertLayoutOp>(user) ||
             user->hasTrait<OpTrait::LocalLoadTrait>()))
@@ -257,26 +265,53 @@ getSharedEncIfAllUsersAreDotEnc(Value loadedValue) {
         tempAttr = ttg::SwizzledSharedEncodingAttr::get(
             loadedValue.getContext(), dotOpEnc, srcTy.getShape(), sharedOrder,
             ctaLayout, bitWidth, /*needTrans=*/false);
+        LDBG("Deduced shared encoding candidate from dot layout: " << tempAttr);
+        sharedEncs.push_back(tempAttr);
       } else if (auto llEnc = dyn_cast<ttg::LinearEncodingAttr>(userResEnc)) {
         // We use linear layout directly for scaled dot fp8 operands. For such
         // cases, we need to look further down the def-use chain to find the dot
         // op for the mfma layout to deduce operand index and other information.
         unsigned opIdx;
-        if (auto dotEnc = getDotEncoding(userResult, &opIdx)) {
-          unsigned vecSize = llEnc.getLinearLayout().getNumConsecutiveInOut();
+        unsigned vecSize;
+        if (auto mfmaEnc = getDotEncoding(userResult, &opIdx, &vecSize)) {
           LDBG("deduced opIdx: " << opIdx << "; deduced vecSize: " << vecSize);
-          tempAttr = dotEnc.composeSharedLayoutForOperand(
+          tempAttr = mfmaEnc.composeSharedLayoutForOperand(
               ctaLayout, opIdx, srcTy.getShape(), order, vecSize, bitWidth,
               /*needTrans=*/false);
+          LDBG("Deduced shared encoding candidate from mfma layout: "
+               << tempAttr);
+          sharedEncs.push_back(tempAttr);
         }
       }
     }
-    // Check that the shared encodings needed by the users are compatible.
-    if (!tempAttr || (attr != nullptr && attr != tempAttr))
-      return std::nullopt;
-    attr = tempAttr;
   }
-  return attr;
+
+  auto equalSharedEncIgnoreVec = [](ttg::SwizzledSharedEncodingAttr a,
+                                    ttg::SwizzledSharedEncodingAttr b) {
+    if (!a || !b)
+      return false;
+    return (a.getPerPhase() == b.getPerPhase() &&
+            a.getMaxPhase() == b.getMaxPhase() &&
+            a.getOrder() == b.getOrder() &&
+            a.getCTALayout() == b.getCTALayout());
+  };
+  if (sharedEncs.empty() || !sharedEncs.front())
+    return std::nullopt;
+  auto maxVecSharedEnc = sharedEncs.front();
+
+  for (auto sharedEnc : sharedEncs) {
+    if (!equalSharedEncIgnoreVec(sharedEnc, maxVecSharedEnc)) {
+      LDBG("Incompatible shared encodings");
+      return std::nullopt;
+    }
+    if (sharedEnc.getVec() > maxVecSharedEnc.getVec()) {
+      maxVecSharedEnc = sharedEnc;
+    }
+  }
+
+  LDBG("Deduced shared encoding: " << maxVecSharedEnc);
+
+  return maxVecSharedEnc;
 }
 
 bool canBeConvertedToAsyncLoad(unsigned numBuffers, tt::LoadOp loadOp,
@@ -403,9 +438,22 @@ preprocessLoop(triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
   LoadToInfoMap loadToInfo;
   for (const auto &[load, info] : loadOpToIndLevel) {
     auto [distance, use] = info;
+<<<<<<< HEAD
     auto sharedEncoding =
         getSharedEncIfAllUsersAreDotEnc(load->getResult(0)).value_or(nullptr);
     loadToInfo[load] = {sharedEncoding, distance, use};
+=======
+    auto newLoad = bypassLDS(load, use);
+    if (newLoad) {
+      loadToInfo[newLoad] = {nullptr, distance, use};
+    } else {
+      LDBG("Deduce shared encoding for: " << *load);
+      auto sharedEncoding =
+          getSharedEncIfAllUsersAreDotEnc(load->getResult(0)).value_or(nullptr);
+      loadToInfo[load] = {sharedEncoding, distance, use};
+      LDBG("Populate loadInfo with shared encoding: " << sharedEncoding);
+    }
+>>>>>>> 8b792c8c7 ([AMD] Redesign stream pipeliner LDS layout selection logic (#8053))
   }
 
   return loadToInfo;
@@ -443,6 +491,7 @@ LogicalResult initSchedule(int maxDist, Stages &stages, int numStages,
                            int localPrefetch, bool useAsyncCopy,
                            bool waitAtTail, Clusters &clusters,
                            tt::CoarseSchedule &schedule) {
+  LDBG("Init SingleDotSchedule");
   int lastStage = numStages - 1;
   stages[SCHED_GLOBAL_LOAD] = 0;
   stages[SCHED_LOCAL_STORE] = globalPrefetch;
@@ -631,6 +680,7 @@ buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
               int globalPrefetch, int localPrefetch, bool useAsyncCopy,
               bool waitAtTail,
               triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+  LDBG("Build SingleDotSchedule");
   tt::CoarseSchedule schedule(numStages);
   Stages stages;
   Clusters clusters;
@@ -926,6 +976,7 @@ tt::CoarseSchedule
 buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
               bool useAsyncCopy,
               triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+  LDBG("Build ChainedDotSchedule");
   tt::CoarseSchedule schedule(numStages);
   ChainedDotClusters clusters;
   std::generate(clusters.begin(), clusters.end(),


### PR DESCRIPTION
⚠️ **MERGE CONFLICTS DETECTED** ⚠️

This cherry-pick contains merge conflicts that require manual resolution.

Original Commit: 8b792c8c7a6444dd0514ff6401cd3b9a236adf0a
Original Author: PMylon
Original Date: 2025-09-08 23:28:58 +0200

**Action Required:**
1. Check out this branch locally
2. Resolve the merge conflicts in the affected files
3. Commit the resolved changes
4. Update this PR

Original commit message:
```
[AMD] Redesign stream pipeliner LDS layout selection logic (#8053)

This commit adapts the LDS layout selection logic in Stream Pipeliner so
that we pick a common swizzled shared memory layout with vecSize = max
kWidth of all users.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
The conflicts have been committed with conflict markers for easier resolution.
