### PR TITLE
[autoWS] add bitwidth to TMEM encoding to unbreak Blackwell/FA kernel

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -293,7 +293,7 @@ ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,
   }
   assert((elemBitWidth == 16 || elemBitWidth == 32) &&
          "TMEM Layout don't support fp8");
-  auto unpacked = elemBitWidth != 16;
+  unsigned colStride = 32 / elemBitWidth;
   // TODO(njriasan): Do we need to handle the ScaleDotElemType::E2M1 && transA
   // case at all from TCGen5MMAScaledOp::getBlockM?
   size_t CTASplitM;
@@ -312,8 +312,7 @@ ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,
     assert(false && "Unsupported encoding");
   }
   auto outputEncoding = ttng::TensorMemoryEncodingAttr::get(
-      context, blockM, blockN,
-      /*unpacked=*/unpacked, CTASplitM, CTASplitN);
+      context, blockM, blockN, colStride, CTASplitM, CTASplitN);
   if (highShape > 0) {
     llvm::SmallVector<int64_t> shapeVec{highShape, blockM, blockN};
     llvm::ArrayRef<int64_t> shape(shapeVec);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1483,10 +1483,10 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
     auto blockM = bufferShape[0];
     auto elemType = tensorType.getElementType();
     unsigned elemBitWidth = elemType.getIntOrFloatBitWidth();
-    bool unpacked = elemBitWidth != 16;
+    unsigned colStride = 32 / elemBitWidth;
     auto encoding = ttng::TensorMemoryEncodingAttr::get(
-        context, blockM, bufferShape[1],
-        /*unpacked=*/unpacked, /*CTASplitM=*/1, /*CTASplitN=*/1);
+        context, blockM, bufferShape[1], colStride, /*CTASplitM=*/1,
+        /*CTASplitN=*/1);
     Type memdescType =
         ttg::MemDescType::get(bufferShape, elemType, encoding,
                               tensorMemorySpace, /*mutableMemory*/ true);


### PR DESCRIPTION
PR#913 cherry-picked upstream commit https://github.com/triton-lang/triton/pull/8136 which changed TensorMemoryEncodingAttr's third parameter from `bool unpacked` to `unsigned colStride`. 

Two Meta AutoWS specific files `TMEMAlloc1D.cpp` and `WSCodePartition.cpp` should be updated too.
