### PR TITLE
[TLX] Enable TMA multicast for hopper_gemm_ws

### DIFF
--- a/third_party/tlx/tutorials/hopper_gemm_ws.py
+++ b/third_party/tlx/tutorials/hopper_gemm_ws.py
@@ -186,7 +186,7 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
                         tlx.barrier_wait(cta_bar, p)
 
                         # Each CTA loads half of B and multicasts to both CTAs
-                        if tlx.cluster_cta_rank() == 0:
+                        if cta_id == 0:
                             buf_b_slice = tlx.local_slice(data_b, [0, 0], [BK, BN // 2])
                         else:
                             buf_b_slice = tlx.local_slice(data_b, [0, BN // 2], [BK, BN // 2])


### PR DESCRIPTION
Summary:
Add TMA multicast support via NUM_CTAS=2 (2-CTA cluster), where each CTA
loads half of the B tile and multicasts to both CTAs, halving DRAM bandwidth
for B. Expand autotune search space to sweep BM, BN, BK, NUM_STAGES, EPILOGUE_SUBTILE, GROUP_SIZE_M, and NUM_CTAS.

On H100 with shape (65536, 1024, 1024):

  best config: BM=128, BN=256, BK=64, GROUP_SIZE_M=1, NUM_STAGES=4,
               NUM_CTAS=2, EPILOGUE_SUBTILE=True

                          aten_matmul-tflops    tlx_matmul_ws-tflops
                        --------------------  ----------------------
    before                             687.305                 672.244
    after                               680.66                 676.373

Differential Revision: D95964737


