### PR TITLE
[BE] [TLX] Cleanup TMEM dummy layouts to avoid fp8 core dump 

### DIFF
--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -186,18 +186,14 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
             # For 8-bit element types (uint8/int8), use a dummy TMEM layout that will
             # be resolved during layout propagation. This is used for scales in
             # scaled MMA operations where the final layout depends on usage context.
-            if dtype == tl.uint8 or dtype == tl.int8:
-                layout = None  # Will be resolved by layout propagation
-                layout_handle = _semantic.builder.make_dummy_tmem_layout_attr()
+            if dtype.primitive_bitwidth < 16:
+                if dtype == tl.uint8 or dtype == tl.int8:
+                    layout = tlx.DummyTMEMLayoutEncoding()
+                else:
+                    raise NotImplementedError(f"TMEM Layouts not supported for {dtype} yet")
             else:
                 layout = tlx.tensor_memory_layout_encoding.make_default(shape)
-                layout_handle = _semantic.builder.make_tensor_memory_encoding_attr(
-                    layout.blockM,
-                    layout.blockN,
-                    layout.unpacked,
-                    layout.CTASplitM,
-                    layout.CTASplitN,
-                )
+            layout_handle = layout.to_ir(_semantic.builder)
     else:
         raise NotImplementedError("User-specified layout encoding not yet implemented.")
 
@@ -217,8 +213,7 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
                                  f"doesn't match local_alloc storage ({storage.value})")
             shared_buffer_handle = reuse.handle
         else:
-            raise ValueError(f"reuse must be a buffered_tensor or storage_alias_spec, "
-                             f"got {type(reuse)}")
+            raise ValueError(f"reuse must be a buffered_tensor or storage_alias_spec, got {type(reuse)}")
 
     if storage == tlx.storage_kind.smem:
         tensor_handle = _semantic.builder.create_local_alloc(full_shape, elem_type, layout_handle, alias_handle,
@@ -333,7 +328,7 @@ def remote_view(
     a cluster of shape [2, 4] a valid unique ID could be 0~7, including the executing CTA itself
     :returns: a remote view of the buffer, located at the same relative location, but just in a possibly different CTA
     """
-    assert isinstance(local_allocated_buffer, tlx.mbarrier), ("remote_view only supports barrier for now")
+    assert isinstance(local_allocated_buffer, tlx.mbarrier), "remote_view only supports barrier for now"
     assert local_allocated_buffer.type.storage == storage_kind.smem, "remote_view requires local smem as input"
     remote_cta_rank_handle = _get_remote_cta_rank_handle(remote_cta_rank, _semantic)
     remote_buf_handle = _semantic.builder.create_map_to_remote_buffer(local_allocated_buffer.handle,

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -281,6 +281,29 @@ class storage_kind(enum.Enum):
     smemCluster = "smemCluster"
 
 
+class DummyTMEMLayoutEncoding(layout_encoding):
+    """
+    Placeholder layout for TMEM tensors that will be resolved during layout propagation.
+    Used for sub-16-bit element types where the final layout depends on usage context
+    (e.g., as scales in scaled MMA operations).
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def to_ir(self, builder: ir.builder):
+        return builder.make_dummy_tmem_layout_attr()
+
+    def __repr__(self):
+        return "DummyTMEMLayoutEncoding<>"
+
+    def __eq__(self, other):
+        return isinstance(other, DummyTMEMLayoutEncoding)
+
+    def __hash__(self):
+        return hash(self.__class__.__name__)
+
+
 class storage_alias_spec(tl.base_value):
     """
     Definition of a storage alias specification.


### PR DESCRIPTION
If you accidentally use fp8 in TMEM you will get a core dump because we force unpacked=True. This updates the dummy layout path to capture this case in Python with a proper exception.