### PR TITLE
[GB300] [Triton] Add a Triton API to disable the experimental API in PyTorch

### DIFF
--- a/python/triton/tools/experimental_descriptor.py
+++ b/python/triton/tools/experimental_descriptor.py
@@ -80,3 +80,7 @@ def create_1d_tma_descriptor_type(ptr, dim, block_dim, dtype):
 
 def create_2d_tma_descriptor_type(ptr, dim1, dim0, block_dim1, block_dim0, dtype):
     return TmaDescKernelParamType(ptr, [dim1, dim0], [block_dim1, block_dim0], dtype)
+
+
+def enable_in_pytorch():
+    return False


### PR DESCRIPTION
Summary: Adds an API so PyTorch won't select the experimental API but that its still possible.

Differential Revision: D87822825


