### PR TITLE
[TLX] Add BM=64 tile size for small unsaturated GEMM shapes (#1119)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -383,7 +383,7 @@ def get_cuda_autotune_config():
             pre_hook=matmul_tma_set_block_size_hook,
             ctas_per_cga=(num_ctas, 1, 1) if num_ctas > 1 else None,
         )
-        for BM in [128, 256]
+        for BM in [64, 128, 256]
         for BN in [64, 128, 256]
         for BK in [64, 128]
         for s in [2, 3, 4, 5, 6, 7]
@@ -484,9 +484,19 @@ def preprocess_configs(configs, named_args, **kwargs):
         if INTERLEAVE_EPILOGUE and NUM_MMA_GROUPS != 2:
             continue
 
+        # Blackwell MMA requires BLOCK_M_SPLIT >= 64
+        if BLOCK_M // NUM_MMA_GROUPS < 64:
+            continue
+
         num_tiles_m = math.ceil(M / BLOCK_M)
         num_tiles_n = math.ceil(N / BLOCK_N)
         num_mn_tiles = num_tiles_m * num_tiles_n
+
+        # BM=64 tiles only help when MN is too small with larger tiles.
+        # Skip them for shapes that already have enough spatial tiles
+        # to avoid bloating the autotuner search space.
+        if BLOCK_M == 64 and math.ceil(M / 128) * math.ceil(N / 128) > 16:
+            continue
 
         # --- Split-K gating: only allow SPLIT_K > 1 for small shapes ---
         # Split-K helps when MN tiles are too few to saturate the GPU.


### PR DESCRIPTION
Summary:

For shapes with very few spatial tiles (mn_tiles <= 16 at 128x128),
adding BM=64 to the autotuner search space gives 4x more tiles to
work with, improving SM utilization under split-K. For example,
256x256 with 128x128 tiles gives only 4 mn_tiles, but with 64x64
tiles gives 16 — enough for SK=8 to reach 128 total tiles (87%
utilization vs 32% with 128x128).

Gated to only activate when ceil(M/128)*ceil(N/128) <= 16, so
shapes with enough spatial tiles at 128x128 see zero extra configs
and no autotuner dilution.

Also adds a missing MMA constraint filter — Blackwell wgmma requires
BLOCK_M_SPLIT >= 64, so BM=64 only works with NUM_MMA_GROUPS=1.

Authored with Claude.

Differential Revision: D97512386
