### PR TITLE
[TLX] Add DialectInlinerInterface to enable inlining of NVGPU ops

### DIFF
--- a/test/TritonNvidiaGPU/inline.mlir
+++ b/test/TritonNvidiaGPU/inline.mlir
@@ -19,4 +19,17 @@ tt.func private @function_with_ttng_ops() {
   tt.return
 }
 
+// CHECK-LABEL: @inline_nvgpu_ops
+tt.func public @inline_nvgpu_ops() -> i32 {
+  // CHECK-NOT: tt.call
+  // CHECK: nvgpu.cluster_id
+  %0 = tt.call @function_with_nvgpu_ops() : () -> i32
+  tt.return %0 : i32
+}
+
+tt.func private @function_with_nvgpu_ops() -> i32 {
+  %0 = nvgpu.cluster_id
+  tt.return %0 : i32
+}
+
 }

--- a/third_party/nvidia/lib/Dialect/NVGPU/IR/Dialect.cpp
+++ b/third_party/nvidia/lib/Dialect/NVGPU/IR/Dialect.cpp
@@ -23,6 +23,7 @@
 
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 // clang-format off
 #include "Dialect/NVGPU/IR/Dialect.h"
@@ -31,6 +32,25 @@
 
 using namespace mlir;
 using namespace mlir::triton::nvgpu;
+
+namespace {
+struct NVGPUInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  bool isLegalToInline(Operation *call, Operation *callable,
+                       bool wouldBeCloned) const final {
+    return true;
+  }
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       IRMapping &valueMapping) const final {
+    return true;
+  }
+  bool isLegalToInline(Operation *, Region *, bool wouldBeCloned,
+                       IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
 
 void mlir::triton::nvgpu::NVGPUDialect::initialize() {
   addAttributes<
@@ -42,6 +62,8 @@ void mlir::triton::nvgpu::NVGPUDialect::initialize() {
 #define GET_OP_LIST
 #include "Dialect/NVGPU/IR/Ops.cpp.inc"
       >();
+
+  addInterfaces<NVGPUInlinerInterface>();
 }
 
 #define GET_OP_CLASSES


### PR DESCRIPTION
The NVGPU dialect was missing a DialectInlinerInterface, which caused the MLIR inliner to reject any function containing NVGPU ops (e.g. nvg.cluster_id). This adds a permissive inliner interface (all ops legal to inline).