### PR TITLE
[triton] Backport ast.Num/ast.Constant fix for stable and beta

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1213,9 +1213,9 @@ class CodeGenerator(ast.NodeVisitor):
             # visit iterator arguments
             # note: only `range` iterator is supported now
             # collect lower bound (lb), upper bound (ub), and step
-            lb = iter_args[0] if len(iter_args) > 1 else self.visit(ast.Num(0))
+            lb = iter_args[0] if len(iter_args) > 1 else self.visit(ast.Constant(0))
             ub = iter_args[1] if len(iter_args) > 1 else self.visit(node.iter.args[0])
-            step = iter_args[2] if len(iter_args) > 2 else self.visit(ast.Num(1))
+            step = iter_args[2] if len(iter_args) > 2 else self.visit(ast.Constant(1))
         else:
             raise RuntimeError("Only `range` and `static_range` iterators are currently supported")
         # handle negative constant step (not supported by scf.for in MLIR)


### PR DESCRIPTION
Summary:
This is already in trunk, but it's helpful to have in earlier versions for
experimenting with Python 3.14.  `ast.Num` is gone in Python 3.14.

Original commit is
https://github.com/triton-lang/triton/commit/c44b870bdd9e1ea8933fd4057b6b59a5e6e5407b.

Differential Revision: D90912100


