### PR TITLE
[Cherry-pick] [Proton] Fix proton intra kernel profiling buffer overflow warning (#8109)

### DIFF
--- a/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
@@ -53,13 +53,16 @@ void CircularLayoutParser::parseMetadata() {
   int maxCountPerUnit = bt.bufSize / getConfig().uidVec.size() / 8;
 
   for (auto uid : getConfig().uidVec) {
+    // Each event is 2 words (8 bytes) and countVec captures the number of words
+    // of each warp captured during profiling
     auto count = countVec[uid];
+    auto numEvent = count / 2;
 
-    if (count > maxCountPerUnit) {
+    if (numEvent > maxCountPerUnit) {
       std::cerr << "Warning (cta" << bt.blockId << ", warp" << uid
-                << "): first " << count - maxCountPerUnit
+                << "): first " << numEvent - maxCountPerUnit
                 << " events are dropped due to insufficient buffer size ("
-                << maxCountPerUnit << "/" << count << ")" << std::endl;
+                << maxCountPerUnit << "/" << numEvent << ")" << std::endl;
     }
 
     auto &trace = bt.traces.emplace_back();


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: d0153b206c9bb0b33534de3cb839e5d15ed98b4b
Original Author: Yuanwei Fang
Original Date: 2025-09-08 18:50:29 -0700

Original commit message:
```
[Proton] Fix proton intra kernel profiling buffer overflow warning (#8109)

Fixed the miscalculated event size that each warp captured for reporting
the overflow warning.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
