### PR TITLE
[triton][beta][proton] Fix Env.h and doStop NVTX asymmetry

### DIFF
--- a/third_party/proton/csrc/include/Utility/Env.h
+++ b/third_party/proton/csrc/include/Utility/Env.h
@@ -1,17 +1,21 @@
+#ifndef PROTON_UTILITY_ENV_H_
+#define PROTON_UTILITY_ENV_H_
+
 #include <algorithm>
 #include <cstdlib>
 #include <mutex>
 #include <string>
 
-static std::mutex getenv_mutex;
-
 inline bool getBoolEnv(const std::string &env, bool defaultValue) {
+  static std::mutex getenv_mutex;
   std::lock_guard<std::mutex> lock(getenv_mutex);
   const char *s = std::getenv(env.c_str());
   if (s == nullptr)
     return defaultValue;
-  std::string str(s ? s : "");
+  std::string str(s);
   std::transform(str.begin(), str.end(), str.begin(),
                  [](unsigned char c) { return std::tolower(c); });
   return str == "on" || str == "true" || str == "1";
 }
+
+#endif // PROTON_UTILITY_ENV_H_

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -449,8 +449,10 @@ void CuptiProfiler::CuptiProfilerPimpl::doStop() {
   setGraphCallbacks(subscriber, /*enable=*/false);
   setRuntimeCallbacks(subscriber, /*enable=*/false);
   setDriverCallbacks(subscriber, /*enable=*/false);
-  nvtx::disable();
-  setNvtxCallbacks(subscriber, /*enable=*/false);
+  if (getBoolEnv("TRITON_ENABLE_NVTX", true)) {
+    nvtx::disable();
+    setNvtxCallbacks(subscriber, /*enable=*/false);
+  }
   cupti::unsubscribe<true>(subscriber);
   cupti::finalize<true>();
 }

--- a/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
@@ -403,7 +403,9 @@ void RoctracerProfiler::RoctracerProfilerPimpl::doFlush() {
 void RoctracerProfiler::RoctracerProfilerPimpl::doStop() {
   roctracer::stop();
   roctracer::disableDomainCallback<true>(ACTIVITY_DOMAIN_HIP_API);
-  roctracer::disableDomainCallback<true>(ACTIVITY_DOMAIN_ROCTX);
+  if (getBoolEnv("TRITON_ENABLE_NVTX", true)) {
+    roctracer::disableDomainCallback<true>(ACTIVITY_DOMAIN_ROCTX);
+  }
   roctracer::disableDomainActivity<true>(ACTIVITY_DOMAIN_HIP_OPS);
   roctracer::closePool<true>();
 }


### PR DESCRIPTION
Summary:
Fix issues introduced by D93835574:

- Add missing include guard to Env.h
- Move static mutex inside getBoolEnv to avoid ODR violation across TUs
- Make doStop() conditionally disable NVTX/ROCTX callbacks to match the
  conditional enable in doStart(), preventing errors when TRITON_ENABLE_NVTX
  is false

Differential Revision: D94012029


