### PR TITLE
[TLX] Split-K, NUM_CTAS, autotune pruning for TLX GEMM

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -20,21 +20,23 @@ def get_cuda_autotune_config():
                 "NUM_TMEM_BUFFERS": t,
                 "NUM_MMA_GROUPS": m,
                 "EPILOGUE_SUBTILE": subtile,
-                "PAIR_CTA": pairCTA,
+                "NUM_CTAS": num_ctas,
+                "SPLIT_K": split_k,
             },
             num_warps=4,
             num_stages=1,
             pre_hook=matmul_tma_set_block_size_hook,
-            ctas_per_cga=(2, 1, 1) if pairCTA else None,
+            ctas_per_cga=(num_ctas, 1, 1) if num_ctas > 1 else None,
         )
         for BM in [128, 256]
-        for BN in [128, 256]
+        for BN in [64, 128, 256]
         for BK in [64, 128]
         for s in [2, 3, 4, 5, 6, 7]
         for t in [1, 2, 3]
         for m in [1, 2]
         for subtile in [1, 2, 4, 8]
-        for pairCTA in [True, False]
+        for num_ctas in [1, 2]
+        for split_k in [1, 4]
     ]
 
 
@@ -44,15 +46,15 @@ def matmul_tma_set_block_size_hook(nargs):
     BLOCK_K = nargs["BLOCK_SIZE_K"]
     NUM_MMA_GROUPS = nargs.get("NUM_MMA_GROUPS", 1)
     nargs["a_desc"].block_shape = [BLOCK_M // NUM_MMA_GROUPS, BLOCK_K]
-    if nargs.get("PAIR_CTA", False):
-        nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N // 2]
-    else:
-        nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N]
+    NUM_CTAS = nargs.get("NUM_CTAS", 1)
+    nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N // NUM_CTAS]
     EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", 1)
     nargs["c_desc"].block_shape = [
         BLOCK_M // NUM_MMA_GROUPS,
         BLOCK_N // EPILOGUE_SUBTILE,
     ]
+    if nargs.get("SPLIT_K", 1) > 1:
+        nargs["c_desc"].base.zero_()
 
 
 @triton.jit
@@ -67,68 +69,130 @@ def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M):
 
 def preprocess_configs(configs, named_args, **kwargs):
     # Blackwell B200A resource limits
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
     MAX_SHARED_MEMORY = 232 * 1024  # bytes (232KB)
     MAX_TENSOR_MEMORY = 256 * 1024  # bytes (256KB TMEM per SM)
 
     MBARRIER_SIZE = 8  # bytes
 
+    M = named_args["M"]
+    N = named_args["N"]
+    K = named_args["K"]
+
     pruned_configs = []
     for conf in configs:
-        M = named_args["M"]
-        N = named_args["N"]
         BLOCK_M = conf.kwargs["BLOCK_SIZE_M"]
         BLOCK_N = conf.kwargs["BLOCK_SIZE_N"]
         BLOCK_K = conf.kwargs["BLOCK_SIZE_K"]
         NUM_SMEM_BUFFERS = conf.kwargs["NUM_SMEM_BUFFERS"]
         NUM_TMEM_BUFFERS = conf.kwargs["NUM_TMEM_BUFFERS"]
-        PAIR_CTA = conf.kwargs["PAIR_CTA"]
+        NUM_CTAS = conf.kwargs["NUM_CTAS"]
         NUM_MMA_GROUPS = conf.kwargs["NUM_MMA_GROUPS"]
+        SPLIT_K = conf.kwargs.get("SPLIT_K", 1)
+        EPILOGUE_SUBTILE = conf.kwargs["EPILOGUE_SUBTILE"]
 
         # Filter out invalid config that causes wrong hardware MMA
         if BLOCK_M // NUM_MMA_GROUPS > 128:
             continue
 
+        # EPILOGUE_SUBTILE must evenly divide BLOCK_N
+        if BLOCK_N % EPILOGUE_SUBTILE != 0:
+            continue
+
         num_tiles_m = math.ceil(M / BLOCK_M)
         num_tiles_n = math.ceil(N / BLOCK_N)
-        # checking num_tiles_m should be sufficent in this case, but adding num_tiles_n for clarity
-        pair_cta_compatible = (num_tiles_m % 2 == 0 and (num_tiles_m * num_tiles_n) % 2 == 0)
-        if not pair_cta_compatible:
-            # fall back to non-pair CTA mode
-            conf.kwargs["PAIR_CTA"] = False
-            PAIR_CTA = False
+        num_mn_tiles = num_tiles_m * num_tiles_n
 
-        # Estimate Shared Memory Usage
-        # buffers_A: BLOCK_M x BLOCK_K x float16 x NUM_SMEM_BUFFERS
+        # --- Split-K gating: only allow SPLIT_K > 1 for small shapes ---
+        # Split-K helps when MN tiles are too few to saturate the GPU.
+        # For large shapes with plenty of MN tiles, SPLIT_K=1 is better
+        # since it avoids the atomic reduction overhead.
+        if SPLIT_K > 1:
+            if num_mn_tiles >= NUM_SMS:
+                continue
+            k_tiles = math.ceil(K / BLOCK_K)
+            if k_tiles < SPLIT_K:
+                continue
+            # Each split must have enough K tiles to be worthwhile
+            if k_tiles // SPLIT_K < 4:
+                continue
+
+        # --- Shared Memory estimation ---
         smem_a = BLOCK_M * BLOCK_K * 2 * NUM_SMEM_BUFFERS
-        # buffers_B: BLOCK_K x BLOCK_N x float16 x NUM_SMEM_BUFFERS
-        # In PAIR_CTA mode, each CTA only loads half of B
-        smem_b_size = (BLOCK_N // 2) if PAIR_CTA else BLOCK_N
+        smem_b_size = BLOCK_N // NUM_CTAS
         smem_b = BLOCK_K * smem_b_size * 2 * NUM_SMEM_BUFFERS
-        # Epilogue staging buffer: BLOCK_M x (BLOCK_N // EPILOGUE_SUBTILE) x float16
-        # The epilog group uses local_load/local_slice which implicitly stages data
-        # from TMEM to shared memory before TMA store to global memory
-        EPILOGUE_SUBTILE = conf.kwargs["EPILOGUE_SUBTILE"]
         smem_epilog = BLOCK_M * (BLOCK_N // EPILOGUE_SUBTILE) * 2
-        smem_barriers = NUM_SMEM_BUFFERS * MBARRIER_SIZE
-        if PAIR_CTA:
-            smem_barriers += (NUM_SMEM_BUFFERS * NUM_MMA_GROUPS * MBARRIER_SIZE)  # cta_bars
-        # tmem_full_bars
+        smem_barriers = NUM_SMEM_BUFFERS * NUM_MMA_GROUPS * MBARRIER_SIZE
+        if NUM_CTAS == 2:
+            smem_barriers += NUM_SMEM_BUFFERS * NUM_MMA_GROUPS * MBARRIER_SIZE
         smem_barriers += NUM_TMEM_BUFFERS
 
         total_smem = smem_a + smem_b + smem_epilog + smem_barriers
-        # Prune configs that exceed memory limits
         if total_smem > MAX_SHARED_MEMORY:
             continue
 
-        # Estimate Tensor Memory (TMEM) Usage
-        # tmem_buffers: BLOCK_M x BLOCK_N x float32 x NUM_TMEM_BUFFERS
-        # TMEM stores the accumulation buffers for MMA operations
-        # use NUM_TMEM_BUFFERS to overlap MMA and epilogue
+        # --- Tensor Memory (TMEM) estimation ---
         total_tmem = BLOCK_M * BLOCK_N * 4 * NUM_TMEM_BUFFERS
         if total_tmem > MAX_TENSOR_MEMORY:
             continue
 
         pruned_configs.append(conf)
+
+    # Prefer configs that maximize SM utilization.
+    # If any config produces enough tiles to fill every SM, discard those
+    # that don't.  Otherwise, keep only configs whose tile count matches the
+    # best available utilization so we don't waste SMs.
+    if pruned_configs:
+
+        def _total_tiles(c):
+            return (math.ceil(M / c.kwargs["BLOCK_SIZE_M"]) * math.ceil(N / c.kwargs["BLOCK_SIZE_N"]) *
+                    c.kwargs.get("SPLIT_K", 1))
+
+        max_tiles = max(_total_tiles(c) for c in pruned_configs)
+        if max_tiles >= NUM_SMS:
+            pruned_configs = [c for c in pruned_configs if _total_tiles(c) >= NUM_SMS]
+        else:
+            pruned_configs = [c for c in pruned_configs if _total_tiles(c) == max_tiles]
+
+    # Pareto-optimal filtering on (NUM_SMEM_BUFFERS, NUM_TMEM_BUFFERS,
+    # NUM_MMA_GROUPS): these are independent resource dimensions where more
+    # buffers / groups generally means better pipelining, but no single
+    # dimension dominates the others.  Keep a config unless another config
+    # in the same (BM, BN, BK, SUBTILE, NUM_CTAS, SPLIT_K) group dominates
+    # it (>= in all dimensions, > in at least one).
+    if pruned_configs:
+
+        def _group_key(c):
+            return (
+                c.kwargs["BLOCK_SIZE_M"],
+                c.kwargs["BLOCK_SIZE_N"],
+                c.kwargs["BLOCK_SIZE_K"],
+                c.kwargs["EPILOGUE_SUBTILE"],
+                c.kwargs["NUM_CTAS"],
+                c.kwargs.get("SPLIT_K", 1),
+            )
+
+        def _val(c):
+            return (
+                c.kwargs["NUM_SMEM_BUFFERS"],
+                c.kwargs["NUM_TMEM_BUFFERS"],
+                c.kwargs["NUM_MMA_GROUPS"],
+            )
+
+        def _dominates(a, b):
+            """Return True if a dominates b (>= in all, > in at least one)."""
+            va, vb = _val(a), _val(b)
+            return all(x >= y for x, y in zip(va, vb)) and any(x > y for x, y in zip(va, vb))
+
+        groups = {}
+        for c in pruned_configs:
+            groups.setdefault(_group_key(c), []).append(c)
+
+        pruned_configs = []
+        for members in groups.values():
+            for c in members:
+                if not any(_dominates(other, c) for other in members if other is not c):
+                    pruned_configs.append(c)
 
     return pruned_configs
 
@@ -141,15 +205,28 @@ def _get_bufidx_phase(accum_cnt, NUM_BUFFERS_KV):
 
 
 @triton.jit
-def _compute_grid_info(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M):
+def _compute_grid_info(
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    GROUP_SIZE_M,
+    SPLIT_K,
+    NUM_CTAS: tl.constexpr,
+):
     """Compute common grid information used across async tasks."""
     start_pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    # Pad num_pid_m to multiple of NUM_CTAS so CTA clusters tile evenly along M.
+    num_pid_m = (num_pid_m + NUM_CTAS - 1) // NUM_CTAS * NUM_CTAS
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
-    num_tiles = num_pid_m * num_pid_n
-    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
-    return start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles
+    num_mn_tiles = num_pid_m * num_pid_n
+    num_tiles = num_mn_tiles * SPLIT_K
+    k_tiles_total = tl.cdiv(K, BLOCK_SIZE_K)
+    return start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_mn_tiles, num_tiles, k_tiles_total
 
 
 @triton.jit
@@ -157,12 +234,15 @@ def _process_tile_epilogue_inner(
     tile_id,
     num_pid_in_group,
     num_pid_m,
+    num_mn_tiles,
     GROUP_SIZE_M,
+    M,
     BLOCK_SIZE_M,
     BLOCK_SIZE_N,
     EPILOGUE_SUBTILE,
     NUM_MMA_GROUPS,
     NUM_TMEM_BUFFERS,
+    SPLIT_K,
     c_desc,
     tmem_buffers,
     tmem_full_bars,
@@ -171,7 +251,8 @@ def _process_tile_epilogue_inner(
     tmem_read_phase,
 ):
     """Process epilogue for a single tile."""
-    pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+    mn_tile_id = tile_id % num_mn_tiles
+    pid_m, pid_n = _compute_pid(mn_tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
     offs_bn = pid_n * BLOCK_SIZE_N
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_SIZE_M // NUM_MMA_GROUPS
 
@@ -196,12 +277,21 @@ def _process_tile_epilogue_inner(
             # Signal MMA consumer after each slice
             tlx.barrier_arrive(tmem_empty_bars[buf_idx], 1)
             c = result.to(tlx.dtype_of(c_desc))
-            c_desc.store([offs_am, offs_bn + slice_id * slice_size], c)
+            if SPLIT_K == 1:
+                c_desc.store([offs_am, offs_bn + slice_id * slice_size], c)
+            else:
+                c_desc.store(
+                    [offs_am, offs_bn + slice_id * slice_size],
+                    c,
+                    store_reduce="add",
+                )
 
 
 @triton.jit
 def _process_tile_mma_inner(
     k_tiles,
+    k_tile_start,
+    k_tile_end,
     NUM_SMEM_BUFFERS,
     NUM_MMA_GROUPS,
     NUM_TMEM_BUFFERS,
@@ -216,14 +306,14 @@ def _process_tile_mma_inner(
     tmem_empty_bars,
     tmem_write_phase,
     smem_accum_cnt,
-    PAIR_CTA,
+    NUM_CTAS,
     cta_bars,
     pred_cta0,
 ):
-    """Process MMA for a single tile. Returns updated smem_accum_cnt."""
+    """Process MMA for a single tile over [k_tile_start, k_tile_end). Returns updated smem_accum_cnt."""
+    local_k_tiles = k_tile_end - k_tile_start
 
     # Peeled first K-iteration: wait for data before acquiring TMEM
-    # This allows previous tile's epilogue to overlap with current tile's TMA load
     buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
 
     # wait for current phase(round) of load for this buf
@@ -243,8 +333,7 @@ def _process_tile_mma_inner(
         tlx.barrier_wait(tmem_empty_bars[cur_barrier_idx], tmem_write_phase ^ 1)
 
         # CTA0 waits for CTA0 and CTA1 to finish loading A and B before issuing dot op
-        # "Arrive Remote, Wait Local" pattern: all CTAs signal CTA 0's barrier, only CTA 0 waits
-        if PAIR_CTA:
+        if NUM_CTAS == 2:
             tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
             tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
@@ -255,14 +344,14 @@ def _process_tile_mma_inner(
             tmem_buffers[acc_buf],
             use_acc=False,
             mBarriers=[A_smem_empty_bars[a_buf]],
-            two_ctas=PAIR_CTA,
+            two_ctas=NUM_CTAS == 2,
             out_dtype=tl.float32,
         )
 
     smem_accum_cnt += 1
 
     # Remaining K iterations with use_acc=True
-    for _ in range(1, k_tiles):
+    for _ in range(1, local_k_tiles):
         buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
 
         # wait for current phase(round) of load for this buf
@@ -278,8 +367,7 @@ def _process_tile_mma_inner(
             tlx.barrier_wait(A_smem_full_bars[a_buf], phase)
 
             # CTA0 waits for CTA0 and CTA1 to finish loading A and B before issuing dot op
-            # "Arrive Remote, Wait Local" pattern: all CTAs signal CTA 0's barrier, only CTA 0 waits
-            if PAIR_CTA:
+            if NUM_CTAS == 2:
                 tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
                 tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
@@ -290,7 +378,7 @@ def _process_tile_mma_inner(
                 tmem_buffers[acc_buf],
                 use_acc=True,
                 mBarriers=[A_smem_empty_bars[a_buf]],
-                two_ctas=PAIR_CTA,
+                two_ctas=NUM_CTAS == 2,
                 out_dtype=tl.float32,
             )
 
@@ -313,12 +401,14 @@ def _process_tile_producer_inner(
     tile_id,
     num_pid_in_group,
     num_pid_m,
+    num_mn_tiles,
     GROUP_SIZE_M,
     BLOCK_SIZE_M,
     BLOCK_SIZE_N,
     BLOCK_SIZE_K,
     NUM_MMA_GROUPS,
-    k_tiles,
+    k_tile_start,
+    k_tile_end,
     NUM_SMEM_BUFFERS,
     a_desc,
     b_desc,
@@ -328,22 +418,22 @@ def _process_tile_producer_inner(
     B_smem_full_bars,
     A_smem_empty_bars,
     smem_accum_cnt,
-    PAIR_CTA,
+    NUM_CTAS,
     cluster_cta_rank,
 ):
-    """Process TMA loads for a single tile with all subtiles."""
-    pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+    """Process TMA loads for a single tile with all subtiles over [k_tile_start, k_tile_end)."""
+    mn_tile_id = tile_id % num_mn_tiles
+    pid_m, pid_n = _compute_pid(mn_tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
     dsize: tl.constexpr = tlx.size_of(tlx.dtype_of(b_desc))
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_SIZE_M // NUM_MMA_GROUPS
-    if PAIR_CTA:
-        offs_bn = pid_n * BLOCK_SIZE_N + cluster_cta_rank * (BLOCK_SIZE_N // 2)
-        expected_bytes: tl.constexpr = dsize * BLOCK_SIZE_N * BLOCK_SIZE_K // 2
-    else:
-        offs_bn = pid_n * BLOCK_SIZE_N
-        expected_bytes: tl.constexpr = dsize * BLOCK_SIZE_N * BLOCK_SIZE_K
+    offs_bn = pid_n * BLOCK_SIZE_N + cluster_cta_rank * (BLOCK_SIZE_N // NUM_CTAS)
+    expected_bytes: tl.constexpr = dsize * BLOCK_SIZE_N * BLOCK_SIZE_K // NUM_CTAS
 
-    # Iterate along K dimension
-    for k in range(0, k_tiles):
+    local_k_tiles = k_tile_end - k_tile_start
+
+    # Iterate along K dimension for this split's range
+    for k_idx in range(0, local_k_tiles):
+        k = k_tile_start + k_idx
         buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
         offs_k = k * BLOCK_SIZE_K
 
@@ -355,23 +445,17 @@ def _process_tile_producer_inner(
         tlx.async_descriptor_load(a_desc, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf])
 
         # Load B once per K iteration (shared across all subtiles)
-        # Wait for the last B subtile buffer from the previous phase to complete its dot operation
-        # This ensures A buffer is ready to be reused
         last_a_buf = (NUM_MMA_GROUPS - 1) * NUM_SMEM_BUFFERS + buf
         tlx.barrier_wait(A_smem_empty_bars[last_a_buf], phase ^ 1)
-        # Set expected bytes for B and load B (once per K iteration)
         tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
         tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf])
 
         # Load all remaining A subtiles for this K iteration
         for group_id in tl.static_range(1, NUM_MMA_GROUPS):
-            # Calculate buffer index: subtile_id * NUM_SMEM_BUFFERS + buf
             a_buf = group_id * NUM_SMEM_BUFFERS + buf
 
-            # Wait for previous phase of dot for this B buffer
             tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
 
-            # Calculate B offset for this subtile
             offs_am2 = offs_am + group_id * BLOCK_M_SPLIT
 
             tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_SIZE_K)
@@ -403,7 +487,8 @@ def matmul_kernel_tma_ws_blackwell(
     NUM_TMEM_BUFFERS: tl.constexpr,
     NUM_MMA_GROUPS: tl.constexpr,
     EPILOGUE_SUBTILE: tl.constexpr,
-    PAIR_CTA: tl.constexpr,
+    NUM_CTAS: tl.constexpr,
+    SPLIT_K: tl.constexpr,
     NUM_SMS: tl.constexpr,
 ):
     # allocate NUM_SMEM_BUFFERS buffers
@@ -413,11 +498,8 @@ def matmul_kernel_tma_ws_blackwell(
         tlx.dtype_of(a_desc),
         NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
     )
-    # In pair CTA mode, each cta only needs to load half of B.
-    if PAIR_CTA:
-        buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N // 2), tlx.dtype_of(b_desc), NUM_SMEM_BUFFERS)
-    else:
-        buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_desc), NUM_SMEM_BUFFERS)
+    # In 2-CTA mode, each CTA only needs to load BLOCK_N // NUM_CTAS of B.
+    buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N // NUM_CTAS), tlx.dtype_of(b_desc), NUM_SMEM_BUFFERS)
     # NUM_TMEM_BUFFERS (overlaps MMA and epilogue)
     # Each buffer holds one subtile: BLOCK_M_SPLIT x BLOCK_SIZE_N
     # Total buffers: NUM_TMEM_BUFFERS * NUM_MMA_GROUPS
@@ -429,7 +511,7 @@ def matmul_kernel_tma_ws_blackwell(
     )
 
     # CTA pairs are placed along M dim
-    if PAIR_CTA:
+    if NUM_CTAS == 2:
         cluster_cta_rank = tlx.cluster_cta_rank()
         pred_cta0 = cluster_cta_rank == 0
         cta_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
@@ -450,8 +532,25 @@ def matmul_kernel_tma_ws_blackwell(
 
     with tlx.async_tasks():
         with tlx.async_task("default"):  # epilogue consumer
-            start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles = (_compute_grid_info(
-                M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M))
+            (
+                start_pid,
+                num_pid_m,
+                num_pid_n,
+                num_pid_in_group,
+                num_mn_tiles,
+                num_tiles,
+                k_tiles_total,
+            ) = _compute_grid_info(
+                M,
+                N,
+                K,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_K,
+                GROUP_SIZE_M,
+                SPLIT_K,
+                NUM_CTAS,
+            )
 
             tmem_accum_cnt = 0
             tile_id = start_pid
@@ -462,12 +561,15 @@ def matmul_kernel_tma_ws_blackwell(
                     tile_id=tile_id,
                     num_pid_in_group=num_pid_in_group,
                     num_pid_m=num_pid_m,
+                    num_mn_tiles=num_mn_tiles,
                     GROUP_SIZE_M=GROUP_SIZE_M,
+                    M=M,
                     BLOCK_SIZE_M=BLOCK_SIZE_M,
                     BLOCK_SIZE_N=BLOCK_SIZE_N,
                     EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
                     NUM_MMA_GROUPS=NUM_MMA_GROUPS,
                     NUM_TMEM_BUFFERS=NUM_TMEM_BUFFERS,
+                    SPLIT_K=SPLIT_K,
                     c_desc=c_desc,
                     tmem_buffers=tmem_buffers,
                     tmem_full_bars=tmem_full_bars,
@@ -479,17 +581,42 @@ def matmul_kernel_tma_ws_blackwell(
                 tile_id += NUM_SMS
 
         with tlx.async_task(num_warps=1, num_regs=24):  # MMA consumer
-            start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles = (_compute_grid_info(
-                M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M))
+            (
+                start_pid,
+                num_pid_m,
+                num_pid_n,
+                num_pid_in_group,
+                num_mn_tiles,
+                num_tiles,
+                k_tiles_total,
+            ) = _compute_grid_info(
+                M,
+                N,
+                K,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_K,
+                GROUP_SIZE_M,
+                SPLIT_K,
+                NUM_CTAS,
+            )
 
             tmem_accum_cnt = 0
             smem_accum_cnt = 0
             tile_id = start_pid
 
             while tile_id < num_tiles:
+                # Compute K range for this split
+                split_id = tile_id // num_mn_tiles
+                k_tiles_per_split = tl.cdiv(k_tiles_total, SPLIT_K)
+                k_tile_start = split_id * k_tiles_per_split
+                k_tile_end = min(k_tile_start + k_tiles_per_split, k_tiles_total)
+
                 cur_tmem_buf, tmem_write_phase = _get_bufidx_phase(tmem_accum_cnt, NUM_TMEM_BUFFERS)
                 smem_accum_cnt = _process_tile_mma_inner(
-                    k_tiles=k_tiles,
+                    k_tiles=k_tiles_total,
+                    k_tile_start=k_tile_start,
+                    k_tile_end=k_tile_end,
                     NUM_SMEM_BUFFERS=NUM_SMEM_BUFFERS,
                     NUM_MMA_GROUPS=NUM_MMA_GROUPS,
                     NUM_TMEM_BUFFERS=NUM_TMEM_BUFFERS,
@@ -504,7 +631,7 @@ def matmul_kernel_tma_ws_blackwell(
                     tmem_empty_bars=tmem_empty_bars,
                     tmem_write_phase=tmem_write_phase,
                     smem_accum_cnt=smem_accum_cnt,
-                    PAIR_CTA=PAIR_CTA,
+                    NUM_CTAS=NUM_CTAS,
                     cta_bars=cta_bars,
                     pred_cta0=pred_cta0,
                 )
@@ -512,23 +639,48 @@ def matmul_kernel_tma_ws_blackwell(
                 tile_id += NUM_SMS
 
         with tlx.async_task(num_warps=1, num_regs=24):  # producer, TMA load
-            start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_tiles, k_tiles = (_compute_grid_info(
-                M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M))
+            (
+                start_pid,
+                num_pid_m,
+                num_pid_n,
+                num_pid_in_group,
+                num_mn_tiles,
+                num_tiles,
+                k_tiles_total,
+            ) = _compute_grid_info(
+                M,
+                N,
+                K,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_K,
+                GROUP_SIZE_M,
+                SPLIT_K,
+                NUM_CTAS,
+            )
 
             smem_accum_cnt = 0
             tile_id = start_pid
 
             while tile_id < num_tiles:
+                # Compute K range for this split
+                split_id = tile_id // num_mn_tiles
+                k_tiles_per_split = tl.cdiv(k_tiles_total, SPLIT_K)
+                k_tile_start = split_id * k_tiles_per_split
+                k_tile_end = min(k_tile_start + k_tiles_per_split, k_tiles_total)
+
                 smem_accum_cnt = _process_tile_producer_inner(
                     tile_id=tile_id,
                     num_pid_in_group=num_pid_in_group,
                     num_pid_m=num_pid_m,
+                    num_mn_tiles=num_mn_tiles,
                     GROUP_SIZE_M=GROUP_SIZE_M,
                     BLOCK_SIZE_M=BLOCK_SIZE_M,
                     BLOCK_SIZE_N=BLOCK_SIZE_N,
                     BLOCK_SIZE_K=BLOCK_SIZE_K,
                     NUM_MMA_GROUPS=NUM_MMA_GROUPS,
-                    k_tiles=k_tiles,
+                    k_tile_start=k_tile_start,
+                    k_tile_end=k_tile_end,
                     NUM_SMEM_BUFFERS=NUM_SMEM_BUFFERS,
                     a_desc=a_desc,
                     b_desc=b_desc,
@@ -538,13 +690,14 @@ def matmul_kernel_tma_ws_blackwell(
                     B_smem_full_bars=B_smem_full_bars,
                     A_smem_empty_bars=A_smem_empty_bars,
                     smem_accum_cnt=smem_accum_cnt,
-                    PAIR_CTA=PAIR_CTA,
+                    NUM_CTAS=NUM_CTAS,
                     cluster_cta_rank=cluster_cta_rank,
                 )
                 tile_id += NUM_SMS
 
 
 def matmul(a, b, config=None):
+    """Matrix multiplication using TLX GEMM kernel."""
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.is_contiguous(), "Matrix A must be contiguous"
@@ -563,7 +716,11 @@ def matmul(a, b, config=None):
 
     if config is not None:
         matmul_tma_set_block_size_hook({"a_desc": a_desc, "b_desc": b_desc, "c_desc": c_desc, **config})
-        total_tiles = triton.cdiv(M, config["BLOCK_SIZE_M"]) * triton.cdiv(N, config["BLOCK_SIZE_N"])
+        NUM_CTAS = config.get("NUM_CTAS", 1)
+        num_pid_m = triton.cdiv(M, config["BLOCK_SIZE_M"])
+        num_pid_n = triton.cdiv(N, config["BLOCK_SIZE_N"])
+        num_pid_m = (num_pid_m + NUM_CTAS - 1) // NUM_CTAS * NUM_CTAS
+        total_tiles = num_pid_m * num_pid_n * config.get("SPLIT_K", 1)
         grid = (min(NUM_SMS, total_tiles), )
         matmul_kernel_tma_ws_blackwell.fn[grid](
             a_desc,
@@ -578,7 +735,13 @@ def matmul(a, b, config=None):
     else:
 
         def grid(META):
-            total_tiles = triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"])
+            NUM_CTAS = META["NUM_CTAS"]
+            num_pid_m = triton.cdiv(M, META["BLOCK_SIZE_M"])
+            num_pid_n = triton.cdiv(N, META["BLOCK_SIZE_N"])
+            # Pad num_pid_m to multiple of NUM_CTAS so CTA clusters tile evenly along M.
+            num_pid_m = (num_pid_m + NUM_CTAS - 1) // NUM_CTAS * NUM_CTAS
+            mn_tiles = num_pid_m * num_pid_n
+            total_tiles = mn_tiles * META["SPLIT_K"]
             return (min(NUM_SMS, total_tiles), )
 
         matmul_kernel_tma_ws_blackwell[grid](

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -61,7 +61,8 @@ class Gemm:
             "NUM_TMEM_BUFFERS": 2,
             "NUM_MMA_GROUPS": 1,
             "EPILOGUE_SUBTILE": 1,
-            "PAIR_CTA": False,
+            "NUM_CTAS": 1,
+            "SPLIT_K": 1,
         },
         "blackwell_gemm_clc": {
             "BLOCK_SIZE_M": 128,


### PR DESCRIPTION
Summary:
Extend the Blackwell warp-specialized GEMM kernel with split-K parallelism
and improve autotune config pruning.

Split-K: add SPLIT_K config parameter (1 or 4), partition K tiles across
split groups, use TMA store_reduce="add" for atomic accumulation, and zero
the output tensor in the pre_hook when SPLIT_K > 1.

Rename PAIR_CTA (bool) → NUM_CTAS (int, 1 or 2) to match the convention
in mma_mx4_pingpong.py. Unify all `if NUM_CTAS == 2: ... // 2` patterns
into `// NUM_CTAS`. Port the 2-CTA grid padding from mma_mx4_pingpong:
pad num_pid_m to a multiple of NUM_CTAS in both the kernel-side
_compute_grid_info and the host-side grid() so CTA clusters tile evenly
along M.

Overhaul preprocess_configs: gate split-K configs to small shapes where
MN tiles don't saturate the GPU, prefer configs that maximize SM
utilization, and apply Pareto-optimal filtering on (NUM_SMEM_BUFFERS,
NUM_TMEM_BUFFERS, NUM_MMA_GROUPS) within each (BM, BN, BK, SUBTILE,
NUM_CTAS, SPLIT_K) group. Also add BN=64 to the config space.

Reviewed By: dshi7

Differential Revision: D93752885


