### PR TITLE
[Draft] Add ProgramIdToAddressAnalysis for tracking program_id to address relationships

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -60,6 +60,7 @@ void registerTestPrintNestingPass();
 void registerTestAMDGPUMembarPass();
 void registerTestTritonAMDGPURangeAnalysis();
 void registerTestLoopPeelingPass();
+void registerTestProgramIdAddressPass();
 namespace proton {
 void registerTestScopeIdAllocationPass();
 } // namespace proton
@@ -82,6 +83,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestLoopPeelingPass();
   mlir::test::registerTestAMDGPUMembarPass();
   mlir::test::registerTestTritonAMDGPURangeAnalysis();
+  mlir::test::registerTestProgramIdAddressPass();
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::registerRelayoutTritonGPUPass();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();

--- a/docs/LOAD_STORE_PROGRAM_ID_ANALYSIS.md
+++ b/docs/LOAD_STORE_PROGRAM_ID_ANALYSIS.md
@@ -1,0 +1,346 @@
+# Load/Store Address Block to Program ID Analysis
+
+This document analyzes how load/store operations' address blocks relate to `program_id` in Triton, and provides a design for implementing an analysis pass.
+
+## 1. Overview
+
+In Triton's SPMD (Single Program Multiple Data) programming model, each program instance is identified by a `program_id` which is used to compute unique memory addresses for load/store operations. Understanding how these addresses are derived from `program_id` is crucial for:
+
+- **Memory coalescing optimization**: Ensuring threads within a warp access contiguous memory
+- **Vectorization**: Determining how many elements each thread should handle
+- **Alias analysis**: Understanding when different programs access the same or different memory
+- **Bounds checking**: Ensuring programs don't access out-of-bounds memory
+
+## 2. Key Triton IR Operations
+
+### 2.1 Program ID Operations
+
+**File**: `/data/users/mren/MetaMain/triton/include/triton/Dialect/Triton/IR/TritonOps.td` (lines 629-647)
+
+```tablegen
+def TT_GetProgramIdOp : TT_Op<"get_program_id", [Pure]> {
+    let arguments = (ins TT_ProgramDim:$axis);
+    let results = (outs I32:$result);
+}
+```
+
+- Returns a scalar `i32` representing the program ID for a given axis (0, 1, or 2 for 3D grids)
+- Pure operation (no side effects)
+- Range: `[0, num_programs - 1]` where max is typically `2^31 - 1`
+
+### 2.2 Pointer Arithmetic Operations
+
+**AddPtrOp** (lines 206-219):
+```tablegen
+def TT_AddPtrOp : TT_Op<"addptr", [Pure, Elementwise, ...]> {
+    let arguments = (ins TT_PtrLike:$ptr, TT_IntLike:$offset);
+    let results = (outs TT_PtrLike:$result);
+}
+```
+
+- Element-wise pointer arithmetic: `ptr + offset * sizeof(pointee)`
+- Critical for computing per-thread memory addresses
+
+### 2.3 Load/Store Operations
+
+**LoadOp** (lines 239-312):
+```tablegen
+def TT_LoadOp : TT_Op<"load", [...MemoryEffectsOpInterface...]> {
+    let arguments = (
+        ins AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>:$ptr,
+        Optional<TT_BoolLike>:$mask,
+        Optional<TT_Type>:$other,
+        ...
+    );
+}
+```
+
+**StoreOp** (lines 314-358):
+```tablegen
+def TT_StoreOp : TT_Op<"store", [...]> {
+    let arguments = (ins
+        Arg<AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>, "", [MemWrite<GlobalMemory>]>:$ptr,
+        TT_Type:$value,
+        Optional<TT_BoolLike>:$mask,
+        ...
+    );
+}
+```
+
+## 3. Typical Address Calculation Pattern
+
+A typical Triton program computes addresses as follows:
+
+```
+%pid = tt.get_program_id x : i32                    // Get program ID
+%block_start = arith.muli %pid, %c128_i32 : i32     // pid * BLOCK_SIZE
+%offsets = tt.make_range {start=0, end=128}         // [0, 1, 2, ..., 127]
+%block_offsets = arith.addi %block_start, %offsets  // [pid*128, pid*128+1, ..., pid*128+127]
+%ptr_base = tt.splat %arg0 : !tt.ptr<f32>           // Broadcast base pointer
+%ptrs = tt.addptr %ptr_base, %block_offsets         // Compute final addresses
+%vals = tt.load %ptrs : tensor<128xf32>             // Load from computed addresses
+```
+
+### 3.1 Data Flow Chain
+
+```
+GetProgramIdOp (scalar i32)
+    ↓
+arith.muli (scale by block size)
+    ↓
+arith.addi / SplatOp + BroadcastOp (combine with per-thread offsets)
+    ↓
+AddPtrOp (add to base pointer tensor)
+    ↓
+LoadOp / StoreOp (memory access)
+```
+
+## 4. Existing Analysis Infrastructure
+
+### 4.1 AxisInfo Analysis
+
+**Location**: `/data/users/mren/MetaMain/triton/lib/Analysis/AxisInfo.cpp`
+
+Tracks three properties per tensor dimension:
+- **Contiguity**: Length of shortest sequence of contiguous integers
+- **Divisibility**: Largest power-of-2 dividing first element of each contiguous sequence
+- **Constancy**: Length of shortest repeating sequence
+
+Example for `AddPtrOp` handling (lines 290-308):
+```cpp
+if constexpr (std::is_same_v<OpTy, triton::AddPtrOp>) {
+    auto elemSize = triton::getPointeeBitWidth(op.getPtr().getType()) / 8;
+    rhsDivisibility = multiplyDivisor(rhs.getDivisibility(dim), elemSize);
+}
+return gcd(lhs.getDivisibility(dim), rhsDivisibility);
+```
+
+### 4.2 RangeAnalysis (AMD)
+
+**Location**: `/data/users/mren/MetaMain/triton/third_party/amd/lib/Analysis/RangeAnalysis.cpp`
+
+Extends MLIR's `IntegerRangeAnalysis` for Triton:
+- Tracks value ranges (min, max) for integer values
+- Special handling for `GetProgramIdOp`: range is `[0, 2^31 - 1]`
+- Supports "abstract interpretation" through loops
+- Uses assumptions (e.g., from `tl.assume`) for tighter bounds
+
+```cpp
+// Lines 612-616: GetProgramIdOp range inference
+if (llvm::isa<GetProgramIdOp, MakeRangeOp, HistogramOp, GetNumProgramsOp>(op)) {
+    llvm::TypeSwitch<Operation *>(op)
+        .Case<GetProgramIdOp>([&](auto getPIDOp) {
+            inferResultRangesPID(getPIDOp, kDefaultMaxPrograms - 1, joinCallback);
+        })
+```
+
+### 4.3 Coalescing Analysis
+
+**Location**: `/data/users/mren/MetaMain/triton/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp`
+
+Uses AxisInfo to determine optimal memory access patterns:
+```cpp
+// Get memory access contiguity from axis info
+auto contiguity = axisInfoAnalysis.getAxisInfo(ptr)->getContiguity();
+SmallVector<unsigned> order = getOrderFromContiguity(contiguity);
+```
+
+## 5. Proposed Analysis Pass Design
+
+### 5.1 Analysis Goal
+
+Track the **affine relationship** between each load/store address and `program_id`:
+
+```
+address[i] = base_ptr + (pid * stride + offset[i]) * elem_size
+```
+
+Where:
+- `base_ptr`: The base pointer argument
+- `pid`: The program ID(s) used
+- `stride`: The multiplier for program_id (typically block size)
+- `offset[i]`: Per-element offset within the block
+- `elem_size`: Size of element being accessed
+
+### 5.2 Lattice State Definition
+
+```cpp
+// Represents the relationship: addr = base + (pid * stride + offset) * elem_size
+class ProgramIdAddressInfo {
+public:
+    struct AddressExpr {
+        Value basePtr;                    // Base pointer value
+        SmallVector<int> pidAxes;         // Which program_id axes are used (0, 1, 2)
+        SmallVector<int64_t> pidStrides;  // Stride for each pid axis
+        int64_t constantOffset;           // Constant offset component
+        bool hasNonConstantOffset;        // true if offset depends on other values
+        int64_t elemSize;                 // Size of accessed element
+    };
+
+    std::optional<AddressExpr> expr;      // None if relationship is unknown
+
+    static ProgramIdAddressInfo join(const ProgramIdAddressInfo& lhs,
+                                     const ProgramIdAddressInfo& rhs);
+    static ProgramIdAddressInfo getPessimisticValueState(Value v);
+};
+```
+
+### 5.3 Pass Implementation Structure
+
+```cpp
+class ProgramIdToAddressAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<
+          dataflow::Lattice<ProgramIdAddressInfo>> {
+private:
+    // Visitors for different operations
+    class GetProgramIdVisitor;
+    class ArithMulIVisitor;
+    class ArithAddIVisitor;
+    class SplatOpVisitor;
+    class AddPtrOpVisitor;
+    class LoadOpVisitor;
+    class StoreOpVisitor;
+
+public:
+    void setToEntryState(dataflow::Lattice<ProgramIdAddressInfo> *lattice) override;
+
+    LogicalResult visitOperation(
+        Operation *op,
+        ArrayRef<const dataflow::Lattice<ProgramIdAddressInfo> *> operands,
+        ArrayRef<dataflow::Lattice<ProgramIdAddressInfo> *> results) override;
+};
+```
+
+### 5.4 Key Transfer Functions
+
+#### GetProgramIdOp:
+```cpp
+AxisInfo getAxisInfo(GetProgramIdOp op, ...) {
+    return ProgramIdAddressInfo{
+        .basePtr = nullptr,
+        .pidAxes = {op.getAxisAsInt()},
+        .pidStrides = {1},
+        .constantOffset = 0,
+        .hasNonConstantOffset = false,
+        .elemSize = 1
+    };
+}
+```
+
+#### arith.muli (pid * constant):
+```cpp
+// If one operand is pid info and other is constant
+if (lhs.isPidBased() && rhs.isConstant()) {
+    return ProgramIdAddressInfo{
+        .pidAxes = lhs.pidAxes,
+        .pidStrides = lhs.pidStrides * rhs.getConstantValue(),
+        ...
+    };
+}
+```
+
+#### tt.addptr:
+```cpp
+// Combines pointer base with offset
+ProgramIdAddressInfo getAxisInfo(AddPtrOp op, ...) {
+    auto ptrInfo = operands[0]->getValue();
+    auto offsetInfo = operands[1]->getValue();
+
+    return ProgramIdAddressInfo{
+        .basePtr = /* extract from ptrInfo or op.getPtr() */,
+        .pidAxes = /* merge from both */,
+        .pidStrides = offsetInfo.pidStrides * elemSize,
+        .constantOffset = offsetInfo.constantOffset * elemSize,
+        ...
+    };
+}
+```
+
+### 5.5 Output: Load/Store Classification
+
+The analysis produces for each load/store:
+
+```cpp
+struct LoadStoreAddressPattern {
+    enum class Pattern {
+        PID_INDEPENDENT,      // Address doesn't depend on program_id
+        PID_AFFINE,           // addr = base + pid * stride + offset
+        PID_MULTI_AXIS,       // Depends on multiple pid axes
+        PID_NONLINEAR,        // Non-affine dependence on pid
+        UNKNOWN               // Cannot determine relationship
+    };
+
+    Pattern pattern;
+    Value basePtr;
+    SmallVector<std::pair<int, int64_t>> pidAxisStrides;  // [(axis, stride), ...]
+    std::optional<int64_t> blockSize;   // Size of contiguous block per program
+    bool isCoalesced;                    // Whether access pattern is coalesced
+};
+```
+
+## 6. Implementation Steps
+
+### Step 1: Define the Lattice
+Create `ProgramIdAddressInfo.h` in `/data/users/mren/MetaMain/triton/include/triton/Analysis/`
+
+### Step 2: Implement Transfer Functions
+Create `ProgramIdAddressInfo.cpp` in `/data/users/mren/MetaMain/triton/lib/Analysis/`
+
+Implement visitors for:
+- `GetProgramIdOp`: Initialize pid info
+- `arith.muli`, `arith.addi`, `arith.subi`: Propagate through arithmetic
+- `tt.splat`, `tt.broadcast`, `tt.expand_dims`: Handle tensor shape changes
+- `tt.addptr`: Combine pointer and offset info
+- `tt.load`, `tt.store`: Record final address pattern
+
+### Step 3: Register the Pass
+Add pass definition to `/data/users/mren/MetaMain/triton/include/triton/Analysis/Passes.td`
+
+### Step 4: Add Tests
+Create test file in `/data/users/mren/MetaMain/triton/test/Analysis/test-pid-address.mlir`
+
+### Step 5: Integration
+Optionally expose results for use by other passes (e.g., coalescing, vectorization)
+
+## 7. Example Analysis Results
+
+### Input IR:
+```mlir
+tt.func @vector_add(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) {
+    %c128 = arith.constant 128 : i32
+    %pid = tt.get_program_id x : i32
+    %block_start = arith.muli %pid, %c128 : i32
+    %offsets = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32>
+    %indices = arith.addi %block_start, %offsets : tensor<128xi32>
+
+    %ptr_a = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %ptrs_a = tt.addptr %ptr_a, %indices : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %a = tt.load %ptrs_a : tensor<128x!tt.ptr<f32>>
+    ...
+}
+```
+
+### Analysis Output:
+```
+%pid:       PID_INFO(axis=0, stride=1, offset=0)
+%block_start: PID_INFO(axis=0, stride=128, offset=0)
+%indices:   PID_INFO(axis=0, stride=128, offset=[0,127], elem_range)
+%ptrs_a:    ADDR_INFO(base=%arg0, axis=0, stride=512, offset=[0,508], coalesced=true)
+%a (load):  PATTERN(PID_AFFINE, block_size=128, stride=512, coalesced=true)
+```
+
+## 8. Potential Applications
+
+1. **Memory Coalescing Verification**: Verify that memory accesses are coalesced
+2. **Vectorization Hints**: Determine optimal vector width based on address patterns
+3. **Out-of-Bounds Detection**: Detect potential OOB accesses when bounds are known
+4. **Alias Analysis**: Determine when different programs access disjoint memory
+5. **Prefetching**: Guide prefetch insertion based on access patterns
+
+## 9. References
+
+- AxisInfo Analysis: `/data/users/mren/MetaMain/triton/lib/Analysis/AxisInfo.cpp`
+- RangeAnalysis: `/data/users/mren/MetaMain/triton/third_party/amd/lib/Analysis/RangeAnalysis.cpp`
+- Coalesce Pass: `/data/users/mren/MetaMain/triton/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp`
+- MLIR DataFlow Framework: `mlir/Analysis/DataFlow/SparseAnalysis.h`
+- Triton IR Operations: `/data/users/mren/MetaMain/triton/include/triton/Dialect/Triton/IR/TritonOps.td`

--- a/include/triton/Analysis/ProgramIdToAddressAnalysis.h
+++ b/include/triton/Analysis/ProgramIdToAddressAnalysis.h
@@ -1,0 +1,244 @@
+//===- ProgramIdToAddressAnalysis.h - Program ID to Address Analysis -----===//
+//
+// Part of the Triton Project, under the Apache License v2.0.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines an analysis that tracks how load/store addresses relate
+// to program_id in Triton programs. This is useful for:
+// - Memory coalescing verification
+// - Vectorization hints
+// - Alias analysis between different program instances
+// - Out-of-bounds detection
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_ANALYSIS_PROGRAMIDTOADDRESSANALYSIS_H
+#define TRITON_ANALYSIS_PROGRAMIDTOADDRESSANALYSIS_H
+
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <optional>
+
+namespace mlir::triton {
+
+//===----------------------------------------------------------------------===//
+// ProgramIdAddressInfo - Lattice value tracking pid-to-address relationship
+//===----------------------------------------------------------------------===//
+
+/// Represents how a value relates to program_id in address calculations.
+/// The general form tracked is:
+///   value = sum(pid[axis] * stride[axis]) + constant_offset + variable_offset
+///
+/// For pointer values, this becomes:
+///   ptr = base_ptr + (sum(pid[axis] * stride[axis]) + offset) * elem_size
+class ProgramIdAddressInfo {
+public:
+  /// Represents a single program_id axis contribution
+  struct PidComponent {
+    int axis;       // 0, 1, or 2 for x, y, z
+    int64_t stride; // Multiplier for this pid axis
+
+    bool operator==(const PidComponent &other) const {
+      return axis == other.axis && stride == other.stride;
+    }
+  };
+
+  /// Classification of the address pattern
+  enum class Pattern {
+    UNKNOWN,       // Cannot determine relationship
+    CONSTANT,      // No dependence on pid (constant across programs)
+    PID_AFFINE,    // Linear dependence: base + sum(pid * stride) + offset
+    PID_NONLINEAR, // Non-linear dependence (e.g., pid * pid)
+  };
+
+public:
+  ProgramIdAddressInfo() = default;
+
+  /// Create info for a constant value
+  static ProgramIdAddressInfo getConstant(int64_t value) {
+    ProgramIdAddressInfo info;
+    info.pattern = Pattern::CONSTANT;
+    info.constantOffset = value;
+    return info;
+  }
+
+  /// Create info for a program_id value
+  static ProgramIdAddressInfo getProgramId(int axis) {
+    ProgramIdAddressInfo info;
+    info.pattern = Pattern::PID_AFFINE;
+    info.pidComponents.push_back({axis, 1});
+    return info;
+  }
+
+  /// Create pessimistic (unknown) state
+  static ProgramIdAddressInfo getPessimisticValueState(Value value);
+
+  /// Join two lattice values (meet operation for forward analysis)
+  static ProgramIdAddressInfo join(const ProgramIdAddressInfo &lhs,
+                                   const ProgramIdAddressInfo &rhs);
+
+  // Accessors
+  Pattern getPattern() const { return pattern; }
+  bool isUnknown() const { return pattern == Pattern::UNKNOWN; }
+  bool isConstant() const { return pattern == Pattern::CONSTANT; }
+  bool isPidAffine() const { return pattern == Pattern::PID_AFFINE; }
+  bool isPidNonlinear() const { return pattern == Pattern::PID_NONLINEAR; }
+
+  ArrayRef<PidComponent> getPidComponents() const { return pidComponents; }
+  int64_t getConstantOffset() const { return constantOffset; }
+  bool getHasVariableOffset() const { return hasVariableOffset; }
+  Value getBasePtr() const { return basePtr; }
+  int64_t getElemSize() const { return elemSize; }
+
+  // Modifiers for building address info through operations
+  void setBasePtr(Value ptr, int64_t size) {
+    basePtr = ptr;
+    elemSize = size;
+  }
+
+  void addPidComponent(int axis, int64_t stride);
+  void multiplyStrides(int64_t factor);
+  void addConstantOffset(int64_t offset);
+  void setHasVariableOffset() { hasVariableOffset = true; }
+
+  // Comparison
+  bool operator==(const ProgramIdAddressInfo &other) const;
+
+  // Debug printing
+  void print(raw_ostream &os) const;
+
+private:
+  Pattern pattern = Pattern::UNKNOWN;
+
+  // For PID_AFFINE pattern:
+  SmallVector<PidComponent, 3> pidComponents; // Up to 3 axes
+  int64_t constantOffset = 0;                 // Known constant offset
+  bool hasVariableOffset = false; // True if offset has non-constant part
+
+  // For pointer values:
+  Value basePtr = nullptr; // Base pointer (if tracking ptr)
+  int64_t elemSize = 1;    // Element size for ptr arithmetic
+
+  // Allow access from the analysis
+  friend class ProgramIdToAddressAnalysis;
+};
+
+inline raw_ostream &operator<<(raw_ostream &os,
+                               const ProgramIdAddressInfo &info) {
+  info.print(os);
+  return os;
+}
+
+//===----------------------------------------------------------------------===//
+// LoadStoreAddressPattern - Summary of address pattern for a memory operation
+//===----------------------------------------------------------------------===//
+
+/// Summary information about a load/store's address relationship to program_id
+struct LoadStoreAddressPattern {
+  using Pattern = ProgramIdAddressInfo::Pattern;
+
+  Operation *op = nullptr;            // The load/store operation
+  Pattern pattern = Pattern::UNKNOWN; // Address pattern type
+  Value basePtr = nullptr;            // Base pointer value
+
+  // For PID_AFFINE pattern:
+  // Maps pid axis -> stride (bytes between consecutive program's first element)
+  SmallVector<std::pair<int, int64_t>, 3> pidAxisStrides;
+
+  // Block size (number of contiguous elements per program)
+  std::optional<int64_t> blockSize;
+
+  // Whether the access pattern is coalesced within a warp
+  bool isCoalesced = false;
+
+  void print(raw_ostream &os) const;
+};
+
+//===----------------------------------------------------------------------===//
+// ProgramIdToAddressAnalysis - The main analysis pass
+//===----------------------------------------------------------------------===//
+
+/// Forward dataflow analysis tracking program_id to address relationships
+class ProgramIdToAddressAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<
+          dataflow::Lattice<ProgramIdAddressInfo>> {
+public:
+  using Lattice = dataflow::Lattice<ProgramIdAddressInfo>;
+
+  explicit ProgramIdToAddressAnalysis(DataFlowSolver &solver);
+
+  using dataflow::SparseForwardDataFlowAnalysis<Lattice>::getLatticeElement;
+
+  /// Get the address pattern for a load/store operation
+  LoadStoreAddressPattern getAddressPattern(Operation *loadOrStore);
+
+protected:
+  void setToEntryState(Lattice *lattice) override;
+
+  LogicalResult visitOperation(Operation *op,
+                               ArrayRef<const Lattice *> operands,
+                               ArrayRef<Lattice *> results) override;
+
+private:
+  // Handlers for specific operations
+  void visitGetProgramIdOp(Operation *op, ArrayRef<Lattice *> results);
+  void visitMakeRangeOp(Operation *op, ArrayRef<Lattice *> results);
+  void visitConstantOp(Operation *op, ArrayRef<Lattice *> results);
+  void visitSplatOp(Operation *op, ArrayRef<const Lattice *> operands,
+                    ArrayRef<Lattice *> results);
+  void visitBroadcastOp(Operation *op, ArrayRef<const Lattice *> operands,
+                        ArrayRef<Lattice *> results);
+  void visitExpandDimsOp(Operation *op, ArrayRef<const Lattice *> operands,
+                         ArrayRef<Lattice *> results);
+  void visitArithBinaryOp(Operation *op, ArrayRef<const Lattice *> operands,
+                          ArrayRef<Lattice *> results);
+  void visitAddPtrOp(Operation *op, ArrayRef<const Lattice *> operands,
+                     ArrayRef<Lattice *> results);
+  void visitLoadStoreOp(Operation *op, ArrayRef<const Lattice *> operands);
+
+  // Cached results for load/store operations
+  DenseMap<Operation *, LoadStoreAddressPattern> loadStorePatterns;
+};
+
+//===----------------------------------------------------------------------===//
+// ModuleProgramIdToAddressAnalysis - Module-level analysis wrapper
+//===----------------------------------------------------------------------===//
+
+/// Module-level analysis that runs ProgramIdToAddressAnalysis on all functions
+/// This is designed to be used similarly to ModuleAxisInfoAnalysis:
+///   ModuleProgramIdToAddressAnalysis analysis(moduleOp);
+///   auto* pattern = analysis.getAddressPattern(loadOp);
+class ModuleProgramIdToAddressAnalysis {
+public:
+  explicit ModuleProgramIdToAddressAnalysis(ModuleOp moduleOp);
+
+  /// Get address pattern for a load/store operation
+  const LoadStoreAddressPattern *
+  getAddressPattern(Operation *loadOrStore) const;
+
+  /// Get the ProgramIdAddressInfo for a value
+  const ProgramIdAddressInfo *getInfo(Value value) const;
+
+  /// Get all analyzed load/store patterns
+  const DenseMap<Operation *, LoadStoreAddressPattern> &getAllPatterns() const {
+    return patterns;
+  }
+
+  /// Print all analysis results
+  void print(raw_ostream &os) const;
+
+private:
+  DenseMap<Operation *, LoadStoreAddressPattern> patterns;
+  DenseMap<Value, ProgramIdAddressInfo> valueInfoMap;
+};
+
+} // namespace mlir::triton
+
+#endif // TRITON_ANALYSIS_PROGRAMIDTOADDRESSANALYSIS_H

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -384,4 +384,24 @@ def TritonGPUCoalesceAsyncCopy: Pass<"tritongpu-coalesce-async-copy", "mlir::Mod
                            "mlir::triton::TritonDialect"];
 }
 
+def TritonGPUAnnotatePidAddressPatterns: Pass<"tritongpu-annotate-pid-address-patterns", "mlir::ModuleOp"> {
+  let summary = "Annotate load/store ops with program_id address patterns";
+
+  let description = [{
+    This pass uses ProgramIdAddressAnalysis to annotate load/store operations
+    with their access patterns relative to program_id. The annotations include:
+    - triton.pid_address_pattern: The pattern type (constant, pid_affine, etc.)
+    - triton.pid_axes: Which program_id axes affect the address
+    - triton.pid_strides: The stride for each axis
+    - triton.is_coalesced: Whether the access pattern is coalesced
+    - triton.block_size: The block size if known
+
+    This information can be used by downstream passes for memory coalescing
+    optimization, vectorization decisions, and out-of-bounds checking hints.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::TritonDialect"];
+}
+
 #endif

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonAnalysis
   Allocation.cpp
   Membar.cpp
   Alias.cpp
+  ProgramIdToAddressAnalysis.cpp
   Utility.cpp
 
   DEPENDS

--- a/lib/Analysis/ProgramIdToAddressAnalysis.cpp
+++ b/lib/Analysis/ProgramIdToAddressAnalysis.cpp
@@ -1,0 +1,637 @@
+//===- ProgramIdToAddressAnalysis.cpp - Program ID to Address Analysis ---===//
+//
+// Part of the Triton Project, under the Apache License v2.0.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/ProgramIdToAddressAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "llvm/Support/Debug.h"
+
+#include <algorithm>
+
+#define DEBUG_TYPE "program-id-to-address-analysis"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::triton {
+
+//===----------------------------------------------------------------------===//
+// ProgramIdAddressInfo Implementation
+//===----------------------------------------------------------------------===//
+
+ProgramIdAddressInfo
+ProgramIdAddressInfo::getPessimisticValueState(Value value) {
+  ProgramIdAddressInfo info;
+  info.pattern = Pattern::UNKNOWN;
+  return info;
+}
+
+ProgramIdAddressInfo
+ProgramIdAddressInfo::join(const ProgramIdAddressInfo &lhs,
+                           const ProgramIdAddressInfo &rhs) {
+  // UNKNOWN is the bottom of the lattice - joining with bottom gives the other
+  // This is critical for dataflow analysis initialization
+  if (lhs.isUnknown()) {
+    return rhs;
+  }
+  if (rhs.isUnknown()) {
+    return lhs;
+  }
+
+  // If both are constants, they must match
+  if (lhs.isConstant() && rhs.isConstant()) {
+    if (lhs.constantOffset == rhs.constantOffset &&
+        lhs.hasVariableOffset == rhs.hasVariableOffset) {
+      return lhs;
+    }
+    // Constants differ - could indicate different control flow paths
+    // Mark as having variable offset
+    ProgramIdAddressInfo result = lhs;
+    result.hasVariableOffset = true;
+    return result;
+  }
+
+  // If patterns don't match, go to pessimistic (top = NONLINEAR)
+  if (lhs.pattern != rhs.pattern) {
+    ProgramIdAddressInfo result;
+    result.pattern = Pattern::PID_NONLINEAR;
+    return result;
+  }
+
+  // For affine patterns, check if components match
+  if (lhs.isPidAffine()) {
+    // Check if pid components match
+    if (lhs.pidComponents.size() != rhs.pidComponents.size()) {
+      ProgramIdAddressInfo result;
+      result.pattern = Pattern::PID_NONLINEAR;
+      return result;
+    }
+
+    for (size_t i = 0; i < lhs.pidComponents.size(); ++i) {
+      if (!(lhs.pidComponents[i] == rhs.pidComponents[i])) {
+        ProgramIdAddressInfo result;
+        result.pattern = Pattern::PID_NONLINEAR;
+        return result;
+      }
+    }
+
+    // If we get here, the affine structures match
+    // Return lhs but mark as having variable offset if offsets differ
+    ProgramIdAddressInfo result = lhs;
+    if (lhs.constantOffset != rhs.constantOffset || lhs.hasVariableOffset ||
+        rhs.hasVariableOffset) {
+      result.hasVariableOffset = true;
+    }
+    return result;
+  }
+
+  // For NONLINEAR, stay NONLINEAR (top of lattice)
+  if (lhs.isPidNonlinear()) {
+    return lhs;
+  }
+
+  ProgramIdAddressInfo result;
+  result.pattern = Pattern::PID_NONLINEAR;
+  return result;
+}
+
+void ProgramIdAddressInfo::addPidComponent(int axis, int64_t stride) {
+  // Check if we already have this axis
+  for (auto &comp : pidComponents) {
+    if (comp.axis == axis) {
+      comp.stride += stride;
+      return;
+    }
+  }
+  // Add new component
+  pidComponents.push_back({axis, stride});
+}
+
+void ProgramIdAddressInfo::multiplyStrides(int64_t factor) {
+  for (auto &comp : pidComponents) {
+    comp.stride *= factor;
+  }
+  constantOffset *= factor;
+}
+
+void ProgramIdAddressInfo::addConstantOffset(int64_t offset) {
+  constantOffset += offset;
+}
+
+bool ProgramIdAddressInfo::operator==(const ProgramIdAddressInfo &other) const {
+  if (pattern != other.pattern)
+    return false;
+  if (pattern == Pattern::UNKNOWN)
+    return true;
+  if (pattern == Pattern::CONSTANT)
+    return constantOffset == other.constantOffset;
+
+  // Compare affine patterns
+  if (pidComponents.size() != other.pidComponents.size())
+    return false;
+  for (size_t i = 0; i < pidComponents.size(); ++i) {
+    if (!(pidComponents[i] == other.pidComponents[i]))
+      return false;
+  }
+  return constantOffset == other.constantOffset &&
+         hasVariableOffset == other.hasVariableOffset &&
+         basePtr == other.basePtr && elemSize == other.elemSize;
+}
+
+void ProgramIdAddressInfo::print(raw_ostream &os) const {
+  switch (pattern) {
+  case Pattern::UNKNOWN:
+    os << "UNKNOWN";
+    return;
+  case Pattern::CONSTANT:
+    os << "CONSTANT(" << constantOffset << ")";
+    return;
+  case Pattern::PID_AFFINE:
+    os << "PID_AFFINE(";
+    for (size_t i = 0; i < pidComponents.size(); ++i) {
+      if (i > 0)
+        os << " + ";
+      os << "pid[" << pidComponents[i].axis << "] * "
+         << pidComponents[i].stride;
+    }
+    if (constantOffset != 0 || hasVariableOffset) {
+      os << " + ";
+      if (constantOffset != 0)
+        os << constantOffset;
+      if (hasVariableOffset)
+        os << " + var";
+    }
+    if (basePtr) {
+      os << ", base=<ptr>, elem_size=" << elemSize;
+    }
+    os << ")";
+    return;
+  case Pattern::PID_NONLINEAR:
+    os << "PID_NONLINEAR";
+    return;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// LoadStoreAddressPattern Implementation
+//===----------------------------------------------------------------------===//
+
+void LoadStoreAddressPattern::print(raw_ostream &os) const {
+  os << "LoadStoreAddressPattern {\n";
+  os << "  op: " << (op ? op->getName().getStringRef() : "<null>") << "\n";
+  os << "  pattern: ";
+  switch (pattern) {
+  case Pattern::UNKNOWN:
+    os << "UNKNOWN";
+    break;
+  case Pattern::CONSTANT:
+    os << "CONSTANT";
+    break;
+  case Pattern::PID_AFFINE:
+    os << "PID_AFFINE";
+    break;
+  case Pattern::PID_NONLINEAR:
+    os << "PID_NONLINEAR";
+    break;
+  }
+  os << "\n";
+
+  if (!pidAxisStrides.empty()) {
+    os << "  pid strides: ";
+    for (const auto &[axis, stride] : pidAxisStrides) {
+      os << "[axis=" << axis << ", stride=" << stride << "] ";
+    }
+    os << "\n";
+  }
+
+  if (blockSize.has_value()) {
+    os << "  block size: " << *blockSize << "\n";
+  }
+
+  os << "  coalesced: " << (isCoalesced ? "true" : "false") << "\n";
+  os << "}\n";
+}
+
+//===----------------------------------------------------------------------===//
+// ProgramIdToAddressAnalysis Implementation
+//===----------------------------------------------------------------------===//
+
+ProgramIdToAddressAnalysis::ProgramIdToAddressAnalysis(DataFlowSolver &solver)
+    : SparseForwardDataFlowAnalysis(solver) {}
+
+void ProgramIdToAddressAnalysis::setToEntryState(Lattice *lattice) {
+  propagateIfChanged(
+      lattice, lattice->join(ProgramIdAddressInfo::getPessimisticValueState(
+                   lattice->getAnchor())));
+}
+
+LogicalResult
+ProgramIdToAddressAnalysis::visitOperation(Operation *op,
+                                           ArrayRef<const Lattice *> operands,
+                                           ArrayRef<Lattice *> results) {
+
+  LDBG("Visiting operation: " << *op);
+
+  // Debug: print that we're visiting
+  llvm::errs() << "[PID-ADDR] Visiting: " << op->getName() << "\n";
+
+  // Handle GetProgramIdOp
+  if (isa<triton::GetProgramIdOp>(op)) {
+    visitGetProgramIdOp(op, results);
+    return success();
+  }
+
+  // Handle MakeRangeOp
+  if (isa<triton::MakeRangeOp>(op)) {
+    visitMakeRangeOp(op, results);
+    return success();
+  }
+
+  // Handle arith.constant
+  if (isa<arith::ConstantOp>(op)) {
+    visitConstantOp(op, results);
+    return success();
+  }
+
+  // Handle SplatOp
+  if (isa<triton::SplatOp>(op)) {
+    visitSplatOp(op, operands, results);
+    return success();
+  }
+
+  // Handle BroadcastOp
+  if (isa<triton::BroadcastOp>(op)) {
+    visitBroadcastOp(op, operands, results);
+    return success();
+  }
+
+  // Handle ExpandDimsOp
+  if (isa<triton::ExpandDimsOp>(op)) {
+    visitExpandDimsOp(op, operands, results);
+    return success();
+  }
+
+  // Handle arithmetic operations
+  if (isa<arith::MulIOp, arith::AddIOp, arith::SubIOp>(op)) {
+    visitArithBinaryOp(op, operands, results);
+    return success();
+  }
+
+  // Handle AddPtrOp
+  if (isa<triton::AddPtrOp>(op)) {
+    visitAddPtrOp(op, operands, results);
+    return success();
+  }
+
+  // Handle LoadOp and StoreOp - just record the pattern
+  if (isa<triton::LoadOp, triton::StoreOp>(op)) {
+    visitLoadStoreOp(op, operands);
+    // Load/store don't produce values we need to track (for store)
+    // For load, we could track if needed, but typically we want to know
+    // about the address, not the loaded value
+    for (auto *result : results) {
+      setToEntryState(result);
+    }
+    return success();
+  }
+
+  // Default: set to unknown
+  for (auto *result : results) {
+    setToEntryState(result);
+  }
+  return success();
+}
+
+void ProgramIdToAddressAnalysis::visitGetProgramIdOp(
+    Operation *op, ArrayRef<Lattice *> results) {
+  auto getPidOp = cast<triton::GetProgramIdOp>(op);
+  int axis = static_cast<int>(getPidOp.getAxisAsInt());
+
+  ProgramIdAddressInfo info = ProgramIdAddressInfo::getProgramId(axis);
+
+  propagateIfChanged(results[0], results[0]->join(info));
+
+  LDBG("  GetProgramIdOp axis=" << axis << " -> " << info);
+}
+
+void ProgramIdToAddressAnalysis::visitMakeRangeOp(Operation *op,
+                                                  ArrayRef<Lattice *> results) {
+  auto rangeOp = cast<triton::MakeRangeOp>(op);
+
+  // make_range produces [start, start+1, ..., end-1]
+  // This is a constant pattern with variable elements (0 to end-start-1)
+  ProgramIdAddressInfo info;
+  info = ProgramIdAddressInfo::getConstant(rangeOp.getStart());
+  info.setHasVariableOffset(); // Elements vary within the range
+
+  propagateIfChanged(results[0], results[0]->join(info));
+
+  LDBG("  MakeRangeOp -> " << info);
+}
+
+void ProgramIdToAddressAnalysis::visitConstantOp(Operation *op,
+                                                 ArrayRef<Lattice *> results) {
+  auto constOp = cast<arith::ConstantOp>(op);
+
+  ProgramIdAddressInfo info;
+
+  if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue())) {
+    info = ProgramIdAddressInfo::getConstant(intAttr.getInt());
+  } else if (auto splatAttr = dyn_cast<SplatElementsAttr>(constOp.getValue())) {
+    if (splatAttr.getElementType().isIntOrIndex()) {
+      int64_t value = splatAttr.getSplatValue<APInt>().getSExtValue();
+      info = ProgramIdAddressInfo::getConstant(value);
+    }
+  }
+
+  propagateIfChanged(results[0], results[0]->join(info));
+
+  LDBG("  ConstantOp -> " << info);
+}
+
+void ProgramIdToAddressAnalysis::visitSplatOp(
+    Operation *op, ArrayRef<const Lattice *> operands,
+    ArrayRef<Lattice *> results) {
+  // Splat broadcasts a scalar to a tensor - preserves the address info
+  if (!operands.empty()) {
+    ProgramIdAddressInfo info = operands[0]->getValue();
+    propagateIfChanged(results[0], results[0]->join(info));
+    LDBG("  SplatOp -> " << info);
+  }
+}
+
+void ProgramIdToAddressAnalysis::visitBroadcastOp(
+    Operation *op, ArrayRef<const Lattice *> operands,
+    ArrayRef<Lattice *> results) {
+  // Broadcast expands a tensor - preserves the address info
+  if (!operands.empty()) {
+    ProgramIdAddressInfo info = operands[0]->getValue();
+    propagateIfChanged(results[0], results[0]->join(info));
+    LDBG("  BroadcastOp -> " << info);
+  }
+}
+
+void ProgramIdToAddressAnalysis::visitExpandDimsOp(
+    Operation *op, ArrayRef<const Lattice *> operands,
+    ArrayRef<Lattice *> results) {
+  // ExpandDims adds a dimension - preserves the address info
+  if (!operands.empty()) {
+    ProgramIdAddressInfo info = operands[0]->getValue();
+    propagateIfChanged(results[0], results[0]->join(info));
+    LDBG("  ExpandDimsOp -> " << info);
+  }
+}
+
+void ProgramIdToAddressAnalysis::visitArithBinaryOp(
+    Operation *op, ArrayRef<const Lattice *> operands,
+    ArrayRef<Lattice *> results) {
+  if (operands.size() != 2) {
+    setToEntryState(results[0]);
+    return;
+  }
+
+  const ProgramIdAddressInfo &lhs = operands[0]->getValue();
+  const ProgramIdAddressInfo &rhs = operands[1]->getValue();
+  ProgramIdAddressInfo result;
+
+  if (isa<arith::MulIOp>(op)) {
+    // Multiplication: pid * constant or constant * pid
+    if (lhs.isPidAffine() && rhs.isConstant()) {
+      result = lhs;
+      result.multiplyStrides(rhs.getConstantOffset());
+    } else if (lhs.isConstant() && rhs.isPidAffine()) {
+      result = rhs;
+      result.multiplyStrides(lhs.getConstantOffset());
+    } else if (lhs.isConstant() && rhs.isConstant()) {
+      result = ProgramIdAddressInfo::getConstant(lhs.getConstantOffset() *
+                                                 rhs.getConstantOffset());
+    } else if (lhs.isPidAffine() && rhs.isPidAffine()) {
+      // pid * pid -> nonlinear
+      result.pattern = ProgramIdAddressInfo::Pattern::PID_NONLINEAR;
+    }
+  } else if (isa<arith::AddIOp>(op)) {
+    // Addition: combine pid components and offsets
+    if (lhs.isConstant() && rhs.isConstant()) {
+      result = ProgramIdAddressInfo::getConstant(lhs.getConstantOffset() +
+                                                 rhs.getConstantOffset());
+    } else if (lhs.isPidAffine() && rhs.isConstant()) {
+      result = lhs;
+      result.addConstantOffset(rhs.getConstantOffset());
+      if (rhs.getHasVariableOffset())
+        result.setHasVariableOffset();
+    } else if (lhs.isConstant() && rhs.isPidAffine()) {
+      result = rhs;
+      result.addConstantOffset(lhs.getConstantOffset());
+      if (lhs.getHasVariableOffset())
+        result.setHasVariableOffset();
+    } else if (lhs.isPidAffine() && rhs.isPidAffine()) {
+      // Combine two affine expressions
+      result = lhs;
+      for (const auto &comp : rhs.getPidComponents()) {
+        result.addPidComponent(comp.axis, comp.stride);
+      }
+      result.addConstantOffset(rhs.getConstantOffset());
+      if (rhs.getHasVariableOffset())
+        result.setHasVariableOffset();
+    } else if (lhs.isPidAffine()) {
+      result = lhs;
+      result.setHasVariableOffset();
+    } else if (rhs.isPidAffine()) {
+      result = rhs;
+      result.setHasVariableOffset();
+    }
+  } else if (isa<arith::SubIOp>(op)) {
+    // Subtraction: similar to addition but negate rhs
+    if (lhs.isConstant() && rhs.isConstant()) {
+      result = ProgramIdAddressInfo::getConstant(lhs.getConstantOffset() -
+                                                 rhs.getConstantOffset());
+    } else if (lhs.isPidAffine() && rhs.isConstant()) {
+      result = lhs;
+      result.addConstantOffset(-rhs.getConstantOffset());
+    } else if (lhs.isPidAffine()) {
+      result = lhs;
+      result.setHasVariableOffset();
+    }
+  }
+
+  propagateIfChanged(results[0], results[0]->join(result));
+  LDBG("  ArithBinaryOp " << op->getName() << " -> " << result);
+}
+
+void ProgramIdToAddressAnalysis::visitAddPtrOp(
+    Operation *op, ArrayRef<const Lattice *> operands,
+    ArrayRef<Lattice *> results) {
+  if (operands.size() != 2) {
+    setToEntryState(results[0]);
+    return;
+  }
+
+  auto addPtrOp = cast<triton::AddPtrOp>(op);
+  const ProgramIdAddressInfo &ptrInfo = operands[0]->getValue();
+  const ProgramIdAddressInfo &offsetInfo = operands[1]->getValue();
+
+  // Get element size
+  int64_t elemSize = std::max<int64_t>(
+      1, triton::getPointeeBitWidth(addPtrOp.getPtr().getType()) / 8);
+
+  ProgramIdAddressInfo result;
+
+  // The offset is scaled by element size
+  if (offsetInfo.isPidAffine() || offsetInfo.isConstant()) {
+    result = offsetInfo;
+    result.multiplyStrides(elemSize);
+    result.setBasePtr(addPtrOp.getPtr(), elemSize);
+
+    // Inherit base ptr from ptr operand if it has one
+    if (ptrInfo.getBasePtr()) {
+      result.setBasePtr(ptrInfo.getBasePtr(), elemSize);
+    }
+  } else {
+    result = ProgramIdAddressInfo::getPessimisticValueState(op->getResult(0));
+  }
+
+  propagateIfChanged(results[0], results[0]->join(result));
+  LDBG("  AddPtrOp (elemSize=" << elemSize << ") -> " << result);
+}
+
+void ProgramIdToAddressAnalysis::visitLoadStoreOp(
+    Operation *op, ArrayRef<const Lattice *> operands) {
+  if (operands.empty())
+    return;
+
+  const ProgramIdAddressInfo &ptrInfo = operands[0]->getValue();
+
+  LoadStoreAddressPattern pattern;
+  pattern.op = op;
+  pattern.pattern = ptrInfo.getPattern();
+  pattern.basePtr = ptrInfo.getBasePtr();
+
+  if (ptrInfo.isPidAffine()) {
+    for (const auto &comp : ptrInfo.getPidComponents()) {
+      pattern.pidAxisStrides.emplace_back(comp.axis, comp.stride);
+    }
+
+    // Estimate block size from the variable offset range
+    // This is a simplification - in practice we'd need more analysis
+    if (!ptrInfo.getHasVariableOffset()) {
+      pattern.blockSize = 1;
+    }
+
+    // Simple coalescing heuristic: check if stride is contiguous for axis 0
+    // (In practice, this needs more sophisticated analysis)
+    pattern.isCoalesced =
+        !ptrInfo.getPidComponents().empty() && ptrInfo.getElemSize() > 0;
+  }
+
+  loadStorePatterns[op] = pattern;
+
+  LDBG("  LoadStoreOp recorded pattern: ");
+  LLVM_DEBUG(pattern.print(llvm::dbgs()));
+}
+
+LoadStoreAddressPattern
+ProgramIdToAddressAnalysis::getAddressPattern(Operation *loadOrStore) {
+  auto it = loadStorePatterns.find(loadOrStore);
+  if (it != loadStorePatterns.end()) {
+    return it->second;
+  }
+  return LoadStoreAddressPattern{};
+}
+
+//===----------------------------------------------------------------------===//
+// ModuleProgramIdToAddressAnalysis Implementation
+//===----------------------------------------------------------------------===//
+
+ModuleProgramIdToAddressAnalysis::ModuleProgramIdToAddressAnalysis(
+    ModuleOp moduleOp) {
+  // Create and run the dataflow solver internally (like ModuleAxisInfoAnalysis)
+  DataFlowSolver solver;
+  solver.load<dataflow::DeadCodeAnalysis>();
+  solver.load<ProgramIdToAddressAnalysis>();
+
+  if (failed(solver.initializeAndRun(moduleOp))) {
+    return;
+  }
+
+  // Collect all value info and load/store patterns by walking the module
+  moduleOp.walk([&](triton::FuncOp funcOp) {
+    funcOp.walk([&](Operation *op) {
+      // Store info for all values
+      for (Value result : op->getResults()) {
+        auto *lattice =
+            solver.lookupState<dataflow::Lattice<ProgramIdAddressInfo>>(result);
+        if (lattice) {
+          valueInfoMap[result] = lattice->getValue();
+        }
+      }
+
+      // Record load/store patterns
+      if (isa<triton::LoadOp, triton::StoreOp>(op)) {
+        Value ptrOperand = op->getOperand(0);
+        auto *lattice =
+            solver.lookupState<dataflow::Lattice<ProgramIdAddressInfo>>(
+                ptrOperand);
+        if (!lattice)
+          return;
+
+        const ProgramIdAddressInfo &ptrInfo = lattice->getValue();
+
+        LoadStoreAddressPattern pattern;
+        pattern.op = op;
+        pattern.pattern = ptrInfo.getPattern();
+        pattern.basePtr = ptrInfo.getBasePtr();
+
+        if (ptrInfo.isPidAffine()) {
+          for (const auto &comp : ptrInfo.getPidComponents()) {
+            pattern.pidAxisStrides.emplace_back(comp.axis, comp.stride);
+          }
+
+          if (!ptrInfo.getHasVariableOffset()) {
+            pattern.blockSize = 1;
+          }
+
+          pattern.isCoalesced =
+              !ptrInfo.getPidComponents().empty() && ptrInfo.getElemSize() > 0;
+        }
+
+        patterns[op] = pattern;
+      }
+    });
+  });
+}
+
+const LoadStoreAddressPattern *
+ModuleProgramIdToAddressAnalysis::getAddressPattern(
+    Operation *loadOrStore) const {
+  auto it = patterns.find(loadOrStore);
+  if (it != patterns.end()) {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+const ProgramIdAddressInfo *
+ModuleProgramIdToAddressAnalysis::getInfo(Value value) const {
+  auto it = valueInfoMap.find(value);
+  if (it != valueInfoMap.end()) {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+void ModuleProgramIdToAddressAnalysis::print(raw_ostream &os) const {
+  os << "=== Program ID to Address Analysis Results ===\n";
+  for (const auto &[op, pattern] : patterns) {
+    os << "\nOperation at " << op->getLoc() << ":\n";
+    pattern.print(os);
+  }
+}
+
+} // namespace mlir::triton

--- a/lib/Dialect/TritonGPU/Transforms/AnnotatePidAddressPatterns.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AnnotatePidAddressPatterns.cpp
@@ -1,0 +1,159 @@
+//===- AnnotatePidAddressPatterns.cpp - Annotate load/store patterns -----===//
+//
+// Part of the Triton Project, under the Apache License v2.0.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass uses ProgramIdAddressAnalysis to annotate load/store operations
+// with their access patterns relative to program_id. This information can be
+// used by downstream passes for:
+// - Memory coalescing optimization
+// - Vectorization decisions
+// - Out-of-bounds checking hints
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "triton/Analysis/ProgramIdToAddressAnalysis.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "tritongpu-annotate-pid-address"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define GEN_PASS_DEF_TRITONGPUANNOTATEPIDADDRESSPATTERNS
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Convert pattern enum to string for annotation
+StringRef patternToString(ProgramIdAddressInfo::Pattern pattern) {
+  switch (pattern) {
+  case ProgramIdAddressInfo::Pattern::UNKNOWN:
+    return "unknown";
+  case ProgramIdAddressInfo::Pattern::CONSTANT:
+    return "constant";
+  case ProgramIdAddressInfo::Pattern::PID_AFFINE:
+    return "pid_affine";
+  case ProgramIdAddressInfo::Pattern::PID_NONLINEAR:
+    return "pid_nonlinear";
+  }
+  llvm_unreachable("Unknown pattern type");
+}
+
+struct AnnotatePidAddressPatternsPass
+    : public impl::TritonGPUAnnotatePidAddressPatternsBase<
+          AnnotatePidAddressPatternsPass> {
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+
+    // Run the ProgramIdAddressAnalysis
+    ModuleProgramIdToAddressAnalysis pidAnalysis(moduleOp);
+
+    LDBG("Running ProgramIdAddressAnalysis annotation pass");
+
+    // Walk all load/store operations and annotate them
+    moduleOp.walk([&](Operation *op) {
+      if (!isa<triton::LoadOp, triton::StoreOp>(op))
+        return;
+
+      const LoadStoreAddressPattern *pattern =
+          pidAnalysis.getAddressPattern(op);
+      if (!pattern) {
+        LDBG("No pattern found for op at " << op->getLoc());
+        return;
+      }
+
+      LDBG("Annotating op at " << op->getLoc() << " with pattern "
+                               << patternToString(pattern->pattern));
+
+      // Add attribute indicating the address pattern type
+      op->setAttr(
+          "triton.pid_address_pattern",
+          StringAttr::get(&getContext(), patternToString(pattern->pattern)));
+
+      // For affine patterns, add stride information
+      if (pattern->pattern == ProgramIdAddressInfo::Pattern::PID_AFFINE) {
+        SmallVector<int64_t> axes;
+        SmallVector<int64_t> strides;
+
+        for (const auto &[axis, stride] : pattern->pidAxisStrides) {
+          axes.push_back(axis);
+          strides.push_back(stride);
+        }
+
+        if (!axes.empty()) {
+          op->setAttr("triton.pid_axes",
+                      DenseI64ArrayAttr::get(&getContext(), axes));
+          op->setAttr("triton.pid_strides",
+                      DenseI64ArrayAttr::get(&getContext(), strides));
+        }
+
+        // Add coalescing hint
+        op->setAttr("triton.is_coalesced",
+                    BoolAttr::get(&getContext(), pattern->isCoalesced));
+
+        // Add block size if known
+        if (pattern->blockSize.has_value()) {
+          op->setAttr("triton.block_size",
+                      IntegerAttr::get(IntegerType::get(&getContext(), 64),
+                                       pattern->blockSize.value()));
+        }
+      }
+    });
+
+    // Print statistics in debug mode
+    LLVM_DEBUG({
+      int numAnnotated = 0;
+      int numCoalesced = 0;
+      int numConstant = 0;
+      int numAffine = 0;
+      int numUnknown = 0;
+
+      moduleOp.walk([&](Operation *op) {
+        if (!isa<triton::LoadOp, triton::StoreOp>(op))
+          return;
+
+        if (auto patternAttr =
+                op->getAttrOfType<StringAttr>("triton.pid_address_pattern")) {
+          numAnnotated++;
+          StringRef pattern = patternAttr.getValue();
+          if (pattern == "constant")
+            numConstant++;
+          else if (pattern == "pid_affine")
+            numAffine++;
+          else
+            numUnknown++;
+        }
+
+        if (auto coalescedAttr =
+                op->getAttrOfType<BoolAttr>("triton.is_coalesced")) {
+          if (coalescedAttr.getValue())
+            numCoalesced++;
+        }
+      });
+
+      DBGS() << "Annotated " << numAnnotated << " load/store ops\n";
+      DBGS() << "  Constant patterns: " << numConstant << "\n";
+      DBGS() << "  PID affine patterns: " << numAffine << "\n";
+      DBGS() << "  Unknown patterns: " << numUnknown << "\n";
+      DBGS() << "  Coalesced accesses: " << numCoalesced << "\n";
+    });
+  }
+};
+
+} // namespace
+
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonGPUTransforms
   AccelerateMatmul.cpp
+  AnnotatePidAddressPatterns.cpp
   Coalesce.cpp
   F32DotTC.cpp
   FuseNestedLoops.cpp

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -97,6 +97,8 @@ void init_triton_passes_ttgpuir(py::module &&m) {
                      createTritonGPUPartitionScheduling);
   ADD_PASS_WRAPPER_0("add_optimize_partition_warps",
                      createTritonGPUOptimizePartitionWarps);
+  ADD_PASS_WRAPPER_0("add_annotate_pid_address_patterns",
+                     createTritonGPUAnnotatePidAddressPatterns);
 }
 
 void init_triton_passes_convert(py::module &&m) {

--- a/test/Analysis/test-program-id-address.mlir
+++ b/test/Analysis/test-program-id-address.mlir
@@ -1,0 +1,117 @@
+// RUN: triton-opt %s -test-print-program-id-address -split-input-file 2>&1 | FileCheck %s
+
+// Test basic program_id to address flow
+// CHECK: remark: PID_AFFINE(pid[0] * 1)
+// CHECK: remark: PID_AFFINE(pid[0] * 128)
+// CHECK: remark: tt.load address pattern: PID_AFFINE
+tt.func @basic_pid_to_load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %pid = tt.get_program_id x : i32
+    %c128 = arith.constant 128 : i32
+    %block_start = arith.muli %pid, %c128 : i32
+
+    %offsets = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+
+    // Splat the scalar to tensor before adding
+    %block_start_splat = tt.splat %block_start : i32 -> tensor<128xi32>
+    %indices = arith.addi %block_start_splat, %offsets : tensor<128xi32>
+
+    %ptr_base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %ptrs = tt.addptr %ptr_base, %indices : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+
+    %vals = tt.load %ptrs : tensor<128x!tt.ptr<f32>>
+
+    tt.return
+}
+
+// -----
+
+// Test multiple program_id axes
+// CHECK: remark: PID_AFFINE(pid[0] * 64 + pid[1] * 128)
+tt.func @multi_axis_pid(%arg0: !tt.ptr<f32>) {
+    %pid_x = tt.get_program_id x : i32
+    %pid_y = tt.get_program_id y : i32
+
+    %c64 = arith.constant 64 : i32
+    %c128 = arith.constant 128 : i32
+
+    %x_offset = arith.muli %pid_x, %c64 : i32
+    %y_offset = arith.muli %pid_y, %c128 : i32
+
+    %combined = arith.addi %x_offset, %y_offset : i32
+
+    tt.return
+}
+
+// -----
+
+// Test pid-independent access (constant pattern)
+// CHECK: remark: tt.load address pattern: CONSTANT
+tt.func @constant_access(%arg0: !tt.ptr<f32>) {
+    %offsets = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+
+    %ptr_base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>>
+
+    // Constant pattern: all programs access same memory
+    %ptrs = tt.addptr %ptr_base, %offsets : tensor<64x!tt.ptr<f32>>, tensor<64xi32>
+
+    %vals = tt.load %ptrs : tensor<64x!tt.ptr<f32>>
+
+    tt.return
+}
+
+// -----
+
+// Test 2D blocking pattern
+// CHECK: remark: PID_AFFINE(pid[0] * 64)
+// CHECK: remark: PID_AFFINE(pid[1] * 64)
+tt.func @matmul_pattern(%arg0: !tt.ptr<f32>, %arg1: i32) {
+    %c0 = arith.constant 0 : i32
+    %c64 = arith.constant 64 : i32
+
+    %pid_m = tt.get_program_id x : i32
+    %pid_n = tt.get_program_id y : i32
+
+    %m_start = arith.muli %pid_m, %c64 : i32
+    %n_start = arith.muli %pid_n, %c64 : i32
+
+    // Row offsets within block
+    %m_offsets = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+
+    // Splat scalar to tensor before adding
+    %m_start_splat = tt.splat %m_start : i32 -> tensor<64xi32>
+    %m_indices = arith.addi %m_start_splat, %m_offsets : tensor<64xi32>
+
+    // Expand to 2D
+    %m_indices_2d = tt.expand_dims %m_indices {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32>
+    %m_indices_bc = tt.broadcast %m_indices_2d : tensor<64x1xi32> -> tensor<64x64xi32>
+
+    // Multiply by stride (K dimension)
+    // This shows row-major layout: addr = base + row * K + col
+    %arg1_splat = tt.splat %arg1 : i32 -> tensor<64x64xi32>
+    %row_offset = arith.muli %m_indices_bc, %arg1_splat : tensor<64x64xi32>
+
+    tt.return
+}
+
+// -----
+
+// Test store operation
+// CHECK: remark: tt.store address pattern: PID_AFFINE
+tt.func @store_pattern(%arg0: !tt.ptr<f32>, %arg1: tensor<128xf32>) {
+    %pid = tt.get_program_id x : i32
+    %c128 = arith.constant 128 : i32
+    %block_start = arith.muli %pid, %c128 : i32
+    %offsets = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+
+    // Splat scalar to tensor before adding
+    %block_start_splat = tt.splat %block_start : i32 -> tensor<128xi32>
+    %indices = arith.addi %block_start_splat, %offsets : tensor<128xi32>
+
+    %ptr_base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+    %ptrs = tt.addptr %ptr_base, %indices : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+
+    // Store pattern: same as load, PID_AFFINE with axis=0, stride=512
+    tt.store %ptrs, %arg1 : tensor<128x!tt.ptr<f32>>
+
+    tt.return
+}

--- a/test/include/Analysis/TestProgramIdAddress.h
+++ b/test/include/Analysis/TestProgramIdAddress.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Analysis/ProgramIdToAddressAnalysis.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace mlir::test {
+
+struct TestProgramIdAddressPass
+    : public PassWrapper<TestProgramIdAddressPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestProgramIdAddressPass);
+
+  StringRef getArgument() const override {
+    return "test-print-program-id-address";
+  }
+  StringRef getDescription() const final {
+    return "print the result of the program id to address analysis pass";
+  }
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+
+    // Create and run the dataflow solver
+    DataFlowSolver solver;
+    // Load DeadCodeAnalysis first to mark blocks as executable
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<ProgramIdToAddressAnalysis>();
+
+    if (failed(solver.initializeAndRun(moduleOp))) {
+      signalPassFailure();
+      return;
+    }
+
+    // Walk and print results for each value
+    moduleOp.walk([&](triton::FuncOp funcOp) {
+      funcOp.walk([&](Operation *op) {
+        if (op->getNumResults() < 1)
+          return;
+        for (Value result : op->getResults()) {
+          auto *lattice =
+              solver.lookupState<dataflow::Lattice<ProgramIdAddressInfo>>(
+                  result);
+          if (!lattice)
+            continue;
+
+          const ProgramIdAddressInfo &info = lattice->getValue();
+          InFlightDiagnostic diag = mlir::emitRemark(op->getLoc());
+          std::string str;
+          llvm::raw_string_ostream os(str);
+          info.print(os);
+          diag << str;
+        }
+      });
+    });
+
+    // Also print summary for load/store operations
+    moduleOp.walk([&](Operation *op) {
+      if (!isa<triton::LoadOp, triton::StoreOp>(op))
+        return;
+
+      Value ptrOperand = op->getOperand(0);
+      auto *lattice =
+          solver.lookupState<dataflow::Lattice<ProgramIdAddressInfo>>(
+              ptrOperand);
+      if (!lattice)
+        return;
+
+      const ProgramIdAddressInfo &ptrInfo = lattice->getValue();
+
+      InFlightDiagnostic diag = mlir::emitRemark(op->getLoc());
+      diag << op->getName().getStringRef() << " address pattern: ";
+      std::string str;
+      llvm::raw_string_ostream os(str);
+      ptrInfo.print(os);
+      diag << str;
+    });
+  }
+};
+
+} // namespace mlir::test

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_library(TritonTestAnalysis
   TestAllocation.cpp
   TestMembar.cpp
   TestPrintNesting.cpp
+  TestProgramIdAddress.cpp
 
   LINK_LIBS PUBLIC
   MLIRPass

--- a/test/lib/Analysis/TestProgramIdAddress.cpp
+++ b/test/lib/Analysis/TestProgramIdAddress.cpp
@@ -1,0 +1,9 @@
+#include "test/include/Analysis/TestProgramIdAddress.h"
+
+namespace mlir {
+namespace test {
+void registerTestProgramIdAddressPass() {
+  PassRegistration<TestProgramIdAddressPass>();
+}
+} // namespace test
+} // namespace mlir

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -301,6 +301,7 @@ class CUDABackend(BaseBackend):
         passes.ttir.add_convert_to_ttgpuir(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
+        passes.ttgpuir.add_annotate_pid_address_patterns(pm)
         tlx.tlx_passes.add_tlx_propagate_layout(pm)
         tlx.tlx_passes.add_tlx_rewrite_local_alias(pm)
         passes.ttgpuir.add_f32_dot_tc(pm, emuTF32)


### PR DESCRIPTION
Summary:
This adds a new MLIR dataflow analysis that tracks how load/store addresses relate to program_id in Triton programs. The analysis determines:
- Whether addresses are constant (no pid dependence)
- Whether addresses are affine functions of program_id (base + pid*stride)
- The stride for each program_id axis

The analysis is exposed via ModuleProgramIdToAddressAnalysis which can be instantiated in any pass similar to ModuleAxisInfoAnalysis.

Also adds AnnotatePidAddressPatterns pass that annotates tt.load/tt.store operations with their address patterns for debugging and downstream use.

Authored with assistance from Claude (Devmate).

Test Plan:
Built and tested with:
```
pip install -e . --no-build-isolation
./build/cmake.linux-aarch64-cpython-3.11/bin/triton-opt test/Analysis/test-program-id-address.mlir -tritongpu-annotate-pid-address-patterns -split-input-file
python python/tutorials/01-vector-add.py
```
