### PR TITLE
[TLX] Use smaller tiles for split-K reduction kernel (#1118)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1030,17 +1030,17 @@ def reduce_post_hook(nargs, exception=None):
         N = nargs["N"]
         workspace = nargs["workspace_desc"].base
         c = nargs["c_desc"].base
-        reduce_grid = (triton.cdiv(M, 128), triton.cdiv(N, 128))
+        reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
         _reduce_k_kernel[reduce_grid](
             workspace,
             c,
             M,
             N,
             SPLIT_K=split_k,
-            BLOCK_SIZE_M=128,
-            BLOCK_SIZE_N=128,
+            BLOCK_SIZE_M=32,
+            BLOCK_SIZE_N=32,
             OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[workspace.dtype],
-            num_warps=8,
+            num_warps=4,
         )
 
 
@@ -1382,17 +1382,17 @@ def matmul(a, b, config=None, use_heuristic=False):
         )
         # Run separate reduction kernel for split-K
         if split_k > 1:
-            reduce_grid = (triton.cdiv(M, 128), triton.cdiv(N, 128))
+            reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
             _reduce_k_kernel[reduce_grid](
                 workspace_desc.base,
                 c,
                 M,
                 N,
                 SPLIT_K=split_k,
-                BLOCK_SIZE_M=128,
-                BLOCK_SIZE_N=128,
+                BLOCK_SIZE_M=32,
+                BLOCK_SIZE_N=32,
                 OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[a.dtype],
-                num_warps=8,
+                num_warps=4,
             )
     else:
         # Pass c as dummy workspace_desc. Pre_hook dynamically allocates
@@ -1425,16 +1425,16 @@ def matmul(a, b, config=None, use_heuristic=False):
         split_k = best.kwargs.get("SPLIT_K", 1)
         if split_k > 1:
             workspace = workspace_desc.base
-            reduce_grid = (triton.cdiv(M, 128), triton.cdiv(N, 128))
+            reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
             _reduce_k_kernel[reduce_grid](
                 workspace,
                 c,
                 M,
                 N,
                 SPLIT_K=split_k,
-                BLOCK_SIZE_M=128,
-                BLOCK_SIZE_N=128,
+                BLOCK_SIZE_M=32,
+                BLOCK_SIZE_N=32,
                 OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[a.dtype],
-                num_warps=8,
+                num_warps=4,
             )
     return c


### PR DESCRIPTION
Summary:

The _reduce_k_kernel uses 128x128 tiles, which creates very few CTAs
for small output shapes — e.g. only 4 CTAs for 256x256 (97% of SMs
idle on B200 with 148 SMs). Switching to 32x32 tiles gives 64 CTAs
for the same output, providing 2-6x faster reduction.

This matters because the reduce kernel was the dominant cost for small
split-K shapes. For example, 256x256 with SK=16 had reduce time of
66us — 174% of the total cuBLAS time for that shape. The GEMM kernel
itself was fast, but the reduction bottleneck negated the split-K
benefit.

The change applies to all 3 call sites of _reduce_k_kernel (autotuner
benchmarking post_hook, heuristic path, and autotuner production path).

Authored with Claude.

Differential Revision: D97513062
