### PR TITLE
[triton][beta] Backport 'Replacing use of deprecated `ast.Num` (#8698)'

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1213,9 +1213,9 @@ class CodeGenerator(ast.NodeVisitor):
             # visit iterator arguments
             # note: only `range` iterator is supported now
             # collect lower bound (lb), upper bound (ub), and step
-            lb = iter_args[0] if len(iter_args) > 1 else self.visit(ast.Num(0))
+            lb = iter_args[0] if len(iter_args) > 1 else self.visit(ast.Constant(0))
             ub = iter_args[1] if len(iter_args) > 1 else self.visit(node.iter.args[0])
-            step = iter_args[2] if len(iter_args) > 2 else self.visit(ast.Num(1))
+            step = iter_args[2] if len(iter_args) > 2 else self.visit(ast.Constant(1))
         else:
             raise RuntimeError("Only `range` and `static_range` iterators are currently supported")
         # handle negative constant step (not supported by scf.for in MLIR)


### PR DESCRIPTION
Summary:
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/8698

Upstream commit message:
```
> Replacing use of deprecated `ast.Num` (#8698)

> <!---
> The core Triton is a small number of people, and we receive many PRs
> (thank
> you!).  To help us review your code more quickly, **if you are a new
> contributor (less than 3 PRs merged) we ask that you complete the
> following
> tasks and include the filled-out checklist in your PR description.**

> Complete the following tasks before sending your PR, and replace `[ ]`
> with
> `[x]` to indicate you have done them.
> -->

> # New contributor declaration
> - [x] I am not making a trivial change, such as fixing a typo in a
> comment.

> - [x] I have written a PR description following these
>   [rules](https://cbea.ms/git-commit/#why-not-how).

> - [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

> - Select one of the following.
>   - [ ] I have added tests.
>     - `/test` for `lit` tests
>     - `/unittest` for C++ tests
>     - `/python/test` for end-to-end tests
> - [x] This PR does not need a test because `Existing tests are
> sufficient`.

> - Select one of the following.
>   - [x] I have not added any `lit` tests.
> - [ ] The `lit` tests I have added follow these [best
> practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
> including the "tests should be minimal" section. (Usually running Python
> code
>     and using the instructions it generates is not minimal.)

> Replacing use of deprecated `ast.Num` class with `ast.Constant`. This
> change is necessary to allow compatibility with Python 3.14, in which
> `ast.Num` was removed.

> Co-authored-by: Rich Coombs <richardc@graphcore.ai>
```

***Do not remove the following line from this commit***
Reactor Backport Revision: c44b870bdd9e1ea8933fd4057b6b59a5e6e5407b
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --version beta --pr 8698
```

Reviewed By: njriasan

Differential Revision: D91136451


