### PR TITLE
[TLX] 4/N define the IR interface for set_buffer_overlap

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -5119,3 +5119,69 @@ class TestToMxfp8:
         ref_scale_swizzled = self._reference_swizzle_scales(ref_scale)
         torch.testing.assert_close(data_out.float().cpu(), ref_data.float())
         assert torch.equal(scale_out.cpu(), ref_scale_swizzled)
+
+
+class TestSetBufferOverlap:
+    """Tests for tlx.set_buffer_overlap and storage_alias_spec.set_buffer_overlap method."""
+
+    def test_set_buffer_overlap_compiles_to_ir(self):
+        """Test that set_buffer_overlap compiles to IR but fails during lowering.
+
+        This test verifies that the JIT API works correctly - the code should
+        successfully lower to MLIR IR but is expected to fail in later lowering
+        passes because offset calculation is not yet implemented.
+        """
+
+        @triton.jit
+        def set_buffer_overlap_kernel(BLOCK_SIZE: tl.constexpr):
+            # Create a storage alias spec
+            spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
+
+            # Allocate buffers using the spec
+            a = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(2), tlx.storage_kind.smem,
+                                reuse=spec)
+            b = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.bfloat16, tl.constexpr(2), tlx.storage_kind.smem,
+                                reuse=spec)
+
+            # Define overlap scheme: a and b share the same memory region
+            spec.set_buffer_overlap(tlx.reuse_group(a, b, group_type=tlx.reuse_group_type.shared))
+
+        grid = lambda meta: (1, )
+
+        # The kernel should compile to IR but fail during lowering
+        # (offset calculation not implemented yet)
+        with pytest.raises(RuntimeError):
+            set_buffer_overlap_kernel[grid](BLOCK_SIZE=64)
+
+    def test_set_buffer_overlap_nested_compiles_to_ir(self):
+        """Test that nested reuse_group in set_buffer_overlap compiles to IR.
+
+        This test verifies Flash Attention-style nested overlap schemes work
+        at the JIT level.
+        """
+
+        @triton.jit
+        def set_buffer_overlap_nested_kernel(BLOCK_SIZE: tl.constexpr):
+            # Create a storage alias spec
+            spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
+
+            # Allocate buffers (Flash Attention pattern)
+            qk = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(2), tlx.storage_kind.smem,
+                                 reuse=spec)
+            p = tlx.local_alloc((BLOCK_SIZE, BLOCK_SIZE), tl.float32, tl.constexpr(2), tlx.storage_kind.smem,
+                                reuse=spec)
+            alpha = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, tl.constexpr(2), tlx.storage_kind.smem, reuse=spec)
+
+            # Define overlap scheme: QK shares with (P distinct from alpha)
+            spec.set_buffer_overlap(
+                tlx.reuse_group(
+                    qk,
+                    tlx.reuse_group(p, alpha, group_type=tlx.reuse_group_type.distinct),
+                    group_type=tlx.reuse_group_type.shared,
+                ))
+
+        grid = lambda meta: (1, )
+
+        # The kernel should compile to IR but fail during lowering
+        with pytest.raises(RuntimeError):
+            set_buffer_overlap_nested_kernel[grid](BLOCK_SIZE=64)

--- a/test/TLX/set-buffer-overlap-errors.mlir
+++ b/test/TLX/set-buffer-overlap-errors.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-opt --split-input-file %s --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// set_buffer_overlap Verifier Error Tests
+//===----------------------------------------------------------------------===//
+
+// Test: duplicate element in reuse_group tree (same allocation appears twice via nesting)
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @set_buffer_overlap_duplicate_element() {
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    // Create a nested group that includes %1 twice (once directly, once via inner group)
+    %inner = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    %outer = tlx.reuse_group(%1, %inner) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !tlx.reuse_group<shared>) -> !tlx.reuse_group<distinct>
+    // expected-error @+1 {{reuse_group tree contains duplicate elements}}
+    tlx.set_buffer_overlap(%0, %outer) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: allocations in reuse_group must all reference the same storage_alias_spec
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @set_buffer_overlap_mismatched_spec() {
+    %spec1 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %spec2 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    // Allocate from different specs
+    %1 = tlx.storage_alias_local_alloc %spec1 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %spec2 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %group = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    // expected-error @+1 {{all allocations in the reuse_group must reference the same storage_alias_spec}}
+    tlx.set_buffer_overlap(%spec1, %group) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}

--- a/test/TLX/storage-alias-spec.mlir
+++ b/test/TLX/storage-alias-spec.mlir
@@ -268,3 +268,55 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     tt.return
   }
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// set_buffer_overlap Tests
+//===----------------------------------------------------------------------===//
+
+// Test basic set_buffer_overlap with smem storage
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @set_buffer_overlap_basic
+  tt.func @set_buffer_overlap_basic() {
+    // CHECK: %[[ALIAS:.*]] = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    // CHECK: %[[A:.*]] = tlx.storage_alias_local_alloc %[[ALIAS]] : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    // CHECK: %[[B:.*]] = tlx.storage_alias_local_alloc %[[ALIAS]] : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    // CHECK: %[[GROUP:.*]] = tlx.reuse_group(%[[A]], %[[B]]) group_kind = shared
+    // CHECK: tlx.set_buffer_overlap(%[[ALIAS]], %[[GROUP]])
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test set_buffer_overlap with nested reuse_group
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @set_buffer_overlap_nested
+  tt.func @set_buffer_overlap_nested() {
+    // CHECK: %[[ALIAS:.*]] = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    // CHECK: %[[QK:.*]] = tlx.storage_alias_local_alloc %[[ALIAS]]
+    // CHECK: %[[P:.*]] = tlx.storage_alias_local_alloc %[[ALIAS]]
+    // CHECK: %[[ALPHA:.*]] = tlx.storage_alias_local_alloc %[[ALIAS]]
+    // CHECK: %[[INNER:.*]] = tlx.reuse_group(%[[P]], %[[ALPHA]]) group_kind = distinct
+    // CHECK: %[[OUTER:.*]] = tlx.reuse_group(%[[QK]], %[[INNER]]) group_kind = shared
+    // CHECK: tlx.set_buffer_overlap(%[[ALIAS]], %[[OUTER]])
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64xf32, #shared, #smem, mutable>
+    %4 = tlx.reuse_group(%2, %3) group_kind = distinct : (!ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<2x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    %5 = tlx.reuse_group(%1, %4) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !tlx.reuse_group<distinct>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %5) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -180,6 +180,61 @@ def TLX_ReuseGroupOp : TLX_Op<"reuse_group", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Set Buffer Overlap Operation
+//===----------------------------------------------------------------------===//
+
+def TLX_SetBufferOverlapOp : TLX_Op<"set_buffer_overlap", []> {
+  let summary = "Define the buffer overlap scheme for a storage alias spec";
+
+  let description = [{
+    Defines the buffer overlap scheme for allocations using a storage alias spec.
+    This operation links a storage_alias_spec to its overlap definition (a reuse_group).
+
+    The compiler will use this information in subsequent passes to:
+    1. Validate that the overlap scheme is achievable
+    2. Compute buffer offsets to satisfy the overlap requirements
+
+    This operation is eliminated during the ReusedBufferOffsetCalculationPass
+    after offsets have been computed and applied.
+
+    Constraints:
+    - All leaf elements in the reuse_group tree must be allocated from the
+      same storage_alias_spec via tlx.storage_alias_local_alloc
+    - All elements must use the same storage kind (smem or tmem)
+    - This operation should appear after all local_alloc operations that
+      reference the storage_alias_spec
+
+    Example:
+    ```mlir
+    %spec = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %qk = tlx.storage_alias_local_alloc %spec : ... -> !ttg.memdesc<...>
+    %p = tlx.storage_alias_local_alloc %spec : ... -> !ttg.memdesc<...>
+
+    %group = tlx.reuse_group(%qk, %p) group_kind = shared
+             : (!ttg.memdesc<...>, !ttg.memdesc<...>) -> !tlx.reuse_group<shared>
+
+    tlx.set_buffer_overlap(%spec, %group)
+             : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    ```
+  }];
+
+  let arguments = (ins
+    TLX_StorageAliasSpecType:$storage_alias_spec,
+    TLX_ReuseGroupType:$overlap_def
+  );
+
+  let results = (outs);
+
+  let assemblyFormat = [{
+    `(` $storage_alias_spec `,` $overlap_def `)`
+    `:` `(` qualified(type($storage_alias_spec)) `,` qualified(type($overlap_def)) `)` `->` `(` `)`
+    attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // Layout Operations
 //===----------------------------------------------------------------------===//
 

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -569,6 +569,13 @@ void init_triton_tlx_ir(py::module &&m) {
              return self.create<tlx::ReuseGroupOp>(resultType, elements,
                                                    groupKindAttr);
            })
+      .def("create_set_buffer_overlap",
+           [](TritonOpBuilder &self, mlir::Value storageAliasSpec,
+              mlir::Value overlapDef) -> void {
+             // Create the set_buffer_overlap operation
+             // This links the storage_alias_spec to the reuse_group tree
+             self.create<tlx::SetBufferOverlapOp>(storageAliasSpec, overlapDef);
+           })
       .def("create_alloc_clc_responses",
            [](TritonOpBuilder &self, int numResponses,
               Attribute clcResEncoding) -> mlir::Value {

--- a/third_party/tlx/doc/storage_alias_spec_design.md
+++ b/third_party/tlx/doc/storage_alias_spec_design.md
@@ -2,7 +2,7 @@
 
 **Author:** Nick Riasanovsky
 **Updated:** 2026-02-07
-**Status:** Draft - Phase 1, Phase 2 & Phase 3
+**Status:** Draft - Phase 1, Phase 2, Phase 3 & Phase 4
 
 ---
 
@@ -1299,27 +1299,27 @@ def TLX_ReuseGroupOp : TLX_Op<"reuse_group", [Pure]> {
     - **distinct**: Elements must be in non-overlapping memory regions.
       Useful when buffers need to be accessed simultaneously.
 
-    The operation takes a storage_alias_spec and a variadic list of elements
-    (buffered tensors or nested reuse groups) and produces a reuse group.
+    The operation takes a variadic list of elements (buffered tensors or
+    nested reuse groups) and produces a reuse group.
+
+    Note: The storage_alias_spec is NOT part of this operation. Validation
+    that all elements reference the same storage_alias_spec is performed
+    by the SetBufferOverlapOp verifier.
 
     Constraints:
-    - All elements must reference the same storage_alias_spec.
     - Nested reuse_groups cannot have the same group_kind as their parent.
     - All elements must use the same storage kind (smem or tmem).
 
     Example:
     ```mlir
-    %spec = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
-
     // Create shared reuse group for A and B
-    %group = tlx.reuse_group(%spec : %a, %b) group_kind = shared
-             : (!tlx.storage_alias_spec<smem> : !ttg.memdesc<...>, !ttg.memdesc<...>)
+    %group = tlx.reuse_group(%a, %b) group_kind = shared
+             : (!ttg.memdesc<...>, !ttg.memdesc<...>)
              -> !tlx.reuse_group<shared>
     ```
   }];
 
   let arguments = (ins
-    TLX_StorageAliasSpecType:$storage_alias_spec,
     Variadic<TLX_ReuseGroupElement>:$elements,
     TLX_ReuseGroupKindAttr:$group_kind
   );
@@ -1327,8 +1327,8 @@ def TLX_ReuseGroupOp : TLX_Op<"reuse_group", [Pure]> {
   let results = (outs TLX_ReuseGroupType:$result);
 
   let assemblyFormat = [{
-    `(` $storage_alias_spec `:` $elements `)` `group_kind` `=` $group_kind attr-dict `:`
-    `(` qualified(type($storage_alias_spec)) `:` qualified(type($elements)) `)` `->` qualified(type($result))
+    `(` $elements `)` `group_kind` `=` $group_kind attr-dict `:`
+    `(` qualified(type($elements)) `)` `->` qualified(type($result))
   }];
 
   let hasVerifier = 1;
@@ -1376,33 +1376,38 @@ class reuse_group:
     - Internal nodes are nested `reuse_group` objects
     - The root defines the top-level sharing relationship
 
+Note: The storage_alias_spec is NOT passed to reuse_group directly in Python.
+    Instead, the spec is associated with the reuse group tree when passed to
+    `storage_alias_spec.set_buffer_overlap()`. During IR lowering, the spec is
+    then attached to each `ReuseGroupOp` in the tree.
+
     Example - Flash Attention buffer sharing:
         ```python
         spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
 
         # Allocate buffers
-        qk_tiles = tlx.local_alloc(...)
-        p_tiles = tlx.local_alloc(...)
-        alpha = tlx.local_alloc(...)
+        qk_tiles = tlx.local_alloc(..., reuse=spec)
+        p_tiles = tlx.local_alloc(..., reuse=spec)
+        alpha = tlx.local_alloc(..., reuse=spec)
 
         # QK and (P, alpha) share the same memory region
         # P and alpha are placed in distinct (non-overlapping) regions
-        buffer_sharing = tlx.reuse_group(
-            spec,
-            qk_tiles,
-            tlx.reuse_group(spec, p_tiles, alpha, group_type=tlx.reuse_group_type.distinct),
-            group_type=tlx.reuse_group_type.shared,
+        # Note: spec is passed to set_buffer_overlap, not to reuse_group
+        spec.set_buffer_overlap(
+            tlx.reuse_group(
+                qk_tiles,
+                tlx.reuse_group(p_tiles, alpha, group_type=tlx.reuse_group_type.distinct),
+                group_type=tlx.reuse_group_type.shared,
+            )
         )
         ```
 
     Constraints:
-        - All elements must be allocated from the same storage_alias_spec.
         - Nested reuse_groups must have different group_type than the parent.
     """
 
     def __init__(
         self,
-        storage_alias_spec: "storage_alias_spec",
         *args: "buffered_tensor | reuse_group",
         group_type: reuse_group_type,
     ):
@@ -1410,7 +1415,6 @@ class reuse_group:
         Initialize a reuse group.
 
         Args:
-            storage_alias_spec: The storage alias spec that all elements share.
             *args: buffered_tensor or reuse_group objects. Must not be empty.
             group_type: The relationship type for elements in this group.
                 - shared: Elements occupy the same logical memory region.
@@ -1421,11 +1425,6 @@ class reuse_group:
             ValueError: If a nested reuse_group has the same group_type as this group.
             TypeError: If any element is not a buffered_tensor or reuse_group.
         """
-        ...
-
-    @property
-    def storage_alias_spec(self) -> "storage_alias_spec":
-        """The storage alias spec for this group (read-only)."""
         ...
 
     @property
@@ -1450,7 +1449,11 @@ Python:
 spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
 a = tlx.local_alloc((64, 64), tl.float32, 2, tlx.storage_kind.smem, reuse=spec)
 b = tlx.local_alloc((64, 64), tl.bfloat16, 2, tlx.storage_kind.smem, reuse=spec)
-group = tlx.reuse_group(spec, a, b, group_type=tlx.reuse_group_type.shared)
+
+# The spec is associated via set_buffer_overlap, not passed to reuse_group
+spec.set_buffer_overlap(
+    tlx.reuse_group(a, b, group_type=tlx.reuse_group_type.shared)
+)
 ```
 
 MLIR:
@@ -1458,9 +1461,11 @@ MLIR:
 %spec = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
 %a = ttg.local_alloc ... : () -> !ttg.memdesc<2x64x64xf32, ...>
 %b = ttg.local_alloc ... : () -> !ttg.memdesc<2x64x64xbf16, ...>
-%group = tlx.reuse_group(%spec : %a, %b) group_kind = shared
-         : (!tlx.storage_alias_spec<smem> : !ttg.memdesc<2x64x64xf32, ...>, !ttg.memdesc<2x64x64xbf16, ...>)
+%group = tlx.reuse_group(%a, %b) group_kind = shared
+         : (!ttg.memdesc<2x64x64xf32, ...>, !ttg.memdesc<2x64x64xbf16, ...>)
          -> !tlx.reuse_group<shared>
+tlx.set_buffer_overlap(%spec, %group)
+         : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
 ```
 
 ### Nested Reuse Groups
@@ -1468,13 +1473,19 @@ MLIR:
 Python:
 ```python
 spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
-qk = tlx.local_alloc(...)
-p = tlx.local_alloc(...)
-alpha = tlx.local_alloc(...)
+qk = tlx.local_alloc(..., reuse=spec)
+p = tlx.local_alloc(..., reuse=spec)
+alpha = tlx.local_alloc(..., reuse=spec)
 
 # P and alpha are distinct, then QK shares with (P, alpha)
-inner = tlx.reuse_group(spec, p, alpha, group_type=tlx.reuse_group_type.distinct)
-outer = tlx.reuse_group(spec, qk, inner, group_type=tlx.reuse_group_type.shared)
+# Note: spec is NOT passed to reuse_group - it's passed to set_buffer_overlap
+spec.set_buffer_overlap(
+    tlx.reuse_group(
+        qk,
+        tlx.reuse_group(p, alpha, group_type=tlx.reuse_group_type.distinct),
+        group_type=tlx.reuse_group_type.shared,
+    )
+)
 ```
 
 MLIR:
@@ -1484,11 +1495,13 @@ MLIR:
 %p = ttg.local_alloc ... : () -> !ttg.memdesc<...>
 %alpha = ttg.local_alloc ... : () -> !ttg.memdesc<...>
 
-%inner = tlx.reuse_group(%spec : %p, %alpha) group_kind = distinct
-         : (!tlx.storage_alias_spec<smem> : ...) -> !tlx.reuse_group<distinct>
-%outer = tlx.reuse_group(%spec : %qk, %inner) group_kind = shared
-         : (!tlx.storage_alias_spec<smem> : !ttg.memdesc<...>, !tlx.reuse_group<distinct>)
+%inner = tlx.reuse_group(%p, %alpha) group_kind = distinct
+         : (!ttg.memdesc<...>, !ttg.memdesc<...>) -> !tlx.reuse_group<distinct>
+%outer = tlx.reuse_group(%qk, %inner) group_kind = shared
+         : (!ttg.memdesc<...>, !tlx.reuse_group<distinct>)
          -> !tlx.reuse_group<shared>
+tlx.set_buffer_overlap(%spec, %outer)
+         : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
 ```
 
 ---
@@ -1526,9 +1539,376 @@ Phase 3 delivers the IR interface for reuse groups:
 | `ReuseGroupType` | MLIR type representing reuse group with its kind |
 | `ReuseGroupOp` | Operation to create reuse groups from elements |
 | `reuse_group_type` | Python enum for group kinds |
-| `reuse_group` | Python class for defining buffer relationships |
+| `reuse_group` | Python class for defining buffer relationships (spec-free) |
 
-**Design Principle**: Reuse groups form a tree structure that declaratively describes buffer overlap relationships. The actual offset calculation and memory layout is deferred to Phase 4.
+**Design Principle**: Reuse groups form a tree structure that declaratively describes buffer overlap relationships. Neither the Python `reuse_group` class nor the IR `ReuseGroupOp` include the spec - validation is performed by `SetBufferOverlapOp`. The actual offset calculation and memory layout is deferred to Phase 5.
+
+---
+---
+
+# Phase 4: `set_buffer_overlap` JIT API
+
+This phase defines the JIT interface for `set_buffer_overlap`, which allows users to define buffer overlap schemes using reuse groups. This phase focuses solely on the frontend API and IR generation, without any lowering or offset calculations.
+
+**Important**: Code using `set_buffer_overlap` will successfully lower to IR but is expected to fail during subsequent lowering passes until Phase 5 implements the offset calculation.
+
+---
+
+## Scope
+
+This phase covers:
+- `set_buffer_overlap` method on `storage_alias_spec`
+- New MLIR operation: `SetBufferOverlapOp`
+- Verification that reuse groups are valid
+
+**Out of scope** for this phase:
+- Offset calculation based on overlap definitions (Phase 5)
+- `SharedBufferSizeDefinitionPass` integration (Phase 5)
+- `ReusedBufferOffsetCalculationPass` (Phase 5)
+
+---
+
+## Motivation
+
+The `set_buffer_overlap` API allows users to declaratively specify their buffer overlap scheme. This is crucial because:
+
+1. **Simplicity**: Users define the logical relationship between buffers without manual offset calculations.
+2. **Safety**: The compiler can verify that the overlap scheme is valid and achievable.
+3. **Flexibility**: The overlap scheme can change based on compile-time constants (e.g., block sizes, data types).
+
+By separating the overlap definition from the offset calculation, users can express their intent while the compiler handles the implementation details.
+
+---
+
+## API Design
+
+### `set_buffer_overlap` Method
+
+The `set_buffer_overlap` method is added to the `storage_alias_spec` class:
+
+```python
+class storage_alias_spec:
+    """
+    Definition of a storage alias specification.
+    ...
+    """
+
+    def set_buffer_overlap(self, overlap_def: reuse_group) -> None:
+        """
+        Define the buffer overlap scheme for allocations using this storage alias spec.
+
+        This method specifies how buffers should be laid out in memory relative to
+        each other. The overlap_def is a reuse_group tree that defines:
+        - **shared**: Elements logically occupy the same memory region
+        - **distinct**: Elements must be in non-overlapping memory regions
+
+        This function lowers to an IR operation that links the storage alias spec
+        to its defined overlap scheme. The compiler will use this information to
+        compute buffer offsets in subsequent passes.
+
+        Note: This method should be called after all allocations using this
+        storage_alias_spec have been created, and the reuse_group should contain
+        all relevant buffered_tensor objects.
+
+        Args:
+            overlap_def: A reuse_group defining the buffer overlap relationships.
+                         The reuse_group must use this storage_alias_spec.
+
+        Raises:
+            ValueError: If overlap_def does not use this storage_alias_spec.
+            TypeError: If overlap_def is not a reuse_group.
+
+        Example:
+            ```python
+            spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
+
+            # Allocate buffers
+            qk_tiles = tlx.local_alloc(..., reuse=spec)
+            p_tiles = tlx.local_alloc(..., reuse=spec)
+            alpha = tlx.local_alloc(..., reuse=spec)
+
+            # Define overlap scheme: QK shares with (P and alpha which are distinct)
+            # Note: spec is NOT passed to reuse_group in Python.
+            # It gets attached to each ReuseGroupOp during IR lowering.
+            spec.set_buffer_overlap(
+                tlx.reuse_group(
+                    qk_tiles,
+                    tlx.reuse_group(p_tiles, alpha, group_type=tlx.reuse_group_type.distinct),
+                    group_type=tlx.reuse_group_type.shared,
+                )
+            )
+            ```
+        """
+        ...
+```
+
+### Design Rationale
+
+The API is designed with these principles:
+
+1. **Called in JIT code**: This allows the overlap definition to depend on compile-time constants (e.g., `tl.constexpr` values), enabling different overlap schemes based on autotuning parameters or data types.
+
+2. **Method on `storage_alias_spec`**: This establishes a clear ownership relationship - the storage alias spec owns its overlap definition.
+
+3. **Takes a `reuse_group`**: Reuses the existing reuse group infrastructure from Phase 3, providing a consistent tree-based overlap representation.
+
+4. **Spec association during lowering**: The Python `reuse_group` class does not take the spec as a parameter. The spec is only associated at the `SetBufferOverlapOp` level, which validates that all leaf elements in the reuse group tree were allocated with the correct storage_alias_spec.
+
+---
+
+## IR Design
+
+### New MLIR Operation: `SetBufferOverlapOp`
+
+```tablegen
+def TLX_SetBufferOverlapOp : TLX_Op<"set_buffer_overlap", []> {
+  let summary = "Define the buffer overlap scheme for a storage alias spec";
+
+  let description = [{
+    Defines the buffer overlap scheme for allocations using a storage alias spec.
+    This operation links a storage_alias_spec to its overlap definition (a reuse_group).
+
+    The compiler will use this information in subsequent passes to:
+    1. Validate that the overlap scheme is achievable
+    2. Compute buffer offsets to satisfy the overlap requirements
+
+    This operation is eliminated during the ReusedBufferOffsetCalculationPass
+    after offsets have been computed and applied.
+
+    Constraints:
+    - The reuse_group must reference the same storage_alias_spec
+    - All elements in the reuse_group must use the same storage kind
+    - This operation should appear after all local_alloc operations that
+      reference the storage_alias_spec
+
+    Example:
+    ```mlir
+    %spec = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %qk = ttg.local_alloc ... : () -> !ttg.memdesc<...>
+    %p = ttg.local_alloc ... : () -> !ttg.memdesc<...>
+
+    %group = tlx.reuse_group(%spec : %qk, %p) group_kind = shared
+             : (!tlx.storage_alias_spec<smem> : ...) -> !tlx.reuse_group<shared>
+
+    tlx.set_buffer_overlap(%spec, %group)
+             : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    ```
+  }];
+
+  let arguments = (ins
+    TLX_StorageAliasSpecType:$storage_alias_spec,
+    TLX_ReuseGroupType:$overlap_def
+  );
+
+  let results = (outs);
+
+  let assemblyFormat = [{
+    `(` $storage_alias_spec `,` $overlap_def `)`
+    `:` `(` qualified(type($storage_alias_spec)) `,` qualified(type($overlap_def)) `)` `->` `(` `)`
+    attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+```
+
+### Verifier Checks
+
+The `ReuseGroupOp` verifier should check:
+
+1. Nested reuse_groups cannot have the same group_kind as their parent
+2. All elements must use the same storage kind (smem or tmem)
+
+The `SetBufferOverlapOp` verifier should check:
+
+1. All leaf elements (buffered tensors) in the reuse group tree were allocated with the same `storage_alias_spec`
+2. The storage kind of all elements matches the storage kind of the `storage_alias_spec`
+
+---
+
+## Python Implementation
+
+### `set_buffer_overlap` Implementation
+
+```python
+class storage_alias_spec(tl.base_value):
+    """..."""
+
+    def set_buffer_overlap(self, overlap_def: reuse_group) -> None:
+        """Define the buffer overlap scheme for this storage alias spec."""
+        # Validate input type
+        if not isinstance(overlap_def, reuse_group):
+            raise TypeError(f"overlap_def must be a reuse_group, got {type(overlap_def).__name__}")
+
+        # Lower to IR operation
+        # The semantic function will create the SetBufferOverlapOp
+        # During lowering, this spec is attached to each ReuseGroupOp in the tree
+        return tlx_language.set_buffer_overlap(self, overlap_def)
+
+
+@builtin
+def set_buffer_overlap(
+    storage_alias_spec: storage_alias_spec,
+    overlap_def: reuse_group,
+    _builder: ir.builder = None,
+) -> None:
+    """
+    Semantic function that lowers set_buffer_overlap to IR.
+
+    The reuse_group tree is lowered to IR without the spec - each ReuseGroupOp
+    only contains its elements and group_kind. The SetBufferOverlapOp then
+    links the spec to the root reuse group, and its verifier validates that
+    all leaf elements were allocated with this spec.
+    """
+    # Get the IR handles
+    spec_handle = storage_alias_spec.handle
+
+    # Lower the reuse_group tree to IR (creates ReuseGroupOp for each node)
+    overlap_handle = _lower_reuse_group(overlap_def, _builder)
+
+    # Create the set_buffer_overlap operation linking spec to the overlap tree
+    _builder.create_set_buffer_overlap(spec_handle, overlap_handle)
+```
+
+---
+
+## Example Usage
+
+### Simple Shared Overlap
+
+```python
+@triton.jit
+def kernel(...):
+    spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
+
+    # Allocate buffers that will share memory
+    a_tiles = tlx.local_alloc((64, 64), tl.float32, 2, tlx.storage_kind.smem, reuse=spec)
+    b_tiles = tlx.local_alloc((64, 64), tl.bfloat16, 2, tlx.storage_kind.smem, reuse=spec)
+
+    # Define that a and b share the same memory region
+    # Note: spec is not passed to reuse_group - it gets attached during lowering
+    spec.set_buffer_overlap(
+        tlx.reuse_group(a_tiles, b_tiles, group_type=tlx.reuse_group_type.shared)
+    )
+
+    # ... kernel code using a_tiles and b_tiles ...
+```
+
+Generated IR:
+```mlir
+%spec = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+%a = ttg.local_alloc ... : () -> !ttg.memdesc<2x64x64xf32, ...>
+%b = ttg.local_alloc ... : () -> !ttg.memdesc<2x64x64xbf16, ...>
+
+%group = tlx.reuse_group(%a, %b) group_kind = shared
+         : (!ttg.memdesc<...>, !ttg.memdesc<...>)
+         -> !tlx.reuse_group<shared>
+
+tlx.set_buffer_overlap(%spec, %group)
+         : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+```
+
+### Complex Nested Overlap (Flash Attention Pattern)
+
+```python
+@triton.jit
+def flash_attention_kernel(...):
+    spec = tlx.storage_alias_spec(storage=tlx.storage_kind.tmem)
+
+    # Allocate buffers
+    qk_tiles = tlx.local_alloc((BLOCK_M, HEAD_DIM), tl.float32, NUM_BUFFERS, tlx.storage_kind.tmem, reuse=spec)
+    p_tiles = tlx.local_alloc((BLOCK_M, HEAD_DIM), tl.bfloat16, NUM_BUFFERS, tlx.storage_kind.tmem, reuse=spec)
+    alpha = tlx.local_alloc((BLOCK_M, 1), tl.float32, NUM_BUFFERS, tlx.storage_kind.tmem, reuse=spec)
+    l = tlx.local_alloc((BLOCK_M, 1), tl.float32, NUM_BUFFERS, tlx.storage_kind.tmem, reuse=spec)
+    m = tlx.local_alloc((BLOCK_M, 1), tl.float32, NUM_BUFFERS, tlx.storage_kind.tmem, reuse=spec)
+
+    # Define overlap scheme:
+    # - QK shares with (P and (alpha, l, m))
+    # - P is distinct from (alpha, l, m)
+    # - alpha, l, m are distinct from each other
+    spec.set_buffer_overlap(
+        tlx.reuse_group(
+            spec,
+            qk_tiles,
+            tlx.reuse_group(
+                spec,
+                p_tiles,
+                tlx.reuse_group(spec, alpha, l, m, group_type=tlx.reuse_group_type.distinct),
+                group_type=tlx.reuse_group_type.distinct,
+            ),
+            group_type=tlx.reuse_group_type.shared,
+        )
+    )
+
+    # ... kernel code ...
+```
+
+### Conditional Overlap Based on Block Size
+
+```python
+@triton.jit
+def kernel(BLOCK_M: tl.constexpr, ...):
+    spec = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
+
+    a_tiles = tlx.local_alloc((BLOCK_M, 64), tl.float32, 2, tlx.storage_kind.smem, reuse=spec)
+    b_tiles = tlx.local_alloc((BLOCK_M, 64), tl.float32, 2, tlx.storage_kind.smem, reuse=spec)
+
+    # Only share buffers if block size is large (memory constrained)
+    if BLOCK_M >= 128:
+        spec.set_buffer_overlap(
+            tlx.reuse_group(a_tiles, b_tiles, group_type=tlx.reuse_group_type.shared)
+        )
+    else:
+        # With smaller blocks, buffers are distinct (no sharing needed)
+        spec.set_buffer_overlap(
+            tlx.reuse_group(a_tiles, b_tiles, group_type=tlx.reuse_group_type.distinct)
+        )
+```
+
+---
+
+## Testing Plan
+
+### Unit Tests
+
+1. **Python API tests**
+   - Call `set_buffer_overlap` with valid reuse_group
+   - Verify error on non-reuse_group argument
+   - Verify error when reuse_group uses different storage_alias_spec
+
+2. **IR lowering tests**
+   - Verify `SetBufferOverlapOp` is correctly generated
+   - Verify operation references correct storage_alias_spec and reuse_group
+   - Verify assembly format is correct
+
+3. **Verifier tests**
+   - Test that mismatched storage_alias_spec in reuse_group fails verification
+
+### Expected Behavior
+
+In this phase, kernels using `set_buffer_overlap` will:
+- ✅ Successfully parse Python code
+- ✅ Successfully lower to TTIR
+- ✅ Successfully lower to TTGIR
+- ❌ Fail during `ReusedBufferOffsetCalculationPass` (not yet implemented)
+
+This is the expected behavior until Phase 5 implements the offset calculation pass.
+
+---
+
+## Summary
+
+Phase 4 delivers the JIT interface for defining buffer overlap schemes:
+
+| Component | Description |
+|-----------|-------------|
+| `set_buffer_overlap` method | Method on `storage_alias_spec` to define overlap scheme |
+| `SetBufferOverlapOp` | MLIR operation linking storage alias spec to overlap definition |
+| Python validation | Type and consistency checks for the API |
+
+**Design Principle**: This phase establishes the frontend API and IR representation without implementing the backend passes. This allows users to start writing code with the new API while the offset calculation logic is developed in Phase 5.
+
+**Note**: Code using `set_buffer_overlap` will fail during lowering until Phase 5 is implemented. This is intentional and allows incremental development of the feature.
 
 ---
 ---
@@ -1537,9 +1917,9 @@ Phase 3 delivers the IR interface for reuse groups:
 
 The following will be addressed in subsequent phases:
 
-1. **Phase 4**: Add `set_buffer_overlap` API for defining overlap schemes and implement offset calculation based on overlap definitions
-2. **Phase 5**: Buffer reuse analysis warnings (optional performance tool)
-3. **Phase 5**: Deprecation path for existing `reuse=buffered_tensor` pattern
+1. **Phase 5**: Implement `ReusedBufferOffsetCalculationPass` to compute offsets based on overlap definitions
+2. **Phase 6**: Buffer reuse analysis warnings (optional performance tool)
+3. **Phase 6**: Deprecation path for existing `reuse=buffered_tensor` pattern
 
 ---
 

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -58,7 +58,6 @@ from .types import (
     reuse_group,
     reuse_group_ir_type,
     reuse_group_type,
-    _validate_reuse_group_elements,
     storage_alias_spec as storage_alias_spec_type_class,
     storage_alias_spec_type,
     shared_layout_encoding,


### PR DESCRIPTION
Summary:
Defines the `set_buffer_overlap` API to use a reuse group in JIT and associate with with a spec. This is from this design: https://docs.google.com/document/d/1gmghlhf6SJuMpKyoWB2NnAzPzFDP2gsUqwJkEoARKl8/edit?fbclid=IwY2xjawP0nztleHRuA2FlbQIxMQBicmlkETFZTmtDQ1piVEpXU3BlUWIzc3J0YwZhcHBfaWQBMAABHjKT8OMqKBb4W-RphK8IZZIT8d71v6k-DIg2yntqRI-I7PLtkiP1p2DLh2d9_aem_BlSpNK3_7Pz4owXK0RJqSw&tab=t.0

Note: This will still result in a compilation failure as the reuse group and associated API for setting buffer overlap cannot be lowered. Those will be eliminated in the next step.

Differential Revision: D92630744


