### PR TITLE
[TLX] Support 2-CTA mode for scaled MMA operations

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -572,7 +572,8 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
     I1:$pred,
     Variadic<TTG_MemDescType>:$barriers,
     Variadic<I1>:$barrier_preds,
-    UnitAttr:$is_async
+    UnitAttr:$is_async,
+    UnitAttr:$two_ctas
   );
   let results = (outs Optional<TTG_AsyncToken>:$token);
 
@@ -591,6 +592,7 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
       "::mlir::Value":$b_scale, "::mlir::triton::ScaleDotElemType":$a_type,
       "::mlir::triton::ScaleDotElemType":$b_type,
       "::mlir::Value":$useD, "::mlir::Value":$pred,
+      CArg<"bool", "false">:$two_ctas,
       CArg<"::mlir::ValueRange", "{}">:$barriers,
       CArg<"::mlir::ValueRange", "{}">:$barrier_preds,
       CArg<"bool", "false">:$is_async)>

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -317,7 +317,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread=[1, 4], threadsPerWarp=[32, 1], warpsPerCTA=[4, 1], order=[0, 1]}>
+#shared_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8, CTAsPerCGA = [2, 1], CTASplitNum = [2, 1], CTAOrder = [1, 0]}>
+#shared1_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8, CTAsPerCGA = [1, 2], CTASplitNum = [1, 2], CTAOrder = [1, 0]}>
+#shared2_scales = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CTAsPerCGA = [2], CTASplitNum = [1], CTAOrder = [0]}>
+#tmem_scales_2ctas = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true, CTASplitM = 2>
+#tmem_scales_enc = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_scaled_2ctas
+  tt.func @tc_gen5_mma_scaled_2ctas(%a: !ttg.memdesc<256x64xf8E4M3FN, #shared_scales, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<64x128xf8E4M3FN, #shared1_scales, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem_scales_2ctas, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<256x2xi8, #tmem_scales_enc, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x2xi8, #tmem_scales_enc, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2_scales, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    // CHECK: tcgen05.mma.cta_group::2.kind::mxf8f6f4
+    // CHECK: tcgen05.mma.cta_group::2.kind::mxf8f6f4
+    // CHECK: tcgen05.commit.cta_group::2.mbarrier::arrive::one
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e4m3, %barrier[%barrierPred] {is_async, two_ctas} :
+       !ttg.memdesc<256x64xf8E4M3FN, #shared_scales, #ttg.shared_memory>,
+       !ttg.memdesc<64x128xf8E4M3FN, #shared1_scales, #ttg.shared_memory>,
+       !ttg.memdesc<256x128xf32, #tmem_scales_2ctas, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<256x2xi8, #tmem_scales_enc, #ttng.tensor_memory>,
+       !ttg.memdesc<128x2xi8, #tmem_scales_enc, #ttng.tensor_memory>,
+       !ttg.memdesc<1xi64, #shared2_scales, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -265,17 +265,20 @@ static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
                                 MemDescOperand a, Value b, MemDescOperand d,
                                 Value scaleA, Value scaleB, Value pred,
                                 Value instDescriptor, Value useInitAcc,
-                                bool aInTmem, mxfpKind mxfpInstKind) {
+                                bool aInTmem, mxfpKind mxfpInstKind,
+                                bool twoCTAs) {
   PTXBuilder ptxBuilder;
+  std::string ctaGroup = std::to_string(twoCTAs ? 2 : 1);
   std::string opcode;
   if (mxfpInstKind == mxfpKind::mxf8f6f4) {
-    opcode =
-        "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X";
+    opcode = "tcgen05.mma.cta_group::" + ctaGroup +
+             ".kind::mxf8f6f4.block_scale.scale_vec::1X";
   } else if (mxfpInstKind == mxfpKind::mxf4) {
-    opcode = "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X";
+    opcode = "tcgen05.mma.cta_group::" + ctaGroup +
+             ".kind::mxf4.block_scale.scale_vec::2X";
   } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
-    opcode =
-        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X";
+    opcode = "tcgen05.mma.cta_group::" + ctaGroup +
+             ".kind::mxf4nvf4.block_scale.scale_vec::4X";
   } else {
     assert(0 && "Unsupported mxfp kind.");
   }
@@ -653,13 +656,13 @@ void convertScaledDot(const LLVMTypeConverter &typeConverter,
         subWordIdx, subWordIdx, mxfpInstKind);
     createScaledGen5MMA(rewriter, loc, op, a, b, accAddress, scaleA, scaleB,
                         pred, instDescriptor, useInitAcc, desc.aInTmem,
-                        mxfpInstKind);
+                        mxfpInstKind, op.getTwoCtas());
   };
 
   convertDotImpl(typeConverter, rewriter, loc, op.getA(), op.getB(),
                  adaptor.getA(), adaptor.getB(), dTensorTy, adaptor.getUseD(),
                  adaptor.getPred(), adaptor.getBarriers(),
-                 adaptor.getBarrierPreds(), /*twoCTAs=*/false,
+                 adaptor.getBarrierPreds(), op.getTwoCtas(),
                  /*tlxPairedMMA*/ false, opKindIsMXFP4, dot);
 }
 

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -127,13 +127,21 @@ public:
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
-    auto hasTLXTwoCTAs = mod.walk([&](ttng::TCGen5MMAOp tcgen05MMAOp) {
-                              if (tcgen05MMAOp.getTwoCtas()) {
-                                return WalkResult::interrupt();
-                              }
-                              return WalkResult::advance();
-                            })
-                             .wasInterrupted();
+    auto hasTLXTwoCTAs =
+        mod.walk([&](Operation *op) {
+             if (auto tcgen05MMAOp = dyn_cast<ttng::TCGen5MMAOp>(op)) {
+               if (tcgen05MMAOp.getTwoCtas()) {
+                 return WalkResult::interrupt();
+               }
+             } else if (auto tcgen05MMAScaledOp =
+                            dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
+               if (tcgen05MMAScaledOp.getTwoCtas()) {
+                 return WalkResult::interrupt();
+               }
+             }
+             return WalkResult::advance();
+           })
+            .wasInterrupted();
 
     if (failed(verifyModule(mod, hasTLXTwoCTAs))) {
       return signalPassFailure();

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -389,7 +389,8 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value a, Value b, Value d, Value aScale,
               Value bScale, tt::ScaleDotElemType aType,
               tt::ScaleDotElemType bType, std::optional<Value> useD,
-              std::optional<Value> pred, std::vector<Value> mBarriers) -> void {
+              std::optional<Value> pred, bool twoCTAs,
+              std::vector<Value> mBarriers) -> void {
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
              std::vector<Value> barrierPreds(mBarriers.size(), predTrue);
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
@@ -401,7 +402,7 @@ void init_triton_tlx_ir(py::module &&m) {
              self.create<ttng::TCGen5MMAScaledOp>(
                  tokType, a, b, d, Value(), aScale, bScale, aType, bType,
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
-                 pred.has_value() ? pred.value() : predTrue /*pred*/,
+                 pred.has_value() ? pred.value() : predTrue /*pred*/, twoCTAs,
                  ValueRange(mBarriers), ValueRange(barrierPreds),
                  !mBarriers.empty() /* is_async */);
            })

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -155,6 +155,7 @@ def async_dot_scaled(
     | tl.tensor = None,  # For blackwell, compute D = A @ B + D instead of D = A @ B. If None, default to True.
     pred=None,
     mBarriers: list[tlx.mbarrier] = [],
+    two_ctas: bool = False,
     out_dtype=tl.float32,
     _semantic=None,
 ) -> tl.tensor:
@@ -205,6 +206,10 @@ def async_dot_scaled(
     mBarriers : list[tlx.mbarrier]
         Optional mbarriers used to coordinate producer/consumer warp-groups
         when `async_dot_scaled` participates in a pipelined MMA schedule.
+
+    two_ctas : bool
+        If True, the op will execute a matmul across two contiguous CTAs,
+        reading data distributed across the two CTAs. Default is False.
 
     out_dtype : tl.dtype
         Output accumulation type before final store (default: fp32).
@@ -271,6 +276,7 @@ def async_dot_scaled(
         B_type,
         use_acc_handle,
         pred,
+        two_ctas,
         bar_handles,
     )
     return tl.tensor(output, tl.void)


### PR DESCRIPTION
Summary:
This change adds support for 2-CTA mode in scaled MMA operations on Blackwell GPUs.

Previously, `tcgen05.mma.cta_group::1` was always generated for scaled MMA operations even when `two_ctas=True` was specified, while non-scaled MMA correctly generated `cta_group::2`. This was causing test failures in `tritongpu_to_llvm_blackwell.mlir`.

The fix includes:

1. **MMAv5.cpp**: Modified `createScaledGen5MMA` to accept a `twoCTAs` parameter and dynamically generate the correct CTA group (`::1` or `::2`) in the PTX opcode for all mxfp kinds (mxf8f6f4, mxf4, mxf4nvf4).

2. **TritonNvidiaGPUOps.td**: Added `two_ctas` UnitAttr to `TCGen5MMAScaledOp` definition.

3. **Ops.cpp**:
   - Updated `TCGen5MMAScaledOp::build` to accept and propagate the `twoCTAs` parameter.
   - Fixed `TCGen5MMAScaledOp::verifyOutputDims()` to allow `oNdim == 2 * bNdim` when in 2-CTA mode.

4. **Fixup.cpp**: Extended `hasTLXTwoCTAs` detection to check both `TCGen5MMAOp` and `TCGen5MMAScaledOp` for the `two_ctas` attribute.

5. **Python bindings**: Added `two_ctas` parameter to `async_dot_scaled` in `mma_ops.py` and updated `triton_tlx.cc` bindings. Test Plan:
1. Added MLIR test `@tc_gen5_mma_scaled_2ctas` in `tritongpu_to_llvm_blackwell.mlir` that verifies:
   - `tcgen05.mma.cta_group::2.kind::mxf8f6f4` is generated for scaled MMA with `two_ctas` attribute

2. Added Python test `test_async_dot_scaled_2cta` in `test_tlx.py` that verifies:
   - Kernel launches with cluster_dims=(2,1,1)
   - TTGIR contains `ttng.tc_gen5_mma_scaled` and `ttng.map_to_remote_buffer`
   - PTX contains `tcgen05.mma.cta_group::2` (not `::1`)
