### PR TITLE
[autoWS] fix pytest failures

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -434,8 +434,8 @@ class JITHookCompileInfo(TypedDict):
     num_warps: int
     num_ctas: int
     num_stages: int
-    minRegAutoWS: int
-    maxRegAutoWS: int
+    minRegAutoWS: Optional[int]
+    maxRegAutoWS: Optional[int]
     enable_fp_fusion: bool
     launch_cooperative_grid: bool
     extern_libs: tuple[tuple[str, str], ...]

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -631,7 +631,24 @@ class JITFunction(JITCallable, KernelInterface[T]):
         name = self.fn.__qualname__
         module = self.fn.__module__
         arg_reprs = ", ".join([f"{param.name}: {ty}" for param, ty in zip(self.params, key[1])])
-        repr = f"{name}[num_warps={options.num_warps}, num_ctas={options.num_ctas}, num_stages={options.num_stages}, minRegAutoWS={options.minRegAutoWS}, maxRegAutoWS={options.maxRegAutoWS}, enable_fp_fusion={options.enable_fp_fusion}, launch_cooperative_grid={options.launch_cooperative_grid}]({arg_reprs})"
+        # Build repr string, only including optional params when they're set
+        repr_parts = [
+            f"num_warps={options.num_warps}",
+            f"num_ctas={options.num_ctas}",
+            f"num_stages={options.num_stages}",
+        ]
+        # Use getattr to safely access backend-specific attributes
+        minRegAutoWS = getattr(options, 'minRegAutoWS', None)
+        maxRegAutoWS = getattr(options, 'maxRegAutoWS', None)
+        if minRegAutoWS is not None:
+            repr_parts.append(f"minRegAutoWS={minRegAutoWS}")
+        if maxRegAutoWS is not None:
+            repr_parts.append(f"maxRegAutoWS={maxRegAutoWS}")
+        repr_parts.extend([
+            f"enable_fp_fusion={options.enable_fp_fusion}",
+            f"launch_cooperative_grid={options.launch_cooperative_grid}",
+        ])
+        repr = f"{name}[{', '.join(repr_parts)}]({arg_reprs})"
         full_name = get_full_name(self.fn)
 
         specialization_data = serialize_specialization_data(full_name, signature, constants, configs[0], options, key)
@@ -643,8 +660,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
             'num_warps': options.num_warps,
             'num_ctas': options.num_ctas,
             'num_stages': options.num_stages,
-            'minRegAutoWS': options.minRegAutoWS,
-            'maxRegAutoWS': options.maxRegAutoWS,
+            'minRegAutoWS': getattr(options, 'minRegAutoWS', None),
+            'maxRegAutoWS': getattr(options, 'maxRegAutoWS', None),
             'enable_fp_fusion': options.enable_fp_fusion,
             'launch_cooperative_grid': options.launch_cooperative_grid,
             'extern_libs': options.extern_libs,


### PR DESCRIPTION
This PR tries to fix pytest errors captured by AMD workflows.
```
E       AttributeError: 'HIPOptions' object has no attribute 'minRegAutoWS'
```
It modifies
- python/triton/knobs.py: make minRegAutoWS and maxRegAutoWS types to be Optional[int]
- python/triton/runtime/jit.py: use getattr(options, 'minRegAutoWS', None) to set values to None if it attempts to get options.minRegAutoWS from HIPOptions.



Stacked PRs:
 * __->__#639


--- --- ---

### [autoWS] fix pytest failures

