### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[BACKEND] Retain mlir reproducer temporaries from prior run pass pipelines (#8113)'

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1948,7 +1948,7 @@ void init_triton_ir(py::module &&m) {
            })
       .def(
           "run",
-          [](PassManager &self, ModuleOp &mod) {
+          [](PassManager &self, ModuleOp &mod, std::string repro_pipeline_tag) {
             // TODO: maybe dump module to file and print error for better
             // diagnostics
 
@@ -1959,6 +1959,11 @@ void init_triton_ir(py::module &&m) {
             auto reproducerPath =
                 triton::tools::getStrEnv("TRITON_REPRODUCER_PATH");
             if (!reproducerPath.empty()) {
+              if (reproducerPath != "-") {
+                std::string repro_suffix =
+                    "." + repro_pipeline_tag + ".repro.mlir";
+                reproducerPath += repro_suffix;
+              }
               auto anchorName = self.getOpAnchorName();
               auto passes = self.getPasses();
               Operation *op = mod.getOperation();

--- a/python/test/unit/language/test_reproducer.py
+++ b/python/test/unit/language/test_reproducer.py
@@ -1,5 +1,6 @@
 import triton
 import re
+import os
 
 
 def test_triton_reproducer_path(monkeypatch, tmp_path):
@@ -13,17 +14,25 @@ def test_triton_reproducer_path(monkeypatch, tmp_path):
     # We need an temp empty file for MLIR to write the reproducer to, and then
     # the TRITON_REPRODUCER_PATH env var enables crash the reproduction
     # generation in MLIR.
-    repro_path = tmp_path / "repro.mlir"
-    repro_path.touch()
+    repro_path = tmp_path / "repro_prefix"
     monkeypatch.setenv("TRITON_REPRODUCER_PATH", str(repro_path))
 
     # Run the kernel so MLIR will generate a crash reproducer. It doesn't really
     # matter what the kernel does, just that the PassManager runs its passes.
     triton_[(1, )]()
 
-    repro = repro_path.read_text()
-    assert "mlir_reproducer" in repro, f"Expected MLIR reproducer in {repro_path}. Got:\n{repro}"
-    m = re.search(r"pipeline: \"(.*)\"", repro)
-    assert m, "Expected to match pass pipeline after \"pipeline:\" in MLIR reproducer"
-    pipeline_str = m.group(1)
-    assert pipeline_str, "Expected non-empty pass pipeline in MLIR reproducer"
+    stages = {
+        'make_ttir': "triton-combine",
+        'make_ttgir': "triton.*-coalesce",
+        'make_llir': "convert-triton-.*gpu-to-llvm",
+    }
+
+    for stage_name, stage_pipeline_check in stages.items():
+        assert os.path.exists(str(repro_path) + '.' + stage_name + '.repro.mlir')
+        curr_repro_path = tmp_path / ("repro_prefix." + stage_name + ".repro.mlir")
+        repro = curr_repro_path.read_text()
+        assert "mlir_reproducer" in repro, f"Expected MLIR reproducer in {curr_repro_path}. Got:\n{repro}"
+        m = re.search(r"pipeline: \"(.*" + stage_pipeline_check + ".*)\"", repro)
+        assert m, "Expected to match pass pipeline after \"pipeline:\" in MLIR reproducer"
+        pipeline_str = m.group(1)
+        assert pipeline_str, "Expected non-empty pass pipeline in MLIR reproducer"

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -199,7 +199,7 @@ class HIPBackend(BaseBackend):
         passes.ttir.add_triton_licm(pm)
         passes.common.add_symbol_dce(pm)
         passes.ttir.add_loop_unroll(pm)
-        pm.run(mod)
+        pm.run(mod, 'make_ttir')
         return mod
 
     @staticmethod
@@ -208,7 +208,7 @@ class HIPBackend(BaseBackend):
         pm.enable_debug()
         passes.ttir.add_convert_to_ttgpuir(pm, f"hip:{options.arch}", options.num_warps, options.warp_size,
                                            options.num_ctas)
-        pm.run(mod)
+        pm.run(mod, 'make_ttgir_early')
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         emuTF32 = False
@@ -281,7 +281,7 @@ class HIPBackend(BaseBackend):
         passes.common.add_symbol_dce(pm)
         if use_async_copy:
             amd.passes.ttgpuir.add_update_async_wait_count(pm, options.arch)
-        pm.run(mod)
+        pm.run(mod, 'make_ttgir')
         return mod
 
     @staticmethod
@@ -297,7 +297,7 @@ class HIPBackend(BaseBackend):
         passes.gluon.add_canonicalizer(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
 
-        pm.run(mod)
+        pm.run(mod, 'gluon_to_ttgir')
         return mod
 
     @staticmethod
@@ -350,7 +350,7 @@ class HIPBackend(BaseBackend):
             passes.llvmir.add_di_scope(pm)
 
         amd.passes.ttgpuir.add_builtin_func_to_llvmir(pm, __HIP_FTZ)
-        pm.run(mod)
+        pm.run(mod, 'make_llir')
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -271,7 +271,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
         passes.ttir.add_loop_unroll(pm)
-        pm.run(mod)
+        pm.run(mod, 'make_ttir')
         return mod
 
     @staticmethod
@@ -382,8 +382,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_canonicalizer(pm)
 
-        pm.run(mod)
-
+        pm.run(mod, 'make_ttgir')
         metadata["cluster_dims"] = (cluster_info.clusterDimX, cluster_info.clusterDimY, cluster_info.clusterDimZ)
         # Track whether ctas_per_cga was explicitly set to distinguish between
         # Triton's way (num_ctas > 1) and TLX/CUDA way (ctas_per_cga set).
@@ -404,7 +403,7 @@ class CUDABackend(BaseBackend):
         passes.gluon.add_canonicalizer(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
 
-        pm.run(mod)
+        pm.run(mod, 'gluon_to_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()
         return mod
 
@@ -449,7 +448,7 @@ class CUDABackend(BaseBackend):
         if CUDABackend.instrumentation:
             CUDABackend.instrumentation.patch("llvmir_to_llvm", pm, mod.context)
 
-        pm.run(mod)
+        pm.run(mod, 'make_llir')
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8113

Upstream commit message:
```
> [BACKEND] Retain mlir reproducer temporaries from prior run pass pipelines (#8113)

> Currently MLIR reproducers for each pass pipeline run overrides the
> previous `TRITON_REPRODUCER_PATH` path. This change allows for including
> a reproducer suffix when calling pm.run() to allow for retaining all
> previously run pipeline reproducers prior to the most recently run pass
> pipeline.

> This is important to add because with multiple pipelines, it is
> necessary to retain all previous pipelines reproducers to reproduce the
> full compilation sequence.

> - [X] I am not making a trivial change, such as fixing a typo in a
> comment.

> - [X] I have written a PR description following these
>   [rules](https://cbea.ms/git-commit/#why-not-how).

> - [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

> - Select one of the following.
>   - [X] I have added tests.
>     - `/python/test` for end-to-end tests

> - Select one of the following.
>   - [X] I have not added any `lit` tests.
```

Conflict Resolution:
- File: third_party/nvidia/backend/compiler.py:385-390
  Action: Took upstream change - added 'make_ttgir' argument to pm.run()
  Reason: This is the feature being cherry-picked (reproducer naming)

- File: third_party/nvidia/backend/compiler.py:451-458
  Action: Took only pm.run(mod, 'make_llir') change, discarded duplicate llvm.init_targets()/context lines
  Reason: The additional lines already exist later in the function; only the reproducer naming is needed

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 625c8cb4545c78c3ee753e5bb68198551c72b24d
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Reviewed By: stashuk-olek

Differential Revision: D93144413


