### PR TITLE
Fix memory leak when autotuner fails a config

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -449,7 +449,7 @@ class AsmDict(dict):
 
 
 def _raise_error(err_ref, *args, **kwargs):
-    exc = err_ref()          # follow the weak ref
+    exc = err_ref()  # follow the weak ref
     if exc is None:
         raise RuntimeError("Original exception has been garbage-collected")
     raise exc
@@ -497,6 +497,7 @@ class CompiledKernel:
         def raise_(err):
             self._run = functools.partial(_raise_error, weakref.ref(err))
             raise err
+
         # Facebook end
 
         device = driver.active.get_current_device()


### PR DESCRIPTION
Summary:
fix by adding weak ref to exception

Differential Revision: D88821969

Test Plan:
Before: https://www.internalfb.com/pytorch_memory_visualizer/ai_efficiency/tree/gpu_snapshot/tlx_fused_projection_rotary_debug_1765353344.snapshot.pickle

<img width="3462" height="1558" alt="image" src="https://github.com/user-attachments/assets/28eb084e-2722-42fb-931e-db924dd003c8" />


After:
https://www.internalfb.com/pytorch_memory_visualizer/ai_efficiency/tree/gpu_snapshot/tlx_fused_projection_rotary_debug_1765353275.snapshot.pickle

<img width="1729" height="794" alt="image" src="https://github.com/user-attachments/assets/628ff963-b985-4164-ab96-7b96cdb03d78" />



