### PR TITLE
[TLX] Add force_async in TLX async_dot and async_dot_scaled

### DIFF
--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -389,7 +389,7 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
               mlir::Value &d, std::optional<Value> useD,
               std::optional<Value> pred, bool twoCTAs,
-              std::vector<Value> mBarriers) -> void {
+              std::vector<Value> mBarriers, bool forceAsync) -> void {
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
              std::vector<Value> barrierPreds(mBarriers.size(), predTrue);
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
@@ -398,14 +398,14 @@ void init_triton_tlx_ir(py::module &&m) {
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
                  pred.has_value() ? pred.value() : predTrue /*pred */, twoCTAs,
                  ValueRange(mBarriers), ValueRange(barrierPreds),
-                 !mBarriers.empty() /* is_async */);
+                 forceAsync || !mBarriers.empty() /* is_async */);
            })
       .def("create_tcgen5_dot_scaled",
            [](TritonOpBuilder &self, Value a, Value b, Value d, Value aScale,
               Value bScale, tt::ScaleDotElemType aType,
               tt::ScaleDotElemType bType, std::optional<Value> useD,
               std::optional<Value> pred, bool twoCTAs,
-              std::vector<Value> mBarriers) -> void {
+              std::vector<Value> mBarriers, bool forceAsync) -> void {
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
              std::vector<Value> barrierPreds(mBarriers.size(), predTrue);
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
@@ -419,7 +419,7 @@ void init_triton_tlx_ir(py::module &&m) {
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
                  pred.has_value() ? pred.value() : predTrue /*pred*/, twoCTAs,
                  ValueRange(mBarriers), ValueRange(barrierPreds),
-                 !mBarriers.empty() /* is_async */);
+                 forceAsync || !mBarriers.empty() /* is_async */);
            })
       .def("create_tcgen05_commit",
            [](TritonOpBuilder &self, Value &barrier, Value &pred) -> void {

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -75,6 +75,7 @@ def async_dot(
     pred=None,
     mBarriers: list[tlx.mbarrier] = [],
     two_ctas: bool = False,
+    force_async: bool = False,
     input_precision=None,
     out_dtype=tl.float32,
     _semantic=None,
@@ -138,7 +139,7 @@ def async_dot(
             else:
                 use_acc_handle = _semantic.builder.get_int1(use_acc.value)
         output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred, two_ctas,
-                                                     handles)
+                                                     handles, force_async)
         return tl.tensor(output, tl.void)
     else:
         mma_layout = _semantic.builder.make_nv_mma_encoding_attr(A_handle, acc_handle, version, 0,
@@ -167,6 +168,7 @@ def async_dot_scaled(
     pred=None,
     mBarriers: list[tlx.mbarrier] = [],
     two_ctas: bool = False,
+    force_async: bool = False,
     out_dtype=tl.float32,
     _semantic=None,
 ) -> tl.tensor:
@@ -308,6 +310,7 @@ def async_dot_scaled(
         pred,
         two_ctas,
         bar_handles,
+        force_async,
     )
     return tl.tensor(output, tl.void)
 

--- a/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
@@ -687,6 +687,7 @@ def _attn_fwd_ws(sm_scale, M,  #
                         kv_slice,
                         acc_tiles[0],
                         use_acc=slice_id > 0,
+                        force_async=True,
                     )
 
                 acc1_init = False
@@ -764,6 +765,7 @@ def _attn_fwd_ws(sm_scale, M,  #
                             kv_slice,
                             acc_tiles[0],
                             use_acc=True,
+                            force_async=True,
                         )
 
                 tlx.tcgen05_commit(q_empties[q_bufIdx])


### PR DESCRIPTION
This PR adds an additional field `force_async` in `tlx.async_dot` and `tlx.async_dot_scaled`. 

Previously the `is_async` field in `ttng::TCGen5MMAOp` and `ttng::TCGen5MMAScaledOp` are set to `!mBarriers.empty()`, while for cases when these MMA ops do not signal mBarriers, having `is_async` equals false forces sequential execution of  back-to-back MMAs and makes the perf inferior. 

It is useful for TLX users to set `force_async` to True which enables back-to-back tcgen5_dot to run asynchronously and gives perf gain.

Test plan:
```
TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_PTXAS_LOG=1 TRITON_DUMP_DIR=/tmp/triton_dumps CUDA_VISIBLE_DEVICES=6 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python blackwell-fa-ws-pipelined-persistent_test.py
```
perf numbers with `{mode, causal, BWD_BLOCK_M1, GROUP_SIZE_M} = {"fwd", False, 128, 8}`:
```
### force_async = False
fused-attention-ws-pipelined-persistent-batch4-head32-d128:
     N_CTX  Triton [FP16]
0   1024.0     753.363945
1   2048.0     901.711970
2   4096.0     916.061337
3   8192.0     932.953036
4  16384.0     954.476291

### force_async = True
fused-attention-ws-pipelined-persistent-batch4-head32-d128:
     N_CTX  Triton [FP16]
0   1024.0     789.257311
1   2048.0     917.391111
2   4096.0     930.486109
3   8192.0     987.343001
4  16384.0    1000.994924
```



# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
