### PR TITLE
[TLX] Enable 2CTA for grouped gemm

### DIFF
--- a/third_party/tlx/tutorials/blackwell-grouped-gemm_test.py
+++ b/third_party/tlx/tutorials/blackwell-grouped-gemm_test.py
@@ -498,9 +498,8 @@ def grouped_matmul_tlx_kernel(
                             tlx.barrier_wait(smem_full_bars[smem_buf], smem_phase)
                             # buffer is now ready with loaded data, tlx.async_dot will signal `mBarrier` when done
                             if NUM_CTAS == 2:
-                                cta_bar = tlx.remote_view(cta_bars[smem_buf], 0)
-                                tlx.barrier_arrive(cta_bar, 1)
-                                tlx.barrier_wait(cta_bar, phase=smem_phase, pred=pred_cta0)
+                                tlx.barrier_arrive(cta_bars[smem_buf], 1, remote_cta_rank=0)
+                                tlx.barrier_wait(cta_bars[smem_buf], phase=smem_phase, pred=pred_cta0)
 
                             tlx.async_dot(
                                 buffers_A[smem_buf],


### PR DESCRIPTION
Very similar to GEMM, with one key difference: the tensor shapes are dynamic and only known after reading data from device memory. This means we cannot enforce that tile count is even along M dim before launching the kernels. 

To tackle that, we "extend the odd-numbered tile count by 1 virtual tile". When a leader CTA processes the a tile at the bottom (e.g. tile_m_idx == 2 from a range of 0~2), its peer CTA will pretend it's processing tile_m_idx == 3 and load operand B (and possibly A, which would zeroes, which we don't care anyway), and cooperate with leader CTA for synchronizations and MMA, but avoid writing anything back because it's out of bound of the real tensor D.

Reminder the 2cta works like this:

```
                               tensor B0 in CTA0  |  tensor B1 in CTA1
A0 in CTA0             [           result D0 in CTA0                       ]
A1 in CTA1             [           result D1 in CTA0                       ]
```
so for the virtual tile we don't care about A1 or D1. We only need it to load B1 to help D0 calculation.


Test Plan: `% pytest -vs third_party/tlx/tutorials/blackwell-grouped-gemm_test.py`
