### PR TITLE
Fix triton_kernels empty package imports

### DIFF
--- a/python/triton_kernels/triton_kernels/__init__.py
+++ b/python/triton_kernels/triton_kernels/__init__.py
@@ -1,0 +1,43 @@
+from . import compaction
+from . import compaction_details
+from . import matmul_ogs
+from . import matmul_ogs_details
+from . import numerics
+from . import numerics_details
+from . import proton_opts
+from . import reduction_details
+from . import roofline
+from . import routing
+from . import routing_details
+from . import specialize
+from . import swiglu
+from . import swiglu_details
+from . import target_info
+from . import tensor
+from . import tensor_details
+from . import testing
+from . import topk
+from . import topk_details
+
+__all__ = [
+    "compaction",
+    "compaction_details",
+    "matmul_ogs",
+    "matmul_ogs_details",
+    "numerics",
+    "numerics_details",
+    "proton_opts",
+    "reduction_details",
+    "roofline",
+    "routing",
+    "routing_details",
+    "specialize",
+    "swiglu",
+    "swiglu_details",
+    "target_info",
+    "tensor",
+    "tensor_details",
+    "testing",
+    "topk",
+    "topk_details",
+]


### PR DESCRIPTION
Summary: The triton_kernels __init__.py was empty, causing import triton_kernels to fail. Added submodule imports for both beta and trunk versions.

Differential Revision: D86547380


