### PR TITLE
[Triton] [GB300] [Beta] Add a pass to warn about FP64 performance

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -91,6 +91,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerConvertTritonGPUToLLVMPass();
   mlir::triton::registerConvertNVGPUToLLVMPass();
   mlir::triton::registerAllocateSharedMemoryNvPass();
+  mlir::triton::registerCudaWarningsPass();
   mlir::registerLLVMDIScope();
   mlir::LLVM::registerInlinerInterface(registry);
   mlir::NVVM::registerInlinerInterface(registry);

--- a/include/triton/Dialect/Triton/Transforms/Passes.h
+++ b/include/triton/Dialect/Triton/Transforms/Passes.h
@@ -3,12 +3,30 @@
 
 #include "mlir/Pass/Pass.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace mlir {
+
+class ModuleOp;
+template <typename T> class OperationPass;
+
 namespace triton {
 
 // Generate the pass class declarations.
 #define GEN_PASS_DECL
 #include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createCudaWarningsPass(int32_t computeCapability);
+
+/// Collect CUDA-specific performance warnings for a module.
+/// Returns a vector of warning messages that can be used to populate Python
+/// warnings. The pass version (createCudaWarningsPass) also emits these as
+/// MLIR warnings for lit testing purposes.
+std::vector<std::string> collectCudaWarnings(ModuleOp module,
+                                             int32_t computeCapability);
 
 #define GEN_PASS_REGISTRATION
 #include "triton/Dialect/Triton/Transforms/Passes.h.inc"

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -90,4 +90,38 @@ def TritonLoopAwareCSE : Pass<"triton-loop-aware-cse", "mlir::ModuleOp"> {
   }];
 }
 
+def CudaWarnings : Pass<"test-cuda-warnings", "mlir::ModuleOp"> {
+  let summary = "Emit warnings for performance-impacting patterns on CUDA targets";
+  let description = [{
+    This pass is intended for testing purposes only. Python code should instead call
+    into the `mlir::triton::collectCudaWarnings` API instead to get warnings visible
+    in Python.
+
+    This pass analyzes TTIR for patterns that may cause performance issues
+    on specific CUDA GPU architectures. Currently detects:
+
+    - FP64 (double-precision) math operations on GB300 (SM103): GB300 has
+      significantly reduced FP64 throughput (1/64th of FP32). The pass warns
+      when operations like arith.addf, arith.mulf, tt.dot, math.exp, etc.
+      operate on f64 types.
+
+    The pass emits MLIR warnings that surface to the user during compilation.
+    It does NOT warn on data movement operations like load/store.
+
+    The pass uses the compute capability to determine which warnings to emit.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::math::MathDialect"
+  ];
+
+  let options = [
+    Option<"computeCapability", "compute-capability",
+           "int32_t", /*default*/"0",
+           "Target GPU compute capability">
+  ];
+}
+
 #endif

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_public_tablegen_target(TritonCombineIncGen)
 
 add_triton_library(TritonTransforms
   Combine.cpp
+  CudaWarningsPass.cpp
   LoopAwareCSE.cpp
   LoopInvariantCodeMotion.cpp
   LoopPeeling.cpp

--- a/lib/Dialect/Triton/Transforms/CudaWarningsPass.cpp
+++ b/lib/Dialect/Triton/Transforms/CudaWarningsPass.cpp
@@ -1,0 +1,180 @@
+//===- CudaWarningsPass.cpp - CUDA target-specific warnings pass ---------===//
+//
+// Emits warnings for performance-impacting patterns on specific CUDA GPUs.
+//
+// Currently warns on FP64 math operations for GB300 (SM103), which has 1/28th
+// the FP64 throughput of GB200.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/CastInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
+
+using namespace mlir;
+
+namespace mlir::triton {
+#define GEN_PASS_DEF_CUDAWARNINGS
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+} // namespace mlir::triton
+
+namespace {
+
+/// Check if a type is or contains f64.
+static bool containsF64(Type type) {
+  if (auto floatType = dyn_cast<FloatType>(type))
+    return floatType.isF64();
+  if (auto shapedType = dyn_cast<ShapedType>(type))
+    return containsF64(shapedType.getElementType());
+  return false;
+}
+
+/// Check if an operation has any f64 operands or results.
+static bool hasF64OperandOrResult(Operation *op) {
+  for (Type type : op->getResultTypes())
+    if (containsF64(type))
+      return true;
+  for (Value operand : op->getOperands())
+    if (containsF64(operand.getType()))
+      return true;
+  return false;
+}
+
+/// Check if an operation is an FP64 math operation.
+static bool isFP64MathOp(Operation *op) {
+  if (!hasF64OperandOrResult(op))
+    return false;
+
+  // Arith dialect floating-point operations that implement
+  // ArithFastMathInterface are FP math ops, but we exclude casts (ExtFOp,
+  // TruncFOp, etc.) which implement the interface for fastmath propagation but
+  // aren't compute ops.
+  if (isa<arith::ArithFastMathInterface>(op) && !isa<CastOpInterface>(op))
+    return true;
+
+  // Math dialect operations (exp, sin, cos, sqrt, fma, etc.)
+  if (op->getDialect() && op->getDialect()->getNamespace() == "math")
+    return true;
+
+  // Triton compute operations
+  if (isa<triton::DotOp, triton::ReduceOp, triton::ScanOp>(op))
+    return true;
+
+  return false;
+}
+
+/// Check if a function name is a Triton builtin/internal function.
+static bool isBuiltinFunction(llvm::StringRef funcName) {
+  return funcName.starts_with("triton.");
+}
+
+/// Get the parent function of an operation by recursively walking up parents.
+static std::string getParentFunctionName(Operation *op) {
+  triton::FuncOp func = op->getParentOfType<triton::FuncOp>();
+  if (func) {
+    return func.getName().str();
+  } else {
+    return "";
+  }
+}
+
+/// Format function names from a set into a comma-separated string.
+static std::string formatFunctionNames(const llvm::StringSet<> &funcNames) {
+  if (funcNames.empty())
+    return "Kernel";
+
+  llvm::SmallVector<llvm::StringRef, 4> names;
+  for (const auto &entry : funcNames)
+    names.push_back(entry.getKey());
+
+  // Sort for deterministic output
+  llvm::sort(names);
+
+  if (names.size() == 1)
+    return names[0].str();
+
+  // Multiple kernels - join with commas
+  std::string result;
+  for (size_t i = 0; i < names.size(); ++i) {
+    if (i > 0)
+      result += ", ";
+    result += names[i].str();
+  }
+  return result;
+}
+
+/// Collect FP64 performance warnings for a module.
+/// Returns a vector of warning messages (empty if no warnings).
+static std::vector<std::string>
+collectFloat64PerformanceWarnings(ModuleOp module) {
+  std::vector<std::string> warnings;
+  llvm::StringSet<> functionsWithFP64Math;
+
+  module.walk([&](Operation *op) {
+    if (isFP64MathOp(op)) {
+      std::string funcName = getParentFunctionName(op);
+      if (!funcName.empty() && !isBuiltinFunction(funcName)) {
+        functionsWithFP64Math.insert(funcName);
+      }
+    }
+    return WalkResult::advance();
+  });
+
+  if (!functionsWithFP64Math.empty()) {
+    std::string kernelNames = formatFunctionNames(functionsWithFP64Math);
+    std::string message =
+        "PERFORMANCE WARNING: " + kernelNames +
+        " contains FP64 (double-precision) math operations on a "
+        "GB300 GPU. FP64 math throughput was reduced significantly on "
+        "GB300 (1/28th GB200 throughput). Consider using tl.float32 for "
+        "compute-intensive operations, possibly with algorithmic changes "
+        "for numeric stability.";
+    warnings.push_back(message);
+  }
+
+  return warnings;
+}
+
+struct CudaWarningsPass
+    : public mlir::triton::impl::CudaWarningsBase<CudaWarningsPass> {
+  using CudaWarningsBase::CudaWarningsBase;
+
+  // Pass is defined solely for lit test integration. Use
+  // collectCudaWarnings directly from Python in the compiler.
+
+  void runOnOperation() override {
+    if (computeCapability == 103) {
+      auto warnings = collectFloat64PerformanceWarnings(getOperation());
+      for (const auto &message : warnings) {
+        getOperation().emitWarning() << message;
+      }
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir::triton {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createCudaWarningsPass(int32_t computeCapability) {
+  return std::make_unique<CudaWarningsPass>(
+      CudaWarningsOptions{computeCapability});
+}
+
+std::vector<std::string> collectCudaWarnings(ModuleOp module,
+                                             int32_t computeCapability) {
+  std::vector<std::string> warnings;
+  if (computeCapability == 103) {
+    warnings = collectFloat64PerformanceWarnings(module);
+  }
+  return warnings;
+}
+
+} // namespace mlir::triton

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -32,6 +32,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -745,6 +746,16 @@ void init_triton_ir(py::module &&m) {
              return py::bool_(ret.getValue());
            })
       .def("get_tensordesc_metadata", getTensorDescMetadata)
+      .def("get_cuda_warnings",
+           [](ModuleOp &self, int32_t computeCapability) -> py::list {
+             py::list result;
+             auto warnings =
+                 mlir::triton::collectCudaWarnings(self, computeCapability);
+             for (const auto &warning : warnings) {
+               result.append(py::str(warning));
+             }
+             return result;
+           })
       .def("create_location_snapshot",
            [](ModuleOp &self, const std::string &fileName) -> void {
              auto printingFlags = getOpPrintingFlags();

--- a/test/Triton/cuda_warnings.mlir
+++ b/test/Triton/cuda_warnings.mlir
@@ -1,0 +1,80 @@
+// Test CudaWarningsPass with different compute capabilities
+// Only SM103 (GB300) should emit FP64 math warnings
+
+// RUN: triton-opt %s -split-input-file --test-cuda-warnings="compute-capability=103" 2>&1 | FileCheck %s --check-prefix=CHECK-SM103
+// RUN: triton-opt %s -split-input-file --test-cuda-warnings="compute-capability=100" 2>&1 | FileCheck %s --check-prefix=CHECK-SM100 --allow-empty
+// RUN: triton-opt %s -split-input-file --test-cuda-warnings="compute-capability=90" 2>&1 | FileCheck %s --check-prefix=CHECK-SM90 --allow-empty
+
+// CHECK-SM103-DAG: warning: PERFORMANCE WARNING: fp64_add contains FP64 (double-precision) math operations on a GB300 GPU
+// CHECK-SM103-DAG: warning: PERFORMANCE WARNING: fp64_mul contains FP64 (double-precision) math operations on a GB300 GPU
+// CHECK-SM103-DAG: warning: PERFORMANCE WARNING: fp64_div contains FP64 (double-precision) math operations on a GB300 GPU
+// CHECK-SM103-NOT: warning: PERFORMANCE WARNING: fp32_add
+// CHECK-SM103-NOT: warning: PERFORMANCE WARNING: fp64_load_store
+// CHECK-SM100-NOT: warning: PERFORMANCE WARNING
+// CHECK-SM90-NOT: warning: PERFORMANCE WARNING
+
+// -----
+
+// Test: FP64 addition should warn on SM103 only
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:103"} {
+  tt.func @fp64_add(%arg0: tensor<256xf64, #blocked>, %arg1: tensor<256xf64, #blocked>) -> tensor<256xf64, #blocked> {
+    %0 = arith.addf %arg0, %arg1 : tensor<256xf64, #blocked>
+    tt.return %0 : tensor<256xf64, #blocked>
+  }
+}
+
+// -----
+
+// Test: FP64 multiplication should warn on SM103 only
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:103"} {
+  tt.func @fp64_mul(%arg0: tensor<256xf64, #blocked>, %arg1: tensor<256xf64, #blocked>) -> tensor<256xf64, #blocked> {
+    %0 = arith.mulf %arg0, %arg1 : tensor<256xf64, #blocked>
+    tt.return %0 : tensor<256xf64, #blocked>
+  }
+}
+
+// -----
+
+// Test: FP64 division should warn on SM103 only
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:103"} {
+  tt.func @fp64_div(%arg0: tensor<256xf64, #blocked>, %arg1: tensor<256xf64, #blocked>) -> tensor<256xf64, #blocked> {
+    %0 = arith.divf %arg0, %arg1 : tensor<256xf64, #blocked>
+    tt.return %0 : tensor<256xf64, #blocked>
+  }
+}
+
+// -----
+
+// Test: FP32 operations should NEVER trigger a warning on any architecture
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:103"} {
+  tt.func @fp32_add(%arg0: tensor<256xf32, #blocked>, %arg1: tensor<256xf32, #blocked>) -> tensor<256xf32, #blocked> {
+    %0 = arith.addf %arg0, %arg1 : tensor<256xf32, #blocked>
+    tt.return %0 : tensor<256xf32, #blocked>
+  }
+}
+
+// -----
+
+// Test: FP64 load/store should NEVER trigger a warning (only math ops should warn)
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:103"} {
+  tt.func @fp64_load_store(%ptr: tensor<256x!tt.ptr<f64>, #blocked>, %val: tensor<256xf64, #blocked>) {
+    %0 = tt.load %ptr : tensor<256x!tt.ptr<f64>, #blocked>
+    tt.store %ptr, %val : tensor<256x!tt.ptr<f64>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -245,6 +245,12 @@ class CUDABackend(BaseBackend):
 
     @staticmethod
     def make_ttir(mod, metadata, opt, capability):
+        # Collect CUDA-specific warnings for Python emission
+        cuda_warnings = mod.get_cuda_warnings(capability)
+        for warning_msg in cuda_warnings:
+            import warnings
+            warnings.warn(warning_msg, stacklevel=2)
+
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         tlx.tlx_passes.add_triton_tlx_fixup(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)


### PR DESCRIPTION
Summary: Adds a pass to warn about FP64 performance on GB300, which is 1/28th that of GB200. This can lead to potential performance issues that may lead to wasted cycles investigating.

Differential Revision: D91165933


