### PR TITLE
[triton][beta] Backport '[AMD] Turn off buffer op cache swizzling for now (#8264)'

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -64,6 +64,9 @@ Value BufferEmitter::createResourceDescriptor(Value basePtr,
   Value stride = b.int_val(16, 0);
   if (llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
                          targetInfo.getISAFamily())) {
+#if 0
+    // Turn off cache-swizzling for the time being while we are figuring out
+    // how to safely use it.
     if (blockStride) {
       Value enableSwizzle = b.int_val(16, 16384);
       Value mask14b = b.int_val(16, 16383);
@@ -78,6 +81,7 @@ Value BufferEmitter::createResourceDescriptor(Value basePtr,
       // stride[14] = swizzle enabling bit
       stride = rewriter.create<LLVM::OrOp>(loc, enableSwizzle, strideSat);
     }
+#endif
   }
 
   Value flagsConst = b.int_val(32, flags);


### PR DESCRIPTION
Summary:
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/8264

Upstream commit message:
```
> [AMD] Turn off buffer op cache swizzling for now (#8264)
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 33814dee7ba20c1353b38c3bbdabe9c625c7d0ba
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --version beta --pr 8264
```

Reviewed By: dshi7

Differential Revision: D86128661


