### PR TITLE
[triton][beta] Backport 'Fix dotCanBeProperlyAsync when wgmma is not yielded by loop (#9274)'

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -507,6 +507,12 @@ static std::optional<int> dotCanBeProperlyAsync(ttng::WarpGroupDotOp dotOp,
       return std::nullopt;
     }
   }
+
+  // The dot result is not used by the loop yield. This could happen if it is
+  // dead, or if it is only used inside (but not yielded by) an scf::IfOp.
+  if (!iterArg)
+    return std::nullopt;
+
   // Rule 2.1: We don't make the dot async if the accumulator is not fp32.
   if (!dotOp.getC().getType().getElementType().isF32()) {
     LDBG("Can't make dot async because the accumulator is not fp32");

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -934,7 +934,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
-
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
@@ -948,6 +947,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     // Note that this "overwriting" makes the program invalid after SWP, since warp_group_dot does not support row-major fp8 RHS.
     // In this case, the TMA load on B should not be pipelined. When this bug is fixed, this test should be rewritten to verify that.
     // CHECK-NOT: order = [0, 1]
+    // CHECK: tt.return
     %c128_i32 = arith.constant 128 : i32
     %c64_i32 = arith.constant 64 : i32
     %c0_i32 = arith.constant 0 : i32
@@ -981,5 +981,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %13 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, 0> to !tt.tensordesc<tensor<128x64xf32, #nvmma_128>>
     tt.descriptor_store %13[%5, %6], %12 : !tt.tensordesc<tensor<128x64xf32, #nvmma_128>>, tensor<128x64xf32, #blocked>
     tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: wgmma_not_yielded
+  // CHECK: scf.for
+  // CHECK-NEXT: ttng.warp_group_dot
+  // CHECK-NEXT: ttng.warp_group_dot_wait
+
+  tt.func public @wgmma_not_yielded() -> tensor<64x32xf32, #mma> {
+    %cst = arith.constant dense<3.000000e+00> : tensor<64x32xf32, #mma>
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x32xf32, #mma>
+    %cst_1 = arith.constant dense<1.000000e+00> : tensor<64x32xbf16, #blocked>
+    %cst_2 = arith.constant dense<1.000000e+00> : tensor<32x32xbf16, #blocked>
+    %0 = ttg.local_alloc %cst_1 : (tensor<64x32xbf16, #blocked>) -> !ttg.memdesc<64x32xbf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc %cst_2 : (tensor<32x32xbf16, #blocked>) -> !ttg.memdesc<32x32xbf16, #shared1, #smem, mutable>
+    %2 = scf.for %arg0 = %c0_i32 to %c64_i32 step %c32_i32 iter_args(%arg1 = %cst_0) -> (tensor<64x32xf32, #mma>)  : i32 {
+      %3 = ttng.warp_group_dot %0, %1, %cst_0 {inputPrecision = 0 : i32} : !ttg.memdesc<64x32xbf16, #shared, #smem, mutable> * !ttg.memdesc<32x32xbf16, #shared1, #smem, mutable> -> tensor<64x32xf32, #mma>
+      %4 = arith.cmpi ne, %arg0, %c0_i32 : i32
+      %5 = scf.if %4 -> (tensor<64x32xf32, #mma>) {
+        %6 = arith.addf %3, %cst : tensor<64x32xf32, #mma>
+        scf.yield %6 : tensor<64x32xf32, #mma>
+      } else {
+        %6 = arith.mulf %3, %cst : tensor<64x32xf32, #mma>
+        scf.yield %6 : tensor<64x32xf32, #mma>
+      }
+      scf.yield %5 : tensor<64x32xf32, #mma>
+    }
+    tt.return %2 : tensor<64x32xf32, #mma>
   }
 }


### PR DESCRIPTION
Summary:
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9274

Upstream commit message:
```
> Fix dotCanBeProperlyAsync when wgmma is not yielded by loop (#9274)
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 1c811b1c17b8124624bcf48fa6dd7a42f1f83622
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --version beta --pr 9274
```

Reviewed By: njriasan, neildhar

Differential Revision: D91276686


