### PR TITLE
[triton] Pick layout with maximum score in RemoveLayoutConversions resolveConflicts

### DIFF
--- a/test/TLX/remove-layout-local-memory.mlir
+++ b/test/TLX/remove-layout-local-memory.mlir
@@ -19,5 +19,44 @@ tt.func @local_load_coalesce(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem>, %a
   ttg.local_store %1, %arg1 : tensor<128x64xf16, #blocked> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
   tt.return
 }
+}
 
+// -----
+
+// Test layout conflict resolution when both tmem_load and local_load are in the
+// same kernel with different layouts. The pass should prefer TMEM's layout with
+// larger sizePerThread ([1, 128], score=128) for better memory access efficiency.
+//
+// After the pass, the larger layout ([1, 128]) should be selected for both loads,
+// eliminating the need for intermediate convert_layout ops.
+
+// CHECK: #[[$TMEM_LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+// CHECK-LABEL: @tmem_and_local_load_conflict_resolution
+// Both loads should use the TMEM layout with higher score [1, 128]
+// CHECK: ttng.tmem_load %{{.*}} -> tensor<128x128xf32, #[[$TMEM_LAYOUT]]>
+// CHECK: ttg.local_load %{{.*}} -> tensor<128x128xbf16, #[[$TMEM_LAYOUT]]>
+// The convert_layout to the original common layout should still exist at the end
+// CHECK: ttg.convert_layout
+
+#blocked_tmem = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked_common = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_smem = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem1 = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+tt.func @tmem_and_local_load_conflict_resolution(
+    %tmem_buf: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %smem_buf: !ttg.memdesc<128x128xbf16, #shared1, #smem1>) -> tensor<128x128xf32, #blocked_common> {
+  // TMEM load with large sizePerThread [1, 128], score = 128
+  %result = ttng.tmem_load %tmem_buf : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked_tmem>
+  %result_cvt = ttg.convert_layout %result : tensor<128x128xf32, #blocked_tmem> -> tensor<128x128xf32, #blocked_common>
+  // SMEM local_load with small sizePerThread [1, 8], score = 8
+  %y = ttg.local_load %smem_buf : !ttg.memdesc<128x128xbf16, #shared1, #smem1> -> tensor<128x128xbf16, #blocked_smem>
+  %y_cvt = ttg.convert_layout %y : tensor<128x128xbf16, #blocked_smem> -> tensor<128x128xbf16, #blocked_common>
+  // Add them together (requires same layout)
+  %y_ext = arith.extf %y_cvt : tensor<128x128xbf16, #blocked_common> to tensor<128x128xf32, #blocked_common>
+  %z = arith.addf %result_cvt, %y_ext : tensor<128x128xf32, #blocked_common>
+  tt.return %z : tensor<128x128xf32, #blocked_common>
+}
 }


### PR DESCRIPTION
Summary:
When multiple layout candidates exist for a value (e.g., from both LocalLoadOp
and TMEMLoadOp), compare their scores and pick the one with the highest score.

Added getLayoutScore() helper that computes a score for layout selection.
Currently based on the product of sizePerThread values (vectorization), but can
be extended with other heuristics. Higher scores indicate better layouts.
Modified resolveConflicts() to iterate through all candidate layouts and select
the one with the highest score.

For example, TMEM's [1, 128] layout (score=128) would be preferred over SMEM's
[1, 8] layout (score=8).

This fixes layout conflicts in the addmm kernel by selecting
layouts that maximize memory access efficiency.

Differential Revision: D90889406


