### PR TITLE
Enable TLX tutorial imports via symlink for tritonbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,21 +729,21 @@ TLX uses **CUDA-native cluster semantics** which differs from Triton's approach:
 ## Kernels Implemented with TLX
 
 ### GEMM kernels
-[Pipelined GEMM on Hopper](third_party/tlx/tutorials/hopper-gemm-pipelined_test.py)
+[Pipelined GEMM on Hopper](third_party/tlx/tutorials/hopper_gemm_pipelined_test.py)
 
-[Pipelined GEMM on Blackwell](third_party/tlx/tutorials/blackwell-gemm-pipelined_test.py)
+[Pipelined GEMM on Blackwell](third_party/tlx/tutorials/blackwell_gemm_pipelined_test.py)
 
-[Warp-specialized GEMM on Hopper](third_party/tlx/tutorials/hopper-gemm-ws_test.py)
+[Warp-specialized GEMM on Hopper](third_party/tlx/tutorials/hopper_gemm_ws_test.py)
 
-[Warp-specialized GEMM on Blackwell](third_party/tlx/tutorials/blackwell-gemm-ws_test.py)
+[Warp-specialized GEMM on Blackwell](third_party/tlx/tutorials/blackwell_gemm_ws_test.py)
 
-[Grouped GEMM on Blackwell](third_party/tlx/tutorials/blackwell-grouped-gemm_test.py)
+[Grouped GEMM on Blackwell](third_party/tlx/tutorials/blackwell_grouped_gemm_test.py)
 
 ### Attention kernels
 
-[Warp-specialized pipelined persistent FA fwd/bwd on Blackwell](third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py)
+[Warp-specialized pipelined persistent FA fwd/bwd on Blackwell](third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_test.py)
 
-[Warp-Specialized computation-pipelined pingpong FA fwd on Hopper](third_party/tlx/tutorials/hopper-fa-ws-pipelined-pingpong_test.py)
+[Warp-Specialized computation-pipelined pingpong FA fwd on Hopper](third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong_test.py)
 
 
 
@@ -760,7 +760,7 @@ pip install -e .
 
 Run the tutorials after the build finishes, e.g,
 ```
-python third_party/tlx/tutorials/hopper-fa-ws-pipelined-pingpong_test.py
+python third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong_test.py
 ```
 
 ## More reading materials

--- a/third_party/tlx/language/tlx/tutorials
+++ b/third_party/tlx/language/tlx/tutorials
@@ -1,0 +1,1 @@
+../../tutorials

--- a/third_party/tlx/tutorials/blackwell_gemm_2cta.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_2cta.py
@@ -1,10 +1,8 @@
-import pytest
 import torch
 
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton._internal_testing import is_blackwell
 
 from typing import Optional
 
@@ -124,21 +122,3 @@ def matmul(a, b):
                                                                 b.stride(1), c, c.stride(0), c.stride(1), **kern_kwargs)
 
     return c
-
-
-@pytest.mark.skipif(
-    not is_blackwell(),
-    reason="Requires Blackwell GPU",
-)
-def test_op():
-    torch.manual_seed(0)
-    for i in [8192]:
-        M, N, K = i, i, i
-        a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-        b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-        torch_output = torch.matmul(a, b)
-        triton_output = matmul(a, b)
-        # print(f"torch_output_with_fp16_inputs={torch_output}")
-        # print(f"triton_output_with_fp16_inputs={triton_output}")
-        rtol = 0
-        torch.testing.assert_close(triton_output, torch_output, atol=1e-2, rtol=rtol)

--- a/third_party/tlx/tutorials/blackwell_gemm_clc.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_clc.py
@@ -1,12 +1,10 @@
 # TLX GEMM kernel optimized for Blackwell Warp Specialization
-import pytest
 import torch
 
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
-from triton._internal_testing import is_blackwell
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -280,65 +278,6 @@ def matmul(a, b):
         M, N, K,  #
         NUM_SMS=NUM_SMS,  #
         NUM_CLC_STAGES=1,  #
-        # launch_cluster=True,
     )
 
     return c
-
-
-@pytest.mark.skipif(
-    not is_blackwell(),
-    reason="Requires Blackwell GPU",
-)
-def test_op():
-    torch.manual_seed(0)
-    M, N, K = 8192, 8192, 8192
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    torch_output = torch.matmul(a, b)
-    triton_output = matmul(a, b)
-    print(f"torch_output_with_fp16_inputs={torch_output}")
-    print(f"triton_output_with_fp16_inputs={triton_output}")
-    rtol = 0
-    torch.testing.assert_close(triton_output, torch_output, atol=1e-2, rtol=rtol)
-
-
-ref_lib = "cuBLAS"
-
-
-@triton.testing.perf_report(
-    triton.testing.Benchmark(
-        x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
-        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
-        # Possible values for `line_arg`
-        # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
-        line_vals=[ref_lib.lower(), "triton_clc"],  # Label name for the lines
-        line_names=[ref_lib, "Triton (CLC)"],  # Line styles
-        styles=[("green", "-"), ("blue", "-")],
-        ylabel="TFLOPS",  # Label name for the y-axis
-        plot_name="matmul-performance-" + ("fp16"),  # Name for the plot, used also as a file name for saving the plot.
-        args={},
-    ))
-def benchmark(M, N, K, provider):
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    quantiles = [0.5, 0.2, 0.8]
-    if provider == ref_lib.lower():
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles, warmup=2000,
-                                                     rep=2000)
-
-    if provider == "triton_clc":
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b, True), quantiles=quantiles, warmup=2000,
-                                                     rep=2000)
-
-    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
-    return perf(ms), perf(max_ms), perf(min_ms)
-
-
-if __name__ == "__main__":
-    if is_blackwell():
-        print("Running benchmarks...")
-        benchmark.run(print_data=True)
-    else:
-        print("Skipping benchmarks, no Blackwell GPU found.")

--- a/third_party/tlx/tutorials/blackwell_gemm_pipelined.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_pipelined.py
@@ -1,4 +1,3 @@
-import pytest
 from typing import Optional
 
 import torch
@@ -6,7 +5,6 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton._internal_testing import is_blackwell
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -171,60 +169,3 @@ def matmul(a, b):
         c.stride(0), c.stride(1),  #
     )
     return c
-
-
-@pytest.mark.skipif(
-    not is_blackwell(),
-    reason="Requires Blackwell GPU",
-)
-def test_op():
-    torch.manual_seed(0)
-    M, N, K = 512, 512, 512
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    torch_output = torch.matmul(a, b)
-    triton_output = matmul(a, b)
-    print(f"torch_output_with_fp16_inputs={torch_output}")
-    print(f"triton_output_with_fp16_inputs={triton_output}")
-    rtol = 0
-    torch.allclose(triton_output, torch_output, atol=1e-2, rtol=rtol)
-
-
-ref_lib = 'cuBLAS'
-
-configs = []
-configs.append(
-    triton.testing.Benchmark(
-        x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
-        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
-        # Possible values for `line_arg`
-        # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
-        line_vals=[ref_lib.lower(), "triton"],  # Label name for the lines
-        line_names=[ref_lib, "Triton"],  # Line styles
-        styles=[("green", "-"), ("blue", "-")],
-        ylabel="TFLOPS",  # Label name for the y-axis
-        plot_name="matmul-performance-" + ("fp16"),  # Name for the plot, used also as a file name for saving the plot.
-        args={},
-    ))
-
-
-@triton.testing.perf_report(configs)
-def benchmark(M, N, K, provider):
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    quantiles = [0.5, 0.2, 0.8]
-    if provider == ref_lib.lower():
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
-    if provider == 'triton':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles)
-    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
-    return perf(ms), perf(max_ms), perf(min_ms)
-
-
-if __name__ == "__main__":
-    if is_blackwell():
-        print("Running benchmarks...")
-        benchmark.run(print_data=True)
-    else:
-        print("Skipping benchmarks, no Blackwell GPU found.")


### PR DESCRIPTION
Summary:
This diff fixes the fragmented perf measuring steps between triton and tritonbench (fbsource) by:
- enable importing TLX tutorial kernels in tritonbench
- make tutorial kernels export `def matmul` only
- unify the correctness check of those tutorial files with way better code structure
- no longer require the `_test` suffix of tutorial kernels
- FWIW this diff focuses on blackwell GEMM

`ln -s ../../tutorials third-party/triton/stable/triton/third_party/tlx/language/tlx/tutorials`
`ln -s ../../tutorials third-party/triton/beta/triton/third_party/tlx/language/tlx/tutorials`

OSS perf tests without tritonbench will be added in a separate PR.

Reviewed By: adamomainz

Differential Revision: D91444440
