### PR TITLE
[autoWS] use CoarseSchedule to determine first arriving keyOp in PingPong

### DIFF
--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -165,7 +165,10 @@ def NVGPUTestPingPongPrep : Pass<"nvgpu-test-ping-pong-prep", "mlir::ModuleOp"> 
            "number of warp groups for warp specialization">,
     Option<"capability", "capability",
            "int32_t", /*default*/"10",
-           "NVIDIA compute capability">
+           "NVIDIA compute capability">,
+    Option<"numStages", "num-stages",
+           "int32_t", /*default*/"3",
+           "number of stages for software pipelining">,
   ];
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -142,20 +142,12 @@ public:
     }
 
     if (pingpongAutoWS) {
-      doPingPongPrep(funcOp, numWarpGroups, capability);
-      if (dumpIntermediateSteps) {
-        llvm::dbgs()
-            << "// -----// WarpSpec internal IR Dump After: doPingPongPrep\n"
-            << moduleOp << "\n\n\n";
-      }
-    }
-
-    if (pingpongAutoWS) {
       doPingPongPrep(funcOp, numWarpGroups, capability, defaultNumStages);
       if (dumpIntermediateSteps) {
         llvm::dbgs()
-            << "// -----// WarpSpec internal IR Dump After: doPingPongPrep\n"
-            << moduleOp << "\n\n\n";
+            << "// -----// WarpSpec internal IR Dump After: doPingPongPrep\n";
+        moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
+        llvm::dbgs() << "\n\n\n";
       }
     }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -154,8 +154,8 @@ public:
       doPingPongPrep(funcOp, numWarpGroups, capability);
       if (dumpIntermediateSteps) {
         llvm::dbgs()
-              << "// -----// WarpSpec internal IR Dump After: doPingPongPrep\n"
-              << moduleOp << "\n\n\n";
+            << "// -----// WarpSpec internal IR Dump After: doPingPongPrep\n"
+            << moduleOp << "\n\n\n";
       }
     }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -35,7 +35,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
 void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
 void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
-                    int capability);
+                    int capability, int defaultNumStages);
 void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
                     int capability);
 
@@ -151,7 +151,7 @@ public:
     }
 
     if (pingpongAutoWS) {
-      doPingPongPrep(funcOp, numWarpGroups, capability);
+      doPingPongPrep(funcOp, numWarpGroups, capability, defaultNumStages);
       if (dumpIntermediateSteps) {
         llvm::dbgs()
             << "// -----// WarpSpec internal IR Dump After: doPingPongPrep\n"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -150,6 +150,15 @@ public:
       }
     }
 
+    if (pingpongAutoWS) {
+      doPingPongPrep(funcOp, numWarpGroups, capability);
+      if (dumpIntermediateSteps) {
+        llvm::dbgs()
+              << "// -----// WarpSpec internal IR Dump After: doPingPongPrep\n"
+              << moduleOp << "\n\n\n";
+      }
+    }
+
     // Canonicalize the SMEM/TEM buffers.
     // Create buffers for register channels.
     doBufferAllocation(funcOp);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -88,8 +88,10 @@ public:
     // Initialize barrier ID to be 9
     barrierId = MIN_BARRIER_ID;
 
-    // Register default expensive operations
-    // IMPORTANT: Assume operations are expensive only for 2D tensors
+    /// Register default expensive operations
+    // Use specific op names of GEMM, such as ttng.warp_group_dot for Hopper,
+    // to avoid matching other GEMM ops using DotInterface
+    // (e.g., ttng.tc_gen5_mma for Blackwell) that we don't enforce pingpong on
     registerCriticalOp(
         "ttng.warp_group_dot",
         CriticalOpType::NonReorderable); // GEMM/Dot operation on Hopper
@@ -227,13 +229,6 @@ bool areControlFlowEquivalent(Operation *op1, Operation *op2,
   return false;
 }
 
-Operation *findStartOp(CriticalRegionManager &crManager, Operation *keyOp,
-                       mlir::DominanceInfo &domInfo,
-                       mlir::PostDominanceInfo &postDomInfo) {
-  // Set the start op of this pingpong region to be the critical op
-  return keyOp;
-}
-
 /// Dump memory effects of an operation for debugging
 void dumpMemoryEffects(Operation *op) {
   auto memInterface = dyn_cast<MemoryEffectOpInterface>(op);
@@ -271,6 +266,17 @@ void dumpMemoryEffects(Operation *op) {
   }
 }
 
+Operation *findStartOp(CriticalRegionManager &crManager, Operation *keyOp,
+                       mlir::DominanceInfo &domInfo,
+                       mlir::PostDominanceInfo &postDomInfo) {
+  // Set the start op of this pingpong region to be the critical op
+  return keyOp;
+}
+
+/// Find the end boundary op for the critical region.
+/// Rules are specific to the CriticalOpType.
+/// For now, we apply the same rule for NonReorderable and PureArithmetic --
+/// the end op is the first op with memory side effect after the critical op.
 Operation *findEndOp(CriticalRegionManager &crManager, Operation *keyOp,
                      mlir::DominanceInfo &domInfo,
                      mlir::PostDominanceInfo &postDomInfo) {
@@ -285,6 +291,7 @@ Operation *findEndOp(CriticalRegionManager &crManager, Operation *keyOp,
   CriticalOpType opType = crManager.keyOpNameToType[opName];
   if (opType == CriticalOpType::NonReorderable) {
     LDBG("Operation " << opName << " is not reorderable.");
+    // Find the first op with memory side effect after this critical op
     Operation *curOp = keyOp;
     while (curOp) {
       if (!isMemoryEffectFree(curOp)) {
@@ -300,6 +307,7 @@ Operation *findEndOp(CriticalRegionManager &crManager, Operation *keyOp,
     }
   } else if (opType == CriticalOpType::PureArithmetic) {
     LDBG("Operation " << opName << " is pure arithmetic.");
+    // Find the first op with memory side effect after this critical op
     Operation *curOp = keyOp;
     while (curOp) {
       if (!isMemoryEffectFree(curOp)) {
@@ -566,7 +574,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
   }
 }
 
-/// doPingPongPrep pass: Insert pingpong barriers to the IR
+/// doPingPongSync pass: Insert pingpong barriers to the IR
 void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
                     int capability) {
   for (auto &block : funcOp.getBody().getBlocks()) {
@@ -621,7 +629,7 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
     if (op->getNumOperands() == 0)
       return;
 
-    // Only 2D tensor operations are considered expensive
+    // IMPORTANT: Assume operations are expensive only for 2D tensors
     auto tensorTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
     if (tensorTy && tensorTy.getRank() > 1) {
       LDBG("Found expensive op " << op->getName().getStringRef().str()
@@ -717,6 +725,24 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
     pingpongID++;
   }
 }
+
+#define GEN_PASS_DEF_NVGPUTESTPINGPONGPREP
+#include "nvidia/hopper/include/Transforms/Passes.h.inc"
+
+class NVGPUTestPingPongPrepPass
+    : public impl::NVGPUTestPingPongPrepBase<NVGPUTestPingPongPrepPass> {
+public:
+  using impl::NVGPUTestPingPongPrepBase<
+      NVGPUTestPingPongPrepPass>::NVGPUTestPingPongPrepBase;
+
+  void runOnFuncOp(triton::FuncOp funcOp) {
+    doPingPongPrep(funcOp, numWarpGroups, capability);
+  }
+
+  void runOnOperation() override {
+    getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });
+  }
+};
 
 #define GEN_PASS_DEF_NVGPUTESTPINGPONGSYNC
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -88,7 +88,7 @@ public:
     // Initialize barrier ID to be 7
     barrierId = MIN_BARRIER_ID;
 
-    /// Register default expensive operations
+    // Register default expensive operations
     // Hopper (compute capability 9)
     registerCriticalOp(
         90, "ttng.warp_group_dot",

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -100,14 +100,8 @@ public:
       if (isa<math::ExpOp, math::Exp2Op>(op)) {
         LDBG("Encounter a " << op->getName() << " op on Blackwell.");
         Type resultType = op->getResult(0).getType();
-        int64_t rank = -1;
-        if (auto tensorTy = dyn_cast<RankedTensorType>(resultType)) {
-          rank = tensorTy.getRank();
-          LDBG("RankedTensorType, rank is " << rank);
-        }
-        if (rank > 1)
-          return true;
-        return false;
+        if (auto tensorTy = dyn_cast<RankedTensorType>(resultType))
+          return tensorTy.getRank() > 1;
       }
       break;
     default:

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -357,8 +357,7 @@ int arrivesFirst(
 
   // Step 2: Validate that the schedule alternates between partitions
   //         - Correct alternation means: after all ops in one partition
-  //         execute,
-  //           the next scheduled op must be in the other partition
+  //         execute, the next scheduled op must be in the other partition
   //         - Check correct alternation until we reach the end of linearized
   //         schedule
   int curPartitionId = getSingleTaskId(firstOp);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -54,38 +54,38 @@ enum class CriticalOpType : uint8_t {
   PureArithmetic = 1,
 };
 
-// Manages expensive operations for critical region identification and
-// assigns unique barrier IDs to each operation type.
+/// Manages expensive operations for critical region identification and
+/// assigns unique barrier IDs to each operation type.
 class CriticalRegionManager {
 private:
-  // Barrier ID range constants
+  /// Barrier ID range constants
   static constexpr unsigned MIN_BARRIER_ID = 7;
   static constexpr unsigned MAX_BARRIER_ID = 15;
 
 public:
-  /// Current barrier ID to assign (wraps around in range [MIN_BARRIER_ID, MAX_BARRIER_ID])
+  /// Current barrier ID to assign (range [MIN_BARRIER_ID, MAX_BARRIER_ID])
   int barrierId;
 
-  // Map from compute capability to a map of critical operation name to its
-  // operation type
+  /// Map from compute capability to a map of critical operation name to its
+  /// operation type
   llvm::DenseMap<int, llvm::StringMap<CriticalOpType>> keyOpNameToType;
 
-  // Map from pingpong region id to its barrier ID
+  /// Map from pingpong region id to its barrier ID
   llvm::DenseMap<int, std::pair<int, int>> pingpongIdToBarrierId;
 
-  // Map from pingpong region id to its critical operations
+  /// Map from pingpong region id to its critical operations
   llvm::DenseMap<int, SmallVector<Operation *>> pingpongIdToKeyOps;
 
-  // Map from pingpong region id to operations that mark
-  // the critical region's start and end
+  /// Map from pingpong region id to operations that mark
+  /// the critical region's start and end
   llvm::DenseMap<int, SmallVector<Operation *>> pingpongIdToPingBoundaryOps;
   llvm::DenseMap<int, SmallVector<Operation *>> pingpongIdToPongBoundaryOps;
 
-  // Map from pingpong region id to the participating thread number
+  /// Map from pingpong region id to the participating thread number
   llvm::DenseMap<int, int> pingpongIdToThreadNum;
 
   CriticalRegionManager() {
-    // Initialize barrier ID to be 7
+    // Initialize barrier ID to be MIN_BARRIER_ID
     barrierId = MIN_BARRIER_ID;
 
     // Register default expensive operations
@@ -100,7 +100,7 @@ public:
                        CriticalOpType::PureArithmetic); // Exponential base 2
   }
 
-  // Register a new expensive operation TYPE and assign it a unique barrier ID.
+  /// Register a new expensive operation TYPE and assign it a unique barrier ID.
   void registerCriticalOp(int computeCapability, const std::string &opTypeName,
                           CriticalOpType type) {
     // Initialize the inner map for this compute capability if it doesn't exist
@@ -124,8 +124,8 @@ public:
                         << computeCapability << ".");
   }
 
-  // Check if an operation is registered as an expensive operation for the given
-  // compute capability
+  /// Check if an operation is registered as an expensive operation for the
+  /// given compute capability
   bool isExpensiveOp(Operation *op, int computeCapability) const {
     std::string opName = op->getName().getStringRef().str();
     auto it = keyOpNameToType.find(computeCapability);
@@ -135,7 +135,7 @@ public:
     return it->second.count(opName) > 0;
   }
 
-  // Get the CriticalOpType for an operation (for the given compute capability)
+  /// Get the CriticalOpType for an operation (for the given compute capability)
   std::optional<CriticalOpType> getCriticalOpType(Operation *op,
                                                   int computeCapability) const {
     std::string opName = op->getName().getStringRef().str();
@@ -150,8 +150,8 @@ public:
     return opIt->second;
   }
 
-  // Get the barrier ID assigned to an operation.
-  // Returns std::nullopt if the operation is not registered.
+  /// Get the barrier ID assigned to an operation.
+  /// Returns std::nullopt if the operation is not registered.
   void assignBarrierId(int pingpongId) {
     if (pingpongIdToBarrierId.count(pingpongId) > 0) {
       LDBG("Barrier ID {" << pingpongIdToBarrierId[pingpongId].first << ", "
@@ -213,7 +213,7 @@ public:
   }
 };
 
-// Returns the taskId if op has a single taskId, otherwise, returns -1.
+/// Returns the taskId if op has a single taskId, otherwise, returns -1.
 static int getSingleTaskId(Operation *op) {
   auto asyncTasks = getAsyncTaskIds(op);
   if (asyncTasks.size() > 1)
@@ -264,7 +264,7 @@ static unsigned getLoopDepth(Operation *op) {
   return depth;
 }
 
-// Return a map of loop depth to the loop ops in the partition.
+/// Return a map of loop depth to the loop ops in the partition.
 void getNestedFor(Region *partition,
                   DenseMap<unsigned, SmallVector<Operation *>> &loopDepthMap) {
   partition->walk([&](Operation *subOp) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -59,10 +59,10 @@ private:
 
 public:
   /// Current barrier ID to assign (range [MIN_BARRIER_ID, MAX_BARRIER_ID])
-  int barrierId;
+  unsigned barrierId = MIN_BARRIER_ID;
 
   /// Map from pingpong region id to its barrier ID
-  llvm::DenseMap<int, std::pair<int, int>> pingpongIdToBarrierId;
+  llvm::DenseMap<int, std::pair<unsigned, unsigned>> pingpongIdToBarrierId;
 
   /// Map from pingpong region id to its critical operations
   llvm::DenseMap<int, SmallVector<Operation *>> pingpongIdToKeyOps;
@@ -75,10 +75,7 @@ public:
   /// Map from pingpong region id to the participating thread number
   llvm::DenseMap<int, int> pingpongIdToThreadNum;
 
-  CriticalRegionManager() {
-    // Initialize barrier ID to be MIN_BARRIER_ID
-    barrierId = MIN_BARRIER_ID;
-  }
+  CriticalRegionManager() = default;
 
   /// Check if an operation is registered as an expensive operation for the
   /// given compute capability. Only considers ops with 2D+ shaped operands.
@@ -122,8 +119,8 @@ public:
     }
 
     // Assign barrier ID to the pingpong region
-    int barrierId = this->barrierId;
-    int barrierId_1 = this->barrierId + 1;
+    unsigned barrierId = this->barrierId;
+    unsigned barrierId_1 = this->barrierId + 1;
 
     // Check if we would exceed the maximum barrier ID
     if (barrierId > MAX_BARRIER_ID || barrierId_1 > MAX_BARRIER_ID) {
@@ -522,8 +519,8 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp, int computeCapability) {
     SmallVector<Operation *> pongBoundOps =
         crManager.pingpongIdToPongBoundaryOps[pingpongId];
 
-    int pingBarrierId = crManager.pingpongIdToBarrierId[pingpongId].first;
-    int pongBarrierId = crManager.pingpongIdToBarrierId[pingpongId].second;
+    unsigned pingBarrierId = crManager.pingpongIdToBarrierId[pingpongId].first;
+    unsigned pongBarrierId = crManager.pingpongIdToBarrierId[pingpongId].second;
 
     if (pingBarrierId == -1 || pongBarrierId == -1) {
       LDBG("Named barriers have run out for the pingpong region " << pingpongId

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -51,7 +51,7 @@ enum class CriticalOpType : uint8_t {
   /// Operations that cannot be reordered by ptxas (warp_group_dot, etc.)
   NonReorderable = 0,
   /// Pure arithmetic operations that can be reordered (exp, exp2, etc.)
-  // The ops should have memory ops as ping-pong boundary
+  /// The ops should have memory ops as ping-pong boundary
   PureArithmetic = 1,
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -26,6 +26,7 @@
 #include "Utility.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/Location.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -78,6 +79,8 @@ public:
     registerExpensiveOp("math.exp2");           // Exponential base 2
 
     // For exp2 operations, critical region might end at tmem_store
+    registerEndOfCriticalOpType("ttng.warp_group_dot", "ttng.warp_group_dot");
+    registerEndOfCriticalOpType("math.exp", "ttng.tmem_store");
     registerEndOfCriticalOpType("math.exp2", "ttng.tmem_store");
   }
 
@@ -304,7 +307,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
     if (!loopDepth.empty()) {
       numPartitionWithLoops += 1;
     }
-    // Check the partition a single outer loop
+    // Check the partition a single outer loop, i.e. loop of depth 0
     if (loopDepth[0].size() != 1) {
       hasSingleOuterLoop = false;
     }
@@ -375,14 +378,17 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
     Operation *expStartOp = nullptr; // exp critical region start
     Operation *expEndOp = nullptr;   // exp critical region end
     SmallVector<Operation *> expOps;
-    for (auto &op : innermostForOp.getBody()->without_terminator()) {
-      // Check for exp or exp2 operations
-      if (isa<math::Exp2Op, math::ExpOp>(op)) {
-        auto tensorTy = dyn_cast<RankedTensorType>(op.getOperand(0).getType());
-        if (tensorTy && tensorTy.getRank() > 1)
-          expOps.push_back(&op);
+    region->walk<WalkOrder::PreOrder>([&](Operation *op) {
+      // Check if this is a warp_group_dot operation
+      if (auto pingpongIdAttr = op->getAttrOfType<IntegerAttr>("pingpong_id")) {
+        LDBG("Found op with pingpong id " << pingpongIdAttr.getInt());
+        expOps.push_back(op);
+        if (crManager.hasPingPongBoundarySetup(
+                op->getName().getStringRef().str())) {
+          return; // Already setup, skip
+        }
       }
-    }
+    });
 
     if (expOps.empty())
       continue;
@@ -525,14 +531,6 @@ void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
   }
 }
 
-Operation* lookUpPingPongOp(Operation *currentOp, const llvm::DenseSet<Operation *> &opSet) {
-  for (Operation *refOp : opSet) {
-    if (currentOp->getName() == refOp->getName())
-      return refOp;
-  }
-  return nullptr;
-}
-
 bool areControlFlowEquivalent(Operation *op1, Operation *op2,
                               DominanceInfo &domInfo,
                               PostDominanceInfo &postDomInfo) {
@@ -550,18 +548,38 @@ bool areControlFlowEquivalent(Operation *op1, Operation *op2,
     return false;
 }
 
+static Operation* getSplitOp(Operation *op) {
+  for (Value operand : op->getOperands()) {
+    if (auto result = dyn_cast<OpResult>(operand)) {
+      if (isa<tt::SplitOp>(result.getOwner())) {
+        return result.getOwner();
+      }
+    }
+  }
+  return nullptr;
+}
+
+static std::optional<NameLoc> getNameLoc(Operation *op) {
+  Location loc = op->getLoc();
+  if (auto callSiteLoc = dyn_cast<CallSiteLoc>(loc)) {
+    if (auto nameLoc = dyn_cast<NameLoc>(callSiteLoc.getCallee())) {
+      return nameLoc;
+    }
+  }
+  return std::nullopt;
+}
+
 void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
                     int capability) {
   CriticalRegionManager crManager;
 
+  // Initialize the dominance and post-dominance info
   mlir::DominanceInfo domInfo(funcOp);
   mlir::PostDominanceInfo postDomInfo(funcOp);
 
-  // pingpong attribute id
-  unsigned pingpongRID = 0;
-
-  // Set of expensive ops that have been not paired
-  llvm::DenseSet<Operation*> expensiveOps;
+  // A list of expensive ops grouped in vectors.
+  // Each vector contains ops that belong to the same pingpong region.
+  llvm::SmallVector<llvm::SmallVector<Operation*, 4>> expensiveOps;
 
   // Scan all operations in the function to find expensive ops
   funcOp.walk([&](Operation *op) {
@@ -574,38 +592,92 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
     // Only 2D tensor operations are considered expensive
     auto tensorTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
     if (tensorTy && tensorTy.getRank() > 1) {
-      Operation *lookUpOp = lookUpPingPongOp(op, expensiveOps);
-      LDBG("Found expensive op: " << op->getName().getStringRef().str());
-      if (lookUpOp == nullptr) {
-        expensiveOps.insert(op);
-        LDBG("No paired expensive op found, insert op " << op->getName().getStringRef().str() << " to expensiveOps set");
-      } else {
-        LDBG("Found paired expensive op, op name: " << op->getName().getStringRef().str() << ", lookUpOp name: " << lookUpOp->getName().getStringRef().str());
-        if (areControlFlowEquivalent(lookUpOp, op, domInfo, postDomInfo)) {
-          int thisOpTaskId = getSingleTaskId(op);
-          int pairOpTaskId = getSingleTaskId(lookUpOp);
-          assert(thisOpTaskId >= 0 && pairOpTaskId >= 0);
+      LDBG("Found expensive op " << op->getName().getStringRef().str() << ", location" << op->getLoc());
 
-          // Make sure the two ops are in different partitions
-          if (thisOpTaskId == pairOpTaskId)
-            return;
+      bool foundGroup = false;
+      for (auto &group : expensiveOps) {
+        bool matchType = true;
+        bool matchVar = false;
+        for (auto &refOp : group) {
+          // Check 1: Same Operation Name
+          if (op->getName() != refOp->getName()) {
+            matchType = false;
+            break;
+          }
+          // Check 2: Control Flow Equivalent
+          if (!areControlFlowEquivalent(op, refOp, domInfo, postDomInfo)) {
+            matchType = false;
+            break;
+          }
 
-          op->setAttr("pingpong_id",
-                        IntegerAttr::get(IntegerType::get(op->getContext(), 32),
-                                        pingpongRID));
-          lookUpOp->setAttr("pingpong_id",
-                        IntegerAttr::get(IntegerType::get(lookUpOp->getContext(), 32),
-                                        pingpongRID));
-          LDBG("Assign pingpong_id " << pingpongRID << " to op '"
-                                        << lookUpOp->getName().getStringRef().str()
-                                        << "' with task_id " << pairOpTaskId
-                                        << " and " << thisOpTaskId);
-          pingpongRID += 1;
-          expensiveOps.erase(lookUpOp);
-         }
+          // Check 3: If in the same partition, the op is dependent on the same tt.split
+          int opTaskId = getSingleTaskId(op);
+          int refTaskId = getSingleTaskId(refOp);
+          if (opTaskId == refTaskId) {
+            Operation *opSplit = getSplitOp(op);
+            Operation *refSplit = getSplitOp(refOp);
+            if (opSplit == refSplit) {
+              LDBG("Same split op");
+              matchVar = true;
+            }
+          } else { // Check 4: If in different partitions, the op is called from the same source var
+            std::optional<NameLoc> opLoc = getNameLoc(op);
+            std::optional<NameLoc> refLoc = getNameLoc(refOp);
+            if (opLoc.has_value() && refLoc.has_value()) {
+              LDBG("op loc: "<< opLoc << ", refLoc" << refLoc);
+              if (opLoc.value() == refLoc.value()) {
+                LDBG("Same source var");
+                matchVar = true;
+              }
+            }
+          }
+        }
+        foundGroup = matchType && matchVar;
+        if (foundGroup) {
+          LDBG("Insert to ref op group " << group[0]->getName().getStringRef().str());
+          group.push_back(op);
+          break;
+        }
+      }
+
+      if (!foundGroup) {
+        LDBG("Create new group for op " << op->getName().getStringRef().str());
+        expensiveOps.push_back({op});
       }
     }
   });
+
+  // pingpong region id
+  unsigned pingpongRID = 0;
+
+  // Assign pingpong IDs to groups
+  for (auto &group : expensiveOps) {
+    if (group.size() < 2)
+      continue;
+
+    // Check if ops are in different partitions
+    bool differentPartitions = false;
+    int firstTaskId = getSingleTaskId(group[0]);
+    for (size_t i = 1; i < group.size(); ++i) {
+      if (getSingleTaskId(group[i]) != firstTaskId) {
+        differentPartitions = true;
+        break;
+      }
+    }
+
+    if (!differentPartitions)
+      continue;
+
+    for (auto *op : group) {
+      op->setAttr("pingpong_id",
+                  IntegerAttr::get(IntegerType::get(op->getContext(), 32),
+                                   pingpongRID));
+      LDBG("Assign pingpong_id " << pingpongRID << " to op '"
+                                 << op->getName().getStringRef().str()
+                                 << "' with task_id " << getSingleTaskId(op));
+    }
+    pingpongRID++;
+  }
 }
 
 #define GEN_PASS_DEF_NVGPUTESTPINGPONGSYNC

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -81,6 +81,9 @@ public:
   llvm::DenseMap<int, SmallVector<Operation *>> pingpongIdToPingBoundaryOps;
   llvm::DenseMap<int, SmallVector<Operation *>> pingpongIdToPongBoundaryOps;
 
+  // Map from pingpong region id to the participating thread number
+  llvm::DenseMap<int, int> pingpongIdToThreadNum;
+
   CriticalRegionManager() {
     // Initialize barrier ID to be 9
     barrierId = MIN_BARRIER_ID;
@@ -430,25 +433,40 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
     });
   }
 
-  // Step 2: Find the boundaries for each pingpong region
-  // Process each pingpong region at a time
+  // Step 2: For each pingpong region,
+  //         i) find the boundaries and
+  //         ii) calculate the participating thread number
   for (auto &[pingpongId, keyOps] : crManager.pingpongIdToKeyOps) {
     // Map from the ping and pong partition id to the start and end ops
     llvm::DenseMap<int, SmallVector<Operation *>> startOps;
     llvm::DenseMap<int, SmallVector<Operation *>> endOps;
+
+    // Map from the ping and pong partition id to its number of warps
+    llvm::DenseMap<int, int> numWarps;
+
+    // Find the start and end ops for each key operation in the pingpong region
     for (auto &keyOp : keyOps) {
       int partitionId = getSingleTaskId(keyOp);
       Operation *startOp = findStartOp(crManager, keyOp, domInfo, postDomInfo);
       Operation *endOp = findEndOp(crManager, keyOp, domInfo, postDomInfo);
       startOps[partitionId].push_back(startOp);
       endOps[partitionId].push_back(endOp);
+      // Look up the number of warps for each partition
+      if (numWarps.count(partitionId) == 0) {
+        numWarps[partitionId] = mlir::triton::gpu::lookupNumWarps(keyOp);
+        LDBG("numWarps of " << partitionId << " is " << numWarps[partitionId]);
+      }
     }
 
-    if (startOps.size() != 2 || endOps.size() != 2) {
+    if (startOps.size() != 2 || endOps.size() != 2 || numWarps.size() != 2) {
       LDBG("pingpong ops are not in two partitions");
       continue;
     }
+
+    int numberOfThreads = 0;
     for (auto [partitionId, startOp] : startOps) {
+      // The start and end ops are unioned for each partition to find the
+      // boundary ops
       Operation *unionStartOp = unionOfStartOps(startOp);
       Operation *unionEndOp = unionOfEndOps(endOps[partitionId]);
       if (!crManager.hasPingBoundary(pingpongId)) {
@@ -460,7 +478,17 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
             unionStartOp);
         crManager.pingpongIdToPongBoundaryOps[pingpongId].push_back(unionEndOp);
       }
+      // The number of participating threads is summed up from ping and pong
+      // partitions
+      numberOfThreads += numWarps[partitionId] * 32; // 32 threads per warp
+      LDBG("numberOfThreads " << numberOfThreads);
     }
+
+    if (crManager.pingpongIdToThreadNum.count(pingpongId) == 0) {
+      crManager.pingpongIdToThreadNum[pingpongId] = numberOfThreads;
+      LDBG("pingpongId " << pingpongId << " has " << numberOfThreads);
+    }
+
     crManager.dumpBoundaryOps();
   }
 
@@ -475,6 +503,8 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
 
     int pingBarrierId = crManager.pingpongIdToBarrierId[pingpongId].first;
     int pongBarrierId = crManager.pingpongIdToBarrierId[pingpongId].second;
+
+    int numThreads = crManager.pingpongIdToThreadNum[pingpongId];
 
     // Insert barriers for the ping partition
     Operation *pingStart = pingBoundOps[0];
@@ -500,9 +530,8 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
         builder.create<arith::ConstantIntOp>(pingRegionLoc, pingBarrierId, 32);
     Value pongBarrier =
         builder.create<arith::ConstantIntOp>(pingRegionLoc, pongBarrierId, 32);
-    // TODO: Should decide the number of threads using heuristics
     Value pingNumThreads =
-        builder.create<arith::ConstantIntOp>(pingRegionLoc, 256, 32);
+        builder.create<arith::ConstantIntOp>(pingRegionLoc, numThreads, 32);
     // Insert arrive barrier for the ping partition to allow the initial entry
     builder.create<ttng::NamedBarrierArriveOp>(pingRegionLoc, pongBarrier,
                                                pingNumThreads);
@@ -526,7 +555,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
     Value pongBarrier2 =
         builder2.create<arith::ConstantIntOp>(pongRegionLoc, pongBarrierId, 32);
     Value pingNumThreads2 =
-        builder2.create<arith::ConstantIntOp>(pongRegionLoc, 256, 32);
+        builder2.create<arith::ConstantIntOp>(pongRegionLoc, numThreads, 32);
     builder2.setInsertionPoint(pongStart);
     builder2.create<ttng::NamedBarrierWaitOp>(pongStart->getLoc(), pongBarrier2,
                                               pingNumThreads2);
@@ -537,7 +566,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
   }
 }
 
-/// doPingPongSync pass: Insert pingpong barriers to the IR
+/// doPingPongPrep pass: Insert pingpong barriers to the IR
 void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
                     int capability) {
   for (auto &block : funcOp.getBody().getBlocks()) {
@@ -571,6 +600,7 @@ static std::optional<NameLoc> getNameLoc(Operation *op) {
   return std::nullopt;
 }
 
+/// doPingPongPrep pass: Group expensive ops into pingpong regions
 void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
                     int capability) {
   CriticalRegionManager crManager;
@@ -579,8 +609,8 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
   mlir::DominanceInfo domInfo(funcOp);
   mlir::PostDominanceInfo postDomInfo(funcOp);
 
-  // A list of expensive ops grouped in vectors.
-  // Each vector contains ops that belong to the same pingpong region.
+  // A list of expensive op groups.
+  // Each group contains ops at the same pingpong region.
   llvm::SmallVector<llvm::SmallVector<Operation *, 4>> expensiveOps;
 
   // Scan all operations in the function to find expensive ops
@@ -597,6 +627,7 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
       LDBG("Found expensive op " << op->getName().getStringRef().str()
                                  << ", location" << op->getLoc());
 
+      // Check if the expensive op belongs to an existing group
       bool foundGroup = false;
       for (auto &group : expensiveOps) {
         bool matchType = true;
@@ -654,15 +685,15 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
     }
   });
 
-  // pingpong region id
+  // pingpong region ID
   unsigned pingpongID = 0;
 
-  // Assign pingpong IDs to groups
+  // Assign pingpong region IDs to groups
   for (auto &group : expensiveOps) {
     if (group.size() < 2)
       continue;
 
-    // Check if ops are in different partitions
+    // Check if ops are from different partitions
     bool differentPartitions = false;
     int firstTaskId = getSingleTaskId(group[0]);
     for (size_t i = 1; i < group.size(); ++i) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -539,7 +539,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
     builder.create<ttng::NamedBarrierWaitOp>(pingStart->getLoc(), pingBarrier,
                                              pingNumThreads);
     // Insert AFTER the pingEnd op
-    builder.setInsertionPointAfter(pingEnd->getNextNode());
+    builder.setInsertionPointAfter(pingEnd);
     builder.create<ttng::NamedBarrierArriveOp>(pingEnd->getLoc(), pongBarrier,
                                                pingNumThreads);
 
@@ -560,7 +560,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
     builder2.create<ttng::NamedBarrierWaitOp>(pongStart->getLoc(), pongBarrier2,
                                               pingNumThreads2);
     // Insert AFTER the pongEnd op
-    builder2.setInsertionPointAfter(pongEnd->getNextNode());
+    builder2.setInsertionPointAfter(pongEnd);
     builder2.create<ttng::NamedBarrierArriveOp>(pongEnd->getLoc(), pingBarrier2,
                                                 pingNumThreads2);
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -352,7 +352,10 @@ int arrivesFirst(
       forOp, &*forOp.getBody()->without_terminator().begin());
   auto firstCriticalOp = linearized.findNext(
       [&](Operation *op) { return criticalOps.contains(op); });
-  assert(firstCriticalOp && "Failed to find the earliest op in the schedule");
+  if (!firstCriticalOp) {
+    LDBG("Failed to find the earliest critical op in the schedule");
+    return -1;
+  }
   Operation *firstOp = *firstCriticalOp;
 
   // Step 2: Validate that the schedule alternates between partitions

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -135,7 +135,7 @@ public:
   /// Check if an operation is registered as an expensive operation for the
   /// given compute capability
   bool isExpensiveOp(Operation *op, int computeCapability) const {
-    std::string opName = op->getName().getStringRef().str();
+    llvm::StringRef opName = op->getName().getStringRef();
     auto it = keyOpNameToType.find(computeCapability);
     if (it == keyOpNameToType.end()) {
       return false;
@@ -146,7 +146,7 @@ public:
   /// Get the CriticalOpType for an operation (for the given compute capability)
   std::optional<CriticalOpType> getCriticalOpType(Operation *op,
                                                   int computeCapability) const {
-    std::string opName = op->getName().getStringRef().str();
+    llvm::StringRef opName = op->getName().getStringRef();
     auto it = keyOpNameToType.find(computeCapability);
     if (it == keyOpNameToType.end()) {
       return std::nullopt;
@@ -222,14 +222,14 @@ public:
     for (const auto &entry : pingpongIdToPingBoundaryOps) {
       LDBG("pingpongId: " << entry.first);
       for (const auto &op : entry.second) {
-        LDBG("  ping boundary op: " << op->getName().getStringRef().str());
+        LDBG("  ping boundary op: " << op->getName().getStringRef());
       }
     }
     LDBG("pingpongIdToPongBoundaryOps");
     for (const auto &entry : pingpongIdToPongBoundaryOps) {
       LDBG("pingpongId: " << entry.first);
       for (const auto &op : entry.second) {
-        LDBG("  pong boundary op: " << op->getName().getStringRef().str());
+        LDBG("  pong boundary op: " << op->getName().getStringRef());
       }
     }
   }
@@ -343,7 +343,7 @@ bool areControlFlowEquivalent(Operation *op1, Operation *op2,
 void dumpMemoryEffects(Operation *op) {
   auto memInterface = dyn_cast<MemoryEffectOpInterface>(op);
   if (!memInterface) {
-    LDBG("  Op '" << op->getName().getStringRef().str()
+    LDBG("  Op '" << op->getName().getStringRef()
                   << "' does not implement MemoryEffectOpInterface");
     return;
   }
@@ -352,13 +352,13 @@ void dumpMemoryEffects(Operation *op) {
   memInterface.getEffects(effects);
 
   if (effects.empty()) {
-    LDBG("  Op '" << op->getName().getStringRef().str()
+    LDBG("  Op '" << op->getName().getStringRef()
                   << "' has no memory effects");
     return;
   }
 
   for (const auto &effect : effects) {
-    std::string effectType;
+    llvm::StringRef effectType;
     if (isa<MemoryEffects::Read>(effect.getEffect()))
       effectType = "Read";
     else if (isa<MemoryEffects::Write>(effect.getEffect()))
@@ -370,8 +370,8 @@ void dumpMemoryEffects(Operation *op) {
     else
       effectType = "Unknown";
 
-    std::string resourceName = effect.getResource()->getName().str();
-    LDBG("  Op '" << op->getName().getStringRef().str() << "' has effect: "
+    llvm::StringRef resourceName = effect.getResource()->getName();
+    LDBG("  Op '" << op->getName().getStringRef() << "' has effect: "
                   << effectType << " on resource: " << resourceName);
   }
 }
@@ -392,7 +392,7 @@ Operation *findEndOp(CriticalRegionManager &crManager, Operation *keyOp,
                      mlir::PostDominanceInfo &postDomInfo) {
   // Set the end op of this pingpong region to be the first op with memory side
   // effect after this critical op
-  std::string opName = keyOp->getName().getStringRef().str();
+  llvm::StringRef opName = keyOp->getName().getStringRef();
   auto opTypeOpt = crManager.getCriticalOpType(keyOp, computeCapability);
   if (!opTypeOpt.has_value()) {
     LDBG("Operation " << opName
@@ -616,7 +616,7 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp, int computeCapability) {
       // Check if this is a warp_group_dot operation
       if (auto pingpongIdAttr = op->getAttrOfType<IntegerAttr>("pingpong_id")) {
         int pingpongId = pingpongIdAttr.getInt();
-        LDBG("Found op " << op->getName().getStringRef().str()
+        LDBG("Found op " << op->getName().getStringRef()
                          << " with pingpong id " << pingpongId);
         // Prepare CriticalRegionManager for this pingpong region
         crManager.pingpongIdToKeyOps[pingpongId].push_back(op);
@@ -873,14 +873,14 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
       foundGroup = matchType && matchVar;
       if (foundGroup) {
         LDBG("Insert to ref op group "
-             << group[0]->getName().getStringRef().str());
+             << group[0]->getName().getStringRef());
         group.push_back(op);
         break;
       }
     }
 
     if (!foundGroup) {
-      LDBG("Create new group for op " << op->getName().getStringRef().str());
+      LDBG("Create new group for op " << op->getName().getStringRef());
       expensiveOps.push_back({op});
     }
   });
@@ -911,7 +911,7 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
           "pingpong_id",
           IntegerAttr::get(IntegerType::get(op->getContext(), 32), pingpongID));
       LDBG("Assign pingpong_id " << pingpongID << " to op '"
-                                 << op->getName().getStringRef().str()
+                                 << op->getName().getStringRef()
                                  << "' with task_id " << getSingleTaskId(op));
     }
     pingpongID++;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -501,12 +501,11 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp, int computeCapability) {
   }
 
   // Step 3: Insert pingpong barriers to the IR
-  for (auto &[pingpongId, keyOps] : crManager.pingpongIdToKeyOps) {
+  for (auto &[pingpongId, pingBoundOps] :
+       crManager.pingpongIdToPingBoundaryOps) {
     if (!crManager.hasPingPongBoundary(pingpongId))
       continue;
-    SmallVector<Operation *> pingBoundOps =
-        crManager.pingpongIdToPingBoundaryOps[pingpongId];
-    SmallVector<Operation *> pongBoundOps =
+    const SmallVector<Operation *> &pongBoundOps =
         crManager.pingpongIdToPongBoundaryOps[pingpongId];
 
     if (crManager.pingpongIdToBarrierId.count(pingpongId) == 0) {
@@ -515,8 +514,8 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp, int computeCapability) {
       continue;
     }
 
-    unsigned pingBarrierId = crManager.pingpongIdToBarrierId[pingpongId].first;
-    unsigned pongBarrierId = crManager.pingpongIdToBarrierId[pingpongId].second;
+    auto [pingBarrierId, pongBarrierId] =
+        crManager.pingpongIdToBarrierId[pingpongId];
 
     int numThreads = crManager.pingpongIdToThreadNum[pingpongId];
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -63,7 +63,7 @@ private:
   static constexpr unsigned MAX_BARRIER_ID = 15;
 
 public:
-  // Current barrier ID to assign (wraps around in range [0, 15])
+  /// Current barrier ID to assign (wraps around in range [MIN_BARRIER_ID, MAX_BARRIER_ID])
   int barrierId;
 
   // Map from compute capability to a map of critical operation name to its

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -410,7 +410,6 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp, int computeCapability) {
     // Walk through the region to find operations that have pingpong_id
     // attribute
     region->walk<WalkOrder::PreOrder>([&](Operation *op) {
-      // Check if this is a warp_group_dot operation
       if (auto pingpongIdAttr = op->getAttrOfType<IntegerAttr>("pingpong_id")) {
         int pingpongId = pingpongIdAttr.getInt();
         LDBG("Found op " << op->getName().getStringRef() << " with pingpong id "
@@ -657,9 +656,6 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
 
   // Assign pingpong region IDs to groups
   for (auto &group : expensiveOps) {
-    if (group.size() < 2)
-      continue;
-
     // Count the number of distinct partitions in the group
     llvm::SmallDenseSet<int, 4> partitionIds;
     for (auto *op : group) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -534,21 +534,21 @@ void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
 bool areControlFlowEquivalent(Operation *op1, Operation *op2,
                               DominanceInfo &domInfo,
                               PostDominanceInfo &postDomInfo) {
-    if (op1->getBlock() != op2->getBlock())
-        return false;
-
-    // Check if op1 dominates op2 AND op2 post-dominates op1
-    if (domInfo.dominates(op1, op2) && postDomInfo.postDominates(op2, op1))
-        return true;
-
-    // Check the reverse (op2 dominates op1 AND op1 post-dominates op2)
-    if (domInfo.dominates(op2, op1) && postDomInfo.postDominates(op1, op2))
-        return true;
-
+  if (op1->getBlock() != op2->getBlock())
     return false;
+
+  // Check if op1 dominates op2 AND op2 post-dominates op1
+  if (domInfo.dominates(op1, op2) && postDomInfo.postDominates(op2, op1))
+    return true;
+
+  // Check the reverse (op2 dominates op1 AND op1 post-dominates op2)
+  if (domInfo.dominates(op2, op1) && postDomInfo.postDominates(op1, op2))
+    return true;
+
+  return false;
 }
 
-static Operation* getSplitOp(Operation *op) {
+static Operation *getSplitOp(Operation *op) {
   for (Value operand : op->getOperands()) {
     if (auto result = dyn_cast<OpResult>(operand)) {
       if (isa<tt::SplitOp>(result.getOwner())) {
@@ -579,7 +579,7 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
 
   // A list of expensive ops grouped in vectors.
   // Each vector contains ops that belong to the same pingpong region.
-  llvm::SmallVector<llvm::SmallVector<Operation*, 4>> expensiveOps;
+  llvm::SmallVector<llvm::SmallVector<Operation *, 4>> expensiveOps;
 
   // Scan all operations in the function to find expensive ops
   funcOp.walk([&](Operation *op) {
@@ -592,7 +592,8 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
     // Only 2D tensor operations are considered expensive
     auto tensorTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
     if (tensorTy && tensorTy.getRank() > 1) {
-      LDBG("Found expensive op " << op->getName().getStringRef().str() << ", location" << op->getLoc());
+      LDBG("Found expensive op " << op->getName().getStringRef().str()
+                                 << ", location" << op->getLoc());
 
       bool foundGroup = false;
       for (auto &group : expensiveOps) {
@@ -610,7 +611,8 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
             break;
           }
 
-          // Check 3: If in the same partition, the op is dependent on the same tt.split
+          // Check 3: If in the same partition, the op is dependent on the same
+          // tt.split
           int opTaskId = getSingleTaskId(op);
           int refTaskId = getSingleTaskId(refOp);
           if (opTaskId == refTaskId) {
@@ -620,11 +622,12 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
               LDBG("Same split op");
               matchVar = true;
             }
-          } else { // Check 4: If in different partitions, the op is called from the same source var
+          } else { // Check 4: If in different partitions, the op is called from
+                   // the same source var
             std::optional<NameLoc> opLoc = getNameLoc(op);
             std::optional<NameLoc> refLoc = getNameLoc(refOp);
             if (opLoc.has_value() && refLoc.has_value()) {
-              LDBG("op loc: "<< opLoc << ", refLoc" << refLoc);
+              LDBG("op loc: " << opLoc << ", refLoc" << refLoc);
               if (opLoc.value() == refLoc.value()) {
                 LDBG("Same source var");
                 matchVar = true;
@@ -634,7 +637,8 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
         }
         foundGroup = matchType && matchVar;
         if (foundGroup) {
-          LDBG("Insert to ref op group " << group[0]->getName().getStringRef().str());
+          LDBG("Insert to ref op group "
+               << group[0]->getName().getStringRef().str());
           group.push_back(op);
           break;
         }
@@ -690,7 +694,7 @@ public:
       NVGPUTestPingPongSyncPass>::NVGPUTestPingPongSyncBase;
 
   void runOnFuncOp(triton::FuncOp funcOp) {
-      doPingPongSync(funcOp, numWarpGroups, capability);
+    doPingPongSync(funcOp, numWarpGroups, capability);
   }
 
   void runOnOperation() override {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -298,7 +298,7 @@ Operation *findEndOp(CriticalRegionManager &crManager, Operation *keyOp,
       return curOp;
     }
     // If we've reached the stop op, there's no memory effect between them
-    if (stopOp && curOp == stopOp) {
+    if (curOp == stopOp) {
       return nullptr;
     }
     // Check if we've hit a control flow boundary


### PR DESCRIPTION
This PR uses CoarseSchedule to determine the partition that contains ops coming first.

# FB-only:

This PR will be imported to fbcode diff. Ensure all internal tests passed.

For TLX, run `third_party/tlx/run_all.sh` to cover TLX unit tests and TLX kernel correctness verification:

```
Need to build triton in this script? {y|n}n
Run all LITs? {y|n}n
Run core Triton python unit tests? {y|n}n
Run all TLX unit tests? {y|n}y
Running TLX Unit Tests
...
Run TLX tutorial kernels (correctness|performance|no)? {c|p|n}c
...
```

# New contributor declaration (copied from Core Triton):
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
