### PR TITLE
[Triton] Fix bool tensor loading issue

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1073,11 +1073,11 @@ class TritonSemantic(Generic[TensorTy]):
         else:
             # Load by de-referencing the pointer of scalar
             dst_ty = elt_ty
-        return dst_ty, ptr, mask, other
+        return dst_ty, ptr, mask, other, is_bool
 
     def _load_legacy(self, ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile):
         # pre-check
-        dst_ty, ptr, mask, other = self._prepare_legacy_load(ptr, mask, other, boundary_check, padding)
+        dst_ty, ptr, mask, other, is_bool = self._prepare_legacy_load(ptr, mask, other, boundary_check, padding)
         # Build IR
         if mask is None:
             ret = tl.tensor(self.builder.create_load(ptr.handle, cache, eviction, is_volatile), dst_ty)
@@ -1087,7 +1087,7 @@ class TritonSemantic(Generic[TensorTy]):
                                                 eviction, is_volatile),
                 dst_ty,
             )
-        if ptr.type.scalar == tl.int1:
+        if is_bool:
             ret = self.cast(ret, tl.int1)
         return ret
 

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -498,7 +498,7 @@ def async_load(
         raise NotImplementedError("async_load by block pointer is not supported yet")
     else:
         # Load by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
-        _, src, mask, other = _semantic._prepare_legacy_load(src, mask, other, None, None)
+        _, src, mask, other, _ = _semantic._prepare_legacy_load(src, mask, other, None, None)
 
     cache = _semantic._str_to_load_cache_modifier(cache_modifier)
     eviction = _semantic._str_to_eviction_policy(eviction_policy)


### PR DESCRIPTION
Summary:
Boolean operators (not, and, or) on values loaded from torch.bool tensors cause: 
`ValueError('Cannot bitcast data-type of size 8 to size 1')`

Note: legacy version doesn't have this bug https://www.internalfb.com/code/fbsource/third-party/triton/legacy/triton/python/triton/language/semantic.py?lines=1104%2C1129

Reviewed By: joshuadeng, dshi7

Differential Revision: D91849601


