### PR TITLE
[AutoWS] Use NameLoc for readable variable names and add source location comments in PrintTTGIRToTLX

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -18,8 +18,9 @@
 //   * Barrier allocations -> tlx.alloc_barriers(count)
 //   * Buffer allocations -> tlx.local_alloc((shape), dtype, count)
 // - Variable name simplification:
-//   * Removes % prefix from SSA names
-//   * Prefixes numeric-only names with "var_" (e.g., %0 -> var_0)
+//   * Uses NameLoc metadata from the Python frontend to recover original
+//     variable names (e.g., %0 -> "Q" if assigned as `Q = tl.load(...)`)
+//   * Falls back to removing % prefix and prefixing numeric names with "var_"
 // - Argument substitution:
 //   * warp_specialize partition args -> original operands
 //   * scf.for outputs -> corresponding iter_args
@@ -413,40 +414,14 @@ getValueName(Value v,
     }
   }
 
-  // Inline constants: if this value is defined by arith.constant, return the
-  // literal value
-  if (inlineConstants) {
-    if (Operation *defOp = v.getDefiningOp()) {
-      if (defOp->getName().getStringRef() == "arith.constant") {
-        if (auto valueAttr = defOp->getAttr("value")) {
-          std::string result;
-          llvm::raw_string_ostream os(result);
-          if (auto intAttr = dyn_cast<IntegerAttr>(valueAttr)) {
-            if (intAttr.getType().isInteger(1)) {
-              os << (intAttr.getValue().getBoolValue() ? "True" : "False");
-            } else {
-              os << intAttr.getValue();
-            }
-          } else if (auto floatAttr = dyn_cast<FloatAttr>(valueAttr)) {
-            SmallString<16> str;
-            floatAttr.getValue().toString(str);
-            os << str;
-          } else {
-            // Fall through to normal name handling for unsupported constant
-            // types
-            goto normal_name;
-          }
-          os.flush();
-          return result;
-        }
-      }
-    }
-  }
-
 normal_name:
   std::string name;
   llvm::raw_string_ostream os(name);
-  v.printAsOperand(os, OpPrintingFlags());
+  // Use printNameLocAsPrefix to recover Python variable names from NameLoc
+  // metadata. The Triton frontend wraps value locations with NameLoc during
+  // code generation (e.g., `x = tl.load(ptr)` → NameLoc("x")), and this flag
+  // tells the MLIR printer to use those names as SSA name prefixes.
+  v.printAsOperand(os, OpPrintingFlags().printNameLocAsPrefix(true));
   os.flush();
   // Remove type info if present (after ':')
   size_t colonPos = name.find(':');
@@ -928,6 +903,50 @@ void printWarpSpecialize(
   }
 }
 
+// Extract source location string (basename:line) from an MLIR Location.
+// Recursively unwraps NameLoc, CallSiteLoc, FusedLoc to find the underlying
+// FileLineColLoc.
+std::string getLocString(Location loc) {
+  if (auto fileLoc = dyn_cast<FileLineColLoc>(loc)) {
+    StringRef filename = fileLoc.getFilename().getValue();
+    size_t lastSlash = filename.rfind('/');
+    if (lastSlash != StringRef::npos)
+      filename = filename.substr(lastSlash + 1);
+    return (filename + ":" + Twine(fileLoc.getLine())).str();
+  }
+  if (auto nameLoc = dyn_cast<NameLoc>(loc)) {
+    return getLocString(nameLoc.getChildLoc());
+  }
+  if (auto callSiteLoc = dyn_cast<CallSiteLoc>(loc)) {
+    std::string result = getLocString(callSiteLoc.getCallee());
+    if (!result.empty())
+      return result;
+    return getLocString(callSiteLoc.getCaller());
+  }
+  if (auto fusedLoc = dyn_cast<FusedLoc>(loc)) {
+    for (Location subLoc : fusedLoc.getLocations()) {
+      std::string result = getLocString(subLoc);
+      if (!result.empty())
+        return result;
+    }
+  }
+  return "";
+}
+
+// Print "  # filename:line\n" comment suffix for an operation, or just "\n"
+// if location is unknown.
+void printLocComment(Operation *op, llvm::raw_ostream &os) {
+  StringRef opName = op->getName().getStringRef();
+  // memdesc_index is a compiler-generated lowering op whose inherited
+  // MLIR location does not correspond to user-written Python code.
+  if (opName != "ttg.memdesc_index") {
+    std::string loc = getLocString(op->getLoc());
+    if (!loc.empty())
+      os << "  # " << loc;
+  }
+  os << "\n";
+}
+
 // Print operation in simplified TLX format
 void printSimplifiedOp(
     Operation *op, llvm::raw_ostream &os,
@@ -950,7 +969,7 @@ void printSimplifiedOp(
     } else {
       os << "const";
     }
-    os << "\n";
+    printLocComment(op, os);
     return;
   }
 
@@ -967,7 +986,8 @@ void printSimplifiedOp(
           os << ", ";
         os << shape[i];
       }
-      os << "])\n";
+      os << "])";
+      printLocComment(op, os);
       return;
     }
   }
@@ -981,7 +1001,8 @@ void printSimplifiedOp(
       os << getValueName(op->getResult(0), argSubstitutionMap) << " = "
          << getValueName(op->getOperand(0), argSubstitutionMap) << " "
          << infixIt->second << " "
-         << getValueName(op->getOperand(1), argSubstitutionMap) << "\n";
+         << getValueName(op->getOperand(1), argSubstitutionMap);
+      printLocComment(op, os);
       return;
     }
   }
@@ -990,7 +1011,8 @@ void printSimplifiedOp(
   if (opName == "arith.negf" && op->getNumOperands() == 1 &&
       op->getNumResults() > 0) {
     os << getValueName(op->getResult(0), argSubstitutionMap) << " = -"
-       << getValueName(op->getOperand(0), argSubstitutionMap) << "\n";
+       << getValueName(op->getOperand(0), argSubstitutionMap);
+    printLocComment(op, os);
     return;
   }
 
@@ -1003,7 +1025,8 @@ void printSimplifiedOp(
                                                  : getCmpFOperator(pred);
       os << getValueName(op->getResult(0), argSubstitutionMap) << " = "
          << getValueName(op->getOperand(0), argSubstitutionMap) << " " << cmpOp
-         << " " << getValueName(op->getOperand(1), argSubstitutionMap) << "\n";
+         << " " << getValueName(op->getOperand(1), argSubstitutionMap);
+      printLocComment(op, os);
       return;
     }
   }
@@ -1018,7 +1041,8 @@ void printSimplifiedOp(
         if (op->getNumResults() > 0) {
           os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
         }
-        os << "tlx.alloc_barriers(" << info.barrierCount << ")\n";
+        os << "tlx.alloc_barriers(" << info.barrierCount << ")";
+        printLocComment(op, os);
         return;
       } else {
         // Print as tlx.local_alloc((shape), dtype, count)
@@ -1032,7 +1056,8 @@ void printSimplifiedOp(
           os << info.shape[i];
         }
         os << "), " << getElementTypeName(info.elementType) << ", "
-           << info.bufferCount << ")\n";
+           << info.bufferCount << ")";
+        printLocComment(op, os);
         return;
       }
     }
@@ -1072,7 +1097,7 @@ void printSimplifiedOp(
   }
   os << ")";
 
-  os << "\n";
+  printLocComment(op, os);
 }
 
 // Print a block


### PR DESCRIPTION
Summary: 
This change improves PrintTTGIRToTLX output readability in two ways:

1. **Recover Python variable names via NameLoc** - Use `printNameLocAsPrefix(true)` when printing SSA value names so that the MLIR printer uses NameLoc metadata (set by the Triton frontend during code generation) to produce meaningful names like `sm_scale`, `desc_q`, `prog_id`, `acc`, `m_ij` instead of generic `var_0`, `var_1`, etc. Values without NameLoc fall back to the existing `var_N` naming.
2. **Append source location comments** - Each operation line now ends with a `# filename:line` comment (e.g., `# blackwell_triton_fused_attention.py:591`) extracted from the op's MLIR Location metadata. The `getLocString` helper recursively unwraps NameLoc, CallSiteLoc, and FusedLoc to find the underlying FileLineColLoc. Operations with unknown locations get no comment. Also removed a duplicate constant-inlining block in `getValueName` that was accidentally introduced in a prior change. Test Plan: Built with `make` in ~/triton. Generated TLX output for flash attention fwd/bwd kernels and verified: (1) variable names now match the Python source (e.g., `sm_scale`, `desc_q` instead of `var_86`, `var_88`), (2) each operation line has a `# source.py:line` comment pointing to the originating Python source line, (3) values without NameLoc still fall back to `var_N` naming.

Test:

```
WITH_OSS_WARPSPEC=1 TRITON_USE_META_PARTITION=1 TRITON_TLX_COMPILABLE=1 TRITON_DUMP_TTGIR_TO_TLX=1 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_tissue030 TRITON_USE_META_WS=1 TRITON_PRINT_AUTOTUNING=1 CUDA_VISIBLE_DEVICES=3 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --rep 3000 --sleep 1.0 --metrics tflops --simple-output --only triton_tutorial_flash_persistent_blackwell --force 2>&1 | tee tmp.txt
```
output: [P2231797178](https://www.internalfb.com/phabricator/paste/view/P2231797178)