### PR TITLE
[TLX] Extend CLC to return all three dimensions of cluster CTA ID (#916)

### DIFF
--- a/.claude/skills/tlx-api-reference/SKILL.md
+++ b/.claude/skills/tlx-api-reference/SKILL.md
@@ -156,7 +156,7 @@ N-blocks.
 |---|---|
 | `tlx.clc_create_context(num_consumers, num_stages=1)` | Create CLC pipeline context (allocates barriers + response buffers) |
 | `tlx.clc_producer(context, p_producer, multi_ctas=False, k=0)` | Issue CLC try_cancel request from CTA 0 |
-| `tlx.clc_consumer(context, p_consumer, multi_ctas=False, k=0)` | Decode tile ID from CLC response, signal completion. Returns tile_id or -1 |
+| `tlx.clc_consumer(context, p_consumer, multi_ctas=False, k=0, return_3d=False)` | Decode tile ID from CLC response, signal completion. Returns tile_id or -1. With `return_3d=True`, returns `(ctaIdX, ctaIdY, ctaIdZ)` tuple. |
 
 For 2-CTA mode: set `multi_ctas=True` (uses "arrive remote, wait local" pattern).
 

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ CLC (Cluster Launch Control) is a Blackwell-specific feature **[Blackwell]** tha
     - `phase`: Current barrier phase (0 or 1, alternates each iteration)
     - `multi_ctas`: Set to `True` for 2-CTA mode (cluster of 2 CTAs). When enabled, `pred_cta0` is computed internally from `cluster_cta_rank()`.
 
-- `tile_id = tlx.clc_consumer(context, p_consumer=phase, multi_ctas=False)` **[Blackwell]**
+- `tile_id = tlx.clc_consumer(context, p_consumer=phase, multi_ctas=False, k=0, return_3d=False)` **[Blackwell]**
 
     Decode the tile ID from a CLC response and signal completion.
 
@@ -600,8 +600,9 @@ CLC (Cluster Launch Control) is a Blackwell-specific feature **[Blackwell]** tha
     - `context`: CLC pipeline context from `clc_create_context`
     - `phase`: Current barrier phase
     - `multi_ctas`: Set to `True` for 2-CTA mode. When enabled, `pred_cta0` is computed internally.
+    - `return_3d`: Set to `True` to return `(ctaIdX, ctaIdY, ctaIdZ)` tuple instead of scalar tile_id.
 
-    **Returns:** The tile ID (already offset by `cluster_cta_rank()` for unique tile assignments), or -1 if no work available.
+    **Returns:** The tile ID (already offset by `cluster_cta_rank()` for unique tile assignments), or -1 if no work available. With `return_3d=True`, returns `(ctaIdX, ctaIdY, ctaIdZ)` tuple.
 
 #### How CLC Works
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -402,9 +402,9 @@ def TTNG_CLCQueryCancelOp : TTNG_Op<"clc_query_cancel", []> {
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$clcResAlloc
   );
 
-  let results = (outs I32:$ctaId);
+  let results = (outs I32:$ctaIdX, I32:$ctaIdY, I32:$ctaIdZ);
 
-  let assemblyFormat = "$clcResAlloc attr-dict `:` functional-type(operands, $ctaId)";
+  let assemblyFormat = "$clcResAlloc attr-dict `:` functional-type(operands, results)";
 }
 
 def TTNG_VoteBallotSyncOp : TTNG_Op<"vote_ballot_sync", [Pure]> {

--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -442,6 +442,67 @@ def test_cluster_launch_control(BLOCK_SIZE, device):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+@pytest.mark.parametrize("GRID_DIMS", [1, 2, 3])
+def test_cluster_launch_control_3d(GRID_DIMS, device):
+    """Test CLC with 1D, 2D, and 3D grids using return_3d=True."""
+
+    @triton.jit
+    def clc_3d_kernel(
+        output_ptr,
+        TILES_X: tl.constexpr,
+        TILES_Y: tl.constexpr,
+        TILES_Z: tl.constexpr,
+    ):
+        tile_x = tl.program_id(0)
+        tile_y = tl.program_id(1)
+        tile_z = tl.program_id(2)
+
+        clc_phase_producer = 1
+        clc_phase_consumer = 0
+        clc_context = tlx.clc_create_context(1)
+
+        while tile_x != -1:
+            tlx.clc_producer(clc_context, clc_phase_producer)
+            clc_phase_producer ^= 1
+
+            linear_idx = tile_z * (TILES_X * TILES_Y) + tile_y * TILES_X + tile_x
+
+            if tlx.thread_id(axis=0) == 0:
+                tl.store(output_ptr + linear_idx, linear_idx)
+
+            tile_x, tile_y, tile_z = tlx.clc_consumer(
+                clc_context, clc_phase_consumer, return_3d=True)
+            clc_phase_consumer ^= 1
+
+    if GRID_DIMS == 1:
+        TILES_X, TILES_Y, TILES_Z = 64, 1, 1
+    elif GRID_DIMS == 2:
+        TILES_X, TILES_Y, TILES_Z = 4, 3, 1
+    else:
+        TILES_X, TILES_Y, TILES_Z = 3, 2, 2
+
+    total_tiles = TILES_X * TILES_Y * TILES_Z
+    output = torch.full((total_tiles,), -1, dtype=torch.int32, device=device)
+    expected = torch.arange(total_tiles, dtype=torch.int32, device=device)
+
+    grid = (TILES_X, TILES_Y, TILES_Z)
+    kernel = clc_3d_kernel[grid](
+        output,
+        TILES_X=TILES_X,
+        TILES_Y=TILES_Y,
+        TILES_Z=TILES_Z,
+        launch_cluster=True,
+    )
+
+    ptx = kernel.asm["ptx"]
+    assert re.search(r"clusterlaunchcontrol.try_cancel", ptx)
+    assert re.search(r"clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128", ptx)
+
+    sorted_output, _ = torch.sort(output)
+    torch.testing.assert_close(sorted_output, expected)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
 @pytest.mark.parametrize("CLUSTER_SIZE", [2, 4])
 def test_cluster_launch_control_multi_cta(CLUSTER_SIZE, device):
     """

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -139,7 +139,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: clusterlaunchcontrol.query_cancel.is_canceled.pred.b128
   // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128
   tt.func @clc_query_cancel(%clc_response: !ttg.memdesc<1xui128, #shared0, #smem, mutable>) {
-    %x = ttng.clc_query_cancel %clc_response : (!ttg.memdesc<1xui128, #shared0, #smem, mutable>) -> i32
+    %x:3 = ttng.clc_query_cancel %clc_response : (!ttg.memdesc<1xui128, #shared0, #smem, mutable>) -> (i32, i32, i32)
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -512,23 +512,33 @@ struct CLCQueryCancelOpConversion
       .reg .b128 clc_result;
       .reg .pred p1;
       mov.s32 $0, -1;
-      ld.shared.b128 clc_result, [$1];
+      mov.s32 $1, -1;
+      mov.s32 $2, -1;
+      ld.shared.b128 clc_result, [$3];
       clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 p1, clc_result;
-      @p1 clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 {$0, _, _, _}, clc_result;
+      @p1 clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 {$0, $1, $2, _}, clc_result;
     }
     )";
 
     PTXBuilder builder;
     auto queryOp = *builder.create<>(ptx);
 
-    SmallVector<PTXBuilder::Operand *, 2> operands = {
+    SmallVector<PTXBuilder::Operand *, 4> operands = {
+        builder.newOperand("=r", true), builder.newOperand("=r", true),
         builder.newOperand("=r", true),
         builder.newOperand(adaptor.getClcResAlloc(), "r")};
     queryOp(operands, /*onlyAttachMLIRArgs=*/true);
 
-    Value ctaId = builder.launch(rewriter, op.getLoc(), i32_ty, false);
+    auto i32Ty = rewriter.getI32Type();
+    auto structTy =
+        LLVM::LLVMStructType::getLiteral(getContext(), {i32Ty, i32Ty, i32Ty});
+    Value result = builder.launch(rewriter, op.getLoc(), structTy, false);
 
-    rewriter.replaceOp(op, ctaId);
+    Value ctaIdX = LLVM::ExtractValueOp::create(rewriter, loc, result, 0);
+    Value ctaIdY = LLVM::ExtractValueOp::create(rewriter, loc, result, 1);
+    Value ctaIdZ = LLVM::ExtractValueOp::create(rewriter, loc, result, 2);
+
+    rewriter.replaceOp(op, {ctaIdX, ctaIdY, ctaIdZ});
 
     return success();
   }

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -647,28 +647,34 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value responseAddr, Value mbar) -> void {
              self.create<ttng::AsyncCLCTryCancelOp>(mbar, responseAddr);
            })
-      // clc_query: Extract tile ID from CLC response.
+      // clc_query: Extract CTA ID (3D) from CLC response.
       //
-      // Returns the tile ID decoded from the CLC response buffer, offset by
-      // cluster_cta_rank() so each CTA gets a unique tile assignment
-      // (CTA 0 gets tile N, CTA 1 gets tile N+1, etc.).
-      // Returns -1 if no work available.
+      // Returns a vector of 3 values {ctaIdX, ctaIdY, ctaIdZ} decoded from the
+      // CLC response buffer. The X dimension is offset by cluster_cta_rank()
+      // so each CTA gets a unique tile assignment (CTA 0 gets tile N, CTA 1
+      // gets tile N+1, etc.). Returns {-1, -1, -1} if no work available.
       //
       // Note: For single-CTA clusters, cluster_cta_rank() returns 0, so the
       // offset is a no-op. This allows the same code path for both cases.
       .def("clc_query",
-           [](TritonOpBuilder &self, Value responseAddr) -> Value {
-             Value tileId = self.create<ttng::CLCQueryCancelOp>(responseAddr);
-             // Always offset by cluster_cta_rank() - for single CTA, rank=0
+           [](TritonOpBuilder &self,
+              Value responseAddr) -> std::vector<Value> {
+             auto queryOp =
+                 self.create<ttng::CLCQueryCancelOp>(responseAddr);
+             Value ctaIdX = queryOp.getCtaIdX();
+             Value ctaIdY = queryOp.getCtaIdY();
+             Value ctaIdZ = queryOp.getCtaIdZ();
+             // Always offset X by cluster_cta_rank() - for single CTA, rank=0
              Value ctaRank = self.create<triton::nvgpu::ClusterCTAIdOp>(
                  self.getBuilder().getI32Type());
              Value negOne = self.create<mlir::arith::ConstantIntOp>(-1, 32);
              Value isNegOne = self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::eq, tileId, negOne);
-             Value offset = self.create<mlir::arith::AddIOp>(tileId, ctaRank);
-             tileId =
-                 self.create<mlir::arith::SelectOp>(isNegOne, tileId, offset);
-             return tileId;
+                 mlir::arith::CmpIPredicate::eq, ctaIdX, negOne);
+             Value offset =
+                 self.create<mlir::arith::AddIOp>(ctaIdX, ctaRank);
+             ctaIdX =
+                 self.create<mlir::arith::SelectOp>(isNegOne, ctaIdX, offset);
+             return std::vector<Value>{ctaIdX, ctaIdY, ctaIdZ};
            })
       .def("vote_ballot_sync",
            [](TritonOpBuilder &self, Value mask, Value pred) -> Value {

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -48,14 +48,19 @@ def _clc_query(
     _semantic=None,
 ):
     """
-    Extract tile ID from CLC response.
+    Extract CTA ID (3D) from CLC response.
 
-    Returns the tile ID decoded from the CLC response buffer, or -1 if no work
-    is available.
+    Returns a tuple (ctaIdX, ctaIdY, ctaIdZ) decoded from the CLC response
+    buffer. The X dimension is automatically offset by cluster_cta_rank() so
+    each CTA gets a unique tile assignment (CTA 0 gets tile N, CTA 1 gets
+    tile N+1, etc.). Returns (-1, -1, -1) if no work available.
+
+    Note: For single-CTA clusters, cluster_cta_rank() returns 0, so the offset
+    is a no-op. This allows the same code path for both single and multi-CTA modes.
     """
     assert isinstance(clc_response_addr, tlx.clc_response)
-    x = _semantic.builder.clc_query(clc_response_addr.handle)
-    return _semantic.tensor(x, tl.int32)
+    results = _semantic.builder.clc_query(clc_response_addr.handle)
+    return tuple(_semantic.tensor(r, tl.int32) for r in results)
 
 
 @tl.builtin
@@ -125,7 +130,7 @@ def clc_producer(context, p_producer=None, multi_ctas: bool = False, k=0, _seman
 
 
 @tl.builtin
-def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, _semantic=None):
+def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, return_3d: bool = False, _semantic=None):
     """
     Decode the tile ID from a CLC response and signal completion.
 
@@ -144,8 +149,10 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, _seman
         k: Stage index
         p_consumer: Phase for consumer
         multi_ctas: If True, compute pred_cta0 internally and use remote signaling
+        return_3d: If True, return (ctaIdX, ctaIdY, ctaIdZ) tuple instead of scalar tile_id
 
     Returns the tile ID if successful, otherwise -1.
+    If return_3d=True, returns (ctaIdX, ctaIdY, ctaIdZ) tuple.
 
     PTX instructions generated:
         clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 p1, clc_response;
@@ -162,7 +169,8 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, _seman
     barrier_wait(bar_full, p_consumer, _semantic=_semantic)
 
     # Extract tile_id from the CLC response.
-    stolen_tile_id = _clc_query(response, _semantic=_semantic)
+    stolen_tile_ids = _clc_query(response, _semantic=_semantic)
+    stolen_tile_id = stolen_tile_ids[0]
 
     # Signal completion: all CTAs signal CTA 0's bar_empty
     # NOTE: if stolen_tile_id is -1, it means no more tile is available. We shouldn't expect
@@ -177,4 +185,6 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, _seman
     else:
         barrier_arrive(bar_empty, pred=pred_has_tile, _semantic=_semantic)
 
+    if return_3d:
+        return stolen_tile_ids
     return stolen_tile_id


### PR DESCRIPTION
Summary:

Port of D93492381. Extends clc_consumer to return all 3 cluster CTA ID dimensions while maintaining backwards compatibility through a new return_3d parameter.

CLCQueryCancelOp now returns (ctaIdX, ctaIdY, ctaIdZ), and the PTX lowering captures all 3 dimensions from get_first_ctaid. clc_consumer(return_3d=True) returns (tile_id_x, tile_id_y, tile_id_z); the default return_3d=False returns tile_id_x only and is backwards compatible. Also adds a 3D CLC test covering 1D, 2D, and 3D grids.

Authored with Claude.

Reviewed By: dshi7

Differential Revision: D93492381


