### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[BACKEND] Generic tcgen05.cp lowering (#8225)'

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -3,6 +3,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 
 using namespace mlir;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1664,7 +1664,7 @@ void SharedLinearEncodingAttr::print(AsmPrinter &printer) const {
         layout.sublayout({kOffset}, llvm::to_vector(layout.getOutDimNames()));
   }
   printLinearLayout(printer, layout);
-  printer << "}, alignment = " << getAlignment() << "}>";
+  printer << "}, alignment = " << getAlignment() << ">";
 }
 
 Attribute SharedLinearEncodingAttr::parse(AsmParser &parser, Type type) {
@@ -2644,19 +2644,17 @@ struct TritonGPUInferLayoutInterface
     }
 
     if (auto enc = dyn_cast<NVMMASharedEncodingAttr>(operandEncoding)) {
-      if (failed(checkRank(enc.getRank())))
-        return failure();
-      if (order != ArrayRef<int32_t>({1, 0})) {
-        return emitOptionalError(
-            loc, "NVMMSharedEncoding can only be transposed in 2D");
-      }
+      if (order == ArrayRef<int32_t>({1, 0})) {
+        if (failed(checkRank(enc.getRank())))
+          return failure();
 
-      CTALayoutAttr ctaLayout =
-          permuteCTALayout(ctx, enc.getCTALayout(), order);
-      resultEncoding = NVMMASharedEncodingAttr::get(
-          ctx, enc.getSwizzlingByteWidth(), !enc.getTransposed(),
-          enc.getElementBitWidth(), enc.getFp4Padded(), ctaLayout);
-      return success();
+        CTALayoutAttr ctaLayout =
+            permuteCTALayout(ctx, enc.getCTALayout(), order);
+        resultEncoding = NVMMASharedEncodingAttr::get(
+            ctx, enc.getSwizzlingByteWidth(), !enc.getTransposed(),
+            enc.getElementBitWidth(), enc.getFp4Padded(), ctaLayout);
+        return success();
+      }
     }
 
     if (auto enc = dyn_cast<BlockedEncodingAttr>(operandEncoding)) {
@@ -2672,20 +2670,25 @@ struct TritonGPUInferLayoutInterface
           applyPermutation(invOrderUnsigned, enc.getOrder()), ctaLayout);
       return success();
     }
+    // Generic case
+    auto padded = dyn_cast<PaddedSharedEncodingAttr>(operandEncoding);
 
-    if (auto enc = dyn_cast<PaddedSharedEncodingAttr>(operandEncoding)) {
-      if (failed(checkRank(enc.getRank())))
-        return failure();
-      const auto &transLL =
-          transposeLinearLayout(enc.getLinearComponent(), order);
-      resultEncoding = PaddedSharedEncodingAttr::get(
-          ctx, enc.getIntervals(), enc.getPaddings(), transLL);
-      return success();
-    }
-
-    auto ll = toLinearLayout(shape, operandEncoding);
+    auto ll = padded ? padded.getLinearComponent()
+                     : toLinearLayout(shape, operandEncoding);
+    if (failed(checkRank(ll.getNumOutDims())))
+      return failure();
     auto transposedLl = transposeLinearLayout(ll, order);
-    resultEncoding = LinearEncodingAttr::get(ctx, std::move(transposedLl));
+    if (isa<DistributedEncodingTrait>(operandEncoding)) {
+      resultEncoding = LinearEncodingAttr::get(ctx, std::move(transposedLl));
+    } else if (padded) {
+      resultEncoding = PaddedSharedEncodingAttr::get(ctx, padded.getIntervals(),
+                                                     padded.getPaddings(),
+                                                     std::move(transposedLl));
+    } else {
+      auto shared = cast<SharedEncodingTrait>(operandEncoding);
+      resultEncoding = SharedLinearEncodingAttr::get(
+          ctx, std::move(transposedLl), shared.getAlignment());
+    }
     return success();
   }
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -564,40 +564,44 @@ static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,
                                                    Attribute srcEnc,
                                                    ArrayRef<int64_t> dstShape,
                                                    Attribute &dstEnc) {
+  // TODO Delete this once SharedLinearEncodingAttr is more widely supported.
   if (auto mmaEncoding = dyn_cast<NVMMASharedEncodingAttr>(srcEnc)) {
-    // TODO: supporting reshape of CTA layouts is non-trivial.
-    if (getNumCTAs(mmaEncoding) > 1)
-      return failure();
-    int innerDimDst =
-        mmaEncoding.getTransposed() ? dstShape.front() : dstShape.back();
-    int innerDimSrc =
-        mmaEncoding.getTransposed() ? srcShape.front() : srcShape.back();
-    // For now disallow reshape of the inner dimension.
-    if (innerDimDst != innerDimSrc)
-      return failure();
     auto *ctx = srcEnc.getContext();
-
-    // CTALayout can be all 1's because we bailed on multi-CTA layouts above.
-    auto CTALayout = CTALayoutAttr::get(
-        ctx,
-        /*CTAsPerCGA=*/SmallVector<unsigned>(dstShape.size(), 1),
-        /*CTASplitNum=*/SmallVector<unsigned>(dstShape.size(), 1),
-        /*CTAOrder=*/llvm::to_vector(llvm::seq<unsigned>(dstShape.size())));
-    dstEnc = NVMMASharedEncodingAttr::get(
-        ctx, mmaEncoding.getSwizzlingByteWidth(), mmaEncoding.getTransposed(),
-        mmaEncoding.getElementBitWidth(), mmaEncoding.getFp4Padded(),
-        CTALayout);
-    // Big guns, check linear layouts are equivalent
-    // We disallow reshaping memdesc_subslice in the verifier
-    // so allocShape == shape
-    auto srcLL = toLinearLayout(srcShape, srcEnc);
-    auto dstLL = toLinearLayout(dstShape, dstEnc);
-    if (reshapeLayout(ctx, srcLL, dstShape) != dstLL) {
-      return failure();
+    if (getNumCTAs(mmaEncoding) == 1) {
+      int innerDimDst =
+          mmaEncoding.getTransposed() ? dstShape.front() : dstShape.back();
+      int innerDimSrc =
+          mmaEncoding.getTransposed() ? srcShape.front() : srcShape.back();
+      // We can keep an NVMMAShared encoding only if the innermost dimension is
+      // preserved. Otherwise fall back to the generic shared-linear encoding
+      // logic below.
+      if (innerDimDst == innerDimSrc) {
+        auto CTALayout = CTALayoutAttr::get(
+            ctx,
+            /*CTAsPerCGA=*/SmallVector<unsigned>(dstShape.size(), 1),
+            /*CTASplitNum=*/SmallVector<unsigned>(dstShape.size(), 1),
+            /*CTAOrder=*/llvm::to_vector(llvm::seq<unsigned>(dstShape.size())));
+        auto candidateEncoding = NVMMASharedEncodingAttr::get(
+            ctx, mmaEncoding.getSwizzlingByteWidth(),
+            mmaEncoding.getTransposed(), mmaEncoding.getElementBitWidth(),
+            mmaEncoding.getFp4Padded(), CTALayout);
+        auto srcLL = toLinearLayout(srcShape, srcEnc);
+        auto dstLL = toLinearLayout(dstShape, candidateEncoding);
+        if (reshapeLayout(ctx, srcLL, dstShape) == dstLL) {
+          dstEnc = candidateEncoding;
+          return success();
+        }
+      }
     }
-    return success();
   }
-  return failure();
+
+  // Generic LL case
+  auto sharedEnc = cast<SharedEncodingTrait>(srcEnc);
+  auto *ctx = srcEnc.getContext();
+  auto srcLL = toLinearLayout(srcShape, srcEnc);
+  auto dstLL = reshapeLayout(ctx, srcLL, dstShape);
+  dstEnc = SharedLinearEncodingAttr::get(ctx, dstLL, sharedEnc.getAlignment());
+  return success();
 }
 
 LogicalResult MemDescReshapeOp::inferReturnTypes(

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -799,6 +799,9 @@ LogicalResult TMEMCopyOp::verify() {
           getSrc().getType().getMemorySpace()))
     return emitOpError("The source must be a shared memory buffer");
 
+  auto srcTy = cast<triton::gpu::MemDescType>(getSrc().getType());
+  auto dstTy = cast<triton::gpu::MemDescType>(getDst().getType());
+
   if (getBarrier() && !isa<triton::gpu::SharedMemorySpaceAttr>(
                           getBarrier().getType().getMemorySpace())) {
     return emitOpError("The optional barrier should be a shared memory buffer");
@@ -806,7 +809,6 @@ LogicalResult TMEMCopyOp::verify() {
   if (!getDst().getType().getMutableMemory()) {
     return emitOpError("Cannot copy into an immutable alloc");
   }
-  auto srcTy = cast<triton::gpu::MemDescType>(getSrc().getType());
   auto sharedEnc =
       dyn_cast<triton::gpu::SharedEncodingTrait>(srcTy.getEncoding());
   if (sharedEnc.getAlignment() < 16) {
@@ -819,23 +821,18 @@ LogicalResult TMEMCopyOp::verify() {
   if (numCTAs != 1)
     return emitOpError("NYI: Only one CTA is supported for now.");
 
+  // Fp4 we could lift if we needed
   auto nvmmaEnc =
       dyn_cast<triton::gpu::NVMMASharedEncodingAttr>(srcTy.getEncoding());
-  if (!nvmmaEnc) {
-    return emitOpError("Source must have nvmma layout.");
-  }
-  // Fp4 we could lift if we needed
-  if (nvmmaEnc.getTransposed() || nvmmaEnc.getFp4Padded())
+  if (nvmmaEnc && (nvmmaEnc.getTransposed() || nvmmaEnc.getFp4Padded())) {
     return emitOpError("The source should not be transposed or padded");
+  }
   if (isa<triton::tlx::DummyTMEMLayoutAttr>(getDst().getType().getEncoding())) {
     return success();
   } else if (isa<TensorMemoryScalesEncodingAttr>(
                  getDst().getType().getEncoding())) {
-    if (nvmmaEnc.getSwizzlingByteWidth() != 0) {
+    if (nvmmaEnc && nvmmaEnc.getSwizzlingByteWidth() != 0) {
       return emitOpError("The source should not be swizzled for now");
-    }
-    if (!triton::gpu::isInnermostContiguous(srcTy, 512)) {
-      return emitOpError("The source must be in a row-major order.");
     }
   } else {
     if (getSrc().getType().getShape() != getDst().getType().getShape()) {
@@ -850,7 +847,7 @@ LogicalResult TMEMCopyOp::verify() {
     if (tmemEnc.getBlockM() != 128) {
       return emitOpError("Tmem layout ahouls have M=128.");
     }
-    if (nvmmaEnc.getSwizzlingByteWidth() == 0) {
+    if (nvmmaEnc && nvmmaEnc.getSwizzlingByteWidth() == 0) {
       return emitOpError("Source layout should be swizzled.");
     }
     // When we lift this, we should make sure we handle unpacked cleanly

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -7,7 +7,7 @@ from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia import blackwell
 from triton.experimental.gluon.language.nvidia import hopper
-from triton.experimental.gluon.language.nvidia.blackwell import mbarrier, tma, TensorMemoryLayout, TensorMemoryScalesLayout, async_copy
+from triton.experimental.gluon.language.nvidia.blackwell import mbarrier, tma, TensorMemoryLayout, async_copy
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.amd import _layouts as amd_layouts
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
@@ -611,23 +611,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
 """)
-
-
-@filecheck_test
-@gluon.jit
-def test_tcgen05_copy():
-    # CHECK-LABEL: test_tcgen05_copy
-    smem_h: ttgl.constexpr = 256
-    num_cols: ttgl.constexpr = smem_h * 4 // 32
-
-    shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=0, element_bitwidth=8, rank=2)
-    tmem_layout: ttgl.constexpr = TensorMemoryScalesLayout()
-    # CHECK: [[SRC:%.*]] = ttg.local_alloc
-    src = ttgl.allocate_shared_memory(ttgl.int8, [smem_h, 4], shared_layout)
-    # CHECK: [[DST:%.*]] = ttng.tmem_alloc
-    dst = blackwell.allocate_tensor_memory(ttgl.int8, [128, num_cols], tmem_layout)
-    # CHECK: ttng.tmem_copy [[SRC]], [[DST]]
-    blackwell.tcgen05_copy(src, dst)
 
 
 @filecheck_test

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1099,7 +1099,7 @@ def test_local_load_store_2d_layouts(shape, dtype, dist_layout, shared_layout, d
                 basis[dim] = stride
                 offset_bases.append(basis)
                 stride <<= 1
-        shared_layout = ttgl.SharedLinearLayout(offset_bases=offset_bases, block_bases=[], shape=list(shape))
+        shared_layout = ttgl.SharedLinearLayout(offset_bases=offset_bases)
 
     if isinstance(shared_layout, ttgl.NVMMASharedLayout):
         contig_dim = 0 if shared_layout.transposed else 1

--- a/python/triton/experimental/gluon/language/_layouts.py
+++ b/python/triton/experimental/gluon/language/_layouts.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 from triton.language.core import _unwrap_if_constexpr, _unwrap_shape, constexpr_type
 from triton.runtime.jit import constexpr_function
@@ -592,18 +592,17 @@ class SharedLinearLayout(SharedLayout):
     """Represents a shared memory layout defined via an explicit LinearLayout."""
 
     offset_bases: List[List[int]]
-    block_bases: List[List[int]]
-    shape: List[int]
+    block_bases: List[List[int]] = field(default_factory=list)
     alignment: int = 16
 
     def __post_init__(self):
         super().__setattr__("offset_bases", _unwrap_shape(self.offset_bases))
         super().__setattr__("block_bases", _unwrap_shape(self.block_bases))
-        super().__setattr__("shape", _unwrap_shape(self.shape))
         super().__setattr__("alignment", _unwrap_if_constexpr(self.alignment))
 
-        rank = len(self.shape)
-        assert rank > 0, "SharedLinearLayout shape must not be empty"
+        assert len(self.offset_bases) != 0, "SharedLinearLayout offset_bases must not be empty"
+        rank = len(self.offset_bases[0])
+        assert rank > 0, "SharedLinearLayout offset_bases must not be empty"
         for basis in self.offset_bases:
             assert len(basis) == rank
         for basis in self.block_bases:
@@ -612,16 +611,15 @@ class SharedLinearLayout(SharedLayout):
             "SharedLinearLayout alignment must be a positive power of two"
 
     def _to_ir(self, builder):
-        return builder.get_shared_linear_layout(self.offset_bases, self.block_bases, self.shape, self.alignment)
+        return builder.get_shared_linear_layout(self.offset_bases, self.block_bases, self.alignment)
 
     def mangle(self) -> str:
-        return f"SharedLinear_{self.offset_bases}_{self.block_bases}_{self.shape}_{self.alignment}_SharedLinear"
+        return f"SharedLinear_{self.offset_bases}_{self.block_bases}_{self.alignment}_SharedLinear"
 
     def __hash__(self):
         return hash((
             tuple(map(tuple, self.offset_bases)),
             tuple(map(tuple, self.block_bases)),
-            tuple(self.shape),
             self.alignment,
         ))
 

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -176,21 +176,21 @@ tt.func @barrier_between_same_index_init_inval() {
 // -----
 
 // CHECK-LABEL: tmem_copy_after_alloc
-#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 
 //#ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @tmem_copy_after_alloc(%arg0: tensor<1x2048xf8E4M3FN, #blocked>) {
+  tt.func @tmem_copy_after_alloc(%arg0: tensor<128x16xf8E4M3FN, #blocked>) {
     // CHECK: local_alloc
-    %0 = ttg.local_alloc %arg0 {allocation.offset = 53248 : i32} : (tensor<1x2048xf8E4M3FN, #blocked>) -> !ttg.memdesc<1x2048xf8E4M3FN, #shared, #smem>
+    %0 = ttg.local_alloc %arg0 {allocation.offset = 53248 : i32} : (tensor<128x16xf8E4M3FN, #blocked>) -> !ttg.memdesc<128x16xf8E4M3FN, #shared, #smem>
     // CHECK: tmem_alloc
     %1 = ttng.tmem_alloc  {tensor_memory_col_offset = 256 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
     // gpu.barrier
     // CHECK: tmem_copy
-    ttng.tmem_copy %0, %1 : !ttg.memdesc<1x2048xf8E4M3FN, #shared, #smem>, !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %0, %1 : !ttg.memdesc<128x16xf8E4M3FN, #shared, #smem>, !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -348,27 +348,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 }
 
 // -----
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+
+
+#blocked = #ttg.blocked<{sizePerThread=[1, 4], threadsPerWarp=[32, 1], warpsPerCTA=[4, 1], order=[0, 1]}>
+#shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared2 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16], [128, 0], [256, 0]]}, alignment = 16>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
-tt.func public @tmem_copy_2d(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>,
+tt.func public @tmem_copy_2d(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
                              %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
 		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
   // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
   // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64
-  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
   tt.return
 }
 
-tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory, 1024x16>,
+tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<128x32xi8, #shared2, #ttg.shared_memory, 512x32>,
                                    %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
   // CHECK: [[OFF0:%.*]] = llvm.extractvalue %arg0[1]
   // CHECK: [[OFF1:%.*]] = llvm.extractvalue %arg0[2]
   // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
-  ttng.tmem_copy %src, %dst : !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory, 1024x16>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+  ttng.tmem_copy %src, %dst : !ttg.memdesc<128x32xi8, #shared2, #ttg.shared_memory, 512x32>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
   tt.return
 }
 
@@ -377,13 +381,13 @@ tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.s
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread=[1, 4], threadsPerWarp=[32, 1], warpsPerCTA=[4, 1], order=[0, 1]}>
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
-tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>,
+tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
                              %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
 		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
   // CHECK: %[[CTAID:.+]] = nvgpu.cluster_id
@@ -391,7 +395,7 @@ tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.sh
   // CHECK: llvm.urem %[[CTAID]], %[[TWO]]
   // CHECK-COUNT-8: tcgen05.cp.cta_group::2.warpx4.32x128b
   // CHECK: tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64
-  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
   tt.return
 }
 

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -136,7 +136,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-LABEL: @scales_in_shmem
   // CHECK: %[[A_LA:.*]] = ttg.local_alloc
   // CHECK: %[[B_LA:.*]] = ttg.local_alloc
-  // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_LA]], %[[B_LA]],
+  // CHECK: %[[A_RS:.*]] = ttg.memdesc_reshape %[[A_LA]]
+  // CHECK: %[[A_TR:.*]] = ttg.memdesc_trans %[[A_RS]]
+  // CHECK: %[[A_FINAL:.*]] = ttg.memdesc_reshape %[[A_TR]]
+  // CHECK: %[[B_RS:.*]] = ttg.memdesc_reshape %[[B_LA]]
+  // CHECK: %[[B_TR:.*]] = ttg.memdesc_trans %[[B_RS]]
+  // CHECK: %[[B_FINAL:.*]] = ttg.memdesc_reshape %[[B_TR]]
+  // CHECK-NOT: ttg.local_load
+  // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_FINAL]], %[[B_FINAL]],
 
   tt.func public @scales_in_shmem(
     %scale: tensor<2x512x!tt.ptr<i8>, #blocked4> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
@@ -228,7 +235,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %desc = tt.make_tensor_descriptor %scale_desc_ptr, [%c1_i32, %c2_i32, %c1_i32, %c32_i32, %c16_i32], [%c1024_i64, %c512_i64, %c512_i64, %c16_i64, %c1_i64] : !tt.ptr<i8>, !tt.tensordesc<tensor<1x2x1x32x16xi8>>
     // CHECK: %[[DESC_LOAD:.*]] = tt.descriptor_load {{.*}} !tt.tensordesc<tensor<1x2x1x32x16xi8>> -> tensor<1x2x1x32x16xi8, #[[BLOCKED5]]>
     %83 = tt.descriptor_load %desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<tensor<1x2x1x32x16xi8>> -> tensor<1x2x1x32x16xi8, #blocked5>
-    // CHECK: %[[SCALE_ALLOC:.*]] = ttg.local_alloc %[[DESC_LOAD]] : (tensor<1x2x1x32x16xi8, #[[BLOCKED5]]>) -> !ttg.memdesc<1x2x1x32x16xi8, #[[SHARED2]], #[[SMEM]]>
+    // CHECK: %[[DESC_LA:.*]] = ttg.local_alloc %[[DESC_LOAD]] : (tensor<1x2x1x32x16xi8, #[[BLOCKED5]]>) -> !ttg.memdesc<1x2x1x32x16xi8, #[[SHARED2]], #[[SMEM]]>
     %84 = ttg.local_alloc %83 : (tensor<1x2x1x32x16xi8, #blocked5>) -> !ttg.memdesc<1x2x1x32x16xi8, #shared2, #smem>
     // CHECK-NOT: ttg.local_load
     %85 = ttg.local_load %84 : !ttg.memdesc<1x2x1x32x16xi8, #shared2, #smem> -> tensor<1x2x1x32x16xi8, #linear1>
@@ -241,7 +248,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %89 = ttng.tmem_alloc %acc : (tensor<128x256xf32, #blocked1>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
     %90 = ttng.tmem_alloc %cst_scales : (tensor<128x4xi8, #linear>) -> !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>
     %91 = ttng.tmem_alloc %88 : (tensor<256x4xi8, #linear4>) -> !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>
-    // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[SCALE_ALLOC]], {{.*}} : {{.*}}, {{.*}}, {{.*}}, {{.*}}, !ttg.memdesc<1x2x1x32x16xi8, #[[SHARED2]], #[[SMEM]]>
+    // CHECK: %[[DESC_RS:.*]] = ttg.memdesc_reshape %[[DESC_LA]] : !ttg.memdesc<1x2x1x32x16xi8, #[[SHARED2]], #[[SMEM]]> -> !ttg.memdesc<2x1x32x4x4xi8, {{.*}}, #smem>
+    // CHECK: %[[DESC_TR:.*]] = ttg.memdesc_trans %[[DESC_RS]]
+    // CHECK: %[[SCALE_ALLOC:.*]] = ttg.memdesc_reshape %[[DESC_TR]] : !ttg.memdesc<2x4x32x1x4xi8, {{.*}}, #smem> -> !ttg.memdesc<256x4xi8, {{.*}}, #smem>
+    // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[SCALE_ALLOC]], {{.*}}
     ttng.tc_gen5_mma_scaled %shmemA, %shmemB, %89, %90, %91, %true, %true lhs = e4m3 rhs = e2m1 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem>, !ttg.memdesc<64x256xi8, #shared1, #smem>, !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>
     tt.return
   }
@@ -256,7 +266,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK-DAG: #[[$SHARED:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 // CHECK-DAG: #[[$SHARED1:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CTAsPerCGA = [1, 1, 1, 1], CTASplitNum = [1, 1, 1, 1], CTAOrder = [3, 2, 1, 0]}>
 module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: reshape_memedesc
+  // CHECK-LABEL: @reshape_memedesc
   tt.func @reshape_memedesc(%arg: tensor<32x1x4x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem> {
     // CHECK: [[A:.+]] = ttg.local_alloc %{{.+}} : (tensor<32x1x4x64xf16, #{{.*}}>) -> !ttg.memdesc<32x1x4x64xf16, #[[$SHARED1]], #smem>
     %r = tt.reshape %arg : tensor<32x1x4x64xf16, #blocked> -> tensor<128x64xf16, #blocked1>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -44,11 +44,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #scales = #ttg.linear<{register = [[0, 1], [0, 2], [32, 0], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[0, 0], [0, 0]], block = []}>
 #tmem = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @alloc_tensor_memory(%arg: !ttg.memdesc<1x512xi8, #shared1, #ttg.shared_memory, mutable>) {
+  tt.func public @alloc_tensor_memory(%arg: !ttg.memdesc<128x4xi8, #shared1, #ttg.shared_memory, mutable>) {
     %cst = arith.constant dense<0> : tensor<128x4xi8, #scales>
     %0 = ttng.tmem_alloc %cst : (tensor<128x4xi8, #scales>) -> !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory>
     // expected-error @+1 {{Cannot copy into an immutable alloc}}
-    ttng.tmem_copy %arg, %0 : !ttg.memdesc<1x512xi8, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory>
+    ttng.tmem_copy %arg, %0 : !ttg.memdesc<128x4xi8, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/mma_lowering.mlir
+++ b/test/TritonNvidiaGPU/mma_lowering.mlir
@@ -12,8 +12,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %A_sh: !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>,
     %B_sh: !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
     %C_tmem: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
-    %A_scale_sh: !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>,
-    %B_scale_sh: !ttg.memdesc<1x2x16x4x4xi8, #shared1, #smem>,
+    %A_scale_sh: !ttg.memdesc<128x8xi8, #shared1, #smem>,
+    %B_scale_sh: !ttg.memdesc<64x8xi8, #shared1, #smem>,
     %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
 
     %true = arith.constant true
@@ -23,7 +23,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<64x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[B_SC_TMEM]]
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_SC_TMEM]], %[[B_SC_TMEM]]
-    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e5m2 rhs = e5m2, %barrier[%true] {is_async} : !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x16x4x4xi8, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e5m2 rhs = e5m2, %barrier[%true] {is_async} : !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #shared1, #smem>, !ttg.memdesc<64x8xi8, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
     tt.return
   }
 }
@@ -43,8 +43,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %A_sh: !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>,
     %B_sh: !ttg.memdesc<256x64xi8, #sharedT, #ttg.shared_memory>,
     %C_tmem: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
-    %A_scale_sh: !ttg.memdesc<1x2x32x4x4xf8E4M3FN, #shared1, #smem>,
-    %B_scale_sh: !ttg.memdesc<1x2x16x4x4xf8E4M3FN, #shared1, #smem>,
+    %A_scale_sh: !ttg.memdesc<128x8xf8E4M3FN, #shared1, #smem>,
+    %B_scale_sh: !ttg.memdesc<64x8xf8E4M3FN, #shared1, #smem>,
     %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
 
     %true = arith.constant true
@@ -54,7 +54,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<64x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[B_SC_TMEM]]
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_SC_TMEM]], %[[B_SC_TMEM]]
-    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e2m1 rhs = e2m1, %barrier[%true] {is_async} : !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<256x64xi8, #sharedT, #ttg.shared_memory>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<1x2x16x4x4xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e2m1 rhs = e2m1, %barrier[%true] {is_async} : !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<256x64xi8, #sharedT, #ttg.shared_memory>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<64x8xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -43,6 +44,62 @@ constexpr TMemAccessAtom TMemAccess16x256b{
 
 constexpr TMemAccessAtom TMemAccess16x32bx2{
     .colsPerThread = 1, .rowsPerThread = 1, .opShape = "16x32bx2"};
+
+struct TMemCopyAtom {
+  int nRow;
+  int bCol;
+  // a multicast of n represents that warps with (warpId & n) != 0 are
+  // broadcasted
+  int multicast;
+};
+
+// .shape     = { .128x256b, .128x128b, .64x128b, .32x128b }
+// .multicast = { .warpx2::02_13 , .warpx2::01_23, .warpx4}
+// .shape = .4x256b NYI
+constexpr TMemCopyAtom TMemCopyAtomNone128{
+    .nRow = 128, .bCol = 128, .multicast = 0};
+
+constexpr TMemCopyAtom TMemCopyAtomNone256{
+    .nRow = 128, .bCol = 256, .multicast = 0};
+
+constexpr TMemCopyAtom TMemCopyAtomWarp02_13{
+    .nRow = 64, .bCol = 128, .multicast = 1};
+
+constexpr TMemCopyAtom TMemCopyAtomWarp01_23{
+    .nRow = 64, .bCol = 128, .multicast = 2};
+
+constexpr TMemCopyAtom TMemCopyAtomWarp4{
+    .nRow = 32, .bCol = 128, .multicast = 3};
+
+TMemCopyAtom getTMemCopyAtom(const LinearLayout &cvt, int bitwidth) {
+  auto *ctx = cvt.getInDimNames().begin()->getContext();
+  auto S = [&](StringRef str) { return StringAttr::get(ctx, str); };
+  auto kRow = S("row");
+  auto kCol = S("col");
+  assert(cvt.getInDimSize(kRow) == 128);
+  auto multicastBit = [&](int i) {
+    assert(i == 0 || i == 1);
+    return cvt.getBasis(kRow, llvm::Log2_32(32) + i) == ArrayRef{0};
+  };
+  auto multicast = multicastBit(0) | multicastBit(1) << 1;
+  if (multicast == 0) {
+    // TODO we will assert this in the verifier
+    if (cvt.getInDimSize(kCol) * bitwidth == 128) {
+      return TMemCopyAtomNone128;
+    } else {
+      assert(cvt.getInDimSize(kCol) * bitwidth >= 256);
+      return TMemCopyAtomNone256;
+    }
+  } else if (multicast == 1) {
+    return TMemCopyAtomWarp02_13;
+  } else if (multicast == 2) {
+    return TMemCopyAtomWarp01_23;
+  } else if (multicast == 3) {
+    return TMemCopyAtomWarp4;
+  } else {
+    llvm_unreachable("invalid multicast");
+  }
+}
 
 std::optional<LinearLayout> getReps(const LinearLayout &cvt,
                                     const LinearLayout &tile) {
@@ -872,24 +929,6 @@ struct TensorMemoryAllocOpConversion
   }
 };
 
-static Value
-createBlockedScalesSMEMDescriptor(ConversionPatternRewriter &rewriter,
-                                  Location loc, Value baseSrc) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  static_assert(sizeof(NVIDIA::SMEMDescriptor) == 8,
-                "Descriptor size should be 64 bits.");
-  NVIDIA::SMEMDescriptor desc;
-  desc.descriptor = 0;
-  desc.swizzlingMode = 0;                    // No swizzling for now
-  desc.leadDimensionBaseOffset = 16 >> 4;    // 16 bytes
-  desc.strideDimensionBaseOffset = 128 >> 4; // 8 x 16 bytes
-  // See matrix-descriptor-encode(x) function in the ptx doc.
-  // matrix-descriptor-encode(addr) = (addr & 0x3FFFF) >> 4
-  auto smemAddr = b.ptrtoint(i64_ty, baseSrc);
-  return b.add(b.int_val(64, desc.descriptor),
-               b.lshr(b.shl(smemAddr, b.int_val(64, 46)), b.int_val(64, 50)));
-}
-
 static void createCommit(ConversionPatternRewriter &rewriter, Location loc,
                          Value barrier, Value pred, bool tlxTwoCTAs) {
   PTXBuilder ptxBuilder;
@@ -927,22 +966,257 @@ static void createCommit(ConversionPatternRewriter &rewriter, Location loc,
 
 static void createTcgen05Cp(ConversionPatternRewriter &rewriter, Location loc,
                             Value tmem_address, Value src_desc, Value pred,
-                            bool scales, bool useTwoCTAs) {
+                            TMemCopyAtom atom, bool useTwoCTAs = false) {
   PTXBuilder ptxBuilder;
   auto dst = ptxBuilder.newAddrOperand(tmem_address, "r");
   auto src = ptxBuilder.newOperand(src_desc, "l");
-  std::string opcode = "tcgen05.cp";
-  if (useTwoCTAs)
-    opcode += ".cta_group::2";
-  else
-    opcode += ".cta_group::1";
-  if (scales)
-    opcode += ".warpx4.32x128b";
-  else
-    opcode += ".128x256b";
+  std::string warp;
+  if (atom.multicast == 1) {
+    warp = ".warpx2::02_13";
+  } else if (atom.multicast == 2) {
+    warp = ".warpx2::01_23";
+  } else if (atom.multicast == 3) {
+    warp = ".warpx4";
+  }
+  std::string ctaGroup = useTwoCTAs ? "cta_group::2" : "cta_group::1";
+  std::string opcode = "tcgen05.cp." + ctaGroup + warp + "." +
+                       std::to_string(atom.nRow) + "x" +
+                       std::to_string(atom.bCol) + "b";
   auto &op = *ptxBuilder.create<PTXInstr>(opcode);
   op({dst, src}).predicate(pred);
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
+}
+
+static Value
+createBlockedScalesSMEMDescriptor(ConversionPatternRewriter &rewriter,
+                                  Location loc, Value baseSrc) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  static_assert(sizeof(NVIDIA::SMEMDescriptor) == 8,
+                "Descriptor size should be 64 bits.");
+  NVIDIA::SMEMDescriptor desc;
+  desc.descriptor = 1ULL << 46;
+  desc.swizzlingMode = 0;                    // No swizzling for now
+  desc.leadDimensionBaseOffset = 16 >> 4;    // 16 bytes
+  desc.strideDimensionBaseOffset = 128 >> 4; // 8 x 16 bytes
+  // See matrix-descriptor-encode(x) function in the ptx doc.
+  // matrix-descriptor-encode(addr) = (addr & 0x3FFFF) >> 4
+  auto smemAddr = b.ptrtoint(i64_ty, baseSrc);
+  return b.add(b.int_val(64, desc.descriptor),
+               b.lshr(b.shl(smemAddr, b.int_val(64, 46)), b.int_val(64, 50)));
+}
+
+static std::optional<std::tuple<int32_t, LinearLayout, LinearLayout,
+                                SmallVector<int64_t>, int32_t, int32_t>>
+getSwizzling(MemDescType shmemTy, MemDescType tmemTy, TMemCopyAtom atom) {
+  // cvt is a map from Tmem to Shmem
+  auto tmemLl = toLinearLayout(tmemTy);
+  auto shmemLl = toLinearLayout(shmemTy);
+  auto inDimNames = to_vector(tmemLl.getInDimNames());
+  auto *ctx = inDimNames[0].getContext();
+  assert(shmemLl.getInDimSize(str_attr("block")) == 1 && "NYI");
+  auto kOffset = str_attr("offset");
+  auto kRow = str_attr("row");
+  auto kCol = str_attr("col");
+  shmemLl = shmemLl.sublayout({kOffset}, to_vector(shmemLl.getOutDimNames()));
+  // Reshape shared memory layout to match TMEM rank (2D) when source is
+  // higher-rank (e.g. 5D scale buffers). invertAndCompose requires matching
+  // out-dimension names.
+  if (shmemTy.getRank() != tmemTy.getRank()) {
+    shmemLl = reshapeLayout(ctx, shmemLl, tmemTy.getShape());
+  }
+  auto cvt = tmemLl.invertAndCompose(shmemLl);
+
+  int32_t bitwidth = tmemTy.getElementType().getIntOrFloatBitWidth();
+
+  // Check if the layout is large enough as to check SBO
+  // TODO Move to the verifier
+  if (shmemLl.getOutDimSizeLog2(str_attr("dim0")) < 4) {
+    return std::nullopt;
+  }
+  // TODO We may need to be careful here if we ever want to support fp4 padded
+  // layouts
+  if (!shmemLl.isInvertible()) {
+    return std::nullopt;
+  }
+
+  // This will be SBO for k-Contiguous layouts (like the ones used in
+  // tcgen05.cp)
+  auto sbo =
+      shmemLl.invert().getBasis(str_attr("dim0"), /*log2(8)=*/3, kOffset);
+
+  const SmallVector<int64_t> instrShape = {atom.nRow, atom.bCol / bitwidth};
+  // TODO Move to the verifier perhaps
+  // Can we move the tile?
+  for (auto [inDimName, instrSize] : llvm::zip(inDimNames, instrShape)) {
+    if (cvt.getInDimSize(inDimName) < instrSize) {
+      return std::nullopt;
+    }
+  }
+
+  auto CTALayout = getCTALayout(shmemTy.getEncoding());
+
+  for (int swizzling : {0, 32, 64, 128}) {
+    // r = 0, 1, 2, 3
+    auto shmemEnc =
+        NVMMASharedEncodingAttr::get(ctx, swizzling, /*transposed=*/false,
+                                     bitwidth, /*fp4Padded=*/false, CTALayout);
+    auto shmemTile =
+        getCoreMatrixLinearLayout(shmemEnc, /*disableSwizzle=*/false);
+    // getCoreMatrixLinearLayout gives the k-contiguous tile
+    // shmemTile is a layout onto a matrix with shape
+    // If swizzling != 0: 8 x (8 * swizzling / bitwidth)
+    // If swizzling == 0: 8 x (8 * 16 / bitwidth)
+    assert(shmemTile.getOutDimSize(str_attr("dim0")) == 8);
+    assert(shmemTile.getOutDimSize(str_attr("dim1")) ==
+           8 * std::max(16, swizzling) / bitwidth);
+    // The shmemTile is mapped identically into the tmem, so we just need to
+    // rename the outDims in shmemTile from dim0, dim1 to row, col
+    auto cvtTileInverted =
+        LinearLayout(shmemTile.getBases(), {str_attr("row"), str_attr("col")});
+    // The tile should be invertible, so we consider it as a map from row, col
+    // to offset
+    // nb. Working with the map from row, col to offset is important to handle
+    // the tcgen05.cp instructions that do broadcasting
+    auto cvtTile = cvtTileInverted.invert();
+    // The sbo stride shall not touch the core tile
+    if (sbo < cvtTile.getOutDimSize(kOffset))
+      continue;
+
+    // As we are copying instrShape[0] columns in one go, to be able to
+    // represent this in the descriptor, we need to have a constant "stride"
+    // along the row dimension from row=8 until the last row.
+    auto bases = cvtTile.getBases();
+    for (int i = 1; i < instrShape[0] / 8; i *= 2) {
+      bases[kRow].push_back({sbo * i});
+    }
+    // Broadcast
+    for (int i = instrShape[0]; i < 128; i *= 2) {
+      bases[kRow].push_back({0});
+    }
+    // If we multicast as warpx2::02_13, we need to swap the last two bases
+    if (atom.multicast == 1) {
+      auto n = bases[kRow].size();
+      std::swap(bases[kRow][n - 1], bases[kRow][n - 2]);
+    }
+    cvtTile = LinearLayout(bases, {{kOffset, sbo * (instrShape[0] / 8)}},
+                           /*requireSurjective=*/false);
+
+    auto quot = divideLeft(cvt, cvtTile);
+    if (quot.has_value()) {
+      if (auto nvmma = dyn_cast<NVMMASharedEncodingAttr>(shmemEnc)) {
+        assert(nvmma.getSwizzlingByteWidth() == swizzling);
+      }
+      auto lbo = 0;
+      if (swizzling == 0) {
+        auto dim1 = str_attr("dim1");
+        auto endTile = shmemTile.getOutDimSizeLog2(dim1);
+        auto shmemInv = shmemLl.invert();
+        if (shmemInv.getInDimSizeLog2(dim1) > endTile) {
+          lbo = shmemInv.getBasis(dim1, endTile, kOffset);
+        }
+      }
+      return std::make_tuple(swizzling, *quot, cvtTile, instrShape, lbo, sbo);
+    }
+  }
+  return std::nullopt;
+}
+
+static void copySharedToTmem(ConversionPatternRewriter &rewriter, Location loc,
+                             const TypeConverter *typeConverter,
+                             triton::nvidia_gpu::TMEMCopyOp op, Value src,
+                             Value baseDst, Value pred, bool useTwoCTAs) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto *ctx = op.getContext();
+  auto kOffset = str_attr("offset");
+  auto kRow = str_attr("row");
+  auto kCol = str_attr("col");
+
+  MemDescType srcTy = op.getSrc().getType();
+  MemDescType dstTy = op.getDst().getType();
+
+  auto sharedLl = toLinearLayout(srcTy);
+  sharedLl =
+      sharedLl.sublayout({kOffset}, to_vector(sharedLl.getOutDimNames()));
+  auto tmemLl = toLinearLayout(dstTy);
+  // Reshape shared memory layout to match TMEM rank (2D) when source is
+  // higher-rank (e.g. 5D scale buffers).
+  if (srcTy.getRank() != dstTy.getRank()) {
+    sharedLl = reshapeLayout(ctx, sharedLl, dstTy.getShape());
+  }
+  auto cvt = tmemLl.invertAndCompose(sharedLl);
+  auto bitwidth = srcTy.getElementType().getIntOrFloatBitWidth();
+  auto atom = getTMemCopyAtom(cvt, bitwidth);
+
+  // Need to find the shmem tile that matches
+  auto maybeSwizzling = getSwizzling(srcTy, dstTy, atom);
+  assert(maybeSwizzling.has_value());
+  auto [swizzling, quot, tile, tileShape, lbo, sbo] =
+      std::move(*maybeSwizzling);
+
+  auto reps = zerosLike(tile) * quot;
+
+  // Get shmem ptr
+  // TODO We should not allow splitting along the swizzling pattern
+  Type elemTy = typeConverter->convertType(srcTy.getElementType());
+  auto smemObj =
+      LLVM::getSharedMemoryObjectFromStruct(loc, src, elemTy, rewriter);
+  Value baseSrcInt =
+      b.ptrtoint(i32_ty, smemObj.getShmemAffineBase(loc, rewriter, srcTy));
+  // We checked in the verifier that the alignment is at least 16
+  Value baseSrcIntShr4 = b.lshr(baseSrcInt, b.i32_val(4));
+  Value baseSrcDesc = b.zext(i64_ty, b.and_(baseSrcIntShr4, b.i32_val(0x3FFF)));
+
+  // Set common fields in the SMEMDescriptor
+  SMEMDescriptor desc;
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-shared-memory-descriptor
+  desc.descriptor = 1ULL << 46;
+  desc.baseAddress = 0;
+  desc.leadDimensionBaseOffset = lbo != 0 ? (lbo * (bitwidth / 8)) >> 4 : 1;
+  // SBO is in elements and we have to pass it to bits and right shift by 4
+  desc.strideDimensionBaseOffset = ((sbo * (bitwidth / 8)) >> 4);
+  desc.matrixBaseOffset = 0;
+  switch (swizzling) {
+  case 0:
+    desc.swizzlingMode = 0;
+    break;
+  case 32:
+    desc.swizzlingMode = 3;
+    break;
+  case 64:
+    desc.swizzlingMode = 2;
+    break;
+  case 128:
+    desc.swizzlingMode = 1;
+    break;
+  default:
+    llvm::report_fatal_error("Unsupported swizzling size.");
+  }
+
+  // Make sure we don't have to iterate along the rows
+  assert(tile.getInDimSize(kRow) == cvt.getInDimSize(kRow) && "NYI");
+  assert(tileShape[1] <= tile.getInDimSize(kCol) && "NYI");
+  int elementBytes = bitwidth / 8;
+  for (int col = 0; col < reps.getInDimSize(kCol);
+       col += tile.getInDimSize(kCol)) {
+    // Compute base offset for the swizzling pattern
+    int32_t off = reps.apply({{kRow, 0}, {kCol, col}})[0].second;
+    desc.matrixBaseOffset = (off * elementBytes / 128) & 0x7;
+    for (int offset = 0; offset < tile.getInDimSize(kCol);
+         offset += tileShape[1]) {
+      // Compute total offset of the current message
+      int32_t totalOffElems =
+          cvt.apply({{kRow, 0}, {kCol, col + offset}})[0].second;
+      int32_t smemByteOffset = totalOffElems * elementBytes;
+      int32_t smemByteOffsetShr4 = smemByteOffset >> 4;
+      Value descValBase = b.int_val(64, desc.descriptor + smemByteOffsetShr4);
+      // Add the base address to the descriptor
+      Value descVal = b.or_(descValBase, baseSrcDesc, /*disjoint=*/true);
+      auto tmemAddr = b.or_(b.ptrtoint(i32_ty, baseDst),
+                            b.i32_val((col + offset) * elementBytes / 4),
+                            /*disjoint=*/true);
+      createTcgen05Cp(rewriter, loc, tmemAddr, descVal, pred, atom, useTwoCTAs);
+    }
+  }
 }
 
 static void copyScales(ConversionPatternRewriter &rewriter, Location loc,
@@ -986,7 +1260,7 @@ static void copyScales(ConversionPatternRewriter &rewriter, Location loc,
         auto smemAddr = b.gep(elemPtrTy, llvmElementTy, baseSrc, smemOffset);
         smemDesc = createBlockedScalesSMEMDescriptor(rewriter, loc, smemAddr);
         createTcgen05Cp(rewriter, loc, tmemAddr, smemDesc, pred,
-                        /*scales=*/true, useTwoCTAs);
+                        TMemCopyAtomWarp4, useTwoCTAs);
       }
     }
   };
@@ -1035,197 +1309,6 @@ static void copyScales(ConversionPatternRewriter &rewriter, Location loc,
   createCopy(repMorN, repK);
 }
 
-static std::optional<std::tuple<int32_t, LinearLayout, LinearLayout,
-                                SmallVector<int64_t>, int32_t>>
-getSwizzling(MemDescType shmemTy, MemDescType tmemTy) {
-  // cvt is a map from Tmem to Shmem
-  auto tmemLl = toLinearLayout(tmemTy);
-  auto shmemLl = toLinearLayout(shmemTy);
-  auto inDimNames = to_vector(tmemLl.getInDimNames());
-  auto *ctx = inDimNames[0].getContext();
-  assert(shmemLl.getInDimSize(str_attr("block")) == 1 && "NYI");
-  auto kOffset = str_attr("offset");
-  auto kRow = str_attr("row");
-  auto kCol = str_attr("col");
-  shmemLl = shmemLl.sublayout({kOffset}, to_vector(shmemLl.getOutDimNames()));
-  auto cvt = tmemLl.invertAndCompose(shmemLl);
-
-  int32_t bitwidth = tmemTy.getElementType().getIntOrFloatBitWidth();
-
-  // Check if the layout is large enough as to check SBO
-  // TODO Move to the verifier
-  if (shmemLl.getOutDimSizeLog2(str_attr("dim0")) < 4) {
-    return std::nullopt;
-  }
-  // TODO We may need to be careful here if we ever want to support fp4 padded
-  // layouts
-  if (!shmemLl.isInvertible()) {
-    return std::nullopt;
-  }
-
-  // This will be SBO for k-Contiguous layouts (like the ones used in
-  // tcgen05.cp)
-  auto sbo =
-      shmemLl.invert().getBasis(str_attr("dim0"), /*log2(8)=*/3, kOffset);
-
-  // TODO hardcoded to 128x256b for now
-  const SmallVector<int64_t> instrShape = {128, 256 / bitwidth};
-  // TODO Move to the verifier perhaps
-  // Can we move the tile?
-  // TODO We should be able to move any descriptor tile with 128x256b
-  // (or 128x128b for unswizzled when it just has one tile)
-  for (auto [inDimName, instrSize] : llvm::zip(inDimNames, instrShape)) {
-    if (cvt.getInDimSize(inDimName) < instrSize) {
-      return std::nullopt;
-    }
-  }
-
-  auto CTALayout = getCTALayout(shmemTy.getEncoding());
-
-  for (int swizzling : {0, 32, 64, 128}) {
-    // r = 0, 1, 2, 3
-    auto shmemEnc =
-        NVMMASharedEncodingAttr::get(ctx, swizzling, /*transposed=*/false,
-                                     bitwidth, /*fp4Padded=*/false, CTALayout);
-    auto shmemTile =
-        getCoreMatrixLinearLayout(shmemEnc, /*disableSwizzle=*/false);
-    // getCoreMatrixLinearLayout gives the k-contiguous tile
-    // shmemTile is a layout onto a matrix with shape
-    // If swizzling != 0: 8 x (8 * swizzling / bitwidth)
-    // If swizzling == 0: 8 x (8 * 16 / bitwidth)
-    assert(shmemTile.getOutDimSize(str_attr("dim0")) == 8);
-    assert(shmemTile.getOutDimSize(str_attr("dim1")) ==
-           8 * std::max(16, swizzling) / bitwidth);
-    // The shmemTile is mapped identically into the tmem, so we just need to
-    // rename the outDims in shmemTile from dim0, dim1 to row, col
-    auto cvtTileInverted =
-        LinearLayout(shmemTile.getBases(), {str_attr("row"), str_attr("col")});
-    // The tile should be invertible, so we consider it as a map from row, col
-    // to offset
-    // nb. Working with the map from row, col to offset is important to handle
-    // the tcgen05.cp instructions that do broadcasting
-    auto cvtTile = cvtTileInverted.invert();
-    // The sbo stride shall not touch the core tile
-    if (sbo < cvtTile.getOutDimSize(kOffset))
-      continue;
-
-    // As we are copying instrShape[0] columns in one go, to be able to
-    // represent this in the descriptor, we need to have a constant "stride"
-    // along the row dimension from row=8 until the last row.
-    auto bases = cvtTile.getBases();
-    for (int i = 1; i < instrShape[0] / 8; i *= 2) {
-      bases[kRow].push_back({sbo * i});
-    }
-    cvtTile = LinearLayout(bases, {{kOffset, sbo * (instrShape[0] / 8)}},
-                           /*requireSurjective=*/false);
-
-    auto quot = divideLeft(cvt, cvtTile);
-    if (quot.has_value()) {
-      if (auto nvmma = dyn_cast<NVMMASharedEncodingAttr>(shmemEnc)) {
-        assert(nvmma.getSwizzlingByteWidth() == swizzling);
-      }
-      return std::make_tuple(swizzling, *quot, cvtTile, instrShape, sbo);
-    }
-  }
-  return std::nullopt;
-}
-
-static void copySharedToTmem(ConversionPatternRewriter &rewriter, Location loc,
-                             const TypeConverter *typeConverter,
-                             triton::nvidia_gpu::TMEMCopyOp op, Value src,
-                             Value baseDst, Value pred, bool useTwoCTAs) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto *ctx = op.getContext();
-  auto kOffset = str_attr("offset");
-  auto kRow = str_attr("row");
-  auto kCol = str_attr("col");
-
-  MemDescType srcTy = op.getSrc().getType();
-  MemDescType dstTy = op.getDst().getType();
-
-  auto sharedLl = toLinearLayout(srcTy);
-  sharedLl =
-      sharedLl.sublayout({kOffset}, to_vector(sharedLl.getOutDimNames()));
-  auto tmemLl = toLinearLayout(dstTy);
-  auto cvt = tmemLl.invertAndCompose(sharedLl);
-
-  auto bitwidth = srcTy.getElementType().getIntOrFloatBitWidth();
-  // Need to find the shmem tile that matches
-  auto maybeSwizzling = getSwizzling(srcTy, dstTy);
-  assert(maybeSwizzling.has_value());
-  auto [swizzling, quot, tile, tileShape, sbo] = std::move(*maybeSwizzling);
-
-  auto reps = zerosLike(tile) * quot;
-
-  // Get shmem ptr
-  // TODO We should not allow splitting along the swizzling pattern
-  Type elemTy = typeConverter->convertType(srcTy.getElementType());
-  auto smemObj =
-      LLVM::getSharedMemoryObjectFromStruct(loc, src, elemTy, rewriter);
-  Value baseSrcInt =
-      b.ptrtoint(i32_ty, smemObj.getShmemAffineBase(loc, rewriter, srcTy));
-  // We checked in the verifier that the alignment is at least 16
-  Value baseSrcIntShr4 = b.lshr(baseSrcInt, b.i32_val(4));
-
-  // Set common fields in the SMEMDescriptor
-  SMEMDescriptor desc;
-  desc.baseAddress = 0;
-  // For K-contig, leadDimension is assumed to be 1
-  desc.leadDimensionBaseOffset = 1;
-  // SBO is in elements and we have to pass it to bits and right shift by 4
-  desc.strideDimensionBaseOffset = ((sbo * (bitwidth / 8)) >> 4);
-  desc.matrixBaseOffset = 0;
-  switch (swizzling) {
-  case 0:
-    desc.swizzlingMode = 0;
-    break;
-  case 32:
-    desc.swizzlingMode = 3;
-    break;
-  case 64:
-    desc.swizzlingMode = 2;
-    break;
-  case 128:
-    desc.swizzlingMode = 1;
-    break;
-  default:
-    llvm::report_fatal_error("Unsupported swizzling size.");
-  }
-
-  // Make sure we don't have to iterate along the rows
-  assert(tile.getInDimSize(kRow) == cvt.getInDimSize(kRow) && "NYI");
-  assert(tileShape[1] <= tile.getInDimSize(kCol) && "NYI");
-  int elementBytes = bitwidth / 8;
-  for (int col = 0; col < reps.getInDimSize(kCol);
-       col += tile.getInDimSize(kCol)) {
-    // Compute base offset for the swizzling pattern
-    int32_t off = reps.apply({{kRow, 0}, {kCol, col}})[0].second;
-    desc.matrixBaseOffset = (off * elementBytes / 128) & 0x7;
-    uint64_t descBase = desc.descriptor;
-    // https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-shared-memory-descriptor
-    descBase |= (1ULL << 46);
-    Value descValBase = b.int_val(64, desc.descriptor);
-    for (int offset = 0; offset < tile.getInDimSize(kCol);
-         offset += tileShape[1]) {
-      // Compute total offset of the current message
-      int32_t totalOffElems =
-          cvt.apply({{kRow, 0}, {kCol, col + offset}})[0].second;
-      int32_t smemByteOffset = totalOffElems * elementBytes;
-      int32_t smemByteOffsetShr4 = smemByteOffset >> 4;
-      // We could fold this add into the descBase if we wanted to
-      Value baseAddr = b.add(baseSrcIntShr4, b.i32_val(smemByteOffsetShr4));
-      Value baseSrcDesc = b.zext(i64_ty, b.and_(baseAddr, b.i32_val(0x3FFF)));
-      // Add the base address to the descriptor
-      Value descVal = b.or_(descValBase, baseSrcDesc, /*disjoint=*/true);
-      auto tmemAddr =
-          b.or_(b.ptrtoint(i32_ty, baseDst), b.i32_val(col + offset),
-                /*disjoint=*/true);
-      createTcgen05Cp(rewriter, loc, tmemAddr, descVal, pred,
-                      /*scales=*/false, useTwoCTAs);
-    }
-  }
-}
-
 struct TensorMemoryCopyOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::TMEMCopyOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -1247,9 +1330,6 @@ struct TensorMemoryCopyOpConversion
     }
     if (isa<TensorMemoryScalesEncodingAttr>(
             op.getDst().getType().getEncoding())) {
-      // Special case for copy of scales as they behave differently from other
-      // copies. This can be unified once we fix the smem layout representation
-      // of the source.
       copyScales(rewriter, loc, typeConverter, op, adaptor.getSrc(),
                  adaptor.getDst(), pred, tlxTwoCTAs);
     } else {
@@ -1312,8 +1392,10 @@ public:
   LogicalResult
   matchAndRewrite(MemDescReinterpretOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
-            op.getSrc().getType().getEncoding())) {
+    auto srcTy = op.getSrc().getType();
+    auto tmem =
+        triton::nvidia_gpu::TensorMemorySpaceAttr::get(srcTy.getContext());
+    if (srcTy.getMemorySpace() != tmem) {
       return failure();
     }
     rewriter.replaceOp(op, adaptor.getSrc());


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8225

Upstream commit message:
```
> [BACKEND] Generic tcgen05.cp lowering (#8225)

> We also fix a ton of issues here and there that we found while working
> on this.

> - We add full support for `memdesc_trans` and `memdesc_reshape` using
> the newly minted `SharedLinearLayout`.
> - We fix a few issues we left out in `SharedLinearLayout`'s initial
> implementation.
> - We now make `tcgen05.cp` take the correct layout, and we fix the
> OptimizeDotOperands
> pass to use `memdesc_trans/reshape` to reflect this.
> - We fix a number of previously broken tests

> We still need to tighten the memdesc_copy verifier to make it a bit more
> user-friendly tho.
```

Conflict Resolution:
- File: third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp:953-1002
  Action: Kept HEAD's createCommit 2CTA support code and adopted upstream's new createTcgen05Cp with TMemCopyAtom signature
  Reason: The upstream refactored createTcgen05Cp from (bool scales, bool useTwoCTAs) to (TMemCopyAtom atom). HEAD had TLX 2CTA commit code that needed preservation. The new generic createTcgen05Cp uses TMemCopyAtom for all copy patterns.

- File: third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp:1008-1100
  Action: Removed the copyScales function (kept upstream's empty side)
  Reason: Upstream removed copyScales because the generic copySharedToTmem now handles scales via TMemCopyAtom. The old copyScales used the removed createTcgen05Cp signature.

- File: third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp:1296-1307
  Action: Adopted upstream's tmemAddr calculation with elementBytes/4 scaling and new createTcgen05Cp(atom) call
  Reason: Upstream corrected the tmem address offset calculation and uses the new generic API.

- File: third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp:1326-1349
  Action: Kept HEAD's TLX 2CTA leader CTA predicate logic, removed copyScales branch, call only copySharedToTmem
  Reason: The 2CTA predicate is a Meta/TLX-specific feature. The copyScales branch was removed since copySharedToTmem now handles all copy types generically.

- File: lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp:833-843
  Action: Merged HEAD's DummyTMEMLayoutAttr early-return (TLX-specific) with upstream's null-guard on nvmmaEnc
  Reason: Both changes are additive — the DummyTMEMLayoutAttr check is a TLX feature, and the nvmmaEnc null guard fixes a potential null dereference.

- File: test/Conversion/tritongpu_to_llvm_blackwell.mlir:351-358
  Action: Used upstream's shared_linear layout definition with blocked layout
  Reason: Upstream changed the test to use shared_linear layout, which matches the new generic tcgen05.cp lowering path.

Raw Conflicts: https://www.internalfb.com/intern/paste/P2209497547/

Diff Versions Comparsion
v2 → v3: Restore TLX-compatible scale copy path
https://www.internalfb.com/phabricator/paste/view/P2212980635

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 70e69cba0b80cd2263fb9229ae3825bf08df258f

Reviewed By: dshi7

Differential Revision: D94673495


