### PR TITLE
[TLX] move is_async logic to python for tl.async_dot and tl.async_dot_scaled

### DIFF
--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -397,8 +397,7 @@ void init_triton_tlx_ir(py::module &&m) {
                  tokType, a, b, d, Value(),
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
                  pred.has_value() ? pred.value() : predTrue /*pred */, twoCTAs,
-                 ValueRange(mBarriers), ValueRange(barrierPreds),
-                 isAsync);
+                 ValueRange(mBarriers), ValueRange(barrierPreds), isAsync);
            })
       .def("create_tcgen5_dot_scaled",
            [](TritonOpBuilder &self, Value a, Value b, Value d, Value aScale,
@@ -418,8 +417,7 @@ void init_triton_tlx_ir(py::module &&m) {
                  tokType, a, b, d, Value(), aScale, bScale, aType, bType,
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
                  pred.has_value() ? pred.value() : predTrue /*pred*/, twoCTAs,
-                 ValueRange(mBarriers), ValueRange(barrierPreds),
-                 isAsync);
+                 ValueRange(mBarriers), ValueRange(barrierPreds), isAsync);
            })
       .def("create_tcgen05_commit",
            [](TritonOpBuilder &self, Value &barrier, Value &pred) -> void {

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -389,7 +389,7 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
               mlir::Value &d, std::optional<Value> useD,
               std::optional<Value> pred, bool twoCTAs,
-              std::vector<Value> mBarriers, bool forceAsync) -> void {
+              std::vector<Value> mBarriers, bool isAsync) -> void {
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
              std::vector<Value> barrierPreds(mBarriers.size(), predTrue);
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
@@ -398,14 +398,14 @@ void init_triton_tlx_ir(py::module &&m) {
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
                  pred.has_value() ? pred.value() : predTrue /*pred */, twoCTAs,
                  ValueRange(mBarriers), ValueRange(barrierPreds),
-                 forceAsync || !mBarriers.empty() /* is_async */);
+                 isAsync);
            })
       .def("create_tcgen5_dot_scaled",
            [](TritonOpBuilder &self, Value a, Value b, Value d, Value aScale,
               Value bScale, tt::ScaleDotElemType aType,
               tt::ScaleDotElemType bType, std::optional<Value> useD,
               std::optional<Value> pred, bool twoCTAs,
-              std::vector<Value> mBarriers, bool forceAsync) -> void {
+              std::vector<Value> mBarriers, bool isAsync) -> void {
              Value predTrue = self.create<arith::ConstantIntOp>(1, 1);
              std::vector<Value> barrierPreds(mBarriers.size(), predTrue);
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
@@ -419,7 +419,7 @@ void init_triton_tlx_ir(py::module &&m) {
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
                  pred.has_value() ? pred.value() : predTrue /*pred*/, twoCTAs,
                  ValueRange(mBarriers), ValueRange(barrierPreds),
-                 forceAsync || !mBarriers.empty() /* is_async */);
+                 isAsync);
            })
       .def("create_tcgen05_commit",
            [](TritonOpBuilder &self, Value &barrier, Value &pred) -> void {

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -130,6 +130,7 @@ def async_dot(
         # D needs to have `unpacked` set to True, see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-packing-formats
         acc_handle = require_tmem_layout_unpacked(acc, True, _semantic.builder)
         handles = [t.handle for t in mBarriers]
+        is_async = force_async or len(handles) > 0
         use_acc_handle = None
         if use_acc is not None:
             assert isinstance(use_acc, tl.tensor) or isinstance(
@@ -139,7 +140,7 @@ def async_dot(
             else:
                 use_acc_handle = _semantic.builder.get_int1(use_acc.value)
         output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred, two_ctas,
-                                                     handles, force_async)
+                                                     handles, is_async)
         return tl.tensor(output, tl.void)
     else:
         mma_layout = _semantic.builder.make_nv_mma_encoding_attr(A_handle, acc_handle, version, 0,
@@ -290,6 +291,7 @@ def async_dot_scaled(
     # D needs to have `unpacked` set to True, see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-packing-formats
     acc_handle = require_tmem_layout_unpacked(acc, True, _semantic.builder)
     bar_handles = [t.handle for t in mBarriers]
+    is_async = force_async or len(bar_handles) > 0
     use_acc_handle = None
     if use_acc is not None:
         assert isinstance(use_acc, tl.tensor) or isinstance(
@@ -310,7 +312,7 @@ def async_dot_scaled(
         pred,
         two_ctas,
         bar_handles,
-        force_async,
+        is_async,
     )
     return tl.tensor(output, tl.void)
 


### PR DESCRIPTION
Small refactor: resolve `is_async` in python to make the python mlir hook cleaner.

# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
