### PR TITLE
[autoWS] Backport fix: bail out when memdesc_reshape roundtrip layouts mismatch

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -165,6 +165,17 @@ public:
             getContext(), allocOp.getLoc(), allocType, srcShape, innerTy)))
       return failure();
 
+    // Verify round-trip: reshaping innerTy back to dstShape must recover
+    // allocType exactly.  This can fail when backward inference changes the
+    // encoding family (e.g. NVMMAShared → SharedLinear) and the forward
+    // direction cannot recover the original encoding.
+    MemDescType roundTripTy;
+    if (failed(MemDescReshapeOp::inferReturnTypes(
+            getContext(), allocOp.getLoc(), innerTy, dstShape, roundTripTy)))
+      return failure();
+    if (roundTripTy != allocType)
+      return failure();
+
     auto newAlloc = rewriter.create<LocalAllocOp>(allocOp.getLoc(), innerTy,
                                                   reshapeOp.getSrc());
     rewriter.replaceOpWithNewOp<MemDescReshapeOp>(allocOp, allocOp.getType(),


### PR DESCRIPTION
Backport PR #1012 added a `#SharedLinear` fallback to `inferMemDescReshapeOpEncoding`: when reshaping an `#NVMMAShared` memdesc changes the innermost dimension, the inference now succeeds with a `#SharedLinear` encoding instead of failing.                                                                                                                                            

This causes "source and destination layout are incompatible" error in OptimizeDotOperands.cpp, which converts local_alloc(reshape(src)) to memdesc_reshape(local_alloc(src)). The pattern infers an inner type by "reverse-reshaping" the alloc's `#NVMMAShared` encoding, getting `#SharedLinear`. It then creates a `memdesc_reshape` back to the original but gets `#SharedLinear`, not `#NVMMAShared`.

The fix adds a round-trip check: after inferring the inner type, re-infer back to the original shape and verify it recovers the original type exactly. If not, bail out. This restores pre cherry-pick behavior.