### PR TITLE
[release 3.5.x] Fix old TMA API not supported issue

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -380,6 +380,8 @@ def create_specialize_impl(specialize_extra):
             return ("constexpr", arg.cache_key)
         elif isinstance(arg, constexpr):
             return ("constexpr", arg)
+        elif hasattr(arg, "tma_desc_cpu_ptr"):
+            return ("nvTmaDesc", None)
         elif isinstance(arg, tuple):
             spec = [specialize_impl(x) for x in arg]
             make_tuple = lambda vals: type(arg)(*vals) if hasattr(arg, "_fields") else tuple(vals)


### PR DESCRIPTION
Issue introduced by
https://github.com/triton-lang/triton/pull/7987/

pytest python/test/unit/cuda/test_experimental_tma.py -k test_experimental_tma_matmul
