### PR TITLE
[TLX] Support explict TMEM-backed MX scales

### DIFF
--- a/test/TLX/propagate-layout.mlir
+++ b/test/TLX/propagate-layout.mlir
@@ -197,6 +197,59 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 }
 
 // -----
+
+// Test that multibuffering is cancelled for TMEM scales allocations.
+// When a TMEMAllocOp with a 3D shape (1xMxK) receives TensorMemoryScalesEncodingAttr,
+// the shape should be flattened to 2D (MxK) and memdesc_index ops should be removed.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CTAsPerCGA = [1, 1, 1, 1, 1], CTASplitNum = [1, 1, 1, 1, 1], CTAOrder = [4, 3, 2, 1, 0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory
+#tmem_acc = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#dummy_tmem_layout = #tlx.dummy_tmem_layout<>
+#scales_encoding = #ttng.tensor_memory_scales_encoding<>
+
+// CHECK-DAG: #[[$TMEM_SCALES:.*]] = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @cancel_multibuffering_for_tmem_scales
+  tt.func public @cancel_multibuffering_for_tmem_scales(
+      %a_smem: !ttg.memdesc<128x256xf8E4M3FN, #shared, #smem, mutable>,
+      %b_smem: !ttg.memdesc<256x128xf8E4M3FN, #shared, #smem, mutable>,
+      %a_scale_smem: !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>,
+      %b_scale_smem: !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>) {
+    %c0_i32 = arith.constant 0 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+
+    // Accumulator in TMEM
+    %c_tile = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem_acc, #tmem, mutable>
+
+    // CHECK: ttng.tmem_alloc : () -> !ttg.memdesc<128x8xi8, #[[$TMEM_SCALES]], #ttng.tensor_memory, mutable>
+    %a_scale_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x8xi8, #dummy_tmem_layout, #tmem, mutable>
+    // CHECK: ttng.tmem_alloc : () -> !ttg.memdesc<256x4xi8, #[[$TMEM_SCALES]], #ttng.tensor_memory, mutable>
+    %b_scale_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<1x256x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // CHECK-NOT: ttg.memdesc_index %{{.*}} : !ttg.memdesc<1x128x8xi8
+    // CHECK-NOT: ttg.memdesc_index %{{.*}} : !ttg.memdesc<1x256x4xi8
+    %a_scale_indexed = ttg.memdesc_index %a_scale_tmem[%c0_i32] : !ttg.memdesc<1x128x8xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable>
+    %b_scale_indexed = ttg.memdesc_index %b_scale_tmem[%c0_i32] : !ttg.memdesc<1x256x4xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // Copy scales from SMEM to TMEM
+    ttng.tmem_copy %a_scale_smem, %a_scale_indexed : !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable>
+    ttng.tmem_copy %b_scale_smem, %b_scale_indexed : !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // Require scales layout for the MMA op
+    %a_scale_req = tlx.require_layout %a_scale_indexed : !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x8xi8, #scales_encoding, #tmem, mutable>
+    %b_scale_req = tlx.require_layout %b_scale_indexed : !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<256x4xi8, #scales_encoding, #tmem, mutable>
+
+    // CHECK: ttng.tc_gen5_mma_scaled
+    %0 = ttng.tc_gen5_mma_scaled %a_smem, %b_smem, %c_tile[], %a_scale_req, %b_scale_req, %false, %true lhs = e4m3 rhs = e4m3 : !ttg.memdesc<128x256xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<256x128xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem_acc, #tmem, mutable>, !ttg.memdesc<128x8xi8, #scales_encoding, #tmem, mutable>, !ttg.memdesc<256x4xi8, #scales_encoding, #tmem, mutable>
+    tt.return
+  }
+}
+
+// -----
 // CHECK-DAG: #[[$SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>

--- a/test/TLX/test.mlir
+++ b/test/TLX/test.mlir
@@ -1,0 +1,54 @@
+// RUN: triton-opt -split-input-file --tlx-propagate-layout %s| FileCheck %s
+
+// -----
+
+// Test that multibuffering is cancelled for TMEM scales allocations.
+// When a TMEMAllocOp with a 3D shape (1xMxK) receives TensorMemoryScalesEncodingAttr,
+// the shape should be flattened to 2D (MxK) and memdesc_index ops should be removed.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CTAsPerCGA = [1, 1, 1, 1, 1], CTASplitNum = [1, 1, 1, 1, 1], CTAOrder = [4, 3, 2, 1, 0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory
+#tmem_acc = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#dummy_tmem_layout = #tlx.dummy_tmem_layout<>
+#scales_encoding = #ttng.tensor_memory_scales_encoding<>
+
+// CHECK-DAG: #[[$TMEM_SCALES:.*]] = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @cancel_multibuffering_for_tmem_scales
+  tt.func public @cancel_multibuffering_for_tmem_scales(
+      %a_smem: !ttg.memdesc<128x256xf8E4M3FN, #shared, #smem, mutable>,
+      %b_smem: !ttg.memdesc<256x128xf8E4M3FN, #shared, #smem, mutable>,
+      %a_scale_smem: !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>,
+      %b_scale_smem: !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>) {
+    %c0_i32 = arith.constant 0 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+
+    // Accumulator in TMEM
+    %c_tile = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem_acc, #tmem, mutable>
+
+    // CHECK: ttng.tmem_alloc : () -> !ttg.memdesc<128x8xi8, #[[$TMEM_SCALES]], #ttng.tensor_memory, mutable>
+    %a_scale_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x8xi8, #dummy_tmem_layout, #tmem, mutable>
+    // CHECK: ttng.tmem_alloc : () -> !ttg.memdesc<256x4xi8, #[[$TMEM_SCALES]], #ttng.tensor_memory, mutable>
+    %b_scale_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<1x256x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // CHECK-NOT: ttg.memdesc_index %{{.*}} : !ttg.memdesc<1x128x8xi8
+    // CHECK-NOT: ttg.memdesc_index %{{.*}} : !ttg.memdesc<1x256x4xi8
+    %a_scale_indexed = ttg.memdesc_index %a_scale_tmem[%c0_i32] : !ttg.memdesc<1x128x8xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable>
+    %b_scale_indexed = ttg.memdesc_index %b_scale_tmem[%c0_i32] : !ttg.memdesc<1x256x4xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // Copy scales from SMEM to TMEM
+    ttng.tmem_copy %a_scale_smem, %a_scale_indexed : !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable>
+    ttng.tmem_copy %b_scale_smem, %b_scale_indexed : !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // Require scales layout for the MMA op
+    %a_scale_req = tlx.require_layout %a_scale_indexed : !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x8xi8, #scales_encoding, #tmem, mutable>
+    %b_scale_req = tlx.require_layout %b_scale_indexed : !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<256x4xi8, #scales_encoding, #tmem, mutable>
+
+    // CHECK: ttng.tc_gen5_mma_scaled
+    %0 = ttng.tc_gen5_mma_scaled %a_smem, %b_smem, %c_tile[], %a_scale_req, %b_scale_req, %false, %true lhs = e4m3 rhs = e4m3 : !ttg.memdesc<128x256xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<256x128xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem_acc, #tmem, mutable>, !ttg.memdesc<128x8xi8, #scales_encoding, #tmem, mutable>, !ttg.memdesc<256x4xi8, #scales_encoding, #tmem, mutable>
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/include/IR/TLXAttrDefs.td
+++ b/third_party/tlx/dialect/include/IR/TLXAttrDefs.td
@@ -43,4 +43,24 @@ def TLX_DummyRegisterLayoutAttr : TLX_Attr<"DummyRegisterLayout", []> {
   let assemblyFormat = "`<` `[` $shape `]` `,` $elementType `,` $tmemCompatible `>`";
 }
 
+def TLX_DummyTMEMLayoutAttr : TLX_Attr<"DummyTMEMLayout", []> {
+  let mnemonic = "dummy_tmem_layout";
+  let summary = "Placeholder layout for TMEM tensors to be resolved during layout propagation";
+
+  let description = [{
+    This attribute represents a placeholder layout for tensors in Tensor Memory (TMEM).
+    It is used when we don't know the final TMEM layout at allocation time.
+
+    During layout propagation, this will be resolved to a concrete TMEM layout:
+    - TensorMemoryEncodingAttr (for regular TMEM data)
+    - TensorMemoryScalesEncodingAttr (for scales in scaled MMA operations)
+
+    The resolution depends on how the TMEM buffer is used (e.g., as scales in tmem_copy).
+  }];
+
+  let parameters = (ins);
+
+  let assemblyFormat = "";
+}
+
 #endif // TLX_ATTRDEFS

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -66,6 +66,105 @@ public:
   using impl::TlxPropagateLayoutBase<
       TlxPropagateLayoutPass>::TlxPropagateLayoutBase;
 
+  /// Cancel multibuffering for TMEM allocations that will receive scales
+  /// encoding.
+  ///
+  /// Background:
+  /// - MX (Microscaling) scales for scaled MMA operations are stored in TMEM
+  ///   with TensorMemoryScalesEncodingAttr layout.
+  /// - Multibuffering creates 3D allocations with shape (num_buffers, M, K)
+  ///   where num_buffers is typically 1 for scales.
+  /// - However, TensorMemoryScalesEncodingAttr only supports 2D shapes (M, K).
+  ///
+  /// This function:
+  /// 1. Uses dataflow analysis to predict which allocs will receive scales
+  ///    encoding (before the encoding is actually applied).
+  /// 2. Flattens 3D shapes (1×M×K) to 2D (M×K) for those allocations.
+  /// 3. Removes memdesc_index ops that access the buffering dimension.
+  ///
+  /// Why this runs BEFORE layout propagation:
+  /// - The layout walk updates types based on dataflow analysis results.
+  /// - If we flattened types during/after the layout walk, memdesc_index ops
+  ///   would still expect 3D input, causing rank mismatch errors.
+  /// - By running this first, index ops are removed before type rewriting.
+  ///
+  /// @param funcOp The function to process.
+  /// @param solver The dataflow solver with layout analysis results.
+  void cancelMultibufferingForScales(triton::FuncOp funcOp,
+                                     DataFlowSolver &solver) {
+    DenseMap<Value, ttg::MemDescType> allocsToFlatten;
+
+    // =========================================================================
+    // Pass 1: Identify TMEMAllocOps that will have scales encoding
+    // =========================================================================
+    // Use dataflow analysis to predict the final encoding before it's applied.
+    // This allows us to identify scale allocs proactively.
+    funcOp.walk([&](ttng::TMEMAllocOp allocOp) {
+      auto origType = allocOp.getType();
+      auto shape = origType.getShape();
+
+      // Only process 3D allocations with buffering dimension of 1.
+      // Shape (1, M, K) indicates single-buffered TMEM allocation.
+      if (shape.size() != 3 || shape[0] != 1)
+        return WalkResult::advance();
+
+      // Query dataflow analysis for the predicted layout encoding.
+      // The solver has already propagated layout constraints through the IR.
+      auto *lattice =
+          solver.lookupState<LayoutEncodingLattice>(allocOp.getResult());
+      if (!lattice || lattice->getValue().isUninitialized())
+        return WalkResult::advance();
+
+      auto encoding = lattice->getValue().getLayoutEncoding();
+
+      // Only flatten allocations that will receive TensorMemoryScalesEncoding.
+      // Other TMEM allocations (e.g., accumulators) should keep their shape.
+      if (!isa<ttng::TensorMemoryScalesEncodingAttr>(encoding))
+        return WalkResult::advance();
+
+      // Build the flattened 2D type: (1, M, K) -> (M, K)
+      // Preserve the original encoding (DummyTMEMLayoutAttr) since the actual
+      // scales encoding will be applied later in the layout walk.
+      SmallVector<int64_t> newShape{shape[1], shape[2]};
+      auto newType = ttg::MemDescType::get(
+          newShape, origType.getElementType(), origType.getEncoding(),
+          origType.getMemorySpace(), origType.getMutableMemory());
+      allocsToFlatten[allocOp.getResult()] = newType;
+      return WalkResult::advance();
+    });
+
+    // =========================================================================
+    // Pass 2: Remove memdesc_index ops that access the buffering dimension
+    // =========================================================================
+    // With single-buffering cancelled, index ops like `memdesc_index %alloc[0]`
+    // become redundant. Replace their uses with the alloc directly.
+    SmallVector<ttg::MemDescIndexOp> indexOpsToRemove;
+    for (auto &[allocValue, newType] : allocsToFlatten) {
+      for (auto &use : allocValue.getUses()) {
+        if (auto indexOp = dyn_cast<ttg::MemDescIndexOp>(use.getOwner())) {
+          // The index op extracts a 2D slice from 3D: (1, M, K)[0] -> (M, K)
+          // After flattening, the alloc is already 2D, so replace all uses
+          // of the index result with the flattened alloc value.
+          indexOp.getResult().replaceAllUsesWith(allocValue);
+          indexOpsToRemove.push_back(indexOp);
+        }
+      }
+    }
+
+    // Erase the now-unused index ops.
+    for (auto indexOp : indexOpsToRemove) {
+      indexOp.erase();
+    }
+
+    // =========================================================================
+    // Pass 3: Update alloc types to the flattened 2D shape
+    // =========================================================================
+    // This must happen after index ops are removed to avoid type mismatches.
+    for (auto &[allocValue, newType] : allocsToFlatten) {
+      allocValue.setType(newType);
+    }
+  }
+
   void runOnFuncOp(triton::FuncOp funcOp) {
     // We can terminate early if we don't have a layout constraint.
     WalkResult walkResult = funcOp.walk([&](mlir::Operation *op) {
@@ -88,6 +187,17 @@ public:
     solver.load<LayoutForwardPropagation>();
     if (failed(solver.initializeAndRun(op)))
       return signalPassFailure();
+
+    // =========================================================================
+    // Cancel multibuffering for scales BEFORE applying layouts
+    // =========================================================================
+    // This must run before the layout walk because:
+    // 1. The layout walk updates types based on dataflow analysis results.
+    // 2. If we tried to flatten types during/after the layout walk,
+    //    memdesc_index ops would still reference 3D types, causing errors.
+    // 3. By running this first, we remove index ops and flatten alloc types
+    //    before any type rewriting occurs.
+    cancelMultibufferingForScales(funcOp, solver);
 
     auto getNewMemDescType = [&](ttg::MemDescType origType,
                                  Attribute encoding) {
@@ -139,6 +249,26 @@ public:
       }
       return WalkResult::advance();
     });
+
+    // =========================================================================
+    // Verification: Ensure all DummyTMEMLayoutAttr have been resolved
+    // =========================================================================
+    // DummyTMEMLayoutAttr is a placeholder for TMEM allocations that should
+    // receive a proper layout (e.g., TensorMemoryScalesEncodingAttr) during
+    // layout propagation. If any remain, it indicates a bug in the analysis.
+    bool hasDummyLayout = false;
+    funcOp.walk([&](ttng::TMEMAllocOp allocOp) {
+      auto encoding = allocOp.getType().getEncoding();
+      if (isa_and_nonnull<DummyTMEMLayoutAttr>(encoding)) {
+        allocOp.emitError(
+            "DummyTMEMLayoutAttr was not resolved during layout propagation");
+        hasDummyLayout = true;
+      }
+      return WalkResult::advance();
+    });
+    if (hasDummyLayout)
+      return signalPassFailure();
+
     return;
   }
 

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -107,6 +107,10 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value &dst, Value &regValues) -> void {
              self.create<ttg::LocalStoreOp>(regValues, dst);
            })
+      .def("create_tmem_copy",
+           [](TritonOpBuilder &self, Value src, Value dst) {
+             self.create<ttng::TMEMCopyOp>(src, dst, /*barrier=*/Value());
+           })
       .def("create_remote_store",
            [](TritonOpBuilder &self, Value &dst, Value &regValues,
               Value remoteCTARank) -> void {
@@ -142,6 +146,13 @@ void init_triton_tlx_ir(py::module &&m) {
              auto context = self.getBuilder().getContext();
              return mlir::cast<Attribute>(ttng::TensorMemoryEncodingAttr::get(
                  context, blockM, blockN, unpacked, CTASplitM, CTASplitN));
+           })
+      .def("make_tensor_memory_scales_encoding_attr",
+           [](TritonOpBuilder &self, unsigned CTASplitM, unsigned CTASplitN) {
+             auto context = self.getBuilder().getContext();
+             return mlir::cast<Attribute>(
+                 ttng::TensorMemoryScalesEncodingAttr::get(context, CTASplitM,
+                                                           CTASplitN));
            })
       .def("make_nv_mma_shared_encoding_attr",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
@@ -208,6 +219,10 @@ void init_triton_tlx_ir(py::module &&m) {
               Type elementType, bool tmemCompatible) -> Attribute {
              return tlx::DummyRegisterLayoutAttr::get(
                  self.getContext(), shape, elementType, tmemCompatible);
+           })
+      .def("make_dummy_tmem_layout_attr",
+           [](TritonOpBuilder &self) -> Attribute {
+             return tlx::DummyTMEMLayoutAttr::get(self.getContext());
            })
       .def("create_fence_async_shared",
            [](TritonOpBuilder &self) -> void {

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -39,6 +39,7 @@ from .mem_ops import (
     async_remote_shmem_store,
     remote_view,
     subslice,
+    tmem_copy,
 )
 from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, tcgen05_commit
 from .types import (

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -53,6 +53,17 @@ def require_tmem_layout_unpacked(src: tlx.buffered_tensor, unpacked: bool, _buil
     return src.handle
 
 
+def require_tmem_scales_layout(src: tlx.buffered_tensor, _builder=None):
+    """
+    Require tensor memory scales layout for a TMEM tensor.
+    """
+    assert isinstance(
+        src, tlx.buffered_tensor) and src.type.storage == tlx.storage_kind.tmem, ("input must be a TMEM tensor")
+    layout = tlx.tensor_memory_scales_layout_encoding.make_default()
+    layout_handle = layout.to_ir(_builder)
+    return _builder.create_require_layout(src.handle, layout_handle)
+
+
 # async dot signature needs to be close to tl.dot as much as possible
 @tl.builtin
 def async_dot(
@@ -183,7 +194,8 @@ def async_dot_scaled(
 
     A_scale : tlx.buffered_tensor
         Per-tile or per-subgroup scaling factors for operand A. Typically encoded
-        as FP8 (E8M0) and stored in SMEM or TMEM.
+        as FP8 (E8M0) and stored in SMEM or TMEM. The storage type is automatically
+        detected from the tensor's storage attribute.
 
     A_format : str
         FP8 format string for operand A (e.g., "e4m3", "e5m2"). Determines how
@@ -257,14 +269,21 @@ def async_dot_scaled(
     A_handle = require_nv_mma_shared_layout(A, True, _semantic.builder, fp4Padded=A_fp4Padded)
     B_handle = require_nv_mma_shared_layout(B, True, _semantic.builder, fp4Padded=B_fp4Padded)
 
-    # Require the shared memory layout for A_scale and B_scale
+    # Handle scale tensors - can be in SMEM or TMEM (auto-detected from storage type)
     assert isinstance(A_scale, tlx.buffered_tensor), "A_scale must be a buffered tensor"
-    assert A_scale.type.storage == tlx.storage_kind.smem, "A_scale must be a shared memory tensor"
     assert isinstance(B_scale, tlx.buffered_tensor), "B_scale must be a buffered tensor"
-    assert B_scale.type.storage == tlx.storage_kind.smem, "B_scale must be a shared memory tensor"
 
-    A_scale_handle = require_nv_mma_shared_layout(A_scale, False, _semantic.builder)
-    B_scale_handle = require_nv_mma_shared_layout(B_scale, False, _semantic.builder)
+    if A_scale.type.storage == tlx.storage_kind.tmem:
+        A_scale_handle = require_tmem_scales_layout(A_scale, _semantic.builder)
+    else:
+        assert A_scale.type.storage == tlx.storage_kind.smem, "A_scale must be in SMEM or TMEM"
+        A_scale_handle = require_nv_mma_shared_layout(A_scale, False, _semantic.builder)
+
+    if B_scale.type.storage == tlx.storage_kind.tmem:
+        B_scale_handle = require_tmem_scales_layout(B_scale, _semantic.builder)
+    else:
+        assert B_scale.type.storage == tlx.storage_kind.smem, "B_scale must be in SMEM or TMEM"
+        B_scale_handle = require_nv_mma_shared_layout(B_scale, False, _semantic.builder)
 
     # D needs to have `unpacked` set to True, see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-packing-formats
     acc_handle = require_tmem_layout_unpacked(acc, True, _semantic.builder)

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -140,6 +140,31 @@ class tensor_memory_layout_encoding(shared_layout_encoding):
         )
 
 
+class tensor_memory_scales_layout_encoding:
+    """
+    Tensor memory scales layout encoding for Blackwell.
+    Used for scales in scaled MMA operations.
+    """
+
+    def __init__(
+        self,
+        CTASplitM: int = 1,
+        CTASplitN: int = 1,
+    ):
+        self.CTASplitM = CTASplitM
+        self.CTASplitN = CTASplitN
+
+    @classmethod
+    def make_default(cls):
+        return cls(CTASplitM=1, CTASplitN=1)
+
+    def to_ir(self, builder: ir.builder) -> None:
+        return builder.make_tensor_memory_scales_encoding_attr(
+            self.CTASplitM,
+            self.CTASplitN,
+        )
+
+
 class nv_mma_shared_layout_encoding(shared_layout_encoding):
 
     def __init__(


### PR DESCRIPTION
Usage:

```python
a_scale_tmem = tlx.local_alloc((128, 8), tl.uint8, num=1, storage=tlx.storage_kind.tmem)
b_scale_tmem = tlx.local_alloc((256, 4), tl.uint8, num=1, storage=tlx.storage_kind.tmem)

tlx.tmem_copy(a_scale_smem, a_scale_tmem)
tlx.tmem_copy(b_scale_smem, b_scale_tmem)

tlx.async_dot_scaled(
    A, B, acc,
    A_scale=a_scale_tmem, A_format="e4m3",
    B_scale=b_scale_tmem, B_format="e4m3",
    ...
)
```

This change adds support for deferred TMEM layout resolution for scales in
scaled MMA operations.

The key insight is that when allocating TMEM buffers for scales (uint8/int8
types), we don't know the final layout at allocation time. The layout depends
on how the buffer is used - specifically, whether it's used as scales in a
scaled MMA operation.

The solution introduces DummyTMEMLayoutAttr as a placeholder that gets resolved
during layout propagation to TensorMemoryScalesEncodingAttr when the buffer is
used with tmem_copy for scales.

Key changes:
- Add DummyTMEMLayoutAttr placeholder for deferred TMEM layout resolution
- Support TensorMemoryScalesEncodingAttr in TMEM buffers (cancels multibuffering
  for 3D->2D)
- Add tmem_copy operation for SMEM to TMEM scale transfers
- Fix CTALayout rank mismatch for high-dimensional nvmma_shared tensors

