### PR TITLE
[TLX] Fix driver.py to enable running gluon with Triton-Beta

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -735,7 +735,7 @@ class CudaLauncher(object):
             libraries=libraries,
         )
 
-        self.tlx_enable_paired_cta_mma = metadata.tlx_enable_paired_cta_mma
+        self.tlx_enable_paired_cta_mma = getattr(metadata, "tlx_enable_paired_cta_mma", False)
         if self.tlx_enable_paired_cta_mma:
             self.num_ctas = 1
         else:


### PR DESCRIPTION
Summary: See title. Fixes the use of `tlx_enable_paired_cta_mma` so I can run a gluon TritonBench variant.

Differential Revision: D87741761


