### PR TITLE
[AutoWS] Add a pass to prune unused barriers

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -189,4 +189,21 @@ def TritonNvidiaGPURemoveTMEMTokensPass : Pass<"triton-nvidia-gpu-remove-tmem-to
   }];
 }
 
+def TritonNvidiaGPUPruneUnusedBarriersPass
+    : Pass<"triton-nvidia-gpu-prune-unused-barriers", "mlir::ModuleOp"> {
+  let summary = "Prune barriers with no wait uses after warp specialization";
+
+  let description = [{
+    After warp specialization materializes barriers for producer-consumer
+    communication channels, some barriers may have no corresponding wait ops.
+    This pass finds and removes such unused barriers and their associated
+    init/arrive/expect/commit ops.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 #endif

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   OptimizeTMemLayouts.cpp
   PlanCTA.cpp
   PromoteLHSToTMem.cpp
+  PruneUnusedBarriers.cpp
   ProxFenceInsertion.cpp
   RemoveTMEMTokens.cpp
   TensorMemoryAllocation.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PruneUnusedBarriers.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PruneUnusedBarriers.cpp
@@ -1,0 +1,204 @@
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUPRUNEUNUSEDBARRIERSPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Classify whether a barrier allocation is pruneable based on its transitive
+/// uses. A barrier is pruneable if it has no wait-like uses and no unknown
+/// (unrecognized) uses.
+enum class UseKind {
+  /// A wait-like use (e.g. wait_barrier).
+  Wait,
+  /// A pruneable use (init, arrive, expect, commit, etc.).
+  Pruneable,
+  /// An op we don't recognize — conservatively non-pruneable.
+  Unknown,
+};
+
+/// Classify a single terminal use of a barrier value.
+UseKind classifyUse(Operation *user) {
+  // Wait-like uses.
+  if (isa<ttng::WaitBarrierOp>(user))
+    return UseKind::Wait;
+
+  // Pure barrier lifecycle ops — always pruneable.
+  if (isa<ttng::InitBarrierOp, ttng::InvalBarrierOp, ttng::ArriveBarrierOp,
+          ttng::AsyncCopyMbarrierArriveOp>(user))
+    return UseKind::Pruneable;
+
+  return UseKind::Unknown;
+}
+
+/// Recursively trace all transitive uses of a barrier value, following through
+/// view ops and warp_specialize captures. Collects terminal (non-view) uses.
+void traceBarrierUses(Value barrierVal,
+                      SmallVectorImpl<OpOperand *> &terminalUses) {
+  for (OpOperand &use : barrierVal.getUses()) {
+    Operation *user = use.getOwner();
+
+    // Follow through MemDescViewTrait ops (memdesc_index, memdesc_subslice,
+    // etc.)
+    if (user->hasTrait<OpTrait::MemDescViewTrait>()) {
+      assert(user->getNumResults() == 1);
+      traceBarrierUses(user->getResult(0), terminalUses);
+      continue;
+    }
+
+    // Follow through warp_specialize captures.
+    if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+      unsigned operandIdx = use.getOperandNumber();
+      for (Region *region : wsOp.getPartitionRegions()) {
+        Value blockArg = region->getArgument(operandIdx);
+        traceBarrierUses(blockArg, terminalUses);
+      }
+      continue;
+    }
+
+    // Terminal use.
+    terminalUses.push_back(&use);
+  }
+}
+
+/// Check if a local_alloc is a barrier allocation: produces memdesc with i64
+/// element type and has no src operand.
+bool isBarrierAlloc(ttg::LocalAllocOp alloc) {
+  auto memDescType = alloc.getType();
+  if (!memDescType.getElementType().isInteger(64))
+    return false;
+  return !alloc.getSrc();
+}
+
+/// Erase a barrier allocation and all its pruneable uses.
+void pruneBarrier(ttg::LocalAllocOp alloc,
+                  SmallVectorImpl<OpOperand *> &terminalUses) {
+  // Phase 1: Handle terminal uses.
+  for (OpOperand *use : terminalUses) {
+    Operation *user = use->getOwner();
+
+    // Pure barrier ops — erase them.
+    if (isa<ttng::InitBarrierOp, ttng::InvalBarrierOp, ttng::ArriveBarrierOp,
+            ttng::AsyncCopyMbarrierArriveOp>(user)) {
+      user->erase();
+      continue;
+    }
+  }
+
+  // Phase 2: Clean up warp_specialize captures. Walk the alloc's uses and
+  // remove captures that are now unused in all partition regions.
+  SmallVector<std::pair<ttg::WarpSpecializeOp, unsigned>> wsCaptures;
+  std::function<void(Value)> collectWSCaptures = [&](Value val) {
+    for (OpOperand &use : val.getUses()) {
+      Operation *user = use.getOwner();
+      if (user->hasTrait<OpTrait::MemDescViewTrait>()) {
+        collectWSCaptures(user->getResult(0));
+        continue;
+      }
+      if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+        wsCaptures.push_back({wsOp, use.getOperandNumber()});
+      }
+    }
+  };
+  collectWSCaptures(alloc.getResult());
+
+  for (auto [wsOp, idx] : wsCaptures) {
+    bool allUnused = true;
+    for (Region *region : wsOp.getPartitionRegions()) {
+      if (!region->getArgument(idx).use_empty()) {
+        allUnused = false;
+        break;
+      }
+    }
+    if (allUnused) {
+      llvm::BitVector toRemove(wsOp.getNumOperands());
+      toRemove.set(idx);
+      for (Region *region : wsOp.getPartitionRegions())
+        region->front().eraseArguments(toRemove);
+      wsOp->eraseOperands(toRemove);
+    }
+  }
+
+  // Phase 3: Clean up dead view ops (bottom-up: users before defs).
+  std::function<void(Value)> eraseDeadViews = [&](Value val) {
+    // Collect users first to avoid iterator invalidation.
+    SmallVector<Operation *> users;
+    for (OpOperand &use : val.getUses())
+      users.push_back(use.getOwner());
+    for (Operation *user : users) {
+      if (user->hasTrait<OpTrait::MemDescViewTrait>() &&
+          user->getResult(0).use_empty()) {
+        user->erase();
+      }
+    }
+  };
+  eraseDeadViews(alloc.getResult());
+
+  // Phase 4: Erase the alloc if it has no remaining uses.
+  if (alloc.use_empty())
+    alloc.erase();
+}
+
+} // anonymous namespace
+
+class TritonNvidiaGPUPruneUnusedBarriersPass
+    : public impl::TritonNvidiaGPUPruneUnusedBarriersPassBase<
+          TritonNvidiaGPUPruneUnusedBarriersPass> {
+public:
+  using TritonNvidiaGPUPruneUnusedBarriersPassBase::
+      TritonNvidiaGPUPruneUnusedBarriersPassBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+
+    // Phase 1: Collect all barrier allocations.
+    SmallVector<ttg::LocalAllocOp> barrierAllocs;
+    mod.walk([&](ttg::LocalAllocOp alloc) {
+      if (isBarrierAlloc(alloc))
+        barrierAllocs.push_back(alloc);
+    });
+
+    // Phase 2-4: For each barrier, trace uses and prune if possible.
+    for (auto alloc : barrierAllocs) {
+      SmallVector<OpOperand *> terminalUses;
+      traceBarrierUses(alloc.getResult(), terminalUses);
+
+      // Classify all terminal uses.
+      bool hasWaitUses = false;
+      bool hasUnknownUses = false;
+
+      for (OpOperand *use : terminalUses) {
+        UseKind kind = classifyUse(use->getOwner());
+        switch (kind) {
+        case UseKind::Wait:
+          hasWaitUses = true;
+          break;
+        case UseKind::Unknown:
+          hasUnknownUses = true;
+          break;
+        case UseKind::Pruneable:
+          break;
+        }
+      }
+
+      // A barrier is pruneable if it has no wait-like and no unknown uses.
+      if (hasWaitUses || hasUnknownUses)
+        continue;
+
+      pruneBarrier(alloc, terminalUses);
+    }
+  }
+};
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -2815,12 +2815,18 @@ def test_barrier_live_range(device):
 
         bars2 = tlx.alloc_barriers(num_barriers=tl.constexpr(1), arrive_count=2)
         tlx.barrier_arrive(bars2[0])
+        # No-op wait to avoid pruning.
+        tlx.barrier_wait(bar=bars2[0], phase=1)
 
         bars3 = tlx.alloc_barriers(num_barriers=tl.constexpr(1), arrive_count=3)
         tlx.barrier_arrive(bars3[0])
+        # No-op wait to avoid pruning.
+        tlx.barrier_wait(bar=bars3[0], phase=1)
 
         # bars1 and bars2 should both be live here
         tlx.barrier_arrive(bars1[0])
+        # No-op wait to avoid pruning.
+        tlx.barrier_wait(bar=bars1[0], phase=0)
 
     torch.manual_seed(0)
     kernel = bar_live_kernel[(2, 1)]()

--- a/test/TritonNvidiaGPU/prune-unused-barriers.mlir
+++ b/test/TritonNvidiaGPU/prune-unused-barriers.mlir
@@ -1,0 +1,62 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-prune-unused-barriers | FileCheck %s
+
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// Test 1: Barrier with only init (no waits) should be fully pruned.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @prune_init_only
+  // CHECK-NOT: ttg.local_alloc
+  // CHECK-NOT: ttng.init_barrier
+  // CHECK: tt.return
+  tt.func @prune_init_only() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// Test 2: Barrier with init + arrive (no waits) should be fully pruned.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @prune_init_arrive
+  // CHECK-NOT: ttg.local_alloc
+  // CHECK-NOT: ttng.init_barrier
+  // CHECK-NOT: ttng.arrive_barrier
+  // CHECK-NOT: ttng.inval_barrier
+  // CHECK: tt.return
+  tt.func @prune_init_arrive(%pred: i1) {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.arrive_barrier %bar, 1, %pred : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// Test 3: Barrier with init + wait should NOT be pruned.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @keep_barrier_with_wait
+  // CHECK: ttg.local_alloc
+  // CHECK: ttng.init_barrier
+  // CHECK: ttng.wait_barrier
+  // CHECK: ttng.inval_barrier
+  // CHECK: tt.return
+  tt.func @keep_barrier_with_wait() {
+    %c0 = arith.constant 0 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -372,6 +372,8 @@ class CUDABackend(BaseBackend):
             nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
             nvidia.passes.ttnvgpuir.add_tma_store_buffer_reuse(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
+        # TODO: Find the optimal place in the pipeline for this pass.
+        nvidia.passes.ttnvgpuir.add_prune_unused_barriers(pm)
         nvidia.passes.ttnvgpuir.add_interleave_tmem(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -77,6 +77,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUOptimizeTMemLayoutsPass);
   ADD_PASS_WRAPPER_0("add_interleave_tmem",
                      ttng::createTritonNvidiaGPUInterleaveTMemPass);
+  ADD_PASS_WRAPPER_0("add_prune_unused_barriers",
+                     ttng::createTritonNvidiaGPUPruneUnusedBarriersPass);
 }
 
 void init_triton_nvidia_passes_nvws(py::module &&m) {


### PR DESCRIPTION
Paul found an issue upstream where a barrier was blocking epilogue optimizations even though they produced an arrive but not an associated wait (non-persistent GEMM). In general for barrier optimizations we wish to do it is likely simpler if we can minimize the needed cleanup work and focus on the associated "proofs" instead.

This branch adds a pass the prune barriers that are either only used in an init or have an arrive without an associated wait operation. This should enable followups where if we can provide 1 barrier's wait dominates another (tricky with things like TMA as you must prove the producers are ordered) then each of these optimizations can just modify the waits instead of eliminating the barriers themselves. In general this is desirable to simplify any barrier remove logic and ever need to support complex patterns.