### PR TITLE
[TLX] fix missing build dep

### DIFF
--- a/third_party/nvidia/lib/NVGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/NVGPUToLLVM/CMakeLists.txt
@@ -6,4 +6,5 @@ add_triton_library(NVGPUToLLVM
 
     LINK_LIBS PUBLIC
     NVGPUIR
+    TLXIR
 )


### PR DESCRIPTION
Example error from https://github.com/facebookexperimental/triton/pull/644#discussion_r2539063059 that occurs rarely:

```
[21/303] Building CXX object third_party/nvidia/lib/NVGPUToLLVM/CMakeFiles/NVGPUToLLVM.dir/NVGPUToLLVMPass.cpp.o
      FAILED: third_party/nvidia/lib/NVGPUToLLVM/CMakeFiles/NVGPUToLLVM.dir/NVGPUToLLVMPass.cpp.o
      /home/hoy/tlx_conda/conda/bin/aarch64-conda-linux-gnu-c++ -DGTEST_HAS_RTTI=0 -I/home/hoy/triton-fb/build/cmake.linux-aarch64-cpython-3.12/third_party/nvidia/lib/NVGPUToLLVM -I/home/hoy/triton-fb/third_party/nvidia/lib/NVGPUToLLVM -I/home/hoy/triton-fb/include -I/home/hoy/triton-fb/. -I/home/hoy/.triton/llvm/llvm-064f02da-ubuntu-arm64/include -I/home/hoy/triton-fb/build/cmake.linux-aarch64-cpython-3.12/include -I/home/hoy/triton-fb/third_party -I/home/hoy/triton-fb/build/cmake.linux-aarch64-cpython-3.12/third_party -I/home/hoy/triton-fb/python/src -I/home/hoy/triton-fb/third_party/nvidia/include -I/home/hoy/triton-fb/build/cmake.linux-aarch64-cpython-3.12/third_party/nvidia/include -fvisibility-inlines-hidden -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe -isystem /home/hoy/tlx_conda/conda/include -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror -Wno-covered-switch-default -fvisibility=hidden -g -std=gnu++17  -fno-exceptions -funwind-tables -fno-rtti -MD -MT third_party/nvidia/lib/NVGPUToLLVM/CMakeFiles/NVGPUToLLVM.dir/NVGPUToLLVMPass.cpp.o -MF third_party/nvidia/lib/NVGPUToLLVM/CMakeFiles/NVGPUToLLVM.dir/NVGPUToLLVMPass.cpp.o.d -o third_party/nvidia/lib/NVGPUToLLVM/CMakeFiles/NVGPUToLLVM.dir/NVGPUToLLVMPass.cpp.o -c /home/hoy/triton-fb/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
      In file included from /home/hoy/triton-fb/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp:12:
      /home/hoy/triton-fb/third_party/tlx/dialect/include/IR/Dialect.h:10:10: fatal error: tlx/dialect/include/IR/Dialect.h.inc: No such file or directory
         10 | #include "tlx/dialect/include/IR/Dialect.h.inc"
            |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      compilation terminated.
```

There might be a race condition during building and I was not able to reproduce the build failure. This PR just adds the dep anyway. Will revisit if the error pops up again.

Testing: build successfully. 