### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[Build] Cleanup Python 3.9 related code/docs (#8222)'

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,8 +88,8 @@ jobs:
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_${{ matrix.config.arch }}:latest"
           fi
 
-          export CIBW_BUILD="cp3{9,10,11,12,13,13t,14,14t}-manylinux_${{ matrix.config.arch }}"
-          export CIBW_SKIP="cp{35,36,37,38}-*"
+          export CIBW_BUILD="cp3{10,11,12,13,13t,14,14t}-manylinux_${{ matrix.config.arch }}"
+          export CIBW_SKIP="cp{35,36,37,38,39}-*"
           export CIBW_ENABLE=cpython-freethreading
           python3 -m cibuildwheel . --output-dir wheelhouse
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ def inspect_stages(_self, stages, options, language, capability):
 triton.knobs.runtime.add_stages_inspection_hook = inspect_stages
 ```
 
+Binary wheels are available for CPython 3.10-3.14.
 
 ### Remote buffer operations
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -14,7 +14,7 @@ You can install the latest stable release of Triton from pip:
 
       pip install triton
 
-Binary wheels are available for CPython 3.9-3.13.
+Binary wheels are available for CPython 3.10-3.14.
 
 -----------
 From Source

--- a/third_party/proton/csrc/lib/Context/Python.cpp
+++ b/third_party/proton/csrc/lib/Context/Python.cpp
@@ -25,32 +25,15 @@ PyObject *_Py_XNewRef(PyObject *obj) {
 #define Py_XNewRef(obj) _Py_XNewRef((PyObject *)(obj))
 #endif
 
-// bpo-40421 added PyFrame_GetCode() to Python 3.9.0b1
-#if PY_VERSION_HEX < 0x030900B1
-PyCodeObject *getFrameCodeObject(PyFrameObject *frame) {
-  assert(frame != nullptr);
-  assert(frame->f_code != nullptr);
-  return (PyCodeObject *)(Py_NewRef(frame->f_code));
-}
-#else
 PyCodeObject *getFrameCodeObject(PyFrameObject *frame) {
   assert(frame != nullptr);
   return PyFrame_GetCode(frame);
 }
-#endif
 
-// bpo-40421 added PyFrame_GetBack() to Python 3.9.0b1
-#if PY_VERSION_HEX < 0x030900B1
-PyFrameObject *getFrameBack(PyFrameObject *frame) {
-  assert(frame != nullptr);
-  return (PyFrameObject *)(Py_XNewRef(frame->f_back));
-}
-#else
 PyFrameObject *getFrameBack(PyFrameObject *frame) {
   assert(frame != nullptr);
   return PyFrame_GetBack(frame);
 }
-#endif
 
 std::string unpackPyobject(PyObject *pyObject) {
   if (PyBytes_Check(pyObject)) {


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8222

Upstream commit message:
```
> [Build] Cleanup Python 3.9 related code/docs (#8222)

> Continuation of
> https://github.com/triton-lang/triton/commit/286d9c205e8f819efacf5d43eeaef3494dd85dcb

> Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>
> Co-authored-by: Keren Zhou <kerenzhou@openai.com>
```

Conflict Resolution:
- File: README.md
  Action: Kept incoming content — added "Binary wheels are available for CPython 3.10-3.14."
  Reason: HEAD side was empty (original line didn't exist in local branch). The upstream PR updated the supported Python version range after dropping 3.9. Accepting the new line is correct.

Raw Conflicts: https://www.internalfb.com/intern/paste/P2209559826/

Diff Versions: Compare V1 (conflict markers) → V2 (resolved) in Phabricator

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 1b27b93fa5a4efdfef285581df4524189da81bba

Reviewed By: dshi7

Differential Revision: D94680621
