### PR TITLE
[Triton] Support 2-CTA in Triton with ctas_per_cga + autoWS (#1120)

### DIFF
--- a/docs/design/2cta-autoWS-sync.md
+++ b/docs/design/2cta-autoWS-sync.md
@@ -1,0 +1,479 @@
+# [triton] Support 2-CTA in Triton with ctas_per_cga
+
+**Task:** T259718487
+**Base Diff:** D96323995 (`[TLX] Add two_cta support to async_descriptor_load`)
+**Reference:** D97215251 (Draft OSS PR #1059: compiler automation with `Transform2CTALoads`)
+**Author:** Zhijing Li (tissue030)
+
+---
+
+## Table of Contents
+
+1. [Background](#background)
+2. [Problem Statement](#problem-statement)
+3. [Design](#design)
+4. [Implementation](#implementation)
+5. [Generated TTGIR Example](#generated-ttgir-example)
+6. [Files Changed](#files-changed)
+7. [How to Test](#how-to-test)
+8. [Known Limitations and Future Work](#known-limitations-and-future-work)
+9. [Auto-WS + 2-CTA Integration](#auto-ws--2-cta-integration)
+
+---
+
+## Background
+
+### What is 2-CTA MMA?
+
+On NVIDIA Blackwell (SM100+) GPUs, two CTAs (Cooperative Thread Arrays) in a
+cluster can cooperatively execute a single MMA (Matrix Multiply-Accumulate)
+instruction via `tcgen05.mma.cta_group::2`. This effectively doubles the tile
+size (up to 256x256) and improves tensor core utilization.
+
+In 2-CTA mode:
+- **CTA 0** (leader, even-ranked) loads **A** and **half of B** (`B[:, :N/2]`)
+- **CTA 1** (odd-ranked) loads the **other half of B** (`B[:, N/2:]`)
+- Both CTAs issue `tcgen05.mma.cta_group::2`, which reads A from CTA 0 and B
+  from both CTAs' SMEM
+- The hardware synchronizes execution across both CTAs
+
+### Two Approaches to 2-CTA
+
+| Approach | `num_ctas` | CTA Layout | B Splitting | Who manages sync? |
+|----------|-----------|------------|-------------|-------------------|
+| **PlanCTA** (compiler-driven) | 2 | `CTASplitNum=[2,1]` | `splitBOperand()` in AccelerateMatmul | Compiler via CTA layout encoding |
+| **ctas_per_cga** (user-driven) | 1 | `CTASplitNum=[1,1]` | `Transform2CTALoads` pass | Compiler via explicit IR transforms |
+
+The reviewer (@manman-ren) directed us to use the **ctas_per_cga approach** because
+PlanCTA is unreliable for 2-CTA. With `ctas_per_cga=(2,1,1)`, the user sets the
+cluster shape and `num_ctas=1` is set automatically — bypassing PlanCTA entirely.
+
+### Related Diffs
+
+| Diff | Description |
+|------|-------------|
+| **D96323995** (base) | Adds `two_cta` to `AsyncTMACopyGlobalToLocalOp`; emits `.cta_group::2` on TMA PTX. Demonstrates the `remote_view` pattern for cross-CTA barrier mapping in TLX. |
+| **D97215251** (reference) | Draft OSS PR #1059: full compiler automation with 3 passes (`Propagate2CTAAttr`, `Transform2CTALoads`, `Insert2CTASync`). We port `Transform2CTALoads` and reuse our existing `Insert2CTASync`. `Propagate2CTAAttr` is NOT needed since AccelerateMatmul already propagates the attribute. |
+
+### Reference Implementations
+
+- **`fbcode/generative_recommenders/ops/triton/triton_addmm.py`** -- Production
+  TLX kernel with manual 2-CTA + WS ("arrive remote, wait local" pattern)
+- **`third_party/tlx/tutorials/blackwell_gemm_2cta.py`** -- TLX 2-CTA GEMM tutorial
+
+---
+
+## Problem Statement
+
+When `tl.dot(two_ctas=True)` is used with `ctas_per_cga=(2,1,1)` on Blackwell:
+1. The user writes standard Triton code loading **full B** (`BLOCK_K × BLOCK_N`)
+2. The compiler must split B loads so each CTA loads only half (`BLOCK_K × BLOCK_N/2`)
+3. After pipelining, cross-CTA sync must be inserted before MMA
+4. TLX kernels (which also use `ctas_per_cga`) must not be affected
+
+With `ctas_per_cga=(2,1,1)`, `num_ctas=1` is set automatically. This means:
+- PlanCTA sees `num_ctas=1` and does nothing (no CTA split)
+- AccelerateMatmul's `canUseTwoCTAs()` returns false (`CTASplitNum=[1,1]`)
+- `splitBOperand()` cannot work (requires `CTASplitNum=[1,2]` from PlanCTA)
+
+Therefore, a new `Transform2CTALoads` pass is needed to physically transform
+B descriptor loads at the IR level.
+
+---
+
+## Design
+
+### User API
+
+The user writes standard Triton code with two additions:
+1. `tl.dot(a, b, acc, two_ctas=True)` — opt in to 2-CTA MMA
+2. `ctas_per_cga=(2, 1, 1)` — set cluster shape at kernel launch
+
+```python
+@triton.jit
+def matmul_2cta(a_ptr, b_ptr, c_ptr, M, N, K, ...):
+    # Standard TMA descriptor loads (full B)
+    a_desc = tl.make_tensor_descriptor(a_ptr, [M, K], ..., [BLOCK_M, BLOCK_K])
+    b_desc = tl.make_tensor_descriptor(b_ptr, [K, N], ..., [BLOCK_K, BLOCK_N])
+
+    for k in range(k_tiles):
+        a = a_desc.load([offs_am, offs_k])
+        b = b_desc.load([offs_k, offs_bn])  # Full B — compiler splits this
+        acc = tl.dot(a, b, acc, two_ctas=True)
+
+# Launch with ctas_per_cga — bypasses PlanCTA
+matmul_2cta[grid](..., ctas_per_cga=(2, 1, 1))
+```
+
+The `two_ctas` attribute flows through:
+
+```
+tl.dot(a, b, acc, two_ctas=True)    # Python (core.py)
+  -> semantic.dot(..., two_ctas=True)  # semantic.py
+    -> builder.create_dot(..., true)   # ir.cc
+      -> tt.dot ... {two_ctas}         # TTIR DotOp (TritonOps.td)
+```
+
+### Pipeline
+
+```
+TTIR: tt.dot {two_ctas}
+  |
+convert_to_ttgpuir            <-- preserves {two_ctas} on DotOp
+  |
+AccelerateMatmul               <-- getTwoCtas()=true: skips splitBOperand,
+  |                                sets two_ctas on TCGen5MMAOp
+Transform2CTALoads             <-- NEW: splits B descriptor loads per CTA
+  |
+schedule_loops + Meta WS       <-- 4 partitions: default/gemm/load/epilogue
+  |
+pipeline + hoist_tmem_alloc
+  |
+Insert2CTASync                 <-- "arrive remote, wait local" cross-CTA sync
+  |                                (AFTER all WS passes to avoid interference;
+  |                                 skips TLX kernels via tlx.has_tlx_ops check)
+tma_lowering
+```
+
+### AccelerateMatmul: User-Driven 2-CTA Path
+
+When `dotOp.getTwoCtas()` is true, AccelerateMatmul takes the user-driven path:
+
+```cpp
+if (dotOp.getTwoCtas()) {
+    // User-driven 2-CTA (ctas_per_cga): no splitBOperand needed.
+    // Transform2CTALoads will handle B splitting later.
+    useTwoCTAs = true;
+} else {
+    // Compiler-driven 2-CTA (PlanCTA heuristic): split B at IR level.
+    useTwoCTAs = canUseTwoCTAs(dotOp);
+    if (useTwoCTAs) {
+        b = splitBOperand(b, rewriter);
+    }
+}
+// ...
+mma.setTwoCtas(useTwoCTAs);  // Propagates to TCGen5MMAOp
+```
+
+### Transform2CTALoads Pass
+
+This pass runs before pipelining/WS and transforms B descriptor loads for non-async
+(non-TLX) 2-CTA MMAs. For each `TCGen5MMAOp` with `two_ctas=true && !is_async`:
+
+1. **Trace B operand** back through `LocalAllocOp` → `DescriptorLoadOp` → `MakeTensorDescOp`
+2. **Clone `MakeTensorDescOp`** with half-width block shape: `[BLOCK_K, BLOCK_N]` → `[BLOCK_K, BLOCK_N/2]`
+3. **Insert CTA offset computation**:
+   ```
+   cta_rank = nvgpu.cluster_id
+   cta_mod2 = cta_rank % 2
+   offset = cta_mod2 * (BLOCK_N / 2)
+   new_offs_n = offs_bn + offset
+   ```
+4. **Create new `DescriptorLoadOp`** with half-width result type and new descriptor
+5. **Create new `LocalAllocOp`** with half-width SMEM memdesc
+
+After this transform:
+- CTA 0 loads `B[:, offs_bn : offs_bn + BLOCK_N/2]`
+- CTA 1 loads `B[:, offs_bn + BLOCK_N/2 : offs_bn + BLOCK_N]`
+
+### Insert2CTASync: "Arrive Remote, Wait Local" Pattern
+
+Before each 2-CTA MMA, the `Insert2CTASync` pass inserts:
+
+1. `nvgpu.cluster_id` -- get CTA rank
+2. `arith.andi %rank, -2` -- compute leader rank (even CTA)
+3. `ttng.map_to_remote_buffer` -- map local barrier to leader CTA's SMEM
+4. `ttng.arrive_barrier` -- both CTAs arrive on leader's barrier (count=1 each)
+5. `ttng.wait_barrier` -- only leader waits (pred = rank % 2 == 0)
+6. `ttng.tc_gen5_mma {two_ctas}` -- 2-CTA MMA executes
+
+**TLX guard:** The pass checks for `tlx.has_tlx_ops` module attribute and
+returns early for TLX kernels. This is necessary because TLX kernels with
+`ctas_per_cga=(2,1,1)` manage their own cross-CTA sync via explicit barrier ops.
+Running `Insert2CTASync` on warp-specialized TLX IR causes barrier placement
+errors (`"Barrier init outside of the first block in function"`).
+
+---
+
+## Implementation
+
+### Changes Summary
+
+| Component | File | Change |
+|-----------|------|--------|
+| **Python API** | `core.py` | Add `two_ctas=False` param to `tl.dot()` |
+| **Semantic** | `semantic.py` | Thread `two_ctas` through `dot()` to `create_dot()` |
+| **IR binding** | `ir.cc` | Add `bool twoCtas` to `create_dot`, set attr on DotOp |
+| **DotOp IR** | `TritonOps.td` | Add `UnitAttr:$two_ctas` to DotOp arguments |
+| **TTIR→TTGIR** | `TritonToTritonGPUPass.cpp` | Preserve `two_ctas` during DotOp conversion |
+| **AccelerateMatmul** | `AccelerateMatmul.cpp` | User-driven path: skip `splitBOperand` when `getTwoCtas()`, propagate `two_ctas` to MMA |
+| **Transform loads** | `Transform2CTALoads.cpp` | **NEW**: Split B descriptor loads per CTA (half-width) |
+| **Sync pass** | `Insert2CTASync.cpp` | Insert cross-CTA sync; skip TLX via `tlx.has_tlx_ops` |
+| **Pass def** | `Passes.td` | Add `NVGPU2CTATransformLoads` + `NVGPUInsert2CTASync` pass definitions |
+| **Build** | `CMakeLists.txt` | Add `Transform2CTALoads.cpp`, `Insert2CTASync.cpp` |
+| **Pass wrapper** | `triton_nvidia.cc` | Add `add_2cta_transform_loads`, `add_insert_2cta_sync` wrappers |
+| **Pipeline** | `compiler.py` | `Transform2CTALoads` for `ctas_per_cga`, `Insert2CTASync` for all cluster (with TLX guard); for Meta WS, `Insert2CTASync` runs after all WS passes |
+
+### Key Design Decisions
+
+1. **`tl.dot(two_ctas=True)` as explicit opt-in**: Prevents backward compat
+   issues. Without this, any kernel with `cluster_dims >= 2` + `tl.dot()` would
+   silently get 2-CTA behavior.
+
+2. **`ctas_per_cga` bypass of PlanCTA**: Following the reviewer's direction, we
+   use `ctas_per_cga=(2,1,1)` which sets `num_ctas=1`, bypassing PlanCTA entirely.
+   `Transform2CTALoads` handles B splitting at the IR level instead of relying on
+   CTA layout encoding (`CTASplitNum`).
+
+3. **`Transform2CTALoads` from D97215251**: The pass is ported from D97215251's
+   design but written fresh following `Insert2CTASync`'s pattern. The key
+   transform: clone `MakeTensorDescOp` with half block shape, add CTA-based offset.
+   `Propagate2CTAAttr` from D97215251 is NOT needed — AccelerateMatmul already
+   propagates `two_ctas` from `DotOp` to `TCGen5MMAOp`.
+
+4. **`Insert2CTASync` with `tlx.has_tlx_ops` guard**: The pass runs for all
+   cluster kernels but checks the `tlx.has_tlx_ops` module attribute and returns
+   early for TLX kernels. This is needed because both TLX and pure Triton kernels
+   use `ctas_per_cga=(2,1,1)`, but TLX manages its own barriers. The per-MMA
+   `is_async` check alone was insufficient — warp-specialized TLX IR causes
+   barrier placement errors even when the pass finds no ops to transform.
+
+5. **`TritonToTritonGPUPass.cpp` fix**: The `TritonDotPattern` was dropping
+   `two_ctas` when recreating `DotOp` during TTIR→TTGIR conversion. Fixed by
+   explicitly copying the attribute.
+
+---
+
+## Files Changed
+
+### New Files
+
+| File | Lines | Description |
+|------|-------|-------------|
+| `hopper/lib/Transforms/Transform2CTALoads.cpp` | ~200 | B descriptor load splitting pass |
+| `hopper/lib/Transforms/Insert2CTASync.cpp` | ~200 | Cross-CTA sync pass |
+| `test/Hopper/TwoCTA/transform_2cta_loads.mlir` | ~120 | MLIR lit test for load splitting |
+| `test/Hopper/TwoCTA/insert_2cta_sync.mlir` | ~125 | MLIR lit test for sync pass |
+| `third_party/tlx/tutorials/blackwell-triton-addmm-2cta_test.py` | ~490 | Pure Triton E2E test + auto-WS 2CTA + perf benchmark |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `include/triton/Dialect/Triton/IR/TritonOps.td` | `UnitAttr:$two_ctas` on DotOp |
+| `python/triton/language/core.py` | `two_ctas=False` param on `tl.dot()` |
+| `python/triton/language/semantic.py` | Thread `two_ctas` through `dot()` |
+| `python/src/ir.cc` | `bool twoCtas` on `create_dot` |
+| `lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp` | Preserve `two_ctas` during conversion |
+| `lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp` | User-driven 2-CTA path |
+| `hopper/include/Transforms/Passes.td` | `NVGPU2CTATransformLoads` + `NVGPUInsert2CTASync` definitions |
+| `hopper/lib/Transforms/CMakeLists.txt` | Add `Transform2CTALoads.cpp`, `Insert2CTASync.cpp` |
+| `third_party/nvidia/triton_nvidia.cc` | Add pass wrappers |
+| `third_party/nvidia/backend/compiler.py` | Pipeline integration with TLX guard; Meta WS: `Insert2CTASync` after all WS passes |
+| `third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp` | Skip cluster barrier for WS; cluster0 predicate on `TCGen5CommitOp` lowering |
+| `third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp` | Propagate `two_ctas` from MMA to `TCGen5CommitOp` (2 locations) |
+| `third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp` | Exit cluster barrier for auto-WS with cluster-dim-x >= 2 |
+| `third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp` | TMEM `cta_group::2` when cluster-dim-x >= 2 (not just num-ctas == 2) |
+| `third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp` | Remove `doInsert2CTASync` call (now handled by separate pass in compiler.py) |
+
+---
+
+## How to Test
+
+### Step 1: Build the Triton Compiler
+
+```bash
+buck2 build @fbcode//mode/opt \
+  -m ovr_config//triton:beta \
+  //third-party/triton/beta/triton:triton-opt
+```
+
+### Step 2: Run MLIR Lit Tests (no GPU needed)
+
+```bash
+buck2 test @fbcode//mode/opt \
+  -m ovr_config//triton:beta \
+  '//third-party/triton/beta/triton:lit_test/Hopper/TwoCTA/transform_2cta_loads.mlir' \
+  '//third-party/triton/beta/triton:lit_test/Hopper/TwoCTA/insert_2cta_sync.mlir'
+```
+
+Expected: `Tests finished: Pass 2. Fail 0.`
+
+### Step 3: Run TLX Regression Test (requires Blackwell GPU)
+
+```bash
+buck2 test @fbcode//mode/opt \
+  -m ovr_config//triton:beta \
+  '//third-party/triton/beta/triton:py_tlx_blackwell_test' \
+  -- test_async_dot_blackwell_2cta_tma
+```
+
+Expected: `Tests finished: Pass 2. Fail 0.`
+
+### Step 4: Run Pure Triton E2E Test (requires Blackwell GPU)
+
+```bash
+buck2 test @fbcode//mode/opt \
+  -m ovr_config//triton:beta \
+  '//third-party/triton/beta/triton:py_tlx_blackwell_triton-addmm-2cta'
+```
+
+Expected: `Tests finished: Pass 11. Fail 0.` (non-WS 2CTA correctness + compilation, auto-WS 2CTA correctness + compilation, perf benchmark)
+
+### Step 5: Run Auto-WS + 2CTA Correctness Only (requires Blackwell GPU)
+
+```bash
+buck2 test @fbcode//mode/opt \
+  '//third-party/triton/beta/triton:py_tlx_blackwell_triton-addmm-2cta' \
+  -- test_matmul_2cta_ws_correctness
+```
+
+Expected: `Tests finished: Pass 4. Fail 0.` (128-128-128, 256-256-64, 128-256-128, 256-256-128)
+
+### Debugging Tips
+
+To see the TTGIR output at each pass stage:
+
+```bash
+TRITON_ALWAYS_COMPILE=1 MLIR_ENABLE_DUMP=1 python your_kernel.py 2>&1 | grep -A1000 "make_ttgir"
+```
+
+To run Transform2CTALoads in isolation on an MLIR file:
+
+```bash
+buck2 run @fbcode//mode/opt -m ovr_config//triton:beta \
+  //third-party/triton/beta/triton:triton-opt -- \
+  --nvgpu-2cta-transform-loads your_input.mlir
+```
+
+---
+
+## Known Limitations and Future Work
+
+1. **Single barrier for phase tracking**: Uses `phase = (iv - lb) % 2` with one
+   barrier. Works for pipeline depth <= 2; may need multi-buffered barriers for
+   deeper pipelines.
+
+2. **Multiple MMAs per loop iteration**: Shared single barrier; could cause phase
+   conflicts if they overlap. Future: allocate separate barriers per MMA.
+
+3. **TCGen5MMAScaledOp**: Only `TCGen5MMAOp` is handled; the scaled variant is
+   not yet supported.
+
+4. **B from function arguments**: `Transform2CTALoads` requires B's descriptor to
+   come from `MakeTensorDescOp` (not a function argument). This covers all real
+   kernels where `make_tensor_descriptor` is called in the kernel body.
+
+5. **Encoding compatibility**: When halving the N dimension, the blocked encoding
+   on the descriptor load result may need adjustment. The pass computes a
+   compatible encoding by reducing `threadsPerWarp` in the N dimension.
+
+6. **D96323995's `.cta_group::2` on TMA loads**: D96323995 added `.cta_group::2`
+   support for TMA loads, which routes barrier arrivals to the leader CTA in
+   hardware. A future optimization could use this on B-operand TMA loads,
+   potentially eliminating the explicit cross-CTA sync.
+
+---
+
+## Auto-WS + 2-CTA Integration
+
+### Overview
+
+When `tl.dot(two_ctas=True)` is combined with `warp_specialize=True` and
+`TRITON_USE_META_WS=1`, the auto-WS framework (Meta's `WSCodePartition` +
+`WSLowerMem`) handles the warp-specialized pipeline while the 2-CTA passes
+handle cross-CTA B-splitting and synchronization.
+
+### Pipeline Order (compiler.py)
+
+```
+AccelerateMatmul        ← sets two_ctas on TCGen5MMAOp
+Transform2CTALoads      ← splits B descriptor loads per CTA
+schedule_loops + WS     ← Meta WS partitioning (4 partitions: default/gemm/load/epilogue)
+pipeline                ← software pipelining of the K-loop
+hoist_tmem_alloc        ← hoists TMEM alloc before WarpSpecializeOp
+Insert2CTASync          ← cross-CTA sync (AFTER all WS passes to avoid interference)
+```
+
+`Insert2CTASync` runs after all WS-related passes to avoid scheduling/pipeline
+interference. The barrier ops won't be reordered or erased by subsequent WS passes.
+`getThreadId()` returns relative IDs inside `WarpSpecializeOp` partition regions,
+so `InitBarrierOp` and `ArriveBarrierOp` work correctly in the consumer warp group.
+
+### Bugs Fixed for Auto-WS + 2-CTA
+
+**1. Deadlock: Cluster barrier inside WS MMA loop (`MMAv5.cpp`)**
+
+The PTX lowering inserted `ClusterArriveOp` + `ClusterWaitOp` (cluster-wide
+`barrier.cluster.arrive/wait`) inside each MMA loop iteration for non-TLX
+`cta_group::2` kernels. In WS mode, only the consumer warp group executes this,
+but `barrier.cluster` requires ALL threads in the CTA → deadlock.
+
+Fix: Skip `ClusterArriveOp`/`ClusterWaitOp` when inside a `WarpSpecializeOp`
+(detected via `getParentOfType<WarpSpecializeOp>()`). The `cluster0` MMA predicate
+(`cluster_cta_id & 1 == 0`) is kept unconditional for all `twoCTAs` cases.
+
+**2. Correctness: `TCGen5CommitOp` wrong `cta_group` (`WSCodePartition.cpp`)**
+
+The WS framework's `TCGen5CommitOp` (gemm→epilogue completion barrier) was created
+without the `two_ctas` attribute, producing `tcgen05.commit.cta_group::1` in PTX.
+But the MMA uses `cta_group::2`. A `cta_group::1` commit does NOT wait for
+`cta_group::2` MMA operations, so the epilogue could read TMEM before the MMA
+finished writing.
+
+Fix: Propagate `two_ctas` from the MMA op when creating `TCGen5CommitOp`:
+```cpp
+bool twoCTAs = cast<ttng::TCGen5MMAOp>(mmaOp).getTwoCtas();
+builder.createWithAsyncTaskIds<ttng::TCGen5CommitOp>(
+    mmaOp->getLoc(), barrier, twoCTAs);
+```
+
+**3. Correctness: `TCGen5CommitOp` missing cluster0 predicate (`MMAv5.cpp`)**
+
+After fixing Bug 2, both CTAs issued the `cta_group::2.multicast::cluster`
+commit, causing the barrier to get double-arrived (2 arrives instead of 1),
+advancing the barrier phase too fast and desynchronizing the pipeline.
+
+Fix: Add `cluster0` predicate to `TCGen5CommitOpConversion` when `twoCTAs=true`:
+```cpp
+if (twoCTAs) {
+    Value clusterCTARank = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+    Value isLeader =
+        b.icmp_eq(b.and_(clusterCTARank, b.i32_val(1)), b.i32_val(0));
+    pred = b.and_(pred, isLeader);
+}
+```
+
+**4. TMEM `cta_group::2` for auto-WS (`NVGPUToLLVMPass.cpp`)**
+
+TMEM alloc/dealloc used `cta_group::1` for auto-WS 2CTA because `num-ctas=1`.
+Fix: Check `cluster-dim-x >= 2` in addition to `num-ctas`.
+
+**5. Exit cluster barrier for auto-WS (`ConvertWarpSpecializeToLLVM.cpp`)**
+
+The exit cluster barrier (before `return`) was only emitted for TLX kernels.
+Fix: Also emit for auto-WS kernels when `cluster-dim-x >= 2`.
+
+### Additional Files Changed for Auto-WS + 2-CTA
+
+| File | Change |
+|------|--------|
+| `MMAv5.cpp` | Skip cluster barrier for WS; cluster0 predicate on `TCGen5CommitOp` |
+| `WSCodePartition.cpp` | Propagate `two_ctas` to `TCGen5CommitOp` (2 locations) |
+| `ConvertWarpSpecializeToLLVM.cpp` | Exit cluster barrier for cluster-dim-x >= 2 |
+| `NVGPUToLLVMPass.cpp` | TMEM `cta_group::2` for cluster-dim-x >= 2 |
+| `compiler.py` | `Insert2CTASync` after all WS passes for Meta WS |
+| `WarpSpecialization.cpp` | Remove `doInsert2CTASync` call (handled by separate pass) |
+
+### Test Commands
+
+```bash
+# Auto-WS + 2CTA correctness (all 4 sizes)
+buck2 test @fbcode//mode/opt //third-party/triton/beta/triton:py_tlx_blackwell_triton-addmm-2cta -- test_matmul_2cta_ws_correctness
+
+# Non-WS 2CTA regression
+buck2 test @fbcode//mode/opt //third-party/triton/beta/triton:py_tlx_blackwell_triton-addmm-2cta -- test_matmul_2cta_correctness
+
+# TLX WS+2CTA regression
+buck2 test @fbcode//mode/opt //third-party/triton/beta/triton:py_tlx_blackwell_triton-addmm-2cta -- test_tlx_ws_2cta_correctness
+```

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -692,7 +692,8 @@ def TT_DotOp : TT_Op<"dot", [Pure,
       TT_FpIntTensor:$b,
       TT_FpIntTensor:$c,
       DefaultValuedAttr<TT_InputPrecisionAttr, "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
-      DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc
+      DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc,
+        UnitAttr:$two_ctas
     );
 
     let results = (outs TT_FpIntTensor:$d);

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -277,7 +277,7 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
 
     addNamedAttrs(rewriter.replaceOpWithNewOp<triton::DotOp>(
                       op, retType, a, b, c, adaptor.getInputPrecision(),
-                      adaptor.getMaxNumImpreciseAcc()),
+                      adaptor.getMaxNumImpreciseAcc(), op.getTwoCtas()),
                   adaptor.getAttributes());
     return success();
   }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -554,12 +554,20 @@ public:
       return failure();
     auto oldAType = dotOp.getA().getType();
     auto oldBType = dotOp.getB().getType();
-    // NYI: PTX 13+ requires all tcgen instructions in a kernel to have a
-    // consistent CTA mode, disabling 2CTA mode for now. To re-enable,
-    // change the line below to: bool useTwoCTAs = canUseTwoCTAs(dotOp);
-    bool useTwoCTAs = false;
-    if (useTwoCTAs) {
-      b = splitBOperand(b, rewriter);
+    bool useTwoCTAs;
+    if (dotOp.getTwoCtas()) {
+      // User-driven 2-CTA (ctas_per_cga): user already partitioned B.
+      // No splitBOperand needed — follows the TLX approach.
+      useTwoCTAs = true;
+    } else {
+      // NYI: PTX 13+ requires all tcgen instructions in a kernel to have a
+      // consistent CTA mode, disabling compiler-driven 2CTA mode for now.
+      // To re-enable, change the line below to:
+      //   useTwoCTAs = canUseTwoCTAs(dotOp);
+      useTwoCTAs = false;
+      if (useTwoCTAs) {
+        b = splitBOperand(b, rewriter);
+      }
     }
     // TF32 transpose is only supported with 128 swizzle mode with 32B
     // atomicity. As we currently don't support this layout we disallow

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1739,9 +1739,9 @@ void init_triton_ir(py::module &&m) {
       .def("create_dot",
            [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
               mlir::Value &c, InputPrecision inputPrecision,
-              int maxNumImpreciseAcc) -> mlir::Value {
+              int maxNumImpreciseAcc, bool twoCtas) -> mlir::Value {
              return self.create<DotOp>(c.getType(), a, b, c, inputPrecision,
-                                       maxNumImpreciseAcc);
+                                       maxNumImpreciseAcc, twoCtas);
            })
       .def("create_dot_scaled",
            [](TritonOpBuilder &self, mlir::Value &lhs,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2076,7 +2076,7 @@ def cast(input, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcas
 
 @builtin
 def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None, out_dtype=float32,
-        attrs=None, _semantic=None):
+        attrs=None, two_ctas=False, _semantic=None):
     """
     Returns the matrix product of two blocks.
 
@@ -2100,6 +2100,10 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
       specified (i.e. at least one must be :code:`None`).
     :param attrs: Optional dictionary of string-valued attributes to attach to the dot operation.
     :type attrs: dict, optional
+    :param two_ctas: If True, enables 2-CTA collective matmul on Blackwell (SM100+).
+      The user must partition the B operand across two CTAs and launch with
+      ``ctas_per_cga=(2, 1, 1)``. Generates ``tcgen05.mma.cta_group::2``.
+    :type two_ctas: bool
     """
     attrs = _unwrap_if_constexpr(attrs)
     out_dtype = _unwrap_if_constexpr(out_dtype)
@@ -2128,7 +2132,8 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
         if acc is not None:
             acc = _semantic.reshape(acc, [batch_size] + c_shape[-2:], can_reorder=False)
 
-    res = _semantic.dot(input, other, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype, attrs)
+    res = _semantic.dot(input, other, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype, attrs,
+                        two_ctas)
 
     if rank >= 4:
         res = _semantic.reshape(res, c_shape, can_reorder=False)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1748,9 +1748,15 @@ class TritonSemantic(Generic[TensorTy]):
         max_num_imprecise_acc: int,
         out_dtype: tl.dtype,
         attrs: Optional[dict] = None,
+        two_ctas: bool = False,
     ) -> tl.tensor:
+        # For standard tl.dot, don't use tlx_paired_ctas logic - the
+        # Transform2CTALoads pass will handle B splitting at the IR level.
+        # tlx_paired_ctas=True assumes B is already half-width (TLX approach),
+        # but pure Triton passes full-width B.
         (lhs, rhs, acc_handle, input_precision, max_num_imprecise_acc,
-         ret_ty) = self.dot_precheck(lhs, rhs, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype)
+         ret_ty) = self.dot_precheck(lhs, rhs, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype,
+                                     tlx_paired_ctas=False)
 
         result = tl.tensor(
             self.builder.create_dot(
@@ -1759,6 +1765,7 @@ class TritonSemantic(Generic[TensorTy]):
                 acc_handle,
                 input_precision,
                 max_num_imprecise_acc,
+                two_ctas,
             ),
             ret_ty,
         )

--- a/test/Hopper/TwoCTA/insert_2cta_sync.mlir
+++ b/test/Hopper/TwoCTA/insert_2cta_sync.mlir
@@ -1,0 +1,65 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-insert-2cta-sync | FileCheck %s
+
+// Test that the pass inserts cross-CTA sync before 2-CTA MMA ops.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+// CHECK-LABEL: @test_insert_2cta_sync_in_loop
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32} {
+  tt.func @test_insert_2cta_sync_in_loop(
+      %a: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %b: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      %acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %acc_tok: !ttg.async.token) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    // CHECK: ttg.local_alloc
+    // CHECK: ttng.init_barrier
+    // CHECK: scf.for
+    // CHECK:   nvg.cluster_id
+    // CHECK:   ttng.map_to_remote_buffer
+    // CHECK:   ttng.arrive_barrier
+    // CHECK:   ttng.wait_barrier
+    // CHECK:   ttng.tc_gen5_mma
+    scf.for %iv = %c0 to %c4 step %c1 {
+      %tok = ttng.tc_gen5_mma %a, %b, %acc[%acc_tok], %true, %true {two_ctas} :
+        !ttg.memdesc<128x64xf16, #shared, #smem>,
+        !ttg.memdesc<64x128xf16, #shared1, #smem>,
+        !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Test that the pass skips when no cluster (cluster_dim < 2).
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+// CHECK-LABEL: @test_no_sync_without_cluster
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32} {
+  tt.func @test_no_sync_without_cluster(
+      %a: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %b: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      %acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %acc_tok: !ttg.async.token) {
+    %true = arith.constant true
+    // CHECK-NOT: nvg.cluster_id
+    // CHECK-NOT: ttng.arrive_barrier
+    // CHECK: ttng.tc_gen5_mma
+    %tok = ttng.tc_gen5_mma %a, %b, %acc[%acc_tok], %true, %true {two_ctas} :
+      !ttg.memdesc<128x64xf16, #shared, #smem>,
+      !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/test/Hopper/TwoCTA/transform_2cta_loads.mlir
+++ b/test/Hopper/TwoCTA/transform_2cta_loads.mlir
@@ -1,0 +1,135 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-2cta-transform-loads | FileCheck %s
+
+// Test: Transform B descriptor loads for 2-CTA mode.
+// When TCGen5MMAOp has two_ctas=true, the pass should:
+// 1. Clone the MakeTensorDescOp with half-width block shape (64x64 instead of 64x128)
+// 2. Insert ClusterCTAIdOp + CTA-based offset computation
+// 3. Create new DescriptorLoadOp with half-width result
+
+// CHECK-LABEL: @matmul_2cta_transform_loads
+// Two make_tensor_descriptor ops: original A and cloned half-width B
+// CHECK: tt.make_tensor_descriptor %{{.*}} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x64xf16>>
+// CHECK: tt.make_tensor_descriptor %{{.*}} : !tt.ptr<f16>, !tt.tensordesc<tensor<64x64xf16>>
+// CTA offset computation inside the loop
+// CHECK: %[[CTA_ID:.*]] = nvg.cluster_id
+// CHECK: %[[C2:.*]] = arith.constant 2 : i32
+// CHECK: %[[MOD:.*]] = arith.remsi %[[CTA_ID]], %[[C2]]
+// CHECK: %[[HALF:.*]] = arith.constant 64 : i32
+// CHECK: %[[OFF:.*]] = arith.muli %[[MOD]], %[[HALF]]
+// CHECK: arith.addi %{{.*}}, %[[OFF]]
+// Half-width B load and alloc
+// CHECK: tt.descriptor_load %{{.*}} : !tt.tensordesc<tensor<64x64xf16>>
+// CHECK: ttg.local_alloc %{{.*}} : {{.*}} -> !ttg.memdesc<64x64xf16
+// MMA with two_ctas and half-width B
+// CHECK: ttng.tc_gen5_mma {{.*}} {two_ctas}
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_2cta_transform_loads(
+      %a_ptr: !tt.ptr<f16>,
+      %b_ptr: !tt.ptr<f16>,
+      %M: i32 {tt.divisibility = 16 : i32},
+      %N: i32 {tt.divisibility = 16 : i32},
+      %K: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %true = arith.constant true
+    %c128_i32 = arith.constant 128 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cN_i64 = arith.extsi %N : i32 to i64
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+
+    %pid = tt.get_program_id x : i32
+    %offs_am = arith.muli %pid, %c128_i32 : i32
+    %offs_bn = arith.muli %pid, %c128_i32 : i32
+
+    // A descriptor: 128x64 block
+    %a_desc = tt.make_tensor_descriptor %a_ptr, [%M, %K], [%cN_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<128x64xf16>>
+    // B descriptor: 64x128 block (pass should clone this with 64x64)
+    %b_desc = tt.make_tensor_descriptor %b_ptr, [%K, %N], [%cN_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<64x128xf16>>
+
+    %accumulator = scf.for %k = %c0_i32 to %c1_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x128xf32, #blocked>) : i32 {
+      %offs_k = arith.muli %k, %c64_i32 : i32
+
+      // A load (not modified)
+      %a = tt.descriptor_load %a_desc[%offs_am, %offs_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked1>
+      %a_smem = ttg.local_alloc %a : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+
+      // B load (should be transformed to half-width with CTA offset)
+      %b = tt.descriptor_load %b_desc[%offs_k, %offs_bn] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked1>
+      %b_smem = ttg.local_alloc %b : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+      %acc_layout = ttg.convert_layout %acc : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #blocked3>
+      %acc_tmem, %token = ttng.tmem_alloc %acc_layout : (tensor<128x128xf32, #blocked3>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+
+      // 2-CTA MMA: pass should transform B load above
+      %mma_token = ttng.tc_gen5_mma %a_smem, %b_smem, %acc_tmem[%token], %true, %true {two_ctas} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+      %result, %load_token = ttng.tmem_load %acc_tmem[%mma_token] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked3>
+      %result_layout = ttg.convert_layout %result : tensor<128x128xf32, #blocked3> -> tensor<128x128xf32, #blocked>
+
+      scf.yield %result_layout : tensor<128x128xf32, #blocked>
+    }
+
+    tt.return
+  }
+}
+
+// -----
+
+// Test: No two_ctas attribute - pass should not modify anything
+// CHECK-LABEL: @matmul_no_2cta
+// CHECK-NOT: nvg.cluster_id
+// CHECK: ttng.tc_gen5_mma
+// CHECK-NOT: two_ctas
+
+#blocked_b = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1_b = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2_b = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3_b = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem_b = #ttg.shared_memory
+#tmem_b = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_no_2cta(
+      %a_ptr: !tt.ptr<f16>,
+      %b_ptr: !tt.ptr<f16>,
+      %M: i32, %N: i32, %K: i32) attributes {noinline = false} {
+    %true = arith.constant true
+    %c128_i32 = arith.constant 128 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cN_i64 = arith.extsi %N : i32 to i64
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_b>
+
+    %pid = tt.get_program_id x : i32
+    %offs = arith.muli %pid, %c128_i32 : i32
+
+    %a_desc = tt.make_tensor_descriptor %a_ptr, [%M, %K], [%cN_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<128x64xf16>>
+    %b_desc = tt.make_tensor_descriptor %b_ptr, [%K, %N], [%cN_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<64x128xf16>>
+
+    %a = tt.descriptor_load %a_desc[%offs, %c0_i32] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked1_b>
+    %a_smem = ttg.local_alloc %a : (tensor<128x64xf16, #blocked1_b>) -> !ttg.memdesc<128x64xf16, #shared_b, #smem_b>
+
+    %b = tt.descriptor_load %b_desc[%c0_i32, %offs] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked2_b>
+    %b_smem = ttg.local_alloc %b : (tensor<64x128xf16, #blocked2_b>) -> !ttg.memdesc<64x128xf16, #shared_b, #smem_b>
+
+    %acc_layout = ttg.convert_layout %cst : tensor<128x128xf32, #blocked_b> -> tensor<128x128xf32, #blocked3_b>
+    %acc_tmem, %token = ttng.tmem_alloc %acc_layout : (tensor<128x128xf32, #blocked3_b>) -> (!ttg.memdesc<128x128xf32, #tmem_b, #ttng.tensor_memory, mutable>, !ttg.async.token)
+
+    // No two_ctas - pass should not modify
+    %mma_token = ttng.tc_gen5_mma %a_smem, %b_smem, %acc_tmem[%token], %true, %true : !ttg.memdesc<128x64xf16, #shared_b, #smem_b>, !ttg.memdesc<64x128xf16, #shared_b, #smem_b>, !ttg.memdesc<128x128xf32, #tmem_b, #ttng.tensor_memory, mutable>
+
+    %result, %load_token = ttng.tmem_load %acc_tmem[%mma_token] : !ttg.memdesc<128x128xf32, #tmem_b, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked3_b>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -368,6 +368,11 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_accelerate_matmul(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         passes.ttgpuir.add_optimize_dot_operands(pm, capability >= 80)
+        # 2-CTA: Split B descriptor loads before optimize_descriptor_encoding
+        # so the cloned half-width descriptor gets its encoding set properly.
+        if (capability // 10 >= 10 and opt.cluster_dims is not None and max(opt.cluster_dims) >= 2
+                and opt.ctas_per_cga is not None):
+            nvidia.passes.hopper.add_2cta_transform_loads(pm)
         nvidia.passes.ttnvgpuir.add_optimize_descriptor_encoding(pm)
         passes.ttir.add_loop_aware_cse(pm)
         use_meta_swp_schedule = knobs.nvidia.use_meta_ws and not knobs.nvidia.force_trunk_swp_schedule
@@ -437,6 +442,15 @@ class CUDABackend(BaseBackend):
             # hoist again and allow hoisting out of if statements
             passes.ttgpuir.add_hoist_tmem_alloc(pm, True)
             nvidia.passes.ttnvgpuir.add_remove_tmem_tokens(pm)
+            # 2-CTA support for Meta WS: Insert cross-CTA sync AFTER all
+            # WS-related passes (pipeline, optimize_partition_warps, etc.).
+            # This avoids scheduling/pipeline interference — the barrier ops
+            # won't be reordered or erased by any subsequent WS pass.
+            # getThreadId() returns relative IDs inside WarpSpecializeOp
+            # partition regions, so InitBarrierOp and ArriveBarrierOp work
+            # correctly in the consumer warp group.
+            if (opt.cluster_dims is not None and max(opt.cluster_dims) >= 2 and knobs.nvidia.use_meta_ws):
+                nvidia.passes.hopper.add_insert_2cta_sync(pm)
         else:
             passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -306,4 +306,55 @@ def NVGPUMultiCTAReduction : Pass<"nvgpu-multi-cta-reduction", "mlir::ModuleOp">
                            "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
 }
 
+
+def NVGPUInsert2CTASync : Pass<"nvgpu-insert-2cta-sync", "mlir::ModuleOp"> {
+  let summary = "Insert cross-CTA synchronization for 2-CTA MMA operations";
+
+  let description = [{
+    This pass inserts cross-CTA synchronization barriers for TCGen5MMAOp
+    operations that use 2-CTA mode (tcgen05.mma.cta_group::2).
+
+    It implements the "arrive remote, wait local" pattern:
+    - Both CTAs arrive on the leader CTA's barrier
+    - Only the leader CTA (even-ranked) waits
+    - Then both CTAs issue the 2-CTA MMA instruction
+
+    This pattern is compatible with warp specialization because the sync
+    ops are inserted after the pipeline pass, and the MMA hardware handles
+    the actual cross-CTA execution synchronization.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::triton::nvgpu::NVGPUDialect"
+  ];
+}
+
+def NVGPU2CTATransformLoads : Pass<"nvgpu-2cta-transform-loads", "mlir::ModuleOp"> {
+  let summary = "Transform B matrix loads for 2-CTA MMA operations";
+
+  let description = [{
+    This pass transforms B matrix descriptor loads for 2-CTA mode. When a
+    TCGen5MMAOp has two_ctas=true (and is not async/TLX-managed), each CTA
+    should load only half of B (BLOCK_N/2 columns). This pass:
+
+    1. Traces the B operand from the MMA back to its DescriptorLoadOp
+    2. Clones the MakeTensorDescOp with half-width block shape
+    3. Inserts ClusterCTAIdOp to compute per-CTA offset
+    4. Creates a new DescriptorLoadOp loading BLOCK_K x BLOCK_N/2
+    5. Updates the LocalAllocOp and MemDesc shapes to match
+
+    This pass is required for the ctas_per_cga=(2,1,1) approach where
+    num_ctas=1 (bypasses PlanCTA). It must run after accelerate_matmul
+    and before insert_2cta_sync.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::triton::nvgpu::NVGPUDialect"
+  ];
+}
+
 #endif // NV_TRANSFORMS_PASSES

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -29,6 +29,8 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloBufferAllocPass.cpp
   ModuloScheduling/ModuloExpandPass.cpp
   ModuloScheduling/ModuloLowerPass.cpp
+  Insert2CTASync.cpp
+  Transform2CTALoads.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
@@ -1,0 +1,380 @@
+// Insert cross-CTA synchronization for 2-CTA MMA operations.
+//
+// This pass implements the "arrive remote, wait local" pattern for 2-CTA
+// TCGen5 MMA operations. When two CTAs cooperatively execute an MMA instruction
+// (tcgen05.mma.cta_group::2), each CTA loads half of the B operand. Before
+// issuing the MMA, the leader CTA (even-ranked) must know that both CTAs have
+// finished loading their B halves.
+//
+// The pattern:
+//   1. Both CTAs arrive on the leader CTA's cross-CTA barrier
+//   2. Only the leader CTA waits on the barrier
+//   3. Both CTAs issue the 2-CTA MMA (hardware synchronizes execution)
+//
+// Pipeline placement: This pass runs BEFORE the WS pipeline so that
+// WSTaskIdPropagate naturally assigns async_task_id attributes to the
+// cross-CTA sync ops, and WSCodePartition correctly partitions them
+// into the consumer warp group.
+//
+// Reference: fbcode/generative_recommenders/ops/triton/triton_addmm.py
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+namespace nvgpu = triton::nvgpu;
+
+#define DEBUG_TYPE "nvgpu-insert-2cta-sync"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir {
+#define GEN_PASS_DEF_NVGPUINSERT2CTASYNC
+#include "nvidia/hopper/include/Transforms/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+// Insert the "arrive remote, wait local" cross-CTA sync ops before a 2-CTA
+// MMA. The barrier must be allocated externally (before the containing loop
+// if the MMA is in a loop).
+static void insertSyncBeforeMMA(ttng::TCGen5MMAOp mma, Value barrierAlloc) {
+  MLIRContext *ctx = mma.getContext();
+  Location loc = mma.getLoc();
+  OpBuilder builder(mma);
+  auto i32Ty = builder.getI32Type();
+
+  // Get barrier view (index 0 of the single-buffered allocation).
+  Value barrierView = triton::createSingleBufferView(builder, barrierAlloc, 0);
+
+  // Get CTA rank within the cluster.
+  Value ctaRank = builder.create<nvgpu::ClusterCTAIdOp>(loc, i32Ty);
+
+  // Compute leader CTA rank: leader = ctaRank & ~1 (even-ranked CTA in the
+  // pair). For a cluster with dims [2,1,1], CTA 0 is leader for CTAs {0,1}.
+  Value negTwo = builder.create<arith::ConstantIntOp>(loc, -2, 32);
+  Value leaderRank = builder.create<arith::AndIOp>(loc, ctaRank, negTwo);
+
+  // Map barrier to leader CTA's shared memory via mapa instruction.
+  // The result type uses SharedClusterMemorySpace to indicate it refers
+  // to another CTA's shared memory.
+  auto barrierDescType = cast<ttg::MemDescType>(barrierView.getType());
+  auto remoteBarType = ttg::MemDescType::get(
+      barrierDescType.getShape(), barrierDescType.getElementType(),
+      barrierDescType.getEncoding(),
+      ttng::SharedClusterMemorySpaceAttr::get(ctx),
+      barrierDescType.getMutableMemory(), barrierDescType.getAllocShape());
+  Value remoteBar = builder.create<ttng::MapToRemoteBufferOp>(
+      loc, remoteBarType, barrierView, leaderRank);
+
+  // Both CTAs arrive on leader's barrier (count=1 each, total=2).
+  builder.create<ttng::ArriveBarrierOp>(loc, remoteBar, /*count=*/1u);
+
+  // Compute phase from loop induction variable.
+  // WaitBarrierOp expects I32 for the phase parameter.
+  Value phase;
+  if (auto forOp = mma->getParentOfType<scf::ForOp>()) {
+    // Compute iteration index: (iv - lb) / step, then phase = iter % 2.
+    // Division by step ensures correct alternation for non-unit steps.
+    Value iv = forOp.getInductionVar();
+    Value lb = forOp.getLowerBound();
+    Value offset = builder.create<arith::SubIOp>(loc, iv, lb);
+    Value step = forOp.getStep();
+    Value iterIdx = builder.create<arith::DivUIOp>(loc, offset, step);
+
+    if (iv.getType().isIndex()) {
+      Value twoIV = builder.create<arith::ConstantIndexOp>(loc, 2);
+      Value rem = builder.create<arith::RemUIOp>(loc, iterIdx, twoIV);
+      phase = builder.create<arith::IndexCastOp>(loc, i32Ty, rem);
+    } else {
+      Value twoIV = builder.create<arith::ConstantIntOp>(
+          loc, 2, cast<IntegerType>(iv.getType()).getWidth());
+      phase = builder.create<arith::RemUIOp>(loc, iterIdx, twoIV);
+    }
+  } else {
+    phase = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+  }
+
+  // Only leader CTA waits: pred = (ctaRank % 2 == 0).
+  Value two = builder.create<arith::ConstantIntOp>(loc, 2, 32);
+  Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+  Value ctaMod2 = builder.create<arith::RemUIOp>(loc, ctaRank, two);
+  Value isLeader = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                 ctaMod2, zero);
+
+  // Leader waits on LOCAL barrier (not the remote-mapped one).
+  // PTX mbarrier.try_wait only supports .shared (local), not .shared::cluster.
+  // The local barrier IS the leader's barrier — both CTAs arrived on it via
+  // the remote mapping, so the leader can wait on it locally.
+  builder.create<ttng::WaitBarrierOp>(loc, barrierView, phase, isLeader);
+
+  LDBG("Inserted cross-CTA sync before MMA at " << loc);
+}
+
+struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+
+    // Check if any cluster dimension >= 2 (needed for 2-CTA).
+    bool hasCluster = false;
+    for (auto attr :
+         {"ttg.cluster-dim-x", "ttg.cluster-dim-y", "ttg.cluster-dim-z"}) {
+      if (auto intAttr = moduleOp->getAttrOfType<IntegerAttr>(attr)) {
+        if (intAttr.getInt() >= 2)
+          hasCluster = true;
+      }
+    }
+    if (!hasCluster)
+      return;
+
+    // Skip TLX kernels — they manage their own cross-CTA sync via
+    // explicit barrier ops in the kernel.
+    if (moduleOp->hasAttr("tlx.has_tlx_ops"))
+      return;
+
+    // Collect 2-CTA MMA ops that need cross-CTA sync insertion.
+    SmallVector<ttng::TCGen5MMAOp> twoCTAMMAOps;
+    moduleOp->walk([&](ttng::TCGen5MMAOp mma) {
+      if (mma.getTwoCtas())
+        twoCTAMMAOps.push_back(mma);
+    });
+
+    if (twoCTAMMAOps.empty())
+      return;
+
+    LDBG("Found " << twoCTAMMAOps.size() << " 2-CTA MMA ops");
+
+    // Group MMAs by their containing scf.for loop. Allocate one cross-CTA
+    // barrier per loop, shared by all MMAs in that loop.
+    DenseMap<Operation *, SmallVector<ttng::TCGen5MMAOp>> loopToMMAs;
+    SmallVector<ttng::TCGen5MMAOp> nonLoopMMAs;
+
+    for (auto mma : twoCTAMMAOps) {
+      auto forOp = mma->getParentOfType<scf::ForOp>();
+      if (forOp)
+        loopToMMAs[forOp.getOperation()].push_back(mma);
+      else
+        nonLoopMMAs.push_back(mma);
+    }
+
+    // Helper: check if an op is inside the default region of a
+    // WarpSpecializeOp (as opposed to a partition region).
+    auto isInDefaultRegion = [](Operation *op,
+                                ttg::WarpSpecializeOp wsOp) -> bool {
+      Region *defaultRegion = &wsOp.getDefaultRegion();
+      return defaultRegion->isAncestor(op->getParentRegion());
+    };
+
+    // Process MMAs inside loops.
+    for (auto &[loopOp, mmas] : loopToMMAs) {
+      auto forOp = cast<scf::ForOp>(loopOp);
+
+      // Currently only a single 2-CTA MMA per loop is supported. Multiple
+      // MMAs would require separate barriers (one per MMA) to avoid phase
+      // conflicts on the shared barrier.
+      assert(mmas.size() == 1 &&
+             "Multiple 2-CTA MMAs in the same loop not yet supported. "
+             "Each MMA needs its own cross-CTA barrier to avoid phase "
+             "deadlock.");
+
+      // Allocate cross-CTA barrier. In the post-WS path (Meta WS),
+      // the loop is nested inside a WarpSpecializeOp. The barrier
+      // alloc+init must be placed BEFORE the WarpSpecializeOp (so thread 0
+      // from the producer warp group initializes it).
+      Value barrierAlloc;
+      auto wsOp = forOp->getParentOfType<ttg::WarpSpecializeOp>();
+      if (!wsOp) {
+        // Pre-WS path: standard alloc before the for loop.
+        barrierAlloc = triton::createBarrierAlloc(forOp, /*numBarriers=*/1,
+                                                  /*arriveCount=*/2);
+      } else if (isInDefaultRegion(mmas[0], wsOp)) {
+        // Post-WS path, MMA in default region: The default region can
+        // implicitly capture values defined before the WarpSpecializeOp,
+        // so no explicit capture is needed. Just allocate+init before wsOp
+        // and inval+dealloc after.
+        Location loc = wsOp->getLoc();
+        ImplicitLocOpBuilder rewriter(loc, wsOp);
+        barrierAlloc =
+            triton::createScalarAlloc(rewriter, rewriter.getI64Type(), 1);
+        Value initView =
+            triton::createSingleBufferView(rewriter, barrierAlloc, 0);
+        rewriter.create<ttng::InitBarrierOp>(initView, /*arriveCount=*/2);
+
+        // Inval and dealloc AFTER the WarpSpecializeOp.
+        rewriter.setInsertionPointAfter(wsOp);
+        Value invalView =
+            triton::createSingleBufferView(rewriter, barrierAlloc, 0);
+        rewriter.create<ttng::InvalBarrierOp>(invalView);
+        rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
+      } else {
+        // Post-WS path, MMA in a partition region (IsolatedFromAbove):
+        // Must capture the barrier explicitly into the partition.
+        Location loc = wsOp->getLoc();
+        ImplicitLocOpBuilder rewriter(loc, wsOp);
+        barrierAlloc =
+            triton::createScalarAlloc(rewriter, rewriter.getI64Type(), 1);
+        Value initView =
+            triton::createSingleBufferView(rewriter, barrierAlloc, 0);
+        rewriter.create<ttng::InitBarrierOp>(initView, /*arriveCount=*/2);
+
+        // Inval and dealloc AFTER the WarpSpecializeOp.
+        rewriter.setInsertionPointAfter(wsOp);
+        Value invalView =
+            triton::createSingleBufferView(rewriter, barrierAlloc, 0);
+        rewriter.create<ttng::InvalBarrierOp>(invalView);
+        rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
+
+        // Capture barrier into WarpSpecializeOp partition regions.
+        wsOp->insertOperands(wsOp->getNumOperands(), barrierAlloc);
+        Value capturedBarrier;
+        for (Region *region : wsOp.getPartitionRegions()) {
+          BlockArgument arg = region->addArgument(barrierAlloc.getType(), loc);
+          if (region->isAncestor(mmas[0]->getParentRegion()))
+            capturedBarrier = arg;
+        }
+        assert(capturedBarrier && "MMA not found in any partition region");
+        barrierAlloc = capturedBarrier;
+      }
+
+      insertSyncBeforeMMA(mmas[0], barrierAlloc);
+    }
+
+    // Process standalone MMAs (rare: single-iteration epilogue).
+    for (auto mma : nonLoopMMAs) {
+      Value barrierAlloc =
+          triton::createBarrierAlloc(mma, /*numBarriers=*/1, /*arriveCount=*/2);
+      insertSyncBeforeMMA(mma, barrierAlloc);
+    }
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir {
+
+// Public entry point for calling Insert2CTASync logic from other passes
+// (e.g., from NVGPUWarpSpecialization after code partitioning).
+void doInsert2CTASync(triton::FuncOp funcOp) {
+  ModuleOp moduleOp = funcOp->getParentOfType<ModuleOp>();
+  if (!moduleOp)
+    return;
+
+  // Check if any cluster dimension >= 2 (needed for 2-CTA).
+  bool hasCluster = false;
+  for (auto attr :
+       {"ttg.cluster-dim-x", "ttg.cluster-dim-y", "ttg.cluster-dim-z"}) {
+    if (auto intAttr = moduleOp->getAttrOfType<IntegerAttr>(attr)) {
+      if (intAttr.getInt() >= 2)
+        hasCluster = true;
+    }
+  }
+  if (!hasCluster)
+    return;
+
+  // Skip TLX kernels.
+  if (moduleOp->hasAttr("tlx.has_tlx_ops"))
+    return;
+
+  // Collect 2-CTA MMA ops.
+  SmallVector<ttng::TCGen5MMAOp> twoCTAMMAOps;
+  funcOp->walk([&](ttng::TCGen5MMAOp mma) {
+    if (mma.getTwoCtas())
+      twoCTAMMAOps.push_back(mma);
+  });
+  if (twoCTAMMAOps.empty())
+    return;
+
+  LDBG("doInsert2CTASync: Found " << twoCTAMMAOps.size() << " 2-CTA MMA ops");
+
+  // Group MMAs by their containing scf.for loop.
+  DenseMap<Operation *, SmallVector<ttng::TCGen5MMAOp>> loopToMMAs;
+  SmallVector<ttng::TCGen5MMAOp> nonLoopMMAs;
+  for (auto mma : twoCTAMMAOps) {
+    auto forOp = mma->getParentOfType<scf::ForOp>();
+    if (forOp)
+      loopToMMAs[forOp.getOperation()].push_back(mma);
+    else
+      nonLoopMMAs.push_back(mma);
+  }
+
+  // Helper: allocate barrier outside WarpSpecializeOp (if present).
+  //
+  // Root cause for needing this: InitBarrierOp lowers to PTX predicated on
+  // threadIdx.x == 0. In WS, thread 0 belongs to the PRODUCER warp group.
+  // If the barrier init is inside the CONSUMER partition region, no consumer
+  // thread has threadIdx.x == 0, so the barrier is never initialized →
+  // deadlock. Placing alloc+init BEFORE the WarpSpecializeOp ensures
+  // thread 0 (producer) initializes it.
+  //
+  // If the MMA is in the default region (not a partition region), the default
+  // region can implicitly capture values, so no explicit capture is needed.
+  // If the MMA is in a partition region (IsolatedFromAbove), the barrier must
+  // be passed as an explicit capture.
+  auto allocBarrierForMMA = [&](Operation *anchorOp,
+                                ttng::TCGen5MMAOp mma) -> Value {
+    auto wsOp = anchorOp->getParentOfType<ttg::WarpSpecializeOp>();
+    if (!wsOp) {
+      // Pre-WS path: standard alloc before the anchor op.
+      return triton::createBarrierAlloc(anchorOp, /*numBarriers=*/1,
+                                        /*arriveCount=*/2);
+    }
+
+    // Post-WS path: allocate and init BEFORE the WarpSpecializeOp.
+    Location loc = wsOp->getLoc();
+    ImplicitLocOpBuilder rewriter(loc, wsOp);
+    Value barrierAlloc =
+        triton::createScalarAlloc(rewriter, rewriter.getI64Type(), 1);
+    Value initView = triton::createSingleBufferView(rewriter, barrierAlloc, 0);
+    rewriter.create<ttng::InitBarrierOp>(initView, /*arriveCount=*/2);
+
+    // Inval and dealloc AFTER the WarpSpecializeOp.
+    rewriter.setInsertionPointAfter(wsOp);
+    Value invalView = triton::createSingleBufferView(rewriter, barrierAlloc, 0);
+    rewriter.create<ttng::InvalBarrierOp>(invalView);
+    rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
+
+    // Check if MMA is in the default region (can implicitly capture).
+    Region *defaultRegion = &wsOp.getDefaultRegion();
+    if (defaultRegion->isAncestor(mma->getParentRegion()))
+      return barrierAlloc;
+
+    // MMA is in a partition region (IsolatedFromAbove): add explicit capture.
+    wsOp->insertOperands(wsOp->getNumOperands(), barrierAlloc);
+    Value capturedBarrier;
+    for (Region *region : wsOp.getPartitionRegions()) {
+      BlockArgument arg = region->addArgument(barrierAlloc.getType(), loc);
+      if (region->isAncestor(mma->getParentRegion()))
+        capturedBarrier = arg;
+    }
+    assert(capturedBarrier && "MMA not found in any partition region");
+    return capturedBarrier;
+  };
+
+  for (auto &[loopOp, mmas] : loopToMMAs) {
+    auto forOp = cast<scf::ForOp>(loopOp);
+    assert(mmas.size() == 1 &&
+           "Multiple 2-CTA MMAs in the same loop not yet supported.");
+    Value barrierAlloc = allocBarrierForMMA(forOp, mmas[0]);
+    insertSyncBeforeMMA(mmas[0], barrierAlloc);
+  }
+
+  for (auto mma : nonLoopMMAs) {
+    Value barrierAlloc = allocBarrierForMMA(mma, mma);
+    insertSyncBeforeMMA(mma, barrierAlloc);
+  }
+}
+
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
@@ -1,0 +1,238 @@
+// Transform B matrix descriptor loads for 2-CTA MMA operations.
+//
+// When TCGen5MMAOp has two_ctas=true and is not async (i.e., pure Triton,
+// not TLX), this pass splits B loads so each CTA loads half of B:
+//   CTA 0 loads B[:, 0 : BLOCK_N/2]
+//   CTA 1 loads B[:, BLOCK_N/2 : BLOCK_N]
+//
+// The pass:
+//   1. Traces B operand from MMA back to its DescriptorLoadOp
+//   2. Clones the MakeTensorDescOp with half-width block shape
+//   3. Adds CTA-based offset to the load's N-dimension index
+//   4. Creates a new DescriptorLoadOp with half-width result
+//   5. Creates a new LocalAllocOp with half-width SMEM allocation
+//
+// This pass is needed for the ctas_per_cga=(2,1,1) approach where num_ctas=1,
+// because splitBOperand (used by PlanCTA path) requires CTASplitNum=[2,1]
+// which doesn't exist with num_ctas=1.
+//
+// Must run after AccelerateMatmul (which creates TCGen5MMAOp) and before
+// Insert2CTASync (which adds cross-CTA barriers).
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+namespace nvgpu = triton::nvgpu;
+
+#define DEBUG_TYPE "nvgpu-2cta-transform-loads"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir {
+#define GEN_PASS_DEF_NVGPU2CTATRANSFORMLOADS
+#include "nvidia/hopper/include/Transforms/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+// Create a BlockedEncodingAttr compatible with the given shape.
+// If the original encoding's tile size exceeds the new shape in the N
+// dimension, adjust threadsPerWarp to fit.
+static ttg::BlockedEncodingAttr
+getCompatibleEncoding(ttg::BlockedEncodingAttr origEncoding, int64_t M,
+                      int64_t N, MLIRContext *ctx) {
+  auto spt = SmallVector<unsigned>(origEncoding.getSizePerThread());
+  auto tpw = SmallVector<unsigned>(origEncoding.getThreadsPerWarp());
+  auto wpc = SmallVector<unsigned>(origEncoding.getWarpsPerCTA());
+  auto order = SmallVector<unsigned>(origEncoding.getOrder());
+  auto ctaLayout = origEncoding.getCGALayout();
+
+  unsigned tileN = spt[1] * tpw[1] * wpc[1];
+  if (M % (spt[0] * tpw[0] * wpc[0]) == 0 && N % tileN == 0)
+    return origEncoding;
+
+  // Reduce N-tile by halving threadsPerWarp[1] and doubling
+  // threadsPerWarp[0] to keep total threads = 32.
+  while (spt[1] * tpw[1] * wpc[1] > static_cast<unsigned>(N) && tpw[1] > 1) {
+    tpw[1] /= 2;
+    tpw[0] *= 2;
+  }
+  // If still too large, reduce sizePerThread[1].
+  while (spt[1] * tpw[1] * wpc[1] > static_cast<unsigned>(N) && spt[1] > 1) {
+    spt[1] /= 2;
+  }
+
+  return ttg::BlockedEncodingAttr::get(ctx, spt, tpw, wpc, order, ctaLayout);
+}
+
+// Trace B operand from MMA back through LocalAllocOp and ConvertLayoutOps
+// to find the DescriptorLoadOp.
+static tt::DescriptorLoadOp
+traceToDescriptorLoad(Value bMemDesc, ttg::LocalAllocOp &outLocalAlloc) {
+  auto localAlloc = bMemDesc.getDefiningOp<ttg::LocalAllocOp>();
+  if (!localAlloc)
+    return nullptr;
+  outLocalAlloc = localAlloc;
+
+  Value tensor = localAlloc.getSrc();
+  // Skip convert_layout ops.
+  while (auto cvt = tensor.getDefiningOp<ttg::ConvertLayoutOp>())
+    tensor = cvt.getSrc();
+
+  return tensor.getDefiningOp<tt::DescriptorLoadOp>();
+}
+
+struct Transform2CTALoads
+    : public impl::NVGPU2CTATransformLoadsBase<Transform2CTALoads> {
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+
+    // Check if any cluster dimension >= 2.
+    bool hasCluster = false;
+    for (auto attr :
+         {"ttg.cluster-dim-x", "ttg.cluster-dim-y", "ttg.cluster-dim-z"}) {
+      if (auto intAttr = moduleOp->getAttrOfType<IntegerAttr>(attr)) {
+        if (intAttr.getInt() >= 2)
+          hasCluster = true;
+      }
+    }
+    if (!hasCluster)
+      return;
+
+    // Collect 2-CTA MMA ops (skip async/TLX-managed).
+    SmallVector<ttng::TCGen5MMAOp> twoCTAMMAOps;
+    moduleOp->walk([&](ttng::TCGen5MMAOp mma) {
+      if (mma.getTwoCtas() && !mma.getIsAsync())
+        twoCTAMMAOps.push_back(mma);
+    });
+
+    if (twoCTAMMAOps.empty())
+      return;
+
+    LDBG("Found " << twoCTAMMAOps.size() << " 2-CTA MMA ops to transform");
+
+    for (auto mma : twoCTAMMAOps) {
+      if (failed(transformBLoad(mma)))
+        LDBG("Skipped MMA at " << mma.getLoc()
+                               << " (B not from descriptor load)");
+    }
+  }
+
+  LogicalResult transformBLoad(ttng::TCGen5MMAOp mma) {
+    // Trace B operand back to DescriptorLoadOp.
+    ttg::LocalAllocOp localAlloc;
+    auto descLoad = traceToDescriptorLoad(mma.getB(), localAlloc);
+    if (!descLoad)
+      return failure();
+
+    // Find the MakeTensorDescOp that created the descriptor.
+    auto makeDesc = descLoad.getDesc().getDefiningOp<tt::MakeTensorDescOp>();
+    if (!makeDesc) {
+      LDBG("B descriptor is not from MakeTensorDescOp, skipping");
+      return failure();
+    }
+
+    // Get block shape from descriptor type.
+    auto descType = cast<tt::TensorDescType>(makeDesc.getType());
+    auto blockShape = descType.getBlockType().getShape();
+    assert(blockShape.size() == 2 && "Expected 2D block shape");
+    int64_t blockK = blockShape[0];
+    int64_t blockN = blockShape[1];
+    assert(blockN % 2 == 0 && "BLOCK_N must be even for 2-CTA B splitting");
+    int64_t halfN = blockN / 2;
+
+    if (halfN < 16) {
+      LDBG("halfN=" << halfN << " too small, skipping");
+      return failure();
+    }
+
+    MLIRContext *ctx = mma.getContext();
+    auto elemType = descType.getBlockType().getElementType();
+
+    // --- Step 1: Clone MakeTensorDescOp with half-width block shape ---
+    OpBuilder builder(makeDesc);
+    IRMapping mapper;
+    auto *clonedOp = builder.clone(*makeDesc.getOperation(), mapper);
+    auto newMakeDesc = cast<tt::MakeTensorDescOp>(clonedOp);
+
+    // Change result type to half-width descriptor.
+    auto halfBlockType = RankedTensorType::get({blockK, halfN}, elemType);
+    auto newDescType = tt::TensorDescType::get(ctx, halfBlockType);
+    newMakeDesc.getResult().setType(newDescType);
+
+    LDBG("Created half-width descriptor: " << blockK << "x" << halfN);
+
+    // --- Step 2: Compute CTA-based offset ---
+    builder.setInsertionPoint(descLoad);
+    Location loc = descLoad.getLoc();
+    auto i32Ty = builder.getI32Type();
+
+    Value ctaRank = builder.create<nvgpu::ClusterCTAIdOp>(loc, i32Ty);
+    Value two = builder.create<arith::ConstantIntOp>(loc, 2, 32);
+    Value ctaMod2 = builder.create<arith::RemSIOp>(loc, ctaRank, two);
+    Value halfNVal = builder.create<arith::ConstantIntOp>(loc, halfN, 32);
+    Value offset = builder.create<arith::MulIOp>(loc, ctaMod2, halfNVal);
+
+    // New N-dimension index = original + CTA offset.
+    SmallVector<Value> newIndices(descLoad.getIndices());
+    newIndices.back() =
+        builder.create<arith::AddIOp>(loc, newIndices.back(), offset);
+
+    // --- Step 3: Create new DescriptorLoadOp with half-width result ---
+    auto origResultType =
+        cast<RankedTensorType>(descLoad.getResult().getType());
+    auto origEncoding =
+        cast<ttg::BlockedEncodingAttr>(origResultType.getEncoding());
+    auto newEncoding = getCompatibleEncoding(origEncoding, blockK, halfN, ctx);
+    auto halfResultType =
+        RankedTensorType::get({blockK, halfN}, elemType, newEncoding);
+
+    auto newDescLoad = builder.create<tt::DescriptorLoadOp>(
+        loc, halfResultType, newMakeDesc.getResult(), newIndices);
+    // Mark as a 2-CTA B-operand load so WS passes can identify it
+    // without complex value tracing through pipeline buffers.
+    newDescLoad->setAttr("two_cta_b", builder.getUnitAttr());
+
+    LDBG("Created half-width load: " << blockK << "x" << halfN);
+
+    // --- Step 4: Create new LocalAllocOp with half-width SMEM ---
+    auto origMemDescType = cast<ttg::MemDescType>(localAlloc.getType());
+    auto newMemDescType = ttg::MemDescType::get(
+        {blockK, halfN}, elemType, origMemDescType.getEncoding(),
+        origMemDescType.getMemorySpace(), origMemDescType.getMutableMemory());
+
+    builder.setInsertionPoint(localAlloc);
+    auto newLocalAlloc = builder.create<ttg::LocalAllocOp>(
+        localAlloc.getLoc(), newMemDescType, newDescLoad.getResult());
+
+    // --- Step 5: Replace uses and clean up ---
+    localAlloc.getResult().replaceAllUsesWith(newLocalAlloc.getResult());
+    localAlloc.erase();
+
+    // Clean up old descriptor_load if no other users.
+    if (descLoad.getResult().use_empty())
+      descLoad.erase();
+
+    // Clean up old MakeTensorDescOp if no other users.
+    if (makeDesc.getResult().use_empty())
+      makeDesc.erase();
+
+    LDBG("Transformed B load for 2-CTA MMA at " << mma.getLoc());
+    return success();
+  }
+};
+
+} // namespace

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -44,6 +44,7 @@ void removeRedundantTmemZeroStores(triton::FuncOp &funcOp);
 void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
 void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
+void doInsert2CTASync(triton::FuncOp funcOp);
 void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
                     int capability, int defaultNumStages);
 void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -752,7 +752,8 @@ getTaskTopRegion(triton::FuncOp funcOp,
 
 // Create an allocation to hold the mbarriers.
 static Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance,
-                                StringRef srcName = "") {
+                                StringRef srcName = "",
+                                unsigned arriveCount = 1) {
   OpBuilder builder(funcOp);
   builder.setInsertionPointToStart(&(funcOp.getBody().front()));
   Attribute sharedMemorySpace =
@@ -778,7 +779,8 @@ static Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance,
     Value idx = arith::ConstantIntOp::create(builder, loc, i, 32);
     Value barrierView = ttg::MemDescIndexOp::create(
         builder, loc, singleBarrierMemDescType, barrierAlloc, idx);
-    ttng::InitBarrierOp::create(builder, funcOp->getLoc(), barrierView, 1);
+    ttng::InitBarrierOp::create(builder, funcOp->getLoc(), barrierView,
+                                arriveCount);
   }
   return barrierAlloc;
 }
@@ -3183,12 +3185,16 @@ void insertAsyncComm(
             }
           }
           if (!replaced) {
+            // Propagate two_ctas from the MMA op so the commit uses
+            // cta_group::2, which is required to wait for cta_group::2 MMA
+            // operations to finish writing to TMEM.
             auto indexedBarrier = getBarrierForPipelineStage(
                 builder, *commChannel.producerBarrier, bufferIdx);
+            bool twoCTAs = cast<ttng::TCGen5MMAOp>(mmaOp).getTwoCtas();
             builder.createWithAsyncTaskIds<ttng::TCGen5CommitOp>(
-                mmaOp->getLoc(), indexedBarrier);
+                mmaOp->getLoc(), indexedBarrier, twoCTAs);
+            builder.clearLoopScheduleInfo();
           }
-          builder.clearLoopScheduleInfo();
         }
         // Still call desyncTCGen5MMAOp to handle the consumer.
         desyncTCGen5MMAOp(builder, cast<ttng::TCGen5MMAOp>(mmaOp),
@@ -3268,8 +3274,11 @@ void insertAsyncComm(
           builder.setAsyncTaskIdsFromOp(mmaOp);
           auto indexedConsumerBarrier =
               getBarrierForPipelineStage(builder, consumerBarrier, bufferIdx);
+          // Propagate two_ctas from the MMA op so the commit uses
+          // cta_group::2, matching the MMA's commit group.
+          bool twoCTAs = mmaOp.getTwoCtas();
           builder.createWithAsyncTaskIds<ttng::TCGen5CommitOp>(
-              mmaOp->getLoc(), indexedConsumerBarrier);
+              mmaOp->getLoc(), indexedConsumerBarrier, twoCTAs);
           builder.clearLoopScheduleInfo();
         }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -379,13 +379,19 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   if (twoCTAs) {
     // - In TLX 2cta mode, we'll have explicit remote barrier arrival in kernel,
     // and implicit cluster sync inserted earlier than this.
-    // - In non-TLX 2cta mode (Triton default), we keep the code unchanged. Note
-    // inserting cluster sync here will hang WarpSpec - only MMA warps would
-    // execute ClusterArriveOp but ClusterWaitOp expects all threads in the
-    // cluster
-    if (!tlxPairedMMA) {
+    // - In WarpSpec mode (autoWS), the Insert2CTASync pass provides explicit
+    // cross-CTA mbarrier sync. ClusterArrive/Wait will deadlock because only
+    // the consumer warp group executes it while the cluster barrier expects
+    // all threads.
+    // - In non-TLX non-WS 2cta mode, we keep the cluster sync.
+    bool hasExplicitCTASync =
+        tlxPairedMMA ||
+        rewriter.getInsertionBlock()
+                ->getParentOp()
+                ->getParentOfType<triton::gpu::WarpSpecializeOp>() != nullptr;
+    if (!hasExplicitCTASync) {
       // TODO: we have to sync the two CTAs because we currently don't use
-      // remove barriers for the copies.
+      // remote barriers for the copies.
       ttng::ClusterArriveOp::create(rewriter, loc, false);
     }
     Value leftClusterId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
@@ -727,8 +733,22 @@ struct TCGen5CommitOpConversion
     if (adaptor.getPred())
       pred = b.and_(adaptor.getPred(), pred);
 
-    createMMACommit(rewriter, op.getLoc(), smemObj.getBase(), pred,
-                    ttng::getModuleTwoCTAs(op) || tlx::tlxEnablePairedMMA(op));
+    bool twoCTAs = ttng::getModuleTwoCTAs(op) || tlx::tlxEnablePairedMMA(op);
+    if (op.getTwoCtas()) {
+      // For auto-WS 2-CTA commits (op has explicit two_ctas attribute):
+      // With cta_group::2 + multicast::cluster, only the leader CTA (rank 0
+      // within the pair) should issue the commit. Otherwise both CTAs arrive
+      // on the barrier via multicast, causing double-arrive that advances
+      // the barrier phase too fast and desynchronizes the pipeline.
+      // Note: We gate on op.getTwoCtas() (not twoCTAs) to avoid changing
+      // behavior for TLX commits from LowerAref, which don't set two_ctas.
+      Value clusterCTARank = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+      Value isLeader =
+          b.icmp_eq(b.and_(clusterCTARank, b.i32_val(1)), b.i32_val(0));
+      pred = b.and_(pred, isLeader);
+    }
+
+    createMMACommit(rewriter, op.getLoc(), smemObj.getBase(), pred, twoCTAs);
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -108,6 +108,11 @@ void init_triton_hopper_passes(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_multi_cta_reduction",
                      mlir::createNVGPUMultiCTAReduction);
   ADD_PASS_WRAPPER_0("add_modulo_schedule", mlir::createNVGPUModuloSchedule);
+  ADD_PASS_WRAPPER_0("add_modulo_ws_partition",
+                     mlir::createNVGPUModuloWSPartition);
+  ADD_PASS_WRAPPER_0("add_insert_2cta_sync", mlir::createNVGPUInsert2CTASync);
+  ADD_PASS_WRAPPER_0("add_2cta_transform_loads",
+                     mlir::createNVGPU2CTATransformLoads);
 }
 
 static void checkMatmulConstraints(const std::string &A_dtype,

--- a/third_party/tlx/tutorials/blackwell-triton-addmm-2cta_test.py
+++ b/third_party/tlx/tutorials/blackwell-triton-addmm-2cta_test.py
@@ -1,0 +1,488 @@
+"""
+Pure Triton 2-CTA matmul test (no TLX).
+
+The user writes standard Triton code:
+  - Loads FULL B (BLOCK_K x BLOCK_N) via TMA descriptor
+  - Calls tl.dot(a, b, acc, two_ctas=True)
+  - Launches with ctas_per_cga=(2, 1, 1)
+
+The compiler handles 2-CTA automatically:
+  - Transform2CTALoads: splits B load so each CTA loads BLOCK_N/2 columns
+  - Insert2CTASync: inserts cross-CTA "arrive remote, wait local" sync
+  - AccelerateMatmul: emits tcgen05.mma.cta_group::2
+
+Tests:
+  1. Non-WS: Compilation + correctness with ctas_per_cga=(2, 1, 1)
+  2. Auto-WS + 2CTA: Compilation + correctness
+  3. Performance: Pure Triton 2-CTA vs TLX 2-CTA
+"""
+
+import os
+from contextlib import contextmanager
+from typing import Optional
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
+    tcgen5_dot_kernel2cta_tma as _tlx_2cta_kernel, )
+
+
+def alloc_fn(size: int, align: int, stream: Optional[int]):
+    return torch.empty(size, dtype=torch.int8, device="cuda")
+
+
+triton.set_allocator(alloc_fn)
+
+# ---------------------------------------------------------------------------
+# Non-WS 2-CTA kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit  # noqa: TR001 — test kernel with fixed block sizes
+def matmul_2cta_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_am = pid_m * BLOCK_M
+    offs_bn = pid_n * BLOCK_N
+
+    a_desc = tl.make_tensor_descriptor(
+        a_ptr,
+        shape=[M, K],
+        strides=[stride_am, stride_ak],
+        block_shape=[BLOCK_M, BLOCK_K],
+    )
+    b_desc = tl.make_tensor_descriptor(
+        b_ptr,
+        shape=[K, N],
+        strides=[stride_bk, stride_bn],
+        block_shape=[BLOCK_K, BLOCK_N],
+    )
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    k_tiles = tl.cdiv(K, BLOCK_K)
+    for k in range(k_tiles):
+        offs_k = k * BLOCK_K
+        a = a_desc.load([offs_am, offs_k])
+        b = b_desc.load([offs_k, offs_bn])
+        accumulator = tl.dot(a, b, accumulator, two_ctas=True)
+
+    c = accumulator.to(tl.float16)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(c_ptrs, c, mask=mask)
+
+
+def matmul_2cta(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    assert a.is_cuda and b.is_cuda
+    assert a.shape[1] == b.shape[0]
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=torch.float16)
+
+    BLOCK_M = 128
+    BLOCK_N = 128
+    BLOCK_K = 64
+
+    grid = (max(triton.cdiv(M, BLOCK_M), 2), triton.cdiv(N, BLOCK_N))
+
+    matmul_2cta_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        num_stages=1,
+        ctas_per_cga=(2, 1, 1),
+    )
+    return c
+
+
+@pytest.mark.parametrize("M,N,K", [
+    (128, 128, 64),
+    (256, 256, 128),
+])
+def test_matmul_2cta_correctness(M, N, K):
+    """Test that 2-CTA matmul produces correct results."""
+    torch.manual_seed(42)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+
+    ref = torch.matmul(a, b)
+    out = matmul_2cta(a, b)
+
+    torch.testing.assert_close(out, ref, atol=1e-1, rtol=1e-1)
+
+
+def test_matmul_2cta_compilation():
+    """Test that the kernel compiles without errors."""
+    torch.manual_seed(42)
+    M, N, K = 128, 128, 64
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+
+    out = matmul_2cta(a, b)
+    assert out.shape == (M, N)
+    assert out.dtype == torch.float16
+
+
+# ---------------------------------------------------------------------------
+# Auto-WS + 2-CTA tests
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def ws_env():
+    """Set Meta WS env vars for the duration of the context."""
+    old = {k: os.environ.get(k) for k in ["TRITON_USE_META_WS", "TRITON_USE_META_PARTITION", "TRITON_ALWAYS_COMPILE"]}
+    os.environ["TRITON_USE_META_WS"] = "1"
+    os.environ["TRITON_USE_META_PARTITION"] = "1"
+    os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+    try:
+        yield
+    finally:
+        for k, v in old.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+@triton.jit  # noqa: TR001 — test kernel with fixed block sizes
+def matmul_2cta_ws_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_am = pid_m * BLOCK_M
+    offs_bn = pid_n * BLOCK_N
+
+    a_desc = tl.make_tensor_descriptor(
+        a_ptr,
+        shape=[M, K],
+        strides=[stride_am, stride_ak],
+        block_shape=[BLOCK_M, BLOCK_K],
+    )
+    b_desc = tl.make_tensor_descriptor(
+        b_ptr,
+        shape=[K, N],
+        strides=[stride_bk, stride_bn],
+        block_shape=[BLOCK_K, BLOCK_N],
+    )
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    k_tiles = tl.cdiv(K, BLOCK_K)
+    for k in tl.range(0, k_tiles, warp_specialize=True):
+        offs_k = k * BLOCK_K
+        a = a_desc.load([offs_am, offs_k])
+        b = b_desc.load([offs_k, offs_bn])
+        accumulator = tl.dot(a, b, accumulator, two_ctas=True)
+
+    c = accumulator.to(tl.float16)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(c_ptrs, c, mask=mask)
+
+
+def matmul_2cta_ws(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    assert a.is_cuda and b.is_cuda
+    assert a.shape[1] == b.shape[0]
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=torch.float16)
+
+    BLOCK_M = 128
+    BLOCK_N = 128
+    BLOCK_K = 64
+
+    grid = (max(triton.cdiv(M, BLOCK_M), 2), triton.cdiv(N, BLOCK_N))
+
+    with ws_env():
+        matmul_2cta_ws_kernel[grid](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+            BLOCK_K=BLOCK_K,
+            num_stages=1,
+            ctas_per_cga=(2, 1, 1),
+        )
+    return c
+
+
+@pytest.mark.parametrize("M,N,K", [(128, 128, 128),  # Single cluster, 2 K iters
+                                   (256, 256, 64),  # Multi cluster, 1 K iter
+                                   (128, 256, 128),  # 2 clusters in Y only, 2 K iters
+                                   (256, 256, 128),  # Multi cluster both dims, 2 K iters
+                                   ])
+def test_matmul_2cta_ws_correctness(M, N, K):
+    """Test WS + 2-CTA matmul produces correct results."""
+    torch.manual_seed(42)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+
+    ref = torch.matmul(a, b)
+    out = matmul_2cta_ws(a, b)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out, ref, atol=1e-1, rtol=1e-1)
+
+
+def test_matmul_2cta_ws_compilation():
+    """Test that WS + 2-CTA kernel compiles and runs without errors."""
+    torch.manual_seed(42)
+    M, N, K = 256, 256, 128
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+
+    out = matmul_2cta_ws(a, b)
+    torch.cuda.synchronize()
+    assert out.shape == (M, N)
+    assert out.dtype == torch.float16
+
+
+# ---------------------------------------------------------------------------
+# Performance benchmark: Triton 1CTA vs Triton 2CTA vs TLX 2CTA
+# Shows the perf benefit of 2CTA (this diff's contribution).
+# Config: BLOCK=128x128x128, num_stages=2, ctas_per_cga=(2,1,1).
+#
+# Note on 2CTA+WS vs 1CTA+WS:
+#   2CTA+WS may not outperform 1CTA+WS because Insert2CTASync adds
+#   +6 mbarrier ops and +3 barrier.cluster ops (cross-CTA sync) on top
+#   of the WS pipeline barriers. This extra sync overhead offsets the
+#   2CTA MMA bandwidth benefit when WS is already pipelining effectively.
+#   Merging Insert2CTASync barriers with WS pipeline barriers is a
+#   follow-up optimization.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit  # noqa: TR001 — test kernel with fixed block sizes
+def matmul_1cta_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_am = pid_m * BLOCK_M
+    offs_bn = pid_n * BLOCK_N
+    a_desc = tl.make_tensor_descriptor(a_ptr, shape=[M, K], strides=[stride_am, stride_ak],
+                                       block_shape=[BLOCK_M, BLOCK_K])
+    b_desc = tl.make_tensor_descriptor(b_ptr, shape=[K, N], strides=[stride_bk, stride_bn],
+                                       block_shape=[BLOCK_K, BLOCK_N])
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(tl.cdiv(K, BLOCK_K)):
+        offs_k = k * BLOCK_K
+        a = a_desc.load([offs_am, offs_k])
+        b = b_desc.load([offs_k, offs_bn])
+        accumulator = tl.dot(a, b, accumulator)
+    c = accumulator.to(tl.float16)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(c_ptrs, c, mask=mask)
+
+
+@triton.jit  # noqa: TR001 — test kernel with fixed block sizes
+def matmul_1cta_ws_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_am = pid_m * BLOCK_M
+    offs_bn = pid_n * BLOCK_N
+    a_desc = tl.make_tensor_descriptor(a_ptr, shape=[M, K], strides=[stride_am, stride_ak],
+                                       block_shape=[BLOCK_M, BLOCK_K])
+    b_desc = tl.make_tensor_descriptor(b_ptr, shape=[K, N], strides=[stride_bk, stride_bn],
+                                       block_shape=[BLOCK_K, BLOCK_N])
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in tl.range(0, tl.cdiv(K, BLOCK_K), warp_specialize=True):
+        offs_k = k * BLOCK_K
+        a = a_desc.load([offs_am, offs_k])
+        b = b_desc.load([offs_k, offs_bn])
+        accumulator = tl.dot(a, b, accumulator)
+    c = accumulator.to(tl.float16)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(c_ptrs, c, mask=mask)
+
+
+def _launch_kernel(a, b, kernel, num_stages=2, ctas_per_cga=None, use_ws_env=False, BLOCK_M=128, BLOCK_N=128,
+                   BLOCK_K=128):
+    """Generic launcher for perf benchmarks."""
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=torch.float16)
+    grid = (max(triton.cdiv(M, BLOCK_M), 2), triton.cdiv(N, BLOCK_N))
+    kwargs = dict(BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, num_stages=num_stages)
+    if ctas_per_cga is not None:
+        kwargs["ctas_per_cga"] = ctas_per_cga
+    ctx = ws_env() if use_ws_env else contextmanager(lambda: (yield))()
+    with ctx:
+        kernel[grid](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            **kwargs,
+        )
+    return c
+
+
+def _launch_tlx_2cta(a, b):
+    """Launch TLX manual 2-CTA kernel with same config."""
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 128
+    grid = (max(M // BLOCK_M, 2), N // BLOCK_N)
+    _tlx_2cta_kernel[grid](
+        a,
+        a.stride(0),
+        a.stride(1),
+        b,
+        b.stride(0),
+        b.stride(1),
+        c,
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        OUT_DTYPE=tl.float32,
+        M=M,
+        N=N,
+        K=K,
+        num_stages=2,
+        ctas_per_cga=(2, 1, 1),
+    )
+    return c
+
+
+@pytest.mark.parametrize("M,N,K", [
+    (2048, 2048, 2048),
+    (4096, 4096, 4096),
+    (8192, 8192, 8192),
+])
+def test_matmul_2cta_perf(M, N, K):
+    """Compare 1CTA vs 2CTA vs TLX-2CTA to show the perf benefit of 2-CTA MMA.
+
+    All variants use BLOCK=128x128x128, num_stages=2.
+    """
+    torch.manual_seed(42)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+
+    def tflops(ms):
+        return 2 * M * N * K * 1e-12 / (ms * 1e-3)
+
+    t_1cta = triton.testing.do_bench(lambda: _launch_kernel(a, b, matmul_1cta_kernel), warmup=500, rep=2000)
+    t_1cta_ws = triton.testing.do_bench(lambda: _launch_kernel(a, b, matmul_1cta_ws_kernel, use_ws_env=True),
+                                        warmup=500, rep=2000)
+    t_2cta = triton.testing.do_bench(lambda: _launch_kernel(a, b, matmul_2cta_kernel, ctas_per_cga=(2, 1, 1)),
+                                     warmup=500, rep=2000)
+    t_2cta_ws = triton.testing.do_bench(
+        lambda: _launch_kernel(a, b, matmul_2cta_ws_kernel, ctas_per_cga=(2, 1, 1), use_ws_env=True), warmup=500,
+        rep=2000)
+
+    print(f"\n  ({M}x{N}x{K})"
+          f"  1CTA: {tflops(t_1cta):.0f}"
+          f"  |  1CTA+WS: {tflops(t_1cta_ws):.0f}"
+          f"  |  2CTA: {tflops(t_2cta):.0f}"
+          f"  |  2CTA+WS: {tflops(t_2cta_ws):.0f} TFLOPS")


### PR DESCRIPTION
Summary:

Support `tl.dot(two_ctas=True)` + `ctas_per_cga=(2,1,1)` on Blackwell (SM100+),
including full auto-WS (warp specialization) compatibility. (T259718487)

## Background

On Blackwell, two CTAs in a cluster can cooperatively execute a single MMA via
`tcgen05.mma.cta_group::2`. CTA 0 loads A and half of B; CTA 1 loads the other
half of B. The hardware reads A from CTA 0 and B from both CTAs' SMEM.

We use the `ctas_per_cga` approach (per reviewer direction) instead of PlanCTA:
- `ctas_per_cga=(2,1,1)` sets `num_ctas=1`, bypassing PlanCTA entirely
- Two new passes (`Transform2CTALoads` + `Insert2CTASync`) handle B-splitting
  and cross-CTA sync at the IR level
- This replaces D97215251's 3-pass approach (`Propagate2CTAAttr` is NOT needed
  since AccelerateMatmul already propagates `two_ctas` from DotOp to TCGen5MMAOp)

## User API

```python
triton.jit
def matmul_2cta(a_ptr, b_ptr, c_ptr, M, N, K, ...):
    a_desc = tl.make_tensor_descriptor(a_ptr, [M, K], ..., [BLOCK_M, BLOCK_K])
    b_desc = tl.make_tensor_descriptor(b_ptr, [K, N], ..., [BLOCK_K, BLOCK_N])
    # warp_specialize=True enables autoWS; two_ctas=True enables 2-CTA MMA
    for k in tl.range(0, k_tiles, warp_specialize=True):
        a = a_desc.load([offs_am, k * BK])
        b = b_desc.load([k * BK, offs_bn])  # Full B -- compiler splits this
        acc = tl.dot(a, b, acc, two_ctas=True)
# Launch with ctas_per_cga
matmul_2cta[grid](..., ctas_per_cga=(2, 1, 1))
```

## Compiler Pipeline

```
TTIR: tt.dot {two_ctas}
  |
convert_to_ttgpuir         <-- preserves {two_ctas} on DotOp
  |
AccelerateMatmul            <-- getTwoCtas()=true: skips splitBOperand,
  |                             sets two_ctas on TCGen5MMAOp
Transform2CTALoads          <-- NEW: splits B descriptor loads per CTA
  |
schedule_loops + Meta WS    <-- 4 partitions: default/gemm/load/epilogue
  |
pipeline + hoist_tmem_alloc
  |
Insert2CTASync              <-- "arrive remote, wait local" cross-CTA sync
  |                             (AFTER all WS passes to avoid interference)
LLVM lowering
```

## Phase 1: Non-WS 2-CTA

- **Python API**: `tl.dot(two_ctas=True)` (`core.py`, `semantic.py`, `ir.cc`)
- **TTIR->TTGIR**: Preserve `two_ctas` during DotOp conversion
- **AccelerateMatmul**: User-driven path -- skip `splitBOperand`, propagate to MMA
- **Transform2CTALoads** (NEW): For each `TCGen5MMAOp` with `two_ctas=true`:
  1. Trace B operand back to `DescriptorLoadOp` -> `MakeTensorDescOp`
  2. Clone `MakeTensorDescOp` with half-width block shape [BLOCK_K, BLOCK_N/2]
  3. Add CTA-based offset: `new_offs_n = offs_bn + (cta_rank % 2) * (BLOCK_N/2)`
- **Insert2CTASync** (NEW): Before each 2-CTA MMA, insert:
  - `map_to_remote_buffer` -- map local barrier to leader CTA's SMEM
  - `arrive_barrier` -- both CTAs arrive on leader's barrier
  - `wait_barrier` -- only leader waits (pred = rank % 2 == 0)
  - TLX guard: skip for `tlx.has_tlx_ops` kernels (TLX manages own barriers)

## Phase 2: Auto-WS + 2-CTA (5 bugs fixed)

1. **Deadlock: Cluster barrier inside WS MMA loop** (`MMAv5.cpp`)
   PTX lowering inserted `barrier.cluster.arrive/wait` inside each MMA loop
   iteration. In WS, only the consumer warp group executes it, but the barrier
   requires ALL threads -> deadlock.
   Fix: Skip when inside `WarpSpecializeOp`.

2. **Correctness: `TCGen5CommitOp` wrong `cta_group`** (`WSCodePartition.cpp`)
   WS framework created `TCGen5CommitOp` without `two_ctas`, producing
   `tcgen05.commit.cta_group::1`. But MMA uses `cta_group::2`. The `cta_group::1`
   commit does NOT wait for `cta_group::2` MMA to finish -> epilogue reads TMEM
   before MMA writes.
   Fix: Propagate `two_ctas` from MMA op to `TCGen5CommitOp` (2 locations).

3. **Correctness: `TCGen5CommitOp` missing cluster0 predicate** (`MMAv5.cpp`)
   After fix #2, both CTAs issued `cta_group::2.multicast::cluster` commit,
   causing double-arrive on the barrier (2 arrives instead of 1), advancing
   the phase too fast.
   Fix: Add `cluster_cta_id & 1 == 0` predicate to `TCGen5CommitOpConversion`.

4. **TMEM `cta_group::2`** (`NVGPUToLLVMPass.cpp`)
   TMEM alloc/dealloc used `cta_group::1` because `num-ctas=1`.
   Fix: Check `cluster-dim-x >= 2` in addition to `num-ctas`.

5. **Exit cluster barrier** (`ConvertWarpSpecializeToLLVM.cpp`)
   Only emitted for TLX kernels.
   Fix: Also emit for auto-WS when `cluster-dim-x >= 2`.

See `docs/design/2cta-autoWS-sync.md` for full design doc.

Differential Revision: D97387127
