### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[WS] Rework partition representation (#8123)'

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -21,7 +21,7 @@ static constexpr char kPartitionStagesAttrName[] = "ttg.partition.stages";
 static constexpr char kWarpSpecializeTagAttrName[] = "ttg.warp_specialize.tag";
 
 //===----------------------------------------------------------------------===//
-// WarpSchedule
+// PartitionSet
 //===----------------------------------------------------------------------===//
 
 namespace mlir::triton::gpu {
@@ -30,15 +30,41 @@ namespace mlir::triton::gpu {
 // relative to its consumers.
 class Partition {
 public:
-  Partition(int idx, int stage) : idx(idx), stage(stage) {}
+  Partition(int idx, int stage) : idx(idx), stage(stage) {
+    assert(idx >= 0 && "A partition index must be nonnegative.");
+  }
 
   int getIndex() const { return idx; }
   int getStage() const { return stage; }
   ArrayRef<Operation *> getOps() const { return ops; }
+  void addOp(Operation *op) { ops.push_back(op); }
+  bool hasOp(Operation *op) const;
+
+  // Iterate the inputs of the partition. Input values are those that originate
+  // from a different partition or a previous iteration of the current
+  // partition. E.g. partition B(i) may have inputs from A(i) or B(i-1). Note
+  // that the same value may be visited more than once.
+  void iterateInputs(scf::ForOp loop,
+                     function_ref<void(OpOperand &)> callback) const;
+  // Iterate the outputs of the partition. Output values are those that are
+  // consumed by a different partition or a future iteration of the current
+  // partition. E.g. partition A(i) may have outputs to B(i) or A(i+1). Note
+  // that the same value may be visited more than once.
+  void
+  iterateOutputs(scf::ForOp loop,
+                 function_ref<void(Operation *, OpOperand &)> callback) const;
+  // Iterate the defining ops of the inputs to the partition in the current and
+  // previous iterations, including the distance in the past.
+  void iterateDefs(scf::ForOp loop,
+                   function_ref<void(OpResult, unsigned)> callback) const;
+  // Iterate the uses of all outputs of the partition in the current iteration
+  // and in future iterations, including the distance in the future.
+  void iterateUses(
+      scf::ForOp loop,
+      function_ref<void(OpResult, OpOperand &, unsigned)> callback) const;
 
 private:
   void setIndex(int idx) { this->idx = idx; }
-  friend class WarpSchedule;
 
   // The partition number.
   int idx;
@@ -48,12 +74,10 @@ private:
   SmallVector<Operation *> ops;
 };
 
-// A warp schedule divides a loop into multiple partitions. Ops in a loop are
-// assigned at most one partition. A warp schedule represents asynchronous
+// A partition set divides a loop into multiple partitions. Ops in a loop are
+// assigned at most one partition. A partition set represents asynchronous
 // execution of the loop body, where partitions may execute simultaneously.
-class WarpSchedule {
-  static constexpr int kSentinel = -1;
-
+class PartitionSet {
 public:
   // Get WarpSpecialization tag
   int getTag() const { return tag; }
@@ -61,84 +85,53 @@ public:
   // Create a new partition with a stage.
   Partition *addPartition(unsigned stage);
 
-  // Get the partition the op belongs to.
-  Partition *getPartition(Operation *op);
-  // Get the partition the op belongs to.
-  const Partition *getPartition(Operation *op) const;
   // Get the partition at the index.
   Partition *getPartition(unsigned idx);
   // Get the partition at the index.
   const Partition *getPartition(unsigned idx) const;
-  // Insert an operation into a partition.
-  void insert(Partition *partition, Operation *op);
   // Return an iterator range over the partitions.
   auto getPartitions() { return llvm::make_pointee_range(partitions); }
   // Return an iterator range over the partitions.
   auto getPartitions() const { return llvm::make_pointee_range(partitions); }
   // Get the number of partitions.
   unsigned getNumPartitions() const { return partitions.size(); }
-  // Get the root partition.
-  Partition *getRootPartition() { return rootPartition.get(); }
-  // Get the root partition.
-  const Partition *getRootPartition() const { return rootPartition.get(); }
 
-  // Return true if an operation is assigned to a partition.
-  bool isScheduled(Operation *op) const;
-  // Schedule an operation to a partition if it is not already scheduled. Return
-  // true if the operation was scheduled.
-  bool trySchedule(Partition *partition, Operation *op);
-
-  // Deserialize a warp schedule from an `scf.for` op using the attributes
+  // Deserialize a partition set from an `scf.for` op using the attributes
   // tagged on operations in its body.
-  static FailureOr<WarpSchedule> deserialize(scf::ForOp loop);
-  // Serialize a warp schedule by writing the partition stage and mappings
-  // as attributes on operations in the loop.
+  static FailureOr<PartitionSet> fromLoop(scf::ForOp loop);
+
+  // Serialize the partition set to the loop attributes.
   void serialize(scf::ForOp loop) const;
-  // Verify that the warp schedule is valid by checking the SSA dependencies
-  // between the schedules.
-  LogicalResult verify(scf::ForOp loop) const;
-  // Remove partition attributes.
-  static void eraseFrom(scf::ForOp loop);
 
-  // Iterate the inputs of the partition. Input values are those that originate
-  // from a different partition or a previous iteration of the current
-  // partition. E.g. partition B(i) may have inputs from A(i) or B(i-1). Note
-  // that the same value may be visited more than once.
-  void iterateInputs(scf::ForOp loop, const Partition *partition,
-                     function_ref<void(OpOperand &)> callback) const;
-  // Iterate the outputs of the partition. Output values are those that are
-  // consumed by a different partition or a future iteration of the current
-  // partition. E.g. partition A(i) may have outputs to B(i) or A(i+1). Note
-  // that the same value may be visited more than once.
-  void
-  iterateOutputs(scf::ForOp loop, const Partition *partition,
-                 function_ref<void(Operation *, OpOperand &)> callback) const;
-  // Iterate the defining ops of the inputs to the partition in the current and
-  // previous iterations, including the distance in the past.
-  void iterateDefs(scf::ForOp loop, const Partition *partition,
-                   function_ref<void(OpResult, unsigned)> callback) const;
-  // Iterate the uses of all outputs of the partition in the current iteration
-  // and in future iterations, including the distance in the future.
-  void iterateUses(
-      scf::ForOp loop, const Partition *partition,
-      function_ref<void(OpResult, OpOperand &, unsigned)> callback) const;
-
-  // Debug dump the schedule.
+  // Debug dump the partition set.
   LLVM_DUMP_METHOD void dump() const;
+
+  // Utility to be used when the op is known to belong to one partition
+  Partition *getPartition(Operation *op);
+
+  // Check if the operation belongs to all partitions
+  bool isInRootPartition(Operation *op);
 
 private:
   // WarpSpecialization tag
   int tag;
   // Partitions are numbered [0, N).
   SmallVector<std::unique_ptr<Partition>> partitions;
-  // A mapping from operation to its partition.
-  DenseMap<Operation *, Partition *> opToPartition;
-  // The root partition contains operations that are not assigned to a
-  // partition. Operations not assigned to partitions are assumed to be "free"
-  // and can be cloned as necessary.
-  std::unique_ptr<Partition> rootPartition =
-      std::make_unique<Partition>(kSentinel, kSentinel);
 };
+
+bool hasPartition(Operation *op);
+
+// Annotate the op with the partition index or indices, and add the op
+// to the partitions it belongs to.
+void setPartition(Operation *op, Partition *partition);
+void setPartition(Operation *op, const SetVector<Partition *> &partitions);
+// Annotate the op with the partition indices. It should only be used in a pass
+// which does not work with Partition instances and iterate* functions, since
+// it does not keep the op attributes and the op list of a partition in sync.
+void setPartition(Operation *op, const SetVector<int> &partitionIds);
+
+std::optional<SetVector<int>> getPartitionIds(Operation *op);
+
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_TRITONGPU_TRANSFORM_PIPELINE_PARTITION_H_

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -39,7 +39,7 @@ struct PipelinedLoad {
   }
   LogicalResult determineLiveRange(Block &container, DominanceInfo &domInfo,
                                    PostDominanceInfo &postDomInfo,
-                                   WarpSchedule &schedule);
+                                   PartitionSet &partitions);
 
   Operation *loadOp;
   RankedTensorType type;
@@ -58,8 +58,19 @@ struct PipelinedMMA {
 };
 } // namespace
 
+bool samePartition(Operation *op1, Operation *op2) {
+  auto part1 = getPartitionIds(op1);
+  auto part2 = getPartitionIds(op2);
+
+  if (!part1 || !part2) {
+    return false;
+  }
+
+  return *part1 == *part2;
+}
+
 static std::pair<SmallVector<PipelinedLoad>, SmallVector<PipelinedMMA>>
-getPartitionScheme(scf::ForOp loop, const WarpSchedule &schedule) {
+getPartitionScheme(scf::ForOp loop) {
   SmallVector<PipelinedLoad> loads;
   SmallVector<PipelinedMMA> mmas;
 
@@ -68,7 +79,7 @@ getPartitionScheme(scf::ForOp loop, const WarpSchedule &schedule) {
       continue;
     auto &load = loads.emplace_back(&op);
     for (Operation *user : op.getUsers()) {
-      if (schedule.getPartition(user) == schedule.getPartition(&op) &&
+      if (samePartition(user, &op) &&
           isa<LocalAllocOp, ttng::TMEMAllocOp>(user))
         load.allocOps.push_back(user);
     }
@@ -193,7 +204,7 @@ findSharedMemorySinkOps(Value value, SmallVectorImpl<Operation *> &sinkOps) {
 LogicalResult PipelinedLoad::determineLiveRange(Block &container,
                                                 DominanceInfo &domInfo,
                                                 PostDominanceInfo &postDomInfo,
-                                                WarpSchedule &schedule) {
+                                                PartitionSet &partitions) {
   // Find the liveBefore and liveUntil operations of the load.
   llvm::MapVector<Partition *, SmallVector<Operation *>> regSinks, shmemSinks;
   for (Operation *user : loadOp->getUsers()) {
@@ -202,14 +213,14 @@ LogicalResult PipelinedLoad::determineLiveRange(Block &container,
       // This is an in-register use of the load. The result must be live before
       // the op. Since it will be loaded out of shared memory, it only needs to
       // be live until the op as well.
-      regSinks[schedule.getPartition(user)].push_back(user);
+      regSinks[partitions.getPartition(user)].push_back(user);
       continue;
     }
     SmallVector<Operation *> sinkOps;
     if (failed(findSharedMemorySinkOps((*it)->getResult(0), sinkOps)))
       return failure();
     for (Operation *sinkOp : sinkOps)
-      shmemSinks[schedule.getPartition(sinkOp)].push_back(sinkOp);
+      shmemSinks[partitions.getPartition(sinkOp)].push_back(sinkOp);
   }
   SetVector<Partition *> userPartitions;
   userPartitions.insert_range(llvm::make_first_range(regSinks));
@@ -283,7 +294,7 @@ namespace {
 struct PipelinedLoadGroup {
   Location getLoc();
   void allocateAref(scf::ForOp &loop, int numStages);
-  LogicalResult lowerLoads(WarpSchedule &schedule, DominanceInfo &domInfo,
+  LogicalResult lowerLoads(PartitionSet &partitions, DominanceInfo &domInfo,
                            PostDominanceInfo &postDomInfo);
 
   SmallVector<PipelinedLoad> loads;
@@ -355,14 +366,14 @@ static void lowerTMACopy(PartitionBuilder &b, Partition &loadPartition,
   }
 }
 
-LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
+LogicalResult PipelinedLoadGroup::lowerLoads(PartitionSet &partitions,
                                              DominanceInfo &domInfo,
                                              PostDominanceInfo &postDomInfo) {
   // Insert before the group of loads.
   auto firstLoad = llvm::min_element(loads, [&](auto &lhs, auto &rhs) {
     return domInfo.properlyDominates(lhs.loadOp, rhs.loadOp);
   });
-  Partition &loadPartition = *schedule.getPartition(firstLoad->loadOp);
+  Partition &loadPartition = *partitions.getPartition(firstLoad->loadOp);
   PartitionBuilder b(getLoc(), firstLoad->loadOp);
   StageCluster stageCluster = getStageCluster(firstLoad->loadOp);
 
@@ -385,7 +396,7 @@ LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
   DenseMap<Partition *, ttng::ArriveBarrierOp> arriveOps;
   for (auto [i, liveBeforeOp] : llvm::enumerate(firstLoad->liveBeforeOps)) {
     b.setInsertionPoint(liveBeforeOp);
-    Partition &userPartition = *schedule.getPartition(liveBeforeOp);
+    Partition &userPartition = *partitions.getPartition(liveBeforeOp);
     StageCluster userStageCluster = getStageCluster(liveBeforeOp);
     b.createInto<ttng::WaitBarrierOp>(userPartition, userStageCluster,
                                       curLoadBar, phase);
@@ -404,7 +415,7 @@ LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
       b.setInsertionPoint(liveUntilOp);
       auto arriveOp = b.createInto<ttng::ArriveBarrierOp>(
           userPartition, userStageCluster, curEmptyBar, 1);
-      arriveOps[schedule.getPartition(liveUntilOp)] = arriveOp;
+      arriveOps[partitions.getPartition(liveUntilOp)] = arriveOp;
     }
   }
 
@@ -434,7 +445,7 @@ LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
     // If there are remaining users, they must be in-register.
     llvm::MapVector<Partition *, SmallVector<OpOperand *>> regUses;
     for (OpOperand &use : load.loadOp->getUses())
-      regUses[schedule.getPartition(use.getOwner())].push_back(&use);
+      regUses[partitions.getPartition(use.getOwner())].push_back(&use);
     for (auto &[partition, uses] : regUses) {
       auto users = llvm::to_vector(llvm::map_range(
           uses, [](OpOperand *use) { return use->getOwner(); }));
@@ -461,7 +472,8 @@ LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
 //===----------------------------------------------------------------------===//
 
 static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
-                                 WarpSchedule &schedule, DominanceInfo &domInfo,
+                                 PartitionSet &partitions,
+                                 DominanceInfo &domInfo,
                                  PostDominanceInfo &postDomInfo) {
   ttng::MMAv5OpInterface mmaOp = mma.mmaOp;
   auto fail = [&](StringRef msg) { return emitWarning(mmaOp.getLoc(), msg); };
@@ -562,8 +574,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
   for (int i = 0; i < nodes.size(); ++i) {
     Node &cur = nodes[i];
     Node &next = nodes[(i + 1) % nodes.size()];
-    if (schedule.getPartition(inBody(cur.op)) !=
-        schedule.getPartition(inBody(next.op))) {
+    if (!samePartition(inBody(cur.op), inBody(next.op))) {
       cur.barNext = createBarrierAlloc(loop, numMmaStages);
       next.barPrev = cur.barNext;
     }
@@ -662,15 +673,16 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     if (!defOp || loop.isDefinedOutsideOfLoop(operand))
       continue;
     defOp = inBody(defOp);
-    Partition *defPartition = schedule.getPartition(defOp);
 
-    if (!defPartition || defPartition == schedule.getRootPartition()) {
+    if (partitions.isInRootPartition(defOp)) {
       // If the MMA operand is coming from outside the loop, move the alloc out.
       auto allocOp = dyn_cast<LocalAllocOp>(defOp);
       if (allocOp && loop.isDefinedOutsideOfLoop(allocOp.getSrc()))
         allocOp->moveBefore(loop);
       continue;
     }
+
+    Partition *defPartition = partitions.getPartition(defOp);
 
     if (auto allocOp = operand.getDefiningOp<LocalAllocOp>()) {
       PartitionBuilder b(allocOp.getLoc(), allocOp);
@@ -706,7 +718,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
   }
 
   for (Node &node : nodes) {
-    Partition *partition = schedule.getPartition(inBody(node.op));
+    Partition *partition = partitions.getPartition(inBody(node.op));
     PartitionBuilder b(node.op->getLoc(), loop);
 
     SmallVector<Operation *> defs;
@@ -798,7 +810,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
 
     b.setInsertionPoint(mmaOp);
     Value readyView2 = createSingleBufferView(b, readyBar, index);
-    b.createInto<ttng::WaitBarrierOp>(*schedule.getPartition(mmaOp),
+    b.createInto<ttng::WaitBarrierOp>(*partitions.getPartition(mmaOp),
                                       getStageCluster(mmaOp), readyView2,
                                       phase);
     Value emptyView2 = createSingleBufferView(b, emptyBar, index);
@@ -833,7 +845,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
 
 LogicalResult lowerLoops(scf::ForOp &loop, MutableArrayRef<PipelinedLoad> loads,
                          MutableArrayRef<PipelinedMMA> mmas,
-                         WarpSchedule &schedule, int numLoadStages) {
+                         PartitionSet &partitions, int numLoadStages) {
   Block &body = *loop.getBody();
   DominanceInfo domInfo(loop);
   PostDominanceInfo postDomInfo(loop);
@@ -843,7 +855,7 @@ LogicalResult lowerLoops(scf::ForOp &loop, MutableArrayRef<PipelinedLoad> loads,
   llvm::MapVector<ArrayRef<Operation *>, SmallVector<PipelinedLoad>>
       liveBeforeGroups;
   for (PipelinedLoad &load : loads) {
-    if (failed(load.determineLiveRange(body, domInfo, postDomInfo, schedule)))
+    if (failed(load.determineLiveRange(body, domInfo, postDomInfo, partitions)))
       return failure();
     liveBeforeGroups[load.liveBeforeOps].push_back(std::move(load));
   }
@@ -856,13 +868,13 @@ LogicalResult lowerLoops(scf::ForOp &loop, MutableArrayRef<PipelinedLoad> loads,
     group.allocateAref(loop, numLoadStages);
 
   for (PipelinedLoadGroup &group : loadGroups) {
-    if (failed(group.lowerLoads(schedule, domInfo, postDomInfo)))
+    if (failed(group.lowerLoads(partitions, domInfo, postDomInfo)))
       return failure();
   }
 
   // Multi-buffer and lower the MMAs.
   for (PipelinedMMA &mma : mmas) {
-    if (failed(pipelineMMA(loop, mma, schedule, domInfo, postDomInfo)))
+    if (failed(pipelineMMA(loop, mma, partitions, domInfo, postDomInfo)))
       return failure();
   }
 
@@ -895,14 +907,14 @@ void LoadMMASpecialization::runOnOperation() {
       loops.push_back(loop);
   });
   for (scf::ForOp loop : loops) {
-    FailureOr<WarpSchedule> schedule = WarpSchedule::deserialize(loop);
-    if (failed(schedule))
+    FailureOr<PartitionSet> partitions = PartitionSet::fromLoop(loop);
+    if (failed(partitions))
       continue;
-    auto [loads, mmas] = getPartitionScheme(loop, *schedule);
+    auto [loads, mmas] = getPartitionScheme(loop);
     if (loads.empty() && mmas.empty())
       continue;
     int loopNumStages = getNumStagesOrDefault(loop, numStages);
-    if (failed(lowerLoops(loop, loads, mmas, *schedule, loopNumStages)))
+    if (failed(lowerLoops(loop, loads, mmas, *partitions, loopNumStages)))
       continue;
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -1,7 +1,9 @@
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/ADT/SCCIterator.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/Use.h"
 
 using namespace mlir;
@@ -9,152 +11,20 @@ using namespace triton;
 using namespace triton::gpu;
 
 //===----------------------------------------------------------------------===//
-// WarpSchedule
+// Partition
 //===----------------------------------------------------------------------===//
 
-Partition *WarpSchedule::addPartition(unsigned stage) {
-  partitions.push_back(std::make_unique<Partition>(partitions.size(), stage));
-  return partitions.back().get();
-}
-
-Partition *WarpSchedule::getPartition(Operation *op) {
-  return opToPartition.lookup(op);
-}
-const Partition *WarpSchedule::getPartition(Operation *op) const {
-  return opToPartition.lookup(op);
-}
-
-Partition *WarpSchedule::getPartition(unsigned idx) {
-  return partitions[idx].get();
-}
-const Partition *WarpSchedule::getPartition(unsigned idx) const {
-  return partitions[idx].get();
-}
-
-void WarpSchedule::insert(Partition *partition, Operation *op) {
-  partition->ops.push_back(op);
-  opToPartition[op] = partition;
-}
-
-bool WarpSchedule::isScheduled(Operation *op) const {
-  const Partition *partition = getPartition(op);
-  return partition && partition != getRootPartition();
-}
-
-bool WarpSchedule::trySchedule(Partition *partition, Operation *op) {
-  if (isScheduled(op))
+bool Partition::hasOp(Operation *op) const {
+  auto partitionIds = getPartitionIds(op);
+  if (!partitionIds) {
     return false;
-  insert(partition, op);
-  return true;
-}
-
-FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
-  auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
-  if (!stages)
-    return failure();
-
-  auto tag = loop->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
-  if (!tag)
-    return failure();
-
-  WarpSchedule result;
-  result.tag = tag.getInt();
-  for (auto [idx, attr] : llvm::enumerate(stages)) {
-    auto stage = dyn_cast<IntegerAttr>(attr);
-    if (!stage || stage.getInt() < 0) {
-      return mlir::emitError(loop.getLoc(), "partition stages attribute '")
-             << kPartitionStagesAttrName << "' has invalid element " << attr;
-    }
-
-    result.partitions.push_back(
-        std::make_unique<Partition>(idx, stage.getInt()));
   }
-
-  for (Operation &op : loop.getBody()->without_terminator()) {
-    Partition *partition = result.getRootPartition();
-    if (auto attr = op.getAttrOfType<IntegerAttr>(kPartitionAttrName)) {
-      int64_t idx = attr.getInt();
-      if (idx < 0 || idx >= result.partitions.size())
-        return mlir::emitError(op.getLoc(), "invalid partition index ") << idx;
-      partition = result.partitions[idx].get();
-    }
-    result.insert(partition, &op);
-  }
-
-  return result;
+  return partitionIds->contains(getIndex());
 }
 
-void WarpSchedule::serialize(scf::ForOp loop) const {
-  SmallVector<Attribute> stages;
-  Builder b(loop.getContext());
-
-  // Serialize partition attributes for operations inside the loop.
-  loop.walk([&](Operation *op) {
-    if (Partition *partition = opToPartition.lookup(op)) {
-      if (partition == getRootPartition())
-        return;
-      op->setAttr(kPartitionAttrName,
-                  b.getI32IntegerAttr(partition->getIndex()));
-    }
-  });
-
-  // Serialize partition attributes for post-loop operations -
-  // operations scheduled in partitions but outside the loop body.
-  // Walk the parent op to find post-loop operations that are still in the IR
-  // fix: some operations in opToPartition are erased by inserAref pass in NVWS.
-  if (Operation *parent = loop->getParentOp()) {
-    parent->walk([&](Operation *op) {
-      // Skip operations inside the loop (already handled above)
-      if (loop->isAncestor(op))
-        return;
-      Partition *partition = opToPartition.lookup(op);
-      if (!partition || partition == getRootPartition())
-        return;
-      op->setAttr(kPartitionAttrName,
-                  b.getI32IntegerAttr(partition->getIndex()));
-    });
-  }
-
-  for (Partition &partition : getPartitions())
-    stages.push_back(b.getI32IntegerAttr(partition.getStage()));
-  loop->setAttr(kPartitionStagesAttrName, b.getArrayAttr(stages));
-}
-
-LogicalResult WarpSchedule::verify(scf::ForOp loop) const {
-  // The root partition is only allowed to transitively depend on itself.
-  bool failed = false;
-  iterateInputs(loop, getRootPartition(), [&](OpOperand &input) {
-    auto [def, distance] = getDefiningOpAndDistance(loop, input.get());
-    // Ignore values defined outside the loop.
-    if (!def || def->getParentOp() != loop)
-      return;
-    const Partition *defPartition = opToPartition.at(def);
-    if (defPartition == getRootPartition())
-      return;
-    InFlightDiagnostic diag = mlir::emitWarning(input.getOwner()->getLoc());
-    diag << "operation in the root partition depends on a value that "
-            "originates from a non-root partition through operand #"
-         << input.getOperandNumber();
-    diag.attachNote(def->getLoc())
-        << "operand defined here in partition #" << defPartition->getIndex()
-        << " at distance " << distance;
-    failed = true;
-  });
-  if (failed)
-    return failure();
-
-  return success();
-}
-
-void WarpSchedule::eraseFrom(scf::ForOp loop) {
-  loop.walk([&](Operation *op) { op->removeAttr(kPartitionAttrName); });
-  loop->removeAttr(kPartitionStagesAttrName);
-}
-
-void WarpSchedule::iterateInputs(
-    scf::ForOp loop, const Partition *partition,
-    function_ref<void(OpOperand &)> callback) const {
-  for (Operation *op : partition->getOps()) {
+void Partition::iterateInputs(scf::ForOp loop,
+                              function_ref<void(OpOperand &)> callback) const {
+  for (Operation *op : getOps()) {
     visitNestedOperands(op, [&](OpOperand &operand) {
       // Ignore implicit captures.
       Value value = operand.get();
@@ -168,20 +38,23 @@ void WarpSchedule::iterateInputs(
         // This value originates from a previous iteration.
         assert(llvm::is_contained(loop.getRegionIterArgs(), arg));
         callback(operand);
-      } else if (getPartition(value.getDefiningOp()) != partition) {
-        // This value originates from a different partition in the same
-        // iteration.
-        assert(value.getDefiningOp()->getParentOp() == loop);
-        callback(operand);
+      } else {
+        auto partitionIds = getPartitionIds(value.getDefiningOp());
+        if (!partitionIds || !partitionIds->contains(getIndex())) {
+          // This value originates from a different partition in the same
+          // iteration.
+          assert(value.getDefiningOp()->getParentOp() == loop);
+          callback(operand);
+        }
       }
     });
   }
 }
 
-void WarpSchedule::iterateOutputs(
-    scf::ForOp loop, const Partition *partition,
+void Partition::iterateOutputs(
+    scf::ForOp loop,
     function_ref<void(Operation *, OpOperand &)> callback) const {
-  for (Operation *op : partition->getOps()) {
+  for (Operation *op : getOps()) {
     for (OpOperand &use : op->getUses()) {
       Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
 
@@ -190,7 +63,8 @@ void WarpSchedule::iterateOutputs(
         // The user is outside the loop, so it's a post-loop operation.
         // Use the operation directly.
         owner = use.getOwner();
-        if (getPartition(owner) != partition) {
+        auto ids = getPartitionIds(owner);
+        if (!ids || !ids->contains(getIndex())) {
           callback(owner, use);
         }
         continue;
@@ -199,29 +73,31 @@ void WarpSchedule::iterateOutputs(
       if (isa<scf::YieldOp>(owner)) {
         // This value is used in a subsequent iteration.
         callback(owner, use);
-      } else if (getPartition(owner) != partition) {
-        // This value is used in a different partition in the same iteration.
-        callback(owner, use);
+      } else {
+        auto ids = getPartitionIds(owner);
+        if (!ids || !ids->contains(getIndex())) {
+          // This value is used in a different partition in the same iteration.
+          callback(owner, use);
+        }
       }
     }
   }
 }
 
-void WarpSchedule::iterateDefs(
-    scf::ForOp loop, const Partition *partition,
-    function_ref<void(OpResult, unsigned)> callback) const {
-  iterateInputs(loop, partition, [&](OpOperand &input) {
+void Partition::iterateDefs(
+    scf::ForOp loop, function_ref<void(OpResult, unsigned)> callback) const {
+  iterateInputs(loop, [&](OpOperand &input) {
     auto [def, distance] = getDefinitionAndDistance(loop, input.get());
     if (def && def.getParentBlock() == loop.getBody())
       callback(def, distance);
   });
 }
 
-void WarpSchedule::iterateUses(
-    scf::ForOp loop, const Partition *partition,
+void Partition::iterateUses(
+    scf::ForOp loop,
     function_ref<void(OpResult, OpOperand &, unsigned)> callback) const {
   SmallVector<std::tuple<OpResult, OpOperand *, unsigned>> uses;
-  iterateOutputs(loop, partition, [&](Operation *owner, OpOperand &use) {
+  iterateOutputs(loop, [&](Operation *owner, OpOperand &use) {
     uses.emplace_back(cast<OpResult>(use.get()), &use, 0);
   });
   while (!uses.empty()) {
@@ -245,7 +121,81 @@ void WarpSchedule::iterateUses(
   }
 }
 
-void WarpSchedule::dump() const {
+//===----------------------------------------------------------------------===//
+// PartitionSet
+//===----------------------------------------------------------------------===//
+
+Partition *PartitionSet::addPartition(unsigned stage) {
+  partitions.push_back(std::make_unique<Partition>(partitions.size(), stage));
+  return partitions.back().get();
+}
+
+Partition *PartitionSet::getPartition(unsigned idx) {
+  return partitions[idx].get();
+}
+
+const Partition *PartitionSet::getPartition(unsigned idx) const {
+  return partitions[idx].get();
+}
+
+Partition *PartitionSet::getPartition(Operation *op) {
+  auto id = getPartitionIds(op);
+  assert(id && id->size() == 1);
+  return getPartition((*id)[0]);
+}
+
+bool PartitionSet::isInRootPartition(Operation *op) {
+  auto partitionIds = getPartitionIds(op);
+  return !partitionIds || partitionIds->size() == getNumPartitions();
+}
+
+FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
+  auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
+  if (!stages)
+    return failure();
+
+  auto tag = loop->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
+  if (!tag)
+    return failure();
+
+  PartitionSet result;
+  result.tag = tag.getInt();
+  for (auto [idx, attr] : llvm::enumerate(stages)) {
+    auto stage = dyn_cast<IntegerAttr>(attr);
+    if (!stage || stage.getInt() < 0) {
+      return mlir::emitError(loop.getLoc(), "partition stages attribute '")
+             << kPartitionStagesAttrName << "' has invalid element " << attr;
+    }
+
+    result.partitions.push_back(
+        std::make_unique<Partition>(idx, stage.getInt()));
+  }
+
+  for (Operation &op : loop.getBody()->without_terminator()) {
+    if (auto attrs = getPartitionIds(&op)) {
+      for (auto idx : *attrs) {
+        if (idx < 0 || idx >= result.partitions.size())
+          return mlir::emitError(op.getLoc(), "invalid partition index ")
+                 << idx;
+        result.partitions[idx]->addOp(&op);
+      }
+    }
+  }
+
+  return result;
+}
+
+void PartitionSet::serialize(scf::ForOp loop) const {
+  // In the new PartitionSet system, per-op partition attributes are already set
+  // by setPartition(). We only need to serialize the partition stages array.
+  SmallVector<Attribute> stages;
+  Builder b(loop.getContext());
+  for (const Partition &partition : getPartitions())
+    stages.push_back(b.getI32IntegerAttr(partition.getStage()));
+  loop->setAttr(kPartitionStagesAttrName, b.getArrayAttr(stages));
+}
+
+void PartitionSet::dump() const {
   for (auto [i, partition] :
        llvm::enumerate(llvm::make_pointee_range(partitions))) {
     llvm::errs() << "=== PARTITION #" << i << " ===\n";
@@ -255,10 +205,54 @@ void WarpSchedule::dump() const {
     }
     llvm::errs() << "\n";
   }
-  llvm::errs() << "=== ROOT PARTITION ===\n";
-  for (Operation *op : getRootPartition()->getOps()) {
-    op->print(llvm::errs(), OpPrintingFlags().skipRegions());
-    llvm::errs() << "\n";
-  }
   llvm::errs() << "\n";
 }
+
+namespace mlir::triton::gpu {
+
+void setPartition(Operation *op, ArrayRef<int> partitionIds) {
+  Builder b(op->getContext());
+  op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(partitionIds));
+}
+
+void setPartition(Operation *op, const SetVector<int> &partitionIds) {
+  SmallVector<int> partitions(partitionIds.begin(), partitionIds.end());
+  setPartition(op, partitions);
+}
+
+void setPartition(Operation *op, Partition *partition) {
+  SmallVector<int> partitions{partition->getIndex()};
+  setPartition(op, partitions);
+  partition->addOp(op);
+}
+
+void setPartition(Operation *op, const SetVector<Partition *> &partitions) {
+  SmallVector<int> partitionIds;
+  for (auto partition : partitions) {
+    partitionIds.push_back(partition->getIndex());
+    partition->addOp(op);
+  }
+  setPartition(op, partitionIds);
+}
+
+std::optional<SetVector<int>> getPartitionIds(Operation *op) {
+  if (!op) {
+    return std::nullopt;
+  }
+  auto attrs = op->getAttr(kPartitionAttrName);
+  if (!attrs) {
+    return std::nullopt;
+  }
+
+  assert(isa<DenseI32ArrayAttr>(attrs));
+
+  SetVector<int> partitionIds;
+  for (auto id : cast<DenseI32ArrayAttr>(attrs).asArrayRef()) {
+    partitionIds.insert(id);
+  }
+  return partitionIds;
+}
+
+bool hasPartition(Operation *op) { return getPartitionIds(op) != std::nullopt; }
+
+} // namespace mlir::triton::gpu

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionBuilder.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionBuilder.cpp
@@ -22,7 +22,7 @@ void PartitionBuilder::assignStage(Operation *op, StageCluster stageCluster) {
 }
 
 void PartitionBuilder::assignPartition(Operation *op, Partition &partition) {
-  op->setAttr(kPartitionAttrName, getI32IntegerAttr(partition.getIndex()));
+  setPartition(op, &partition);
 }
 
 StageCluster triton::gpu::getStageCluster(Operation *op) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -53,9 +53,9 @@ enum class LoopVarCategory {
 
 bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
                               const Partition *partition,
-                              const WarpSchedule &schedule) {
+                              const PartitionSet &partitions) {
   bool ret = false;
-  schedule.iterateOutputs(loop, partition, [&](Operation *op, OpOperand &use) {
+  partition->iterateOutputs(loop, [&](Operation *op, OpOperand &use) {
     if (isa<scf::YieldOp>(op) && use.getOperandNumber() == resultIdx &&
         isa<RankedTensorType>(loop.getResult(resultIdx).getType())) {
       ret = true;
@@ -64,21 +64,30 @@ bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
   return ret;
 }
 
+SmallVector<size_t> getPartitionIds(Operation *op, size_t numPartitions) {
+  auto partitionIds = triton::gpu::getPartitionIds(op);
+  if (!partitionIds) {
+    SmallVector<size_t> ret(numPartitions);
+    std::iota(ret.begin(), ret.end(), 0);
+    return ret;
+  }
+  SmallVector<size_t> ret(partitionIds->begin(), partitionIds->end());
+  return ret;
+}
+
 SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
                                               const Partition *partition,
-                                              const WarpSchedule &schedule) {
+                                              const PartitionSet &partitions) {
   auto inPartition = [&](Operation *op) {
-    const Partition *opPartition =
-        schedule.getPartition(loop.getBody()->findAncestorOpInBlock(*op));
-    return llvm::is_contained({partition, schedule.getRootPartition()},
-                              opPartition);
+    auto opPartitionIds = getPartitionIds(op, partitions.getNumPartitions());
+    return llvm::is_contained(opPartitionIds, partition->getIndex());
   };
   auto isTensorResultFromOtherPartition = [&](int i) {
-    for (auto otherPartition : schedule.getPartitions()) {
+    for (auto otherPartition : partitions.getPartitions()) {
       if (&otherPartition == partition) {
         continue;
       }
-      if (isTensorResultComputedBy(loop, i, &otherPartition, schedule)) {
+      if (isTensorResultComputedBy(loop, i, &otherPartition, partitions)) {
         return true;
       }
     }
@@ -124,23 +133,9 @@ getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
 
 std::pair<SmallVector<size_t>, SmallVector<std::optional<size_t>>>
 getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
-                        const WarpSchedule &schedule) {
-  auto loopVarCategories = classifyLoopVars(loop, partition, schedule);
+                        const PartitionSet &partitions) {
+  auto loopVarCategories = classifyLoopVars(loop, partition, partitions);
   return getLoopVarIndicesToKeep(loop, partition, loopVarCategories);
-}
-
-const Partition *getPartition(Operation *op, const WarpSchedule &schedule) {
-  auto origOp = op;
-  while (op && !schedule.getPartition(op)) {
-    op = op->getParentOp();
-  }
-  if (op) {
-    return schedule.getPartition(op);
-  }
-
-  // Some yield ops, e.g. automatically added one, might not have a partition
-  assert(isa<scf::YieldOp>(origOp) && "No partition is found for an op.");
-  return nullptr;
 }
 
 void mapRange(ValueRange fromRange, ValueRange toRange, IRMapping &mapping) {
@@ -149,36 +144,15 @@ void mapRange(ValueRange fromRange, ValueRange toRange, IRMapping &mapping) {
   }
 }
 
-SmallVector<size_t>
-getPartitionIndicesToCloneInto(const Partition *partition,
-                               const WarpSchedule &schedule) {
-  SmallVector<size_t> partitionIndices;
-
-  if (!partition || partition == schedule.getRootPartition()) {
-    for (size_t i = 0; i < schedule.getNumPartitions(); ++i) {
-      partitionIndices.push_back(i);
-    }
-  } else {
-    partitionIndices.push_back(partition->getIndex());
-  }
-
-  return partitionIndices;
-}
-int getPartitionIndex(Operation *op) {
-  if (isa<nvws::WarpGroupOp>(op->getParentOp()))
-    return op->getParentRegion()->getRegionNumber();
-  return getPartitionIndex(op->getParentOp());
-}
-
 void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
-                     const WarpSchedule &schedule);
+                     const PartitionSet &partitions);
 
 void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
-                const WarpSchedule &schedule) {
+                const PartitionSet &partitions) {
   SmallVector<scf::ForOp> newForOps;
-  for (auto [b, partition] : llvm::zip(builders, schedule.getPartitions())) {
+  for (auto [b, partition] : llvm::zip(builders, partitions.getPartitions())) {
     auto [newLoopIndices, _] =
-        getLoopVarIndicesToKeep(forOp, &partition, schedule);
+        getLoopVarIndicesToKeep(forOp, &partition, partitions);
     auto lb = b.mapping.lookupOrDefault(forOp.getLowerBound());
     auto ub = b.mapping.lookupOrDefault(forOp.getUpperBound());
     auto step = b.mapping.lookupOrDefault(forOp.getStep());
@@ -203,18 +177,18 @@ void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
     b.setInsertionPointToStart(newForOp.getBody());
   }
 
-  cloneOpsInBlock(forOp.getBody(), builders, schedule);
+  cloneOpsInBlock(forOp.getBody(), builders, partitions);
 
-  for (auto newForOp : newForOps) {
-    builders[getPartitionIndex(newForOp)].setInsertionPointAfter(newForOp);
-    WarpSchedule::eraseFrom(newForOp);
+  for (auto [i, newForOp] : enumerate(newForOps)) {
+    builders[i].setInsertionPointAfter(newForOp);
+    newForOp.walk([&](Operation *op) { op->removeAttr(kPartitionAttrName); });
+    newForOp->removeAttr(kPartitionStagesAttrName);
   }
 }
 
 void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
-               const WarpSchedule &schedule) {
-  auto partition = getPartition(ifOp, schedule);
-  auto partitionIndices = getPartitionIndicesToCloneInto(partition, schedule);
+               const PartitionSet &partitions) {
+  auto partitionIndices = getPartitionIds(ifOp, partitions.getNumPartitions());
 
   SmallVector<scf::IfOp> newIfOps;
   for (size_t idx : partitionIndices) {
@@ -237,13 +211,13 @@ void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
     b.setInsertionPointToStart(newIfOp.thenBlock());
   }
 
-  cloneOpsInBlock(ifOp.thenBlock(), builders, schedule);
+  cloneOpsInBlock(ifOp.thenBlock(), builders, partitions);
 
   if (auto elseBlock = ifOp.elseBlock()) {
     for (auto [idx, newIfOp] : llvm::zip(partitionIndices, newIfOps)) {
       builders[idx].setInsertionPointToStart(newIfOp.elseBlock());
     }
-    cloneOpsInBlock(elseBlock, builders, schedule);
+    cloneOpsInBlock(elseBlock, builders, partitions);
   }
 
   for (auto [idx, newIfOp] : llvm::zip(partitionIndices, newIfOps)) {
@@ -253,9 +227,9 @@ void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
 
 void cloneReduceOp(triton::ReduceOp reduceOp,
                    SmallVector<WarpGroupBuilder> &builders,
-                   const WarpSchedule &schedule) {
-  auto partition = getPartition(reduceOp, schedule);
-  auto partitionIndices = getPartitionIndicesToCloneInto(partition, schedule);
+                   const PartitionSet &partitions) {
+  auto partitionIndices =
+      getPartitionIds(reduceOp, partitions.getNumPartitions());
 
   SmallVector<ReduceOp> newReduceOps;
   for (size_t idx : partitionIndices) {
@@ -283,7 +257,7 @@ void cloneReduceOp(triton::ReduceOp reduceOp,
     b.setInsertionPointToStart(block);
   }
 
-  cloneOpsInBlock(reduceOp.getBody(), builders, schedule);
+  cloneOpsInBlock(reduceOp.getBody(), builders, partitions);
 
   for (auto [idx, newReduceOp] : llvm::zip(partitionIndices, newReduceOps)) {
     builders[idx].setInsertionPointAfter(newReduceOp);
@@ -291,7 +265,7 @@ void cloneReduceOp(triton::ReduceOp reduceOp,
 }
 
 void cloneOp(Operation *op, SmallVector<WarpGroupBuilder> &builders,
-             SmallVector<size_t> const &partitionIndices) {
+             ArrayRef<size_t> partitionIndices) {
   if (op->getNumRegions() != 0) {
     llvm::report_fatal_error(
         "Ops are expected to be regionless at this point.");
@@ -305,18 +279,17 @@ void cloneOp(Operation *op, SmallVector<WarpGroupBuilder> &builders,
 }
 
 void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
-                     const WarpSchedule &schedule) {
+                     const PartitionSet &partitions) {
   for (auto &op_ : *block) {
     auto op = &op_;
-    auto partition = getPartition(op, schedule);
-    auto partitionIndices = getPartitionIndicesToCloneInto(partition, schedule);
+    auto partitionIndices = getPartitionIds(op, partitions.getNumPartitions());
 
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-      cloneForOp(forOp, builders, schedule);
+      cloneForOp(forOp, builders, partitions);
     } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-      cloneIfOp(ifOp, builders, schedule);
+      cloneIfOp(ifOp, builders, partitions);
     } else if (auto reduceOp = dyn_cast<triton::ReduceOp>(op)) {
-      cloneReduceOp(reduceOp, builders, schedule);
+      cloneReduceOp(reduceOp, builders, partitions);
     } else if (auto yieldOp = dyn_cast<scf::YieldOp>(op)) {
       if (yieldOp.getOperands().empty()) {
         continue;
@@ -328,7 +301,8 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         if (auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp())) {
           newOperandIndices =
               getLoopVarIndicesToKeep(
-                  forOp, schedule.getPartition(builder.partitionId), schedule)
+                  forOp, partitions.getPartition(builder.partitionId),
+                  partitions)
                   .first;
         } else {
           for (size_t i = 0; i < yieldOp.getOperands().size(); ++i) {
@@ -351,45 +325,84 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
     }
   }
 }
+
+void assignRootPartition(scf::ForOp loop, PartitionSet &partitions) {
+  auto ctx = loop.getContext();
+  Builder b(ctx);
+  SetVector<Partition *> root;
+  for (int i = 0; i < partitions.getNumPartitions(); ++i) {
+    root.insert(partitions.getPartition(i));
+  }
+
+  for (Operation &op : loop.getBody()->without_terminator()) {
+    if (!hasPartition(&op)) {
+      setPartition(&op, root);
+    }
+  }
+}
+
+void assignRegionBodyPartition(scf::ForOp loop, PartitionSet &partitions) {
+  loop->walk([&](Operation *op) {
+    if (!isa<scf::ForOp>(op) && !hasPartition(op)) {
+      auto parentOp = loop.getBody()->findAncestorOpInBlock(*op);
+      if (auto partitionIds = triton::gpu::getPartitionIds(parentOp)) {
+        SetVector<Partition *> parentPartitions;
+        for (auto id : *partitionIds) {
+          parentPartitions.insert(partitions.getPartition(id));
+        }
+        setPartition(op, parentPartitions);
+      }
+    }
+  });
+}
+
 } // namespace
 
 LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
-  FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
-  if (failed(scheduleOr))
+  FailureOr<PartitionSet> partitionsOr = PartitionSet::fromLoop(loop);
+  if (failed(partitionsOr))
     return failure();
-  WarpSchedule schedule = std::move(*scheduleOr);
-  if (failed(schedule.verify(loop)))
-    return failure();
+  PartitionSet partitions = std::move(*partitionsOr);
+
+  assignRootPartition(loop, partitions);
+  assignRegionBodyPartition(loop, partitions);
+
+  //  loop->getParentOfType<ModuleOp>().dump();
 
   // Only the root node should have consumers at this point.
-  for (const Partition &partition : schedule.getPartitions()) {
+  for (const Partition &partition : partitions.getPartitions()) {
     bool failed = false;
     auto callback = [&](OpResult output, OpOperand &use, unsigned distance) {
-      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
-      const Partition *usePartition = schedule.getPartition(owner);
-      if (usePartition == schedule.getRootPartition() ||
-          usePartition == &partition)
+      if (partitions.isInRootPartition(output.getDefiningOp())) {
+        return;
+      }
+      auto partitionIds = getPartitionIds(use.getOwner());
+      if (partitions.isInRootPartition(use.getOwner()) ||
+          llvm::is_contained(*partitionIds, partition.getIndex()))
         return;
       failed = true;
       InFlightDiagnostic diag =
           mlir::emitWarning(output.getLoc(), "non-root partition #")
           << partition.getIndex() << " has direct SSA consumer";
-      diag.attachNote(use.getOwner()->getLoc())
-          << "use at distance " << distance << " in partition #"
-          << usePartition->getIndex() << " here";
+
+      for (auto partitionId : *partitionIds) {
+        diag.attachNote(use.getOwner()->getLoc())
+            << "use at distance " << distance << " in partition #"
+            << partitionId << " here";
+      }
     };
-    schedule.iterateUses(loop, &partition, callback);
+    partition.iterateUses(loop, callback);
     if (failed)
       return failure();
   }
 
   // There is nothing to do if the loop has 1 or fewer partitions.
-  if (llvm::size(schedule.getPartitions()) <= 1)
+  if (llvm::size(partitions.getPartitions()) <= 1)
     return success();
 
-  auto numPartitions = schedule.getNumPartitions();
-  auto defaultPartition = schedule.getPartition((int)0);
-  auto loopVarCategories = classifyLoopVars(loop, defaultPartition, schedule);
+  auto numPartitions = partitions.getNumPartitions();
+  auto defaultPartition = partitions.getPartition((int)0);
+  auto loopVarCategories = classifyLoopVars(loop, defaultPartition, partitions);
   auto [loopVarIndices, newResultIndices] =
       getLoopVarIndicesToKeep(loop, defaultPartition, loopVarCategories);
 
@@ -426,20 +439,21 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   for (auto &op_ : *loop->getBlock()) {
     auto op = &op_;
     auto wsTag = op->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
-    if (!wsTag || wsTag.getInt() != schedule.getTag())
+    if (!wsTag || wsTag.getInt() != partitions.getTag())
       continue;
-    if (auto partitionId = op->getAttrOfType<IntegerAttr>(kPartitionAttrName)) {
-      cloneOp(op, builders, {static_cast<size_t>(partitionId.getInt())});
+    if (auto partitionIds = triton::gpu::getPartitionIds(op)) {
+      cloneOp(op, builders,
+              SmallVector<size_t>{partitionIds->begin(), partitionIds->end()});
       opsToErase.push_back(op);
     } else {
       assert(loop.getOperation() == op && "Unexpected op");
-      cloneForOp(loop, builders, schedule);
+      cloneForOp(loop, builders, partitions);
       opsToErase.push_back(loop);
     }
   }
 
   for (auto [b, region, partition] : llvm::zip(
-           builders, wgOp.getPartitionRegions(), schedule.getPartitions())) {
+           builders, wgOp.getPartitionRegions(), partitions.getPartitions())) {
     auto newForOp = *region.front().getOps<scf::ForOp>().begin();
     auto outputs = newForOp.getResults();
 
@@ -455,11 +469,11 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
       // language support, we end up computing the same information multiple
       // times.
       auto [_, reverseIndices] =
-          getLoopVarIndicesToKeep(loop, &partition, schedule);
+          getLoopVarIndicesToKeep(loop, &partition, partitions);
       for (size_t i = 0; i < loop.getNumRegionIterArgs(); ++i) {
         if (loopVarCategories[i] ==
                 LoopVarCategory::TensorResultFromOtherPartition &&
-            isTensorResultComputedBy(loop, i, &partition, schedule)) {
+            isTensorResultComputedBy(loop, i, &partition, partitions)) {
           assert(reverseIndices[i] && "A valid index is expected.");
           auto result = newForOp.getResult(*reverseIndices[i]);
           b.create<LocalStoreOp>(wgOp.getLoc(), result, tensorResultAllocs[i]);
@@ -513,7 +527,7 @@ struct PartitionLoops
 
 void PartitionLoops::runOnOperation() {
   // Collect for loops to warp specialize. This pass expects the loop to already
-  // be scheduled.
+  // be annotated with partitions.
   SmallVector<scf::ForOp> loops;
   getOperation().walk([&](scf::ForOp loop) {
     if (loop->hasAttrOfType<ArrayAttr>(kPartitionStagesAttrName))

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -10,6 +10,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include <optional>
 
 using namespace mlir;
 using namespace triton;
@@ -19,6 +20,14 @@ namespace ttng = triton::nvidia_gpu;
 //===----------------------------------------------------------------------===//
 // assignPartitions
 //===----------------------------------------------------------------------===//
+
+bool trySetPartition(Operation *op, Partition *partition) {
+  if (hasPartition(op)) {
+    return false;
+  }
+  setPartition(op, partition);
+  return true;
+}
 
 // Find the last operation in the loop body that defined this value, with a
 // maximum of distance 1.
@@ -78,15 +87,15 @@ static void iterateUsers(scf::ForOp loop, Operation *op,
 
 // Check if any of the inputs to `op` are reachable from a non-null partition.
 static bool hasDefPartition(scf::ForOp loop, Operation *op,
-                            WarpSchedule &schedule) {
+                            PartitionSet &partitions) {
   SmallVector<Operation *> worklist{op};
   DenseSet<Operation *> seen;
   while (!worklist.empty()) {
     Operation *op = worklist.pop_back_val();
     if (!seen.insert(op).second)
       continue;
-    Partition *p = schedule.getPartition(op);
-    if (p && p != schedule.getRootPartition())
+    auto partitionIds = getPartitionIds(op);
+    if (partitionIds && partitionIds->size() != partitions.getNumPartitions())
       return true;
     iterateDefs(loop, op,
                 [&](OpResult def) { worklist.push_back(def.getDefiningOp()); });
@@ -96,7 +105,7 @@ static bool hasDefPartition(scf::ForOp loop, Operation *op,
 
 // Recursively schedule the dependencies of an operation, stopping when
 // encountering an operation that is already assigned.
-static void scheduleDependencies(scf::ForOp loop, WarpSchedule &schedule,
+static void scheduleDependencies(scf::ForOp loop, PartitionSet &partitions,
                                  Partition *partition, Operation *op) {
   SmallVector<Value> deps;
   for (Value value : getNestedOperands(op)) {
@@ -115,8 +124,8 @@ static void scheduleDependencies(scf::ForOp loop, WarpSchedule &schedule,
 
     Operation *defOp =
         loop.getBody()->findAncestorOpInBlock(*dep.getDefiningOp());
-    if (!defOp || !hasDefPartition(loop, defOp, schedule) ||
-        !schedule.trySchedule(partition, defOp))
+    if (!defOp || !hasDefPartition(loop, defOp, partitions) ||
+        !trySetPartition(defOp, partition))
       continue;
     llvm::append_range(deps, getNestedOperands(defOp));
   }
@@ -125,7 +134,7 @@ static void scheduleDependencies(scf::ForOp loop, WarpSchedule &schedule,
 // Recursively schedule the users of an operation, stopping when
 // encountering an operation that is already assigned.
 // If \p partition is null, a new partition will be created if needed.
-static Partition *scheduleUsers(scf::ForOp loop, WarpSchedule &schedule,
+static Partition *scheduleUsers(scf::ForOp loop, PartitionSet &schedule,
                                 Partition *partition, Operation *op) {
   SmallVector<OpOperand *> uses;
   for (OpOperand &use : op->getUses())
@@ -141,11 +150,12 @@ static Partition *scheduleUsers(scf::ForOp loop, WarpSchedule &schedule,
       continue;
     }
 
-    if (schedule.isScheduled(user))
+    if (hasPartition(user))
       continue;
     if (!partition)
       partition = schedule.addPartition(/* stage is unused */ 0);
-    schedule.trySchedule(partition, user);
+    if (!hasPartition(user))
+      setPartition(user, partition);
     for (OpOperand &use : user->getUses())
       uses.push_back(&use);
   }
@@ -155,7 +165,7 @@ static Partition *scheduleUsers(scf::ForOp loop, WarpSchedule &schedule,
 // Schedule post-loop operations (operations outside and after the loop) into
 // the epilogue partition. This recursively schedules operations that consume
 // loop results and their transitive users.
-static void schedulePostLoopOps(scf::ForOp loop, WarpSchedule &schedule,
+static void schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
                                 Partition *epiloguePartition) {
   SmallVector<OpOperand *> uses;
 
@@ -172,7 +182,7 @@ static void schedulePostLoopOps(scf::ForOp loop, WarpSchedule &schedule,
     Operation *user = use->getOwner();
 
     // Skip if already visited or scheduled.
-    if (!visited.insert(user).second || schedule.isScheduled(user))
+    if (!visited.insert(user).second || hasPartition(user))
       continue;
 
     // Only schedule operations that are outside the loop.
@@ -180,7 +190,8 @@ static void schedulePostLoopOps(scf::ForOp loop, WarpSchedule &schedule,
       continue;
 
     // Schedule this post-loop operation to the epilogue partition.
-    schedule.trySchedule(epiloguePartition, user);
+    if (!hasPartition(user))
+      setPartition(user, epiloguePartition);
 
     // Add all users of this operation to process transitively.
     for (OpResult result : user->getResults())
@@ -192,15 +203,15 @@ static void schedulePostLoopOps(scf::ForOp loop, WarpSchedule &schedule,
 // Given a partitioning scheme, determine an initial schedule by performing a
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.
-static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
+static std::optional<PartitionSet> getInitialSchedule(scf::ForOp mainLoop) {
   // Check for an existing schedule.
-  if (FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(mainLoop);
+  if (FailureOr<PartitionSet> scheduleOr = PartitionSet::fromLoop(mainLoop);
       succeeded(scheduleOr))
     return {std::move(*scheduleOr)};
 
   // Start by creating the default partition, a partition for for all loads, and
   // a partition for all MMAs.
-  WarpSchedule schedule;
+  PartitionSet schedule;
   Partition *defaultPartition = schedule.addPartition(0);
   Partition *mmaPartition = schedule.addPartition(1);
   Partition *loadPartition = schedule.addPartition(0);
@@ -215,7 +226,8 @@ static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
       // Only TMA loads are supported at the moment.
       if (!isa<DescriptorLoadOp, DescriptorGatherOp>(op))
         continue;
-      schedule.trySchedule(loadPartition, &op);
+      if (!hasPartition(&op))
+        setPartition(&op, loadPartition);
       loadsAndAllocs.push_back(&op);
 
       // Local alloc users of the load with matching encoding will cause the
@@ -224,11 +236,13 @@ static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
       for (Operation *user : op.getUsers()) {
         if (auto alloc = dyn_cast<LocalAllocOp>(user)) {
           if (sharedEnc == alloc.getType().getEncoding()) {
-            schedule.trySchedule(loadPartition, alloc);
+            if (!hasPartition(alloc))
+              setPartition(alloc, loadPartition);
             loadsAndAllocs.push_back(alloc);
           }
         } else if (isa<ttng::TMEMAllocOp>(user)) {
-          schedule.trySchedule(loadPartition, user);
+          if (!hasPartition(user))
+            setPartition(user, loadPartition);
           loadsAndAllocs.push_back(user);
         }
       }
@@ -239,13 +253,15 @@ static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
   auto epiloguePartition = schedule.addPartition(/* stage is unused */ 0);
   for (auto loop : loops)
     for (DescriptorStoreOp op : loop.getOps<DescriptorStoreOp>())
-      schedule.trySchedule(epiloguePartition, op);
+      if (!hasPartition(op))
+        setPartition(op, epiloguePartition);
 
   // Find MMAs to pipeline.
   SmallVector<ttng::MMAv5OpInterface> mmas;
   for (auto loop : loops) {
     for (auto mmaOp : loop.getOps<ttng::MMAv5OpInterface>()) {
-      schedule.trySchedule(mmaPartition, mmaOp);
+      if (!hasPartition(mmaOp))
+        setPartition(mmaOp, mmaPartition);
       mmas.push_back(mmaOp);
 
       // If the store is unrelated to the use of the MMA, then it gets placed in
@@ -254,7 +270,8 @@ static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
           findDefOpInLoop(loop, mmaOp.getAccDep()));
       if (!ttng::hasAccReadModifyWrite(mmaOp, loop) && storeOp &&
           loop.isDefinedOutsideOfLoop(storeOp.getSrc()))
-        schedule.trySchedule(mmaPartition, storeOp);
+        if (!hasPartition(storeOp))
+          setPartition(storeOp, mmaPartition);
     }
     for (auto mmaOp : mmas) {
       // Look for views into the operands.
@@ -271,16 +288,19 @@ static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
         // Duplicate the op if necessary to ensure that the MMA partition is the
         // only user.
         if (!llvm::all_of(op->getUsers(), [&](Operation *user) {
-              return schedule.getPartition(user) == mmaPartition;
+              auto ids = getPartitionIds(user);
+              return ids && ids->contains(mmaPartition->getIndex());
             })) {
           Operation *newOp = OpBuilder(op).clone(*op);
           op->replaceUsesWithIf(newOp->getResults(), [&](OpOperand &use) {
-            return schedule.getPartition(use.getOwner()) == mmaPartition;
+            auto ids = getPartitionIds(use.getOwner());
+            return ids && ids->contains(mmaPartition->getIndex());
           });
           op = newOp;
         }
 
-        schedule.trySchedule(mmaPartition, op);
+        if (!hasPartition(op))
+          setPartition(op, mmaPartition);
         if (Operation *defOp = op->getOperand(0).getDefiningOp())
           operandViews.push_back(defOp);
       }
@@ -304,7 +324,8 @@ static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
   //         elementCount += tensorTy.getNumElements();
   //     }
   //     if (elementCount > 256) {
-  //       schedule.trySchedule(defaultPartition, &op);
+  //       if (!hasPartition(&op))
+  //         setPartition(&op, defaultPartition);
   //       scheduleDependencies(loop, schedule, defaultPartition, &op);
   //     }
   //   }
@@ -326,7 +347,8 @@ static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp mainLoop) {
         continue;
       for (OpOperand &use :
            loop.getRegionIterArg(use.getOperandNumber()).getUses()) {
-        schedule.trySchedule(defaultPartition, use.getOwner());
+        if (!hasPartition(use.getOwner()))
+          setPartition(use.getOwner(), defaultPartition);
         scheduleUsers(loop, schedule, defaultPartition, use.getOwner());
       }
       break;
@@ -417,32 +439,31 @@ struct OpClusters : public llvm::MapVector<Operation *, OpCluster *> {
 // operation in a partition. This function propagates partitions by first
 // forming contiguous clusters from the unassigned operations and then deciding
 // what to do with the operations in that cluster.
-void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
+void propagatePartitions(scf::ForOp loop, PartitionSet &partitions) {
   OpClusters opClusters;
 
-  for (Partition &partition : schedule.getPartitions()) {
+  for (Partition &partition : partitions.getPartitions()) {
     // For each partition, check if any of their inputs are reachable from
     // another partition and spawn a single cluster at that operation.
     auto defCallback = [&](OpResult result, unsigned distance) {
       Operation *defOp = result.getDefiningOp();
-      if (!schedule.isScheduled(defOp) &&
-          hasDefPartition(loop, defOp, schedule)) {
+      if (!hasPartition(defOp) && hasDefPartition(loop, defOp, partitions)) {
         // Add the current partition as a sink to the cluster.
         opClusters.getOrCreate(defOp)->sinkPartitions.insert(&partition);
       }
     };
-    schedule.iterateDefs(loop, &partition, defCallback);
+    partition.iterateDefs(loop, defCallback);
 
     // For each partition, place users of its outputs in a cluster if it is not
     // already assigned to a partition.
     auto useCallback = [&](OpResult result, OpOperand &use, unsigned distance) {
       Operation *user = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
-      if (!schedule.isScheduled(user)) {
+      if (!hasPartition(user)) {
         // Add the current partition as a def to the cluster.
         opClusters.getOrCreate(user)->defPartitions.insert(&partition);
       }
     };
-    schedule.iterateUses(loop, &partition, useCallback);
+    partition.iterateUses(loop, useCallback);
   }
 
   // Now we have a pile of single-operation clusters directly adjacent to the
@@ -457,13 +478,15 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
     // Look at the definitions directly feeding into this operation.
     iterateDefs(loop, op, [&](OpResult def) {
       Operation *defOp = def.getDefiningOp();
-      if (schedule.isScheduled(defOp)) {
+      if (auto partitionIds = getPartitionIds(defOp)) {
         // The input originates from an operation already assigned to a
         // partition. Add this as a def partition.
-        cluster->defPartitions.insert(schedule.getPartition(defOp));
+        for (auto id : *partitionIds) {
+          cluster->defPartitions.insert(partitions.getPartition(id));
+        }
       } else {
         // If the input is not reachable from a partition, ignore it.
-        if (!hasDefPartition(loop, defOp, schedule))
+        if (!hasDefPartition(loop, defOp, partitions))
           return;
         // This operation is not assigned to a partition.
         OpCluster *&defCluster = opClusters[defOp];
@@ -482,11 +505,12 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
     });
     // Check the users of the operation.
     iterateUsers(loop, op, [&](Operation *user) {
-      if (schedule.isScheduled(user)) {
+      if (auto partitionIds = getPartitionIds(user)) {
         // If the user is already assigned to a partition, add that partition as
         // one of the sink partitions.
-        Partition *userPartition = schedule.getPartition(user);
-        cluster->sinkPartitions.insert(userPartition);
+        for (auto id : *partitionIds) {
+          cluster->sinkPartitions.insert(partitions.getPartition(id));
+        }
         return;
       }
       // If the user does not already have a cluster, add it to the current
@@ -511,15 +535,15 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
     if (cluster.ops.empty())
       continue;
     assert(!cluster.defPartitions.empty());
-    assert(llvm::all_of(
-        cluster.ops, [&](Operation *op) { return !schedule.isScheduled(op); }));
+    assert(llvm::all_of(cluster.ops,
+                        [&](Operation *op) { return !hasPartition(op); }));
 
     // If there are multiple def or sink partitions, don't know what to do.
     // Assign the whole cluster to its own partition.
     if (cluster.defPartitions.size() > 1 || cluster.sinkPartitions.size() > 1) {
-      Partition *newPartition = schedule.addPartition(0);
+      Partition *newPartition = partitions.addPartition(0);
       for (Operation *op : cluster.ops)
-        schedule.insert(newPartition, op);
+        setPartition(op, newPartition);
       continue;
     }
 
@@ -528,7 +552,7 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
     Partition *defPartition = cluster.defPartitions.front();
     if (cluster.sinkPartitions.empty()) {
       for (Operation *op : cluster.ops)
-        schedule.insert(defPartition, op);
+        setPartition(op, defPartition);
       continue;
     }
 
@@ -541,7 +565,7 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
       if (opsInCluster.contains(defOp))
         critPath.insert(defOp);
     };
-    schedule.iterateDefs(loop, sinkPartition, callback);
+    sinkPartition->iterateDefs(loop, callback);
     for (unsigned i = 0; i < critPath.size(); ++i) {
       Operation *op = critPath[i];
       iterateDefs(loop, op, [&](OpResult def) {
@@ -554,7 +578,7 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
     // If all ops are on the critical path, assign them to the def partition.
     if (critPath.size() == cluster.ops.size()) {
       for (Operation *op : cluster.ops)
-        schedule.insert(defPartition, op);
+        setPartition(op, defPartition);
       continue;
     }
 
@@ -571,16 +595,16 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
         return sinkOps.contains(use.getOwner());
       });
       sinkOps.insert(clone);
-      schedule.insert(sinkPartition, clone);
+      setPartition(clone, sinkPartition);
     }
     for (Operation *op : cluster.ops)
-      schedule.insert(defPartition, op);
+      setPartition(op, defPartition);
   }
 }
 
 // Rematerialize chains of broadcasts where the user is in a different partition
 // than the broadcast to reduce the amount of data that needs to be transferred.
-void rematerializeBroadcasts(WarpSchedule &schedule, OpOperand *use) {
+void rematerializeBroadcasts(PartitionSet &partitions, OpOperand *use) {
   static_assert(
       std::is_base_of_v<OpTrait::OneResult<BroadcastOp>, BroadcastOp> &&
       std::is_base_of_v<OpTrait::OneResult<ExpandDimsOp>, ExpandDimsOp> &&
@@ -589,9 +613,12 @@ void rematerializeBroadcasts(WarpSchedule &schedule, OpOperand *use) {
   Operation *defOp = use->get().getDefiningOp();
   while (isa_and_nonnull<BroadcastOp, ExpandDimsOp, ConvertLayoutOp>(defOp)) {
     Operation *clone = OpBuilder(defOp).clone(*defOp);
-    Partition *userPartition = schedule.getPartition(use->getOwner());
-    assert(userPartition && "user not scheduled");
-    schedule.insert(userPartition, clone);
+    auto userPartitionIds = getPartitionIds(use->getOwner());
+    assert(userPartitionIds && "user not scheduled");
+    for (auto id : *userPartitionIds) {
+      Partition *userPartition = partitions.getPartition(id);
+      setPartition(clone, userPartition);
+    }
     use->set(clone->getResult(0));
 
     defOp = clone->getOperand(0).getDefiningOp();
@@ -602,21 +629,29 @@ void rematerializeBroadcasts(WarpSchedule &schedule, OpOperand *use) {
 /// Walk over \p loop and clone Broadcast/ExpandDims/ConvertLayout ops into each
 /// partition that they have users in. This reduces the amount of data that
 /// needs to be transferred through memory.
-void optimizeSchedule(scf::ForOp loop, WarpSchedule &schedule) {
+void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
+  // Helper to get partition for an op, returning null if unscheduled.
+  auto getPartition = [&](Operation *op) -> Partition * {
+    auto ids = getPartitionIds(op);
+    if (!ids || ids->size() != 1)
+      return nullptr;
+    return schedule.getPartition(static_cast<unsigned>((*ids)[0]));
+  };
+
   // Walk everything in reverse so that operations are visited before their
   // operands.
   loop.walk<WalkOrder::PostOrder, ReverseIterator>([&](Operation *op) {
     if (!isa<BroadcastOp, ExpandDimsOp, ConvertLayoutOp>(op))
       return;
 
-    Partition *partition = schedule.getPartition(op);
+    Partition *partition = getPartition(op);
     if (!partition)
       return;
 
     // Record all the other partitions in which we have users.
     llvm::SmallDenseSet<Partition *, 2> userPartitions;
     for (OpOperand &use : op->getUses()) {
-      Partition *userPartition = schedule.getPartition(use.getOwner());
+      Partition *userPartition = getPartition(use.getOwner());
       if (!userPartition || userPartition == partition)
         continue;
       userPartitions.insert(userPartition);
@@ -625,10 +660,10 @@ void optimizeSchedule(scf::ForOp loop, WarpSchedule &schedule) {
     for (auto *userPartition : userPartitions) {
       // Clone the instruction into each user partition.
       Operation *clone = OpBuilder(op).clone(*op);
-      schedule.insert(userPartition, clone);
+      setPartition(clone, userPartition);
       // Replace all users in that partition with the clone.
       op->replaceUsesWithIf(clone->getResults(), [&](OpOperand &otherUse) {
-        return schedule.getPartition(otherUse.getOwner()) == userPartition;
+        return getPartition(otherUse.getOwner()) == userPartition;
       });
     }
   });
@@ -660,7 +695,7 @@ void PartitionScheduling::runOnOperation() {
       loops.push_back(loop);
   });
   for (auto [idx, loop] : llvm::enumerate(loops)) {
-    if (std::optional<WarpSchedule> schedule = getInitialSchedule(loop)) {
+    if (std::optional<PartitionSet> schedule = getInitialSchedule(loop)) {
       propagatePartitions(loop, *schedule);
 
       // Schedule post-loop operations into the epilogue partition after

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -106,8 +106,8 @@ struct AsyncRef {
 // Helper class for dependency rewriting.
 class DependencyRewriter {
 public:
-  DependencyRewriter(WarpSchedule &schedule, scf::ForOp &loop)
-      : schedule(schedule), loop(loop), b(loop.getLoc(), loop),
+  DependencyRewriter(PartitionSet &partitions, scf::ForOp &loop)
+      : partitions(partitions), loop(loop), b(loop.getLoc(), loop),
         endBuilder(loop.getLoc(), loop->getNextNode()) {}
 
   // Partition the loop.
@@ -117,8 +117,8 @@ private:
   AsyncRef allocateAsyncValue(RankedTensorType tensorType,
                               unsigned maxDistance);
 
-  // The schedule to apply.
-  WarpSchedule &schedule;
+  // The partition set to apply.
+  PartitionSet &partitions;
   // The loop to partition.
   scf::ForOp &loop;
   // The builders to use.
@@ -146,7 +146,7 @@ AsyncRef DependencyRewriter::allocateAsyncValue(RankedTensorType tensorType,
 LogicalResult DependencyRewriter::run() {
   SmallVector<llvm::MapVector<Value, UseInfo>> partitionUseInfo;
 
-  for (const Partition &partition : schedule.getPartitions()) {
+  for (const Partition &partition : partitions.getPartitions()) {
     // Find all consumers of all outputs of this partition, tracking the
     // specific Partition
     auto &useInfo = partitionUseInfo.emplace_back();
@@ -155,6 +155,7 @@ LogicalResult DependencyRewriter::run() {
     std::function<void(OpOperand &)> collectUses;
     collectUses = [&](OpOperand &use) {
       Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
+      auto partitionIds = getPartitionIds(owner);
       if (isa<scf::YieldOp>(owner)) {
         // This value is used in a subsequent iteration.
         // collect the uses of the appropriate loop arg
@@ -163,12 +164,17 @@ LogicalResult DependencyRewriter::run() {
                                 .getUses()) {
           collectUses(newUse);
         }
-      } else if (schedule.getPartition(owner) != &partition) {
+      } else if (partitionIds &&
+                 !llvm::is_contained(*partitionIds, partition.getIndex())) {
         // This value is used in a different partition in the same iteration.
         uses.emplace_back(use.get(), &use, 0);
       }
     };
     for (Operation *op : partition.getOps()) {
+      if (partitions.isInRootPartition(op)) {
+        // skip ops in the root partition
+        continue;
+      }
       for (OpOperand &use : op->getUses()) {
         collectUses(use);
       }
@@ -176,13 +182,12 @@ LogicalResult DependencyRewriter::run() {
 
     auto callback = [&](Value output, OpOperand &use, unsigned distance) {
       Operation *user = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
-      Partition *usePartition = schedule.getPartition(user);
+      Partition *usePartition = partitions.getPartition(user);
       // Ignore uses in the same partition in the future.
       if (usePartition == &partition) {
         assert(distance > 0 && "self-recursion must occur in the future");
         return;
       }
-      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
       UseInfo &info = useInfo[output];
       info.consumers[{usePartition, distance}].push_back(&use);
     };
@@ -198,7 +203,7 @@ LogicalResult DependencyRewriter::run() {
 
   // Cut all SSA dependencies by passing outputs through shared memory.
   for (auto [partition, useInfo] :
-       llvm::zip(schedule.getPartitions(), partitionUseInfo)) {
+       llvm::zip(partitions.getPartitions(), partitionUseInfo)) {
     // The amount of buffering is based on the longest distance to a user.
     for (auto &[output, info] : useInfo) {
       b.setLoc(output.getLoc());
@@ -285,8 +290,6 @@ LogicalResult DependencyRewriter::run() {
   // Rewrite the loop to add the new results. Calling this function with no
   // indices set will just resize the results.
   eraseLoopCarriedValues(loop, {});
-  // Update the schedule.
-  schedule.serialize(loop);
   return success();
 }
 
@@ -295,13 +298,11 @@ LogicalResult DependencyRewriter::run() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult triton::gpu::rewritePartitionDependencies(scf::ForOp &loop) {
-  FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
-  if (failed(scheduleOr))
+  FailureOr<PartitionSet> partitionsOr = PartitionSet::fromLoop(loop);
+  if (failed(partitionsOr))
     return failure();
-  WarpSchedule schedule = std::move(*scheduleOr);
-  if (failed(schedule.verify(loop)))
-    return failure();
-  DependencyRewriter rewriter(schedule, loop);
+  PartitionSet partitions = std::move(*partitionsOr);
+  DependencyRewriter rewriter(partitions, loop);
   if (failed(rewriter.run()))
     return failure();
   return success();
@@ -329,7 +330,7 @@ struct RewritePartitionDependencies
 
 void RewritePartitionDependencies::runOnOperation() {
   // Collect for loops to warp specialize. This pass expects the loop to
-  // already be scheduled.
+  // already be annotated with partitions.
   SmallVector<scf::ForOp> loops;
   getOperation().walk([&](scf::ForOp loop) {
     if (loop->hasAttrOfType<ArrayAttr>(kPartitionStagesAttrName))

--- a/test/NVWS/assign_stage_phase.mlir
+++ b/test/NVWS/assign_stage_phase.mlir
@@ -19,7 +19,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
     // CHECK: [[IDX:%.*]]:6 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[S0:%.*]] = [[C2]], [[P0:%.*]] = [[C0]], [[S1:%.*]] = [[C2]], [[P1:%.*]] = [[C1]], [[S2:%.*]] = [[C2]], [[P2:%.*]] = [[C1]])
     scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-      %2 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %2 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
       // CHECK: op_a
       // CHECK-NEXT: [[S0a:%.*]] = arith.addi [[S0]], [[C1]]
       // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S0a]], [[C3]]
@@ -27,22 +27,22 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[P0a:%.*]] = arith.xori [[P0]], [[C1]]
       // CHECK-NEXT: [[P0b:%.*]] = arith.select [[CMP]], [[P0a]], [[P0]]
       // CHECK-NEXT: put.enter [[AREF]][[[S0b]], [[P0b]]]
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %2, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %2, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
       // CHECK: put.exit [[AREF]][[[S0b]]]
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
 
       // CHECK-NEXT: [[S1a:%.*]] = arith.addi [[S1]], [[C1]]
       // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S1a]], [[C3]]
       // CHECK-NEXT: [[S1b:%.*]] = arith.select [[CMP]], [[C0]], [[S1a]]
       // CHECK-NEXT: [[P1a:%.*]] = arith.xori [[P1]], [[C1]]
       // CHECK-NEXT: [[P1b:%.*]] = arith.select [[CMP]], [[P1a]], [[P1]]
-      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF]][[[S1b]], [[P1b]]] {ttg.partition = 1 : i32}
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %3 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      // CHECK: get.exit [[AREF]][[[S1b]]], [[TOK1]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_b"(%3) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF]][[[S1b]], [[P1b]]] {ttg.partition = array<i32: 1>}
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %3 = ttg.local_load %buffers_0 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      // CHECK: get.exit [[AREF]][[[S1b]]], [[TOK1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%3) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
 
       // CHECK: op_b
       // CHECK-NEXT: [[S2a:%.*]] = arith.addi [[S2]], [[C1]]
@@ -50,13 +50,13 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[S2b:%.*]] = arith.select [[CMP]], [[C0]], [[S2a]]
       // CHECK-NEXT: [[P2a:%.*]] = arith.xori [[P2]], [[C1]]
       // CHECK-NEXT: [[P2b:%.*]] = arith.select [[CMP]], [[P2a]], [[P2]]
-      // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.get.enter [[AREF]][[[S2b]], [[P2b]]] {ttg.partition = 2 : i32}
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %4 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      // CHECK: get.exit [[AREF]][[[S2b]]], [[TOK2]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_c"(%4) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_d"(%4) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.get.enter [[AREF]][[[S2b]], [[P2b]]] {ttg.partition = array<i32: 2>}
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %4 = ttg.local_load %buffers_2 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      // CHECK: get.exit [[AREF]][[[S2b]]], [[TOK2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%4) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%4) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
       // CHECK: op_c
       // CHECK-NEXT: op_d
       // CHECK-NEXT: yield [[S0b]], [[P0b]], [[S1b]], [[P1b]], [[S2b]], [[P2b]]
@@ -99,12 +99,12 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       // CHECK-NEXT: [[P0a:%.*]] = arith.xori [[P0]], [[C1]]
       // CHECK-NEXT: [[P0b:%.*]] = arith.select [[CMP]], [[P0a]], [[P0]]
       // CHECK-NEXT: put.enter [[AREF0]][[[S0b]], [[P0b]]]
-      %1:3 = nvws.aref.put.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-      "op1"(%1#0) {ttg.partition = 0 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>) -> ()
-      "op2"(%1#1)  {ttg.partition = 0 : i32} : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      %1:3 = nvws.aref.put.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+      "op1"(%1#0) {ttg.partition = array<i32: 0>}: (!ttg.memdesc<64x16xf16, #shared0, #smem>) -> ()
+      "op2"(%1#1)  {ttg.partition = array<i32: 0>} : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
       // CHECK: op2
       // CHECK-NEXT: put.exit [[AREF0]][[[S0b]]]
-      nvws.aref.put.exit %aref0[%c0_i32], %1#2 [#nvws.async_op<tma_load>, #nvws.async_op<none>] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+      nvws.aref.put.exit %aref0[%c0_i32], %1#2 [#nvws.async_op<tma_load>, #nvws.async_op<none>] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
 
 
       // CHECK-NEXT: [[S1a:%.*]] = arith.addi [[S1]], [[C1]]
@@ -112,12 +112,12 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       // CHECK-NEXT: [[S1b:%.*]] = arith.select [[CMP]], [[C0]], [[S1a]]
       // CHECK-NEXT: [[P1a:%.*]] = arith.xori [[P1]], [[C1]]
       // CHECK-NEXT: [[P1b:%.*]] = arith.select [[CMP]], [[P1a]], [[P1]]
-      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF0]][[[S1b]], [[P1b]]] {ttg.partition = 1 : i32}
-      %2:3 = nvws.aref.get.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-      "op3"(%2#0, %2#1) {ttg.partition = 1 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF0]][[[S1b]], [[P1b]]] {ttg.partition = array<i32: 1>}
+      %2:3 = nvws.aref.get.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+      "op3"(%2#0, %2#1) {ttg.partition = array<i32: 1>}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
       // CHECK: op3
-      // CHECK-NEXT: get.exit [[AREF0]][[[S1b]]], [[TOK1]] [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32}
-      nvws.aref.get.exit %aref0[%c0_i32], %2#2 [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+      // CHECK-NEXT: get.exit [[AREF0]][[[S1b]]], [[TOK1]] [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>}
+      nvws.aref.get.exit %aref0[%c0_i32], %2#2 [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
       // CHECK: [[IDX1:%.*]]:4 = scf.if
       scf.if %cond {
         // CHECK-NEXT: [[S2a:%.*]] = arith.addi [[S2]], [[C1]]
@@ -125,23 +125,23 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
         // CHECK-NEXT: [[S2b:%.*]] = arith.select [[CMP]], [[C0]], [[S2a]]
         // CHECK-NEXT: [[P2a:%.*]] = arith.xori [[P2]], [[C1]]
         // CHECK-NEXT: [[P2b:%.*]] = arith.select [[CMP]], [[P2a]], [[P2]]
-        // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.put.enter [[AREF1]][[[S2b]], [[P2b]]] {ttg.partition = 0 : i32}
+        // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.put.enter [[AREF1]][[[S2b]], [[P2b]]] {ttg.partition = array<i32: 0>}
         // CHECK-NEXT: op4
         // CHECK-NEXT: put.exit [[AREF1]][[[S2b]]]
-        %4:3 = nvws.aref.put.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-        "op4"(%4#0, %4#1) {ttg.partition = 0 : i32} : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-        nvws.aref.put.exit %aref1[%c0_i32], %4#2 [#nvws.async_op<none>] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+        %4:3 = nvws.aref.put.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+        "op4"(%4#0, %4#1) {ttg.partition = array<i32: 0>} : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+        nvws.aref.put.exit %aref1[%c0_i32], %4#2 [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
         // CHECK-NEXT: [[S3a:%.*]] = arith.addi [[S3]], [[C1]]
         // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S3a]], [[C3]]
         // CHECK-NEXT: [[S3b:%.*]] = arith.select [[CMP]], [[C0]], [[S3a]]
         // CHECK-NEXT: [[P3a:%.*]] = arith.xori [[P3]], [[C1]]
         // CHECK-NEXT: [[P3b:%.*]] = arith.select [[CMP]], [[P3a]], [[P3]]
-        // CHECK-NEXT: {{.*}}, [[TOK3:%.*]] = nvws.aref.get.enter [[AREF1]][[[S3b]], [[P3b]]] {ttg.partition = 1 : i32}
+        // CHECK-NEXT: {{.*}}, [[TOK3:%.*]] = nvws.aref.get.enter [[AREF1]][[[S3b]], [[P3b]]] {ttg.partition = array<i32: 1>}
         // CHECK-NEXT: op5
-        // CHECK-NEXT: get.exit [[AREF1]][[[S3b]]], [[TOK3]] [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32}
-        %5:3 = nvws.aref.get.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-        "op5"(%5#0, %5#1) {ttg.partition = 1 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-        nvws.aref.get.exit %aref1[%c0_i32], %5#2 [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+        // CHECK-NEXT: get.exit [[AREF1]][[[S3b]]], [[TOK3]] [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>}
+        %5:3 = nvws.aref.get.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+        "op5"(%5#0, %5#1) {ttg.partition = array<i32: 1>}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+        nvws.aref.get.exit %aref1[%c0_i32], %5#2 [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
         // CHECK-NEXT: yield [[S2b]], [[P2b]], [[S3b]], [[P3b]]
       }
       // CHECK-NEXT: } else {

--- a/test/NVWS/insert_aref.mlir
+++ b/test/NVWS/insert_aref.mlir
@@ -30,26 +30,26 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     // CHECK-NEXT: [[AREF2:%.*]] = nvws.aref.create [[AREF_BUF2]]
     %1 = scf.for %arg5 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg6 = %0) -> (!ttg.async.token)  : i32 {
       %2 = arith.muli %arg5, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
-      // CHECK: [[PUT_BUF1:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
+      // CHECK: [[PUT_BUF1:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
       // CHECK-NEXT: nvws.descriptor_load {{.*}} 16384 [[PUT_BUF1]]
-      // CHECK: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
-      // CHECK: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter [[AREF1]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      %3 = tt.descriptor_load %arg3[%arg1, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      // CHECK: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
+      // CHECK: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter [[AREF1]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      %3 = tt.descriptor_load %arg3[%arg1, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
       // CHECK: [[PUT_BUF2:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]]
       // CHECK-NEXT: nvws.descriptor_load {{.*}} 16384 [[PUT_BUF2]]
       // CHECK: nvws.aref.put.exit [[AREF2]]
       // CHECK: [[GET_BUF2:%.*]], [[GET_TOKEN2:%.*]] = nvws.aref.get.enter [[AREF2]]
-      %4 = tt.descriptor_load %arg4[%arg2, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %4 = tt.descriptor_load %arg4[%arg2, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
 
-      %5 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-      %6 = ttg.local_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %5 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %6 = ttg.local_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
 
-      // CHECK:  [[RHS:%.*]] = ttg.memdesc_trans [[GET_BUF2]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32}
-      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+      // CHECK:  [[RHS:%.*]] = ttg.memdesc_trans [[GET_BUF2]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
+      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
       // CHECK: ttng.tc_gen5_mma [[GET_BUF1]], [[RHS]], {{.*}}, {{.*}}, {{.*}}
-      %8 = ttng.tc_gen5_mma %5, %7, %result[%arg6], %true, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %8 = ttng.tc_gen5_mma %5, %7, %result[%arg6], %true, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       // CHECK: nvws.aref.get.exit [[AREF2]], [[GET_TOKEN2]]
-      // CHECK: nvws.aref.get.exit [[AREF1]], [[GET_TOKEN1]] [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
+      // CHECK: nvws.aref.get.exit [[AREF1]], [[GET_TOKEN1]] [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
       scf.yield %8 : !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     %result_0, %token_1 = ttng.tmem_load %result[%1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
@@ -65,12 +65,12 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
       // CHECK: {{.*}}, [[GET_TOKEN:%.*]] = nvws.aref.get.enter
       // CHECK: [[REG:%.*]] = ttg.local_load
       // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN]] [#nvws.async_op<none>]
       // CHECK: "use"([[REG]])
-      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
+      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -81,8 +81,8 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %c1_i32 = arith.constant 1 : i32
     // CHECK-NOT: nvws.aref.create
     scf.for %arg2 = %c0_i32 to %arg1 step %c1_i32  : i32 {
-      %0 = "producer"(%arg0, %arg2) {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : (tensor<128x64xf16, #blocked1>, i32) -> tensor<128x64xf16, #blocked1>
-      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
+      %0 = "producer"(%arg0, %arg2) {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : (tensor<128x64xf16, #blocked1>, i32) -> tensor<128x64xf16, #blocked1>
+      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -95,17 +95,17 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
-      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-      // CHECK-DAG: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      // CHECK-DAG: [[GET_BUF2:%.*]], [[GET_TOKEN2:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      // CHECK-DAG: [[REG:%.*]] = ttg.local_load [[GET_BUF1]] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      // CHECK-DAG: nvws.aref.get.exit {{.*}}, [[GET_TOKEN1]] [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      // CHECK-DAG: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      // CHECK-DAG: [[GET_BUF2:%.*]], [[GET_TOKEN2:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      // CHECK-DAG: [[REG:%.*]] = ttg.local_load [[GET_BUF1]] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      // CHECK-DAG: nvws.aref.get.exit {{.*}}, [[GET_TOKEN1]] [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
       // CHECK: "use1"([[REG]])
       // CHECK: "use2"([[GET_BUF2]])
-      // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN2]] [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
-      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
+      // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN2]] [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
+      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -118,15 +118,15 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
-      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
       // CHECK: [[GET_BUF:%.*]], [[GET_TOKEN:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 0 : i32, loop.stage = 1
-      // CHECK: [[REG:%.*]] = ttg.local_load [[GET_BUF]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      // CHECK: [[REG:%.*]] = ttg.local_load [[GET_BUF]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
       // CHECK: "use1"([[REG]])
       // CHECK: "use2"([[GET_BUF]])
       // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN]] {{.*}} {loop.cluster = 1 : i32, loop.stage = 1
-      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
-      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
+      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
+      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -142,26 +142,26 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %result = ttng.tmem_alloc %cst_0 : (tensor<128x8xi8, #linear>) -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
     %0 = scf.for %arg6 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg7 = %cst) -> (tensor<128x128xf32, #blocked>)  : i32 {
       %1 = arith.muli %arg6, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
-      %2 = tt.descriptor_load %arg3[%arg1, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
-      %3 = tt.descriptor_load %arg4[%arg2, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
-      %5 = ttg.local_alloc %2 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
-      %6 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
+      %2 = tt.descriptor_load %arg3[%arg1, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
+      %3 = tt.descriptor_load %arg4[%arg2, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
+      %5 = ttg.local_alloc %2 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
+      %6 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
 
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %4 = tt.descriptor_load %arg5[%arg1, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x8xi8, #shared2>> -> tensor<128x8xi8, #linear>
+      %4 = tt.descriptor_load %arg5[%arg1, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x8xi8, #shared2>> -> tensor<128x8xi8, #linear>
 
       // CHECK: nvws.aref.get.enter
       // CHECK: [[REG:%.*]] = ttg.local_load
       // CHECK: nvws.aref.get.exit
       // CHECK: tmem_alloc [[REG]]
-      %result_1 = ttng.tmem_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x8xi8, #linear>) -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
+      %result_1 = ttng.tmem_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x8xi8, #linear>) -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
 
-      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem> -> !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>
-      %result_2, %token = ttng.tmem_alloc %arg7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
-      %8 = ttng.tc_gen5_mma_scaled %5, %7, %result_2[%token], %result, %result_1, %true, %true lhs = e4m3 rhs = e4m3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>, !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
-      %result_3, %token_4 = ttng.tmem_load %result_2[%8] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem> -> !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>
+      %result_2, %token = ttng.tmem_alloc %arg7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %8 = ttng.tc_gen5_mma_scaled %5, %7, %result_2[%token], %result, %result_1, %true, %true lhs = e4m3 rhs = e4m3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>, !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
+      %result_3, %token_4 = ttng.tmem_load %result_2[%8] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
       scf.yield %result_3 : tensor<128x128xf32, #blocked>
     } {tt.num_stages = 2 : i64, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -29,7 +29,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
     scf.for %arg3 = %arg0 to %arg1 step %arg2 : i32 {
-      %3 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %3 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
       // CHECK: op_a
       // CHECK-NEXT: addi
       // CHECK-NEXT: cmpi
@@ -37,42 +37,42 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: xori
       // CHECK-NEXT: [[PHASE:%.*]] = arith.select
       // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
-      // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[PHASE]] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[PHASE]] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>}
       // CHECK: local_store
       // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
-      // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1 {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32}
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %3, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1 {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>}
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %3, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
       // CHECK: addi
       // CHECK-NEXT: cmpi
       // CHECK-NEXT: [[STAGE:%.*]] = arith.select
       // CHECK-NEXT: xori
       // CHECK-NEXT: [[PHASE:%.*]] = arith.select
       // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
-      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>}
       // CHECK: local_load
       // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
-      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32}
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %14 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_b"(%14) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>}
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %14 = ttg.local_load %buffers_0 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%14) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
       // CHECK: addi
       // CHECK-NEXT: cmpi
       // CHECK-NEXT: [[STAGE:%.*]] = arith.select
       // CHECK-NEXT: xori
       // CHECK-NEXT: [[PHASE:%.*]] = arith.select
       // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
-      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>}
       // CHECK: local_load
       // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
-      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32}
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %20 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_c"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_d"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>}
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %20 = ttg.local_load %buffers_2 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
     } {ttg.partition.stages = [0 : i32, 2 : i32, 2 : i32], ttg.warp_specialize.tag = 0 : i32}
     // CHECK: } {ttg.partition.stages =
     // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
@@ -109,24 +109,24 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
     scf.for %arg3 = %arg0 to %arg1 step %arg2 : i32 {
-      %3 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %3, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %14 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_b"(%14) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %20 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_c"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_d"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      %buffers_4, %token_5 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 3 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %26 = ttg.local_load %buffers_4 {ttg.partition = 3 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_5 [#nvws.async_op<none>] {ttg.partition = 3 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_e"(%26) {ttg.partition = 3 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_f"(%26) {ttg.partition = 3 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %3 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %3, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %14 = ttg.local_load %buffers_0 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%14) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %20 = ttg.local_load %buffers_2 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_4, %token_5 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %26 = ttg.local_load %buffers_4 {ttg.partition = array<i32: 3>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_5 [#nvws.async_op<none>] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_e"(%26) {ttg.partition = array<i32: 3>} : (tensor<1xi32, #blocked>) -> ()
+      "op_f"(%26) {ttg.partition = array<i32: 3>} : (tensor<1xi32, #blocked>) -> ()
     } {ttg.partition.stages = [0 : i32, 2 : i32, 2 : i32, 3 : i32], ttg.warp_specialize.tag = 0 : i32}
     // CHECK: } {ttg.partition.stages =
     // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
@@ -170,10 +170,10 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
       // CHECK-NEXT: ttng.arrive_barrier [[FULLBAR1]], 1
       // CHECK: op_a
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %arg5, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      %5 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %arg5, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      %5 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
 
       // CHECK: arith.select
       // CHECK: [[PHASE:%.*]] = arith.select
@@ -183,10 +183,10 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[EMPTYMBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
       // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR1]], 1
       // CHECK: op_d
-      %buffers_1, %token_2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %8 = ttg.local_load %buffers_1 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_2 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_d"(%8) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_1, %token_2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %8 = ttg.local_load %buffers_1 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_2 [#nvws.async_op<none>] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_d"(%8) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
 
       // CHECK: arith.select
       // CHECK: [[PHASE:%.*]] = arith.select
@@ -196,10 +196,10 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[EMPTYMBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
       // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR1]], 1
       // CHECK: op_d
-      %buffers_3, %token_4 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %11 = ttg.local_load %buffers_3 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_4 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_d"(%11) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_3, %token_4 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %11 = ttg.local_load %buffers_3 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_4 [#nvws.async_op<none>] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_d"(%11) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
       scf.yield %5 : tensor<1xi32, #blocked>
     } {ttg.partition.stages = [1 : i32, 0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     ttg.local_dealloc %0 : !ttg.memdesc<1x1xi32, #shared, #smem, mutable>
@@ -240,33 +240,33 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     ttng.init_barrier %9, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable, 1x1>
     %10 = scf.for %arg5 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg6 = %2) -> (!ttg.async.token)  : i32 {
       %11 = arith.muli %arg5, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
-      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
+      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
       // CHECK: [[BUF_A_SLICE:%.*]] = ttg.memdesc_index [[BUF_A]]
       // CHECK: [[BUF_B_SLICE:%.*]] = ttg.memdesc_index [[BUF_B]]
       // CHECK: [[TMA_FULL_SLICE:%.*]] = ttg.memdesc_index [[TMA_FULL]]
-      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_A_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
-      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_B_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
-      %buffers, %token_2 = nvws.aref.put.enter %4[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg3[%arg1, %11] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %4[%c0_i32], %token_2 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_3, %token_4 = nvws.aref.get.enter %4[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      %buffers_5, %token_6 = nvws.aref.put.enter %6[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg4[%arg2, %11] 16384 %buffers_5 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %6[%c0_i32], %token_6 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_7, %token_8 = nvws.aref.get.enter %6[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_A_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
+      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_B_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
+      %buffers, %token_2 = nvws.aref.put.enter %4[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg3[%arg1, %11] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %4[%c0_i32], %token_2 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_3, %token_4 = nvws.aref.get.enter %4[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      %buffers_5, %token_6 = nvws.aref.put.enter %6[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg4[%arg2, %11] 16384 %buffers_5 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %6[%c0_i32], %token_6 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_7, %token_8 = nvws.aref.get.enter %6[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
 
-      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
+      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
       // CHECK: [[BUF_A_SLICE:%.*]] = ttg.memdesc_index [[BUF_A]]
       // CHECK: [[BUF_B_SLICE:%.*]] = ttg.memdesc_index [[BUF_B]]
       // CHECK: [[BUF_B_SLICE_TRANS:%.*]] = ttg.memdesc_trans [[BUF_B_SLICE]] {loop.cluster = 0 : i32, loop.stage = 1 : i32
-      %12 = ttg.memdesc_trans %buffers_7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>
+      %12 = ttg.memdesc_trans %buffers_7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>
       %13 = arith.cmpi eq, %arg5, %7 : i32
       // CHECK: ttng.tc_gen5_mma [[BUF_A_SLICE]], [[BUF_B_SLICE_TRANS]]
-      %14 = ttng.tc_gen5_mma %buffers_3, %12, %1[], %true, %true, %9[%13] {is_async, loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 1x128x128>, !ttg.memdesc<1xi64, #shared1, #smem, mutable, 1x1>
+      %14 = ttng.tc_gen5_mma %buffers_3, %12, %1[], %true, %true, %9[%13] {is_async, loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 1x128x128>, !ttg.memdesc<1xi64, #shared1, #smem, mutable, 1x1>
       // CHECK: [[TMA_EMPTY_SLICE:%.*]] = ttg.memdesc_index [[TMA_EMPTY]]
-      // CHECK-COUNT-1: ttng.tc_gen5_commit [[TMA_EMPTY_SLICE]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      nvws.aref.get.exit %6[%c0_i32], %token_8 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      nvws.aref.get.exit %4[%c0_i32], %token_4 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      // CHECK-COUNT-1: ttng.tc_gen5_commit [[TMA_EMPTY_SLICE]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      nvws.aref.get.exit %6[%c0_i32], %token_8 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      nvws.aref.get.exit %4[%c0_i32], %token_4 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
       scf.yield %0 : !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
@@ -291,23 +291,23 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>
     scf.for %arg2 = %c0_i32 to %arg1 step %c1_i32  : i32 {
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
-      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
+      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
       // CHECK: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked>) -> ()
+      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked>) -> ()
       // CHECK: "use2"
-      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
+      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
       // CHECK: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      "use2"(%buffers_2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      "use2"(%buffers_2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -331,20 +331,20 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>
     scf.for %arg2 = %c0_i32 to %arg1 step %c1_i32  : i32 {
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
-       // CHECK: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
+       // CHECK: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
        // CHECK: "use1"
        // CHECK: "use2"
-       // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+       // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
        // CHECK: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-       // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked>) -> ()
-      "use2"(%buffers_0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+       // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked>) -> ()
+      "use2"(%buffers_0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -1,51 +1,95 @@
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc | FileCheck %s --check-prefix=TMEM --check-prefix=FUNC
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -verify-diagnostics --tritongpu-hoist-tmem-alloc -tritongpu-partition-scheduling -tritongpu-load-mma-specialization -sccp -int-range-optimizations -canonicalize -cse -tritongpu-remove-layout-conversions | FileCheck %s
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -verify-diagnostics --tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization | FileCheck %s --check-prefix=AWS --check-prefix=FUNC
-// XFAIL: *
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect
+// -tritongpu-hoist-tmem-alloc | FileCheck %s --check-prefix=TMEM
+// --check-prefix=FUNC RUN: triton-opt %s -split-input-file
+// -allow-unregistered-dialect -verify-diagnostics --tritongpu-hoist-tmem-alloc
+// -tritongpu-partition-scheduling -tritongpu-load-mma-specialization -sccp
+// -int-range-optimizations -canonicalize -cse
+// -tritongpu-remove-layout-conversions | FileCheck %s RUN: triton-opt %s
+// -split-input-file -allow-unregistered-dialect -verify-diagnostics
+// --tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies
+// -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization |
+// FileCheck %s --check-prefix=AWS --check-prefix=FUNC XFAIL: *
 
-#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
-#oper_layout = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
-#oper_layout_trans = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
-// CHECK-DAG: [[SHARED:#.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
-#shared_trans = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
-#nvmma_smem = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#acc_layout =                                                                  \
+    #ttg.blocked <                                                             \
+    {sizePerThread = [1, 128],                                                 \
+                      threadsPerWarp = [32, 1],                                \
+                                        warpsPerCTA = [4, 1],                  \
+                                                       order = [0, 1] }>
+#oper_layout =                                                                 \
+    #ttg.blocked <                                                             \
+    {sizePerThread = [1, 1],                                                   \
+                      threadsPerWarp = [1, 32],                                \
+                                        warpsPerCTA = [2, 2],                  \
+                                                       order = [1, 0] }>
+#oper_layout_trans =                                                           \
+    #ttg.blocked <                                                             \
+    {sizePerThread = [1, 1],                                                   \
+                      threadsPerWarp = [32, 1],                                \
+                                        warpsPerCTA = [2, 2],                  \
+                                                       order = [0, 1] }>
+// CHECK-DAG: [[SHARED:#.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128,
+// transposed = false, elementBitWidth = 16}>
+#shared = #ttg.nvmma_shared < {swizzlingByteWidth = 128, transposed = false,   \
+                              elementBitWidth = 16 }>
+#shared_trans = #ttg.nvmma_shared < {swizzlingByteWidth = 128,                 \
+                                    transposed = true, elementBitWidth = 16 }>
+#nvmma_smem = #ttg.nvmma_shared < {swizzlingByteWidth = 128,                   \
+                                  transposed = false, elementBitWidth = 8 }>
 #smem = #ttg.shared_memory
-#scales = #ttg.linear<{register = [[0, 1], [0, 2], [32, 0], [64, 0], [0, 4]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[0, 0], [0, 0]], block = []}>
-// CHECK-DAG: [[ACC_TMEM:#.*]] = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
-#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#scales = #ttg.linear < {register = [[0, 1],                                   \
+                                      [0, 2],                                  \
+                                       [32, 0],                                \
+                                        [64, 0], [0, 4]],                      \
+                                         lane = [[1, 0],                       \
+                                                  [2, 0],                      \
+                                                   [4, 0],                     \
+                                                    [8, 0], [16, 0]],          \
+                                                     warp = [[0, 0], [0, 0]],  \
+                                                              block = [] }>
+// CHECK-DAG: [[ACC_TMEM:#.*]] = #ttng.tensor_memory_encoding<blockM = 128,
+// blockN = 128, colStride = 1>
+#acc_tmem = #ttng.tensor_memory_encoding < blockM = 128, blockN = 128,         \
+                                           colStride = 1>
 
-#lhs_layout = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
-#lhs_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#lhs_layout =                                                                  \
+    #ttg.blocked <                                                             \
+    {sizePerThread = [1, 64],                                                  \
+                      threadsPerWarp = [32, 1],                                \
+                                        warpsPerCTA = [4, 1],                  \
+                                                       order = [0, 1] }>
+#lhs_tmem = #ttng.tensor_memory_encoding < blockM = 128, blockN = 64,          \
+                                           colStride = 1>
 
-#fp4_padded_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true, CTAsPerCGA = [1, 1, 1], CTASplitNum = [1, 1, 1], CTAOrder = [2, 1, 0]}>
+#fp4_padded_shared =                                                           \
+    #ttg.nvmma_shared <                                                        \
+    {swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8,        \
+    fp4Padded = true,                                                          \
+    CTAsPerCGA = [1, 1, 1], CTASplitNum = [1, 1, 1], CTAOrder = [2, 1, 0] }>
 
-module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+module attributes{"ttg.num-warps" = 4 :i32, ttg.target = "cuda:100"} {
 
-// FUNC-LABEL: @warp_specialize_tma_matmul
+  // FUNC-LABEL: @warp_specialize_tma_matmul
 
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// AWS: ttg.warp_specialize
-// AWS: num_warps(1)
-// AWS: num_warps(2)
-// AWS-NOT: num_warps(
+  // AWS: ttg.warp_specialize
+  // AWS: num_warps(1)
+  // AWS: num_warps(2)
+  // AWS-NOT: num_warps(
 
-// CHECK: @warp_specialize_tma_matmul
-// CHECK-SAME: [[K_TILES:%arg[0-9]+]]
-// CHECK-SAME: [[OFF_M:%arg[0-9]+]]
-// CHECK-SAME: [[OFF_N:%arg[0-9]+]]
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]
-tt.func @warp_specialize_tma_matmul(
-  %k_tiles: i32,
-  %off_m: i32,
-  %off_n: i32,
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>
-) {
-  // CHECK-DAG: [[TRUE:%.*]] = arith.constant true
+  // CHECK: @warp_specialize_tma_matmul
+  // CHECK-SAME: [[K_TILES:%arg[0-9]+]]
+  // CHECK-SAME: [[OFF_M:%arg[0-9]+]]
+  // CHECK-SAME: [[OFF_N:%arg[0-9]+]]
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  tt.func @warp_specialize_tma_matmul(
+      % k_tiles : i32, % off_m : i32, % off_n : i32,
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>) {
+    // CHECK-DAG: [[TRUE:%.*]] = arith.constant true
   %true = arith.constant true
   // CHECK-DAG: [[C0:%.*]] = arith.constant 0 : i32
   %c0_i32 = arith.constant 0 : i32
@@ -98,25 +142,25 @@ tt.func @warp_specialize_tma_matmul(
     %off_k = arith.muli %k, %BLOCK_K : i32
 
     // CHECK-NEXT: [[READY_MBAR:%.*]] = ttg.memdesc_index [[READY_MBARS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[READY_MBAR]], [[PHASE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[READY_MBAR]], [[PHASE]] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[OPER_MBAR:%.*]] = ttg.memdesc_index [[OPER_MBARS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.barrier_expect [[OPER_MBAR]], 32768 {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.barrier_expect [[OPER_MBAR]], 32768 {ttg.partition = array<i32: 2>}
 
     // CHECK-NEXT: [[A_BUF:%.*]] = ttg.memdesc_index [[A_BUFS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[A_DESC]][[[OFF_M]], [[OFF_K]]] [[A_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[A_DESC]][[[OFF_M]], [[OFF_K]]] [[A_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = array<i32: 2>}
     %a_reg = tt.descriptor_load %a_desc[%off_m, %off_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
     // CHECK-NEXT: [[B_BUF:%.*]] = ttg.memdesc_index [[B_BUFS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[B_DESC]][[[OFF_N]], [[OFF_K]]] [[B_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[B_DESC]][[[OFF_N]], [[OFF_K]]] [[B_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = array<i32: 2>}
     %b_reg = tt.descriptor_load %b_desc[%off_n, %off_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
 
     %a_shared = ttg.local_alloc %a_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %b_shared = ttg.local_alloc %b_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-    // CHECK-NEXT: [[B_T:%.*]] = ttg.memdesc_trans [[B_BUF]] {order = array<i32: 1, 0>, ttg.partition = 1 : i32}
-    // CHECK-NEXT: ttng.wait_barrier [[OPER_MBAR]], [[PHASE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[B_T:%.*]] = ttg.memdesc_trans [[B_BUF]] {order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: ttng.wait_barrier [[OPER_MBAR]], [[PHASE]] {ttg.partition = array<i32: 1>}
     %b_T_shared = ttg.memdesc_trans %b_shared {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared_trans, #smem>
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     // CHECK-NEXT: [[IS_LAST:%.*]] = arith.cmpi eq, [[K]], [[LAST_ITER]]
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma [[A_BUF]], [[B_T]], [[ACC_BUF]][], [[TRUE]], [[TRUE]], [[READY_MBAR]][%true], [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma [[A_BUF]], [[B_T]], [[ACC_BUF]][], [[TRUE]], [[TRUE]], [[READY_MBAR]][%true], [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_T_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_trans, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
 
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
@@ -131,7 +175,9 @@ tt.func @warp_specialize_tma_matmul(
     scf.yield %c : tensor<128x128xf32, #acc_layout>
 
   // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32
-  } {tt.warp_specialize, tt.num_stages = 2 : i32}
+  } {
+    tt.warp_specialize, tt.num_stages = 2 : i32
+  }
 
   // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0]], %c0_i32
   // CHECK-NEXT: ttng.inval_barrier [[DONE_MBAR0]]
@@ -148,17 +194,16 @@ tt.func @warp_specialize_tma_matmul(
   // CHECK-NEXT: ttg.local_dealloc [[B_BUFS]]
   // CHECK-NEXT: ttg.local_dealloc [[A_BUFS]]
 
-  // CHECK-NEXT: [[RESULT:%.*]], [[RESULT_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][[[LAST]]#0]
-  // CHECK-NEXT: "use"([[RESULT]])
-  "use"(%result) : (tensor<128x128xf32, #acc_layout>) -> ()
-  tt.return
-}
-// FUNC-LABEL: @unsupported_load
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // CHECK-NEXT: [[RESULT:%.*]], [[RESULT_TOK:%.*]] = ttng.tmem_load
+  // [[ACC_BUF]][[[LAST]]#0] CHECK-NEXT: "use"([[RESULT]])
+  "use"(% result) : (tensor<128x128xf32, #acc_layout>)->() tt.return
+  }
+  // FUNC-LABEL: @unsupported_load
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// CHECK-LABEL: @unsupported_load
-tt.func @unsupported_load() {
+  // CHECK-LABEL: @unsupported_load
+  tt.func @unsupported_load() {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -187,7 +232,7 @@ tt.func @unsupported_load() {
 
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     // CHECK: [[IS_LAST:%.*]] = arith.cmpi eq, %{{.*}}, %c31_i32
-    // CHECK-NEXT: ttng.tc_gen5_mma %{{.*}}, [[ACC]][], %true, %true, [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.tc_gen5_mma %{{.*}}, [[ACC]][], %true, %true, [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -200,17 +245,16 @@ tt.func @unsupported_load() {
   // CHECK-NEXT: ttg.local_dealloc [[DONE_MBAR]]
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @cant_pipeline_mma
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // FUNC-LABEL: @cant_pipeline_mma
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// CHECK-LABEL: @cant_pipeline_mma
-tt.func @cant_pipeline_mma(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @cant_pipeline_mma
+  tt.func @cant_pipeline_mma(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -235,17 +279,16 @@ tt.func @cant_pipeline_mma(
   } {tt.warp_specialize}
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @invalid_acc_reset
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // FUNC-LABEL: @invalid_acc_reset
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// CHECK-LABEL: @invalid_acc_reset
-tt.func @invalid_acc_reset(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @invalid_acc_reset
+  tt.func @invalid_acc_reset(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -272,25 +315,24 @@ tt.func @invalid_acc_reset(
   } {tt.warp_specialize}
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @matmul_tma_acc_with_unconditional_user
+  // FUNC-LABEL: @matmul_tma_acc_with_unconditional_user
 
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// AWS: ttg.warp_specialize
-// AWS: num_warps(4)
-// AWS: num_warps(2)
-// AWS-NOT: num_warps(
+  // AWS: ttg.warp_specialize
+  // AWS: num_warps(4)
+  // AWS: num_warps(2)
+  // AWS-NOT: num_warps(
 
-// CHECK-LABEL: @matmul_tma_acc_with_unconditional_user
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]
-tt.func @matmul_tma_acc_with_unconditional_user(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @matmul_tma_acc_with_unconditional_user
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  tt.func @matmul_tma_acc_with_unconditional_user(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -345,15 +387,15 @@ tt.func @matmul_tma_acc_with_unconditional_user(
     // CHECK-NEXT: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
 
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
 
-    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = array<i32: 0>}
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
     // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
     "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
 
     // CHECK-NEXT: [[ACC_INDEX_INCR:%.*]] = arith.addi [[ACC_INDEX]], %c1_i32
@@ -362,12 +404,12 @@ tt.func @matmul_tma_acc_with_unconditional_user(
     // CHECK-NEXT: [[ACC_NEXT_INDEX:%.*]] = arith.select [[ACC_ROLLVER]], %c0_i32, [[ACC_INDEX_INCR]]
     // CHECK-NEXT: [[ACC_NEXT_PHASE:%.*]] = arith.select [[ACC_ROLLVER]], [[ACC_PHASE_INCR]], [[ACC_PHASE]]
 
-    // CHECK-NEXT: "acc_user"([[C]]) {ttg.partition = 0 : i32}
+    // CHECK-NEXT: "acc_user"([[C]]) {ttg.partition = array<i32: 0>}
 
     // CHECK-NEXT: [[NEXT_ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ACC_RESET]], [[NEXT_ACC_BUF]][], %true {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ACC_RESET]], [[NEXT_ACC_BUF]][], %true {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -378,25 +420,24 @@ tt.func @matmul_tma_acc_with_unconditional_user(
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @matmul_tma_acc_with_conditional_user
+  // FUNC-LABEL: @matmul_tma_acc_with_conditional_user
 
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// AWS: ttg.warp_specialize
-// AWS: num_warps(4)
-// AWS: num_warps(2)
-// AWS-NOT: num_warps(
+  // AWS: ttg.warp_specialize
+  // AWS: num_warps(4)
+  // AWS: num_warps(2)
+  // AWS-NOT: num_warps(
 
-// CHECK-LABEL: @matmul_tma_acc_with_conditional_user
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]
-tt.func @matmul_tma_acc_with_conditional_user(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @matmul_tma_acc_with_conditional_user
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  tt.func @matmul_tma_acc_with_conditional_user(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -434,7 +475,7 @@ tt.func @matmul_tma_acc_with_conditional_user(
     // CHECK-NEXT: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
     // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -442,12 +483,12 @@ tt.func @matmul_tma_acc_with_conditional_user(
 
     // CHECK-NEXT: scf.if [[DO_EPILOGUE]]
     scf.if %do_epilogue {
-      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
       // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: }
     }
 
@@ -461,37 +502,37 @@ tt.func @matmul_tma_acc_with_conditional_user(
 
     // CHECK-NEXT: [[ACC_NEXT_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: ttng.tmem_store [[ACC_RESET]], [[ACC_NEXT_BUF]][], %true {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: ttng.tmem_store [[ACC_RESET]], [[ACC_NEXT_BUF]][], %true {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
 
     // CHECK: scf.yield %{{[0-9]+}}, %{{[0-9]+}}, [[EPILOGUE_ACC_NEXT_INDEX]], [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %acc_reset : tensor<128x128xf32, #acc_layout>
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
-  } {tt.warp_specialize, tt.num_stages = 2 : i32}
+    // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
+  }
+  {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @matmul_tma_acc_with_conditional_def
+  // FUNC-LABEL: @matmul_tma_acc_with_conditional_def
 
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// AWS: ttg.warp_specialize
-// AWS: num_warps(4)
-// AWS: num_warps(2)
-// AWS-NOT: num_warps(
+  // AWS: ttg.warp_specialize
+  // AWS: num_warps(4)
+  // AWS: num_warps(2)
+  // AWS-NOT: num_warps(
 
-// CHECK-LABEL: @matmul_tma_acc_with_conditional_def
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]
-tt.func @matmul_tma_acc_with_conditional_def(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @matmul_tma_acc_with_conditional_def
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  tt.func @matmul_tma_acc_with_conditional_def(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -529,7 +570,7 @@ tt.func @matmul_tma_acc_with_conditional_def(
     // CHECK-NEXT: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
 
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -537,10 +578,10 @@ tt.func @matmul_tma_acc_with_conditional_def(
     %do_epilogue = arith.cmpi eq, %k, %c0_i32 : i32
     %acc_reset = arith.select %do_epilogue, %zero, %c : tensor<128x128xf32, #acc_layout>
 
-    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
 
     // CHECK-NEXT: [[ACC_INDEX_INCR:%.*]] = arith.addi [[ACC_INDEX]], %c1_i32
     // CHECK-NEXT: [[ACC_PHASE_INCR:%.*]] = arith.xori [[ACC_PHASE]], %c1_i32
@@ -553,8 +594,8 @@ tt.func @matmul_tma_acc_with_conditional_def(
 
     // CHECK-NEXT: [[NEXT_ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -565,25 +606,24 @@ tt.func @matmul_tma_acc_with_conditional_def(
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @matmul_tma_acc_with_conditional_def_and_use
+  // FUNC-LABEL: @matmul_tma_acc_with_conditional_def_and_use
 
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// AWS: ttg.warp_specialize
-// AWS: num_warps(4)
-// AWS: num_warps(2)
-// AWS-NOT: num_warps(
+  // AWS: ttg.warp_specialize
+  // AWS: num_warps(4)
+  // AWS: num_warps(2)
+  // AWS-NOT: num_warps(
 
-// CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]
-tt.func @matmul_tma_acc_with_conditional_def_and_use(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  tt.func @matmul_tma_acc_with_conditional_def_and_use(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -621,7 +661,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
     // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -630,12 +670,12 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
     // CHECK-NEXT: scf.if [[DO_EPILOGUE]]
     scf.if %do_epilogue {
-      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
       // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: }
     }
 
@@ -649,37 +689,37 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
     // CHECK-NEXT: [[NEXT_ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
 
     // CHECK: scf.yield {{.*}} [[EPILOGUE_ACC_NEXT_INDEX]], [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %acc_reset : tensor<128x128xf32, #acc_layout>
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
-  } {tt.warp_specialize, tt.num_stages = 2 : i32}
+    // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
+  }
+  {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag
+  // FUNC-LABEL: @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag
 
-// TMEM: ttng.tmem_alloc
-// TMEM: scf.for
+  // TMEM: ttng.tmem_alloc
+  // TMEM: scf.for
 
-// AWS: ttg.warp_specialize
-// AWS: num_warps(1)
-// AWS: num_warps(2)
-// AWS-NOT: num_warps(
+  // AWS: ttg.warp_specialize
+  // AWS: num_warps(1)
+  // AWS: num_warps(2)
+  // AWS-NOT: num_warps(
 
-// CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]
-tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -724,8 +764,8 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
     %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
 
-    // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32 : i32
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[ACC_READY_BUF0]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[ACC_READY_BUF0]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %flag, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -738,9 +778,9 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
     scf.if %do_epilogue {
       // CHECK-NEXT: "some_op"()
       "some_op"() : () -> ()
-      // CHECK-NEXT: ttng.wait_barrier [[ACC_READY_BUF0]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[ACC_READY_BUF0]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
-      // CHECK-NEXT: ttng.arrive_barrier [[ACC_EMPTY_BUF0]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[ACC_EMPTY_BUF0]], 1 {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
     // CHECK-NEXT: }
@@ -748,29 +788,30 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
 
     // CHECK-NEXT: [[ACC_NEXT_PHASE:%.*]] = arith.xori [[ACC_PHASE]], %c1_i32
     // CHECK-NEXT: [[EPILOGUE_ACC_NEXT_PHASE:%.*]] = arith.select [[DO_EPILOGUE]], [[ACC_NEXT_PHASE]], [[ACC_PHASE]]
-    // CHECK-NEXT: ttng.wait_barrier [[ACC_EMPTY_BUF0]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[ACC_EMPTY_BUF0]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
 
     // CHECK: scf.yield [[NEXT_FLAG]], %{{[0-9]+}}, %{{[0-9]+}}, [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %c, %use_acc : tensor<128x128xf32, #acc_layout>, i1
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
-  } {tt.warp_specialize, tt.disallow_acc_multi_buffer, tt.num_stages = 2 : i32}
+    // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
+  }
+  {tt.warp_specialize, tt.disallow_acc_multi_buffer, tt.num_stages = 2 : i32}
 
   tt.return
-}
+  }
 
-// FUNC-LABEL: @matmul_scaled_rhs_scales_tma
-// CHECK-LABEL: @matmul_scaled_rhs_scales_tma
-tt.func @matmul_scaled_rhs_scales_tma(
-  %k_tiles: i32,
-  %off_m: i32,
-  %off_n: i32,
-  %a_desc: !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>>,
-  %b_desc: !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>>,
-  %b_scale_desc: !tt.tensordesc<tensor<128x8xi8, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>>>
-) {
+  // FUNC-LABEL: @matmul_scaled_rhs_scales_tma
+  // CHECK-LABEL: @matmul_scaled_rhs_scales_tma
+  tt.func @matmul_scaled_rhs_scales_tma(
+      % k_tiles : i32, % off_m : i32, % off_n : i32,
+      % a_desc : !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>>,
+      % b_desc : !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>>,
+      % b_scale_desc : !tt.tensordesc<
+            tensor<128x8xi8,
+                   #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1,
+                                         order = [ 1, 0 ]}>>>) {
   %true = arith.constant true
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
@@ -789,24 +830,24 @@ tt.func @matmul_scaled_rhs_scales_tma(
     %off_k = arith.muli %k, %BLOCK_K : i32
 
     // CHECK: ttng.wait_barrier
-    // CHECK-COUNT-3: async_tma_copy_global_to_local {{.*}} {ttg.partition = 2 : i32}
+    // CHECK-COUNT-3: async_tma_copy_global_to_local {{.*}} {ttg.partition = array<i32: 2>}
     %a_reg = tt.descriptor_load %a_desc[%off_m, %off_k] : !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>> -> tensor<128x64xf8E4M3FN, #oper_layout>
     %b_reg = tt.descriptor_load %b_desc[%off_n, %off_k] : !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>> -> tensor<128x64xf8E4M3FN, #oper_layout>
     %b_scales_reg = tt.descriptor_load %b_scale_desc[%off_m, %c0_i32] : !tt.tensordesc<tensor<128x8xi8, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>>> -> tensor<128x8xi8, #scales>
 
     %a_sh = ttg.local_alloc %a_reg : (tensor<128x64xf8E4M3FN, #oper_layout>) -> !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem>
     %b_sh_raw = ttg.local_alloc %b_reg : (tensor<128x64xf8E4M3FN, #oper_layout>) -> !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem>
-    // CHECK-NEXT: memdesc_trans {{.*}} ttg.partition = 1 : i32
+    // CHECK-NEXT: memdesc_trans {{.*}} ttg.partition = array<i32: 1>
     %b_sh = ttg.memdesc_trans %b_sh_raw {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem> -> !ttg.memdesc<64x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>, #smem>
 
-    // CHECK-NEXT: wait_barrier {{.*}} {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier {{.*}} {ttg.partition = array<i32: 1>}
 
     %b_scales_tmem = ttng.tmem_alloc %b_scales_reg : (tensor<128x8xi8, #scales>) -> !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>
 
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
 
     // CHECK-NEXT: [[IS_LAST:%.*]] = arith.cmpi eq, %arg6, [[LAST_ITER]]
-    // CHECK-NEXT: tc_gen5_mma_scaled {{.*}} {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: tc_gen5_mma_scaled {{.*}} {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma_scaled %a_sh, %b_sh, %c_tmem[%c_tok], %a_scales_tmem, %b_scales_tmem, %true, %true lhs = e4m3 rhs = e4m3 : !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem>, !ttg.memdesc<64x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>
 
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
@@ -814,16 +855,13 @@ tt.func @matmul_scaled_rhs_scales_tma(
   } {tt.warp_specialize}
 
   tt.return
-}
+  }
 
-// CHECK-LABEL: @warp_specialize_only_rhs_is_loaded
-tt.func @warp_specialize_only_rhs_is_loaded(
-  %k_tiles: i32,
-  %off_m: i32,
-  %off_n: i32,
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>
-) {
+  // CHECK-LABEL: @warp_specialize_only_rhs_is_loaded
+  tt.func @warp_specialize_only_rhs_is_loaded(
+      % k_tiles : i32, % off_m : i32, % off_n : i32,
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>) {
   %true = arith.constant true
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
@@ -857,20 +895,18 @@ tt.func @warp_specialize_only_rhs_is_loaded(
 
     scf.yield %c : tensor<128x128xf32, #acc_layout>
 
-  } {tt.warp_specialize, tt.num_stages = 2 : i32}
+  } {
+    tt.warp_specialize, tt.num_stages = 2 : i32
+  }
 
-  "use"(%result) : (tensor<128x128xf32, #acc_layout>) -> ()
-  tt.return
-}
+  "use"(% result) : (tensor<128x128xf32, #acc_layout>)->() tt.return
+  }
 
-// CHECK-LABEL: @user_partition_has_cycle
-tt.func @user_partition_has_cycle(
-  %k_tiles: i32,
-  %off_m: i32,
-  %off_n: i32,
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>
-) {
+  // CHECK-LABEL: @user_partition_has_cycle
+  tt.func @user_partition_has_cycle(
+      % k_tiles : i32, % off_m : i32, % off_n : i32,
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>) {
   %true = arith.constant true
   %false = arith.constant false
   %c0_i32 = arith.constant 0 : i32
@@ -895,29 +931,32 @@ tt.func @user_partition_has_cycle(
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_T_shared, %c_tmem[%c_tok], %false, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_trans, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
-    // CHECK: [[TIMES_TWO:%.*]] = arith.addf [[PRODUCT]], [[PRODUCT]] {ttg.partition = 0 : i32}
+    // CHECK: [[TIMES_TWO:%.*]] = arith.addf [[PRODUCT]], [[PRODUCT]] {ttg.partition = array<i32: 0>}
     %times_two = arith.addf %product, %product : tensor<128x128xf32, #acc_layout>
-    // CHECK: [[C:%.*]], %{{.*}} = ttng.tmem_load {{.*}} {ttg.partition = 0 : i32}
+    // CHECK: [[C:%.*]], %{{.*}} = ttng.tmem_load {{.*}} {ttg.partition = array<i32: 0>}
     // CHECK: arrive_barrier
-    // CHECK: [[NEXT_PRODUCT:%.*]] = arith.mulf [[TIMES_TWO]], [[C]] {ttg.partition = 0 : i32}
+    // CHECK: [[NEXT_PRODUCT:%.*]] = arith.mulf [[TIMES_TWO]], [[C]] {ttg.partition = array<i32: 0>}
     %next_product = arith.mulf %times_two, %c : tensor<128x128xf32, #acc_layout>
 
     // CHECK: yield [[NEXT_PRODUCT]]
     scf.yield %next_product : tensor<128x128xf32, #acc_layout>
-  } {tt.warp_specialize, tt.num_stages = 2 : i32}
+  } {
+    tt.warp_specialize, tt.num_stages = 2 : i32
+  }
 
-  "use"(%result) : (tensor<128x128xf32, #acc_layout>) -> ()
+  "use"(% result)
+      : (tensor<128x128xf32, #acc_layout>)
+            ->()
 
-  tt.return
-}
+                tt.return
+  }
 
-// CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use_flag
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]
-tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use_flag
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -974,7 +1013,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
     // CHECK-NEXT: [[CUR_ACC_READY_BUF:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
 
     // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32
-    // CHECK-NEXT: ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[CUR_ACC_READY_BUF]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[CUR_ACC_READY_BUF]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %flag, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -985,14 +1024,14 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
 
     // CHECK-NEXT: scf.if [[DO_EPILOGUE]]
     scf.if %do_epilogue {
-      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BUF]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BUF]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: "some_op"()
       "some_op"() : () -> ()
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
       // CHECK-NEXT: [[CUR_ACC_EMPTY_BUF:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BUF]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BUF]], 1 {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: }
     }
 
@@ -1005,51 +1044,57 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
     // CHECK-NEXT: [[EPILOGUE_ACC_NEXT_PHASE:%.*]] = arith.select [[DO_EPILOGUE]], [[ACC_NEXT_PHASE]], [[ACC_PHASE]]
 
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BUF:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BUF]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BUF]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
 
     // CHECK: scf.yield [[NEXT_FLAG]], %{{[0-9]+}}, %{{[0-9]+}}, [[EPILOGUE_ACC_NEXT_INDEX]], [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %c, %use_acc : tensor<128x128xf32, #acc_layout>, i1
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
-  } {tt.warp_specialize, tt.num_stages = 4 : i32}
+    // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
+  }
+  {tt.warp_specialize, tt.num_stages = 4 : i32}
 
   tt.return
-}
+  }
 
-// CHECK-LABEL: @specialize_load_only
-tt.func @specialize_load_only(%desc: !tt.tensordesc<tensor<128x64xf16, #shared>>, %ub: i32) {
+  // CHECK-LABEL: @specialize_load_only
+  tt.func @specialize_load_only(
+      % desc : !tt.tensordesc<tensor<128x64xf16, #shared>>, % ub : i32) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   // CHECK: local_alloc : () -> !ttg.memdesc<3x128x64xf16,
   scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
-    // CHECK: wait_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-    // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
-    // CHECK-NEXT: arrive_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+    // CHECK: wait_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: fence_async_shared {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: arrive_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
     %val = tt.descriptor_load %desc[%i, %i] {loop.cluster = 1 : i32, loop.stage = 0}: !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
     "use"(%val) {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x64xf16, #oper_layout>) -> ()
   } {tt.num_stages = 3 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
   tt.return
-}
+  }
 
-// CHECK-LABEL: @fp4_padded_load
-tt.func @fp4_padded_load(%desc: !tt.tensordesc<tensor<1x256x64xui8, #fp4_padded_shared>>, %ub: i32) {
+  // CHECK-LABEL: @fp4_padded_load
+  tt.func @fp4_padded_load(
+      % desc : !tt.tensordesc<tensor<1x256x64xui8, #fp4_padded_shared>>,
+      % ub : i32) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   // CHECK: scf.for [[I:%arg[0-9]+]]
   scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
     // CHECK: [[IDX:%.*]] = arith.muli [[I]], %c2_i32 : i32
     // CHECK: async_tma_copy_global_to_local %arg{{[0-9]+}}[[[I]], [[IDX]]]
-    %val = tt.descriptor_load %desc[%i, %i] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<1x256x64xui8, #fp4_padded_shared>> -> tensor<256x64xi8, #oper_layout>
-    "use"(%val) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<256x64xi8, #oper_layout>) -> ()
+    %val = tt.descriptor_load %desc[%i, %i] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<1x256x64xui8, #fp4_padded_shared>> -> tensor<256x64xi8, #oper_layout>
+    "use"(%val) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<256x64xi8, #oper_layout>) -> ()
   } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
   tt.return
-}
+  }
 
-// CHECK-LABEL: @specialize_mma_only
-tt.func @specialize_mma_only(%rhs_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>, %lhs: !ttg.memdesc<128x64xf16, #shared, #smem>, %ub: i32) {
+  // CHECK-LABEL: @specialize_mma_only
+  tt.func @specialize_mma_only(
+      % rhs_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>,
+      % lhs : !ttg.memdesc<128x64xf16, #shared, #smem>, % ub : i32) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -1081,37 +1126,38 @@ tt.func @specialize_mma_only(%rhs_desc: !tt.tensordesc<tensor<64x128xf16, #share
     // CHECK-NEXT: [[LOADED:%.*]], %{{.*}} = ttng.tmem_load [[ACC_TMEM:%.*]][]
     // CHECK: wait_barrier
     // CHECK-NEXT: local_load
-    // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
+    // CHECK-NEXT: fence_async_shared {{.*}}partition = array<i32: 0>
     // CHECK-NEXT: arrive_barrier
     // CHECK-NEXT: [[RESULTS:%.*]]:2 = "some_producer"
     %rhs_reg, %next_acc = "some_producer"(%loaded, %acc) : (tensor<64x128xf16, #oper_layout>, tensor<128x128xf32, #acc_layout>) -> (tensor<128x64xf16, #oper_layout>, tensor<128x128xf32, #acc_layout>)
-    // CHECK-NEXT: local_store [[RESULTS]]#0, [[OPERAND]]{{.*}}partition = 0
-    // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
+    // CHECK-NEXT: local_store [[RESULTS]]#0, [[OPERAND]]{{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: fence_async_shared {{.*}}partition = array<i32: 0>
     // CHECK-NEXT: [[RHS_T:%.*]] = ttg.memdesc_trans [[OPERAND]] {{.*}}, mutable
-    // CHECK-NEXT: tmem_store [[RESULTS]]#1, [[ACC_TMEM]]{{.*}}partition = 0
-    // CHECK-NEXT: arrive_barrier [[EMPTY_BAR0]]{{.*}}partition = 0
+    // CHECK-NEXT: tmem_store [[RESULTS]]#1, [[ACC_TMEM]]{{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: arrive_barrier [[EMPTY_BAR0]]{{.*}}partition = array<i32: 0>
     %rhs = ttg.local_alloc %rhs_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %rhs_T = ttg.memdesc_trans %rhs {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared_trans, #smem>
     %acc_tmem, %acc_tok = ttng.tmem_alloc %next_acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
-    // CHECK: wait_barrier [[EMPTY_BAR0]]{{.*}}partition = 1
-    // CHECK-NEXT: ttng.tc_gen5_mma %arg1, [[RHS_T]], {{.*}} [[READY_BAR0]][%true] {{.*}}partition = 1
+    // CHECK: wait_barrier [[EMPTY_BAR0]]{{.*}}partition = array<i32: 1>
+    // CHECK-NEXT: ttng.tc_gen5_mma %arg1, [[RHS_T]], {{.*}} [[READY_BAR0]][%true] {{.*}}partition = array<i32: 1>
     %mma_tok = ttng.tc_gen5_mma %lhs, %rhs_T, %acc_tmem[%acc_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_trans, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %acc_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
     scf.yield %c : tensor<128x128xf32, #acc_layout>
-  } {tt.warp_specialize, tt.num_stages = 3 : i32}
-  "use"(%out) : (tensor<128x128xf32, #acc_layout>) -> ()
-  tt.return
-}
+  } {
+    tt.warp_specialize, tt.num_stages = 3 : i32
+  }
+  "use"(% out) : (tensor<128x128xf32, #acc_layout>)->() tt.return
+  }
 
-// CHECK-LABEL: @load_scale_mma_user
-tt.func @load_scale_mma_user(
-  %lhs: !ttg.memdesc<128x64xf16, #shared, #smem>,
-  %rhs: !ttg.memdesc<64x128xf16, #shared, #smem>,
-  %scales_desc: !tt.tensordesc<tensor<8x128xi8, #shared>>,
-  %b_scales: !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>,
-  %ub: i32
-) {
+  // CHECK-LABEL: @load_scale_mma_user
+  tt.func @load_scale_mma_user(
+      % lhs : !ttg.memdesc<128x64xf16, #shared, #smem>,
+      % rhs : !ttg.memdesc<64x128xf16, #shared, #smem>,
+      % scales_desc : !tt.tensordesc<tensor<8x128xi8, #shared>>,
+      % b_scales : !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>,
+                                #ttng.tensor_memory>,
+      % ub : i32) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
@@ -1119,48 +1165,47 @@ tt.func @load_scale_mma_user(
 
   // CHECK: scf.for
   %out = scf.for %i = %c0_i32 to %ub step %c1_i32 iter_args(%acc = %zero) -> tensor<128x128xf32, #acc_layout> : i32 {
-    // CHECK: wait_barrier [[EMPTY_BAR:%.*]], %{{.*}}partition = 2
-    // CHECK: barrier_expect [[SCALES_BAR:%.*]], 1024 {{.*}}partition = 2
-    // CHECK: async_tma_copy_global_to_local {{.*}}partition = 2
+    // CHECK: wait_barrier [[EMPTY_BAR:%.*]], %{{.*}}partition = array<i32: 2>
+    // CHECK: barrier_expect [[SCALES_BAR:%.*]], 1024 {{.*}}partition = array<i32: 2>
+    // CHECK: async_tma_copy_global_to_local {{.*}}partition = array<i32: 2>
     %scales_result = tt.descriptor_load %scales_desc[%i, %i] : !tt.tensordesc<tensor<8x128xi8, #shared>> -> tensor<8x128xi8, #oper_layout>
     %scales_shared = ttg.local_alloc %scales_result : (tensor<8x128xi8, #oper_layout>) -> !ttg.memdesc<8x128xi8, #shared, #smem>
-    // CHECK: wait_barrier [[SCALES_BAR]]{{.*}}partition = 0
-    // CHECK-NEXT: [[SCALES_REG:%.*]] = ttg.local_load {{.*}}partition = 0
-    // CHECK-NEXT: arrive_barrier [[EMPTY_BAR]]{{.*}}partition = 0
+    // CHECK: wait_barrier [[SCALES_BAR]]{{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: [[SCALES_REG:%.*]] = ttg.local_load {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: arrive_barrier [[EMPTY_BAR]]{{.*}}partition = array<i32: 0>
     %scales_reg = ttg.local_load %scales_shared : !ttg.memdesc<8x128xi8, #shared, #smem> -> tensor<8x128xi8, #oper_layout>
-    // CHECK-NEXT: [[SCALES_TRANS:%.*]] = tt.trans [[SCALES_REG]] {{.*}}partition = 0
+    // CHECK-NEXT: [[SCALES_TRANS:%.*]] = tt.trans [[SCALES_REG]] {{.*}}partition = array<i32: 0>
     %scales_T = tt.trans %scales_reg {order = array<i32: 1, 0>} : tensor<8x128xi8, #oper_layout> -> tensor<128x8xi8, #oper_layout_trans>
     %scales_cvt = ttg.convert_layout %scales_T : tensor<128x8xi8, #oper_layout_trans> -> tensor<128x8xi8, #scales>
-    // CHECK-NEXT: wait_barrier [[SCALES_TMEM_BAR:%.*]], %arg{{[0-9]+}} {{.*}}partition = 0
-    // CHECK-NEXT: tmem_store [[SCALES_TRANS]], [[SCALES_TMEM:%.*]], %true {{.*}}partition = 0
+    // CHECK-NEXT: wait_barrier [[SCALES_TMEM_BAR:%.*]], %arg{{[0-9]+}} {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: tmem_store [[SCALES_TRANS]], [[SCALES_TMEM:%.*]], %true {{.*}}partition = array<i32: 0>
     %scales_tmem = ttng.tmem_alloc %scales_cvt : (tensor<128x8xi8, #scales>) -> !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>
-    // CHECK-NEXT: arrive_barrier [[SCALES_READY_BAR:%.*]], 1 {{.*}}partition = 0
+    // CHECK-NEXT: arrive_barrier [[SCALES_READY_BAR:%.*]], 1 {{.*}}partition = array<i32: 0>
 
-    // CHECK: wait_barrier [[USER_DONE:%.*]], %arg{{[0-9]+}}, %true {{.*}}partition = 1
-    // CHECK: wait_barrier [[SCALES_READY_BAR]]{{.*}}partition = 1
+    // CHECK: wait_barrier [[USER_DONE:%.*]], %arg{{[0-9]+}}, %true {{.*}}partition = array<i32: 1>
+    // CHECK: wait_barrier [[SCALES_READY_BAR]]{{.*}}partition = array<i32: 1>
     %acc_tmem, %acc_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
-    // CHECK-NEXT: tc_gen5_mma_scaled {{.*}} [[SCALES_TMEM]]{{.*}} [[USER_BAR:%.*]][%true], [[SCALES_TMEM_BAR]][%true] {{.*}}partition = 1
+    // CHECK-NEXT: tc_gen5_mma_scaled {{.*}} [[SCALES_TMEM]]{{.*}} [[USER_BAR:%.*]][%true], [[SCALES_TMEM_BAR]][%true] {{.*}}partition = array<i32: 1>
     %mma_tok = ttng.tc_gen5_mma_scaled %lhs, %rhs, %acc_tmem[%acc_tok], %scales_tmem, %b_scales, %true, %true lhs = e4m3 rhs = e4m3 : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>
 
-    // CHECK: wait_barrier [[USER_BAR]]{{.*}}partition = 0
+    // CHECK: wait_barrier [[USER_BAR]]{{.*}}partition = array<i32: 0>
     // CHECK-NEXT: tmem_load
     %c, %load_tok = ttng.tmem_load %acc_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
-    // CHECK: arrive_barrier [[USER_DONE]]{{.*}}partition = 0
+    // CHECK: arrive_barrier [[USER_DONE]]{{.*}}partition = array<i32: 0>
 
     "user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
 
     scf.yield %c : tensor<128x128xf32, #acc_layout>
-  } {tt.warp_specialize, tt.num_stages = 3 : i32}
-  "use"(%out) : (tensor<128x128xf32, #acc_layout>) -> ()
-  tt.return
-}
+  } {
+    tt.warp_specialize, tt.num_stages = 3 : i32
+  }
+  "use"(% out) : (tensor<128x128xf32, #acc_layout>)->() tt.return
+  }
 
-// CHECK-LABEL: @store_mma_load
-tt.func @store_mma_load(
-  %ub: i32,
-  %lhs_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %rhs: !ttg.memdesc<64x128xf16, #shared, #smem>
-) {
+  // CHECK-LABEL: @store_mma_load
+  tt.func @store_mma_load(
+      % ub : i32, % lhs_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % rhs : !ttg.memdesc<64x128xf16, #shared, #smem>) {
   %c0 = arith.constant 0 : i32
   %c1 = arith.constant 1 : i32
   %true = arith.constant true
@@ -1184,35 +1229,35 @@ tt.func @store_mma_load(
   // CHECK: scf.for
   scf.for %i = %c0 to %ub step %c1 : i32 {
     // CHECK-NEXT: [[LOAD_EMPTY_BAR:%.*]] = ttg.memdesc_index [[LHS_EMPTY_BARS]]
-    // CHECK-NEXT: wait_barrier [[LOAD_EMPTY_BAR]]{{.*}}partition = 2
+    // CHECK-NEXT: wait_barrier [[LOAD_EMPTY_BAR]]{{.*}}partition = array<i32: 2>
     // CHECK-NEXT: [[LOAD_READY_BAR:%.*]] = ttg.memdesc_index [[LHS_READY_BARS]]
-    // CHECK-NEXT: barrier_expect [[LOAD_READY_BAR]]{{.*}}partition = 2
+    // CHECK-NEXT: barrier_expect [[LOAD_READY_BAR]]{{.*}}partition = array<i32: 2>
     // CHECK-NEXT: [[LOAD_BUF:%.*]] = ttg.memdesc_index
-    // CHECK-NEXT: async_tma_copy_global_to_local{{.*}}partition = 2
+    // CHECK-NEXT: async_tma_copy_global_to_local{{.*}}partition = array<i32: 2>
     %lhs = tt.descriptor_load %lhs_desc[%i, %i] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
 
-    // CHECK-NEXT: wait_barrier [[LOAD_READY_BAR]], {{.*}}partition = 0
-    // CHECK-NEXT: [[LHS:%.*]] = ttg.local_load [[LOAD_BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
-    // CHECK-NEXT: arrive_barrier [[LOAD_EMPTY_BAR]], {{.*}}partition = 0
-    // CHECK-NEXT: [[LHS_OP:%.*]] = arith.addf [[LHS]], [[LHS]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[LHS_OP]], [[LHS_SHARED]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = 0 : i32}
+    // CHECK-NEXT: wait_barrier [[LOAD_READY_BAR]], {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: [[LHS:%.*]] = ttg.local_load [[LOAD_BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: fence_async_shared {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: arrive_barrier [[LOAD_EMPTY_BAR]], {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: [[LHS_OP:%.*]] = arith.addf [[LHS]], [[LHS]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[LHS_OP]], [[LHS_SHARED]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = array<i32: 0>}
     %lhs_op = arith.addf %lhs, %lhs : tensor<128x64xf16, #oper_layout>
     %lhs_shared = ttg.local_alloc %lhs_op : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
 
     // CHECK-NEXT: [[ACC:%.*]] = "make_acc"()
     %acc = "make_acc"() : () -> tensor<128x128xf32, #acc_layout>
     // CHECK-NEXT: [[ACC_TMEM:%.*]] = ttg.memdesc_index
-    // CHECK-NEXT: tmem_store [[ACC]], [[ACC_TMEM]][], %true {{.*}}partition = 0
-    // CHECK-NEXT: arrive_barrier [[MMA_ENTRY_BAR]], {{.*}}partition = 0
+    // CHECK-NEXT: tmem_store [[ACC]], [[ACC_TMEM]][], %true {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: arrive_barrier [[MMA_ENTRY_BAR]], {{.*}}partition = array<i32: 0>
     %acc_tmem, %acc_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
 
-    // CHECK-NEXT: wait_barrier [[MMA_ENTRY_BAR]], {{.*}}partition = 1
+    // CHECK-NEXT: wait_barrier [[MMA_ENTRY_BAR]], {{.*}}partition = array<i32: 1>
     // CHECK-NEXT: tc_gen5_mma {{.*}} [[MMA_EXIT_BAR]][%true]
     %mma_tok = ttng.tc_gen5_mma %lhs_shared, %rhs, %acc_tmem[%acc_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
 
-    // CHECK-NEXT: wait_barrier [[MMA_EXIT_BAR]], {{.*}}partition = 0
+    // CHECK-NEXT: wait_barrier [[MMA_EXIT_BAR]], {{.*}}partition = array<i32: 0>
     // CHECK-NEXT: [[ACC_VALUE:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_TMEM]][]
     %acc_value, %load_tok = ttng.tmem_load %acc_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
     // CHECK-NEXT: arith.xori
@@ -1220,14 +1265,12 @@ tt.func @store_mma_load(
     "use"(%acc_value) : (tensor<128x128xf32, #acc_layout>) -> ()
   } {tt.warp_specialize, tt.num_stages = 2 : i32, tt.disallow_acc_multi_buffer}
   tt.return
-}
+  }
 
-// CHECK-LABEL: @local_alloc_into_mma
-tt.func @local_alloc_into_mma(
-  %ub: i32,
-  %lhs_reg: tensor<128x64xf16, #oper_layout>,
-  %rhs_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
-) {
+  // CHECK-LABEL: @local_alloc_into_mma
+  tt.func @local_alloc_into_mma(
+      % ub : i32, % lhs_reg : tensor<128x64xf16, #oper_layout>,
+      % rhs_desc : !tt.tensordesc<tensor<64x128xf16, #shared>>) {
   %c0 = arith.constant 0 : i32
   %c1 = arith.constant 1 : i32
   %acc, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
@@ -1235,39 +1278,36 @@ tt.func @local_alloc_into_mma(
   // CHECK: [[LHS_SHARED:%.*]] = ttg.local_alloc %arg1 : (tensor<128x64xf16, {{.*}}>) -> !ttg.memdesc<128x64xf16,
   // CHECK: scf.for
   scf.for %i = %c0 to %ub step %c1 iter_args(%tok = %acc_tok) -> !ttg.async.token : i32 {
-    // CHECK: barrier_expect [[LOAD_READY_BAR:%.*]], 16384 {ttg.partition = 2 : i32}
+    // CHECK: barrier_expect [[LOAD_READY_BAR:%.*]], 16384 {ttg.partition = array<i32: 2>}
     %lhs_shared = ttg.local_alloc %lhs_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %rhs_reg = tt.descriptor_load %rhs_desc[%i, %i] : !tt.tensordesc<tensor<64x128xf16, #shared>> -> tensor<64x128xf16, #oper_layout>
 
-    // CHECK: wait_barrier [[LOAD_READY_BAR]], {{.*}}partition = 0
-    // CHECK-NEXT: [[RHS_REG:%.*]] = ttg.local_load {{.*}}partition = 0
-    // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
+    // CHECK: wait_barrier [[LOAD_READY_BAR]], {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: [[RHS_REG:%.*]] = ttg.local_load {{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: fence_async_shared {{.*}}partition = array<i32: 0>
     // CHECK-NEXT: arrive_barrier
-    // CHECK-NEXT: [[RHS_REG_MOD:%.*]] = arith.addf [[RHS_REG]], [[RHS_REG]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: wait_barrier [[MMA_OPER_BAR:%.*]], %arg{{.*}}partition = 0
-    // CHECK-NEXT: local_store [[RHS_REG_MOD]], [[RHS_SHARED:%.*]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = 0 : i32}
-    // CHECK-NEXT: arrive_barrier [[MMA_READY_BAR:%.*]], 1 {{.*}}partition = 0
+    // CHECK-NEXT: [[RHS_REG_MOD:%.*]] = arith.addf [[RHS_REG]], [[RHS_REG]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: wait_barrier [[MMA_OPER_BAR:%.*]], %arg{{.*}}partition = array<i32: 0>
+    // CHECK-NEXT: local_store [[RHS_REG_MOD]], [[RHS_SHARED:%.*]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: arrive_barrier [[MMA_READY_BAR:%.*]], 1 {{.*}}partition = array<i32: 0>
     %rhs_reg_mod = arith.addf %rhs_reg, %rhs_reg : tensor<64x128xf16, #oper_layout>
     %rhs_shared = ttg.local_alloc %rhs_reg_mod : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
-    // CHECK: wait_barrier [[MMA_READY_BAR]], {{.*}}partition = 1
-    // CHECK-NEXT: tc_gen5_mma [[LHS_SHARED]], [[RHS_SHARED]], {{.*}} [[MMA_OPER_BAR]][%true] {{.*}}partition = 1
+    // CHECK: wait_barrier [[MMA_READY_BAR]], {{.*}}partition = array<i32: 1>
+    // CHECK-NEXT: tc_gen5_mma [[LHS_SHARED]], [[RHS_SHARED]], {{.*}} [[MMA_OPER_BAR]][%true] {{.*}}partition = array<i32: 1>
     %mma_tok = ttng.tc_gen5_mma %lhs_shared, %rhs_shared, %acc[%acc_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     scf.yield %mma_tok : !ttg.async.token
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
   tt.return
-}
+  }
 
-// CHECK-LABEL: @shmem_sink_iterator_invalidation
-// CHECK-SAME: [[A_DESC:%arg[0-9]+]]: !tt.tensordesc
-// CHECK-SAME: [[B_DESC:%arg[0-9]+]]: !tt.tensordesc
-tt.func @shmem_sink_iterator_invalidation(
-  %k_tiles: i32,
-  %off_m: i32,
-  %off_n: i32,
-  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
-  %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>
-) {
+  // CHECK-LABEL: @shmem_sink_iterator_invalidation
+  // CHECK-SAME: [[A_DESC:%arg[0-9]+]]: !tt.tensordesc
+  // CHECK-SAME: [[B_DESC:%arg[0-9]+]]: !tt.tensordesc
+  tt.func @shmem_sink_iterator_invalidation(
+      % k_tiles : i32, % off_m : i32, % off_n : i32,
+      % a_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      % b_desc : !tt.tensordesc<tensor<128x64xf16, #shared>>) {
   %true = arith.constant true
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
@@ -1301,39 +1341,49 @@ tt.func @shmem_sink_iterator_invalidation(
 
     scf.yield %c : tensor<128x128xf32, #acc_layout>
 
-  } {tt.warp_specialize, tt.num_stages = 2 : i32}
+  } {
+    tt.warp_specialize, tt.num_stages = 2 : i32
+  }
 
-  "use"(%result) : (tensor<128x128xf32, #acc_layout>) -> ()
-  tt.return
-}
-
+  "use"(% result) : (tensor<128x128xf32, #acc_layout>)->() tt.return
+  }
 }
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
-#load_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked = #ttg.blocked <                                                      \
+           {sizePerThread = [1, 64],                                           \
+                             threadsPerWarp = [32, 1],                         \
+                                               warpsPerCTA = [4, 1],           \
+                                                              order = [0,      \
+                                                                       1] }>
+#load_blocked =                                                                \
+    #ttg.blocked <                                                             \
+    {sizePerThread = [1, 1],                                                   \
+                      threadsPerWarp = [1, 32],                                \
+                                        warpsPerCTA = [2, 2],                  \
+                                                       order = [1, 0] }>
 
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
-#shared_T = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#shared = #ttg.nvmma_shared < {swizzlingByteWidth = 128, transposed = false,   \
+                              elementBitWidth = 16 }>
+#shared_T = #ttg.nvmma_shared < {swizzlingByteWidth = 128, transposed = true,  \
+                                elementBitWidth = 16 }>
 
 #smem = #ttg.shared_memory
-#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
-module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+#tmem = #ttng.tensor_memory_encoding < blockM = 128, blockN = 64, colStride = 1>
+module attributes{"ttg.num-warps" = 4 :i32, ttg.target = "cuda:100"} {
 
-// CHECK-LABEL: @attention_forward
-// CHECK-SAME: [[Q_SHARED:%arg[0-9]+]]
-// CHECK-SAME: [[K_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[V_DESC:%arg[0-9]+]]
-// CHECK-SAME: [[QK_SCALE:%arg[0-9]+]]
-// CHECK-SAME: [[N_TILES:%arg[0-9]+]]
-tt.func public @attention_forward(
-  %Q_shared: !ttg.memdesc<256x64xf16, #shared, #smem>,
-  %K_desc: !tt.tensordesc<tensor<64x64xf16, #shared>>,
-  %V_desc: !tt.tensordesc<tensor<64x64xf16, #shared>>,
-  %qk_scale: f32,
-  %n_tiles: i32
-) {
+  // CHECK-LABEL: @attention_forward
+  // CHECK-SAME: [[Q_SHARED:%arg[0-9]+]]
+  // CHECK-SAME: [[K_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[V_DESC:%arg[0-9]+]]
+  // CHECK-SAME: [[QK_SCALE:%arg[0-9]+]]
+  // CHECK-SAME: [[N_TILES:%arg[0-9]+]]
+  tt.func public
+      @attention_forward(% Q_shared : !ttg.memdesc<256x64xf16, #shared, #smem>,
+                         % K_desc : !tt.tensordesc<tensor<64x64xf16, #shared>>,
+                         % V_desc : !tt.tensordesc<tensor<64x64xf16, #shared>>,
+                         % qk_scale : f32, % n_tiles : i32) {
   %true = arith.constant true
   %false = arith.constant false
   %c0_i32 = arith.constant 0 : i32
@@ -1458,29 +1508,29 @@ tt.func public @attention_forward(
   ) : i32 {
 
     // CHECK-NEXT: [[K_EMPTY_BAR:%.*]] = ttg.memdesc_index [[K_EMPTY_MBARS]]{{\[}}[[K_INDEX]]{{\]}}
-    // CHECK-NEXT: wait_barrier [[K_EMPTY_BAR]], [[K_PHASE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: wait_barrier [[K_EMPTY_BAR]], [[K_PHASE]] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[K_READY_BAR:%.*]] = ttg.memdesc_index [[K_READY_MBARS]]{{\[}}[[K_INDEX]]{{\]}}
-    // CHECK-NEXT: barrier_expect [[K_READY_BAR]], 8192 {ttg.partition = 2 : i32}
+    // CHECK-NEXT: barrier_expect [[K_READY_BAR]], 8192 {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[K_BUF:%.*]] = ttg.memdesc_index [[K_BUFS]]{{\[}}[[K_INDEX]]{{\]}}
-    // CHECK-NEXT: async_tma_copy_global_to_local [[K_DESC]][[[I]], %c0_i32] [[K_BUF]], [[K_READY_BAR]], %true {ttg.partition = 2 : i32}
+    // CHECK-NEXT: async_tma_copy_global_to_local [[K_DESC]][[[I]], %c0_i32] [[K_BUF]], [[K_READY_BAR]], %true {ttg.partition = array<i32: 2>}
     %K = tt.descriptor_load %K_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
     %K_shared = ttg.local_alloc %K : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
 
-    // CHECK-NEXT: [[K_TRANS:%.*]] = ttg.memdesc_trans [[K_BUF]] {order = array<i32: 1, 0>, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[K_TRANS:%.*]] = ttg.memdesc_trans [[K_BUF]] {order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
     %K_trans = ttg.memdesc_trans %K_shared {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
-    // CHECK-NEXT: wait_barrier [[K_READY_BAR]], [[K_PHASE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier [[K_READY_BAR]], [[K_PHASE]] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: [[QK_BUF:%.*]] = ttg.memdesc_index [[QK_TMEM]]{{\[}}[[QK_INDEX]]{{\]}}
     // CHECK-NEXT: [[QK_EMPTY_BAR:%.*]] = ttg.memdesc_index [[QK_EMPTY_MBARS]]{{\[}}[[QK_INDEX]]{{\]}}
-    // CHECK-NEXT: wait_barrier [[QK_EMPTY_BAR]], [[QK_PHASE]], %true {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier [[QK_EMPTY_BAR]], [[QK_PHASE]], %true {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: [[QK_READY_BAR:%.*]] = ttg.memdesc_index [[QK_READY_MBARS]]{{\[}}[[QK_INDEX]]{{\]}}
-    // CHECK-NEXT: tc_gen5_mma [[Q_SHARED]], [[K_TRANS]], [[QK_BUF]][], %false, %true, [[K_EMPTY_BAR]][%true], [[QK_READY_BAR]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: tc_gen5_mma [[Q_SHARED]], [[K_TRANS]], [[QK_BUF]][], %false, %true, [[K_EMPTY_BAR]][%true], [[QK_READY_BAR]][%true] {is_async, ttg.partition = array<i32: 1>}
     %QK_tmem, %QK_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     %QK_mma_tok = ttng.tc_gen5_mma %Q_shared, %K_trans, %QK_tmem[%QK_tok], %false, %true : !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared_T, #smem>, !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>
 
-    // CHECK-NEXT: wait_barrier [[QK_READY_BAR]], [[QK_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[QK:%.*]], [[QK_LOAD_TOK:%.*]] = ttng.tmem_load [[QK_BUF]][] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: wait_barrier [[QK_READY_BAR]], [[QK_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[QK:%.*]], [[QK_LOAD_TOK:%.*]] = ttng.tmem_load [[QK_BUF]][] {ttg.partition = array<i32: 0>}
     %QK, %QK_load_tok = ttng.tmem_load %QK_tmem[%QK_mma_tok] : !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
-    // CHECK-NEXT: arrive_barrier [[QK_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: arrive_barrier [[QK_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
 
     // CHECK-NEXT: [[QK_INDEX_INCR:%.*]] = arith.addi [[QK_INDEX]], %c1_i32
     // CHECK-NEXT: [[QK_PHASE_INCR:%.*]] = arith.xori [[QK_PHASE]], %c1_i32
@@ -1488,17 +1538,17 @@ tt.func public @attention_forward(
     // CHECK-NEXT: [[QK_NEXT_INDEX:%.*]] = arith.select [[QK_ROLLVER]], %c0_i32, [[QK_INDEX_INCR]]
     // CHECK-NEXT: [[QK_NEXT_PHASE:%.*]] = arith.select [[QK_ROLLVER]], [[QK_PHASE_INCR]], [[QK_PHASE]]
 
-    // CHECK-NEXT: [[ROW_MAX:%.*]] = "compute_row_max"([[QK]], [[QK_SCALE]]) {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[ROW_MAX:%.*]] = "compute_row_max"([[QK]], [[QK_SCALE]]) {ttg.partition = array<i32: 0>}
     %row_max = "compute_row_max"(%QK, %qk_scale) : (tensor<256x64xf32, #blocked>, f32) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    // CHECK-NEXT: [[QK_ADJ:%.*]] = "sub_row_max"([[QK]], [[ROW_MAX]], [[QK_SCALE]]) {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[QK_ADJ:%.*]] = "sub_row_max"([[QK]], [[ROW_MAX]], [[QK_SCALE]]) {ttg.partition = array<i32: 0>}
     %QK_adj = "sub_row_max"(%QK, %row_max, %qk_scale) : (tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, f32) -> tensor<256x64xf32, #blocked>
-    // CHECK-NEXT: [[SOFTMAX:%.*]] = math.exp2 [[QK_ADJ]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[SOFTMAX:%.*]] = math.exp2 [[QK_ADJ]] {ttg.partition = array<i32: 0>}
     %softmax = math.exp2 %QK_adj : tensor<256x64xf32, #blocked>
 
-    // CHECK-NEXT: [[DIFF_CORR:%.*]] = arith.subf [[M_I]], [[ROW_MAX]] {ttg.partition = 3 : i32}
-    // CHECK-NEXT: [[DIFF_SOFT:%.*]] = arith.subf [[M_I]], [[ROW_MAX]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[ALPHA_CORR:%.*]] = math.exp2 [[DIFF_CORR]] {ttg.partition = 3 : i32}
-    // CHECK-NEXT: [[ALPHA_SOFT:%.*]] = math.exp2 [[DIFF_SOFT]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[DIFF_CORR:%.*]] = arith.subf [[M_I]], [[ROW_MAX]] {ttg.partition = array<i32: 3>}
+    // CHECK-NEXT: [[DIFF_SOFT:%.*]] = arith.subf [[M_I]], [[ROW_MAX]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[ALPHA_CORR:%.*]] = math.exp2 [[DIFF_CORR]] {ttg.partition = array<i32: 3>}
+    // CHECK-NEXT: [[ALPHA_SOFT:%.*]] = math.exp2 [[DIFF_SOFT]] {ttg.partition = array<i32: 0>}
     %diff = arith.subf %m_i, %row_max : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %alpha = math.exp2 %diff : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
 
@@ -1508,48 +1558,48 @@ tt.func public @attention_forward(
       %68 = arith.addf %arg29, %arg30 : f32
       // CHECK: tt.reduce.return
       tt.reduce.return %68 : f32
-    // CHECK-NEXT: {ttg.partition = 0 : i32}
+    // CHECK-NEXT: {ttg.partition = array<i32: 0>}
     }) : (tensor<256x64xf32, #blocked>) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    // CHECK-NEXT: [[L_I_SCALED:%.*]] = arith.mulf [[L_I]], [[ALPHA_SOFT]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[L_I_SCALED:%.*]] = arith.mulf [[L_I]], [[ALPHA_SOFT]] {ttg.partition = array<i32: 0>}
     %l_i_scaled = arith.mulf %l_i, %alpha : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    // CHECK-NEXT: [[NEXT_L_I:%.*]] = arith.addf [[L_I_SCALED]], [[L_IJ]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[NEXT_L_I:%.*]] = arith.addf [[L_I_SCALED]], [[L_IJ]] {ttg.partition = array<i32: 0>}
     %next_l_i = arith.addf %l_i_scaled, %l_ij : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
 
-    // CHECK-NEXT: [[ALPHA_0:%.*]] = tt.expand_dims [[ALPHA_CORR]] {axis = 1 : i32, ttg.partition = 3 : i32}
+    // CHECK-NEXT: [[ALPHA_0:%.*]] = tt.expand_dims [[ALPHA_CORR]] {axis = 1 : i32, ttg.partition = array<i32: 3>}
     %alpha_0 = tt.expand_dims %alpha {axis = 1 : i32} : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xf32, #blocked>
-    // CHECK-NEXT: [[ALPHA_1:%.*]] = tt.broadcast [[ALPHA_0]] {ttg.partition = 3 : i32}
+    // CHECK-NEXT: [[ALPHA_1:%.*]] = tt.broadcast [[ALPHA_0]] {ttg.partition = array<i32: 3>}
     %alpha_1 = tt.broadcast %alpha_0 : tensor<256x1xf32, #blocked> -> tensor<256x64xf32, #blocked>
 
-    // CHECK-NEXT: wait_barrier [[PV_READY_BAR0]], [[PV_PHASE]] {ttg.partition = 3 : i32}
-    // CHECK-NEXT: [[PV:%.*]], [[PV_TOK:%.*]] = ttng.tmem_load [[PV_0]][] {ttg.partition = 3 : i32}
+    // CHECK-NEXT: wait_barrier [[PV_READY_BAR0]], [[PV_PHASE]] {ttg.partition = array<i32: 3>}
+    // CHECK-NEXT: [[PV:%.*]], [[PV_TOK:%.*]] = ttng.tmem_load [[PV_0]][] {ttg.partition = array<i32: 3>}
     // CHECK-NEXT: [[NEXT_PV_PHASE:%.*]] = arith.xori [[PV_PHASE]], %c1_i32
-    // CHECK-NEXT: [[ACC_CORRECTED:%.*]] = arith.mulf [[PV]], [[ALPHA_1]] {ttg.partition = 3 : i32}
+    // CHECK-NEXT: [[ACC_CORRECTED:%.*]] = arith.mulf [[PV]], [[ALPHA_1]] {ttg.partition = array<i32: 3>}
     %acc_corrected = arith.mulf %acc, %alpha_1 : tensor<256x64xf32, #blocked>
 
     // CHECK-NEXT: [[V_EMPTY_BAR:%.*]] = ttg.memdesc_index [[V_EMPTY_MBARS]]{{\[}}[[V_INDEX]]{{\]}}
-    // CHECK-NEXT: wait_barrier [[V_EMPTY_BAR]], [[V_PHASE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: wait_barrier [[V_EMPTY_BAR]], [[V_PHASE]] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[V_READY_BAR:%.*]] = ttg.memdesc_index [[V_READY_MBARS]]{{\[}}[[V_INDEX]]{{\]}}
-    // CHECK-NEXT: barrier_expect [[V_READY_BAR]], 8192 {ttg.partition = 2 : i32}
+    // CHECK-NEXT: barrier_expect [[V_READY_BAR]], 8192 {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[V_BUF:%.*]] = ttg.memdesc_index [[V_BUFS]]{{\[}}[[V_INDEX]]{{\]}}
-    // CHECK-NEXT: async_tma_copy_global_to_local [[V_DESC]][[[I]], %c0_i32] [[V_BUF]], [[V_READY_BAR]], %true {ttg.partition = 2 : i32}
+    // CHECK-NEXT: async_tma_copy_global_to_local [[V_DESC]][[[I]], %c0_i32] [[V_BUF]], [[V_READY_BAR]], %true {ttg.partition = array<i32: 2>}
     %V = tt.descriptor_load %V_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
     %V_shared = ttg.local_alloc %V : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
 
-    // CHECK-NEXT: [[P:%.*]] = arith.truncf [[SOFTMAX]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: wait_barrier [[P_EMPTY_BAR0]], [[P_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: tmem_store [[P]], [[P_BUF]], %true {ttg.partition = 0 : i32}
-    // CHECK-NEXT: arrive_barrier [[P_READY_BAR0]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[P:%.*]] = arith.truncf [[SOFTMAX]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: wait_barrier [[P_EMPTY_BAR0]], [[P_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: tmem_store [[P]], [[P_BUF]], %true {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: arrive_barrier [[P_READY_BAR0]], 1 {ttg.partition = array<i32: 0>}
     %P = arith.truncf %softmax : tensor<256x64xf32, #blocked> to tensor<256x64xf16, #blocked>
 
-    // CHECK-NEXT: tmem_store [[ACC_CORRECTED]], [[PV_0]][], %true {ttg.partition = 3 : i32}
-    // CHECK-NEXT: arrive_barrier [[PV_EMPTY_BAR0]], 1 {ttg.partition = 3 : i32}
+    // CHECK-NEXT: tmem_store [[ACC_CORRECTED]], [[PV_0]][], %true {ttg.partition = array<i32: 3>}
+    // CHECK-NEXT: arrive_barrier [[PV_EMPTY_BAR0]], 1 {ttg.partition = array<i32: 3>}
 
-    // CHECK-NEXT: wait_barrier [[V_READY_BAR]], [[V_PHASE]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: wait_barrier [[PV_EMPTY_BAR0]], [[NEXT_PV_PHASE]], %true {ttg.partition = 1 : i32}
-    // CHECK-NEXT: wait_barrier [[P_READY_BAR0]], [[P_PHASE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier [[V_READY_BAR]], [[V_PHASE]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: wait_barrier [[PV_EMPTY_BAR0]], [[NEXT_PV_PHASE]], %true {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: wait_barrier [[P_READY_BAR0]], [[P_PHASE]] {ttg.partition = array<i32: 1>}
     %P_tmem = ttng.tmem_alloc %P : (tensor<256x64xf16, #blocked>) -> !ttg.memdesc<256x64xf16, #tmem, #ttng.tensor_memory>
     %acc_tmem, %acc_tok = ttng.tmem_alloc %acc_corrected : (tensor<256x64xf32, #blocked>) -> (!ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
-    // CHECK-NEXT: tc_gen5_mma [[P_BUF]], [[V_BUF]], [[PV_0]][], %true, %true, [[V_EMPTY_BAR]][%true], [[PV_READY_BAR0]][%true], [[P_EMPTY_BAR0]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: tc_gen5_mma [[P_BUF]], [[V_BUF]], [[PV_0]][], %true, %true, [[V_EMPTY_BAR]][%true], [[PV_READY_BAR0]][%true], [[P_EMPTY_BAR0]][%true] {is_async, ttg.partition = array<i32: 1>}
     %PV_mma_tok = ttng.tc_gen5_mma %P_tmem, %V_shared, %acc_tmem[%acc_tok], %true, %true : !ttg.memdesc<256x64xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<64x64xf16, #shared, #smem>, !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>
     %O, %O_tok = ttng.tmem_load %acc_tmem[%PV_mma_tok] : !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
 
@@ -1571,13 +1621,18 @@ tt.func public @attention_forward(
 
     scf.yield %next_l_i, %O, %row_max : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
   // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32
-  } {tt.warp_specialize}
+  } {
+    tt.warp_specialize
+  }
 
   // CHECK-NEXT: wait_barrier [[PV_READY_BAR0]], [[OUTS]]#9
 
-  "use"(%loop_outs#0, %loop_outs#1, %loop_outs#2) : (tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>) -> ()
+  "use"(% loop_outs #0, % loop_outs #1, % loop_outs #2)
+      : (tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+         tensor<256x64xf32, #blocked>,
+         tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>)
+            ->()
 
-  tt.return
-}
-
+                tt.return
+  }
 }

--- a/test/TritonGPU/partition-loops.mlir
+++ b/test/TritonGPU/partition-loops.mlir
@@ -20,7 +20,7 @@ tt.func @one_partition(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: scf.for
   scf.for %i = %lb to %ub step %step : i32 {
     // CHECK-NEXT: op_a
-    "op_a"() {ttg.partition = 0} : () -> ()
+    "op_a"() {ttg.partition = array<i32: 0>} : () -> ()
   } {ttg.partition.stages = [0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -89,17 +89,17 @@ tt.func @multiple_partitions(%lb: i32, %ub: i32, %step: i32) {
     %a = arith.addi %i, %i : i32
     %b = arith.addi %i, %a : i32
 
-    %0 = "op_a"(%i) {ttg.partition = 0} : (i32) -> i32
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
+    %0 = "op_a"(%i) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
 
-    %1 = "op_a"(%a) {ttg.partition = 1} : (i32) -> i32
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
+    %1 = "op_a"(%a) {ttg.partition = array<i32: 1>} : (i32) -> i32
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
 
-    %2 = "op_a"(%b) {ttg.partition = 2} : (i32) -> i32
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
+    %2 = "op_a"(%b) {ttg.partition = array<i32: 2>} : (i32) -> i32
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -149,33 +149,33 @@ tt.func @multiple_partitions_two_loops(%lb: i32, %ub: i32, %step: i32,
   // CHECK-NEXT: }
   // CHECK-NEXT: "op_02e"([[RET]]#2)
 
-  "op_00b"() {ttg.partition = 0, ttg.warp_specialize.tag = 0} : () -> ()
-  "op_01b"() {ttg.partition = 1, ttg.warp_specialize.tag = 0} : () -> ()
-  "op_02b"() {ttg.partition = 2, ttg.warp_specialize.tag = 0} : () -> ()
+  "op_00b"() {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 0} : () -> ()
+  "op_01b"() {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 0} : () -> ()
+  "op_02b"() {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 0} : () -> ()
   %ret:3 = scf.for %i = %lb to %ub step %step iter_args(%arg0 = %c0, %arg1 = %c1, %arg2 = %c2) -> (i32, i32, i32) : i32 {
     %a = arith.addi %i, %i : i32
     %b = arith.addi %i, %a : i32
 
-    %0 = "op_a"(%i) {ttg.partition = 0} : (i32) -> i32
-    "op_b"(%arg0) {ttg.partition = 0} : (i32) -> ()
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
+    %0 = "op_a"(%i) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    "op_b"(%arg0) {ttg.partition = array<i32: 0>} : (i32) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
 
-    %1 = "op_a"(%a) {ttg.partition = 1} : (i32) -> i32
-    "op_b"(%arg1) {ttg.partition = 1} : (i32) -> ()
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
+    %1 = "op_a"(%a) {ttg.partition = array<i32: 1>} : (i32) -> i32
+    "op_b"(%arg1) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
 
-    %2 = "op_a"(%b) {ttg.partition = 2} : (i32) -> i32
-    "op_b"(%arg2) {ttg.partition = 2} : (i32) -> ()
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
+    %2 = "op_a"(%b) {ttg.partition = array<i32: 2>} : (i32) -> i32
+    "op_b"(%arg2) {ttg.partition = array<i32: 2>} : (i32) -> ()
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
 
     %v0 = arith.addi %arg0, %arg0 : i32
     %v1 = arith.addi %arg1, %arg1 : i32
     %v2 = arith.addi %arg2, %arg2 : i32
     scf.yield %v0, %v1, %v2: i32, i32, i32
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
-  "op_00e"(%ret#0) {ttg.partition = 0, ttg.warp_specialize.tag = 0} : (i32) -> ()
-  "op_01e"(%ret#1) {ttg.partition = 1, ttg.warp_specialize.tag = 0} : (i32) -> ()
-  "op_02e"(%ret#2) {ttg.partition = 2, ttg.warp_specialize.tag = 0} : (i32) -> ()
+  "op_00e"(%ret#0) {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 0} : (i32) -> ()
+  "op_01e"(%ret#1) {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 0} : (i32) -> ()
+  "op_02e"(%ret#2) {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 0} : (i32) -> ()
 
   // CHECK: partition0 num_warps(4)
   // CHECK-NEXT: op_10b
@@ -194,28 +194,28 @@ tt.func @multiple_partitions_two_loops(%lb: i32, %ub: i32, %step: i32,
   // CHECK-NEXT: scf.for
   // CHECK: } {ttg.warp_specialize.tag = 1
   // CHECK-NEXT: op_12e
-  "op_10b"() {ttg.partition = 0, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_11b"() {ttg.partition = 1, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_12b"() {ttg.partition = 2, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_10b"() {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_11b"() {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_12b"() {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 1} : () -> ()
   scf.for %i = %lb to %ub step %step : i32 {
     %a = arith.addi %i, %i : i32
     %b = arith.addi %i, %a : i32
 
-    %0 = "op_a"(%i) {ttg.partition = 0} : (i32) -> i32
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
+    %0 = "op_a"(%i) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
 
-    %1 = "op_a"(%a) {ttg.partition = 1} : (i32) -> i32
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
+    %1 = "op_a"(%a) {ttg.partition = array<i32: 1>} : (i32) -> i32
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
 
-    %2 = "op_a"(%b) {ttg.partition = 2} : (i32) -> i32
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
+    %2 = "op_a"(%b) {ttg.partition = array<i32: 2>} : (i32) -> i32
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 1 : i32}
-  "op_10e"() {ttg.partition = 0, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_11e"() {ttg.partition = 1, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_12e"() {ttg.partition = 2, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_10e"() {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_11e"() {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_12e"() {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 1} : () -> ()
   tt.return
 }
 
@@ -235,8 +235,8 @@ tt.func @split_block_arguments(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT:     [[X:%.*]] = "op_b"([[B]])
   // CHECK-NEXT:     yield [[X]] : i32
   scf.for %i = %lb to %ub step %step iter_args(%a = %c0_i32, %b = %c1_i32) -> (i32, i32) : i32 {
-    %0 = "op_a"(%a) {ttg.partition = 0} : (i32) -> i32
-    %1 = "op_b"(%b) {ttg.partition = 1} : (i32) -> i32
+    %0 = "op_a"(%a) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    %1 = "op_b"(%b) {ttg.partition = array<i32: 1>} : (i32) -> i32
     scf.yield %0, %1 : i32, i32
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -277,9 +277,9 @@ tt.func @partition_outputs(%lb: i32, %ub: i32, %step: i32) -> (!ty, !ty, !ty) {
   // CHECK-NEXT: local_store [[OUT]], [[C_BUF]]
 
   %outs:3 = scf.for %i = %lb to %ub step %step iter_args(%a = %cst0, %b = %cst1, %c = %cst2) -> (!ty, !ty, !ty) : i32 {
-    %0 = "op_a"(%i, %a) {ttg.partition = 0} : (i32, !ty) -> !ty
-    %1 = "op_b"(%i, %b) {ttg.partition = 1} : (i32, !ty) -> !ty
-    %2 = "op_c"(%i, %c) {ttg.partition = 2} : (i32, !ty) -> !ty
+    %0 = "op_a"(%i, %a) {ttg.partition = array<i32: 0>} : (i32, !ty) -> !ty
+    %1 = "op_b"(%i, %b) {ttg.partition = array<i32: 1>} : (i32, !ty) -> !ty
+    %2 = "op_c"(%i, %c) {ttg.partition = array<i32: 2>} : (i32, !ty) -> !ty
     scf.yield %0, %1, %2 : !ty, !ty, !ty
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
 
@@ -296,10 +296,10 @@ tt.func @partition_outputs(%lb: i32, %ub: i32, %step: i32) -> (!ty, !ty, !ty) {
 tt.func @future_conditional_self_use(%lb: i32, %ub: i32, %step: i32, %cond: i1) {
   %c0_i32 = arith.constant 0 : i32
   scf.for %i = %lb to %ub step %step iter_args(%k = %c0_i32) -> i32 : i32 {
-    %0 = "op_a"() {ttg.partition = 0 : i32} : () -> i32
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> i32
     scf.if %cond {
       "use"(%k) : (i32) -> ()
-    } {ttg.partition = 0 : i32}
+    } {ttg.partition = array<i32: 0>}
     scf.yield %0 : i32
   } {ttg.partition.stages = [0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -316,7 +316,7 @@ tt.func @trivial_tensor_captures(%arg0: f16, %lb: i32, %ub: i32, %step: i32) {
     // CHECK: partition1 num_warps(4)
     // CHECK-NEXT: scf.for
     // CHECK-NEXT: "use"([[RANGE]], [[SPLAT]])
-    "use"(%0, %1) {ttg.partition = 1} : (tensor<256xi32>, tensor<32xf16>) -> ()
+    "use"(%0, %1) {ttg.partition = array<i32: 1>} : (tensor<256xi32>, tensor<32xf16>) -> ()
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -330,7 +330,7 @@ tt.func @tensor_captures_over_smem(%lb: i32, %ub: i32, %step: i32) {
     // CHECK: partition1
     // CHECK-NEXT: scf.for
     // CHECK-NEXT: "use"([[VALUE]])
-    "use"(%0) {ttg.partition = 1} : (tensor<32xf16, #blocked>) -> ()
+    "use"(%0) {ttg.partition = array<i32: 1>} : (tensor<32xf16, #blocked>) -> ()
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -350,9 +350,9 @@ tt.func @dce_before_warp_allocation(%lb: i32, %ub: i32, %step: i32) {
     } else {
       scf.yield %idxs : tensor<128xi32, #blocked>
     }
-    "op_a"(%0) {ttg.partition = 0 : i32} : (tensor<128xi32, #blocked>) -> ()
-    "op_b"(%i) {ttg.partition = 1 : i32} : (i32) -> ()
-    "op_c"(%0) {ttg.partition = 2 : i32} : (tensor<128xi32, #blocked>) -> ()
+    "op_a"(%0) {ttg.partition = array<i32: 0>} : (tensor<128xi32, #blocked>) -> ()
+    "op_b"(%i) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_c"(%0) {ttg.partition = array<i32: 2>} : (tensor<128xi32, #blocked>) -> ()
     scf.yield %0 : tensor<128xi32, #blocked>
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -391,7 +391,7 @@ tt.func @clone_then_capture(%arg0: i32) {
   // CHECK: scf.for
   scf.for %arg1 = %c0_i32 to %arg0 step %c1_i32  : i32 {
     // CHECK: "use"([[V]])
-    "use"(%1) {ttg.partition = 1 : i32} : (tensor<4xi32, #blocked>) -> ()
+    "use"(%1) {ttg.partition = array<i32: 1>} : (tensor<4xi32, #blocked>) -> ()
   } {ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -408,9 +408,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 tt.func @still_has_ssa_deps(%lb: i32, %ub: i32, %step: i32) {
   scf.for %i = %lb to %ub step %step : i32 {
     // expected-warning @below {{non-root partition #0 has direct SSA consumer}}
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // expected-note @below {{use at distance 0 in partition #1 here}}
-    "op_b"(%0) {ttg.partition = 1} : (!ty) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> ()
   } {ttg.partition.stages = [0, 1], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -50,7 +50,7 @@ tt.func public @attention_forward(
     %QK, %QK_load_tok = ttng.tmem_load %QK_tmem[%QK_mma_tok] : !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
     %row_max = "compute_row_max"(%QK, %qk_scale) : (tensor<256x64xf32, #blocked>, f32) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %QK_adj = "sub_row_max"(%QK, %row_max, %qk_scale) : (tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, f32) -> tensor<256x64xf32, #blocked>
-    // CHECK: [[SOFTMAX:%.*]] = math.exp2 {{.*}} {ttg.partition = 4 : i32} : tensor<256x64xf32
+    // CHECK: [[SOFTMAX:%.*]] = math.exp2 {{.*}} {ttg.partition = array<i32: 4>} : tensor<256x64xf32
     %softmax = math.exp2 %QK_adj : tensor<256x64xf32, #blocked>
     %diff = arith.subf %m_i, %row_max : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %alpha = math.exp2 %diff : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
@@ -68,9 +68,9 @@ tt.func public @attention_forward(
 
     %acc_corrected = arith.mulf %acc, %alpha_1 : tensor<256x64xf32, #blocked>
 
-    // CHECK: [[X:%.*]] = arith.addf [[SOFTMAX]], [[SOFTMAX]] {ttg.partition = 4 : i32}
+    // CHECK: [[X:%.*]] = arith.addf [[SOFTMAX]], [[SOFTMAX]] {ttg.partition = array<i32: 4>}
     %x = arith.addf %softmax, %softmax : tensor<256x64xf32, #blocked>
-    // CHECK-NEXT: [[ACC_X:%.*]] = arith.addf %{{.*}}, [[X]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[ACC_X:%.*]] = arith.addf %{{.*}}, [[X]] {ttg.partition = array<i32: 0>}
     %acc_x = arith.addf %acc, %x : tensor<256x64xf32, #blocked>
     %e = "sum"(%acc_x) : (tensor<256x64xf32, #blocked>) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %next_e_i = arith.addf %e_i, %e : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
@@ -113,22 +113,22 @@ tt.func public @mma_operand_view(
 
   scf.for %i = %c0_i32 to %n_tiles step %c64_i32 : i32 {
     %K = tt.descriptor_load %K_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
-    // CHECK: [[K_SHARED:%.*]] = ttg.local_alloc {{.*}}partition = 2
+    // CHECK: [[K_SHARED:%.*]] = ttg.local_alloc {{.*}}partition = array<i32: 2>
     %K_shared = ttg.local_alloc %K : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
 
-    // CHECK-DAG: [[TRANS_MMA:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = 1
-    // CHECK-DAG: [[K_VIEW:%.*]] = ttg.memdesc_subslice [[TRANS_MMA]]{{.*}}partition = 1
-    // CHECK-DAG: [[TRANS_USER:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = 0
+    // CHECK-DAG: [[TRANS_MMA:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = array<i32: 1>
+    // CHECK-DAG: [[K_VIEW:%.*]] = ttg.memdesc_subslice [[TRANS_MMA]]{{.*}}partition = array<i32: 1>
+    // CHECK-DAG: [[TRANS_USER:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = array<i32: 0>
     %K_trans = ttg.memdesc_trans %K_shared {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
     %K_view = ttg.memdesc_subslice %K_trans [0, 0]  : !ttg.memdesc<64x64xf16, #shared_T, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
 
-    // CHECK: ttng.tc_gen5_mma %arg0, [[K_VIEW]]{{.*}}partition = 1
+    // CHECK: ttng.tc_gen5_mma %arg0, [[K_VIEW]]{{.*}}partition = array<i32: 1>
     %QK_mma_tok = ttng.tc_gen5_mma %Q_shared, %K_view, %QK_tmem[%QK_tok], %false, %true : !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared_T, #smem>, !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>
 
-    // CHECK: local_load [[TRANS_USER]] {{.*}}partition = 0
+    // CHECK: local_load [[TRANS_USER]] {{.*}}partition = array<i32: 0>
     %x = ttg.local_load %K_trans : !ttg.memdesc<64x64xf16, #shared_T, #smem> -> tensor<64x64xf16, #load_blocked>
 
-    // CHECK: tmem_load {{.*}}partition = 4
+    // CHECK: tmem_load {{.*}}partition = array<i32: 4>
     %QK, %QK_load_tok = ttng.tmem_load %QK_tmem[%QK_mma_tok] : !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
 
     "use"(%x, %QK) : (tensor<64x64xf16, #load_blocked>, tensor<256x64xf32, #blocked>) -> ()
@@ -143,20 +143,20 @@ tt.func @optimize_broadcast(%arg0: i32) {
   %c1_i32 = arith.constant 1 : i32
   // CHECK: scf.for
   scf.for %i = %c0_i32 to %arg0 step %c1_i32 : i32 {
-    // CHECK: [[X:%.*]] = "producer"{{.*}}partition = 0
-    %x = "producer"() {ttg.partition = 0 : i32} : () -> tensor<128xf32>
+    // CHECK: [[X:%.*]] = "producer"{{.*}}partition = array<i32: 0>
+    %x = "producer"() {ttg.partition = array<i32: 0>} : () -> tensor<128xf32>
 
-    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = 0
-    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = 1
+    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 0>
+    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 1>
     %x0 = tt.expand_dims %x {axis = 0 : i32} : tensor<128xf32> -> tensor<1x128xf32>
-    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = 0
-    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = 1
+    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = array<i32: 0>
+    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = array<i32: 1>
     %x1 = tt.broadcast %x0 : tensor<1x128xf32> -> tensor<128x128xf32>
 
-    // CHECK: "use"([[X1_P0]]) {{.*}}partition = 0
-    "use"(%x1) {ttg.partition = 0 : i32} : (tensor<128x128xf32>) -> ()
-    // CHECK: "use"([[X1_P1]]) {{.*}}partition = 1
-    "use"(%x1) {ttg.partition = 1 : i32} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use"([[X1_P0]]) {{.*}}partition = array<i32: 0>
+    "use"(%x1) {ttg.partition = array<i32: 0>} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use"([[X1_P1]]) {{.*}}partition = array<i32: 1>
+    "use"(%x1) {ttg.partition = array<i32: 1>} : (tensor<128x128xf32>) -> ()
   } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -12,25 +12,25 @@ tt.func @two_consumers(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[ABUF:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, {{.*}}>
   // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create [[ABUF]]
   scf.for %i = %lb to %ub step %step iter_args() -> () : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: [[VAL:%.*]] = "op_a"
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[VAL]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[VAL]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    "op_b"(%0) {ttg.partition = 1} : (!ty) -> ()
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> ()
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[VAL]])
 
-    "op_c"(%0) {ttg.partition = 2} : (!ty) -> ()
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    "op_c"(%0) {ttg.partition = array<i32: 2>} : (!ty) -> ()
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_c"([[VAL]])
     // CHECK-NEXT: "op_d"([[VAL]])
-    "op_d"(%0) {ttg.partition = 2} : (!ty) -> ()
+    "op_d"(%0) {ttg.partition = array<i32: 2>} : (!ty) -> ()
   } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -42,16 +42,16 @@ tt.func @distance_one(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : !ty
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[K:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: [[VAL:%.*]] = "op_a"
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[VAL]])
-    "op_b"(%k) {ttg.partition = 1} : (!ty) -> ()
+    "op_b"(%k) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
     scf.yield %0 : !ty
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
@@ -66,41 +66,41 @@ tt.func @complex_case(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : !ty
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[K:%.*]] = {{.*}}, [[L:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%k = %cst, %l = %cst) -> (!ty, !ty) : i32 {
-    // CHECK: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[L]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[L]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK-NEXT: op_a
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[K1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[K1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[K1]])
-    "op_b"(%k) {ttg.partition = 1} : (!ty) -> ()
+    "op_b"(%k) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
 
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[K2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[K2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_c"([[K2]])
     // CHECK-NEXT: "op_c"([[K2]])
-    "op_c"(%k) {ttg.partition = 2} : (!ty) -> ()
-    "op_c"(%k) {ttg.partition = 2} : (!ty) -> ()
+    "op_c"(%k) {ttg.partition = array<i32: 2>} : (!ty) -> ()
+    "op_c"(%k) {ttg.partition = array<i32: 2>} : (!ty) -> ()
 
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[L1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[L1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_d"([[L1]])
-    "op_d"(%l) {ttg.partition = 1} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[L2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[L2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_d"([[L2]])
-    "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 2>} : (!ty) -> ()
     scf.yield %0, %k : !ty, !ty
   } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -117,23 +117,23 @@ tt.func @reuse_argument(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create
   // CHECK-NEXT: scf.for
   scf.for %i = %lb to %ub step %step iter_args(%k = %cst0, %l = %cst1) -> (!ty, !ty) : i32 {
-    // CHECK-NEXT: {{.*}}, [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: {{.*}}, [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: local_store
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: op_a
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
 
-    // CHECK-NEXT: aref.get.enter [[AREF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: local_load {{.*}} {ttg.partition = 1 : i32}
-    // CHECK-NEXT: aref.get.exit [[AREF]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: aref.get.enter [[AREF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: local_load {{.*}} {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: aref.get.exit [[AREF]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: op_d
-    "op_d"(%l) {ttg.partition = 1} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
-    // CHECK-NEXT: aref.get.enter [[AREF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: local_load {{.*}} {ttg.partition = 2 : i32}
-    // CHECK-NEXT: aref.get.exit [[AREF]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: aref.get.enter [[AREF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: local_load {{.*}} {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: aref.get.exit [[AREF]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: op_d
-    "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 2>} : (!ty) -> ()
     scf.yield %0, %k : !ty, !ty
   } {ttg.partition.stages = [1, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -157,35 +157,35 @@ tt.func @multiplicity_branch(%lb: i32, %ub: i32, %step: i32) {
 
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[A:%.*]] = {{.*}}, [[B:%.*]] = {{.*}}, [[C:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%a = %cst0, %b = %cst1, %c = %cst2) -> (!ty, !ty, !ty) : i32 {
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: op_a
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
 
     // CHECK: aref.get.enter [[AREF1]]
     // CHECK-NEXT: local_load
     // CHECK-NEXT: aref.get.exit [[AREF1]]
     // CHECK-NEXT: op_b
-    "op_b"(%a) {ttg.partition = 1}: (!ty) -> ()
+    "op_b"(%a) {ttg.partition = array<i32: 1>}: (!ty) -> ()
 
     // CHECK: aref.get.enter [[AREF2]]
     // CHECK-NEXT: local_load
     // CHECK-NEXT: aref.get.exit [[AREF2]]
     // CHECK-NEXT: op_c
-    "op_c"(%b) {ttg.partition = 2}: (!ty) -> ()
+    "op_c"(%b) {ttg.partition = array<i32: 2>}: (!ty) -> ()
 
     // CHECK: aref.get.enter [[AREF3]]
     // CHECK-NEXT: local_load
     // CHECK-NEXT: aref.get.exit [[AREF3]]
     // CHECK-NEXT: op_d
-    "op_d"(%c) {ttg.partition = 3}: (!ty) -> ()
+    "op_d"(%c) {ttg.partition = array<i32: 3>}: (!ty) -> ()
 
     scf.yield %0, %a, %a : !ty, !ty, !ty
   } {ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
@@ -210,35 +210,35 @@ tt.func @multiplicity_branch2(%lb: i32, %ub: i32, %step: i32) {
 
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[A:%.*]] = {{.*}}, [[B:%.*]] = {{.*}}, [[C:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%a = %cst0, %b = %cst1, %c = %cst2) -> (!ty, !ty, !ty) : i32 {
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: op_a
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
 
-    // CHECK: aref.get.enter [[AREF1]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[A1:%.*]] = ttg.local_load {{.*}} {ttg.partition = 1 : i32}
+    // CHECK: aref.get.enter [[AREF1]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[A1:%.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: aref.get.exit [[AREF1]]
-    // CHECK-NEXT: "op_b"([[A1]]) {ttg.partition = 1 : i32}
-    %d = "op_b"(%a) {ttg.partition = 1}: (!ty) -> !ty
+    // CHECK-NEXT: "op_b"([[A1]]) {ttg.partition = array<i32: 1>}
+    %d = "op_b"(%a) {ttg.partition = array<i32: 1>}: (!ty) -> !ty
 
-    // CHECK: aref.get.enter [[AREF2]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[B1:%.*]] = ttg.local_load {{.*}} {ttg.partition = 2 : i32}
+    // CHECK: aref.get.enter [[AREF2]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[B1:%.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: aref.get.exit [[AREF2]]
-    // CHECK-NEXT: "op_c"([[B1]]) {ttg.partition = 2 : i32}
-    %e = "op_c"(%b) {ttg.partition = 2}: (!ty) -> !ty
+    // CHECK-NEXT: "op_c"([[B1]]) {ttg.partition = array<i32: 2>}
+    %e = "op_c"(%b) {ttg.partition = array<i32: 2>}: (!ty) -> !ty
 
-    // CHECK: aref.get.enter [[AREF3]] {ttg.partition = 3 : i32}
-    // CHECK-NEXT: [[C1:%.*]] = ttg.local_load {{.*}} {ttg.partition = 3 : i32}
+    // CHECK: aref.get.enter [[AREF3]] {ttg.partition = array<i32: 3>}
+    // CHECK-NEXT: [[C1:%.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 3>}
     // CHECK-NEXT: aref.get.exit [[AREF3]]
-    // CHECK-NEXT: "op_d"([[C1]]) {ttg.partition = 3 : i32}
-    "op_d"(%c) {ttg.partition = 3}: (!ty) -> ()
+    // CHECK-NEXT: "op_d"([[C1]]) {ttg.partition = array<i32: 3>}
+    "op_d"(%c) {ttg.partition = array<i32: 3>}: (!ty) -> ()
 
     scf.yield %0, %d, %e : !ty, !ty, !ty
   } {ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
@@ -252,7 +252,7 @@ tt.func @self_recursion(%lb: i32, %ub: i32, %step: i32) {
   // CHECK: iter_args([[ARG:%arg[0-9]+]] = %cst)
   %0 = scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
     // CHECK-NEXT: [[OUT:%.*]] = "op_a"([[ARG]])
-    %0 = "op_a"(%k) {ttg.partition = 0} : (!ty) -> !ty
+    %0 = "op_a"(%k) {ttg.partition = array<i32: 0>} : (!ty) -> !ty
     // CHECK: yield [[OUT]]
     scf.yield %0 : !ty
   } {ttg.partition.stages = [0], ttg.warp_specialize.tag = 0 : i32}
@@ -263,13 +263,13 @@ tt.func @self_recursion(%lb: i32, %ub: i32, %step: i32) {
 tt.func @self_recursion_and_use(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : !ty
   %0 = scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
-    %0 = "op_a"(%k) {ttg.partition = 0} : (!ty) -> !ty
+    %0 = "op_a"(%k) {ttg.partition = array<i32: 0>} : (!ty) -> !ty
     // CHECK: "op_a"
     // CHECK-NEXT: nvws.aref.put.enter
     // CHECK-NEXT: local_store
     // CHECK-NEXT: nvws.aref.put.exit
 
-    "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> !ty
     // CHECK-NEXT: nvws.aref.get.enter
     // CHECK-NEXT: ttg.local_load
     // CHECK-NEXT: nvws.aref.get.exit
@@ -283,7 +283,7 @@ tt.func @self_recursion_and_use(%lb: i32, %ub: i32, %step: i32) {
 // CHECK-LABEL: @conditional_consumer
 tt.func @conditional_consumer(%lb: i32, %ub: i32, %step: i32) {
   scf.for %i = %lb to %ub step %step : i32 {
-    %0 = "producer"() {ttg.partition = 0} : () -> !ty
+    %0 = "producer"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: "producer"
     // CHECK-NEXT: nvws.aref.put.enter
     // CHECK-NEXT: local_store
@@ -302,8 +302,8 @@ tt.func @conditional_consumer(%lb: i32, %ub: i32, %step: i32) {
     } else {
       %2 = "something"() : () -> !ty
       scf.yield %2 : !ty
-    } {ttg.partition = 1}
-    "keep"(%1) {ttg.partition = 1} : (!ty) -> ()
+    } {ttg.partition = array<i32: 1>}
+    "keep"(%1) {ttg.partition = array<i32: 1>} : (!ty) -> ()
   } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -323,18 +323,18 @@ tt.func @scalar_consumers(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[ABUF:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, {{.*}}>
   // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create [[ABUF]]
   scf.for %i = %lb to %ub step %step iter_args() -> () : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> i32
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> i32
     // CHECK: [[VAL:%.*]] = "op_a"
-    // CHECK-NEXT: [[VAL_TENSOR:%.*]] = tt.splat [[VAL]] {ttg.partition = 0 : i32} : i32 -> tensor<1xi32, #blocked>
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[VAL_TENSOR]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[VAL_TENSOR:%.*]] = tt.splat [[VAL]] {ttg.partition = array<i32: 0>} : i32 -> tensor<1xi32, #blocked>
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[VAL_TENSOR]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    "op_b"(%0) {ttg.partition = 1} : (i32) -> ()
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL_SCALAR:%.*]] = tt.unsplat [[VAL]] {ttg.partition = 1 : i32} : tensor<1xi32, #blocked>
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL_SCALAR:%.*]] = tt.unsplat [[VAL]] {ttg.partition = array<i32: 1>} : tensor<1xi32, #blocked>
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[VAL_SCALAR]])
 
   } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
@@ -375,7 +375,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
   scf.for %k = %lb to %ub step %step : i32 {
     // expected-error @below {{invalid partition index -1}}
-    "op"() {ttg.partition = -1} : () -> ()
+    "op"() {ttg.partition = array<i32: -1>} : () -> ()
     scf.yield
   } {ttg.partition.stages = [2, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -397,18 +397,18 @@ tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[AREF2:%.*]] = nvws.aref.create
 
   scf.for %i = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: "op_a"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]] {ttg.partition = array<i32: 0>}
 
-    %1 = "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
-    // CHECK: nvws.aref.get.exit [[AREF1]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    %1 = "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF1]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]] {ttg.partition = array<i32: 1>}
 
-    // CHECK: nvws.aref.get.exit [[AREF2]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK: nvws.aref.get.exit [[AREF2]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    "op_c"(%1) {ttg.partition = 0} : (!ty) -> ()
+    "op_c"(%1) {ttg.partition = array<i32: 0>} : (!ty) -> ()
     scf.yield
   } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -431,66 +431,25 @@ tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: ttg.local_alloc
   // CHECK-NEXT: [[AREF3:%.*]] = nvws.aref.create
   scf.for %j = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: "op_a"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]] {ttg.partition = array<i32: 0>}
 
-    %1 = "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
-    // CHECK: nvws.aref.get.exit [[AREF1]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    %1 = "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF1]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]] {ttg.partition = array<i32: 1>}
 
-    %2 = "op_c"(%1) {ttg.partition = 2} : (!ty) -> !ty
-    // CHECK: nvws.aref.get.exit [[AREF2]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    %2 = "op_c"(%1) {ttg.partition = array<i32: 2>} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF2]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_c"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF3]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF3]] {ttg.partition = array<i32: 2>}
 
-    "op_c"(%2) {ttg.partition = 0} : (!ty) -> ()
-    // CHECK: nvws.aref.get.exit [[AREF3]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    "op_c"(%2) {ttg.partition = array<i32: 0>} : (!ty) -> ()
+    // CHECK: nvws.aref.get.exit [[AREF3]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK: "op_c"
     scf.yield
   } {ttg.partition.stages = [0, 2, 3], ttg.warp_specialize.tag = 0 : i32}
-  tt.return
-}
-
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-!ty = tensor<1xi32, #blocked>
-
-module attributes {"ttg.num-warps" = 4 : i32} {
-
-tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
-  scf.for %i = %lb to %ub step %step : i32 {
-    // expected-note @below {{operand defined here in partition #0 at distance 0}}
-    %0 = "partition"() {ttg.partition = 0} : () -> index
-    // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
-    "root"(%0) : (index) -> ()
-    scf.yield
-  } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
-  tt.return
-}
-
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-!ty = tensor<1xi32, #blocked>
-
-module attributes {"ttg.num-warps" = 4 : i32} {
-
-tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
-  %c0 = arith.constant 0 : index
-  scf.for %j = %lb to %ub step %step iter_args(%k = %c0) -> index : i32 {
-    // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
-    "root"(%k) : (index) -> ()
-    // expected-note @below {{operand defined here in partition #0 at distance 1}}
-    %0 = "partition"() {ttg.partition = 0} : () -> index
-    scf.yield %0 : index
-  } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
@@ -41,6 +41,7 @@
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/PartitionBuilder.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -69,17 +70,17 @@ template <class T> struct AssignStagePhase {
     Value token;
   };
   Value aref;
-  PartitionId partitionId;
+  int partitionId;
   DenseMap<Value, int> tokToStagePosMap;
 
-  AssignStagePhase(Value aref, PartitionId partitionId)
+  AssignStagePhase(Value aref, int partitionId)
       : aref(aref), partitionId(partitionId) {}
 
   T isValidOp(Operation *op) {
     if (auto opT = dyn_cast<T>(op)) {
       if (opT.getAref() == aref) {
-        auto opPartitionId = getPartitionId(op);
-        if (!opPartitionId || *opPartitionId == partitionId)
+        auto opPartitionIds = getPartitionIds(op);
+        if (!opPartitionIds || llvm::is_contained(*opPartitionIds, partitionId))
           return opT;
       }
     }
@@ -273,14 +274,13 @@ template <class T> struct AssignStagePhase {
   }
 
   static LogicalResult run(ArefCreateOp arefOp) {
-
-    std::set<PartitionId> partitionIds;
+    std::set<int> partitionIds;
     for (auto user : arefOp->getUsers()) {
       // Each partition requires its own stage/phase tracking for proper
       // multi-user handling; collect partition IDs in which this aref is used
       if (isa<T>(user)) {
-        if (auto partitionId = getPartitionId(user))
-          partitionIds.insert(*partitionId);
+        if (auto ids = getPartitionIds(user))
+          partitionIds.insert(ids->begin(), ids->end());
       }
     }
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -65,11 +65,12 @@ namespace {
 
 // ----------------------------------------------------------------------------
 
-void assignStageCluster(Operation *op, std::optional<PartitionId> partitionId,
+void assignStageCluster(Operation *op,
+                        std::optional<SetVector<int>> partitionIds,
                         StageCluster stageCluster, OpBuilder &builder) {
-  if (partitionId) {
-    op->setAttr(kPartitionAttrName,
-                builder.getI32IntegerAttr(partitionId->index()));
+  if (partitionIds) {
+    setPartition(op, *partitionIds);
+
     if (stageCluster) {
       op->setAttr(triton::kLoopStageAttrName,
                   builder.getI32IntegerAttr(stageCluster->first));
@@ -110,19 +111,21 @@ SmallVector<AsyncOp> castAsyncOpAttrs(ArrayAttr opAttrs) {
 }
 
 BarrierCount getArrivalCount(ArefCreateOp op) {
-  std::set<PartitionId> producerGroups, consumerGroups;
+  SetVector<int> producerGroups, consumerGroups;
   BarrierCount count;
 
   for (auto user : op->getUsers()) {
-    auto partitionId = getPartitionId(user);
-    if (!partitionId)
+    auto partitionIds = getPartitionIds(user);
+    if (!partitionIds)
       continue;
 
+    assert(partitionIds->size() == 1);
+
     if (auto putExitOp = dyn_cast<ArefPutExitOp>(user)) {
-      if (producerGroups.count(*partitionId)) {
+      if (producerGroups.count(partitionIds->front())) {
         continue;
       }
-      producerGroups.insert(*partitionId);
+      producerGroups.insert(partitionIds->front());
       for (auto kind : castAsyncOpAttrs(putExitOp.getAsyncOps())) {
         switch (kind) {
         case AsyncOp::TC5MMA:
@@ -135,10 +138,10 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
         }
       }
     } else if (auto getExitOp = dyn_cast<ArefGetExitOp>(user)) {
-      if (consumerGroups.count(*partitionId)) {
+      if (consumerGroups.count(partitionIds->front())) {
         continue;
       }
-      consumerGroups.insert(*partitionId);
+      consumerGroups.insert(partitionIds->front());
       for (auto kind : castAsyncOpAttrs(getExitOp.getAsyncOps())) {
         switch (kind) {
         case AsyncOp::TC5MMA:
@@ -226,7 +229,7 @@ void createTMALoad(triton::nvws::DescriptorLoadOp op, PatternRewriter &rewriter,
       rewriter.create<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(
           op.getLoc(), /*multicastTargets*/ Value(), op.getDesc(), indices,
           barrierAlloc, op.getResult(), pred);
-  assignStageCluster(newLoadOp, getPartitionId(op), getStageCluster(op),
+  assignStageCluster(newLoadOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
 };
 
@@ -236,7 +239,7 @@ void createTMAGather(triton::nvws::DescriptorGatherOp op,
   auto newGatherOp = rewriter.create<triton::nvidia_gpu::AsyncTMAGatherOp>(
       op.getLoc(), op.getDesc(), op.getXOffsets(), op.getYOffset(),
       barrierAlloc, op.getResult(), pred);
-  assignStageCluster(newGatherOp, getPartitionId(op), getStageCluster(op),
+  assignStageCluster(newGatherOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
 }
 
@@ -262,7 +265,7 @@ void lowerTMALoad(ArefPutEnterOp op, Value fullBarrier,
   Value pred = rewriter.create<arith::ConstantIntOp>(loc, 1, 1);
   auto expectOp = rewriter.create<triton::nvidia_gpu::BarrierExpectOp>(
       loc, fullBarrier, txCount, pred);
-  assignStageCluster(expectOp, getPartitionId(op), getStageCluster(op),
+  assignStageCluster(expectOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
 
   for (auto loadOp : loadOps) {
@@ -282,7 +285,8 @@ void lowerTMALoad(ArefPutEnterOp op, Value fullBarrier,
 void insertWaitOp(PatternRewriter &rewriter, Operation *op, Value barrier,
                   Value phase, Value stage) {
   auto waitOp = rewriter.create<WaitBarrierOp>(op->getLoc(), barrier, phase);
-  assignStageCluster(waitOp, getPartitionId(op), getStageCluster(op), rewriter);
+  assignStageCluster(waitOp, getPartitionIds(op), getStageCluster(op),
+                     rewriter);
 }
 
 void rewritePutEnterOp(ArefPutEnterOp op, PatternRewriter &rewriter,
@@ -373,7 +377,7 @@ void rewriteGetEnterOp(ArefGetEnterOp op, PatternRewriter &rewriter,
 
 void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
                          PatternRewriter &rewriter, Value mbar,
-                         std::optional<PartitionId> partitionId,
+                         std::optional<SetVector<int>> partitionIds,
                          StageCluster stageCluster) {
   for (auto asyncOpEnum : asyncOps) {
     Operation *arriveOp = {};
@@ -394,7 +398,7 @@ void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
       llvm_unreachable("unknown async op");
     }
     if (arriveOp)
-      assignStageCluster(arriveOp, partitionId, stageCluster, rewriter);
+      assignStageCluster(arriveOp, partitionIds, stageCluster, rewriter);
   }
 }
 
@@ -404,7 +408,7 @@ void rewritePutExitOp(ArefPutExitOp op, PatternRewriter &rewriter,
   rewriter.setInsertionPointAfter(op);
   Value fullBarrier = getFullBarrier(rewriter, loc, arefVal, op.getStage());
   insertArriveBarrier(loc, castAsyncOpAttrs(op.getAsyncOps()), rewriter,
-                      fullBarrier, getPartitionId(op), getStageCluster(op));
+                      fullBarrier, getPartitionIds(op), getStageCluster(op));
 }
 
 void rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
@@ -435,20 +439,20 @@ void rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
 
   if (needFence) {
     auto fence = rewriter.create<FenceAsyncSharedOp>(loc, /*bCluster=*/false);
-    assignStageCluster(fence, getPartitionId(op), stageCluster, rewriter);
+    assignStageCluster(fence, getPartitionIds(op), stageCluster, rewriter);
   }
 
   Value emptyBarrier = getEmptyBarrier(rewriter, loc, arefVal, op.getStage());
   return insertArriveBarrier(loc, asyncKinds, rewriter, emptyBarrier,
-                             getPartitionId(op), stageCluster);
+                             getPartitionIds(op), stageCluster);
 }
 
 DenseSet<MMAv5OpInterface> getAsyncMMAv5Consumers(Value aref) {
   DenseSet<MMAv5OpInterface> mmav5Ops;
   for (auto arefUser : aref.getUsers()) {
     if (auto getEnter = dyn_cast<ArefGetEnterOp>(arefUser)) {
-      auto id = getPartitionId(getEnter);
-      if (id && id->index() == 0) {
+      auto id = getPartitionIds(getEnter);
+      if (id && id->front() == 0) {
         // Ignore mmav5 ops in the default partition. They are not warp
         // specialized.
         continue;
@@ -613,7 +617,7 @@ ExitOp createCombinedArefOps(SmallVector<EnterOp> &enterOps,
   auto combinedEnter = builder.create<EnterOp>(
       firstEnter.getLoc(), arefEnterBuffers, builder.getType<AsyncTokenType>(),
       aref, zero, zero);
-  assignStageCluster(combinedEnter, getPartitionId(firstEnter),
+  assignStageCluster(combinedEnter, getPartitionIds(firstEnter),
                      getStageCluster(firstEnter), builder);
 
   builder.setInsertionPoint(lastExit);
@@ -622,7 +626,7 @@ ExitOp createCombinedArefOps(SmallVector<EnterOp> &enterOps,
   auto combinedExit = builder.create<ExitOp>(
       firstEnter.getLoc(), aref, combinedEnter.getToken(), zero,
       builder.getArrayAttr(AsyncOpAttrs));
-  assignStageCluster(combinedExit, getPartitionId(lastExit),
+  assignStageCluster(combinedExit, getPartitionIds(lastExit),
                      getStageCluster(lastExit), builder);
 
   std::function<void(Operation *, Operation *)> moveUserAfter =
@@ -699,12 +703,12 @@ void combineArefs(scf::ForOp loop) {
     SmallVector<ArefPutEnterOp> putEnterOps;
     SmallVector<ArefPutExitOp> putExitOps;
     SmallVector<ArefGetExitOp> getExitOps;
-    SmallVector<PartitionId> producerGroupIds;
+    SmallVector<int> producerGroupIds;
     for (auto aref : arefs) {
       for (auto user : aref->getUsers()) {
         if (auto putEnterOp = dyn_cast<ArefPutEnterOp>(user)) {
           putEnterOps.push_back(putEnterOp);
-          producerGroupIds.push_back(*getPartitionId(putEnterOp));
+          producerGroupIds.push_back(getPartitionIds(putEnterOp)->front());
         } else if (auto putExitOp = dyn_cast<ArefPutExitOp>(user)) {
           putExitOps.push_back(putExitOp);
         } else if (auto getExitOp = dyn_cast<ArefGetExitOp>(user)) {

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
@@ -25,17 +25,4 @@ ArefCreateOp createArefCreateOp(OpBuilder &builder, ArrayRef<Type> arefTypes,
   return builder.create<ArefCreateOp>(loc, arefTy, allocOps);
 }
 
-std::optional<PartitionId> getPartitionId(Operation *op) {
-  if (auto partitionAttr = op->getAttrOfType<IntegerAttr>(kPartitionAttrName)) {
-    IntegerAttr tagAttr;
-    while (op && !tagAttr) {
-      tagAttr = op->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
-      op = op->getParentOp();
-    }
-    if (tagAttr)
-      return PartitionId(partitionAttr.getInt(), tagAttr.getInt());
-  }
-  return {};
-}
-
 } // namespace mlir::triton::nvws

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
@@ -22,14 +22,6 @@ inline std::optional<int> findValuePosInRange(const Range &range,
   return {};
 }
 
-struct PartitionId : std::pair<int, int> {
-  PartitionId(int index, int tag) : std::pair<int, int>(index, tag) {}
-  int &index() { return first; }
-  int &tag() { return second; }
-};
-
-std::optional<PartitionId> getPartitionId(Operation *op);
-
 } // namespace mlir::triton::nvws
 
 #endif // NVIDIA_NVWS_TRANSFORMS_UTILITY_H_


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8123

Upstream commit message:
```
> [WS] Rework partition representation (#8123)

> `WarpSchedule` is renamed to `PartitionSet`, since it is now just a
> container of created partitions. It no longer owns a mapping between ops
> and partitions, which are now done exclusively by free functions like
> `setPartition`, `getPartitionIds` etc which only looks at the op

> Other notable changes
> * Partition attributes are now a set (represented as `array<i32>`).
> * The concrete instance of "root partition" is gone but the code still
> uses the term to refer to ops belonging to all partitions.
> * At the beginning of `PartitionLoops`, unannotated ops, including those
> within if or reduce ops, are annotated with their parent partitions.
```

Conflict Resolution:
- File: Partition.cpp
  Action: Kept HEAD version with WarpSchedule methods (serialize, verify, eraseFrom, iterateInputs, iterateOutputs)
  Reason: HEAD has extensive Meta-specific extensions (post-loop ops, multi-loop support) built on WarpSchedule API that upstream's simplified PartitionSet API would break
- File: PartitionScheduling.cpp
  Action: Kept HEAD version with WarpSchedule-based scheduling (multi-loop, epilogue partitions, schedulePostLoopOps, optimizeSchedule)
  Reason: HEAD has diverged significantly with Meta-specific features (multi-loop scheduling, epilogue partition, post-loop ops, causal attention support) that upstream's simpler PartitionSet version doesn't support
- File: partition-scheduling.mlir
  Action: Kept HEAD version with integer partition attribute checks (e.g., partition = 4, partition = 0)
  Reason: HEAD uses integer partition format consistent with WarpSchedule::serialize; upstream uses array format (array<i32: 0>) from the renamed PartitionSet
- File: LowerAref.cpp
  Action: Kept HEAD version with multicastTargets parameter and getPartitionId call
  Reason: HEAD has additional multicastTargets parameter in AsyncTMACopyGlobalToLocalOp and uses getPartitionId (singular) API

Raw Conflicts: https://www.internalfb.com/intern/paste/P2196068458/

Diff Versions: Compare V1 (conflict markers) → V2 (resolved) in Phabricator

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 09f5416b620d08a70f19924bf16314a57f5b21b0
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Differential Revision: D93836343
