### PR TITLE
[autoWS] Fix tl.store epilogue scheduling for FA kernels with TMA stores

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1102,7 +1102,7 @@ getInitialSchedule(scf::ForOp mainLoop,
       // main output and should go to epilogue for warp-specialization overlap.
       if (loop.getOps<DescriptorStoreOp>().empty()) {
         for (StoreOp op : loop.getOps<StoreOp>())
-          tryScheduleOp(epiloguePartition, op);
+          setPartition(op, epiloguePartition);
       }
     }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1093,8 +1093,17 @@ getInitialSchedule(scf::ForOp mainLoop,
     for (auto loop : loops) {
       for (DescriptorStoreOp op : loop.getOps<DescriptorStoreOp>())
         tryScheduleOp(epiloguePartition, op);
-      for (StoreOp op : loop.getOps<StoreOp>())
-        setPartition(op, epiloguePartition);
+      // Schedule regular StoreOps to epilogue only when the loop has no
+      // DescriptorStoreOps. When DescriptorStoreOps exist (e.g., FA kernels),
+      // they handle the main output via TMA and any additional StoreOps are
+      // auxiliary metadata (e.g., LSE) that should stay in the computation
+      // partition to avoid cross-partition TMEM overhead. When there are no
+      // DescriptorStoreOps (e.g., GEMM with tl.store), the StoreOps ARE the
+      // main output and should go to epilogue for warp-specialization overlap.
+      if (loop.getOps<DescriptorStoreOp>().empty()) {
+        for (StoreOp op : loop.getOps<StoreOp>())
+          tryScheduleOp(epiloguePartition, op);
+      }
     }
 
     // Also schedule categorized epilogue stores (includes post-loop stores for

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1090,21 +1090,9 @@ getInitialSchedule(scf::ForOp mainLoop,
   // truncf, etc.)
   if (epiloguePartition) {
     // Stores inside loops
-    for (auto loop : loops) {
+    for (auto loop : loops)
       for (DescriptorStoreOp op : loop.getOps<DescriptorStoreOp>())
         tryScheduleOp(epiloguePartition, op);
-      // Schedule regular StoreOps to epilogue only when the loop has no
-      // DescriptorStoreOps. When DescriptorStoreOps exist (e.g., FA kernels),
-      // they handle the main output via TMA and any additional StoreOps are
-      // auxiliary metadata (e.g., LSE) that should stay in the computation
-      // partition to avoid cross-partition TMEM overhead. When there are no
-      // DescriptorStoreOps (e.g., GEMM with tl.store), the StoreOps ARE the
-      // main output and should go to epilogue for warp-specialization overlap.
-      if (loop.getOps<DescriptorStoreOp>().empty()) {
-        for (StoreOp op : loop.getOps<StoreOp>())
-          setPartition(op, epiloguePartition);
-      }
-    }
 
     // Also schedule categorized epilogue stores (includes post-loop stores for
     // bwd) and their backward slice (tmem_load, truncf that feed into them)
@@ -1143,6 +1131,17 @@ getInitialSchedule(scf::ForOp mainLoop,
           tryScheduleOp(epiloguePartition, op);
         }
       }
+    }
+
+    // Schedule regular StoreOps to epilogue only when the epilogue partition
+    // is otherwise empty (no DescriptorStoreOps or categorized epilogue stores
+    // were scheduled above). When epilogue already has stores (e.g., FA kernels
+    // with TMA output stores), additional StoreOps should stay in the
+    // computation partition to avoid cross-partition TMEM overhead.
+    if (epiloguePartition->getOps().empty()) {
+      for (auto loop : loops)
+        for (StoreOp op : loop.getOps<StoreOp>())
+          tryScheduleOp(epiloguePartition, op);
     }
   }
 


### PR DESCRIPTION
PR #998 added support to assign `tl.store` to the epilogue partition. This breaks FA kernels where `tl.store(m_ptrs0, m_i0)` also gets assigned to epilogue, as it creates cross-partition boundaries that exceed TMEM capacity.

This PR gates the `tl.store` to epilogue assignment on whether the loop already has DescriptorStoreOps. When TMA stores exist, they handle the main output and any additional StoreOps are metadata that should stay in the computation partition. When no TMA stores exist (e.g., GEMM with tl.store), the StoreOps are the main output and go to epilogue as intended.
