### PR TITLE
[triton][PR] [triton-beta] Add a pass to use CircularStoreOp to store barrier related information

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -124,6 +124,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::proton::gpu::registerAllocateProtonSharedMemoryPass();
   mlir::triton::proton::gpu::registerAllocateProtonGlobalScratchBufferPass();
   mlir::triton::proton::gpu::registerScheduleBufferStorePass();
+  mlir::triton::proton::gpu::registerMppStoreBarrierInfoPass();
   mlir::triton::proton::gpu::registerAddSchedBarriersPass();
 
   // TLX passes

--- a/test/Proton/store_barrier_info.mlir
+++ b/test/Proton/store_barrier_info.mlir
@@ -1,0 +1,605 @@
+// RUN: triton-opt --split-input-file -proton-mpp-store-barrier-info %s | FileCheck %s
+
+// Test 1: Basic barrier record resolution - simple wait_barrier
+// The ReadCounterOp should be replaced with allocOpId (start) and index (end)
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_simple_wait_barrier_resolution
+  tt.func @test_simple_wait_barrier_resolution() {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+
+    %barriers = ttg.local_alloc {mpp.op.id = 100 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %barrier = ttg.memdesc_index %barriers[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: %[[ALLOC_ID:.*]] = arith.constant 100 : i32
+    // CHECK-NEXT: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID]] {scopeId = 0 : i32}
+    %start_counter = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_counter {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    ttng.wait_barrier %barrier, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    // CHECK: proton_gpu.circular_store end %{{.*}}, %c0_i32{{.*}} {scopeId = 0 : i32}
+    %end_counter = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_counter {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 2: Dynamic index from loop
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_dynamic_index_from_loop
+  tt.func @test_dynamic_index_from_loop() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %true = arith.constant true
+
+    %barriers = ttg.local_alloc {mpp.op.id = 200 : i64} : () -> !ttg.memdesc<4xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} : i32
+    scf.for %i = %c0_i32 to %c4_i32 step %c1_i32 : i32 {
+      %barrier = ttg.memdesc_index %barriers[%i] : !ttg.memdesc<4xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      // CHECK: %[[ALLOC_ID:.*]] = arith.constant 200 : i32
+      // CHECK-NEXT: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID]] {scopeId = 1 : i32}
+      %start_counter = proton_gpu.read_counter : i32
+      proton_gpu.circular_store start %segment, %start_counter {scopeId = 1 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+        ttng.wait_barrier %barrier, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+        // CHECK: proton_gpu.circular_store end %{{.*}}, %[[IV]] {scopeId = 1 : i32}
+        %end_counter = proton_gpu.read_counter : i32
+        proton_gpu.circular_store end %segment, %end_counter {scopeId = 1 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+      }
+
+      gpu.barrier
+      proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+      tt.return
+    }
+}
+
+// -----
+
+// Test 3: TMA copy operation with barrier
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32, ttg.target = "cuda:90"} {
+  // CHECK-LABEL: @test_tma_copy_barrier_resolution
+  tt.func @test_tma_copy_barrier_resolution(%a_desc: !tt.tensordesc<tensor<64x32xbf16, #shared>>) {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+
+    %data_smem = ttg.local_alloc : () -> !ttg.memdesc<64x32xbf16, #shared, #smem, mutable>
+    %barriers = ttg.local_alloc {mpp.op.id = 300 : i64} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    ttng.init_barrier %barriers, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.barrier_expect %barriers, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared1, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared1, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: %[[ALLOC_ID:.*]] = arith.constant 300 : i32
+    // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID]]
+    %start_counter = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_counter {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    ttng.async_tma_copy_global_to_local %a_desc[%c0_i32, %c0_i32] %data_smem, %barriers, %true : !tt.tensordesc<tensor<64x32xbf16, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x32xbf16, #shared, #smem, mutable>
+
+    // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}}
+    %end_counter = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_counter {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 4: Multiple barriers with different allocOpIds
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_multiple_barriers_different_allocs
+  tt.func @test_multiple_barriers_different_allocs() {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+
+    %barriers_a = ttg.local_alloc {mpp.op.id = 400 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %barriers_b = ttg.local_alloc {mpp.op.id = 401 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %barrier_a = ttg.memdesc_index %barriers_a[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %barrier_b = ttg.memdesc_index %barriers_b[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    ttng.init_barrier %barrier_a, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier_b, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: %[[ALLOC_ID_A:.*]] = arith.constant 400 : i32
+    // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID_A]] {scopeId = 0 : i32}
+    %start_counter_a = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_counter_a {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    ttng.wait_barrier %barrier_a, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %end_counter_a = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_counter_a {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    // CHECK: %[[ALLOC_ID_B:.*]] = arith.constant 401 : i32
+    // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID_B]] {scopeId = 1 : i32}
+    %start_counter_b = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_counter_b {scopeId = 1 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    ttng.wait_barrier %barrier_b, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %end_counter_b = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_counter_b {scopeId = 1 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 5: Index selected via scf.if
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_index_via_scf_if
+  tt.func @test_index_via_scf_if(%cond: i1) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %true = arith.constant true
+
+    %barriers = ttg.local_alloc {mpp.op.id = 800 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+
+    // CHECK: %[[SELECTED_INDEX:.*]] = scf.if %{{.*}} -> (i32)
+    %selected_index = scf.if %cond -> i32 {
+      scf.yield %c0_i32 : i32
+    } else {
+      scf.yield %c1_i32 : i32
+    }
+
+    %barrier = ttg.memdesc_index %barriers[%selected_index] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: %[[ALLOC_ID:.*]] = arith.constant 800 : i32
+    // CHECK-NEXT: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID]] {scopeId = 0 : i32}
+    %start_counter = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_counter {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    ttng.wait_barrier %barrier, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    // CHECK: proton_gpu.circular_store end %{{.*}}, %[[SELECTED_INDEX]] {scopeId = 0 : i32}
+    %end_counter = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_counter {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 6: Loop variable with memdesc_index - barrier yielded through loop
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_loop_memdesc_index_barrier
+  tt.func @test_loop_memdesc_index_barrier() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %true = arith.constant true
+
+    %barriers = ttg.local_alloc {mpp.op.id = 900 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+
+    %init_barrier = ttg.memdesc_index %barriers[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %barrier_0 = ttg.memdesc_index %barriers[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %barrier_1 = ttg.memdesc_index %barriers[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier_0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier_1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: scf.for %[[IV:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[BARRIER_ARG:.*]] = %{{.*}}, %{{.*}} = %{{.*}}) -> (!ttg.memdesc<1xi64,{{.*}}, i32)
+    %result = scf.for %i = %c0_i32 to %c4_i32 step %c1_i32
+        iter_args(%curr_barrier = %init_barrier)
+        -> (!ttg.memdesc<1xi64, #shared, #smem, mutable>) : i32 {
+
+      // CHECK: %[[ALLOC_ID_IN_LOOP:.*]] = arith.constant 900 : i32
+      // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID_IN_LOOP]]
+      %start_counter = proton_gpu.read_counter : i32
+      proton_gpu.circular_store start %segment, %start_counter {scopeId = 6 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+      ttng.wait_barrier %curr_barrier, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}}
+      %end_counter = proton_gpu.read_counter : i32
+      proton_gpu.circular_store end %segment, %end_counter {scopeId = 6 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+      // CHECK: %[[NEXT_IDX:.*]] = arith.remsi %{{.*}}, %{{.*}} : i32
+      %next_idx = arith.remsi %i, %c2_i32 : i32
+      // CHECK: ttg.memdesc_index %{{.*}}[%[[NEXT_IDX]]]
+      %next_barrier = ttg.memdesc_index %barriers[%next_idx] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      // CHECK: scf.yield %{{.*}}, %[[NEXT_IDX]] : !ttg.memdesc<1xi64,{{.*}}, i32
+      scf.yield %next_barrier : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    }
+
+    // CHECK: %[[ALLOC_ID_AFTER:.*]] = arith.constant 900 : i32
+    // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID_AFTER]]
+    %start_after = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_after {scopeId = 7 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    ttng.wait_barrier %result, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}}
+    %end_after = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_after {scopeId = 7 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 7: Nested loops with different barrier arrays
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_outer_loop_barrier_in_inner_loop
+  tt.func @test_outer_loop_barrier_in_inner_loop() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %true = arith.constant true
+
+    %outer_barriers = ttg.local_alloc {mpp.op.id = 1800 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %inner_barriers = ttg.local_alloc {mpp.op.id = 1801 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+
+    %outer_bar_0 = ttg.memdesc_index %outer_barriers[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %inner_bar_0 = ttg.memdesc_index %inner_barriers[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    ttng.init_barrier %outer_bar_0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %inner_bar_0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: scf.for
+    %outer_result = scf.for %i = %c0_i32 to %c2_i32 step %c1_i32
+        iter_args(%outer_barrier = %outer_bar_0)
+        -> (!ttg.memdesc<1xi64, #shared, #smem, mutable>) : i32 {
+
+      // CHECK: %[[OUTER_ALLOC_ID:.*]] = arith.constant 1800 : i32
+      // CHECK: proton_gpu.circular_store start %{{.*}}, %[[OUTER_ALLOC_ID]] {scopeId = 23 : i32}
+      %outer_start = proton_gpu.read_counter : i32
+      proton_gpu.circular_store start %segment, %outer_start {scopeId = 23 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+      ttng.wait_barrier %outer_barrier, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}} {scopeId = 23 : i32}
+      %outer_end = proton_gpu.read_counter : i32
+      proton_gpu.circular_store end %segment, %outer_end {scopeId = 23 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+      // CHECK: scf.for
+      %inner_result = scf.for %j = %c0_i32 to %c2_i32 step %c1_i32
+          iter_args(%inner_barrier = %inner_bar_0)
+          -> (!ttg.memdesc<1xi64, #shared, #smem, mutable>) : i32 {
+
+        // CHECK: %[[INNER_ALLOC_ID:.*]] = arith.constant 1801 : i32
+        // CHECK: proton_gpu.circular_store start %{{.*}}, %[[INNER_ALLOC_ID]] {scopeId = 24 : i32}
+        %inner_start = proton_gpu.read_counter : i32
+        proton_gpu.circular_store start %segment, %inner_start {scopeId = 24 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+        ttng.wait_barrier %inner_barrier, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+        // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}} {scopeId = 24 : i32}
+        %inner_end = proton_gpu.read_counter : i32
+        proton_gpu.circular_store end %segment, %inner_end {scopeId = 24 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+
+        %next_j_phase = arith.xori %j, %c1_i32 : i32
+        %next_inner_barrier = ttg.memdesc_index %inner_barriers[%next_j_phase] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+        scf.yield %next_inner_barrier : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      }
+
+      %next_i_phase = arith.xori %i, %c1_i32 : i32
+      %next_outer_barrier = ttg.memdesc_index %outer_barriers[%next_i_phase] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      scf.yield %next_outer_barrier : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    }
+
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 8: CF dialect control flow pattern (lowered from scf.if)
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_cf_branch_control_flow
+  tt.func @test_cf_branch_control_flow() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %true = arith.constant true
+    %cond = arith.constant true
+
+    %barriers = ttg.local_alloc {mpp.op.id = 61 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+
+    %barrier_0 = ttg.memdesc_index %barriers[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %barrier_1 = ttg.memdesc_index %barriers[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier_0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier_1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    cf.br ^bb2(%barrier_1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable>, i32)
+
+  ^bb2(%block_barrier: !ttg.memdesc<1xi64, #shared, #smem, mutable>, %phase: i32):
+    cf.cond_br %cond, ^bb3, ^bb_exit
+
+  ^bb3:
+    cf.cond_br %cond, ^bb4, ^bb5
+
+  ^bb4:
+    %start = proton_gpu.read_counter : i32
+    // CHECK: %[[ALLOC_ID:.*]] = arith.constant 61 : i32
+    // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID]] {scopeId = 23 : i32}
+    proton_gpu.circular_store start %segment, %start {scopeId = 23 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+    cf.br ^bb5
+
+  ^bb5:
+    ttng.wait_barrier %block_barrier, %phase, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    cf.cond_br %cond, ^bb6, ^bb7
+
+  ^bb6:
+    %end = proton_gpu.read_counter : i32
+    // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}} {scopeId = 23 : i32}
+    proton_gpu.circular_store end %segment, %end {scopeId = 23 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+    cf.br ^bb7
+
+  ^bb7:
+    cf.br ^bb_exit
+
+  ^bb_exit:
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 9: Multi-barrier tc_gen5_mma with nested circular_store patterns
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @test_tc_gen5_mma_multi_barrier_nested_stores
+  tt.func @test_tc_gen5_mma_multi_barrier_nested_stores() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    %cond = arith.constant true
+
+    %barrier_array_59 = ttg.local_alloc {mpp.op.id = 59 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %barrier_array_84 = ttg.local_alloc {mpp.op.id = 84 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+
+    %barrier_59_0 = ttg.memdesc_index %barrier_array_59[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %barrier_84_0 = ttg.memdesc_index %barrier_array_84[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier_59_0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %barrier_84_0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %a_smem = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+    %b_smem = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared3, #smem, mutable>
+    %acc_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    cf.br ^bb20
+
+  ^bb20:
+    // CHECK: %[[ALLOC_59:.*]] = arith.constant 59 : i32
+    // CHECK-NEXT: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_59]] {scopeId = 21 : i32}
+    %start_21 = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_21 {scopeId = 21 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+    cf.br ^bb21
+
+  ^bb21:
+    cf.cond_br %cond, ^bb22, ^bb23
+
+  ^bb22:
+    // CHECK: %[[ALLOC_84:.*]] = arith.constant 84 : i32
+    // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_84]] {scopeId = 22 : i32}
+    %start_22 = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %segment, %start_22 {scopeId = 22 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+    cf.br ^bb23
+
+  ^bb23:
+    ttng.tc_gen5_mma %a_smem, %b_smem, %acc_tmem, %false, %true, %barrier_59_0[%true], %barrier_84_0[%true] {is_async, mpp.op.id = 302 : i64} : !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    cf.cond_br %cond, ^bb24, ^bb25
+
+  ^bb24:
+    // CHECK: proton_gpu.circular_store end %{{.*}}, %c0_i32{{.*}} {scopeId = 22 : i32}
+    %end_22 = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_22 {scopeId = 22 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+    cf.br ^bb25
+
+  ^bb25:
+    cf.cond_br %cond, ^bb26, ^bb27
+
+  ^bb26:
+    // CHECK: proton_gpu.circular_store end %{{.*}}, %c0_i32{{.*}} {scopeId = 21 : i32}
+    %end_21 = proton_gpu.read_counter : i32
+    proton_gpu.circular_store end %segment, %end_21 {scopeId = 21 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+    cf.br ^bb27
+
+  ^bb27:
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 10: HSTU pattern - barrier from loop arg with SEPARATE phase counter
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @test_barrier_loop_arg_separate_phase_counter
+  tt.func @test_barrier_loop_arg_separate_phase_counter() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %true = arith.constant true
+    %cond = arith.constant true
+
+    %acc_36 = ttg.local_alloc {mpp.op.id = 61 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %acc_44 = ttg.local_alloc {mpp.op.id = 74 : i64} : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+
+    %acc_37 = ttg.memdesc_index %acc_36[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %acc_38 = ttg.memdesc_index %acc_36[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %acc_37, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %acc_38, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %acc_45 = ttg.memdesc_index %acc_44[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %acc_46 = ttg.memdesc_index %acc_44[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %acc_45, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %acc_46, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %scratch = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+    proton_gpu.initialize %scratch : !tt.ptr<i32>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+    %segment = proton_gpu.segment_alloc %buf : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+
+    // CHECK: scf.for
+    %result:4 = scf.for %iv = %c0_i32 to %c4_i32 step %c1_i32
+        iter_args(%acc_98 = %acc_38, %arg33 = %c0_i32,
+                  %acc_134_barrier = %acc_45, %acc_133 = %c0_i32)
+        -> (!ttg.memdesc<1xi64, #shared, #smem, mutable>, i32,
+            !ttg.memdesc<1xi64, #shared, #smem, mutable>, i32) : i32 {
+
+      scf.if %cond {
+        %start_142 = proton_gpu.read_counter : i32
+        // CHECK: %[[ALLOC_ID_142:.*]] = arith.constant 61 : i32
+        // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID_142]] {scopeId = 33 : i32}
+        proton_gpu.circular_store start %segment, %start_142 {scopeId = 33 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+      }
+
+      ttng.wait_barrier %acc_98, %arg33, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      scf.if %cond {
+        %end_142 = proton_gpu.read_counter : i32
+        // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}} {scopeId = 33 : i32}
+        proton_gpu.circular_store end %segment, %end_142 {scopeId = 33 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+      }
+
+      %acc_132 = arith.xori %acc_133, %c1_i32 : i32
+      %acc_134 = ttg.memdesc_index %acc_44[%acc_132] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      scf.if %cond {
+        %start_165 = proton_gpu.read_counter : i32
+        // CHECK: %[[ALLOC_ID_165:.*]] = arith.constant 74 : i32
+        // CHECK: proton_gpu.circular_store start %{{.*}}, %[[ALLOC_ID_165]] {scopeId = 34 : i32}
+        proton_gpu.circular_store start %segment, %start_165 {scopeId = 34 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+      }
+
+      ttng.wait_barrier %acc_134, %acc_133, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      scf.if %cond {
+        %end_165 = proton_gpu.read_counter : i32
+        // CHECK: proton_gpu.circular_store end %{{.*}}, %{{.*}} {scopeId = 34 : i32}
+        proton_gpu.circular_store end %segment, %end_165 {scopeId = 34 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+      }
+
+      %next_phase = arith.xori %arg33, %c1_i32 : i32
+      %next_acc_98 = ttg.memdesc_index %acc_36[%next_phase] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+      scf.yield %next_acc_98, %next_phase, %acc_134, %acc_132 :
+        !ttg.memdesc<1xi64, #shared, #smem, mutable>, i32,
+        !ttg.memdesc<1xi64, #shared, #smem, mutable>, i32
+    }
+
+    gpu.barrier
+    proton_gpu.finalize %segment, %scratch : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+    tt.return
+  }
+}

--- a/third_party/proton/Dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
+++ b/third_party/proton/Dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
@@ -12,4 +12,22 @@ def ScheduleBufferStorePass: Pass<"proton-schedule-buffer-store", "mlir::ModuleO
   let dependentDialects = ["gpu::ProtonGPUDialect"];
 }
 
+def MppStoreBarrierInfoPass: Pass<"proton-mpp-store-barrier-info", "mlir::ModuleOp"> {
+  let summary = "Replace ReadCounterOp with barrier allocOpId and index for barrier record ops";
+
+  let description = [{
+    This pass finds RecordOp pairs that track barrier operations and replaces
+    the generated ReadCounterOp with barrier allocation IDs (for start records)
+    and barrier indices (for end records).
+
+    The pass is gated by the PROTON_ENABLE_MPP_STORE_BARRIER_INFO_PASS environment variable.
+    When enabled, it tracks barrier info (allocOpId, index) through value propagation
+    and replaces the counter values in CircularStoreOp with the computed values.
+  }];
+
+  let dependentDialects = ["gpu::ProtonGPUDialect",
+                           "mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
+}
+
 #endif  // PROTONGPU_TRANSFORMS_PASSES

--- a/third_party/proton/Dialect/lib/Dialect/ProtonGPU/Transforms/CMakeLists.txt
+++ b/third_party/proton/Dialect/lib/Dialect/ProtonGPU/Transforms/CMakeLists.txt
@@ -1,8 +1,13 @@
 add_triton_library(ProtonGPUTransforms
   ProtonGPUTransformsPass.cpp
+  MppStoreBarrierInfoPass.cpp
 
   DEPENDS
   ProtonGPUTransformsIncGen
   LINK_LIBS PUBLIC
   ProtonGPUIR
+  TritonGPUIR
+  TritonNvidiaGPUIR
+  MLIRSCFDialect
+  MLIRArithDialect
 )

--- a/third_party/proton/Dialect/lib/Dialect/ProtonGPU/Transforms/MppStoreBarrierInfoPass.cpp
+++ b/third_party/proton/Dialect/lib/Dialect/ProtonGPU/Transforms/MppStoreBarrierInfoPass.cpp
@@ -1,0 +1,828 @@
+#include "Dialect/ProtonGPU/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+
+#include "Dialect/ProtonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#define DEBUG_TYPE "mpp-store-barrier-info"
+
+namespace mlir::triton::proton::gpu {
+
+#define GEN_PASS_DEF_MPPSTOREBARRIERINFOPASS
+#include "Dialect/ProtonGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+struct BarrierInfo {
+  int64_t allocOpId = -1;
+  bool hasIndex = false;
+  int64_t constantIndex = -1;
+  Value dynamicIndex = nullptr;
+  int dynamicIndexYieldPosition = -1;
+  bool hasAdjacentIndex = false;
+
+  BarrierInfo() = default;
+  explicit BarrierInfo(int64_t id) : allocOpId(id) {}
+
+  BarrierInfo withConstantIndex(int64_t idx) const {
+    BarrierInfo n = *this;
+    n.hasIndex = true;
+    n.constantIndex = idx;
+    n.dynamicIndex = nullptr;
+    return n;
+  }
+
+  BarrierInfo withDynamicIndex(Value idx, int yieldPos = -1) const {
+    BarrierInfo n = *this;
+    n.hasIndex = true;
+    n.constantIndex = -1;
+    n.dynamicIndex = idx;
+    n.dynamicIndexYieldPosition = yieldPos;
+    return n;
+  }
+
+  BarrierInfo withAdjacentIndex() const {
+    BarrierInfo n = *this;
+    n.hasAdjacentIndex = true;
+    return n;
+  }
+};
+
+int64_t getMppOpId(Operation *op) {
+  if (auto attr = op->getAttrOfType<IntegerAttr>("mpp.op.id"))
+    return attr.getInt();
+  return -1;
+}
+
+std::optional<int64_t> getConstantIntValue(Value v) {
+  if (auto c = v.getDefiningOp<arith::ConstantIntOp>())
+    return c.value();
+  if (auto c = v.getDefiningOp<arith::ConstantOp>())
+    if (auto intAttr = dyn_cast<IntegerAttr>(c.getValue()))
+      return intAttr.getInt();
+  return std::nullopt;
+}
+
+bool isBarrierType(Type type) {
+  auto memdescType = dyn_cast<triton::gpu::MemDescType>(type);
+  return memdescType && memdescType.getElementType().isInteger(64);
+}
+
+Value getBarrierOperand(Operation *op, int idx) {
+  if (auto o = dyn_cast<triton::nvidia_gpu::WaitBarrierOp>(op))
+    return o.getAlloc();
+  if (auto o = dyn_cast<triton::nvidia_gpu::ArriveBarrierOp>(op))
+    return o.getAlloc();
+  if (auto o = dyn_cast<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(op))
+    return o.getBarrier();
+  if (auto o = dyn_cast<triton::nvidia_gpu::TCGen5MMAOp>(op)) {
+    auto b = o.getBarriers();
+    return (idx >= 0 && idx < (int)b.size()) ? b[idx]
+           : b.empty()                       ? nullptr
+                                             : b[0];
+  }
+  if (auto o = dyn_cast<triton::nvidia_gpu::TCGen5CommitOp>(op))
+    return o.getBarrier();
+  return nullptr;
+}
+
+} // namespace
+
+struct MppStoreBarrierInfoPass
+    : public impl::MppStoreBarrierInfoPassBase<MppStoreBarrierInfoPass> {
+
+  using impl::MppStoreBarrierInfoPassBase<
+      MppStoreBarrierInfoPass>::MppStoreBarrierInfoPassBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    OpBuilder builder(module.getContext());
+
+    transformLoopsToTrackIndices(module, builder);
+    transformCfBlocksToTrackIndices(module, builder);
+    propagateBarrierInfo(module);
+
+    for (auto func : module.getOps<triton::FuncOp>())
+      if (failed(processFunction(func, builder)))
+        return signalPassFailure();
+  }
+
+private:
+  DenseMap<Value, BarrierInfo> valueToBarrierInfo;
+  DenseSet<Value> visitedValues;
+
+  //===--------------------------------------------------------------------===//
+  // Loop Transformation - Track indices alongside barrier iter_args
+  //===--------------------------------------------------------------------===//
+
+  void transformLoopsToTrackIndices(ModuleOp module, OpBuilder &builder) {
+    SmallVector<scf::ForOp> forOps;
+    module.walk([&](scf::ForOp forOp) { forOps.push_back(forOp); });
+    for (auto forOp : forOps)
+      transformSingleLoop(forOp, builder);
+  }
+
+  void transformSingleLoop(scf::ForOp forOp, OpBuilder &builder) {
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+
+    // Find barrier iter_args that need index tracking
+    SmallVector<std::tuple<unsigned, Value, Value>> indicesToInsert;
+
+    for (unsigned i = 0; i < yieldOp.getNumOperands(); ++i) {
+      Value yieldedValue = yieldOp.getOperand(i);
+      auto yieldIndexOp =
+          yieldedValue.getDefiningOp<triton::gpu::MemDescIndexOp>();
+      if (!isBarrierType(yieldedValue.getType()) || !yieldIndexOp)
+        continue;
+
+      Value yieldIndexValue = yieldIndexOp.getIndex();
+      if (i + 1 < yieldOp.getNumOperands() &&
+          yieldOp.getOperand(i + 1) == yieldIndexValue)
+        continue;
+
+      auto initIndexOp =
+          forOp.getInitArgs()[i].getDefiningOp<triton::gpu::MemDescIndexOp>();
+      unsigned adjustedPos =
+          i + 1 + llvm::count_if(indicesToInsert, [i](auto &t) {
+            return std::get<0>(t) <= i;
+          });
+      indicesToInsert.push_back(
+          {adjustedPos, yieldIndexValue,
+           initIndexOp ? initIndexOp.getIndex() : nullptr});
+    }
+
+    if (indicesToInsert.empty())
+      return;
+
+    Location loc = forOp.getLoc();
+    SmallVector<Value> newInitArgs(forOp.getInitArgs().begin(),
+                                   forOp.getInitArgs().end());
+    SmallVector<Value> newYieldOperands(yieldOp.getOperands().begin(),
+                                        yieldOp.getOperands().end());
+
+    // Insert in reverse order
+    for (auto it = indicesToInsert.rbegin(); it != indicesToInsert.rend();
+         ++it) {
+      auto [pos, yieldIndexValue, initIndexValue] = *it;
+      if (pos <= newYieldOperands.size())
+        newYieldOperands.insert(newYieldOperands.begin() + pos,
+                                yieldIndexValue);
+
+      builder.setInsertionPoint(forOp);
+      Value initValue =
+          initIndexValue
+              ? (initIndexValue.getType().isInteger(32)
+                     ? initIndexValue
+                     : builder.create<arith::IndexCastOp>(
+                           loc, builder.getI32Type(), initIndexValue))
+              : builder.create<arith::ConstantOp>(loc, builder.getI32Type(),
+                                                  builder.getI32IntegerAttr(0));
+      if (pos <= newInitArgs.size())
+        newInitArgs.insert(newInitArgs.begin() + pos, initValue);
+    }
+
+    // Create new for loop
+    builder.setInsertionPoint(forOp);
+    auto newForOp = builder.create<scf::ForOp>(loc, forOp.getLowerBound(),
+                                               forOp.getUpperBound(),
+                                               forOp.getStep(), newInitArgs);
+
+    Block *newBlock = newForOp.getBody();
+    Block *oldBlock = forOp.getBody();
+    IRMapping mapping;
+    mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
+
+    SmallVector<unsigned> insertedPositions;
+    for (auto &tup : indicesToInsert)
+      insertedPositions.push_back(std::get<0>(tup));
+    llvm::sort(insertedPositions);
+
+    unsigned newIdx = 0, numInserted = 0;
+    for (unsigned oldIdx = 0; oldIdx < forOp.getRegionIterArgs().size();
+         ++oldIdx) {
+      while (numInserted < insertedPositions.size() &&
+             insertedPositions[numInserted] == newIdx) {
+        newIdx++;
+        numInserted++;
+      }
+      mapping.map(forOp.getRegionIterArgs()[oldIdx],
+                  newForOp.getRegionIterArgs()[newIdx]);
+      newIdx++;
+    }
+
+    builder.setInsertionPointToStart(newBlock);
+    for (auto &op : oldBlock->without_terminator())
+      builder.clone(op, mapping);
+
+    SmallVector<Value> mappedYieldOperands;
+    for (Value v : newYieldOperands)
+      mappedYieldOperands.push_back(mapping.lookupOrDefault(v));
+
+    builder.create<scf::YieldOp>(loc, mappedYieldOperands);
+
+    numInserted = 0;
+    newIdx = 0;
+    for (unsigned oldIdx = 0; oldIdx < forOp.getNumResults(); ++oldIdx) {
+      while (numInserted < insertedPositions.size() &&
+             insertedPositions[numInserted] == newIdx) {
+        newIdx++;
+        numInserted++;
+      }
+      forOp.getResult(oldIdx).replaceAllUsesWith(newForOp.getResult(newIdx));
+      newIdx++;
+    }
+
+    forOp.erase();
+  }
+
+  //===--------------------------------------------------------------------===//
+  // CF Block Transformation - Track indices alongside barrier block args
+  //===--------------------------------------------------------------------===//
+
+  void transformCfBlocksToTrackIndices(ModuleOp module, OpBuilder &builder) {
+    for (auto func : module.getOps<triton::FuncOp>())
+      transformCfBlocksInFunction(func, builder);
+  }
+
+  void transformCfBlocksInFunction(FuncOp func, OpBuilder &builder) {
+    DenseMap<std::pair<Block *, unsigned>, bool> barrierArgNeedsIndex;
+
+    // Identify barrier arguments that need index tracking
+    for (Block &block : func.getBody()) {
+      if (block.isEntryBlock())
+        continue;
+
+      for (Block *pred : block.getPredecessors()) {
+        Operation *terminator = pred->getTerminator();
+
+        auto checkBranchOperands = [&](OperandRange operands, Block *dest) {
+          if (dest != &block)
+            return;
+
+          for (unsigned i = 0; i < operands.size(); ++i) {
+            Value operand = operands[i];
+            if (!isBarrierType(operand.getType()))
+              continue;
+
+            auto indexOp = operand.getDefiningOp<triton::gpu::MemDescIndexOp>();
+            if (!indexOp)
+              continue;
+
+            Value indexValue = indexOp.getIndex();
+            auto key = std::make_pair(&block, i);
+
+            bool hasIndexNext = false;
+            if (i + 1 < operands.size()) {
+              Value nextOperand = operands[i + 1];
+              if (nextOperand == indexValue)
+                hasIndexNext = true;
+              else if (auto castOp =
+                           nextOperand.getDefiningOp<arith::IndexCastOp>())
+                if (castOp.getIn() == indexValue)
+                  hasIndexNext = true;
+            }
+
+            if (!hasIndexNext)
+              barrierArgNeedsIndex[key] = true;
+          }
+        };
+
+        if (auto branchOp = dyn_cast<cf::BranchOp>(terminator)) {
+          checkBranchOperands(branchOp.getDestOperands(), branchOp.getDest());
+        } else if (auto condBranchOp = dyn_cast<cf::CondBranchOp>(terminator)) {
+          checkBranchOperands(condBranchOp.getTrueDestOperands(),
+                              condBranchOp.getTrueDest());
+          checkBranchOperands(condBranchOp.getFalseDestOperands(),
+                              condBranchOp.getFalseDest());
+        }
+      }
+    }
+
+    if (barrierArgNeedsIndex.empty())
+      return;
+
+    DenseMap<Block *, SmallVector<unsigned>> blockToBarrierArgs;
+    for (auto &[key, needsIndex] : barrierArgNeedsIndex) {
+      if (needsIndex)
+        blockToBarrierArgs[key.first].push_back(key.second);
+    }
+
+    for (auto &[block, barrierArgIndices] : blockToBarrierArgs) {
+      llvm::sort(barrierArgIndices, std::greater<unsigned>());
+
+      for (unsigned barrierArgIdx : barrierArgIndices) {
+        Type indexType = builder.getI32Type();
+        unsigned insertPos = barrierArgIdx + 1;
+        block->insertArgument(insertPos, indexType, block->front().getLoc());
+
+        for (Block *pred : block->getPredecessors()) {
+          Operation *terminator = pred->getTerminator();
+
+          auto getIndexForBarrier = [&](Value barrierOperand) -> Value {
+            if (auto indexOp =
+                    barrierOperand
+                        .getDefiningOp<triton::gpu::MemDescIndexOp>()) {
+              Value idx = indexOp.getIndex();
+              builder.setInsertionPoint(terminator);
+              if (idx.getType().isInteger(32))
+                return idx;
+              return builder.create<arith::IndexCastOp>(
+                  terminator->getLoc(), builder.getI32Type(), idx);
+            }
+            builder.setInsertionPoint(terminator);
+            return builder.create<arith::ConstantOp>(
+                terminator->getLoc(), builder.getI32Type(),
+                builder.getI32IntegerAttr(0));
+          };
+
+          if (auto branchOp = dyn_cast<cf::BranchOp>(terminator)) {
+            if (branchOp.getDest() == block) {
+              Value barrierOperand = branchOp.getDestOperands()[barrierArgIdx];
+              Value newIndexValue = getIndexForBarrier(barrierOperand);
+
+              SmallVector<Value> newOperands(branchOp.getDestOperands().begin(),
+                                             branchOp.getDestOperands().end());
+              newOperands.insert(newOperands.begin() + insertPos,
+                                 newIndexValue);
+
+              builder.setInsertionPoint(branchOp);
+              builder.create<cf::BranchOp>(branchOp.getLoc(), block,
+                                           newOperands);
+              branchOp.erase();
+            }
+          } else if (auto condBranchOp =
+                         dyn_cast<cf::CondBranchOp>(terminator)) {
+            bool updateTrue = (condBranchOp.getTrueDest() == block);
+            bool updateFalse = (condBranchOp.getFalseDest() == block);
+
+            SmallVector<Value> newTrueOperands(
+                condBranchOp.getTrueDestOperands().begin(),
+                condBranchOp.getTrueDestOperands().end());
+            SmallVector<Value> newFalseOperands(
+                condBranchOp.getFalseDestOperands().begin(),
+                condBranchOp.getFalseDestOperands().end());
+
+            if (updateTrue && barrierArgIdx < newTrueOperands.size()) {
+              Value newIndexValue =
+                  getIndexForBarrier(newTrueOperands[barrierArgIdx]);
+              newTrueOperands.insert(newTrueOperands.begin() + insertPos,
+                                     newIndexValue);
+            }
+            if (updateFalse && barrierArgIdx < newFalseOperands.size()) {
+              Value newIndexValue =
+                  getIndexForBarrier(newFalseOperands[barrierArgIdx]);
+              newFalseOperands.insert(newFalseOperands.begin() + insertPos,
+                                      newIndexValue);
+            }
+
+            builder.setInsertionPoint(condBranchOp);
+            builder.create<cf::CondBranchOp>(
+                condBranchOp.getLoc(), condBranchOp.getCondition(),
+                condBranchOp.getTrueDest(), newTrueOperands,
+                condBranchOp.getFalseDest(), newFalseOperands);
+            condBranchOp.erase();
+          }
+        }
+      }
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Barrier Info Propagation
+  //===--------------------------------------------------------------------===//
+
+  void propagateBarrierInfo(ModuleOp module) {
+    valueToBarrierInfo.clear();
+    module.walk([&](triton::gpu::LocalAllocOp allocOp) {
+      if (!isBarrierType(allocOp.getType()))
+        return;
+      BarrierInfo info(getMppOpId(allocOp));
+      valueToBarrierInfo[allocOp.getResult()] = info;
+      visitedValues.clear();
+      propagateToUses(allocOp.getResult(), info);
+    });
+  }
+
+  void propagateToPartitions(triton::gpu::WarpSpecializePartitionsOp op,
+                             unsigned argIdx, const BarrierInfo &info) {
+    for (Region &r : op->getRegions())
+      if (!r.empty() && argIdx < r.front().getNumArguments())
+        propagateToUses(r.front().getArgument(argIdx), info);
+  }
+
+  void propagateToUses(Value value, const BarrierInfo &info) {
+    if (!visitedValues.insert(value).second)
+      return;
+    valueToBarrierInfo[value] = info;
+
+    for (OpOperand &use : value.getUses()) {
+      Operation *user = use.getOwner();
+      unsigned idx = use.getOperandNumber();
+
+      if (auto op = dyn_cast<triton::gpu::MemDescIndexOp>(user)) {
+        Value idxVal = op.getIndex();
+        auto constIdx = getConstantIntValue(idxVal);
+        propagateToUses(op.getResult(), constIdx
+                                            ? info.withConstantIndex(*constIdx)
+                                            : info.withDynamicIndex(idxVal));
+      } else if (auto op = dyn_cast<scf::ForOp>(user)) {
+        handleScfForOp(op, use, info);
+      } else if (auto op = dyn_cast<scf::YieldOp>(user)) {
+        handleScfYieldOp(op, use, info);
+      } else if (auto op = dyn_cast<cf::BranchOp>(user)) {
+        Block *dest = op.getDest();
+        if (idx >= dest->getNumArguments())
+          continue;
+        BarrierInfo newInfo = info;
+        if (idx + 1 < dest->getNumArguments() &&
+            dest->getArgument(idx + 1).getType().isInteger(32))
+          newInfo = info.withDynamicIndex(dest->getArgument(idx + 1))
+                        .withAdjacentIndex();
+        propagateToUses(dest->getArgument(idx), newInfo);
+      } else if (auto op = dyn_cast<cf::CondBranchOp>(user)) {
+        if (idx == 0)
+          continue;
+        unsigned numTrue = op.getTrueDestOperands().size();
+        Block *dest = (idx <= numTrue) ? op.getTrueDest() : op.getFalseDest();
+        unsigned argIdx = (idx <= numTrue) ? idx - 1 : idx - 1 - numTrue;
+        if (argIdx < dest->getNumArguments())
+          propagateToUses(dest->getArgument(argIdx), info);
+      } else if (auto op = dyn_cast<triton::gpu::WarpSpecializeOp>(user)) {
+        if (op->getNumRegions() > 1 && !op->getRegion(1).empty())
+          for (Operation &inner : op->getRegion(1).front())
+            if (auto p =
+                    dyn_cast<triton::gpu::WarpSpecializePartitionsOp>(&inner))
+              propagateToPartitions(p, idx, info);
+      } else if (auto op =
+                     dyn_cast<triton::gpu::WarpSpecializePartitionsOp>(user)) {
+        propagateToPartitions(op, idx, info);
+      }
+    }
+  }
+
+  void handleScfForOp(scf::ForOp forOp, OpOperand &use,
+                      const BarrierInfo &info) {
+    unsigned opIdx = use.getOperandNumber();
+    if (opIdx < 3)
+      return;
+
+    unsigned iterIdx = opIdx - 3;
+    Block &block = forOp.getRegion().front();
+    if (iterIdx + 1 >= block.getNumArguments())
+      return;
+
+    BarrierInfo newInfo = info;
+    if (info.hasIndex && info.constantIndex < 0 && info.dynamicIndex &&
+        iterIdx + 1 < forOp.getInitArgs().size() &&
+        iterIdx + 2 < block.getNumArguments()) {
+      Value nextInit = forOp.getInitArgs()[iterIdx + 1];
+      if (nextInit == info.dynamicIndex ||
+          (nextInit.getDefiningOp<arith::IndexCastOp>() &&
+           nextInit.getDefiningOp<arith::IndexCastOp>().getIn() ==
+               info.dynamicIndex))
+        newInfo = newInfo.withDynamicIndex(block.getArgument(iterIdx + 2));
+    }
+
+    propagateToUses(block.getArgument(iterIdx + 1), newInfo);
+    if (iterIdx < forOp.getNumResults())
+      propagateToUses(forOp.getResult(iterIdx), info);
+  }
+
+  void handleScfYieldOp(scf::YieldOp yieldOp, OpOperand &use,
+                        const BarrierInfo &info) {
+    unsigned opIdx = use.getOperandNumber();
+    Operation *parentOp = yieldOp->getParentOp();
+
+    // Find yield position once
+    std::optional<unsigned> yieldPos;
+    if (info.hasIndex && info.constantIndex < 0 && info.dynamicIndex)
+      for (unsigned i = 0; i < yieldOp.getNumOperands(); ++i)
+        if (yieldOp.getOperand(i) == info.dynamicIndex) {
+          yieldPos = i;
+          break;
+        }
+
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+      BarrierInfo updatedInfo =
+          yieldPos ? info.withDynamicIndex(info.dynamicIndex, *yieldPos)
+                         .withAdjacentIndex()
+                   : info;
+
+      if (opIdx < forOp.getNumResults())
+        propagateToUses(forOp.getResult(opIdx), updatedInfo);
+
+      Block &block = forOp.getRegion().front();
+      if (opIdx + 1 < block.getNumArguments()) {
+        Value newDynIdx = (yieldPos && *yieldPos + 1 < block.getNumArguments())
+                              ? block.getArgument(*yieldPos + 1)
+                              : nullptr;
+        BarrierInfo blockInfo =
+            (yieldPos && newDynIdx)
+                ? info.withDynamicIndex(newDynIdx, *yieldPos)
+                      .withAdjacentIndex()
+                : info;
+        propagateToUses(block.getArgument(opIdx + 1), blockInfo);
+      }
+    } else if (auto ifOp = dyn_cast<scf::IfOp>(parentOp)) {
+      if (opIdx < ifOp.getNumResults())
+        propagateToUses(ifOp.getResult(opIdx), info);
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Barrier Info Retrieval
+  //===--------------------------------------------------------------------===//
+
+  std::optional<BarrierInfo> getBarrierInfo(Value barrier, int depth = 0) {
+    if (depth > 10)
+      return std::nullopt;
+    if (auto it = valueToBarrierInfo.find(barrier);
+        it != valueToBarrierInfo.end())
+      return it->second;
+
+    std::optional<BarrierInfo> result;
+
+    if (auto indexOp = barrier.getDefiningOp<triton::gpu::MemDescIndexOp>()) {
+      if (auto src = getBarrierInfo(indexOp.getSrc(), depth + 1)) {
+        auto idx = indexOp.getIndex();
+        auto constIdx = getConstantIntValue(idx);
+        result = constIdx ? src->withConstantIndex(*constIdx)
+                          : src->withDynamicIndex(idx);
+      }
+    } else if (auto allocOp =
+                   barrier.getDefiningOp<triton::gpu::LocalAllocOp>()) {
+      if (isBarrierType(allocOp.getResult().getType()))
+        result = BarrierInfo(getMppOpId(allocOp));
+    } else if (auto blockArg = dyn_cast<BlockArgument>(barrier)) {
+      result = getBarrierInfoForBlockArg(blockArg, depth);
+    } else if (auto forOp = barrier.getDefiningOp<scf::ForOp>()) {
+      unsigned idx =
+          llvm::find(forOp.getResults(), barrier) - forOp.getResults().begin();
+      auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      if (idx < yieldOp.getNumOperands())
+        result = getBarrierInfo(yieldOp.getOperand(idx), depth + 1);
+    }
+
+    if (result)
+      valueToBarrierInfo[barrier] = *result;
+    return result;
+  }
+
+  std::optional<BarrierInfo> getBarrierInfoForBlockArg(BlockArgument blockArg,
+                                                       int depth) {
+    Block *block = blockArg.getOwner();
+    unsigned argIdx = blockArg.getArgNumber();
+    Operation *parentOp = block->getParentOp();
+
+    // Check CF predecessors
+    for (Block *pred : block->getPredecessors()) {
+      Operation *term = pred->getTerminator();
+      Value incoming = nullptr;
+      if (auto br = dyn_cast<cf::BranchOp>(term)) {
+        if (br.getDest() == block && argIdx < br.getDestOperands().size())
+          incoming = br.getDestOperands()[argIdx];
+      } else if (auto cbr = dyn_cast<cf::CondBranchOp>(term)) {
+        if (cbr.getTrueDest() == block &&
+            argIdx < cbr.getTrueDestOperands().size())
+          incoming = cbr.getTrueDestOperands()[argIdx];
+        else if (cbr.getFalseDest() == block &&
+                 argIdx < cbr.getFalseDestOperands().size())
+          incoming = cbr.getFalseDestOperands()[argIdx];
+      }
+      if (incoming)
+        if (auto info = getBarrierInfo(incoming, depth + 1))
+          return info;
+    }
+
+    // Check scf.for init args
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp))
+      if (argIdx > 0 && argIdx - 1 < forOp.getInitArgs().size())
+        return getBarrierInfo(forOp.getInitArgs()[argIdx - 1], depth + 1);
+
+    // Check warp specialize partitions
+    if (auto partitionsOp =
+            dyn_cast<triton::gpu::WarpSpecializePartitionsOp>(parentOp))
+      if (argIdx < partitionsOp.getParentOp().getNumOperands())
+        return getBarrierInfo(partitionsOp.getParentOp().getOperand(argIdx),
+                              depth + 1);
+
+    return std::nullopt;
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Dominance and Index Extraction
+  //===--------------------------------------------------------------------===//
+
+  bool valueDominatesOp(Value value, Operation *op) {
+    DominanceInfo dom(op->getParentOfType<FuncOp>());
+    if (auto defOp = value.getDefiningOp())
+      return dom.properlyDominates(defOp, op);
+    if (auto arg = dyn_cast<BlockArgument>(value))
+      return dom.dominates(arg.getOwner(), op->getBlock());
+    return false;
+  }
+
+  Value findIndexValue(Value barrierValue, Operation *op, OpBuilder &builder) {
+    auto toI32 = [&](Value v) {
+      if (v.getType().isInteger(32))
+        return v;
+      builder.setInsertionPoint(op);
+      return builder
+          .create<arith::IndexCastOp>(op->getLoc(), builder.getI32Type(), v)
+          .getResult();
+    };
+
+    // Direct memdesc_index
+    if (auto indexOp =
+            barrierValue.getDefiningOp<triton::gpu::MemDescIndexOp>()) {
+      Value idx = indexOp.getIndex();
+      if (valueDominatesOp(idx, op))
+        return toI32(idx);
+    }
+
+    // Block arg from scf.for - check yield
+    if (auto blockArg = dyn_cast<BlockArgument>(barrierValue)) {
+      auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+      unsigned argIdx = blockArg.getArgNumber();
+      if (forOp && argIdx > 0) {
+        auto yieldOp = cast<scf::YieldOp>(blockArg.getOwner()->getTerminator());
+        unsigned iterIdx = argIdx - 1;
+        if (iterIdx < yieldOp.getNumOperands())
+          if (auto indexOp =
+                  yieldOp.getOperand(iterIdx)
+                      .getDefiningOp<triton::gpu::MemDescIndexOp>()) {
+            Value idx = indexOp.getIndex();
+            if (valueDominatesOp(idx, op))
+              return toI32(idx);
+          }
+      }
+    }
+    return nullptr;
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Process Circular Store Pairs
+  //===--------------------------------------------------------------------===//
+
+  static bool isBarrierOp(Operation *op) {
+    return isa<
+        triton::nvidia_gpu::WaitBarrierOp, triton::nvidia_gpu::ArriveBarrierOp,
+        triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp,
+        triton::nvidia_gpu::TCGen5MMAOp, triton::nvidia_gpu::TCGen5CommitOp>(
+        op);
+  }
+
+  struct StoreWithBarrierInfo {
+    CircularStoreOp startStore;
+    Value barrierValue;
+    BarrierInfo info;
+  };
+
+  void walkBlockForStores(Block &block, SmallVectorImpl<CircularStoreOp> &stack,
+                          SmallVectorImpl<StoreWithBarrierInfo> &results,
+                          DenseMap<int, CircularStoreOp> &endMap) {
+    for (Operation &op : block) {
+      if (auto store = dyn_cast<CircularStoreOp>(&op)) {
+        if (store.getIsStart())
+          stack.push_back(store);
+        else
+          endMap[store.getScopeId()] = store;
+        continue;
+      }
+
+      if (isBarrierOp(&op)) {
+        int numBarriers = isa<triton::nvidia_gpu::TCGen5MMAOp>(&op)
+                              ? cast<triton::nvidia_gpu::TCGen5MMAOp>(&op)
+                                    .getBarriers()
+                                    .size()
+                              : 1;
+        SmallVector<std::pair<CircularStoreOp, int>> pending;
+        while (!stack.empty())
+          pending.push_back(
+              {stack.pop_back_val(),
+               std::max(0, numBarriers - 1 - (int)pending.size())});
+
+        for (auto &[startStore, barrierIdx] : llvm::reverse(pending)) {
+          Value bv = getBarrierOperand(&op, barrierIdx);
+          if (!bv)
+            bv = getBarrierOperand(&op, -1);
+          if (!bv)
+            continue;
+
+          auto infoOpt = getBarrierInfo(bv);
+          BarrierInfo info =
+              (infoOpt && infoOpt->allocOpId >= 0)
+                  ? *infoOpt
+                  : BarrierInfo(bv.getDefiningOp()
+                                    ? getMppOpId(bv.getDefiningOp())
+                                    : getMppOpId(&op));
+          results.push_back({startStore, bv, info});
+        }
+        continue;
+      }
+
+      for (Region &r : op.getRegions())
+        for (Block &b : r)
+          walkBlockForStores(b, stack, results, endMap);
+    }
+  }
+
+  Value computeIndexValue(const BarrierInfo &info, Value barrierValue,
+                          CircularStoreOp endStore, ReadCounterOp readCounterOp,
+                          OpBuilder &builder) {
+    Location loc = readCounterOp.getLoc();
+    Type counterType = readCounterOp.getCounter().getType();
+
+    auto toCounterType = [&](Value v) -> Value {
+      return v.getType() == counterType
+                 ? v
+                 : builder.create<arith::IndexCastOp>(loc, counterType, v)
+                       .getResult();
+    };
+
+    // Try: CF block arg with adjacent tracked index
+    if (auto blockArg = dyn_cast<BlockArgument>(barrierValue)) {
+      Block *block = blockArg.getOwner();
+      unsigned argIdx = blockArg.getArgNumber();
+      if (!isa<scf::ForOp>(block->getParentOp()) &&
+          argIdx + 1 < block->getNumArguments() &&
+          block->getArgument(argIdx + 1).getType().isInteger(32))
+        return block->getArgument(argIdx + 1);
+    }
+
+    // Try: Direct index from barrier value
+    if (Value idx = findIndexValue(barrierValue, endStore, builder))
+      return idx;
+
+    // Try: Constant index from info
+    if (info.hasIndex && info.constantIndex >= 0)
+      return arith::ConstantIntOp::create(builder, loc, counterType,
+                                          info.constantIndex);
+
+    // Try: Dynamic index from info
+    if (info.dynamicIndex && valueDominatesOp(info.dynamicIndex, endStore))
+      return toCounterType(info.dynamicIndex);
+
+    // Try: Loop result from yield position
+    if (info.dynamicIndexYieldPosition >= 0 && info.hasAdjacentIndex)
+      if (auto forOp = barrierValue.getDefiningOp<scf::ForOp>())
+        if ((unsigned)info.dynamicIndexYieldPosition < forOp.getNumResults()) {
+          Value result = forOp.getResult(info.dynamicIndexYieldPosition);
+          if (valueDominatesOp(result, endStore))
+            return toCounterType(result);
+        }
+
+    // Fallback: zero
+    return arith::ConstantIntOp::create(builder, loc, counterType, 0);
+  }
+
+  LogicalResult processFunction(FuncOp func, OpBuilder &builder) {
+    SmallVector<CircularStoreOp, 8> stack;
+    SmallVector<StoreWithBarrierInfo, 8> stores;
+    DenseMap<int, CircularStoreOp> endMap;
+
+    for (Block &block : func.getBody())
+      walkBlockForStores(block, stack, stores, endMap);
+
+    auto replaceCounter = [](CircularStoreOp store, Value newVal) {
+      if (auto rcOp = store.getCounter().getDefiningOp<ReadCounterOp>()) {
+        store.getCounterMutable().assign(newVal);
+        if (rcOp->use_empty())
+          rcOp->erase();
+      }
+    };
+
+    for (auto &si : stores) {
+      auto endStore = endMap.lookup(si.startStore.getScopeId());
+      if (!endStore)
+        continue;
+
+      if (auto rcOp =
+              si.startStore.getCounter().getDefiningOp<ReadCounterOp>()) {
+        builder.setInsertionPoint(rcOp);
+        replaceCounter(si.startStore,
+                       arith::ConstantIntOp::create(builder, rcOp.getLoc(),
+                                                    rcOp.getCounter().getType(),
+                                                    si.info.allocOpId));
+      }
+
+      if (auto rcOp = endStore.getCounter().getDefiningOp<ReadCounterOp>()) {
+        builder.setInsertionPoint(rcOp);
+        replaceCounter(endStore, computeIndexValue(si.info, si.barrierValue,
+                                                   endStore, rcOp, builder));
+      }
+    }
+    return success();
+  }
+};
+
+} // namespace mlir::triton::proton::gpu

--- a/third_party/proton/Dialect/triton_proton.cc
+++ b/third_party/proton/Dialect/triton_proton.cc
@@ -107,6 +107,8 @@ void init_triton_proton(py::module &&m) {
                      proton::gpu::createAllocateProtonGlobalScratchBufferPass);
   ADD_PASS_WRAPPER_0("add_schedule_buffer_store",
                      proton::gpu::createScheduleBufferStorePass);
+  ADD_PASS_WRAPPER_0("add_mpp_store_barrier_info",
+                     proton::gpu::createMppStoreBarrierInfoPass);
   ADD_PASS_WRAPPER_0("add_sched_barriers",
                      proton::gpu::createAddSchedBarriersPass);
 }

--- a/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
@@ -128,7 +128,9 @@ void CircularLayoutParser::parseSegment(
 
           if (activeProfileEvent.first->cycle >
               activeProfileEvent.second->cycle) {
-            throw ClockOverflowException("Clock overflow");
+            if (!std::getenv("PROTON_ENABLE_MPP_STORE_BARRIER_INFO_PASS")) {
+              throw ClockOverflowException("Clock overflow");
+            }
           }
           trace.profileEvents.push_back(activeProfileEvent);
         } else {

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -1,4 +1,5 @@
 import functools
+import os
 from typing import Dict, Optional, Union, Any
 
 import triton
@@ -166,6 +167,10 @@ class InstrumentationHook(Hook):
                                                           self.profile_buffer_size, self.profile_buffer_alignment,
                                                           is_long_clk)
             triton_passes.common.add_cse(pm)
+
+            # Store barrier info if enabled via env var
+            if os.getenv("PROTON_ENABLE_MPP_STORE_BARRIER_INFO_PASS"):
+                triton_proton.add_mpp_store_barrier_info(pm)
 
             if mode.Optimize.SCHED_STORES in self.mode.optimizations:
                 triton_proton.add_schedule_buffer_store(pm)


### PR DESCRIPTION
Summary:
### Summary

This diff introduces a new pass to store barrier related information using the `CircularStoreOp`. The changes include:

*   Added a new pass `createStoreBarrierInfoPass` to the `ProtonGPUTransformsPass.cpp` file.
*   Registered the new pass in the `triton_proton.cc` file.
*   Added a new test case `store_barrier_info.mlir` to verify the correctness of the pass.
*   Modified the `CircularLayoutParser.cpp` file to **not** handle clock overflow exceptions when the `PROTON_ENABLE_STORE_BARRIER_INFO_PASS` environment variable is set.
*   Registered the new pass in the `RegisterTritonDialects.h` file.

These changes enable the use of the `CircularStoreOp` to store barrier related information, which is crucial for the Proton dialect. The added test case ensures that the pass is working correctly.

Differential Revision: D89157715


