### PR TITLE
Reland #705 [TLX] Skip InvalidBarrierOp insertion in Fixup on AMD

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -119,6 +119,11 @@ public:
     return success();
   }
 
+  bool isAMD() const {
+    // target is set up as f"hip:{options.arch}"
+    return (target.getValue().find("hip:") == 0);
+  }
+
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
@@ -134,7 +139,8 @@ public:
       return signalPassFailure();
     }
 
-    if (failed(insertInvalBarrier(mod))) {
+    // InvalBarrierOp insertion is not needed for AMD
+    if (!isAMD() && failed(insertInvalBarrier(mod))) {
       return signalPassFailure();
     }
 


### PR DESCRIPTION
This patch fixes the broken TLX unit test on AMD

third-party/triton/beta/triton:py_tlx_amd_test - test_tlx.py::test_wait_arrive_non_ws[1024]
