### PR TITLE
[TLX] Unify correctness test and perf test of Blackwell GEMM tutorial kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ python/triton/tlx
 
 # macOS
 .DS_Store
+
+# claude
+.claude/

--- a/README.md
+++ b/README.md
@@ -729,21 +729,25 @@ TLX uses **CUDA-native cluster semantics** which differs from Triton's approach:
 ## Kernels Implemented with TLX
 
 ### GEMM kernels
-[Pipelined GEMM on Hopper](third_party/tlx/tutorials/hopper-gemm-pipelined_test.py)
+[Pipelined GEMM on Hopper](third_party/tlx/tutorials/hopper_gemm_pipelined_test.py)
 
-[Pipelined GEMM on Blackwell](third_party/tlx/tutorials/blackwell-gemm-pipelined_test.py)
+[Warp-specialized GEMM on Hopper](third_party/tlx/tutorials/hopper_gemm_ws_test.py)
 
-[Warp-specialized GEMM on Hopper](third_party/tlx/tutorials/hopper-gemm-ws_test.py)
+[Warp-specialized GEMM on Blackwell](third_party/tlx/tutorials/blackwell_gemm_ws.py)
 
-[Warp-specialized GEMM on Blackwell](third_party/tlx/tutorials/blackwell-gemm-ws_test.py)
+[Grouped GEMM on Blackwell](third_party/tlx/tutorials/blackwell_grouped_gemm_test.py)
 
-[Grouped GEMM on Blackwell](third_party/tlx/tutorials/blackwell-grouped-gemm_test.py)
+[Pipelined GEMM on Blackwell](third_party/tlx/tutorials/blackwell_gemm_pipelined.py)
+
+[CLC GEMM on Blackwell](third_party/tlx/tutorials/blackwell_gemm_clc.py)
+
+[2-CTA GEMM on Blackwell](third_party/tlx/tutorials/blackwell_gemm_2cta.py)
 
 ### Attention kernels
 
-[Warp-specialized pipelined persistent FA fwd/bwd on Blackwell](third_party/tlx/tutorials/blackwell-fa-ws-pipelined-persistent_test.py)
+[Warp-specialized pipelined persistent FA fwd/bwd on Blackwell](third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_test.py)
 
-[Warp-Specialized computation-pipelined pingpong FA fwd on Hopper](third_party/tlx/tutorials/hopper-fa-ws-pipelined-pingpong_test.py)
+[Warp-Specialized computation-pipelined pingpong FA fwd on Hopper](third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong_test.py)
 
 
 
@@ -760,7 +764,19 @@ pip install -e .
 
 Run the tutorials after the build finishes, e.g,
 ```
-python third_party/tlx/tutorials/hopper-fa-ws-pipelined-pingpong_test.py
+python third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong_test.py
+```
+
+To run Blackwell GEMM tutorial kernels, you can use the following command:
+
+Correctness test:
+```
+[TLX_GEMM_VERSION={ws|clc|pipelined|2cta}] pytest third_party/tlx/tutorials/correctness_test.py
+```
+
+Performance test:
+```
+third_party/tlx/denoise.sh third_party/tlx/tutorials/blackwell_gemm_perf_test.py [--version {ws|clc|pipelined|2cta}]
 ```
 
 ## More reading materials

--- a/third_party/tlx/language/tlx/tutorials
+++ b/third_party/tlx/language/tlx/tutorials
@@ -1,0 +1,1 @@
+../../tutorials

--- a/third_party/tlx/run_all.sh
+++ b/third_party/tlx/run_all.sh
@@ -91,6 +91,7 @@ case $user_choice in
     c)
         echo "Verifying correctness of TLX tutorial kernels"
         pytest third_party/tlx/tutorials/*.py
+        pytest third_party/tlx/tutorials/correctness_test.py
         ;;
     p)
         echo "Measuring performance of TLX tutorial kernels"
@@ -98,6 +99,7 @@ case $user_choice in
             echo "Running $k"
             third_party/tlx/denoise.sh python $k
         done
+        third_party/tlx/denoise.sh third_party/tlx/tutorials/blackwell_gemm_perf_test.py
         ;;
     n)
         break

--- a/third_party/tlx/tutorials/blackwell_gemm_2cta.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_2cta.py
@@ -1,10 +1,8 @@
-import pytest
 import torch
 
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton._internal_testing import is_blackwell
 
 from typing import Optional
 
@@ -124,21 +122,3 @@ def matmul(a, b):
                                                                 b.stride(1), c, c.stride(0), c.stride(1), **kern_kwargs)
 
     return c
-
-
-@pytest.mark.skipif(
-    not is_blackwell(),
-    reason="Requires Blackwell GPU",
-)
-def test_op():
-    torch.manual_seed(0)
-    for i in [8192]:
-        M, N, K = i, i, i
-        a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-        b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-        torch_output = torch.matmul(a, b)
-        triton_output = matmul(a, b)
-        # print(f"torch_output_with_fp16_inputs={torch_output}")
-        # print(f"triton_output_with_fp16_inputs={triton_output}")
-        rtol = 0
-        torch.testing.assert_close(triton_output, torch_output, atol=1e-2, rtol=rtol)

--- a/third_party/tlx/tutorials/blackwell_gemm_clc.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_clc.py
@@ -1,12 +1,10 @@
 # TLX GEMM kernel optimized for Blackwell Warp Specialization
-import pytest
 import torch
 
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
-from triton._internal_testing import is_blackwell
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -280,65 +278,6 @@ def matmul(a, b):
         M, N, K,  #
         NUM_SMS=NUM_SMS,  #
         NUM_CLC_STAGES=1,  #
-        # launch_cluster=True,
     )
 
     return c
-
-
-@pytest.mark.skipif(
-    not is_blackwell(),
-    reason="Requires Blackwell GPU",
-)
-def test_op():
-    torch.manual_seed(0)
-    M, N, K = 8192, 8192, 8192
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    torch_output = torch.matmul(a, b)
-    triton_output = matmul(a, b)
-    print(f"torch_output_with_fp16_inputs={torch_output}")
-    print(f"triton_output_with_fp16_inputs={triton_output}")
-    rtol = 0
-    torch.testing.assert_close(triton_output, torch_output, atol=1e-2, rtol=rtol)
-
-
-ref_lib = "cuBLAS"
-
-
-@triton.testing.perf_report(
-    triton.testing.Benchmark(
-        x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
-        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
-        # Possible values for `line_arg`
-        # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
-        line_vals=[ref_lib.lower(), "triton_clc"],  # Label name for the lines
-        line_names=[ref_lib, "Triton (CLC)"],  # Line styles
-        styles=[("green", "-"), ("blue", "-")],
-        ylabel="TFLOPS",  # Label name for the y-axis
-        plot_name="matmul-performance-" + ("fp16"),  # Name for the plot, used also as a file name for saving the plot.
-        args={},
-    ))
-def benchmark(M, N, K, provider):
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    quantiles = [0.5, 0.2, 0.8]
-    if provider == ref_lib.lower():
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles, warmup=2000,
-                                                     rep=2000)
-
-    if provider == "triton_clc":
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b, True), quantiles=quantiles, warmup=2000,
-                                                     rep=2000)
-
-    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
-    return perf(ms), perf(max_ms), perf(min_ms)
-
-
-if __name__ == "__main__":
-    if is_blackwell():
-        print("Running benchmarks...")
-        benchmark.run(print_data=True)
-    else:
-        print("Skipping benchmarks, no Blackwell GPU found.")

--- a/third_party/tlx/tutorials/blackwell_gemm_perf_test.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_perf_test.py
@@ -1,0 +1,86 @@
+import argparse
+
+import torch
+
+import triton
+
+from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import (
+    matmul as _tlx_matmul_ws, )
+from triton.language.extra.tlx.tutorials.blackwell_gemm_clc import (
+    matmul as _tlx_matmul_clc, )
+from triton.language.extra.tlx.tutorials.blackwell_gemm_pipelined import (
+    matmul as _tlx_matmul_pipelined, )
+from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
+    matmul as _tlx_matmul_2cta, )
+
+from triton._internal_testing import is_blackwell
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# Registry of available matmul implementations
+MATMUL_METHODS = {
+    "ws": _tlx_matmul_ws,
+    "clc": _tlx_matmul_clc,
+    "pipelined": _tlx_matmul_pipelined,
+    "2cta": _tlx_matmul_2cta,
+}
+
+ref_lib = "cuBLAS"
+"""
+This script is used for benchmarking the performance of TLX tutorial kernels.
+It's recommended to run with `third_party/tlx/denoise.sh third_party/tlx/tutorials/blackwell_gemm_perf_test.py`
+
+Facebook: If you are developing in fbsource, use tritonbench instead to collect perf numbers.
+"""
+
+
+def create_benchmark(versions):
+    line_vals = [ref_lib.lower()] + versions
+    line_names = [ref_lib] + versions
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["M", "N", "K"],
+            x_vals=[2048, 4096, 8192],
+            line_arg="provider",
+            line_vals=line_vals,
+            line_names=line_names,
+            ylabel="TFLOPS",
+            plot_name="matmul-performance-fp16",
+            args={},
+        ))
+    def benchmark(M, N, K, provider):
+        a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+        b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+        quantiles = [0.5, 0.2, 0.8]
+        if provider == ref_lib.lower():
+            ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles, warmup=2000,
+                                                         rep=2000)
+        elif provider in MATMUL_METHODS:
+            matmul = MATMUL_METHODS[provider]
+            ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles, warmup=2000,
+                                                         rep=2000)
+
+        perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+        return perf(ms), perf(max_ms), perf(min_ms)
+
+    return benchmark
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark TLX Blackwell GEMM implementations")
+    parser.add_argument(
+        "--version",
+        type=str,
+        choices=list(MATMUL_METHODS.keys()),
+        help=f"Run only the specified version. Choices: {list(MATMUL_METHODS.keys())}",
+    )
+    args = parser.parse_args()
+
+    if is_blackwell():
+        versions = [args.version] if args.version else list(MATMUL_METHODS.keys())
+        print(f"Running benchmarks for: {versions}")
+        benchmark = create_benchmark(versions)
+        benchmark.run(print_data=True)
+    else:
+        print("Skipping benchmarks, no Blackwell GPU found.")

--- a/third_party/tlx/tutorials/blackwell_gemm_pipelined.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_pipelined.py
@@ -1,4 +1,3 @@
-import pytest
 from typing import Optional
 
 import torch
@@ -6,7 +5,6 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton._internal_testing import is_blackwell
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -171,60 +169,3 @@ def matmul(a, b):
         c.stride(0), c.stride(1),  #
     )
     return c
-
-
-@pytest.mark.skipif(
-    not is_blackwell(),
-    reason="Requires Blackwell GPU",
-)
-def test_op():
-    torch.manual_seed(0)
-    M, N, K = 512, 512, 512
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    torch_output = torch.matmul(a, b)
-    triton_output = matmul(a, b)
-    print(f"torch_output_with_fp16_inputs={torch_output}")
-    print(f"triton_output_with_fp16_inputs={triton_output}")
-    rtol = 0
-    torch.allclose(triton_output, torch_output, atol=1e-2, rtol=rtol)
-
-
-ref_lib = 'cuBLAS'
-
-configs = []
-configs.append(
-    triton.testing.Benchmark(
-        x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
-        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
-        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
-        # Possible values for `line_arg`
-        # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
-        line_vals=[ref_lib.lower(), "triton"],  # Label name for the lines
-        line_names=[ref_lib, "Triton"],  # Line styles
-        styles=[("green", "-"), ("blue", "-")],
-        ylabel="TFLOPS",  # Label name for the y-axis
-        plot_name="matmul-performance-" + ("fp16"),  # Name for the plot, used also as a file name for saving the plot.
-        args={},
-    ))
-
-
-@triton.testing.perf_report(configs)
-def benchmark(M, N, K, provider):
-    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
-    quantiles = [0.5, 0.2, 0.8]
-    if provider == ref_lib.lower():
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
-    if provider == 'triton':
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles)
-    perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
-    return perf(ms), perf(max_ms), perf(min_ms)
-
-
-if __name__ == "__main__":
-    if is_blackwell():
-        print("Running benchmarks...")
-        benchmark.run(print_data=True)
-    else:
-        print("Skipping benchmarks, no Blackwell GPU found.")

--- a/third_party/tlx/tutorials/correctness_test.py
+++ b/third_party/tlx/tutorials/correctness_test.py
@@ -1,0 +1,59 @@
+import os
+
+import pytest
+
+import torch
+
+import triton
+
+from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import (
+    matmul as _tlx_matmul_ws, )
+from triton.language.extra.tlx.tutorials.blackwell_gemm_clc import (
+    matmul as _tlx_matmul_clc, )
+from triton.language.extra.tlx.tutorials.blackwell_gemm_pipelined import (
+    matmul as _tlx_matmul_pipelined, )
+from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
+    matmul as _tlx_matmul_2cta, )
+
+from triton._internal_testing import is_blackwell
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# Registry of available matmul implementations
+MATMUL_METHODS = {
+    "ws": _tlx_matmul_ws,
+    "clc": _tlx_matmul_clc,
+    "pipelined": _tlx_matmul_pipelined,
+    "2cta": _tlx_matmul_2cta,
+}
+
+
+def get_gemm_types():
+    version = os.environ.get("TLX_GEMM_VERSION")
+    if version:
+        if version not in MATMUL_METHODS:
+            raise ValueError(f"Invalid TLX_GEMM_VERSION: {version}. Valid options: {list(MATMUL_METHODS.keys())}")
+        return [version]
+    return list(MATMUL_METHODS.keys())
+
+
+@pytest.mark.skipif(
+    not is_blackwell(),
+    reason="Requires Blackwell GPU",
+)
+@pytest.mark.parametrize("gemm_type", get_gemm_types())
+@pytest.mark.parametrize("shape", ((4096, 4096, 4096), (8192, 8192, 8192)))
+def test_blackwell_gemm(gemm_type, shape):
+    matmul = MATMUL_METHODS[gemm_type]
+    M, N, K = shape
+
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+    torch_output = torch.matmul(a, b)
+    triton_output = matmul(a, b)
+
+    torch.testing.assert_close(triton_output, torch_output)
+
+
+# TODO. test_blackwell_attention, test_hopper_gemm, test_amd_gemm, test_hopper_attention, etc.


### PR DESCRIPTION
https://www.internalfb.com/diff/D91444440?dst_version_fbid=888124530472052&transaction_fbid=1586157762701980

For perf_test.py:                                                                  
                                                                                     
  # (1) Run all versions (default)                                                   
  third_party/tlx/denoise.sh python third_party/tlx/tutorials/blackwell_gemm_perf_test.py 

```
Running benchmarks for: ['ws', 'clc', 'pipelined', '2cta']
matmul-performance-fp16:
        M       N       K       cuBLAS          ws         clc   pipelined        2cta
0  2048.0  2048.0  2048.0   798.915054  729.444158  707.339789  671.088657  466.033761
1  4096.0  4096.0  4096.0  1056.832449  980.138625  980.138625  866.794649  709.911954
2  8192.0  8192.0  8192.0  1059.014943  973.391285  923.189769  888.158382  710.124680
```                                     
                                                                                     
  # (2) Run a specific version                                                       
  third_party/tlx/denoise.sh python third_party/tlx/tutorials/blackwell_gemm_perf_test.py --version ws       
```
Running benchmarks for: ['ws']
matmul-performance-fp16:
        M       N       K       cuBLAS           ws
0  2048.0  2048.0  2048.0   800.105697   644.502897
1  4096.0  4096.0  4096.0  1056.832449  1024.074272
2  8192.0  8192.0  8192.0  1057.971474   977.823505
```                  
  third_party/tlx/denoise.sh python third_party/tlx/tutorials/blackwell_gemm_perf_test.py --version clc                        
  third_party/tlx/denoise.sh python third_party/tlx/tutorials/blackwell_gemm_perf_test.py --version pipelined                  
  third_party/tlx/denoise.sh python third_party/tlx/tutorials/blackwell_gemm_perf_test.py --version 2cta                       
                                                                                     
  For correctness_test.py:                                                           
                                                                                     
  # (1) Run all versions (default)                                                   
  pytest third_party/tlx/tutorials/correctness_test.py          
```
collected 4 items                                                                   

third_party/tlx/tutorials/correctness_test.py ....                            [100%]

================================ 4 passed in 28.34s =================================
```                     
                                                                                     
  # (2) Run a specific version                                                       
  TLX_GEMM_VERSION=ws pytest third_party/tlx/tutorials/correctness_test.py           
```
collected 1 item                                                                    

third_party/tlx/tutorials/correctness_test.py .                               [100%]

================================ 1 passed in 33.65s =================================
```
  TLX_GEMM_VERSION=clc pytest third_party/tlx/tutorials/correctness_test.py          
  TLX_GEMM_VERSION=pipelined pytest third_party/tlx/tutorials/correctness_test.py    
  TLX_GEMM_VERSION=2cta pytest third_party/tlx/tutorials/correctness_test.py      
