### PR TITLE
[triton][beta] Fix autoWS lit test crashes and MLIR parse errors

### DIFF
--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -67,7 +67,7 @@ std::optional<std::pair<AllocOp, LoadOp>> isLoadAndAlloc(Value result) {
   if (!alloc)
     return std::nullopt;
   if (auto load = alloc.getSrc().template getDefiningOp<LoadOp>();
-      *getPartitionIds(alloc) == *getPartitionIds(load)) {
+      load && samePartition(alloc, load)) {
     // if alloc and load are in different partitions, they are treated as two
     // different producer operations.
     return std::make_pair(alloc, load);


### PR DESCRIPTION
Summary:
Fix Triton beta autoWS lit tests that were failing due to three categories of bugs:

1. Null dereference crash in InsertAref.cpp — The isLoadAndAlloc function
   dereferences std::optional values from getPartitionIds() without checking
   if they're engaged. Fixed by reusing the existing samePartition() helper
   which already has null guards, plus adding a null check on load.

2. Invalid MLIR syntax in load-mma-specialization.mlir — The file used
   backslash line continuation characters (invalid MLIR) and had spaces
   between % and SSA names. Fixed by collapsing attributes onto single lines
   and removing errant spaces (~70 occurrences).

3. Corrupted RUN lines in load-mma-specialization.mlir — The // RUN:
   directives were broken across comment lines. Restored to proper format.

Both tests now parse and execute without crashes. CHECK line mismatches
remain (the autoWS pass produces different partition structures than
expectations), so XFAIL: * is retained.

Authored with Claude.

Differential Revision: D94611228


