### PR TITLE
[TLX] Fix atomic operations in clustered kernels

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -6528,3 +6528,53 @@ def test_fence_sys(device):
     # Verify correctness
     assert x[0].item() == 1
     assert x[1].item() == 1
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")
+def test_atomic_add_cga(device):
+    """Test that atomic operations work correctly in CGA (cluster) kernels.
+
+    In a 2-CTA cluster, both CTAs should execute the atomic_add,
+    resulting in a counter value of 2 (one increment per CTA).
+    """
+
+    @triton.heuristics(values={"ctas_per_cga": lambda args: (2, 1, 1)})
+    @triton.jit
+    def atomic_add_cga_kernel(counter_ptr, out_ptr, NUM_CTAS: tl.constexpr):
+        pid = tl.program_id(0)
+        cta_rank = tlx.cluster_cta_rank()
+
+        # Each CTA's thread 0 should atomic_add on the same counter
+        val = tl.atomic_add(counter_ptr, 1, sem="relaxed")
+
+        # Store the returned value and CTA rank for verification
+        tl.store(out_ptr + pid * 2, val)
+        tl.store(out_ptr + pid * 2 + 1, cta_rank)
+
+    grid_size = 2  # 2 CTAs in the cluster
+    counter = torch.zeros(1, dtype=torch.int32, device=device)
+    out = torch.full((grid_size * 2, ), -1, dtype=torch.int32, device=device)
+
+    atomic_add_cga_kernel[(grid_size, )](counter, out, NUM_CTAS=grid_size)
+
+    # Check the results
+    counter_val = counter.item()
+
+    # Each CTA should have executed the atomic, so counter should be 2
+    assert counter_val == grid_size, f"Expected counter={grid_size}, got {counter_val}"
+
+    # Check that both CTAs participated
+    atomic_vals = []
+    cta_ranks = []
+    for i in range(grid_size):
+        atomic_val = out[i * 2].item()
+        cta_rank = out[i * 2 + 1].item()
+        atomic_vals.append(atomic_val)
+        cta_ranks.append(cta_rank)
+
+    # The atomic values should be 0 and 1 (in some order)
+    # showing that both CTAs executed the atomic
+    assert set(atomic_vals) == {0, 1}, f"Expected atomic values {{0, 1}}, got {set(atomic_vals)}"
+
+    # CTA ranks should be 0 and 1
+    assert set(cta_ranks) == {0, 1}, f"Expected CTA ranks {{0, 1}}, got {set(cta_ranks)}"

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -55,7 +55,7 @@ Value maybeAnd(RewriterBase &rewriter, Location loc, Value a, Value b) {
 Value emitRedundantThreadPredicate(
     const llvm::MapVector<StringAttr, int32_t> &freeVarMasks,
     ConversionPatternRewriter &rewriter, Location loc,
-    const NVIDIA::TargetInfo &targetInfo) {
+    const NVIDIA::TargetInfo &targetInfo, Operation *op) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto ctx = rewriter.getContext();
   auto kLane = str_attr("lane");
@@ -64,7 +64,22 @@ Value emitRedundantThreadPredicate(
 
   Value zero = b.i32_val(0);
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-  Value blockId = freeVarMasks.lookup(kBlock) == 0
+
+  // In TLX clustered kernels, always use zero for blockId instead of cluster
+  // CTA ID This ensures operations execute based on the CTA-local thread ID,
+  // not cluster position
+  bool isClusteredKernel = false;
+  if (op) {
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    if (moduleOp) {
+      const SmallVector<int> clusterDims =
+          triton::gpu::TritonGPUDialect::getClusterDims(moduleOp);
+      isClusteredKernel =
+          llvm::any_of(clusterDims, [](int dim) { return dim > 1; });
+    }
+  }
+
+  Value blockId = (freeVarMasks.lookup(kBlock) == 0 || isClusteredKernel)
                       ? zero
                       : targetInfo.getClusterCTAId(rewriter, loc);
 
@@ -466,8 +481,8 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     const size_t valueElemNBits = dtsize * 8;
 
     auto freeVarMasks = getFreeVariableMasks(ptr.getType());
-    Value threadPred =
-        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    Value threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
+                                                    targetInfo, op);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
 
     const int numVecs = elemsPerThread / vec;
@@ -612,8 +627,8 @@ struct AtomicCASOpConversion
     auto valueElemNBits = valueElemTy.getIntOrFloatBitWidth();
     auto elemsPerThread = getTotalElemsPerThread(op.getVal().getType());
     auto freeVarMasks = getFreeVariableMasks(op.getPtr().getType());
-    Value threadPred =
-        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    Value threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
+                                                    targetInfo, op);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
 
     SmallVector<Value> resultVals(elemsPerThread);
@@ -811,8 +826,8 @@ public:
                        << " numElems = " << numElems;
 
     auto freeVarMasks = getFreeVariableMasks(ptr.getType());
-    Value threadPred =
-        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    Value threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
+                                                    targetInfo, op);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
 
     auto packedTy = vec_ty(valueElemTy, packed);
@@ -1250,8 +1265,8 @@ struct AsyncCopyGlobalToLocalOpConversion
     // is available in each CTAs respective shared memory. Otherwise, we would
     // need an additional broadcast step to copy the data between CTAs.
     freeVarMasks[str_attr("block")] = 0;
-    Value threadPred =
-        emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
+    Value threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
+                                                    targetInfo, op);
 
     auto emitCpAsync = [&b, threadPred, ptrTy, hasMask = bool(llMask)](
                            RewriterBase &rewriter, Location loc,


### PR DESCRIPTION
In clustered (CGA) kernels, atomic operations were incorrectly being executed only by thread 0 of CTA 0, rather than thread 0 of all CTAs. This was due to the redundant thread predicate using cluster CTA ID to determine which threads should execute.

The fix modifies emitRedundantThreadPredicate to always use zero for blockId in clustered kernels, ensuring operations execute based on CTA-local thread ID rather than cluster position.

Added test_atomic_add_cga to verify the fix works correctly.