### PR TITLE
[TLX GEMM] Filter out split-K values that create empty splits in autotuner

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -508,6 +508,11 @@ def preprocess_configs(configs, named_args, **kwargs):
             k_tiles = math.ceil(K / BLOCK_K)
             if k_tiles < SPLIT_K:
                 continue
+            # Reject SK values where cdiv overallocation leaves the last split empty
+            # (causes deadlock: producer loop is empty but MMA consumer waits on barrier)
+            k_tiles_per_split = math.ceil(k_tiles / SPLIT_K)
+            if k_tiles_per_split * (SPLIT_K - 1) >= k_tiles:
+                continue
             # Each split must have enough K tiles to be worthwhile
             if k_tiles // SPLIT_K < 4:
                 continue


### PR DESCRIPTION
Summary:
When cdiv(k_tiles, SPLIT_K) overallocates tiles per split, the last
split can end up with zero K-tiles. This causes a deadlock in the
persistent WS kernel (D98032419). Filter these values at config
generation time to avoid wasting autotuner budget on broken configs.

Reviewed By: htyu

Differential Revision: D98045115
