### PR TITLE
[triton][tlx] Map ttg.memdesc_index to tlx.local_view in TTGIR-to-TLX pass

### DIFF
--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -36,6 +36,7 @@
 // CHECK-DAG: tlx.tmem_store(
 // CHECK-DAG: tlx.local_trans(
 // CHECK-DAG: tlx.subslice(
+// CHECK-DAG: tlx.local_view(
 
 // Verify warp specialization uses Python-like async_tasks syntax
 // CHECK-DAG: with tlx.async_tasks():

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -126,7 +126,7 @@ static const TTGIRToTLXMapping opMappings[] = {
     {"ttg.memdesc_reinterpret", "tlx.local_reinterpret",
      "Reinterpret buffer dtype/shape"},
     {"ttng.tmem_subslice", "tlx.subslice", "TMEM subslice (Blackwell)"},
-    {"ttg.memdesc_index", "tlx.memdesc_index", "Index into memdesc"},
+    {"ttg.memdesc_index", "tlx.local_view", "Index into memdesc (buffer view)"},
 
     // Async copy operations (cp.async)
     {"ttg.async_load", "tlx.async_load",


### PR DESCRIPTION
Summary:
The PrintTTGIRToTLX debug pass mapped `ttg.memdesc_index` to
`tlx.memdesc_index`, but the correct TLX Python API name is
`tlx.local_view`. This change aligns the emitted pseudocode with the
actual TLX DSL, making the output closer to compilable TLX Python.

This is the rebased remainder of D94700558 after [PR #983](https://github.com/facebookexperimental/triton/pull/983) and [PR #1005](https://github.com/facebookexperimental/triton/pull/1005)
landed upstream. Those PRs already covered 6 of 7 changes (math op
mappings, unsigned div/rem, NaN-propagating min/max, skipping
gpu.barrier/convert_layout, convert layout transparent substitution via
getValueName, TMA descriptor, constant deduplication--obsolete as #983
inlines constants at use sites).

Rebased and authored with Claude.

Note that while the original intent of D94700558 was to ensure that generated
TLX from the TTGIR-to-TLX pass could compile, it did not achieve this yet. This
PR is to just get us up to speed with the earlier WIP, and then we'll post additional
fixes on top of this towards compilable TLX Python.

Differential Revision: D96554961


