### PR TITLE
Support FA MXFP8 with HEAD-DIM=128

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -63,10 +63,6 @@ struct TMemAllocation {
 
 TMemAllocation getTmemAllocSizes(gpu::MemDescType memDescType);
 
-// Compute the number of TMEM columns for a single buffer of MMA scales
-// given per-CTA M and K dimensions.
-int getTmemScalesColumnsPerBuffer(int m, int k);
-
 gpu::DistributedEncodingTrait getTmemCompatibleLayout(unsigned M, unsigned N,
                                                       RankedTensorType oltType,
                                                       unsigned numWarps);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -50,10 +50,6 @@ namespace nvidia_gpu {
 
 static constexpr int numTmemRows = 128;
 
-int getTmemScalesColumnsPerBuffer(int m, int k) {
-  return ceil<int>(m, 32) * ceil<int>(k, 4);
-}
-
 TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
   auto *ctx = memDescType.getContext();
   auto S = [&](StringRef str) { return StringAttr::get(ctx, str); };


### PR DESCRIPTION
Implements the buffer sharing strategy described in https://docs.google.com/document/d/16QRLjx0a_KJWkZamD7l5qQpRaHqBpaz-aYUwTI_yCxc/edit?tab=t.0 to allow overlapping the scales with QK. This lets us keep BLOCK_N=128 for HEAD-DIM=128.

This is not optimized for performance. I will analyze that next. In additional I will add a followup to support BLOCK_N=64 (which should be blocked on P's quantization) so I can compare the performance of these strategies.