### PR TITLE
[triton] fix build issue seen in OSS from vector inline sizing

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3496,7 +3496,7 @@ int TritonGPUDialect::getNumCTAs(ModuleOp module) {
 }
 
 SmallVector<int> TritonGPUDialect::getClusterDims(ModuleOp module) {
-  SmallVector<int, 3> values(3);
+  SmallVector<int> values(3);
   unsigned i = 0;
   for (auto attrName : {AttrClusterDimX, AttrClusterDimY, AttrClusterDimZ}) {
     values[i] = 1;


### PR DESCRIPTION
Summary:
Fix for 
  /home/kmanivannan/fb-triton/lib/Dialect/TritonGPU/IR/Dialect.cpp: In static member function ‘static llvm::SmallVector<int> mlir::triton::gpu::TritonGPUDialect::getClusterDims(mlir::ModuleOp)’:
      /home/kmanivannan/fb-triton/lib/Dialect/TritonGPU/IR/Dialect.cpp:3509:10: error: could not convert ‘values’ from ‘SmallVector<[...],3>’ to ‘SmallVector<[...],12>’
       3509 |   return values;
            |          ^~~~~~
            |          |
            |          SmallVector<[...],3>

Differential Revision: D89751850


