### PR TITLE
[MemoryPlanner] a new algorithm for smem allocation

### DIFF
--- a/autows-doc/smem_allocation_design.md
+++ b/autows-doc/smem_allocation_design.md
@@ -1,0 +1,618 @@
+# SMEM Allocation Redesign in Memory Planner
+
+## Goal
+
+Redesign the SMEM allocation in `MemoryPlanner::run()` so that:
+
+1. Each `local_alloc` is modeled as a **WSBuffer**.
+2. Every WSBuffer starts with a single copy (`buffer.copy = 1`).
+3. WSBuffers that span multiple `loop.stage` must have at least 2 copies.
+4. `num_buffers` (the `--num-buffers` pass parameter) determines the maximum copies.
+5. Copies are incrementally increased for high-priority WSBuffers while
+   fitting within the SMEM budget.
+6. A pass option `--smem-circular-reuse` (default: off) gates all
+   reuse-group pairing logic.
+7. At each iteration we choose either a **single WSBuffer** or a **pair of
+   WSBuffers** and increase the copies by 1:
+   - A pair is chosen only when `--smem-circular-reuse` is on and there
+     are **exactly two** WSBuffers at the current highest priority.
+   - A chosen pair becomes a **reuse group** (sharing a `buffer.id`).
+   - If the final copy count is even, the group is split back
+     (each buffer gets `numCopies/2` with its own `buffer.id`).
+   - A chosen single WSBuffer has **no reuse** (its own `buffer.id`).
+8. After all WSBuffers at the highest priority are handled,
+   proceed to the next level.
+
+---
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| **WSBuffer** | A wrapper around one `ttg.local_alloc` op, tracking its size, liveness interval, channel properties, and allocation decisions (`buffer.id`, `buffer.copy`). |
+| **num_buffers** | The `--num-buffers` pass parameter. Determines the maximum `buffer.copy` value for any WSBuffer. |
+| **Reuse group** | A pair of WSBuffers that share a single `buffer.id`. The physical allocation is `max(size_A, size_B) * buffer.copy`. Only formed when `--smem-circular-reuse` is on. |
+| **smem-circular-reuse** | Pass option (default: off). When on, enables reuse-group pairing in Phase 4. When off, every WSBuffer keeps its own `buffer.id`. |
+| **Cross-stage** | A WSBuffer whose channel has producer and consumer(s) in different `loop.stage` values. |
+
+---
+
+## Algorithm
+
+### Phase 1: Initialize — One WSBuffer Per `local_alloc`, All `copy = 1`
+
+Walk the function in **deterministic order** (sorted by operation ID). For
+each `ttg.local_alloc` that is a shared memory alloc, create a **WSBuffer**:
+
+```cpp
+struct WSBuffer {
+    Operation *allocOp;        // the local_alloc
+    unsigned   sizeBytes;      // numElems * elemBitWidth / 8
+    Interval<size_t> liveness; // [firstUser, lastUser)
+    bool       isInnermost;    // users all in innermost loop, 2D+ shape
+    bool       isTMA;          // channel source is TMA/descriptor_load
+    bool       isCrossStage;   // src and dst in different loop.stage
+    unsigned   bufferId;       // assigned buffer.id
+    unsigned   numCopies;      // assigned buffer.copy (starts at 1)
+};
+```
+
+All WSBuffers start with:
+- A unique `bufferId` (0, 1, 2, …)
+- `numCopies = 1`
+
+### Phase 2: Enforce Cross-Stage Minimum
+
+Any WSBuffer with `isCrossStage == true` must have at least 2 copies
+(as long as `num_buffers >= 2`). For each such WSBuffer, set `numCopies = 2`.
+
+Note: no budget check is performed here. The total SMEM may temporarily
+exceed the budget after this phase. Phase 4 will resolve this — either by
+grouping cross-stage buffers into reuse groups (which reduces physical SMEM)
+or by confirming the allocation fits. If Phase 4 cannot bring the total
+within budget, it reports the failure.
+
+### Phase 3: Classify and Prioritize
+
+Sort WSBuffers into priority levels. Only **innermost-loop** WSBuffers are
+candidates for further copy increases. The `isCrossStage` property does
+**not** affect priority — it only enforces a minimum copy count in Phase 2.
+
+| Priority | Criteria | Description |
+|----------|----------|-------------|
+| **P0** (highest) | `isInnermost && isTMA` | TMA loads in innermost loop. Most critical for multi-buffering. |
+| **P1** | `isInnermost && !isTMA` | Non-TMA innermost buffers. Lower priority. |
+| **P2** (lowest) | `!isInnermost` | Outside-loop or non-innermost buffers. Stay at current copies. |
+
+### Phase 4: Iterative Copy Increase
+
+Process each priority level from P0 to P1 (P2 is never increased).
+
+A pass option `--smem-circular-reuse` (default: off) controls whether
+reuse-group pairing is attempted. When off, every WSBuffer keeps its own
+`buffer.id` and only individual copy increases are tried.
+
+#### Algorithm
+
+For a given priority level with a set of candidate WSBuffers:
+
+```
+candidates = WSBuffers at this priority
+
+# ── Step 0: Decide grouping upfront ──────────────────────────────
+#
+# When smem-circular-reuse is on and there are exactly 2 candidates,
+# tentatively group them into a reuse group. The incremental loop
+# operates on the group as a unit. After the loop, if the final
+# copy count is even, the group is split back (Step 2) since each
+# buffer gets exactly half — no circular reuse benefit.
+#
+# The group's starting copies must satisfy the cross-stage constraint:
+# if any member has isCrossStage (needing N=2 individual copies),
+# the group needs at least 2*N - 1 = 3 copies so that each member
+# retains at least N effective pipeline slots.
+
+reuseGroup = null
+
+if smem_circular_reuse AND |candidates| == 2:
+    reuseGroup = form reuse group (A, B)
+    B.bufferId = A.bufferId            # B shares A's buffer.id
+    maxCrossStageMin = max(A.crossStageMin, B.crossStageMin)  # 2 or 1
+    if maxCrossStageMin >= 2:
+        reuseGroup.numCopies = maxCrossStageMin * 2 - 1       # e.g., 3
+    else:
+        reuseGroup.numCopies = 1
+
+# ── Step 1: Incremental loop ─────────────────────────────────────
+
+if reuseGroup:
+    currentGroupCopies = reuseGroup.numCopies
+else:
+    currentGroupCopies = 1
+
+foundValidSolution = false
+
+while currentGroupCopies <= num_buffers:
+
+    if reuseGroup:
+        # ── Reuse group path (handled separately) ────────────
+        tentatively set group copies = currentGroupCopies
+        if totalSmem(tentative) <= smemBudget:
+            commit: reuseGroup.numCopies = currentGroupCopies
+            currentGroupCopies += 1
+            foundValidSolution = true
+        else:
+            break  # budget exhausted
+
+    else:
+        # ── Individual WSBuffers path ────────────────────────
+        pending = [c for c in candidates if c.numCopies < currentGroupCopies]
+
+        if not pending:
+            currentGroupCopies += 1
+            continue
+
+        advanced_any = false
+        for each wsBuffer in pending:
+            tentatively set wsBuffer.copies = currentGroupCopies
+            if totalSmem(tentative) <= smemBudget:
+                commit: wsBuffer.numCopies = currentGroupCopies
+                advanced_any = true
+                foundValidSolution = true
+            else:
+                continue  # try next candidate at this level
+
+        if not advanced_any:
+            break  # budget exhausted, done with this priority
+
+        currentGroupCopies += 1
+
+# ── Step 2: Finalize reuse decision ──────────────────────────────
+#
+# If the reuse group's final numCopies is even, there is no benefit
+# from circular reuse — each buffer would get exactly numCopies/2
+# effective copies. Split the group back into separate buffers.
+
+if reuseGroup AND reuseGroup.numCopies is EVEN:
+    half = reuseGroup.numCopies / 2
+    A.numCopies = half
+    B.numCopies = half
+    B.bufferId = nextBufferId++    # restore B's own buffer.id
+    reuseGroup = null
+
+# ── Step 3: Validate ─────────────────────────────────────────────
+#
+# After the loop, check if we found any allocation that fits.
+# This catches cases where even the minimum required copies (e.g.,
+# cross-stage group at 3 copies) exceeds the budget.
+
+if not foundValidSolution:
+    report error: cannot fit SMEM allocation within budget
+```
+
+#### Initial value of `currentGroupCopies`
+
+| Scenario | Initial value | Why |
+|----------|:---:|-----|
+| Reuse group, one member cross-stage (N=2) | **3** (`2*2-1`) | Ensures the cross-stage member retains ≥2 effective pipeline slots |
+| Reuse group, no cross-stage members | **1** | No constraint; start from bottom |
+| No reuse group | **1** | Each WSBuffer increments individually |
+
+#### Advancement of `currentGroupCopies`
+
+`currentGroupCopies` advances by 1 after each level is processed:
+- **Reuse group path:** try to bring the group to `currentGroupCopies`,
+  then advance. No iteration over pending — the group is a single unit.
+- **Individual path:** iterate over all pending WSBuffers at this level,
+  then advance.
+
+The loop runs while `currentGroupCopies <= num_buffers`.
+
+**Key rules:**
+- `--smem-circular-reuse` gates all pairing/reuse logic. When off,
+  only single-WSBuffer increases are tried.
+- When `smem-circular-reuse` is on and there are **exactly 2** candidates
+  at a priority level, they are tentatively grouped into a reuse group
+  before the loop begins.
+- A pair is chosen (i.e., remains as a reuse group) only when there are
+  **exactly 2** candidates **and** the final copy count is **odd**.
+  If the final copy count is even, the group is split back in Step 2
+  (each buffer gets `numCopies/2` with its own `buffer.id`).
+- Once grouped, the loop increments the group's copies as a single unit
+  (no iteration over pending).
+- The loop terminates when budget is exhausted or
+  `currentGroupCopies > num_buffers`.
+
+### Phase 4: Total SMEM Computation
+
+```
+totalSmem = 0
+for each unique buffer.id:
+    groupSize = max(sizeBytes of WSBuffers sharing this buffer.id)
+    copies    = buffer.copy for this group
+    totalSmem += groupSize * copies
+```
+
+### Phase 5: Emit Attributes
+
+Write `buffer.id` and `buffer.copy` attributes onto each `local_alloc` op.
+For WSBuffers in a reuse group, both ops get the same `buffer.id`.
+
+---
+
+## BWD Test Case Walkthrough
+
+### Setup
+
+```
+num_buffers = 2   (from --num-buffers=2 on the RUN line)
+smemBudget  = 232448 bytes  (227 KB, Blackwell sm_100)
+```
+
+### SMEM WSBuffers
+
+| # | Name   | Size   | Innermost | TMA | Cross-Stage | Why cross-stage? |
+|---|--------|--------|-----------|-----|-------------|------------------|
+| 0 | `dsT`  | 32 KB  | Yes | No  | No  | Producer (stage 1) → consumers (stage 1) |
+| 1 | `do`   | 32 KB  | Yes | Yes | Yes | Producer (stage 0) → consumers at stage 0 and stage 1 |
+| 2 | `q`    | 32 KB  | Yes | Yes | Yes | Producer (stage 0) → consumers at stage 0 and stage 1 |
+| 3 | `k_42` | 32 KB  | No  | —   | —   | Outside loop |
+| 4 | `v_43` | 32 KB  | No  | —   | —   | Outside loop |
+
+### Phase 1 — Initialize
+
+All WSBuffers get unique IDs, all `numCopies = 1`.
+
+```
+Total SMEM = 5 × 32 KB = 160 KB
+```
+
+### Phase 2 — Cross-Stage Minimum
+
+`do` and `q` are cross-stage → set `numCopies = 2`.
+
+```
+Total SMEM = 32(dsT) + 64(do) + 64(q) + 32(k) + 32(v) = 224 KB ≤ 227 KB ✓
+```
+
+### Phase 3 — Classification
+
+| Priority | WSBuffers |
+|----------|-----------|
+| P0 (innermost + TMA) | `do`, `q` |
+| P1 (innermost, non-TMA) | `dsT` |
+| P2 (not innermost) | `k_42`, `v_43` |
+
+### Phase 4 — Iterative Increase
+
+**P0: `do`, `q`**  (`smem-circular-reuse = false`)
+
+No grouping. Each WSBuffer is independent.
+Both at `numCopies = 2` from Phase 2. `currentGroupCopies = 1`.
+
+- Level 2: pending = none (both already at 2). Advance.
+- Level 3: 3 > 2 → exit (num_buffers = 2). **Done.**
+
+**P0: `do`, `q`**  (`smem-circular-reuse = true`)
+
+|candidates|=2 → group `do`+`q` upfront. Both are cross-stage (need 2
+individual copies), so group minimum = `2*2-1 = 3`. But `num_buffers = 2`,
+so `3 > num_buffers` — the group's starting copies is clamped to
+`num_buffers = 2`. `currentGroupCopies = 2`.
+
+- Level 2: group not yet at 2.
+  - Group tries `numCopies = 2`: cost = max(32,32) × 2 = 64 KB.
+    total = 32(dsT) + **64**(do+q) + 32(k) + 32(v) = 160 KB ≤ 227 KB ✓.
+  - Commit. Advance.
+- Level 3: 3 > 2 → exit (num_buffers = 2). **Done.**
+
+**P1: `dsT`**
+
+1 WSBuffer at P1. `numCopies = 1`, `currentGroupCopies = 1`.
+
+With `smem-circular-reuse = false` (do=2, q=2, separate):
+- Level 2: total = 64(dsT) + 64(do) + 64(q) + 32(k) + 32(v) = 256 KB > 227 KB ✗.
+  Cannot increase.
+
+With `smem-circular-reuse = true` (do+q group at 2):
+- Level 2: total = 64(dsT) + 64(do+q) + 32(k) + 32(v) = 192 KB ≤ 227 KB ✓.
+  Commit.
+
+**P2: `k_42`, `v_43`**
+
+Not innermost. **Do not increase.**
+
+### Final Result (`smem-circular-reuse = false`)
+
+| WSBuffer | `buffer.id` | `buffer.copy` | Reuse Group |
+|----------|-------------|---------------|-------------|
+| `dsT`    | 0           | 1             | — |
+| `do`     | 1           | 2             | — |
+| `q`      | 2           | 2             | — |
+| `k_42`   | 3           | 1             | — |
+| `v_43`   | 4           | 1             | — |
+
+```
+Total SMEM = 32 + 64 + 64 + 32 + 32 = 224 KB
+```
+
+### Final Result (`smem-circular-reuse = true`)
+
+| WSBuffer | `buffer.id` | `buffer.copy` | Reuse Group |
+|----------|-------------|---------------|-------------|
+| `dsT`    | 0           | 2             | — |
+| `do`     | 1           | 2             | `do` + `q` |
+| `q`      | 1           | 2             | `do` + `q` |
+| `k_42`   | 2           | 1             | — |
+| `v_43`   | 3           | 1             | — |
+
+```
+Total SMEM = 64 + 64 + 32 + 32 = 192 KB
+```
+
+Grouping `do`+`q` saves 64 KB (from 224 KB to 160 KB for those two),
+freeing budget for `dsT` to increase to 2 copies.
+
+---
+
+## Pairing Logic — Detailed Examples
+
+### Example 1: 2 candidates, both at copies=1, `smem-circular-reuse=true`
+
+```
+P0 candidates: [A(copies=1), B(copies=1)]
+  → |candidates| = 2, smem-circular-reuse → group upfront
+  → group.numCopies = 1
+  → Loop: level 2 → group tries 2, budget check ✓ → copies = 2
+  → Loop: level 3 → group tries 3, budget check ✓ → copies = 3
+  → Physical = max(sizeA, sizeB) × 3
+```
+
+### Example 2: 2 candidates, `smem-circular-reuse=false`
+
+```
+P0 candidates: [A(copies=1), B(copies=1)]
+  → No grouping. Each keeps its own buffer.id.
+  → Loop: level 2 → A tries 2, budget ✓ → A.copies = 2
+  →                  B tries 2, budget ✓ → B.copies = 2
+  → Loop: level 3 → A tries 3, budget ✓ → A.copies = 3
+  →                  B tries 3, budget ✗ → B stays at 2
+  → Physical = sizeA × 3 + sizeB × 2
+```
+
+### Example 3: 3 candidates, `smem-circular-reuse=true`
+
+```
+P0 candidates: [A(copies=1), B(copies=1), C(copies=1)]
+  → |candidates| = 3, not exactly 2 → no grouping
+  → Each keeps its own buffer.id.
+  → Loop processes each individually at each level.
+```
+
+### Example 4: Different starting copies (FWD case), `smem-circular-reuse=true`
+
+```
+v(copies=2 from cross-stage), k(copies=1)
+  → |candidates| = 2, smem-circular-reuse → group upfront
+  → v is cross-stage (needs 2), so group starts at 2*2-1 = 3
+  → Loop: level 3 → group tries 3 → 96 KB, budget ✓ → copies = 3
+  → Result: both v and k share 3 pipeline slots
+  → v retains ≥2 effective slots, k gets ≥1
+```
+
+### Example 5: Different starting copies, `smem-circular-reuse=false`
+
+```
+v(copies=2 from cross-stage), k(copies=1)
+  → No grouping.
+  → Loop: level 2 → k tries 2 → 64 KB extra, budget ✗ → k stays at 1
+  → v stays at 2, k stays at 1
+  → Grouping would have unlocked copies=3 for both within budget
+```
+
+---
+
+## FWD Test Case Walkthrough
+
+### Setup
+
+```
+num_buffers = 2   (hypothetical; the existing test uses num-buffers=3)
+smemBudget  = 232448 bytes  (227 KB, Blackwell sm_100)
+```
+
+### SMEM WSBuffers
+
+The Flash Attention forward pass (`_attn_fwd_persist`) has 6 SMEM allocations.
+There is an **outer** `scf.for` (persistent tile loop, line 162) and an
+**inner** `scf.for` (KV loop, line 184, `tt.scheduled_max_stage = 1`).
+
+| # | Name    | Size  | In inner loop? | TMA? | Cross-Stage? | Notes |
+|---|---------|-------|----------------|------|-------------|-------|
+| 0 | `%0`    | 32 KB | No | — | — | Alloc outside all loops |
+| 1 | `%1`    | 32 KB | No | — | — | Alloc outside all loops |
+| 2 | `v`     | 32 KB | Yes (innermost) | Yes | **Yes** | Producer stage 0; consumers at stage 0 (MMA line 286) and stage 1 (MMA line 287) |
+| 3 | `k`     | 32 KB | Yes (innermost) | Yes | **No** | Producer stage 0; all consumers at stage 0 (lines 187, 190–191) |
+| 4 | `q0`    | 32 KB | No | — | — | Alloc in outer loop, used in inner loop but produced before inner loop |
+| 5 | `q0_18` | 32 KB | No | — | — | Same as `q0` |
+
+### Phase 1 — Initialize
+
+All 6 WSBuffers get unique IDs 0–5, all `numCopies = 1`.
+
+```
+Total SMEM = 6 × 32 KB = 192 KB
+```
+
+### Phase 2 — Cross-Stage Minimum
+
+Only `v` is cross-stage → set `v.numCopies = 2`.
+
+```
+Total SMEM = 32×1(%0) + 32×1(%1) + 32×2(v) + 32×1(k) + 32×1(q0) + 32×1(q0_18)
+           = 32 + 32 + 64 + 32 + 32 + 32 = 224 KB ≤ 227 KB ✓
+```
+
+### Phase 3 — Classification
+
+| Priority | WSBuffers |
+|----------|-----------|
+| P0 (innermost + TMA) | `v`, `k` |
+| P1 (innermost, non-TMA) | — |
+| P2 (not innermost) | `%0`, `%1`, `q0`, `q0_18` |
+
+### Phase 4 — Iterative Increase
+
+**P0: `v`, `k`**  (`smem-circular-reuse = false`)
+
+No grouping. Each WSBuffer is independent.
+
+`v` is at `numCopies = 2` (cross-stage minimum), `k` at `numCopies = 1`.
+`currentGroupCopies = 1`.
+
+- Level 2: pending = [`k`] (only `k` is below 2, `v` already at 2).
+  - Single: `k` tries `numCopies = 2`:
+    total = 32 + 32 + 64 + **64** + 32 + 32 = 256 KB > 227 KB ✗.
+  - Cannot increase. Budget exhausted. **Done.**
+
+**P0: `v`, `k`**  (`smem-circular-reuse = true`)
+
+|candidates|=2 → group `v`+`k` upfront. `v` is cross-stage (needs 2
+individual copies), so group starts at `2*2-1 = 3` copies.
+`currentGroupCopies = 3`.
+
+- Level 3: group not yet at 3.
+  - Group tries `numCopies = 3`: cost = max(32,32) × 3 = 96 KB.
+    total = 32 + 32 + **96** + 32 + 32 = 224 KB ≤ 227 KB ✓. Commit.
+  - Advance.
+- Level 4: 4 > 3 → exit (num_buffers = 3). **Done.**
+
+**P1: (empty)** Skip.
+
+**P2: `%0`, `%1`, `q0`, `q0_18`**
+
+Not innermost. **Do not increase.**
+
+### Final Result (`smem-circular-reuse = false`)
+
+| WSBuffer | `buffer.id` | `buffer.copy` | Reuse Group |
+|----------|-------------|---------------|-------------|
+| `%0`     | 0           | 1             | — |
+| `%1`     | 1           | 1             | — |
+| `v`      | 2           | 2             | — |
+| `k`      | 3           | 1             | — |
+| `q0`     | 4           | 1             | — |
+| `q0_18`  | 5           | 1             | — |
+
+```
+Total SMEM = 32 + 32 + 64 + 32 + 32 + 32 = 224 KB
+```
+
+### Final Result (`smem-circular-reuse = true`)
+
+| WSBuffer | `buffer.id` | `buffer.copy` | Reuse Group |
+|----------|-------------|---------------|-------------|
+| `%0`     | 0           | 1             | — |
+| `%1`     | 1           | 1             | — |
+| `v`      | 2           | 3             | `v` + `k` |
+| `k`      | 2           | 3             | `v` + `k` |
+| `q0`     | 3           | 1             | — |
+| `q0_18`  | 4           | 1             | — |
+
+```
+Total SMEM = 32 + 32 + 96 + 32 + 32 = 224 KB
+```
+
+> **Note:** The current algorithm assigns `copy = 3` to both `v` and `k`
+> without reuse (total = 320 KB — exceeding budget). The new algorithm with
+> `smem-circular-reuse = true` achieves the same `copy = 3` for both within
+> budget via a reuse group. With reuse off, `v` stays at 2 and `k` at 1.
+
+---
+
+## Key Design Decisions
+
+### 1. SMEM Budget Parameter
+
+The hardware SMEM capacity must be known. Options:
+
+- Derive from `ttg.target` attribute (e.g., `"cuda:100"` → 227 KB).
+- Add a pass option `--smem-budget=<bytes>` for testing.
+- Use a conservative default to leave room for barriers/scratch.
+
+### 2. `num_buffers` Source
+
+Passed as the `--num-buffers` parameter to the pass (same as today).
+This is the maximum number of copies any WSBuffer can have.
+
+### 3. Deterministic Iteration Order
+
+Sort WSBuffers by their operation ID (from `buildOperationIdMap`) before
+processing, ensuring reproducible results.
+
+### 4. Reuse Group Constraints
+
+Two WSBuffers can form a reuse group only if:
+1. `--smem-circular-reuse` is on.
+2. They are at the **same priority level**.
+3. They have the same element type.
+
+Liveness overlap and dependency ordering do not need to be checked —
+the reuse group shares a circular buffer, and the circular indexing
+handles producer-consumer separation.
+
+The reuse decision is recorded by assigning the same `buffer.id` to
+both WSBuffers. No additional pointer or data structure is needed —
+downstream passes already group allocs by `buffer.id`.
+
+### 5. Interaction with TMEM Planner
+
+The SMEM planner runs first (Step 2 of `doMemoryPlanner`) and returns
+`lastBufferId`. The TMEM planner (Step 4) starts numbering from there.
+This interface is unchanged.
+
+---
+
+## Summary of Changes
+
+| Component | Current | Proposed |
+|-----------|---------|----------|
+| Abstraction | Raw `BufferT` + `DenseMap` | `WSBuffer` struct per `local_alloc` |
+| Initial state | Single pass, group by type | Phase 1: unique IDs, all `copy = 1` |
+| Cross-stage | Not considered | Phase 2: force `copy ≥ 2` |
+| Multi-buffering | Unconditional for TMA+innermost | Phase 4: iterative, budget-aware |
+| Reuse | Not done | Pair of 2 same-priority WSBuffers; grouping-first when copies ≥ 2 |
+| Max copies | `numBuffers` param (all-or-nothing) | `num_buffers` param (incremental cap) |
+| Budget | Not checked | Enforced at every iteration |
+| Iteration order | Non-deterministic | Sorted by operation ID |
+
+---
+
+## Pipeline Context
+
+```
+doMemoryPlanner(funcOp, numBuffers)
+  ├── Step 0: reorderOpsBySchedule (disabled)
+  ├── Step 1: collectPostChannels
+  ├── Step 1.5: identify cross-stage channels
+  ├── Step 2: MemoryPlanner::run(numBuffers)       ← THIS CHANGES
+  │     ├── Phase 1: create WSBuffers, unique IDs, all copy=1
+  │     ├── Phase 2: enforce cross-stage minimum (copy ≥ 2)
+  │     ├── Phase 3: classify P0–P2
+  │     ├── Phase 4: iterative copy increase within SMEM budget
+  │     │     ├── per priority level, pair or single selection
+  │     │     └── reuse group creation when paired
+  │     └── Phase 5: emit buffer.id / buffer.copy attributes
+  ├── Step 3: MemoryPlannerTmem::collectTMemAllocsAndLiveness
+  └── Step 4: MemoryPlannerTmem::allocateBuffers(lastBufferId)
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `WSMemoryPlanner.cpp` — `MemoryPlanner` class | Add `WSBuffer` struct, rewrite `run()` with 5-phase algorithm |
+| `WSMemoryPlanner.cpp` — `doMemoryPlanner` | Pass cross-stage info from Step 1.5 into the planner |
+| `Passes.td` | Add `--smem-budget` and `--smem-circular-reuse` options |
+| `ws_memory_planner_bwd.mlir` | Update CHECK lines for new assignments |
+| `ws_memory_planner_fwd.mlir` | Update CHECK lines similarly |

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1197,6 +1197,9 @@ class CodeGenerator(ast.NodeVisitor):
         data_partition_factor = None
         merge_epilogue = False
         tmem_alloc_algo = None
+        smem_alloc_algo = None
+        smem_budget = None
+        smem_circular_reuse = None
         flatten = False
         warp_specialize = False
         disable_licm = False
@@ -1214,6 +1217,9 @@ class CodeGenerator(ast.NodeVisitor):
             data_partition_factor = iterator.data_partition_factor
             merge_epilogue = iterator.merge_epilogue
             tmem_alloc_algo = iterator.tmem_alloc_algo
+            smem_alloc_algo = iterator.smem_alloc_algo
+            smem_budget = iterator.smem_budget
+            smem_circular_reuse = iterator.smem_circular_reuse
             flatten = iterator.flatten
             warp_specialize = iterator.warp_specialize
             disable_licm = iterator.disable_licm
@@ -1285,6 +1291,12 @@ class CodeGenerator(ast.NodeVisitor):
                 for_op.set_attr("tt.merge_epilogue", self.builder.get_bool_attr(True))
             if tmem_alloc_algo is not None:
                 for_op.set_attr("tt.tmem_alloc_algo", self.builder.get_int32_attr(tmem_alloc_algo))
+            if smem_alloc_algo is not None:
+                for_op.set_attr("tt.smem_alloc_algo", self.builder.get_int32_attr(smem_alloc_algo))
+            if smem_budget is not None:
+                for_op.set_attr("tt.smem_budget", self.builder.get_int32_attr(smem_budget))
+            if smem_circular_reuse is not None:
+                for_op.set_attr("tt.smem_circular_reuse", self.builder.get_bool_attr(smem_circular_reuse))
             if disable_licm:
                 for_op.set_attr("llvm.loop_annotation", self.builder.get_disable_loop_licm_attr())
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3271,7 +3271,8 @@ class range(base_value):
 
     def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None,
                  disallow_acc_multi_buffer=False, flatten=False, warp_specialize=False, disable_licm=False,
-                 data_partition_factor=None, merge_epilogue=False, tmem_alloc_algo=None):
+                 data_partition_factor=None, merge_epilogue=False, tmem_alloc_algo=None, smem_alloc_algo=None,
+                 smem_budget=None, smem_circular_reuse=None):
         if step is None:
             self.step = constexpr(1)
         else:
@@ -3288,6 +3289,9 @@ class range(base_value):
         self.data_partition_factor = data_partition_factor
         self.merge_epilogue = merge_epilogue
         self.tmem_alloc_algo = tmem_alloc_algo
+        self.smem_alloc_algo = smem_alloc_algo
+        self.smem_budget = smem_budget
+        self.smem_circular_reuse = smem_circular_reuse
         self.flatten = flatten
         self.warp_specialize = warp_specialize
         self.disable_licm = disable_licm

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -666,7 +666,8 @@ def _attn_bwd_dkdv(
     tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
     curr_m = start_m
     step_m = BLOCK_M1
-    for blk_idx in tl.range(0, num_steps, warp_specialize=warp_specialize, tmem_alloc_algo=2):
+    for blk_idx in tl.range(0, num_steps, warp_specialize=warp_specialize, tmem_alloc_algo=2, smem_alloc_algo=1,
+                            smem_budget=200000):
         q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
         qT = tl.trans(q)
         # Load m before computing qk to reduce pipeline stall.
@@ -1204,7 +1205,7 @@ for HEAD_DIM in [64, 128]:
                 "H": N_HEADS,
                 "BATCH": BATCH,
                 "HEAD_DIM": HEAD_DIM,
-                "mode": "fwd",
+                "mode": "bwd",
             },
         ))
 

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
@@ -1,7 +1,8 @@
 // RUN: triton-opt %s --nvgpu-test-ws-memory-planner=num-buffers=2 --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s
 
-// Test case: FA BWD pattern using allocateTMemAllocs2 backtracking algorithm.
-// This test verifies the TMEM buffer allocation for Flash Attention backward pass.
+// Test case: FA BWD pattern with budget-aware SMEM allocation (algo=1).
+// With smem_budget=200000, only one of the two cross-stage TMA buffers
+// (do, q) can get copy=2 before exceeding budget. The other stays at copy=1.
 //
 // The key buffers in allocation order:
 //   [0] dk: liveness=[44-112) size=128x128 - accumulator, long-lived
@@ -26,32 +27,32 @@
 
 // CHECK-LABEL: tt.func public @_attn_bwd
 //
-// SMEM allocations: innermost-loop buffers share buffer.id = 0
-// CHECK: %dsT = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32}
+// SMEM allocations
+// CHECK: %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
 //
 // TMEM allocation: dv (bf16) reuses qkT's buffer at offset 0
-// CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32, buffer.offset = 0 : i32}
+// CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
 //
 // SMEM allocations
-// CHECK: %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32}
-// CHECK: %q = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32}
-// CHECK: %k_42 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32}
-// CHECK: %v_43 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
+// CHECK: %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
+// CHECK: %q = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
+// CHECK: %k_42 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: %v_43 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
 //
-// TMEM allocations: qkT owns buffer 5
-// CHECK: %qkT, %qkT_44 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// TMEM allocations: qkT owns buffer 7
+// CHECK: %qkT, %qkT_44 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
 //
-// TMEM allocation: dv_45 (f32 accumulator) owns buffer 4
-// CHECK: %dv_45, %dv_46 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 4 : i32}
+// TMEM allocation: dv_45 (f32 accumulator) owns buffer 6
+// CHECK: %dv_45, %dv_46 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
 //
-// TMEM allocation: dpT owns buffer 6
-// CHECK: %dpT, %dpT_47 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
+// TMEM allocation: dpT owns buffer 8
+// CHECK: %dpT, %dpT_47 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
 //
-// TMEM allocation: dk owns buffer 3
-// CHECK: %dk, %dk_48 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// TMEM allocation: dk owns buffer 5
+// CHECK: %dk, %dk_48 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
 //
-// TMEM allocation: dq reuses dpT (buffer.id=6, buffer.offset=0) — key verification
-// CHECK: %dq, %dq_49 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32, buffer.offset = 0 : i32}
+// TMEM allocation: dq reuses dpT (buffer.id=8, buffer.offset=0) — key verification
+// CHECK: %dq, %dq_49 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
 
 // -----// WarpSpec internal IR Dump After: doBufferAllocation
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
@@ -198,7 +199,7 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
       tt.descriptor_reduce add, %desc_dq[%q_90, %c0_i32], %dqN_140 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9> loc(#loc132)
       %curr_m_141 = arith.addi %arg45, %c128_i32 {async_task_id = array<i32: 1, 2, 3>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i32 loc(#loc167)
       scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %curr_m_141, %true, %qkT_100, %dv_105, %dpT_114, %dk_118, %dq_122 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token loc(#loc134)
-    } {async_task_id = array<i32: 0, 1, 2, 3>, "tt.tmem_alloc_algo" = 2 : i32, tt.merge_epilogue = true, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32} loc(#loc203)
+    } {async_task_id = array<i32: 0, 1, 2, 3>, "tt.smem_alloc_algo" = 1 : i32, "tt.smem_budget" = 200000 : i32, "tt.tmem_alloc_algo" = 2 : i32, tt.merge_epilogue = true, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32} loc(#loc203)
     %dv_52, %dv_53 = ttng.tmem_load %dv_45[%curr_m#3] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc(#loc139)
     %dvs = tt.reshape %dv_52 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4> loc(#loc168)
     %dk_54, %dk_55 = ttng.tmem_load %dk[%curr_m#5] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc(#loc147)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -331,7 +331,11 @@ class CUDABackend(BaseBackend):
             passes.ttir.add_triton_licm(pm)
             passes.common.add_canonicalizer(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
-            nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS, dump_enabled)
+            from triton.runtime.driver import driver as rt_driver
+            smem_budget = rt_driver.active.utils.get_device_properties(
+                rt_driver.active.get_current_device())["max_shared_mem"]
+            nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS, dump_enabled,
+                                                     smem_budget)
             passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
@@ -353,8 +357,11 @@ class CUDABackend(BaseBackend):
                     nvidia.passes.hopper.add_partition_scheduling_meta(pm)
                 else:
                     passes.ttgpuir.add_partition_scheduling(pm)
+                from triton.runtime.driver import driver as rt_driver
+                smem_budget = rt_driver.active.utils.get_device_properties(
+                    rt_driver.active.get_current_device())["max_shared_mem"]
                 nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS,
-                                                         dump_enabled)
+                                                         dump_enabled, smem_budget)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             # hoist again and allow hoisting out of if statements

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -27,9 +27,12 @@ def NVGPUWarpSpecialization : Pass<"nvgpu-warp-specialization", "mlir::ModuleOp"
            "bool", /*default*/"false",
            "Enable ping pong barrier insertion around critical regions">,
     Option<"dumpIntermediateSteps", "dump-intermediate-steps",
-           "bool", /*default*/"false",
-           "Dump intermediate steps">
-  ];
+             "bool", /*default*/"false",
+             "Dump intermediate steps">,
+    Option<"smemBudget", "smem-budget",
+             "int32_t", /*default*/"0",
+             "SMEM budget in bytes (0 = auto-detect from target)">
+    ];
 }
 
 def NVGPUTestWSTaskPartition : Pass<"nvgpu-test-ws-task-partition", "mlir::ModuleOp"> {
@@ -55,6 +58,15 @@ def NVGPUTestWSMemoryPlanner : Pass<"nvgpu-test-ws-memory-planner", "mlir::Modul
     Option<"numBuffers", "num-buffers",
            "int32_t", /*default*/"0",
            "number of buffering for warp specialization">,
+    Option<"smemAllocAlgo", "smem-alloc-algo",
+           "int32_t", /*default*/"0",
+           "SMEM allocation algorithm: 0 = original, 1 = WSBuffer-based">,
+    Option<"smemBudget", "smem-budget",
+           "int32_t", /*default*/"0",
+           "SMEM budget in bytes (0 = auto-detect from target)">,
+    Option<"smemCircularReuse", "smem-circular-reuse",
+           "bool", /*default*/"false",
+           "Enable circular buffer reuse for SMEM allocation">,
     Option<"readDecisionFile", "read-decision-file",
            "std::string", /*default*/"\"\"",
            "path to JSON file containing buffer decisions to apply">,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -30,7 +30,9 @@ void doTaskPartition(triton::FuncOp &funcOp, unsigned numWarpGroups);
 int doTaskIdPropagate(triton::FuncOp &funcOp);
 LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
                               StringRef readDecisionFile = "",
-                              StringRef writeDecisionFile = "");
+                              StringRef writeDecisionFile = "",
+                              int smemAllocAlgo = 0, unsigned smemBudget = 0,
+                              bool smemCircularReuse = false);
 bool doDataPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups);
 void doBufferAllocation(triton::FuncOp &funcOp);
 void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
@@ -162,7 +164,9 @@ public:
       llvm::dbgs() << "\n\n\n";
     }
 
-    if (failed(doMemoryPlanner(funcOp, numStages))) {
+    if (failed(doMemoryPlanner(funcOp, numStages, /*readDecisionFile=*/"",
+                               /*writeDecisionFile=*/"",
+                               /*smemAllocAlgo=*/0, smemBudget))) {
       signalPassFailure();
       return;
     }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -596,6 +596,403 @@ private:
 };
 } // namespace triton
 
+//===----------------------------------------------------------------------===//
+// New SMEM Allocation — WSBuffer-based approach (Phases 1–3)
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Priority levels for SMEM multi-buffering candidates.
+enum class WSBufferPriority {
+  P0_InnermostTMA = 0, // innermost loop + TMA channel
+  P1_InnermostNonTMA,  // innermost loop, non-TMA
+  P2_Other,            // outside loop / non-innermost (never increased)
+};
+
+/// A wrapper around one ttg.local_alloc op for the new SMEM allocation.
+struct WSBuffer {
+  Operation *allocOp;
+  unsigned sizeBytes;
+  Interval<size_t> liveness;
+  bool isInnermost;
+  bool isTMA;
+  bool isCrossStage;
+  unsigned bufferId;
+  unsigned numCopies;
+  WSBufferPriority priority;
+};
+
+/// Check if all users of a channel are in the same innermost loop and the
+/// alloc type has at least 2 non-trivial dimensions.
+static bool isInnermostSmemChannel(Operation *alloc,
+                                   SmallVector<Channel *> &channels) {
+  Channel *ch = findChannelForOp(alloc, channels);
+  if (!ch || ch->channelKind != DataChannelKind::SMEMPost)
+    return false;
+  DenseSet<Operation *> users;
+  (void)getAllAcutalUsersForChannel(ch, users, alloc);
+  if (users.empty())
+    return false;
+  auto *first = *(users.begin());
+  for (auto *user : users) {
+    if (user->getBlock() != first->getBlock())
+      return false;
+  }
+  auto parentLoop = first->getParentOfType<scf::ForOp>();
+  if (!parentLoop)
+    return false;
+  if (!isInnermostLoop(parentLoop))
+    return false;
+
+  // Check 2D+ shape.
+  auto sAlloc = cast<ttg::LocalAllocOp>(alloc);
+  auto allocDescType = cast<ttg::MemDescType>(sAlloc.getType());
+  unsigned numD = 0;
+  for (int64_t shape : allocDescType.getShape()) {
+    if (shape > 1)
+      ++numD;
+  }
+  return numD >= 2;
+}
+
+/// Check if a channel's producer is a TMA operation.
+static bool isSmemTMAChannel(Operation *alloc,
+                             SmallVector<Channel *> &channels) {
+  Channel *ch = findChannelForOp(alloc, channels);
+  if (!ch || ch->channelKind != DataChannelKind::SMEMPost)
+    return false;
+  auto *chPost = static_cast<ChannelPost *>(ch);
+  Operation *srcOp = chPost->getSrcOp();
+  if (!srcOp)
+    return false;
+  if (isa<ttng::AsyncTMACopyGlobalToLocalOp>(srcOp))
+    return true;
+  if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(srcOp)) {
+    Value stored = storeOp.getSrc();
+    if (auto *defOp = stored.getDefiningOp())
+      return isa<tt::DescriptorLoadOp>(defOp);
+  }
+  return false;
+}
+
+/// Helper to read the loop.stage attribute from an op. Returns -1 if absent.
+static int getLoopStage(Operation *op) {
+  auto attr = op->getAttrOfType<IntegerAttr>(tt::kLoopStageAttrName);
+  return attr ? attr.getValue().getSExtValue() : -1;
+}
+
+/// Check if a channel's source and destination(s) are in different
+/// loop.stage values.
+static bool isSmemCrossStage(Operation *alloc,
+                             SmallVector<Channel *> &channels) {
+  Channel *ch = findChannelForOp(alloc, channels);
+  if (!ch || ch->channelKind != DataChannelKind::SMEMPost)
+    return false;
+  Operation *srcOp = ch->getSrcOp();
+  if (!srcOp)
+    return false;
+  int srcStage = getLoopStage(srcOp);
+  if (srcStage < 0)
+    return false;
+
+  SmallVector<Operation *> dstOps;
+  ch->getDstOps(dstOps);
+  if (dstOps.empty()) {
+    if (Operation *dst = ch->getDstOp())
+      dstOps.push_back(dst);
+  }
+  for (Operation *dstOp : dstOps) {
+    int dstStage = getLoopStage(dstOp);
+    if (dstStage >= 0 && dstStage != srcStage)
+      return true;
+  }
+  return false;
+}
+
+/// Compute the byte size for a local_alloc op.
+static unsigned getSmemAllocSizeBytes(ttg::LocalAllocOp alloc) {
+  auto allocType = alloc.getType();
+  int64_t numElems = 0;
+  if (auto paddedEnc =
+          dyn_cast<ttg::PaddedSharedEncodingAttr>(allocType.getEncoding())) {
+    SmallVector<int64_t> unpaddedShape = ttg::getShapePerCTA(allocType);
+    numElems = paddedEnc.getPaddedSize(unpaddedShape);
+  } else {
+    auto shapePerCTA = ttg::getAllocationShapePerCTA(allocType);
+    numElems = product<int64_t>(shapePerCTA);
+  }
+  return static_cast<unsigned>(numElems * allocType.getElementTypeBitWidth() /
+                               8);
+}
+
+/// Compute total SMEM usage in bytes across all WSBuffers.
+/// Buffers sharing the same buffer.id (reuse group) contribute
+/// max(sizes) * copies instead of sum(sizes) * copies.
+static unsigned computeTotalSmem(const SmallVector<WSBuffer> &wsBuffers) {
+  DenseMap<unsigned, std::pair<unsigned, unsigned>>
+      idInfo; // id -> (maxSize, copies)
+  for (const auto &buf : wsBuffers) {
+    auto it = idInfo.find(buf.bufferId);
+    if (it == idInfo.end()) {
+      idInfo[buf.bufferId] = {buf.sizeBytes, buf.numCopies};
+    } else {
+      it->second.first = std::max(it->second.first, buf.sizeBytes);
+      it->second.second = std::max(it->second.second, buf.numCopies);
+    }
+  }
+  unsigned total = 0;
+  for (auto &kv : idInfo)
+    total += kv.second.first * kv.second.second;
+  return total;
+}
+
+/// New SMEM allocation: Phases 1–5.
+///
+/// Phase 1: Create one WSBuffer per local_alloc, all copy=1, unique IDs.
+/// Phase 2: Enforce cross-stage minimum (copy >= 2).
+/// Phase 3: Classify into priority levels P0/P1/P2.
+/// Phase 4: Iterative copy increase within SMEM budget.
+/// Phase 5: Emit buffer.id and buffer.copy attributes.
+///
+/// Returns the next available buffer ID after the SMEM allocations.
+static unsigned allocateSmemBuffers(triton::FuncOp funcOp,
+                                    SmallVector<Channel *> &channels,
+                                    unsigned numBuffers, unsigned smemBudget,
+                                    bool smemCircularReuse) {
+  // ── Phase 1: Create WSBuffers ───────────────────────────────────────
+  SmallVector<WSBuffer> wsBuffers;
+  unsigned nextBufferId = 0;
+
+  funcOp->walk<WalkOrder::PreOrder>([&](ttg::LocalAllocOp alloc) {
+    if (!alloc.isSharedMemoryAlloc())
+      return;
+
+    WSBuffer buf;
+    buf.allocOp = alloc;
+    buf.sizeBytes = getSmemAllocSizeBytes(alloc);
+    buf.isInnermost = isInnermostSmemChannel(alloc, channels);
+    buf.isTMA = buf.isInnermost && isSmemTMAChannel(alloc, channels);
+    buf.isCrossStage = isSmemCrossStage(alloc, channels);
+    buf.bufferId = nextBufferId++;
+    buf.numCopies = 1;
+    buf.priority = WSBufferPriority::P2_Other;
+
+    wsBuffers.push_back(buf);
+
+    LDBG("Phase 1: WSBuffer["
+         << buf.bufferId << "] " << buf.sizeBytes << " bytes"
+         << " innermost=" << buf.isInnermost << " TMA=" << buf.isTMA
+         << " crossStage=" << buf.isCrossStage);
+  });
+
+  if (wsBuffers.empty())
+    return nextBufferId;
+
+  // ── Phase 2: Enforce cross-stage minimum ────────────────────────────
+  // Budget-aware: only set copy=2 if the total SMEM stays within budget.
+  for (auto &buf : wsBuffers) {
+    if (buf.isCrossStage && numBuffers >= 2) {
+      unsigned saved = buf.numCopies;
+      buf.numCopies = 2;
+      unsigned totalSmem = computeTotalSmem(wsBuffers);
+      if (totalSmem <= smemBudget) {
+        LDBG("Phase 2: WSBuffer[" << buf.bufferId
+                                  << "] cross-stage → numCopies=2"
+                                  << " (totalSmem=" << totalSmem << ")");
+      } else {
+        buf.numCopies = saved;
+        LDBG("Phase 2: WSBuffer["
+             << buf.bufferId << "] cross-stage copy=2 skipped"
+             << " (would exceed budget: " << totalSmem << " > " << smemBudget
+             << ")");
+      }
+    }
+  }
+
+  // ── Phase 3: Classify and prioritize ────────────────────────────────
+  for (auto &buf : wsBuffers) {
+    if (buf.isInnermost && buf.isTMA) {
+      buf.priority = WSBufferPriority::P0_InnermostTMA;
+    } else if (buf.isInnermost) {
+      buf.priority = WSBufferPriority::P1_InnermostNonTMA;
+    } else {
+      buf.priority = WSBufferPriority::P2_Other;
+    }
+    LDBG("Phase 3: WSBuffer["
+         << buf.bufferId << "] priority=" << static_cast<int>(buf.priority));
+  }
+
+  // ── Phase 4: Iterative copy increase ────────────────────────────────
+  // Process P0 then P1. P2 is never increased.
+  for (auto priority : {WSBufferPriority::P0_InnermostTMA,
+                        WSBufferPriority::P1_InnermostNonTMA}) {
+    // Collect candidate indices at this priority.
+    SmallVector<unsigned> candidateIndices;
+    for (unsigned i = 0; i < wsBuffers.size(); ++i) {
+      if (wsBuffers[i].priority == priority)
+        candidateIndices.push_back(i);
+    }
+    if (candidateIndices.empty())
+      continue;
+
+    LDBG("Phase 4: processing priority=" << static_cast<int>(priority)
+                                         << " with " << candidateIndices.size()
+                                         << " candidates");
+
+    // Step 0: Decide grouping upfront.
+    bool isReuseGroup = false;
+    if (smemCircularReuse && candidateIndices.size() == 2) {
+      isReuseGroup = true;
+      auto &bufA = wsBuffers[candidateIndices[0]];
+      auto &bufB = wsBuffers[candidateIndices[1]];
+
+      // B shares A's buffer.id.
+      bufB.bufferId = bufA.bufferId;
+
+      // Compute starting copies for the group based on cross-stage.
+      unsigned maxCrossStageMin = 1;
+      if (bufA.isCrossStage)
+        maxCrossStageMin = std::max(maxCrossStageMin, 2u);
+      if (bufB.isCrossStage)
+        maxCrossStageMin = std::max(maxCrossStageMin, 2u);
+
+      unsigned groupStart = 1;
+      if (maxCrossStageMin >= 2)
+        groupStart = maxCrossStageMin * 2 - 1; // e.g., 3
+
+      // Clamp to num_buffers.
+      if (groupStart > numBuffers)
+        groupStart = numBuffers;
+
+      bufA.numCopies = groupStart;
+      bufB.numCopies = groupStart;
+
+      LDBG("Phase 4: formed reuse group ["
+           << bufA.bufferId << "] with startCopies=" << groupStart
+           << " (crossStageMin=" << maxCrossStageMin << ")");
+    }
+
+    // Step 1: Incremental loop.
+    unsigned currentGroupCopies;
+    if (isReuseGroup) {
+      currentGroupCopies = wsBuffers[candidateIndices[0]].numCopies;
+    } else {
+      // Start at the minimum numCopies across candidates (may be > 1
+      // after Phase 2 cross-stage enforcement).
+      currentGroupCopies = numBuffers; // will be lowered
+      for (unsigned idx : candidateIndices)
+        currentGroupCopies =
+            std::min(currentGroupCopies, wsBuffers[idx].numCopies);
+    }
+
+    bool foundValidSolution = false;
+
+    while (currentGroupCopies <= numBuffers) {
+      if (isReuseGroup) {
+        // Reuse group path: set group copies and check budget.
+        auto &bufA = wsBuffers[candidateIndices[0]];
+        auto &bufB = wsBuffers[candidateIndices[1]];
+        unsigned savedA = bufA.numCopies, savedB = bufB.numCopies;
+        bufA.numCopies = currentGroupCopies;
+        bufB.numCopies = currentGroupCopies;
+
+        unsigned totalSmem = computeTotalSmem(wsBuffers);
+        if (totalSmem <= smemBudget) {
+          foundValidSolution = true;
+          LDBG("Phase 4: reuse group copies=" << currentGroupCopies
+                                              << " totalSmem=" << totalSmem
+                                              << " ≤ " << smemBudget);
+          currentGroupCopies++;
+        } else {
+          bufA.numCopies = savedA;
+          bufB.numCopies = savedB;
+          LDBG("Phase 4: reuse group copies="
+               << currentGroupCopies << " totalSmem=" << totalSmem << " > "
+               << smemBudget << " — budget exhausted");
+          break;
+        }
+      } else {
+        // Individual path: bring each pending candidate to currentGroupCopies.
+        SmallVector<unsigned> pending;
+        for (unsigned idx : candidateIndices) {
+          if (wsBuffers[idx].numCopies < currentGroupCopies)
+            pending.push_back(idx);
+        }
+
+        if (pending.empty()) {
+          currentGroupCopies++;
+          continue;
+        }
+
+        bool advancedAny = false;
+        for (unsigned idx : pending) {
+          auto &buf = wsBuffers[idx];
+          unsigned saved = buf.numCopies;
+          buf.numCopies = currentGroupCopies;
+
+          unsigned totalSmem = computeTotalSmem(wsBuffers);
+          if (totalSmem <= smemBudget) {
+            advancedAny = true;
+            foundValidSolution = true;
+            LDBG("Phase 4: WSBuffer["
+                 << buf.bufferId << "] copies=" << currentGroupCopies
+                 << " totalSmem=" << totalSmem << " ≤ " << smemBudget);
+          } else {
+            buf.numCopies = saved;
+            LDBG("Phase 4: WSBuffer["
+                 << buf.bufferId << "] copies=" << currentGroupCopies
+                 << " totalSmem=" << totalSmem << " > " << smemBudget
+                 << " — skipped");
+          }
+        }
+
+        if (!advancedAny)
+          break;
+
+        currentGroupCopies++;
+      }
+    }
+
+    // Step 2: Finalize reuse decision.
+    // If final copies is even, split the group back.
+    if (isReuseGroup) {
+      auto &bufA = wsBuffers[candidateIndices[0]];
+      auto &bufB = wsBuffers[candidateIndices[1]];
+      if (bufA.numCopies % 2 == 0) {
+        unsigned half = bufA.numCopies / 2;
+        bufA.numCopies = half;
+        bufB.numCopies = half;
+        bufB.bufferId = nextBufferId++;
+        isReuseGroup = false;
+        LDBG("Phase 4: split reuse group — even copies="
+             << (half * 2) << " → each gets " << half);
+      }
+    }
+
+    // Step 3: Validate.
+    if (!foundValidSolution) {
+      LDBG("Phase 4: WARNING — no valid SMEM allocation found for priority="
+           << static_cast<int>(priority));
+    }
+  }
+
+  LDBG("Phase 4 complete: totalSmem=" << computeTotalSmem(wsBuffers));
+
+  // ── Phase 5: Emit buffer.id and buffer.copy attributes ──────────────
+  auto i32Type = IntegerType::get(funcOp.getContext(), 32);
+  for (auto &buf : wsBuffers) {
+    buf.allocOp->setAttr("buffer.id", IntegerAttr::get(i32Type, buf.bufferId));
+    buf.allocOp->setAttr("buffer.copy",
+                         IntegerAttr::get(i32Type, buf.numCopies));
+    LDBG("Phase 5: WSBuffer[" << buf.bufferId << "] buffer.id=" << buf.bufferId
+                              << " buffer.copy=" << buf.numCopies);
+  }
+
+  return nextBufferId;
+}
+
+} // anonymous namespace
+
 /// Collect all users of a TMEM allocation from its channel.
 /// For operand D allocations (accumulator), collects all direct users.
 /// For other allocations, delegates to getAllAcutalUsersForChannel.
@@ -1866,7 +2263,9 @@ LogicalResult readDecisionsFromFile(SmallVector<Channel *> &channels,
 
 LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
                               StringRef readDecisionFile = "",
-                              StringRef writeDecisionFile = "") {
+                              StringRef writeDecisionFile = "",
+                              int smemAllocAlgo = 0, unsigned smemBudget = 0,
+                              bool smemCircularReuse = false) {
 
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;
@@ -1905,13 +2304,45 @@ LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
   // Step 2: figure out smem/tmem sizes and liveness.
   // If two buffers are sharing a multi-staged alloc, the liveness can overlap,
   // otherwise, the liveness can't overlap.
-  Allocation allocation;
-  triton::MemoryPlanner planner(funcOp, &allocation, &channels);
-  if (failed(planner.run(numBuffers)))
-    return failure();
-  unsigned bufferId = planner.getLastBufferId();
-  LLVM_DEBUG(funcOp.dump());
-  LLVM_DEBUG(planner.dumpBuffers());
+
+  // Check for per-loop SMEM allocation attributes on the WS ForOp.
+  // These override the pass-level defaults, following the same pattern
+  // as tt.tmem_alloc_algo.
+  int effectiveSmemAllocAlgo = smemAllocAlgo;
+  unsigned effectiveSmemBudget = smemBudget;
+  bool effectiveSmemCircularReuse = smemCircularReuse;
+  funcOp->walk([&](scf::ForOp forOp) {
+    if (!forOp->hasAttr("tt.warp_specialize"))
+      return;
+    if (auto attr = forOp->getAttrOfType<IntegerAttr>("tt.smem_alloc_algo"))
+      effectiveSmemAllocAlgo = attr.getInt();
+    if (auto attr = forOp->getAttrOfType<IntegerAttr>("tt.smem_budget"))
+      effectiveSmemBudget = static_cast<unsigned>(attr.getInt());
+    if (auto attr = forOp->getAttrOfType<BoolAttr>("tt.smem_circular_reuse"))
+      effectiveSmemCircularReuse = attr.getValue();
+  });
+
+  unsigned bufferId;
+  if (effectiveSmemAllocAlgo == 1) {
+    // New WSBuffer-based SMEM allocation (Phases 1-5).
+    LDBG("using SMEM allocation algorithm 1 (WSBuffer-based)"
+         << " smemBudget=" << effectiveSmemBudget
+         << " smemCircularReuse=" << effectiveSmemCircularReuse);
+    assert(effectiveSmemBudget != 0 && "smem budget is not set");
+    bufferId =
+        allocateSmemBuffers(funcOp, channels, numBuffers, effectiveSmemBudget,
+                            effectiveSmemCircularReuse);
+  } else {
+    // Original SMEM allocation.
+    LDBG("using SMEM allocation algorithm 0 (original)");
+    Allocation allocation;
+    triton::MemoryPlanner planner(funcOp, &allocation, &channels);
+    if (failed(planner.run(numBuffers)))
+      return failure();
+    bufferId = planner.getLastBufferId();
+    LLVM_DEBUG(funcOp.dump());
+    LLVM_DEBUG(planner.dumpBuffers());
+  }
 
   // Dump combined key ops + channel graph (side by side visualization)
   // Note: Placed before MemoryPlannerTmem to visualize state even if TMEM
@@ -1964,7 +2395,8 @@ public:
   void runOnFuncOp(triton::FuncOp funcOp) {
     if (numBuffers >= 1 || !readDecisionFile.empty()) {
       if (failed(doMemoryPlanner(funcOp, numBuffers, readDecisionFile,
-                                 writeDecisionFile)))
+                                 writeDecisionFile, smemAllocAlgo, smemBudget,
+                                 smemCircularReuse)))
         signalPassFailure();
     }
   }

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -91,9 +91,9 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
 
 void init_triton_hopper_passes(py::module &&m) {
   // Meta's autoWS
-  ADD_PASS_OPTION_WRAPPER_4("add_hopper_warpspec",
+  ADD_PASS_OPTION_WRAPPER_5("add_hopper_warpspec",
                             mlir::createNVGPUWarpSpecialization, int, int, bool,
-                            bool);
+                            bool, int);
   ADD_PASS_OPTION_WRAPPER_1("add_data_partitioning",
                             mlir::createNVGPUWSDataPartition, int);
   ADD_PASS_WRAPPER_0("add_partition_scheduling_meta",

--- a/third_party/proton/csrc/include/Utility/Env.h
+++ b/third_party/proton/csrc/include/Utility/Env.h
@@ -21,7 +21,6 @@ inline bool getBoolEnv(const std::string &env, bool defaultValue) {
   return str == "on" || str == "true" || str == "1";
 }
 
-
 inline std::string getStrEnv(const std::string &env) {
   std::lock_guard<std::mutex> lock(getenv_mutex);
   const char *s = std::getenv(env.c_str());


### PR DESCRIPTION
WSBuffers that span multiple `loop.stage` must have at least 2 copies.
Copies are incrementally increased for high-priority WSBuffers while fitting within the SMEM budget.
A pass option `--smem-circular-reuse` (default: off) gates all reuse-group pairing logic.
At each iteration we choose either a **single WSBuffer** or a **pair of WSBuffers** and increase the copies by 1:
```
   - A pair is chosen only when `--smem-circular-reuse` is on and there
     are **exactly two** WSBuffers at the current highest priority.
   - A chosen pair becomes a **reuse group** (sharing a `buffer.id`).
   - If the final copy count is even, the group is split back
     (each buffer gets `numCopies/2` with its own `buffer.id`).
   - A chosen single WSBuffer has **no reuse** (its own `buffer.id`).
```
The new algorithm is guarded with a ForOp annotation. We will migrate over to this new algorithm once confirming it is fully working for all cases.