### PR TITLE
[WIP][TLX][lint] Add barrier execution order analysis pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -57,6 +57,7 @@ void registerTestAlignmentPass();
 void registerAMDTestAlignmentPass();
 void registerTestAllocationPass();
 void registerTestMembarPass();
+void registerTestBarrierAnalysisPass();
 void registerTestPrintNestingPass();
 void registerTestAMDGPUMembarPass();
 void registerTestTritonAMDGPURangeAnalysis();
@@ -79,6 +80,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerAMDTestAlignmentPass();
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
+  mlir::test::registerTestBarrierAnalysisPass();
   mlir::test::registerTestPrintNestingPass();
   mlir::test::registerTestLoopPeelingPass();
   mlir::test::registerTestAMDGPUMembarPass();

--- a/include/triton/Analysis/BarrierAnalysis.h
+++ b/include/triton/Analysis/BarrierAnalysis.h
@@ -126,7 +126,7 @@ private:
   /// Resolve a barrier Value to (allocName, slotIndex) by tracing def-use
   /// chains through memdesc_index and warp_specialize captures.
   std::pair<std::string, int64_t> resolveBarrier(Value barrierVal,
-                                                  OperandRange captures);
+                                                 OperandRange captures);
 
   /// Evaluate an integer SSA value to a concrete int at a given loop
   /// iteration. Returns nullopt if the value cannot be resolved.

--- a/include/triton/Analysis/BarrierAnalysis.h
+++ b/include/triton/Analysis/BarrierAnalysis.h
@@ -1,0 +1,150 @@
+#ifndef TRITON_ANALYSIS_BARRIERANALYSIS_H
+#define TRITON_ANALYSIS_BARRIERANALYSIS_H
+
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mlir::scf {
+class ForOp;
+} // namespace mlir::scf
+
+namespace mlir::triton {
+
+//===----------------------------------------------------------------------===//
+// Barrier Operation Kinds (for the concrete trace)
+//===----------------------------------------------------------------------===//
+
+/// Classification of barrier operations following the design doc.
+enum class BarrierOpKind {
+  ArriveSync,  // ttng.arrive_barrier — pending_arrives -= cnt
+  ExpectBytes, // ttng.barrier_expect — arrive (cnt=1) + pending_bytes += sz
+  TmaLoad,     // ttng.async_tma_copy_global_to_local — pending_bytes -= xfer
+  Wait,        // ttng.wait_barrier — blocks while phase == phi
+};
+
+/// Convert BarrierOpKind to string for printing.
+StringRef barrierOpKindToString(BarrierOpKind kind);
+
+//===----------------------------------------------------------------------===//
+// Concrete Operation Instance (after loop unrolling)
+//===----------------------------------------------------------------------===//
+
+/// A single barrier operation after loop unrolling with all parameters
+/// resolved to concrete values.
+struct ConcreteBarrierOp {
+  BarrierOpKind kind;
+
+  /// Which task (warp group) this belongs to.
+  int64_t taskId = -1;
+  std::string taskName;
+
+  /// Barrier identity: (allocName, slotIndex) uniquely identifies a barrier.
+  std::string allocName;
+  int64_t slotIndex = -1;
+
+  /// Phase for wait operations (-1 if unresolved).
+  int64_t phase = -1;
+
+  /// Arrive count: 1 for ArriveSync/ExpectBytes, 0 for TmaLoad.
+  int64_t arriveCount = 1;
+
+  /// Expected bytes for ExpectBytes operations.
+  int64_t expectedBytes = -1;
+
+  /// Loop iteration this came from (-1 if not in a loop).
+  int64_t iteration = -1;
+
+  /// Position within the task's operation sequence.
+  size_t position = 0;
+
+  /// Source location string for diagnostics.
+  std::string locInfo;
+};
+
+/// Per-task operation trace after loop unrolling.
+struct TaskTrace {
+  int64_t taskId = -1;
+  std::string taskName;
+  std::vector<ConcreteBarrierOp> ops;
+};
+
+/// Barrier allocation info (from local_alloc + init_barrier).
+struct BarrierAllocInfo {
+  std::string name;
+  int64_t numSlots = 0;
+  int64_t arriveCount = 1;
+};
+
+//===----------------------------------------------------------------------===//
+// BarrierDeadlockAnalysis
+//===----------------------------------------------------------------------===//
+
+/// Extracts concrete barrier operation traces from TTGIR by walking
+/// warp_specialize regions and unrolling scf.for loops.
+///
+/// This is Step 1 of the deadlock detection pipeline: building the program
+/// model. Step 2 (Z3 constraint encoding) is added in a follow-up PR.
+class BarrierDeadlockAnalysis {
+public:
+  explicit BarrierDeadlockAnalysis(FunctionOpInterface funcOp,
+                                   int unrollBound = 0);
+
+  /// Run the full trace extraction pipeline.
+  void run();
+
+  /// Print a human-readable summary of the extracted traces.
+  void printSummary(llvm::raw_ostream &os) const;
+
+  /// Get the task traces.
+  const std::vector<TaskTrace> &getTaskTraces() const { return taskTraces; }
+
+  /// Get barrier allocations.
+  const std::vector<BarrierAllocInfo> &getBarrierAllocs() const {
+    return barrierAllocs;
+  }
+
+private:
+  /// Extract barrier allocations (local_alloc ops with i64 element type).
+  void collectBarrierAllocs();
+
+  /// Build concrete operation traces by walking warp_specialize regions.
+  void buildTaskTraces();
+
+  /// Unroll an scf.for loop body and append concrete ops to trace.
+  void unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
+                  const std::string &taskName, TaskTrace &trace,
+                  OperandRange captures);
+
+  /// Resolve a barrier Value to (allocName, slotIndex) by tracing def-use
+  /// chains through memdesc_index and warp_specialize captures.
+  std::pair<std::string, int64_t> resolveBarrier(Value barrierVal,
+                                                  OperandRange captures);
+
+  /// Evaluate an integer SSA value to a concrete int at a given loop
+  /// iteration. Returns nullopt if the value cannot be resolved.
+  std::optional<int64_t> tryEvalInt(Value val, int64_t loopVar,
+                                    Value loopInductionVar);
+
+  FunctionOpInterface funcOp;
+  int unrollBound;
+  std::vector<TaskTrace> taskTraces;
+  std::vector<BarrierAllocInfo> barrierAllocs;
+
+  /// Map from local_alloc Operation* to barrier alloc name.
+  DenseMap<Operation *, std::string> allocOpToName;
+
+  /// Map capture index to the original value's alloc name.
+  std::map<unsigned, std::string> captureIndexToAllocName;
+};
+
+} // namespace mlir::triton
+
+#endif // TRITON_ANALYSIS_BARRIERANALYSIS_H

--- a/lib/Analysis/BarrierAnalysis.cpp
+++ b/lib/Analysis/BarrierAnalysis.cpp
@@ -130,8 +130,8 @@ BarrierDeadlockAnalysis::resolveBarrier(Value barrierVal,
     if (auto partitionsOp =
             dyn_cast<gpu::WarpSpecializePartitionsOp>(parentOp)) {
       unsigned argIndex = blockArg.getArgNumber();
-      if (auto wsOp = dyn_cast<gpu::WarpSpecializeOp>(
-              partitionsOp->getParentOp())) {
+      if (auto wsOp =
+              dyn_cast<gpu::WarpSpecializeOp>(partitionsOp->getParentOp())) {
         if (argIndex < wsOp.getExplicitCaptures().size()) {
           tracedSrc = wsOp.getExplicitCaptures()[argIndex];
           continue;
@@ -232,8 +232,7 @@ BarrierDeadlockAnalysis::tryEvalInt(Value val, int64_t loopVar,
 // Loop unrolling and trace construction
 //===----------------------------------------------------------------------===//
 
-void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
-                                         int64_t taskId,
+void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
                                          const std::string &taskName,
                                          TaskTrace &trace,
                                          OperandRange captures) {
@@ -287,8 +286,7 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
         concreteOp.kind = BarrierOpKind::Wait;
         auto [name, slot] = resolveBarrier(waitOp.getAlloc(), captures);
         concreteOp.allocName = name;
-        concreteOp.slotIndex =
-            resolveDynSlot(waitOp.getAlloc(), slot, k);
+        concreteOp.slotIndex = resolveDynSlot(waitOp.getAlloc(), slot, k);
 
         // Resolve phase: try direct eval, then iter_args
         auto phaseVal = tryEvalInt(waitOp.getPhase(), k, inductionVar);
@@ -303,8 +301,7 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
         concreteOp.phase = phaseVal.value_or(-1);
         isBarrierOp = true;
 
-      } else if (auto arriveOp =
-                     dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
+      } else if (auto arriveOp = dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
         concreteOp.kind = BarrierOpKind::ArriveSync;
         auto [name, slot] = resolveBarrier(arriveOp.getAlloc(), captures);
         concreteOp.allocName = name;
@@ -312,8 +309,7 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
         concreteOp.arriveCount = arriveOp.getCount();
         isBarrierOp = true;
 
-      } else if (auto expectOp =
-                     dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
+      } else if (auto expectOp = dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
         concreteOp.kind = BarrierOpKind::ExpectBytes;
         auto [name, slot] = resolveBarrier(expectOp.getAlloc(), captures);
         concreteOp.allocName = name;
@@ -455,8 +451,8 @@ void BarrierDeadlockAnalysis::printSummary(llvm::raw_ostream &os) const {
 
   os << "\nTask traces:\n";
   for (const auto &task : taskTraces) {
-    os << "  " << task.taskName << " (task " << task.taskId << "): "
-       << task.ops.size() << " barrier ops\n";
+    os << "  " << task.taskName << " (task " << task.taskId
+       << "): " << task.ops.size() << " barrier ops\n";
     for (const auto &op : task.ops) {
       os << "    [" << op.position << "] " << barrierOpKindToString(op.kind)
          << " " << op.allocName << "[" << op.slotIndex << "]";

--- a/lib/Analysis/BarrierAnalysis.cpp
+++ b/lib/Analysis/BarrierAnalysis.cpp
@@ -1,0 +1,474 @@
+//===-- BarrierAnalysis.cpp - Barrier trace extraction ----------*- C++ -*-===//
+//
+// Extracts concrete barrier operation traces from TTGIR warp-specialized
+// kernels. This is Step 1 of the deadlock detection pipeline (program model
+// extraction). See docs/barrier_deadlock_detection_design.md.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/BarrierAnalysis.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+namespace mlir::triton {
+
+namespace gpu = triton::gpu;
+namespace nvidia_gpu = triton::nvidia_gpu;
+
+//===----------------------------------------------------------------------===//
+// BarrierOpKind string conversion
+//===----------------------------------------------------------------------===//
+
+StringRef barrierOpKindToString(BarrierOpKind kind) {
+  switch (kind) {
+  case BarrierOpKind::ArriveSync:
+    return "arrive_barrier";
+  case BarrierOpKind::ExpectBytes:
+    return "barrier_expect";
+  case BarrierOpKind::TmaLoad:
+    return "tma_load";
+  case BarrierOpKind::Wait:
+    return "wait_barrier";
+  }
+  llvm_unreachable("Unknown BarrierOpKind");
+}
+
+//===----------------------------------------------------------------------===//
+// BarrierDeadlockAnalysis
+//===----------------------------------------------------------------------===//
+
+BarrierDeadlockAnalysis::BarrierDeadlockAnalysis(FunctionOpInterface funcOp,
+                                                 int unrollBound)
+    : funcOp(funcOp), unrollBound(unrollBound) {}
+
+void BarrierDeadlockAnalysis::run() {
+  collectBarrierAllocs();
+  buildTaskTraces();
+}
+
+//===----------------------------------------------------------------------===//
+// Barrier allocation collection
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::collectBarrierAllocs() {
+  funcOp.walk([&](gpu::LocalAllocOp allocOp) {
+    auto result = allocOp.getResult();
+    auto memDescType = dyn_cast<gpu::MemDescType>(result.getType());
+    if (!memDescType)
+      return;
+
+    // Barrier allocations have i64 element type
+    if (!memDescType.getElementType().isInteger(64))
+      return;
+
+    // Try to get a name from the location
+    std::string name;
+    if (auto nameLoc = dyn_cast<NameLoc>(allocOp.getLoc())) {
+      name = nameLoc.getName().str();
+    } else if (auto fusedLoc = dyn_cast<FusedLoc>(allocOp.getLoc())) {
+      for (auto loc : fusedLoc.getLocations()) {
+        if (auto nl = dyn_cast<NameLoc>(loc)) {
+          name = nl.getName().str();
+          break;
+        }
+      }
+    }
+    if (name.empty())
+      name = "bar_" + std::to_string(allocOpToName.size());
+
+    allocOpToName[allocOp] = name;
+
+    // Number of slots from the shape
+    auto shape = memDescType.getShape();
+    int64_t numSlots = shape.empty() ? 1 : shape[0];
+
+    // Find arrive count from init_barrier ops that use indexed slots
+    int64_t arriveCount = 1;
+    for (auto *user : result.getUsers()) {
+      if (auto indexOp = dyn_cast<gpu::MemDescIndexOp>(user)) {
+        for (auto *indexUser : indexOp.getResult().getUsers()) {
+          if (auto initOp = dyn_cast<nvidia_gpu::InitBarrierOp>(indexUser)) {
+            arriveCount = initOp.getCount();
+            break;
+          }
+        }
+      }
+    }
+
+    barrierAllocs.push_back({name, numSlots, arriveCount});
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// Barrier resolution via def-use chains
+//===----------------------------------------------------------------------===//
+
+std::pair<std::string, int64_t>
+BarrierDeadlockAnalysis::resolveBarrier(Value barrierVal,
+                                        OperandRange captures) {
+  // Trace through memdesc_index to find (allocName, slotIndex)
+  auto indexOp =
+      dyn_cast_or_null<gpu::MemDescIndexOp>(barrierVal.getDefiningOp());
+  if (!indexOp)
+    return {"", -1};
+
+  Value src = indexOp.getSrc();
+
+  // Try to get static slot index
+  int64_t slotIdx = -1;
+  if (auto constOp = indexOp.getIndex().getDefiningOp<arith::ConstantIntOp>())
+    slotIdx = constOp.value();
+
+  // Trace source through block arguments (warp_specialize captures)
+  Value tracedSrc = src;
+  while (auto blockArg = dyn_cast<BlockArgument>(tracedSrc)) {
+    auto *parentOp = blockArg.getOwner()->getParentOp();
+
+    if (auto partitionsOp =
+            dyn_cast<gpu::WarpSpecializePartitionsOp>(parentOp)) {
+      unsigned argIndex = blockArg.getArgNumber();
+      if (auto wsOp = dyn_cast<gpu::WarpSpecializeOp>(
+              partitionsOp->getParentOp())) {
+        if (argIndex < wsOp.getExplicitCaptures().size()) {
+          tracedSrc = wsOp.getExplicitCaptures()[argIndex];
+          continue;
+        }
+      }
+    }
+    break;
+  }
+
+  // Look up alloc name from the traced source
+  std::string allocName;
+  if (auto *defOp = tracedSrc.getDefiningOp()) {
+    auto it = allocOpToName.find(defOp);
+    if (it != allocOpToName.end())
+      allocName = it->second;
+  }
+
+  return {allocName, slotIdx};
+}
+
+//===----------------------------------------------------------------------===//
+// Concrete integer expression evaluation
+//===----------------------------------------------------------------------===//
+
+std::optional<int64_t>
+BarrierDeadlockAnalysis::tryEvalInt(Value val, int64_t loopVar,
+                                    Value loopInductionVar) {
+  if (val == loopInductionVar)
+    return loopVar;
+
+  if (auto constOp = val.getDefiningOp<arith::ConstantIntOp>())
+    return constOp.value();
+
+  if (auto constOp = val.getDefiningOp<arith::ConstantIndexOp>())
+    return constOp.value();
+
+  Operation *defOp = val.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  // Handle unary ops first (1 operand) — must come before the binary check
+  if (isa<arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp>(defOp))
+    return tryEvalInt(defOp->getOperand(0), loopVar, loopInductionVar);
+
+  // Binary ops require 2 operands
+  if (defOp->getNumOperands() < 2)
+    return std::nullopt;
+
+  auto lhs = tryEvalInt(defOp->getOperand(0), loopVar, loopInductionVar);
+  auto rhs = tryEvalInt(defOp->getOperand(1), loopVar, loopInductionVar);
+  if (!lhs || !rhs)
+    return std::nullopt;
+
+  if (isa<arith::AddIOp>(defOp))
+    return *lhs + *rhs;
+  if (isa<arith::SubIOp>(defOp))
+    return *lhs - *rhs;
+  if (isa<arith::MulIOp>(defOp))
+    return *lhs * *rhs;
+  if (isa<arith::RemSIOp>(defOp))
+    return *rhs != 0 ? std::optional(*lhs % *rhs) : std::nullopt;
+  if (isa<arith::DivSIOp>(defOp))
+    return *rhs != 0 ? std::optional(*lhs / *rhs) : std::nullopt;
+  if (isa<arith::XOrIOp>(defOp))
+    return *lhs ^ *rhs;
+  if (isa<arith::AndIOp>(defOp))
+    return *lhs & *rhs;
+  if (isa<arith::OrIOp>(defOp))
+    return *lhs | *rhs;
+  if (isa<arith::MinSIOp>(defOp))
+    return std::min(*lhs, *rhs);
+
+  if (auto cmpOp = dyn_cast<arith::CmpIOp>(defOp)) {
+    switch (cmpOp.getPredicate()) {
+    case arith::CmpIPredicate::eq:
+      return (*lhs == *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::ne:
+      return (*lhs != *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::slt:
+    case arith::CmpIPredicate::ult:
+      return (*lhs < *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::sle:
+    case arith::CmpIPredicate::ule:
+      return (*lhs <= *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::sgt:
+    case arith::CmpIPredicate::ugt:
+      return (*lhs > *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::sge:
+    case arith::CmpIPredicate::uge:
+      return (*lhs >= *rhs) ? 1 : 0;
+    }
+  }
+
+  return std::nullopt;
+}
+
+//===----------------------------------------------------------------------===//
+// Loop unrolling and trace construction
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
+                                         int64_t taskId,
+                                         const std::string &taskName,
+                                         TaskTrace &trace,
+                                         OperandRange captures) {
+  auto lbConst = forOp.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
+  auto stepConst = forOp.getStep().getDefiningOp<arith::ConstantIntOp>();
+
+  int64_t lb = lbConst ? lbConst.value() : 0;
+  int64_t step = stepConst ? stepConst.value() : 1;
+  int64_t ub = unrollBound > 0 ? unrollBound : 5;
+
+  Value inductionVar = forOp.getInductionVar();
+
+  // Resolve slot index dynamically when it depends on the loop variable
+  auto resolveDynSlot = [&](Value alloc, int64_t staticSlot,
+                            int64_t k) -> int64_t {
+    if (staticSlot >= 0)
+      return staticSlot;
+    if (auto indexOp =
+            dyn_cast_or_null<gpu::MemDescIndexOp>(alloc.getDefiningOp())) {
+      if (auto evalIdx = tryEvalInt(indexOp.getIndex(), k, inductionVar))
+        return *evalIdx;
+    }
+    return staticSlot;
+  };
+
+  // Track iter_args (e.g., phase variable) across iterations
+  SmallVector<int64_t> iterArgValues;
+  for (auto initVal : forOp.getInitArgs()) {
+    if (auto constOp = initVal.getDefiningOp<arith::ConstantIntOp>())
+      iterArgValues.push_back(constOp.value());
+    else
+      iterArgValues.push_back(0);
+  }
+
+  auto &bodyBlock = forOp.getRegion().front();
+  // Block args: [inductionVar, iterArg0, iterArg1, ...]
+  SmallVector<Value> iterArgBlockArgs;
+  for (unsigned i = 1; i < bodyBlock.getNumArguments(); ++i)
+    iterArgBlockArgs.push_back(bodyBlock.getArgument(i));
+
+  for (int64_t k = lb; k < lb + ub * step; k += step) {
+    for (auto &op : bodyBlock) {
+      ConcreteBarrierOp concreteOp;
+      concreteOp.taskId = taskId;
+      concreteOp.taskName = taskName;
+      concreteOp.iteration = k;
+
+      bool isBarrierOp = false;
+
+      if (auto waitOp = dyn_cast<nvidia_gpu::WaitBarrierOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::Wait;
+        auto [name, slot] = resolveBarrier(waitOp.getAlloc(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex =
+            resolveDynSlot(waitOp.getAlloc(), slot, k);
+
+        // Resolve phase: try direct eval, then iter_args
+        auto phaseVal = tryEvalInt(waitOp.getPhase(), k, inductionVar);
+        if (!phaseVal) {
+          for (unsigned i = 0; i < iterArgBlockArgs.size(); ++i) {
+            if (waitOp.getPhase() == iterArgBlockArgs[i]) {
+              phaseVal = iterArgValues[i];
+              break;
+            }
+          }
+        }
+        concreteOp.phase = phaseVal.value_or(-1);
+        isBarrierOp = true;
+
+      } else if (auto arriveOp =
+                     dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::ArriveSync;
+        auto [name, slot] = resolveBarrier(arriveOp.getAlloc(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex = resolveDynSlot(arriveOp.getAlloc(), slot, k);
+        concreteOp.arriveCount = arriveOp.getCount();
+        isBarrierOp = true;
+
+      } else if (auto expectOp =
+                     dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::ExpectBytes;
+        auto [name, slot] = resolveBarrier(expectOp.getAlloc(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex = resolveDynSlot(expectOp.getAlloc(), slot, k);
+        concreteOp.expectedBytes = expectOp.getSize();
+        // barrier_expect does arrive (PTX mbarrier.arrive.expect_tx)
+        concreteOp.arriveCount = 1;
+        isBarrierOp = true;
+
+      } else if (auto tmaOp =
+                     dyn_cast<nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::TmaLoad;
+        auto [name, slot] = resolveBarrier(tmaOp.getBarrier(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex = resolveDynSlot(tmaOp.getBarrier(), slot, k);
+        // TMA load does NOT arrive; only contributes bytes
+        concreteOp.arriveCount = 0;
+        isBarrierOp = true;
+      }
+
+      if (isBarrierOp) {
+        std::string locStr;
+        llvm::raw_string_ostream locOs(locStr);
+        op.getLoc()->print(locOs);
+        concreteOp.locInfo = locStr;
+        concreteOp.position = trace.ops.size();
+        trace.ops.push_back(concreteOp);
+      }
+    }
+
+    // Update iter_arg values for next iteration
+    auto *terminator = bodyBlock.getTerminator();
+    if (auto yieldOp = dyn_cast<scf::YieldOp>(terminator)) {
+      for (unsigned i = 0;
+           i < yieldOp.getNumOperands() && i < iterArgValues.size(); ++i) {
+        auto newVal = tryEvalInt(yieldOp.getOperand(i), k, inductionVar);
+
+        // If direct eval fails, try resolving through iter_args
+        if (!newVal) {
+          for (unsigned j = 0; j < iterArgBlockArgs.size(); ++j) {
+            if (yieldOp.getOperand(i) == iterArgBlockArgs[j]) {
+              newVal = iterArgValues[j];
+              break;
+            }
+          }
+        }
+
+        // Handle XOR pattern: phase = old_phase ^ (buf == NUM_STAGES-1)
+        if (!newVal) {
+          if (auto xorOp =
+                  yieldOp.getOperand(i).getDefiningOp<arith::XOrIOp>()) {
+            auto lhsVal = tryEvalInt(xorOp.getLhs(), k, inductionVar);
+            auto rhsVal = tryEvalInt(xorOp.getRhs(), k, inductionVar);
+            if (!lhsVal) {
+              for (unsigned j = 0; j < iterArgBlockArgs.size(); ++j) {
+                if (xorOp.getLhs() == iterArgBlockArgs[j]) {
+                  lhsVal = iterArgValues[j];
+                  break;
+                }
+              }
+            }
+            if (lhsVal && rhsVal)
+              newVal = *lhsVal ^ *rhsVal;
+          }
+        }
+
+        if (newVal)
+          iterArgValues[i] = *newVal;
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Build task traces from warp_specialize regions
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::buildTaskTraces() {
+  funcOp.walk([&](gpu::WarpSpecializeOp wsOp) {
+    auto explicitCaptures = wsOp.getExplicitCaptures();
+
+    // Build capture name map
+    for (unsigned i = 0; i < explicitCaptures.size(); ++i) {
+      Value cap = explicitCaptures[i];
+      if (auto *defOp = cap.getDefiningOp()) {
+        auto it = allocOpToName.find(defOp);
+        if (it != allocOpToName.end())
+          captureIndexToAllocName[i] = it->second;
+      }
+    }
+
+    // Process default region (typically the producer, task 0)
+    {
+      TaskTrace trace;
+      trace.taskId = 0;
+      trace.taskName = "default";
+
+      for (auto &op : wsOp.getDefaultRegion().front()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(&op))
+          unrollLoop(forOp, 0, "default", trace, explicitCaptures);
+      }
+
+      if (!trace.ops.empty())
+        taskTraces.push_back(std::move(trace));
+    }
+
+    // Process partition regions (typically consumers)
+    int partIdx = 0;
+    for (Region *region : wsOp.getPartitionRegions()) {
+      std::string taskName = "partition" + std::to_string(partIdx);
+      int64_t taskId = partIdx + 1;
+
+      TaskTrace trace;
+      trace.taskId = taskId;
+      trace.taskName = taskName;
+
+      for (auto &op : region->front()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(&op))
+          unrollLoop(forOp, taskId, taskName, trace, explicitCaptures);
+      }
+
+      if (!trace.ops.empty())
+        taskTraces.push_back(std::move(trace));
+      partIdx++;
+    }
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// Summary printing
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::printSummary(llvm::raw_ostream &os) const {
+  os << "Barrier allocations:\n";
+  for (const auto &alloc : barrierAllocs) {
+    os << "  " << alloc.name << ": " << alloc.numSlots
+       << " slots, arrive_count=" << alloc.arriveCount << "\n";
+  }
+
+  os << "\nTask traces:\n";
+  for (const auto &task : taskTraces) {
+    os << "  " << task.taskName << " (task " << task.taskId << "): "
+       << task.ops.size() << " barrier ops\n";
+    for (const auto &op : task.ops) {
+      os << "    [" << op.position << "] " << barrierOpKindToString(op.kind)
+         << " " << op.allocName << "[" << op.slotIndex << "]";
+      if (op.phase >= 0)
+        os << " phase=" << op.phase;
+      if (op.arriveCount > 1)
+        os << " count=" << op.arriveCount;
+      if (op.expectedBytes > 0)
+        os << " bytes=" << op.expectedBytes;
+      os << " (iter " << op.iteration << ")\n";
+    }
+  }
+}
+
+} // namespace mlir::triton

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonAnalysis
   AxisInfo.cpp
   Allocation.cpp
+  BarrierAnalysis.cpp
   Membar.cpp
   Alias.cpp
   Utility.cpp

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -365,6 +365,7 @@ class compilation_knobs(base_knobs):
     disable_line_info: env_bool = env_bool("TRITON_DISABLE_LINE_INFO")
     front_end_debugging: env_bool = env_bool("TRITON_FRONT_END_DEBUGGING")
     allow_non_constexpr_globals: env_bool = env_bool("TRITON_ALLOW_NON_CONSTEXPR_GLOBALS")
+    static_analysis: env_bool = env_bool("TRITON_ENABLE_STATIC_ANALYSIS")
     # Instrumentation mode is checked on every run, which is expensive.
     # We cache the value here to avoid the expensive check on every run.
     instrumentation_mode: str = env_str("TRITON_INSTRUMENTATION_MODE", "").get()

--- a/test/Analysis/test-barrier-analysis.mlir
+++ b/test/Analysis/test-barrier-analysis.mlir
@@ -1,0 +1,169 @@
+// RUN: triton-opt %s -split-input-file -test-print-barrier-analysis="unroll-bound=5" 2>&1 | FileCheck %s
+
+// Test: Simple producer-consumer pipeline with 4 stages.
+// Producer: wait(empty), expect(full), tma_load(full)
+// Consumer: wait(full), arrive(empty)
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Analysis: simple_pipeline ===
+// CHECK: Barrier allocations:
+// CHECK:   bars_empty: 4 slots, arrive_count=1
+// CHECK:   bars_full: 4 slots, arrive_count=1
+// CHECK: Task traces:
+// CHECK:   default (task 0): 15 barrier ops
+// CHECK:     [0] wait_barrier bars_empty[0] phase=0 (iter 0)
+// CHECK:     [1] barrier_expect bars_full[0] bytes=8192 (iter 0)
+// CHECK:     [2] tma_load bars_full[0] (iter 0)
+// CHECK:     [3] wait_barrier bars_empty[1] phase=0 (iter 1)
+// CHECK:     [4] barrier_expect bars_full[1] bytes=8192 (iter 1)
+// CHECK:     [5] tma_load bars_full[1] (iter 1)
+// CHECK:     [6] wait_barrier bars_empty[2] phase=0 (iter 2)
+// CHECK:     [7] barrier_expect bars_full[2] bytes=8192 (iter 2)
+// CHECK:     [8] tma_load bars_full[2] (iter 2)
+// CHECK:     [9] wait_barrier bars_empty[3] phase=0 (iter 3)
+// CHECK:     [10] barrier_expect bars_full[3] bytes=8192 (iter 3)
+// CHECK:     [11] tma_load bars_full[3] (iter 3)
+// CHECK:     [12] wait_barrier bars_empty[0] phase=1 (iter 4)
+// CHECK:     [13] barrier_expect bars_full[0] bytes=8192 (iter 4)
+// CHECK:     [14] tma_load bars_full[0] (iter 4)
+// CHECK:   partition0 (task 1): 10 barrier ops
+// CHECK:     [0] wait_barrier bars_full[0] phase=0 (iter 0)
+// CHECK:     [1] arrive_barrier bars_empty[0] (iter 0)
+// CHECK:     [2] wait_barrier bars_full[1] phase=0 (iter 1)
+// CHECK:     [3] arrive_barrier bars_empty[1] (iter 1)
+// CHECK:     [4] wait_barrier bars_full[2] phase=0 (iter 2)
+// CHECK:     [5] arrive_barrier bars_empty[2] (iter 2)
+// CHECK:     [6] wait_barrier bars_full[3] phase=0 (iter 3)
+// CHECK:     [7] arrive_barrier bars_empty[3] (iter 3)
+// CHECK:     [8] wait_barrier bars_full[0] phase=1 (iter 4)
+// CHECK:     [9] arrive_barrier bars_empty[0] (iter 4)
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @simple_pipeline(%K: i32, %desc: !tt.tensordesc<tensor<64x64xf16>>) {
+    %true = arith.constant true
+    %c4_i32 = arith.constant 4 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %data = ttg.local_alloc : () -> !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable>
+    %bars_empty = ttg.local_alloc : () -> !ttg.memdesc<4xi64, #shared1, #smem, mutable> loc("bars_empty")
+    %be0 = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be1 = ttg.memdesc_index %bars_empty[%c1_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be2 = ttg.memdesc_index %bars_empty[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be3 = ttg.memdesc_index %bars_empty[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    %bars_full = ttg.local_alloc : () -> !ttg.memdesc<4xi64, #shared1, #smem, mutable> loc("bars_full")
+    %bf0 = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf1 = ttg.memdesc_index %bars_full[%c1_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf2 = ttg.memdesc_index %bars_full[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf3 = ttg.memdesc_index %bars_full[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
+    default {
+      // Producer: wait(empty[buf]), expect(full[buf]), tma_load(full[buf])
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c4_i32 : i32
+        %empty_bar = ttg.memdesc_index %bars_empty[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %full_bar = ttg.memdesc_index %bars_full[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %data_buf = ttg.memdesc_index %data[%buf] : !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+
+        ttng.wait_barrier %empty_bar, %phase, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.barrier_expect %full_bar, 8192, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %data_buf, %full_bar, %true : !tt.tensordesc<tensor<64x64xf16>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+
+        // phase ^= (buf == 3)
+        %is_last = arith.cmpi eq, %buf, %c3_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<4xi64, #shared1, #smem, mutable>, %arg3: !ttg.memdesc<4xi64, #shared1, #smem, mutable>, %arg4: !tt.tensordesc<tensor<64x64xf16>>) num_warps(4) {
+      // Consumer: wait(full[buf]), arrive(empty[buf])
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c3 = arith.constant 3 : i32
+      %c4 = arith.constant 4 : i32
+      %t = arith.constant true
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%phase = %c0) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c4 : i32
+        %full_bar = ttg.memdesc_index %arg3[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %empty_bar = ttg.memdesc_index %arg2[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+        ttng.wait_barrier %full_bar, %phase, %t : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.arrive_barrier %empty_bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+        %is_last = arith.cmpi eq, %buf, %c3 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<4xi64, #shared1, #smem, mutable>, !ttg.memdesc<4xi64, #shared1, #smem, mutable>, !tt.tensordesc<tensor<64x64xf16>>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Phase tracking correctness with 2 stages (phases flip every 2 iterations).
+
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem2 = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Analysis: two_stage_pipeline ===
+// CHECK: Barrier allocations:
+// CHECK:   bars: 2 slots, arrive_count=1
+// CHECK: Task traces:
+// CHECK:   default (task 0): 5 barrier ops
+// Phase flips at buf==1, so: iter0=phase0, iter1=phase0->flip, iter2=phase1, iter3=phase1->flip, iter4=phase0
+// CHECK:     [0] wait_barrier bars[0] phase=0 (iter 0)
+// CHECK:     [1] wait_barrier bars[1] phase=0 (iter 1)
+// CHECK:     [2] wait_barrier bars[0] phase=1 (iter 2)
+// CHECK:     [3] wait_barrier bars[1] phase=1 (iter 3)
+// CHECK:     [4] wait_barrier bars[0] phase=0 (iter 4)
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @two_stage_pipeline(%K: i32) {
+    %true = arith.constant true
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared3, #smem2, mutable> loc("bars")
+    %b0 = ttg.memdesc_index %bars[%c0_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %b0, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    %b1 = ttg.memdesc_index %bars[%c1_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %b1, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+
+    ttg.warp_specialize(%K, %bars)
+    default {
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2_i32 : i32
+        %bar = ttg.memdesc_index %bars[%buf] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        ttng.wait_barrier %bar, %phase, %true : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        // phase ^= (buf == 1)
+        %is_last = arith.cmpi eq, %buf, %c1_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    } : (i32, !ttg.memdesc<2xi64, #shared3, #smem2, mutable>) -> ()
+    tt.return
+  }
+}

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_library(TritonTestAnalysis
   TestAlias.cpp
   TestAxisInfo.cpp
   TestAllocation.cpp
+  TestBarrierAnalysis.cpp
   TestMembar.cpp
   TestPrintNesting.cpp
 

--- a/test/lib/Analysis/TestBarrierAnalysis.cpp
+++ b/test/lib/Analysis/TestBarrierAnalysis.cpp
@@ -1,0 +1,51 @@
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Analysis/BarrierAnalysis.h"
+
+using namespace mlir;
+
+namespace {
+
+struct TestBarrierAnalysisPass
+    : public PassWrapper<TestBarrierAnalysisPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestBarrierAnalysisPass);
+
+  TestBarrierAnalysisPass() = default;
+  TestBarrierAnalysisPass(const TestBarrierAnalysisPass &other)
+      : PassWrapper<TestBarrierAnalysisPass, OperationPass<ModuleOp>>(other) {}
+
+  StringRef getArgument() const final { return "test-print-barrier-analysis"; }
+  StringRef getDescription() const final {
+    return "print the result of the barrier deadlock trace extraction";
+  }
+
+  Option<int> unrollBound{*this, "unroll-bound",
+                          llvm::cl::desc("Loop unrolling bound"),
+                          llvm::cl::init(0)};
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    moduleOp.walk([&](FunctionOpInterface funcOp) {
+      triton::BarrierDeadlockAnalysis analysis(funcOp, unrollBound);
+      analysis.run();
+
+      if (analysis.getTaskTraces().empty())
+        return;
+
+      llvm::outs() << "=== Barrier Analysis: " << funcOp.getName() << " ===\n";
+      analysis.printSummary(llvm::outs());
+    });
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestBarrierAnalysisPass() {
+  PassRegistration<TestBarrierAnalysisPass>();
+}
+} // namespace test
+} // namespace mlir

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -318,6 +318,10 @@ class CUDABackend(BaseBackend):
         passes.common.add_symbol_dce(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
+
+        if knobs.compilation.static_analysis:
+            CUDABackend.run_static_analysis(mod)
+
         return mod
 
     @staticmethod
@@ -664,6 +668,12 @@ please share the reproducer above with Triton project.
             if os.path.exists(fbin):
                 os.remove(fbin)
         return cubin
+
+    @staticmethod
+    def run_static_analysis(mod):
+        # Optional static analyses gated by TRITON_ENABLE_STATIC_ANALYSIS.
+        # TODO: Add barrier deadlock detection pass (PR 2).
+        pass
 
     def add_stages(self, stages, options, language):
         capability = self._parse_arch(options.arch)


### PR DESCRIPTION
Add BarrierDeadlockAnalysis for extracting concrete barrier operation traces from warp-specialized TTGIR. This is the program model extraction step (PR 1) of the barrier deadlock detection series.

The analysis walks ttg.warp_specialize regions, unrolls scf.for loops with concrete evaluation of barrier indices and phases, and produces per-task operation traces. It resolves barrier identity via SSA def-use chains through captures and tracks phase evolution faithfully.

Also adds TRITON_ENABLE_STATIC_ANALYSIS env var to gate optional static analyses in the compilation pipeline (currently a no-op, will be wired up in a follow-up PR).

Authored with Claude.