### PR TITLE
[TLX] Use torch.empty instead of torch.zeros for hopper_gemm_ws

### DIFF
--- a/third_party/tlx/tutorials/hopper_gemm_ws.py
+++ b/third_party/tlx/tutorials/hopper_gemm_ws.py
@@ -207,7 +207,7 @@ def matmul(a, b, config=None):
     triton.set_allocator(alloc_fn)
 
     (M, N, K) = (a.shape[0], b.shape[1], a.shape[1])
-    c = torch.zeros(
+    c = torch.empty(
         (M, N),
         dtype=torch.float16,
         device=DEVICE,


### PR DESCRIPTION
Summary:
Performance results on H100 (65536x1024x1024):
- aten_matmul: 583.318 TFLOPS
- tlx_matmul_ws: 502.335 TFLOPS (86.1% of aten baseline)
- tlx_matmul_ws accuracy: 1.0 (perfect accuracy)

Using torch.empty() instead of torch.zeros() avoids unnecessary zero initialization
of the output tensor, as the GEMM operation will overwrite all values.

Differential Revision: D95298919


