### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[GLUON][TEST] Complete remaining convert layout tests (#7962)'

### DIFF
--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -22,7 +22,7 @@ def _is_layout_applicable(layout) -> bool:
             return False
         return True
     elif is_hip():
-        if layout in ["padded_shared_layout_single_interval", "padded_shared_layout_multi_interval"]:
+        if isinstance(layout, ttgl.PaddedSharedLayout):
             return True
         # TODO: Add other amd layouts
         return isinstance(layout, ttgl.amd.AMDMFMALayout)


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/7962

Upstream commit message:
```
> [GLUON][TEST] Complete remaining convert layout tests (#7962)
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 5e98c906a8b8d013c8d016a305de7e0816fbdf0c
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 3
```

Reviewed By: stashuk-olek

Differential Revision: D91917588


