### PR TITLE
[AutoWS] Fuse allocations in AutoWS with TMA store descriptor

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -94,6 +94,21 @@ def TritonNvidiaGPUTMALoweringPass : Pass<"triton-nvidia-tma-lowering", "mlir::M
   ];
 }
 
+def TritonNvidiaGPUTMAStoreBufferReusePass
+    : Pass<"triton-nvidia-tma-store-buffer-reuse", "mlir::ModuleOp"> {
+  let summary = "Reuse SMEM buffers across sequential TMA stores";
+  let description = [{
+    After TMA lowering, sequential descriptor stores each allocate their own
+    shared memory buffer. When a tma_store_wait with pendings=0 guarantees
+    the buffer is safe to reuse, this pass merges compatible allocations
+    into a single mutable buffer with local_store writes.
+  }];
+  let dependentDialects = [
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+
 def TritonTensorMemoryAllocationPass : Pass<"triton-tensor-memory-allocation", "mlir::ModuleOp"> {
   let summary = "Assign tensor memory allocation";
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   RemoveTMEMTokens.cpp
   TensorMemoryAllocation.cpp
   TMALowering.cpp
+  TMAStoreBufferReuse.cpp
   TMAUtilities.cpp
   Utility.cpp
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAStoreBufferReuse.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAStoreBufferReuse.cpp
@@ -1,0 +1,173 @@
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUTMASTOREBUFFERREUSEPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+namespace ttg = triton::gpu;
+
+struct CandidateInfo {
+  ttg::LocalAllocOp alloc;
+  Operation *tmaCopyOp;
+  Operation *donePoint;
+  unsigned blockPosition;
+};
+
+static bool isTMAStoreUser(Operation *op) {
+  return isa<AsyncTMACopyLocalToGlobalOp, AsyncTMAScatterOp, AsyncTMAReduceOp>(
+      op);
+}
+
+// A LocalAllocOp is a candidate for buffer reuse if:
+// - It has a src operand (initialized alloc from TMA lowering)
+// - Its result memdesc is in shared memory
+// - It has exactly one user, which is a TMA store op
+static bool isCandidate(ttg::LocalAllocOp alloc) {
+  if (!alloc.getSrc())
+    return false;
+
+  auto memDescTy = cast<ttg::MemDescType>(alloc.getType());
+  if (!isa<ttg::SharedMemorySpaceAttr>(memDescTy.getMemorySpace()))
+    return false;
+
+  if (!alloc->hasOneUse())
+    return false;
+
+  return isTMAStoreUser(*alloc->getUsers().begin());
+}
+
+// Walk forward from the TMA copy op to find a TMAStoreWaitOp with pendings=0
+// in the same block.
+static Operation *findDonePoint(Operation *tmaCopyOp) {
+  for (Operation *op = tmaCopyOp->getNextNode(); op; op = op->getNextNode()) {
+    if (auto waitOp = dyn_cast<TMAStoreWaitOp>(op)) {
+      if (waitOp.getPendings() == 0)
+        return op;
+    }
+  }
+  return nullptr;
+}
+
+static ttg::MemDescType getMutableType(ttg::MemDescType ty) {
+  return ttg::MemDescType::get(ty.getShape(), ty.getElementType(),
+                               ty.getEncoding(), ty.getMemorySpace(),
+                               /*mutableMemory=*/true);
+}
+
+static void processBlock(Block &block) {
+  // Build position map for ordering checks.
+  DenseMap<Operation *, unsigned> opPosition;
+  unsigned pos = 0;
+  for (Operation &op : block)
+    opPosition[&op] = pos++;
+
+  // Collect candidates in block order.
+  SmallVector<CandidateInfo> candidates;
+  for (Operation &op : block) {
+    auto alloc = dyn_cast<ttg::LocalAllocOp>(&op);
+    if (!alloc || !isCandidate(alloc))
+      continue;
+
+    Operation *tmaOp = *alloc->getUsers().begin();
+    Operation *donePoint = findDonePoint(tmaOp);
+    if (!donePoint)
+      continue;
+
+    candidates.push_back({alloc, tmaOp, donePoint, opPosition[alloc]});
+  }
+
+  if (candidates.size() < 2)
+    return;
+
+  // Group candidates by compatible mutable memdesc type.
+  // MLIR types are uniqued, so pointer equality works for DenseMap keys.
+  DenseMap<Type, SmallVector<unsigned>> groups;
+  for (unsigned i = 0; i < candidates.size(); ++i) {
+    auto mutableTy =
+        getMutableType(cast<ttg::MemDescType>(candidates[i].alloc.getType()));
+    groups[mutableTy].push_back(i);
+  }
+
+  for (auto &[ty, indices] : groups) {
+    if (indices.size() < 2)
+      continue;
+
+    // Candidates are already in block order since we collected in order.
+    // Build reuse chains: consecutive candidates where the previous
+    // candidate's done point comes before the current candidate's alloc.
+    SmallVector<SmallVector<unsigned>> chains;
+    SmallVector<unsigned> currentChain = {indices[0]};
+
+    for (unsigned i = 1; i < indices.size(); ++i) {
+      auto &prev = candidates[currentChain.back()];
+      auto &curr = candidates[indices[i]];
+
+      if (opPosition[prev.donePoint] < curr.blockPosition) {
+        currentChain.push_back(indices[i]);
+      } else {
+        if (currentChain.size() >= 2)
+          chains.push_back(std::move(currentChain));
+        currentChain = {indices[i]};
+      }
+    }
+    if (currentChain.size() >= 2)
+      chains.push_back(std::move(currentChain));
+
+    // Rewrite each chain to share a single mutable buffer.
+    auto mutableTy = cast<ttg::MemDescType>(ty);
+    for (auto &chain : chains) {
+      // First alloc: replace local_alloc %src with
+      //   %buf = local_alloc (mutable, no src)
+      //   local_store %src, %buf
+      auto &first = candidates[chain[0]];
+      OpBuilder builder(first.alloc);
+      Value src = first.alloc.getSrc();
+      auto buf =
+          builder.create<ttg::LocalAllocOp>(first.alloc.getLoc(), mutableTy);
+      builder.create<ttg::LocalStoreOp>(first.alloc.getLoc(), src, buf);
+      first.alloc.replaceAllUsesWith(buf.getResult());
+      first.alloc.erase();
+
+      // Subsequent allocs: replace local_alloc %srcN with
+      //   local_store %srcN, %buf
+      // and RAUW the old alloc value with %buf.
+      for (unsigned i = 1; i < chain.size(); ++i) {
+        auto &cand = candidates[chain[i]];
+        OpBuilder b(cand.alloc);
+        Value srcN = cand.alloc.getSrc();
+        b.create<ttg::LocalStoreOp>(cand.alloc.getLoc(), srcN, buf);
+        cand.alloc.replaceAllUsesWith(buf.getResult());
+        cand.alloc.erase();
+      }
+    }
+  }
+}
+
+class TritonNvidiaGPUTMAStoreBufferReusePass
+    : public impl::TritonNvidiaGPUTMAStoreBufferReusePassBase<
+          TritonNvidiaGPUTMAStoreBufferReusePass> {
+public:
+  void runOnOperation() override {
+    SmallVector<Block *> blocks;
+    getOperation()->walk([&](Operation *op) {
+      for (Region &region : op->getRegions())
+        for (Block &block : region)
+          blocks.push_back(&block);
+    });
+    for (Block *block : blocks)
+      processBlock(*block);
+  }
+};
+
+} // anonymous namespace
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/test/TritonNvidiaGPU/tma_store_buffer_reuse.mlir
+++ b/test/TritonNvidiaGPU/tma_store_buffer_reuse.mlir
@@ -1,0 +1,351 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-tma-store-buffer-reuse | FileCheck %s
+
+// Test 1: basic_two_stores — Two sequential TMA stores with compatible types
+// should be merged into a single mutable buffer.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @basic_two_stores
+//       CHECK: %[[BUF:.+]] = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+//       CHECK: ttg.local_store %arg2, %[[BUF]]
+//       CHECK: ttng.fence_async_shared
+//       CHECK: ttng.async_tma_copy_local_to_global %arg0[%arg1, %arg1] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//       CHECK: ttg.local_store %arg3, %[[BUF]]
+//       CHECK: ttng.fence_async_shared
+//       CHECK: ttng.async_tma_copy_local_to_global %arg0[%arg1, %arg1] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//  CHECK-NOT: ttg.local_alloc %
+  tt.func @basic_two_stores(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>,
+      %src1: tensor<128x64xf16, #blocked>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    %alloc1 = ttg.local_alloc %src1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test 2: three_stores — Three sequential TMA stores should all share one buffer.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @three_stores
+//       CHECK: %[[BUF:.+]] = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+//       CHECK: ttg.local_store %arg2, %[[BUF]]
+//       CHECK: ttng.async_tma_copy_local_to_global %arg0[%arg1, %arg1] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//       CHECK: ttg.local_store %arg3, %[[BUF]]
+//       CHECK: ttng.async_tma_copy_local_to_global %arg0[%arg1, %arg1] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//       CHECK: ttg.local_store %arg4, %[[BUF]]
+//       CHECK: ttng.async_tma_copy_local_to_global %arg0[%arg1, %arg1] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//  CHECK-NOT: ttg.local_alloc %
+  tt.func @three_stores(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>,
+      %src1: tensor<128x64xf16, #blocked>,
+      %src2: tensor<128x64xf16, #blocked>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    %alloc1 = ttg.local_alloc %src1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    %alloc2 = ttg.local_alloc %src2 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc2 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test 3: scatter_op — Two sequential TMA scatter ops should also be merged.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @scatter_op
+//       CHECK: %[[BUF:.+]] = ttg.local_alloc : () -> !ttg.memdesc<32x128xbf16, #shared, #smem, mutable>
+//       CHECK: ttg.local_store %arg3, %[[BUF]]
+//       CHECK: ttng.fence_async_shared
+//       CHECK: ttng.async_tma_scatter %arg0[%arg1, %arg2] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//       CHECK: ttg.local_store %arg4, %[[BUF]]
+//       CHECK: ttng.fence_async_shared
+//       CHECK: ttng.async_tma_scatter %arg0[%arg1, %arg2] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//  CHECK-NOT: ttg.local_alloc %
+  tt.func @scatter_op(
+      %desc: !tt.tensordesc<tensor<1x128xbf16, #shared>>,
+      %x_offsets: tensor<32xi32, #blocked>,
+      %y_offset: i32,
+      %src0: tensor<32x128xbf16, #blocked1>,
+      %src1: tensor<32x128xbf16, #blocked1>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<32x128xbf16, #blocked1>) -> !ttg.memdesc<32x128xbf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_scatter %desc[%x_offsets, %y_offset] %alloc0 : !tt.tensordesc<tensor<1x128xbf16, #shared>>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<32x128xbf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    %alloc1 = ttg.local_alloc %src1 : (tensor<32x128xbf16, #blocked1>) -> !ttg.memdesc<32x128xbf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_scatter %desc[%x_offsets, %y_offset] %alloc1 : !tt.tensordesc<tensor<1x128xbf16, #shared>>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<32x128xbf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test 4: interleaved_incompatible — A (128x64xf16), B (64x128xf32), C (128x64xf16).
+// A and C have compatible types and should merge; B keeps its original alloc.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @interleaved_incompatible
+//       CHECK: %[[BUF:.+]] = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+//       CHECK: ttg.local_store %arg3, %[[BUF]]
+//       CHECK: ttng.async_tma_copy_local_to_global %arg0[%arg2, %arg2] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//       CHECK: ttg.local_alloc %arg4 : (tensor<64x128xf32, #blocked>) -> !ttg.memdesc<64x128xf32, #shared1, #smem>
+//       CHECK: ttng.async_tma_copy_local_to_global %arg1[%arg2, %arg2]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+//       CHECK: ttg.local_store %arg5, %[[BUF]]
+//       CHECK: ttng.async_tma_copy_local_to_global %arg0[%arg2, %arg2] %[[BUF]]
+//       CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+  tt.func @interleaved_incompatible(
+      %desc_f16: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %desc_f32: !tt.tensordesc<tensor<64x128xf32, #shared1>>,
+      %x: i32,
+      %srcA: tensor<128x64xf16, #blocked>,
+      %srcB: tensor<64x128xf32, #blocked>,
+      %srcC: tensor<128x64xf16, #blocked>) {
+    // Store A (f16)
+    %allocA = ttg.local_alloc %srcA : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc_f16[%x, %x] %allocA : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    // Store B (f32) — incompatible type
+    %allocB = ttg.local_alloc %srcB : (tensor<64x128xf32, #blocked>) -> !ttg.memdesc<64x128xf32, #shared1, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc_f32[%x, %x] %allocB : !tt.tensordesc<tensor<64x128xf32, #shared1>>, !ttg.memdesc<64x128xf32, #shared1, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    // Store C (f16) — compatible with A
+    %allocC = ttg.local_alloc %srcC : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc_f16[%x, %x] %allocC : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test 5: incompatible_types — Two stores with different buffer shapes/element types.
+// Each type group has only one candidate, so no transformation occurs.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @incompatible_types
+//       CHECK: ttg.local_alloc %arg3 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//       CHECK: ttg.local_alloc %arg4 : (tensor<64x128xf32, #blocked>) -> !ttg.memdesc<64x128xf32, #shared1, #smem>
+//   CHECK-NOT: ttg.local_store
+  tt.func @incompatible_types(
+      %desc_f16: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %desc_f32: !tt.tensordesc<tensor<64x128xf32, #shared1>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>,
+      %src1: tensor<64x128xf32, #blocked>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc_f16[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    %alloc1 = ttg.local_alloc %src1 : (tensor<64x128xf32, #blocked>) -> !ttg.memdesc<64x128xf32, #shared1, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc_f32[%x, %x] %alloc1 : !tt.tensordesc<tensor<64x128xf32, #shared1>>, !ttg.memdesc<64x128xf32, #shared1, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test 6: no_wait — Two stores with no tma_store_wait at all.
+// No transformation (findDonePoint returns nullptr for both).
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @no_wait
+//       CHECK: ttg.local_alloc %arg2 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//       CHECK: ttg.local_alloc %arg3 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//   CHECK-NOT: ttg.local_store
+  tt.func @no_wait(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>,
+      %src1: tensor<128x64xf16, #blocked>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    %alloc1 = ttg.local_alloc %src1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 7: nonzero_pendings — Two stores separated by tma_store_wait {pendings = 1}.
+// No transformation (only pendings = 0 qualifies as a done point).
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @nonzero_pendings
+//       CHECK: ttg.local_alloc %arg2 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//       CHECK: ttg.local_alloc %arg3 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//   CHECK-NOT: ttg.local_store
+  tt.func @nonzero_pendings(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>,
+      %src1: tensor<128x64xf16, #blocked>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 1 : i32}
+    %alloc1 = ttg.local_alloc %src1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+// Test 8: single_store — Only one TMA store in the block.
+// No transformation (need >= 2 candidates).
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @single_store
+//       CHECK: ttg.local_alloc %arg2 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//   CHECK-NOT: ttg.local_store
+  tt.func @single_store(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test 9: multiple_users — First alloc is used by both a TMA copy and a local_load.
+// The alloc has two users so it is not a candidate. Only one valid candidate remains.
+// No transformation.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @multiple_users
+//       CHECK: ttg.local_alloc %arg2 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//       CHECK: ttg.local_load
+//       CHECK: ttg.local_alloc %arg3 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//   CHECK-NOT: ttg.local_store
+  tt.func @multiple_users(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>,
+      %src1: tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, #blocked> {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    %loaded = ttg.local_load %alloc0 : !ttg.memdesc<128x64xf16, #shared, #smem> -> tensor<128x64xf16, #blocked>
+    %alloc1 = ttg.local_alloc %src1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return %loaded : tensor<128x64xf16, #blocked>
+  }
+}
+
+// -----
+
+// Test 10: ordering_violation — Two compatible stores where the second alloc
+// appears before the first's tma_store_wait. The chain condition
+// (prev.donePoint < curr.alloc) fails, so no transformation.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @ordering_violation
+//       CHECK: ttg.local_alloc %arg2 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//       CHECK: ttg.local_alloc %arg3 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+//   CHECK-NOT: ttg.local_store
+  tt.func @ordering_violation(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %x: i32,
+      %src0: tensor<128x64xf16, #blocked>,
+      %src1: tensor<128x64xf16, #blocked>) {
+    %alloc0 = ttg.local_alloc %src0 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.fence_async_shared {bCluster = false}
+    // Second alloc appears BEFORE first's store_wait
+    %alloc1 = ttg.local_alloc %src1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %alloc1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -370,6 +370,7 @@ class CUDABackend(BaseBackend):
         nvidia.passes.ttnvgpuir.add_optimize_tmem_layouts(pm)
         if capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
+            nvidia.passes.ttnvgpuir.add_tma_store_buffer_reuse(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         nvidia.passes.ttnvgpuir.add_interleave_tmem(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -57,6 +57,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      createTritonGPUProxyFenceInsertionWrapper, int32_t);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
+  ADD_PASS_WRAPPER_0("add_tma_store_buffer_reuse",
+                     ttng::createTritonNvidiaGPUTMAStoreBufferReusePass);
   ADD_PASS_WRAPPER_0("add_promote_lhs_to_tmem",
                      ttng::createTritonNvidiaGPUPromoteLHSToTMemPass);
   ADD_PASS_WRAPPER_0("add_remove_tmem_tokens",


### PR DESCRIPTION
Merges local alloc calls used in TMA store to enable buffer reuse/sharing for blocking stores. An issue with AutoWS. Unclear if it impacts other code components.