### PR TITLE
[TLX] throw errors for M=64 2cta mma

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1696,6 +1696,7 @@ class TritonSemantic(Generic[TensorTy]):
 
         M = lhs.type.shape[-2]
         if tlx_paired_ctas:
+            assert M == 128, f"Currently only supports M=128 per CTA for pair-CTA mma, but got M={M}"
             N = 2 * rhs.type.shape[-1]  # rhs is actually [K, N/2] in two_ctas mode so we scale it back
         else:
             N = rhs.type.shape[-1]


### PR DESCRIPTION
When M is 64 per CTA for 2cta case, the tensor memory layout is different than other cases: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-data-path-layout-b. Specifically, for tensor A 64xK, it will be stored in TMEM [:64, :K] and then stored again in TMEM [64:128, :K] inside one CTA, while if it's tensor D 64xN, it will store 
- D[:32, :N/2] in TMEM[:32, :N/2], 
- D[32:64, :N/2] in TMEM[32:64, :N/2], 
- D[:32, N/2:N] in TMEM[64:96, :N/2],
- D[32:64, N/2:N] in TMEM[96:128, :N/2]

This means we need to check TMEM buffer usage to determine the access pattern when doing a tmem local_store, which is non trivial. Since we're not seeing a good use case now, to minimize merge conflict with upstream, we do not support this case now.

Note for other cases (1cta or M is not 64), access patterns for tensor A and D are the same (each warp accesses exactly M/4 rows of A, and M/4 rows of D), so there's no such issue.

Test plan: added a unit test