### PR TITLE
[triton] Fix tlx.async_load constexpr handling for mask/other parameters

### DIFF
--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -398,6 +398,14 @@ def async_load(
     """
     Loads buffer from global to local memory asynchronously.
     """
+    # Unwrap constexpr and convert to tensor (same as tl.load)
+    mask = tl._unwrap_if_constexpr(mask)
+    other = tl._unwrap_if_constexpr(other)
+    if mask is not None:
+        mask = _semantic.to_tensor(mask)
+    if other is not None:
+        other = _semantic.to_tensor(other)
+
     if src.type.is_ptr() and src.type.element_ty.is_block():
         # Load by a block pointer: `pointer_type<block_type<>>`
         # unsupported for now


### PR DESCRIPTION
Summary:
Add constexpr unwrapping and tensor conversion to tlx.async_load to match
tl.load behavior. This fixes the 'constexpr_type has no attribute is_block'
error when using tlx.async_load with literal values like other=0.0.

The fix adds _unwrap_if_constexpr() and _semantic.to_tensor() preprocessing
for mask and other parameters before calling _prepare_legacy_load.

Authored with Claude.

Differential Revision: D91379054


