### PR TITLE
[autoWS] Backport fix: TMEMallocation argument order

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -1202,7 +1202,7 @@ public:
       allocToIntervals[alloc.getOperation()] = liveInterval;
       allocToSize.insert(
           {alloc.getOperation(),
-           ttng::TMemAllocation(allocSize.numCols, allocSize.numRows)});
+           ttng::TMemAllocation(allocSize.numRows, allocSize.numCols)});
       allocToChannel[alloc.getOperation()] = TheCh;
     }
     // Sort allocs according to isOperandD, size, live interval.


### PR DESCRIPTION
PR #975 switched the order of `numRows` and `numCols` in `TMemAllocation`. 
We fix in the Meta autoWS passes to be consistent.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/a9b19d7f-24e9-4d40-a437-745c8052bfa5" />