### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[BACKEND] Pick better layouts for descriptor load/store (#8208)'

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -106,6 +106,11 @@ def TT_DescriptorStoreLikeOpInterface : OpInterface<"DescriptorStoreLikeOpInterf
       /*retType=*/"::mlir::TypedValue<mlir::RankedTensorType>",
       /*methodName=*/"getSrc",
       /*args=*/(ins)>,
+    InterfaceMethod<
+      /*desc=*/"Get mutable source tensor",
+      /*retType=*/"::mlir::OpOperand&",
+      /*methodName=*/"getSrcMutable",
+      /*args=*/(ins)>,
   ];
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -22,6 +22,51 @@ namespace gpu {
 #define GEN_PASS_DEF_TRITONGPUCOALESCE
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
+// Descriptor load/stores don't need to consider L1 coalescing but the
+// destination layout will affect the shared memory load/store generated. So we
+// still want to allow vectorization for the src/destination layout up to
+// 16bytes.
+static Attribute pickDescriptorLoadStoreLayout(int numWarps, int threadsPerWarp,
+                                               RankedTensorType type) {
+  auto shapePerCTA = triton::gpu::getShapePerCTA(type);
+  int numElems = product<int64_t>(shapePerCTA);
+  int numThreads = numWarps * threadsPerWarp;
+  int numElemsPerThread = std::max(numElems / numThreads, 1);
+
+  int maxVectorSize = 128 / type.getElementTypeBitWidth();
+
+  int vectorSize = std::min(numElemsPerThread, maxVectorSize);
+  SmallVector<unsigned> sizePerThread(type.getRank(), 1);
+  sizePerThread.back() = vectorSize;
+
+  SmallVector<unsigned> order =
+      getMatrixOrder(type.getRank(), /*rowMajor*/ true);
+  auto CTALayout = triton::gpu::getCTALayout(type.getEncoding());
+
+  Attribute layout = triton::gpu::BlockedEncodingAttr::get(
+      type.getContext(), type.getShape(), sizePerThread, order, numWarps,
+      threadsPerWarp, CTALayout);
+  return layout;
+}
+
+static void pickDescriptorLoadStoreLayout(
+    ModuleOp moduleOp, llvm::MapVector<Operation *, Attribute> &layoutMap) {
+  int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(moduleOp);
+  moduleOp.walk([&](Operation *op) {
+    int numWarps = lookupNumWarps(op);
+    if (auto load = dyn_cast<DescriptorOpInterface>(op)) {
+      if (load->getNumResults() == 1)
+        layoutMap[op] = pickDescriptorLoadStoreLayout(
+            numWarps, threadsPerWarp,
+            cast<RankedTensorType>(load->getResult(0).getType()));
+    }
+    if (auto store = dyn_cast<DescriptorStoreLikeOpInterface>(op)) {
+      layoutMap[op] = pickDescriptorLoadStoreLayout(numWarps, threadsPerWarp,
+                                                    store.getSrc().getType());
+    }
+  });
+}
+
 struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
   // Set coalesced encoding for memory operations.
   // For local_load, we assume full contiguity since shared memory has known
@@ -179,6 +224,9 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
       setCoalescedEncoding(axisInfoAnalysis, curr, numWarps, threadsPerWarp,
                            layoutMap);
     });
+
+    // Also pick a layout for descriptor load/store ops.
+    pickDescriptorLoadStoreLayout(moduleOp, layoutMap);
 
     // For each memory op that has a layout L1:
     // 1. Create a coalesced memory layout L2 of the pointer operands

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -264,6 +264,8 @@ static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
 // Return true if the op is an op with a layout we don't want to change. We will
 // propagate the layout starting from anchor ops.
 bool isLayoutAnchor(Operation *op) {
+  if (isa<DescriptorOpInterface>(op))
+    return true;
   if (isa<LoadOp, StoreOp>(op))
     return isExpensiveLoadOrStore(op);
   // local_load is expensive as it reads from shared memory with specific layout

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1206,6 +1206,16 @@ static Type getNewType(Type type, Attribute encoding) {
                                tensorType.getElementType(), encoding);
 }
 
+static bool skipOperand(Operation *op, unsigned operandNumber) {
+  if (auto gather = dyn_cast<DescriptorGatherOp>(op)) {
+    return operandNumber == gather.getXOffsetsMutable().getOperandNumber();
+  }
+  if (auto scatter = dyn_cast<DescriptorScatterOp>(op)) {
+    return operandNumber == scatter.getXOffsetsMutable().getOperandNumber();
+  }
+  return false;
+}
+
 Operation *convertDistributedOpEncoding(Attribute encoding, Operation *op) {
   OpBuilder builder(op);
   // Convert operands
@@ -1213,10 +1223,11 @@ Operation *convertDistributedOpEncoding(Attribute encoding, Operation *op) {
   // operands' type, we do this by changing the outputs' type of
   // `make_tensor_ptr`
   SmallVector<Value, 4> newArgs;
-  for (auto operand : op->getOperands()) {
+  for (auto &opOperand : op->getOpOperands()) {
+    Value operand = opOperand.get();
     auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
-    if (tensorType &&
-        !isa<triton::gpu::SharedEncodingTrait>(tensorType.getEncoding())) {
+    bool skip = skipOperand(op, opOperand.getOperandNumber());
+    if (tensorType && !skip) {
       Type newType = getNewType(tensorType, encoding);
       newArgs.push_back(builder.create<triton::gpu::ConvertLayoutOp>(
           op->getLoc(), newType, operand));

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -364,14 +364,14 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_optimize_dot_operands(pm, capability >= 80)
         passes.ttgpuir.add_coalesce_async_copy(pm)
         nvidia.passes.ttnvgpuir.add_optimize_tmem_layouts(pm)
+        if capability // 10 >= 9:
+            nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         nvidia.passes.ttnvgpuir.add_interleave_tmem(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.ttir.add_loop_aware_cse(pm)
         passes.common.add_symbol_dce(pm)
-        if capability // 10 >= 9:
-            nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
         # Optimize the number of warps and registers after TMA lowering, so
         # that any local loads eliminated by TMA lowering do not inflate them.
         if capability // 10 >= 10 and knobs.nvidia.use_meta_ws:


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8208

Upstream commit message:
```
> [BACKEND] Pick better layouts for descriptor load/store (#8208)

> Those ops later generate smem load/store therefore we should pick a
> layout that will allow efficient accesses.
```

Conflict Resolution:
- File: third_party/nvidia/backend/compiler.py:375-383
  Action: Removed duplicate add_tma_lowering call (already moved earlier in pipeline at line 367-368 by this same upstream commit), preserved Meta-specific add_optimize_partition_warps block
  Reason: Upstream reorganized the pass pipeline, moving add_tma_lowering earlier. The duplicate at this location was removed upstream. The Meta-specific add_optimize_partition_warps pass (guarded by knobs.nvidia.use_meta_ws) is not present upstream and must be preserved.

Raw Conflicts: https://www.internalfb.com/intern/paste/P2202883498/

Diff Versions: Compare V1 (conflict markers) → V2 (resolved) in Phabricator

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 3241bd20068778ba85ac386c82168d25454d9fab

Reviewed By: stashuk-olek

Differential Revision: D94221091
