### PR TITLE
[AutoWS] Enable merging barriers with split TMA loads

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_code_partition_merged_barrier.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_merged_barrier.mlir
@@ -1,0 +1,117 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=3 post-channel-creation=1" | FileCheck %s
+
+// Test: When two SMEM buffers share a reuse group (same buffer.id) and one
+// requires TMA split copies, the code partition pass merges their consumer
+// groups so a single barrier_expect + wait is emitted. Without the merge,
+// each channel's separate insertAsyncComm call would create its own
+// BarrierExpectOp, causing barrier over-arrival (UB).
+//
+// A (128x64xf16): inner dim = 64 * 2B = 128B = swizzle -> no split
+// B (64x256xf16): inner dim = 256 * 2B = 512B > 128B swizzle -> split copies
+//
+// Both buffers share buffer.id = 0 (same reuse group), and the merged
+// barrier_expect has size 49152 = 128*64*2 + 64*256*2.
+
+// CHECK-LABEL: @matmul_kernel_tma_persistent
+// CHECK: ttg.warp_specialize
+// Default group: MMA consumer
+// CHECK: default
+// CHECK: ttng.tc_gen5_mma
+// Producer partition: single barrier_expect for merged consumer group
+// CHECK: partition0
+// CHECK: ttng.barrier_expect {{.*}}, 49152
+// CHECK-NOT: ttng.barrier_expect
+// CHECK: ttng.async_tma_copy_global_to_local
+// CHECK: ttng.async_tma_copy_global_to_local
+// Epilogue partition: load from TMEM and store results
+// CHECK: partition1
+// CHECK: ttng.tmem_load
+// CHECK: tt.descriptor_store
+// CHECK: tt.descriptor_store
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 2, 128], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 128, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.tensordesc<tensor<128x64xf16, #shared>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<64x256xf16, #shared>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<tensor<128x128xf16, #shared>>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<64x256xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %result, %token = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32} : () -> (!ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %false = arith.constant {async_task_id = array<i32: 0>} false
+    %true = arith.constant {async_task_id = array<i32: 0>} true
+    %c148_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 148 : i32
+    %c8_i32 = arith.constant {async_task_id = array<i32: 1, 2>} 8 : i32
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 128 : i32
+    %c256_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 256 : i32
+    %c64_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 64 : i32
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : i32
+    %c127_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 127 : i32
+    %c255_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 255 : i32
+    %c63_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 63 : i32
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    %2 = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2>} : i32
+    %3 = arith.addi %arg15, %c127_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %4 = arith.divsi %3, %c128_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %5 = arith.addi %arg16, %c255_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %6 = arith.divsi %5, %c256_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %7 = arith.addi %arg17, %c63_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %8 = arith.divsi %7, %c64_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %9 = arith.muli %4, %6 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %10 = arith.subi %2, %c148_i32 {async_task_id = array<i32: 2>} : i32
+    %11 = arith.muli %6, %c8_i32 {async_task_id = array<i32: 1, 2>} : i32
+    %12 = scf.for %arg19 = %2 to %9 step %c148_i32 iter_args(%arg20 = %10) -> (i32)  : i32 {
+      %13 = arith.divsi %arg19, %11 {async_task_id = array<i32: 1>} : i32
+      %14 = arith.muli %13, %c8_i32 {async_task_id = array<i32: 1>} : i32
+      %15 = arith.subi %4, %14 {async_task_id = array<i32: 1>} : i32
+      %16 = arith.minsi %15, %c8_i32 {async_task_id = array<i32: 1>} : i32
+      %17 = arith.remsi %arg19, %16 {async_task_id = array<i32: 1>} : i32
+      %18 = arith.addi %14, %17 {async_task_id = array<i32: 1>} : i32
+      %19 = arith.remsi %arg19, %11 {async_task_id = array<i32: 1>} : i32
+      %20 = arith.divsi %19, %16 {async_task_id = array<i32: 1>} : i32
+      %21 = arith.muli %18, %c128_i32 {async_task_id = array<i32: 1>} : i32
+      %22 = arith.muli %20, %c256_i32 {async_task_id = array<i32: 1>} : i32
+      %23 = ttng.tmem_store %cst, %result[%token], %true {async_task_id = array<i32: 0>, tmem.start = array<i32: 2>} : tensor<128x256xf32, #blocked> -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+      %24:2 = scf.for %arg21 = %c0_i32 to %8 step %c1_i32 iter_args(%arg22 = %false, %arg23 = %23) -> (i1, !ttg.async.token)  : i32 {
+        %43 = arith.muli %arg21, %c64_i32 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
+        %44 = tt.descriptor_load %arg0[%21, %43] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+        ttg.local_store %44, %1 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<128x64xf16, #blocked1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %45 = tt.descriptor_load %arg5[%43, %22] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<64x256xf16, #shared>> -> tensor<64x256xf16, #blocked2>
+        ttg.local_store %45, %0 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x256xf16, #blocked2> -> !ttg.memdesc<64x256xf16, #shared, #smem, mutable>
+        %46 = ttng.tc_gen5_mma %1, %0, %result[%arg23], %arg22, %true {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 2 : i32, tmem.start = array<i32: 3>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x256xf16, #shared, #smem, mutable>, !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield {async_task_id = array<i32: 0, 2>} %true, %46 : i1, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2>, tt.scheduled_max_stage = 2 : i32}
+      %25 = arith.addi %arg20, %c148_i32 {async_task_id = array<i32: 2>} : i32
+      %26 = arith.divsi %25, %11 {async_task_id = array<i32: 2>} : i32
+      %27 = arith.muli %26, %c8_i32 {async_task_id = array<i32: 2>} : i32
+      %28 = arith.subi %4, %27 {async_task_id = array<i32: 2>} : i32
+      %29 = arith.minsi %28, %c8_i32 {async_task_id = array<i32: 2>} : i32
+      %30 = arith.remsi %25, %29 {async_task_id = array<i32: 2>} : i32
+      %31 = arith.addi %27, %30 {async_task_id = array<i32: 2>} : i32
+      %32 = arith.remsi %25, %11 {async_task_id = array<i32: 2>} : i32
+      %33 = arith.divsi %32, %29 {async_task_id = array<i32: 2>} : i32
+      %34 = arith.muli %31, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      %35 = arith.muli %33, %c256_i32 {async_task_id = array<i32: 2>} : i32
+      %result_0, %token_1 = ttng.tmem_load %result[%24#1] {async_task_id = array<i32: 2>, tmem.end = array<i32: 2, 3>} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
+      %36 = tt.reshape %result_0 {async_task_id = array<i32: 2>} : tensor<128x256xf32, #blocked> -> tensor<128x2x128xf32, #blocked3>
+      %37 = tt.trans %36 {async_task_id = array<i32: 2>, order = array<i32: 0, 2, 1>} : tensor<128x2x128xf32, #blocked3> -> tensor<128x128x2xf32, #blocked4>
+      %outLHS, %outRHS = tt.split %37 {async_task_id = array<i32: 2>} : tensor<128x128x2xf32, #blocked4> -> tensor<128x128xf32, #blocked5>
+      %38 = arith.truncf %outRHS {async_task_id = array<i32: 2>} : tensor<128x128xf32, #blocked5> to tensor<128x128xf16, #blocked5>
+      %39 = arith.truncf %outLHS {async_task_id = array<i32: 2>} : tensor<128x128xf32, #blocked5> to tensor<128x128xf16, #blocked5>
+      %40 = ttg.convert_layout %39 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked5> -> tensor<128x128xf16, #blocked6>
+      tt.descriptor_store %arg10[%34, %35], %40 {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, tensor<128x128xf16, #blocked6>
+      %41 = ttg.convert_layout %38 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked5> -> tensor<128x128xf16, #blocked6>
+      %42 = arith.addi %35, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      tt.descriptor_store %arg10[%34, %42], %41 {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, tensor<128x128xf16, #blocked6>
+      scf.yield {async_task_id = array<i32: 2>} %25 : i32
+    } {async_task_id = array<i32: 0, 1, 2>, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
@@ -26,32 +26,32 @@
 
 // CHECK-LABEL: tt.func public @_attn_bwd
 //
-// SMEM allocations: each gets its own buffer.id
-// CHECK: %dsT = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
+// SMEM allocations: innermost-loop buffers share buffer.id = 0
+// CHECK: %dsT = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32}
 //
 // TMEM allocation: dv (bf16) reuses qkT's buffer at offset 0
-// CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
+// CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32, buffer.offset = 0 : i32}
 //
 // SMEM allocations
-// CHECK: %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 2 : i32}
-// CHECK: %q = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 3 : i32}
-// CHECK: %k_42 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
-// CHECK: %v_43 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// CHECK: %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32}
+// CHECK: %q = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32}
+// CHECK: %k_42 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32}
+// CHECK: %v_43 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
 //
-// TMEM allocations: qkT owns buffer 8
-// CHECK: %qkT, %qkT_44 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// TMEM allocations: qkT owns buffer 5
+// CHECK: %qkT, %qkT_44 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
 //
-// TMEM allocation: dv_45 (f32 accumulator) owns buffer 7
-// CHECK: %dv_45, %dv_46 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
+// TMEM allocation: dv_45 (f32 accumulator) owns buffer 4
+// CHECK: %dv_45, %dv_46 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 4 : i32}
 //
-// TMEM allocation: dpT owns buffer 9
-// CHECK: %dpT, %dpT_47 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 9 : i32}
+// TMEM allocation: dpT owns buffer 6
+// CHECK: %dpT, %dpT_47 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
 //
-// TMEM allocation: dk owns buffer 6
-// CHECK: %dk, %dk_48 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
+// TMEM allocation: dk owns buffer 3
+// CHECK: %dk, %dk_48 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 3 : i32}
 //
-// TMEM allocation: dq reuses dpT (buffer.id=9, buffer.offset=0) — key verification
-// CHECK: %dq, %dq_49 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 9 : i32, buffer.offset = 0 : i32}
+// TMEM allocation: dq reuses dpT (buffer.id=6, buffer.offset=0) — key verification
+// CHECK: %dq, %dq_49 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32, buffer.offset = 0 : i32}
 
 // -----// WarpSpec internal IR Dump After: doBufferAllocation
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_merged_barrier.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_merged_barrier.mlir
@@ -1,0 +1,104 @@
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner=num-buffers=3 | FileCheck %s
+
+// Test: When two SMEM buffers are in the same innermost loop, the memory
+// planner assigns both the same buffer.id (reuse group). The code partition
+// pass later merges consumer groups for channels sharing a reuse group, so a
+// single barrier_expect + wait is emitted.
+//
+// A (128x64xf16): inner dim = 64 * 2B = 128B = swizzle -> no split
+// B (64x256xf16): inner dim = 256 * 2B = 512B > 128B swizzle -> split copies
+//
+// Both buffers share buffer.id = 0 (same reuse group).
+
+// CHECK-LABEL: @matmul_kernel_tma_persistent
+// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32}
+// CHECK-SAME: 64x256xf16
+// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32}
+// CHECK-SAME: 128x64xf16
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 2, 128], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 128, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.tensordesc<tensor<128x64xf16, #shared>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<64x256xf16, #shared>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<tensor<128x128xf16, #shared>>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<64x256xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %false = arith.constant {async_task_id = array<i32: 0>} false
+    %true = arith.constant {async_task_id = array<i32: 0>} true
+    %c148_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 148 : i32
+    %c8_i32 = arith.constant {async_task_id = array<i32: 1, 2>} 8 : i32
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 128 : i32
+    %c256_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 256 : i32
+    %c64_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 64 : i32
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : i32
+    %c127_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 127 : i32
+    %c255_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 255 : i32
+    %c63_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 63 : i32
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    %2 = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2>} : i32
+    %3 = arith.addi %arg15, %c127_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %4 = arith.divsi %3, %c128_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %5 = arith.addi %arg16, %c255_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %6 = arith.divsi %5, %c256_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %7 = arith.addi %arg17, %c63_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %8 = arith.divsi %7, %c64_i32 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %9 = arith.muli %4, %6 {async_task_id = array<i32: 0, 1, 2>} : i32
+    %10 = arith.subi %2, %c148_i32 {async_task_id = array<i32: 2>} : i32
+    %11 = arith.muli %6, %c8_i32 {async_task_id = array<i32: 1, 2>} : i32
+    %12 = scf.for %arg19 = %2 to %9 step %c148_i32 iter_args(%arg20 = %10) -> (i32)  : i32 {
+      %13 = arith.divsi %arg19, %11 {async_task_id = array<i32: 1>} : i32
+      %14 = arith.muli %13, %c8_i32 {async_task_id = array<i32: 1>} : i32
+      %15 = arith.subi %4, %14 {async_task_id = array<i32: 1>} : i32
+      %16 = arith.minsi %15, %c8_i32 {async_task_id = array<i32: 1>} : i32
+      %17 = arith.remsi %arg19, %16 {async_task_id = array<i32: 1>} : i32
+      %18 = arith.addi %14, %17 {async_task_id = array<i32: 1>} : i32
+      %19 = arith.remsi %arg19, %11 {async_task_id = array<i32: 1>} : i32
+      %20 = arith.divsi %19, %16 {async_task_id = array<i32: 1>} : i32
+      %21 = arith.muli %18, %c128_i32 {async_task_id = array<i32: 1>} : i32
+      %22 = arith.muli %20, %c256_i32 {async_task_id = array<i32: 1>} : i32
+      %23 = ttng.tmem_store %cst, %result[%token], %true {async_task_id = array<i32: 0>} : tensor<128x256xf32, #blocked> -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+      %24:2 = scf.for %arg21 = %c0_i32 to %8 step %c1_i32 iter_args(%arg22 = %false, %arg23 = %23) -> (i1, !ttg.async.token)  : i32 {
+        %43 = arith.muli %arg21, %c64_i32 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
+        %44 = tt.descriptor_load %arg0[%21, %43] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+        ttg.local_store %44, %1 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<128x64xf16, #blocked1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %45 = tt.descriptor_load %arg5[%43, %22] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<64x256xf16, #shared>> -> tensor<64x256xf16, #blocked2>
+        ttg.local_store %45, %0 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x256xf16, #blocked2> -> !ttg.memdesc<64x256xf16, #shared, #smem, mutable>
+        %46 = ttng.tc_gen5_mma %1, %0, %result[%arg23], %arg22, %true {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 2 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x256xf16, #shared, #smem, mutable>, !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield {async_task_id = array<i32: 0, 2>} %true, %46 : i1, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2>, tt.scheduled_max_stage = 2 : i32}
+      %25 = arith.addi %arg20, %c148_i32 {async_task_id = array<i32: 2>} : i32
+      %26 = arith.divsi %25, %11 {async_task_id = array<i32: 2>} : i32
+      %27 = arith.muli %26, %c8_i32 {async_task_id = array<i32: 2>} : i32
+      %28 = arith.subi %4, %27 {async_task_id = array<i32: 2>} : i32
+      %29 = arith.minsi %28, %c8_i32 {async_task_id = array<i32: 2>} : i32
+      %30 = arith.remsi %25, %29 {async_task_id = array<i32: 2>} : i32
+      %31 = arith.addi %27, %30 {async_task_id = array<i32: 2>} : i32
+      %32 = arith.remsi %25, %11 {async_task_id = array<i32: 2>} : i32
+      %33 = arith.divsi %32, %29 {async_task_id = array<i32: 2>} : i32
+      %34 = arith.muli %31, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      %35 = arith.muli %33, %c256_i32 {async_task_id = array<i32: 2>} : i32
+      %result_0, %token_1 = ttng.tmem_load %result[%24#1] {async_task_id = array<i32: 2>} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
+      %36 = tt.reshape %result_0 {async_task_id = array<i32: 2>} : tensor<128x256xf32, #blocked> -> tensor<128x2x128xf32, #blocked3>
+      %37 = tt.trans %36 {async_task_id = array<i32: 2>, order = array<i32: 0, 2, 1>} : tensor<128x2x128xf32, #blocked3> -> tensor<128x128x2xf32, #blocked4>
+      %outLHS, %outRHS = tt.split %37 {async_task_id = array<i32: 2>} : tensor<128x128x2xf32, #blocked4> -> tensor<128x128xf32, #blocked5>
+      %38 = arith.truncf %outRHS {async_task_id = array<i32: 2>} : tensor<128x128xf32, #blocked5> to tensor<128x128xf16, #blocked5>
+      %39 = arith.truncf %outLHS {async_task_id = array<i32: 2>} : tensor<128x128xf32, #blocked5> to tensor<128x128xf16, #blocked5>
+      %40 = ttg.convert_layout %39 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked5> -> tensor<128x128xf16, #blocked6>
+      tt.descriptor_store %arg10[%34, %35], %40 {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, tensor<128x128xf16, #blocked6>
+      %41 = ttg.convert_layout %38 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked5> -> tensor<128x128xf16, #blocked6>
+      %42 = arith.addi %35, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      tt.descriptor_store %arg10[%34, %42], %41 {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, tensor<128x128xf16, #blocked6>
+      scf.yield {async_task_id = array<i32: 2>} %25 : i32
+    } {async_task_id = array<i32: 0, 1, 2>, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_split_copy.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_split_copy.mlir
@@ -1,21 +1,18 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-memory-planner=num-buffers=3 | FileCheck %s
 
-// Test: When a SMEM buffer requires TMA split copies (inner dim exceeds the
-// swizzle byte width), the memory planner assigns it a unique buffer.id.
-// This prevents it from sharing a barrier with other buffers, since each split
-// copy emits a separate barrier_expect/arrive, and sharing would cause barrier
-// over-arrival (UB per CUDA PTX spec).
+// Test: When two SMEM buffers are in the same innermost loop but one requires
+// TMA split copies (inner dim exceeds the swizzle byte width), the memory
+// planner assigns both the same buffer.id. The code partition pass later
+// merges consumer groups for channels sharing a reuse group, so a single
+// barrier_expect + wait is emitted.
 //
 // A_smem (128x64xf16, swizzle=128): inner dim = 64 × 2B = 128B = swizzle → no split
 // B_smem (64x128xf16, swizzle=128): inner dim = 128 × 2B = 256B > swizzle → split needed
-//
-// Without the fix, both allocs would share buffer.id = 0 (same innermost loop).
-// With the fix, B_smem gets a separate buffer.id to use its own barrier.
 
 // CHECK-LABEL: @tma_split_copy_separate_buffer_id
 // CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32}
 // CHECK-SAME: 128x64xf16
-// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 1 : i32}
+// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32}
 // CHECK-SAME: 64x128xf16
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3541,6 +3541,47 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
       config.groups.push_back(group);
     }
   }
+  // Merge consumer groups for channels in the same reuse group.
+  // All channels in a reuse group share a barrier, so they must be processed
+  // together in insertAsyncComm to produce a single barrier_expect + wait.
+  DenseSet<Channel *> mergedChannels;
+  for (auto &group : config.groups) {
+    if (group.channels.size() <= 1)
+      continue;
+    Channel *rep = group.channels[0];
+    for (size_t i = 1; i < group.channels.size(); i++) {
+      Channel *ch = group.channels[i];
+      if (ch->relation.second != rep->relation.second)
+        continue;
+      if (ch->getDstOp() != rep->getDstOp())
+        continue;
+      // Skip if either producer is a TCGen5MMAOp: commit handling for
+      // MMA-produced TMEM channels doesn't work when fused into one group.
+      //
+      // Even once supported we will need to prove that the MMA op dominates
+      // the other op in program order.
+      if (isa<ttng::TCGen5MMAOp>(ch->getSrcOp()) ||
+          isa<ttng::TCGen5MMAOp>(rep->getSrcOp()))
+        continue;
+      // Only merge TMA-produced channels with other TMA-produced channels.
+      // This is because otherwise the barriers cannot be "fused" properly
+      // as one step is async.
+      //
+      // To support this we need to prove the TMA op dominates the non-TMA op
+      // in program order.
+      bool chIsTMA = isProducerTMA(ch, /*isPost=*/true);
+      bool repIsTMA = isProducerTMA(rep, /*isPost=*/true);
+      if (chIsTMA != repIsTMA)
+        continue;
+      channelsGroupedByConsumers[rep].push_back(ch);
+      channelsGroupedByConsumers.erase(ch);
+      mergedChannels.insert(ch);
+    }
+  }
+  orderedChannels.erase(
+      llvm::remove_if(orderedChannels,
+                      [&](Channel *ch) { return mergedChannels.count(ch); }),
+      orderedChannels.end());
   appendAccumCntsForOps(asyncTaskTopOps, channels, regionsWithChannels,
                         &config);
   LLVM_DEBUG({

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -47,25 +47,6 @@ namespace mlir {
 
 using OperationListT = std::vector<Operation *>;
 
-// Check if a SMEM allocation requires TMA split copies. This happens when the
-// TMA block shape (clamped by swizzle) is smaller than the shapePerCTA in any
-// dimension, causing the codegen to emit multiple cp.async.bulk.tensor ops.
-// Buffers requiring split copies must not share a reuse group (and thus a
-// barrier) with other buffers, because each copy emits a separate
-// barrier_expect/arrive on the shared barrier, causing over-arrival.
-static bool requiresTMASplitCopies(ttg::MemDescType memDescTy) {
-  auto encoding = memDescTy.getEncoding();
-  if (!isa<ttg::NVMMASharedEncodingAttr>(encoding))
-    return false;
-  auto blockShape = ttng::getTMABlockShape(memDescTy, /*packedSize=*/true);
-  auto shapePerCTA = ttg::getShapePerCTA(memDescTy);
-  for (size_t i = 0; i < shapePerCTA.size(); ++i) {
-    if (blockShape[i] != shapePerCTA[i])
-      return true;
-  }
-  return false;
-}
-
 //===----------------------------------------------------------------------===//
 // MemoryPlannerBase - Abstract base class for memory planners
 //===----------------------------------------------------------------------===//
@@ -569,19 +550,10 @@ public:
           idTypes[bufferIdInnermost] = elemType;
           ++bufferId;
         }
-        // Buffers requiring TMA split copies get their own unique buffer.id
-        // to avoid sharing a barrier with other buffers. Each split copy
-        // emits a separate barrier_expect/arrive, so sharing would cause
-        // barrier over-arrival (UB per CUDA PTX spec).
-        unsigned assignedId = bufferIdInnermost;
-        if (requiresTMASplitCopies(allocDescType)) {
-          assignedId = bufferId;
-          ++bufferId;
-        }
         owner->setAttr(
             "buffer.id",
             IntegerAttr::get(IntegerType::get(owner->getContext(), 32),
-                             assignedId));
+                             bufferIdInnermost));
         owner->setAttr(
             "buffer.copy",
             IntegerAttr::get(IntegerType::get(owner->getContext(), 32),


### PR DESCRIPTION
The previous issue with sharing barriers can be resolved in you provide 1 singular wait on two TMA loads. This updates the group logic to enable fusion the overall expect bytes to be the sum of loads on A and B. The net result is that we remove the older conservative path and get a performance win from fewer barriers.