### PR TITLE
 Add `alloc_warp_barrier` for multi-thread barrier arrival"

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_clc.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_clc.py
@@ -20,6 +20,7 @@ def get_cuda_autotune_config():
                 "NUM_SMEM_BUFFERS": s,
                 "NUM_TMEM_BUFFERS": t,
                 "EPILOGUE_SUBTILE": subtile,
+                "USE_WARP_BARRIER": uwb,
             },
             num_warps=4,
             num_stages=1,
@@ -31,6 +32,7 @@ def get_cuda_autotune_config():
         for s in [2, 3, 4]
         for t in [2, 3]
         for subtile in [True]
+        for uwb in [False, True]
     ]
 
 
@@ -246,7 +248,7 @@ def matmul_kernel_tma_ws_blackwell_clc(a_desc, b_desc, c_desc, M, N, K, BLOCK_SI
                 clc_phase_consumer ^= 1
 
 
-def matmul(a, b, config=None, use_warp_barrier=False):
+def matmul(a, b, config=None):
     """Matrix multiplication using TLX GEMM kernel."""
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
@@ -282,7 +284,6 @@ def matmul(a, b, config=None, use_warp_barrier=False):
             K,
             NUM_SMS=NUM_SMS,
             NUM_CLC_STAGES=1,
-            USE_WARP_BARRIER=use_warp_barrier,
             **config,
         )
     else:
@@ -296,11 +297,6 @@ def matmul(a, b, config=None, use_warp_barrier=False):
             K,
             NUM_SMS=NUM_SMS,
             NUM_CLC_STAGES=1,
-            USE_WARP_BARRIER=use_warp_barrier,
         )
 
     return c
-
-
-def matmul_warp_barrier(a, b, config=None):
-    return matmul(a, b, config=config, use_warp_barrier=True)

--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -376,6 +376,7 @@ def get_cuda_autotune_config():
                 "NUM_CTAS": num_ctas,
                 "SPLIT_K": split_k,
                 "INTERLEAVE_EPILOGUE": interleave,
+                "USE_WARP_BARRIER": uwb,
             },
             num_warps=4,
             num_stages=1,
@@ -393,6 +394,7 @@ def get_cuda_autotune_config():
         for split_k in [1, 2, 3, 4, 5, 6]  # pruning selects one optimal SPLIT_K per tile group
         for interleave in [0, 1]
         for g in [1, 8, 64]
+        for uwb in [False, True]
     ]
 
 
@@ -1294,7 +1296,7 @@ def matmul_kernel_tma_ws_blackwell(
                 tile_id += NUM_SMS
 
 
-def matmul(a, b, config=None, use_heuristic=False, use_warp_barrier=False):
+def matmul(a, b, config=None, use_heuristic=False):
     """Matrix multiplication using TLX GEMM kernel.
 
     Args:
@@ -1375,7 +1377,6 @@ def matmul(a, b, config=None, use_heuristic=False, use_warp_barrier=False):
             N,
             K,
             NUM_SMS=NUM_SMS,
-            USE_WARP_BARRIER=use_warp_barrier,
             ctas_per_cga=ctas_per_cga,
             **config,
         )
@@ -1417,11 +1418,6 @@ def matmul(a, b, config=None, use_heuristic=False, use_warp_barrier=False):
             N,
             K,
             NUM_SMS=NUM_SMS,
-            USE_WARP_BARRIER=use_warp_barrier,
         )
         # post_hook handles reduction for split-K > 1
     return c
-
-
-def matmul_warp_barrier(a, b, config=None, use_heuristic=True):
-    return matmul(a, b, config=config, use_heuristic=use_heuristic, use_warp_barrier=True)

--- a/third_party/tlx/tutorials/hopper_gemm_ws.py
+++ b/third_party/tlx/tutorials/hopper_gemm_ws.py
@@ -72,6 +72,7 @@ def get_autotune_configs():
                 "NUM_MMA_GROUPS": 2,
                 "EPILOGUE_SUBTILE": epilogue,
                 "NUM_CTAS": num_ctas,
+                "USE_WARP_BARRIER": uwb,
             },
             num_stages=1,
             num_warps=4,
@@ -85,6 +86,7 @@ def get_autotune_configs():
         for epilogue in [True, False]
         for g in [1, 8, 64]
         for num_ctas in [1, 2]
+        for uwb in [False, True]
     ]
 
 
@@ -281,7 +283,7 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
                 tile_id += NUM_SMS
 
 
-def matmul(a, b, config=None, use_warp_barrier=False):
+def matmul(a, b, config=None):
     """Matrix multiplication using TLX GEMM kernel."""
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Illegal dimensions of input operands"
@@ -344,7 +346,6 @@ def matmul(a, b, config=None, use_warp_barrier=False):
             N,
             K,
             NUM_SMS=NUM_SMS,
-            USE_WARP_BARRIER=use_warp_barrier,
             **config,
         )
     else:
@@ -358,10 +359,5 @@ def matmul(a, b, config=None, use_warp_barrier=False):
             N,
             K,
             NUM_SMS=NUM_SMS,
-            USE_WARP_BARRIER=use_warp_barrier,
         )
     return c
-
-
-def matmul_warp_barrier(a, b, config=None):
-    return matmul(a, b, config=config, use_warp_barrier=True)

--- a/third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py
+++ b/third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py
@@ -5,13 +5,9 @@ import torch
 import triton
 
 from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import (
-    matmul as _tlx_matmul_ws,
-    matmul_warp_barrier as _tlx_matmul_ws_warp_barrier,
-)
+    matmul as _tlx_matmul_ws, )
 from triton.language.extra.tlx.tutorials.blackwell_gemm_clc import (
-    matmul as _tlx_matmul_clc,
-    matmul_warp_barrier as _tlx_matmul_clc_warp_barrier,
-)
+    matmul as _tlx_matmul_clc, )
 from triton.language.extra.tlx.tutorials.blackwell_gemm_pipelined import (
     matmul as _tlx_matmul_pipelined, )
 from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
@@ -24,9 +20,7 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 # Registry of available matmul implementations
 MATMUL_METHODS = {
     "ws": _tlx_matmul_ws,
-    "ws_warp_barrier": _tlx_matmul_ws_warp_barrier,
     "clc": _tlx_matmul_clc,
-    "clc_warp_barrier": _tlx_matmul_clc_warp_barrier,
     "pipelined": _tlx_matmul_pipelined,
     "2cta": _tlx_matmul_2cta,
 }

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -5,13 +5,9 @@ import torch
 import triton
 
 from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import (
-    matmul as _blackwell_gemm_ws,
-    matmul_warp_barrier as _blackwell_gemm_ws_warp_barrier,
-)
+    matmul as _blackwell_gemm_ws, )
 from triton.language.extra.tlx.tutorials.blackwell_gemm_clc import (
-    matmul as _blackwell_gemm_clc,
-    matmul_warp_barrier as _blackwell_gemm_clc_warp_barrier,
-)
+    matmul as _blackwell_gemm_clc, )
 from triton.language.extra.tlx.tutorials.blackwell_gemm_pipelined import (
     matmul as _blackwell_gemm_pipelined, )
 from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
@@ -31,9 +27,7 @@ from triton.language.extra.tlx.tutorials.blackwell_fa_ws import (
 from triton.language.extra.tlx.tutorials.hopper_gemm_pipelined import (
     matmul as _hopper_gemm_pipelined, )
 from triton.language.extra.tlx.tutorials.hopper_gemm_ws import (
-    matmul as _hopper_gemm_ws,
-    matmul_warp_barrier as _hopper_gemm_ws_warp_barrier,
-)
+    matmul as _hopper_gemm_ws, )
 from triton.language.extra.tlx.tutorials.hopper_fa_ws_pipelined_pingpong_persistent import (
     attention as _hopper_fa_ws_pipelined_pingpong_persistent, )
 from triton.language.extra.tlx.tutorials.hopper_fa_ws_pipelined_pingpong import (
@@ -104,6 +98,41 @@ class Gemm:
             "NUM_MMA_WARPS": 8,
             "NUM_MMA_GROUPS": 2,
             "EPILOGUE_SUBTILE": False,
+        },
+        "blackwell_gemm_ws_warp_barrier": {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 256,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 8,
+            "NUM_SMEM_BUFFERS": 2,
+            "NUM_TMEM_BUFFERS": 2,
+            "NUM_MMA_GROUPS": 1,
+            "EPILOGUE_SUBTILE": 1,
+            "NUM_CTAS": 1,
+            "SPLIT_K": 1,
+            "INTERLEAVE_EPILOGUE": 0,
+            "USE_WARP_BARRIER": True,
+        },
+        "blackwell_gemm_clc_warp_barrier": {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 256,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 8,
+            "NUM_SMEM_BUFFERS": 2,
+            "NUM_TMEM_BUFFERS": 2,
+            "EPILOGUE_SUBTILE": True,
+            "USE_WARP_BARRIER": True,
+        },
+        "hopper_gemm_ws_warp_barrier": {
+            "BM": 128,
+            "BN": 256,
+            "BK": 64,
+            "GROUP_SIZE_M": 8,
+            "NUM_STAGES": 3,
+            "NUM_MMA_WARPS": 8,
+            "NUM_MMA_GROUPS": 2,
+            "EPILOGUE_SUBTILE": False,
+            "USE_WARP_BARRIER": True,
         },
     }
 
@@ -240,13 +269,13 @@ def test_blackwell_gemm_clc(dtype):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_gemm_ws_warp_barrier(dtype):
-    Gemm.run_test(_blackwell_gemm_ws_warp_barrier, Gemm.CONFIGS["blackwell_gemm_ws"], dtype=dtype)
+    Gemm.run_test(_blackwell_gemm_ws, Gemm.CONFIGS["blackwell_gemm_ws_warp_barrier"], dtype=dtype)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_gemm_clc_warp_barrier(dtype):
-    Gemm.run_test(_blackwell_gemm_clc_warp_barrier, Gemm.CONFIGS["blackwell_gemm_clc"], dtype=dtype)
+    Gemm.run_test(_blackwell_gemm_clc, Gemm.CONFIGS["blackwell_gemm_clc_warp_barrier"], dtype=dtype)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
@@ -361,7 +390,7 @@ def test_hopper_gemm_ws():
 
 @pytest.mark.skipif(not is_hopper(), reason="Requires Hopper GPU")
 def test_hopper_gemm_ws_warp_barrier():
-    Gemm.run_test(_hopper_gemm_ws_warp_barrier, Gemm.CONFIGS["hopper_gemm_ws"])
+    Gemm.run_test(_hopper_gemm_ws, Gemm.CONFIGS["hopper_gemm_ws_warp_barrier"])
 
 
 # =============================================================================

--- a/third_party/tlx/tutorials/testing/test_hopper_gemm_perf.py
+++ b/third_party/tlx/tutorials/testing/test_hopper_gemm_perf.py
@@ -7,9 +7,7 @@ import triton
 from triton.language.extra.tlx.tutorials.hopper_gemm_pipelined import (
     matmul as _matmul_pipelined, )
 from triton.language.extra.tlx.tutorials.hopper_gemm_ws import (
-    matmul as _matmul_ws,
-    matmul_warp_barrier as _matmul_ws_warp_barrier,
-)
+    matmul as _matmul_ws, )
 
 from triton._internal_testing import is_hopper
 
@@ -18,7 +16,6 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 MATMUL_METHODS = {
     "pipelined": _matmul_pipelined,
     "ws": _matmul_ws,
-    "ws_warp_barrier": _matmul_ws_warp_barrier,
 }
 
 ref_lib = "cuBLAS"


### PR DESCRIPTION
Summary:
See https://github.com/facebookexperimental/triton/pull/1031. This is adding autotune to benchmark for that change

X-link: https://github.com/meta-pytorch/tritonbench/pull/925

Differential Revision: D95353897

Pulled By: tissue3


