### PR TITLE
[triton][beta] [Cherry-pick] '[PROTON] Use the `TRITON_NVTX_ENABLED` env var to optionally turn off nvtx (#8171)'

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -518,7 +518,8 @@ class amd_knobs(base_knobs):
 
 
 class proton_knobs(base_knobs):
-    cupti_dir: env_opt_str = env_opt_str("TRITON_CUPTI_LIB_PATH")
+    cupti_lib_dir: env_opt_str = env_opt_str("TRITON_CUPTI_LIB_PATH")
+    enable_nvtx: env_bool = env_bool("TRITON_ENABLE_NVTX", True)
 
 
 build = build_knobs()

--- a/third_party/proton/csrc/Proton.cpp
+++ b/third_party/proton/csrc/Proton.cpp
@@ -17,7 +17,7 @@ static void initProton(pybind11::module &&m) {
       "start",
       [](const std::string &path, const std::string &contextSourceName,
          const std::string &dataName, const std::string &profilerName,
-         const std::string &mode, const std::string &profilerPath) {
+         const std::string &profilerPath, const std::string &mode) {
         auto sessionId = SessionManager::instance().addSession(
             path, profilerName, profilerPath, contextSourceName, dataName,
             mode);
@@ -26,7 +26,7 @@ static void initProton(pybind11::module &&m) {
       },
       pybind11::arg("path"), pybind11::arg("contextSourceName"),
       pybind11::arg("dataName"), pybind11::arg("profilerName"),
-      pybind11::arg("mode") = "", pybind11::arg("profilerPath") = "");
+      pybind11::arg("profilerPath") = "", pybind11::arg("mode") = "");
 
   m.def("activate", [](size_t sessionId) {
     SessionManager::instance().activateSession(sessionId);

--- a/third_party/proton/csrc/include/Utility/Env.h
+++ b/third_party/proton/csrc/include/Utility/Env.h
@@ -1,0 +1,17 @@
+#include <algorithm>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+
+static std::mutex getenv_mutex;
+
+inline bool getBoolEnv(const std::string &env, bool defaultValue) {
+  std::lock_guard<std::mutex> lock(getenv_mutex);
+  const char *s = std::getenv(env.c_str());
+  if (s == nullptr)
+    return defaultValue;
+  std::string str(s ? s : "");
+  std::transform(str.begin(), str.end(), str.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return str == "on" || str == "true" || str == "1";
+}

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -6,6 +6,7 @@
 #include "Driver/GPU/CuptiApi.h"
 #include "Driver/GPU/NvtxApi.h"
 #include "Profiler/Cupti/CuptiPCSampling.h"
+#include "Utility/Env.h"
 #include "Utility/Map.h"
 
 #include <cstdlib>
@@ -401,8 +402,10 @@ void CuptiProfiler::CuptiProfilerPimpl::doStart() {
   setGraphCallbacks(subscriber, /*enable=*/true);
   setRuntimeCallbacks(subscriber, /*enable=*/true);
   setDriverCallbacks(subscriber, /*enable=*/true);
-  nvtx::enable();
-  setNvtxCallbacks(subscriber, /*enable=*/true);
+  if (getBoolEnv("TRITON_ENABLE_NVTX", true)) {
+    nvtx::enable();
+    setNvtxCallbacks(subscriber, /*enable=*/true);
+  }
 }
 
 void CuptiProfiler::CuptiProfilerPimpl::doFlush() {

--- a/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
@@ -4,6 +4,7 @@
 #include "Driver/GPU/HipApi.h"
 #include "Driver/GPU/HsaApi.h"
 #include "Driver/GPU/RoctracerApi.h"
+#include "Utility/Env.h"
 
 #include "hip/amd_detail/hip_runtime_prof.h"
 #include "roctracer/roctracer_ext.h"
@@ -372,8 +373,10 @@ void RoctracerProfiler::RoctracerProfilerPimpl::activityCallback(
 }
 
 void RoctracerProfiler::RoctracerProfilerPimpl::doStart() {
-  roctracer::enableDomainCallback<true>(ACTIVITY_DOMAIN_ROCTX, apiCallback,
-                                        nullptr);
+  if (getBoolEnv("TRITON_ENABLE_NVTX", true)) {
+    roctracer::enableDomainCallback<true>(ACTIVITY_DOMAIN_ROCTX, apiCallback,
+                                          nullptr);
+  }
   roctracer::enableDomainCallback<true>(ACTIVITY_DOMAIN_HIP_API, apiCallback,
                                         nullptr);
   // Activity Records

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -122,8 +122,8 @@ void SessionManager::activateSessionImpl(size_t sessionId) {
   throwIfSessionNotInitialized(sessions, sessionId);
   if (sessionActive[sessionId])
     return;
-  sessionActive[sessionId] = true;
   sessions[sessionId]->activate();
+  sessionActive[sessionId] = true;
   registerInterface<ScopeInterface>(sessionId, scopeInterfaceCounts);
   registerInterface<OpInterface>(sessionId, opInterfaceCounts);
   registerInterface<InstrumentationInterface>(sessionId,

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -27,7 +27,10 @@ def _get_backend_default_path(backend: str) -> str:
     lib_path = ""
     if backend == "cupti":
         # First try to get the path from the environment variable that overrides the default path
-        lib_path = knobs.proton.cupti_dir
+        lib_path = knobs.proton.cupti_lib_dir
+        if lib_path is not None and os.path.isfile(lib_path):
+            # The env var may point to the library file itself rather than its directory
+            lib_path = os.path.dirname(lib_path)
         if lib_path is None:
             # Get the default path for the cupti backend,
             # which is the most compatible with the current CUPTI header file triton is compiled with
@@ -108,12 +111,12 @@ def start(
     name = DEFAULT_PROFILE_NAME if name is None else name
     backend = _select_backend() if backend is None else backend
     backend_path = _get_backend_default_path(backend)
+    # Convert mode to its string representation for libproton's runtime
     mode_str = _get_mode_str(backend, mode)
 
     _check_env(backend)
 
-    # Convert mode to its string representation for libproton's runtime
-    session = libproton.start(name, context, data, backend, mode_str, backend_path)
+    session = libproton.start(name, context, data, backend, backend_path, mode_str)
 
     if hook == "triton":
         HookManager.register(LaunchHook(), session)

--- a/third_party/proton/test/conftest.py
+++ b/third_party/proton/test/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.fixture
+def fresh_knobs():
+    from triton._internal_testing import _fresh_knobs_impl
+
+    fresh_function, reset_function = _fresh_knobs_impl()
+    try:
+        yield fresh_function()
+    finally:
+        reset_function()

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -481,7 +481,10 @@ def test_scope_multiple_threads(tmp_path: pathlib.Path):
     assert names == expected
 
 
-def test_nvtx_range_push_pop(tmp_path: pathlib.Path):
+@pytest.mark.parametrize("enable_nvtx", [None, True, False])
+def test_nvtx_range_push_pop(enable_nvtx, fresh_knobs, tmp_path: pathlib.Path):
+    if enable_nvtx is not None:
+        fresh_knobs.proton.enable_nvtx = enable_nvtx
     temp_file = tmp_path / "test_nvtx_range_push_pop.hatchet"
     proton.start(str(temp_file.with_suffix("")))
 
@@ -502,12 +505,15 @@ def test_nvtx_range_push_pop(tmp_path: pathlib.Path):
     proton_scope = children[0]
     assert proton_scope["frame"]["name"] == "proton_scope"
     assert len(proton_scope["children"]) == 1
-    nvtx_range0 = proton_scope["children"][0]
-    assert nvtx_range0["frame"]["name"] == "nvtx_range0"
-    assert len(nvtx_range0["children"]) == 1
-    nvtx_range1 = nvtx_range0["children"][0]
-    assert nvtx_range1["frame"]["name"] == "nvtx_range1"
-    assert len(nvtx_range1["children"]) == 1
-    kernel = nvtx_range1["children"][0]
+    if enable_nvtx or enable_nvtx is None:
+        nvtx_range0 = proton_scope["children"][0]
+        assert nvtx_range0["frame"]["name"] == "nvtx_range0"
+        assert len(nvtx_range0["children"]) == 1
+        nvtx_range1 = nvtx_range0["children"][0]
+        assert nvtx_range1["frame"]["name"] == "nvtx_range1"
+        assert len(nvtx_range1["children"]) == 1
+        kernel = nvtx_range1["children"][0]
+    else:
+        kernel = proton_scope["children"][0]
     assert "elementwise" in kernel["frame"]["name"]
     assert kernel["metrics"]["count"] == 1


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8171

Upstream commit message:
```
> [PROTON] Use the `TRITON_NVTX_ENABLED` env var to optionally turn off nvtx (#8171)

> In case we want a more succinct call path
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 08f0046fa0370b239af44f76b28bfe6333856c58
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Differential Revision: D93835574
