### PR TITLE
[TLX] Handle LocalLoadOp in layout propagation for BlockedEncodingAttr

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -72,6 +72,11 @@ public:
       if (auto requireLayoutOp = dyn_cast<tlx::RequireLayoutOp>(op))
         if (isa<gpu::MemDescType>(requireLayoutOp.getType()))
           return WalkResult::interrupt();
+
+      // Check for local_load ops that may need smem layout inference
+      if (isa<ttg::LocalLoadOp>(op))
+        return WalkResult::interrupt();
+
       return WalkResult::advance();
     });
     if (!walkResult.wasInterrupted())


### PR DESCRIPTION
Summary:
Add backward propagation support for LocalLoadOp in the layout propagation analysis. When a LocalLoadOp has a BlockedEncodingAttr result, we now infer the shared memory layout from the result encoding by:
- Computing the vector size from the contiguity per thread in the fastest-varying dimension
- Limiting vector size to 128 bits (max vectorized load size)
- Computing bank-conflict-free swizzling parameters (perPhase and maxPhase)
- Creating a SwizzledSharedEncodingAttr with the computed parameters

This enables the compiler to automatically infer optimal shared memory layouts for local loads with blocked encodings, avoiding manual layout specification.

Test Plan:
Added lit test in test/TLX/propagate-layout.mlir that verifies:
- BlockedEncodingAttr with sizePerThread=[1,8] infers vec=8 shared encoding
- The shared encoding order matches the blocked encoding order [1, 0]
- Bank conflict avoidance parameters are computed correctly (perPhase=1, maxPhase=8)
