### PR TITLE
[TLX] Add TLX TableGen dependencies to TritonNvidiaGPUIR

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/IR/CMakeLists.txt
@@ -6,6 +6,9 @@ add_triton_library(TritonNvidiaGPUIR
   TritonNvidiaGPUTableGen
   TritonNvidiaGPUAttrDefsIncGen
   TritonNvidiaGPUOpInterfacesIncGen
+  TLXTableGen
+  TLXTypesIncGen
+  TLXAttrDefsIncGen
 
   LINK_LIBS PUBLIC
   TritonIR


### PR DESCRIPTION
Summary:
Fixing a build failure due to missing TLX dependencies:

In file included from 28: In file included from 15: 10:10: fatal error: 'tlx/dialect/include/IR/TLXTypesEnums.h.inc' file not found 10 | #include "tlx/dialect/include/IR/TLXTypesEnums.h.inc" | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 1 error generated.
TritonNvidiaGPUIR includes TLX headers via Ops.cpp, which transitively include TableGen-generated .inc files. Without explicit dependencies on TLXTableGen, TLXTypesIncGen, and TLXAttrDefsIncGen, the build could fail when these generated files don't exist yet at compile time.

Differential Revision: D92529196


