### PR TITLE
Unify TLX backward attention kernel with triton-fb (#1148)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1017,11 +1017,7 @@ def _bwd_host_descriptor_pre_hook_tlx(nargs):
 configs_bwd_tlx = [
     triton.Config(
         {
-            # Note: BLOCK_M1 is removed from this autotuning step
-            # so that we can test alternative code paths based on
-            # BLOCK_M1.
-            # Not all EPILOGUE_SUBTILE are viable with all BLOCK_M1
-            # and H-DIM options, so we set those in the kernel as well.
+            "BLOCK_M1": bm1,
             "BLOCK_N1": 128,
             "BLOCK_M2": 128,
             "BLOCK_N2": 128,
@@ -1030,12 +1026,14 @@ configs_bwd_tlx = [
             "NUM_BUFFERS_DO": 1,
             "NUM_BUFFERS_DS": 1,
             "NUM_BUFFERS_TMEM": 1,
+            "EPILOGUE_SUBTILE": 4 if bm1 == 128 else 2,
+            "GROUP_SIZE_M": 1,
             "USE_WARP_BARRIER": uwb,
         },
         num_warps=4,
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
-    ) for uwb in [False, True]
+    ) for bm1 in [64, 128] for uwb in [False, True]
 ]
 
 
@@ -1718,7 +1716,7 @@ def _attn_bwd_ws(
 class _attention(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, q, k, v, sm_scale, causal, BWD_BLOCK_M1, GROUP_SIZE_M):
+    def forward(ctx, q, k, v, sm_scale, causal):
         HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
         HEAD_DIM_V = v.shape[-1]
         assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
@@ -1796,10 +1794,6 @@ class _attention(torch.autograd.Function):
         ctx.sm_scale = sm_scale
         ctx.HEAD_DIM = HEAD_DIM_K
         ctx.causal = causal
-        # Store BLOCK_M1 for bwd so we can test divergent
-        # code paths.
-        ctx.BWD_BLOCK_M1 = BWD_BLOCK_M1
-        ctx.GROUP_SIZE_M = GROUP_SIZE_M
         return o
 
     @staticmethod
@@ -1891,7 +1885,6 @@ class _attention(torch.autograd.Function):
             )
 
         stage = 3 if ctx.causal else 1
-        EPILOGUE_SUBTILE = 4 if ctx.BWD_BLOCK_M1 == 128 and ctx.HEAD_DIM == 128 else 2
         _attn_bwd_ws[grid_persistent](
             desc_q, desc_k, desc_v, ctx.sm_scale, desc_do, desc_dq, desc_dk, desc_dv,  #
             M, delta,  #
@@ -1901,17 +1894,14 @@ class _attention(torch.autograd.Function):
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM,  #
             STAGE=stage,  #
-            BLOCK_M1=ctx.BWD_BLOCK_M1,  #
-            EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,  #
-            GROUP_SIZE_M=ctx.GROUP_SIZE_M,  #
         )
 
-        return dq, dk, dv, None, None, None, None
+        return dq, dk, dv, None, None
 
 
-def attention(q, k, v, sm_scale, causal, BWD_BLOCK_M1, GROUP_SIZE_M, config=None):
+def attention(q, k, v, sm_scale, causal, config=None):
     if config is None:
-        return _attention.apply(q, k, v, sm_scale, causal, BWD_BLOCK_M1, GROUP_SIZE_M)
+        return _attention.apply(q, k, v, sm_scale, causal)
 
     # Non-autotuned path with explicit config
     HEAD_DIM_K = q.shape[-1]

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -374,7 +374,7 @@ def test_blackwell_fa_ws_pipelined_persistent(causal, RESCALE_OPT, USE_WHERE):
     for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:
         q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM)
         ref_out = FlashAttention.get_reference(q, k, v, sm_scale, causal)
-        tri_out = _blackwell_fa_ws_pipelined_persistent(q, k, v, sm_scale, causal, 64, 1, config=config)
+        tri_out = _blackwell_fa_ws_pipelined_persistent(q, k, v, sm_scale, causal, config=config)
         torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
 
 
@@ -389,7 +389,7 @@ def test_blackwell_fa_ws_pipelined_persistent_warp_barrier(causal, RESCALE_OPT, 
     for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:
         q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM)
         ref_out = FlashAttention.get_reference(q, k, v, sm_scale, causal)
-        tri_out = _blackwell_fa_ws_pipelined_persistent(q, k, v, sm_scale, causal, 64, 1, config=config)
+        tri_out = _blackwell_fa_ws_pipelined_persistent(q, k, v, sm_scale, causal, config=config)
         torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
 
 
@@ -404,8 +404,6 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
     fwd_config["RESCALE_OPT"] = RESCALE_OPT
     fwd_config["USE_WHERE"] = USE_WHERE
     sm_scale = 0.5
-    BWD_BLOCK_M1 = 64
-    GROUP_SIZE_M = 1
 
     for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:
         q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM)
@@ -483,7 +481,6 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
         desc_dv = TensorDescriptor(dv, shape=[Z * H * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
 
         BLK_SLICE_FACTOR = 2
-        EPILOGUE_SUBTILE = 4 if BWD_BLOCK_M1 == 128 and HEAD_DIM == 128 else 2
 
         def grid_persistent(meta):
             return (min(NUM_SMS, triton.cdiv(N_CTX, meta["BLOCK_N1"]) * Z * H), 1, 1)
@@ -509,9 +506,6 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,
             HEAD_DIM=HEAD_DIM,
             STAGE=stage,
-            BLOCK_M1=BWD_BLOCK_M1,
-            EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
-            GROUP_SIZE_M=GROUP_SIZE_M,
         )
 
         tri_dq = dq.to(q.dtype)


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/971


Import the TLX backward attention kernel from its canonical location
in triton-fb (third_party/tlx/tutorials/), following the same pattern
as the blackwell GEMM kernels.

Kernel changes:
- Move BLOCK_M1, EPILOGUE_SUBTILE, GROUP_SIZE_M into backward
  autotuning configs (configs_bwd_tlx), expanding from 2 to 4 configs
  (BLOCK_M1 ∈ {64, 128} × USE_WARP_BARRIER ∈ {False, True})
- Simplify attention() API to (q, k, v, sm_scale, causal, config=None)
  by removing BWD_BLOCK_M1 and GROUP_SIZE_M parameters
- Remove BWD_BLOCK_M1/GROUP_SIZE_M from forward() ctx and backward()
  call site — autotuner now handles these

Tritonbench changes:
- Remove local copy: tritonbench/kernels/tlx_attention_ws_pipelined.py
- Update operator import to triton.language.extra.tlx.tutorials path
- Simplify operator call to attention(q, k, v, sm_scale, causal)

Test changes:
- Remove explicit BLOCK_M1/EPILOGUE_SUBTILE/GROUP_SIZE_M kwargs from
  bwd test (autotuner picks them from configs)
- Remove BWD_BLOCK_M1/GROUP_SIZE_M args from fwd test calls

Reviewed By: xuzhao9

Differential Revision: D98078001


