### PR TITLE
[triton][beta] Fix smem_budget query for offline compilation

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -101,6 +101,7 @@ def sm_arch_from_capability(capability: int):
     suffix = "a" if capability >= 90 else ""
     return f"sm_{capability}{suffix}"
 
+
 def _max_shared_mem_for_capability(capability: int) -> int:
     """Return CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN for a given SM capability.
 
@@ -109,30 +110,30 @@ def _max_shared_mem_for_capability(capability: int) -> int:
     """
     try:
         from triton.runtime.driver import driver as rt_driver
-        return rt_driver.active.utils.get_device_properties(
-            rt_driver.active.get_current_device())["max_shared_mem"]
+        return rt_driver.active.utils.get_device_properties(rt_driver.active.get_current_device())["max_shared_mem"]
     except (RuntimeError, Exception):
         pass
     # Fallback for offline compilation (no GPU present).
     # Values are CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN per
     # the CUDA Programming Guide "Technical Specifications per Compute Capability".
     _SMEM_SIZES = {
-        70: 98304,   # V100:    96 KB per SM, optin = 96 KB
-        75: 65536,   # Turing:  64 KB per SM, optin = 64 KB
+        70: 98304,  # V100:    96 KB per SM, optin = 96 KB
+        75: 65536,  # Turing:  64 KB per SM, optin = 64 KB
         80: 166912,  # A100:   164 KB per SM, optin = 163 KB
         86: 101376,  # GA10x:  100 KB per SM, optin = 99 KB
         87: 166912,  # Orin:   164 KB per SM, optin = 163 KB
         89: 101376,  # AD10x:  100 KB per SM, optin = 99 KB
         90: 232448,  # H100:   228 KB per SM, optin = 227 KB
-        100: 232448, # B200:   228 KB per SM, optin = 227 KB
-        103: 232448, # GB300:  228 KB per SM, optin = 227 KB
-        110: 232448, # SM110: 228 KB per SM, optin = 227 KB
-        120: 101376, # SM120: 100 KB per SM, optin = 99 KB
+        100: 232448,  # B200:   228 KB per SM, optin = 227 KB
+        103: 232448,  # GB300:  228 KB per SM, optin = 227 KB
+        110: 232448,  # SM110: 228 KB per SM, optin = 227 KB
+        120: 101376,  # SM120: 100 KB per SM, optin = 99 KB
     }
     # Try exact capability first (e.g. 86), then round to family base
     # (e.g. 86 -> 80) for unknown sub-variants, then fall back to 48 KB
     # (the default max shared mem per block without optin).
     return _SMEM_SIZES.get(capability, _SMEM_SIZES.get(capability // 10 * 10, 49152))
+
 
 @dataclass(frozen=True)
 class CUDAOptions:

--- a/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
@@ -160,7 +160,6 @@ std::vector<int> assignLineIds(
 
 } // namespace
 
-
 void StreamChromeTraceWriter::writeKernel(json &object,
                                           const KernelTrace &kernelTrace,
                                           const uint64_t minInitTime) {


### PR DESCRIPTION
Summary:
D95898963 added `smem_budget` as a parameter to `add_hopper_warpspec`, querying it via `rt_driver.active.utils.get_device_properties()`. This requires a live GPU driver, but Triton CC compiles kernels on RE (remote execution) where no GPU is available, causing `RuntimeError: 0 active drivers`.

In addition to D96671173, this diff tries querying the GPU driver first and falls back to a static lookup table when no driver is available. The fallback values are `CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN` per the CUDA Programming Guide.

Reviewed By: njriasan

Differential Revision: D97003359


