### PR TITLE
Fix static srcMap bug causing multi-arch FP8 compilation failures

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -182,3 +182,41 @@ def test_signature_ordering():
     )
     target = triton.runtime.driver.active.get_current_target()
     triton.compile(src=src, target=target)
+
+
+def test_fp8_compiles_for_multiple_architectures_hip():
+    """
+    Validate FP8 compilation succeeds for architectures with different
+    hardware support.
+
+    gfx950 has native FP8 instructions; gfx942 does not and requires software
+    conversion. Compiling for both in sequence must succeed for each target.
+    """
+
+    @triton.jit
+    def fp8_convert(src, dst):
+        idx = tl.arange(0, 64)
+        tl.store(dst + idx, tl.load(src + idx).to(tl.float8e5))
+
+    src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
+    triton.compile(src, target=GPUTarget("hip", "gfx950", 64))
+    triton.compile(src, target=GPUTarget("hip", "gfx942", 64))
+
+
+def test_fp8_compiles_for_multiple_architectures_cuda():
+    """
+    Validate FP8 compilation succeeds for architectures with different
+    hardware support.
+
+    SM90 has native FP8 instructions; SM80 does not and requires software
+    conversion. Compiling for both in sequence must succeed for each target.
+    """
+
+    @triton.jit
+    def fp8_convert(src, dst):
+        idx = tl.arange(0, 64)
+        tl.store(dst + idx, tl.load(src + idx).to(tl.float8e5))
+
+    src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
+    triton.compile(src, target=GPUTarget("cuda", 90, 32))
+    triton.compile(src, target=GPUTarget("cuda", 80, 32))

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1696,59 +1696,56 @@ struct FpToFpOpConversion
 
     auto undefRounding = static_cast<RoundingMode>(-1);
 
-    static DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, ConverterT>
-        srcMap = {
-            // F8 -> F16
-            {{F8E4M3FNUZTyID, F16TyID, undefRounding},
-             Fp8E4M3FNUZ_to_Fp16(isaFamily)},
-            {{F8E4M3FNTyID, F16TyID, undefRounding},
-             Fp8E4M3FN_to_Fp16(isaFamily)},
-            {{F8E5M2FNUZTyID, F16TyID, undefRounding},
-             Fp8E5M2FNUZ_to_Fp16(isaFamily)},
-            {{F8E5M2TyID, F16TyID, undefRounding}, Fp8E5M2_to_Fp16(isaFamily)},
-            // F16 -> F8
-            {{F16TyID, F8E4M3FNTyID, RoundingMode::RTNE},
-             Fp16_to_Fp8E4M3FN_RTNE(isaFamily)},
-            {{F16TyID, F8E5M2FNUZTyID, RoundingMode::RTNE},
-             Fp16_to_Fp8E5M2FNUZ(isaFamily)},
-            {{F16TyID, F8E4M3FNUZTyID, RoundingMode::RTNE},
-             Fp16_to_Fp8E4M3FNUZ(isaFamily)},
-            {{F16TyID, F8E5M2TyID, RoundingMode::RTNE},
-             Fp16_to_Fp8E5M2_RTNE(isaFamily)},
-            {{F16TyID, F8E5M2TyID, RoundingMode::RTZ}, Fp16_to_Fp8E5M2_RTZ},
-            // F8 -> BF16
-            {{F8E5M2TyID, BF16TyID, undefRounding}, Fp8E5M2_to_Bf16(isaFamily)},
-            {{F8E5M2FNUZTyID, BF16TyID, undefRounding}, Fp8E5M2FNUZ_to_Bf16},
-            {{F8E4M3FNTyID, BF16TyID, undefRounding},
-             Fp8E4M3FN_to_Bf16(isaFamily)},
-            {{F8E4M3FNUZTyID, BF16TyID, undefRounding},
-             Fp8E4M3FNUZ_to_Bf16(isaFamily)},
-            // BF16 -> F8
-            {{BF16TyID, F8E5M2TyID, RoundingMode::RTNE},
-             Bf16_to_Fp8E5M2(isaFamily)},
-            {{BF16TyID, F8E4M3FNTyID, RoundingMode::RTNE},
-             Bf16_to_Fp8E4M3FN(isaFamily)},
-            {{BF16TyID, F8E5M2FNUZTyID, RoundingMode::RTNE},
-             Bf16_to_Fp8E5M2FNUZ(isaFamily)},
-            {{BF16TyID, F8E4M3FNUZTyID, RoundingMode::RTNE},
-             Bf16_to_Fp8E4M3FNUZ(isaFamily)},
-            // F32 <-> F8
-            {{F32TyID, F8E4M3FNUZTyID, RoundingMode::RTNE},
-             Fp32_to_Fp8E4M3FNUZ(isaFamily)},
-            {{F32TyID, F8E5M2FNUZTyID, RoundingMode::RTNE},
-             Fp32_to_Fp8E5M2FNUZ(isaFamily)},
-            {{F32TyID, F8E4M3FNTyID, RoundingMode::RTNE},
-             Fp32_to_Fp8E4M3FN_RTNE(isaFamily)},
-            {{F32TyID, F8E5M2TyID, RoundingMode::RTNE},
-             Fp32_to_Fp8E5M2_RTNE(isaFamily)},
-            {{F32TyID, F8E5M2TyID, RoundingMode::RTZ}, Fp32_to_Fp8E5M2_RTZ},
-            {{F8E4M3FNUZTyID, F32TyID, undefRounding}, Fp8E4M3FNUZ_to_Fp32},
-            {{F8E5M2FNUZTyID, F32TyID, undefRounding}, Fp8E5M2FNUZ_to_Fp32},
-            {{F8E4M3FNTyID, F32TyID, undefRounding}, Fp8E4M3FN_to_Fp32},
-            {{F8E5M2TyID, F32TyID, undefRounding}, Fp8E5M2_to_Fp32},
-            // F32 -> F16 with RTZ
-            {{F32TyID, F16TyID, RoundingMode::RTZ}, convertFp32ToFp16RTZ},
-        };
+    DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, ConverterT> srcMap = {
+        // F8 -> F16
+        {{F8E4M3FNUZTyID, F16TyID, undefRounding},
+         Fp8E4M3FNUZ_to_Fp16(isaFamily)},
+        {{F8E4M3FNTyID, F16TyID, undefRounding}, Fp8E4M3FN_to_Fp16(isaFamily)},
+        {{F8E5M2FNUZTyID, F16TyID, undefRounding},
+         Fp8E5M2FNUZ_to_Fp16(isaFamily)},
+        {{F8E5M2TyID, F16TyID, undefRounding}, Fp8E5M2_to_Fp16(isaFamily)},
+        // F16 -> F8
+        {{F16TyID, F8E4M3FNTyID, RoundingMode::RTNE},
+         Fp16_to_Fp8E4M3FN_RTNE(isaFamily)},
+        {{F16TyID, F8E5M2FNUZTyID, RoundingMode::RTNE},
+         Fp16_to_Fp8E5M2FNUZ(isaFamily)},
+        {{F16TyID, F8E4M3FNUZTyID, RoundingMode::RTNE},
+         Fp16_to_Fp8E4M3FNUZ(isaFamily)},
+        {{F16TyID, F8E5M2TyID, RoundingMode::RTNE},
+         Fp16_to_Fp8E5M2_RTNE(isaFamily)},
+        {{F16TyID, F8E5M2TyID, RoundingMode::RTZ}, Fp16_to_Fp8E5M2_RTZ},
+        // F8 -> BF16
+        {{F8E5M2TyID, BF16TyID, undefRounding}, Fp8E5M2_to_Bf16(isaFamily)},
+        {{F8E5M2FNUZTyID, BF16TyID, undefRounding}, Fp8E5M2FNUZ_to_Bf16},
+        {{F8E4M3FNTyID, BF16TyID, undefRounding}, Fp8E4M3FN_to_Bf16(isaFamily)},
+        {{F8E4M3FNUZTyID, BF16TyID, undefRounding},
+         Fp8E4M3FNUZ_to_Bf16(isaFamily)},
+        // BF16 -> F8
+        {{BF16TyID, F8E5M2TyID, RoundingMode::RTNE},
+         Bf16_to_Fp8E5M2(isaFamily)},
+        {{BF16TyID, F8E4M3FNTyID, RoundingMode::RTNE},
+         Bf16_to_Fp8E4M3FN(isaFamily)},
+        {{BF16TyID, F8E5M2FNUZTyID, RoundingMode::RTNE},
+         Bf16_to_Fp8E5M2FNUZ(isaFamily)},
+        {{BF16TyID, F8E4M3FNUZTyID, RoundingMode::RTNE},
+         Bf16_to_Fp8E4M3FNUZ(isaFamily)},
+        // F32 <-> F8
+        {{F32TyID, F8E4M3FNUZTyID, RoundingMode::RTNE},
+         Fp32_to_Fp8E4M3FNUZ(isaFamily)},
+        {{F32TyID, F8E5M2FNUZTyID, RoundingMode::RTNE},
+         Fp32_to_Fp8E5M2FNUZ(isaFamily)},
+        {{F32TyID, F8E4M3FNTyID, RoundingMode::RTNE},
+         Fp32_to_Fp8E4M3FN_RTNE(isaFamily)},
+        {{F32TyID, F8E5M2TyID, RoundingMode::RTNE},
+         Fp32_to_Fp8E5M2_RTNE(isaFamily)},
+        {{F32TyID, F8E5M2TyID, RoundingMode::RTZ}, Fp32_to_Fp8E5M2_RTZ},
+        {{F8E4M3FNUZTyID, F32TyID, undefRounding}, Fp8E4M3FNUZ_to_Fp32},
+        {{F8E5M2FNUZTyID, F32TyID, undefRounding}, Fp8E5M2FNUZ_to_Fp32},
+        {{F8E4M3FNTyID, F32TyID, undefRounding}, Fp8E4M3FN_to_Fp32},
+        {{F8E5M2TyID, F32TyID, undefRounding}, Fp8E5M2_to_Fp32},
+        // F32 -> F16 with RTZ
+        {{F32TyID, F16TyID, RoundingMode::RTZ}, convertFp32ToFp16RTZ},
+    };
     std::tuple<TypeID, TypeID, RoundingMode> key = {
         srcTy.getTypeID(), dstTy.getTypeID(),
         roundingMode.value_or(undefRounding)};

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -417,7 +417,7 @@ struct FpToFpOpConversion
 
     auto undefRounding = static_cast<RoundingMode>(-1);
 
-    static DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, Fp8ConversionDesc>
+    DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, Fp8ConversionDesc>
         srcMap = {
             // F8 -> F16
             {{F8E4M3TyID, F16TyID, undefRounding}, Fp8E4M3Nv_to_Fp16},


### PR DESCRIPTION
Summary:
Fixes T251684669 wherein compiling FP8 kernels for multiple AMD architectures in the
same process fails with "failed to legalize operation 'tt.fp_to_fp'".

The bug is in ElementwiseOpToLLVM.cpp's FpToFpOpConversion::getConversionFunc().
The srcMap that maps (srcType, dstType, roundingMode) to converter functions
was declared `static`, causing it to be initialized once with the first
architecture's isaFamily. Subsequent architectures would reuse the wrong
converters.

Example failure scenario:
1. Compile FP8 kernel for gfx950 (CDNA4) first
   - static srcMap initialized with CDNA4 converters (e.g., Fp8E4M3FNUZ_to_Fp16)
2. Compile same kernel for gfx942 (CDNA3)
   - srcMap already initialized, returns CDNA4 converters
   - CDNA3 lacks CDNA4-specific instructions, compilation fails

The fix removes the `static` keyword so the map is rebuilt with the correct
isaFamily for each architecture. The performance impact is negligible since
the map has only ~25 entries and is built per-conversion, not per-instruction.

This fix addresses the C++ lowering layer. It is independent of D90703927,
which fixes the Python dtype assignment layer (ensuring each CC gets the
correct FP8 dtype in the signature). Both fixes are needed for correct
multi-architecture FP8 support:
- D90703927: Python layer - assigns correct dtype per architecture
- This diff: C++ layer - uses correct converter per architecture

Reviewed By: fengxizhou

Differential Revision: D90807930


