### PR TITLE
[TLX] Support column-major A and B inputs in blackwell_gemm_ws (#1116)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -403,9 +403,18 @@ def matmul_tma_set_block_size_hook(nargs):
     BLOCK_N = nargs["BLOCK_SIZE_N"]
     BLOCK_K = nargs["BLOCK_SIZE_K"]
     NUM_MMA_GROUPS = nargs.get("NUM_MMA_GROUPS", 1)
-    nargs["a_desc"].block_shape = [BLOCK_M // NUM_MMA_GROUPS, BLOCK_K]
+    BLOCK_M_SPLIT = BLOCK_M // NUM_MMA_GROUPS
     NUM_CTAS = nargs.get("NUM_CTAS", 1)
-    nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N // NUM_CTAS]
+    BLOCK_N_PER_CTA = BLOCK_N // NUM_CTAS
+    # For column-major inputs, TMA descriptor block shape matches the transposed view
+    if nargs.get("A_ROW_MAJOR", True):
+        nargs["a_desc"].block_shape = [BLOCK_M_SPLIT, BLOCK_K]
+    else:
+        nargs["a_desc"].block_shape = [BLOCK_K, BLOCK_M_SPLIT]
+    if nargs.get("B_ROW_MAJOR", True):
+        nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N_PER_CTA]
+    else:
+        nargs["b_desc"].block_shape = [BLOCK_N_PER_CTA, BLOCK_K]
     EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", 1)
     nargs["c_desc"].block_shape = [
         BLOCK_M // NUM_MMA_GROUPS,
@@ -837,6 +846,8 @@ def _process_tile_mma_inner(
     NUM_CTAS,
     cta_bars,
     pred_cta0,
+    A_ROW_MAJOR: tl.constexpr = True,
+    B_ROW_MAJOR: tl.constexpr = True,
 ):
     """Process MMA for a single tile over [k_tile_start, k_tile_end). Returns updated smem_accum_cnt."""
     local_k_tiles = k_tile_end - k_tile_start
@@ -865,10 +876,14 @@ def _process_tile_mma_inner(
             tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
             tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
+        # Transpose SMEM buffers if inputs were column-major
+        a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
+        b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
+
         # Perform MMA: use_acc=False for first K iteration (clears accumulator)
         tlx.async_dot(
-            buffers_A[a_buf],
-            buffers_B[buf],
+            a_operand,
+            b_operand,
             tmem_buffers[acc_buf],
             use_acc=False,
             mBarriers=[A_smem_empty_bars[a_buf]],
@@ -899,10 +914,14 @@ def _process_tile_mma_inner(
                 tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
                 tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
+            # Transpose SMEM buffers if inputs were column-major
+            a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
+            b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
+
             # Perform MMA: use_acc=True for remaining K iterations
             tlx.async_dot(
-                buffers_A[a_buf],
-                buffers_B[buf],
+                a_operand,
+                b_operand,
                 tmem_buffers[acc_buf],
                 use_acc=True,
                 mBarriers=[A_smem_empty_bars[a_buf]],
@@ -948,6 +967,8 @@ def _process_tile_producer_inner(
     smem_accum_cnt,
     NUM_CTAS,
     cluster_cta_rank,
+    A_ROW_MAJOR: tl.constexpr = True,
+    B_ROW_MAJOR: tl.constexpr = True,
 ):
     """Process TMA loads for a single tile with all subtiles over [k_tile_start, k_tile_end)."""
     mn_tile_id = tile_id % num_mn_tiles
@@ -970,15 +991,23 @@ def _process_tile_producer_inner(
         tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
         offs_am = pid_m * BLOCK_SIZE_M
         tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_SIZE_K)
-        tlx.async_descriptor_load(a_desc, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
-                                  eviction_policy="evict_last")
+        if not A_ROW_MAJOR:
+            tlx.async_descriptor_load(a_desc, buffers_A[a_buf], [offs_k, offs_am], A_smem_full_bars[a_buf],
+                                      eviction_policy="evict_last")
+        else:
+            tlx.async_descriptor_load(a_desc, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
+                                      eviction_policy="evict_last")
 
         # Load B once per K iteration (shared across all subtiles)
         last_a_buf = (NUM_MMA_GROUPS - 1) * NUM_SMEM_BUFFERS + buf
         tlx.barrier_wait(A_smem_empty_bars[last_a_buf], phase ^ 1)
         tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
-        tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
-                                  eviction_policy="evict_last")
+        if not B_ROW_MAJOR:
+            tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_bn, offs_k], B_smem_full_bars[buf],
+                                      eviction_policy="evict_last")
+        else:
+            tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
+                                      eviction_policy="evict_last")
 
         # Load all remaining A subtiles for this K iteration
         for group_id in tl.static_range(1, NUM_MMA_GROUPS):
@@ -989,8 +1018,12 @@ def _process_tile_producer_inner(
             offs_am2 = offs_am + group_id * BLOCK_M_SPLIT
 
             tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_SIZE_K)
-            tlx.async_descriptor_load(a_desc, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
-                                      eviction_policy="evict_last")
+            if not A_ROW_MAJOR:
+                tlx.async_descriptor_load(a_desc, buffers_A[a_buf], [offs_k, offs_am2], A_smem_full_bars[a_buf],
+                                          eviction_policy="evict_last")
+            else:
+                tlx.async_descriptor_load(a_desc, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
+                                          eviction_policy="evict_last")
 
         smem_accum_cnt += 1
 
@@ -1081,17 +1114,29 @@ def matmul_kernel_tma_ws_blackwell(
     SPLIT_K: tl.constexpr,
     INTERLEAVE_EPILOGUE: tl.constexpr,
     NUM_SMS: tl.constexpr,
+    A_ROW_MAJOR: tl.constexpr = True,
+    B_ROW_MAJOR: tl.constexpr = True,
     USE_WARP_BARRIER: tl.constexpr = False,
 ):
     # allocate NUM_SMEM_BUFFERS buffers
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_SIZE_M // NUM_MMA_GROUPS
-    buffers_A = tlx.local_alloc(
-        (BLOCK_M_SPLIT, BLOCK_SIZE_K),
-        tlx.dtype_of(a_desc),
-        NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
-    )
+    if not A_ROW_MAJOR:
+        buffers_A = tlx.local_alloc(
+            (BLOCK_SIZE_K, BLOCK_M_SPLIT),
+            tlx.dtype_of(a_desc),
+            NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
+        )
+    else:
+        buffers_A = tlx.local_alloc(
+            (BLOCK_M_SPLIT, BLOCK_SIZE_K),
+            tlx.dtype_of(a_desc),
+            NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
+        )
     # In 2-CTA mode, each CTA only needs to load BLOCK_N // NUM_CTAS of B.
-    buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N // NUM_CTAS), tlx.dtype_of(b_desc), NUM_SMEM_BUFFERS)
+    if not B_ROW_MAJOR:
+        buffers_B = tlx.local_alloc((BLOCK_SIZE_N // NUM_CTAS, BLOCK_SIZE_K), tlx.dtype_of(b_desc), NUM_SMEM_BUFFERS)
+    else:
+        buffers_B = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N // NUM_CTAS), tlx.dtype_of(b_desc), NUM_SMEM_BUFFERS)
     # NUM_TMEM_BUFFERS (overlaps MMA and epilogue)
     # Each buffer holds one subtile: BLOCK_M_SPLIT x BLOCK_SIZE_N
     # Total buffers: NUM_TMEM_BUFFERS * NUM_MMA_GROUPS
@@ -1244,6 +1289,8 @@ def matmul_kernel_tma_ws_blackwell(
                     NUM_CTAS=NUM_CTAS,
                     cta_bars=cta_bars,
                     pred_cta0=pred_cta0,
+                    A_ROW_MAJOR=A_ROW_MAJOR,
+                    B_ROW_MAJOR=B_ROW_MAJOR,
                 )
                 tmem_accum_cnt += 1
                 tile_id += NUM_SMS
@@ -1302,6 +1349,8 @@ def matmul_kernel_tma_ws_blackwell(
                     smem_accum_cnt=smem_accum_cnt,
                     NUM_CTAS=NUM_CTAS,
                     cluster_cta_rank=cluster_cta_rank,
+                    A_ROW_MAJOR=A_ROW_MAJOR,
+                    B_ROW_MAJOR=B_ROW_MAJOR,
                 )
                 tile_id += NUM_SMS
 
@@ -1321,16 +1370,28 @@ def matmul(a, b, config=None):
     """
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
-    assert a.is_contiguous(), "Matrix A must be contiguous"
     M, K = a.shape
     K, N = b.shape
     # Allocates output.
     c = torch.empty((M, N), device=a.device, dtype=a.dtype)
 
+    # Detect column-major inputs.
+    # A column-major (M, K) tensor has strides (1, M); its .T is row-major (K, M).
+    a_row_major = a.is_contiguous()
+    b_row_major = b.is_contiguous()
+
     # A dummy block value that will be overwritten when we have the real block size
     dummy_block = [1, 1]
-    a_desc = TensorDescriptor(a, a.shape, a.stride(), dummy_block)
-    b_desc = TensorDescriptor(b, b.shape, b.stride(), dummy_block)
+    if not a_row_major:
+        a_t = a.T  # (K, M) with strides (M, 1) — row-major
+        a_desc = TensorDescriptor(a_t, a_t.shape, a_t.stride(), dummy_block)
+    else:
+        a_desc = TensorDescriptor(a, a.shape, a.stride(), dummy_block)
+    if not b_row_major:
+        b_t = b.T  # (N, K) with strides (K, 1) — row-major
+        b_desc = TensorDescriptor(b_t, b_t.shape, b_t.stride(), dummy_block)
+    else:
+        b_desc = TensorDescriptor(b, b.shape, b.stride(), dummy_block)
     c_desc = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
 
     NUM_SMS = _get_num_sms()
@@ -1365,6 +1426,8 @@ def matmul(a, b, config=None):
             "M": M,
             "N": N,
             "K": K,
+            "A_ROW_MAJOR": a_row_major,
+            "B_ROW_MAJOR": b_row_major,
             **config,
         }
         if pre_hook:
@@ -1385,6 +1448,8 @@ def matmul(a, b, config=None):
             M,
             N,
             K,
+            A_ROW_MAJOR=a_row_major,
+            B_ROW_MAJOR=b_row_major,
             NUM_SMS=NUM_SMS,
             ctas_per_cga=ctas_per_cga,
             **config,
@@ -1426,6 +1491,8 @@ def matmul(a, b, config=None):
             M,
             N,
             K,
+            A_ROW_MAJOR=a_row_major,
+            B_ROW_MAJOR=b_row_major,
             NUM_SMS=NUM_SMS,
         )
         # Run split-K reduction after the autotuner picks and launches the kernel.

--- a/third_party/tlx/tutorials/hopper_gemm_ws.py
+++ b/third_party/tlx/tutorials/hopper_gemm_ws.py
@@ -28,9 +28,16 @@ def matmul_tma_set_block_size_hook(nargs):
     BLOCK_K = nargs["BK"]
     NUM_MMA_GROUPS = nargs["NUM_MMA_GROUPS"]
     BLOCK_M_SPLIT = BLOCK_M // NUM_MMA_GROUPS
-    nargs["a_desc"].block_shape = [BLOCK_M_SPLIT, BLOCK_K]
     NUM_CTAS = nargs.get("NUM_CTAS", 1)
-    nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N // NUM_CTAS]
+    # For column-major inputs, TMA descriptor block shape matches the transposed view
+    if nargs.get("A_ROW_MAJOR", True):
+        nargs["a_desc"].block_shape = [BLOCK_M_SPLIT, BLOCK_K]
+    else:
+        nargs["a_desc"].block_shape = [BLOCK_K, BLOCK_M_SPLIT]
+    if nargs.get("B_ROW_MAJOR", True):
+        nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N // NUM_CTAS]
+    else:
+        nargs["b_desc"].block_shape = [BLOCK_N // NUM_CTAS, BLOCK_K]
     EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", False)
     if EPILOGUE_SUBTILE:
         nargs["c_desc"].block_shape = [BLOCK_M_SPLIT, BLOCK_N // 2]
@@ -110,6 +117,8 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
                          NUM_CTAS: tl.constexpr,  #
                          NUM_SMS: tl.constexpr,  #
                          USE_WARP_BARRIER: tl.constexpr = False,  #
+                         A_ROW_MAJOR: tl.constexpr = True,  #
+                         B_ROW_MAJOR: tl.constexpr = True,  #
                          ):
     # Descriptor
     BLOCK_M_SPLIT: tl.constexpr = BM // NUM_MMA_GROUPS
@@ -117,8 +126,14 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
     # Need NUM_STAGES sets of SMEM buffers for A and B
     # where each set contains two for A and one for B.
     # Split A into two in M-dimension to have two consumer tasks for wgmma
-    a = tlx.local_alloc((BLOCK_M_SPLIT, BK), tlx.dtype_of(a_desc), NUM_STAGES * NUM_MMA_GROUPS)
-    b = tlx.local_alloc((BK, BN), tlx.dtype_of(b_desc), NUM_STAGES)
+    if not A_ROW_MAJOR:
+        a = tlx.local_alloc((BK, BLOCK_M_SPLIT), tlx.dtype_of(a_desc), NUM_STAGES * NUM_MMA_GROUPS)
+    else:
+        a = tlx.local_alloc((BLOCK_M_SPLIT, BK), tlx.dtype_of(a_desc), NUM_STAGES * NUM_MMA_GROUPS)
+    if not B_ROW_MAJOR:
+        b = tlx.local_alloc((BN, BK), tlx.dtype_of(b_desc), NUM_STAGES)
+    else:
+        b = tlx.local_alloc((BK, BN), tlx.dtype_of(b_desc), NUM_STAGES)
 
     # Need NUM_STAGES sets of mbarriers for A and B
     # where each set contains two for A and one for B.
@@ -170,7 +185,10 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
                     tlx.barrier_wait(bar=empty_a_1st, phase=p ^ 1)  # EmptyBar A1 wait
                     tlx.barrier_expect_bytes(full_a_1st, BLOCK_M_SPLIT * BK * tlx.size_of(tlx.dtype_of(a_desc)))
                     data_a_1st = tlx.local_view(a, buf)  # smem data
-                    tlx.async_descriptor_load(a_desc, data_a_1st, [offset_am, offset_k], full_a_1st)
+                    if not A_ROW_MAJOR:
+                        tlx.async_descriptor_load(a_desc, data_a_1st, [offset_k, offset_am], full_a_1st)
+                    else:
+                        tlx.async_descriptor_load(a_desc, data_a_1st, [offset_am, offset_k], full_a_1st)
 
                     # Async load to b[buf]
                     empty_b = tlx.local_view(bars_empty_b, buf)
@@ -188,19 +206,35 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
                         tlx.barrier_wait(cta_bar, p)
 
                         # Each CTA loads half of B and multicasts to both CTAs
-                        if cta_id == 0:
-                            buf_b_slice = tlx.local_slice(data_b, [0, 0], [BK, BN // 2])
+                        if not B_ROW_MAJOR:
+                            if cta_id == 0:
+                                buf_b_slice = tlx.local_slice(data_b, [0, 0], [BN // 2, BK])
+                            else:
+                                buf_b_slice = tlx.local_slice(data_b, [BN // 2, 0], [BN // 2, BK])
+                            tlx.async_descriptor_load(
+                                b_desc,
+                                buf_b_slice,
+                                [offset_bn + cta_id * BN // 2, offset_k],
+                                full_b,
+                                multicast_targets=[cta_id, cta_id ^ 1],
+                            )
                         else:
-                            buf_b_slice = tlx.local_slice(data_b, [0, BN // 2], [BK, BN // 2])
-                        tlx.async_descriptor_load(
-                            b_desc,
-                            buf_b_slice,
-                            [offset_k, offset_bn + cta_id * BN // 2],
-                            full_b,
-                            multicast_targets=[cta_id, cta_id ^ 1],
-                        )
+                            if cta_id == 0:
+                                buf_b_slice = tlx.local_slice(data_b, [0, 0], [BK, BN // 2])
+                            else:
+                                buf_b_slice = tlx.local_slice(data_b, [0, BN // 2], [BK, BN // 2])
+                            tlx.async_descriptor_load(
+                                b_desc,
+                                buf_b_slice,
+                                [offset_k, offset_bn + cta_id * BN // 2],
+                                full_b,
+                                multicast_targets=[cta_id, cta_id ^ 1],
+                            )
                     else:
-                        tlx.async_descriptor_load(b_desc, data_b, [offset_k, offset_bn], full_b)
+                        if not B_ROW_MAJOR:
+                            tlx.async_descriptor_load(b_desc, data_b, [offset_bn, offset_k], full_b)
+                        else:
+                            tlx.async_descriptor_load(b_desc, data_b, [offset_k, offset_bn], full_b)
 
                     # Async load to a[buf+NUM_STAGES]
                     empty_a_2nd = tlx.local_view(bars_empty_a, buf + NUM_STAGES)
@@ -209,7 +243,10 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
                     tlx.barrier_expect_bytes(bar=full_a_2nd,
                                              size=BLOCK_M_SPLIT * BK * tlx.size_of(tlx.dtype_of(a_desc)))
                     data_a_2nd = tlx.local_view(a, buf + NUM_STAGES)  # smem data
-                    tlx.async_descriptor_load(a_desc, data_a_2nd, [offset_am + BLOCK_M_SPLIT, offset_k], full_a_2nd)
+                    if not A_ROW_MAJOR:
+                        tlx.async_descriptor_load(a_desc, data_a_2nd, [offset_k, offset_am + BLOCK_M_SPLIT], full_a_2nd)
+                    else:
+                        tlx.async_descriptor_load(a_desc, data_a_2nd, [offset_am + BLOCK_M_SPLIT, offset_k], full_a_2nd)
 
                     smem_accum_cnt += 1
 
@@ -251,9 +288,12 @@ def matmul_kernel_tlx_ws(a_desc, b_desc, c_desc,  #
                     # async_dot
                     data_a = tlx.local_view(a, buf + NUM_STAGES * tlx.async_task_replica_id())  # noqa
                     data_b = tlx.local_view(b, buf)
+                    # Transpose SMEM buffers if inputs were column-major
+                    a_operand = tlx.local_trans(data_a) if not A_ROW_MAJOR else data_a
+                    b_operand = tlx.local_trans(data_b) if not B_ROW_MAJOR else data_b
                     acc = tlx.async_dot(
-                        data_a,
-                        data_b,
+                        a_operand,
+                        b_operand,
                         acc,
                     )
                     # async_wait
@@ -287,47 +327,52 @@ def matmul(a, b, config=None):
     """Matrix multiplication using TLX GEMM kernel."""
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Illegal dimensions of input operands"
-    assert a.is_contiguous(), "Matrix A must be contiguous"
+    M, K = a.shape
+    K, N = b.shape
 
     triton.set_allocator(alloc_fn)
 
-    (M, N, K) = (a.shape[0], b.shape[1], a.shape[1])
+    # Allocates output.
     c = torch.empty(
         (M, N),
         dtype=torch.float16,
         device=DEVICE,
     )
 
+    # Detect column-major inputs.
+    # A column-major (M, K) tensor has strides (1, M); its .T is row-major (K, M).
+    a_row_major = a.is_contiguous()
+    b_row_major = b.is_contiguous()
+
     # Get number of SMs
     NUM_SMS = torch.cuda.get_device_properties(DEVICE).multi_processor_count
 
     dummy_block = [1, 1]
-    desc_in_1 = TensorDescriptor(
-        a,
-        shape=[M, K],
-        strides=[K, 1],
-        block_shape=dummy_block,
-    )
-
-    desc_in_2 = TensorDescriptor(
-        b,
-        shape=[K, N],
-        strides=[N, 1],
-        block_shape=dummy_block,
-    )
-    desc_out = TensorDescriptor(
-        c,
-        shape=[M, N],
-        strides=[N, 1],
-        block_shape=dummy_block,
-    )
+    if not a_row_major:
+        a_t = a.T  # (K, M) with strides (M, 1) — row-major
+        desc_in_1 = TensorDescriptor(a_t, a_t.shape, a_t.stride(), dummy_block)
+    else:
+        desc_in_1 = TensorDescriptor(a, a.shape, a.stride(), dummy_block)
+    if not b_row_major:
+        b_t = b.T  # (N, K) with strides (K, 1) — row-major
+        desc_in_2 = TensorDescriptor(b_t, b_t.shape, b_t.stride(), dummy_block)
+    else:
+        desc_in_2 = TensorDescriptor(b, b.shape, b.stride(), dummy_block)
+    desc_out = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
 
     if config is not None:
         # Set descriptor block shapes according to config
         NUM_MMA_GROUPS = config["NUM_MMA_GROUPS"]
         BLOCK_M_SPLIT = config["BM"] // NUM_MMA_GROUPS
-        desc_in_1.block_shape = [BLOCK_M_SPLIT, config["BK"]]
-        desc_in_2.block_shape = [config["BK"], config["BN"] // config.get("NUM_CTAS", 1)]
+        NUM_CTAS = config.get("NUM_CTAS", 1)
+        if a_row_major:
+            desc_in_1.block_shape = [BLOCK_M_SPLIT, config["BK"]]
+        else:
+            desc_in_1.block_shape = [config["BK"], BLOCK_M_SPLIT]
+        if b_row_major:
+            desc_in_2.block_shape = [config["BK"], config["BN"] // NUM_CTAS]
+        else:
+            desc_in_2.block_shape = [config["BN"] // NUM_CTAS, config["BK"]]
         if config.get("EPILOGUE_SUBTILE", False):
             desc_out.block_shape = [BLOCK_M_SPLIT, config["BN"] // 2]
         else:
@@ -345,6 +390,8 @@ def matmul(a, b, config=None):
             M,
             N,
             K,
+            A_ROW_MAJOR=a_row_major,
+            B_ROW_MAJOR=b_row_major,
             NUM_SMS=NUM_SMS,
             **config,
         )
@@ -358,6 +405,8 @@ def matmul(a, b, config=None):
             M,
             N,
             K,
+            A_ROW_MAJOR=a_row_major,
+            B_ROW_MAJOR=b_row_major,
             NUM_SMS=NUM_SMS,
         )
     return c


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/968


Column-major inputs are handled by creating TensorDescriptors from the
transposed view (which is row-major), allocating SMEM buffers in the
TMA-load shape, swapping TMA load coordinates, and using tlx.local_trans()
to transpose back before async_dot. This follows the same pattern used by
Flash Attention kernels for transposed K tiles.

Reviewed By: wlei-llvm

Differential Revision: D97524850
