### PR TITLE
[triton][beta] [Cherry-pick] '[BC-BREAK][PROTON] Prevent updating the same metric valueId with different types. (#7979)'

### DIFF
--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -184,6 +184,7 @@ def test_scope_metrics(tmp_path: pathlib.Path):
     proton.exit_scope(metrics={"b": 1.0})
 
     proton.finalize()
+
     assert temp_file.exists()
     with temp_file.open() as f:
         data = json.load(f)
@@ -193,6 +194,26 @@ def test_scope_metrics(tmp_path: pathlib.Path):
             assert child["metrics"]["a"] == 2.0
         elif child["frame"]["name"] == "test4":
             assert child["metrics"]["b"] == 1.0
+
+
+def test_scope_metrics_invalid(tmp_path: pathlib.Path):
+    temp_file = tmp_path / "test_scope_metrics.hatchet"
+    proton.start(str(temp_file.with_suffix("")), backend="instrumentation")
+
+    error = None
+
+    try:
+        with proton.scope("test0", {"a": 1.0}):
+            pass
+
+        with proton.scope("test0", {"a": 1}):
+            pass
+    except Exception as e:
+        error = str(e)
+    finally:
+        proton.finalize()
+
+    assert error is not None and "Metric value type mismatch for valueId 0 (a): current=double, new=uint64_t" in error
 
 
 def test_scope_properties(tmp_path: pathlib.Path):


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/7979

Upstream commit message:
```
> [BC-BREAK][PROTON] Prevent updating the same metric valueId with different types. (#7979)
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 9effbbb1f649d414b29c4b71ad4d0f22ab232ada
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Reviewed By: stashuk-olek

Differential Revision: D94231619


