### PR TITLE
[autoWS] try to pass op categories to later passes to decide num_warps

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -5,6 +5,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir {
 class Operation;
@@ -19,6 +20,7 @@ class ForOp;
 static constexpr char kPartitionAttrName[] = "ttg.partition";
 static constexpr char kPartitionOutputsAttrName[] = "ttg.partition.outputs";
 static constexpr char kPartitionStagesAttrName[] = "ttg.partition.stages";
+static constexpr char kPartitionTypesAttrName[] = "ttg.partition.types";
 static constexpr char kWarpSpecializeTagAttrName[] = "ttg.warp_specialize.tag";
 
 //===----------------------------------------------------------------------===//
@@ -40,6 +42,8 @@ public:
   ArrayRef<Operation *> getOps() const { return ops; }
   void addOp(Operation *op) { ops.push_back(op); }
   bool hasOp(Operation *op) const;
+  StringRef getType() const { return type; }
+  void setType(StringRef t) { type = t.str(); }
 
   // Iterate the inputs of the partition. Input values are those that originate
   // from a different partition or a previous iteration of the current
@@ -73,6 +77,8 @@ private:
   int stage;
   // The ops in the partition.
   SmallVector<Operation *> ops;
+  // The type of the partition (e.g., "gemm", "load", "reduction", "default").
+  std::string type;
 };
 
 // A partition set divides a loop into multiple partitions. Ops in a loop are

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -6,6 +6,7 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/ADT/ScopeExit.h"
@@ -253,6 +254,42 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
       }
     }
   } while (changed);
+
+  // Read partition types if available for type-aware warp assignment.
+  SmallVector<StringRef> partitionTypes;
+  if (auto typesAttr =
+          wsOp->getAttrOfType<ArrayAttr>(kPartitionTypesAttrName)) {
+    for (Attribute attr : typesAttr) {
+      if (auto strAttr = dyn_cast<StringAttr>(attr))
+        partitionTypes.push_back(strAttr.getValue());
+      else
+        partitionTypes.push_back("");
+    }
+  }
+
+  // Apply type-aware warp assignment overrides BEFORE relayout.
+  // This ensures layouts are computed with the correct warp counts.
+  //
+  // For bwd FA (has reduction): computation partition gets 8 warps.
+  // With reduction=4 (TMEM floor), gemm=1, load=1, computation=8,
+  // total = 14, within the 16 warp budget.
+  //
+  // Note: the types array comes from the scheduler and may be longer than
+  // partitionNumWarps (the WarpSpecializeOp may have fewer regions). We scan
+  // the full types array to detect the BWD pattern, then apply the override
+  // to the last partition (which is computation in BWD).
+  bool hasReduction = false;
+  bool hasComputation = false;
+  for (StringRef type : partitionTypes) {
+    if (type == "reduction")
+      hasReduction = true;
+    if (type == "computation")
+      hasComputation = true;
+  }
+
+  if (hasReduction && hasComputation && !partitionNumWarps.empty()) {
+    partitionNumWarps.back() = 8;
+  }
 
   // Read the attribute from the module
   ModuleOp mod = axisInfo.getModuleOp();

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -189,10 +189,14 @@ void PartitionSet::serialize(scf::ForOp loop) const {
   // In the new PartitionSet system, per-op partition attributes are already set
   // by setPartition(). We only need to serialize the partition stages array.
   SmallVector<Attribute> stages;
+  SmallVector<Attribute> types;
   Builder b(loop.getContext());
-  for (const Partition &partition : getPartitions())
+  for (const Partition &partition : getPartitions()) {
     stages.push_back(b.getI32IntegerAttr(partition.getStage()));
+    types.push_back(b.getStringAttr(partition.getType()));
+  }
   loop->setAttr(kPartitionStagesAttrName, b.getArrayAttr(stages));
+  loop->setAttr(kPartitionTypesAttrName, b.getArrayAttr(types));
 }
 
 void PartitionSet::dump() const {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -437,6 +437,12 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   auto wgOp = topBuilder.create<nvws::WarpGroupOp>(resultTypes, numWarps,
                                                    numPartitions);
 
+  // Copy partition types attribute from the loop if present
+  if (auto typesAttr =
+          loop->getAttrOfType<ArrayAttr>(kPartitionTypesAttrName)) {
+    wgOp->setAttr(kPartitionTypesAttrName, typesAttr);
+  }
+
   SmallVector<WarpGroupBuilder> builders;
   for (Region &region : wgOp.getPartitionRegions()) {
     auto partitionId = builders.size();

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-types.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-types.mlir
@@ -1,0 +1,55 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta -allow-unregistered-dialect | FileCheck %s
+
+// Tests that partition scheduling Meta pass serializes partition types as ttg.partition.types attribute.
+// For bwd FA (hasReduction): reduction at index 0, then gemm, load, computation
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#load_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_T = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+
+#smem = #ttg.shared_memory
+#tmem_acc = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// Test: Verify partition types attribute is serialized
+// The partition scheduling pass should add ttg.partition.types attribute to the ForOp
+// CHECK-LABEL: @simple_gemm_partition_types
+// CHECK: scf.for
+// CHECK: ttg.partition.types
+tt.func public @simple_gemm_partition_types(
+  %A_shared: !ttg.memdesc<128x64xf16, #shared, #smem>,
+  %B_desc: !tt.tensordesc<tensor<64x64xf16, #shared>>,
+  %n_tiles: i32
+) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x64xf32, #blocked>
+
+  %loop_out = scf.for %i = %c0_i32 to %n_tiles step %c64_i32 iter_args(
+    %acc = %zero
+  ) -> (tensor<128x64xf32, #blocked>) : i32 {
+    // Load B
+    %B = tt.descriptor_load %B_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
+    %B_shared = ttg.local_alloc %B : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+    %B_trans = ttg.memdesc_trans %B_shared {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
+
+    // MMA operation
+    %C_tmem, %C_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %A_shared, %B_trans, %C_tmem[%C_tok], %false, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared_T, #smem>, !ttg.memdesc<128x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>
+
+    %result, %result_tok = ttng.tmem_load %C_tmem[%mma_tok] : !ttg.memdesc<128x64xf32, #tmem_acc, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    %new_acc = arith.addf %acc, %result : tensor<128x64xf32, #blocked>
+
+    scf.yield %new_acc : tensor<128x64xf32, #blocked>
+  } {tt.warp_specialize}
+
+  "use"(%loop_out) : (tensor<128x64xf32, #blocked>) -> ()
+  tt.return
+}
+
+}

--- a/test/TritonGPU/optimize-partition-warps-type-aware.mlir
+++ b/test/TritonGPU/optimize-partition-warps-type-aware.mlir
@@ -1,0 +1,100 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-optimize-partition-warps | FileCheck %s
+
+// Tests for type-aware warp assignment in OptimizePartitionWarps pass.
+// When partition types are specified via ttg.partition.types attribute:
+// - For bwd FA (has reduction + computation): last partition gets 8 warps
+
+#blocked8 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared_1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {ttg.target = "cuda:100", "ttg.num-warps" = 8 : i32} {
+
+// Test 1: BWD FA pattern - computation (last partition) gets 8 warps
+// CHECK-LABEL: @bwd_fa_computation_gets_8_warps
+tt.func @bwd_fa_computation_gets_8_warps(%arg0: i32) {
+  ttg.warp_specialize(%arg0) attributes {"ttg.partition.types" = ["reduction", "gemm", "load", "computation"]}
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // CHECK: partition1({{.*}}) num_warps(1)
+  partition1(%arg1: i32) num_warps(8) {
+    %0 = arith.muli %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // CHECK: partition2({{.*}}) num_warps(8)
+  // computation (last partition) gets 8 warps
+  partition2(%arg1: i32) num_warps(4) {
+    %0 = arith.subi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+// Test 2: Without partition types attribute, normal optimization applies
+// CHECK-LABEL: @no_partition_types_normal_optimization
+tt.func @no_partition_types_normal_optimization(%arg0: i32) {
+  ttg.warp_specialize(%arg0)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // CHECK: partition1({{.*}}) num_warps(1)
+  partition1(%arg1: i32) num_warps(8) {
+    %0 = arith.subi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+// Test 3: Without reduction, computation does not get override
+// CHECK-LABEL: @no_reduction_no_override
+tt.func @no_reduction_no_override(%arg0: i32) {
+  ttg.warp_specialize(%arg0) attributes {"ttg.partition.types" = ["gemm", "load", "computation"]}
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // CHECK: partition1({{.*}}) num_warps(1)
+  partition1(%arg1: i32) num_warps(8) {
+    %0 = arith.muli %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // CHECK: partition2({{.*}}) num_warps(1)
+  partition2(%arg1: i32) num_warps(4) {
+    %0 = arith.subi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+// Test 4: Empty partition types array - should behave like no attribute
+// CHECK-LABEL: @empty_partition_types
+tt.func @empty_partition_types(%arg0: i32) {
+  ttg.warp_specialize(%arg0) attributes {"ttg.partition.types" = []}
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -248,6 +248,7 @@ public:
     // This makes reduction the "default" partition in warp_specialize.
     if (options.hasReduction) {
       reductionPartition = schedule.addPartition(0);
+      reductionPartition->setType("reduction");
       defaultPartition = nullptr; // No separate default for bwd
     } else {
       reductionPartition = nullptr;
@@ -255,13 +256,16 @@ public:
       bool needDefault = options.hasCorrection || options.hasEpilogue;
       if (needDefault) {
         defaultPartition = schedule.addPartition(0);
+        defaultPartition->setType("default");
       } else {
         defaultPartition = nullptr;
       }
     }
 
     gemmPartition = schedule.addPartition(1); // stage 1 for MMA
+    gemmPartition->setType("gemm");
     loadPartition = schedule.addPartition(0);
+    loadPartition->setType("load");
 
     // Correction: merge into default partition.
     if (options.hasCorrection)
@@ -271,10 +275,12 @@ public:
 
     // Epilogue: only if there are epilogue stores and not merged into
     // computation.
-    if (options.hasEpilogue && !options.mergeEpilogueIntoComputation)
+    if (options.hasEpilogue && !options.mergeEpilogueIntoComputation) {
       epiloguePartition = schedule.addPartition(0);
-    else
+      epiloguePartition->setType("epilogue");
+    } else {
       epiloguePartition = nullptr;
+    }
 
     // Note: computation partitions are NOT pre-allocated here.
     // They are created dynamically by scheduleUsers() in Phase 5.
@@ -320,9 +326,13 @@ class GEMMTemplate : public SchedulingTemplate {
 public:
   void createPartitions(PartitionSet &schedule) override {
     defaultPartition = schedule.addPartition(0);
+    defaultPartition->setType("default");
     gemmPartition = schedule.addPartition(1);
+    gemmPartition->setType("gemm");
     loadPartition = schedule.addPartition(0);
+    loadPartition->setType("load");
     epiloguePartition = schedule.addPartition(0);
+    epiloguePartition->setType("epilogue");
   }
 
   Partition *getPartition(AbstractPartition absPart,
@@ -887,8 +897,10 @@ static Partition *scheduleUsers(scf::ForOp loop, PartitionSet &schedule,
 
     if (hasPartition(user))
       continue;
-    if (!partition)
+    if (!partition) {
       partition = schedule.addPartition(/* stage is unused */ 0);
+      partition->setType("computation");
+    }
     tryScheduleOp(partition, user);
     for (OpOperand &use : user->getUses())
       uses.push_back(&use);
@@ -1267,6 +1279,25 @@ getInitialSchedule(scf::ForOp mainLoop,
         }
       }
     }
+
+    // For BWD (hasReduction): tag pre-loop TMEMStoreOp with the reduction
+    // partition index. These ops initialize accumulators (e.g., zeroing dK/dV)
+    // before the loop. Without explicit assignment, they would get pulled
+    // into the gemm partition via token chains to the in-loop MMA, causing
+    // gemm to require >=4 warps (TMEM ops need 4 warps).
+    // We set the attribute directly rather than using schedule.trySchedule
+    // because pre-loop ops must not be added to the partition's ops list
+    // (optimizeSchedule only handles in-loop ops).
+    if (reductionPartition) {
+      Builder b(mainLoop->getContext());
+      for (Operation &op : *mainLoop->getBlock()) {
+        if (&op == mainLoop)
+          break;
+        if (isa<ttng::TMEMStoreOp>(op))
+          op.setAttr(kPartitionAttrName,
+                     b.getI32IntegerAttr(reductionPartition->getIndex()));
+      }
+    }
   }
 
   //===--------------------------------------------------------------------===//
@@ -1498,6 +1529,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule) {
     // Assign the whole cluster to its own partition.
     if (cluster.defPartitions.size() > 1 || cluster.sinkPartitions.size() > 1) {
       Partition *newPartition = schedule.addPartition(0);
+      newPartition->setType("computation");
       for (Operation *op : cluster.ops)
         setPartition(op, newPartition);
       continue;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -539,6 +539,15 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
   auto wsOp = impB.create<ttg::WarpSpecializeOp>(dummyTypes, partitionNumWarps,
                                                  nTaskIds.size() - 1);
 
+  // Copy partition types attribute from the loop to the WarpSpecializeOp.
+  // This is needed by OptimizePartitionWarps for type-aware warp assignment.
+  funcOp.walk([&](scf::ForOp forOp) {
+    if (auto typesAttr =
+            forOp->getAttrOfType<ArrayAttr>(kPartitionTypesAttrName)) {
+      wsOp->setAttr(kPartitionTypesAttrName, typesAttr);
+    }
+  });
+
   // Clone all operations into the corresponding if blocks. If the operation
   // has multiple taskIds, it will be cloned for multiple if blocks.
   // If the original code has an IfOp, we should only clone its

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerWarpGroup.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerWarpGroup.cpp
@@ -160,6 +160,11 @@ class LowerWarpGroup : public OpRewritePattern<WarpGroupOp> {
 
     wsOp.setPartitionNumWarps(numWarps);
 
+    // Copy partition types attribute if present
+    if (auto typesAttr = warpGroupOp->getAttr("ttg.partition.types")) {
+      wsOp->setAttr("ttg.partition.types", typesAttr);
+    }
+
     auto &defaultBlock = wsOp.getDefaultRegion().emplaceBlock();
     rewriter.setInsertionPointToEnd(&defaultBlock);
 


### PR DESCRIPTION
The categories are passed via annotations and we teach relevant passes to keep the annotations.