### PR TITLE
[TLX] Insert cluster barrier before ret for all clustered kernels (#1105)

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -304,6 +304,11 @@ def compile(src, target=None, options=None, _env_vars=None):
         config_parts.append(f"stages{options.num_stages}")
         config_parts.append(f"ctas{options.num_ctas}")
         config_name = "_".join(config_parts)
+        # Truncate long config names to avoid filesystem path length limits.
+        # Keep the first 150 chars and append a hash of the full name for uniqueness.
+        if len(config_name) > 150:
+            config_hash = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:16]
+            config_name = config_name[:150] + "_" + config_hash
         config_dump_dir = os.path.join(fn_dump_manager.cache_dir, config_name)
         os.makedirs(config_dump_dir, exist_ok=True)
         fn_dump_manager.cache_dir = config_dump_dir

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -825,7 +825,7 @@ llvm.func @dynamic_register_reallocation_overalloc() attributes {allocation.offs
 
 // -----
 
-module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 6 : i32} {
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 6 : i32, "ttg.cluster-dim-x" = 2 : i32} {
 
 llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 
@@ -860,6 +860,49 @@ llvm.func @paired_cta_cluster_sync(%a: !llvm.ptr<3>, %b: i1) attributes {allocat
   }
   partition0() num_warps(1) {
     %1 = llvm.mlir.constant(32 : i32) : i32
+    ttg.warp_return
+  } : () -> ()
+  llvm.return
+}
+}
+
+// -----
+
+// Test that cluster sync is inserted before return for non-WS clustered kernels.
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 4 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+
+llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
+// CHECK-LABEL: @clustered_no_ws_exit_sync
+// CHECK: nvvm.cluster.arrive {aligned}
+// CHECK-NEXT: nvvm.cluster.wait {aligned}
+// CHECK-NEXT: llvm.return
+llvm.func @clustered_no_ws_exit_sync() attributes {allocation.offset = 0 : i32} {
+  llvm.return
+}
+}
+
+// -----
+
+// Test that cluster sync is inserted before return for WS clustered kernels,
+// not just paired CTA MMA.
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 5 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+
+llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
+// CHECK-LABEL: @clustered_kernel_exit_sync
+// CHECK: nvvm.cluster.arrive {aligned}
+// CHECK-NEXT: nvvm.cluster.wait {aligned}
+// CHECK-NEXT: llvm.return
+// CHECK: nvvm.cluster.arrive {aligned}
+// CHECK-NEXT: nvvm.cluster.wait {aligned}
+// CHECK-NEXT: llvm.return
+llvm.func @clustered_kernel_exit_sync() attributes {allocation.offset = 0 : i32} {
+  ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 4>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(1) {
     ttg.warp_return
   } : () -> ()
   llvm.return

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -586,14 +586,18 @@ struct ConvertWarpSpecializeToLLVM
     // make sure all warps execute it. Note: we put this piece of code here to
     // make sure it's executed right after WS lowering, but it's not part of WS
     // lowering, so without WS ops this piece should still execute
-    if (tlx::tlxEnablePairedMMA(mod)) {
+    const SmallVector<int> clusterDims =
+        triton::gpu::TritonGPUDialect::getClusterDims(mod);
+    int clusterSize = 1;
+    for (int d : clusterDims)
+      clusterSize *= d;
+    if (clusterSize > 1) {
       for (LLVM::LLVMFuncOp kernel : kernels) {
         kernel.walk([&](LLVM::ReturnOp ret) {
           auto ctx = ret->getContext();
           auto loc = ret.getLoc();
           IRRewriter rewriter(kernel.getContext());
 
-          // for 2cta, this is needed
           // "When the current CTA issues the operation, the peer CTA should be
           // active and should not have exited."
           auto unitAttr = UnitAttr::get(ctx);


### PR DESCRIPTION
Summary:

Generalize the exit cluster sync from paired CTA MMA only to all kernels
with clusterDims > 1. This prevents CUDA_EXCEPTION_17 (cluster target
block not present) when CLC recycles SMs before all CTAs in a cluster
have exited, which can cause DSMEM access to fail against a departed peer CTA.

Reviewed By: karthik-man

Differential Revision: D97054326
