### PR TITLE
Add TRITON_PROFILE_COMPILE knob for compilation time profiling

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -365,6 +365,7 @@ class compilation_knobs(base_knobs):
     front_end_debugging: env_bool = env_bool("TRITON_FRONT_END_DEBUGGING")
     allow_non_constexpr_globals: env_bool = env_bool("TRITON_ALLOW_NON_CONSTEXPR_GLOBALS")
     enable_experimental_consan: env_bool = env_bool("TRITON_ENABLE_EXPERIMENTAL_CONSAN")
+    profile_compile: env_bool = env_bool("TRITON_PROFILE_COMPILE")
     listener: Union[CompilationListener, None] = None
 
 


### PR DESCRIPTION
When enabled, prints per-stage compilation time breakdowns to stderr for each kernel compilation (ir_init, ttir, ttgir, llir, ptx, cubin, store), and benchmark timing summaries after autotuning completes. Default off.

Test plan:

`TRITON_ALWAYS_COMPILE=1 TRITON_PROFILE_COMPILE=1 CUDA_VISIBLE_DEVICES=7 third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py --version ws`

LOG: https://www.internalfb.com/intern/paste/P2186293125/

Authored with Claude.