### PR TITLE
[TLX] Update tlx.sizeof to support passing the type as a constexpr

### DIFF
--- a/third_party/tlx/language/tlx/utility.py
+++ b/third_party/tlx/language/tlx/utility.py
@@ -69,6 +69,7 @@ def size_of(dtype: tl.dtype, _semantic=None) -> tl.constexpr:
     """
     Returns the size of a given dtype.
     """
+    dtype = tl._unwrap_if_constexpr(dtype)
     assert isinstance(dtype, tl.dtype), f"size_of expects a dtype, but got {type(dtype)}"
     return tl.constexpr(dtype.primitive_bitwidth // 8)
 


### PR DESCRIPTION
Summary: If the output dtype is best computed outside the function we may still want to use sizeof. This updates the logic to handle constexprs to derive the type.

Differential Revision: D91592323


