### PR TITLE
[fix] Solved issues from promoting stable

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -336,7 +336,8 @@ class Config:
     """
 
     def __init__(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, maxnreg=None, pre_hook=None, ir_override=None,
-                 minRegAutoWS=None, maxRegAutoWS=None):
+                 minRegAutoWS=None, maxRegAutoWS=None, num_buffers_warp_spec=0, num_consumer_groups=0,
+                 reg_dec_producer=0, reg_inc_consumer=0):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas


### PR DESCRIPTION
Summary:
* Issue1 :
Incompatible parameter type [6]: In call `pl.enter_scope`, for 1st positional argument, expected `constexpr` but got `str`.
  * Modifying the `pl.enter_scope` and `pl.exit_scope` statements to use `tl.constexpr`

* Issue2 :Deprecated fields num_consumer_groups/num_buffers_warp_spec
  * Add back the parameter in autotuner.py 

* Issue3 :Build error no driver found 
  * Add try except to capture the issue in triton_hstu_attention.py

* Issue4 : metric_type exists but it is not in the pyre recognized format
  * add pyre-ignore and suppress it

Reviewed By: srivatsan-ramesh

Differential Revision: D86986842


