### PR TITLE
[PartitionLoops] Fix stray scf.yield when if-op spans fewer partition…

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -324,7 +324,18 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         continue;
       }
 
-      for (size_t idx : partitionIndices) {
+      // For yields inside if-ops, restrict to the if-op's partition set.
+      // The yield op itself typically has no partition annotation, so
+      // partitionIndices defaults to all partitions. But we must only create
+      // yields for partitions that actually contain the parent if-op,
+      // otherwise the yield is placed in the wrong block.
+      auto yieldPartitionIndices = partitionIndices;
+      if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp())) {
+        yieldPartitionIndices =
+            getPartitionIds(ifOp.getOperation(), partitions.getNumPartitions());
+      }
+
+      for (size_t idx : yieldPartitionIndices) {
         auto &builder = builders[idx];
         SmallVector<size_t> newOperandIndices;
         if (auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp())) {

--- a/test/TritonGPU/partition-loops.mlir
+++ b/test/TritonGPU/partition-loops.mlir
@@ -396,6 +396,29 @@ tt.func @clone_then_capture(%arg0: i32) {
   tt.return
 }
 
+// Regression test: an scf.if inside a loop where the if-op is only in one
+// partition (partition 1), but a result (async token) is not produced by any
+// annotated op. inferIfOpPartitions assigns it to partition 0 by default. The
+// yield inside the if-op must only be created for the if-op's own partitions,
+// not for all partitions, otherwise a stray scf.yield lands in the wrong block.
+// CHECK-LABEL: @if_result_partition_mismatch
+tt.func @if_result_partition_mismatch(%lb: i32, %ub: i32, %step: i32, %cond: i1) {
+  %c0 = arith.constant 0 : i32
+  %poison_token = ub.poison : !ttg.async.token
+  // CHECK: nvws.warp_group
+  scf.for %i = %lb to %ub step %step iter_args(%k = %c0) -> (i32) : i32 {
+    "op_a"(%i) {ttg.partition = array<i32: 0>} : (i32) -> ()
+    %ret:2 = scf.if %cond -> (i32, !ttg.async.token) {
+      %v = "op_b"(%i) {ttg.partition = array<i32: 1>} : (i32) -> i32
+      scf.yield %v, %poison_token : i32, !ttg.async.token
+    } else {
+      scf.yield %k, %poison_token : i32, !ttg.async.token
+    }
+    scf.yield %ret#0 : i32
+  } {ttg.partition.stages = [0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+  tt.return
+}
+
 // CHECK-LABEL: @if_stmt_split
 tt.func @if_stmt_split(%arg1: !ty, %ub: i32, %lb: i32, %step: i32) {
   %out:2 = scf.for %i = %lb to %ub step %step iter_args(%a = %arg1, %b = %arg1) -> (!ty, !ty) : i32 {


### PR DESCRIPTION
  When an scf.if inside a partitioned loop belongs to only a subset of partitions (e.g., partition 4), but produces an !ttg.async.token result that inferIfOpPartitions assigns to
  partition 0 by default, the yield inside the if-op's then/else block was created for all partitions. For partitions without the if-op, the builder's insert point is in the outer for
  body, so the yield landed as a non-terminal op — causing 'scf.yield' op must be the last operation in the parent block.

  Fix: restrict yield creation inside if-ops to the if-op's own partition set. Added a LIT test.