### PR TITLE
[TLX] 6/N Enable subtiling for reuse groups

### DIFF
--- a/test/TLX/buffer-layout-attrs-errors.mlir
+++ b/test/TLX/buffer-layout-attrs-errors.mlir
@@ -15,7 +15,7 @@
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   tt.func @bytes_between_not_divisible_error() {
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
-    // expected-error @+1 {{bytes_between_buffers (24576) must be a multiple of the original buffer size (16384)}}
+    // expected-error @+1 {{bytes_between_buffer_groups (24576) must be a multiple of the original buffer size (16384)}}
     %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x32xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x32xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
@@ -36,7 +36,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   tt.func @bytes_between_not_divisible_error_2() {
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
-    // expected-error @+1 {{bytes_between_buffers (49152) must be a multiple of the original buffer size (32768)}}
+    // expected-error @+1 {{bytes_between_buffer_groups (49152) must be a multiple of the original buffer size (32768)}}
     %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x128x64xf32, #shared, #smem, mutable>
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x128x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>

--- a/test/TLX/buffer-offset-calculation.mlir
+++ b/test/TLX/buffer-offset-calculation.mlir
@@ -4,11 +4,11 @@
 // Buffer Offset Calculation Pass Tests
 //===----------------------------------------------------------------------===//
 
-// Test: Basic shared reuse group - both allocations get same shape expansion
-// Two allocations: 2x64x64xf32 (16384 bytes per buffer) and 2x64x64xf16 (8192 bytes)
-// max size = 16384 bytes * 2 buffers = 32768 bytes total
-// For f32: bytes_between_buffers = 16384, buffer_size = 16384, scale = 1, no expansion needed
-// For f16: bytes_between_buffers = 16384, buffer_size = 8192, scale = 2, shape expands 2->4
+// Test: Basic shared reuse group with two allocations of different sizes
+// shared(f32[2,64,64], f16[2,64,64])
+// bytes_between_buffers = max(16384, 8192) = 16384
+// For f32: scale = 16384/16384 = 1, offset = 0, shape unchanged
+// For f16: scale = 16384/8192 = 2, offset = 0, shape expands 2->3
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
@@ -18,8 +18,8 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     // CHECK: memdesc<32768xi8
     // f32 allocation: no expansion needed (scale=1, offset=0)
     // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
-    // f16 allocation: expanded from 2 to 4 buffers (scale=2, offset=0)
-    // CHECK: local_alias{{.*}}memdesc<4x64x64xf16
+    // f16 allocation: expanded from 2 to 3 (scale=2, offset=0)
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf16
     // CHECK-NOT: reuse_group
     // CHECK-NOT: set_buffer_overlap
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
@@ -33,12 +33,11 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Basic distinct reuse group - allocations placed sequentially with shape expansion
-// Two allocations: 2x64x64xf32 (16384 bytes per buffer) each
-// total = (16384 + 16384) * 2 = 65536 bytes
-// bytes_between_buffers = 32768 for both
-// For first: scale = 32768/16384 = 2, offset = 0, shape: 2 -> 4
-// For second: scale = 32768/16384 = 2, offset = 16384/16384 = 1, shape: 2 -> 2*2+1 = 5
+// Test: Basic distinct reuse group with two allocations
+// distinct(f32[2,64,64], f32[2,64,64])
+// bytes_between_buffers = 16384 + 16384 = 32768
+// For first: scale = 32768/16384 = 2, offset = 0, shape: 2 -> 3
+// For second: scale = 32768/16384 = 2, offset = 16384/16384 = 1, shape: 2 -> 4
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
@@ -46,10 +45,10 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   tt.func @distinct_reuse_group_basic() {
     // For distinct reuse group: total size = (16384 + 16384) * 2 = 65536 bytes
     // CHECK: memdesc<65536xi8
-    // First allocation: scale=2, offset=0, shape: 2 -> 4
+    // First allocation: scale=2, offset=0, shape: 2 -> 3
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf32
+    // Second allocation: scale=2, offset=1, shape: 2 -> 4
     // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
-    // Second allocation: scale=2, offset=1, shape: 2 -> 5
-    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
     // CHECK-NOT: reuse_group
     // CHECK-NOT: set_buffer_overlap
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
@@ -63,17 +62,9 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Nested reuse groups - shared containing distinct
-// shared(QK, distinct(P, alpha))
-// QK: 2x64x64xf32 = 16384 bytes per buffer
-// P: 2x64x64xf16 = 8192 bytes per buffer
-// alpha: 2x64xf32 = 256 bytes per buffer
-// distinct(P, alpha) size = 8192 + 256 = 8448 bytes
-// shared max = max(16384, 8448) = 16384 bytes * 2 = 32768 bytes total
-// bytes_between_buffers = 16384 for all
-// QK: scale = 16384/16384 = 1, offset = 0, no expansion
-// P: scale = 16384/8192 = 2, offset = 0, shape: 2 -> 4
-// alpha: scale = 16384/256 = 64, offset = 8192/256 = 32, shape: 2 -> 2*64+32 = 160
+// Test: Nested shared(distinct) reuse group
+// P: scale = 16384/8192 = 2, offset = 0, shape: 2 -> 3
+// alpha: scale = 16384/256 = 64, offset = 8192/256 = 32, shape: 2 -> 97
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
@@ -82,86 +73,63 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     // CHECK: memdesc<32768xi8
     // QK: no expansion (scale=1, offset=0)
     // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
-    // P: scale=2, offset=0, shape: 2 -> 4
-    // CHECK: local_alias{{.*}}memdesc<4x64x64xf16
-    // alpha: scale=64, offset=32, shape: 2 -> 160
-    // CHECK: local_alias{{.*}}memdesc<160x64xf32
+    // P: scale=2, offset=0, shape: 2 -> 3
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf16
+    // alpha: scale=64, offset=32, shape: 2 -> 97
+    // CHECK: local_alias{{.*}}memdesc<97x64xf32
     // CHECK-NOT: set_buffer_overlap
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
     %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
     %3 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64xf32, #shared, #smem, mutable>
-    %4 = tlx.reuse_group(%2, %3) group_kind = distinct : (!ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<2x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
-    %5 = tlx.reuse_group(%1, %4) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !tlx.reuse_group<distinct>) -> !tlx.reuse_group<shared>
-    tlx.set_buffer_overlap(%0, %5) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
+    %inner_distinct = tlx.reuse_group(%2, %3) group_kind = distinct : (!ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<2x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
+    %outer_shared = tlx.reuse_group(%1, %inner_distinct) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !tlx.reuse_group<distinct>) -> !tlx.reuse_group<shared>
+    tlx.set_buffer_overlap(%0, %outer_shared) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
     tt.return
   }
 }
 
 // -----
 
-// Test: Distinct containing shared
+// Test: Nested distinct(shared) reuse group
 // distinct(A, shared(B, C))
-// A: 2x64x64xf32 = 16384 bytes per buffer
-// B: 2x64x64xf16 = 8192 bytes per buffer
-// C: 2x32x32xf32 = 4096 bytes per buffer
-// shared(B, C) size = max(8192, 4096) = 8192 bytes
-// distinct total = 16384 + 8192 = 24576 bytes * 2 = 49152 bytes
-// bytes_between_buffers = 24576 for all
-// A: scale = 24576/16384 = 1.5 -> NOT EVENLY DIVISIBLE - should use shape = 2 * 24576/16384
-// Actually let's recalculate: 24576 is not evenly divisible by 16384
-// We need sizes that are evenly divisible. Let me use different shapes.
+// A at offset 0, scale = 8192/4096 = 2, shape: 2 -> 3
+// B at offset 4096, scale = 8192/4096 = 2, offset = 4096/4096 = 1, shape: 2 -> 4
+// C shares with B, scale = 8192/2048 = 4, offset = 4096/2048 = 2, shape: 2 -> 7
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: nested_distinct_shared
   tt.func @nested_distinct_shared() {
-    // A: 2x32x32xf32 = 4096 bytes per buffer
-    // B: 2x32x32xf16 = 2048 bytes per buffer
-    // C: 2x16x16xf32 = 1024 bytes per buffer
-    // shared(B,C) = max(2048, 1024) = 2048
-    // distinct = 4096 + 2048 = 6144 bytes per buffer * 2 = 12288 total
-    // bytes_between_buffers = 6144
-    // A: scale = 6144/4096 = 1.5 -> still not evenly divisible
-    // Let's use sizes that work: A=4096, B=2048, C=2048
-    // distinct = 4096 + 2048 = 6144, but 6144/4096 = 1.5 still
-    // Need: A=2048, B=1024, C=1024 -> distinct = 2048+1024 = 3072
-    // 3072/2048 = 1.5 still...
-    // Let's try: A=4096, B=4096 -> distinct = 8192, 8192/4096 = 2 ✓
     // CHECK: memdesc<16384xi8
-    // A at offset 0, scale = 8192/4096 = 2, shape: 2 -> 4
+    // A at offset 0, scale = 8192/4096 = 2, shape: 2 -> 3
+    // CHECK: local_alias{{.*}}memdesc<3x32x32xf32
+    // B at offset 4096, scale = 8192/4096 = 2, offset = 4096/4096 = 1, shape: 2 -> 4
     // CHECK: local_alias{{.*}}memdesc<4x32x32xf32
-    // B at offset 4096, scale = 8192/4096 = 2, offset = 4096/4096 = 1, shape: 2 -> 5
-    // CHECK: local_alias{{.*}}memdesc<5x32x32xf32
-    // C shares with B, same offset, scale = 8192/2048 = 4, offset = 4096/2048 = 2, shape: 2 -> 10
-    // CHECK: local_alias{{.*}}memdesc<10x32x32xf16
+    // C shares with B, same offset, scale = 8192/2048 = 4, offset = 4096/2048 = 2, shape: 2 -> 7
+    // CHECK: local_alias{{.*}}memdesc<7x32x32xf16
     // CHECK-NOT: set_buffer_overlap
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
     %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
     %3 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x32x32xf16, #shared, #smem, mutable>
-    %4 = tlx.reuse_group(%2, %3) group_kind = shared : (!ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<2x32x32xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
-    %5 = tlx.reuse_group(%1, %4) group_kind = distinct : (!ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>, !tlx.reuse_group<shared>) -> !tlx.reuse_group<distinct>
-    tlx.set_buffer_overlap(%0, %5) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
+    %inner_shared = tlx.reuse_group(%2, %3) group_kind = shared : (!ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<2x32x32xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
+    %outer_distinct = tlx.reuse_group(%1, %inner_shared) group_kind = distinct : (!ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>, !tlx.reuse_group<shared>) -> !tlx.reuse_group<distinct>
+    tlx.set_buffer_overlap(%0, %outer_distinct) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
     tt.return
   }
 }
 
 // -----
 
-// Test: Index rewriting for MemDescIndexOp
-// When scale > 1 or offset > 0, MemDescIndexOp indices must be rewritten
-// This test verifies the arithmetic operations are generated
+// Test: Index rewriting with scale only (first allocation in distinct)
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: index_rewriting_scale_only
   tt.func @index_rewriting_scale_only(%idx: i32) {
-    // Two f32 allocations in distinct: each 16384 bytes per buffer
-    // bytes_between_buffers = 32768, scale = 2
-    // First: offset = 0, scale = 2 -> index rewritten: new_idx = 2 * idx
     // CHECK: memdesc<65536xi8
-    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf32
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli
     // CHECK: memdesc_index
@@ -170,7 +138,6 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
-    // Use the first allocation with memdesc_index
     %4 = ttg.memdesc_index %1[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -184,15 +151,9 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: index_rewriting_scale_and_offset
   tt.func @index_rewriting_scale_and_offset(%idx: i32) {
-    // Two f32 allocations in distinct: each 16384 bytes per buffer
-    // bytes_between_buffers = 32768, scale = 2
-    // Second allocation: offset = 16384, scale = 2
-    // offset_slots = 16384/16384 = 1
-    // new_idx = 2 * idx + 1
     // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf32
     // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
-    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
-    // For second allocation's index:
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli
     // CHECK: arith.constant 1 : i32
@@ -203,7 +164,6 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
-    // Use the second allocation with memdesc_index (it has scale=2 and offset=1)
     %4 = ttg.memdesc_index %2[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -211,8 +171,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: No set_buffer_overlap - allocations should NOT have expanded shapes
-// 2x64x64xf32 = 32768 bytes total
+// Test: No set_buffer_overlap -> no expansion
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
@@ -230,16 +189,13 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Single allocation in reuse group (degenerate case) - no expansion needed
-// shared(A) - just A with scale=1, offset=0
-// A: 2x64x64xf32 = 16384 bytes per buffer * 2 = 32768 bytes
+// Test: Single allocation in reuse group -> no expansion
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: single_allocation_reuse_group
   tt.func @single_allocation_reuse_group() {
     // CHECK: memdesc<32768xi8
-    // No expansion needed since scale=1 and offset=0
     // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
     // CHECK-NOT: reuse_group
     // CHECK-NOT: set_buffer_overlap
@@ -253,21 +209,16 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Shape expansion with same element type different sizes
-// Two f16 allocations: 2x64x64xf16 (8192 bytes) and 2x32x32xf16 (2048 bytes)
-// shared group: max = 8192 bytes per buffer
-// First (8192): scale = 1, no expansion
-// Second (2048): scale = 8192/2048 = 4, shape: 2 -> 8
+// Test: Shared reuse group with different sizes but same element type
+// Small: scale = 8192/2048 = 4, offset = 0, shape: 2 -> 5
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: shared_different_sizes_same_type
   tt.func @shared_different_sizes_same_type() {
     // CHECK: memdesc<16384xi8
-    // Large allocation: no expansion
     // CHECK: local_alias{{.*}}memdesc<2x64x64xf16
-    // Small allocation: scale=4, shape: 2 -> 8
-    // CHECK: local_alias{{.*}}memdesc<8x32x32xf16
+    // CHECK: local_alias{{.*}}memdesc<5x32x32xf16
     // CHECK-NOT: set_buffer_overlap
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
     %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
@@ -280,20 +231,15 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Index rewriting with constant index value
-// The constant index should be transformed: new_idx = 2 * 0 + 1 = 1
+// Test: Index rewriting with constant index (second allocation)
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: index_rewriting_constant_index
   tt.func @index_rewriting_constant_index() {
-    // Two f32 allocations in distinct: each 16384 bytes per buffer
-    // bytes_between_buffers = 32768, scale = 2
-    // Second allocation: offset = 16384, offset_slots = 1
-    // For constant index 0: new_idx = 2 * 0 + 1 = 1
     // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf32
     // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
-    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
     // CHECK: arith.constant 0 : i32
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli
@@ -305,7 +251,6 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
-    // Use constant index 0
     %c0 = arith.constant 0 : i32
     %4 = ttg.memdesc_index %2[%c0] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     tt.return
@@ -314,20 +259,15 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Index rewriting with non-constant (dynamic) index
-// The dynamic index should be transformed: new_idx = 2 * idx + 1
+// Test: Index rewriting with dynamic function argument index
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: index_rewriting_dynamic_index
   tt.func @index_rewriting_dynamic_index(%idx: i32) {
-    // Two f32 allocations in distinct: each 16384 bytes per buffer
-    // bytes_between_buffers = 32768, scale = 2
-    // Second allocation: offset = 16384, offset_slots = 1
-    // For dynamic index %idx: new_idx = 2 * %idx + 1
     // CHECK: memdesc<65536xi8
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf32
     // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
-    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli %arg0
     // CHECK: arith.constant 1 : i32
@@ -338,7 +278,6 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
-    // Use dynamic function argument index
     %4 = ttg.memdesc_index %2[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -346,21 +285,15 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Index rewriting with computed (arithmetic result) index
-// Tests that index rewriting works with values computed from arithmetic
+// Test: Index rewriting with computed index (add of two args)
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: index_rewriting_computed_index
   tt.func @index_rewriting_computed_index(%a: i32, %b: i32) {
-    // Two f32 allocations in distinct: each 16384 bytes per buffer
-    // bytes_between_buffers = 32768, scale = 2
-    // First allocation: offset = 0, scale = 2
-    // For computed index %a + %b: new_idx = 2 * (%a + %b)
     // CHECK: memdesc<65536xi8
-    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf32
     // CHECK: arith.addi %arg0, %arg1
-    // Then the index rewriting:
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli
     // CHECK: memdesc_index
@@ -369,33 +302,25 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
-    // Use computed index from arithmetic
-    %computed = arith.addi %a, %b : i32
-    %4 = ttg.memdesc_index %1[%computed] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    %sum = arith.addi %a, %b : i32
+    %4 = ttg.memdesc_index %1[%sum] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     tt.return
   }
 }
 
 // -----
 
-// Test: Multiple MemDescIndexOp uses of the same alias with different indices
-// Each index should be independently rewritten
+// Test: Multiple index uses of the same allocation
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: multiple_index_uses
   tt.func @multiple_index_uses(%idx0: i32, %idx1: i32) {
-    // Two f32 allocations in distinct: each 16384 bytes per buffer
-    // bytes_between_buffers = 32768, scale = 2
-    // First allocation: offset = 0, scale = 2
-    // Both indices should be scaled by 2
     // CHECK: memdesc<65536xi8
-    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
-    // First index rewriting:
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf32
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli %arg0
     // CHECK: memdesc_index
-    // Second index rewriting:
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli %arg1
     // CHECK: memdesc_index
@@ -404,7 +329,6 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
-    // Multiple uses with different indices
     %4 = ttg.memdesc_index %1[%idx0] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     %5 = ttg.memdesc_index %1[%idx1] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     tt.return
@@ -413,19 +337,14 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: No index rewriting when scale=1 and offset=0 (no expansion needed)
-// When the largest allocation is used, no transformation is needed
+// Test: No index rewriting for the largest allocation (scale=1, offset=0)
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: no_index_rewriting_for_largest_alloc
   tt.func @no_index_rewriting_for_largest_alloc(%idx: i32) {
-    // f32 (16384 bytes) and f16 (8192 bytes) in shared
-    // bytes_between_buffers = 16384 (max size)
-    // f32 allocation: scale = 1, offset = 0 -> no rewriting needed
     // CHECK: memdesc<32768xi8
     // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
-    // No multiplication or addition for the f32 allocation's index
     // CHECK: memdesc_index %{{.*}}[%arg0]
     // CHECK-NOT: arith.muli %arg0
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
@@ -433,7 +352,6 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
-    // Use the largest allocation (f32) - should NOT have index rewriting
     %4 = ttg.memdesc_index %1[%idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -441,20 +359,15 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Index rewriting for smaller allocation in shared group
-// The smaller allocation should have its index scaled
+// Test: Index rewriting for the smaller allocation (scale=2)
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: index_rewriting_for_smaller_alloc
   tt.func @index_rewriting_for_smaller_alloc(%idx: i32) {
-    // f32 (16384 bytes) and f16 (8192 bytes) in shared
-    // bytes_between_buffers = 16384 (max size)
-    // f16 allocation: scale = 16384/8192 = 2, offset = 0 -> multiply by 2
     // CHECK: memdesc<32768xi8
     // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
-    // CHECK: local_alias{{.*}}memdesc<4x64x64xf16
-    // For f16 allocation:
+    // CHECK: local_alias{{.*}}memdesc<3x64x64xf16
     // CHECK: arith.constant 2 : i32
     // CHECK: arith.muli
     // CHECK: memdesc_index
@@ -463,7 +376,6 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
-    // Use the smaller allocation (f16) - should have index rewriting
     %4 = ttg.memdesc_index %2[%idx] : !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     tt.return
   }
@@ -471,11 +383,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Warp specialization with shared reuse group - partition args must have expanded types
-// Two allocations in shared group: f32 (16384 bytes) and f16 (8192 bytes)
-// f16 gets expanded from 2 to 4 buffers (scale=2)
-// The warp_specialize captures both allocations; partition args must reflect the new types
-// Additionally, memdesc_index inside the partition region must have index rewriting
+// Test: Warp specialize with shared reuse group
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
@@ -486,21 +394,18 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     // f32: no expansion (scale=1, offset=0)
     // CHECK: %[[ALIAS0:.*]] = tlx.local_alias{{.*}}memdesc<2x64x64xf32
     %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
-    // f16: expanded from 2 to 4 (scale=2, offset=0)
-    // CHECK: %[[ALIAS1:.*]] = tlx.local_alias{{.*}}memdesc<4x64x64xf16
+    // f16: expanded from 2 to 3 (scale=2, offset=0)
+    // CHECK: %[[ALIAS1:.*]] = tlx.local_alias{{.*}}memdesc<3x64x64xf16
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = shared : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>) -> !tlx.reuse_group<shared>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<shared>) -> ()
-    // Captures should have the expanded types
     // CHECK: ttg.warp_specialize(%[[ALIAS0]], %[[ALIAS1]],
     ttg.warp_specialize(%1, %2, %idx)
     default {
       ttg.warp_yield
     }
-    // Partition args must reflect the expanded types
-    // CHECK: partition0(%{{.*}}: !ttg.memdesc<2x64x64xf32, {{.*}}>, %{{.*}}: !ttg.memdesc<4x64x64xf16, {{.*}}>
+    // CHECK: partition0(%{{.*}}: !ttg.memdesc<2x64x64xf32, {{.*}}>, %{{.*}}: !ttg.memdesc<3x64x64xf16, {{.*}}>
     partition0(%arg0: !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, %arg1: !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, %arg_idx: i32) num_warps(1) {
-      // Index rewriting for the f16 block arg (scale=2)
       // CHECK: arith.constant 2 : i32
       // CHECK: arith.muli
       // CHECK: memdesc_index
@@ -513,12 +418,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
-// Test: Warp specialization with distinct reuse group - partition args must have expanded types
-// Two f32 allocations in distinct group: each 16384 bytes per buffer
-// First: scale=2, offset=0, shape: 2->4
-// Second: scale=2, offset=1, shape: 2->5
-// Both are captured by warp_specialize; partition args must reflect expanded types
-// Additionally, memdesc_index inside the partition must have index rewriting
+// Test: Warp specialize with distinct reuse group
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
@@ -526,29 +426,25 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   tt.func @warp_specialize_distinct_reuse_group(%idx: i32) {
     // CHECK: memdesc<65536xi8
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
-    // First: scale=2, offset=0, shape: 2->4
-    // CHECK: %[[ALIAS0:.*]] = tlx.local_alias{{.*}}memdesc<4x64x64xf32
+    // First: scale=2, offset=0, shape: 2->3
+    // CHECK: %[[ALIAS0:.*]] = tlx.local_alias{{.*}}memdesc<3x64x64xf32
     %1 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
-    // Second: scale=2, offset=1, shape: 2->5
-    // CHECK: %[[ALIAS1:.*]] = tlx.local_alias{{.*}}memdesc<5x64x64xf32
+    // Second: scale=2, offset=1, shape: 2->4
+    // CHECK: %[[ALIAS1:.*]] = tlx.local_alias{{.*}}memdesc<4x64x64xf32
     %2 = tlx.storage_alias_local_alloc %0 : !tlx.storage_alias_spec<smem> -> !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>
     %3 = tlx.reuse_group(%1, %2) group_kind = distinct : (!ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>) -> !tlx.reuse_group<distinct>
     tlx.set_buffer_overlap(%0, %3) : (!tlx.storage_alias_spec<smem>, !tlx.reuse_group<distinct>) -> ()
-    // Captures should have the expanded types
     // CHECK: ttg.warp_specialize(%[[ALIAS0]], %[[ALIAS1]],
     ttg.warp_specialize(%1, %2, %idx)
     default {
       ttg.warp_yield
     }
-    // Partition args must reflect the expanded types
-    // CHECK: partition0(%{{.*}}: !ttg.memdesc<4x64x64xf32, {{.*}}>, %{{.*}}: !ttg.memdesc<5x64x64xf32, {{.*}}>
+    // CHECK: partition0(%{{.*}}: !ttg.memdesc<3x64x64xf32, {{.*}}>, %{{.*}}: !ttg.memdesc<4x64x64xf32, {{.*}}>
     partition0(%arg0: !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, %arg1: !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable>, %arg_idx: i32) num_warps(1) {
-      // Index rewriting for first block arg (scale=2, offset=0)
       // CHECK: arith.constant 2 : i32
       // CHECK: arith.muli
       // CHECK: memdesc_index
       %4 = ttg.memdesc_index %arg0[%arg_idx] : !ttg.memdesc<2x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
-      // Index rewriting for second block arg (scale=2, offset=1)
       // CHECK: arith.constant 2 : i32
       // CHECK: arith.muli
       // CHECK: arith.constant 1 : i32
@@ -564,28 +460,18 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // -----
 
 // Test: Shared reuse group with 3 elements
-// shared(A, B, C) where:
-// A: 2x64x64xf32 = 16384 bytes per buffer
-// B: 2x32x32xf32 = 4096 bytes per buffer
-// C: 2x16x16xf32 = 1024 bytes per buffer
-// shared max = max(16384, 4096, 1024) = 16384
-// bytes_between_buffers = alignUp(16384, 128) = 16384
-// A: scale = 16384/16384 = 1, offset = 0, no expansion
-// B: scale = 16384/4096 = 4, offset = 0, shape: 2 -> 8
-// C: scale = 16384/1024 = 16, offset = 0, shape: 2 -> 32
-// Total backing alloc = 16384 * 2 = 32768
+// A: scale=1, offset=0 (no expansion)
+// B: scale = 16384/4096 = 4, offset = 0, shape: 2 -> 5
+// C: scale = 16384/1024 = 16, offset = 0, shape: 2 -> 17
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: shared_reuse_group_three_elements
   tt.func @shared_reuse_group_three_elements() {
     // CHECK: memdesc<32768xi8
-    // A: no expansion (scale=1, offset=0)
     // CHECK: local_alias{{.*}}memdesc<2x64x64xf32
-    // B: scale=4, offset=0, shape: 2 -> 8
-    // CHECK: local_alias{{.*}}memdesc<8x32x32xf32
-    // C: scale=16, offset=0, shape: 2 -> 32
-    // CHECK: local_alias{{.*}}memdesc<32x16x16xf32
+    // CHECK: local_alias{{.*}}memdesc<5x32x32xf32
+    // CHECK: local_alias{{.*}}memdesc<17x16x16xf32
     // CHECK-NOT: reuse_group
     // CHECK-NOT: set_buffer_overlap
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>
@@ -601,29 +487,18 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // -----
 
 // Test: Distinct reuse group with 3 elements
-// distinct(A, B, C) where:
-// A: 2x64x64xf32 = 16384 bytes per buffer
-// B: 2x64x64xf32 = 16384 bytes per buffer
-// C: 2x64x64xf32 = 16384 bytes per buffer
-// alignment = 128
-// distinct total = 16384 + 16384 + 16384 = 49152 (all already 128-aligned)
-// bytes_between_buffers = alignUp(49152, 128) = 49152
-// A: scale = 49152/16384 = 3, offset_slots = 0/16384 = 0, shape: 2 -> 6
-// B: scale = 49152/16384 = 3, offset_slots = 16384/16384 = 1, shape: 2 -> 2*3+1 = 7
-// C: scale = 49152/16384 = 3, offset_slots = 32768/16384 = 2, shape: 2 -> 2*3+2 = 8
-// Total backing alloc = 49152 * 2 = 98304
+// A: scale=3, offset=0, shape: 2 -> 4
+// B: scale=3, offset=1, shape: 2 -> 5
+// C: scale=3, offset=2, shape: 2 -> 6
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: distinct_reuse_group_three_elements
   tt.func @distinct_reuse_group_three_elements() {
     // CHECK: memdesc<98304xi8
-    // A: scale=3, offset=0, shape: 2 -> 6
+    // CHECK: local_alias{{.*}}memdesc<4x64x64xf32
+    // CHECK: local_alias{{.*}}memdesc<5x64x64xf32
     // CHECK: local_alias{{.*}}memdesc<6x64x64xf32
-    // B: scale=3, offset=1, shape: 2 -> 7
-    // CHECK: local_alias{{.*}}memdesc<7x64x64xf32
-    // C: scale=3, offset=2, shape: 2 -> 8
-    // CHECK: local_alias{{.*}}memdesc<8x64x64xf32
     // CHECK-NOT: reuse_group
     // CHECK-NOT: set_buffer_overlap
     %0 = tlx.storage_alias_spec storage = smem : !tlx.storage_alias_spec<smem>

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -107,13 +107,15 @@ inline int64_t getElementSize(Value element, int64_t alignment) {
   if (auto reuseGroupOp = element.getDefiningOp<ReuseGroupOp>()) {
     auto groupKind = reuseGroupOp.getGroupKind();
     auto elements = reuseGroupOp.getElements();
+    int64_t groupSize = reuseGroupOp.getGroupSize();
 
     if (groupKind == ReuseGroupKind::shared) {
       int64_t maxSize = 0;
       for (auto child : elements) {
         maxSize = std::max(maxSize, getElementSize(child, alignment));
       }
-      return maxSize;
+      // Multiply by group_size for subtiling
+      return maxSize * groupSize;
     } else { // distinct
       int64_t totalSize = 0;
       for (auto child : elements) {

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -140,40 +140,44 @@ def TLX_ReuseGroupOp : TLX_Op<"reuse_group", [Pure]> {
       stored in smem or tmem)
     - Internal nodes are nested `!tlx.reuse_group` values
 
+    The `group_size` attribute enables **subtiling** for mixed buffer counts.
+    When group_size > 1, K consecutive buffers are treated as a single logical
+    group for offset calculation. For example, if a tensor has 4 buffers and
+    group_size=2, buffers [0,1] form logical group 0 and [2,3] form group 1.
+
     Note: The storage_alias_spec is NOT part of this operation. Validation
     that all elements reference the same storage_alias_spec is performed
     by the SetBufferOverlapOp verifier when the overlap scheme is defined.
 
     Constraints:
     - At least one element must be provided.
-    - Nested reuse groups must have alternating group_kind (shared <-> distinct).
     - All elements must use the same storage kind (smem or tmem).
+    - group_size must be a positive integer (default: 1).
 
     Example:
     ```mlir
     // Simple shared group: A and B share the same memory
-    %group = tlx.reuse_group(%a, %b) group_kind = shared
+    %group = tlx.reuse_group(%a, %b) group_kind = shared, group_size = 1
              : (!ttg.memdesc<2x64x64xf32, ...>, !ttg.memdesc<2x64x64xbf16, ...>)
              -> !tlx.reuse_group<shared>
 
-    // Complex scheme: QK shared with (P distinct from alpha, l, m)
-    %inner = tlx.reuse_group(%p, %alpha, %l, %m) group_kind = distinct
-             : (...) -> !tlx.reuse_group<distinct>
-    %outer = tlx.reuse_group(%qk, %inner) group_kind = shared
-             : (!ttg.memdesc<...>, !tlx.reuse_group<distinct>)
-             -> !tlx.reuse_group<shared>
+    // Subtiling: P has 4 buffers, treated as 2 logical groups of 2
+    %subtiled = tlx.reuse_group(%p) group_kind = shared, group_size = 2
+                : (!ttg.memdesc<4x64x64xf32, ...>)
+                -> !tlx.reuse_group<shared>
     ```
   }];
 
   let arguments = (ins
     Variadic<TLX_ReuseGroupElement>:$elements,
-    TLX_ReuseGroupKindAttr:$group_kind
+    TLX_ReuseGroupKindAttr:$group_kind,
+    DefaultValuedAttr<I64Attr, "1">:$group_size
   );
 
   let results = (outs TLX_ReuseGroupType:$result);
 
   let assemblyFormat = [{
-    `(` $elements `)` `group_kind` `=` $group_kind attr-dict `:`
+    `(` $elements `)` `group_kind` `=` $group_kind (`,` `group_size` `=` $group_size^)? attr-dict `:`
     `(` qualified(type($elements)) `)` `->` qualified(type($result))
   }];
 

--- a/third_party/tlx/dialect/lib/IR/Ops.cpp
+++ b/third_party/tlx/dialect/lib/IR/Ops.cpp
@@ -92,6 +92,13 @@ LogicalResult ReuseGroupOp::verify() {
     return emitOpError("reuse_group requires at least one element");
   }
 
+  // Verify group_size is positive
+  int64_t groupSize = getGroupSize();
+  if (groupSize < 1) {
+    return emitOpError("group_size must be a positive integer, got ")
+           << groupSize;
+  }
+
   // Get result type properties
   auto resultType = cast<ReuseGroupType>(getResult().getType());
   auto expectedGroupKind = resultType.getGroupKind();

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasLowering.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasLowering.cpp
@@ -27,10 +27,13 @@ namespace tlx {
 // Forward declarations of functions from the individual passes
 LogicalResult computeOrValidateStorageAliasSizes(ModuleOp m);
 LogicalResult processBufferOverlapOps(
-    ModuleOp m, DenseMap<Value, std::pair<int64_t, int64_t>> &offsetMap);
+    ModuleOp m,
+    DenseMap<Value, std::tuple<int64_t, int64_t, int64_t>> &offsetMap);
 LogicalResult materializeStorageAliasAllocations(
-    ModuleOp m, const DenseMap<Value, std::pair<int64_t, int64_t>> &offsetMap,
-    DenseMap<Value, std::pair<int64_t, int64_t>> &localAliasOffsetMap);
+    ModuleOp m,
+    const DenseMap<Value, std::tuple<int64_t, int64_t, int64_t>> &offsetMap,
+    DenseMap<Value, std::tuple<int64_t, int64_t, int64_t>>
+        &localAliasOffsetMap);
 
 struct TLXStorageAliasLoweringPass
     : public impl::TLXStorageAliasLoweringBase<TLXStorageAliasLoweringPass> {
@@ -57,7 +60,7 @@ public:
     // The computed offsets are returned in a map to be applied during
     // materialization.
     LDBG("Step 2: Processing buffer overlap operations");
-    DenseMap<Value, std::pair<int64_t, int64_t>> offsetMap;
+    DenseMap<Value, std::tuple<int64_t, int64_t, int64_t>> offsetMap;
     if (failed(processBufferOverlapOps(m, offsetMap))) {
       signalPassFailure();
       return;
@@ -67,7 +70,7 @@ public:
     // This creates LocalAllocOp/TMEMAllocOp and LocalAliasOp.
     // The computed offsets are stored in localAliasOffsetMap for later use.
     LDBG("Step 3: Materializing storage alias allocations");
-    DenseMap<Value, std::pair<int64_t, int64_t>> localAliasOffsetMap;
+    DenseMap<Value, std::tuple<int64_t, int64_t, int64_t>> localAliasOffsetMap;
     if (failed(materializeStorageAliasAllocations(m, offsetMap,
                                                   localAliasOffsetMap))) {
       signalPassFailure();

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -543,7 +543,7 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("create_reuse_group",
            [](TritonOpBuilder &self, const std::vector<mlir::Value> &elements,
-              const std::string &groupKind) -> mlir::Value {
+              const std::string &groupKind, int64_t groupSize) -> mlir::Value {
              auto context = self.getBuilder().getContext();
 
              // Parse group kind
@@ -557,6 +557,13 @@ void init_triton_tlx_ir(py::module &&m) {
                                            ", expected 'shared' or 'distinct'");
              }
 
+             // Validate group_size
+             if (groupSize < 1) {
+               throw std::invalid_argument(
+                   "group_size must be a positive integer, got " +
+                   std::to_string(groupSize));
+             }
+
              // Create the result type
              auto resultType = tlx::ReuseGroupType::get(context, groupKindEnum);
 
@@ -564,10 +571,14 @@ void init_triton_tlx_ir(py::module &&m) {
              auto groupKindAttr =
                  tlx::ReuseGroupKindAttr::get(context, groupKindEnum);
 
+             // Create the group_size attribute
+             auto groupSizeAttr =
+                 self.getBuilder().getI64IntegerAttr(groupSize);
+
              // Create the operation (no storage_alias_spec - that's handled by
              // set_buffer_overlap)
-             return self.create<tlx::ReuseGroupOp>(resultType, elements,
-                                                   groupKindAttr);
+             return self.create<tlx::ReuseGroupOp>(
+                 resultType, elements, groupKindAttr, groupSizeAttr);
            })
       .def("create_set_buffer_overlap",
            [](TritonOpBuilder &self, mlir::Value storageAliasSpec,

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -359,6 +359,8 @@ class reuse_group:
         qk_tiles = tlx.local_alloc(..., reuse=spec)
         p_tiles = tlx.local_alloc(..., reuse=spec)
         alpha = tlx.local_alloc(..., reuse=spec)
+        l = tlx.local_alloc(..., reuse=spec)
+        m = tlx.local_alloc(..., reuse=spec)
 
         # QK and (P, alpha) share the same memory region
         # P and alpha are placed in distinct (non-overlapping) regions
@@ -366,20 +368,43 @@ class reuse_group:
         spec.set_buffer_overlap(
             tlx.reuse_group(
                 qk_tiles,
-                tlx.reuse_group(p_tiles, alpha, group_type=tlx.reuse_group_type.distinct),
-                group_type=tlx.reuse_group_type.shared,
+                tlx.reuse_group(
+                    p_tiles,
+                    alpha,
+                    l,
+                    m,
+                    group_type=tlx.reuse_group_type.distinct
+                ),
             )
         )
         ```
 
-    Constraints:
-        - Nested reuse_groups must have different group_type than the parent.
+    Example - Subtiling with group_size:
+        ```python
+        # P has 2 * NUM_SLICES buffers, QK has 2 buffers.
+        # We need to be able to access NUM_SLICES buffers at once as logically
+        # this subtiled buffer is a single iteration.
+        # With NUM_SLICES=2, P's buffers [0,1] map to QK[0], [2,3] map to QK[1]
+        spec.set_buffer_overlap(
+            tlx.reuse_group(
+                qk_tiles,
+                tlx.reuse_group(
+                    tlx.reuse_group(p_tiles, group_size=NUM_SLICES),  # Subtiling wrapper
+                    alpha,
+                    l,
+                    m,
+                    group_type=tlx.reuse_group_type.distinct,
+                ),
+            )
+        )
+        ```
     """
 
     def __init__(
         self,
         *args: "buffered_tensor | reuse_group",
-        group_type: reuse_group_type,
+        group_type: "reuse_group_type" = reuse_group_type.shared,
+        group_size: int = 1,
     ):
         """
         Initialize a reuse group.
@@ -389,30 +414,42 @@ class reuse_group:
             group_type: The relationship type for elements in this group.
                 - shared: Elements occupy the same logical memory region.
                 - distinct: Elements must be in non-overlapping regions.
+                Defaults to shared.
+            group_size: Multiplier for buffer grouping (subtiling). Defaults to 1.
+                When > 1, K consecutive buffers are treated as a single logical
+                group for offset calculation. This enables subtiling where a
+                logical buffer is divided into smaller chunks.
+
+                For example, with group_size=2 on a tensor with 4 buffers:
+                - Buffers [0,1] are treated as logical group 0
+                - Buffers [2,3] are treated as logical group 1
+
+                This changes buffer count validation: after dividing by group_size,
+                all elements at each level must have identical effective buffer counts.
 
         Raises:
             ValueError: If args is empty.
-            ValueError: If a nested reuse_group has the same group_type as this group.
+            ValueError: If group_size is not a positive integer.
             TypeError: If any element is not a buffered_tensor or reuse_group.
         """
         if len(args) == 0:
             raise ValueError("reuse_group requires at least one element")
 
-        # Validate element types and check for nested same group_type
+        # Validate group_size
+        group_size = tl._unwrap_if_constexpr(group_size)
+        if not isinstance(group_size, int) or group_size < 1:
+            raise ValueError(f"group_size must be a positive integer, got {group_size}")
+
+        # Validate element types
         args = tuple(tl._unwrap_if_constexpr(elem) for elem in args)
         for elem in args:
-            if isinstance(elem, reuse_group):
-                if elem.group_type == group_type:
-                    raise ValueError(f"Cannot nest reuse_group with the same group_type ({group_type.value}). "
-                                     f"Nested groups must alternate between 'shared' and 'distinct'.")
-            elif isinstance(elem, buffered_tensor):
-                pass  # Valid element type
-            else:
+            if not isinstance(elem, (reuse_group, buffered_tensor)):
                 raise TypeError(f"reuse_group elements must be buffered_tensor or reuse_group, "
                                 f"got {type(elem).__name__}")
 
         self._args = args
         self._group_type = group_type
+        self._group_size = group_size
 
     @property
     def args(self) -> tuple:
@@ -423,6 +460,15 @@ class reuse_group:
     def group_type(self) -> reuse_group_type:
         """The relationship type for this group (read-only)."""
         return self._group_type
+
+    @property
+    def group_size(self) -> int:
+        """The buffer grouping multiplier for subtiling (read-only).
+
+        Defaults to 1 (no grouping). When > 1, K consecutive buffers are
+        treated as a single logical group for offset calculation purposes.
+        """
+        return self._group_size
 
     def _flatten_ir(self, handles) -> None:
         """Recursively flatten IR handles from all elements in the group."""
@@ -454,10 +500,13 @@ class reuse_group:
 
         # Create the reuse_group IR operation
         group_kind = self._group_type.value  # "shared" or "distinct"
-        return builder.create_reuse_group(ir_elements, group_kind)
+        return builder.create_reuse_group(ir_elements, group_kind, self._group_size)
 
     def __repr__(self):
-        return f"reuse_group({self._args}, group_type={self._group_type.value})"
+        if self._group_size == 1:
+            return f"reuse_group({self._args}, group_type={self._group_type.value})"
+        else:
+            return f"reuse_group({self._args}, group_type={self._group_type.value}, group_size={self._group_size})"
 
 
 class reuse_group_ir_type(tl.base_type):


### PR DESCRIPTION
Adds support for subtiling by allowing you to specify group multiple buffers per group. This is needed to allow buffers of unequal sizes in the current design. With this change you can update the Blackwell FA kernel to fully work with the reuse groups. 


Differential Revision: D92849209


