### PR TITLE
[triton][beta] [Cherry-pick] '[GLUON] Fix the bank_conflict computation in the presence of shmem broadcasting (#8200)'

### DIFF
--- a/include/triton/Tools/GenericSwizzling.h
+++ b/include/triton/Tools/GenericSwizzling.h
@@ -40,18 +40,17 @@ optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
 LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
                                   const LinearLayout &dst, int32_t bitwidth);
 
-std::pair<int, int> logBankConflictsLdSt(const LinearLayout &src,
-                                         const LinearLayout &dst,
-                                         const LinearLayout &smem,
-                                         int32_t bitwidth);
+std::pair<int, int> bankConflictsLdSt(const LinearLayout &src,
+                                      const LinearLayout &dst,
+                                      const LinearLayout &smem,
+                                      int32_t bitwidth);
 
-int logBankConflictsMemDesc(const LinearLayout &reg, const LinearLayout &smem,
-                            int32_t bitwidth);
+int bankConflictsMemDesc(const LinearLayout &reg, const LinearLayout &smem,
+                         int32_t bitwidth);
 
-std::pair<int, int> logBankConflicts(llvm::ArrayRef<int32_t> tileSrc,
-                                     llvm::ArrayRef<int32_t> tileDst,
-                                     const LinearLayout &smem,
-                                     int32_t bitwidth);
+std::pair<int, int> bankConflicts(llvm::ArrayRef<int32_t> tileSrc,
+                                  llvm::ArrayRef<int32_t> tileDst,
+                                  const LinearLayout &smem);
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_GENERIC_SWIZZLING_H

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -141,6 +141,12 @@ LinearLayout reshapeLayout(MLIRContext *ctx, LinearLayout layout,
 // order.
 LinearLayout transposeLinearLayout(LinearLayout layout, ArrayRef<int> order);
 
+// Given a distributed into shmem layout, return the largest vectorisation
+// that can be used to lower the layout via ld/st.
+std::pair<int, ColumnAction>
+largestVectorisation(MLIRContext *ctx, const LinearLayout &cvt, int bitwidth,
+                     std::optional<int> maybeMaxVecElems = std::nullopt);
+
 } // namespace mlir::triton
 
 #endif // TRITON_TOOLS_LAYOUTUTILS_H

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -554,8 +554,7 @@ void init_gluon_ir(py::module &&m) {
               int bitwidth) -> int {
              auto regLayout = ttg::toLinearLayout(shape, regLayoutAttr);
              auto smemLayout = ttg::toLinearLayout(shape, sharedLayoutAttr);
-             return 1 << ttg::logBankConflictsMemDesc(regLayout, smemLayout,
-                                                      bitwidth);
+             return ttg::bankConflictsMemDesc(regLayout, smemLayout, bitwidth);
            })
       .def("create_local_dealloc",
            [](GluonOpBuilder &self, Value memDesc) -> Operation * {

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -535,10 +535,13 @@ def thread_barrier(_semantic=None):
 @builtin
 def bank_conflicts(distr_ty, shared_ty, _semantic=None) -> int:
     """
-    Count the N-way bank conflicts of all the load/store instructions generated when
-    reading/writing the distributed tensor from/to the shared memory descriptor.
+    Count the bank conflicts per wavefront of each instruction generated when
+    reading/writing the distributed tensor from/to the shared memory descriptor
+    using ld.shared/st.shared instructions.
 
-    Note that 1-way bank conflict is, confusingly enough, the same as being bank-conflict free.
+    We define a bank conflict of N to be the excess number of memory accesses that each
+    wavefront needs to access the shared memory descriptor. When one uses no ld/st
+    vectorization, this is equal to t he number of excess memory accesses per instruction.
 
     Args:
         distr_ty (distributed_type): The distributed tensor.

--- a/unittest/Dialect/TritonGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonGPU/CMakeLists.txt
@@ -2,6 +2,11 @@ add_triton_ut(
   NAME TestSwizzling
   SRCS SwizzleTest.cpp
   LIBS
+    TritonAnalysis
+    TritonGPUIR
+    TritonNvidiaGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
     TritonTools
     LLVMSupport
     MLIRSupport

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -1,20 +1,35 @@
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 
 #include "mlir/Support/LLVM.h"
 #include "llvm/Support/Signals.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <functional>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <llvm/ADT/SmallSet.h>
 
 using namespace mlir;
 using namespace mlir::triton;
 
-using mlir::triton::gpu::logBankConflictsLdSt;
+using mlir::triton::gpu::bankConflictsLdSt;
 using mlir::triton::gpu::optimalSwizzling;
 using mlir::triton::gpu::optimalSwizzlingLdSt;
 
 namespace {
+
+static std::string attrStr(Attribute a) {
+  std::string s;
+  llvm::raw_string_ostream os(s);
+  a.print(os);
+  return s;
+}
 
 SmallVector<int32_t> flatten(const LinearLayout &ll, StringAttr dim) {
   assert(ll.hasInDim(dim) && "in dim must exist");
@@ -33,6 +48,139 @@ protected:
   MLIRContext ctx;
 };
 
+class BankConflictTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    ctx.loadDialect<mlir::triton::TritonDialect,
+                    mlir::triton::gpu::TritonGPUDialect>();
+  }
+
+  MLIRContext ctx;
+
+  using LinearLayout = mlir::triton::LinearLayout;
+
+  mlir::triton::gpu::BlockedEncodingAttr
+  blocked(ArrayRef<unsigned> spt, ArrayRef<unsigned> tpw,
+          ArrayRef<unsigned> wpcta, ArrayRef<unsigned> order,
+          ArrayRef<unsigned> cpg = {}, ArrayRef<unsigned> split = {},
+          ArrayRef<unsigned> cOrder = {}) {
+    SmallVector<unsigned> cpgStorage;
+    SmallVector<unsigned> splitStorage;
+    SmallVector<unsigned> cOrderStorage;
+    if (cpg.empty())
+      cpgStorage.assign(spt.size(), 1);
+    if (split.empty())
+      splitStorage.assign(spt.size(), 1);
+    if (cOrder.empty())
+      cOrderStorage.assign(order.begin(), order.end());
+
+    auto cta = mlir::triton::gpu::CTALayoutAttr::get(
+        &ctx, cpgStorage.empty() ? cpg : ArrayRef<unsigned>(cpgStorage),
+        splitStorage.empty() ? split : ArrayRef<unsigned>(splitStorage),
+        cOrderStorage.empty() ? cOrder : ArrayRef<unsigned>(cOrderStorage));
+    return mlir::triton::gpu::BlockedEncodingAttr::get(&ctx, spt, tpw, wpcta,
+                                                       order, cta);
+  }
+
+  mlir::triton::gpu::NvidiaMmaEncodingAttr mma(ArrayRef<unsigned> version,
+                                               ArrayRef<unsigned> warpsPerCTA,
+                                               ArrayRef<unsigned> instrShape) {
+    auto cta =
+        mlir::triton::gpu::CTALayoutAttr::getDefault(&ctx, warpsPerCTA.size());
+    return mlir::triton::gpu::NvidiaMmaEncodingAttr::get(
+        &ctx, version[0], version[1], warpsPerCTA, cta, instrShape);
+  }
+
+  mlir::triton::gpu::NVMMASharedEncodingAttr
+  nvmmaShared(unsigned swizzle, unsigned bitwidth, unsigned rank,
+              bool transposed = false) {
+    SmallVector<unsigned> cpg(rank, 1), split(rank, 1), order(rank);
+    std::iota(order.begin(), order.end(), 0);
+    auto cta = mlir::triton::gpu::CTALayoutAttr::get(&ctx, cpg, split, order);
+    return mlir::triton::gpu::NVMMASharedEncodingAttr::get(
+        &ctx, swizzle, transposed, bitwidth,
+        /*fp4Padded=*/false, cta);
+  }
+
+  LinearLayout toLL(ArrayRef<int64_t> shape, Attribute attr) {
+    return mlir::triton::gpu::toLinearLayout(shape, attr);
+  }
+
+  int computeConflicts(ArrayRef<int64_t> shape, Attribute regAttr,
+                       Attribute sharedAttr, int bitwidth) {
+    auto regLL = toLL(shape, regAttr);
+    auto sharedLL = toLL(shape, sharedAttr);
+    return mlir::triton::gpu::bankConflictsMemDesc(regLL, sharedLL, bitwidth);
+  }
+
+  int bruteforceBankConflictsPerWavefront(ArrayRef<int64_t> shape,
+                                          Attribute regAttr,
+                                          Attribute sharedAttr, int bitwidth) {
+    // Compute the bank conflicts per wavefront
+    // In other words, we compute how many extra memory accesses (bank
+    // conflicts) are needed for a given wavefront.
+    auto regLL = toLL(shape, regAttr);
+    auto sharedLL = toLL(shape, sharedAttr);
+
+    auto *ctx = sharedLL.getInDimNames().begin()->getContext();
+    auto S = [ctx](StringRef str) { return StringAttr::get(ctx, str); };
+
+    auto kOffset = S("offset");
+    auto kReg = S("register");
+    auto kLane = S("lane");
+    auto kWarp = S("warp");
+    auto regToShared = regLL.invertAndCompose(sharedLL);
+    assert(regToShared.isTrivialOver({S("block")}) && "NYI");
+    regToShared = regToShared.sublayout({kReg, kLane, kWarp}, {kOffset});
+
+    // Remove broadcasting
+    regToShared = actionRemoveBroadcastedRegs(regToShared).apply(regToShared);
+    auto [elemsPerVec, permutation] =
+        largestVectorisation(ctx, regToShared, bitwidth);
+    regToShared = permutation.apply(regToShared);
+
+    int vectorisation = llvm::divideCeil(bitwidth * elemsPerVec, 32);
+    assert(vectorisation == 1 || vectorisation == 2 || vectorisation == 4);
+    int wavefronts = 0;
+    // For all the emitted instructions
+    for (int regIdx = 0; regIdx < regToShared.getInDimSize(kReg);
+         regIdx += elemsPerVec) {
+      for (int warpIdx = 0; warpIdx < regToShared.getInDimSize(kWarp);
+           warpIdx++) {
+        // For each instruction
+        for (int laneIdx = 0; laneIdx < regToShared.getInDimSize(kLane);
+             laneIdx += (32 / vectorisation)) {
+          // For each wavefront
+          llvm::SmallSet<int, 32> uniqueOffsets;
+          for (int laneIdx = 0; laneIdx < 32 / vectorisation; laneIdx++) {
+            for (int vecIdx = 0; vecIdx < elemsPerVec; vecIdx++) {
+              auto offset = regToShared
+                                .apply({{kReg, regIdx + vecIdx},
+                                        {kLane, laneIdx},
+                                        {kWarp, warpIdx}})[0]
+                                .second;
+              auto offsetB32 = offset * bitwidth / 32;
+              uniqueOffsets.insert(offsetB32);
+            }
+          }
+          llvm::SmallVector<int, 32> banks(32, 0);
+          for (int offset : uniqueOffsets) {
+            banks[offset % 32]++;
+          }
+          wavefronts += *llvm::max_element(banks);
+        }
+      }
+    }
+    auto minWavefronts =
+        (regToShared.getInDimSize(kReg) / elemsPerVec) *
+        regToShared.getInDimSize(kWarp) *
+        (regToShared.getInDimSize(kLane) / (32 / vectorisation));
+    // Assert homogeneity
+    assert(wavefronts % minWavefronts == 0);
+    return wavefronts / minWavefronts - 1;
+  }
+};
+
 // ——— Tests ———
 
 TEST_F(SwizzleTest, Test128x128Float8Transpose) {
@@ -45,7 +193,7 @@ TEST_F(SwizzleTest, Test128x128Float8Transpose) {
   auto matrix_t = transposeLinearLayout(matrix, {1, 0});
 
   auto smem = optimalSwizzlingLdSt(matrix, matrix_t, /*bitwidth=*/8);
-  auto [r, w] = logBankConflictsLdSt(matrix, matrix_t, smem, /*bitwidth=*/8);
+  auto [r, w] = bankConflictsLdSt(matrix, matrix_t, smem, /*bitwidth=*/8);
   EXPECT_EQ(r, 0);
   EXPECT_EQ(w, 0);
 }
@@ -64,7 +212,7 @@ TEST_F(SwizzleTest, Test16x16Bf16BlockedMma) {
                    /*requireSurjective=*/true);
 
   auto smem = optimalSwizzlingLdSt(blocked, mma, /*bitwidth=*/16);
-  auto [r, w] = logBankConflictsLdSt(blocked, mma, smem, /*bitwidth=*/16);
+  auto [r, w] = bankConflictsLdSt(blocked, mma, smem, /*bitwidth=*/16);
   EXPECT_EQ(r, 0);
   EXPECT_EQ(w, 0);
 }
@@ -85,7 +233,7 @@ TEST_F(SwizzleTest, Test16x256U4Mma) {
       {{S("dim0"), 16}, {S("dim1"), 256}}, /*requireSurjective=*/true);
 
   auto smem = optimalSwizzlingLdSt(blocked, mma, /*bitwidth=*/4);
-  auto [r, w] = logBankConflictsLdSt(blocked, mma, smem, /*bitwidth=*/4);
+  auto [r, w] = bankConflictsLdSt(blocked, mma, smem, /*bitwidth=*/4);
   EXPECT_EQ(r, 0);
   EXPECT_EQ(w, 0);
 }
@@ -103,7 +251,7 @@ TEST_F(SwizzleTest, Test32x16F32Transpose) {
                         {{S("dim0"), 32}, {S("dim1"), 16}},
                         /*requireSurjective=*/true);
   auto smem = optimalSwizzlingLdSt(matrix, matrix_t, /*bitwidth=*/32);
-  auto [r, w] = logBankConflictsLdSt(matrix, matrix_t, smem, /*bitwidth=*/32);
+  auto [r, w] = bankConflictsLdSt(matrix, matrix_t, smem, /*bitwidth=*/32);
   EXPECT_EQ(r, 0);
   EXPECT_EQ(w, 0);
 }
@@ -122,9 +270,97 @@ TEST_F(SwizzleTest, Test128x128F16Transpose) {
       {{S("dim0"), 128}, {S("dim1"), 128}},
       /*requireSurjective=*/true);
   auto smem = optimalSwizzlingLdSt(matrix, matrix_t, /*bitwidth=*/16);
-  auto [r, w] = logBankConflictsLdSt(matrix, matrix_t, smem, /*bitwidth=*/16);
+  auto [r, w] = bankConflictsLdSt(matrix, matrix_t, smem, /*bitwidth=*/16);
   EXPECT_EQ(r, 0);
   EXPECT_EQ(w, 0);
+}
+
+TEST_F(BankConflictTest, bankConflicts) {
+  using mlir::triton::gpu::DotOperandEncodingAttr;
+
+  auto mmaV3 = mma({3, 0}, {4, 1}, {16, 32, 16});
+  auto mmaV2 = mma({2, 0}, {1, 4}, {16, 8});
+  auto mmaV2Large = mma({2, 0}, {2, 4}, {16, 8});
+
+  auto dotA =
+      DotOperandEncodingAttr::get(&ctx, /*opIdx=*/0, mmaV2, /*kWidth=*/2);
+  auto dotB =
+      DotOperandEncodingAttr::get(&ctx, /*opIdx=*/1, mmaV2, /*kWidth=*/2);
+  auto dotBInt8 =
+      DotOperandEncodingAttr::get(&ctx, /*opIdx=*/1, mmaV2, /*kWidth=*/1);
+  auto dotBNoswizzle =
+      DotOperandEncodingAttr::get(&ctx, /*opIdx=*/1, mmaV2Large, /*kWidth=*/2);
+
+  struct Case {
+    Attribute reg;
+    Attribute shared;
+    SmallVector<int64_t, 3> shape;
+    int bitwidth;
+  };
+
+  SmallVector<Case, 11> cases = {
+      {blocked({1}, {32}, {4}, {0}),
+       mlir::triton::gpu::SwizzledSharedEncodingAttr::get(
+           &ctx, 1, 1, 1, {0},
+           mlir::triton::gpu::CTALayoutAttr::getDefault(&ctx, 1)),
+       {32},
+       32},
+      {blocked({1}, {32}, {4}, {0}),
+       mlir::triton::gpu::SwizzledSharedEncodingAttr::get(
+           &ctx, 1, 1, 1, {0},
+           mlir::triton::gpu::CTALayoutAttr::getDefault(&ctx, 1)),
+       {32},
+       16},
+      {mmaV3,
+       nvmmaShared(/*swizzle=*/128, /*bitwidth=*/16, /*rank=*/2),
+       {128, 128},
+       16},
+      {dotB,
+       nvmmaShared(/*swizzle=*/64, /*bitwidth=*/16, /*rank=*/2),
+       {64, 32},
+       16},
+      {dotA,
+       nvmmaShared(/*swizzle=*/64, /*bitwidth=*/16, /*rank=*/2,
+                   /*transposed=*/true),
+       {32, 64},
+       16},
+      {dotBInt8,
+       nvmmaShared(/*swizzle=*/32, /*bitwidth=*/8, /*rank=*/2),
+       {8, 32},
+       8},
+      {mma({2, 0}, {4, 1}, {16, 8}),
+       nvmmaShared(/*swizzle=*/64, /*bitwidth=*/16, /*rank=*/2,
+                   /*transposed=*/true),
+       {64, 64},
+       16},
+      {mma({3, 0}, {2, 2}, {16, 32, 16}),
+       nvmmaShared(/*swizzle=*/64, /*bitwidth=*/16, /*rank=*/2),
+       {64, 32},
+       16},
+      {mma({2, 0}, {4, 1}, {16, 8}),
+       nvmmaShared(/*swizzle=*/32, /*bitwidth=*/8, /*rank=*/2),
+       {32, 32},
+       8},
+      {dotBNoswizzle,
+       nvmmaShared(/*swizzle=*/0, /*bitwidth=*/16, /*rank=*/2),
+       {4, 64},
+       16},
+      {mma({3, 0}, {4, 1}, {16, 32, 16}),
+       nvmmaShared(/*swizzle=*/128, /*bitwidth=*/32, /*rank=*/2),
+       {128, 64},
+       32},
+  };
+
+  for (const auto &c : cases) {
+    EXPECT_EQ(computeConflicts(c.shape, c.reg, c.shared, c.bitwidth),
+              bruteforceBankConflictsPerWavefront(c.shape, c.reg, c.shared,
+                                                  c.bitwidth))
+
+        << toLL(c.shape, c.reg).invertAndCompose(toLL(c.shape, c.shared))
+        << "\nbitwidth=" << c.bitwidth << "\n"
+        << attrStr(c.reg) << "\n"
+        << attrStr(c.shared);
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8200

Upstream commit message:
```
> [GLUON] Fix the bank_conflict computation in the presence of shmem broadcasting (#8200)

> Before we forgot to model the fact that if two threads access the same
> address, this address is broadcasted. We model this, and test against a
> function that computes the bankconflicts bruteforcing all the memory
> accesses.

> We assume in the writes the hardware will just do one write per
> wavefront.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 5608ea1c450b136d71f0867b64e663026e201323
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Reviewed By: dshi7

Differential Revision: D93954605
