### PR TITLE
[triton][beta] [Cherry-pick] '[AMD] Specify waves_per_eu=N,N to focus LLVM heuristics (#8151)'

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -397,11 +397,13 @@ class HIPBackend(BaseBackend):
         # LLVM AMDGPU backend supports the attribute "amdgpu-waves-per-eu"="<min>[, <max>]".
         # This attribute may be attached to a kernel function definition and is an optimization hint.
         # <min> parameter specifies the requested minimum number of waves per EU, and optional <max> parameter
-        # specifies the requested maximum number of waves per EU (must be greater than <min> if specified).
+        # specifies the requested maximum number of waves per EU (must be >= <min> if specified).
         # If <max> is omitted, then there is no restriction on the maximum number of waves per EU other than
         # the one dictated by the hardware for which the kernel is compiled. Passing 0, 0 as <min>, <max>
         # implies the default behavior (no limits).
-        fns[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}")
+        # Specifying N, N forces LLVM to focus on a single register count, simplifies some heuristics
+        # and may improve scheduling.
+        fns[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}, {options.waves_per_eu}")
         denormal_mode = "preserve-sign" if options.allow_flush_denorm else "ieee"
         fns[0].add_fn_attr("denormal-fp-math-f32", denormal_mode)
         if knobs.compilation.enable_asan:


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8151

Upstream commit message:
```
> [AMD] Specify waves_per_eu=N,N to focus LLVM heuristics (#8151)

> Triton to specify waves_per_eu=N,N to focus LLVM heuristics, such as
> regalloc, which will better focus on a single register target. This will
> simplify future improvements to LLVM and may improve some scheduling.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: e8bfb7143cbe5089ad1a801868b3a1a52e8ca83b
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Differential Revision: D93311566


