### PR TITLE
[Release/3.5.0.1] [TLX] Fix CLC barrier race for multi-CTA clusters (…

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -3143,6 +3143,114 @@ def test_cluster_launch_control(BLOCK_SIZE, device):
     assert torch.count_nonzero(output) == size
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+@pytest.mark.parametrize("CLUSTER_SIZE", [2, 4])
+def test_cluster_launch_control_multi_cta(CLUSTER_SIZE, device):
+    """
+    Test CLC with 2-CTA clusters (multi_ctas=True).
+
+    Verifies that:
+    1. Both CTAs call barrier_expect_bytes (unpredicated) on their own local bar_full,
+       because try_cancel with multicast::cluster::all signals each CTA's mbarrier.
+    2. Both CTAs call barrier_wait (unpredicated) on their own local bar_full
+       before reading the CLC response.
+    3. The kernel produces correct results with persistent multi-CTA CLC scheduling.
+    """
+
+    @triton.jit
+    def mul2_clc_multi_cta(
+        x_ptr,
+        y_ptr,
+        z_ptr,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+        CLUSTER_SIZE: tl.constexpr,
+    ):
+        # Each CTA in the cluster handles half the block
+        tile_id = tl.program_id(axis=0)
+
+        # CLC Init — num_consumers=CLUSTER_SIZE because all CTAs in the cluster
+        # arrive at CTA 0's bar_empty in clc_consumer
+        clc_phase_producer = 1
+        clc_phase_consumer = 0
+        clc_context = tlx.clc_create_context(CLUSTER_SIZE)
+
+        while tile_id != -1:
+            # CLC producer
+            tlx.clc_producer(clc_context, clc_phase_producer, multi_ctas=True)
+            clc_phase_producer ^= 1
+
+            block_start = tile_id * BLOCK_SIZE
+
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+
+            x = tl.load(x_ptr + offsets, mask=mask)
+            y = tl.load(y_ptr + offsets, mask=mask)
+            output = x + y
+            tl.store(z_ptr + offsets, output, mask=mask)
+
+            # CLC consumer
+            tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=True)
+            clc_phase_consumer ^= 1
+
+    torch.manual_seed(0)
+    BLOCK_SIZE = 1024
+    size = BLOCK_SIZE * CLUSTER_SIZE
+    x = torch.ones(size, device=device)
+    y = torch.ones(size, device=device)
+
+    output = torch.zeros_like(x)
+    ref_out = x + y
+
+    n_elements = output.numel()
+    # Grid: each logical tile is handled by 2 CTAs, so total CTAs = 2 * num_tiles
+    num_tiles = triton.cdiv(n_elements, BLOCK_SIZE)
+    # Pad to multiple of 2 for 2-CTA clusters
+    num_tiles = (num_tiles + 1) // CLUSTER_SIZE * CLUSTER_SIZE
+    grid = (num_tiles, )
+    kernel = mul2_clc_multi_cta[grid](
+        x,
+        y,
+        output,
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+        CLUSTER_SIZE=CLUSTER_SIZE,
+        launch_cluster=True,
+        ctas_per_cga=(CLUSTER_SIZE, 1, 1),
+    )
+
+    ptx = kernel.asm["ptx"]
+
+    # CLC instructions are present
+    assert re.search(r"clusterlaunchcontrol.try_cancel", ptx, flags=re.DOTALL)
+    assert re.search(r"clusterlaunchcontrol.query_cancel.is_canceled.pred.b128", ptx, flags=re.DOTALL)
+    assert re.search(r"clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128", ptx, flags=re.DOTALL)
+
+    # Multicast is used (2-CTA cluster)
+    assert re.search(r"multicast::cluster::all", ptx, flags=re.DOTALL)
+
+    # mapa.shared::cluster for remote barrier arrive (consumer signals CTA 0's bar_empty)
+    assert "mapa.shared::cluster" in ptx
+
+    # Verify barrier_expect_bytes is NOT predicated by cluster_ctaid check.
+    # Both CTAs must initialize their own bar_full because try_cancel with
+    # multicast::cluster::all signals the mbarrier on each CTA's shared memory.
+    # Look for expect_tx lines and ensure none are guarded by cluster_ctaid predicates.
+    expect_tx_lines = [line.strip() for line in ptx.split("\n") if "expect_tx" in line]
+    assert len(expect_tx_lines) > 0, "Expected mbarrier.arrive.expect_tx in PTX"
+
+    # The mbarrier.try_wait for the CLC response should NOT be skipped by rank-1.
+    # In the buggy version, rank-1 would branch past the try_wait with:
+    #   @!pred_cta0 bra skipWait
+    # After the fix, all CTAs should hit mbarrier.try_wait unconditionally.
+    try_wait_lines = [line.strip() for line in ptx.split("\n") if "mbarrier.try_wait" in line]
+    assert len(try_wait_lines) > 0, "Expected mbarrier.try_wait in PTX"
+
+    # Verify correctness
+    torch.testing.assert_close(output, ref_out)
+
+
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")
 def test_async_tasks_region_error(device):
 

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -115,8 +115,10 @@ def clc_producer(context, p_producer=None, multi_ctas: bool = False, k=0, _seman
     # Only CTA 0 waits on its LOCAL bar_empty (arrive remote, wait local)
     barrier_wait(bar_empty, p_producer, pred_cta0, _semantic=_semantic)
 
-    # Only CTA 0 sets barrier_expect_bytes
-    barrier_expect_bytes(bar_full, tl.constexpr(16), pred_cta0, _semantic=_semantic)
+    # ALL CTAs set barrier_expect_bytes on their local bar_full.
+    # The try_cancel with multicast::cluster::all signals the mbarrier on each
+    # CTA's shared memory, so each CTA needs its own barrier initialized.
+    barrier_expect_bytes(bar_full, tl.constexpr(16), _semantic=_semantic)
 
     # CLC issue - hardware handles multicast to all CTAs
     _clc_issue(
@@ -133,8 +135,10 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, _seman
 
     Multi-CTA Synchronization ("Arrive Remote, Wait Local"):
     ---------------------------------------------------------
-    - WAIT: Only CTA 0 waits on its LOCAL bar_full (predicated by pred_cta0).
-            CLC multicasts response to all CTAs, but only CTA 0 needs to wait.
+    - WAIT: ALL CTAs wait on their own LOCAL bar_full (unpredicated).
+            CLC try_cancel with multicast::cluster::all writes the response AND
+            signals the mbarrier in every CTA's shared memory. Each CTA must wait
+            on its own local mbarrier before reading the response.
     - QUERY: Extract tile_id from response. Automatically offset by cluster_cta_rank().
     - SIGNAL: All CTAs signal CTA 0's bar_empty via remote_cta_rank=0.
               This is valid because we can arrive at remote mbar, but not wait on it.
@@ -155,17 +159,11 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, _seman
     bar_full = local_view(context._clc_mbars_full, k, _semantic=_semantic)
     response = local_view(context._clc_responses, k, _semantic=_semantic)
 
-    # Compute pred_cta0 internally for multi-CTA mode
-    if multi_ctas:
-        cta_rank = cluster_cta_rank(_semantic=_semantic)
-        zero = _semantic.builder.get_int32(0)
-        pred_cta0_handle = _semantic.builder.create_icmpEQ(cta_rank.handle, zero)
-        pred_cta0 = tl.tensor(pred_cta0_handle, tl.int1)
-    else:
-        pred_cta0 = None
-
-    # Only CTA 0 waits on its LOCAL bar_full
-    barrier_wait(bar_full, p_consumer, pred_cta0, _semantic=_semantic)
+    # ALL CTAs wait on their own LOCAL bar_full.
+    # The try_cancel.async with multicast::cluster::all signals the mbarrier
+    # in every CTA's shared memory, so each CTA must wait on its own copy
+    # before reading the CLC response.
+    barrier_wait(bar_full, p_consumer, _semantic=_semantic)
 
     # Extract tile_id (automatically offset by cluster_cta_rank())
     stolen_tile_id = _clc_query(response, _semantic=_semantic)


### PR DESCRIPTION
…#908)

Summary:
Pull Request resolved: https://github.com/facebookexperimental/triton/pull/908

Per NVIDIA spec, `try_cancel.async` with `multicast::cluster::all` writes the CLC response to each CTA's local shared memory AND signals the mbarrier on each CTA's shared memory via `complete_tx`.

https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-matrix-data-movement-shape

> The .multicast::cluster::all qualifier indicates that the response is asynchronously written using weak async-proxy writes to the corresponding local shared memory addr of each CTA in the requesting cluster. The completion of the writes to addr of a particular CTA is signaled via a complete-tx operation to the mbarrier object on the shared memory of that CTA.

However, only CTA 0 was calling `barrier_expect_bytes` (guarded by `pred_cta0`), so CTA 1's mbarrier was never initialized with `expect_tx`. This caused CTA 1's `mbarrier.try_wait` to never complete, hanging all odd-ranked CTAs.

Fix both producer and consumer in `dynamic_launch.py`:
- Producer: `barrier_expect_bytes` is now unpredicated for `multi_ctas` mode so all CTAs initialize their own local `bar_full`.
- Consumer: `barrier_wait` is now unpredicated so all CTAs wait on their own local `bar_full` before reading the CLC response.

Also adds `test_cluster_launch_control_multi_cta` to verify the fix with a 2-CTA cluster CLC kernel, checking PTX for unpredicated `expect_tx` and `try_wait`, and validating end-to-end correctness.

Reviewed By: dshi7

Differential Revision: D93351112

fbshipit-source-id: 53cd6f825d90266637b68f25881efcbf58c49969