### PR TITLE
[AutoWS] [SWP] Fully split AutoWS SWP implementation

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -306,9 +306,11 @@ determineIndependentDotChains(scf::ForOp forOp, int maxStages) {
   return {dotChains, true};
 }
 
-CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
-                              const DenseMap<Operation *, int> &opLatency,
-                              int defaultNumStages) {
+CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
+                                    const DenseMap<Operation *, int> &opLatency,
+                                    int defaultNumStages) {
+  // TODO(njriasan): Refactor this so we can more easily share code with
+  // upstream. This is currently a complete split to enable proper debugging.
   llvm::MapVector<Operation *, int> opToStage;
   // Find terminator for later reference
   auto terminator = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
@@ -400,7 +402,6 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
     }
   }
 
-  auto metaWS = triton::tools::getBoolEnv("TRITON_USE_META_WS");
   DominanceInfo domInfo(forOp);
   // The return value is a tuple of <distance, cluster number>.
   // If the cluster number is -1, then the op will eventually be
@@ -435,9 +436,7 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
     // latency otherwise it contributes 0 to the distance.
     //
     // The maximum distance allowed is the maxmium number of stages.
-    int d = lat + (maxDist < 0 ? 0 : maxDist);
-    if (metaWS)
-      d = std::min(d, maxPossibleDistance);
+    int d = std::min(lat + (maxDist < 0 ? 0 : maxDist), maxPossibleDistance);
     distance[op] = d;
     int c = -1;
     // We must always be scheduled as early as our earliest user for the same
@@ -491,9 +490,7 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
     minIndex = std::min(minIndex, clusterIdx);
     maxIndex = std::max(maxIndex, clusterIdx);
   }
-  int numClusters = maxStage + 1;
-  if (metaWS)
-    numClusters = maxIndex - minIndex + 1;
+  int numClusters = maxIndex - minIndex + 1;
   CoarseSchedule schedule(maxStage + 1);
   SmallVector<CoarseSchedule::Cluster> clusters(numClusters);
   for (int i = 0; i < numClusters; i++) {
@@ -509,9 +506,105 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
       auto dist = maxDistance - stage;
       clusterIdx = maxClusterPerDistance[dist];
     }
-    schedule.insert(
-        op, stage, clusters[metaWS ? clusterIdx - minIndex : maxStage - stage]);
+    schedule.insert(op, stage, clusters[clusterIdx - minIndex]);
   }
+
+  // Move `scf.if` ops in the current schedule (forward slice of the latency
+  // ops) into a new epilogue cluster at the end of the schedule, pushing them
+  // as close to the end of the loop body as possible.
+  CoarseSchedule::Cluster epilogue = schedule.clusters.newAtBack();
+  for (auto [op, stage] : opToStage) {
+    auto ifOp = dyn_cast<scf::IfOp>(op);
+    if (!ifOp)
+      continue;
+    // If the `scf.if` op itself is a latency op, skip it.
+    if (opLatency.contains(ifOp))
+      continue;
+    // Ensure this does not create scheduling conflicts by ensuring the forward
+    // slice of the `scf.if` does not contain ops that are already scheduled, as
+    // this will cause the `scf.if` to be scheduled after its dependents.
+    SetVector<Operation *> slice;
+    getForwardSlice(ifOp, &slice);
+    if (llvm::any_of(slice, [&](Operation *op) { return opToStage.count(op); }))
+      continue;
+    schedule.insert(ifOp, stage, epilogue);
+  }
+  return schedule;
+}
+
+CoarseSchedule
+scheduleKeyOpsUpstream(scf::ForOp forOp,
+                       const DenseMap<Operation *, int> &opLatency) {
+  llvm::MapVector<Operation *, int> opToStage;
+  // Find terminator for later reference
+  auto terminator = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  // Determine all operations that have a non-zero latency
+  SmallVector<Operation *> latOps;
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    if (opLatency.count(&op))
+      latOps.push_back(&op);
+  }
+  // If no latency ops, nothing to schedule
+  if (latOps.empty())
+    return CoarseSchedule(0);
+
+  DominanceInfo domInfo(forOp);
+  // Compute the longest path to the yield for each operation reachable
+  // from any latency operation.
+  DenseMap<Operation *, int> distance;
+  std::function<int(Operation *)> computeDistance = [&](Operation *op) -> int {
+    auto it = distance.find(op);
+    if (it != distance.end())
+      return it->second;
+    // Compute max distance among all users that are inside the loop body
+    int maxDist = -1;
+    for (Operation *user : op->getUsers()) {
+      // Only consider users inside the same block and not the terminator
+      Operation *inBlockUser = forOp.getBody()->findAncestorOpInBlock(*user);
+      if (!inBlockUser || inBlockUser == terminator)
+        continue;
+      int distUser = computeDistance(inBlockUser);
+      if (distUser > maxDist)
+        maxDist = distUser;
+    }
+    int lat = 0;
+    if (opLatency.count(op))
+      lat = opLatency.lookup(op);
+    // If an op has no users (maxDist == -1) but has latency, we include its
+    // latency otherwise it contributes 0 to the distance.
+    int d = lat + (maxDist < 0 ? 0 : maxDist);
+    distance[op] = d;
+    return d;
+  };
+
+  // Compute distances for all latency-starting ops
+  int maxDistance = 0;
+  for (Operation *latOp : latOps) {
+    int d = computeDistance(latOp);
+    if (d > maxDistance)
+      maxDistance = d;
+  }
+
+  // Assign stage to each op reachable from a latency op
+  for (auto [op, dist] : distance) {
+    // We only schedule ops that are downstream of a latency op
+    // (had a non-negative distance due to a latency op).
+    if (dist >= 0)
+      opToStage[op] = maxDistance - dist;
+  }
+
+  auto stages = llvm::make_second_range(opToStage);
+  int maxStage = *llvm::max_element(stages);
+  CoarseSchedule schedule(maxStage + 1);
+  SmallVector<CoarseSchedule::Cluster> clusters(maxStage + 1);
+  for (int i = 0; i <= maxStage; i++) {
+    clusters[i] = schedule.clusters.newAtBack();
+  }
+  // Assign ops to the clusters in reverse-stage order;
+  // ops with higher stage numbers are assigned first. This way we will
+  // end up with roughly reverse program order in the clusters.
+  for (auto [op, stage] : opToStage)
+    schedule.insert(op, stage, clusters[maxStage - stage]);
 
   // Move `scf.if` ops in the current schedule (forward slice of the latency
   // ops) into a new epilogue cluster at the end of the schedule, pushing them
@@ -535,6 +628,17 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
   }
 
   return schedule;
+}
+
+CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
+                              const DenseMap<Operation *, int> &opLatency,
+                              int defaultNumStages) {
+  auto metaWS = triton::tools::getBoolEnv("TRITON_USE_META_WS");
+  if (metaWS) {
+    return scheduleKeyOpsMetaWS(forOp, opLatency, defaultNumStages);
+  } else {
+    return scheduleKeyOpsUpstream(forOp, opLatency);
+  }
 }
 
 // Get an initial schedule for the loop. This is the base schedule from which


### PR DESCRIPTION
Fully separates the AutoWS SWP scheduling implementation from the SWP scheduling information. This is done because there are several logical inconsistencies that can arise when swapping between the two implementations.