### PR TITLE
Reformat with precommit (#1111)

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
@@ -123,10 +123,9 @@ getIndirectLevel(triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
       isaFamily != triton::AMD::ISAFamily::CDNA4 && !isRDNA(isaFamily);
   llvm::DenseMap<Operation *, int> unusedOpLatency;
   llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel =
-      triton::gpu::loadOpsToIndirectionLevel(forOp, pipelineWithoutDot,
-                                             axisInfoAnalysis, numStages,
-                                             unusedOpLatency,
-                                             filterSmallVectors);
+      triton::gpu::loadOpsToIndirectionLevel(
+          forOp, pipelineWithoutDot, axisInfoAnalysis, numStages,
+          unusedOpLatency, filterSmallVectors);
 
   return loadOpToIndLevel;
 }

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -51,9 +51,9 @@ LogicalResult insertRequireLayout(ModuleOp m) {
           localLoadOp.dump();
         });
         // Get the shared encoding for this local load op based on the dot op
-        auto encoding = mlir::getSharedEncIfAllUsersAreDotEnc(
-                            localLoadOp->getResult(0))
-                            .value_or(nullptr);
+        auto encoding =
+            mlir::getSharedEncIfAllUsersAreDotEnc(localLoadOp->getResult(0))
+                .value_or(nullptr);
         if (encoding) {
           LLVM_DEBUG({
             llvm::dbgs() << "SwizzledSharedEncodingAttr\n";


### PR DESCRIPTION
Summary:
Somehow the trunk is broken in terms of clang format, and would cause pre-commit CI errors for every new PR. Ran `pre-commit run clang-format --all-files` locally to fix this.


Reviewed By: dshi7

Differential Revision: D97353809

Pulled By: pchen7e2
