### PR TITLE
[TLX] Add a DummyRegisterLayout for handling function outlining

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -25,6 +25,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/Support/LLVM.h"
+#include "tlx/dialect/include/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -629,6 +630,9 @@ static LogicalResult verifyTMEMOperand(Operation *op, RankedTensorType type,
   if (type.getRank() != 2)
     return op->emitOpError(regName) << " must be a 2D tensor";
   if (type.getEncoding()) {
+    // Skip verification for placeholder layouts - they will be resolved later
+    if (isa<triton::tlx::DummyRegisterLayoutAttr>(type.getEncoding()))
+      return success();
     auto enc = dyn_cast<DistributedEncodingTrait>(type.getEncoding());
     if (!enc) {
       return op->emitOpError(regName)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -249,6 +249,8 @@ class CUDABackend(BaseBackend):
         pm.enable_debug()
         tlx.tlx_passes.add_triton_tlx_fixup(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
         passes.common.add_inliner(pm)
+        # Only determine layouts after inlining is finished.
+        tlx.tlx_passes.add_tlx_resolve_placeholder_layouts(pm)
         passes.ttir.add_rewrite_tensor_pointer(pm)
         if capability // 10 < 9:
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)

--- a/third_party/tlx/dialect/include/IR/TLXAttrDefs.td
+++ b/third_party/tlx/dialect/include/IR/TLXAttrDefs.td
@@ -1,5 +1,5 @@
-#ifndef PROTON_ATTRDEFS
-#define PROTON_ATTRDEFS
+#ifndef TLX_ATTRDEFS
+#define TLX_ATTRDEFS
 
 include "mlir/IR/AttrTypeBase.td"
 include "TLXDialect.td"
@@ -9,4 +9,38 @@ class TLX_Attr<string name, list<Trait> traits = [],
   : AttrDef<TLX_Dialect, name, traits, baseCppClass> {
 }
 
-#endif // PROTON_ATTRDEFS
+//===----------------------------------------------------------------------===//
+// Dummy Layout Attributes for Deferred Layout Resolution
+//===----------------------------------------------------------------------===//
+
+def TLX_DummyRegisterLayoutAttr : TLX_Attr<"DummyRegisterLayout", []> {
+  let mnemonic = "dummy_register_layout";
+  let summary = "Placeholder layout for register-distributed tensors to be resolved after inlining";
+
+  let description = [{
+    This attribute represents a placeholder layout for tensors distributed
+    across registers. It is generated during initial lowering when we don't
+    have enough context to determine the final distribution layout.
+
+    After function inlining, a pass will resolve this to a concrete layout such as:
+    - BlockedEncodingAttr (default blocked distribution)
+    - TMEM-compatible BlockedEncodingAttr (for tensors loaded from TMEM)
+    - MmaEncodingAttr (for MMA operation results)
+    - DotOperandEncodingAttr (for dot operation inputs)
+
+    Parameters:
+    - shape: The shape of the tensor
+    - elementType: The element type
+    - tmemCompatible: If true, create a layout compatible with TMEM load/store
+  }];
+
+  let parameters = (ins
+    ArrayRefParameter<"int64_t">:$shape,
+    "Type":$elementType,
+    "bool":$tmemCompatible
+  );
+
+  let assemblyFormat = "`<` `[` $shape `]` `,` $elementType `,` $tmemCompatible `>`";
+}
+
+#endif // TLX_ATTRDEFS

--- a/third_party/tlx/dialect/include/IR/TLXDialect.td
+++ b/third_party/tlx/dialect/include/IR/TLXDialect.td
@@ -15,6 +15,8 @@ def TLX_Dialect : Dialect {
     "triton::TritonDialect",
     "triton::gpu::TritonGPUDialect",
   ];
+
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif

--- a/third_party/tlx/dialect/include/Transforms/Passes.td
+++ b/third_party/tlx/dialect/include/Transforms/Passes.td
@@ -64,4 +64,26 @@ def TLXRewriteLocalAlias : Pass<"tlx-rewrite-local-alias", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
 
 }
+
+def TLXResolvePlaceholderLayouts : Pass<"tlx-resolve-placeholder-layouts", "mlir::ModuleOp"> {
+  let summary = "Resolve placeholder layouts after function inlining";
+
+  let description = [{
+    This pass resolves placeholder layout encodings that were generated during
+    initial lowering. After function inlining, we have more context to determine
+    the correct layouts for TMEM loads/stores and other TLX operations.
+
+    The pass replaces:
+    - DummyRegisterLayoutAttr -> BlockedEncodingAttr
+
+    Each resolved layout uses the same default values as the corresponding
+    Python make_default() methods.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 #endif // TRITON_TLX_PASSES

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -1,6 +1,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "triton/Dialect/Triton/IR/Interfaces.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 // clang-format off
 #include "IR/Dialect.h"

--- a/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonTLXTransforms
   PropagateLayout.cpp
   InsertRequireLayout.cpp
   RewriteLocalAlias.cpp
+  ResolvePlaceholderLayouts.cpp
 
   DEPENDS
   TritonTLXTransformsIncGen

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -1,0 +1,209 @@
+#include "IR/Dialect.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+#include <numeric>
+
+#define DEBUG_TYPE "tlx-resolve-placeholder-layouts"
+#define DBGS() (llvm::errs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) DBGS() << X << "\n"
+
+using namespace mlir;
+namespace ttg = ::mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+
+namespace mlir {
+namespace triton {
+namespace tlx {
+
+#define GEN_PASS_DEF_TLXRESOLVEPLACEHOLDERLAYOUTS
+
+#include "tlx/dialect/include/Transforms/Passes.h.inc"
+
+/// Check if an attribute is any of the dummy layout types
+static bool isDummyLayoutAttr(Attribute attr) {
+  return isa<DummyRegisterLayoutAttr>(attr);
+}
+
+/// Extract the dummy layout attribute from a type, if present
+static Attribute getDummyLayoutFromType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+    if (auto encoding = tensorType.getEncoding()) {
+      if (isDummyLayoutAttr(encoding))
+        return encoding;
+    }
+  }
+  return nullptr;
+}
+
+/// Compute the resolved layout for a dummy register layout.
+/// If tmemCompatible is true, creates a TMEM-compatible register layout using
+/// getTmemCompatibleLayout (matches
+/// make_default_tmem_compatible_tensor_layout_encoding). Otherwise, creates a
+/// default BlockedEncodingAttr.
+///
+static Attribute resolveRegisterLayout(DummyRegisterLayoutAttr dummyLayout,
+                                       Operation *contextOp,
+                                       ModuleOp moduleOp) {
+  auto shape = dummyLayout.getShape();
+  auto elementType = dummyLayout.getElementType();
+  auto rank = shape.size();
+
+  // Use contextOp for lookupNumWarps to get partition-aware num_warps
+  int numWarps = ttg::lookupNumWarps(contextOp);
+  int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(moduleOp);
+  int numCTAs = ttg::TritonGPUDialect::getNumCTAs(moduleOp);
+
+  if (dummyLayout.getTmemCompatible()) {
+    // Create a TMEM-compatible register layout
+    // Matches make_default_tmem_compatible_tensor_layout_encoding
+    //
+    // Use the allocation shape (not the subsliced shape) for the
+    // TMEM-compatible layout calculation. The allocation shape determines the
+    // TMEM block dimensions.
+    assert(rank == 2 &&
+           "Only supporting 2D tensors for TMEM compatible layout.");
+    assert(!elementType.isInteger() && "Integer type not supported for TMEM.");
+    assert((numWarps == 4 || numWarps == 8) &&
+           "Currently only support numWarps 4 or 8 for TMEM load and store.");
+
+    ttg::BlockedEncodingAttr defaultBlockedEncoding =
+        ttg::getDefaultBlockedEncoding(moduleOp.getContext(), shape, numWarps,
+                                       threadsPerWarp, numCTAs);
+    auto oldType =
+        RankedTensorType::get(shape, elementType, defaultBlockedEncoding);
+
+    auto result =
+        ttng::getTmemCompatibleLayout(shape[0], shape[1], oldType, numWarps);
+    return result;
+  }
+
+  // Default: create a standard blocked encoding
+  // sizePerThread: all 1s (default)
+  SmallVector<unsigned> sizePerThread(rank, 1);
+
+  // order: reversed range [rank-1, rank-2, ..., 1, 0]
+  SmallVector<unsigned> order(rank);
+  std::iota(order.rbegin(), order.rend(), 0);
+
+  return ttg::BlockedEncodingAttr::get(moduleOp.getContext(), shape,
+                                       sizePerThread, order, numWarps,
+                                       threadsPerWarp, numCTAs);
+}
+
+/// Resolve a dummy layout attribute to a concrete layout
+/// For TMEM layouts and TMEM-compatible register layouts, allocShape is used
+/// to determine the block dimensions.
+/// For register layouts from TMEMLoadOp, definingOp is used to get the source
+/// memdesc's allocation shape.
+static Attribute resolveDummyLayout(Attribute dummyLayout,
+                                    ArrayRef<int64_t> allocShape, Value value,
+                                    ModuleOp moduleOp) {
+  // Get the context operation for lookupNumWarps - this allows finding
+  // partition-specific num_warps for warp specialized regions
+  Operation *contextOp = nullptr;
+  if (auto defOp = value.getDefiningOp()) {
+    contextOp = defOp;
+  } else if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+    contextOp = blockArg.getOwner()->getParentOp();
+  }
+  if (!contextOp) {
+    contextOp = moduleOp;
+  }
+
+  if (auto regLayout = dyn_cast<DummyRegisterLayoutAttr>(dummyLayout))
+    return resolveRegisterLayout(regLayout, contextOp, moduleOp);
+
+  llvm_unreachable("Unknown dummy layout type");
+}
+
+/// Replace the type of a value with a new encoding
+static void replaceTypeWithNewEncoding(Value value, Attribute newEncoding) {
+  Type oldType = value.getType();
+  Type newType;
+
+  if (auto tensorType = dyn_cast<RankedTensorType>(oldType)) {
+    newType = RankedTensorType::get(tensorType.getShape(),
+                                    tensorType.getElementType(), newEncoding);
+  } else if (auto memDescType = dyn_cast<ttg::MemDescType>(oldType)) {
+    // Preserve the allocation shape when replacing the encoding
+    newType = ttg::MemDescType::get(
+        memDescType.getShape(), memDescType.getElementType(), newEncoding,
+        memDescType.getMemorySpace(), memDescType.getMutableMemory(),
+        memDescType.getAllocShape());
+  } else {
+    return;
+  }
+
+  value.setType(newType);
+}
+
+LogicalResult resolvePlaceholderLayouts(ModuleOp moduleOp) {
+  // Collect all values that have dummy layouts
+  SmallVector<std::pair<Value, Attribute>> valuesToResolve;
+
+  moduleOp.walk([&](Operation *op) {
+    // Check all result types for dummy layouts
+    for (Value result : op->getResults()) {
+      if (Attribute dummyLayout = getDummyLayoutFromType(result.getType())) {
+        valuesToResolve.emplace_back(result, dummyLayout);
+      }
+    }
+
+    // Check block arguments in all regions (for ops like WarpSpecializeOp)
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region) {
+        for (BlockArgument arg : block.getArguments()) {
+          if (Attribute dummyLayout = getDummyLayoutFromType(arg.getType())) {
+            valuesToResolve.emplace_back(arg, dummyLayout);
+          }
+        }
+      }
+    }
+  });
+
+  // Resolve each dummy layout
+  for (auto &[value, dummyLayout] : valuesToResolve) {
+    // Get allocation shape for TMEM layouts
+    ArrayRef<int64_t> allocShape;
+    if (auto memDescType = dyn_cast<ttg::MemDescType>(value.getType())) {
+      allocShape = memDescType.getAllocShape();
+    }
+    Attribute resolvedLayout =
+        resolveDummyLayout(dummyLayout, allocShape, value, moduleOp);
+    LLVM_DEBUG({
+      DBGS() << "Resolving dummy layout: ";
+      dummyLayout.dump();
+      DBGS() << "  to: ";
+      resolvedLayout.dump();
+    });
+    replaceTypeWithNewEncoding(value, resolvedLayout);
+  }
+
+  return success();
+}
+
+struct TLXResolvePlaceholderLayoutsPass
+    : public impl::TLXResolvePlaceholderLayoutsBase<
+          TLXResolvePlaceholderLayoutsPass> {
+public:
+  using impl::TLXResolvePlaceholderLayoutsBase<
+      TLXResolvePlaceholderLayoutsPass>::TLXResolvePlaceholderLayoutsBase;
+
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    if (failed(tlx::resolvePlaceholderLayouts(m))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace tlx
+} // namespace triton
+} // namespace mlir

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -189,41 +189,11 @@ void init_triton_tlx_ir(py::module &&m) {
              return ttg::DotOperandEncodingAttr::get(context, opIdx, parentEnc,
                                                      eltType);
            })
-      .def("make_default_tmem_compatible_tensor_layout_encoding",
+      .def("make_dummy_register_layout_attr",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
-              Type elementType, int moduleNumWarps, int threadsPerWarp,
-              int numCTAs) {
-             // Include various assert to vet the input to make sure they're
-             // valid for MMAv5. See also lib/Analysis/Utiity.cpp:supportMMA
-             assert(shape.size() == 2 &&
-                    "Only supporting 2D tensors for TMEM layout.");
-             assert((!elementType.isInteger()) &&
-                    "Integer type not supported.");
-
-             Block *parentBlock = self.getBuilder().getInsertionBlock();
-             int numWarps =
-                 ttg::maybeLookupNumWarps(parentBlock).value_or(moduleNumWarps);
-             assert((numWarps == 4 || numWarps == 8) &&
-                    "Currently only support numWarps 4 or 8 for TMEM load and "
-                    "store.");
-
-             ttg::BlockedEncodingAttr defaultBlockedEncoding =
-                 ttg::getDefaultBlockedEncoding(self.getContext(), shape,
-                                                numWarps, threadsPerWarp,
-                                                numCTAs);
-             auto oldType = RankedTensorType::get(shape, elementType,
-                                                  defaultBlockedEncoding);
-             auto oldTypeShapePerCTA = ttg::getShapePerCTA(oldType);
-             auto rank = oldTypeShapePerCTA.size();
-             assert((oldTypeShapePerCTA[rank - 2] % 64 == 0 &&
-                     ((oldTypeShapePerCTA[rank - 1] % 8 == 0) ||
-                      oldTypeShapePerCTA[rank - 1] == 1)) &&
-                    "Shape unsupported by TMEM ops.");
-
-             Attribute newDistributedEncoding =
-                 nvidia_gpu::getTmemCompatibleLayout(shape[0], shape[1],
-                                                     oldType, numWarps);
-             return newDistributedEncoding;
+              Type elementType, bool tmemCompatible) -> Attribute {
+             return tlx::DummyRegisterLayoutAttr::get(
+                 self.getContext(), shape, elementType, tmemCompatible);
            })
       .def("create_fence_async_shared",
            [](TritonOpBuilder &self) -> void {
@@ -649,6 +619,8 @@ void init_triton_tlx_passes(py::module &&m) {
                      tlx::createTLXInsertRequireLayout);
   ADD_PASS_WRAPPER_0("add_tlx_rewrite_local_alias",
                      tlx::createTLXRewriteLocalAlias);
+  ADD_PASS_WRAPPER_0("add_tlx_resolve_placeholder_layouts",
+                     tlx::createTLXResolvePlaceholderLayouts);
   ADD_PASS_OPTION_WRAPPER_4("add_triton_tlx_fixup", tlx::createTritonTLXFixup,
                             std::string, int32_t, int32_t, int32_t);
 }

--- a/third_party/tlx/doc/PlaceholderLayouts.md
+++ b/third_party/tlx/doc/PlaceholderLayouts.md
@@ -1,0 +1,124 @@
+# Placeholder Layouts in TLX
+
+## Motivating Problem
+
+In Triton, layout encodings (such as `BlockedEncodingAttr`, `NvidiaMmaEncodingAttr`, `DotOperandEncodingAttr`, etc.) determine how tensor data is distributed across threads, warps, and CTAs. Many of these layouts depend on the **number of warps** (`num_warps`) to compute the correct distribution.
+
+A critical issue arises when TLX functions are defined separately from their call sites:
+
+1. **Separate function definition**: When a TLX kernel helper is written as a separate function, any layout computation during lowering sees the **global module's `num_warps`**.
+
+2. **Inlined context**: After function inlining, the same code may execute in a different context (e.g., inside a `tlx.async_task` region) where the **effective `num_warps` is different** from the global value.
+
+This mismatch causes incorrect or inconsistent layouts. For example:
+- A function lowered with `num_warps=4` at the global level
+- Gets inlined into an `async_task` that executes with `num_warps=2`
+- The pre-computed layout is now wrong for the actual execution context
+
+**Solution**: We use **placeholder (dummy) layouts** during initial lowering that defer the actual layout computation until after function inlining. A dedicated pass (`TLXResolvePlaceholderLayouts`) then resolves these placeholders to concrete layouts when the correct `num_warps` and other context information is available.
+
+Right now we have only implemented the placeholder layouts for TMEM dependent layouts, which is the requirement for Flash Attention Backwards.
+
+---
+
+## Overview
+
+The placeholder layout system consists of three components:
+
+1. **Placeholder Layout Attributes**: MLIR attributes that carry shape and type information but defer concrete layout decisions
+2. **Python Encoding Classes**: Frontend classes that generate placeholder layout attributes during lowering
+3. **Resolution Pass**: A C++ pass that replaces placeholder layouts with concrete layouts after inlining
+
+---
+
+## Placeholder Layout Types
+
+We define one placeholder layout types, organized by memory space and use case:
+
+| Placeholder Type | Memory Space | Resolves To |
+|------------------|--------------|-------------|
+| `DummyRegisterLayoutAttr` | Registers | `BlockedEncodingAttr` |
+
+
+### IR Examples
+
+**Before resolution:**
+```mlir
+// Register tensor with placeholder layout
+%0 = tlx.require_layout %arg : tensor<128x64xf16, #tlx.dummy_register_layout<[128, 64], f16>>
+```
+
+**After resolution:**
+```mlir
+// Register resolved to Blocked encoding
+%0 = tlx.require_layout %arg : tensor<128x64xf16, #ttg.blocked<...>>
+```
+
+---
+
+## Python Frontend Classes
+
+The following Python classes generate placeholder layouts during lowering:
+
+### DummyRegisterLayoutEncoding
+```python
+class DummyRegisterLayoutEncoding(layout_encoding):
+    def __init__(self, shape: List[int], element_type: tl.dtype):
+        self.shape = shape
+        self.element_type = element_type
+```
+
+---
+
+## Resolution Pass
+
+The `TLXResolvePlaceholderLayouts` pass runs after function inlining and resolves all placeholder layouts to concrete layouts.
+
+### Pipeline Location
+
+```python
+# In nvidia/backend/compiler.py
+passes.common.add_inliner(pm)
+tlx.tlx_passes.add_tlx_resolve_placeholder_layouts(pm)  # <-- Runs here
+passes.ttir.add_rewrite_tensor_pointer(pm)
+```
+
+### Resolution Logic
+
+Each placeholder type has a dedicated resolution function:
+
+| Placeholder | Resolution Function | Key Parameters Used |
+|-------------|---------------------|---------------------|
+| `DummyRegisterLayoutAttr` | `resolveRegisterLayout()` | shape, numWarps, threadsPerWarp, numCTAs |
+
+The resolution functions use `ttg::lookupNumWarps()` and similar utilities to obtain the correct context-dependent values after inlining.
+
+---
+
+## TableGen Definitions
+
+The placeholder layout attributes are defined in `TLXAttrDefs.td`:
+
+```tablegen
+def TLX_DummyRegisterLayoutAttr : TLX_Attr<"DummyRegisterLayout", []> {
+  llet parameters = (ins
+    ArrayRefParameter<"int64_t">:$shape,
+    "Type":$elementType,
+    "bool":$tmemCompatible
+  );
+}
+```
+
+---
+
+## File Summary
+
+| File | Purpose |
+|------|---------|
+| `language/tlx/types.py` | Python placeholder layout classes |
+| `language/tlx/__init__.py` | Exports placeholder layout classes |
+| `dialect/include/IR/TLXAttrDefs.td` | TableGen definitions for placeholder attributes |
+| `dialect/triton_tlx.cc` | C++ builder methods for creating placeholder attributes |
+| `dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp` | Resolution pass implementation |
+| `dialect/include/Transforms/Passes.td` | Pass declaration |
+| `nvidia/backend/compiler.py` | Pipeline integration |

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -1,76 +1,71 @@
+from . import compiler
 from .async_task_utils import async_task, async_tasks
-from .types import (
-    layout_encoding,
-    shared_layout_encoding,
-    swizzled_shared_layout_encoding,
-    tensor_memory_layout_encoding,
-    nv_mma_shared_layout_encoding,
-    storage_kind,
-    buffered_tensor,
-    buffered_tensor_type,
-    mbarrier,
-    mbarrier_type,
-    clc_response,
-    clc_response_type,
-    CLCPipelineContext,
-    async_token,
-    tensor_descriptor_ptr,
-    tensor_descriptor_ptr_type,
-)
-from .mem_ops import (
-    local_alloc,
-    local_view,
-    remote_view,
-    local_slice,
-    subslice,
-    async_load,
-    async_load_commit_group,
-    async_load_wait_group,
-    local_load,
-    local_store,
-    local_trans,
-    local_reinterpret,
-    allocate_tensor_descriptor,
-    async_descriptor_load,
-    async_descriptor_store,
-    async_descriptor_store_wait,
-    fence_async_shared,
-    make_tensor_descriptor,
-    reinterpret_tensor_descriptor,
-)
 from .barrier import (
     alloc_barriers,
+    barrier_arrive,
     barrier_expect_bytes,
     barrier_wait,
-    barrier_arrive,
-    named_barrier_wait,
     named_barrier_arrive,
-)
-from .mma_ops import (
-    async_dot,
-    async_dot_scaled,
-    async_dot_wait,
-    tcgen05_commit,
-)
-from .utility import (
-    cluster_cta_rank,
-    thread_id,
-    async_task_replica_id,
-    dtype_of,
-    size_of,
-    clock64,
-    stoch_round,
+    named_barrier_wait,
 )
 from .dynamic_launch import (
     _alloc_clc_responses,
     _clc_issue,
     _clc_query,
-    clc_producer,
     clc_consumer,
     clc_create_context,
+    clc_producer,
 )
-
-from . import compiler
+from .mem_ops import (
+    allocate_tensor_descriptor,
+    async_descriptor_load,
+    async_descriptor_store,
+    async_descriptor_store_wait,
+    async_load,
+    async_load_commit_group,
+    async_load_wait_group,
+    fence_async_shared,
+    local_alloc,
+    local_load,
+    local_reinterpret,
+    local_slice,
+    local_store,
+    local_trans,
+    local_view,
+    make_tensor_descriptor,
+    reinterpret_tensor_descriptor,
+    remote_view,
+    subslice,
+)
+from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, tcgen05_commit
+from .types import (
+    async_token,
+    buffered_tensor,
+    buffered_tensor_type,
+    clc_response,
+    clc_response_type,
+    CLCPipelineContext,
+    DummyRegisterLayoutEncoding,
+    layout_encoding,
+    mbarrier,
+    mbarrier_type,
+    nv_mma_shared_layout_encoding,
+    shared_layout_encoding,
+    storage_kind,
+    swizzled_shared_layout_encoding,
+    tensor_descriptor_ptr,
+    tensor_descriptor_ptr_type,
+    tensor_memory_layout_encoding,
+)
+from .utility import (
+    async_task_replica_id,
+    clock64,
+    cluster_cta_rank,
+    dtype_of,
+    size_of,
+    stoch_round,
+    thread_id,
+)
 
 __all__ = [
     # async_tasks
@@ -141,4 +136,5 @@ __all__ = [
     "clc_producer",
     "clc_consumer",
     "CLCPipelineContext",
+    "DummyRegisterLayoutEncoding",
 ]

--- a/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
@@ -1140,7 +1140,6 @@ configs_bwd_tlx = [
 ]
 
 
-# TODO: Unused. Fix layout issue inside TLX.
 @triton.jit
 def _bwd_compute_inner_loop(
     start_n,
@@ -1425,88 +1424,61 @@ def _attn_bwd_ws(
                 do_out_dtype = tlx.dtype_of(desc_do)
                 q_out_dtype = tlx.dtype_of(desc_q)
                 if STAGE & 1:
-                    offs_n = start_block_n + tl.arange(0, BLOCK_N1)
-                    lo, hi = _get_unfused_bwd_loop_bounds(start_n, N_CTX, BLOCK_N1, STAGE=4 - STAGE)
-                    num_steps = (hi - lo) // BLOCK_M1
-                    for _ in range(num_steps):
-                        tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
-                        ds_buf_id, ds_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
-
-                        offs_m = curr_m + tl.arange(0, BLOCK_M1)
-                        m = tl.load(M_updated + offs_m)
-
-                        # wait for qkT = tl.dot(k, qT)
-                        tlx.barrier_wait(tlx.local_view(qk_fulls, tmem_buf_id), tmem_phase)
-                        qkT = tlx.local_load(tlx.local_view(qk_tiles, tmem_buf_id))
-                        tlx.barrier_arrive(tlx.local_view(qk_empties, tmem_buf_id))
-
-                        pT = tl.math.exp2(qkT - m[None, :])
-                        if STAGE == 3:
-                            mask = offs_m[None, :] >= offs_n[:, None]
-                            pT = tl.where(mask, pT, 0.0)
-
-                        # ppT *= qk_scale
-                        ppT = pT
-                        ppT = ppT.to(do_out_dtype)
-                        tlx.local_store(tlx.local_view(p_tiles, tmem_buf_id), ppT)
-                        tlx.barrier_arrive(tlx.local_view(p_fulls, tmem_buf_id))
-
-                        # D (= delta) is pre-divided by ds_scale.
-                        Di = tl.load(D_updated + offs_m)
-
-                        # Wait for dpT = tl.dot(v, tl.trans(do))
-                        tlx.barrier_wait(tlx.local_view(dp_fulls, tmem_buf_id), tmem_phase)
-                        dpT = tlx.local_load(tlx.local_view(dp_tiles, tmem_buf_id))
-                        # We can only signal the arrive if DP is not shared with DQ.
-                        # Otherwise we need to wait for DQ to be done.
-                        if not REUSE_DP_FOR_DQ:
-                            tlx.barrier_arrive(tlx.local_view(dp_empties, tmem_buf_id))
-                        dsT = pT * (dpT - Di[None, :])
-                        dsT = dsT.to(q_out_dtype)
-                        tlx.local_store(tlx.local_view(ds_tiles, ds_buf_id), dsT)
-                        tlx.fence_async_shared()
-                        tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
-                        curr_m += step_m
-                        blk_idx += 1
+                    curr_m, blk_idx = _bwd_compute_inner_loop(
+                        start_n,
+                        qk_fulls,
+                        qk_tiles,
+                        qk_empties,
+                        p_tiles,
+                        p_fulls,
+                        dp_empties,
+                        dp_fulls,
+                        dp_tiles,
+                        ds_tiles,
+                        ds_fulls,
+                        M_updated,
+                        D_updated,
+                        curr_m,
+                        blk_idx,
+                        step_m,
+                        do_out_dtype,
+                        q_out_dtype,
+                        N_CTX,
+                        NUM_BUFFERS_TMEM,
+                        NUM_BUFFERS_DS,
+                        BLOCK_M1,
+                        BLOCK_N1,
+                        STAGE=4 - STAGE,
+                        REUSE_DP_FOR_DQ=REUSE_DP_FOR_DQ,
+                    )
                 if STAGE & 2:
-                    lo, hi = _get_unfused_bwd_loop_bounds(start_n, N_CTX, BLOCK_N1, STAGE=2)
-                    num_steps = (hi - lo) // BLOCK_M1
-                    for _ in range(num_steps):
-                        tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
-                        ds_buf_id, ds_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
-
-                        offs_m = curr_m + tl.arange(0, BLOCK_M1)
-                        m = tl.load(M_updated + offs_m)
-
-                        # wait for qkT = tl.dot(k, qT)
-                        tlx.barrier_wait(tlx.local_view(qk_fulls, tmem_buf_id), tmem_phase)
-                        qkT = tlx.local_load(tlx.local_view(qk_tiles, tmem_buf_id))
-                        tlx.barrier_arrive(tlx.local_view(qk_empties, tmem_buf_id))
-
-                        pT = tl.math.exp2(qkT - m[None, :])
-                        # ppT *= qk_scale
-                        ppT = pT
-                        ppT = ppT.to(do_out_dtype)
-                        tlx.local_store(tlx.local_view(p_tiles, tmem_buf_id), ppT)
-                        tlx.barrier_arrive(tlx.local_view(p_fulls, tmem_buf_id))
-
-                        # D (= delta) is pre-divided by ds_scale.
-                        Di = tl.load(D_updated + offs_m)
-
-                        # Wait for dpT = tl.dot(v, tl.trans(do))
-                        tlx.barrier_wait(tlx.local_view(dp_fulls, tmem_buf_id), tmem_phase)
-                        dpT = tlx.local_load(tlx.local_view(dp_tiles, tmem_buf_id))
-                        # We can only signal the arrive if DP is not shared with DQ.
-                        # Otherwise we need to wait for DQ to be done.
-                        if not REUSE_DP_FOR_DQ:
-                            tlx.barrier_arrive(tlx.local_view(dp_empties, tmem_buf_id))
-                        dsT = pT * (dpT - Di[None, :])
-                        dsT = dsT.to(q_out_dtype)
-                        tlx.local_store(tlx.local_view(ds_tiles, ds_buf_id), dsT)
-                        tlx.fence_async_shared()
-                        tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
-                        curr_m += step_m
-                        blk_idx += 1
+                    curr_m, blk_idx = _bwd_compute_inner_loop(
+                        start_n,
+                        qk_fulls,
+                        qk_tiles,
+                        qk_empties,
+                        p_tiles,
+                        p_fulls,
+                        dp_empties,
+                        dp_fulls,
+                        dp_tiles,
+                        ds_tiles,
+                        ds_fulls,
+                        M_updated,
+                        D_updated,
+                        curr_m,
+                        blk_idx,
+                        step_m,
+                        do_out_dtype,
+                        q_out_dtype,
+                        N_CTX,
+                        NUM_BUFFERS_TMEM,
+                        NUM_BUFFERS_DS,
+                        BLOCK_M1,
+                        BLOCK_N1,
+                        STAGE=2,
+                        REUSE_DP_FOR_DQ=REUSE_DP_FOR_DQ,
+                    )
 
                 kv_buf_id, kv_phase = _get_bufidx_phase(i, NUM_BUFFERS_KV)
 


### PR DESCRIPTION
Register layouts depend on the number of warps, which is modified when the code is inside an async task. This replaces the register layout creation in TMEM needed used in Python with a dummy layout that is then expanded to the original Python layout after function inlining.

This does not fully apply dummy layouts because that adds significant complexity to the code. Currently we only modify the location that directly create such a layout in the Python. 