### PR TITLE
[TLX] Add async_store to planCTA

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -394,7 +394,7 @@ void CTAPlanner::processStoreLikeOps(triton::FuncOp &funcOp) {
   llvm::SmallVector<Operation *> stores;
   funcOp.walk([&](Operation *op) {
     if (llvm::isa<triton::StoreOp, triton::AtomicRMWOp, triton::AtomicCASOp,
-                  triton::DescriptorStoreLikeOpInterface>(op))
+                  triton::DescriptorStoreLikeOpInterface, AsyncStoreOp>(op))
       stores.push_back(op);
   });
   assert(stores.size() > 0 && "Cannot find store-like ops");


### PR DESCRIPTION
planCTA expects a store. This adds async_store to the options being considered to prevent compilation failures if the only store is an async store.