### PR TITLE
[autoWS] support taskIDPropagation for tt.map_elementwise region

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation.mlir
@@ -137,3 +137,58 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Test that task IDs propagate correctly through tt.map_elementwise ops and
+// into their region bodies. This validates the fix for a crash where
+// TaskIdPropagation hit an unsupported parent op (MapElementwiseOp) when
+// propagating task IDs for ops inside the map_elementwise region.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 0}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: @matmul_with_map_elementwise
+  //
+  // Verify ops inside the map_elementwise region get task IDs.
+  // CHECK:      "tt.map_elementwise"
+  // CHECK:        arith.constant {async_task_id = array<i32: 1, 2>} 0xFF800000 : f32
+  // CHECK:        arith.maxnumf %{{.*}}, %{{.*}} {async_task_id = array<i32: 1, 2>} : f32
+  // CHECK:        tt.map_elementwise.return {async_task_id = array<i32: 1, 2>} %{{.*}} : f32
+  //
+  // Verify the map_elementwise op itself gets the consumer task IDs.
+  // CHECK:      }) {async_task_id = array<i32: 1, 2>} :
+
+  tt.func public @matmul_with_map_elementwise(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: !tt.tensordesc<tensor<64x256xf16>>, %arg2: !tt.tensordesc<tensor<128x256xf16>>, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_num_programs x : i32
+    scf.for %arg6 = %0 to %arg3 step %1  : i32 {
+      %2 = scf.for %arg7 = %c0_i32 to %arg5 step %c1_i32 iter_args(%arg8 = %cst) -> (tensor<128x256xf32, #mma>)  : i32 {
+        %5 = tt.descriptor_load %arg0[%arg6, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+        %6 = ttg.local_alloc %5 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %7 = tt.descriptor_load %arg1[%c0_i32, %arg6] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<64x256xf16>> -> tensor<64x256xf16, #blocked1>
+        %8 = ttg.local_alloc %7 : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %9 = ttng.warp_group_dot %6, %8, %arg8 {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        // Apply map_elementwise to the dot result (simulates causal mask)
+        %10 = "tt.map_elementwise"(%9) <{pack = 1 : i32}> ({
+        ^bb0(%val: f32):
+          %neg_inf = arith.constant 0xFF800000 : f32
+          %result = arith.maxnumf %val, %neg_inf : f32
+          tt.map_elementwise.return %result : f32
+        }) : (tensor<128x256xf32, #mma>) -> tensor<128x256xf32, #mma>
+        scf.yield %10 : tensor<128x256xf32, #mma>
+      }
+      %3 = arith.truncf %2 : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+      %4 = ttg.convert_layout %3 : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+      tt.descriptor_store %arg2[%arg6, %arg6], %4 {async_task_id = array<i32: 1, 2>} : !tt.tensordesc<tensor<128x256xf16>>, tensor<128x256xf16, #blocked1>
+    }
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.cpp
@@ -105,7 +105,8 @@ void TaskIdBackwardPropagation::propagateToParent(Operation *op,
       ChangeResult changed = condLattice->meet(taskId);
       propagateIfChanged(condLattice, changed);
     } else {
-      if (!isa<triton::FuncOp, triton::ReduceOp>(parentOp))
+      if (!isa<triton::FuncOp, triton::ReduceOp, triton::MapElementwiseOp>(
+              parentOp))
         llvm_unreachable("Other parent ops are not supported.");
     }
     parentOp = parentOp->getParentOp();
@@ -142,6 +143,19 @@ LogicalResult TaskIdBackwardPropagation::visitOperation(
       if (auto reduceOp = dyn_cast<triton::ReduceOp>(op)) {
         propagateToTerminator(reduceOp.getCombineOp().front().getTerminator(),
                               results);
+      } else if (auto mapOp = dyn_cast<triton::MapElementwiseOp>(op)) {
+        // MapElementwiseOp's region terminator may have pack * num_results
+        // operands, so propagate all result task IDs to every terminator
+        // operand.
+        auto *terminator = mapOp.getScalarOp().front().getTerminator();
+        for (auto terminatorOperand : terminator->getOperands()) {
+          auto terminatorLattice = getLatticeElement(terminatorOperand);
+          for (auto resultLattice : results) {
+            ChangeResult changed =
+                terminatorLattice->meet(resultLattice->getValue());
+            propagateIfChanged(terminatorLattice, changed);
+          }
+        }
       }
     }
 
@@ -174,6 +188,16 @@ LogicalResult TaskIdBackwardPropagation::visitOperation(
     if (auto reduceOp = dyn_cast<triton::ReduceOp>(op)) {
       propagateToTerminator(reduceOp.getCombineOp().front().getTerminator(),
                             results);
+    } else if (auto mapOp = dyn_cast<triton::MapElementwiseOp>(op)) {
+      auto *terminator = mapOp.getScalarOp().front().getTerminator();
+      for (auto terminatorOperand : terminator->getOperands()) {
+        auto terminatorLattice = getLatticeElement(terminatorOperand);
+        for (auto resultLattice : results) {
+          ChangeResult changed =
+              terminatorLattice->meet(resultLattice->getValue());
+          propagateIfChanged(terminatorLattice, changed);
+        }
+      }
     }
   }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -1341,6 +1341,13 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     // recursively set async task ids for child ops
     newOp->walk(
         [&](Operation *childOp) { setAsyncTaskIds(childOp, sliceTaskIds); });
+  } else if (isa<MapElementwiseOp>(op)) {
+    for (Value operand : op->getOperands())
+      sliceOp(operand, offset, mappings, reverseMappings, partitionScheme);
+    newOp = cloneAndSetResultType(op);
+    // recursively set async task ids for child ops
+    newOp->walk(
+        [&](Operation *childOp) { setAsyncTaskIds(childOp, sliceTaskIds); });
   } else {
     llvm_unreachable("unsupported op type");
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -368,6 +368,14 @@ Operation *SpecializeOp(Operation *op, IRMapping &mapping,
       for (unsigned i = 0; i < op->getNumResults(); ++i)
         mapping.map(op->getResult(i), newOp->getResult(i));
       return newOp;
+    } else if (isa<triton::MapElementwiseOp>(op)) {
+      Operation *newOp = builder.clone(*op, mapping);
+      // recursively set async task ids for child ops
+      newOp->walk(
+          [&](Operation *childOp) { setAsyncTaskIds(childOp, asyncTaskId); });
+      for (unsigned i = 0; i < op->getNumResults(); ++i)
+        mapping.map(op->getResult(i), newOp->getResult(i));
+      return newOp;
     } else {
       llvm_unreachable("Unexpected Op with regions");
     }


### PR DESCRIPTION
This PR adds support to assembly causal mask for causal Flash Attention.
It improves the performance from ~245 tflops to ~604 tflops for Dhead=128.

Test plan:
Using the kernel in https://github.com/meta-pytorch/tritonbench/pull/923:
```
CUDA_VISIBLE_DEVICES=5 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_USE_META_WS=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --mode fwd  --causal --rep 3000 --sleep 1.0 --metrics tflops --simple-output --only triton_tutorial_flash_dp_persistent_blackwell --force
```
result:
```
(Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)
----------------------------------------------------
(4, 32, 32, 8192, 8192, 128) Causal fwd
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_tutorial_flash_dp_persistent_blackwell-tflops
----------------------------------------------------  ------------------------------------------------------
             (4, 32, 32, 8192, 8192, 128) Causal fwd                                                 604.739
                                   604.7386331592675
```

accuracy test:
```
WITH_GLUON=1 CUDA_VISIBLE_DEVICES=5 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_USE_META_WS=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --mode fwd  --causal --rep 3000 --sleep 1.0 --metrics accuracy --simple-output --o
nly tlx_blackwell_ws_pipelined_persistent,triton_tutorial_flash_dp_persistent_blackwell,gluon_blackwell_tutorial_persistent_fwd
```
result:
```
Processing GPU 5...
→ Locking power cap to 750 W and SM clock to 1965 MHz on GPU 5
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_tutorial_flash_dp_persistent_blackwell-accuracy    gluon_blackwell_tutorial_persistent_fwd-accuracy
----------------------------------------------------  --------------------------------------------------------  --------------------------------------------------
             (4, 32, 32, 8192, 8192, 128) Causal fwd                                                         1                                                   1
                                             1.0,1.0
```