### PR TITLE
[Cherry-pick][RESOLVED] [GLUON][TEST] Generate correct linear layouts for testing (#8033)

### DIFF
--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -142,60 +142,6 @@ def _reduce_layouts():
                                transposed=True),
         # TODO: AMDWMMA layouts
         ttgl.DotOperandLayout(
-<<<<<<< HEAD
-            parent=ttgl.NVMMADistributedLayout(
-                version=[2, 0],
-                warps_per_cta=[2, 4],
-                ctas_per_cga=[1, 1],  #
-                cta_split_num=[1, 1],
-                cta_order=[0, 1],
-                instr_shape=[16, 8],
-            ),  #
-            operand_index=1,
-            k_width=8,
-        ),
-        ttgl.DotOperandLayout(
-            parent=ttgl.NVMMADistributedLayout(
-                version=[3, 0],
-                warps_per_cta=[8, 1],
-                ctas_per_cga=[1, 1],  #
-                cta_split_num=[1, 1],
-                cta_order=[1, 0],
-                instr_shape=[16, 32, 16],
-            ),  #
-            operand_index=0,
-            k_width=2,
-        ),
-        ttgl.SliceLayout(
-            dim=0,
-            parent=ttgl.NVMMADistributedLayout(
-                version=[2, 0],
-                warps_per_cta=[4, 1, 1],
-                ctas_per_cga=[1, 1, 1],  #
-                cta_split_num=[1, 1, 1],
-                cta_order=[2, 1, 0],
-                instr_shape=[1, 16, 8],
-            ),
-        ),  #
-        ttgl.SliceLayout(
-            dim=1,
-            parent=ttgl.DotOperandLayout(
-                parent=ttgl.NVMMADistributedLayout(
-                    version=[2, 0],
-                    warps_per_cta=[4, 1, 1],
-                    ctas_per_cga=[1, 1, 1],  #
-                    cta_split_num=[1, 1, 1],
-                    cta_order=[2, 1, 0],
-                    instr_shape=[1, 16, 8],
-                ),  #
-                operand_index=1,
-                k_width=2,
-            ),
-        ),
-        "linear_layout",
-    ]),
-)
-=======
             parent=ttgl.NVMMADistributedLayout(version=[2, 0], warps_per_cta=[2, 4], ctas_per_cga=[1, 1],
                                                cta_split_num=[1, 1], cta_order=[0, 1], instr_shape=[16, 8]),
             operand_index=1, k_width=8),
@@ -233,32 +179,12 @@ def _reduce_cases():
 
 
 @pytest.mark.parametrize("M, N, src_layout", _reduce_cases())
->>>>>>> ce47711f0 ([GLUON][TEST] Generate correct linear layouts for testing (#8033))
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("epilogue_kind", ["reduce1d", "reduce2d", "expand_reduce2d"])
 @pytest.mark.parametrize("dtype_str, sanitize_overflow", [("int32", False), ("int32", True), ("float32", False),
                                                           ("float16", False)])
 @pytest.mark.parametrize("reduce_op", ["sum", "max"])
 def test_reduce_layouts(M, N, src_layout, axis, epilogue_kind, dtype_str, sanitize_overflow, reduce_op, device):
-<<<<<<< HEAD
-    if src_layout == "linear_layout":
-        src_layout = ttgl.DistributedLinearLayout(
-            reg_bases=[[0, 16], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0]],  #
-            lane_bases=[[0, 0], [0, 1], [0, 2], [0, 4], [0, 8]],  #
-            warp_bases=[[32, 0], [0, 32]],
-            block_bases=[],
-            shape=[M, N],
-        )
-        if THREADS_PER_WARP != (1 << len(src_layout.lane_bases)):
-            pytest.skip(f"Skipping. This LinearLayout assumes {1 << len(src_layout.lane_bases)} threads per warp")
-        elif M < 64 or N < 64:
-            pytest.skip(f"Skipping. This LinearLayout assumes M >= 64 and N >= 64, got M={M}, N={N}")
-    if isinstance(src_layout,
-                  (ttgl.amd.AMDMFMALayout, ttgl.NVMMADistributedLayout)) and (M < src_layout.instr_shape[0]
-                                                                              or N < src_layout.instr_shape[1]):
-        pytest.skip("Skipping because tensor shape is smaller than M(f)maLayout instr_shape")
-=======
->>>>>>> ce47711f0 ([GLUON][TEST] Generate correct linear layouts for testing (#8033))
 
     @gluon.jit
     def _add(a, b):


### PR DESCRIPTION
⚠️ **MERGE CONFLICTS DETECTED** ⚠️

This cherry-pick contains merge conflicts that require manual resolution.

Original Commit: ce47711f008f45f8fed5444e9967fe1881f3872c
Original Author: Keren Zhou
Original Date: 2025-09-02 15:22:35 -0400

**Action Required:**
1. Check out this branch locally
2. Resolve the merge conflicts in the affected files
3. Commit the resolved changes
4. Update this PR

Original commit message:
```
[GLUON][TEST] Generate correct linear layouts for testing (#8033)

Previously passing the "linear_layout" string in the reduce test is
wrong because _filter_layouts will skip the string and yield no test.
This PR should also cover problems we found in
https://github.com/triton-lang/triton/pull/8016
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
The conflicts have been committed with conflict markers for easier resolution.
