### PR TITLE
Advance version 3.4.0 -> 3.5.0.1 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -810,7 +810,7 @@ def get_git_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.4.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
+TRITON_VERSION = "3.5.0.1" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 9)


### PR DESCRIPTION
Summary:
The wheel version in the setup.py was set to 3.5.0 on the release/3.5.0.1 branch. This causes inconsistency because the __initi__.py has already been changed to 3.5.0.1+fb. This pr changes it so that the version is consistent.

@htyu 