### PR TITLE
[triton] Expose tl.async_task by default

### DIFF
--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -3,6 +3,8 @@
 
 from . import math
 from . import extra
+# Import TLX features (async_task, async_tasks) for backward compatibility
+from .extra.tlx import async_task, async_tasks
 from .standard import (
     argmax,
     argmin,
@@ -154,6 +156,8 @@ __all__ = [
     "argmax",
     "argmin",
     "associative_scan",
+    "async_task",
+    "async_tasks",
     "assume",
     "atomic_add",
     "atomic_and",


### PR DESCRIPTION
Summary: We need to expose async_task for changes to work.

Reviewed By: agron911

Differential Revision: D87308091


