### PR TITLE
[TLX] Fix buffer indexing semantic espcated to callee function issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ While this approach places more responsibility on the user, it reduces the compi
 
     Allocate `NUM_BUFFERS` of buffers in the tensor memory per thread block, each with size size. The memory layout is inferred from its consumers.
 
-- `buffer = tlx.local_view(buffers, buffer_idx)`
+- `buffer = tlx.local_view(buffers, buffer_idx)` or `buffer = buffers[buffer_idx]`
 
-    Return a subview of the buffer indexed by `buffer_idx` from `buffers`.
+    Return a subview of the buffer indexed by `buffer_idx` from `buffers`. Both the explicit `local_view()` call and the indexing syntax `[]` are supported.
 
 
 - `distributed_tensor = tlx.local_load(buffer, optional_token)`

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -27,8 +27,11 @@ def alloc_barriers(
         layout.numCTASplit,
         layout.numCTAOrder,
     )
-    return tlx.mbarrier(_semantic.builder.create_alloc_barriers(num_barriers.value, arrive_count.value, layout_handle),
-                        num_barriers, layout, _semantic)
+    return tlx.mbarrier(
+        _semantic.builder.create_alloc_barriers(num_barriers.value, arrive_count.value, layout_handle),
+        num_barriers,
+        layout,
+    )
 
 
 @tl.builtin

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -112,7 +112,7 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
     else:
         tensor_handle = _semantic.builder.create_tmem_alloc(full_shape, elem_type, layout_handle, alias_handle)
 
-    return tlx.buffered_tensor(tensor_handle, dtype, unwrapped_shape, unwrapped_num, storage, layout, _semantic)
+    return tlx.buffered_tensor(tensor_handle, dtype, unwrapped_shape, unwrapped_num, storage, layout)
 
 
 # overload declarations just to make linter happy
@@ -178,12 +178,12 @@ def local_view(
             0,
             local_allocated_buffers.type.storage,
             local_allocated_buffers.type.layout,
-            local_allocated_buffers.type.semantic,
         )
 
 
-def _buffered_tensor_getitem(self, buffer_idx):
-    return local_view(self, buffer_idx, _semantic=self.type.semantic)
+@tl.builtin
+def _buffered_tensor_getitem(self, buffer_idx, _semantic=None):
+    return local_view(self, buffer_idx, _semantic=_semantic)
 
 
 @tl.builtin
@@ -270,7 +270,6 @@ def local_slice(
             0,
             buffer.type.storage,
             buffer.type.layout,
-            buffer.type.semantic,
         )
 
 


### PR DESCRIPTION
Buffer indexing operations (e.g., `buffers[0]`, `barriers[idx]`) were failing when used inside called functions due to stale semantic context. When the compiler compiles a callee function, the IR builder's semantic context updates to reflect the new inlined location. However, `buffered_tensor` types were still using the semantic object stored during buffer allocation, which pointed to the original (now-stale) program location.

The `__getitem__` implementation for buffered tensors called `local_view()` which accessed `local_allocated_buffers.type.semantic` - a semantic context captured at buffer allocation time. This semantic became invalid because it referenced the old, pre-inlining program structure.

1. **Modified `_buffered_tensor_getitem`** to use the `@tl.builtin` decorator, which automatically injects a fresh `_semantic` parameter containing the current program location context

2. **Updated `local_view()`** in `mem_ops.py` to use the injected `_semantic` parameter instead of the stale `local_allocated_buffers.type.semantic`

3. **Fixed `dynamic_launch.py`** to properly import `local_view` from `mem_ops` module and explicitly pass `_semantic` to all buffer/barrier indexing operations

4. **Added a test in `test_tlx.py` with `test_buffer_indexing_in_function_call()` which verifies that buffer indexing (`buffers[idx]`) works correctly when performed inside helper functions
