### PR TITLE
 [AutoWS] Initial SubtiledRegion Op Design (SubtiledOperator 1/N) (#1062)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -42,6 +42,8 @@ namespace mlir::triton::nvidia_gpu::impl {
 LogicalResult verifyMMAv5Op(Operation *op);
 } // namespace mlir::triton::nvidia_gpu::impl
 
+#include "triton/Dialect/TritonNvidiaGPU/IR/OpsEnums.h.inc"
+
 #define GET_ATTRDEF_CLASSES
 #include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.h.inc"
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -2,6 +2,7 @@
 #define TRITONNVIDIAGPU_ATTRDEFS
 
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
 include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUDialect.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 
@@ -78,6 +79,48 @@ def TTG_TensorMemoryScalesEncodingAttr : AttrDef<TritonNvidiaGPU_Dialect, "Tenso
     ins
     DefaultValuedParameter<"unsigned", "1">:$CTASplitM,
     DefaultValuedParameter<"unsigned", "1">:$CTASplitN
+  );
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+//===----------------------------------------------------------------------===//
+// BarrierPlacement enum
+//===----------------------------------------------------------------------===//
+
+def TTNG_BarrierPlacementBefore : I32EnumAttrCase<"BEFORE", 0, "before">;
+def TTNG_BarrierPlacementAfter  : I32EnumAttrCase<"AFTER",  1, "after">;
+
+def TTNG_BarrierPlacement : I32EnumAttr<"BarrierPlacement",
+    "Barrier placement relative to first/last tile",
+    [TTNG_BarrierPlacementBefore, TTNG_BarrierPlacementAfter]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+}
+
+//===----------------------------------------------------------------------===//
+// BarrierAnnotation attribute
+//===----------------------------------------------------------------------===//
+
+def TTNG_BarrierAnnotationAttr : AttrDef<TritonNvidiaGPU_Dialect, "BarrierAnnotation"> {
+  let mnemonic = "barrier_annotation";
+  let description = [{
+    Describes where to insert a barrier operation during subtiled region lowering.
+
+    - `barrierIdx`: index into the op's barriers operand list
+    - `placement`: BEFORE first tile or AFTER last tile
+    - `targetOpIdx`: index of the target op in the tile region body (0-based,
+      counting only non-terminator ops). The barrier is placed immediately
+      before (BEFORE placement, first tile) or after (AFTER placement, last
+      tile) this op.
+    - `barrierOpKind`: "wait_barrier" or "arrive_barrier"
+    - `count`: arrive count for arrive_barrier (default 1)
+  }];
+  let parameters = (
+    ins
+    "unsigned":$barrierIdx,
+    "BarrierPlacement":$placement,
+    "unsigned":$targetOpIdx,
+    "StringAttr":$barrierOpKind,
+    DefaultValuedParameter<"unsigned", "1">:$count
   );
   let assemblyFormat = "`<` struct(params) `>`";
 }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -37,6 +37,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td" // Pure
 include "mlir/Interfaces/InferTypeOpInterface.td" // SameOperandsAndResultType
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td" // ReturnLike
 
 def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
 def SharedMemory : Resource<"::mlir::triton::gpu::SharedMemory">;
@@ -1116,6 +1117,83 @@ def TTNG_PrefetchTensormapOp: TTNG_Op<
   let assemblyFormat = [{
     $desc attr-dict `:` qualified(type($desc))
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// SubtiledRegionOp
+//===----------------------------------------------------------------------===//
+
+def TTNG_SubtiledRegionOp : TTNG_Op<"subtiled_region", [
+    RecursiveMemoryEffects,
+    AttrSizedOperandSegments
+]> {
+  let summary = "Encapsulates a subtiling pattern for epilogue operations";
+
+  let description = [{
+    The `ttng.subtiled_region` operation explicitly represents a subtiling
+    pattern where a large tile is split into subtiles processed sequentially.
+    This gives the compiler a structured way to reason about per-tile operations
+    and barrier placement.
+
+    The op has three regions:
+    - `setupRegion`: computes subtile values (e.g. tmem_subslice + tmem_load,
+      constants). Terminated by `subtiled_region_yield`.
+    - `tileRegion`: per-tile body that is replicated during lowering. Block
+      arguments are substituted from setup outputs via `tileMappings`.
+      Terminated by `subtiled_region_yield`.
+    - `teardownRegion`: runs once after all tiles are processed (e.g. final
+      reductions, epilogue barriers for FA). Terminated by
+      `subtiled_region_yield` which yields the op's results.
+
+    `tileMappings` is an array of arrays: one per tile, each entry is an index
+    into the setup yield values. The length of each inner array must equal the
+    number of tile block arguments.
+
+    `barrierAnnotations` describes where to insert barrier operations during
+    lowering. Each annotation references a target op by index in the tile body
+    (0-based, non-terminator ops only).
+  }];
+
+  let arguments = (ins
+    Variadic<TTG_MemDescType>:$barriers,
+    Variadic<I32>:$barrierPhases,
+    ArrayAttr:$tileMappings,
+    ArrayAttr:$barrierAnnotations
+  );
+
+  let results = (outs Variadic<AnyType>:$results);
+
+  let regions = (region
+    SizedRegion<1>:$setupRegion,
+    SizedRegion<1>:$tileRegion,
+    SizedRegion<1>:$teardownRegion
+  );
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// SubtiledRegionYieldOp
+//===----------------------------------------------------------------------===//
+
+def TTNG_SubtiledRegionYieldOp : TTNG_Op<"subtiled_region_yield", [
+    Pure, Terminator, ReturnLike,
+    ParentOneOf<["SubtiledRegionOp"]>
+]> {
+  let summary = "Terminate a region of subtiled_region and optionally yield values";
+
+  let description = [{
+    Terminates any region of a `subtiled_region` op.
+    - In the setup region, the yielded values are referenced by the tile
+      mappings to provide arguments to each tile replication.
+    - In the tile region, no values are yielded.
+    - In the teardown region, the yielded values become the results of the
+      enclosing `subtiled_region` op.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$results);
+  let assemblyFormat = "($results^ `:` type($results))? attr-dict";
 }
 
 #endif

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -180,6 +180,23 @@ def TritonNvidiaGPUInterleaveTMemPass : Pass<"triton-nvidia-interleave-tmem", "m
   }];
 }
 
+def TritonNvidiaGPULowerSubtiledRegionPass
+    : Pass<"triton-nvidia-gpu-lower-subtiled-region", "mlir::ModuleOp"> {
+  let summary = "Lower subtiled_region ops into flat IR with barriers";
+
+  let description = [{
+    This pass lowers `ttng.subtiled_region` ops by:
+    1. Inlining the setup region ops before the op
+    2. Replicating the tile region for each tile in the tile mappings
+    3. Inserting barrier operations (wait_barrier / arrive_barrier) at
+       the positions specified by barrier annotations
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 def TritonNvidiaGPURemoveTMEMTokensPass : Pass<"triton-nvidia-gpu-remove-tmem-tokens", "mlir::ModuleOp"> {
   let summary = "remove TMEM tokens";
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -466,6 +466,8 @@ LogicalResult impl::verifyMMAv5Op(Operation *op) {
 #define GET_ATTRDEF_CLASSES
 #include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.cpp.inc"
 
+#include "triton/Dialect/TritonNvidiaGPU/IR/OpsEnums.cpp.inc"
+
 //===----------------------------------------------------------------------===//
 // ASM Interface (i.e.: alias)
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1087,6 +1087,272 @@ void TMEMSubSliceOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, subsliceType, alloc, offset);
 }
 
+// -- SubtiledRegionOp --
+LogicalResult SubtiledRegionOp::verify() {
+  // 1. Setup region terminates with SubtiledRegionYieldOp
+  auto &setupBlock = getSetupRegion().front();
+  if (!isa<SubtiledRegionYieldOp>(setupBlock.getTerminator()))
+    return emitOpError("setup region must terminate with "
+                       "'ttng.subtiled_region_yield'");
+
+  // 2. Tile region terminates with SubtiledRegionYieldOp
+  auto &tileBlock = getTileRegion().front();
+  if (!isa<SubtiledRegionYieldOp>(tileBlock.getTerminator()))
+    return emitOpError("tile region must terminate with "
+                       "'ttng.subtiled_region_yield'");
+
+  // 3. Teardown region terminates with SubtiledRegionYieldOp
+  auto &teardownBlock = getTeardownRegion().front();
+  if (!isa<SubtiledRegionYieldOp>(teardownBlock.getTerminator()))
+    return emitOpError("teardown region must terminate with "
+                       "'ttng.subtiled_region_yield'");
+
+  // 4. Teardown results must match op results
+  auto teardownOp =
+      cast<SubtiledRegionYieldOp>(teardownBlock.getTerminator());
+  if (teardownOp.getResults().size() != getNumResults())
+    return emitOpError("teardown yields ")
+           << teardownOp.getResults().size() << " values but op has "
+           << getNumResults() << " results";
+  for (auto [i, pair] :
+       llvm::enumerate(llvm::zip(teardownOp.getResults(), getResults()))) {
+    auto [teardownVal, opResult] = pair;
+    if (teardownVal.getType() != opResult.getType())
+      return emitOpError("teardown result ")
+             << i << " has type " << teardownVal.getType()
+             << " but op result has type " << opResult.getType();
+  }
+
+  auto yieldOp = cast<SubtiledRegionYieldOp>(setupBlock.getTerminator());
+  unsigned numSetupOutputs = yieldOp.getResults().size();
+  unsigned numTileArgs = tileBlock.getNumArguments();
+
+  // 5. tileMappings is non-empty
+  ArrayAttr tileMappings = getTileMappings();
+  if (tileMappings.empty())
+    return emitOpError("tileMappings must have at least one tile");
+
+  // 6-8. Validate each tile mapping
+  for (auto [i, mapping] : llvm::enumerate(tileMappings)) {
+    auto indices = dyn_cast<DenseI32ArrayAttr>(mapping);
+    if (!indices)
+      return emitOpError("tileMappings[")
+             << i << "] must be a DenseI32ArrayAttr";
+
+    // 6. Inner array length = number of tile block args
+    if (static_cast<unsigned>(indices.size()) != numTileArgs)
+      return emitOpError("tileMappings[") << i << "] has " << indices.size()
+                                          << " entries but tile region has "
+                                          << numTileArgs << " block arguments";
+
+    for (auto [j, idx] : llvm::enumerate(indices.asArrayRef())) {
+      // 7. Indices in range
+      if (idx < 0 || static_cast<unsigned>(idx) >= numSetupOutputs)
+        return emitOpError("tileMappings[")
+               << i << "][" << j << "] = " << idx << " is out of range [0, "
+               << numSetupOutputs << ")";
+
+      // 8. Types match
+      Type setupType = yieldOp.getResults()[idx].getType();
+      Type tileArgType = tileBlock.getArgument(j).getType();
+      if (setupType != tileArgType)
+        return emitOpError("type mismatch: setup output ")
+               << idx << " has type " << setupType << " but tile block arg "
+               << j << " has type " << tileArgType;
+    }
+  }
+
+  // Count non-terminator ops in tile body for targetOpIdx validation.
+  unsigned numTileOps = 0;
+  for (Operation &op : tileBlock.without_terminator())
+    ++numTileOps;
+
+  // 9-10. Validate barrier annotations
+  unsigned numBarriers = getBarriers().size();
+  unsigned numPhases = getBarrierPhases().size();
+  for (auto [i, attr] : llvm::enumerate(getBarrierAnnotations())) {
+    auto annotation = dyn_cast<BarrierAnnotationAttr>(attr);
+    if (!annotation)
+      return emitOpError("barrierAnnotations[")
+             << i << "] must be a BarrierAnnotationAttr";
+
+    // 9. barrierIdx in range
+    if (annotation.getBarrierIdx() >= numBarriers)
+      return emitOpError("barrierAnnotations[")
+             << i << "] has barrierIdx=" << annotation.getBarrierIdx()
+             << " but there are only " << numBarriers << " barriers";
+
+    // 10. For wait_barrier, check phase exists
+    if (annotation.getBarrierOpKind().getValue() == "wait_barrier") {
+      if (annotation.getBarrierIdx() >= numPhases)
+        return emitOpError("barrierAnnotations[")
+               << i << "] is a wait_barrier with barrierIdx="
+               << annotation.getBarrierIdx() << " but there are only "
+               << numPhases << " phases";
+    }
+
+    // Validate barrierOpKind is one of the known values
+    StringRef kind = annotation.getBarrierOpKind().getValue();
+    if (kind != "wait_barrier" && kind != "arrive_barrier")
+      return emitOpError("barrierAnnotations[")
+             << i << "] has unknown barrierOpKind '" << kind << "'";
+
+    // Validate targetOpIdx is in range
+    if (annotation.getTargetOpIdx() >= numTileOps)
+      return emitOpError("barrierAnnotations[")
+             << i << "] has targetOpIdx=" << annotation.getTargetOpIdx()
+             << " but tile region has only " << numTileOps
+             << " non-terminator ops";
+  }
+
+  return success();
+}
+
+void SubtiledRegionOp::print(OpAsmPrinter &p) {
+  // Print barriers
+  if (!getBarriers().empty()) {
+    p << " barriers(";
+    llvm::interleaveComma(getBarriers(), p,
+                          [&](Value v) { p.printOperand(v); });
+    p << " : ";
+    llvm::interleaveComma(getBarriers().getTypes(), p,
+                          [&](Type t) { p.printType(t); });
+    p << ")";
+  }
+
+  // Print phases
+  if (!getBarrierPhases().empty()) {
+    p << " phases(";
+    llvm::interleaveComma(getBarrierPhases(), p,
+                          [&](Value v) { p.printOperand(v); });
+    p << " : ";
+    llvm::interleaveComma(getBarrierPhases().getTypes(), p,
+                          [&](Type t) { p.printType(t); });
+    p << ")";
+  }
+
+  // Print tileMappings
+  p << " tile_mappings = ";
+  p.printAttribute(getTileMappings());
+
+  // Print barrierAnnotations
+  p << " barrier_annotations = ";
+  p.printAttribute(getBarrierAnnotations());
+
+  // Print attr-dict (excluding our custom attrs and operand segment sizes)
+  p.printOptionalAttrDict(
+      (*this)->getAttrs(),
+      {"tileMappings", "barrierAnnotations", getOperandSegmentSizeAttr()});
+
+  // Print setup region
+  p << " setup ";
+  p.printRegion(getSetupRegion(), /*printEntryBlockArgs=*/false);
+
+  // Print tile region with block args
+  p << " tile";
+  p.printRegion(getTileRegion(), /*printEntryBlockArgs=*/true);
+
+  // Print teardown region
+  p << " teardown ";
+  p.printRegion(getTeardownRegion(), /*printEntryBlockArgs=*/false);
+
+  // Print result types if any
+  if (getNumResults() > 0) {
+    p << " -> (";
+    llvm::interleaveComma(getResultTypes(), p, [&](Type t) { p.printType(t); });
+    p << ")";
+  }
+}
+
+ParseResult SubtiledRegionOp::parse(OpAsmParser &parser,
+                                    OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand> barrierOperands;
+  SmallVector<Type> barrierTypes;
+  SmallVector<OpAsmParser::UnresolvedOperand> phaseOperands;
+  SmallVector<Type> phaseTypes;
+
+  // Parse optional barriers(...)
+  if (succeeded(parser.parseOptionalKeyword("barriers"))) {
+    if (parser.parseLParen() || parser.parseOperandList(barrierOperands) ||
+        parser.parseColonTypeList(barrierTypes) || parser.parseRParen())
+      return failure();
+  }
+
+  // Parse optional phases(...)
+  if (succeeded(parser.parseOptionalKeyword("phases"))) {
+    if (parser.parseLParen() || parser.parseOperandList(phaseOperands) ||
+        parser.parseColonTypeList(phaseTypes) || parser.parseRParen())
+      return failure();
+  }
+
+  // Parse tile_mappings = <attr>
+  Attribute tileMappingsAttr;
+  if (parser.parseKeyword("tile_mappings") || parser.parseEqual() ||
+      parser.parseAttribute(tileMappingsAttr))
+    return failure();
+  result.addAttribute("tileMappings", tileMappingsAttr);
+
+  // Parse barrier_annotations = <attr>
+  Attribute barrierAnnotationsAttr;
+  if (parser.parseKeyword("barrier_annotations") || parser.parseEqual() ||
+      parser.parseAttribute(barrierAnnotationsAttr))
+    return failure();
+  result.addAttribute("barrierAnnotations", barrierAnnotationsAttr);
+
+  // Parse optional attr-dict
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  // Resolve operands
+  if (parser.resolveOperands(barrierOperands, barrierTypes,
+                             parser.getCurrentLocation(), result.operands) ||
+      parser.resolveOperands(phaseOperands, phaseTypes,
+                             parser.getCurrentLocation(), result.operands))
+    return failure();
+
+  // Set operand segment sizes
+  result.addAttribute(SubtiledRegionOp::getOperandSegmentSizeAttr(),
+                      parser.getBuilder().getDenseI32ArrayAttr(
+                          {static_cast<int32_t>(barrierOperands.size()),
+                           static_cast<int32_t>(phaseOperands.size())}));
+
+  // Parse setup region
+  if (parser.parseKeyword("setup"))
+    return failure();
+  Region *setupRegion = result.addRegion();
+  if (parser.parseRegion(*setupRegion))
+    return failure();
+
+  // Parse tile region with block arguments
+  if (parser.parseKeyword("tile"))
+    return failure();
+  SmallVector<OpAsmParser::Argument> tileArgs;
+  if (parser.parseArgumentList(tileArgs, OpAsmParser::Delimiter::Paren,
+                               /*allowType=*/true))
+    return failure();
+  Region *tileRegion = result.addRegion();
+  if (parser.parseRegion(*tileRegion, tileArgs))
+    return failure();
+
+  // Parse teardown region
+  if (parser.parseKeyword("teardown"))
+    return failure();
+  Region *teardownRegion = result.addRegion();
+  if (parser.parseRegion(*teardownRegion))
+    return failure();
+
+  // Parse optional result types: -> (type, ...)
+  if (succeeded(parser.parseOptionalArrow())) {
+    SmallVector<Type> resultTypes;
+    if (parser.parseLParen() || parser.parseTypeList(resultTypes) ||
+        parser.parseRParen())
+      return failure();
+    result.addTypes(resultTypes);
+  }
+
+  return success();
+}
+
 // -- TensormapCreateOp --
 LogicalResult TensormapCreateOp::verify() {
   auto rank = getBoxDim().size();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   CheckMatmulTwoCTAs.cpp
   FenceInsertion.cpp
   InterleaveTMem.cpp
+  LowerSubtiledRegion.cpp
   MMALowering.cpp
   OptimizeDescriptorEncoding.cpp
   OptimizeTMemLayouts.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/LowerSubtiledRegion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/LowerSubtiledRegion.cpp
@@ -1,0 +1,137 @@
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPULOWERSUBTILEDREGIONPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Emit a barrier operation based on the annotation kind.
+static void emitBarrierOp(OpBuilder &builder, Location loc,
+                          BarrierAnnotationAttr annotation, ValueRange barriers,
+                          ValueRange phases) {
+  unsigned idx = annotation.getBarrierIdx();
+  StringRef kind = annotation.getBarrierOpKind().getValue();
+  if (kind == "wait_barrier") {
+    WaitBarrierOp::create(builder, loc, barriers[idx], phases[idx]);
+  } else {
+    assert(kind == "arrive_barrier");
+    ArriveBarrierOp::create(builder, loc, barriers[idx], annotation.getCount());
+  }
+}
+
+class TritonNvidiaGPULowerSubtiledRegionPass
+    : public impl::TritonNvidiaGPULowerSubtiledRegionPassBase<
+          TritonNvidiaGPULowerSubtiledRegionPass> {
+public:
+  using TritonNvidiaGPULowerSubtiledRegionPassBase::
+      TritonNvidiaGPULowerSubtiledRegionPassBase;
+
+  void runOnOperation() override {
+    // Collect all SubtiledRegionOps first to avoid modifying while iterating.
+    SmallVector<SubtiledRegionOp> ops;
+    getOperation().walk([&](SubtiledRegionOp op) { ops.push_back(op); });
+
+    for (auto op : ops)
+      lowerSubtiledRegion(op);
+  }
+
+private:
+  void lowerSubtiledRegion(SubtiledRegionOp op) {
+    OpBuilder builder(op);
+    Location loc = op.getLoc();
+
+    // 1. Clone setup region ops (except yield) before the op.
+    Block &setupBlock = op.getSetupRegion().front();
+    IRMapping setupMapping;
+    for (Operation &setupOp : setupBlock.without_terminator())
+      builder.clone(setupOp, setupMapping);
+
+    // 2. Collect remapped setup outputs from the cloned yield operands.
+    auto yieldOp = cast<SubtiledRegionYieldOp>(setupBlock.getTerminator());
+    SmallVector<Value> setupOutputs;
+    for (Value v : yieldOp.getResults())
+      setupOutputs.push_back(setupMapping.lookupOrDefault(v));
+
+    // 3. Pre-process barrier annotations by target op index.
+    //    beforeFirst[opIdx] -> annotations with placement=BEFORE
+    //    afterLast[opIdx]   -> annotations with placement=AFTER
+    llvm::DenseMap<unsigned, SmallVector<BarrierAnnotationAttr>> beforeFirst,
+        afterLast;
+    for (Attribute attr : op.getBarrierAnnotations()) {
+      auto annotation = cast<BarrierAnnotationAttr>(attr);
+      unsigned opIdx = annotation.getTargetOpIdx();
+      if (annotation.getPlacement() == BarrierPlacement::BEFORE)
+        beforeFirst[opIdx].push_back(annotation);
+      else
+        afterLast[opIdx].push_back(annotation);
+    }
+
+    ArrayAttr tileMappings = op.getTileMappings();
+    unsigned numTiles = tileMappings.size();
+    Block &tileBlock = op.getTileRegion().front();
+
+    ValueRange barriers = op.getBarriers();
+    ValueRange phases = op.getBarrierPhases();
+
+    // 4. For each tile, clone tile region ops with substitution.
+    for (unsigned tileIdx = 0; tileIdx < numTiles; ++tileIdx) {
+      auto indices = cast<DenseI32ArrayAttr>(tileMappings[tileIdx]);
+      IRMapping tileMapping;
+
+      // Build mapping: tile block arg -> setup output
+      for (auto [j, idx] : llvm::enumerate(indices.asArrayRef()))
+        tileMapping.map(tileBlock.getArgument(j), setupOutputs[idx]);
+
+      unsigned opIdx = 0;
+      for (Operation &tileOp : tileBlock.without_terminator()) {
+        // Before first tile: emit BEFORE annotations for this op index
+        if (tileIdx == 0) {
+          auto it = beforeFirst.find(opIdx);
+          if (it != beforeFirst.end()) {
+            for (auto &annotation : it->second)
+              emitBarrierOp(builder, loc, annotation, barriers, phases);
+          }
+        }
+
+        builder.clone(tileOp, tileMapping);
+
+        // After last tile: emit AFTER annotations for this op index
+        if (tileIdx == numTiles - 1) {
+          auto it = afterLast.find(opIdx);
+          if (it != afterLast.end()) {
+            for (auto &annotation : it->second)
+              emitBarrierOp(builder, loc, annotation, barriers, phases);
+          }
+        }
+        ++opIdx;
+      }
+    }
+
+    // 5. Clone teardown region ops (except terminator) and collect results.
+    Block &teardownBlock = op.getTeardownRegion().front();
+    IRMapping teardownMapping;
+    for (Operation &teardownOp : teardownBlock.without_terminator())
+      builder.clone(teardownOp, teardownMapping);
+
+    // 6. Replace op results with teardown yield values.
+    auto teardownTerminator =
+        cast<SubtiledRegionYieldOp>(teardownBlock.getTerminator());
+    for (auto [opResult, teardownVal] :
+         llvm::zip(op.getResults(), teardownTerminator.getResults()))
+      opResult.replaceAllUsesWith(teardownMapping.lookupOrDefault(teardownVal));
+
+    // 7. Erase the SubtiledRegionOp.
+    op.erase();
+  }
+};
+
+} // anonymous namespace
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -178,3 +178,257 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+// Verify: tileMappings must have at least one tile
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_empty_tile_mappings(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{tileMappings must have at least one tile}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = []
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0.0 : f32
+        ttng.subtiled_region_yield %c0 : f32
+      } tile(%arg0: f32) {
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: tileMappings inner array length must match tile block args
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_wrong_mapping_length(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{tileMappings[0] has 1 entries but tile region has 2 block arguments}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32, %arg1: i32) {
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: setup index out of range
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_index_out_of_range(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{tileMappings[0][0] = 5 is out of range [0, 2)}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 5>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: type mismatch between setup output and tile block arg
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_type_mismatch(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{type mismatch: setup output 0 has type 'i32' but tile block arg 0 has type 'f32'}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        ttng.subtiled_region_yield %c0 : i32
+      } tile(%arg0: f32) {
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: barrierIdx out of range
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_barrier_idx_out_of_range(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{barrierAnnotations[0] has barrierIdx=3 but there are only 1 barriers}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 3, placement = after,
+              targetOpIdx = 0, barrierOpKind = "arrive_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        ttng.subtiled_region_yield %c0 : i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: wait_barrier without corresponding phase
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_wait_no_phase(
+      %bar0: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %bar1: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{barrierAnnotations[0] is a wait_barrier with barrierIdx=1 but there are only 1 phases}}
+    ttng.subtiled_region
+        barriers(%bar0, %bar1 : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 1, placement = before,
+              targetOpIdx = 0, barrierOpKind = "wait_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        ttng.subtiled_region_yield %c0 : i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: unknown barrierOpKind
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_unknown_barrier_kind(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{barrierAnnotations[0] has unknown barrierOpKind 'bogus'}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = after,
+              targetOpIdx = 0, barrierOpKind = "bogus">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        ttng.subtiled_region_yield %c0 : i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: targetOpIdx out of range
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_target_op_idx_out_of_range(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{barrierAnnotations[0] has targetOpIdx=5 but tile region has only 1 non-terminator ops}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = after,
+              targetOpIdx = 5, barrierOpKind = "arrive_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        ttng.subtiled_region_yield %c0 : i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Verify: teardown result count mismatch
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @subtiled_region_teardown_result_mismatch(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // expected-error @+1 {{teardown yields 1 values but op has 0 results}}
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        ttng.subtiled_region_yield %c0 : i32
+      } tile(%arg0: i32) {
+        ttng.subtiled_region_yield
+      } teardown {
+        %c42 = arith.constant 42 : i32
+        ttng.subtiled_region_yield %c42 : i32
+      }
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/lower_subtiled_region.mlir
+++ b/test/TritonNvidiaGPU/lower_subtiled_region.mlir
@@ -1,0 +1,286 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-lower-subtiled-region | FileCheck %s
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // Test basic lowering: two tiles, no barriers.
+  // CHECK-LABEL: @basic_two_tiles
+  tt.func @basic_two_tiles() {
+    // Setup ops should be inlined:
+    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+    // CHECK: %[[C1:.*]] = arith.constant 1 : i32
+    // Tile 0 (arg0 = c0):
+    // CHECK: arith.index_cast %[[C0]]
+    // Tile 1 (arg0 = c1):
+    // CHECK: arith.index_cast %[[C1]]
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        %idx = arith.index_cast %arg0 : i32 to index
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test lowering with arrive_barrier AFTER last tile.
+  // CHECK-LABEL: @arrive_after_last
+  tt.func @arrive_after_last(
+      %bar: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
+      %phase: i32,
+      %desc: !tt.tensordesc<tensor<128x128xf32, #blocked>>,
+      %row: i32) {
+    // Tile 0:
+    // CHECK: arith.addi
+    // CHECK-NOT: ttng.arrive_barrier
+    // Tile 1 (last):
+    // CHECK: arith.addi
+    // arrive_barrier emitted AFTER last tile's op at index 0:
+    // CHECK-NEXT: ttng.arrive_barrier %{{.*}}, 1
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = after,
+              targetOpIdx = 0, barrierOpKind = "arrive_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c128 = arith.constant 128 : i32
+        ttng.subtiled_region_yield %c0, %c128 : i32, i32
+      } tile(%arg0: i32) {
+        %off = arith.addi %arg0, %row : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test lowering with wait_barrier BEFORE first tile.
+  // CHECK-LABEL: @wait_before_first
+  tt.func @wait_before_first(
+      %bar: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
+      %phase: i32) {
+    // wait_barrier emitted BEFORE first tile's op at index 0:
+    // CHECK: ttng.wait_barrier %{{.*}}, %{{.*}}
+    // CHECK-NEXT: arith.addi
+    // Tile 1: no wait_barrier
+    // CHECK: arith.addi
+    // CHECK-NOT: ttng.wait_barrier
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = before,
+              targetOpIdx = 0, barrierOpKind = "wait_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test with multiple block args per tile.
+  // CHECK-LABEL: @multi_arg_tiles
+  tt.func @multi_arg_tiles() {
+    // Setup outputs: c0, c1, c10, c20
+    // Tile 0 maps [0, 2] => (c0, c10)
+    // Tile 1 maps [1, 3] => (c1, c20)
+    // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : i32
+    // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : i32
+    // CHECK-DAG: %[[C10:.*]] = arith.constant 10 : i32
+    // CHECK-DAG: %[[C20:.*]] = arith.constant 20 : i32
+    // Tile 0: addi c0, c10
+    // CHECK: arith.addi %[[C0]], %[[C10]]
+    // Tile 1: addi c1, c20
+    // CHECK: arith.addi %[[C1]], %[[C20]]
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 3>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        %c10 = arith.constant 10 : i32
+        %c20 = arith.constant 20 : i32
+        ttng.subtiled_region_yield %c0, %c1, %c10, %c20 : i32, i32, i32, i32
+      } tile(%a: i32, %b: i32) {
+        %sum = arith.addi %a, %b : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test with both wait_barrier BEFORE and arrive_barrier AFTER.
+  // CHECK-LABEL: @wait_and_arrive
+  tt.func @wait_and_arrive(
+      %bar_wait: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
+      %bar_arrive: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
+      %phase: i32) {
+    // wait_barrier BEFORE first tile's op at index 0:
+    // CHECK: ttng.wait_barrier %{{.*}}, %{{.*}}
+    // CHECK-NEXT: arith.muli
+    // Tile 1:
+    // CHECK: arith.muli
+    // arrive_barrier AFTER last tile's op at index 0:
+    // CHECK-NEXT: ttng.arrive_barrier %{{.*}}, 2
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        barriers(%bar_wait, %bar_arrive : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>)
+        phases(%phase, %phase : i32, i32)
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = before,
+              targetOpIdx = 0, barrierOpKind = "wait_barrier">,
+          #ttng.barrier_annotation<barrierIdx = 1, placement = after,
+              targetOpIdx = 0, barrierOpKind = "arrive_barrier",
+              count = 2>
+        ]
+      setup {
+        %c3 = arith.constant 3 : i32
+        %c5 = arith.constant 5 : i32
+        ttng.subtiled_region_yield %c3, %c5 : i32, i32
+      } tile(%arg0: i32) {
+        %res = arith.muli %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test with a single tile (degenerate case).
+  // CHECK-LABEL: @single_tile
+  tt.func @single_tile(
+      %bar: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
+      %phase: i32) {
+    // Both BEFORE and AFTER fire on the same (only) tile:
+    // CHECK: ttng.wait_barrier
+    // CHECK-NEXT: arith.addi
+    // CHECK-NEXT: ttng.arrive_barrier
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = before,
+              targetOpIdx = 0, barrierOpKind = "wait_barrier">,
+          #ttng.barrier_annotation<barrierIdx = 0, placement = after,
+              targetOpIdx = 0, barrierOpKind = "arrive_barrier">
+        ]
+      setup {
+        %c42 = arith.constant 42 : i32
+        ttng.subtiled_region_yield %c42 : i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test capturing values from the outer scope.
+  // CHECK-LABEL: @capture_outer_value
+  // CHECK-SAME: %[[OUTER:arg0]]: i32
+  tt.func @capture_outer_value(%outer: i32) {
+    // CHECK: arith.constant 0 : i32
+    // Tile 0: addi c0, %outer
+    // CHECK: arith.addi %{{.*}}, %[[OUTER]]
+    // Tile 1: addi c1, %outer
+    // CHECK: arith.addi %{{.*}}, %[[OUTER]]
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %outer : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test no barriers, no phases.
+  // CHECK-LABEL: @no_barriers
+  tt.func @no_barriers() {
+    // CHECK: arith.constant 0 : i32
+    // CHECK: arith.constant 1 : i32
+    // CHECK: arith.index_cast
+    // CHECK: arith.index_cast
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        %idx = arith.index_cast %arg0 : i32 to index
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test teardown region with results.
+  // CHECK-LABEL: @teardown_with_results
+  tt.func @teardown_with_results() -> i32 {
+    // CHECK: arith.constant 0 : i32
+    // CHECK: arith.constant 1 : i32
+    // Tiles:
+    // CHECK: arith.addi
+    // CHECK: arith.addi
+    // Teardown:
+    // CHECK: %[[RESULT:.*]] = arith.constant 42 : i32
+    // CHECK: tt.return %[[RESULT]]
+    // CHECK-NOT: ttng.subtiled_region
+    %result = ttng.subtiled_region
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        %c42 = arith.constant 42 : i32
+        ttng.subtiled_region_yield %c42 : i32
+      } -> (i32)
+    tt.return %result : i32
+  }
+}

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -97,4 +97,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %1 = ttng.tmem_alloc %arg1 : (tensor<128x8xf8E5M2, #scales>) -> !ttg.memdesc<128x8xf8E5M2, #tmem_scales, #ttng.tensor_memory>
     tt.return
   }
+
+  // CHECK-LABEL: @subtiled_region
+  // CHECK-SAME: %[[BAR:arg[0-9]+]]: !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+  // CHECK-SAME: %[[PHASE:arg[0-9]+]]: i32
+  tt.func @subtiled_region(
+      %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+      %phase: i32) {
+    // CHECK: ttng.subtiled_region
+    // CHECK-SAME: barriers(%[[BAR]] : !ttg.memdesc<1xi64, #shared2, #smem, mutable>)
+    // CHECK-SAME: phases(%[[PHASE]] : i32)
+    // CHECK-SAME: tile_mappings = [array<i32: 0>, array<i32: 1>]
+    // CHECK-SAME: barrier_annotations = [#ttng.barrier_annotation<barrierIdx = 0, placement = after, targetOpIdx = 0, barrierOpKind = "arrive_barrier">]
+    // CHECK: setup
+    // CHECK: ttng.subtiled_region_yield
+    // CHECK: tile
+    // CHECK: ttng.subtiled_region_yield
+    // CHECK: teardown
+    // CHECK: ttng.subtiled_region_yield
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>)
+        phases(%phase : i32)
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = after,
+              targetOpIdx = 0, barrierOpKind = "arrive_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        %res = arith.addi %arg0, %arg0 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
 }


### PR DESCRIPTION
Summary:
Adds the initial definition for the SubtiledOperator, which will be used to handle integrating subtiling natively into AutoWS. This step simply adds the most basic lowering (possibly not fully tested) and the definition of the operator.

In the next followup PR I will be targeting creating the SubtiledOperator for the example GEMM use case. The rough scope for the PRs I'm expecting are:

1. Operator Definition (here)
2. Operator Generation for GEMM
3. Operator support in the memory planner.
4. Operator support in Code Partition
5. Other Pass integration (e.g. TMEM handling).
6. Optimized Lowering.


Reviewed By: Sibylau

Differential Revision: D101017879

Pulled By: njriasan


