### PR TITLE
[GB300] [Triton] Disable experimental Triton API inside PyTorch

### DIFF
--- a/python/triton/tools/experimental_descriptor.py
+++ b/python/triton/tools/experimental_descriptor.py
@@ -80,3 +80,6 @@ def create_1d_tma_descriptor_type(ptr, dim, block_dim, dtype):
 
 def create_2d_tma_descriptor_type(ptr, dim1, dim0, block_dim1, block_dim0, dtype):
     return TmaDescKernelParamType(ptr, [dim1, dim0], [block_dim1, block_dim0], dtype)
+
+def enable_in_pytorch():
+    return False


### PR DESCRIPTION
Summary:
Disables PyTorch path that use the old API because the new API should always be preferred. Seems to be certain tests that fail internally with this setup.

Ideally we should fully remove this once everyone is upgraded.

Differential Revision: D87820553


