### PR TITLE
[Cherry-pick] Reapply "[NVIDIA] Add native MXFP FP8 scaled_dot for SM120 (#7918)" (#8029) (#8129)

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -49,7 +49,12 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
       /*retType=*/"::mlir::Value",
       /*methodName=*/"getB",
       /*args=*/(ins)>,
-  InterfaceMethod<
+    InterfaceMethod<
+      /*desc=*/"Get the output tensor",
+      /*retType=*/"::mlir::Value",
+      /*methodName=*/"getD",
+      /*args=*/(ins)>,
+    InterfaceMethod<
       /*desc=*/"Verify the dimensions of the A and B DotOp operands.",
       /*retType=*/"bool",
       /*methodName=*/"verifyDims",
@@ -64,6 +69,7 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
         auto aTy = cast<ShapedType>($_op.getA().getType());
         auto bTy = cast<ShapedType>($_op.getB().getType());
         auto cTy = cast<ShapedType>($_op->getOperand(2).getType());
+        auto dTy = cast<ShapedType>($_op.getD().getType());
         auto aShape = aTy.getShape();
         auto bShape = bTy.getShape();
         auto cShape = cTy.getShape();

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -126,6 +126,13 @@ LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          ArrayRef<unsigned> tilesPerWarp,
                                          ArrayRef<unsigned> warpsPerCTA);
 
+LinearLayout getSM120DotScaledScaleLayout(MLIRContext *ctx, int dotOperandIdx,
+                                          ArrayRef<int64_t> dotOperandShape,
+                                          ArrayRef<unsigned> tilesPerWarp,
+                                          ArrayRef<unsigned> warpsPerCTA,
+                                          unsigned instrM, unsigned instrN,
+                                          CTALayoutAttr ctaLayoutAttr);
+
 // Create LinearLayout for nvidia mma tile.
 LinearLayout nvidiaMmaTile(MLIRContext *ctx, ArrayRef<unsigned> tileShape,
                            unsigned kWidth, ArrayRef<unsigned> order,

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -1,3 +1,4 @@
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Types.h"
@@ -8,6 +9,7 @@
 #include "triton/Analysis/Utility.h"
 #include "triton/Conversion/MLIRTypes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/OpInterfaces.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -66,7 +68,8 @@ static int getMMAVersionSafe(int computeCapability, DotOp op) {
   return 0;
 }
 
-SmallVector<unsigned> warpsPerTileV2(DotOp dotOp, const ArrayRef<int64_t> shape,
+SmallVector<unsigned> warpsPerTileV2(DotOpInterface dotOp,
+                                     const ArrayRef<int64_t> shape,
                                      int numWarps) {
   auto rank = shape.size();
   // Early exit for batched matmul
@@ -80,9 +83,8 @@ SmallVector<unsigned> warpsPerTileV2(DotOp dotOp, const ArrayRef<int64_t> shape,
   auto slices = multiRootGetSlice(dotOp, {filter}, {filter});
   bool hasChainedDot = false;
   for (Operation *op : slices) {
-    if (isa<DotOp>(op) && (op != dotOp)) {
-      auto chainedDot = cast<DotOp>(op);
-      auto resTy = chainedDot.getResult().getType();
+    if (isa<DotOp, DotScaledOp>(op) && (op != dotOp)) {
+      auto resTy = cast<RankedTensorType>(op->getResult(0).getType());
       if (resTy.getRank() != rank) {
         continue;
       }
@@ -129,12 +131,11 @@ SmallVector<unsigned> warpsPerTileV2(DotOp dotOp, const ArrayRef<int64_t> shape,
   }
   return {(unsigned)warps[0], (unsigned)warps[1]};
 }
-
 SmallVector<unsigned, 2>
-warpsPerTileV3(DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps,
-               const SmallVector<unsigned, 3> &instrShape) {
+warpsPerTileV3(DotOpInterface dotOp, const ArrayRef<int64_t> shape,
+               int numWarps, const SmallVector<unsigned, 3> &instrShape) {
   SetVector<Operation *> slices;
-  mlir::getForwardSlice(dotOp.getResult(), &slices);
+  mlir::getForwardSlice(dotOp.getD(), &slices);
   // Contains a chained dot. We prefer to assign warps to one axis
   // to facilitate use cases like flash attention, allowing reductions within
   // the same warp.
@@ -232,8 +233,9 @@ getSharedMemoryScale(Value arg, mlir::PatternRewriter &rewriter, Location loc) {
 }
 
 SmallVector<unsigned, 3>
-getWarpsPerTile(DotOp dotOp, const ArrayRef<int64_t> shape, int version,
-                int numWarps, const SmallVector<unsigned, 3> &instrShape) {
+getWarpsPerTile(DotOpInterface dotOp, const ArrayRef<int64_t> shape,
+                int version, int numWarps,
+                const SmallVector<unsigned, 3> &instrShape) {
   switch (version) {
   case 2:
     return warpsPerTileV2(dotOp, shape, numWarps);
@@ -293,6 +295,66 @@ static int computeOrigBitWidth(Value x) {
   return origBitWidth;
 }
 
+namespace {
+
+// Common MMA encoding creation
+struct MMAEncodingResult {
+  NvidiaMmaEncodingAttr mmaEnc;
+  RankedTensorType newRetType;
+  Value newAcc;
+  int versionMajor;
+  int versionMinor;
+};
+
+// Unified implementation for DotOpInterface
+static MMAEncodingResult createMMAEncodingForDot(DotOpInterface dotOp,
+                                                 PatternRewriter &rewriter,
+                                                 int computeCapability,
+                                                 int versionMajor) {
+  auto oldRetType = cast<RankedTensorType>(dotOp.getD().getType());
+  auto oldAType = cast<RankedTensorType>(dotOp.getA().getType());
+
+  int numWarps = lookupNumWarps(dotOp);
+
+  int versionMinor = computeCapability == 75 ? 1 : 0;
+  // Only MMAv2 and MMAv3 rely on computing instrShape/warpsPerTile here.
+  if (!(versionMajor == 2 || versionMajor == 3)) {
+    return {nullptr, RankedTensorType(), Value(), versionMajor, versionMinor};
+  }
+
+  auto CTALayout = getCTALayout(oldRetType.getEncoding());
+  auto retShapePerCTA = getShapePerCTA(oldRetType);
+  auto instrShape = mmaVersionToInstrShape(versionMajor, retShapePerCTA,
+                                           oldAType.getElementType(), numWarps);
+  auto warpsPerTile = getWarpsPerTile(dotOp, retShapePerCTA, versionMajor,
+                                      numWarps, instrShape);
+
+  auto mmaEnc = NvidiaMmaEncodingAttr::get(oldRetType.getContext(),
+                                           versionMajor, versionMinor,
+                                           warpsPerTile, CTALayout, instrShape);
+  auto newRetType = oldRetType.cloneWithEncoding(mmaEnc);
+
+  auto oldAcc = dotOp->getOperand(2);
+  auto newAcc =
+      rewriter.create<ConvertLayoutOp>(oldAcc.getLoc(), newRetType, oldAcc);
+
+  return {mmaEnc, newRetType, newAcc, versionMajor, versionMinor};
+}
+
+// Common operand conversion
+static Value convertDotOperandForMMA(Value v, int opIdx, int bitwidth,
+                                     RankedTensorType newRetType,
+                                     PatternRewriter &rewriter) {
+  auto minType = bitwidth > 0 ? rewriter.getIntegerType(bitwidth) : v.getType();
+  auto vType = cast<RankedTensorType>(v.getType());
+  auto newVEncoding = DotOperandEncodingAttr::get(
+      v.getContext(), opIdx, newRetType.getEncoding(), minType);
+  auto newVType = vType.cloneWithEncoding(newVEncoding);
+  return rewriter.create<ConvertLayoutOp>(v.getLoc(), newVType, v);
+}
+
+} // namespace
+
 class BlockedToMMA : public mlir::OpRewritePattern<DotOp> {
   int computeCapability;
   mutable llvm::DenseMap<Operation *, unsigned> dotOpInstNs;
@@ -314,18 +376,10 @@ public:
       return failure();
     }
     // TODO: Check data-types and SM compatibility
-    if (!dotOp.getType().getEncoding() ||
-        mlir::isa<NvidiaMmaEncodingAttr>(dotOp.getType().getEncoding()))
+    auto retType = dotOp.getType();
+    if (!retType.getEncoding() ||
+        mlir::isa<NvidiaMmaEncodingAttr>(retType.getEncoding()))
       return failure();
-
-    int numWarps = lookupNumWarps(dotOp);
-    int versionMajor = getMMAVersionSafe(computeCapability, dotOp);
-    if (!(versionMajor >= 1 && versionMajor <= 3))
-      return failure();
-
-    bool aFromLoad = comesFromLoadOrBlockArg(dotOp.getA());
-    bool bFromLoad = comesFromLoadOrBlockArg(dotOp.getB());
-    auto origDotOp = dotOp;
 
     Value a = dotOp.getA();
     Value b = dotOp.getB();
@@ -342,43 +396,23 @@ public:
       return failure();
     }
 
-    // get MMA encoding for the given number of warps
-    auto CTALayout = getCTALayout(oldRetType.getEncoding());
-    auto retShapePerCTA = getShapePerCTA(oldRetType);
-    auto instrShape = mmaVersionToInstrShape(
-        versionMajor, retShapePerCTA, oldAType.getElementType(), numWarps);
-
-    assert(versionMajor == 2 || versionMajor == 3);
-    int versionMinor = computeCapability == 75 ? 1 : 0;
-    auto warpsPerTile = getWarpsPerTile(dotOp, retShapePerCTA, versionMajor,
-                                        numWarps, instrShape);
-    auto mmaEnc = NvidiaMmaEncodingAttr::get(
-        oldRetType.getContext(), versionMajor, versionMinor, warpsPerTile,
-        CTALayout, instrShape);
-    auto newRetType = oldRetType.cloneWithEncoding(mmaEnc);
-    // convert accumulator
-    auto oldAcc = dotOp.getOperand(2);
-    auto newAcc =
-        rewriter.create<ConvertLayoutOp>(oldAcc.getLoc(), newRetType, oldAcc);
-
-    auto getDotOperand = [&](Value v, int opIdx, int bitwidth) {
-      auto minType =
-          bitwidth > 0 ? rewriter.getIntegerType(bitwidth) : v.getType();
-      auto vType = cast<RankedTensorType>(v.getType());
-      auto newVEncoding = DotOperandEncodingAttr::get(
-          v.getContext(), opIdx, newRetType.getEncoding(), minType);
-      auto newVType = vType.cloneWithEncoding(newVEncoding);
-      return rewriter.create<ConvertLayoutOp>(v.getLoc(), newVType, v);
-    };
+    auto mmaVersion = getMMAVersionSafe(computeCapability, dotOp);
+    auto mmaResult =
+        createMMAEncodingForDot(dotOp, rewriter, computeCapability, mmaVersion);
+    if (!(mmaResult.versionMajor >= 1 && mmaResult.versionMajor <= 3))
+      return failure();
 
     Operation *newDot = nullptr;
-    if (versionMajor == 3) {
-      auto eltType = dotOp.getA().getType().getElementType();
-      // In MMAV3 transpose is only supported for f16 and bf16.
+    bool aFromLoad = comesFromLoadOrBlockArg(a);
+    bool bFromLoad = comesFromLoadOrBlockArg(b);
+
+    if (mmaResult.versionMajor == 3) {
+      auto eltType = cast<RankedTensorType>(a.getType()).getElementType();
       bool allowTranspose = eltType.isF16() || eltType.isBF16();
       if (!aFromLoad) {
         int bitwidth = getElementTypeOrSelf(a).getIntOrFloatBitWidth();
-        a = getDotOperand(a, 0, bitwidth);
+        a = convertDotOperandForMMA(a, 0, bitwidth, mmaResult.newRetType,
+                                    rewriter);
       } else {
         a = getSharedMemoryMMAOperand(a, rewriter, 0, allowTranspose,
                                       /*isMMAv5Fp4Padded=*/false,
@@ -389,21 +423,21 @@ public:
                                     /*forceTranspose=*/false, dotOp);
 
       newDot = rewriter.create<triton::nvidia_gpu::WarpGroupDotOp>(
-          dotOp.getLoc(), newRetType, a, b, newAcc, nullptr,
+          dotOp.getLoc(), mmaResult.newRetType, a, b, mmaResult.newAcc, nullptr,
           dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc(), false);
     } else {
-      // convert operands
       int minBitwidth =
           std::min(computeOrigBitWidth(a), computeOrigBitWidth(b));
-
-      a = getDotOperand(a, 0, minBitwidth);
-      b = getDotOperand(b, 1, minBitwidth);
-      newDot = rewriter.create<DotOp>(dotOp.getLoc(), newRetType, a, b, newAcc,
-                                      dotOp.getInputPrecision(),
-                                      dotOp.getMaxNumImpreciseAcc());
+      a = convertDotOperandForMMA(a, 0, minBitwidth, mmaResult.newRetType,
+                                  rewriter);
+      b = convertDotOperandForMMA(b, 1, minBitwidth, mmaResult.newRetType,
+                                  rewriter);
+      newDot = rewriter.create<DotOp>(
+          dotOp.getLoc(), mmaResult.newRetType, a, b, mmaResult.newAcc,
+          dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
     }
-    // convert dot instruction
-    rewriter.replaceOpWithNewOp<ConvertLayoutOp>(origDotOp, origDotOp.getType(),
+
+    rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, dotOp.getType(),
                                                  newDot->getResult(0));
     return success();
   }
@@ -616,6 +650,125 @@ Value addSmemStageToScaleLoad(Value scale, mlir::PatternRewriter &rewriter) {
     return localLoad;
   }
 }
+
+class ScaledBlockedToMMA : public mlir::OpRewritePattern<triton::DotScaledOp> {
+  int computeCapability;
+
+public:
+  ScaledBlockedToMMA(mlir::MLIRContext *context, int computeCapability,
+                     int benefit)
+      : mlir::OpRewritePattern<triton::DotScaledOp>(context, benefit),
+        computeCapability(computeCapability) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(triton::DotScaledOp dotOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (computeCapability != 120)
+      return failure();
+
+    auto numCTAs = lookupNumCTAs(rewriter);
+    if (numCTAs != 1) {
+      return failure();
+    }
+
+    // TODO: support mxfp4 variants.
+    if (!((dotOp.getAElemType() == ScaleDotElemType::E5M2 ||
+           dotOp.getAElemType() == ScaleDotElemType::E4M3) &&
+          (dotOp.getBElemType() == ScaleDotElemType::E5M2 ||
+           dotOp.getBElemType() == ScaleDotElemType::E4M3))) {
+      return rewriter.notifyMatchFailure(dotOp, "only E5M2/E4M3 is supported");
+    }
+
+    // Skip if any scale is missing. This pattern requires both scales.
+    if (!dotOp.getAScale() || !dotOp.getBScale())
+      return failure();
+
+    auto aScaleType = dotOp.getAScale().getType();
+    auto bScaleType = dotOp.getBScale().getType();
+
+    if (mlir::isa<LinearEncodingAttr>(aScaleType.getEncoding()) ||
+        mlir::isa<LinearEncodingAttr>(bScaleType.getEncoding())) {
+      return failure();
+    }
+
+    // Common MMA encoding creation
+    auto mmaResult =
+        createMMAEncodingForDot(dotOp, rewriter, computeCapability, 2);
+
+    // Operand processing
+    Value a = dotOp.getA();
+    Value b = dotOp.getB();
+    auto oldAType = cast<RankedTensorType>(a.getType());
+    auto oldBType = cast<RankedTensorType>(b.getType());
+
+    Operation *newDot = nullptr;
+
+    // ScaledBlockedToMMA logic
+    int bitwidthA = oldAType.getElementType().getIntOrFloatBitWidth();
+    int bitwidthB = oldBType.getElementType().getIntOrFloatBitWidth();
+    int minBitwidth = std::min(bitwidthA, bitwidthB);
+
+    Value newA = convertDotOperandForMMA(a, 0, minBitwidth,
+                                         mmaResult.newRetType, rewriter);
+    Value newB = convertDotOperandForMMA(b, 1, minBitwidth,
+                                         mmaResult.newRetType, rewriter);
+
+    // Compute tiles per warp for each operand
+    auto computeTilePerWarp = [&](Value operand, int operandIdx) -> unsigned {
+      auto operandTy = cast<RankedTensorType>(operand.getType());
+      auto dotEncoding = dyn_cast<triton::gpu::DotOperandEncodingAttr>(
+          operandTy.getEncoding());
+      if (!dotEncoding)
+        return 1;
+
+      const int bitWidth = operandTy.getElementType().getIntOrFloatBitWidth();
+      const int kWidth = dotEncoding.getKWidth();
+      auto rep = mmaResult.mmaEnc.getRepForOperand(
+          triton::gpu::getShapePerCTA(operandTy), bitWidth, kWidth,
+          dotEncoding.getOpIdx());
+
+      // repA = [repM, repK], repB = [repK, repN]
+      // For operand A (idx 0): return rep[1] (repK)
+      // For operand B (idx 1): return rep[2] (repN)
+      if (operandIdx == 0) {
+        return rep.size() >= 2 ? rep[1] : 1;
+      } else {
+        return rep.size() >= 3 ? rep[2] : 1;
+      }
+    };
+    SmallVector<unsigned, 2> tilesPerWarp{computeTilePerWarp(newA, 0),
+                                          computeTilePerWarp(newB, 1)};
+    // Convert scales to Linear layout
+    auto convertScale = [&](Value scale, int opIdx) -> Value {
+      if (!scale)
+        return Value();
+      auto ty = cast<RankedTensorType>(scale.getType());
+      SmallVector<int64_t> shape = llvm::to_vector(ty.getShape());
+      MLIRContext *ctx = ty.getContext();
+      const auto mmaWarps = mmaResult.mmaEnc.getWarpsPerCTA(); // [wM, wN]
+      const auto instr = mmaResult.mmaEnc.getInstrShape(); // [instrM, instrN]
+      const unsigned instrM = instr[0], instrN = instr[1];
+
+      auto blocked = cast<triton::gpu::BlockedEncodingAttr>(ty.getEncoding());
+      auto ll = triton::gpu::getSM120DotScaledScaleLayout(
+          ctx, opIdx, shape, tilesPerWarp,
+          /*warpsPerCTA=*/mmaWarps, instrM, instrN, blocked.getCTALayout());
+      auto newEnc = triton::gpu::LinearEncodingAttr::get(ctx, ll);
+      auto newTy = RankedTensorType::get(shape, ty.getElementType(), newEnc);
+      return rewriter.create<ConvertLayoutOp>(scale.getLoc(), newTy, scale);
+    };
+    Value aScale = convertScale(dotOp.getAScale(), /*opIdx=*/0);
+    Value bScale = convertScale(dotOp.getBScale(), /*opIdx=*/1);
+
+    newDot = rewriter.create<triton::DotScaledOp>(
+        dotOp.getLoc(), mmaResult.newRetType, newA, newB, mmaResult.newAcc,
+        aScale, bScale, dotOp.getAElemType(), dotOp.getBElemType(),
+        dotOp.getFastMath(), dotOp.getLhsKPack(), dotOp.getRhsKPack());
+    rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, dotOp.getType(),
+                                                 newDot->getResult(0));
+    return success();
+  }
+};
 
 class ScaledBlockedToMMAv5
     : public mlir::OpRewritePattern<triton::DotScaledOp> {
@@ -866,7 +1019,10 @@ public:
     mlir::RewritePatternSet patterns(context);
     constexpr int benefitDefault = 1;
     constexpr int benefitMMAv5 = 10;
+    constexpr int benefitSM120 = 10;
+
     patterns.add<BlockedToMMA>(context, computeCapability, benefitDefault);
+    patterns.add<ScaledBlockedToMMA>(context, computeCapability, benefitSM120);
     populateDecomposeScaledBlockedPatterns(patterns, benefitDefault);
     patterns.add<BlockedToMMAv5, ScaledBlockedToMMAv5>(
         context, computeCapability, benefitMMAv5);

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -7,6 +7,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 using namespace mlir;
 using namespace mlir::triton;

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -127,8 +127,8 @@ def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, 
     precision = "tf32" if dtype_src_str == "tensorfloat32" else "ieee"
     dtype_src_str = "float32" if dtype_src_str == "tensorfloat32" else dtype_src_str
     if dtype_src_str == "float8e5":
-        a = torch.randint(20, 40, (M, K), dtype=torch.int8, device=device).view(torch.float8_e5m2)
-        b = torch.randint(20, 40, (K, N), dtype=torch.int8, device=device).view(torch.float8_e5m2)
+        a = torch.randint(20, 40, (M, K), dtype=torch.uint8, device=device).view(torch.float8_e5m2)
+        b = torch.randint(20, 40, (K, N), dtype=torch.uint8, device=device).view(torch.float8_e5m2)
         A = f8_to_f16(a, dtype_src_str)
         B = f8_to_f16(b, dtype_src_str)
     else:
@@ -369,8 +369,8 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     a_f16 = f8_to_f16(a, dtype_src_str)
     b = torch.randint(20, 40, (K, N), dtype=torch.uint8, device=device).view(torch.float8_e5m2)
     b_f16 = f8_to_f16(b, dtype_src_str)
-    a_scale = torch.randint(130, (M, K // 32), dtype=torch.uint8, device=device)
-    b_scale = torch.randint(130, (N, K // 32), dtype=torch.uint8, device=device)
+    a_scale = torch.randint(64, 130, (M, K // 32), dtype=torch.uint8, device=device)
+    b_scale = torch.randint(64, 130, (N, K // 32), dtype=torch.uint8, device=device)
 
     dtype_dst = getattr(torch, dtype_dst_str)
     output = torch.empty((M, N), dtype=dtype_dst, device=device)
@@ -378,9 +378,10 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     kernel_kwargs = {}
     if is_hip():
         kernel_kwargs["matrix_instr_nonkdim"] = nonKDim
-    mxfp_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1), b.stride(0),
-                      b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES=NUM_STAGES,
-                      **kernel_kwargs, num_warps=NUM_WARPS)
+
+    out = mxfp_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1),
+                            b.stride(0), b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K,
+                            NUM_STAGES=NUM_STAGES, **kernel_kwargs, num_warps=NUM_WARPS)
     a_scale_f32 = fp8e8m0_to_float32(a_scale)
     b_scale_f32 = fp8e8m0_to_float32(b_scale)
     a_scale_f32 = a_scale_f32.repeat_interleave(32, dim=1)
@@ -393,9 +394,12 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     b = b_f16 * b_scale_f32
     ref_out = torch.matmul(a, b).to(torch.float32)
     output = output.to(torch.float32)
-    atol = 0.0001
-    rtol = 0.0001
-    torch.testing.assert_close(ref_out, output, atol=atol, rtol=rtol)
+    atol = 1e-2 * math.sqrt(K / 32)
+    torch.testing.assert_close(ref_out, output, atol=atol, rtol=0)
+
+    if is_cuda() and torch.cuda.get_device_capability()[0] == 12:
+        ptx = out.asm["ptx"]
+        assert "mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X" in ptx
 
 
 def _knob_promote_lhs_to_tmem(monkeypatch):

--- a/test/Conversion/tritongpu_to_llvm_sm120.mlir
+++ b/test/Conversion/tritongpu_to_llvm_sm120.mlir
@@ -1,0 +1,30 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-accelerate-matmul --allocate-shared-memory-nv='compute-capability=120' --convert-triton-gpu-to-llvm='compute-capability=120' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [1, 4], instrShape = [16, 8]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_mmav2_dot_scaled
+  // CHECK: mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X
+  tt.func public @sm120_mmav2_dot_scaled(
+    %a: tensor<128x32xf8E5M2, #blocked_k>,
+    %sa: tensor<128x2xi8, #blocked>,
+    %b: tensor<32x128xf8E5M2, #blocked>,
+    %sb: tensor<128x2xi8, #blocked>,
+    %out: !tt.ptr<f32>
+  ){
+    %c = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %a_d = ttg.convert_layout %a : tensor<128x32xf8E5M2, #blocked_k> -> tensor<128x32xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %b_d = ttg.convert_layout %b : tensor<32x128xf8E5M2, #blocked> -> tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %d = tt.dot_scaled %a_d scale %sa, %b_d scale %sb, %c lhs = e5m2 rhs = e5m2 {fastMath = false}
+      : tensor<128x32xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<128x2xi8, #blocked>
+        * tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>, tensor<128x2xi8, #blocked>
+        -> tensor<128x128xf32, #blocked>
+    %out_splat = tt.splat %out : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked>
+    %out_ptrs = tt.broadcast %out_splat : tensor<128x1x!tt.ptr<f32>, #blocked> -> tensor<128x128x!tt.ptr<f32>, #blocked>
+    %zero = arith.constant dense<0> : tensor<128x128xi1, #blocked>
+    tt.store %out_ptrs, %d, %zero : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -667,3 +667,83 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return %19 : tensor<128x128xf32, #blocked>
   }
 }
+
+// -----
+
+// Verify that for SM_120 with FP8 inputs, tt.dot_scaled is preserved and
+// scales are converted to linear layout for hardware acceleration.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_dot_scaled_basic
+  tt.func public @sm120_dot_scaled_basic(
+    %a: tensor<128x32xi8, #blocked_k>,
+    %scale_a: tensor<128x2xi8, #blocked>,
+    %b: tensor<32x128xi8, #blocked>,
+    %scale_b: tensor<128x2xi8, #blocked>
+  ) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK-DAG: tt.dot_scaled
+    // CHECK-DAG: #linear
+    // CHECK-DAG: #linear1
+    // CHECK-NOT: ttng.tc_gen5_mma_scaled
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e4m3 {fastMath = false}
+      : tensor<128x32xi8, #blocked_k>, tensor<128x2xi8, #blocked>
+        * tensor<32x128xi8, #blocked>, tensor<128x2xi8, #blocked>
+        -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// Verify that for SM_120 with FP4 inputs, tt.dot_scaled is decomposed into:
+// 1. ttg.fp4_to_fp for unpacking FP4 values
+// 2. Scale application with arith.mulf
+// 3. Regular tt.dot operation with MMA encoding
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked2_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_dot_scaled_fp4_fallback
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: ttg.fp4_to_fp
+  // CHECK: tt.dot
+  // CHECK: #mma
+  tt.func public @sm120_dot_scaled_fp4_fallback(
+    %a: tensor<128x32xi8, #blocked2_k>,
+    %scale_a: tensor<128x2xi8, #blocked2>,
+    %b: tensor<32x128xi8, #blocked2>,
+    %scale_b: tensor<128x2xi8, #blocked2>
+  ) -> tensor<128x128xf32, #blocked2> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked2>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e2m1 {fastMath = false}
+      : tensor<128x32xi8, #blocked2_k>, tensor<128x2xi8, #blocked2>
+        * tensor<32x128xi8, #blocked2>, tensor<128x2xi8, #blocked2>
+        -> tensor<128x128xf32, #blocked2>
+    tt.return %d : tensor<128x128xf32, #blocked2>
+  }
+}
+
+// -----
+
+// Verify that for SM_100 (Blackwell), tt.dot_scaled uses the specialized
+// MMAv5 path with tensor memory and tc_gen5_mma_scaled instruction.
+
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked3_1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3_2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm100_dot_scaled_mma_v5
+  // CHECK: ttng.tc_gen5_mma_scaled
+  // CHECK-NOT: tt.dot_scaled
+  tt.func public @sm100_dot_scaled_mma_v5(%a: tensor<128x64xi8, #blocked3_2>, %scale_a: tensor<128x2xi8, #blocked3_1>, %b: tensor<64x128xi8, #blocked3>, %scale_b: tensor<128x2xi8, #blocked3_1>) -> tensor<128x128xf32, #blocked3> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked3>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<128x64xi8, #blocked3_2>, tensor<128x2xi8, #blocked3_1> * tensor<64x128xi8, #blocked3>, tensor<128x2xi8, #blocked3_1> -> tensor<128x128xf32, #blocked3>
+    tt.return %d : tensor<128x128xf32, #blocked3>
+  }
+}

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3607,6 +3607,96 @@ TEST_F(LinearLayoutConversionsTest, TensorMemory_CTASplit) {
                 LinearLayout::identity1D(2, kCol, d1));
 }
 
+// Tests for SM120 DotScaled Scale Layout
+TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_AScale_Basic) {
+  // Test basic A-scale (per-row) layout for SM120
+  // dotOperandIdx = 0 (A-scale), shape = [128, 32], tilesPerWarp = [1, 1],
+  // warpsPerCTA = [4, 1], instrM = 16, instrN = 8
+  auto layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/0, /*dotOperandShape=*/{128, 32},
+      /*tilesPerWarp=*/{1, 1}, /*warpsPerCTA=*/{4, 1},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+
+  auto ll = LinearLayout(
+      {{S("register"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {64, 0}}},
+       {S("lane"), {{8, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+       {S("warp"), {{16, 0}, {32, 0}}},
+       {S("block"), {}}},
+      {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+}
+
+TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_BScale_Basic) {
+  // Test basic B-scale (per-col) layout for SM120
+  // dotOperandIdx = 1 (B-scale), shape = [32, 128], tilesPerWarp = [1, 1],
+  // warpsPerCTA = [1, 4], instrM = 16, instrN = 8
+  auto layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/1, /*dotOperandShape=*/{32, 128},
+      /*tilesPerWarp=*/{1, 1}, /*warpsPerCTA=*/{1, 4},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+  auto ll = LinearLayout(
+      {{S("register"),
+        {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {0, 32}, {0, 64}}},
+       {S("lane"), {{0, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+       {S("warp"), {{8, 0}, {16, 0}}},
+       {S("block"), {}}},
+      {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+}
+
+TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_MultiWarp) {
+  // Test with multiple warps configuration
+  // A-scale with 2x2 warp layout
+  auto layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/0, /*dotOperandShape=*/{256, 64},
+      /*tilesPerWarp=*/{2, 1}, /*warpsPerCTA=*/{2, 2},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+  auto ll = LinearLayout({{S("register"),
+                           {{32, 0},
+                            {0, 1},
+                            {0, 2},
+                            {0, 4},
+                            {0, 8},
+                            {0, 16},
+                            {0, 32},
+                            {64, 0},
+                            {128, 0}}},
+                          {S("lane"), {{8, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+                          {S("warp"), {{0, 0}, {16, 0}}},
+                          {S("block"), {}}},
+                         {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+
+  layout = getSM120DotScaledScaleLayout(
+      &ctx, /*dotOperandIdx=*/1, /*dotOperandShape=*/{256, 64},
+      /*tilesPerWarp=*/{2, 1}, /*warpsPerCTA=*/{2, 2},
+      /*mmaInstrM=*/16, /*mmaInstrN=*/8,
+      /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
+  ll = LinearLayout({{S("register"),
+                      {{0, 1},
+                       {0, 2},
+                       {0, 4},
+                       {0, 8},
+                       {0, 16},
+                       {0, 32},
+                       {16, 0},
+                       {32, 0},
+                       {64, 0},
+                       {128, 0}}},
+                     {S("lane"), {{0, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}}},
+                     {S("warp"), {{8, 0}, {0, 0}}},
+                     {S("block"), {}}},
+                    {S("dim0"), S("dim1")});
+
+  EXPECT_EQ(ll, layout);
+}
+
 } // anonymous namespace
 } // namespace mlir::triton::gpu
 


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: 27f406c62fe7b6f6f3e0682ff6110516d6ee251d
Original Author: Thomas Raoux
Original Date: 2025-09-09 19:30:10 -0700

Original commit message:
```
Reapply "[NVIDIA] Add native MXFP FP8 scaled_dot for SM120 (#7918)" (#8029) (#8129)

Add a fix for the crash happening on BW. 

Still doing some perf test
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
