### PR TITLE
[autoWS] enable buffer.id sharing for split TMA copy buffers

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_memory_planner_split_copy.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_split_copy.mlir
@@ -46,3 +46,84 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
     tt.return
   }
 }
+
+// -----
+
+// Test: When ALL innermost-loop buffers require TMA split copies (same split
+// pattern), they CAN share a buffer.id. The barrier arrive count is symmetric
+// across all buffers in the group, so the accounting remains correct.
+// This is the flash-attention case: v and k are both 128x128xbf16 with
+// swizzle=128, so both need split copies (inner dim 128 × 2B = 256B > 128B).
+// They should share a buffer.id to avoid wasting SMEM.
+
+// CHECK-LABEL: @tma_split_copy_both_split_share
+// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = [[SPLIT_ID:[0-9]+]] : i32}
+// CHECK-SAME: 128x128xbf16
+// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = [[SPLIT_ID]] : i32}
+// CHECK-SAME: 128x128xbf16
+
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem2 = #ttg.shared_memory
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tma_split_copy_both_split_share(
+      %v_desc: !tt.tensordesc<tensor<128x128xbf16, #shared2>>,
+      %k_desc: !tt.tensordesc<tensor<128x128xbf16, #shared2>>) {
+    %v_smem = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem2, mutable>
+    %k_smem = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem2, mutable>
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c10 = arith.constant 10 : i32
+    scf.for %iv = %c0 to %c10 step %c1 : i32 {
+      %v = tt.descriptor_load %v_desc[%c0, %c0] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x128xbf16, #shared2>> -> tensor<128x128xbf16, #blocked2>
+      ttg.local_store %v, %v_smem {async_task_id = array<i32: 1>} : tensor<128x128xbf16, #blocked2> -> !ttg.memdesc<128x128xbf16, #shared2, #smem2, mutable>
+      %k = tt.descriptor_load %k_desc[%c0, %c0] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x128xbf16, #shared2>> -> tensor<128x128xbf16, #blocked2>
+      ttg.local_store %k, %k_smem {async_task_id = array<i32: 1>} : tensor<128x128xbf16, #blocked2> -> !ttg.memdesc<128x128xbf16, #shared2, #smem2, mutable>
+      %v_val = ttg.local_load %v_smem {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xbf16, #shared2, #smem2, mutable> -> tensor<128x128xbf16, #blocked2>
+      %k_val = ttg.local_load %k_smem {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xbf16, #shared2, #smem2, mutable> -> tensor<128x128xbf16, #blocked2>
+      scf.yield
+    } {tt.warp_specialize}
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Split buffers with different TMA block shapes must NOT share a
+// buffer.id. Both C (64x128) and D (128x128) split along the contiguous dim
+// (128 → 64), but their outer dims differ (64 vs 128), producing different
+// TMA block shapes ([64, 64] vs [128, 64]). Conservatively separated.
+
+// CHECK-LABEL: @tma_split_copy_different_split_factors
+// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = [[ID1:[0-9]+]] : i32}
+// CHECK-SAME: 64x128xf16
+// CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = [[ID2:[0-9]+]] : i32}
+// CHECK-SAME: 128x128xf16
+
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem3 = #ttg.shared_memory
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tma_split_copy_different_split_factors(
+      %c_desc: !tt.tensordesc<tensor<64x128xf16, #shared3>>,
+      %d_desc: !tt.tensordesc<tensor<128x128xf16, #shared3>>) {
+    // C: 64x128, inner dim = 128 × 2B = 256B > 128B swizzle → block [64, 64], split into 2
+    %C_smem = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #shared3, #smem3, mutable>
+    // D: 128x128, inner dim = 128 × 2B = 256B > 128B swizzle → block [128, 64], split into 2
+    // Different outer dim means different TMA block shape → separate group
+    %D_smem = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared3, #smem3, mutable>
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c10 = arith.constant 10 : i32
+    scf.for %iv = %c0 to %c10 step %c1 : i32 {
+      %c = tt.descriptor_load %c_desc[%c0, %c0] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<64x128xf16, #shared3>> -> tensor<64x128xf16, #blocked3>
+      ttg.local_store %c, %C_smem {async_task_id = array<i32: 1>} : tensor<64x128xf16, #blocked3> -> !ttg.memdesc<64x128xf16, #shared3, #smem3, mutable>
+      %d = tt.descriptor_load %d_desc[%c0, %c0] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x128xf16, #shared3>> -> tensor<128x128xf16, #blocked3>
+      ttg.local_store %d, %D_smem {async_task_id = array<i32: 1>} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared3, #smem3, mutable>
+      %c_val = ttg.local_load %C_smem {async_task_id = array<i32: 0>} : !ttg.memdesc<64x128xf16, #shared3, #smem3, mutable> -> tensor<64x128xf16, #blocked3>
+      %d_val = ttg.local_load %D_smem {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf16, #shared3, #smem3, mutable> -> tensor<128x128xf16, #blocked3>
+      scf.yield
+    } {tt.warp_specialize}
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -543,6 +543,12 @@ public:
 
     unsigned bufferId = 0;
     int bufferIdInnermost = -1;
+    // Separate shared group for buffers requiring TMA split copies.
+    // These must not share a barrier with non-split buffers (different
+    // arrive counts), but CAN share with each other when they have the
+    // same TMA block shape (same split pattern).
+    int bufferIdSplit = -1;
+    SmallVector<int64_t> splitBlockShape;
 
     DenseMap<int, Type> idTypes;
     for (auto bufferIter : bufferRange) {
@@ -569,14 +575,25 @@ public:
           idTypes[bufferIdInnermost] = elemType;
           ++bufferId;
         }
-        // Buffers requiring TMA split copies get their own unique buffer.id
-        // to avoid sharing a barrier with other buffers. Each split copy
-        // emits a separate barrier_expect/arrive, so sharing would cause
-        // barrier over-arrival (UB per CUDA PTX spec).
+        // Buffers requiring TMA split copies must not share a barrier with
+        // non-split buffers (the split copies produce extra barrier arrives
+        // that would cause over-arrival). However, split buffers CAN share
+        // with each other when they have the same TMA block shape (same
+        // split pattern), so the barrier accounting stays symmetric.
         unsigned assignedId = bufferIdInnermost;
         if (requiresTMASplitCopies(allocDescType)) {
-          assignedId = bufferId;
-          ++bufferId;
+          auto blockShape = ttng::getTMABlockShape(allocDescType,
+                                                   /*packedSize=*/true);
+          bool needNewGroup = bufferIdSplit < 0 ||
+                              idTypes[bufferIdSplit] != elemType ||
+                              blockShape != splitBlockShape;
+          if (needNewGroup) {
+            bufferIdSplit = bufferId;
+            idTypes[bufferIdSplit] = elemType;
+            splitBlockShape = blockShape;
+            ++bufferId;
+          }
+          assignedId = bufferIdSplit;
         }
         owner->setAttr(
             "buffer.id",
@@ -833,7 +850,7 @@ public:
       allocToIntervals[alloc.getOperation()] = liveInterval;
       allocToSize.insert(
           {alloc.getOperation(),
-           ttng::TMemAllocation(allocSize.numCols, allocSize.numRows)});
+           ttng::TMemAllocation(allocSize.numRows, allocSize.numCols)});
       allocToChannel[alloc.getOperation()] = TheCh;
     }
     // Sort allocs according to isOperandD, size, live interval.


### PR DESCRIPTION
This PR tries to enable buffer.id sharing for buffers with the same TMA split copy shapes.

PR #972 prevented SMEM buffers requiring TMA split copies from sharing a buffer.id (and thus a barrier) with other buffers. This was correct for the GEMM case where a non-split buffer (A: 128×64) and a split buffer (B: 64×128) would cause barrier over-arrival if they shared.

But it seems to be over conservative to prevent buffer.id sharing for buffers with TMA split copies, and it causes error for Flash Attention kernel: `Triton OOR: out of resource: shared memory, Required: 329304, Hardware limit: 232448.` Since preventing K and V to share buffer.id caused an extra 3×128×128×bf16 = 96KB SMEM allocation, pushing the total past the 232KB hardware limit (329KB vs 232KB).

The fix introduces a shared group (bufferIdSplit) for split-copy buffers, analogous to the existing bufferIdInnermost group for non-split buffers. Split buffers share when they have the same element type and TMA block shape; otherwise they get a new group.


