### PR TITLE
[triton][proton] Implement AMD global memory buffer operations for CircularStoreOp

### DIFF
--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
@@ -1,9 +1,11 @@
 #include "Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.h"
+#include "BufferOpsEmitter.h"
 #include "Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.h"
 #include "Conversion/ProtonGPUToLLVM/Utility.h"
 #include "Dialect/ProtonGPU/IR/Dialect.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
@@ -34,10 +36,39 @@ struct CircularStoreOpConversion
 
     uint32_t addrSpace = dataPack.addrSpace;
     if (addrSpace == 1) {
-      // TODO(crobeck): see what buffer ops performance looks like here for
-      // global mem (address space 1) compared to predicated ops to shared
-      // memory
-      llvm::report_fatal_error("unimplemented");
+      // Global memory path — use ROCDL buffer operations for branchless
+      // predicated stores.  The offset-masking trick avoids branch divergence:
+      // when isWriter is false the offset is set past num_records, causing the
+      // hardware to silently NOP the store.
+
+      // Build a buffer resource descriptor via BufferEmitter.
+      auto &amdTargetInfo = static_cast<const triton::AMD::TargetInfo &>(
+          targetInfo.getTritonTargetInfo());
+      LLVM::AMD::BufferEmitter bufEmitter(rewriter, loc, amdTargetInfo);
+      Value rsrcDesc = bufEmitter.createResourceDescriptor(dataPack.ptr);
+
+      // Branchless predication via offset masking.
+      // Real offset = 0 (the pointer already points to the target slot).
+      // OOB  offset = 0x80000000 (exceeds num_records → hardware NOP).
+      Value realOffset = b.int_val(32, 0);
+      Value oobOffset =
+          b.int_val(32, static_cast<int32_t>(std::numeric_limits<int>::max() +
+                                             int64_t(1)));
+      Value maskedOffset = b.select(dataPack.isWriter, realOffset, oobOffset);
+
+      // Scalar offset and cache control.
+      // Use SC0=1, NT=1 (cache-streaming / non-temporal) to avoid polluting
+      // the L1 data cache with profiling traffic.
+      Value sgprOffset = b.int_val(32, 0);
+      constexpr int32_t auxCacheStreaming = 0x3; // SC0 | NT
+      Value aux = b.int_val(32, auxCacheStreaming);
+
+      // Emit the buffer store.
+      // dataPack.record is <2 x i32> (8 bytes: tag+upperClock, lowerClock).
+      SmallVector<Value, 5> args{dataPack.record, rsrcDesc, maskedOffset,
+                                 sgprOffset, aux};
+      rewriter.create<ROCDL::RawPtrBufferStoreOp>(loc, TypeRange{}, args,
+                                                  ArrayRef<NamedAttribute>());
     } else if (addrSpace == 3) {
       targetInfo.getTritonTargetInfo().storeDShared(
           rewriter, loc, dataPack.ptr, std::nullopt, dataPack.record,


### PR DESCRIPTION
Summary:
Adds ROCm device library buffer operation support for Proton's CircularStoreOp on AMD GPUs.

Reuses BufferEmitter and branchless predicated stores via offset masking for profiling data collection. This is a self-contained LLVM backend change.

This code change is part of a larger project exploring widescale AMD tooling support

Differential Revision: D95463880


