### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[AMD] Initial support for wmma on gfx1250 (#8174)'

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1202,15 +1202,16 @@ def AMDWmmaEncodingAttr : DistributedEncoding<"AMDWmmaEncoding", "amd_wmma_encod
   let description = [{
 An encoding for tensors that have been produced by WMMA matrix core instructions,
 available on AMD Radeon GPUs of RDNA architectures.
-- A `version` parameter specifies instruction version to lower in. The data
-  distribution within one warp is also depends on it. Following architectures are
-  supported:
-  - 1: gfx11
-  - 2: gfx12
-- A `warpsPerCTA` parameter characterizes data distribution between warps.
-  An important limitation of WMMA for layout is a shape for tiles processed
-  by a single warp. It is [16, 16].
-  This encoding assumes specific access to matrix elements by threads.
+
+It is characterized by the following parameters:
+- `version` indicates the GPU architecture:
+  - 1: RDNA3; e.g., gfx1100, gfx1101
+  - 2: RDNA4; e.g., gfx1200, gfx1201
+  - 3: gfx1250
+- `warpsPerCTA` indicates the warp layout in the block.
+- `instrShape` indicates the shape in the form of (M, N, K) of the matrix
+   operation performed by a single WMMA instruction. Defaults to (16, 16, 16).
+- `isTransposed` indicates the layout of the result tensor is transposed.
 
 Example:
 Suppose we have a tensor with shape [32, 64], `warpsPerCTA` set to [2, 2].
@@ -1239,7 +1240,7 @@ Row |                  warp 0                                    warp 1
 30  |[0  1  2  ... 14 15] [0  1  2  ... 14 15] [0  1  2  ... 14 15] [0  1  2  ... 14 15]
 31  |[16 17 18 ... 30 31] [16 17 18 ... 30 31] [16 17 18 ... 30 31] [16 17 18 ... 30 31]
 
-// ------------------------ version = 2, isTransposed = false ------------------------ //
+// ------------------------ version = 2/3, isTransposed = false ------------------------ //
 
 Row |       warp 0                warp 1
     |/--------^---------\ /---------^--------\
@@ -1267,7 +1268,7 @@ Row |       warp 0                warp 1
 30  |[16 17 18 ... 30 31] [16 17 18 ... 30 31]
 31  |[16 17 18 ... 30 31] [16 17 18 ... 30 31]
 
-// ------------------------ version = 2, isTransposed = true ------------------------ //
+// ------------------------ version = 2/3, isTransposed = true ------------------------ //
 
     |               warp 0                     warp 1
     |/----------------^----------------\ /-------^-------\
@@ -1293,18 +1294,21 @@ Row |
     "unsigned": $version,
     "bool":$isTransposed,
     ArrayRefParameter<"unsigned">:$warpsPerCTA,
-    "CTALayoutAttr":$CTALayout
+    "CTALayoutAttr":$CTALayout,
+    ArrayRefParameter<"unsigned">:$instrShape
   );
 
   let genVerifyDecl = 1;
   let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = extraDistributedDeclaration # [{
-    SmallVector<int64_t> getElemsPerInstrForOperands(int kDim, int opIdx) const;
     SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> operandShape,
-                                          Type elemType, int kWidth, int kDim, int opIdx) const;
+                                          Type elemType, int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
-    static SmallVector<unsigned> getMNKDimPerInstr();
+
+    static SmallVector<unsigned, 3> getDefaultInstrShape() {
+      return {16, 16, 16};
+    }
 
     // Returns a swizzled shared layout matching this WMMA layout for the
     // dot operand at the given |operandIdx| with |operandShape|.

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1303,6 +1303,7 @@ Attribute AMDWmmaEncodingAttr::parse(AsmParser &parser, Type type) {
   std::optional<SmallVector<unsigned>> CTAsPerCGA;
   std::optional<SmallVector<unsigned>> CTASplitNum;
   std::optional<SmallVector<unsigned>> CTAOrder;
+  SmallVector<unsigned> instrShape = getDefaultInstrShape();
 
   for (const NamedAttribute &attr : dict) {
     if (attr.getName() == "version") {
@@ -1332,6 +1333,12 @@ Attribute AMDWmmaEncodingAttr::parse(AsmParser &parser, Type type) {
               .failed())
         return {};
     }
+    if (attr.getName() == "instrShape") {
+      instrShape.clear();
+      if (parseIntArrayAttr(parser, attr, instrShape, "instrShape").failed()) {
+        return {};
+      }
+    }
   }
 
   std::optional<CTALayoutAttr> CTALayout = getCTALayoutOrError(
@@ -1339,28 +1346,48 @@ Attribute AMDWmmaEncodingAttr::parse(AsmParser &parser, Type type) {
   if (!CTALayout.has_value())
     return {};
 
-  return parser.getChecked<AMDWmmaEncodingAttr>(
-      parser.getContext(), version, isTransposed, warpsPerCTA, *CTALayout);
+  return parser.getChecked<AMDWmmaEncodingAttr>(parser.getContext(), version,
+                                                isTransposed, warpsPerCTA,
+                                                *CTALayout, instrShape);
 }
 
 void AMDWmmaEncodingAttr::print(AsmPrinter &printer) const {
   printer << "<{"
           << "version = " << getVersion()
-          << ", isTranspose = " << getIsTransposed() << ", warpsPerCTA = ["
-          << ArrayRef(getWarpsPerCTA()) << "]";
+          << ", isTranspose = " << getIsTransposed() //
+          << ", warpsPerCTA = [" << ArrayRef(getWarpsPerCTA()) << "]";
+
   maybePrintCTALayout(getContext(), printer, getCTALayout(),
                       /*rank=*/getWarpsPerCTA().size());
+
+  if (getInstrShape() != ArrayRef(getDefaultInstrShape())) {
+    printer << ", instrShape = [" << getInstrShape() << "]";
+  }
   printer << "}>";
 }
 
-LogicalResult
-AMDWmmaEncodingAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
-                            unsigned version, bool isTransposed,
-                            llvm::ArrayRef<unsigned int> warpsPerCTA,
-                            mlir::triton::gpu::CTALayoutAttr) {
-  if (version != 1 && version != 2) {
-    return emitError() << "WMMA version must be in the [1, 2] range";
-  }
+LogicalResult AMDWmmaEncodingAttr::verify(
+    function_ref<mlir::InFlightDiagnostic()> emitError, unsigned version,
+    bool isTransposed, llvm::ArrayRef<unsigned int> warpsPerCTA,
+    CTALayoutAttr ctaLayout, llvm::ArrayRef<unsigned> instrShape) {
+  if (!(version >= 1 && version <= 3))
+    return emitError() << "WMMA version must be in the [1, 3] range";
+
+  auto shape = SmallVector<unsigned>(instrShape);
+  auto validShapesV1 = std::vector<llvm::SmallVector<unsigned>>{{16, 16, 16}};
+  if (version == 1 && !llvm::is_contained(validShapesV1, shape))
+    return emitError() << "invalid WMMA v1 instruction shape";
+
+  auto validShapesV2 =
+      std::vector<llvm::SmallVector<unsigned>>{{16, 16, 16}, {16, 16, 32}};
+  if (version == 2 && !llvm::is_contained(validShapesV2, shape))
+    return emitError() << "invalid WMMA v2 instruction shape";
+
+  auto validShapesV3 =
+      std::vector<llvm::SmallVector<unsigned>>{{16, 16, 32}, {16, 16, 64}};
+  if (version == 3 && !llvm::is_contained(validShapesV3, shape))
+    return emitError() << "invalid WMMA v3 instruction shape";
+
   return success();
 }
 
@@ -2273,18 +2300,13 @@ AMDWmmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
 }
 
 SmallVector<int64_t>
-AMDWmmaEncodingAttr::getElemsPerInstrForOperands(int kDim, int opIdx) const {
-  if (opIdx == 0)
-    return {16, kDim};
-  else
-    return {kDim, 16};
-}
-
-SmallVector<int64_t>
 AMDWmmaEncodingAttr::getRepForOperand(ArrayRef<int64_t> operandShape,
-                                      Type elemType, int kWidth, int kDim,
-                                      int opIdx) const {
-  auto operandTileShape = getElemsPerInstrForOperands(kDim, opIdx);
+                                      Type elemType, int opIdx) const {
+  auto mnkDim = getInstrShape();
+  auto operandTileShape = opIdx == 0
+                              ? SmallVector<int64_t>{mnkDim[0], mnkDim[2]}
+                              : SmallVector<int64_t>{mnkDim[2], mnkDim[1]};
+
   assert(operandTileShape.size() == 2);
   auto warpsPerCTA = getWarpsPerCTA();
   auto rank = operandShape.size();
@@ -2305,11 +2327,6 @@ AMDWmmaEncodingAttr::getRepForOperand(ArrayRef<int64_t> operandShape,
         std::max<int64_t>(1, operandShape[rank - 1] / (operandTileShape[1] *
                                                        warpsPerCTA[rank - 1]))};
   }
-}
-
-SmallVector<unsigned> AMDWmmaEncodingAttr::getMNKDimPerInstr() {
-  // TODO: move magic numbers out of the code
-  return {16, 16, 16};
 }
 
 SwizzledSharedEncodingAttr AMDWmmaEncodingAttr::composeSharedLayoutForOperand(
@@ -2340,7 +2357,7 @@ SwizzledSharedEncodingAttr AMDWmmaEncodingAttr::composeSharedLayoutForOperand(
   // for both RDNA3 and RDNA4, the M/N dimension of wmma is 16
   // This represents the max number of rows that can be accessed
   // at the same time
-  int mDim = getMNKDimPerInstr()[0];
+  int mDim = getInstrShape()[0];
   int maxPhase =
       std::max(std::min(mDim / perPhase, innerDimLength / vectorSize), 1);
 
@@ -2473,12 +2490,17 @@ LogicalResult DotOperandEncodingAttr::verify(
   }
 
   if (auto parentAttr = mlir::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
-    if (kWidth != 8 && kWidth != 16 && parentAttr.getVersion() == 1 ||
-        kWidth != 4 && kWidth != 8 && kWidth != 16 &&
-            parentAttr.getVersion() == 2)
-      return emitError() << "ttg.dot_op kWidth parameter must be 8/16 for "
-                            "gfx11 and 4/8/16 for gfx12 (including packed "
-                            "cases for `scaled_dot`)";
+    if (parentAttr.getVersion() == 1 && (kWidth != 8 && kWidth != 16))
+      return emitError()
+             << "ttg.dot_op kWidth parameter must be 8/16 for WMMA v1 "
+                "(including packed cases for `scaled_dot`)";
+    if (parentAttr.getVersion() == 2 &&
+        (kWidth != 4 && kWidth != 8 && kWidth != 16))
+      return emitError()
+             << "ttg.dot_op kWidth parameter must be 4/8/16 for WMMA v2 "
+                "(including packed cases for `scaled_dot`)";
+    if (parentAttr.getVersion() == 3 && (kWidth != 8))
+      return emitError() << "ttg.dot_op kWidth parameter must be 8 for WMMA v3";
     return success();
   }
 

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -235,6 +235,7 @@ py::object layoutToGluon(Attribute layout) {
     return layouts.AMDWMMALayout(amdWmma.getVersion(),
                                  amdWmma.getIsTransposed(),
                                  toStdVector(amdWmma.getWarpsPerCTA()),
+                                 toStdVector(amdWmma.getInstrShape()),
                                  toStdVector(ctaLayout.getCTAsPerCGA()),
                                  toStdVector(ctaLayout.getCTASplitNum()),
                                  toStdVector(ctaLayout.getCTAOrder()));
@@ -382,12 +383,13 @@ void init_gluon_ir(py::module &&m) {
               std::vector<unsigned> &warpsPerCta,
               std::vector<unsigned> &ctasPerCga,
               std::vector<unsigned> &ctaSplitNum,
-              std::vector<unsigned> &ctaOrder) -> Attribute {
+              std::vector<unsigned> &ctaOrder,
+              std::vector<unsigned> &instrShape) -> Attribute {
              auto ctx = self.getContext();
              auto ctaLayout = self.getChecked<ttg::CTALayoutAttr>(
                  ctx, ctasPerCga, ctaSplitNum, ctaOrder);
-             return ttg::AMDWmmaEncodingAttr::get(ctx, version, transposed,
-                                                  warpsPerCta, ctaLayout);
+             return ttg::AMDWmmaEncodingAttr::get(
+                 ctx, version, transposed, warpsPerCta, ctaLayout, instrShape);
            })
       .def("get_padded_shared_layout",
            [](GluonOpBuilder &self, std::vector<unsigned> &intervals,

--- a/python/triton/experimental/gluon/language/amd/_ops.py
+++ b/python/triton/experimental/gluon/language/amd/_ops.py
@@ -1,0 +1,26 @@
+from triton import knobs
+from triton.experimental.gluon.language import _core as ttgl
+from triton.experimental.gluon.language._semantic import _check
+
+from .._layouts import DotOperandLayout
+from ._layouts import AMDWMMALayout
+
+
+def _wmma(version, a, b, acc, semantic):
+    """ Shared implementation for AMD WMMA operations for Gluon builtins """
+
+    _check(acc is not None, lambda: "acc is required")
+    layout = acc.type.layout
+    _check(
+        isinstance(layout, AMDWMMALayout) and layout.version == version,
+        lambda: f"Expected layout to be an instance of AMDWMMALayout with version {version}")
+    _check(
+        isinstance(a.type.layout, DotOperandLayout) and a.type.layout.parent == layout,
+        lambda: "Expected a's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
+    _check(
+        isinstance(b.type.layout, DotOperandLayout) and b.type.layout.parent == layout,
+        lambda: "Expected b's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
+
+    handle = semantic.dot(a, b, acc, input_precision=knobs.language.fp32_default, max_num_imprecise_acc=None,
+                          out_dtype=acc.dtype).handle
+    return ttgl.tensor(handle, acc.type)

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -1,0 +1,17 @@
+from ..._core import builtin
+from .._ops import _wmma
+
+__all__ = ["wmma"]
+
+
+@builtin
+def wmma(a, b, acc, _semantic=None):
+    """
+    Computes matrix-multiplication of a * b + acc using AMD WMMA instruction.
+
+    Args:
+        a (tensor): The operand a to be multiplied.
+        b (tensor): The operand b to be multiplied.
+        acc (tensor): The accumulator tensor.
+    """
+    return _wmma(3, a, b, acc, _semantic)

--- a/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
@@ -1,10 +1,5 @@
-from triton import knobs
-from triton.experimental.gluon.language import _core as ttgl
-from triton.experimental.gluon.language._semantic import _check
-
-from .._layouts import AMDWMMALayout
-from ..._layouts import DotOperandLayout
 from ..._core import builtin
+from .._ops import _wmma
 
 __all__ = ["wmma"]
 
@@ -19,18 +14,4 @@ def wmma(a, b, acc, _semantic=None):
         b (tensor): The operand b to be multiplied.
         acc (tensor): The accumulator tensor.
     """
-    _check(acc is not None, lambda: "acc is required")
-    layout = acc.type.layout
-    _check(
-        isinstance(layout, AMDWMMALayout) and layout.version == 1,
-        lambda: "Expected layout to be an instance of AMDWMMALayout with version 1")
-    _check(
-        isinstance(a.type.layout, DotOperandLayout) and a.type.layout.parent == layout,
-        lambda: "Expected a's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
-    _check(
-        isinstance(b.type.layout, DotOperandLayout) and b.type.layout.parent == layout,
-        lambda: "Expected b's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
-
-    handle = _semantic.dot(a, b, acc, input_precision=knobs.language.fp32_default, max_num_imprecise_acc=None,
-                           out_dtype=acc.dtype).handle
-    return ttgl.tensor(handle, acc.type)
+    return _wmma(1, a, b, acc, _semantic)

--- a/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
@@ -1,10 +1,5 @@
-from triton import knobs
-from triton.experimental.gluon.language import _core as ttgl
-from triton.experimental.gluon.language._semantic import _check
-
-from .._layouts import AMDWMMALayout
-from ..._layouts import DotOperandLayout
 from ..._core import builtin
+from .._ops import _wmma
 
 __all__ = ["wmma"]
 
@@ -19,18 +14,4 @@ def wmma(a, b, acc, _semantic=None):
         b (tensor): The operand b to be multiplied.
         acc (tensor): The accumulator tensor.
     """
-    _check(acc is not None, lambda: "acc is required")
-    layout = acc.type.layout
-    _check(
-        isinstance(layout, AMDWMMALayout) and layout.version == 2,
-        lambda: "Expected layout to be an instance of AMDWMMALayout with version 2")
-    _check(
-        isinstance(a.type.layout, DotOperandLayout) and a.type.layout.parent == layout,
-        lambda: "Expected a's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
-    _check(
-        isinstance(b.type.layout, DotOperandLayout) and b.type.layout.parent == layout,
-        lambda: "Expected b's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
-
-    handle = _semantic.dot(a, b, acc, input_precision=knobs.language.fp32_default, max_num_imprecise_acc=None,
-                           out_dtype=acc.dtype).handle
-    return ttgl.tensor(handle, acc.type)
+    return _wmma(2, a, b, acc, _semantic)

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt --split-input-file %s --verify-diagnostics
 
-// expected-error @+1 {{WMMA version must be in the [1, 2] range}}
+// expected-error @+1 {{WMMA version must be in the [1, 3] range}}
 #wmma = #ttg.amd_wmma<{version = 0, isTranspose = false, warpsPerCTA = [2, 2]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
     tt.func public @fn(%arg0: !tt.ptr<i32>) {

--- a/test/TritonGPU/invalid-attributes.mlir
+++ b/test/TritonGPU/invalid-attributes.mlir
@@ -42,15 +42,30 @@
 
 // -----
 
-// expected-error@+2 {{ttg.dot_op kWidth parameter must be 8/16 for gfx11 and 4/8/16 for gfx12 (including packed cases for `scaled_dot`)}}
+// expected-error@+2 {{ttg.dot_op kWidth parameter must be 8/16 for WMMA v1 (including packed cases for `scaled_dot`)}}
 #wmma = #ttg.amd_wmma<{version = 1, warpsPerCTA = [1, 4]}>
 #dot_op = #ttg.dot_op<{opIdx = 1, parent = #wmma}>
 
 // -----
 
-// expected-error@+2 {{ttg.dot_op kWidth parameter must be 8/16 for gfx11 and 4/8/16 for gfx12 (including packed cases for `scaled_dot`)}}
+// expected-error@+2 {{ttg.dot_op kWidth parameter must be 4/8/16 for WMMA v2 (including packed cases for `scaled_dot`)}}
 #wmma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 4]}>
 #dot_op = #ttg.dot_op<{opIdx = 1, parent = #wmma, kWidth = 32}>
+
+// -----
+
+// expected-error@+1 {{invalid WMMA v1 instruction shape}}
+#wmma = #ttg.amd_wmma<{version = 1, warpsPerCTA = [1, 1], instrShape = [16, 16, 32]}>
+
+// -----
+
+// expected-error@+1 {{invalid WMMA v2 instruction shape}}
+#wmma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 1], instrShape = [16, 16, 64]}>
+
+// -----
+
+// expected-error@+1 {{invalid WMMA v3 instruction shape}}
+#wmma = #ttg.amd_wmma<{version = 3, warpsPerCTA = [1, 1], instrShape = [16, 16, 16]}>
 
 // -----
 

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -2,6 +2,7 @@
 
 // CHECK: #[[$WMMA_GEN1:.*]] = #ttg.amd_wmma<{{.*}}version = 1{{.*}}>
 // CHECK: #[[$WMMA_GEN2:.*]] = #ttg.amd_wmma<{{.*}}version = 2{{.*}}>
+// CHECK: #[[$WMMA_GEN3:.*]] = #ttg.amd_wmma<{{.*}}version = 3{{.*}}>
 #blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [4, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
@@ -30,6 +31,20 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   tt.func @wmma_gen2_dot_op_layout(%0: tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) {
     %1 = ttg.convert_layout %0 : tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 1]}>, kWidth = 8}>>
     // CHECK:  %{{.+}} = ttg.convert_layout %{{.+}} : tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #{{.+}}}>> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$WMMA_GEN2]], kWidth = 8}>>
+    tt.return
+  }
+
+  // CHECK-LABEL: wmma_gen3_layout
+  tt.func @wmma_gen3_layout(%0: tensor<16x16xf32, #blocked>) {
+    %1 = ttg.convert_layout %0 : tensor<16x16xf32, #blocked> -> tensor<16x16xf32, #ttg.amd_wmma<{version = 3, warpsPerCTA = [1, 1], instrShape = [16, 16, 32]}>>
+    // CHECK:  %{{.+}} = ttg.convert_layout %{{.+}} : tensor<16x16xf32, #{{.+}}> -> tensor<16x16xf32, #[[$WMMA_GEN3]]>
+    tt.return
+  }
+
+  // CHECK-LABEL: wmma_gen3_dot_op_layout
+  tt.func @wmma_gen3_dot_op_layout(%0: tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    %1 = ttg.convert_layout %0 : tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #ttg.amd_wmma<{version = 3, warpsPerCTA = [1, 1], instrShape = [16, 16, 32]}>, kWidth = 8}>>
+    // CHECK:  %{{.+}} = ttg.convert_layout %{{.+}} : tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #{{.+}}}>> -> tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #[[$WMMA_GEN3]], kWidth = 8}>>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -49,11 +49,10 @@ enum class WMMAInstrType : uint8_t {
 
 using ValueTable = std::map<std::tuple<unsigned, unsigned, unsigned>, Value>;
 
-ValueTable
-getValuesFromDotOperandLayoutStruct(ConversionPatternRewriter &rewriter,
-                                    const LLVMTypeConverter *typeConverter,
-                                    Value value, int batch, int n0, int n1,
-                                    int kWidth, Type type, Location loc) {
+ValueTable getValuesFromDotOperandLayoutStruct(
+    ConversionPatternRewriter &rewriter, const LLVMTypeConverter *typeConverter,
+    int wmmaVer, Value value, int batch, int n0, int n1, int kBase, Type type,
+    Location loc) {
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
   auto elems = unpackLLElements(loc, value, rewriter);
   ValueTable vals;
@@ -61,23 +60,23 @@ getValuesFromDotOperandLayoutStruct(ConversionPatternRewriter &rewriter,
     for (int i = 0; i < n0; i++) {
       for (int j = 0; j < n1; j++) {
         Type elemTy = typeConverter->convertType(type);
-        Type ty = vec_ty(elemTy, kWidth);
+        Type ty = vec_ty(elemTy, kBase);
         Value rawElems = tb.undef(ty);
-        for (int k = 0; k < kWidth; ++k) {
+        for (int k = 0; k < kBase; ++k) {
           rawElems = tb.insert_element(
               ty, rawElems,
-              elems[n0 * n1 * kWidth * b + kWidth * (n1 * i + j) + k],
+              elems[n0 * n1 * kBase * b + kBase * (n1 * i + j) + k],
               tb.i32_val(k));
         }
 
         Value convertedElems;
-        if (type.isF16()) {
+        if (type.isF16() || (wmmaVer == 3 && type.isBF16())) {
           convertedElems = rawElems;
         } else if (type.isBF16()) {
-          convertedElems = tb.bitcast(rawElems, vec_ty(i16_ty, kWidth));
+          convertedElems = tb.bitcast(rawElems, vec_ty(i16_ty, kBase));
         } else {
           convertedElems = tb.bitcast(
-              rawElems, vec_ty(i32_ty, kWidth * type.getIntOrFloatBitWidth() /
+              rawElems, vec_ty(i32_ty, kBase * type.getIntOrFloatBitWidth() /
                                            i32_ty.getIntOrFloatBitWidth()));
         }
         vals[{b, i, j}] = convertedElems;
@@ -211,55 +210,87 @@ StringRef getWmmaIntrinsicName(Type aElTy, Type bElTy, Type dElTy, Type valATy,
   return intrinsics[h];
 }
 
-std::string addInstructionSuffix(std::string intrinsicName, unsigned kWidth,
-                                 Type aElTy, Type bElTy, Type dElTy,
-                                 bool tied) {
+std::string addInstructionSuffix(std::string intrinsicName, unsigned kBase,
+                                 unsigned elemsPerVec, Type aElTy, Type bElTy,
+                                 Type dElTy, bool tied) {
   if (tied) {
     intrinsicName += ".tied";
   } else {
     if (isa<FloatType>(aElTy) && aElTy.getIntOrFloatBitWidth() == 8)
       intrinsicName += "." + getTypeStr(bElTy);
-    intrinsicName += ".v" + std::to_string(kWidth) + getTypeStr(dElTy);
-    intrinsicName += ".v" + std::to_string(kWidth) + getTypeStr(aElTy);
+    intrinsicName += ".v" + std::to_string(elemsPerVec) + getTypeStr(dElTy);
+    intrinsicName += ".v" + std::to_string(kBase) + getTypeStr(aElTy);
   }
 
   return intrinsicName;
 }
 
 Value generateWMMAIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
-                            Value valA, Value valB, Value valC, Type aElType,
-                            Type bElType, Type dElType, StringRef name,
-                            std::optional<bool> tiedLower) {
+                            int wmmaVer, Value valA, Value valB, Value valC,
+                            Type aElType, Type bElType, Type dElType,
+                            StringRef name, std::optional<bool> tiedLower) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   LLVM::FastmathFlagsAttr defaultFlags{};
   SmallVector<Value> operands;
-  if (aElType.isInteger())
-    operands.push_back(b.int_val(1, !aElType.isUnsignedInteger()));
-  operands.push_back(valA);
-  if (bElType.isInteger())
-    operands.push_back(b.int_val(1, !bElType.isUnsignedInteger()));
-  operands.push_back(valB);
-  operands.push_back(valC);
-  // Flag for using low bits in registers. Result could be already packed to
-  // int32. Set low bits by default for now.
-  if (tiedLower.has_value() || 32 / dElType.getIntOrFloatBitWidth() > 1 ||
-      dElType.isInteger(32)) {
-    operands.push_back(b.int_val(1, tiedLower.value_or(false)));
+
+  if (wmmaVer == 1 || wmmaVer == 2) {
+    // arguments for v1 and v2:
+    // int:   %A_sign, %A, %B_sign, %B, %C, [%clamp]
+    // float: %A, %B, %C, [%tied_to_high]
+    if (aElType.isInteger())
+      operands.push_back(b.int_val(1, !aElType.isUnsignedInteger()));
+    operands.push_back(valA);
+
+    if (bElType.isInteger())
+      operands.push_back(b.int_val(1, !bElType.isUnsignedInteger()));
+    operands.push_back(valB);
+
+    operands.push_back(valC);
+
+    if (tiedLower.has_value() || 32 / dElType.getIntOrFloatBitWidth() > 1 ||
+        dElType.isInteger(32))
+      operands.push_back(b.int_val(1, tiedLower.value_or(false)));
+  } else {
+    assert(wmmaVer == 3 && "unexpected wmma version");
+    // arguments for v3:
+    // int:       %A_mod, %A, %B_mod, %B, %C, %A_reuse, %B_reuse
+    // fp16/bf16: %A_mod, %A, %B_mod, %B, %C_mod, %C, %A_reuse, %B_reuse
+    // fp8/bf8:   %A, %B, %C_mod, %C, %A_reuse, %B_reuse
+    if (aElType.isInteger())
+      operands.push_back(b.int_val(1, !aElType.isUnsignedInteger()));
+    else if (aElType.isBF16() || aElType.isF16())
+      operands.push_back(b.int_val(1, 0));
+    operands.push_back(valA);
+
+    if (bElType.isInteger())
+      operands.push_back(b.int_val(1, !bElType.isUnsignedInteger()));
+    else if (bElType.isBF16() || bElType.isF16())
+      operands.push_back(b.int_val(1, 0));
+    operands.push_back(valB);
+
+    if ((bElType.isBF16() || bElType.isF16()) || aElType.isInteger())
+      operands.push_back(b.int_val(16, 0));
+    operands.push_back(valC);
+
+    operands.push_back(b.i1_val(0));
+    operands.push_back(b.i1_val(0));
   }
+
   auto wmmaIntrinsic = LLVM::createLLVMIntrinsicCallOp(
       rewriter, loc, name, valC.getType(), operands);
   return wmmaIntrinsic.getResult(0);
 }
 
 Value generateWMMAOp(ConversionPatternRewriter &rewriter, Location loc,
-                     Value valA, Value valB, Value valC, Type aElType,
-                     Type bElType, Type dElType, StringRef intrinsicName,
-                     std::optional<bool> tiedLower) {
+                     int version, Value valA, Value valB, Value valC,
+                     Type aElType, Type bElType, Type dElType,
+                     StringRef intrinsicName, std::optional<bool> tiedLower) {
   // Independent of wmma version because builtin functions are backward
   // compatible
-  return generateWMMAIntrinsic(rewriter, loc, valA, valB, valC, aElType,
-                               bElType, dElType, intrinsicName, tiedLower);
+  return generateWMMAIntrinsic(rewriter, loc, version, valA, valB, valC,
+                               aElType, bElType, dElType, intrinsicName,
+                               tiedLower);
 }
 
 // Conduct the Dot conversion.
@@ -270,7 +301,7 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
       cast<RankedTensorType>(op.getResult().getType()).getEncoding());
   int wmmaVer = wmmaLayout.getVersion();
   auto warpsPerCTA = wmmaLayout.getWarpsPerCTA();
-  auto mnkDim = AMDWmmaEncodingAttr::getMNKDimPerInstr();
+  auto mnkDim = wmmaLayout.getInstrShape();
 
   auto loc = op.getLoc();
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
@@ -300,13 +331,10 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
 
   auto aEncoding = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
   auto bEncoding = cast<DotOperandEncodingAttr>(bTensorTy.getEncoding());
-  int kWidth = aEncoding.getKWidth();
   intrinsicName = maybeWmmaIntrinsic->name;
 
-  auto repA = wmmaLayout.getRepForOperand(aTensorTy.getShape(), aElemTy, kWidth,
-                                          kDim, 0);
-  auto repB = wmmaLayout.getRepForOperand(bTensorTy.getShape(), bElemTy, kWidth,
-                                          kDim, 1);
+  auto repA = wmmaLayout.getRepForOperand(aTensorTy.getShape(), aElemTy, 0);
+  auto repB = wmmaLayout.getRepForOperand(bTensorTy.getShape(), bElemTy, 1);
 
   assert(repA[2] == repB[1]);
 
@@ -318,12 +346,13 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   auto numRepK = repA[2];
   auto numRepB = repA[0];
 
+  int kBase = maybeWmmaIntrinsic->kBase;
   ValueTable ha = getValuesFromDotOperandLayoutStruct(
-      rewriter, typeConverter, loadedA, numRepB, numRepM, numRepK, kWidth,
-      aTensorTy.getElementType(), loc);
+      rewriter, typeConverter, wmmaVer, loadedA, numRepB, numRepM, numRepK,
+      kBase, aTensorTy.getElementType(), loc);
   ValueTable hb = getValuesFromDotOperandLayoutStruct(
-      rewriter, typeConverter, loadedB, numRepB, numRepN, numRepK, kWidth,
-      aTensorTy.getElementType(), loc);
+      rewriter, typeConverter, wmmaVer, loadedB, numRepB, numRepN, numRepK,
+      kBase, aTensorTy.getElementType(), loc);
   auto dstElemTy = dTensorTy.getElementType();
   auto fc = unpackLLElements(loc, loadedC, rewriter);
 
@@ -339,8 +368,8 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   bool tied = numRepM % 2 == 0 && paddedOutputElemSize == 2;
   int tiedGroup = tied ? 2 : 1;
 
-  intrinsicName = addInstructionSuffix(intrinsicName, kWidth, aElemTy, bElemTy,
-                                       dElemTy, tied);
+  intrinsicName = addInstructionSuffix(intrinsicName, kBase, elemsPerVec,
+                                       aElemTy, bElemTy, dElemTy, tied);
   for (int b = 0; b < numRepB; ++b) {
     for (int m = 0; m < numRepM / tiedGroup; ++m) {
       for (int n = 0; n < numRepN; ++n) {
@@ -364,16 +393,17 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
             auto optTied =
                 tied ? std::optional<bool>(subTied != 0) : std::nullopt;
             acc = wmmaLayout.getIsTransposed()
-                      ? generateWMMAOp(rewriter, loc, hb[{b, n, k}],
+                      ? generateWMMAOp(rewriter, loc, wmmaVer, hb[{b, n, k}],
                                        ha[{b, m * tiedGroup + subTied, k}], acc,
                                        bTensorTy.getElementType(),
                                        aTensorTy.getElementType(), dstElemTy,
                                        intrinsicName, optTied)
-                      : generateWMMAOp(
-                            rewriter, loc, ha[{b, m * tiedGroup + subTied, k}],
-                            hb[{b, n, k}], acc, aTensorTy.getElementType(),
-                            bTensorTy.getElementType(), dstElemTy,
-                            intrinsicName, optTied);
+                      : generateWMMAOp(rewriter, loc, wmmaVer,
+                                       ha[{b, m * tiedGroup + subTied, k}],
+                                       hb[{b, n, k}], acc,
+                                       aTensorTy.getElementType(),
+                                       bTensorTy.getElementType(), dstElemTy,
+                                       intrinsicName, optTied);
           }
         }
         for (unsigned v = 0; v < dElemsToStorePerThread; ++v) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
@@ -43,7 +43,7 @@ createTmpLayout(triton::gpu::DistributedEncodingTrait layout,
   if (auto src = dyn_cast<triton::gpu::AMDWmmaEncodingAttr>(layout))
     return triton::gpu::AMDWmmaEncodingAttr::get(
         ctx, src.getVersion(), src.getIsTransposed(), warpsPerCTA,
-        src.getCTALayout());
+        src.getCTALayout(), src.getInstrShape());
   if (auto src = dyn_cast<triton::gpu::BlockedEncodingAttr>(layout))
     return triton::gpu::BlockedEncodingAttr::get(
         ctx, src.getSizePerThread(), src.getThreadsPerWarp(), warpsPerCTA,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1298,7 +1298,8 @@ public:
     // store instructions.
     bool isTransposed = true;
     wmmaEnc = ttg::AMDWmmaEncodingAttr::get(ctx, wmmaVersion, isTransposed,
-                                            warpsPerTile, CTALayout);
+                                            warpsPerTile, CTALayout,
+                                            {mDim, nDim, kDim});
 
     auto newRetType = RankedTensorType::get(retShape, operandTypes[3], wmmaEnc);
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
@@ -90,6 +90,10 @@ WmmaDatabase::WmmaDatabase(MLIRContext *context) {
       TRITON_WMMA_v(2, 16, 16, bf16T, bf16T, 16, f32T, 32,
                     "llvm.amdgcn.wmma.f32.16x16x16.bf16", 16, 8),
 
+      // wmma_f32_16x16x32_bf16
+      TRITON_WMMA_v(3, 16, 16, bf16T, bf16T, 16, f32T, 32,
+                    "llvm.amdgcn.wmma.f32.16x16x32.bf16.bf16", 32, 16),
+
       // wmma_f32_16x16x16_f16
       TRITON_WMMA_v(1, 16, 16, f16T, f16T, 16, f32T, 32,
                     "llvm.amdgcn.wmma.f32.16x16x16.f16", 16, 16),
@@ -133,6 +137,9 @@ WmmaDatabase::WmmaDatabase(MLIRContext *context) {
       TRITON_WMMA_v(2, 16, 16, ocpBf8T, ocpBf8T, 8, f32T, 32,
                     "llvm.amdgcn.wmma.f32.16x16x16.bf8.bf8", 16, 8),
 
+      // wmma_f32_16x16x64_bf8_bf8
+      TRITON_WMMA_v(3, 16, 16, ocpBf8T, ocpBf8T, 8, f32T, 32,
+                    "llvm.amdgcn.wmma.f32.16x16x64.bf8.bf8", 64, 32),
   };
 }
 

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -1,0 +1,111 @@
+# ruff: noqa: E402
+import hip
+
+hip.hip.hipInit(0)
+# Needed for internal dev flow for now; will remove later
+
+import re
+import pytest
+import torch
+
+import triton
+from triton.backends.compiler import GPUTarget
+from triton.experimental import gluon
+import triton.experimental.gluon.language as ttgl
+
+
+@gluon.jit
+def gemm_kernel(a_ptr, b_ptr, c_ptr,  #
+                M, N, K,  #
+                stride_am, stride_ak,  #
+                stride_bk, stride_bn,  #
+                stride_cm, stride_cn,  #
+                BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr):
+
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
+    WMMA_LAYOUT: ttgl.constexpr = ttgl.amd.AMDWMMALayout(3, True, [2, 2], [16, 16, 32])
+
+    pid = ttgl.program_id(axis=0)
+    num_pid_m = ttgl.cdiv(M, BLOCK_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+
+    offs_am = pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))
+    offs_ak = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
+    offs_a = offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak
+
+    offs_bk = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))
+    offs_bn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
+    offs_b = offs_bk[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+
+    accumulator = ttgl.zeros((BLOCK_M, BLOCK_N), dtype=ttgl.float32, layout=WMMA_LAYOUT)
+    for k in range(0, ttgl.cdiv(K, BLOCK_K)):
+        mask_a = (offs_ak[None, :] < K - k * BLOCK_K) & (offs_am[:, None] < M)
+        mask_b = (offs_bk[:, None] < K - k * BLOCK_K) & (offs_bn[None, :] < N)
+
+        a = ttgl.load(a_ptr + offs_a, mask=mask_a, other=0.0)
+        b = ttgl.load(b_ptr + offs_b, mask=mask_b, other=0.0)
+
+        a = ttgl.convert_layout(a, ttgl.DotOperandLayout(0, WMMA_LAYOUT, 8))
+        b = ttgl.convert_layout(b, ttgl.DotOperandLayout(1, WMMA_LAYOUT, 8))
+
+        accumulator = ttgl.amd.gfx1250.wmma(a, b, accumulator)
+
+        offs_a += BLOCK_K * stride_ak
+        offs_b += BLOCK_K * stride_bk
+
+    offs_cm = pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, WMMA_LAYOUT))
+    offs_cn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, WMMA_LAYOUT))
+    offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    ttgl.store(c_ptr + offs_c, accumulator, mask=mask_c)
+
+
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(32, 32, 32), (64, 64, 64), (128, 128, 64)])
+def test_compile_gemm_bf16(BLOCK_M, BLOCK_N, BLOCK_K):
+    k = triton.compile(
+        gluon._runtime.GluonASTSource(
+            fn=gemm_kernel, signature={
+                "a_ptr": "*bf16", "b_ptr": "*bf16", "c_ptr": "*fp32", "M": "i32", "N": "i32", "K": "i32", "stride_am":
+                "i32", "stride_ak": "i32", "stride_bk": "i32", "stride_bn": "i32", "stride_cm": "i32", "stride_cn":
+                "i32", "BLOCK_M": "constexpr", "BLOCK_N": "constexpr", "BLOCK_K": "constexpr"
+            }, constexprs={"BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "BLOCK_K": BLOCK_K}),
+        target=GPUTarget("hip", 'gfx1250', 32))
+
+    amdgcn = k.asm["amdgcn"]
+    pattern = r"v_wmma_f32_16x16x32_bf16"
+    assert re.search(pattern, amdgcn), "The AMDGCN assembly does not contain the expected WMMA instruction."
+
+
+@pytest.mark.parametrize("M,N,K", [
+    (128, 128, 64),
+    (256, 256, 128),
+    (256, 128, 64),
+    (128, 256, 64),
+    (120, 120, 60),
+])
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(32, 32, 32), (64, 64, 64), (128, 128, 64)])
+def test_runtime_gemm_bf16(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K):
+    torch.manual_seed(42)
+    a = torch.randn((M, K), dtype=torch.bfloat16)
+    b = torch.randn((K, N), dtype=torch.bfloat16)
+    c = torch.zeros((M, N), dtype=torch.float32)
+    stride_am, stride_ak = a.stride(0), a.stride(1)
+    stride_bk, stride_bn = b.stride(0), b.stride(1)
+    stride_cm, stride_cn = c.stride(0), c.stride(1)
+
+    a_device = a.cuda()
+    b_device = b.cuda()
+    c_device = c.cuda()
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1)
+    gemm_kernel[grid](
+        a_device, b_device, c_device,  #
+        M, N, K,  #
+        stride_am, stride_ak,  #
+        stride_bk, stride_bn,  #
+        stride_cm, stride_cn,  #
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+
+    c_triton = c_device.cpu()
+    c_torch = a.to(torch.float32) @ b.to(torch.float32)
+    torch.testing.assert_close(c_triton, c_torch, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8174

Upstream commit message:
```
> [AMD] Initial support for wmma on gfx1250 (#8174)

> This PR adds initla support for wmma on gfx1250 architecture.
> Exposes the layout and wmma op through gluon.
```

Conflict Resolution:
- File: .github/workflows/integration-tests-amd.yml
  Action: Skipped (file does not exist in fbsource tree)
  Reason: GitHub CI workflow files are excluded from the internal repo. The 1 hunk for this file was harmlessly ignored. No actual merge conflict markers were present in any file.

Raw Conflicts: https://www.internalfb.com/intern/paste/P2202469190/

Diff Versions: Compare V1 (conflict markers) → V2 (resolved) in Phabricator

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: d638e58f06b7312c31a980a2fae09e2f94a0ba95

Reviewed By: stashuk-olek

Differential Revision: D94189801


