### PR TITLE
[TLX] 2cta ws persistent tlx gemm tutorial

### DIFF
--- a/third_party/tlx/tutorials/blackwell-gemm-ws-2cta.py
+++ b/third_party/tlx/tutorials/blackwell-gemm-ws-2cta.py
@@ -67,6 +67,13 @@ def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M):
 @triton.autotune(
     configs=get_cuda_autotune_config(),
     key=["M", "N", "K"],
+    # Uncomment do_bench for stable autotuning when running perf benchmarks
+    # do_bench=lambda kernel_call, quantiles: triton.testing.do_bench(
+    #     kernel_call,
+    #     warmup=100,
+    #     rep=2000,
+    #     quantiles=quantiles,
+    # )
 )
 @triton.jit
 def matmul_kernel_tma_ws_blackwell(a_desc, b_desc, c_desc, M, N, K, BLOCK_SIZE_M: tl.constexpr,


### PR DESCRIPTION
Add a flag PAIR_CTA to highlight difference from 1cta kernel. In practice, can just give it more values to autotune between 1cta and 2cta.

- Correctness testing: pytest passing for both PAIR_CTA True and False.
```
% pytest third_party/tlx/tutorials/blackwell-gemm-ws-2cta.py
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.11.13, pytest-8.3.4, pluggy-1.5.0
rootdir: /data/users/pchen7e4/triton
configfile: pyproject.toml
plugins: xdist-3.7.0, forked-1.6.0, typeguard-4.3.0
collected 1 item                                                                                                                                                                                           

third_party/tlx/tutorials/blackwell-gemm-ws-2cta.py .                                                                                                                                                [100%]

============================================================================================ 1 passed in 21.15s ===
```

- Perf testing: PAIR_CTA=True (with autotune do_bench uncommented)
```
Locking GPU 6 power cap to 750 W
Locking GPU 6 frequency cap to 1965 Hz
Running benchmarks...
matmul-performance-fp16:
        M       N       K       cuBLAS       Triton
0   512.0   512.0   512.0    29.026326    13.617871
1  1024.0  1024.0  1024.0   190.110091    95.596674
2  1536.0  1536.0  1536.0   543.147277   336.042155
3  2048.0  2048.0  2048.0   798.915054   725.501244
4  2560.0  2560.0  2560.0   992.030259   839.532450
5  3072.0  3072.0  3072.0  1154.837080  1065.846649
6  3584.0  3584.0  3584.0  1083.726022  1057.828145
7  4096.0  4096.0  4096.0  1108.951041  1073.205166
8  8192.0  8192.0  8192.0  1112.541733   950.950349
```

In the best shape we get 1057/1083 = 0.976 of cuBLAS without expanding autotune config search space from 1cta.

