### PR TITLE
[TLX] Changes to support clustered-grid in Fixup

### DIFF
--- a/test/TLX/clustered_grid.mlir
+++ b/test/TLX/clustered_grid.mlir
@@ -1,0 +1,11 @@
+// RUN: triton-opt -split-input-file -pass-pipeline='builtin.module(triton-tlx-fixup{num-warps=8 target=cuda:90 num-ctas=1 threads-per-warp=32 cluster-dims=1,2,1})' --verify-diagnostics %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @map_smem_to_remote(%arg: !ttg.memdesc<1xi64, #shared, #smem, mutable>) {
+    %c1_i32 = arith.constant 1 : i32
+    %0 = ttng.map_to_remote_buffer %arg, %c1_i32: !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -188,7 +188,8 @@ class HIPBackend(BaseBackend):
     def make_ttir(mod, metadata, options):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        tlx.tlx_passes.add_triton_tlx_fixup(pm, f"hip:{options.arch}", options.num_warps, 64, options.num_ctas)
+        tlx.tlx_passes.add_triton_tlx_fixup(pm, f"hip:{options.arch}", options.num_warps, 64, options.num_ctas,
+                                            list((1, 1, 1)))
         passes.common.add_inliner(pm)
         passes.ttir.add_rewrite_tensor_pointer(pm)
         passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -253,7 +253,9 @@ class CUDABackend(BaseBackend):
 
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        tlx.tlx_passes.add_triton_tlx_fixup(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
+        # Pass cluster_dims as a list
+        tlx.tlx_passes.add_triton_tlx_fixup(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas,
+                                            list(opt.cluster_dims))
         passes.common.add_inliner(pm)
         # Handle storage lowering. In the future this may need
         # dummy layouts

--- a/third_party/tlx/dialect/include/Transforms/Passes.td
+++ b/third_party/tlx/dialect/include/Transforms/Passes.td
@@ -23,6 +23,8 @@ def TritonTLXFixup : Pass</*cli-arg*/"triton-tlx-fixup", /*Op*/"mlir::ModuleOp">
       Option<"numCTAs", "num-ctas",
              "int32_t", /*default*/"1",
              "number of ctas in a cga">,
+      ListOption<"clusterDims", "cluster-dims", "int32_t",
+             "cluster dimensions (X, Y, Z)">,
    ];
 }
 


### PR DESCRIPTION
Summary: Pass cluster dims as an option to the Fixup pass, so the 2-cta remote_view check does not cause a failure when running a kernel in a clustered-grid but without 2-cta.

Differential Revision: D92423558


