### PR TITLE
[TLX] Add mxfp4 (e2m1) scaled dot support

### DIFF
--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -168,7 +168,7 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
     """
 
     @classmethod
-    def make_default(cls, shape, elemType):
+    def make_default(cls, shape, elemType, fp4Padded=False):
         rank = len(shape)
         return cls(
             shape=shape,
@@ -177,7 +177,7 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
             numCTAsPerCGA=[1] * rank,
             numCTASplit=[1] * rank,
             numCTAOrder=[1] * rank,
-            fp4Padded=False,
+            fp4Padded=fp4Padded,
             swizzled=True,
         )
 


### PR DESCRIPTION
Summary:
Add test_async_dot_scaled_mxfp4 to test TLX's async_dot_scaled with mxfp4 (e2m1 x e2m1) format for both A and B matrices on Blackwell.

Key changes:
- Add fp4Padded parameter to nv_mma_shared_layout_encoding.make_default() and require_nv_mma_shared_layout() to enable 128-byte swizzle width for fp4 data
- Set fp4Padded=True when A_format or B_format is "e2m1" in async_dot_scaled
- Use 4D TMA scale layout [rep_m, rep_k, 2, 256] matching the working fp8 test pattern
