### PR TITLE
[1/N][TLX-2cta] Introduce TTNG_MapToRemoteBufferOp

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -70,6 +70,25 @@ def TTNG_ClusterWaitOp : TTNG_Op<"cluster_wait", []> {
   let assemblyFormat = "attr-dict";
 }
 
+def TTNG_MapToRemoteBufferOp : TTNG_Op<"map_to_remote_buffer", [Pure, MemDescViewTrait]> {
+  let summary = "Map shared memory buffer to the corresponding buffer in the target CTA";
+  let description = [{
+    Given a shared memory buffer mem desc `src`, return a mem desc referring to the corresponding buffer in the specified
+    target CTA.
+
+    `$ctaRank` refers to the unique CTA id in a cluster acorss all dims. e.g. For a 2x4 CTA cluster, a valid CTA rank
+    will be 0~7.
+  }];
+
+  let arguments = (ins TTG_MemDescType:$src, I32:$ctaRank);
+
+  let results = (outs TTG_MemDescType:$result);
+
+  let assemblyFormat = [{$src`,` $ctaRank attr-dict `:` qualified(type($src)) `->` qualified(type($result))}];
+
+  let hasVerifier = 1;
+}
+
 //
 // WarpGroupDot Op
 //

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -15,7 +15,7 @@ from .types import (
     CLCPipelineContext,
     async_token,
 )
-from .mem_ops import (local_alloc, local_view, local_slice, subslice, async_load, async_load_commit_group,
+from .mem_ops import (local_alloc, local_view, remote_view, local_slice, subslice, async_load, async_load_commit_group,
                       async_load_wait_group, local_load, local_store, local_trans, local_reinterpret,
                       async_descriptor_load, async_descriptor_store, async_descriptor_store_wait, fence_async_shared)
 from .barrier import (
@@ -69,6 +69,7 @@ __all__ = [
     # mem_ops
     "local_alloc",
     "local_view",
+    "remote_view",
     "local_slice",
     "subslice",
     "async_load",

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -4,6 +4,7 @@ from typing import Optional, List, Tuple
 import enum
 from abc import abstractmethod
 from triton._C.libtriton import ir
+
 from triton.language.semantic import TritonSemantic
 
 
@@ -287,9 +288,10 @@ class mbarrier(tl.base_value):
     """
 
     def __init__(self, handle, num: int, layout: Optional[swizzled_shared_layout_encoding],
-                 semantics: TritonSemantic = None):
+                 semantics: TritonSemantic = None, storage: storage_kind = storage_kind.smem):
+        assert storage == storage_kind.smem or storage == storage_kind.smemCluster, "mbarrier requires storage to be smem or smemCluster"
         self.handle = handle
-        self.type = mbarrier_type(num, layout, semantics)
+        self.type = mbarrier_type(num, layout, semantics, storage)
         self.num = num
 
     def _flatten_ir(self, handles) -> None:
@@ -305,8 +307,8 @@ class mbarrier(tl.base_value):
 
 class mbarrier_type(buffered_tensor_type):
 
-    def __init__(self, num: int, layout: Optional[swizzled_shared_layout_encoding], semantic: TritonSemantic):
-        super().__init__(tl.int64, [1], num, storage_kind.smem, layout, semantic)
+    def __init__(self, num: int, layout: Optional[swizzled_shared_layout_encoding], semantic: TritonSemantic, storage):
+        super().__init__(tl.int64, [1], num, storage, layout, semantic)
 
     def _unflatten_ir(self, handles: List[ir.value], cursor: int) -> Tuple[mbarrier, int]:
         value = mbarrier(handles[cursor], self.num, self.layout, self.semantic)


### PR DESCRIPTION
Reviewers: Only the latest one commit is new in this PR. All other commits will be in main branch if all previous PRs land and this one rebases.

To be able to essentially call NV's "mapa" on an SMEM buffer (or a barrier living there), we need to open up this API to front end. This will make it possible to explicitly arrive a remote barrier, and in the future, read/write DSMEM. Note if the CTAId is the executing CTA, original src address will be returned.

Marking this Op as `MemDescViewTrait` will automatically handle alias analysis like MemDescIndex ops etc.

```
% make test-lit                                                     
ninja -C /data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11 check-triton-lit-tests
ninja: Entering directory `/data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11'
[0/1] Running the triton regression tests

Testing Time: 7.81s

Total Discovered Tests: 208
  Passed           : 207 (99.52%)
  Expectedly Failed:   1 (0.48%)

% third_party/tlx/run_all.sh
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...

====================================================================================== 31 passed, 76 skipped in 19.55s ======================================================================================
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}
c
Verifying correctness of TLX tutorial kernels
(all passing)
```
