### PR TITLE
[TLX] Add L2 cache policy support for TMA store

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -394,11 +394,13 @@ def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global">
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
     Variadic<I32>:$coord,
-    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
+    DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict
   );
 
   let assemblyFormat = [{
     $desc `[` $coord `]` $src
+    oilist(`evictionPolicy` `=` $evict)
     attr-dict `:` qualified(type($desc)) `,` qualified(type($src))
   }];
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -152,7 +152,7 @@ struct TMAStoreLowering : public OpRewritePattern<DescriptorStoreOp> {
           rewriter, op.getLoc(),
           op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
       rewriter.create<triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp>(
-          op.getLoc(), tmaPtr, indices, alloc);
+          op.getLoc(), tmaPtr, indices, alloc, triton::EvictionPolicy::NORMAL);
     };
     lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);
     return success();

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -610,9 +610,9 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("create_async_TMA_store",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &coord,
-              Value source) -> void {
-             self.create<ttng::AsyncTMACopyLocalToGlobalOp>(desc, coord,
-                                                            source);
+              Value source, tt::EvictionPolicy evictionPolicy) -> void {
+             self.create<ttng::AsyncTMACopyLocalToGlobalOp>(desc, coord, source,
+                                                            evictionPolicy);
            })
       .def("create_async_TMA_store_wait",
            [](TritonOpBuilder &self, int pendings) {


### PR DESCRIPTION
Add L2 cache eviction policy support for async TMA store operations, following the pattern established for TMA loads. This enables users to control L2 cache behavior (evict_first, evict_last) for TMA store operations.

The implementation adds:
- evict attribute to AsyncTMACopyLocalToGlobalOp at TTGIR level
- L2 cache policy register creation in LLVM lowering using createpolicy.fractional.L2::evict_first/last.b64 PTX instruction
- .L2::cache_hint modifier to the TMA store PTX instruction when eviction policy is specified
- eviction_policy parameter to tlx.async_descriptor_store() Python API

Test Plan:
- Added lit tests for evict_first and evict_last policies
- Added parameterized Python test that verifies TTGIR and PTX output
