### PR TITLE
[TLX] Fix async_token_type not supported in conditional block issue

### DIFF
--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -407,10 +407,6 @@ class async_token(tl.base_value):
         handles.append(self.handle)
 
     def _unflatten_ir(self, handles, cursor):
-        """Build a frontend value with the current dtype, wrapping a list of existing handles.
-        cursor is the index of the first handle relevant to this value, and the function
-        should return the updated cursor position after any handles consumed by the created value.
-        """
         raise NotImplementedError
 
 
@@ -431,5 +427,5 @@ class async_token_type(tl.base_type):
     def _flatten_ir_types(self, builder: ir.builder, out: List[ir.type]) -> None:
         return
 
-    def _unflatten_ir(self, handles, cursor):
-        return async_token(self.value), cursor
+    def _unflatten_ir(self, handles: List[ir.value], cursor: int):
+        return async_token(handles[cursor]), cursor + 1


### PR DESCRIPTION
Fix NotImplementedError issue caused by conditional code like

      ```
        if not EVEN_EMB and i == num_iter - 1:
            token_x = tlx.async_load(x_ptrs, x_smem, mask=emb_edge_mask)
            token_y = tlx.async_load(y_ptrs_i, y_smem, mask=emb_edge_mask)
        else:
            token_x = tlx.async_load(x_ptrs, x_smem)
            token_y = tlx.async_load(y_ptrs_i, y_smem)
        tlx.async_load_commit_group([token_x, token_y])
```