### PR TITLE
[SWP] [AutoWS] Enable disabling AutoWS ScheduleLoop changes

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -50,7 +50,10 @@ def TritonGPUScheduleLoops : Pass<"tritongpu-schedule-loops", "mlir::ModuleOp"> 
 
   let options = [
     Option<"numStages", "num-stages", "int32_t", /*default*/"3",
-           "number of pipeline stages">
+           "number of pipeline stages">,
+    Option<"useAutoWSPath", "use-autoWS-path",
+           "bool", /*default*/"true",
+           "Use the AutoWS modifications to the LoopSchedule">
   ];
 }
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -23,7 +23,7 @@ bool isSafeToPipeline(scf::ForOp forOp);
 // Do any preprocessing on the loop information for a given module.
 void doLoopSchedulePreprocessing(ModuleOp moduleOp, Builder &builder);
 // TODO: Remove me and move to pass structure.
-void scheduleLoops(ModuleOp moduleOp, int defaultNumStages);
+void scheduleLoops(ModuleOp moduleOp, int defaultNumStages, bool useAutoWSPath);
 llvm::MapVector<Operation *, std::pair<int, Operation *>>
 loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
                           triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -63,8 +63,8 @@ void init_triton_passes_ttgpuir(py::module &&m) {
                             createTritonGPUHoistTMEMAlloc, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_assign_latencies",
                             createTritonGPUAssignLatencies, int);
-  ADD_PASS_OPTION_WRAPPER_1("add_schedule_loops", createTritonGPUScheduleLoops,
-                            int);
+  ADD_PASS_OPTION_WRAPPER_2("add_schedule_loops", createTritonGPUScheduleLoops,
+                            int, bool);
   ADD_PASS_OPTION_WRAPPER_2("add_pipeline", createTritonGPUPipeline, int, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_warp_specialize",
                             createTritonGPUAutomaticWarpSpecialization, int);

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -291,7 +291,7 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_assign_latencies(pm, opt.num_stages)
-            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages)
+            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, not knobs.nvidia.use_oai_ws)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
         elif capability // 10 >= 10:
             passes.ttgpuir.add_fuse_nested_loops(pm)
@@ -302,7 +302,7 @@ class CUDABackend(BaseBackend):
             nvidia.passes.ttnvgpuir.add_promote_lhs_to_tmem(pm)
             nvidia.passes.hopper.add_data_partitioning(pm, 1)
             passes.ttgpuir.add_assign_latencies(pm, opt.num_stages)
-            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages)
+            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, not knobs.nvidia.use_oai_ws)
             if knobs.nvidia.use_oai_ws:
                 passes.ttgpuir.add_warp_specialize(pm, opt.num_stages)
             else:

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -168,7 +168,8 @@ public:
                       "doLoopSchedulePreprocessing\n"
                    << moduleOp << "\n\n\n";
     }
-    triton::gpu::scheduleLoops(moduleOp, defaultNumStages);
+    triton::gpu::scheduleLoops(moduleOp, defaultNumStages,
+                               /* useAutoWSPath */ true);
     if (dumpIntermediateSteps) {
       llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
                       "doLoopSchedule\n"


### PR DESCRIPTION
Reuses the environment variable that specifies OpenAI Warp specialization to select the old software pipelining code from upstream. Right now this is two whole copies, but as I improve the issues in the AutoWS version I'll work on a more elegant split so there are fewer upstream changes.

TODO: Test internally