### PR TITLE
[autoWS] expose pingpong as a pass argument

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -435,6 +435,7 @@ class JITHookCompileInfo(TypedDict):
     num_stages: int
     minRegAutoWS: Optional[int]
     maxRegAutoWS: Optional[int]
+    pingpongAutoWS: Optional[bool]
     enable_fp_fusion: bool
     launch_cooperative_grid: bool
     extern_libs: tuple[tuple[str, str], ...]

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -336,7 +336,7 @@ class Config:
     """
 
     def __init__(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, maxnreg=None, pre_hook=None, ir_override=None,
-                 minRegAutoWS=None, maxRegAutoWS=None, num_buffers_warp_spec=0, num_consumer_groups=0,
+                 minRegAutoWS=None, maxRegAutoWS=None, pingpongAutoWS=None, num_buffers_warp_spec=0, num_consumer_groups=0,
                  reg_dec_producer=0, reg_inc_consumer=0):
         self.kwargs = kwargs
         self.num_warps = num_warps
@@ -347,6 +347,7 @@ class Config:
         self.ir_override = ir_override
         self.minRegAutoWS = minRegAutoWS
         self.maxRegAutoWS = maxRegAutoWS
+        self.pingpongAutoWS = pingpongAutoWS
 
     def __setstate__(self, state):
         self.kwargs = state.get("kwargs", {})
@@ -358,6 +359,7 @@ class Config:
         self.ir_override = state.get("ir_override", None)
         self.minRegAutoWS = state.get("minRegAutoWS", None)
         self.maxRegAutoWS = state.get("maxRegAutoWS", None)
+        self.pingpongAutoWS = state.get("pingpongAutoWS", None)
 
     def all_kwargs(self):
         return {
@@ -371,6 +373,7 @@ class Config:
                     ("ir_override", self.ir_override),
                     ("minRegAutoWS", self.minRegAutoWS),
                     ("maxRegAutoWS", self.maxRegAutoWS),
+                    ("pingpongAutoWS", self.pingpongAutoWS),
                 ) if v is not None
             }
         }
@@ -385,6 +388,7 @@ class Config:
         res.append(f"maxnreg: {self.maxnreg}")
         res.append(f"minRegAutoWS: {self.minRegAutoWS}")
         res.append(f"maxRegAutoWS: {self.maxRegAutoWS}")
+        res.append(f"pingpongAutoWS: {self.pingpongAutoWS}")
         return ", ".join(res)
 
     def __hash__(self):

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -336,8 +336,8 @@ class Config:
     """
 
     def __init__(self, kwargs, num_warps=4, num_stages=3, num_ctas=1, maxnreg=None, pre_hook=None, ir_override=None,
-                 minRegAutoWS=None, maxRegAutoWS=None, pingpongAutoWS=None, num_buffers_warp_spec=0, num_consumer_groups=0,
-                 reg_dec_producer=0, reg_inc_consumer=0):
+                 minRegAutoWS=None, maxRegAutoWS=None, pingpongAutoWS=None, num_buffers_warp_spec=0,
+                 num_consumer_groups=0, reg_dec_producer=0, reg_inc_consumer=0):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -643,10 +643,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # Use getattr to safely access backend-specific attributes
         minRegAutoWS = getattr(options, 'minRegAutoWS', None)
         maxRegAutoWS = getattr(options, 'maxRegAutoWS', None)
+        pingpongAutoWS = getattr(options, 'pingpongAutoWS', None)
         if minRegAutoWS is not None:
             repr_parts.append(f"minRegAutoWS={minRegAutoWS}")
         if maxRegAutoWS is not None:
             repr_parts.append(f"maxRegAutoWS={maxRegAutoWS}")
+        if pingpongAutoWS is not None:
+            repr_parts.append(f"pingpongAutoWS={pingpongAutoWS}")
         repr_parts.extend([
             f"enable_fp_fusion={options.enable_fp_fusion}",
             f"launch_cooperative_grid={options.launch_cooperative_grid}",
@@ -665,6 +668,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
             'num_stages': options.num_stages,
             'minRegAutoWS': getattr(options, 'minRegAutoWS', None),
             'maxRegAutoWS': getattr(options, 'maxRegAutoWS', None),
+            'pingpongAutoWS': getattr(options, 'pingpongAutoWS', None),
             'enable_fp_fusion': options.enable_fp_fusion,
             'launch_cooperative_grid': options.launch_cooperative_grid,
             'extern_libs': options.extern_libs,

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -309,7 +309,8 @@ class CUDABackend(BaseBackend):
             else:
                 # use Meta's WS internally which supports both hopper and blackwell
                 passes.ttgpuir.add_partition_scheduling(pm)
-                nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS, dump_enabled)
+                nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS,
+                                                         dump_enabled)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             # hoist again and allow hoisting out of if statements

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -20,6 +20,12 @@ def NVGPUWarpSpecialization : Pass<"nvgpu-warp-specialization", "mlir::ModuleOp"
     Option<"numStages", "num-stages",
            "int32_t", /*default*/"0",
            "number of buffers for warp specialization">,
+    Option<"capability", "capability",
+           "int32_t", /*default*/"10",
+           "NVIDIA compute capability">,
+    Option<"pingpongAutoWS", "pingpong-auto-ws",
+           "bool", /*default*/"false",
+           "Enable ping pong barrier insertion around critical regions">,
     Option<"dumpIntermediateSteps", "dump-intermediate-steps",
            "bool", /*default*/"false",
            "Dump intermediate steps">
@@ -117,7 +123,10 @@ def NVGPUTestPingPongSync : Pass<"nvgpu-test-ping-pong-sync", "mlir::ModuleOp"> 
   let options = [
     Option<"numWarpGroups", "num-warp-groups",
            "int32_t", /*default*/"0",
-           "number of warp groups for warp specialization">
+           "number of warp groups for warp specialization">,
+    Option<"capability", "capability",
+           "int32_t", /*default*/"10",
+           "NVIDIA compute capability">
   ];
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -24,7 +24,8 @@ void doBufferAllocation(triton::FuncOp &funcOp);
 void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
 void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
-void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups, int capability);
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
+                    int capability);
 
 #define GEN_PASS_DEF_NVGPUWARPSPECIALIZATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -24,7 +24,7 @@ void doBufferAllocation(triton::FuncOp &funcOp);
 void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
 void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
-void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups);
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups, int capability);
 
 #define GEN_PASS_DEF_NVGPUWARPSPECIALIZATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
@@ -77,7 +77,7 @@ public:
     auto moduleOp = funcOp->getParentOfType<ModuleOp>();
     // FIXME: skip data partitioning with on-host TMA.
     // FIXME: skip data partitioning for Blackwell.
-    const int ForBlackWell = true;
+    bool ForBlackWell = (capability / 10) > 9;
     unsigned numWarpGroups = ForBlackWell ? 2 : 3;
     if (!ForBlackWell) {
       bool success = false;
@@ -146,8 +146,9 @@ public:
           << "// -----// WarpSpec internal IR Dump After: doCodePartition\n"
           << moduleOp << "\n\n\n";
     }
-    if (!ForBlackWell) {
-      doPingPongSync(funcOp, numWarpGroups);
+
+    if (pingpongAutoWS) {
+      doPingPongSync(funcOp, numWarpGroups, capability);
       if (dumpIntermediateSteps) {
         llvm::dbgs()
             << "// -----// WarpSpec internal IR Dump After: doPingPongSync\n"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -247,7 +247,8 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
   }
 }
 
-void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups, int capability) {
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
+                    int capability) {
   // Insert sync points in ForOp for consumer warp groups. Enable this pass
   // when number of consumer warp groups == 2.
   if (numWarpGroups != 3)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -247,7 +247,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
   }
 }
 
-void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups) {
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups, int capability) {
   // Insert sync points in ForOp for consumer warp groups. Enable this pass
   // when number of consumer warp groups == 2.
   if (numWarpGroups != 3)
@@ -280,7 +280,7 @@ public:
   void runOnFuncOp(triton::FuncOp funcOp) {
     if (numWarpGroups >= 3)
       // Assuming one producer warp group.
-      doPingPongSync(funcOp, numWarpGroups);
+      doPingPongSync(funcOp, numWarpGroups, capability);
   }
 
   void runOnOperation() override {

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -88,7 +88,8 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
 void init_triton_hopper_passes(py::module &&m) {
   // Meta's autoWS
   ADD_PASS_OPTION_WRAPPER_4("add_hopper_warpspec",
-                            mlir::createNVGPUWarpSpecialization, int, int, bool, bool);
+                            mlir::createNVGPUWarpSpecialization, int, int, bool,
+                            bool);
   ADD_PASS_OPTION_WRAPPER_1("add_data_partitioning",
                             mlir::createNVGPUWSDataPartition, int);
 }

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -87,8 +87,8 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
 
 void init_triton_hopper_passes(py::module &&m) {
   // Meta's autoWS
-  ADD_PASS_OPTION_WRAPPER_2("add_hopper_warpspec",
-                            mlir::createNVGPUWarpSpecialization, int, bool);
+  ADD_PASS_OPTION_WRAPPER_4("add_hopper_warpspec",
+                            mlir::createNVGPUWarpSpecialization, int, int, bool, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_data_partitioning",
                             mlir::createNVGPUWSDataPartition, int);
 }


### PR DESCRIPTION
This PR is supposed to be a predecessor of PR #668.

This PR tries to
- expose pingpongAutoWS as a tunable JIT knob, and 
- pass both pingpongAutoWS and the compute capability to be pass arguments to our warp specialization pass.

Stacked PRs:
 * __->__#684


--- --- ---

### [autoWS] expose pingpong as a pass argument

