### PR TITLE
[TLX] 5/N Add lowering support for shared and distinct

### DIFF
--- a/test/TLX/buffer-layout-attrs-errors.mlir
+++ b/test/TLX/buffer-layout-attrs-errors.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-opt --split-input-file %s --tlx-storage-alias-lowering --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Buffer Layout Error Tests (during TLXStorageAliasLowering)
+//===----------------------------------------------------------------------===//
+
+// Test: bytes_between_buffers not evenly divisible by buffer size
+// Two allocations in distinct with power-of-2 shapes that don't divide evenly
+// A: 2x64x64xf32 = 16384 bytes per buffer
+// B: 2x64x32xf32 = 8192 bytes per buffer
+// distinct total = 16384 + 8192 = 24576 bytes per buffer
+// For A: 24576 % 16384 = 8192 (NOT divisible)
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @bytes_between_not_divisible_error() {
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    // expected-error @+1 {{bytes_between_buffers (24576) must be a multiple of the original buffer size (16384)}}
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x32xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x32xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Another case where bytes_between_buffers is not evenly divisible
+// A: 2x128x64xf32 = 32768 bytes per buffer
+// B: 2x64x64xf32 = 16384 bytes per buffer
+// distinct total = 32768 + 16384 = 49152 bytes per buffer
+// For A: 49152 % 32768 = 16384 (not divisible)
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @bytes_between_not_divisible_error_2() {
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    // expected-error @+1 {{bytes_between_buffers (49152) must be a multiple of the original buffer size (32768)}}
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x128x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x128x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}

--- a/test/TLX/buffer-offset-alignment.mlir
+++ b/test/TLX/buffer-offset-alignment.mlir
@@ -1,0 +1,93 @@
+// RUN: triton-opt --split-input-file %s --tlx-storage-alias-lowering | FileCheck %s
+
+// Test SMEM alignment (128-byte) with nested reuse group tree:
+//   distinct(shared(A, distinct(B, C)), D)
+// where A, B, D are f32 [4,2] and C is bf16 [1,1]
+//
+// Per-buffer sizes:
+//   A = 2*4 = 8 bytes, B = 2*4 = 8 bytes, C = 1*2 = 2 bytes, D = 2*4 = 8 bytes
+//
+// Alignment = max(128, max_elem_bytes) = 128 for all (SMEM)
+//
+// getElementSize (alignment=128):
+//   distinct(B, C):    alignUp(0,128) + 8 = 8;  alignUp(8,128) + 2 = 130
+//   shared(A, distinct(B,C)):  max(8, 130) = 130
+//   distinct(shared(..), D):   alignUp(0,128) + 130 = 130;  alignUp(130,128) + 8 = 264
+//
+// sizePerBuffer = 264, bytesBetweenBuffers = alignUp(264, 128) = 384
+// totalSizeBytes = 384 * 4 = 1536
+//
+// Offsets:
+//   A: offset=0,   bytesBetweenBuffers=384 → scale=48, offSlots=0  → [192, 2]
+//   B: offset=0,   bytesBetweenBuffers=384 → scale=48, offSlots=0  → [192, 2]
+//   C: offset=128, bytesBetweenBuffers=384 → scale=192, offSlots=64 → [256, 1]
+//   D: offset=256, bytesBetweenBuffers=384 → scale=48, offSlots=32 → [224, 2]
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @smem_distinct_shared_distinct_alignment
+  tt.func @smem_distinct_shared_distinct_alignment() {
+    // CHECK: ttg.local_alloc : () -> !ttg.memdesc<1536xi8
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<192x2xf32
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<192x2xf32
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<256x1xbf16
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<224x2xf32
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %A = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<4x2xf32, #shared, #smem, mutable>
+    %B = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<4x2xf32, #shared, #smem, mutable>
+    %C = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<1x1xbf16, #shared, #smem, mutable>
+    %D = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<4x2xf32, #shared, #smem, mutable>
+    %inner_distinct = tlx.reuse_group(%B, %C) group_kind = distinct : (!ttg.memdesc<4x2xf32, #shared, #smem, mutable>, !ttg.memdesc<1x1xbf16, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    %inner_shared = tlx.reuse_group(%A, %inner_distinct) group_kind = shared : (!ttg.memdesc<4x2xf32, #shared, #smem, mutable>, !tlx.reuse_group<distinct>) -> !tlx.reuse_group<shared>
+    %outer_distinct = tlx.reuse_group(%inner_shared, %D) group_kind = distinct : (!tlx.reuse_group<shared>, !ttg.memdesc<4x2xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %outer_distinct) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test TMEM alignment (32-byte) with nested reuse group tree:
+//   distinct(shared(A, distinct(B, C)), D)
+// where A, B, D are f32 [4,2] and C is bf16 [1,1]
+//
+// Per-buffer sizes:
+//   A = 2*4 = 8 bytes, B = 2*4 = 8 bytes, C = 1*2 = 2 bytes, D = 2*4 = 8 bytes
+//
+// Alignment = max(32, max_elem_bytes) = 32 for all (TMEM)
+//
+// getElementSize (alignment=32):
+//   distinct(B, C):    alignUp(0,32) + 8 = 8;  alignUp(8,32) + 2 = 34
+//   shared(A, distinct(B,C)):  max(8, 34) = 34
+//   distinct(shared(..), D):   alignUp(0,32) + 34 = 34;  alignUp(34,32) + 8 = 72
+//
+// sizePerBuffer = 72, bytesBetweenBuffers = alignUp(72, 32) = 96
+// totalSizeBytes = 96 * 4 = 384
+//
+// Offsets:
+//   A: offset=0,  bytesBetweenBuffers=96 → scale=12, offSlots=0  → [48, 2]
+//   B: offset=0,  bytesBetweenBuffers=96 → scale=12, offSlots=0  → [48, 2]
+//   C: offset=32, bytesBetweenBuffers=96 → scale=48, offSlots=16 → [64, 1]
+//   D: offset=64, bytesBetweenBuffers=96 → scale=12, offSlots=8  → [56, 2]
+#dummy_tmem_layout = #tlx.dummy_tmem_layout<>
+#tmem = #ttng.tensor_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @tmem_distinct_shared_distinct_alignment
+  tt.func @tmem_distinct_shared_distinct_alignment() {
+    // CHECK: ttng.tmem_alloc
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<48x2xf32
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<48x2xf32
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<64x1xbf16
+    // CHECK: tlx.local_alias {{.*}} -> !ttg.memdesc<56x2xf32
+    %0 = tlx.storage_alias_spec storage = tmem : !tlx.storage_alias_spec<tmem>
+    %A = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<tmem> -> !ttg.memdesc<4x2xf32, #dummy_tmem_layout, #tmem, mutable>
+    %B = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<tmem> -> !ttg.memdesc<4x2xf32, #dummy_tmem_layout, #tmem, mutable>
+    %C = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<tmem> -> !ttg.memdesc<1x1xbf16, #dummy_tmem_layout, #tmem, mutable>
+    %D = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<tmem> -> !ttg.memdesc<4x2xf32, #dummy_tmem_layout, #tmem, mutable>
+    %inner_distinct = tlx.reuse_group(%B, %C) group_kind = distinct : (!ttg.memdesc<4x2xf32, #dummy_tmem_layout, #tmem, mutable>, !ttg.memdesc<1x1xbf16, #dummy_tmem_layout, #tmem, mutable>) -> !tlx.reuse_group<distinct>
+    %inner_shared = tlx.reuse_group(%A, %inner_distinct) group_kind = shared : (!ttg.memdesc<4x2xf32, #dummy_tmem_layout, #tmem, mutable>, !tlx.reuse_group<distinct>) -> !tlx.reuse_group<shared>
+    %outer_distinct = tlx.reuse_group(%inner_shared, %D) group_kind = distinct : (!tlx.reuse_group<shared>, !ttg.memdesc<4x2xf32, #dummy_tmem_layout, #tmem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %outer_distinct) : (!tlx.storage_alias_spec<tmem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}

--- a/test/TLX/buffer-offset-calculation-errors.mlir
+++ b/test/TLX/buffer-offset-calculation-errors.mlir
@@ -1,0 +1,22 @@
+// RUN: triton-opt --split-input-file %s --tlx-storage-alias-lowering --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Buffer Offset Calculation Error Tests
+//===----------------------------------------------------------------------===//
+
+// Test: Duplicate set_buffer_overlap on same spec
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @duplicate_set_buffer_overlap() {
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    %4 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    // expected-error @+1 {{storage_alias_spec already has a set_buffer_overlap defined}}
+    tlx.set_buffer_overlap(%0, %4) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}

--- a/test/TLX/buffer-offset-calculation.mlir
+++ b/test/TLX/buffer-offset-calculation.mlir
@@ -1,0 +1,637 @@
+// RUN: triton-opt --split-input-file %s --tlx-storage-alias-lowering --verify-each=false 2>&1 | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Buffer Offset Calculation Pass Tests
+//===----------------------------------------------------------------------===//
+
+// Test: Basic shared reuse group - both allocations get same shape expansion
+// Two allocations: 2x64x64xf32 (16384 bytes per buffer) and 2x64x64xf16 (8192 bytes)
+// max size = 16384 bytes * 2 buffers = 32768 bytes total
+// For f32: bytes_between_buffers = 16384, buffer_size = 16384, scale = 1, no expansion needed
+// For f16: bytes_between_buffers = 16384, buffer_size = 8192, scale = 2, shape expands 2->4
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: shared_reuse_group_basic
+  tt.func @shared_reuse_group_basic() {
+    // For shared reuse group: total size = max(16384, 8192) * 2 = 32768 bytes
+    // CHECK: memdesc<32768xi8
+    // f32 allocation: no expansion needed (scale=1, offset=0)
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
+    // f16 allocation: expanded from 2 to 4 buffers (scale=2, offset=0)
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf16
+    // CHECK-NOT: reuse_group
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Basic distinct reuse group - allocations placed sequentially with shape expansion
+// Two allocations: 2x64x64xf32 (16384 bytes per buffer) each
+// total = (16384 + 16384) * 2 = 65536 bytes
+// bytes_between_buffers = 32768 for both
+// For first: scale = 32768/16384 = 2, offset = 0, shape: 2 -> 4
+// For second: scale = 32768/16384 = 2, offset = 16384/16384 = 1, shape: 2 -> 2*2+1 = 5
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: distinct_reuse_group_basic
+  tt.func @distinct_reuse_group_basic() {
+    // For distinct reuse group: total size = (16384 + 16384) * 2 = 65536 bytes
+    // CHECK: memdesc<65536xi8
+    // First allocation: scale=2, offset=0, shape: 2 -> 4
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // Second allocation: scale=2, offset=1, shape: 2 -> 5
+    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
+    // CHECK-NOT: reuse_group
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Nested reuse groups - shared containing distinct
+// shared(QK, distinct(P, alpha))
+// QK: 2x64x64xf32 = 16384 bytes per buffer
+// P: 2x64x64xf16 = 8192 bytes per buffer
+// alpha: 2x64xf32 = 256 bytes per buffer
+// distinct(P, alpha) size = 8192 + 256 = 8448 bytes
+// shared max = max(16384, 8448) = 16384 bytes * 2 = 32768 bytes total
+// bytes_between_buffers = 16384 for all
+// QK: scale = 16384/16384 = 1, offset = 0, no expansion
+// P: scale = 16384/8192 = 2, offset = 0, shape: 2 -> 4
+// alpha: scale = 16384/256 = 64, offset = 8192/256 = 32, shape: 2 -> 2*64+32 = 160
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: nested_shared_distinct
+  tt.func @nested_shared_distinct() {
+    // CHECK: memdesc<32768xi8
+    // QK: no expansion (scale=1, offset=0)
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
+    // P: scale=2, offset=0, shape: 2 -> 4
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf16
+    // alpha: scale=64, offset=32, shape: 2 -> 160
+    // CHECK: local_alias{{.*}}memdesc<160x64xf32
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64xf32, #shared, #smem, mutable>
+    %4 = tlx.reuse_group(%2, %3) group_kind = distinct : (!ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<2x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    %5 = tlx.reuse_group(%1, %4) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !tlx.reuse_group<distinct>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %5) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Distinct containing shared
+// distinct(A, shared(B, C))
+// A: 2x64x64xf32 = 16384 bytes per buffer
+// B: 2x64x64xf16 = 8192 bytes per buffer
+// C: 2x32x32xf32 = 4096 bytes per buffer
+// shared(B, C) size = max(8192, 4096) = 8192 bytes
+// distinct total = 16384 + 8192 = 24576 bytes * 2 = 49152 bytes
+// bytes_between_buffers = 24576 for all
+// A: scale = 24576/16384 = 1.5 -> NOT EVENLY DIVISIBLE - should use shape = 2 * 24576/16384
+// Actually let's recalculate: 24576 is not evenly divisible by 16384
+// We need sizes that are evenly divisible. Let me use different shapes.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: nested_distinct_shared
+  tt.func @nested_distinct_shared() {
+    // A: 2x32x32xf32 = 4096 bytes per buffer
+    // B: 2x32x32xf16 = 2048 bytes per buffer
+    // C: 2x16x16xf32 = 1024 bytes per buffer
+    // shared(B,C) = max(2048, 1024) = 2048
+    // distinct = 4096 + 2048 = 6144 bytes per buffer * 2 = 12288 total
+    // bytes_between_buffers = 6144
+    // A: scale = 6144/4096 = 1.5 -> still not evenly divisible
+    // Let's use sizes that work: A=4096, B=2048, C=2048
+    // distinct = 4096 + 2048 = 6144, but 6144/4096 = 1.5 still
+    // Need: A=2048, B=1024, C=1024 -> distinct = 2048+1024 = 3072
+    // 3072/2048 = 1.5 still...
+    // Let's try: A=4096, B=4096 -> distinct = 8192, 8192/4096 = 2 ✓
+    // CHECK: memdesc<16384xi8
+    // A at offset 0, scale = 8192/4096 = 2, shape: 2 -> 4
+    // CHECK: local_alias{{.*}}memdesc<4x32x32xf32
+    // B at offset 4096, scale = 8192/4096 = 2, offset = 4096/4096 = 1, shape: 2 -> 5
+    // CHECK: local_alias{{.*}}memdesc<5x32x32xf32
+    // C shares with B, same offset, scale = 8192/2048 = 4, offset = 4096/2048 = 2, shape: 2 -> 10
+    // CHECK: local_alias{{.*}}memdesc<10x32x32xf16
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
+    %3 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf16, #shared, #smem, mutable>
+    %4 = tlx.reuse_group(%2, %3) group_kind = shared : (!ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<2x32x32xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    %5 = tlx.reuse_group(%1, %4) group_kind = distinct : (!ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>, !tlx.reuse_group<shared>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %5) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Index rewriting for MemDescIndexOp
+// When scale > 1 or offset > 0, MemDescIndexOp indices must be rewritten
+// This test verifies the arithmetic operations are generated
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: index_rewriting_scale_only
+  tt.func @index_rewriting_scale_only(%idx: i32) {
+    // Two f32 allocations in distinct: each 16384 bytes per buffer
+    // bytes_between_buffers = 32768, scale = 2
+    // First: offset = 0, scale = 2 -> index rewritten: new_idx = 2 * idx
+    // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli
+    // CHECK: memdesc_index
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    // Use the first allocation with memdesc_index
+    %4 = ttg.memdesc_index %1[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Index rewriting with both scale and offset
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: index_rewriting_scale_and_offset
+  tt.func @index_rewriting_scale_and_offset(%idx: i32) {
+    // Two f32 allocations in distinct: each 16384 bytes per buffer
+    // bytes_between_buffers = 32768, scale = 2
+    // Second allocation: offset = 16384, scale = 2
+    // offset_slots = 16384/16384 = 1
+    // new_idx = 2 * idx + 1
+    // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
+    // For second allocation's index:
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli
+    // CHECK: arith.constant 1 : i32
+    // CHECK: arith.addi
+    // CHECK: memdesc_index
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    // Use the second allocation with memdesc_index (it has scale=2 and offset=1)
+    %4 = ttg.memdesc_index %2[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: No set_buffer_overlap - allocations should NOT have expanded shapes
+// 2x64x64xf32 = 32768 bytes total
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: no_set_buffer_overlap
+  tt.func @no_set_buffer_overlap() {
+    // CHECK: memdesc<32768xi8
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
+    // CHECK-NOT: arith.muli
+    // CHECK-NOT: arith.addi
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Single allocation in reuse group (degenerate case) - no expansion needed
+// shared(A) - just A with scale=1, offset=0
+// A: 2x64x64xf32 = 16384 bytes per buffer * 2 = 32768 bytes
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: single_allocation_reuse_group
+  tt.func @single_allocation_reuse_group() {
+    // CHECK: memdesc<32768xi8
+    // No expansion needed since scale=1 and offset=0
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
+    // CHECK-NOT: reuse_group
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.reuse_group(%1) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %2) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Shape expansion with same element type different sizes
+// Two f16 allocations: 2x64x64xf16 (8192 bytes) and 2x32x32xf16 (2048 bytes)
+// shared group: max = 8192 bytes per buffer
+// First (8192): scale = 1, no expansion
+// Second (2048): scale = 8192/2048 = 4, shape: 2 -> 8
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: shared_different_sizes_same_type
+  tt.func @shared_different_sizes_same_type() {
+    // CHECK: memdesc<16384xi8
+    // Large allocation: no expansion
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf16
+    // Small allocation: scale=4, shape: 2 -> 8
+    // CHECK: local_alias{{.*}}memdesc<8x32x32xf16
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf16, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<2x32x32xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Index rewriting with constant index value
+// The constant index should be transformed: new_idx = 2 * 0 + 1 = 1
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: index_rewriting_constant_index
+  tt.func @index_rewriting_constant_index() {
+    // Two f32 allocations in distinct: each 16384 bytes per buffer
+    // bytes_between_buffers = 32768, scale = 2
+    // Second allocation: offset = 16384, offset_slots = 1
+    // For constant index 0: new_idx = 2 * 0 + 1 = 1
+    // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
+    // CHECK: arith.constant 0 : i32
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli
+    // CHECK: arith.constant 1 : i32
+    // CHECK: arith.addi
+    // CHECK: memdesc_index
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    // Use constant index 0
+    %c0 = arith.constant 0 : i32
+    %4 = ttg.memdesc_index %2[%c0] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Index rewriting with non-constant (dynamic) index
+// The dynamic index should be transformed: new_idx = 2 * idx + 1
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: index_rewriting_dynamic_index
+  tt.func @index_rewriting_dynamic_index(%idx: i32) {
+    // Two f32 allocations in distinct: each 16384 bytes per buffer
+    // bytes_between_buffers = 32768, scale = 2
+    // Second allocation: offset = 16384, offset_slots = 1
+    // For dynamic index %idx: new_idx = 2 * %idx + 1
+    // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli %arg0
+    // CHECK: arith.constant 1 : i32
+    // CHECK: arith.addi
+    // CHECK: memdesc_index
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    // Use dynamic function argument index
+    %4 = ttg.memdesc_index %2[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Index rewriting with computed (arithmetic result) index
+// Tests that index rewriting works with values computed from arithmetic
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: index_rewriting_computed_index
+  tt.func @index_rewriting_computed_index(%a: i32, %b: i32) {
+    // Two f32 allocations in distinct: each 16384 bytes per buffer
+    // bytes_between_buffers = 32768, scale = 2
+    // First allocation: offset = 0, scale = 2
+    // For computed index %a + %b: new_idx = 2 * (%a + %b)
+    // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: arith.addi %arg0, %arg1
+    // Then the index rewriting:
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli
+    // CHECK: memdesc_index
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    // Use computed index from arithmetic
+    %computed = arith.addi %a, %b : i32
+    %4 = ttg.memdesc_index %1[%computed] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Multiple MemDescIndexOp uses of the same alias with different indices
+// Each index should be independently rewritten
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: multiple_index_uses
+  tt.func @multiple_index_uses(%idx0: i32, %idx1: i32) {
+    // Two f32 allocations in distinct: each 16384 bytes per buffer
+    // bytes_between_buffers = 32768, scale = 2
+    // First allocation: offset = 0, scale = 2
+    // Both indices should be scaled by 2
+    // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // First index rewriting:
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli %arg0
+    // CHECK: memdesc_index
+    // Second index rewriting:
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli %arg1
+    // CHECK: memdesc_index
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    // Multiple uses with different indices
+    %4 = ttg.memdesc_index %1[%idx0] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    %5 = ttg.memdesc_index %1[%idx1] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: No index rewriting when scale=1 and offset=0 (no expansion needed)
+// When the largest allocation is used, no transformation is needed
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: no_index_rewriting_for_largest_alloc
+  tt.func @no_index_rewriting_for_largest_alloc(%idx: i32) {
+    // f32 (16384 bytes) and f16 (8192 bytes) in shared
+    // bytes_between_buffers = 16384 (max size)
+    // f32 allocation: scale = 1, offset = 0 -> no rewriting needed
+    // CHECK: memdesc<32768xi8
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
+    // No multiplication or addition for the f32 allocation's index
+    // CHECK: memdesc_index %{{.*}}[%arg0]
+    // CHECK-NOT: arith.muli %arg0
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    // Use the largest allocation (f32) - should NOT have index rewriting
+    %4 = ttg.memdesc_index %1[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Index rewriting for smaller allocation in shared group
+// The smaller allocation should have its index scaled
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: index_rewriting_for_smaller_alloc
+  tt.func @index_rewriting_for_smaller_alloc(%idx: i32) {
+    // f32 (16384 bytes) and f16 (8192 bytes) in shared
+    // bytes_between_buffers = 16384 (max size)
+    // f16 allocation: scale = 16384/8192 = 2, offset = 0 -> multiply by 2
+    // CHECK: memdesc<32768xi8
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf16
+    // For f16 allocation:
+    // CHECK: arith.constant 2 : i32
+    // CHECK: arith.muli
+    // CHECK: memdesc_index
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    // Use the smaller allocation (f16) - should have index rewriting
+    %4 = ttg.memdesc_index %2[%idx] : !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Warp specialization with shared reuse group - partition args must have expanded types
+// Two allocations in shared group: f32 (16384 bytes) and f16 (8192 bytes)
+// f16 gets expanded from 2 to 4 buffers (scale=2)
+// The warp_specialize captures both allocations; partition args must reflect the new types
+// Additionally, memdesc_index inside the partition region must have index rewriting
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: warp_specialize_shared_reuse_group
+  tt.func @warp_specialize_shared_reuse_group(%idx: i32) {
+    // CHECK: memdesc<32768xi8
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    // f32: no expansion (scale=1, offset=0)
+    // CHECK: %[[ALIAS0:.*]] = tlx.local_alias{{.*}}memdesc<2x64x64xf32
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    // f16: expanded from 2 to 4 (scale=2, offset=0)
+    // CHECK: %[[ALIAS1:.*]] = tlx.local_alias{{.*}}memdesc<4x64x64xf16
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    // Captures should have the expanded types
+    // CHECK: ttg.warp_specialize(%[[ALIAS0]], %[[ALIAS1]],
+    ttg.warp_specialize(%1, %2, %idx)
+    default {
+      ttg.warp_yield
+    }
+    // Partition args must reflect the expanded types
+    // CHECK: partition0(%{{.*}}: !ttg.memdesc<2x64x64xf32, {{.*}}>, %{{.*}}: !ttg.memdesc<4x64x64xf16, {{.*}}>
+    partition0(%arg0: !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, %arg1: !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, %arg_idx: i32) num_warps(1) {
+      // Index rewriting for the f16 block arg (scale=2)
+      // CHECK: arith.constant 2 : i32
+      // CHECK: arith.muli
+      // CHECK: memdesc_index
+      %4 = ttg.memdesc_index %arg1[%arg_idx] : !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, i32) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Warp specialization with distinct reuse group - partition args must have expanded types
+// Two f32 allocations in distinct group: each 16384 bytes per buffer
+// First: scale=2, offset=0, shape: 2->4
+// Second: scale=2, offset=1, shape: 2->5
+// Both are captured by warp_specialize; partition args must reflect expanded types
+// Additionally, memdesc_index inside the partition must have index rewriting
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: warp_specialize_distinct_reuse_group
+  tt.func @warp_specialize_distinct_reuse_group(%idx: i32) {
+    // CHECK: memdesc<65536xi8
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    // First: scale=2, offset=0, shape: 2->4
+    // CHECK: %[[ALIAS0:.*]] = tlx.local_alias{{.*}}memdesc<4x64x64xf32
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    // Second: scale=2, offset=1, shape: 2->5
+    // CHECK: %[[ALIAS1:.*]] = tlx.local_alias{{.*}}memdesc<5x64x64xf32
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    // Captures should have the expanded types
+    // CHECK: ttg.warp_specialize(%[[ALIAS0]], %[[ALIAS1]],
+    ttg.warp_specialize(%1, %2, %idx)
+    default {
+      ttg.warp_yield
+    }
+    // Partition args must reflect the expanded types
+    // CHECK: partition0(%{{.*}}: !ttg.memdesc<4x64x64xf32, {{.*}}>, %{{.*}}: !ttg.memdesc<5x64x64xf32, {{.*}}>
+    partition0(%arg0: !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, %arg1: !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, %arg_idx: i32) num_warps(1) {
+      // Index rewriting for first block arg (scale=2, offset=0)
+      // CHECK: arith.constant 2 : i32
+      // CHECK: arith.muli
+      // CHECK: memdesc_index
+      %4 = ttg.memdesc_index %arg0[%arg_idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+      // Index rewriting for second block arg (scale=2, offset=1)
+      // CHECK: arith.constant 2 : i32
+      // CHECK: arith.muli
+      // CHECK: arith.constant 1 : i32
+      // CHECK: arith.addi
+      // CHECK: memdesc_index
+      %5 = ttg.memdesc_index %arg1[%arg_idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, i32) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Shared reuse group with 3 elements
+// shared(A, B, C) where:
+// A: 2x64x64xf32 = 16384 bytes per buffer
+// B: 2x32x32xf32 = 4096 bytes per buffer
+// C: 2x16x16xf32 = 1024 bytes per buffer
+// shared max = max(16384, 4096, 1024) = 16384
+// bytes_between_buffers = alignUp(16384, 128) = 16384
+// A: scale = 16384/16384 = 1, offset = 0, no expansion
+// B: scale = 16384/4096 = 4, offset = 0, shape: 2 -> 8
+// C: scale = 16384/1024 = 16, offset = 0, shape: 2 -> 32
+// Total backing alloc = 16384 * 2 = 32768
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: shared_reuse_group_three_elements
+  tt.func @shared_reuse_group_three_elements() {
+    // CHECK: memdesc<32768xi8
+    // A: no expansion (scale=1, offset=0)
+    // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
+    // B: scale=4, offset=0, shape: 2 -> 8
+    // CHECK: local_alias{{.*}}memdesc<8x32x32xf32
+    // C: scale=16, offset=0, shape: 2 -> 32
+    // CHECK: local_alias{{.*}}memdesc<32x16x16xf32
+    // CHECK-NOT: reuse_group
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
+    %3 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x16x16xf32, #shared, #smem, mutable>
+    %4 = tlx.reuse_group(%1, %2, %3) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<2x16x16xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %4) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Distinct reuse group with 3 elements
+// distinct(A, B, C) where:
+// A: 2x64x64xf32 = 16384 bytes per buffer
+// B: 2x64x64xf32 = 16384 bytes per buffer
+// C: 2x64x64xf32 = 16384 bytes per buffer
+// alignment = 128
+// distinct total = 16384 + 16384 + 16384 = 49152 (all already 128-aligned)
+// bytes_between_buffers = alignUp(49152, 128) = 49152
+// A: scale = 49152/16384 = 3, offset_slots = 0/16384 = 0, shape: 2 -> 6
+// B: scale = 49152/16384 = 3, offset_slots = 16384/16384 = 1, shape: 2 -> 2*3+1 = 7
+// C: scale = 49152/16384 = 3, offset_slots = 32768/16384 = 2, shape: 2 -> 2*3+2 = 8
+// Total backing alloc = 49152 * 2 = 98304
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: distinct_reuse_group_three_elements
+  tt.func @distinct_reuse_group_three_elements() {
+    // CHECK: memdesc<98304xi8
+    // A: scale=3, offset=0, shape: 2 -> 6
+    // CHECK: local_alias{{.*}}memdesc<6x64x64xf32
+    // B: scale=3, offset=1, shape: 2 -> 7
+    // CHECK: local_alias{{.*}}memdesc<7x64x64xf32
+    // C: scale=3, offset=2, shape: 2 -> 8
+    // CHECK: local_alias{{.*}}memdesc<8x64x64xf32
+    // CHECK-NOT: reuse_group
+    // CHECK-NOT: set_buffer_overlap
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %3 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    %4 = tlx.reuse_group(%1, %2, %3) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %4) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    tt.return
+  }
+}

--- a/test/TLX/storage-alias-spec.mlir
+++ b/test/TLX/storage-alias-spec.mlir
@@ -320,3 +320,54 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     tt.return
   }
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Buffer Layout Attribute Tests
+//===----------------------------------------------------------------------===//
+
+// Test storage_alias_local_alloc with explicit buffer_offset = 0 (valid default)
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @buffer_offset_zero
+  tt.func @buffer_offset_zero() {
+    // CHECK: tlx.storage_alias_local_alloc %{{.*}} {buffer_offset = 0 : i64}
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 {buffer_offset = 0 : i64} : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test storage_alias_local_alloc with explicit bytes_between_buffers = allocation size (valid default)
+// Allocation is 2x64x64xf32, so per-buffer size = 64*64*4 = 16384 bytes
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @bytes_between_buffers_default
+  tt.func @bytes_between_buffers_default() {
+    // CHECK: tlx.storage_alias_local_alloc %{{.*}} {bytes_between_buffers = 16384 : i64}
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 {bytes_between_buffers = 16384 : i64} : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test storage_alias_local_alloc with both attributes set to valid defaults
+// Allocation is 2x64x64xf16, so per-buffer size = 64*64*2 = 8192 bytes
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @both_layout_attrs_default
+  tt.func @both_layout_attrs_default() {
+    // CHECK: tlx.storage_alias_local_alloc %{{.*}} {buffer_offset = 0 : i64, bytes_between_buffers = 8192 : i64}
+    %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
+    %1 = tlx.storage_alias_local_alloc %0 {buffer_offset = 0 : i64, bytes_between_buffers = 8192 : i64} : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -6,6 +6,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 #include "tlx/dialect/include/IR/Dialect.h.inc"
 #include "tlx/dialect/include/IR/Traits.h"
@@ -28,6 +29,104 @@ constexpr static char AttrTLXEnablePairedCTAMMAName[] =
     "tlx.enable_paired_cta_mma";
 
 bool tlxEnablePairedMMA(Operation *op);
+
+// Get element size in bytes for a type, handling pointer types (8 bytes)
+// and using ceiling division for sub-byte types.
+inline int64_t getElementBytes(mlir::Type elemType) {
+  int64_t elemBits = isa<triton::PointerType>(elemType)
+                         ? 64
+                         : elemType.getIntOrFloatBitWidth();
+  return (elemBits + 7) / 8;
+}
+
+// Compute the size of one buffer in an allocation (excluding the num
+// dimension). For a shape like [num, d1, d2, ...], returns d1 * d2 * ... *
+// elemBytes.
+inline int64_t
+getAllocationSizePerBuffer(triton::gpu::MemDescType memDescType) {
+  int64_t totalBytes = memDescType.getNumElements() *
+                       getElementBytes(memDescType.getElementType());
+  return totalBytes / memDescType.getShape()[0];
+}
+
+// TODO: We currently force data to be 128-byte aligned for SMEM (TMA) and
+// 32-byte aligned for TMEM, but we may want to consider relaxing this in the
+// future by examining the full IR.
+constexpr int64_t kSmemAlignment = 128;
+constexpr int64_t kTmemAlignment = 32;
+
+inline int64_t alignUp(int64_t value, int64_t alignment) {
+  return (value + alignment - 1) / alignment * alignment;
+}
+
+// Get the alignment requirement for a single allocation.
+// The alignment is the max of the storage type alignment (SMEM or TMEM)
+// and the element type alignment.
+inline int64_t getAllocAlignment(triton::gpu::MemDescType memDescType) {
+  int64_t storageAlignment = isa<triton::nvidia_gpu::TensorMemorySpaceAttr>(
+                                 memDescType.getMemorySpace())
+                                 ? kTmemAlignment
+                                 : kSmemAlignment;
+  int64_t elemAlignment = getElementBytes(memDescType.getElementType());
+  return std::max(storageAlignment, elemAlignment);
+}
+
+// Recursively compute the alignment requirement for an element in the
+// reuse group tree. For allocations: alignment is determined by the memory
+// space and element type. For groups (both shared and distinct): alignment
+// is the max of all children's alignments.
+inline int64_t getElementAlignment(Value element) {
+  if (auto allocOp = element.getDefiningOp<StorageAliasLocalAllocOp>()) {
+    auto memDescType =
+        cast<triton::gpu::MemDescType>(allocOp.getResult().getType());
+    return getAllocAlignment(memDescType);
+  }
+
+  if (auto reuseGroupOp = element.getDefiningOp<ReuseGroupOp>()) {
+    int64_t maxAlignment = 1;
+    for (auto child : reuseGroupOp.getElements()) {
+      maxAlignment = std::max(maxAlignment, getElementAlignment(child));
+    }
+    return maxAlignment;
+  }
+
+  llvm_unreachable("unexpected element type in reuse group");
+}
+
+// Recursively compute the size of an element in the reuse group tree.
+// For allocations: size is the per-buffer allocation size.
+// For shared groups: size is the max of children.
+// For distinct groups: size is the sum of children (with alignment padding).
+inline int64_t getElementSize(Value element, int64_t alignment) {
+  if (auto allocOp = element.getDefiningOp<StorageAliasLocalAllocOp>()) {
+    auto memDescType =
+        cast<triton::gpu::MemDescType>(allocOp.getResult().getType());
+    return getAllocationSizePerBuffer(memDescType);
+  }
+
+  if (auto reuseGroupOp = element.getDefiningOp<ReuseGroupOp>()) {
+    auto groupKind = reuseGroupOp.getGroupKind();
+    auto elements = reuseGroupOp.getElements();
+
+    if (groupKind == ReuseGroupKind::shared) {
+      int64_t maxSize = 0;
+      for (auto child : elements) {
+        maxSize = std::max(maxSize, getElementSize(child, alignment));
+      }
+      return maxSize;
+    } else { // distinct
+      int64_t totalSize = 0;
+      for (auto child : elements) {
+        totalSize = alignUp(totalSize, alignment);
+        totalSize += getElementSize(child, alignment);
+      }
+      return totalSize;
+    }
+  }
+
+  llvm_unreachable("unexpected element type in reuse group");
+}
+
 } // namespace tlx
 } // namespace triton
 } // namespace mlir

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -86,8 +86,7 @@ def TLX_StorageAliasLocalAllocOp : TLX_Op<"storage_alias_local_alloc",
     called with a `storage_alias_spec` in the `reuse` parameter.
 
     After the StorageAliasAllocationPass runs, this operation is replaced with
-    a LocalAliasOp (or MemDescSubviewOp for non-zero offsets) pointing to a
-    standard LocalAllocOp/TMEMAllocOp.
+    a LocalAliasOp pointing to a standard LocalAllocOp/TMEMAllocOp.
 
     Example:
     ```mlir
@@ -97,7 +96,9 @@ def TLX_StorageAliasLocalAllocOp : TLX_Op<"storage_alias_local_alloc",
     ```
   }];
 
-  let arguments = (ins TLX_StorageAliasSpecType:$storage_alias);
+  let arguments = (ins
+    TLX_StorageAliasSpecType:$storage_alias
+  );
 
   let results = (outs TTG_MemDescType:$result);
 
@@ -267,11 +268,27 @@ def TLX_ReleaseLayoutOp : TLX_Op<"release_layout",
 }
 
 def TLX_LocalAliasOp : TLX_Op<"local_alias",
-                                 [SameOperandAndResultMemorySpace,
-                                  Pure]> {
+                                   [SameOperandAndResultMemorySpace,
+                                    Pure]> {
   let summary = "Create an alias of a local memory buffer";
 
-  let arguments = (ins TTG_TensorOrMemDesc:$src);
+  let description = [{
+    Creates an alias of a local memory buffer with a different view (shape,
+    element type, or encoding). This operation is produced during the
+    StorageAliasAllocationPass when lowering StorageAliasLocalAllocOp.
+
+    Example:
+    ```mlir
+    %backing = ttg.local_alloc : () -> !ttg.memdesc<32768xi8, #shared, #smem, mutable>
+    %alias = tlx.local_alias %backing
+             : !ttg.memdesc<32768xi8, #shared, #smem, mutable>
+             -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
+    ```
+  }];
+
+  let arguments = (ins
+    TTG_TensorOrMemDesc:$src
+  );
 
   let results = (outs TTG_TensorOrMemDesc:$result);
 

--- a/third_party/tlx/dialect/lib/Transforms/BufferOffsetCalculation.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/BufferOffsetCalculation.cpp
@@ -1,0 +1,183 @@
+#include "IR/Dialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "tlx-buffer-offset-calculation"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace ttg = ::mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+
+namespace mlir {
+namespace triton {
+namespace tlx {
+
+// Recursively collect offsets for StorageAliasLocalAllocOp values
+static LogicalResult
+collectOffsets(Value element, int64_t currentOffset,
+               int64_t bytesBetweenBuffers, int64_t alignment,
+               DenseMap<Value, std::pair<int64_t, int64_t>> &offsetMap) {
+  if (auto allocOp = element.getDefiningOp<StorageAliasLocalAllocOp>()) {
+    LDBG("  Recording buffer_offset="
+         << currentOffset << ", bytes_between_buffers=" << bytesBetweenBuffers
+         << " for StorageAliasLocalAllocOp");
+    offsetMap[element] = {currentOffset, bytesBetweenBuffers};
+    return success();
+  }
+
+  if (auto reuseGroupOp = element.getDefiningOp<ReuseGroupOp>()) {
+    auto groupKind = reuseGroupOp.getGroupKind();
+    auto elements = reuseGroupOp.getElements();
+
+    if (groupKind == ReuseGroupKind::shared) {
+      LDBG("  Processing shared group at offset " << currentOffset);
+      // All children start at the same offset
+      for (auto child : elements) {
+        if (failed(collectOffsets(child, currentOffset, bytesBetweenBuffers,
+                                  alignment, offsetMap)))
+          return failure();
+      }
+    } else { // distinct
+      LDBG("  Processing distinct group at offset " << currentOffset);
+      // Children are placed sequentially, each aligned
+      int64_t runningOffset = currentOffset;
+      for (auto child : elements) {
+        runningOffset = alignUp(runningOffset, alignment);
+        if (failed(collectOffsets(child, runningOffset, bytesBetweenBuffers,
+                                  alignment, offsetMap)))
+          return failure();
+        int64_t childSize = getElementSize(child, alignment);
+        LDBG("    Child size: " << childSize << ", next offset: "
+                                << runningOffset + childSize);
+        runningOffset += childSize;
+      }
+
+      // Verify we have enough space
+      int64_t totalSize = runningOffset - currentOffset;
+      if (totalSize > bytesBetweenBuffers) {
+        return reuseGroupOp.emitError()
+               << "not enough space for distinct allocations: need "
+               << totalSize << " bytes, have " << bytesBetweenBuffers
+               << " bytes";
+      }
+    }
+    return success();
+  }
+
+  llvm_unreachable("unexpected element type in reuse group");
+}
+
+// Clean up unused ReuseGroupOp operations after processing
+// Uses worklist algorithm to handle nested groups
+static void cleanupReuseGroupOps(ModuleOp module) {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    SmallVector<ReuseGroupOp> toErase;
+    module.walk([&](ReuseGroupOp op) {
+      if (op.getResult().use_empty()) {
+        toErase.push_back(op);
+        changed = true;
+      }
+    });
+    for (auto op : toErase) {
+      LDBG("Erasing unused ReuseGroupOp");
+      op.erase();
+    }
+  }
+}
+
+LogicalResult processBufferOverlapOps(
+    ModuleOp module, DenseMap<Value, std::pair<int64_t, int64_t>> &offsetMap) {
+  LDBG("processBufferOverlapOps");
+
+  // Track which storage_alias_specs have been processed
+  DenseSet<Value> processedSpecs;
+
+  // Collect all SetBufferOverlapOps
+  SmallVector<SetBufferOverlapOp> overlapOps;
+  module.walk([&](SetBufferOverlapOp op) { overlapOps.push_back(op); });
+
+  LDBG("Found " << overlapOps.size() << " SetBufferOverlapOp(s)");
+
+  // Process each SetBufferOverlapOp
+  for (auto overlapOp : overlapOps) {
+    Value overlapDef = overlapOp.getOverlapDef();
+    Value specValue = overlapOp.getStorageAliasSpec();
+
+    LDBG("Processing SetBufferOverlapOp");
+
+    // Check for duplicate set_buffer_overlap on same spec
+    if (processedSpecs.contains(specValue)) {
+      return overlapOp.emitError(
+          "storage_alias_spec already has a set_buffer_overlap defined; "
+          "each spec can only have one overlap definition");
+    }
+
+    // Find any allocation to get the num_buffers
+    int64_t numBuffers = 1;
+    std::function<bool(Value)> findNumBuffers = [&](Value element) -> bool {
+      if (auto allocOp = element.getDefiningOp<StorageAliasLocalAllocOp>()) {
+        auto memDescType =
+            cast<ttg::MemDescType>(allocOp.getResult().getType());
+        numBuffers = memDescType.getShape()[0];
+        return true;
+      }
+      if (auto reuseGroupOp = element.getDefiningOp<ReuseGroupOp>()) {
+        for (auto child : reuseGroupOp.getElements()) {
+          if (findNumBuffers(child))
+            return true;
+        }
+      }
+      return false;
+    };
+
+    if (!findNumBuffers(overlapDef)) {
+      return overlapOp.emitError(
+          "could not find StorageAliasLocalAllocOp in overlap definition");
+    }
+
+    // Compute alignment from the reuse group tree
+    int64_t alignment = getElementAlignment(overlapDef);
+
+    // Compute total size from the reuse group tree
+    int64_t sizePerBuffer = getElementSize(overlapDef, alignment);
+    int64_t bytesBetweenBuffers = alignUp(sizePerBuffer, alignment);
+
+    LDBG("  numBuffers=" << numBuffers << ", sizePerBuffer=" << sizePerBuffer
+                         << ", bytesBetweenBuffers=" << bytesBetweenBuffers
+                         << ", alignment=" << alignment);
+
+    // Recursively collect offsets starting at offset 0
+    if (failed(collectOffsets(overlapDef, /*currentOffset=*/0,
+                              bytesBetweenBuffers, alignment, offsetMap))) {
+      return failure();
+    }
+
+    // Mark spec as processed
+    processedSpecs.insert(specValue);
+
+    // Erase the SetBufferOverlapOp
+    LDBG("Erasing SetBufferOverlapOp");
+    overlapOp.erase();
+  }
+
+  // Clean up unused ReuseGroupOp operations
+  cleanupReuseGroupOps(module);
+
+  LDBG("processBufferOverlapOps completed successfully");
+  return success();
+}
+
+} // namespace tlx
+} // namespace triton
+} // namespace mlir

--- a/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
+++ b/third_party/tlx/dialect/lib/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonTLXTransforms
   StorageAliasSizeDefinition.cpp
   StorageAliasAllocation.cpp
   StorageAliasLowering.cpp
+  BufferOffsetCalculation.cpp
 
   DEPENDS
   TritonTLXTransformsIncGen

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
@@ -1,4 +1,5 @@
 #include "IR/Dialect.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
@@ -6,6 +7,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "tlx-storage-alias-allocation"
@@ -20,7 +22,60 @@ namespace mlir {
 namespace triton {
 namespace tlx {
 
-LogicalResult materializeStorageAliasAllocations(ModuleOp m) {
+// After replacing a storage_alias_local_alloc with a local_alias that has
+// an expanded type (e.g., from buffer overlap shape expansion), we need to
+// update any ops that capture the value and propagate types to block
+// arguments. In particular, WarpSpecializeOp captures values as operands
+// and each partition region has block arguments whose types must match
+// the capture types (verified by WarpSpecializeOp::verify).
+static void updateBlockArgTypesForUsers(Value newValue) {
+  Type newType = newValue.getType();
+  for (OpOperand &use : newValue.getUses()) {
+    Operation *user = use.getOwner();
+    if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+      unsigned idx = use.getOperandNumber();
+      for (Region *partition : wsOp.getPartitionRegions()) {
+        if (idx < partition->getNumArguments()) {
+          partition->getArgument(idx).setType(newType);
+        }
+      }
+    }
+  }
+}
+
+// Helper function to collect all MemDescIndexOp operations that use a given
+// memdesc value, following through MemDescReinterpretOp, LocalAliasOp, and
+// WarpSpecializeOp captures (to the corresponding partition block arguments).
+static void
+collectMemDescIndexOps(Value memDesc,
+                       SmallVectorImpl<ttg::MemDescIndexOp> &result) {
+  for (auto &use : memDesc.getUses()) {
+    Operation *user = use.getOwner();
+    if (auto indexOp = dyn_cast<ttg::MemDescIndexOp>(user)) {
+      result.push_back(indexOp);
+    } else if (auto reinterpret = dyn_cast<ttg::MemDescReinterpretOp>(user)) {
+      // Follow through reinterpret ops
+      collectMemDescIndexOps(reinterpret.getResult(), result);
+    } else if (auto alias = dyn_cast<LocalAliasOp>(user)) {
+      // Follow through nested aliases
+      collectMemDescIndexOps(alias.getResult(), result);
+    } else if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+      // Follow through warp_specialize captures to partition block arguments.
+      // The alias may be captured as an operand; the corresponding block arg
+      // in each partition region is used inside the isolated region.
+      unsigned idx = use.getOperandNumber();
+      for (Region *partition : wsOp.getPartitionRegions()) {
+        if (idx < partition->getNumArguments()) {
+          collectMemDescIndexOps(partition->getArgument(idx), result);
+        }
+      }
+    }
+  }
+}
+
+LogicalResult materializeStorageAliasAllocations(
+    ModuleOp m, const DenseMap<Value, std::pair<int64_t, int64_t>> &offsetMap,
+    DenseMap<Value, std::pair<int64_t, int64_t>> &localAliasOffsetMap) {
   LDBG("materializeStorageAliasAllocations");
 
   OpBuilder builder(m.getContext());
@@ -125,14 +180,151 @@ LogicalResult materializeStorageAliasAllocations(ModuleOp m) {
 
     builder.setInsertionPoint(allocOp);
 
-    // Create a LocalAliasOp to reinterpret the allocation with the correct type
-    auto resultType = allocOp.getResult().getType();
+    // Get the original result type
+    auto originalResultType =
+        cast<ttg::MemDescType>(allocOp.getResult().getType());
+
+    // Check if we have offset information for this allocation
+    auto offsetIt = offsetMap.find(allocOp.getResult());
+
+    // Determine the result type - may be expanded based on
+    // bytes_between_buffers
+    ttg::MemDescType resultType = originalResultType;
+    if (offsetIt != offsetMap.end()) {
+      int64_t bufferOffset = offsetIt->second.first;
+      int64_t bytesBetweenBuffers = offsetIt->second.second;
+
+      // Compute original buffer size (shape[0] is num_buffers, rest is
+      // per-buffer)
+      auto shape = originalResultType.getShape();
+      int64_t elemBits = originalResultType.getElementTypeBitWidth();
+      int64_t bufferElements = 1;
+      for (size_t i = 1; i < shape.size(); ++i) {
+        bufferElements *= shape[i];
+      }
+      int64_t originalBufferBytes = (bufferElements * elemBits) / 8;
+
+      // Check if bytes_between_buffers divides evenly by original buffer size
+      if (bytesBetweenBuffers % originalBufferBytes != 0) {
+        allocOp.emitError("bytes_between_buffers (")
+            << bytesBetweenBuffers
+            << ") must be a multiple of the original buffer size ("
+            << originalBufferBytes << ")";
+        return failure();
+      }
+
+      // Check if buffer_offset divides evenly by original buffer size
+      if (bufferOffset % originalBufferBytes != 0) {
+        allocOp.emitError("buffer_offset (")
+            << bufferOffset
+            << ") must be a multiple of the original buffer size ("
+            << originalBufferBytes << ")";
+        return failure();
+      }
+
+      int64_t scaleFactor = bytesBetweenBuffers / originalBufferBytes;
+      int64_t offsetSlots = bufferOffset / originalBufferBytes;
+
+      // If there's padding or offset, expand the shape
+      if (scaleFactor > 1 || offsetSlots > 0) {
+        // Compute expanded shape:
+        // new_buffer_dim = num_buffers * scale_factor + offset_slots
+        int64_t numBuffers = shape[0];
+        int64_t newBufferDim = numBuffers * scaleFactor + offsetSlots;
+
+        SmallVector<int64_t> expandedShape;
+        expandedShape.push_back(newBufferDim);
+        for (size_t i = 1; i < shape.size(); ++i) {
+          expandedShape.push_back(shape[i]);
+        }
+
+        LDBG("  Expanding shape from [" << shape[0] << ", ...] to ["
+                                        << newBufferDim << ", ...]");
+        LDBG("  (scale_factor=" << scaleFactor
+                                << ", offset_slots=" << offsetSlots << ")");
+
+        // Create new MemDescType with expanded shape
+        resultType = ttg::MemDescType::get(
+            expandedShape, originalResultType.getElementType(),
+            originalResultType.getEncoding(),
+            originalResultType.getMemorySpace(),
+            originalResultType.getMutableMemory());
+      }
+    }
+
+    // Create a LocalAliasOp to reinterpret the allocation with the
+    // (possibly expanded) type
     auto localAliasOp =
         builder.create<LocalAliasOp>(allocOp.getLoc(), resultType, it->second);
 
     // Replace all uses and erase the old operation
     allocOp.getResult().replaceAllUsesWith(localAliasOp.getResult());
     allocOp.erase();
+
+    // If the type changed (e.g., due to shape expansion), update block
+    // argument types for any ops that capture this value (e.g.,
+    // WarpSpecializeOp partition region args must match capture types).
+    if (resultType != originalResultType) {
+      updateBlockArgTypesForUsers(localAliasOp.getResult());
+    }
+
+    // If the shape was expanded, rewrite MemDescIndexOp indices to account
+    // for the scale factor and offset
+    if (offsetIt != offsetMap.end()) {
+      int64_t bufferOffset = offsetIt->second.first;
+      int64_t bytesBetweenBuffers = offsetIt->second.second;
+
+      // Recompute scale factor and offset slots
+      auto shape = originalResultType.getShape();
+      int64_t elemBits = originalResultType.getElementTypeBitWidth();
+      int64_t bufferElements = 1;
+      for (size_t i = 1; i < shape.size(); ++i) {
+        bufferElements *= shape[i];
+      }
+      int64_t originalBufferBytes = (bufferElements * elemBits) / 8;
+      int64_t scaleFactor = bytesBetweenBuffers / originalBufferBytes;
+      int64_t offsetSlots = bufferOffset / originalBufferBytes;
+
+      // Only rewrite if there's actual scaling or offset
+      if (scaleFactor > 1 || offsetSlots > 0) {
+        LDBG("  Rewriting MemDescIndexOp indices (scale="
+             << scaleFactor << ", offset=" << offsetSlots << ")");
+
+        // Collect all MemDescIndexOp users (need to collect first to avoid
+        // iterator invalidation)
+        SmallVector<ttg::MemDescIndexOp> indexOpsToRewrite;
+        collectMemDescIndexOps(localAliasOp.getResult(), indexOpsToRewrite);
+
+        for (auto indexOp : indexOpsToRewrite) {
+          builder.setInsertionPoint(indexOp);
+          Location loc = indexOp.getLoc();
+          Value originalIndex = indexOp.getIndex();
+
+          // Compute: newIndex = scaleFactor * originalIndex + offsetSlots
+          Value newIndex = originalIndex;
+
+          if (scaleFactor > 1) {
+            Value scaleVal = builder.create<arith::ConstantOp>(
+                loc, builder.getI32IntegerAttr(scaleFactor));
+            newIndex =
+                builder.create<arith::MulIOp>(loc, originalIndex, scaleVal);
+          }
+
+          if (offsetSlots > 0) {
+            Value offsetVal = builder.create<arith::ConstantOp>(
+                loc, builder.getI32IntegerAttr(offsetSlots));
+            newIndex = builder.create<arith::AddIOp>(loc, newIndex, offsetVal);
+          }
+
+          // Update the index operand
+          indexOp.getIndexMutable().assign(newIndex);
+          LDBG("    Rewrote index at " << loc);
+        }
+      }
+
+      // Store offset information in the output map for reference
+      localAliasOffsetMap[localAliasOp.getResult()] = offsetIt->second;
+    }
   }
 
   // Third pass: erase storage_alias_spec operations

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasLowering.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasLowering.cpp
@@ -7,6 +7,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "tlx-storage-alias-lowering"
@@ -25,7 +26,11 @@ namespace tlx {
 
 // Forward declarations of functions from the individual passes
 LogicalResult computeOrValidateStorageAliasSizes(ModuleOp m);
-LogicalResult materializeStorageAliasAllocations(ModuleOp m);
+LogicalResult processBufferOverlapOps(
+    ModuleOp m, DenseMap<Value, std::pair<int64_t, int64_t>> &offsetMap);
+LogicalResult materializeStorageAliasAllocations(
+    ModuleOp m, const DenseMap<Value, std::pair<int64_t, int64_t>> &offsetMap,
+    DenseMap<Value, std::pair<int64_t, int64_t>> &localAliasOffsetMap);
 
 struct TLXStorageAliasLoweringPass
     : public impl::TLXStorageAliasLoweringBase<TLXStorageAliasLoweringPass> {
@@ -45,12 +50,33 @@ public:
       return;
     }
 
-    // Step 2: Materialize storage alias allocations
-    LDBG("Step 2: Materializing storage alias allocations");
-    if (failed(materializeStorageAliasAllocations(m))) {
+    // Step 2: Process buffer overlap operations (compute offsets)
+    // This must run BEFORE materialization because:
+    // - SetBufferOverlapOp uses StorageAliasSpecOp
+    // - Materialization erases StorageAliasSpecOp
+    // The computed offsets are returned in a map to be applied during
+    // materialization.
+    LDBG("Step 2: Processing buffer overlap operations");
+    DenseMap<Value, std::pair<int64_t, int64_t>> offsetMap;
+    if (failed(processBufferOverlapOps(m, offsetMap))) {
       signalPassFailure();
       return;
     }
+
+    // Step 3: Materialize storage alias allocations
+    // This creates LocalAllocOp/TMEMAllocOp and LocalAliasOp.
+    // The computed offsets are stored in localAliasOffsetMap for later use.
+    LDBG("Step 3: Materializing storage alias allocations");
+    DenseMap<Value, std::pair<int64_t, int64_t>> localAliasOffsetMap;
+    if (failed(materializeStorageAliasAllocations(m, offsetMap,
+                                                  localAliasOffsetMap))) {
+      signalPassFailure();
+      return;
+    }
+
+    // Note: localAliasOffsetMap contains the buffer layout information for
+    // LocalAliasOps that have custom offsets (from set_buffer_overlap).
+    // This can be used in a future Step 4 for Phase 6 implementation.
 
     LDBG("TLXStorageAliasLowering completed successfully");
   }


### PR DESCRIPTION
Summary:
Implements the Compiler pass to calculate a buffer's offset and its padding to enable compiler defined offsets for buffer reuse. This follows from this design: https://docs.google.com/document/d/1gmghlhf6SJuMpKyoWB2NnAzPzFDP2gsUqwJkEoARKl8/edit?fbclid=IwY2xjawP0nztleHRuA2FlbQIxMQBicmlkETFZTmtDQ1piVEpXU3BlUWIzc3J0YwZhcHBfaWQBMAABHjKT8OMqKBb4W-RphK8IZZIT8d71v6k-DIg2yntqRI-I7PLtkiP1p2DLh2d9_aem_BlSpNK3_7Pz4owXK0RJqSw&tab=t.0#heading=h.ijjyh6oq6awv

This code has limitations, namely that all padding/offsets can be lowered by multiplying the size of the buffer and just modifying the indexing. This is done as opposed to modifying the underlying lowering because I didn't want to risk breaking the linear layout support on MemDesc and felt this could introduce more bugs. In the future if this can't support use cases then we will need to extend this lowering implementation.

This can't quite handle FA yet because we need to be able to handle subtiling for P (sharing multiple entries per buffer). This is handled in a followup diff.

Differential Revision: D92632183


