### PR TITLE
[triton][tlx] Extend live range of shmem allocs used by remote stores

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -281,6 +281,19 @@ SetVector<Operation *>
 multiRootGetSlice(Operation *op, TransitiveFilter backwardFilter = nullptr,
                   TransitiveFilter forwardFilter = nullptr);
 
+// Check if the given operations's forward slice has an op of the template types
+template <typename... OpTs>
+bool hasOpOfAnyTypeInForwardSlice(Operation *liveOp) {
+  llvm::SetVector<Operation *> forwardSlice;
+  getForwardSlice(liveOp, &forwardSlice);
+
+  for (Operation *op : forwardSlice) {
+    if ((isa<OpTs>(op) || ...))
+      return true;
+  }
+  return false;
+}
+
 /// Create a basic DataFlowSolver with constant and dead code analysis included.
 std::unique_ptr<DataFlowSolver> createDataFlowSolver();
 


### PR DESCRIPTION
Extend live range of allocs used by RemoteShmemStoreOp or AsyncRemoteShmemStoreOp.Without this change, expensive cluster_barriers are required to protect against WAR hazards from reuse of SHMEM to which a remote CTA is writing.

Test using the added lit test