### PR TITLE
[TLX] Refactor grouped gemm with configurable sublicing 

### DIFF
--- a/third_party/tlx/tutorials/blackwell-grouped-gemm.py
+++ b/third_party/tlx/tutorials/blackwell-grouped-gemm.py
@@ -344,7 +344,7 @@ tlx_configs = [
         },
         num_warps=4,
         num_stages=1,
-    ) for BM in [128] for BN in [128, 256] for BK in [64, 128] for s in [2, 3, 4] for t in [2] for subtile in [1,2,4]
+    ) for BM in [128] for BN in [128, 256] for BK in [64, 128] for s in [2, 3, 4] for t in [2] for subtile in [1, 2, 4]
 ]
 
 
@@ -440,7 +440,6 @@ def grouped_matmul_tlx_kernel(
                             result = tlx.local_load(acc_slice)
                             c = result.to(tl.float16)
                             c_desc.store([offs_cm, offs_cn + slice_id * slice_size], c)
-
 
                         # done storing this buffer, signal MMA consumer to resume writing to it
                         tlx.barrier_arrive(tmem_empty_bars[tmem_buf], 1)


### PR DESCRIPTION
Subslicing enables bigger tile size and more pipeline stages. It benefits certain shapes: 


Triton autotuning for function grouped_matmul_tlx_kernel,
best config selected: BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 64, NUM_SMEM_BUFFERS: 3, NUM_TMEM_BUFFERS: 2, EPILOGUE_SUBTILE: **4**, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None;


```
  x_val    preprocessed_aten_grouped_mm-tflops    precompiled_cutedsl_grouped_mm_tuned-tflops        tlx_grouped_gemm-tflops   
-------  -------------------------------------  ---------------------------------------------  -----------------------------------------------  ------------------------- 
   8192                                1042.51                                         998.59                                               984.4     

```
