### PR TITLE
  [TLX] Make heuristic config selection in blackwell_gemm_ws configurable via env var (#1115) (#1115)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1306,17 +1306,15 @@ def matmul_kernel_tma_ws_blackwell(
                 tile_id += NUM_SMS
 
 
-def matmul(a, b, config=None, use_heuristic=False):
+def matmul(a, b, config=None):
     """Matrix multiplication using TLX GEMM kernel.
 
     Args:
         a: Input matrix A of shape (M, K)
         b: Input matrix B of shape (K, N)
-        config: Optional dict with kernel config. If None and use_heuristic=True,
-                uses shape-dependent heuristic selection. If heuristic fails,
-                falls back to full autotuning.
-        use_heuristic: When config is None, try heuristic config selection first.
-                      Default True for faster kernel launch.
+        config: Optional dict with kernel config. If None and
+                TLX_GEMM_USE_HEURISTIC=1, uses shape-dependent heuristic
+                selection. If heuristic fails, falls back to full autotuning.
 
     Returns:
         Output matrix C of shape (M, N)
@@ -1337,7 +1335,8 @@ def matmul(a, b, config=None, use_heuristic=False):
 
     NUM_SMS = _get_num_sms()
 
-    # Use heuristic config if no config provided and heuristic is enabled
+    # Use heuristic config if no config provided and env var is set
+    use_heuristic = os.environ.get("TLX_GEMM_USE_HEURISTIC", "0") == "1"
     if config is None and use_heuristic:
         config = get_heuristic_config(M, N, K, NUM_SMS)
         if config is not None and os.environ.get("TRITON_PRINT_AUTOTUNING") == "1":


### PR DESCRIPTION
Summary:
Keep API signatures consistent with other hardware types in tritonbench

https://github.com/meta-pytorch/tritonbench/blob/50d55af9ac4a8a1579094b3685488668cef101c0/tritonbench/operators/gemm/operator.py#L608-L616

Pulled By:
dshi7


dshi7

Differential Revision: D97489286


