### PR TITLE
[5/N][TLX-2cta] Override backend codegen if 2cta mode

### DIFF
--- a/test/Conversion/nvgpu_to_llvm.mlir
+++ b/test/Conversion/nvgpu_to_llvm.mlir
@@ -98,6 +98,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tensor_memory_base_lowering_tlx_2cta
+  //      CHECK:    llvm.inline_asm has_side_effects
+  // CHECK-SAME:    "@$0 tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [$1], 128;", "b,r"
+  //      CHECK:    llvm.inline_asm has_side_effects
+  // CHECK-SAME:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned;", "b"
+  //      CHECK:    llvm.inline_asm has_side_effects
+  // CHECK-SAME:    "@$0 tcgen05.dealloc.cta_group::2.sync.aligned.b32 $1, 128;", "b,r"
+  llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  llvm.func @tensor_memory_base_lowering_tlx_2cta() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {
+    %263 = nvgpu.tensor_memory_base
+    %264 = llvm.ptrtoint %263 : !llvm.ptr<6> to i32
+    llvm.return %264 : i32
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
 llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -325,6 +325,29 @@ tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.s
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread=[1, 4], threadsPerWarp=[32, 1], warpsPerCTA=[4, 1], order=[0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+
+tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>,
+                             %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
+		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
+  // CHECK: %[[CTAID:.+]] = nvgpu.cluster_id
+  // CHECK: %[[TWO:.+]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK: llvm.urem %[[CTAID]], %[[TWO]]
+  // CHECK-COUNT-8: tcgen05.cp.cta_group::2.warpx4.32x128b
+  // CHECK: tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  tt.return
+}
+
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
@@ -850,6 +873,40 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %true = arith.constant true
     ttng.tmem_store %cst_0, %0, %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @not_fold_cta_id_2cta
+  // CHECK: nvgpu.cluster_id
+  tt.func public @not_fold_cta_id_2cta(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #blocked>
+    %1 = nvgpu.cluster_id
+    %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<32x!tt.ptr<i32>, #blocked>
+    %3 = tt.addptr %2, %0 : tensor<32x!tt.ptr<i32>, #blocked>, tensor<32xi32, #blocked>
+    %4 = tt.splat %1 : i32 -> tensor<32xi32, #blocked>
+    tt.store %3, %4 : tensor<32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @fold_cta_id_1cta
+  // CHECK-NOT: nvgpu.cluster_id
+  tt.func public @fold_cta_id_1cta(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #blocked>
+    %1 = nvgpu.cluster_id
+    %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<32x!tt.ptr<i32>, #blocked>
+    %3 = tt.addptr %2, %0 : tensor<32x!tt.ptr<i32>, #blocked>, tensor<32xi32, #blocked>
+    %4 = tt.splat %1 : i32 -> tensor<32xi32, #blocked>
+    tt.store %3, %4 : tensor<32x!tt.ptr<i32>, #blocked>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -9,6 +9,8 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h"
+#include "tlx/dialect/include/IR/Dialect.h"
+
 #include "llvm/Support/ErrorHandling.h"
 
 namespace ttn = mlir::triton::nvgpu;
@@ -695,7 +697,13 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func) {
     return rewriter.create<LLVM::UndefOp>(loc, ptr_ty(ctx, 6));
   }
 
-  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
+  int numCTAs;
+  if (tlx::tlxEnablePairedMMA(mod)) {
+    // TLX attr takes precedence
+    numCTAs = 2;
+  } else {
+    numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
+  }
   // Assume that 2CTAs is used if we have two CTAs this is pessimistic but
   // should be fine for now.
   bool useTwoCTAs = numCTAs == 2;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -21,6 +21,7 @@
 
 #include "Allocation.h"
 #include "PatternTritonGPUOpToLLVM.h"
+#include "tlx/dialect/include/IR/Dialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
 
@@ -190,7 +191,7 @@ struct ConvertTritonGPUToLLVM
 
     // Fold CTAId when there is only 1 CTA.
     int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
-    if (numCTAs == 1) {
+    if (numCTAs == 1 && !tlx::tlxEnablePairedMMA(mod)) {
       mod.walk([](triton::nvgpu::ClusterCTAIdOp id) {
         OpBuilder b(id);
         Value zero = LLVM::createConstantI32(id->getLoc(), b, 0);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -137,6 +137,16 @@ Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter) {
   return b.and_(warp0, createElectPredicate(loc, rewriter));
 }
 
+Value createLeaderCTAPredicate(Location loc, RewriterBase &rewriter) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value clusterCTARank = rewriter.create<triton::nvgpu::ClusterCTAIdOp>(
+      loc, rewriter.getI32Type());
+  // Always pick the even numbered CTA in the CTA pair to be the leader
+  Value rem =
+      rewriter.create<mlir::arith::RemUIOp>(loc, clusterCTARank, b.i32_val(2));
+  return b.icmp_eq(rem, b.i32_val(0));
+}
+
 LogicalResult lowerLdStMatrix(
     Location loc, LinearLayout cvt, bool transpose,
     SmallVector<Value> &vals, // Input for stmatrix, output for ldmatrix

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -44,6 +44,7 @@ Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
 /// Create a predicate with just single active thread.
 Value createElectPredicate(Location loc, RewriterBase &rewriter);
 Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter);
+Value createLeaderCTAPredicate(Location loc, RewriterBase &rewriter);
 
 // Create bar.warp.sync
 void createSyncWarp(Location loc, OpBuilder &builder);

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -25,6 +25,8 @@ constexpr static char AttrHasTLXOpsName[] = "tlx.has_tlx_ops";
 constexpr static char AttrHasWarpSpecOpsName[] = "tlx.has_warp_spec_ops";
 constexpr static char AttrTLXEnablePairedCTAMMAName[] =
     "tlx.enable_paired_cta_mma";
+
+bool tlxEnablePairedMMA(Operation *op);
 } // namespace tlx
 } // namespace triton
 } // namespace mlir

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -25,3 +25,15 @@ void mlir::triton::tlx::TLXDialect::initialize() {
 
 #define GET_ATTRDEF_CLASSES
 #include "IR/TLXAttrDefs.cpp.inc"
+
+bool mlir::triton::tlx::tlxEnablePairedMMA(Operation *op) {
+  assert(op != nullptr && "expecting nonnull op for checking TLX 2cta mode");
+  auto module = op;
+  if (!isa<ModuleOp>(module)) {
+    module = op->getParentOfType<ModuleOp>();
+  }
+  assert(module != nullptr &&
+         "expecting op nested in a module for checking TLX 2cta mode");
+  auto attr = module->getAttrOfType<BoolAttr>(AttrTLXEnablePairedCTAMMAName);
+  return attr != nullptr && attr.getValue() == true;
+}


### PR DESCRIPTION
According to Nvidia, CUDA 13 will enforce cta_group consistency at the kernel instruction level - meaning all tcgen05 instructions must all specify `cta_group::2` together or none of them does.

In this PR we do a few things:
- Do not fold cluster CTA id to 0 if it's tlx 2cta mode
- Do not insert cluster level barrier arrive/wait ops before MMA, because it does not work well with WarpSpec, and we now have the capability to precisely arrive a remote barrier.
- Go over all tcgen05 ops that can possibly have `cta_group::2` and override them if tlx 2cta mode. Here's a full list of all PTX instructions that support `cta_group::2`:

 ~~TMA load~~
~~When .cta_group::2 is specified, the mbarrier object mbar can be in shared memory of either the same CTA as the shared memory destination dstMem or in its [peer-CTA](https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-peer-cta).~~

~~2cta is strictly more general than 1cta so we only need to tweak the flag here.~~

### tcgen05.alloc, tcgen05.dealloc, tcgen05.relinquish_alloc_permit

These require two ctas to go through the same path such that the allocated tmem addresses are the same. We now only alloc and relinquish permit very early, and dealloc right before return, so we only need to tweak the flag.

### tcgen05.cp
>When .cta_group::2 is specified, the data is copied into the [Tensor Memory](https://docs.nvidia.com/cuda/parallel-thread-execution/#tensor-memory) of both the current and the [peer CTAs](https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-peer-cta)

This is analagous to mma in the sense that a single thread issues a call affecting both CTAs. We override the pred to elect the leader CTA. 

### tcgen05.shift
Not currently in use by Triton.
### tcgen05.mma
Scaled MMA is not exposed to tlx front end. And Triton default hardcodes it to 1cta mode, so we do not support that right now as well.

For regular MMA op, we rely on users to mark a two_cta flag in kernel on this op. It also serves as the killswitch for tlx 2cta mode - once we detect this flag we'll have a corresponding module attr which will activate TLX 2cta mode. Since the flag is also on the MMA op itself, we can just reuse existing MMA op lowering for 2cta. (e.g. the commit op following the MMA op)

One particular thing we're overriding is cluster sync ops inserted before 2cta MMA. With TLX 2cta mode we'll have explicit remote barrier arrival for synchronizations (with one-time cluster sync for remote bar init), which will also work in WarpSpec case.

2cta mma will broadcast signals to barriers living in both CTAs when done.

### tcgen05.commit
>Similarly, the instruction tcgen05.commit.cta_group::2 tracks for the completion of all prior asynchronous tcgen05 operations with .cta_group::2 issued by the current thread
>The optional qualifier .multicast::cluster allows signaling on the mbarrier objects of multiple CTAs in the cluster.

For commit we also only need to just tweak the flag. 

One thing to note is that only thread in the leader CTA out of the CTA pair will issue the mma instruction so non-leader CTA should not call commit without a pred ("current thread" didn't really issue an mma)

There're a few cases when a `tcgen05.commit` instruction might be generated:
- When lowering mma, a commit could be generated following that (the thread issuing mma might also then issue commit). This commit op reads 2cta flag from mma op.
- Front end directly calling commit. We override the backend codegen if tlx 2cta mode, but still rely on front end kernel code to pass in a proper pred to leader CTA.
- When lowering tcgen05.cp op, there could be a following commit generated. We override it the same way as mma's commit.


```
% make test-lit 
ninja -C /data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11 check-triton-lit-tests
ninja: Entering directory `/data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11'
[0/1] Running the triton regression tests

Testing Time: 8.29s

Total Discovered Tests: 208
  Passed           : 207 (99.52%)
  Expectedly Failed:   1 (0.48%)

% third_party/tlx/run_all.sh
Hello! (Facebook-only)
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.11.13, pytest-8.3.4, pluggy-1.5.0
rootdir: /data/users/pchen7e4/triton
configfile: pyproject.toml
plugins: xdist-3.7.0, forked-1.6.0, typeguard-4.3.0
collected 109 items                                                                                                                                                                                        

python/test/unit/language/test_tlx.py ...sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss.............s.................                                                  [100%]

===================================================================================== 33 passed, 76 skipped in 17.12s ======================================================================================
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}
c
Verifying correctness of TLX tutorial kernels
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.11.13, pytest-8.3.4, pluggy-1.5.0
rootdir: /data/users/pchen7e4/triton
configfile: pyproject.toml
plugins: xdist-3.7.0, forked-1.6.0, typeguard-4.3.0
collected 17 items                                                                                                                                                                                         

third_party/tlx/tutorials/amd-gemm-pipelined.py s                                                                                                                                                    [  5%]
third_party/tlx/tutorials/blackwell-fa-ws-persistent_test.py .                                                                                                                                       [ 11%]
third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py .                                                                                                                             [ 17%]
third_party/tlx/tutorials/blackwell-fa-ws-pipelined_test.py .                                                                                                                                        [ 23%]
third_party/tlx/tutorials/blackwell-fa-ws_test.py .                                                                                                                                                  [ 29%]
third_party/tlx/tutorials/blackwell-gemm-clc.py .                                                                                                                                                    [ 35%]
third_party/tlx/tutorials/blackwell-gemm-pipelined.py .                                                                                                                                              [ 41%]
third_party/tlx/tutorials/blackwell-gemm-ws.py .                                                                                                                                                     [ 47%]
third_party/tlx/tutorials/blackwell-grouped-gemm.py .                                                                                                                                                [ 52%]
third_party/tlx/tutorials/hopper-fa-ws-pipelined-pingpong_test.py s                                                                                                                                  [ 58%]
third_party/tlx/tutorials/hopper-fa-ws-pipelined_test.py s                                                                                                                                           [ 64%]
third_party/tlx/tutorials/hopper-fa-ws_test.py s                                                                                                                                                     [ 70%]
third_party/tlx/tutorials/hopper-gemm-pipelined_test.py s                                                                                                                                            [ 76%]
third_party/tlx/tutorials/hopper-gemm-ws_test.py s                                                                                                                                                   [ 82%]
third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py s                                                                                                                                 [ 88%]
third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong.py s                                                                                                                                    [ 94%]
third_party/tlx/tutorials/vector-add2.py .                                                                                                                                                           [100%]
...
=========================================================================== 9 passed, 8 skipped, 4 warnings in 90.14s (0:01:30) =====
```