### PR TITLE
[AutoWS] Fix token wait lowering with no barrier

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -100,10 +100,8 @@ struct NVGPUTMAStoreTokenWaitLoweringPass
           NVGPUTMAStoreTokenWaitLoweringPass> {
   void runOnOperation() override {
     SmallVector<ttng::TMAStoreTokenWaitOp> opsToLower;
-    getOperation()->walk([&](ttng::TMAStoreTokenWaitOp op) {
-      if (!op.getBarriers().empty())
-        opsToLower.push_back(op);
-    });
+    getOperation()->walk(
+        [&](ttng::TMAStoreTokenWaitOp op) { opsToLower.push_back(op); });
     for (auto op : opsToLower) {
       OpBuilder builder(op);
       auto loc = op.getLoc();


### PR DESCRIPTION
When the token wait doesn't have a barrier it wasn't being lowered properly. This fixes `test/Conversion/tritonnvidiagpu_to_llvm.mlir`