### PR TITLE
  [TLX] Fix planCTA for TLX (#1094) (#1094)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -398,10 +398,10 @@ void CTAPlanner::processStoreLikeOps(triton::FuncOp &funcOp) {
       stores.push_back(op);
   });
   assert(stores.size() > 0 && "Cannot find store-like ops");
-  auto numWarps = ttg::lookupNumWarps(funcOp);
 
   ttg::CTALayoutAttr CTALayout;
   for (Operation *store : stores) {
+    auto numWarps = ttg::lookupNumWarps(store);
     auto val = [store]() -> Value {
       if (auto descStore =
               dyn_cast<triton::DescriptorStoreLikeOpInterface>(store))

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -7010,3 +7010,46 @@ def test_named_barrier_wait_1warp_async_deadlock_single_proc(device):
     result = output.cpu().tolist()
     assert result[0] == 5, f"Expected output[0]=5, got {result[0]}"
     assert result[1] == 99, f"Expected output[1]=99, got {result[1]}"
+
+
+@triton.jit
+def _store_ws_kernel(
+    output_ptr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Warp-specialized store kernel for PlanCTA regression test.
+
+    Tests tl.store in a warp-specialized context where the store partition
+    has fewer warps (1) than the default partition, with num_ctas=2 to
+    ensure PlanCTA actually runs (it skips when num_ctas=1).
+
+    This exercises PlanCTA's per-op numWarps lookup: the store's layout
+    must be planned with 1 warp (the partition's warp count), not the
+    function-level total. Without the fix (lookupNumWarps(store) instead
+    of lookupNumWarps(funcOp)), PlanCTA would assign warpsPerCTA=[4]
+    inside the 1-warp partition, producing an invalid layout.
+    """
+    pid = tl.program_id(axis=0)
+
+    with tlx.async_tasks():
+        with tlx.async_task("default"):
+            _ = tl.arange(0, BLOCK_SIZE)
+
+        with tlx.async_task(num_warps=1):
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            data = offsets.to(tl.float32)
+            tl.store(output_ptr + offsets, data)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")
+def test_store_ws(device):
+    BLOCK_SIZE = 256
+    n_elements = 1024
+    n_blocks = n_elements // BLOCK_SIZE
+
+    output = torch.empty(n_elements, device=device, dtype=torch.float32)
+    # num_ctas=2 ensures PlanCTA runs (it skips when num_ctas=1).
+    _store_ws_kernel[(n_blocks, )](output, BLOCK_SIZE=BLOCK_SIZE, num_ctas=2)
+
+    expected = torch.arange(n_elements, device=device, dtype=torch.float32)
+    torch.testing.assert_close(output, expected)

--- a/test/TritonNvidiaGPU/async_store.mlir
+++ b/test/TritonNvidiaGPU/async_store.mlir
@@ -1,0 +1,87 @@
+// RUN: triton-opt --split-input-file %s | FileCheck %s
+// RUN: triton-opt --split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm=compute-capability=90 --convert-nv-gpu-to-llvm %s | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: triton-opt --split-input-file --triton-nvidia-gpu-plan-cta --mlir-print-local-scope %s | FileCheck %s --check-prefix=CHECK-CTA
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: async_store
+  // CHECK-LLVM-LABEL: llvm.func @async_store
+  tt.func @async_store(%dst: !tt.ptr<i8>, %size: i32) {
+    %src = ttg.local_alloc : () -> !ttg.memdesc<1024xi8, #shared, #smem, mutable>
+    // CHECK: ttng.async_store
+    // CHECK-SAME: !ttg.memdesc<1024xi8, #shared, #smem, mutable>, !tt.ptr<i8>
+    // CHECK-LLVM: llvm.inline_asm has_side_effects asm_dialect = att
+    // CHECK-LLVM-SAME: cp.async.bulk.global.shared::cta.bulk_group
+    // CHECK-LLVM: nvvm.cp.async.bulk.commit.group
+    ttng.async_store %src, %dst, %size : !ttg.memdesc<1024xi8, #shared, #smem, mutable>, !tt.ptr<i8>
+    tt.return
+  }
+}
+
+// -----
+
+// Test async_store with data originating from a register layout (blocked).
+// tl.arange creates a blocked layout in registers; local_alloc writes it to SMEM;
+// async_store bulk-copies from SMEM to global memory.
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem1 = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: async_store_from_registers
+  // CHECK-LLVM-LABEL: llvm.func @async_store_from_registers
+  tt.func @async_store_from_registers(%dst: !tt.ptr<f32>) {
+    %range = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32, #blocked>
+    %data = arith.sitofp %range : tensor<128xi32, #blocked> to tensor<128xf32, #blocked>
+    %smem = ttg.local_alloc %data : (tensor<128xf32, #blocked>) -> !ttg.memdesc<128xf32, #shared1, #smem1, mutable>
+    %size = arith.constant 512 : i32
+    // CHECK: ttng.async_store
+    // CHECK-SAME: !ttg.memdesc<128xf32, #{{.*}}, #{{.*}}, mutable>, !tt.ptr<f32>
+    // CHECK-LLVM: llvm.inline_asm has_side_effects asm_dialect = att
+    // CHECK-LLVM-SAME: cp.async.bulk.global.shared::cta.bulk_group
+    // CHECK-LLVM: nvvm.cp.async.bulk.commit.group
+    ttng.async_store %smem, %dst, %size : !ttg.memdesc<128xf32, #shared1, #smem1, mutable>, !tt.ptr<f32>
+    tt.return
+  }
+}
+
+// -----
+
+// Test PlanCTA with tt.store inside a warp_specialize partition with 1 warp.
+// PlanCTA must use per-op numWarps (1 for partition0), not function-level
+// numWarps (4). Without the fix, the store layout would get warpsPerCTA=[4],
+// which is incorrect for a 1-warp partition.
+
+#blocked2 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [2], CTASplitNum = [2], CTAOrder = [0]}>
+#blocked_ws = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [2], CTASplitNum = [2], CTAOrder = [0]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-CTA-LABEL: store_ws_plan_cta
+  tt.func @store_ws_plan_cta(%ptr: !tt.ptr<f32>) {
+    ttg.warp_specialize(%ptr)
+    default {
+      // Default partition (4 warps): store with warpsPerCTA=[4]
+      %range = tt.make_range {start = 0 : i32, end = 512 : i32} : tensor<512xi32, #blocked2>
+      %data = arith.sitofp %range : tensor<512xi32, #blocked2> to tensor<512xf32, #blocked2>
+      %splatted = tt.splat %ptr : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>, #blocked2>
+      %ptrs = tt.addptr %splatted, %range : tensor<512x!tt.ptr<f32>, #blocked2>, tensor<512xi32, #blocked2>
+      tt.store %ptrs, %data : tensor<512x!tt.ptr<f32>, #blocked2>
+      ttg.warp_yield
+    }
+    partition0(%arg0: !tt.ptr<f32>) num_warps(1) {
+      // Store partition (1 warp): store must keep warpsPerCTA=[1]
+      %range = tt.make_range {start = 0 : i32, end = 512 : i32} : tensor<512xi32, #blocked_ws>
+      %data = arith.sitofp %range : tensor<512xi32, #blocked_ws> to tensor<512xf32, #blocked_ws>
+      %splatted = tt.splat %arg0 : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>, #blocked_ws>
+      %ptrs = tt.addptr %splatted, %range : tensor<512x!tt.ptr<f32>, #blocked_ws>, tensor<512xi32, #blocked_ws>
+      // CHECK-CTA: partition0
+      // CHECK-CTA: tt.store {{.*}} warpsPerCTA = [1]
+      tt.store %ptrs, %data : tensor<512x!tt.ptr<f32>, #blocked_ws>
+      ttg.warp_return
+    } : (!tt.ptr<f32>) -> ()
+    tt.return
+  }
+}


### PR DESCRIPTION
Summary: PlanCTA extracts the number of warps for stores globally for a funcOp. This means that in warp specialized regions (e.g. TLX) this may break due to invalid layouts. I hit this on an MOE kernel in another repo

Pulled By:
njriasan


njriasan

Differential Revision: D97199393


