### PR TITLE
[tritonbench] Add Triton MXFP8 grouped GEMM to fb/fp8_grouped_gemm

### DIFF
--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -75,6 +75,7 @@ type_canonicalisation_dict = {
     "float8_e5m2": "fp8e5",
     "float8e5b16": "fp8e5b16",
     "float8_e5m2fnuz": "fp8e5b16",
+    "float8_e8m0fnu": "u8",
     "half": "fp16",
     "float16": "fp16",
     "bfloat16": "bf16",


### PR DESCRIPTION
Summary:
Add standalone Triton MXFP8 grouped GEMM kernel and benchmark to the fb/fp8_grouped_gemm operator.

This adds a Triton kernel implementation using:
- On-device TMA (tl.make_tensor_descriptor) for dynamic descriptor creation
- tl.dot_scaled for proper FP8 microscaling on Blackwell GPUs
- 5D packed scale format for efficient TMA loading

New benchmark:
- triton_mxfp8_grouped_gemm: Regular Triton MXFP8 grouped GEMM kernel

Differential Revision: D90267285


