### PR TITLE
[TLX] Fix split-K reduction in autotuner production path

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1419,5 +1419,22 @@ def matmul(a, b, config=None, use_heuristic=False):
             K,
             NUM_SMS=NUM_SMS,
         )
-        # post_hook handles reduction for split-K > 1
+        # Run split-K reduction after the autotuner picks and launches the kernel.
+        # The autotuner's post_hook only runs during benchmarking, not production calls.
+        best = matmul_kernel_tma_ws_blackwell.best_config
+        split_k = best.kwargs.get("SPLIT_K", 1)
+        if split_k > 1:
+            workspace = workspace_desc.base
+            reduce_grid = (triton.cdiv(M, 128), triton.cdiv(N, 128))
+            _reduce_k_kernel[reduce_grid](
+                workspace,
+                c,
+                M,
+                N,
+                SPLIT_K=split_k,
+                BLOCK_SIZE_M=128,
+                BLOCK_SIZE_N=128,
+                OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[a.dtype],
+                num_warps=8,
+            )
     return c


### PR DESCRIPTION
Summary:
The autotuner's post_hook (reduce_post_hook) only runs during
benchmarking, not during production calls. This means split-K
reduction was never performed in the autotuner path — the kernel
wrote partial sums to workspace but nobody reduced them into the
output tensor c.

The bug was masked because torch.empty() reuses memory from the
CUDA caching allocator, so c contained stale correct data from
the autotuning warmup phase.

Fix: explicitly run _reduce_k_kernel after the autotuner call
when the best config has SPLIT_K > 1, matching the behavior of
the heuristic/config path.

Authored with Claude.

Differential Revision: D97366836


