### PR TITLE
[TLX][triton beta] Gate Blackwell "preferred cluster size" control with cuda version >=12.8

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -376,6 +376,7 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas
       ++num_attrs;
     }}
 
+    #if CUDA_VERSION >= 12080
     if (preferredClusterDimX > 0) {{
       CUlaunchAttribute preferredClusterAttr = {{}};
       preferredClusterAttr.id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
@@ -385,6 +386,7 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas
       launchAttr[num_attrs] = preferredClusterAttr;
       ++num_attrs;
     }}
+    #endif
 
     config.numAttrs = num_attrs;
 


### PR DESCRIPTION
Summary:
Attribute `CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION` is undefined prior to 12.8. Although the line accessing it is not actually executed (without user explicitly opting into this hardware feature in kernel), the driver c code piece would get compiled and would fail to compile on cuda 12.4.

12.8 doc: https://docs.nvidia.com/cuda/archive/12.8.0/cuda-driver-api/unionCUlaunchAttributeValue.html#unionCUlaunchAttributeValue

Differential Revision: D96628389


