### PR TITLE
[TLX] tutorial fix: pass arguments into bench_flash_attention

### DIFF
--- a/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import pytest
 import torch
 import triton
@@ -1941,27 +1942,33 @@ print(N_HEADS)
 # vary seq length for fixed head and batch=4
 configs = []
 for mode in ["fwd", "bwd"]:
-    configs.append(
-        triton.testing.Benchmark(
-            x_names=["N_CTX"],
-            x_vals=[2**i for i in range(10, 15)],
-            line_arg="provider",
-            line_vals=["triton-fp16"] + (["flash"] if HAS_FLASH else []),
-            line_names=["Triton [FP16]"] + (["Flash-2"] if HAS_FLASH else []),
-            styles=[("red", "-"), ("blue", "-"), ("green", "-")],
-            ylabel="TFLOPS",
-            plot_name=f"fused-attention-ws-pipelined-persistent-batch{BATCH}-head{N_HEADS}-d{HEAD_DIM}",
-            args={
-                "H": N_HEADS,
-                "BATCH": BATCH,
-                "HEAD_DIM": HEAD_DIM,
-                "mode": mode,
-            },
-        ))
+    for causal in [False, True]:
+        for BWD_BLOCK_M1 in [64, 128]:
+            for GROUP_SIZE_M in [8]:
+                configs.append(
+                    triton.testing.Benchmark(
+                        x_names=["N_CTX"],
+                        x_vals=[2**i for i in range(10, 15)],
+                        line_arg="provider",
+                        line_vals=["triton-fp16"] + (["flash"] if HAS_FLASH else []),
+                        line_names=["Triton [FP16]"] + (["Flash-2"] if HAS_FLASH else []),
+                        styles=[("red", "-"), ("blue", "-"), ("green", "-")],
+                        ylabel="TFLOPS",
+                        plot_name=f"fused-attention-ws-pipelined-persistent-batch{BATCH}-head{N_HEADS}-d{HEAD_DIM}",
+                        args={
+                            "H": N_HEADS,
+                            "BATCH": BATCH,
+                            "HEAD_DIM": HEAD_DIM,
+                            "mode": mode,
+                            "causal": causal,
+                            "BWD_BLOCK_M1": BWD_BLOCK_M1,
+                            "GROUP_SIZE_M": GROUP_SIZE_M,
+                        },
+                    ))
 
 
 @triton.testing.perf_report(configs)
-def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVICE, dtype=torch.float16):
+def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, causal, BWD_BLOCK_M1, GROUP_SIZE_M, device=DEVICE, dtype=torch.float16):
     assert mode in ["fwd", "bwd"]
     assert dtype in [torch.float16, torch.bfloat16, torch.float8_e5m2]
     if "triton" in provider:
@@ -1973,7 +1980,7 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, device=DEVI
             k = k.to(dtype)
             v = v.to(dtype)
         sm_scale = 1.3
-        fn = lambda: attention(q, k, v, sm_scale)
+        fn = lambda: attention(q, k, v, sm_scale, causal, BWD_BLOCK_M1, GROUP_SIZE_M)
         if mode == "bwd":
             o = fn()
             do = torch.randn_like(o)

--- a/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
+++ b/third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import pytest
 import torch
 import triton
@@ -1968,7 +1967,8 @@ for mode in ["fwd", "bwd"]:
 
 
 @triton.testing.perf_report(configs)
-def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, causal, BWD_BLOCK_M1, GROUP_SIZE_M, device=DEVICE, dtype=torch.float16):
+def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, provider, causal, BWD_BLOCK_M1, GROUP_SIZE_M, device=DEVICE,
+                          dtype=torch.float16):
     assert mode in ["fwd", "bwd"]
     assert dtype in [torch.float16, torch.bfloat16, torch.float8_e5m2]
     if "triton" in provider:


### PR DESCRIPTION
# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
