### PR TITLE
[Cherry-pick] [BACKEND] Limit vec size with minimum padding interval (#8050)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -569,6 +569,7 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                 std::function<Value(Value)> calcPaddedOffset,
                 Value affineOffset, uint64_t maskSpanAffineOffset,
                 RewriterBase &rewriter, const TargetInfoBase &targetInfo,
+                std::optional<int> maybeMaxVecElems = {},
                 Operation *localLoadOp = nullptr);
 
 // Lower an ld/st-like operation given a layout and a callback that creates the

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -480,6 +480,36 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#shared = #ttg.padded_shared<[4:+4] {offset=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [1, 0], [2, 0], [4, 0], [8, 0]], block=[]}>
+#smem = #ttg.shared_memory
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 4], instrShape = [16, 16], isTransposed = true}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: padded_shared_layout_vectorization_limited_by_min_interval
+  tt.func @padded_shared_layout_vectorization_limited_by_min_interval(%arg0: tensor<16x32xf16, #blocked>) {
+    // CHECK-NOT: llvm.store
+    // CHECK: llvm.store {{.*}} : vector<4xf16>
+    // CHECK: llvm.store {{.*}} : vector<4xf16>
+    // CHECK-NOT: llvm.store
+    %0 = ttg.local_alloc %arg0 : (tensor<16x32xf16, #blocked>) -> !ttg.memdesc<16x32xf16, #shared, #smem, mutable>
+
+    // CHECK-NOT: llvm.load
+    // CHECK: llvm.load {{.*}} !llvm.ptr<3> -> vector<4xf16>
+    // CHECK: llvm.load {{.*}} !llvm.ptr<3> -> vector<4xf16>
+    // CHECK-NOT: llvm.load
+    %1 = ttg.local_load %0: !ttg.memdesc<16x32xf16, #shared, #smem, mutable, 16x32> -> tensor<16x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+
+    // CHECK-NOT: llvm.store
+    // CHECK: llvm.store {{.*}} : vector<4xf16>
+    // CHECK: llvm.store {{.*}} : vector<4xf16>
+    // CHECK-NOT: llvm.store
+    ttg.local_store %1, %0 : tensor<16x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> -> !ttg.memdesc<16x32xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // GFX950-LABEL: reduce_32x32
 // GFX950: llvm.call_intrinsic "llvm.amdgcn.permlane32.swap"
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {


### PR DESCRIPTION
Cherry-picked from upstream OAI repository.

Original Commit: e2ddc50821dc16e75968bd32f8e0c1d076d9d0be
Original Author: Alexander Weinrauch
Original Date: 2025-09-03 21:05:04 +0100

Original commit message:
```
[BACKEND] Limit vec size with minimum padding interval (#8050)

When lowering we need to limit the vec size based on the minimum
interval. This is already done in the old lowering in
`emitTransferBetweenRegistersAndShared`.
```

This PR was automatically cherry-picked from the upstream triton-lang/triton repository.
