### PR TITLE
[autoWS][BufferCreation] Split local_alloc with tensor value

### DIFF
--- a/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
+++ b/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
@@ -1,0 +1,91 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-ws-buffer-allocation | FileCheck %s
+
+// Test swapTransposedLocalAllocs: when a local_alloc stores into a transposed
+// nvmma_shared layout and its sole use is a memdesc_trans feeding into
+// operand A of a tc_gen5_mma, swap the layouts so the alloc uses the
+// non-transposed layout. This enables buffer sharing with other allocs of the
+// same source value that already use non-transposed layout.
+
+// CHECK-LABEL: @swap_transposed_alloc
+//
+// After buffer allocation, both dsT and dq allocs should have non-transposed
+// #shared layout. The two separated local_alloc ops (hoisted above the loop)
+// should both be non-transposed:
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+//
+// Inside the loop, memdesc_trans goes from #shared (non-transposed) to #shared1
+// (transposed), confirming the swap happened:
+// CHECK: ttg.memdesc_trans {{.*}} !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_T = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @swap_transposed_alloc(%desc_k: !tt.tensordesc<tensor<128x128xbf16, #shared>>, %desc_q: !tt.tensordesc<tensor<128x128xbf16, #shared>>) {
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32
+    %c4_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 4 : i32
+    %dk, %dk_token = ttng.tmem_alloc {async_task_id = array<i32: 0, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dq, %dq_token = ttng.tmem_alloc {async_task_id = array<i32: 0, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %k = tt.descriptor_load %desc_k[%c0_i32, %c0_i32] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked>
+    %k_smem = ttg.local_alloc %k {async_task_id = array<i32: 1>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+    %q = tt.descriptor_load %desc_q[%c0_i32, %c0_i32] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked>
+    %q_smem = ttg.local_alloc %q {async_task_id = array<i32: 1>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+    %loop:4 = scf.for %iv = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%use_d = %false, %dk_dep = %dk_token, %dq_dep = %dq_token, %prev = %true) -> (i1, !ttg.async.token, !ttg.async.token, i1) : i32 {
+      %dsT_val = tt.descriptor_load %desc_k[%c0_i32, %c0_i32] {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked>
+      // dsT alloc: non-transposed layout, feeds dk MMA operand A directly.
+      %dsT = ttg.local_alloc %dsT_val {async_task_id = array<i32: 3>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+      %dk_tok = ttng.tc_gen5_mma %dsT, %q_smem, %dk[%dk_dep], %use_d, %true {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      // dq alloc: TRANSPOSED layout, then memdesc_trans back to non-transposed.
+      // This is the pattern that should be swapped.
+      %dq_alloc = ttg.local_alloc %dsT_val {async_task_id = array<i32: 3>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared_T, #smem>
+      %dq_trans = ttg.memdesc_trans %dq_alloc {async_task_id = array<i32: 0>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared_T, #smem> -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+      %dq_tok = ttng.tc_gen5_mma %dq_trans, %k_smem, %dq[%dq_dep], %use_d, %true {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %true, %dk_tok, %dq_tok, %prev : i1, !ttg.async.token, !ttg.async.token, i1
+    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.warp_specialize}
+    tt.return
+  }
+}
+
+// -----
+
+// Negative test: memdesc_trans feeds into operand B (not A) of tc_gen5_mma.
+// The swap should NOT apply.
+
+// CHECK-LABEL: @no_swap_operand_b
+// The transposed alloc should remain transposed (no swap).
+// Note: #shared1 is the transposed layout alias in the output.
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+
+#blocked_2 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_T_2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem_2 = #ttg.shared_memory
+#tmem_2 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @no_swap_operand_b(%desc_k: !tt.tensordesc<tensor<128x128xbf16, #shared_2>>) {
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32
+    %c4_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 4 : i32
+    %acc, %acc_token = ttng.tmem_alloc {async_task_id = array<i32: 0, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem_2, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %a_val = tt.descriptor_load %desc_k[%c0_i32, %c0_i32] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x128xbf16, #shared_2>> -> tensor<128x128xbf16, #blocked_2>
+    %a_smem = ttg.local_alloc %a_val {async_task_id = array<i32: 1>} : (tensor<128x128xbf16, #blocked_2>) -> !ttg.memdesc<128x128xbf16, #shared_2, #smem_2>
+    %loop:2 = scf.for %iv = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%use_d = %false, %dep = %acc_token) -> (i1, !ttg.async.token) : i32 {
+      %b_val = tt.descriptor_load %desc_k[%c0_i32, %c0_i32] {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x128xbf16, #shared_2>> -> tensor<128x128xbf16, #blocked_2>
+      // Transposed alloc whose memdesc_trans feeds operand B, not A.
+      %b_alloc = ttg.local_alloc %b_val {async_task_id = array<i32: 3>} : (tensor<128x128xbf16, #blocked_2>) -> !ttg.memdesc<128x128xbf16, #shared_T_2, #smem_2>
+      %b_trans = ttg.memdesc_trans %b_alloc {async_task_id = array<i32: 0>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared_T_2, #smem_2> -> !ttg.memdesc<128x128xbf16, #shared_2, #smem_2>
+      // Note: %b_trans is operand B (second operand), not A.
+      %tok = ttng.tc_gen5_mma %a_smem, %b_trans, %acc[%dep], %use_d, %true {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xbf16, #shared_2, #smem_2>, !ttg.memdesc<128x128xbf16, #shared_2, #smem_2>, !ttg.memdesc<128x128xf32, #tmem_2, #ttng.tensor_memory, mutable>
+      scf.yield %true, %tok : i1, !ttg.async.token
+    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
+++ b/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
@@ -8,21 +8,21 @@
 
 // CHECK-LABEL: @swap_transposed_alloc
 //
-// After buffer allocation, both dsT and dq allocs should have non-transposed
-// #shared layout. The two separated local_alloc ops (hoisted above the loop)
-// should both be non-transposed:
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+// After buffer allocation, the dsT alloc is swapped to non-transposed #shared
+// layout and hoisted above the loop.
+// CHECK: %[[B0:.*]] = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
 //
 // Inside the loop, memdesc_trans goes from #shared (non-transposed) to #shared1
 // (transposed), confirming the swap happened:
-// CHECK: ttg.memdesc_trans {{.*}} !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+// CHECK: gen5_mma %[[B0]]
+// CHECK: %[[T0:.*]] = ttg.memdesc_trans %[[B0]]{{.*}} !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+// CHECK: gen5_mma %[[T0]]
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared_T = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
-#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @swap_transposed_alloc(%desc_k: !tt.tensordesc<tensor<128x128xbf16, #shared>>, %desc_q: !tt.tensordesc<tensor<128x128xbf16, #shared>>) {
     %true = arith.constant true
@@ -66,7 +66,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared_2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared_T_2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
 #smem_2 = #ttg.shared_memory
-#tmem_2 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#tmem_2 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @no_swap_operand_b(%desc_k: !tt.tensordesc<tensor<128x128xbf16, #shared_2>>) {
     %true = arith.constant true

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -22,6 +22,7 @@ namespace mlir {
 static OpPrintingFlags getOpPrintingFlagsWithLoc() {
   OpPrintingFlags flags;
   flags.enableDebugInfo();
+  flags.printNameLocAsPrefix(true);
   return flags;
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3158,7 +3158,6 @@ static void separateLocalAllocWithSrc(triton::FuncOp &funcOp) {
     builder.setLoopScheduleInfoFromOp(allocOp);
     auto storeOp = builder.createWithAsyncTaskIds<ttg::LocalStoreOp>(
         allocOp.getLoc(), allocOp.getSrc(), newAlloc);
-    storeOp->moveBefore(allocOp);
 
     mlir::triton::replaceUsesAndPropagateType(builder, allocOp,
                                               newAlloc.getResult());

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3130,7 +3130,221 @@ static void cleanupTmemTokens(triton::FuncOp funcOp) {
   });
 }
 
+// Split local_alloc ops that have a tensor source into a separate
+// empty local_alloc + local_store. This ensures doCodePartitionPost
+// can detect cross-task SMEM channels via the LocalStoreOp producer.
+static void separateLocalAllocWithSrc(triton::FuncOp &funcOp) {
+  SmallVector<ttg::LocalAllocOp> toSplit;
+  funcOp.walk([&](ttg::LocalAllocOp allocOp) {
+    if (allocOp.getSrc())
+      toSplit.push_back(allocOp);
+  });
+
+  OpBuilderWithAsyncTaskIds builder(funcOp->getContext());
+  for (auto allocOp : toSplit) {
+    auto allocDescType = cast<ttg::MemDescType>(allocOp.getType());
+    SmallVector<int64_t> shape(allocDescType.getShape());
+    Type memdescType = ttg::MemDescType::get(
+        shape, allocDescType.getElementType(), allocDescType.getEncoding(),
+        allocDescType.getMemorySpace(), /*mutableMemory*/ true);
+
+    builder.setInsertionPoint(allocOp);
+    auto newAlloc =
+        builder.create<ttg::LocalAllocOp>(allocOp.getLoc(), memdescType);
+
+    auto originTaskIds = builder.getAsyncTaskIds();
+    auto originLoopScheduleInfo = builder.getLoopScheduleInfo();
+    builder.setAsyncTaskIdsFromOp(allocOp);
+    builder.setLoopScheduleInfoFromOp(allocOp);
+    auto storeOp = builder.createWithAsyncTaskIds<ttg::LocalStoreOp>(
+        allocOp.getLoc(), allocOp.getSrc(), newAlloc);
+    storeOp->moveBefore(allocOp);
+
+    mlir::triton::replaceUsesAndPropagateType(builder, allocOp,
+                                              newAlloc.getResult());
+    builder.setAsynTaskIdsFromArray(originTaskIds);
+    builder.setLoopScheduleInfoFromInfo(originLoopScheduleInfo);
+    allocOp.erase();
+  }
+}
+
+// When a local_alloc stores into a transposed nvmma_shared layout (#shared2)
+// and its sole use is a memdesc_trans back to non-transposed (#shared) that
+// feeds into operand A of a tc_gen5_mma, swap the layouts so the alloc uses
+// #shared directly. This enables the alloc to share a buffer with other allocs
+// of the same source that already use #shared layout.
+//
+// Before:
+//   %a = local_alloc %val -> memdesc<#shared_transposed>
+//   %b = memdesc_trans %a  -> memdesc<#shared_nontransposed>
+//   tc_gen5_mma %b, ...    (operand A)
+//
+// After:
+//   %a = local_alloc %val -> memdesc<#shared_nontransposed>
+//   %b = memdesc_trans %a  -> memdesc<#shared_transposed>
+//   tc_gen5_mma %b, ...    (operand A)
+static void swapTransposedLocalAllocs(triton::FuncOp &funcOp) {
+  SmallVector<ttg::LocalAllocOp> toSwap;
+  funcOp.walk([&](ttg::LocalAllocOp allocOp) {
+    if (!allocOp.getSrc())
+      return;
+    auto memDescType = cast<ttg::MemDescType>(allocOp.getType());
+    auto encoding =
+        dyn_cast<ttg::NVMMASharedEncodingAttr>(memDescType.getEncoding());
+    if (!encoding || !encoding.getTransposed())
+      return;
+    if (!allocOp->hasOneUse())
+      return;
+    auto transOp = dyn_cast<ttg::MemDescTransOp>(*allocOp->user_begin());
+    if (!transOp)
+      return;
+    // Verify the memdesc_trans result feeds into operand A of a tc_gen5_mma.
+    bool feedsIntoMmaOperandA = false;
+    for (auto *user : transOp->getUsers()) {
+      if (auto mmaOp = dyn_cast<ttng::TCGen5MMAOp>(user)) {
+        if (mmaOp.getA() == transOp.getResult()) {
+          feedsIntoMmaOperandA = true;
+          break;
+        }
+      }
+    }
+    if (!feedsIntoMmaOperandA)
+      return;
+    toSwap.push_back(allocOp);
+  });
+
+  for (auto allocOp : toSwap) {
+    auto memDescType = cast<ttg::MemDescType>(allocOp.getType());
+    auto encoding =
+        cast<ttg::NVMMASharedEncodingAttr>(memDescType.getEncoding());
+    auto transOp = cast<ttg::MemDescTransOp>(*allocOp->user_begin());
+    auto transDescType = cast<ttg::MemDescType>(transOp.getType());
+
+    // Create non-transposed encoding for the alloc.
+    auto nonTransposedEncoding = ttg::NVMMASharedEncodingAttr::get(
+        encoding.getContext(), encoding.getSwizzlingByteWidth(),
+        /*transposed=*/false, encoding.getElementBitWidth(),
+        encoding.getFp4Padded(), encoding.getCTALayout());
+
+    // New alloc type: non-transposed encoding.
+    auto newAllocType = ttg::MemDescType::get(
+        memDescType.getShape(), memDescType.getElementType(),
+        nonTransposedEncoding, memDescType.getMemorySpace(),
+        memDescType.getMutableMemory());
+
+    // New memdesc_trans output type: transposed encoding (the original).
+    auto newTransType = ttg::MemDescType::get(
+        transDescType.getShape(), transDescType.getElementType(), encoding,
+        transDescType.getMemorySpace(), transDescType.getMutableMemory());
+
+    LLVM_DEBUG({
+      LDBG("swapTransposedLocalAllocs: swapping layouts for alloc at "
+           << allocOp.getLoc());
+      LDBG("  alloc: " << memDescType << " -> " << newAllocType);
+      LDBG("  trans: " << transDescType << " -> " << newTransType);
+    });
+
+    allocOp.getResult().setType(newAllocType);
+    transOp.getResult().setType(newTransType);
+  }
+}
+
+// Merge duplicate local_alloc ops that have:
+// 1. Same source value
+// 2. Same SMEM layout (MemDescType)
+// 3. No modification to the source value between the allocs
+//
+// This optimization is enabled after swapTransposedLocalAllocs, which
+// normalizes transposed allocs to use non-transposed layout so they can
+// share the same buffer.
+//
+// Before:
+//   %val = descriptor_load ...
+//   %a = local_alloc %val -> memdesc<#shared>
+//   ... (no modification to %val) ...
+//   %b = local_alloc %val -> memdesc<#shared>  // same src, same layout
+//
+// After:
+//   %val = descriptor_load ...
+//   %a = local_alloc %val -> memdesc<#shared>
+//   ... (no modification to %val) ...
+//   // %b is replaced with %a
+static void mergeDuplicateLocalAllocs(triton::FuncOp &funcOp) {
+  // Map from (src, memDescType) to the first alloc op with that signature.
+  // We use a vector of pairs since we need to process allocs in program order.
+  SmallVector<ttg::LocalAllocOp> allocs;
+  funcOp.walk([&](ttg::LocalAllocOp allocOp) {
+    if (allocOp.getSrc())
+      allocs.push_back(allocOp);
+  });
+
+  // Group allocs by source value and MemDescType.
+  // For each group, check if they can be merged.
+  DenseMap<Value, SmallVector<ttg::LocalAllocOp>> allocsBySrc;
+  for (auto allocOp : allocs) {
+    allocsBySrc[allocOp.getSrc()].push_back(allocOp);
+  }
+
+  SmallVector<ttg::LocalAllocOp> toErase;
+
+  for (auto &[src, allocGroup] : allocsBySrc) {
+    if (allocGroup.size() < 2)
+      continue;
+
+    // Further group by MemDescType (layout).
+    DenseMap<Type, SmallVector<ttg::LocalAllocOp>> allocsByType;
+    for (auto allocOp : allocGroup) {
+      allocsByType[allocOp.getType()].push_back(allocOp);
+    }
+
+    for (auto &[type, typeGroup] : allocsByType) {
+      if (typeGroup.size() < 2)
+        continue;
+
+      // Sort by program order (using operation order in the IR).
+      // The first alloc in the group is the "canonical" one.
+      // We check if subsequent allocs can be merged into the first.
+      // For now, we do a simple check: if the source value is not modified
+      // between allocs (i.e., src is defined once and not reassigned).
+      // Since SSA values are immutable, if two allocs have the same src,
+      // the source cannot have been modified between them.
+
+      ttg::LocalAllocOp firstAlloc = typeGroup[0];
+      for (size_t i = 1; i < typeGroup.size(); ++i) {
+        ttg::LocalAllocOp laterAlloc = typeGroup[i];
+
+        // Check dominance: firstAlloc must dominate laterAlloc.
+        // Since we walk in program order, firstAlloc comes before laterAlloc.
+        // We can simply replace laterAlloc's uses with firstAlloc's result.
+
+        LLVM_DEBUG({
+          LDBG("mergeDuplicateLocalAllocs: merging alloc at "
+               << laterAlloc.getLoc() << " into alloc at "
+               << firstAlloc.getLoc());
+          LDBG("  src: " << src);
+          LDBG("  type: " << type);
+        });
+
+        laterAlloc.getResult().replaceAllUsesWith(firstAlloc.getResult());
+        toErase.push_back(laterAlloc);
+      }
+    }
+  }
+
+  for (auto allocOp : toErase) {
+    allocOp.erase();
+  }
+}
+
 void doBufferAllocation(triton::FuncOp &funcOp) {
+  // Step 0: Swap transposed local_alloc + memdesc_trans patterns so that
+  // allocs that share the same source value can also share a buffer.
+  swapTransposedLocalAllocs(funcOp);
+
+  // Step 0.5: Merge duplicate local_allocs with same src and layout.
+  // This must be done after swapTransposedLocalAllocs which normalizes layouts.
+  mergeDuplicateLocalAllocs(funcOp);
+
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;
   collectAsyncChannels(channelsOrigin, funcOp, 1 /*numBuffers*/);
@@ -3138,15 +3352,17 @@ void doBufferAllocation(triton::FuncOp &funcOp) {
   for (const auto &c : channelsOrigin) {
     channels.push_back(c.get());
   }
-  if (channels.empty()) {
-    return;
+  if (!channels.empty()) {
+    // Step 2: Reorder ops based on channel information.
+    reorderEpilogOps(channels, funcOp);
+
+    // Step 3: Create buffers. A buffer for each channel.
+    createBuffer(channels, funcOp, true);
   }
 
-  // Step 2: Reorder ops based on channel information.
-  reorderEpilogOps(channels, funcOp);
-
-  // Step 3: Create buffers. A buffer for each channel.
-  createBuffer(channels, funcOp, true);
+  // Step 4: Split remaining local_alloc with tensor source into
+  // local_alloc + local_store for downstream channel detection.
+  separateLocalAllocWithSrc(funcOp);
 }
 
 void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {


### PR DESCRIPTION
Summary: Canonicalize it to local_alloc + local_store
When a local_alloc stores into a transposed nvmma_shared layout (#shared2)
and its sole use is a memdesc_trans back to non-transposed (#shared) that
feeds into operand A of a tc_gen5_mma, swap the layouts so the alloc uses
#shared directly.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: