### PR TITLE
[7/N][TLX-2cta] Front end: expose two_ctas option; read mod attr for cluster launch

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -723,6 +723,13 @@ void init_triton_ir(py::module &&m) {
                return py::none();
              return py::int_(ret.getInt());
            })
+      .def("get_bool_attr",
+           [](ModuleOp &self, const std::string &name) -> py::object {
+             auto ret = self->getAttrOfType<BoolAttr>(name);
+             if (!ret)
+               return py::none();
+             return py::bool_(ret.getValue());
+           })
       .def("get_tensordesc_metadata", getTensorDescMetadata)
       .def("create_location_snapshot",
            [](ModuleOp &self, const std::string &fileName) -> void {

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1587,6 +1587,7 @@ class TritonSemantic(Generic[TensorTy]):
         allow_tf32,
         max_num_imprecise_acc: int,
         out_dtype: tl.dtype,
+        tlx_paired_ctas: bool = False,
     ) -> Tuple[Any]:
         input_precision = tl._unwrap_if_constexpr(input_precision)
         allow_tf32 = tl._unwrap_if_constexpr(allow_tf32)
@@ -1676,7 +1677,10 @@ class TritonSemantic(Generic[TensorTy]):
             ret_scalar_ty = out_dtype
 
         M = lhs.type.shape[-2]
-        N = rhs.type.shape[-1]
+        if tlx_paired_ctas:
+            N = 2 * rhs.type.shape[-1]  # rhs is actually [K, N/2] in two_ctas mode so we scale it back
+        else:
+            N = rhs.type.shape[-1]
         K = lhs.type.shape[-1]
         B = lhs.type.shape[0] if lhs_rank == 3 else None
         ret_ty = tl.block_type(ret_scalar_ty, [B, M, N] if B else [M, N])

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -735,14 +735,18 @@ class CudaLauncher(object):
             libraries=libraries,
         )
 
-        self.num_ctas = functools.reduce(operator.mul, metadata.cluster_dims, 1)
+        self.tlx_enable_paired_cta_mma = metadata.tlx_enable_paired_cta_mma
+        if self.tlx_enable_paired_cta_mma:
+            self.num_ctas = 1
+        else:
+            self.num_ctas = functools.reduce(operator.mul, metadata.cluster_dims, 1)
         self.launch = wrap_handle_tensordesc(mod.launch, signature, tensordesc_meta)
         self.global_scratch_size = metadata.global_scratch_size
         self.global_scratch_align = metadata.global_scratch_align
         self.profile_scratch_size = metadata.profile_scratch_size
         self.profile_scratch_align = metadata.profile_scratch_align
         self.launch_cooperative_grid = metadata.launch_cooperative_grid
-        self.launch_cluster = metadata.launch_cluster
+        self.launch_cluster = metadata.launch_cluster or self.tlx_enable_paired_cta_mma
         self.launch_pdl = metadata.launch_pdl
 
     def __call__(self, gridX, gridY, gridZ, stream, function, *args):

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -373,16 +373,17 @@ void init_triton_tlx_ir(py::module &&m) {
       .def("create_tcgen5_dot",
            [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
               mlir::Value &d, std::optional<Value> useD,
-              std::optional<Value> pred, std::vector<Value> mBarriers) -> void {
+              std::optional<Value> pred, bool twoCTAs,
+              std::vector<Value> mBarriers) -> void {
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
              std::vector<Value> barrierPreds(mBarriers.size(), predTrue);
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
              self.create<ttng::TCGen5MMAOp>(
                  tokType, a, b, d, Value(),
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
-                 pred.has_value() ? pred.value() : predTrue /*pred */,
-                 false /* two_ctas*/, ValueRange(mBarriers),
-                 ValueRange(barrierPreds), !mBarriers.empty() /* is_async */);
+                 pred.has_value() ? pred.value() : predTrue /*pred */, twoCTAs,
+                 ValueRange(mBarriers), ValueRange(barrierPreds),
+                 !mBarriers.empty() /* is_async */);
            })
       .def("create_tcgen05_commit",
            [](TritonOpBuilder &self, Value &barrier) -> void {


### PR DESCRIPTION
Expose the two_ctas option for Blackwell async_dot op to front end. This will be the ultimate switch for users to get into TLX 2cta mode.

Also read the module attribute after getting ttgir to feed into kernel metadata. If we detect 2cta, we override the kernel launch cluster dim to be (2, 1, 1). Grid size remains unchanged.

This PR cannot be tested alone since it depends on proper barrier sync. Locally I've patched next PR #652 for proper sync and ran a 2cta gemm and ws gemm successfully on various shapes. Will land unit test cases together in next PR.

```
% make test-lit 
ninja -C /data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11 check-triton-lit-tests
ninja: Entering directory `/data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11'
[0/1] Running the triton regression tests

Testing Time: 8.31s

Total Discovered Tests: 212
  Passed           : 207 (97.64%)
  Expectedly Failed:   5 (2.36%)


% third_party/tlx/run_all.sh
Hello! (Facebook-only)
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.11.13, pytest-8.3.4, pluggy-1.5.0
rootdir: /data/users/pchen7e4/triton
configfile: pyproject.toml
plugins: xdist-3.7.0, forked-1.6.0, typeguard-4.3.0
collected 109 items                                                                                                                                                                                        

python/test/unit/language/test_tlx.py ...sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss.............s.................                                                  [100%]

===================================================================================== 33 passed, 76 skipped in 22.05s ======================================================================================
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}
c
Verifying correctness of TLX tutorial kernels
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.11.13, pytest-8.3.4, pluggy-1.5.0
rootdir: /data/users/pchen7e4/triton
configfile: pyproject.toml
plugins: xdist-3.7.0, forked-1.6.0, typeguard-4.3.0
collected 17 items                                                                                                                                                                                         

third_party/tlx/tutorials/amd-gemm-pipelined.py s                                                                                                                                                    [  5%]
third_party/tlx/tutorials/blackwell-fa-ws-persistent_test.py .                                                                                                                                       [ 11%]
third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py .                                                                                                                             [ 17%]
third_party/tlx/tutorials/blackwell-fa-ws-pipelined_test.py .                                                                                                                                        [ 23%]
third_party/tlx/tutorials/blackwell-fa-ws_test.py .                                                                                                                                                  [ 29%]
third_party/tlx/tutorials/blackwell-gemm-clc.py .                                                                                                                                                    [ 35%]
third_party/tlx/tutorials/blackwell-gemm-pipelined.py .                                                                                                                                              [ 41%]
third_party/tlx/tutorials/blackwell-gemm-ws.py .                                                                                                                                                     [ 47%]
third_party/tlx/tutorials/blackwell-grouped-gemm.py .                                                                                                                                                [ 52%]
third_party/tlx/tutorials/hopper-fa-ws-pipelined-pingpong_test.py s                                                                                                                                  [ 58%]
third_party/tlx/tutorials/hopper-fa-ws-pipelined_test.py s                                                                                                                                           [ 64%]
third_party/tlx/tutorials/hopper-fa-ws_test.py s                                                                                                                                                     [ 70%]
third_party/tlx/tutorials/hopper-gemm-pipelined_test.py s                                                                                                                                            [ 76%]
third_party/tlx/tutorials/hopper-gemm-ws_test.py s                                                                                                                                                   [ 82%]
third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py s                                                                                                                                 [ 88%]
third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong.py s                                                                                                                                    [ 94%]
third_party/tlx/tutorials/vector-add2.py .                                                                                                                                                           [100%]
...
=========================================================================== 9 passed, 8 skipped, 4 warnings in 127.26s (0:02:07) ======

```
