### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[AMD] Enable f16 * mxfp scaled dot decomposition for gfx950 (#7839)'

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/include/triton/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -24,3 +24,8 @@ set(LLVM_TARGET_DEFINITIONS TritonGPUTypeInterfaces.td)
 mlir_tablegen(TypeInterfaces.h.inc -gen-type-interface-decls)
 mlir_tablegen(TypeInterfaces.cpp.inc -gen-type-interface-defs)
 add_public_tablegen_target(TritonGPUTypeInterfacesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TritonGPUOpInterfaces.td)
+mlir_tablegen(OpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(OpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(TritonGPUOpInterfacesIncGen)

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h
@@ -1,8 +1,11 @@
 #ifndef TRITON_GPU_DIALECT_INTERFACES_H
 #define TRITON_GPU_DIALECT_INTERFACES_H
 
+#include "mlir/IR/OpDefinition.h"
+
 // clang-format off
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Dialect/TritonGPU/IR/OpInterfaces.h.inc"
 #include "triton/Dialect/TritonGPU/IR/AttrInterfaces.h.inc"
 // clang-format on
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
@@ -1,0 +1,29 @@
+#ifndef TRITONGPU_OP_INTERFACES
+#define TRITONGPU_OP_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def UpcastFpOpInterface : OpInterface<"UpcastFpOpInterface"> {
+    let description = [{
+        This interface is for operations that upcast floating-point numbers.
+    }];
+
+    let cppNamespace = "::mlir::triton::gpu";
+
+    let methods = [
+        InterfaceMethod<
+            /*desc=*/"Infer destination encoding",
+            /*retType=*/"mlir::Attribute",
+            /*methodName=*/"inferDstEncoding",
+            /*args=*/(ins "unsigned":$opIdx, "mlir::Attribute":$srcEnc)
+        >,
+        InterfaceMethod<
+            /*desc=*/"Infer operand encoding from dst encoding",
+            /*retType=*/"mlir::Attribute",
+            /*methodName=*/"inferSrcEncoding",
+            /*args=*/(ins "unsigned":$opIdx, "mlir::Attribute":$dstEnc)
+        >
+    ];
+}
+
+#endif // TRITONGPU_OP_INTERFACES

--- a/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
@@ -1,6 +1,45 @@
 #include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace mlir::triton::gpu {
+
+class DecomposeScaledBlocked : public OpRewritePattern<DotScaledOp> {
+public:
+  DecomposeScaledBlocked(MLIRContext *context, PatternBenefit benefit)
+      : OpRewritePattern<DotScaledOp>(context, benefit) {}
+
+  LogicalResult matchAndRewrite(DotScaledOp scaledDotOp,
+                                PatternRewriter &rewriter) const override;
+
+protected:
+  FloatType getComputeType(ScaleDotElemType aType, ScaleDotElemType bType,
+                           PatternRewriter &rewriter) const;
+  TypedValue<RankedTensorType> scaleTo16(PatternRewriter &rewriter,
+                                         TypedValue<RankedTensorType> scale,
+                                         FloatType computeType) const;
+  TypedValue<RankedTensorType>
+  broadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
+                 ModuleOp mod, TypedValue<RankedTensorType> scale,
+                 int dim) const;
+  TypedValue<RankedTensorType> maskNan(PatternRewriter &rewriter,
+                                       DotScaledOp scaledDotOp,
+                                       TypedValue<RankedTensorType> mxfp,
+                                       TypedValue<RankedTensorType> scale,
+                                       int dim) const;
+  virtual TypedValue<RankedTensorType> scaleArg(PatternRewriter &rewriter,
+                                                DotScaledOp scaledDotOp,
+                                                int opIdx,
+                                                FloatType computeType) const;
+  TypedValue<RankedTensorType>
+  cvtDotOperand(PatternRewriter &rewriter, DotScaledOp scaledDotOp, int opIdx,
+                TypedValue<RankedTensorType> v) const;
+  TypedValue<RankedTensorType>
+  extendAndBroadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
+                          TypedValue<RankedTensorType> &scale,
+                          FloatType computeType, RankedTensorType dstType,
+                          int opIdx) const;
+  static SmallVector<int, 2> getTransposeOrder(int rank);
+};
 
 void populateDecomposeScaledBlockedPatterns(mlir::RewritePatternSet &patterns,
                                             int benefit);

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonAnalysis
   TritonGPUTableGen
   TritonGPUAttrDefsIncGen
   TritonGPUTypeInterfacesIncGen
+  TritonGPUOpInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -9,6 +9,7 @@ add_triton_library(TritonGPUIR
   TritonGPUTableGen
   TritonGPUAttrDefsIncGen
   TritonGPUTypeInterfacesIncGen
+  TritonGPUOpInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -27,6 +27,7 @@
 
 // Include TableGen'erated code
 #include "triton/Dialect/TritonGPU/IR/Dialect.cpp.inc"
+#include "triton/Dialect/TritonGPU/IR/OpInterfaces.cpp.inc"
 #include "triton/Dialect/TritonGPU/IR/TypeInterfaces.cpp.inc"
 
 using namespace mlir;

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -13,9 +13,9 @@ using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 
-namespace {
+namespace mlir::triton::gpu {
 
-SmallVector<int, 2> getTransposeOrder(int rank) {
+SmallVector<int, 2> DecomposeScaledBlocked::getTransposeOrder(int rank) {
   assert(rank >= 2);
   auto transOrder = llvm::to_vector<2>(llvm::seq<int>(rank - 2));
   transOrder.push_back(rank - 1);
@@ -23,235 +23,235 @@ SmallVector<int, 2> getTransposeOrder(int rank) {
   return transOrder;
 }
 
-class DecomposeScaledBlocked : public OpRewritePattern<DotScaledOp> {
+LogicalResult
+DecomposeScaledBlocked::matchAndRewrite(DotScaledOp scaledDotOp,
+                                        PatternRewriter &rewriter) const {
+  if (isa_and_nonnull<MmaEncodingTrait>(
+          scaledDotOp.getResult().getType().getEncoding()))
+    return failure();
 
-public:
-  DecomposeScaledBlocked(MLIRContext *context, int benefit)
-      : OpRewritePattern<DotScaledOp>(context, benefit) {}
+  // TODO: add support for m/n packed formats.
+  if (!scaledDotOp.getLhsKPack() || !scaledDotOp.getRhsKPack())
+    return failure();
 
-  LogicalResult matchAndRewrite(DotScaledOp scaledDotOp,
-                                PatternRewriter &rewriter) const override {
-    auto resTy = cast<RankedTensorType>(scaledDotOp.getType());
-    if (mlir::isa<NvidiaMmaEncodingAttr>(resTy.getEncoding()))
-      return failure();
+  // Types
+  auto computeType = getComputeType(scaledDotOp.getAElemType(),
+                                    scaledDotOp.getBElemType(), rewriter);
 
-    if (isa_and_nonnull<MmaEncodingTrait>(
-            scaledDotOp.getResult().getType().getEncoding()))
-      return failure();
+  auto scaledA = scaleArg(rewriter, scaledDotOp, 0, computeType);
+  scaledA = cvtDotOperand(rewriter, scaledDotOp, 0, scaledA);
+  auto scaledB = scaleArg(rewriter, scaledDotOp, 1, computeType);
+  scaledB = cvtDotOperand(rewriter, scaledDotOp, 1, scaledB);
+  auto newDot = rewriter.create<DotOp>(scaledDotOp.getLoc(), scaledA, scaledB,
+                                       scaledDotOp.getC());
 
-    // TODO: add support for m/n packed formats.
-    if (!scaledDotOp.getLhsKPack() || !scaledDotOp.getRhsKPack())
-      return failure();
+  rewriter.replaceOpWithNewOp<ConvertLayoutOp>(scaledDotOp,
+                                               scaledDotOp.getType(), newDot);
+  return success();
+}
 
-    // Types
-    auto computeType = getComputeType(scaledDotOp.getAElemType(),
-                                      scaledDotOp.getBElemType(), rewriter);
-    auto loc = scaledDotOp.getLoc();
+FloatType
+DecomposeScaledBlocked::getComputeType(ScaleDotElemType aType,
+                                       ScaleDotElemType bType,
+                                       PatternRewriter &rewriter) const {
+  if (aType == ScaleDotElemType::FP16 || bType == ScaleDotElemType::FP16)
+    return rewriter.getF16Type();
+  return rewriter.getBF16Type();
+}
 
-    auto cvtDotOperand = [&](TypedValue<RankedTensorType> v,
-                             int opIdx) -> TypedValue<RankedTensorType> {
-      auto *ctx = rewriter.getContext();
-      auto retEnc = scaledDotOp.getType().getEncoding();
-      auto vType = v.getType();
-      auto encoding = DotOperandEncodingAttr::get(ctx, opIdx, retEnc,
-                                                  vType.getElementType());
-      auto retTy = vType.cloneWithEncoding(encoding);
-      return rewriter.create<ConvertLayoutOp>(loc, retTy, v);
-    };
+TypedValue<RankedTensorType>
+DecomposeScaledBlocked::scaleTo16(PatternRewriter &rewriter,
+                                  TypedValue<RankedTensorType> scale,
+                                  FloatType computeType) const {
+  auto loc = scale.getLoc();
+  auto scaleTy = scale.getType();
+  assert(computeType == rewriter.getBF16Type() ||
+         computeType == rewriter.getF16Type());
 
-    auto scaledA = scaleArg(rewriter, scaledDotOp, 0, computeType);
-    scaledA = cvtDotOperand(scaledA, 0);
-    auto scaledB = scaleArg(rewriter, scaledDotOp, 1, computeType);
-    scaledB = cvtDotOperand(scaledB, 1);
-    auto newDot = rewriter.create<DotOp>(scaledDotOp.getLoc(), scaledA, scaledB,
-                                         scaledDotOp.getC());
+  // Choose an fp type that can fit the scale value.
+  FloatType largeFpType = computeType == rewriter.getF16Type()
+                              ? rewriter.getF32Type()
+                              : computeType;
+  int intWidth = largeFpType.getIntOrFloatBitWidth();
+  auto intType = rewriter.getIntegerType(intWidth);
 
-    rewriter.replaceOpWithNewOp<ConvertLayoutOp>(scaledDotOp,
-                                                 scaledDotOp.getType(), newDot);
-    return success();
+  auto zexted =
+      rewriter.create<arith::ExtUIOp>(loc, scaleTy.clone(intType), scale);
+  // getFpMantissaWidth() returns the number of bits in the mantissa plus the
+  // sign bit!
+  int shiftValue = largeFpType.getFPMantissaWidth() - 1;
+  auto shiftConst =
+      rewriter.create<arith::ConstantIntOp>(loc, shiftValue, intWidth);
+  auto shift =
+      rewriter.create<SplatOp>(loc, scaleTy.clone(intType), shiftConst);
+  auto shlRes = rewriter.create<arith::ShLIOp>(loc, zexted, shift);
+  Value scaleFP =
+      rewriter.create<BitcastOp>(loc, scaleTy.clone(largeFpType), shlRes);
+  if (largeFpType != computeType) {
+    scaleFP = rewriter.create<arith::TruncFOp>(loc, scaleTy.clone(computeType),
+                                               scaleFP);
+  }
+  return cast<TypedValue<RankedTensorType>>(scaleFP);
+}
+
+TypedValue<RankedTensorType> DecomposeScaledBlocked::broadcastScale(
+    PatternRewriter &rewriter, DotScaledOp scaledDotOp, ModuleOp mod,
+    TypedValue<RankedTensorType> scale, int dim) const {
+  auto *ctx = rewriter.getContext();
+  auto loc = scale.getLoc();
+  auto scaleTy = scale.getType();
+  auto rank = scaleTy.getRank();
+  // 2.1) Expand dims along the last dimension
+  {
+    // 2.1.1) Find default encoding for ExpandDims
+    auto shape = to_vector(scaleTy.getShape());
+    shape.insert(shape.end(), 1);
+    auto nWarps = lookupNumWarps(scaledDotOp);
+    auto threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
+    auto numCTAs = TritonGPUDialect::getNumCTAs(mod);
+    auto blockedEnc =
+        getDefaultBlockedEncoding(ctx, shape, nWarps, threadsPerWarp, numCTAs);
+    // 2.1.2) Cast scale16 to SliceEncoding
+    auto sliceEnc = SliceEncodingAttr::get(ctx, rank, blockedEnc);
+    auto sliceType = scaleTy.cloneWithEncoding(sliceEnc);
+    scale = rewriter.create<ConvertLayoutOp>(loc, sliceType, scale);
+  }
+  auto expandScale = rewriter.create<ExpandDimsOp>(loc, scale, rank);
+  // 2.2) Broadcast the dimension to size 32
+  auto scaleShape = to_vector(scaleTy.getShape());
+  scaleShape.push_back(32);
+  auto broadcastScale = rewriter.create<BroadcastOp>(
+      loc, expandScale.getType().clone(scaleShape), expandScale);
+  // 2.3) Transpose the dimension to the scaled dimension
+  auto transposeOrder = llvm::to_vector(llvm::seq<int32_t>(rank));
+  transposeOrder.insert(transposeOrder.begin() + dim + 1, rank);
+  auto transposedScale =
+      rewriter.create<TransOp>(loc, broadcastScale, transposeOrder);
+  // 2.4) Reshape to the shape of v
+  scaleShape.pop_back();
+  scaleShape[dim] *= 32;
+  auto reshapeScale =
+      rewriter.create<ReshapeOp>(loc, scaleShape, transposedScale);
+  return reshapeScale;
+}
+
+TypedValue<RankedTensorType> DecomposeScaledBlocked::maskNan(
+    PatternRewriter &rewriter, DotScaledOp scaledDotOp,
+    TypedValue<RankedTensorType> mxfp, TypedValue<RankedTensorType> scale,
+    int dim) const {
+  // Skip NaN checks if fastMath
+  if (scaledDotOp.getFastMath())
+    return mxfp;
+
+  // Implement tl.where(scale == 0xFF, float("nan"), mxfp)
+  auto loc = scale.getLoc();
+  auto mod = scaledDotOp->getParentOfType<ModuleOp>();
+
+  // Scale is NaN
+  auto scaleTy = scale.getType();
+  auto constFF = rewriter.create<arith::ConstantOp>(
+      loc, scaleTy,
+      DenseElementsAttr::get(scaleTy,
+                             APInt(scaleTy.getElementTypeBitWidth(), 0xff)));
+  auto scaleIsNan = cast<TypedValue<RankedTensorType>>(
+      rewriter
+          .create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, scale, constFF)
+          .getResult());
+  auto cond = broadcastScale(rewriter, scaledDotOp, mod, scaleIsNan, dim);
+  // Make scale is NaN compatible with mxfp
+  auto condTy = cond.getType();
+  condTy = condTy.cloneWithEncoding(mxfp.getType().getEncoding());
+  cond = rewriter.create<ConvertLayoutOp>(loc, condTy, cond);
+
+  // Create NaN
+  auto mxfpTy = mxfp.getType();
+  auto nan = APFloat::getNaN(
+      cast<FloatType>(mxfpTy.getElementType()).getFloatSemantics());
+  auto constNan = rewriter.create<arith::ConstantOp>(
+      loc, mxfpTy, DenseElementsAttr::get(mxfpTy, nan));
+
+  auto result = rewriter.create<arith::SelectOp>(loc, cond, constNan, mxfp);
+  return cast<TypedValue<RankedTensorType>>(result.getResult());
+}
+
+TypedValue<RankedTensorType>
+DecomposeScaledBlocked::scaleArg(PatternRewriter &rewriter,
+                                 DotScaledOp scaledDotOp, int opIdx,
+                                 FloatType computeType) const {
+  auto v = opIdx == 0 ? scaledDotOp.getA() : scaledDotOp.getB();
+  auto scale = opIdx == 0 ? scaledDotOp.getAScale() : scaledDotOp.getBScale();
+  auto isFp4 =
+      ScaleDotElemType::E2M1 ==
+      (opIdx == 0 ? scaledDotOp.getAElemType() : scaledDotOp.getBElemType());
+
+  auto loc = v.getLoc();
+  auto rank = v.getType().getRank();
+  auto kDim = opIdx == 0 ? rank - 1 : rank - 2;
+
+  // 0) Upcast value to computeType (fp16/bf16)
+  if (isFp4) {
+    // We always pack along the fastest moving dimension, kDim
+    v = rewriter.create<Fp4ToFpOp>(loc, v, computeType, kDim);
+  } else {
+    auto vType16 = v.getType().clone(computeType);
+    v = cast<TypedValue<RankedTensorType>>(
+        rewriter.create<FpToFpOp>(loc, vType16, v).getResult());
+  }
+  if (!scale)
+    return v;
+
+  // 1) Cast scale to fp16/bf16, broadcast it and convert its layout
+  auto reshapeScale = extendAndBroadcastScale(rewriter, scaledDotOp, scale,
+                                              computeType, v.getType(), opIdx);
+
+  // 2) Multiply
+  auto mxfp = cast<TypedValue<RankedTensorType>>(
+      rewriter.create<arith::MulFOp>(loc, v, reshapeScale).getResult());
+
+  // 3) If the scale is NaN, return NaN, else return the scaled value.
+  return maskNan(rewriter, scaledDotOp, mxfp, scale, kDim);
+}
+
+TypedValue<RankedTensorType> DecomposeScaledBlocked::extendAndBroadcastScale(
+    PatternRewriter &rewriter, DotScaledOp scaledDotOp,
+    TypedValue<RankedTensorType> &scale, FloatType computeType,
+    RankedTensorType dstType, int opIdx) const {
+  auto loc = scale.getLoc();
+  auto mod = scaledDotOp->getParentOfType<ModuleOp>();
+  auto v = opIdx == 0 ? scaledDotOp.getA() : scaledDotOp.getB();
+  auto rank = v.getType().getRank();
+  auto kDim = opIdx == 0 ? rank - 1 : rank - 2;
+
+  // For some weird reason, we take the scale with shape as if it were coming
+  // from the lhs even when it's the rhs. In a normal world, we should accept
+  // this parameter transposed, as we do with the mxfp.
+  //
+  // Notice: this is an inplace change.
+  if (opIdx == 1) {
+    auto order = getTransposeOrder(rank);
+    scale = rewriter.create<TransOp>(loc, scale, order);
   }
 
-private:
-  FloatType getComputeType(ScaleDotElemType aType, ScaleDotElemType bType,
-                           PatternRewriter &rewriter) const {
-    if (aType == ScaleDotElemType::FP16 || bType == ScaleDotElemType::FP16)
-      return rewriter.getF16Type();
-    return rewriter.getBF16Type();
-  }
+  // 1) Cast scale to compute type (fp16/bf16)
+  auto scale16 = scaleTo16(rewriter, scale, computeType);
 
-  TypedValue<RankedTensorType> scaleTo16(PatternRewriter &rewriter,
-                                         TypedValue<RankedTensorType> scale,
-                                         FloatType computeType) const {
-    auto loc = scale.getLoc();
-    auto scaleTy = scale.getType();
-    assert(computeType == rewriter.getBF16Type() ||
-           computeType == rewriter.getF16Type());
+  // 2) Broadcast scale to the same shape as v and convert the layout
+  auto reshapeScale = broadcastScale(rewriter, scaledDotOp, mod, scale16, kDim);
+  return rewriter.create<ConvertLayoutOp>(loc, dstType, reshapeScale);
+}
 
-    // Choose an fp type that can fit the scale value.
-    FloatType largeFpType = computeType == rewriter.getF16Type()
-                                ? rewriter.getF32Type()
-                                : computeType;
-    int intWidth = largeFpType.getIntOrFloatBitWidth();
-    auto intType = rewriter.getIntegerType(intWidth);
-
-    auto zexted =
-        rewriter.create<arith::ExtUIOp>(loc, scaleTy.clone(intType), scale);
-    // getFpMantissaWidth() returns the number of bits in the mantissa plus the
-    // sign bit!
-    int shiftValue = largeFpType.getFPMantissaWidth() - 1;
-    auto shiftConst =
-        rewriter.create<arith::ConstantIntOp>(loc, shiftValue, intWidth);
-    auto shift =
-        rewriter.create<SplatOp>(loc, scaleTy.clone(intType), shiftConst);
-    auto shlRes = rewriter.create<arith::ShLIOp>(loc, zexted, shift);
-    Value scaleFP =
-        rewriter.create<BitcastOp>(loc, scaleTy.clone(largeFpType), shlRes);
-    if (largeFpType != computeType) {
-      scaleFP = rewriter.create<arith::TruncFOp>(
-          loc, scaleTy.clone(computeType), scaleFP);
-    }
-    return cast<TypedValue<RankedTensorType>>(scaleFP);
-  }
-
-  TypedValue<RankedTensorType>
-  broadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
-                 ModuleOp mod, TypedValue<RankedTensorType> scale,
-                 int dim) const {
-    auto *ctx = rewriter.getContext();
-    auto loc = scale.getLoc();
-    auto scaleTy = scale.getType();
-    auto rank = scaleTy.getRank();
-    // 2.1) Expand dims along the last dimension
-    {
-      // 2.1.1) Find default encoding for ExpandDims
-      auto shape = to_vector(scaleTy.getShape());
-      shape.insert(shape.end(), 1);
-      auto nWarps = lookupNumWarps(scaledDotOp);
-      auto threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
-      auto numCTAs = TritonGPUDialect::getNumCTAs(mod);
-      auto blockedEnc = getDefaultBlockedEncoding(ctx, shape, nWarps,
-                                                  threadsPerWarp, numCTAs);
-      // 2.1.2) Cast scale16 to SliceEncoding
-      auto sliceEnc = SliceEncodingAttr::get(ctx, rank, blockedEnc);
-      auto sliceType = scaleTy.cloneWithEncoding(sliceEnc);
-      scale = rewriter.create<ConvertLayoutOp>(loc, sliceType, scale);
-    }
-    auto expandScale = rewriter.create<ExpandDimsOp>(loc, scale, rank);
-    // 2.2) Broadcast the dimension to size 32
-    auto scaleShape = to_vector(scaleTy.getShape());
-    scaleShape.push_back(32);
-    auto broadcastScale = rewriter.create<BroadcastOp>(
-        loc, expandScale.getType().clone(scaleShape), expandScale);
-    // 2.3) Transpose the dimension to the scaled dimension
-    auto transposeOrder = llvm::to_vector(llvm::seq<int32_t>(rank));
-    transposeOrder.insert(transposeOrder.begin() + dim + 1, rank);
-    auto transposedScale =
-        rewriter.create<TransOp>(loc, broadcastScale, transposeOrder);
-    // 2.4) Reshape to the shape of v
-    scaleShape.pop_back();
-    scaleShape[dim] *= 32;
-    auto reshapeScale =
-        rewriter.create<ReshapeOp>(loc, scaleShape, transposedScale);
-    return reshapeScale;
-  }
-
-  TypedValue<RankedTensorType> maskNan(PatternRewriter &rewriter,
-                                       DotScaledOp scaledDotOp, ModuleOp mod,
-                                       TypedValue<RankedTensorType> mxfp,
-                                       TypedValue<RankedTensorType> scale,
-                                       int dim) const {
-    // Implement tl.where(scale == 0xFF, float("nan"), mxfp)
-    auto loc = scale.getLoc();
-
-    // Scale is NaN
-    auto scaleTy = scale.getType();
-    auto constFF = rewriter.create<arith::ConstantOp>(
-        loc, scaleTy,
-        DenseElementsAttr::get(scaleTy,
-                               APInt(scaleTy.getElementTypeBitWidth(), 0xff)));
-    auto scaleIsNan = cast<TypedValue<RankedTensorType>>(
-        rewriter
-            .create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, scale,
-                                   constFF)
-            .getResult());
-    auto cond = broadcastScale(rewriter, scaledDotOp, mod, scaleIsNan, dim);
-    // Make scale is NaN compatible with mxfp
-    auto condTy = cond.getType();
-    condTy = condTy.cloneWithEncoding(mxfp.getType().getEncoding());
-    cond = rewriter.create<ConvertLayoutOp>(loc, condTy, cond);
-
-    // Create NaN
-    auto mxfpTy = mxfp.getType();
-    auto nan = APFloat::getNaN(
-        cast<FloatType>(mxfpTy.getElementType()).getFloatSemantics());
-    auto constNan = rewriter.create<arith::ConstantOp>(
-        loc, mxfpTy, DenseElementsAttr::get(mxfpTy, nan));
-
-    auto result = rewriter.create<arith::SelectOp>(loc, cond, constNan, mxfp);
-    return cast<TypedValue<RankedTensorType>>(result.getResult());
-  }
-
-  TypedValue<RankedTensorType> scaleArg(PatternRewriter &rewriter,
-                                        DotScaledOp scaledDotOp, int opIdx,
-                                        FloatType computeType) const {
-    auto v = opIdx == 0 ? scaledDotOp.getA() : scaledDotOp.getB();
-    auto scale = opIdx == 0 ? scaledDotOp.getAScale() : scaledDotOp.getBScale();
-    auto isFp4 =
-        ScaleDotElemType::E2M1 ==
-        (opIdx == 0 ? scaledDotOp.getAElemType() : scaledDotOp.getBElemType());
-    auto fastMath = scaledDotOp.getFastMath();
-
-    auto *ctx = rewriter.getContext();
-    auto loc = v.getLoc();
-    auto mod = scaledDotOp->getParentOfType<ModuleOp>();
-    auto rank = v.getType().getRank();
-    auto kDim = opIdx == 0 ? rank - 1 : rank - 2;
-
-    // 0) Upcast value to computeType (fp16/bf16)
-    if (isFp4) {
-      // We always pack along the fastest moving dimension, kDim
-      v = rewriter.create<Fp4ToFpOp>(loc, v, computeType, kDim);
-    } else {
-      auto vType16 = v.getType().clone(computeType);
-      v = cast<TypedValue<RankedTensorType>>(
-          rewriter.create<FpToFpOp>(loc, vType16, v).getResult());
-    }
-    if (!scale)
-      return v;
-
-    // For some weird reason, we take the scale with shape as if it were coming
-    // from the lhs even when it's the rhs. In a normal world, we should accept
-    // this parameter transposed, as we do with the mxfp.
-    if (opIdx == 1) {
-      auto order = getTransposeOrder(rank);
-      scale = rewriter.create<TransOp>(loc, scale, order);
-    }
-
-    // 1) Cast scale to compute type (fp16/bf16)
-    auto scale16 = scaleTo16(rewriter, scale, computeType);
-
-    // 2) Broadcast scale to the same shape and layout as v
-    auto reshapeScale =
-        broadcastScale(rewriter, scaledDotOp, mod, scale16, kDim);
-    reshapeScale =
-        rewriter.create<ConvertLayoutOp>(loc, v.getType(), reshapeScale);
-
-    // 3) Multiply
-    auto mxfp = cast<TypedValue<RankedTensorType>>(
-        rewriter.create<arith::MulFOp>(loc, v, reshapeScale).getResult());
-
-    // Skip NaN checks if fastMath
-    if (fastMath)
-      return mxfp;
-
-    // 4) If the scale is NaN, return NaN, else return the scaled value.
-    return maskNan(rewriter, scaledDotOp, mod, mxfp, scale, kDim);
-  }
-};
-
-} // namespace
-
-namespace mlir::triton::gpu {
+TypedValue<RankedTensorType>
+DecomposeScaledBlocked::cvtDotOperand(PatternRewriter &rewriter,
+                                      DotScaledOp scaledDotOp, int opIdx,
+                                      TypedValue<RankedTensorType> v) const {
+  auto *ctx = rewriter.getContext();
+  auto retEnc = scaledDotOp.getType().getEncoding();
+  auto vType = v.getType();
+  auto encoding =
+      DotOperandEncodingAttr::get(ctx, opIdx, retEnc, vType.getElementType());
+  auto retTy = vType.cloneWithEncoding(encoding);
+  return rewriter.create<ConvertLayoutOp>(v.getLoc(), retTy, v);
+}
 
 void populateDecomposeScaledBlockedPatterns(RewritePatternSet &patterns,
                                             int benefit) {

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -17,6 +17,7 @@
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
@@ -1446,7 +1447,9 @@ void LayoutRematerialization::hoistConvertDotOperand(
   // threads We do views and elementwise pure ops for now
   auto noDataMovement = [](Operation *op) {
     return (op->hasTrait<OpTrait::Elementwise>() && isMemoryEffectFree(op)) ||
-           isa<BroadcastOp, Fp4ToFpOp, ConvertLayoutOp>(op) || isView(op);
+           isa<BroadcastOp, Fp4ToFpOp, ConvertLayoutOp, UpcastFpOpInterface>(
+               op) ||
+           isView(op);
   };
   // Stop the slice as soon as we find an operation that cannot be done without
   // data movement between threads

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -525,6 +525,10 @@ Attribute inferSrcEncoding(Operation *op, Attribute encoding) {
     if (!isa<triton::gpu::BlockedEncodingAttr>(encoding))
       return {};
   }
+
+  if (isa<triton::gpu::UpcastFpOpInterface>(op))
+    return {};
+
   if (op->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
       op->hasTrait<mlir::OpTrait::SameLoadStoreOperandsAndResultEncoding>() ||
       op->hasTrait<mlir::OpTrait::Elementwise>() ||
@@ -558,6 +562,9 @@ Attribute inferDstEncoding(Operation *op, Attribute encoding) {
     if (!isa<triton::gpu::BlockedEncodingAttr>(encoding))
       return {};
   }
+  if (isa<triton::gpu::UpcastFpOpInterface>(op))
+    return {};
+
   if (op->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
       op->hasTrait<mlir::OpTrait::SameLoadStoreOperandsAndResultEncoding>() ||
       op->hasTrait<mlir::OpTrait::Elementwise>() ||
@@ -957,7 +964,13 @@ LogicalResult getConvertBackwardSlice(
         continue;
       }
       for (auto [i, operand] : llvm::enumerate(definingOp->getOpOperands())) {
-        auto srcEncoding = inferSrcEncoding(definingOp, encoding);
+        Attribute srcEncoding;
+        if (auto upcast =
+                dyn_cast<triton::gpu::UpcastFpOpInterface>(definingOp)) {
+          srcEncoding = upcast.inferSrcEncoding(i, encoding);
+        } else {
+          srcEncoding = inferSrcEncoding(definingOp, encoding);
+        }
         if (!srcEncoding)
           return failure();
         // If the infered layout matches the original one we don't need to keep

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
@@ -1,0 +1,99 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul="arch-generation-name=gfx950 matrix-instruction-size=0" -tritongpu-remove-layout-conversions | FileCheck %s --check-prefixes CHECK
+
+// CHECK-LABEL: mfma_dot_scaled_bf16_fp8e4
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_dot_scaled_bf16_fp8e4(
+      %arg0: tensor<32x64x!tt.ptr<bf16>, #blocked2>,
+      %arg1: tensor<64x32x!tt.ptr<f8E4M3FN>, #blocked>,
+      %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
+      %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
+    ) {
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
+    // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf8E4M3FN, #blocked{{.*}}> -> tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
+    // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
+    // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
+    // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
+    // CHECK: %[[EPS:.*]] = tt.expand_dims %[[BS]] {axis = 2 : i32} : tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32x1xbf16, #linear{{.*}}>
+    // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x32x1xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
+    // CHECK: %[[TBCS:.*]] = tt.trans %[[BCS]] {order = array<i32: 0, 2, 1>} : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
+    // CHECK: %[[RTBCS:.*]] = tt.reshape %[[TBCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[UB:.*]] = amdgpu.scaled_upcast_fp8 %[[B]] scale %[[RTBCS]] : tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[SELECTEDB:.*]] = arith.select %{{.*}}, %{{.*}}, %[[UB]] : tensor<64x32xi1, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[A:.*]] = ttg.convert_layout %{{.*}} : tensor<32x64xbf16, #blocked{{.*}}> -> tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    // CHECK: %{{.*}} = tt.dot %[[A]], %[[SELECTEDB]], %{{.*}} : tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<32x32xf32, #mma>
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %1 = tt.load %arg0 : tensor<32x64x!tt.ptr<bf16>, #blocked2>
+    %2 = tt.load %arg1 : tensor<64x32x!tt.ptr<f8E4M3FN>, #blocked>
+    %3 = tt.load %arg2 : tensor<32x2x!tt.ptr<i8>, #blocked1>
+    %4 = tt.dot_scaled %1, %2 scale %3, %cst lhs = bf16 rhs = e4m3 {fastMath = false} : tensor<32x64xbf16, #blocked2> * tensor<64x32xf8E4M3FN, #blocked>, tensor<32x2xi8, #blocked1> -> tensor<32x32xf32, #blocked>
+    tt.store %arg3, %4 : tensor<32x32x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: mfma_dot_scaled_bf16_fp8e4_fast_math
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_dot_scaled_bf16_fp8e4_fast_math(
+      %arg0: tensor<32x64x!tt.ptr<bf16>, #blocked2>,
+      %arg1: tensor<64x32x!tt.ptr<f8E4M3FN>, #blocked>,
+      %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
+      %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
+    ) {
+    // CHECK: %[[UB:.*]] = amdgpu.scaled_upcast_fp8 %{{.*}} scale %{{.*}} : tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %{{.*}} = tt.dot %{{.*}}, %[[UB]], %{{.*}} : tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<32x32xf32, #mma>
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %1 = tt.load %arg0 : tensor<32x64x!tt.ptr<bf16>, #blocked2>
+    %2 = tt.load %arg1 : tensor<64x32x!tt.ptr<f8E4M3FN>, #blocked>
+    %3 = tt.load %arg2 : tensor<32x2x!tt.ptr<i8>, #blocked1>
+    %4 = tt.dot_scaled %1, %2 scale %3, %cst lhs = bf16 rhs = e4m3 {fastMath = true} : tensor<32x64xbf16, #blocked2> * tensor<64x32xf8E4M3FN, #blocked>, tensor<32x2xi8, #blocked1> -> tensor<32x32xf32, #blocked>
+    tt.store %arg3, %4 : tensor<32x32x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: mfma_dot_scaled_bf16_fp4
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_dot_scaled_bf16_fp4(
+      %arg0: tensor<32x64x!tt.ptr<bf16>, #blocked2>,
+      %arg1: tensor<32x32x!tt.ptr<i8>, #blocked>,
+      %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
+      %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
+    ) {
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
+    // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<32x32xi8, #blocked{{.*}}> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
+    // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
+    // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
+    // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
+    // CHECK: %[[EPS:.*]] = tt.expand_dims %[[BS]] {axis = 2 : i32} : tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32x1xbf16, #linear{{.*}}>
+    // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x32x1xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
+    // CHECK: %[[TBCS:.*]] = tt.trans %[[BCS]] {order = array<i32: 0, 2, 1>} : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
+    // CHECK: %[[RTBCS:.*]] = tt.reshape %[[TBCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[UB:.*]] = amdgpu.scaled_upcast_fp4 %[[B]] scale %[[RTBCS]] {axis = 0 : i32} : tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[A:.*]] = ttg.convert_layout %{{.*}} : tensor<32x64xbf16, #blocked{{.*}}> -> tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    // CHECK: %{{.*}} = tt.dot %[[A]], %[[UB]], %{{.*}} : tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<32x32xf32, #mma>
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %1 = tt.load %arg0 : tensor<32x64x!tt.ptr<bf16>, #blocked2>
+    %2 = tt.load %arg1 : tensor<32x32x!tt.ptr<i8>, #blocked>
+    %3 = tt.load %arg2 : tensor<32x2x!tt.ptr<i8>, #blocked1>
+    %4 = tt.dot_scaled %1, %2 scale %3, %cst lhs = bf16 rhs = e2m1 {fastMath = true} : tensor<32x64xbf16, #blocked2> * tensor<32x32xi8, #blocked>, tensor<32x2xi8, #blocked1> -> tensor<32x32xf32, #blocked>
+    tt.store %arg3, %4 : tensor<32x32x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -33,6 +33,7 @@ include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td"
+include "triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td"
 
 include "mlir/IR/EnumAttr.td"
 include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
@@ -573,7 +574,7 @@ def MaskedStoreOp : TT_AMDGPU_Op<"masked_store", []> {
 // ScaledUpcastFp4Op
 //===----------------------------------------------------------------------===//
 
-def ScaledUpcastFp4Op : TT_AMDGPU_Op<"scaled_upcast_fp4", [Pure]> {
+def ScaledUpcastFp4Op : TT_AMDGPU_Op<"scaled_upcast_fp4", [Pure, DeclareOpInterfaceMethods<UpcastFpOpInterface>]> {
   let summary = "Upcast fp4 and then multiply scale";
 
   let description = [{
@@ -610,7 +611,8 @@ def ScaledUpcastFp8Op : TT_AMDGPU_Op<"scaled_upcast_fp8", [
     Pure,
     Elementwise,
     SameOperandsAndResultShape,
-    SameOperandsAndResultEncoding]> {
+    SameOperandsAndResultEncoding,
+    DeclareOpInterfaceMethods<UpcastFpOpInterface>]> {
   let summary = "Upcast Fp8 and then multiply scale";
 
   let description = [{

--- a/third_party/amd/test/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/test/lib/Analysis/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_library(TritonAMDGPUTestAnalysis
   TritonGPUTableGen
   TritonGPUAttrDefsIncGen
   TritonGPUTypeInterfacesIncGen
+  TritonGPUOpInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRPass


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/7839

Upstream commit message:
```
> [AMD] Enable f16 * mxfp scaled dot decomposition for gfx950 (#7839)

> This PR
> - Made f16/bf16 x mxfp4/mxfp8 dot_scaled go through the decomposition
> pass
> - Added `amdgpu.scaled_upcast_fp8` and `amdgpu.scaled_upcast_fp4`
> operations to use scaled conversion instructions
> - Propagate layouts through the `remove-layout-conversions` pass
```

Conflict Resolution:
- File: include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
  Action: Replaced with upstream version
  Reason: Upstream refactored to expose DecomposeScaledBlocked as an extensible base class with virtual methods, replacing simple function declaration

- File: lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
  Action: Replaced with upstream version (4 conflict hunks resolved)
  Reason: Upstream moved implementation from anonymous namespace to named namespace mlir::triton::gpu, enabling class inheritance for AMD backend

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 85e99d639293a56fa357a8dc162008844eafe34b
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Reviewed By: stashuk-olek

Differential Revision: D92985775


