### PR TITLE
[triton][beta] [Cherry-pick] '[LAYOUTS] Have MemDesc{Trans,Reshape} accept equivalent layouts (#8251)'

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -280,8 +280,8 @@ llvm::SmallVector<unsigned>
 expandMatrixOrderWithBatch(llvm::ArrayRef<unsigned> o);
 
 // Return true if the two layouts represent the exact same mapping.
-bool areLayoutsEquivalent(ArrayRef<int64_t> shape, DistributedEncodingTrait lhs,
-                          DistributedEncodingTrait rhs);
+bool areLayoutsEquivalent(ArrayRef<int64_t> shape, LayoutEncodingTrait lhs,
+                          LayoutEncodingTrait rhs);
 
 // Return true if the innermost numElems are contiguous.
 bool isInnermostContiguous(MemDescType type, unsigned numElems);

--- a/lib/Dialect/Triton/IR/CMakeLists.txt
+++ b/lib/Dialect/Triton/IR/CMakeLists.txt
@@ -14,6 +14,10 @@ add_triton_library(TritonIR
   DEPENDS
   TritonTableGen
   TritonCanonicalizeIncGen
+  TritonGPUTableGen
+  TritonGPUAttrDefsIncGen
+  TritonGPUTypeInterfacesIncGen
+  TritonGPUOpInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Dialect/Triton/IR/Traits.cpp
+++ b/lib/Dialect/Triton/IR/Traits.cpp
@@ -6,11 +6,41 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace mlir;
+using namespace mlir::triton::gpu;
 
 LogicalResult OpTrait::impl::verifyEquivalentType(Type typeA, Type typeB) {
+  auto memdescA = dyn_cast<MemDescType>(typeA);
+  auto memdescB = dyn_cast<MemDescType>(typeB);
+  if (memdescA || memdescB) {
+    if (!memdescA || !memdescB)
+      return failure();
+    if (memdescA.getShape() != memdescB.getShape())
+      return failure();
+    if (memdescA.getAllocShape() != memdescB.getAllocShape())
+      return failure();
+    if (memdescA.getElementType() != memdescB.getElementType())
+      return failure();
+    if (memdescA.getMemorySpace() != memdescB.getMemorySpace())
+      return failure();
+    if (memdescA.getMutableMemory() != memdescB.getMutableMemory())
+      return failure();
+
+    Attribute encodingA = memdescA.getEncoding();
+    Attribute encodingB = memdescB.getEncoding();
+    if (encodingA == encodingB)
+      return success();
+    if (static_cast<bool>(encodingA) != static_cast<bool>(encodingB))
+      return failure();
+
+    auto layoutInterface =
+        cast<triton::DialectInferLayoutInterface>(&encodingA.getDialect());
+    return layoutInterface->verifyLayoutsAreEqual(memdescA.getShape(),
+                                                  encodingA, encodingB, {});
+  }
   auto tensorTypeA = dyn_cast<RankedTensorType>(typeA);
   auto tensorTypeB = dyn_cast<RankedTensorType>(typeB);
   if (!(bool(tensorTypeA) && bool(tensorTypeB)))

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3009,8 +3009,8 @@ struct TritonGPUInferLayoutInterface
       return failure();
 
     // Check whether the encodings are structurally the same.
-    if (!areLayoutsEquivalent(shape, cast<DistributedEncodingTrait>(expected),
-                              cast<DistributedEncodingTrait>(got))) {
+    if (!areLayoutsEquivalent(shape, cast<LayoutEncodingTrait>(expected),
+                              cast<LayoutEncodingTrait>(got))) {
       return emitOptionalError(loc, "Expected result encoding ", expected,
                                " but was ", got);
     }
@@ -3064,8 +3064,8 @@ struct TritonGPUInferLayoutInterface
       Attribute splitEnc;
       auto result = inferSplitOpEncoding(parent, splitEnc, joinedShape, loc);
       if (succeeded(result) &&
-          areLayoutsEquivalent(shape, cast<DistributedEncodingTrait>(splitEnc),
-                               cast<DistributedEncodingTrait>(srcEnc))) {
+          areLayoutsEquivalent(shape, cast<LayoutEncodingTrait>(splitEnc),
+                               cast<LayoutEncodingTrait>(srcEnc))) {
         dstEnc = parent;
         return success();
       }
@@ -3777,8 +3777,8 @@ int triton::gpu::lookupNumCTAs(OpBuilder &rewriter) {
 }
 
 bool triton::gpu::areLayoutsEquivalent(ArrayRef<int64_t> shape,
-                                       DistributedEncodingTrait lhs,
-                                       DistributedEncodingTrait rhs) {
+                                       LayoutEncodingTrait lhs,
+                                       LayoutEncodingTrait rhs) {
   auto lhsLL = triton::gpu::toLinearLayout(shape, lhs);
   auto rhsLL = triton::gpu::toLinearLayout(shape, rhs);
   return lhsLL == rhsLL;

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -548,16 +548,7 @@ LogicalResult MemDescReshapeOp::verify() {
   if (failed(inferReturnTypes(getContext(), getLoc(), srcType,
                               dstType.getShape(), expectedTy)))
     return failure();
-  // Check that the alloc shape separately to give a cleaner error, given that
-  // it's the most likely source of the error.
-  if (expectedTy.getAllocShape() != dstType.getAllocShape()) {
-    return emitError(
-        "The result alloc shape does not match the expected alloc shape.");
-  }
-  if (expectedTy != dstType) {
-    return emitError("source and destination layout are incompatible.");
-  }
-  return success();
+  return OpTrait::impl::verifyEquivalentType(expectedTy, dstType);
 }
 
 static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -178,8 +178,8 @@ bool isDistributedLayoutSplitMTmemLoadStore(RankedTensorType tensorType,
   if (!layout)
     return false;
   return areLayoutsEquivalent(
-      tensorType.getShape(), cast<DistributedEncodingTrait>(layout),
-      cast<DistributedEncodingTrait>(tensorType.getEncoding()));
+      tensorType.getShape(), cast<LayoutEncodingTrait>(layout),
+      cast<LayoutEncodingTrait>(tensorType.getEncoding()));
 }
 
 SmallVector<DistributedEncodingTrait>
@@ -226,9 +226,10 @@ bool isDistributedLayoutTMemCompatible(Operation *op,
                                        gpu::MemDescType memType) {
   SmallVector<DistributedEncodingTrait> layouts =
       getTmemCompatibleLayouts(op, tensorType, memType);
-  auto enc = cast<DistributedEncodingTrait>(tensorType.getEncoding());
+  auto enc = cast<LayoutEncodingTrait>(tensorType.getEncoding());
   return llvm::any_of(layouts, [&](DistributedEncodingTrait layout) {
-    return areLayoutsEquivalent(tensorType.getShape(), layout, enc);
+    return areLayoutsEquivalent(tensorType.getShape(),
+                                cast<LayoutEncodingTrait>(layout), enc);
   });
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -722,7 +722,9 @@ static LogicalResult verifyTMEMOperand(Operation *op, RankedTensorType type,
              << " does not have any TMEM compatible layouts";
     }
     if (llvm::none_of(layouts, [&](DistributedEncodingTrait layout) {
-          return areLayoutsEquivalent(type.getShape(), layout, enc);
+          return areLayoutsEquivalent(type.getShape(),
+                                      cast<LayoutEncodingTrait>(layout),
+                                      cast<LayoutEncodingTrait>(enc));
         })) {
       InFlightDiagnostic diag = op->emitOpError(regName)
                                 << " layout is not TMEM compatible";


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8251

Upstream commit message:
```
> [LAYOUTS] Have MemDesc{Trans,Reshape} accept equivalent layouts (#8251)

> As per title
```

Build Fix:
- File: lib/Dialect/Triton/IR/CMakeLists.txt
  Action: Added TritonGPU tablegen dependencies (TritonGPUTableGen, TritonGPUAttrDefsIncGen,
  TritonGPUTypeInterfacesIncGen, TritonGPUOpInterfacesIncGen) to TritonIR DEPENDS section
  Reason: Cherry-pick added #include "triton/Dialect/TritonGPU/IR/Types.h" to Traits.cpp,
  creating a transitive dependency on TritonGPU tablegen-generated headers. Upstream commit
  did not update CMakeLists.txt. Re-ran buckify to regenerate BUCK file.

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: f22c53ad71c73d02834a0afd74196042ee431980

Reviewed By: stashuk-olek

Differential Revision: D95261959


