### PR TITLE
[TLX] Fix named barrier deadlock caused by LLVM jump threading

### DIFF
--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -6675,3 +6675,92 @@ def test_atomic_add_cga(device):
 
     # CTA ranks should be 0 and 1
     assert set(cta_ranks) == {0, 1}, f"Expected CTA ranks {{0, 1}}, got {set(cta_ranks)}"
+
+
+# =============================================================================
+# Test: named_barrier_wait in 1-warp async_task (DEADLOCKS)
+# =============================================================================
+
+
+def _run_kernel_diverge_both_1warp(result_queue):
+    """Subprocess target: runs the deadlocking kernel and reports back."""
+    try:
+        import torch
+        import triton
+        import triton.language as tl
+        import triton.language.extra.tlx as tlx
+
+        @triton.jit
+        def _kernel_diverge_both_1warp(output_ptr):
+            """1-warp task, divergence on both sides -> DEADLOCKS."""
+            with tlx.async_tasks():
+                with tlx.async_task(num_warps=1):
+                    if tlx.thread_id(axis=0) % 32 == 0:
+                        tl.store(output_ptr + 1, 99)  # divergence BEFORE
+                    tlx.named_barrier_wait(14, 32)
+                    if tlx.thread_id(axis=0) % 32 == 0:
+                        tl.store(output_ptr + 0, 5)  # divergence AFTER
+                with tlx.async_task("default"):
+                    pass
+
+        output = torch.zeros(2, dtype=torch.int32, device="cuda")
+        _kernel_diverge_both_1warp[(1, )](output, num_warps=4)
+        torch.cuda.synchronize()
+        result_queue.put(("PASS", output.cpu().tolist()))
+    except Exception as e:
+        result_queue.put(("ERROR", str(e)))
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")
+def test_named_barrier_wait_1warp_async_deadlock(device):
+    """Test that named_barrier_wait(14, 32) in 1-warp async_task deadlocks.
+
+    This test demonstrates a known deadlock scenario where a named barrier
+    with divergent code on both sides deadlocks inside an async_task.
+    The kernel is run in a subprocess with a timeout so a deadlock doesn't
+    hang the entire test suite.
+    """
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    result_queue = ctx.Queue()
+    proc = ctx.Process(target=_run_kernel_diverge_both_1warp, args=(result_queue, ))
+    proc.start()
+    proc.join(timeout=15)
+
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=10)
+        pytest.xfail("Kernel deadlocked as expected (known issue: named_barrier_wait "
+                     "with divergent code on both sides inside async_task)")
+    elif result_queue.empty():
+        pytest.fail("Subprocess exited without producing a result")
+    else:
+        status, detail = result_queue.get()
+        if status == "PASS":
+            # If this passes, the bug has been fixed!
+            pass
+        else:
+            pytest.fail(f"Kernel raised an error: {detail}")
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")
+def test_named_barrier_wait_1warp_async_deadlock_single_proc(device):
+    """Same as test_named_barrier_wait_1warp_async_deadlock but runs in the
+    current process for easier IR debugging. WARNING: will hang if the bug
+    is present — use with a timeout (e.g. ``pytest --timeout=15``)."""
+
+    @triton.jit
+    def _kernel_diverge_both_1warp_sp(output_ptr):
+        if tlx.thread_id(axis=0) % 32 == 0:
+            tl.store(output_ptr + 1, 99)  # divergence BEFORE
+        tlx.named_barrier_wait(14, 32)
+        if tlx.thread_id(axis=0) % 32 == 0:
+            tl.store(output_ptr + 0, 5)  # divergence AFTER
+
+    output = torch.zeros(2, dtype=torch.int32, device=device)
+    _kernel_diverge_both_1warp_sp[(1, )](output, num_warps=4)
+    torch.cuda.synchronize()
+    result = output.cpu().tolist()
+    assert result[0] == 5, f"Expected output[0]=5, got {result[0]}"
+    assert result[1] == 99, f"Expected output[1]=99, got {result[1]}"

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -83,7 +83,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %c256_i32 = arith.constant 256 : i32
     // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
     // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
-    // CHECK-NEXT: "bar.arrive $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    // CHECK-NEXT: "llvm.nvvm.barrier.cta.arrive.aligned.count"([[BAR_ID]], [[NUM_THRADS]])
     ttng.arrive_barrier_named %c9_i32, %c256_i32 : i32, i32
     tt.return
   }
@@ -101,7 +101,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %c256_i32 = arith.constant 256 : i32
     // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
     // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
-    // CHECK-NEXT: "bar.sync $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    // CHECK-NEXT: "llvm.nvvm.barrier.cta.sync.aligned.count"([[BAR_ID]], [[NUM_THRADS]])
     ttng.wait_barrier_named %c9_i32, %c256_i32 : i32, i32
     tt.return
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -333,18 +333,11 @@ struct NamedBarrierArriveOpConversion
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
-    std::string ptxAsm = "bar.arrive $0, $1;";
-
-    PTXBuilder ptxBuilder;
-    SmallVector<PTXBuilder::Operand *, 2> operands = {
-        ptxBuilder.newOperand(adaptor.getBar(), "r"),
-        ptxBuilder.newOperand(adaptor.getNumThreads(), "r")};
-
-    auto arriveOp = *ptxBuilder.create<>(ptxAsm);
-    arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(getContext());
-    ptxBuilder.launch(rewriter, op.getLoc(), voidTy);
-
+    // Use the NVVM intrinsic which has IntrConvergent, preventing LLVM from
+    // duplicating this barrier across control flow (e.g., jump threading).
+    LLVM::createLLVMIntrinsicCallOp(
+        rewriter, loc, "llvm.nvvm.barrier.cta.arrive.aligned.count",
+        TypeRange{}, {adaptor.getBar(), adaptor.getNumThreads()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -359,18 +352,11 @@ struct NamedBarrierWaitOpConversion
   matchAndRewrite(triton::nvidia_gpu::NamedBarrierWaitOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
-    std::string ptxAsm = "bar.sync $0, $1;";
-
-    PTXBuilder ptxBuilder;
-    SmallVector<PTXBuilder::Operand *, 2> operands = {
-        ptxBuilder.newOperand(adaptor.getBar(), "r"),
-        ptxBuilder.newOperand(adaptor.getNumThreads(), "r")};
-
-    auto waitOp = *ptxBuilder.create<>(ptxAsm);
-    waitOp(operands, /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(getContext());
-    ptxBuilder.launch(rewriter, op.getLoc(), voidTy);
-
+    // Use the NVVM intrinsic which has IntrConvergent, preventing LLVM from
+    // duplicating this barrier across control flow (e.g., jump threading).
+    LLVM::createLLVMIntrinsicCallOp(
+        rewriter, loc, "llvm.nvvm.barrier.cta.sync.aligned.count", TypeRange{},
+        {adaptor.getBar(), adaptor.getNumThreads()});
     rewriter.eraseOp(op);
     return success();
   }


### PR DESCRIPTION

Summary:
Problem
-------
`tlx.named_barrier_wait(14, 32)` was being duplicated into if-else branches by LLVM's jump threading pass. When a named barrier (`bar.sync`) appears inside divergent control flow (e.g., an `scf.if` on both sides), jump threading can clone the barrier instruction into each branch. This breaks the barrier's synchronization semantics and causes a GPU deadlock.

Root Cause
----------
Named barrier wait (`bar.sync`) and arrive (`bar.arrive`) were lowered to PTX inline assembly via `PTXBuilder`. The resulting `llvm.inline_asm` op does not carry the `convergent` attribute, so LLVM treats it as a normal side-effecting call that can be freely duplicated across control flow.

Fix
---
Replace the inline asm lowering with calls to NVVM intrinsics that are already marked `IntrConvergent` in LLVM's tablegen:

  - `bar.sync $0, $1;`  -> `llvm.nvvm.barrier.cta.sync.aligned.count`
  - `bar.arrive $0, $1;` -> `llvm.nvvm.barrier.cta.arrive.aligned.count`

These intrinsics produce identical PTX but carry `IntrConvergent`, which tells LLVM that the call must not be duplicated or moved across control flow boundaries.

Testing
-------
TRITON_DUMP_DIR=/tmp/tissue030 TRITON_KERNEL_DUMP=1 TRITON_ALWAYS_COMPILE=1     pytest python/test/unit/language/test_tlx.py::test_named_barrier_wait_1warp_async_deadlock -xvs

before this change, we got P2220682555, after it we got P2220683241


 The barrier should appear once between the two if blocks. All 32 threads in the warp must hit the same single bar.sync
  instruction.

  ---
  BEFORE (P2220682555) — broken, deadlocks:
```
  br i1 %6, label %7, label %.critedge          ; branch on tid%32==0

  7:                                              ; tid%32==0 (lane 0)
    store 99 ...                                  ; store BEFORE
    asm "bar.sync $0, $1;"  (14, 32)              ; ← barrier COPY 1
    store 5 ...                                   ; store AFTER
    br label %11

  .critedge:                                      ; tid%32!=0 (lanes 1-31)
    asm "bar.sync $0, $1;"  (14, 32)              ; ← barrier COPY 2
    br label %11

  11:
    ret
```
  AFTER (P2220683241) — fixed, correct:
```
  br i1 %6, label %7, label %11                  ; branch on tid%32==0

  7:                                              ; tid%32==0 (lane 0)
    store 99 ...                                  ; store BEFORE
    br label %11                                  ; rejoin

  11:                                             ; ALL threads converge here
    call void @llvm.nvvm.barrier.cta.sync.aligned.count(i32 14, i32 32)
    br i1 %6, label %12, label %15               ; ← barrier is ONE instruction

  12:                                             ; tid%32==0 (lane 0)
    store 5 ...                                   ; store AFTER
    br label %15

  15:
    ret
```
  The barrier is a call to @llvm.nvvm.barrier.cta.sync.aligned.count which is declared with attribute #2 = { convergent nocallback nounwind }. The convergent attribute tells LLVM: "you must not duplicate or move this call across control flow." Jump threading respects this and leaves the barrier as a single instruction in a block where all threads converge. All 32 threads hit the same bar.sync → correct synchronization.


PTX comparison: https://www.internalfb.com/intern/diffing/?paste_number=2220769362


Why Single Warp not deadlock
---


SAAS code comparison: https://www.internalfb.com/intern/diffing/?paste_number=2221599559
 The SASS is structurally different between the two cases, even though the PTX was identical.

  1-warp SASS (no deadlock)
```
      LOP3.LUT P0, RZ, R0, 0x1f, RZ, 0xc0, !PT;   // P0 = (tid & 31 != 0)
      @!P0 STG.E desc[...][R4.64+0x4], R7;          // thread 0: store 99
      @!P0 BAR.SYNC.DEFER_BLOCKING 0xe, 0x20;       // thread 0: bar.sync 14, 32
      @!P0 STG.E desc[...][R2.64], R9;              // thread 0: store 5
      @!P0 EXIT;                                     // thread 0: exit
      BAR.SYNC.DEFER_BLOCKING 0xe, 0x20;             // threads 1-31: bar.sync 14, 32
      EXIT;                                          // threads 1-31: exit
```
  No branch instruction at all! ptxas converted the if/else into predicated execution (@!P0). All instructions are linear — no BRA,
   no BSSY/BSYNC. The warp executes everything in sequence:
  1. ALL 32 threads execute each instruction, but @!P0 masks threads 1-31 for the if-branch instructions
  2. Thread 0 hits @!P0 BAR.SYNC (predicated) — only thread 0 executes it. But per the ISA, the barrier counts the full warp since
  barriers execute "as if all threads are active"
  3. Thread 0 exits via @!P0 EXIT
  4. Threads 1-31 (still alive) hit the unpredicated BAR.SYNC → full warp arrival → barrier fires
  5. Threads 1-31 exit

  Single BAR.SYNC per thread group, fully linearized, no divergence. The warp never splits.

  4-warp SASS (deadlocks)
```
      LOP3.LUT P0, RZ, R0, 0x1f, RZ, 0xc0, !PT;   // P0 = (tid & 31 != 0)
      @P0 BRA LBB0;                                  // threads 1-31: JUMP to LBB0
      // --- if-branch (thread 0 falls through) ---
      STG.E desc[...][R2.64+0x4], R5;               // store 99
      WARPSYNC.ALL;
      BAR.SYNC.DEFER_BLOCKING 0xe, 0x20;            // bar.sync 14, 64(!)
      STG.E desc[...][R2.64], R5;                    // store 5
      EXIT;
      // --- else-branch ---
  LBB0:
      WARPSYNC.ALL;
      BAR.SYNC.DEFER_BLOCKING 0xe, 0x20;            // bar.sync 14, 32(!)
      EXIT;
```
  Real branch (@P0 BRA LBB0)! The warp actually splits — thread 0 goes one way, threads 1-31 jump to LBB0. Two separate BAR.SYNC instructions at different PCs. And notably, the barrier count changed to 0x40 (64 threads = 2 warps) instead of 0x20 (32).

  Also note the WARPSYNC.ALL before each BAR.SYNC — this is the Volta+ convergence mechanism, but it only synchronizes threads within the same branch, not across branches.

  Conclusion:

  - 1 warp: ptxas optimizes away the branch entirely, using predicated execution. The warp never diverges. Each BAR.SYNC sees the full warp (masked threads still count). No deadlock.
  - 4 warps: ptxas emits a real branch (BRA). The warp truly splits. Each BAR.SYNC only sees a partial warp at its PC. No full warp ever arrives at either copy. Deadlock.

  The key difference is a ptxas optimization decision: with 1 warp (.reqntid 32), it chose predication over branching. With 4 warps (.reqntid 128), it chose a real branch. This is likely a heuristic based on register pressure, thread count, or code size — with more threads, the cost of predicated execution (all threads execute all instructions) is higher, so the assembler prefers branching.



@FindHao 's study with CUTracer agent: [P2221130382](https://www.internalfb.com/phabricator/paste/view/P2221130382)
Looking at the generated SASS, the key barrier instruction is at 0x290:
sass
```
/*0290*/   BAR.SYNC.DEFER_BLOCKING 0xe, 0x20 ;   // Barrier 14, expecting 32 threads
The corresponding code flow for warp 6 (the one executing the async_task):
sass
.L_x_25:
    /*0220*/   BSSY.RECONVERGENT B0, `(.L_x_7) ;   // Setup reconvergence point
    /*0230*/   @P0 BRA `(.L_x_8) ;                 // Branch if P0 is true (divergence)
    /*0240*/   @!P1 LDC.64 R2, c[0x0][0x380] ;     // Load for store (only if !P1)
    /*0250*/   @!P1 MOV R5, 0x63 ;                 // Load 99 (0x63)
    /*0260*/   WARPSYNC.ALL ;                      // ← WARPSYNC before barrier
    /*0270*/   NOP ;
    /*0280*/   @!P1 STG.E desc[UR4][R2.64+0x4], R5 ; // Store 99
    /*0290*/   BAR.SYNC.DEFER_BLOCKING 0xe, 0x20 ; // Barrier 14, wait for 32 threads
```
The Problem: WARPSYNC.ALL Under Divergence
At address 0x260, there's a WARPSYNC.ALL instruction. This instruction requires all 32 threads in the warp to participate. However:
Before the barrier: Threads have already diverged due to the if tlx.thread_id(axis=0) % 32 == 0 condition
The condition tlx.thread_id(axis=0) % 32 == 0 is true only for thread 0 within the warp (lane 0)
This means:
Thread 0 (lane 0): Takes the if branch, executes the store, then hits WARPSYNC.ALL
Threads 1-31 (lanes 1-31): Skip the if branch (P0 is true), jump to .L_x_8




