### PR TITLE
[AutoWS] [SWP] Normalize AutoWS Loop Schedule to handle minimum distance > 1

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -376,7 +376,7 @@ CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
   DenseMap<Operation *, int> clusterMap;
   auto [chains, success] = determineIndependentDotChains(forOp, maxStages);
   size_t numDots = 0;
-  SmallVector<int> maxClusterPerDistance(maxStages, -1);
+  SmallVector<int> maxClusterPerDistance(maxPossibleDistance, -1);
   if (success) {
     size_t maxChainLength = 0;
     for (auto &chain : chains) {
@@ -435,7 +435,7 @@ CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
   // Assign ops to the clusters in reverse-stage order;
   // ops with higher stage numbers are assigned first. This way we will
   // end up with roughly reverse program order in the clusters.
-  for (int i = 0; i < maxStages; i++) {
+  for (int i = 0; i < maxPossibleDistance; i++) {
     if (maxClusterPerDistance[i] == -1) {
       maxClusterPerDistance[i] = numDots + offset++;
     }
@@ -523,7 +523,7 @@ CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
     if (mappedClusterIdx != clusterMap.end()) {
       clusterIdx = mappedClusterIdx->second;
     } else {
-      auto dist = maxDistance - stage;
+      auto dist = maxDistance - (stage + minDistance);
       clusterIdx = maxClusterPerDistance[dist];
     }
     minIndex = std::min(minIndex, clusterIdx);
@@ -542,7 +542,7 @@ CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
     if (mappedClusterIdx != clusterMap.end()) {
       clusterIdx = mappedClusterIdx->second;
     } else {
-      auto dist = maxDistance - stage;
+      auto dist = maxDistance - (stage + minDistance);
       clusterIdx = maxClusterPerDistance[dist];
     }
     schedule.insert(op, stage, clusters[clusterIdx - minIndex]);


### PR DESCRIPTION
Summary:
The current implementation of SWP in AutoWS assumes that all distances are between 0, max_stage - 1. In general this may not be sufficient for certain schedules, such as the schedule(s) introduced in gdpa. In those schedules the minimum distance might be 1, so we need to normalize our results.

This implementation does that by computing the minimum distance and adding that value to all other distance computations.

Differential Revision: D87285035


