### PR TITLE
[TLX] [Triton] Fix TritonGPURemoveLayoutConversion to mark the nestedForLoop bounds as live

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1272,6 +1272,10 @@ public:
         auto result = mlir::cast<OpResult>(value);
         OpOperand &forOperand = *nestedFor.getTiedLoopInit(result);
         markLive(forOperand.get());
+        // Mark the lowerBound, upperBound, and step as live.
+        markLive(nestedFor.getLowerBound());
+        markLive(nestedFor.getUpperBound());
+        markLive(nestedFor.getStep());
         auto nestedYieldOp =
             cast<scf::YieldOp>(nestedFor.getBody()->getTerminator());
         Value nestedYieldOperand =


### PR DESCRIPTION
Updates the logic in TritonGPURemoveLayoutConversion to correctly mark the nestedForLoop bounds as live. This prevents the pass incorrectly assuming the arguments to an outer for loop may be unused and is the blocker for causal attention.

As a followup I will submit an upstream PR with a lit test to OAI. As a placeholder this is the reproducer I need to shrink: [P2053187188](https://www.internalfb.com/phabricator/paste/view/P2053187188)