### PR TITLE
[TLX] Extend Split-K range for undersaturated GEMM shapes

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -391,7 +391,7 @@ def get_cuda_autotune_config():
         for m in [1, 2]
         for subtile in [1, 2, 4, 8]
         for num_ctas in [1, 2]
-        for split_k in [1, 2, 3, 4, 5, 6]  # pruning selects one optimal SPLIT_K per tile group
+        for split_k in [1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 19, 24]  # pruning selects one optimal SPLIT_K per tile group
         for interleave in [0, 1]
         for g in [1, 8, 64]
         for uwb in [False, True]


### PR DESCRIPTION
Summary:
Extends the static Split-K sweep from [1..6] to
[1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 19, 24] and removes the dynamic
Split-K injection logic. The two-level filter (minimize waves, then
maximize SK) selects one optimal value per tile group, so the wider
sweep does not increase autotuning cost.

The previous [1..6] range was insufficient for highly undersaturated
shapes (e.g. mn_tiles=1-4 on 152 SMs). Higher SK values like 19 or 24
provide much better SM utilization without kernel hangs.

Ideally, we would dynamically compute the optimal Split-K value
(SK = NUM_SMS // mn_tiles) rather than relying on a static list, since
the exact optimal value depends on the shape and GPU SM count. However,
the kernel currently hangs with high Split-K values (observed at SK >= ~38
on GB200 for certain tile configurations), and the `_reduce_k_kernel`
compilation with large SPLIT_K constexpr values is extremely slow due to
loop unrolling. We plan to investigate and fix these kernel-level issues
in a follow-up, which would enable fully dynamic Split-K computation.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D96779479


