### PR TITLE
[AutoWS] Update buffer limit based on reuse/sharing

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -861,7 +861,7 @@ static unsigned allocateSmemBuffers(triton::FuncOp funcOp,
         groupStart = maxCrossStageMin * 2 - 1; // e.g., 3
 
       // Clamp to the reuse group limit (numBuffers per channel).
-      unsigned reuseGroupLimit = numBuffers * 2;
+      unsigned reuseGroupLimit = numBuffers * candidateIndices.size();
       if (groupStart > reuseGroupLimit)
         groupStart = reuseGroupLimit;
 


### PR DESCRIPTION
Update the buffer limit when two values will share the buffer. Right now we are capped at num_stages, but since when we have 2 buffers that can be scaled up to num_stages we should have 2 * num_stages as our limit.