### PR TITLE
[WIP][TLX][lint] Add Z3-based barrier deadlock detection pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -60,6 +60,7 @@ void registerTestAlignmentPass();
 void registerAMDTestAlignmentPass();
 void registerTestAllocationPass();
 void registerTestMembarPass();
+void registerTestBarrierAnalysisPass();
 void registerTestPrintNestingPass();
 void registerTestAMDGPUMembarPass();
 void registerTestTritonAMDGPURangeAnalysis();
@@ -82,6 +83,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerAMDTestAlignmentPass();
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
+  mlir::test::registerTestBarrierAnalysisPass();
   mlir::test::registerTestPrintNestingPass();
   mlir::test::registerTestLoopPeelingPass();
   mlir::test::registerTestAMDGPUMembarPass();

--- a/docs/barrier_deadlock_detection_design.md
+++ b/docs/barrier_deadlock_detection_design.md
@@ -1,0 +1,513 @@
+# Barrier Deadlock Detection for TTGIR — Design Document
+
+This document describes the design of a **constraint-based barrier deadlock
+detector** operating on Triton GPU IR (TTGIR). The detector is an MLIR
+analysis pass that extracts a concrete barrier operation trace from
+`ttg.warp_specialize` regions, encodes barrier semantics as Z3 constraints,
+and checks satisfiability: SAT = deadlock witness, UNSAT = safe within the
+unroll bound.
+
+The constraint encoding follows the authoritative design in
+`triton_lint/docs/deadlock_detection/barrier_deadlock_design.tex` (Sections
+2-5). This document focuses on the **MLIR-specific adaptation** — how the
+program model is extracted from TTGIR rather than Python AST, and what each
+PR delivers.
+
+## 1. Background
+
+### 1.1 Problem
+
+TLX warp-specialized kernels coordinate producer-consumer tasks through
+hardware mbarriers. Incorrect barrier usage — missing arrives, mismatched
+counts, wrong phases — causes silent GPU deadlocks that are extremely hard to
+debug.
+
+### 1.2 Why TTGIR instead of Python AST
+
+The `triton_lint` implementation operates on the Python AST of TLX kernels.
+An MLIR-based detector has several advantages:
+
+| Aspect | Python AST (`triton_lint`) | TTGIR (this work) |
+|--------|---------------------------|-------------------|
+| Constexpr resolution | Needs `# triton-lint: assume` annotations | Already specialized in IR |
+| Barrier identity | Name resolution across scopes | SSA def-use chains (`memdesc_index` → `local_alloc`) |
+| Replicas | Must expand `replicate=N` manually | Already separate `warp_specialize` partition regions |
+| Helper functions | Must inline Python calls | Already inlined by compiler |
+| Language coupling | Python-only | Works on any frontend that emits TTGIR |
+
+### 1.3 Constraint encoding summary
+
+The detector encodes the mbarrier state machine as Z3 constraints (see tex
+doc Sections 2, 5 for full details):
+
+- **Variables**: cut-point `c_i` per task (where stuck), timestamp `τ_j` per
+  op (global order), async completion timestamp `τ'_l` for TMA loads and
+  async arrives.
+- **Φ_ord**: intra-task program ordering via timestamps.
+- **Φ_async**: causal constraint `τ < τ'` for async ops; `async_dot_wait`
+  ordering.
+- **Φ_stall**: tasks can only stall at WAIT positions.
+- **Φ_B** (blocking): stalled WAIT's barrier is permanently blocked — either
+  arrive/byte deficit or phase cycling.
+- **Φ_R** (reachability): every passed-through WAIT was satisfiable *at the
+  time it was reached*, using timestamp-filtered arrive counts.
+- **Deadlock query**: `∨(c_i < n_i)` — at least one task is stuck.
+
+## 2. Program Model
+
+After loop unrolling with bound U, the program model is a tuple
+`(T, B, O)`:
+
+- **T**: set of concurrent tasks (from `warp_specialize` regions).
+- **B**: set of barrier slots. Each slot `b` has arrive count `ac(b)`.
+- **O**: set of concrete barrier operation instances (after unrolling).
+
+### 2.1 Operation kinds
+
+Each operation has a `kind` from the following classification (tex doc
+Section 2.2):
+
+| Kind | TTGIR op | Barrier effect | Effect time |
+|------|----------|----------------|-------------|
+| **ARRIVE_SYNC** | `ttng.arrive_barrier` | `pending_arrives -= cnt` | τ (synchronous) |
+| **EXPECT_BYTES** | `ttng.barrier_expect` | `pending_arrives -= 1` AND `pending_bytes += sz` | τ (synchronous) |
+| **TMA_LOAD** | `ttng.async_tma_copy_global_to_local` | `pending_bytes -= xfer` on DMA completion | τ' (async) |
+| **ARRIVE_ASYNC** | from `async_dot` / `tcgen05_commit` lowering | `pending_arrives -= 1` on engine completion | τ' (async) |
+| **WAIT** | `ttng.wait_barrier` | blocks while `phase == φ` | τ (timestamp of return) |
+| **ASYNC_DOT_WAIT** | `ttng.async_dot_wait` | forces completion of prior async dots | τ |
+
+Key semantic points (from tex doc Remarks):
+- **`barrier_expect`** (PTX `mbarrier.arrive.expect_tx`) does both an arrive
+  (cnt=1) AND sets expected bytes. It is a full arrive operation.
+- **TMA load** only does byte completion, NOT an arrive.
+- **`async_dot`** arrives are asynchronous — the barrier update happens when
+  the tensor core completes, not when the instruction retires.
+
+### 2.2 Operation attributes
+
+Each concrete operation carries (all concrete integers, no symbolic
+variables):
+
+- `task(o)`: enclosing task.
+- `pos(o)`: position within task (program order after unrolling).
+- `kind(o)`: from the table above.
+- `slot(o) = (alloc_name, slot_index)`: target barrier slot.
+- `cnt(o)`: arrive count (for arrive kinds).
+- `sz(o)`: byte count (for EXPECT_BYTES).
+- `xfer(o)`: transfer size in bytes (for TMA_LOAD).
+- `phase(o)` / `parity(o)`: target phase for WAIT.
+- `iteration`: which unrolled loop iteration produced this op.
+
+## 3. TTGIR to Program Model (PR 1)
+
+This is the MLIR-specific adaptation of tex doc Section 4 ("From AST to
+Program Model"). The translation extracts concrete barrier traces from TTGIR.
+
+### 3.1 `warp_specialize` structure
+
+A TLX kernel in TTGIR has the form:
+
+```mlir
+ttg.warp_specialize(%cap1, %cap2, ...)
+    default {
+        // Producer task (task 0, "default")
+        scf.for %k = %c0 to %K step %c1 {
+            ttng.wait_barrier %bar_empty, %phase_e
+            ttng.barrier_expect %bar_full, %size
+            ttng.async_tma_copy_global_to_local %desc, %buf, %bar_full
+            // phase update...
+        }
+    }
+    partition0(%arg0 = %cap1, %arg1 = %cap2, ...) {
+        // Consumer task (task 1, "partition0")
+        scf.for %k = %c0 to %K step %c1 {
+            ttng.wait_barrier %bar_full, %phase_f
+            // compute...
+            ttng.arrive_barrier %bar_empty
+            // phase update...
+        }
+    }
+```
+
+Key observations:
+- The **default region** and each **partition region** are separate concurrent
+  tasks.
+- Shared values (barriers, descriptors) are passed via **explicit captures** —
+  operands of `warp_specialize` that appear as block arguments in partition
+  regions.
+- Replicas are already expanded: `replicate=2` produces `partition0` and
+  `partition1` with separate block arguments.
+
+### 3.2 Barrier allocation collection
+
+Walk the function for `ttng.local_alloc` ops that produce barrier memdesc
+types. For each allocation:
+
+```
+BarrierAllocInfo {
+    name:         unique identifier (e.g., "alloc_0" from op ordering)
+    numSlots:     number of barrier slots (from memdesc shape)
+    arriveCount:  from init_barrier's arrive_count attribute
+}
+```
+
+Build a map `allocOp → name` for later barrier resolution.
+
+### 3.3 Barrier resolution via def-use chains
+
+Given a barrier `Value` used by a barrier op, resolve it to
+`(allocName, slotIndex)` by tracing the SSA def-use chain:
+
+```
+barrier Value
+  ↓ (defining op)
+memdesc_subview or memdesc_index
+  ↓ (source operand)
+block argument of partition region
+  ↓ (corresponding capture operand of warp_specialize)
+memdesc_subview or local_alloc in the parent scope
+  ↓
+local_alloc (→ allocName from map)
+```
+
+The slot index comes from the index operand of `memdesc_subview`, which must
+evaluate to a concrete integer (it depends on the loop induction variable
+after unrolling).
+
+### 3.4 Concrete evaluation (`tryEvalInt`)
+
+During loop unrolling, we evaluate integer expressions by walking the SSA
+def-use chain with the loop induction variable bound to a concrete value.
+Supported patterns:
+
+- `arith.constant` → literal value
+- `arith.addi`, `arith.subi`, `arith.muli`, `arith.remsi`, `arith.divsi` →
+  binary arithmetic
+- `arith.xori`, `arith.andi`, `arith.ori` → bitwise ops
+- `arith.cmpi` → comparison (returns 0 or 1)
+- `arith.extui`, `arith.extsi`, `arith.trunci` → unary casts (must be
+  handled before the binary-op check since they have only 1 operand)
+- `arith.select` → conditional selection
+- Loop induction variable → current iteration value
+- Block arguments → trace through captures to parent scope
+
+If any expression cannot be resolved to a concrete integer, the operation is
+skipped with a warning (consistent with the tex doc's no-symbolic-fallback
+policy).
+
+### 3.5 Loop unrolling
+
+For each `scf.for` in a task region:
+
+1. Determine unroll bound U:
+   - If `unrollBound` pass option > 0, use that.
+   - Else if loop bounds are static, use `min(tripCount, NUM_STAGES + 1)`.
+   - Else default to U = 2.
+2. For each iteration k = 0, 1, ..., U-1:
+   - Bind the induction variable to `lowerBound + k * step`.
+   - Walk the loop body for barrier ops.
+   - For each barrier op, evaluate all parameters (slot index, phase, size,
+     count) using `tryEvalInt`.
+   - Append a `ConcreteBarrierOp` to the task's trace.
+
+Phase tracking is handled by **faithful evaluation** of the programmer's
+actual expressions (tex doc Section 4.2). For example, the pattern
+`phase ^= (buf == NUM_STAGES - 1)` naturally evaluates correctly: `buf` and
+`NUM_STAGES` are concrete, so `cmpi eq` returns 0 or 1, `extui` extends it,
+and `xori` flips the phase when appropriate.
+
+### 3.6 Output: TaskTrace
+
+The result is a `std::vector<TaskTrace>`, where each `TaskTrace` contains the
+ordered sequence of `ConcreteBarrierOp`s for one task.
+
+### 3.7 Data structures (C++)
+
+```cpp
+enum class BarrierOpKind {
+    ArriveSync,      // ttng.arrive_barrier
+    ExpectBytes,     // ttng.barrier_expect (arrive + set bytes)
+    TmaLoad,         // ttng.async_tma_copy_global_to_local (bytes only)
+    ArriveAsync,     // from async_dot / tcgen05_commit
+    Wait,            // ttng.wait_barrier
+    AsyncDotWait,    // ttng.async_dot_wait
+};
+
+struct ConcreteBarrierOp {
+    BarrierOpKind kind;
+    std::string allocName;
+    int64_t slotIndex;
+    int64_t phase;          // for Wait
+    int64_t arriveCount;    // for arrive kinds (0 for TmaLoad)
+    int64_t expectedBytes;  // for ExpectBytes
+    int64_t xferBytes;      // for TmaLoad
+    int64_t iteration;
+    size_t position;        // within task trace
+};
+
+struct TaskTrace {
+    int64_t taskId;
+    std::string taskName;
+    std::vector<ConcreteBarrierOp> ops;
+};
+
+struct BarrierAllocInfo {
+    std::string name;
+    int64_t numSlots;
+    int64_t arriveCount;
+};
+```
+
+## 4. Z3 Constraint Encoding (PR 2)
+
+PR 2 generates a standalone Python Z3 script from the program model. This
+follows tex doc Section 5 and the reference implementation in
+`z3_encoding.py`.
+
+### 4.1 Variables
+
+```python
+# Cut-point per task: where execution is stuck
+c_<task> = Int('c_<task>')    # 0 <= c_i <= n_i
+
+# Timestamp per operation: global execution order
+tau_<idx> = Int('tau_<idx>')  # >= 0
+
+# Async completion timestamp (TMA_LOAD, ARRIVE_ASYNC only)
+tau_prime_<idx> = Int('tau_prime_<idx>')  # >= 0
+```
+
+### 4.2 Helper predicates
+
+```python
+# exec(o) = pos(o) < c_task(o)
+def exec_op(o): return o.pos < c[o.task]
+
+# effect_time(o) = tau'_o for async ops, tau_o for sync ops
+def effect_time(o):
+    if o.kind in {TMA_LOAD, ARRIVE_ASYNC}: return tau_prime[o]
+    else: return tau[o]
+
+# A(b) = Σ If(exec(o), cnt(o), 0) for arrive-kind ops on slot b
+# A^{<t}(b) = Σ If(exec(o) ∧ effect_time(o) < t, cnt(o), 0)
+```
+
+### 4.3 Completion and blocking (arrive-only simplification)
+
+For the initial implementation, we use the **arrive-only** completion model
+(tex doc Eq. 6, simplified without per-cycle byte tracking):
+
+```python
+# ct(b, i) = A(b) >= (i+1) * ac(b) ∧ total_loaded >= total_expected
+# blocked(b, i) = ¬ct(b,i) ∨ ct(b,i+1)
+```
+
+The byte condition uses **cumulative** (not per-cycle) tracking: sum all
+executed EXPECT_BYTES sizes vs. sum all executed TMA_LOAD transfer sizes.
+This is the approach used in the reference implementation (`completion()`
+method), which avoids the complexity of timestamp-based per-cycle byte
+attribution while remaining sound.
+
+### 4.4 Parity-based blocking (Φ_B)
+
+When the wait's phase/parity is concretely known (which it always is after
+our concrete evaluation), we use the parity-based blocked predicate:
+
+```python
+# blocked_parity(b, p) = (A(b) / ac(b)) % 2 == p
+# i.e., the barrier's current phase equals the wait's parity → still blocked
+```
+
+This is equivalent to the cycle-based `blocked(b, i)` but uses only the
+global arrive count, which is simpler. Falls back to cycle-based when
+parity is unknown.
+
+### 4.5 Release constraint (Φ_R)
+
+For each WAIT that was passed through (pos < c_i):
+
+```python
+# Parity-based: phase at τ_w must differ from wait's parity
+a_before = arrive_count_before(b, tau_w)
+phase_before = (a_before / ac) % 2
+release_cond = (phase_before != parity)
+
+# Cycle-based fallback:
+# arrive_ready = A^{<τ_w}(b) >= (i_w+1) * ac(b)
+# anti_cycle = ¬ct^{<τ_w}(b, i_w+1)
+# release_cond = arrive_ready ∧ anti_cycle
+```
+
+### 4.6 Constraint assembly
+
+```python
+solver = Solver()
+
+# Structural
+solver.add(0 <= c_i, c_i <= n_i)
+solver.add(tau >= 0, tau_prime >= 0)
+
+# Φ_ord: consecutive ops in same task
+solver.add(Implies(exec(a) ∧ exec(b), tau_a < tau_b))
+
+# Φ_async: causal ordering
+solver.add(Implies(exec(l), tau_l < tau_prime_l))
+
+# Φ_stall: stall only at WAIT positions
+solver.add(Implies(c_i < n_i, Or(c_i == w.pos for w in waits)))
+
+# Φ_B: blocked barrier at stall point
+solver.add(Implies(c_i == w.pos ∧ c_i < n_i, blocked(w)))
+
+# Φ_R: passed-through waits were satisfiable
+solver.add(Implies(w.pos < c_i, release_cond(w)))
+
+# Deadlock query
+solver.add(Or(c_i < n_i for each task))
+```
+
+### 4.7 Development vs. production
+
+- **Development (PR 2)**: Generate a standalone Python script that imports
+  `z3` and prints SAT/UNSAT with diagnostic extraction. Run via
+  `python3 /tmp/triton_deadlock_check.py`.
+- **Future (PR 5)**: Migrate to MLIR SMT dialect + SMT-LIB export for
+  in-process solving without Python dependency.
+
+## 5. Pass Registration (PR 2)
+
+The pass is registered as `--triton-barrier-deadlock-detection` in
+`triton-opt`:
+
+```tablegen
+def TritonBarrierDeadlockDetection
+    : Pass<"triton-barrier-deadlock-detection", "ModuleOp"> {
+  let summary = "Detect potential barrier deadlocks in warp-specialized kernels";
+  let options = [
+    Option<"outputPath", "output-path", "std::string", /*default=*/"\"\"",
+           "Path to write Z3 script (empty = stderr)">,
+    Option<"runSolver", "run-solver", "bool", /*default=*/"false",
+           "Run python3 on the generated Z3 script">,
+    Option<"unrollBound", "unroll-bound", "int", /*default=*/"0",
+           "Loop unrolling bound (0 = auto)">,
+  ];
+}
+```
+
+Usage:
+```bash
+triton-opt --triton-barrier-deadlock-detection \
+           --triton-barrier-deadlock-detection-output-path=/tmp/check.py \
+           input.ttgir
+python3 /tmp/check.py
+```
+
+## 6. Lit Tests (PR 3)
+
+Test cases as TTGIR `.mlir` files:
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| `correct_pipeline.mlir` | Standard producer-consumer with correct phases | UNSAT |
+| `missing_arrive.mlir` | Consumer waits but no arrive from producer | SAT |
+| `missing_tma_load.mlir` | `barrier_expect` without matching TMA load | SAT |
+| `phase_mismatch.mlir` | Consumer waits with wrong phase | SAT |
+| `circular_dependency.mlir` | Two tasks each waiting on the other's arrive | SAT |
+| `arrive_count_mismatch.mlir` | `arrive_count=2` but only 1 arrive | SAT |
+
+Each test uses `FileCheck` to verify the generated Z3 script structure (or
+uses `--run-solver` to verify SAT/UNSAT directly if Z3 is available in CI).
+
+## 7. PR Plan
+
+### PR 1: Program model extraction
+
+**Scope**: Extract concrete barrier operation traces from TTGIR.
+
+**Files**:
+- `include/triton/Analysis/BarrierAnalysis.h` — Data structures
+  (`ConcreteBarrierOp`, `TaskTrace`, `BarrierAllocInfo`) and
+  `BarrierDeadlockAnalysis` class declaration (trace-building methods only,
+  no Z3).
+- `lib/Analysis/BarrierAnalysis.cpp` — Implementation of:
+  - `collectBarrierAllocs()`: walk for `local_alloc` + `init_barrier`.
+  - `buildTaskTraces()`: walk `warp_specialize`, dispatch to
+    `processWarpRegion()`.
+  - `processWarpRegion()`: walk region for barrier ops and `scf.for` loops.
+  - `unrollLoop()`: iterate k=0..U-1, evaluate parameters, build
+    `ConcreteBarrierOp`s.
+  - `resolveBarrier()`: trace def-use chain to `(allocName, slotIndex)`.
+  - `tryEvalInt()`: concrete integer expression evaluator.
+- `lib/Analysis/CMakeLists.txt` — Add `BarrierAnalysis.cpp`.
+
+**Does NOT include**: Z3 encoding, pass registration, `dumpPythonZ3Script()`.
+
+**Testing**: Unit-style verification by dumping traces (print method) and
+checking against expected output for a hand-written TTGIR test case.
+
+### PR 2: Z3 constraint encoding + pass
+
+**Scope**: Generate Z3 constraints from the program model and register the
+`triton-opt` pass.
+
+**Files**:
+- `include/triton/Analysis/BarrierAnalysis.h` — Add `dumpPythonZ3Script()`
+  method.
+- `lib/Analysis/BarrierAnalysis.cpp` — Implement `dumpPythonZ3Script()`:
+  emit Python Z3 script with all constraint components (Φ_ord, Φ_async,
+  Φ_stall, Φ_B, Φ_R, deadlock query).
+- `include/triton/Dialect/TritonGPU/Transforms/Passes.td` — Register
+  `TritonBarrierDeadlockDetection` pass with options.
+- `lib/Dialect/TritonGPU/Transforms/BarrierDeadlockDetection.cpp` — Pass
+  entry point: instantiate `BarrierDeadlockAnalysis`, run, dump script.
+- `lib/Dialect/TritonGPU/Transforms/CMakeLists.txt` — Add source file.
+
+### PR 3: Lit tests
+
+Hand-crafted TTGIR test cases covering correct and buggy scenarios.
+
+### PR 4: Pipeline integration
+
+Wire into TLX compilation pipeline as an optional diagnostic pass.
+
+### PR 5 (future): MLIR SMT dialect migration
+
+Replace Python Z3 script generation with `smt.*` dialect ops and SMT-LIB
+export.
+
+## 8. Relationship to `BarrierExecutionOrderAnalysis`
+
+The existing `BarrierExecutionOrderAnalysis` on the `mren/barrier-ana` branch
+is a separate analysis with a different purpose: it collects barrier ops,
+groups by warp group, and identifies producer-consumer dependencies using a
+graph-based approach. It does **not** do loop unrolling, concrete evaluation,
+or constraint encoding.
+
+`BarrierDeadlockAnalysis` is a new, independent analysis. It may reuse
+some utility code (e.g., `barrierOpKindToString`, value tracing through
+block args) but is not built on top of `BarrierExecutionOrderAnalysis`.
+The two analyses can coexist.
+
+## 9. Scope Limitations
+
+The initial implementation focuses on the core producer-consumer mbarrier
+pattern. The following are out of scope for the initial PRs:
+
+- **Named barriers** (`bar.arrive` / `bar.sync`): different completion
+  semantics (thread-count based). Tex doc Section 2.2.6.
+- **Multi-CTA barriers**: remote CTA rank, predicated operations.
+- **Path sensitivity**: branches in unrolled TTGIR are rare (constexprs
+  already specialized). If encountered, operations under unresolvable
+  conditions are included unconditionally (over-approximation).
+- **`async_dot_wait` ordering** (Φ_async^adw): requires tracking wgmma
+  groups. Added in a follow-up.
+- **Per-cycle byte tracking**: uses cumulative byte balance instead.
+  Sound but may miss some byte-timing-related deadlocks.
+
+## References
+
+- **Authoritative design**: `triton_lint/docs/deadlock_detection/barrier_deadlock_design.tex`
+- **Reference implementation**: `triton_lint/analysis/barrier/z3_encoding.py`,
+  `triton_lint/analysis/barrier/program_model.py`
+- GCatch: Liu et al., "Automatically Detecting and Fixing Concurrency Bugs
+  in Go Software Systems", ASPLOS 2021.

--- a/docs/deadlock_detection_issue.md
+++ b/docs/deadlock_detection_issue.md
@@ -1,0 +1,201 @@
+# Barrier deadlock detection for TLX warp-specialized kernels
+
+TLX warp-specialized kernels coordinate producer-consumer tasks through hardware mbarriers. Incorrect barrier usage (missing arrives, mismatched counts, wrong phases) causes silent GPU deadlocks that are extremely hard to debug.
+
+This issue tracks the work to add a **constraint-based barrier deadlock detector** as an MLIR pass operating on TTGIR. The approach encodes barrier semantics as Z3 constraints following the design in `triton_lint`'s `barrier_deadlock_design.tex`, adapted to work on MLIR IR instead of Python AST.
+
+## Advantages over the Python AST approach (triton_lint)
+
+- No `# triton-lint: assume` annotations needed — constexprs already specialized in IR
+- Barrier identity is clear from SSA def-use chains (no name resolution)
+- Replicas already expanded into separate `warp_specialize` partition regions
+- Can run on any TTGIR, not just Python-authored kernels
+
+## Design
+
+The detector:
+1. Walks `ttg.warp_specialize` regions to identify concurrent tasks
+2. Unrolls `scf.for` loops with concrete evaluation of barrier indices and phases
+3. Produces a concrete operation trace per task
+4. Generates Z3 constraints (Phi_ord, Phi_async, Phi_stall, Phi_B, Phi_R) encoding barrier semantics
+5. SAT = deadlock witness; UNSAT = safe within unroll bound
+
+Development phase dumps a standalone Python Z3 script; production phase will migrate to MLIR SMT dialect + SMT-LIB export.
+
+## PR Plan
+
+- [x] **PR 1: Program model extraction** — `BarrierDeadlockAnalysis` class with concrete barrier trace extraction from TTGIR.
+- [x] **PR 2: Z3 constraint encoding + pass** — `dumpPythonZ3Script()` method + `BarrierDeadlockDetection` pass.
+- [ ] **PR 3: Lit tests** — More lit tests covering additional bug patterns.
+- [ ] **PR 4: Integration** — Wire into TLX compilation pipeline as an optional diagnostic pass.
+- [ ] **(Future) PR 5: MLIR SMT dialect migration** — Replace Python Z3 script with `smt.*` dialect ops.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `include/triton/Analysis/BarrierAnalysis.h` | Data structures and `BarrierDeadlockAnalysis` class |
+| `lib/Analysis/BarrierAnalysis.cpp` | Implementation: trace extraction (PR 1) + Z3 encoding (PR 2) |
+| `lib/Dialect/TritonGPU/Transforms/BarrierDeadlockDetection.cpp` | Pass entry point (PR 2) |
+| `docs/barrier_deadlock_detection_design.md` | Design doc (MLIR adaptation of `barrier_deadlock_design.tex`) |
+
+---
+
+## Current Status (2026-04-06)
+
+### PR 1 — Merged
+
+Branch `shuofei/barrier-deadlock-analysis-pr1`, GitHub PR #1157 (draft).
+- Trace extraction working: walks `warp_specialize`, unrolls `scf.for`, tracks barrier ops with slot/phase.
+
+### PR 2 — Committed locally, NOT yet pushed
+
+Branch `shuofei/barrier-deadlock-analysis-pr2` (stacked on PR 1).
+- Z3 constraint encoding (`dumpPythonZ3Script`) fully implemented.
+- `BarrierDeadlockDetection` pass registered as `tritongpu-barrier-deadlock-detection`.
+- `collectInitialArrives()` handles pre-task barrier arrives.
+- Lit tests: 6 total (1 UNSAT correct pipeline + 5 SAT bug patterns). All verified with Z3 solver.
+
+---
+
+## Validation on Real TLX Hopper Kernels
+
+### hopper_gemm_ws — **64/64 UNSAT, 0 false positives**
+
+All 64 TTIR variants (different tile sizes, stages, etc.) pass deadlock detection with UNSAT result. This is a strong validation that the detector produces no false positives on correct warp-specialized kernels.
+
+### hopper_gemm_pipelined — NO-WS (not applicable)
+
+This kernel does not use `warp_specialize`, so no analysis is performed.
+
+### hopper_fa_ws_pipelined_pingpong_persistent — **Z3 timeout**
+
+The FA kernel generates 470 barrier ops across all tasks, producing a 3060-line Z3 script. The Z3 solver returns `unknown` (timeout). See scalability section below.
+
+---
+
+## Technical Notes
+
+### 1. Handling `perThread` Arrives
+
+**Problem**: `ttng.arrive_barrier` supports a `perThread` attribute. When `perThread` is set, each thread in the warp group arrives independently, so the effective arrive count is `count × numWarps × threadsPerWarp`.
+
+**Which ops support perThread**: Only `ArriveBarrierOp` (`ttng.arrive_barrier`) has the `perThread` attribute. Other barrier ops (`barrier_expect`, `wait_barrier`, `async_tma_copy_global_to_local`) do not have it.
+
+**Solution**:
+- In `tryAppendBarrierOp`, when processing an `arrive_barrier` with `getPerThread() == true`, multiply the arrive count by `numThreads`:
+  ```cpp
+  if (arriveOp.getPerThread())
+    count *= numThreads;
+  ```
+- `numThreads` is computed per-task from:
+  - `partitionNumWarps`: per-partition warp count from `WarpSpecializeOp.getPartitionNumWarps()` array attribute.
+  - `threadsPerWarp`: from the module attribute `ttg.threads-per-warp` (typically 32).
+  - `numThreads = partitionNumWarps[taskIdx] × threadsPerWarp`
+- For the default region (task 0), `numWarps` is derived from the total module `ttg.num-warps` minus the sum of all partition warp counts.
+
+**Validation**: Without this handling, hopper_gemm_ws produced 32 SAT false positives (barriers initialized with `arrive_count=128` but analysis only saw 1 arrive per `perThread` arrive op). After the fix, all 64 variants are UNSAT.
+
+### 2. Handling Cluster Barriers (cta_bars)
+
+**Problem**: Some Hopper kernels use cluster barriers for inter-CTA synchronization. These barriers use `ttng.map_to_remote_buffer` to arrive on a remote CTA's barrier. The analysis only models a single CTA, so it sees only the local arrive (count=1) but the barrier expects arrives from multiple CTAs (e.g., `arrive_count=2`), causing false SAT results.
+
+**Current workaround**: In `collectBarrierAllocs()`, detect cluster barriers by checking if any user of the barrier allocation flows into a `MapToRemoteBufferOp`, and skip the entire alloc:
+```cpp
+bool isClusterBarrier = false;
+for (auto *user : result.getUsers()) {
+  if (auto indexOp = dyn_cast<gpu::MemDescIndexOp>(user)) {
+    for (auto *indexUser : indexOp.getResult().getUsers()) {
+      if (isa<nvidia_gpu::MapToRemoteBufferOp>(indexUser)) {
+        isClusterBarrier = true;
+        break;
+      }
+    }
+  }
+  if (isClusterBarrier) break;
+}
+if (isClusterBarrier) return;  // skip this alloc entirely
+```
+When a barrier alloc is skipped, all operations referencing it (arrives, waits, expects, TMA loads) are also skipped — they fail barrier resolution and are silently dropped.
+
+**Why this doesn't cause false positives**: The skip is at alloc granularity. A cluster barrier alloc and a local barrier alloc are always separate `local_alloc` ops — they are never mixed. Skipping the entire alloc means both the waits and arrives on that barrier are dropped together, so there is no arrive/wait imbalance. The remaining local barriers are unaffected and independently analyzable.
+
+**⚠️ Known limitation — false negatives**: This workaround **cannot detect deadlocks in cluster barrier usage**. If a cluster barrier has a bug (e.g., missing remote arrive, wrong phase), the detector will not catch it. This is a soundness gap: no false positives, but possible false negatives for multi-CTA synchronization patterns. The correct fix is to implement full multi-CTA barrier modeling (see Future Work), not to keep skipping.
+
+**Validation**: Without this handling, hopper_gemm_ws produced 32 SAT false positives from cluster barriers. After the fix, combined with perThread handling, all 64 variants are UNSAT.
+
+### 3. `tryEvalInt` Refactoring for `scf.while` iter_args
+
+**Problem**: The original `tryEvalInt` only tracked the `scf.for` induction variable as a known value. Real kernels pass barrier slot indices and phase values through `scf.for` iter_args (e.g., `accum_cnt` for round-robin slot indexing), which could not be resolved, producing `slotIndex=-1`.
+
+**Solution**: Changed `tryEvalInt` to accept a `DenseMap<Value, int64_t> &knownValues` map instead of a single `(loopVar, loopInductionVar)` pair. The map is populated with:
+- The induction variable → `lowerBound + k * step`
+- All `scf.for` iter_arg block arguments → their initial values (from `getInitArgs()`) for iteration 0, then yield values from the previous iteration
+
+This unified approach handles all value resolution through a single mechanism and naturally supports the phase XOR pattern (`phase ^= (buf == NUM_STAGES - 1)`).
+
+### 4. `scf.while` Loop Traversal
+
+**Problem**: Persistent kernels wrap the `scf.for` K-loop in an `scf.while` tile loop. The analysis needs to find and unroll the inner `scf.for` loops.
+
+**Solution**: `findAndUnrollLoops()` recursively traverses `scf.while` bodies to find `scf.for` loops:
+- Walk each region of each op in the task
+- If the op is `scf.for`, unroll it
+- If the op is `scf.while`, recurse into its `before` and `after` regions
+- This finds the K-loop regardless of how many `scf.while` wrappers exist
+
+### 5. Z3 slotKey Sanitization
+
+Barrier slot keys like `alloc_0_neg1` (for slot index -1 from unresolved values) need to be valid Python identifiers. Negative indices are converted using a `neg` prefix (e.g., `-1` → `neg1`).
+
+---
+
+## Z3 Solver Scalability
+
+### The Problem
+
+The FA kernel (`hopper_fa_ws_pipelined_pingpong_persistent`) generates significantly more barrier operations than GEMM:
+
+| Kernel | Barrier Ops | Z3 Script Lines | Solver Result |
+|--------|------------|-----------------|---------------|
+| hopper_gemm_ws (per variant) | ~40-60 | ~500-800 | UNSAT (<1s) |
+| hopper_fa_ws_pipelined_pingpong_persistent | ~470 | ~3060 | unknown (timeout) |
+
+### Root Cause
+
+The constraint system grows quadratically with the number of operations:
+- **Φ_ord** constraints: O(n²) timestamp ordering within each task
+- **Φ_R** (release) constraints: each WAIT needs an `arrive_count_before(b, tau_w)` predicate that sums over all arrive ops with `If(effect_time < tau_w, count, 0)` — this creates O(n × m) terms where n = waits and m = arrives
+- **Φ_B** (blocking) constraints: similarly require aggregating over all arrive ops
+
+With 470 ops, the solver gets ~220,000 constraint terms, overwhelming Z3's integer arithmetic solver.
+
+### Potential Solutions (Future Work)
+
+1. **Barrier-local decomposition**: Solve each barrier independently instead of one global formula. Most barriers are independent (don't share arrive ops), so this would reduce to many small problems.
+2. **Symmetry reduction**: Exploit the pipeline stage symmetry — iterations 0..N-1 of the unrolled loop have identical structure shifted by one stage.
+3. **Bounded model checking with abstraction**: Instead of full Z3, use a simpler fixed-point check on the barrier state machine per barrier slot.
+4. **Reduce unroll bound**: The FA kernel may need a smarter unroll bound selection. Currently it unrolls based on `NUM_STAGES + 1`, but FA has more complex phase patterns.
+5. **In-process solving (MLIR SMT dialect)**: Eliminating the Python overhead and using C++ Z3 API directly would help, though the fundamental complexity remains.
+
+---
+
+## Future Work
+
+### Short-term (PR 3-4)
+
+1. **More lit tests** (PR 3): phase mismatch, circular dependency, arrive count mismatch.
+2. **Pipeline integration** (PR 4): Wire into `CUDABackend.run_static_analysis()` behind `TRITON_ENABLE_STATIC_ANALYSIS` env var. Currently `run_static_analysis` is a no-op.
+
+### Medium-term
+
+3. **Multi-CTA / cluster barrier modeling** ⚠️: Currently cluster barriers are **silently skipped**, creating a false-negative gap (see Technical Note §2). The correct fix is to model multi-CTA semantics: track `map_to_remote_buffer` to identify which remote CTA arrives on which barrier, and include remote arrives in the constraint encoding. This is needed for Hopper cluster kernels and is critical for Blackwell 2-CTA kernels (`blackwell_gemm_2cta`).
+4. **FA scalability**: Investigate barrier-local decomposition or abstraction to handle FA kernel's 470 ops.
+5. **`warp_group_dot` / `warp_group_dot_wait` support**: These are async tensor core ops that affect barrier semantics (ARRIVE_ASYNC kind). Real FA kernels use these extensively.
+6. **`scf.while` full support**: Currently we traverse `scf.while` bodies to find `scf.for` loops, but don't unroll the `scf.while` itself. For persistent kernels, the outer while loop's iteration count may matter.
+
+### Long-term
+
+7. **MLIR SMT dialect migration** (PR 5): Replace Python Z3 script generation with `smt.*` dialect ops + SMT-LIB export for in-process solving.
+8. **Named barrier support**: Thread-count-based barriers (`bar.arrive` / `bar.sync`) have different completion semantics.
+9. **Blackwell kernel support**: `tcgen05_commit`, TMEM barriers, CLC patterns.

--- a/include/triton/Analysis/BarrierAnalysis.h
+++ b/include/triton/Analysis/BarrierAnalysis.h
@@ -126,7 +126,7 @@ private:
   /// Resolve a barrier Value to (allocName, slotIndex) by tracing def-use
   /// chains through memdesc_index and warp_specialize captures.
   std::pair<std::string, int64_t> resolveBarrier(Value barrierVal,
-                                                  OperandRange captures);
+                                                 OperandRange captures);
 
   /// Evaluate an integer SSA value to a concrete int at a given loop
   /// iteration. Returns nullopt if the value cannot be resolved.

--- a/include/triton/Analysis/BarrierAnalysis.h
+++ b/include/triton/Analysis/BarrierAnalysis.h
@@ -122,6 +122,20 @@ public:
     return initialArrives;
   }
 
+  /// Unroll an scf.for loop body and append concrete ops to trace.
+  /// numThreads is the number of threads in this task (for perThread arrives).
+  void unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
+                  const std::string &taskName, TaskTrace &trace,
+                  OperandRange captures, int64_t numThreads);
+
+  /// Try to convert a single MLIR op into a ConcreteBarrierOp and append it
+  /// to the trace. Returns true if the op was a recognized barrier op.
+  bool tryAppendBarrierOp(Operation &op, int64_t taskId,
+                          const std::string &taskName, TaskTrace &trace,
+                          OperandRange captures,
+                          const DenseMap<Value, int64_t> &knownValues,
+                          int64_t iteration, int64_t numThreads);
+
 private:
   /// Extract barrier allocations (local_alloc ops with i64 element type).
   void collectBarrierAllocs();
@@ -133,20 +147,16 @@ private:
   /// Build concrete operation traces by walking warp_specialize regions.
   void buildTaskTraces();
 
-  /// Unroll an scf.for loop body and append concrete ops to trace.
-  void unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
-                  const std::string &taskName, TaskTrace &trace,
-                  OperandRange captures);
-
   /// Resolve a barrier Value to (allocName, slotIndex) by tracing def-use
   /// chains through memdesc_index and warp_specialize captures.
   std::pair<std::string, int64_t> resolveBarrier(Value barrierVal,
                                                  OperandRange captures);
 
-  /// Evaluate an integer SSA value to a concrete int at a given loop
-  /// iteration. Returns nullopt if the value cannot be resolved.
-  std::optional<int64_t> tryEvalInt(Value val, int64_t loopVar,
-                                    Value loopInductionVar);
+  /// Evaluate an integer SSA value to a concrete int using a map of known
+  /// values (induction variable, iter_args, etc.). Returns nullopt if the
+  /// value cannot be resolved.
+  std::optional<int64_t>
+  tryEvalInt(Value val, const DenseMap<Value, int64_t> &knownValues);
 
   FunctionOpInterface funcOp;
   int unrollBound;

--- a/include/triton/Analysis/BarrierAnalysis.h
+++ b/include/triton/Analysis/BarrierAnalysis.h
@@ -103,6 +103,12 @@ public:
   /// Print a human-readable summary of the extracted traces.
   void printSummary(llvm::raw_ostream &os) const;
 
+  /// Generate a standalone Python Z3 script encoding the barrier deadlock
+  /// constraints. The script imports z3, creates variables, adds all
+  /// constraint components (Phi_ord, Phi_async, Phi_stall, Phi_B, Phi_R,
+  /// deadlock query), runs the solver, and prints SAT/UNSAT with diagnostics.
+  void dumpPythonZ3Script(llvm::raw_ostream &os) const;
+
   /// Get the task traces.
   const std::vector<TaskTrace> &getTaskTraces() const { return taskTraces; }
 
@@ -111,9 +117,18 @@ public:
     return barrierAllocs;
   }
 
+  /// Get initial arrive counts per slot key ("allocName_slotIndex").
+  const std::map<std::string, int64_t> &getInitialArrives() const {
+    return initialArrives;
+  }
+
 private:
   /// Extract barrier allocations (local_alloc ops with i64 element type).
   void collectBarrierAllocs();
+
+  /// Collect pre-task barrier operations (arrives/expects before
+  /// warp_specialize) as initial arrive counts per slot.
+  void collectInitialArrives();
 
   /// Build concrete operation traces by walking warp_specialize regions.
   void buildTaskTraces();
@@ -143,6 +158,10 @@ private:
 
   /// Map capture index to the original value's alloc name.
   std::map<unsigned, std::string> captureIndexToAllocName;
+
+  /// Initial arrive counts per slot key ("allocName_slotIndex") from
+  /// barrier operations that occur before the warp_specialize region.
+  std::map<std::string, int64_t> initialArrives;
 };
 
 } // namespace mlir::triton

--- a/include/triton/Analysis/BarrierAnalysis.h
+++ b/include/triton/Analysis/BarrierAnalysis.h
@@ -1,0 +1,150 @@
+#ifndef TRITON_ANALYSIS_BARRIERANALYSIS_H
+#define TRITON_ANALYSIS_BARRIERANALYSIS_H
+
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mlir::scf {
+class ForOp;
+} // namespace mlir::scf
+
+namespace mlir::triton {
+
+//===----------------------------------------------------------------------===//
+// Barrier Operation Kinds (for the concrete trace)
+//===----------------------------------------------------------------------===//
+
+/// Classification of barrier operations following the design doc.
+enum class BarrierOpKind {
+  ArriveSync,  // ttng.arrive_barrier — pending_arrives -= cnt
+  ExpectBytes, // ttng.barrier_expect — arrive (cnt=1) + pending_bytes += sz
+  TmaLoad,     // ttng.async_tma_copy_global_to_local — pending_bytes -= xfer
+  Wait,        // ttng.wait_barrier — blocks while phase == phi
+};
+
+/// Convert BarrierOpKind to string for printing.
+StringRef barrierOpKindToString(BarrierOpKind kind);
+
+//===----------------------------------------------------------------------===//
+// Concrete Operation Instance (after loop unrolling)
+//===----------------------------------------------------------------------===//
+
+/// A single barrier operation after loop unrolling with all parameters
+/// resolved to concrete values.
+struct ConcreteBarrierOp {
+  BarrierOpKind kind;
+
+  /// Which task (warp group) this belongs to.
+  int64_t taskId = -1;
+  std::string taskName;
+
+  /// Barrier identity: (allocName, slotIndex) uniquely identifies a barrier.
+  std::string allocName;
+  int64_t slotIndex = -1;
+
+  /// Phase for wait operations (-1 if unresolved).
+  int64_t phase = -1;
+
+  /// Arrive count: 1 for ArriveSync/ExpectBytes, 0 for TmaLoad.
+  int64_t arriveCount = 1;
+
+  /// Expected bytes for ExpectBytes operations.
+  int64_t expectedBytes = -1;
+
+  /// Loop iteration this came from (-1 if not in a loop).
+  int64_t iteration = -1;
+
+  /// Position within the task's operation sequence.
+  size_t position = 0;
+
+  /// Source location string for diagnostics.
+  std::string locInfo;
+};
+
+/// Per-task operation trace after loop unrolling.
+struct TaskTrace {
+  int64_t taskId = -1;
+  std::string taskName;
+  std::vector<ConcreteBarrierOp> ops;
+};
+
+/// Barrier allocation info (from local_alloc + init_barrier).
+struct BarrierAllocInfo {
+  std::string name;
+  int64_t numSlots = 0;
+  int64_t arriveCount = 1;
+};
+
+//===----------------------------------------------------------------------===//
+// BarrierDeadlockAnalysis
+//===----------------------------------------------------------------------===//
+
+/// Extracts concrete barrier operation traces from TTGIR by walking
+/// warp_specialize regions and unrolling scf.for loops.
+///
+/// This is Step 1 of the deadlock detection pipeline: building the program
+/// model. Step 2 (Z3 constraint encoding) is added in a follow-up PR.
+class BarrierDeadlockAnalysis {
+public:
+  explicit BarrierDeadlockAnalysis(FunctionOpInterface funcOp,
+                                   int unrollBound = 0);
+
+  /// Run the full trace extraction pipeline.
+  void run();
+
+  /// Print a human-readable summary of the extracted traces.
+  void printSummary(llvm::raw_ostream &os) const;
+
+  /// Get the task traces.
+  const std::vector<TaskTrace> &getTaskTraces() const { return taskTraces; }
+
+  /// Get barrier allocations.
+  const std::vector<BarrierAllocInfo> &getBarrierAllocs() const {
+    return barrierAllocs;
+  }
+
+private:
+  /// Extract barrier allocations (local_alloc ops with i64 element type).
+  void collectBarrierAllocs();
+
+  /// Build concrete operation traces by walking warp_specialize regions.
+  void buildTaskTraces();
+
+  /// Unroll an scf.for loop body and append concrete ops to trace.
+  void unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
+                  const std::string &taskName, TaskTrace &trace,
+                  OperandRange captures);
+
+  /// Resolve a barrier Value to (allocName, slotIndex) by tracing def-use
+  /// chains through memdesc_index and warp_specialize captures.
+  std::pair<std::string, int64_t> resolveBarrier(Value barrierVal,
+                                                  OperandRange captures);
+
+  /// Evaluate an integer SSA value to a concrete int at a given loop
+  /// iteration. Returns nullopt if the value cannot be resolved.
+  std::optional<int64_t> tryEvalInt(Value val, int64_t loopVar,
+                                    Value loopInductionVar);
+
+  FunctionOpInterface funcOp;
+  int unrollBound;
+  std::vector<TaskTrace> taskTraces;
+  std::vector<BarrierAllocInfo> barrierAllocs;
+
+  /// Map from local_alloc Operation* to barrier alloc name.
+  DenseMap<Operation *, std::string> allocOpToName;
+
+  /// Map capture index to the original value's alloc name.
+  std::map<unsigned, std::string> captureIndexToAllocName;
+};
+
+} // namespace mlir::triton
+
+#endif // TRITON_ANALYSIS_BARRIERANALYSIS_H

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -374,4 +374,32 @@ def TritonGPUCoalesceAsyncCopy: Pass<"tritongpu-coalesce-async-copy", "mlir::Mod
                            "mlir::triton::TritonDialect"];
 }
 
+def TritonGPUBarrierDeadlockDetection : Pass<"tritongpu-barrier-deadlock-detection", "mlir::ModuleOp"> {
+  let summary = "Detect potential barrier deadlocks in warp-specialized kernels";
+
+  let description = [{
+    Extracts concrete barrier operation traces from `ttg.warp_specialize`
+    regions, unrolls `scf.for` loops, and generates Z3 constraints encoding
+    barrier semantics. SAT = deadlock witness, UNSAT = safe within the unroll
+    bound.
+
+    The pass outputs a standalone Python Z3 script that can be run with
+    `python3` to check for deadlocks. Optionally runs the solver automatically.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+                           "mlir::scf::SCFDialect",
+                           "mlir::arith::ArithDialect"];
+
+  let options = [
+    Option<"outputPath", "output-path", "std::string", /*default=*/"\"\"",
+           "Path to write Z3 script (empty = stderr)">,
+    Option<"runSolver", "run-solver", "bool", /*default=*/"false",
+           "Run python3 on the generated Z3 script">,
+    Option<"unrollBound", "unroll-bound", "int", /*default=*/"0",
+           "Loop unrolling bound (0 = auto)">
+  ];
+}
+
 #endif

--- a/lib/Analysis/BarrierAnalysis.cpp
+++ b/lib/Analysis/BarrierAnalysis.cpp
@@ -130,8 +130,8 @@ BarrierDeadlockAnalysis::resolveBarrier(Value barrierVal,
     if (auto partitionsOp =
             dyn_cast<gpu::WarpSpecializePartitionsOp>(parentOp)) {
       unsigned argIndex = blockArg.getArgNumber();
-      if (auto wsOp = dyn_cast<gpu::WarpSpecializeOp>(
-              partitionsOp->getParentOp())) {
+      if (auto wsOp =
+              dyn_cast<gpu::WarpSpecializeOp>(partitionsOp->getParentOp())) {
         if (argIndex < wsOp.getExplicitCaptures().size()) {
           tracedSrc = wsOp.getExplicitCaptures()[argIndex];
           continue;
@@ -232,8 +232,7 @@ BarrierDeadlockAnalysis::tryEvalInt(Value val, int64_t loopVar,
 // Loop unrolling and trace construction
 //===----------------------------------------------------------------------===//
 
-void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
-                                         int64_t taskId,
+void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
                                          const std::string &taskName,
                                          TaskTrace &trace,
                                          OperandRange captures) {
@@ -287,8 +286,7 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
         concreteOp.kind = BarrierOpKind::Wait;
         auto [name, slot] = resolveBarrier(waitOp.getAlloc(), captures);
         concreteOp.allocName = name;
-        concreteOp.slotIndex =
-            resolveDynSlot(waitOp.getAlloc(), slot, k);
+        concreteOp.slotIndex = resolveDynSlot(waitOp.getAlloc(), slot, k);
 
         // Resolve phase: try direct eval, then iter_args
         auto phaseVal = tryEvalInt(waitOp.getPhase(), k, inductionVar);
@@ -303,8 +301,7 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
         concreteOp.phase = phaseVal.value_or(-1);
         isBarrierOp = true;
 
-      } else if (auto arriveOp =
-                     dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
+      } else if (auto arriveOp = dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
         concreteOp.kind = BarrierOpKind::ArriveSync;
         auto [name, slot] = resolveBarrier(arriveOp.getAlloc(), captures);
         concreteOp.allocName = name;
@@ -312,8 +309,7 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
         concreteOp.arriveCount = arriveOp.getCount();
         isBarrierOp = true;
 
-      } else if (auto expectOp =
-                     dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
+      } else if (auto expectOp = dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
         concreteOp.kind = BarrierOpKind::ExpectBytes;
         auto [name, slot] = resolveBarrier(expectOp.getAlloc(), captures);
         concreteOp.allocName = name;
@@ -455,8 +451,8 @@ void BarrierDeadlockAnalysis::printSummary(llvm::raw_ostream &os) const {
 
   os << "\nTask traces:\n";
   for (const auto &task : taskTraces) {
-    os << "  " << task.taskName << " (task " << task.taskId << "): "
-       << task.ops.size() << " barrier ops\n";
+    os << "  " << task.taskName << " (task " << task.taskId
+       << "): " << task.ops.size() << " barrier ops\n";
     for (const auto &op : task.ops) {
       os << "    [" << op.position << "] " << barrierOpKindToString(op.kind)
          << " " << op.allocName << "[" << op.slotIndex << "]";

--- a/lib/Analysis/BarrierAnalysis.cpp
+++ b/lib/Analysis/BarrierAnalysis.cpp
@@ -13,6 +13,8 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
+#include <functional>
+
 namespace mlir::triton {
 
 namespace gpu = triton::gpu;
@@ -65,6 +67,24 @@ void BarrierDeadlockAnalysis::collectBarrierAllocs() {
     if (!memDescType.getElementType().isInteger(64))
       return;
 
+    // Skip cluster barriers (used with map_to_remote_buffer).
+    // These are inter-CTA barriers that require multi-CTA modeling.
+    bool isClusterBarrier = false;
+    for (auto *user : result.getUsers()) {
+      if (auto indexOp = dyn_cast<gpu::MemDescIndexOp>(user)) {
+        for (auto *indexUser : indexOp.getResult().getUsers()) {
+          if (isa<nvidia_gpu::MapToRemoteBufferOp>(indexUser)) {
+            isClusterBarrier = true;
+            break;
+          }
+        }
+      }
+      if (isClusterBarrier)
+        break;
+    }
+    if (isClusterBarrier)
+      return;
+
     // Try to get a name from the location
     std::string name;
     if (auto nameLoc = dyn_cast<NameLoc>(allocOp.getLoc())) {
@@ -108,6 +128,18 @@ void BarrierDeadlockAnalysis::collectBarrierAllocs() {
 //===----------------------------------------------------------------------===//
 
 void BarrierDeadlockAnalysis::collectInitialArrives() {
+  // Get total threads in the CTA for perThread arrives
+  int64_t totalThreads = 128; // default: 4 warps * 32
+  if (auto mod = funcOp->getParentOfType<ModuleOp>()) {
+    int64_t numWarps = 4;
+    int64_t threadsPerWarp = 32;
+    if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.num-warps"))
+      numWarps = attr.getInt();
+    if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.threads-per-warp"))
+      threadsPerWarp = attr.getInt();
+    totalThreads = numWarps * threadsPerWarp;
+  }
+
   // Walk barrier ops that are OUTSIDE warp_specialize regions but inside the
   // function. These represent pre-task arrives that set the initial barrier
   // state (e.g., pre-arriving "empty" barriers so the producer can start).
@@ -138,7 +170,10 @@ void BarrierDeadlockAnalysis::collectInitialArrives() {
       if (slotIdx < 0)
         return;
       std::string key = allocName + "_" + std::to_string(slotIdx);
-      initialArrives[key] += arriveOp.getCount();
+      int64_t count = arriveOp.getCount();
+      if (arriveOp.getPerThread())
+        count *= totalThreads;
+      initialArrives[key] += count;
 
     } else if (auto expectOp = dyn_cast<nvidia_gpu::BarrierExpectOp>(op)) {
       auto indexOp = dyn_cast_or_null<gpu::MemDescIndexOp>(
@@ -174,9 +209,15 @@ void BarrierDeadlockAnalysis::collectInitialArrives() {
 std::pair<std::string, int64_t>
 BarrierDeadlockAnalysis::resolveBarrier(Value barrierVal,
                                         OperandRange captures) {
+  // Trace through map_to_remote_buffer to the underlying local memdesc.
+  Value tracedBarrier = barrierVal;
+  if (auto mapOp = dyn_cast_or_null<nvidia_gpu::MapToRemoteBufferOp>(
+          tracedBarrier.getDefiningOp()))
+    tracedBarrier = mapOp.getSrc();
+
   // Trace through memdesc_index to find (allocName, slotIndex)
   auto indexOp =
-      dyn_cast_or_null<gpu::MemDescIndexOp>(barrierVal.getDefiningOp());
+      dyn_cast_or_null<gpu::MemDescIndexOp>(tracedBarrier.getDefiningOp());
   if (!indexOp)
     return {"", -1};
 
@@ -221,11 +262,12 @@ BarrierDeadlockAnalysis::resolveBarrier(Value barrierVal,
 // Concrete integer expression evaluation
 //===----------------------------------------------------------------------===//
 
-std::optional<int64_t>
-BarrierDeadlockAnalysis::tryEvalInt(Value val, int64_t loopVar,
-                                    Value loopInductionVar) {
-  if (val == loopInductionVar)
-    return loopVar;
+std::optional<int64_t> BarrierDeadlockAnalysis::tryEvalInt(
+    Value val, const DenseMap<Value, int64_t> &knownValues) {
+  // Check if this value is in the known values map (induction var, iter_args)
+  auto it = knownValues.find(val);
+  if (it != knownValues.end())
+    return it->second;
 
   if (auto constOp = val.getDefiningOp<arith::ConstantIntOp>())
     return constOp.value();
@@ -239,14 +281,14 @@ BarrierDeadlockAnalysis::tryEvalInt(Value val, int64_t loopVar,
 
   // Handle unary ops first (1 operand) — must come before the binary check
   if (isa<arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp>(defOp))
-    return tryEvalInt(defOp->getOperand(0), loopVar, loopInductionVar);
+    return tryEvalInt(defOp->getOperand(0), knownValues);
 
   // Binary ops require 2 operands
   if (defOp->getNumOperands() < 2)
     return std::nullopt;
 
-  auto lhs = tryEvalInt(defOp->getOperand(0), loopVar, loopInductionVar);
-  auto rhs = tryEvalInt(defOp->getOperand(1), loopVar, loopInductionVar);
+  auto lhs = tryEvalInt(defOp->getOperand(0), knownValues);
+  auto rhs = tryEvalInt(defOp->getOperand(1), knownValues);
   if (!lhs || !rhs)
     return std::nullopt;
 
@@ -294,43 +336,131 @@ BarrierDeadlockAnalysis::tryEvalInt(Value val, int64_t loopVar,
 }
 
 //===----------------------------------------------------------------------===//
+// Barrier op detection helper
+//===----------------------------------------------------------------------===//
+
+bool BarrierDeadlockAnalysis::tryAppendBarrierOp(
+    Operation &op, int64_t taskId, const std::string &taskName,
+    TaskTrace &trace, OperandRange captures,
+    const DenseMap<Value, int64_t> &knownValues, int64_t iteration,
+    int64_t numThreads) {
+  // Helper to resolve dynamic slot indices.
+  auto resolveDynSlot = [&](Value alloc, int64_t staticSlot) -> int64_t {
+    if (staticSlot >= 0)
+      return staticSlot;
+    Value traced = alloc;
+    if (auto mapOp = dyn_cast_or_null<nvidia_gpu::MapToRemoteBufferOp>(
+            traced.getDefiningOp()))
+      traced = mapOp.getSrc();
+    if (auto indexOp =
+            dyn_cast_or_null<gpu::MemDescIndexOp>(traced.getDefiningOp())) {
+      if (auto evalIdx = tryEvalInt(indexOp.getIndex(), knownValues))
+        return *evalIdx;
+    }
+    return staticSlot;
+  };
+
+  ConcreteBarrierOp concreteOp;
+  concreteOp.taskId = taskId;
+  concreteOp.taskName = taskName;
+  concreteOp.iteration = iteration;
+
+  bool isBarrierOp = false;
+
+  if (auto waitOp = dyn_cast<nvidia_gpu::WaitBarrierOp>(&op)) {
+    concreteOp.kind = BarrierOpKind::Wait;
+    auto [name, slot] = resolveBarrier(waitOp.getAlloc(), captures);
+    concreteOp.allocName = name;
+    concreteOp.slotIndex = resolveDynSlot(waitOp.getAlloc(), slot);
+    concreteOp.phase = tryEvalInt(waitOp.getPhase(), knownValues).value_or(-1);
+    isBarrierOp = true;
+
+  } else if (auto arriveOp = dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
+    concreteOp.kind = BarrierOpKind::ArriveSync;
+    auto [name, slot] = resolveBarrier(arriveOp.getAlloc(), captures);
+    concreteOp.allocName = name;
+    concreteOp.slotIndex = resolveDynSlot(arriveOp.getAlloc(), slot);
+    int64_t count = arriveOp.getCount();
+    if (arriveOp.getPerThread())
+      count *= numThreads;
+    concreteOp.arriveCount = count;
+    isBarrierOp = true;
+
+  } else if (auto expectOp = dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
+    concreteOp.kind = BarrierOpKind::ExpectBytes;
+    auto [name, slot] = resolveBarrier(expectOp.getAlloc(), captures);
+    concreteOp.allocName = name;
+    concreteOp.slotIndex = resolveDynSlot(expectOp.getAlloc(), slot);
+    concreteOp.expectedBytes = expectOp.getSize();
+    concreteOp.arriveCount = 1;
+    isBarrierOp = true;
+
+  } else if (auto tmaOp =
+                 dyn_cast<nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(&op)) {
+    concreteOp.kind = BarrierOpKind::TmaLoad;
+    auto [name, slot] = resolveBarrier(tmaOp.getBarrier(), captures);
+    concreteOp.allocName = name;
+    concreteOp.slotIndex = resolveDynSlot(tmaOp.getBarrier(), slot);
+    concreteOp.arriveCount = 0;
+    isBarrierOp = true;
+  }
+
+  if (isBarrierOp && !concreteOp.allocName.empty() &&
+      concreteOp.slotIndex >= 0) {
+    std::string locStr;
+    llvm::raw_string_ostream locOs(locStr);
+    op.getLoc()->print(locOs);
+    concreteOp.locInfo = locStr;
+    concreteOp.position = trace.ops.size();
+    trace.ops.push_back(concreteOp);
+    return true;
+  }
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
 // Loop unrolling and trace construction
 //===----------------------------------------------------------------------===//
 
 void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
                                          const std::string &taskName,
                                          TaskTrace &trace,
-                                         OperandRange captures) {
+                                         OperandRange captures,
+                                         int64_t numThreads) {
   auto lbConst = forOp.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
   auto stepConst = forOp.getStep().getDefiningOp<arith::ConstantIntOp>();
 
   int64_t lb = lbConst ? lbConst.value() : 0;
   int64_t step = stepConst ? stepConst.value() : 1;
-  int64_t ub = unrollBound > 0 ? unrollBound : 5;
+  int64_t numIters = unrollBound > 0 ? unrollBound : 5;
+
+  // Try to resolve the loop's actual upper bound.
+  std::optional<int64_t> resolvedUb;
+  if (auto intOp = forOp.getUpperBound().getDefiningOp<arith::ConstantIntOp>())
+    resolvedUb = intOp.value();
+  else if (auto idxOp =
+               forOp.getUpperBound().getDefiningOp<arith::ConstantIndexOp>())
+    resolvedUb = idxOp.value();
+
+  // Compute the effective upper bound for unrolling.
+  // If the loop's actual upper bound is known, use it (capped by numIters).
+  // If unknown, use numIters * step as an ABSOLUTE ceiling (not relative to
+  // lb). This ensures that loops with different lower bounds but the same
+  // unknown upper bound get different iteration counts, matching the real
+  // behavior where a producer loop starting at 0 runs more iterations than
+  // a consumer loop starting at a positive offset.
+  int64_t effectiveUb;
+  if (resolvedUb) {
+    int64_t maxUb = lb + numIters * step;
+    effectiveUb = std::min(*resolvedUb, maxUb);
+  } else {
+    effectiveUb = numIters * step;
+    // Ensure at least 1 iteration when lb > 0.
+    if (effectiveUb <= lb)
+      effectiveUb = lb + step;
+  }
 
   Value inductionVar = forOp.getInductionVar();
-
-  // Resolve slot index dynamically when it depends on the loop variable
-  auto resolveDynSlot = [&](Value alloc, int64_t staticSlot,
-                            int64_t k) -> int64_t {
-    if (staticSlot >= 0)
-      return staticSlot;
-    if (auto indexOp =
-            dyn_cast_or_null<gpu::MemDescIndexOp>(alloc.getDefiningOp())) {
-      if (auto evalIdx = tryEvalInt(indexOp.getIndex(), k, inductionVar))
-        return *evalIdx;
-    }
-    return staticSlot;
-  };
-
-  // Track iter_args (e.g., phase variable) across iterations
-  SmallVector<int64_t> iterArgValues;
-  for (auto initVal : forOp.getInitArgs()) {
-    if (auto constOp = initVal.getDefiningOp<arith::ConstantIntOp>())
-      iterArgValues.push_back(constOp.value());
-    else
-      iterArgValues.push_back(0);
-  }
 
   auto &bodyBlock = forOp.getRegion().front();
   // Block args: [inductionVar, iterArg0, iterArg1, ...]
@@ -338,109 +468,112 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
   for (unsigned i = 1; i < bodyBlock.getNumArguments(); ++i)
     iterArgBlockArgs.push_back(bodyBlock.getArgument(i));
 
-  for (int64_t k = lb; k < lb + ub * step; k += step) {
-    for (auto &op : bodyBlock) {
-      ConcreteBarrierOp concreteOp;
-      concreteOp.taskId = taskId;
-      concreteOp.taskName = taskName;
-      concreteOp.iteration = k;
+  // Track iter_args (e.g., phase variable, accum_cnt) across iterations.
+  // Try to resolve initial values; default to 0 for while-loop carried args.
+  SmallVector<int64_t> iterArgValues;
+  for (auto initVal : forOp.getInitArgs()) {
+    if (auto constOp = initVal.getDefiningOp<arith::ConstantIntOp>())
+      iterArgValues.push_back(constOp.value());
+    else if (auto constOp = initVal.getDefiningOp<arith::ConstantIndexOp>())
+      iterArgValues.push_back(constOp.value());
+    else
+      iterArgValues.push_back(0);
+  }
 
-      bool isBarrierOp = false;
+  // Build known values map: induction var + all iter_arg block args.
+  // This is rebuilt at each iteration with updated values.
+  auto buildKnownValues = [&](int64_t k) -> DenseMap<Value, int64_t> {
+    DenseMap<Value, int64_t> known;
+    known[inductionVar] = k;
+    for (unsigned i = 0; i < iterArgBlockArgs.size(); ++i)
+      known[iterArgBlockArgs[i]] = iterArgValues[i];
+    return known;
+  };
 
-      if (auto waitOp = dyn_cast<nvidia_gpu::WaitBarrierOp>(&op)) {
-        concreteOp.kind = BarrierOpKind::Wait;
-        auto [name, slot] = resolveBarrier(waitOp.getAlloc(), captures);
-        concreteOp.allocName = name;
-        concreteOp.slotIndex = resolveDynSlot(waitOp.getAlloc(), slot, k);
+  // Recursive helper: process all ops in a block, handling nested for loops.
+  // `known` is passed by reference so that nested loop results are visible
+  // to subsequent ops in the same block (e.g., ops after an inner for loop
+  // that reference the inner loop's result values).
+  std::function<void(Block &, DenseMap<Value, int64_t> &, int64_t)>
+      processBlockOps = [&](Block &block, DenseMap<Value, int64_t> &known,
+                            int64_t outerIter) {
+        for (auto &op : block) {
+          // Handle nested scf.for: unroll inline and map results.
+          if (auto nestedFor = dyn_cast<scf::ForOp>(&op)) {
+            int64_t innerLb =
+                tryEvalInt(nestedFor.getLowerBound(), known).value_or(0);
+            int64_t innerStep =
+                tryEvalInt(nestedFor.getStep(), known).value_or(1);
+            auto innerUbOpt = tryEvalInt(nestedFor.getUpperBound(), known);
+            int64_t innerUb;
+            if (innerUbOpt)
+              innerUb = *innerUbOpt;
+            else
+              innerUb =
+                  innerLb + (unrollBound > 0 ? unrollBound : 5) * innerStep;
 
-        // Resolve phase: try direct eval, then iter_args
-        auto phaseVal = tryEvalInt(waitOp.getPhase(), k, inductionVar);
-        if (!phaseVal) {
-          for (unsigned i = 0; i < iterArgBlockArgs.size(); ++i) {
-            if (waitOp.getPhase() == iterArgBlockArgs[i]) {
-              phaseVal = iterArgValues[i];
-              break;
+            // Resolve init arg values using outer known values.
+            auto &innerBlock = nestedFor.getRegion().front();
+            SmallVector<int64_t> innerIterArgVals;
+            for (auto initVal : nestedFor.getInitArgs())
+              innerIterArgVals.push_back(
+                  tryEvalInt(initVal, known).value_or(0));
+
+            SmallVector<Value> innerIterArgBAs;
+            for (unsigned i = 1; i < innerBlock.getNumArguments(); ++i)
+              innerIterArgBAs.push_back(innerBlock.getArgument(i));
+
+            Value innerIndVar = nestedFor.getInductionVar();
+
+            for (int64_t ik = innerLb; ik < innerUb; ik += innerStep) {
+              // Build inner known: inherit outer, add inner loop vars.
+              DenseMap<Value, int64_t> innerKnown = known;
+              innerKnown[innerIndVar] = ik;
+              for (unsigned i = 0; i < innerIterArgBAs.size(); ++i)
+                innerKnown[innerIterArgBAs[i]] = innerIterArgVals[i];
+
+              // Recursively process inner block (handles deeper nesting).
+              processBlockOps(innerBlock, innerKnown, outerIter);
+
+              // Update inner iter_arg values for next iteration.
+              auto *innerTerm = innerBlock.getTerminator();
+              if (auto yieldOp = dyn_cast<scf::YieldOp>(innerTerm)) {
+                for (unsigned i = 0; i < yieldOp.getNumOperands() &&
+                                     i < innerIterArgVals.size();
+                     ++i) {
+                  auto nv = tryEvalInt(yieldOp.getOperand(i), innerKnown);
+                  if (nv)
+                    innerIterArgVals[i] = *nv;
+                }
+              }
             }
+
+            // Map inner loop results to final values in outer known.
+            for (unsigned i = 0;
+                 i < nestedFor.getNumResults() && i < innerIterArgVals.size();
+                 ++i)
+              known[nestedFor.getResult(i)] = innerIterArgVals[i];
+
+            continue;
           }
+
+          // Barrier op detection — delegate to shared helper.
+          tryAppendBarrierOp(op, taskId, taskName, trace, captures, known,
+                             outerIter, numThreads);
         }
-        concreteOp.phase = phaseVal.value_or(-1);
-        isBarrierOp = true;
+      };
 
-      } else if (auto arriveOp = dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
-        concreteOp.kind = BarrierOpKind::ArriveSync;
-        auto [name, slot] = resolveBarrier(arriveOp.getAlloc(), captures);
-        concreteOp.allocName = name;
-        concreteOp.slotIndex = resolveDynSlot(arriveOp.getAlloc(), slot, k);
-        concreteOp.arriveCount = arriveOp.getCount();
-        isBarrierOp = true;
+  for (int64_t k = lb; k < effectiveUb; k += step) {
+    auto knownValues = buildKnownValues(k);
 
-      } else if (auto expectOp = dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
-        concreteOp.kind = BarrierOpKind::ExpectBytes;
-        auto [name, slot] = resolveBarrier(expectOp.getAlloc(), captures);
-        concreteOp.allocName = name;
-        concreteOp.slotIndex = resolveDynSlot(expectOp.getAlloc(), slot, k);
-        concreteOp.expectedBytes = expectOp.getSize();
-        // barrier_expect does arrive (PTX mbarrier.arrive.expect_tx)
-        concreteOp.arriveCount = 1;
-        isBarrierOp = true;
-
-      } else if (auto tmaOp =
-                     dyn_cast<nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(&op)) {
-        concreteOp.kind = BarrierOpKind::TmaLoad;
-        auto [name, slot] = resolveBarrier(tmaOp.getBarrier(), captures);
-        concreteOp.allocName = name;
-        concreteOp.slotIndex = resolveDynSlot(tmaOp.getBarrier(), slot, k);
-        // TMA load does NOT arrive; only contributes bytes
-        concreteOp.arriveCount = 0;
-        isBarrierOp = true;
-      }
-
-      if (isBarrierOp) {
-        std::string locStr;
-        llvm::raw_string_ostream locOs(locStr);
-        op.getLoc()->print(locOs);
-        concreteOp.locInfo = locStr;
-        concreteOp.position = trace.ops.size();
-        trace.ops.push_back(concreteOp);
-      }
-    }
+    processBlockOps(bodyBlock, knownValues, k);
 
     // Update iter_arg values for next iteration
     auto *terminator = bodyBlock.getTerminator();
     if (auto yieldOp = dyn_cast<scf::YieldOp>(terminator)) {
       for (unsigned i = 0;
            i < yieldOp.getNumOperands() && i < iterArgValues.size(); ++i) {
-        auto newVal = tryEvalInt(yieldOp.getOperand(i), k, inductionVar);
-
-        // If direct eval fails, try resolving through iter_args
-        if (!newVal) {
-          for (unsigned j = 0; j < iterArgBlockArgs.size(); ++j) {
-            if (yieldOp.getOperand(i) == iterArgBlockArgs[j]) {
-              newVal = iterArgValues[j];
-              break;
-            }
-          }
-        }
-
-        // Handle XOR pattern: phase = old_phase ^ (buf == NUM_STAGES-1)
-        if (!newVal) {
-          if (auto xorOp =
-                  yieldOp.getOperand(i).getDefiningOp<arith::XOrIOp>()) {
-            auto lhsVal = tryEvalInt(xorOp.getLhs(), k, inductionVar);
-            auto rhsVal = tryEvalInt(xorOp.getRhs(), k, inductionVar);
-            if (!lhsVal) {
-              for (unsigned j = 0; j < iterArgBlockArgs.size(); ++j) {
-                if (xorOp.getLhs() == iterArgBlockArgs[j]) {
-                  lhsVal = iterArgValues[j];
-                  break;
-                }
-              }
-            }
-            if (lhsVal && rhsVal)
-              newVal = *lhsVal ^ *rhsVal;
-          }
-        }
-
+        auto newVal = tryEvalInt(yieldOp.getOperand(i), knownValues);
         if (newVal)
           iterArgValues[i] = *newVal;
       }
@@ -451,6 +584,31 @@ void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp, int64_t taskId,
 //===----------------------------------------------------------------------===//
 // Build task traces from warp_specialize regions
 //===----------------------------------------------------------------------===//
+
+/// Recursively find and process all barrier ops in a block: standalone barrier
+/// ops (outside loops) are appended directly; scf.for loops are unrolled;
+/// scf.while bodies (persistent loop wrappers) are recursed into.
+static void processBlockBarrierOps(Block &block,
+                                   BarrierDeadlockAnalysis &analysis,
+                                   int64_t taskId, const std::string &taskName,
+                                   TaskTrace &trace, OperandRange captures,
+                                   int64_t numThreads) {
+  DenseMap<Value, int64_t> emptyKnown;
+  for (auto &op : block) {
+    if (auto forOp = dyn_cast<scf::ForOp>(&op)) {
+      analysis.unrollLoop(forOp, taskId, taskName, trace, captures, numThreads);
+    } else if (auto whileOp = dyn_cast<scf::WhileOp>(&op)) {
+      // Persistent loop: recurse into the "after" (body) region.
+      if (!whileOp.getAfter().empty())
+        processBlockBarrierOps(whileOp.getAfter().front(), analysis, taskId,
+                               taskName, trace, captures, numThreads);
+    } else {
+      // Standalone barrier op (not inside a loop).
+      analysis.tryAppendBarrierOp(op, taskId, taskName, trace, captures,
+                                  emptyKnown, /*iteration=*/-1, numThreads);
+    }
+  }
+}
 
 void BarrierDeadlockAnalysis::buildTaskTraces() {
   funcOp.walk([&](gpu::WarpSpecializeOp wsOp) {
@@ -466,16 +624,33 @@ void BarrierDeadlockAnalysis::buildTaskTraces() {
       }
     }
 
+    // Get threads-per-warp from module attribute (default 32)
+    int64_t threadsPerWarp = 32;
+    if (auto mod = funcOp->getParentOfType<ModuleOp>()) {
+      if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.threads-per-warp"))
+        threadsPerWarp = attr.getInt();
+    }
+
+    // Get default region num_warps from module attribute
+    int64_t defaultNumWarps = 4;
+    if (auto mod = funcOp->getParentOfType<ModuleOp>()) {
+      if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.num-warps"))
+        defaultNumWarps = attr.getInt();
+    }
+    int64_t defaultNumThreads = defaultNumWarps * threadsPerWarp;
+
+    // Get per-partition num_warps
+    auto partitionNumWarps = wsOp.getPartitionNumWarps();
+
     // Process default region (typically the producer, task 0)
     {
       TaskTrace trace;
       trace.taskId = 0;
       trace.taskName = "default";
 
-      for (auto &op : wsOp.getDefaultRegion().front()) {
-        if (auto forOp = dyn_cast<scf::ForOp>(&op))
-          unrollLoop(forOp, 0, "default", trace, explicitCaptures);
-      }
+      processBlockBarrierOps(wsOp.getDefaultRegion().front(), *this, 0,
+                             "default", trace, explicitCaptures,
+                             defaultNumThreads);
 
       if (!trace.ops.empty())
         taskTraces.push_back(std::move(trace));
@@ -487,14 +662,16 @@ void BarrierDeadlockAnalysis::buildTaskTraces() {
       std::string taskName = "partition" + std::to_string(partIdx);
       int64_t taskId = partIdx + 1;
 
+      int64_t partNumThreads = defaultNumThreads; // fallback
+      if (partIdx < static_cast<int>(partitionNumWarps.size()))
+        partNumThreads = partitionNumWarps[partIdx] * threadsPerWarp;
+
       TaskTrace trace;
       trace.taskId = taskId;
       trace.taskName = taskName;
 
-      for (auto &op : region->front()) {
-        if (auto forOp = dyn_cast<scf::ForOp>(&op))
-          unrollLoop(forOp, taskId, taskName, trace, explicitCaptures);
-      }
+      processBlockBarrierOps(region->front(), *this, taskId, taskName, trace,
+                             explicitCaptures, partNumThreads);
 
       if (!trace.ops.empty())
         taskTraces.push_back(std::move(trace));
@@ -544,8 +721,14 @@ void BarrierDeadlockAnalysis::printSummary(llvm::raw_ostream &os) const {
 
 void BarrierDeadlockAnalysis::dumpPythonZ3Script(llvm::raw_ostream &os) const {
   // Helper: unique barrier slot key string for Z3 variable naming.
+  // Sanitize to produce valid Python identifiers (replace '-' with 'neg').
   auto slotKey = [](const ConcreteBarrierOp &op) -> std::string {
-    return op.allocName + "_" + std::to_string(op.slotIndex);
+    std::string key = op.allocName + "_";
+    if (op.slotIndex < 0)
+      key += "neg" + std::to_string(-op.slotIndex);
+    else
+      key += std::to_string(op.slotIndex);
+    return key;
   };
 
   // Build flat operation list with global indices, and per-task op lists.
@@ -829,8 +1012,9 @@ void BarrierDeadlockAnalysis::dumpPythonZ3Script(llvm::raw_ostream &os) const {
         os << "blocked_parity('" << sk << "', " << op.phase << ", " << ac
            << ")";
       } else {
-        // Fallback: cycle-based (not expected with concrete eval)
-        os << "blocked_parity('" << sk << "', 0, " << ac << ")";
+        // Unresolved phase: conservatively assume NOT blocked (avoids
+        // false positives from post-loop ops with unresolvable phases).
+        os << "False";
       }
       os << "))\n";
     }

--- a/lib/Analysis/BarrierAnalysis.cpp
+++ b/lib/Analysis/BarrierAnalysis.cpp
@@ -1,0 +1,474 @@
+//===-- BarrierAnalysis.cpp - Barrier trace extraction ----------*- C++ -*-===//
+//
+// Extracts concrete barrier operation traces from TTGIR warp-specialized
+// kernels. This is Step 1 of the deadlock detection pipeline (program model
+// extraction). See docs/barrier_deadlock_detection_design.md.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/BarrierAnalysis.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+namespace mlir::triton {
+
+namespace gpu = triton::gpu;
+namespace nvidia_gpu = triton::nvidia_gpu;
+
+//===----------------------------------------------------------------------===//
+// BarrierOpKind string conversion
+//===----------------------------------------------------------------------===//
+
+StringRef barrierOpKindToString(BarrierOpKind kind) {
+  switch (kind) {
+  case BarrierOpKind::ArriveSync:
+    return "arrive_barrier";
+  case BarrierOpKind::ExpectBytes:
+    return "barrier_expect";
+  case BarrierOpKind::TmaLoad:
+    return "tma_load";
+  case BarrierOpKind::Wait:
+    return "wait_barrier";
+  }
+  llvm_unreachable("Unknown BarrierOpKind");
+}
+
+//===----------------------------------------------------------------------===//
+// BarrierDeadlockAnalysis
+//===----------------------------------------------------------------------===//
+
+BarrierDeadlockAnalysis::BarrierDeadlockAnalysis(FunctionOpInterface funcOp,
+                                                 int unrollBound)
+    : funcOp(funcOp), unrollBound(unrollBound) {}
+
+void BarrierDeadlockAnalysis::run() {
+  collectBarrierAllocs();
+  buildTaskTraces();
+}
+
+//===----------------------------------------------------------------------===//
+// Barrier allocation collection
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::collectBarrierAllocs() {
+  funcOp.walk([&](gpu::LocalAllocOp allocOp) {
+    auto result = allocOp.getResult();
+    auto memDescType = dyn_cast<gpu::MemDescType>(result.getType());
+    if (!memDescType)
+      return;
+
+    // Barrier allocations have i64 element type
+    if (!memDescType.getElementType().isInteger(64))
+      return;
+
+    // Try to get a name from the location
+    std::string name;
+    if (auto nameLoc = dyn_cast<NameLoc>(allocOp.getLoc())) {
+      name = nameLoc.getName().str();
+    } else if (auto fusedLoc = dyn_cast<FusedLoc>(allocOp.getLoc())) {
+      for (auto loc : fusedLoc.getLocations()) {
+        if (auto nl = dyn_cast<NameLoc>(loc)) {
+          name = nl.getName().str();
+          break;
+        }
+      }
+    }
+    if (name.empty())
+      name = "bar_" + std::to_string(allocOpToName.size());
+
+    allocOpToName[allocOp] = name;
+
+    // Number of slots from the shape
+    auto shape = memDescType.getShape();
+    int64_t numSlots = shape.empty() ? 1 : shape[0];
+
+    // Find arrive count from init_barrier ops that use indexed slots
+    int64_t arriveCount = 1;
+    for (auto *user : result.getUsers()) {
+      if (auto indexOp = dyn_cast<gpu::MemDescIndexOp>(user)) {
+        for (auto *indexUser : indexOp.getResult().getUsers()) {
+          if (auto initOp = dyn_cast<nvidia_gpu::InitBarrierOp>(indexUser)) {
+            arriveCount = initOp.getCount();
+            break;
+          }
+        }
+      }
+    }
+
+    barrierAllocs.push_back({name, numSlots, arriveCount});
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// Barrier resolution via def-use chains
+//===----------------------------------------------------------------------===//
+
+std::pair<std::string, int64_t>
+BarrierDeadlockAnalysis::resolveBarrier(Value barrierVal,
+                                        OperandRange captures) {
+  // Trace through memdesc_index to find (allocName, slotIndex)
+  auto indexOp =
+      dyn_cast_or_null<gpu::MemDescIndexOp>(barrierVal.getDefiningOp());
+  if (!indexOp)
+    return {"", -1};
+
+  Value src = indexOp.getSrc();
+
+  // Try to get static slot index
+  int64_t slotIdx = -1;
+  if (auto constOp = indexOp.getIndex().getDefiningOp<arith::ConstantIntOp>())
+    slotIdx = constOp.value();
+
+  // Trace source through block arguments (warp_specialize captures)
+  Value tracedSrc = src;
+  while (auto blockArg = dyn_cast<BlockArgument>(tracedSrc)) {
+    auto *parentOp = blockArg.getOwner()->getParentOp();
+
+    if (auto partitionsOp =
+            dyn_cast<gpu::WarpSpecializePartitionsOp>(parentOp)) {
+      unsigned argIndex = blockArg.getArgNumber();
+      if (auto wsOp = dyn_cast<gpu::WarpSpecializeOp>(
+              partitionsOp->getParentOp())) {
+        if (argIndex < wsOp.getExplicitCaptures().size()) {
+          tracedSrc = wsOp.getExplicitCaptures()[argIndex];
+          continue;
+        }
+      }
+    }
+    break;
+  }
+
+  // Look up alloc name from the traced source
+  std::string allocName;
+  if (auto *defOp = tracedSrc.getDefiningOp()) {
+    auto it = allocOpToName.find(defOp);
+    if (it != allocOpToName.end())
+      allocName = it->second;
+  }
+
+  return {allocName, slotIdx};
+}
+
+//===----------------------------------------------------------------------===//
+// Concrete integer expression evaluation
+//===----------------------------------------------------------------------===//
+
+std::optional<int64_t>
+BarrierDeadlockAnalysis::tryEvalInt(Value val, int64_t loopVar,
+                                    Value loopInductionVar) {
+  if (val == loopInductionVar)
+    return loopVar;
+
+  if (auto constOp = val.getDefiningOp<arith::ConstantIntOp>())
+    return constOp.value();
+
+  if (auto constOp = val.getDefiningOp<arith::ConstantIndexOp>())
+    return constOp.value();
+
+  Operation *defOp = val.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  // Handle unary ops first (1 operand) — must come before the binary check
+  if (isa<arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp>(defOp))
+    return tryEvalInt(defOp->getOperand(0), loopVar, loopInductionVar);
+
+  // Binary ops require 2 operands
+  if (defOp->getNumOperands() < 2)
+    return std::nullopt;
+
+  auto lhs = tryEvalInt(defOp->getOperand(0), loopVar, loopInductionVar);
+  auto rhs = tryEvalInt(defOp->getOperand(1), loopVar, loopInductionVar);
+  if (!lhs || !rhs)
+    return std::nullopt;
+
+  if (isa<arith::AddIOp>(defOp))
+    return *lhs + *rhs;
+  if (isa<arith::SubIOp>(defOp))
+    return *lhs - *rhs;
+  if (isa<arith::MulIOp>(defOp))
+    return *lhs * *rhs;
+  if (isa<arith::RemSIOp>(defOp))
+    return *rhs != 0 ? std::optional(*lhs % *rhs) : std::nullopt;
+  if (isa<arith::DivSIOp>(defOp))
+    return *rhs != 0 ? std::optional(*lhs / *rhs) : std::nullopt;
+  if (isa<arith::XOrIOp>(defOp))
+    return *lhs ^ *rhs;
+  if (isa<arith::AndIOp>(defOp))
+    return *lhs & *rhs;
+  if (isa<arith::OrIOp>(defOp))
+    return *lhs | *rhs;
+  if (isa<arith::MinSIOp>(defOp))
+    return std::min(*lhs, *rhs);
+
+  if (auto cmpOp = dyn_cast<arith::CmpIOp>(defOp)) {
+    switch (cmpOp.getPredicate()) {
+    case arith::CmpIPredicate::eq:
+      return (*lhs == *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::ne:
+      return (*lhs != *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::slt:
+    case arith::CmpIPredicate::ult:
+      return (*lhs < *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::sle:
+    case arith::CmpIPredicate::ule:
+      return (*lhs <= *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::sgt:
+    case arith::CmpIPredicate::ugt:
+      return (*lhs > *rhs) ? 1 : 0;
+    case arith::CmpIPredicate::sge:
+    case arith::CmpIPredicate::uge:
+      return (*lhs >= *rhs) ? 1 : 0;
+    }
+  }
+
+  return std::nullopt;
+}
+
+//===----------------------------------------------------------------------===//
+// Loop unrolling and trace construction
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::unrollLoop(mlir::scf::ForOp forOp,
+                                         int64_t taskId,
+                                         const std::string &taskName,
+                                         TaskTrace &trace,
+                                         OperandRange captures) {
+  auto lbConst = forOp.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
+  auto stepConst = forOp.getStep().getDefiningOp<arith::ConstantIntOp>();
+
+  int64_t lb = lbConst ? lbConst.value() : 0;
+  int64_t step = stepConst ? stepConst.value() : 1;
+  int64_t ub = unrollBound > 0 ? unrollBound : 5;
+
+  Value inductionVar = forOp.getInductionVar();
+
+  // Resolve slot index dynamically when it depends on the loop variable
+  auto resolveDynSlot = [&](Value alloc, int64_t staticSlot,
+                            int64_t k) -> int64_t {
+    if (staticSlot >= 0)
+      return staticSlot;
+    if (auto indexOp =
+            dyn_cast_or_null<gpu::MemDescIndexOp>(alloc.getDefiningOp())) {
+      if (auto evalIdx = tryEvalInt(indexOp.getIndex(), k, inductionVar))
+        return *evalIdx;
+    }
+    return staticSlot;
+  };
+
+  // Track iter_args (e.g., phase variable) across iterations
+  SmallVector<int64_t> iterArgValues;
+  for (auto initVal : forOp.getInitArgs()) {
+    if (auto constOp = initVal.getDefiningOp<arith::ConstantIntOp>())
+      iterArgValues.push_back(constOp.value());
+    else
+      iterArgValues.push_back(0);
+  }
+
+  auto &bodyBlock = forOp.getRegion().front();
+  // Block args: [inductionVar, iterArg0, iterArg1, ...]
+  SmallVector<Value> iterArgBlockArgs;
+  for (unsigned i = 1; i < bodyBlock.getNumArguments(); ++i)
+    iterArgBlockArgs.push_back(bodyBlock.getArgument(i));
+
+  for (int64_t k = lb; k < lb + ub * step; k += step) {
+    for (auto &op : bodyBlock) {
+      ConcreteBarrierOp concreteOp;
+      concreteOp.taskId = taskId;
+      concreteOp.taskName = taskName;
+      concreteOp.iteration = k;
+
+      bool isBarrierOp = false;
+
+      if (auto waitOp = dyn_cast<nvidia_gpu::WaitBarrierOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::Wait;
+        auto [name, slot] = resolveBarrier(waitOp.getAlloc(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex =
+            resolveDynSlot(waitOp.getAlloc(), slot, k);
+
+        // Resolve phase: try direct eval, then iter_args
+        auto phaseVal = tryEvalInt(waitOp.getPhase(), k, inductionVar);
+        if (!phaseVal) {
+          for (unsigned i = 0; i < iterArgBlockArgs.size(); ++i) {
+            if (waitOp.getPhase() == iterArgBlockArgs[i]) {
+              phaseVal = iterArgValues[i];
+              break;
+            }
+          }
+        }
+        concreteOp.phase = phaseVal.value_or(-1);
+        isBarrierOp = true;
+
+      } else if (auto arriveOp =
+                     dyn_cast<nvidia_gpu::ArriveBarrierOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::ArriveSync;
+        auto [name, slot] = resolveBarrier(arriveOp.getAlloc(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex = resolveDynSlot(arriveOp.getAlloc(), slot, k);
+        concreteOp.arriveCount = arriveOp.getCount();
+        isBarrierOp = true;
+
+      } else if (auto expectOp =
+                     dyn_cast<nvidia_gpu::BarrierExpectOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::ExpectBytes;
+        auto [name, slot] = resolveBarrier(expectOp.getAlloc(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex = resolveDynSlot(expectOp.getAlloc(), slot, k);
+        concreteOp.expectedBytes = expectOp.getSize();
+        // barrier_expect does arrive (PTX mbarrier.arrive.expect_tx)
+        concreteOp.arriveCount = 1;
+        isBarrierOp = true;
+
+      } else if (auto tmaOp =
+                     dyn_cast<nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(&op)) {
+        concreteOp.kind = BarrierOpKind::TmaLoad;
+        auto [name, slot] = resolveBarrier(tmaOp.getBarrier(), captures);
+        concreteOp.allocName = name;
+        concreteOp.slotIndex = resolveDynSlot(tmaOp.getBarrier(), slot, k);
+        // TMA load does NOT arrive; only contributes bytes
+        concreteOp.arriveCount = 0;
+        isBarrierOp = true;
+      }
+
+      if (isBarrierOp) {
+        std::string locStr;
+        llvm::raw_string_ostream locOs(locStr);
+        op.getLoc()->print(locOs);
+        concreteOp.locInfo = locStr;
+        concreteOp.position = trace.ops.size();
+        trace.ops.push_back(concreteOp);
+      }
+    }
+
+    // Update iter_arg values for next iteration
+    auto *terminator = bodyBlock.getTerminator();
+    if (auto yieldOp = dyn_cast<scf::YieldOp>(terminator)) {
+      for (unsigned i = 0;
+           i < yieldOp.getNumOperands() && i < iterArgValues.size(); ++i) {
+        auto newVal = tryEvalInt(yieldOp.getOperand(i), k, inductionVar);
+
+        // If direct eval fails, try resolving through iter_args
+        if (!newVal) {
+          for (unsigned j = 0; j < iterArgBlockArgs.size(); ++j) {
+            if (yieldOp.getOperand(i) == iterArgBlockArgs[j]) {
+              newVal = iterArgValues[j];
+              break;
+            }
+          }
+        }
+
+        // Handle XOR pattern: phase = old_phase ^ (buf == NUM_STAGES-1)
+        if (!newVal) {
+          if (auto xorOp =
+                  yieldOp.getOperand(i).getDefiningOp<arith::XOrIOp>()) {
+            auto lhsVal = tryEvalInt(xorOp.getLhs(), k, inductionVar);
+            auto rhsVal = tryEvalInt(xorOp.getRhs(), k, inductionVar);
+            if (!lhsVal) {
+              for (unsigned j = 0; j < iterArgBlockArgs.size(); ++j) {
+                if (xorOp.getLhs() == iterArgBlockArgs[j]) {
+                  lhsVal = iterArgValues[j];
+                  break;
+                }
+              }
+            }
+            if (lhsVal && rhsVal)
+              newVal = *lhsVal ^ *rhsVal;
+          }
+        }
+
+        if (newVal)
+          iterArgValues[i] = *newVal;
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Build task traces from warp_specialize regions
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::buildTaskTraces() {
+  funcOp.walk([&](gpu::WarpSpecializeOp wsOp) {
+    auto explicitCaptures = wsOp.getExplicitCaptures();
+
+    // Build capture name map
+    for (unsigned i = 0; i < explicitCaptures.size(); ++i) {
+      Value cap = explicitCaptures[i];
+      if (auto *defOp = cap.getDefiningOp()) {
+        auto it = allocOpToName.find(defOp);
+        if (it != allocOpToName.end())
+          captureIndexToAllocName[i] = it->second;
+      }
+    }
+
+    // Process default region (typically the producer, task 0)
+    {
+      TaskTrace trace;
+      trace.taskId = 0;
+      trace.taskName = "default";
+
+      for (auto &op : wsOp.getDefaultRegion().front()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(&op))
+          unrollLoop(forOp, 0, "default", trace, explicitCaptures);
+      }
+
+      if (!trace.ops.empty())
+        taskTraces.push_back(std::move(trace));
+    }
+
+    // Process partition regions (typically consumers)
+    int partIdx = 0;
+    for (Region *region : wsOp.getPartitionRegions()) {
+      std::string taskName = "partition" + std::to_string(partIdx);
+      int64_t taskId = partIdx + 1;
+
+      TaskTrace trace;
+      trace.taskId = taskId;
+      trace.taskName = taskName;
+
+      for (auto &op : region->front()) {
+        if (auto forOp = dyn_cast<scf::ForOp>(&op))
+          unrollLoop(forOp, taskId, taskName, trace, explicitCaptures);
+      }
+
+      if (!trace.ops.empty())
+        taskTraces.push_back(std::move(trace));
+      partIdx++;
+    }
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// Summary printing
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::printSummary(llvm::raw_ostream &os) const {
+  os << "Barrier allocations:\n";
+  for (const auto &alloc : barrierAllocs) {
+    os << "  " << alloc.name << ": " << alloc.numSlots
+       << " slots, arrive_count=" << alloc.arriveCount << "\n";
+  }
+
+  os << "\nTask traces:\n";
+  for (const auto &task : taskTraces) {
+    os << "  " << task.taskName << " (task " << task.taskId << "): "
+       << task.ops.size() << " barrier ops\n";
+    for (const auto &op : task.ops) {
+      os << "    [" << op.position << "] " << barrierOpKindToString(op.kind)
+         << " " << op.allocName << "[" << op.slotIndex << "]";
+      if (op.phase >= 0)
+        os << " phase=" << op.phase;
+      if (op.arriveCount > 1)
+        os << " count=" << op.arriveCount;
+      if (op.expectedBytes > 0)
+        os << " bytes=" << op.expectedBytes;
+      os << " (iter " << op.iteration << ")\n";
+    }
+  }
+}
+
+} // namespace mlir::triton

--- a/lib/Analysis/BarrierAnalysis.cpp
+++ b/lib/Analysis/BarrierAnalysis.cpp
@@ -46,6 +46,7 @@ BarrierDeadlockAnalysis::BarrierDeadlockAnalysis(FunctionOpInterface funcOp,
 
 void BarrierDeadlockAnalysis::run() {
   collectBarrierAllocs();
+  collectInitialArrives();
   buildTaskTraces();
 }
 
@@ -99,6 +100,70 @@ void BarrierDeadlockAnalysis::collectBarrierAllocs() {
     }
 
     barrierAllocs.push_back({name, numSlots, arriveCount});
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// Initial arrive collection (pre-task barrier ops)
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::collectInitialArrives() {
+  // Walk barrier ops that are OUTSIDE warp_specialize regions but inside the
+  // function. These represent pre-task arrives that set the initial barrier
+  // state (e.g., pre-arriving "empty" barriers so the producer can start).
+  funcOp.walk([&](Operation *op) {
+    // Skip ops inside warp_specialize regions
+    if (op->getParentOfType<gpu::WarpSpecializeOp>())
+      return;
+
+    // Resolve barrier for arrive/expect ops and count initial arrives
+    if (auto arriveOp = dyn_cast<nvidia_gpu::ArriveBarrierOp>(op)) {
+      auto indexOp = dyn_cast_or_null<gpu::MemDescIndexOp>(
+          arriveOp.getAlloc().getDefiningOp());
+      if (!indexOp)
+        return;
+      Value src = indexOp.getSrc();
+      std::string allocName;
+      if (auto *defOp = src.getDefiningOp()) {
+        auto it = allocOpToName.find(defOp);
+        if (it != allocOpToName.end())
+          allocName = it->second;
+      }
+      if (allocName.empty())
+        return;
+      int64_t slotIdx = -1;
+      if (auto constOp =
+              indexOp.getIndex().getDefiningOp<arith::ConstantIntOp>())
+        slotIdx = constOp.value();
+      if (slotIdx < 0)
+        return;
+      std::string key = allocName + "_" + std::to_string(slotIdx);
+      initialArrives[key] += arriveOp.getCount();
+
+    } else if (auto expectOp = dyn_cast<nvidia_gpu::BarrierExpectOp>(op)) {
+      auto indexOp = dyn_cast_or_null<gpu::MemDescIndexOp>(
+          expectOp.getAlloc().getDefiningOp());
+      if (!indexOp)
+        return;
+      Value src = indexOp.getSrc();
+      std::string allocName;
+      if (auto *defOp = src.getDefiningOp()) {
+        auto it = allocOpToName.find(defOp);
+        if (it != allocOpToName.end())
+          allocName = it->second;
+      }
+      if (allocName.empty())
+        return;
+      int64_t slotIdx = -1;
+      if (auto constOp =
+              indexOp.getIndex().getDefiningOp<arith::ConstantIntOp>())
+        slotIdx = constOp.value();
+      if (slotIdx < 0)
+        return;
+      // barrier_expect counts as an arrive (cnt=1)
+      std::string key = allocName + "_" + std::to_string(slotIdx);
+      initialArrives[key] += 1;
+    }
   });
 }
 
@@ -449,6 +514,12 @@ void BarrierDeadlockAnalysis::printSummary(llvm::raw_ostream &os) const {
        << " slots, arrive_count=" << alloc.arriveCount << "\n";
   }
 
+  if (!initialArrives.empty()) {
+    os << "\nInitial arrives (pre-task):\n";
+    for (const auto &[key, cnt] : initialArrives)
+      os << "  " << key << ": " << cnt << "\n";
+  }
+
   os << "\nTask traces:\n";
   for (const auto &task : taskTraces) {
     os << "  " << task.taskName << " (task " << task.taskId
@@ -465,6 +536,450 @@ void BarrierDeadlockAnalysis::printSummary(llvm::raw_ostream &os) const {
       os << " (iter " << op.iteration << ")\n";
     }
   }
+}
+
+//===----------------------------------------------------------------------===//
+// Z3 Python script generation
+//===----------------------------------------------------------------------===//
+
+void BarrierDeadlockAnalysis::dumpPythonZ3Script(llvm::raw_ostream &os) const {
+  // Helper: unique barrier slot key string for Z3 variable naming.
+  auto slotKey = [](const ConcreteBarrierOp &op) -> std::string {
+    return op.allocName + "_" + std::to_string(op.slotIndex);
+  };
+
+  // Build flat operation list with global indices, and per-task op lists.
+  struct OpRef {
+    size_t globalIdx;
+    const ConcreteBarrierOp *op;
+    const TaskTrace *task;
+  };
+  std::vector<OpRef> allOps;
+  std::map<int64_t, std::vector<OpRef>> taskOps; // taskId -> ops
+  // slot key -> ops
+  std::map<std::string, std::vector<OpRef>> slotOps;
+
+  size_t globalIdx = 0;
+  for (const auto &task : taskTraces) {
+    for (const auto &op : task.ops) {
+      OpRef ref{globalIdx, &op, &task};
+      allOps.push_back(ref);
+      taskOps[task.taskId].push_back(ref);
+      slotOps[slotKey(op)].push_back(ref);
+      globalIdx++;
+    }
+  }
+
+  // Collect arrive counts per slot from barrierAllocs.
+  // Key: (allocName, slotIndex) -> arriveCount
+  std::map<std::string, int64_t> slotArriveCount;
+  for (const auto &alloc : barrierAllocs) {
+    for (int64_t s = 0; s < alloc.numSlots; s++) {
+      std::string key = alloc.name + "_" + std::to_string(s);
+      slotArriveCount[key] = alloc.arriveCount;
+    }
+  }
+
+  // --- Emit Python script ---
+  os << "#!/usr/bin/env python3\n";
+  os << "\"\"\"Auto-generated barrier deadlock check (Z3 constraints).\n\n";
+  os << "Encoding follows barrier_deadlock_design.tex Sections 2-5.\n";
+  os << "SAT = deadlock witness, UNSAT = safe within unroll bound.\n";
+  os << "\"\"\"\n\n";
+  os << "from z3 import *\n\n";
+
+  // --- Variables ---
+  os << "# ---- Variables ----\n\n";
+
+  // Cut-point per task
+  os << "# Cut-point per task: where execution is stuck\n";
+  for (const auto &task : taskTraces) {
+    os << "c_" << task.taskName << " = Int('c_" << task.taskName << "')\n";
+  }
+  os << "\n";
+
+  // Timestamps per operation
+  os << "# Timestamp per operation (global execution order)\n";
+  for (const auto &ref : allOps) {
+    os << "tau_" << ref.globalIdx << " = Int('tau_" << ref.globalIdx << "')\n";
+  }
+  os << "\n";
+
+  // Async timestamps (TMA_LOAD only for now)
+  os << "# Async completion timestamps (TMA_LOAD)\n";
+  bool hasAsync = false;
+  for (const auto &ref : allOps) {
+    if (ref.op->kind == BarrierOpKind::TmaLoad) {
+      os << "tau_prime_" << ref.globalIdx << " = Int('tau_prime_"
+         << ref.globalIdx << "')\n";
+      hasAsync = true;
+    }
+  }
+  if (!hasAsync)
+    os << "# (none)\n";
+  os << "\n";
+
+  // --- Operation metadata as comments ---
+  os << "# ---- Operation index ----\n";
+  for (const auto &ref : allOps) {
+    os << "# op " << ref.globalIdx << ": task=" << ref.op->taskName
+       << " pos=" << ref.op->position << " "
+       << barrierOpKindToString(ref.op->kind).str() << " " << ref.op->allocName
+       << "[" << ref.op->slotIndex << "]";
+    if (ref.op->kind == BarrierOpKind::Wait)
+      os << " phase=" << ref.op->phase;
+    if (ref.op->expectedBytes > 0)
+      os << " bytes=" << ref.op->expectedBytes;
+    os << " iter=" << ref.op->iteration << "\n";
+  }
+  os << "\n";
+
+  // --- Helper functions ---
+  os << "# ---- Helper functions ----\n\n";
+
+  // exec(o) predicate
+  os << "def exec_op(global_idx, task_name, pos):\n";
+  os << "    \"\"\"exec(o) = pos(o) < c_task(o)\"\"\"\n";
+  os << "    c = {'";
+  bool first = true;
+  for (const auto &task : taskTraces) {
+    if (!first)
+      os << ", '";
+    os << task.taskName << "': c_" << task.taskName;
+    first = false;
+  }
+  os << "}\n";
+  os << "    return pos < c[task_name]\n\n";
+
+  // effect_time(o): tau' for async, tau for sync
+  os << "def effect_time(global_idx):\n";
+  os << "    \"\"\"effect_time(o) = tau'_o for async, tau_o for sync\"\"\"\n";
+  os << "    async_ops = {";
+  first = true;
+  for (const auto &ref : allOps) {
+    if (ref.op->kind == BarrierOpKind::TmaLoad) {
+      if (!first)
+        os << ", ";
+      os << ref.globalIdx << ": tau_prime_" << ref.globalIdx;
+      first = false;
+    }
+  }
+  os << "}\n";
+  os << "    if global_idx in async_ops:\n";
+  os << "        return async_ops[global_idx]\n";
+  os << "    return globals()[f'tau_{global_idx}']\n\n";
+
+  // initial_arrives — pre-task arrive counts per slot
+  os << "# Initial arrives (pre-task barrier ops)\n";
+  os << "initial_arrives = {";
+  first = true;
+  for (const auto &[sk, cnt] : initialArrives) {
+    if (!first)
+      os << ", ";
+    os << "'" << sk << "': " << cnt;
+    first = false;
+  }
+  os << "}\n\n";
+
+  // arrive_count(slot) — cumulative arrives
+  os << "def arrive_count(slot_key):\n";
+  os << "    \"\"\"A(b) = initial + sum If(exec(o), cnt(o), 0) for arrive ops "
+        "on slot b\"\"\"\n";
+  os << "    initial = initial_arrives.get(slot_key, 0)\n";
+  os << "    terms = []\n";
+
+  // Group arrive ops by slot
+  for (const auto &[sk, ops] : slotOps) {
+    os << "    if slot_key == '" << sk << "':\n";
+    bool hasArrives = false;
+    for (const auto &ref : ops) {
+      if (ref.op->kind == BarrierOpKind::ArriveSync ||
+          ref.op->kind == BarrierOpKind::ExpectBytes) {
+        os << "        terms.append(If(exec_op(" << ref.globalIdx << ", '"
+           << ref.op->taskName << "', " << ref.op->position << "), "
+           << ref.op->arriveCount << ", 0))\n";
+        hasArrives = true;
+      }
+    }
+    if (!hasArrives)
+      os << "        pass\n";
+  }
+  os << "    return (initial + Sum(terms)) if terms else IntVal(initial)\n\n";
+
+  // arrive_count_before(slot, t) — arrives before timestamp t
+  os << "def arrive_count_before(slot_key, t):\n";
+  os << "    \"\"\"A^{<t}(b) = initial + sum If(exec(o) & effect_time(o) < t, "
+        "cnt(o), 0)\"\"\"\n";
+  os << "    initial = initial_arrives.get(slot_key, 0)\n";
+  os << "    terms = []\n";
+  for (const auto &[sk, ops] : slotOps) {
+    os << "    if slot_key == '" << sk << "':\n";
+    bool hasArrives = false;
+    for (const auto &ref : ops) {
+      if (ref.op->kind == BarrierOpKind::ArriveSync ||
+          ref.op->kind == BarrierOpKind::ExpectBytes) {
+        os << "        terms.append(If(And(exec_op(" << ref.globalIdx << ", '"
+           << ref.op->taskName << "', " << ref.op->position << "), effect_time("
+           << ref.globalIdx << ") < t), " << ref.op->arriveCount << ", 0))\n";
+        hasArrives = true;
+      }
+    }
+    if (!hasArrives)
+      os << "        pass\n";
+  }
+  os << "    return (initial + Sum(terms)) if terms else IntVal(initial)\n\n";
+
+  // blocked_parity(slot, parity) — parity-based blocking
+  os << "def blocked_parity(slot_key, parity, ac):\n";
+  os << "    \"\"\"blocked_parity(b, p) = (A(b) / ac) % 2 == p\"\"\"\n";
+  os << "    a = arrive_count(slot_key)\n";
+  os << "    if ac == 1:\n";
+  os << "        return a % 2 == parity\n";
+  os << "    return (a / ac) % 2 == parity\n\n";
+
+  // --- Solver and constraints ---
+  os << "# ---- Solver ----\n\n";
+  os << "s = Solver()\n\n";
+
+  // Structural constraints: cut-point bounds
+  os << "# Structural: cut-point bounds\n";
+  for (const auto &task : taskTraces) {
+    os << "s.add(c_" << task.taskName << " >= 0, c_" << task.taskName
+       << " <= " << task.ops.size() << ")\n";
+  }
+  os << "\n";
+
+  // Timestamp positivity
+  os << "# Structural: timestamp positivity\n";
+  for (const auto &ref : allOps) {
+    os << "s.add(tau_" << ref.globalIdx << " >= 0)\n";
+  }
+  for (const auto &ref : allOps) {
+    if (ref.op->kind == BarrierOpKind::TmaLoad)
+      os << "s.add(tau_prime_" << ref.globalIdx << " >= 0)\n";
+  }
+  os << "\n";
+
+  // Phi_ord: intra-task ordering (consecutive ops)
+  os << "# Phi_ord: intra-task operation ordering\n";
+  for (const auto &[taskId, ops] : taskOps) {
+    for (size_t i = 0; i + 1 < ops.size(); i++) {
+      const auto &a = ops[i];
+      const auto &b = ops[i + 1];
+      os << "s.add(Implies(And(exec_op(" << a.globalIdx << ", '"
+         << a.op->taskName << "', " << a.op->position << "), exec_op("
+         << b.globalIdx << ", '" << b.op->taskName << "', " << b.op->position
+         << ")), tau_" << a.globalIdx << " < tau_" << b.globalIdx << "))\n";
+    }
+  }
+  os << "\n";
+
+  // Phi_async: causal ordering for async ops
+  os << "# Phi_async: causal ordering (tau < tau' for async ops)\n";
+  for (const auto &ref : allOps) {
+    if (ref.op->kind == BarrierOpKind::TmaLoad) {
+      os << "s.add(Implies(exec_op(" << ref.globalIdx << ", '"
+         << ref.op->taskName << "', " << ref.op->position << "), tau_"
+         << ref.globalIdx << " < tau_prime_" << ref.globalIdx << "))\n";
+    }
+  }
+  os << "\n";
+
+  // Phi_stall: tasks can only stall at WAIT positions
+  os << "# Phi_stall: stall only at WAIT positions\n";
+  for (const auto &task : taskTraces) {
+    std::vector<const ConcreteBarrierOp *> waits;
+    for (const auto &op : task.ops) {
+      if (op.kind == BarrierOpKind::Wait)
+        waits.push_back(&op);
+    }
+    if (waits.empty()) {
+      os << "s.add(c_" << task.taskName << " == " << task.ops.size() << ")\n";
+    } else {
+      os << "s.add(Implies(c_" << task.taskName << " < " << task.ops.size()
+         << ", Or(";
+      first = true;
+      for (const auto *w : waits) {
+        if (!first)
+          os << ", ";
+        os << "c_" << task.taskName << " == " << w->position;
+        first = false;
+      }
+      os << ")))\n";
+    }
+  }
+  os << "\n";
+
+  // Phi_B: blocked barrier at stall point
+  os << "# Phi_B: stalled at WAIT -> barrier is blocked\n";
+  for (const auto &task : taskTraces) {
+    for (const auto &op : task.ops) {
+      if (op.kind != BarrierOpKind::Wait)
+        continue;
+      std::string sk = slotKey(op);
+      int64_t ac = 1;
+      auto it = slotArriveCount.find(sk);
+      if (it != slotArriveCount.end())
+        ac = it->second;
+
+      os << "s.add(Implies(And(c_" << task.taskName << " == " << op.position
+         << ", c_" << task.taskName << " < " << task.ops.size() << "), ";
+      if (op.phase >= 0) {
+        // Parity-based blocking
+        os << "blocked_parity('" << sk << "', " << op.phase << ", " << ac
+           << ")";
+      } else {
+        // Fallback: cycle-based (not expected with concrete eval)
+        os << "blocked_parity('" << sk << "', 0, " << ac << ")";
+      }
+      os << "))\n";
+    }
+  }
+  os << "\n";
+
+  // Phi_R: release constraint for passed-through waits
+  os << "# Phi_R: passed-through WAIT -> barrier was ready when reached\n";
+  for (const auto &task : taskTraces) {
+    for (const auto &op : task.ops) {
+      if (op.kind != BarrierOpKind::Wait)
+        continue;
+      std::string sk = slotKey(op);
+      int64_t ac = 1;
+      auto it = slotArriveCount.find(sk);
+      if (it != slotArriveCount.end())
+        ac = it->second;
+
+      // Find the global index for this op
+      size_t gIdx = 0;
+      for (const auto &ref : allOps) {
+        if (ref.op == &op) {
+          gIdx = ref.globalIdx;
+          break;
+        }
+      }
+
+      os << "s.add(Implies(And(" << op.position << " < c_" << task.taskName
+         << ", c_" << task.taskName << " <= " << task.ops.size() << "), ";
+
+      if (op.phase >= 0) {
+        // Parity-based release: phase at tau_w must differ from parity
+        if (ac == 1) {
+          os << "arrive_count_before('" << sk << "', tau_" << gIdx
+             << ") % 2 != " << op.phase;
+        } else {
+          os << "(arrive_count_before('" << sk << "', tau_" << gIdx << ") / "
+             << ac << ") % 2 != " << op.phase;
+        }
+      } else {
+        // Fallback
+        os << "True";
+      }
+      os << "))\n";
+    }
+  }
+  os << "\n";
+
+  // Byte balance constraints (cumulative): total loaded >= total expected
+  // Only emit if there are EXPECT_BYTES ops on any slot.
+  bool hasByteOps = false;
+  for (const auto &[sk, ops] : slotOps) {
+    for (const auto &ref : ops) {
+      if (ref.op->kind == BarrierOpKind::ExpectBytes) {
+        hasByteOps = true;
+        break;
+      }
+    }
+    if (hasByteOps)
+      break;
+  }
+
+  if (hasByteOps) {
+    os << "# Byte balance: cumulative loaded >= expected per slot\n";
+    os << "# (Over-approximation: not per-cycle, but cumulative)\n";
+    for (const auto &[sk, ops] : slotOps) {
+      std::vector<OpRef> expectOps, tmaOps;
+      for (const auto &ref : ops) {
+        if (ref.op->kind == BarrierOpKind::ExpectBytes)
+          expectOps.push_back(ref);
+        if (ref.op->kind == BarrierOpKind::TmaLoad)
+          tmaOps.push_back(ref);
+      }
+      if (expectOps.empty())
+        continue;
+
+      // For the completion predicate to be correct, we need byte balance.
+      // This is encoded as: if all tasks complete, loaded >= expected.
+      // But more precisely, we add it to the blocking predicate:
+      // blocked also if bytes are insufficient.
+      os << "# Slot " << sk << ": byte balance\n";
+      os << "total_expected_" << sk << " = ";
+      first = true;
+      for (const auto &ref : expectOps) {
+        if (!first)
+          os << " + ";
+        os << "If(exec_op(" << ref.globalIdx << ", '" << ref.op->taskName
+           << "', " << ref.op->position << "), " << ref.op->expectedBytes
+           << ", 0)";
+        first = false;
+      }
+      os << "\n";
+
+      os << "total_loaded_" << sk << " = ";
+      if (tmaOps.empty()) {
+        os << "IntVal(0)";
+      } else {
+        first = true;
+        for (const auto &ref : tmaOps) {
+          if (!first)
+            os << " + ";
+          // TMA load transfer size: use expectedBytes from corresponding
+          // expect_bytes as approximation (xfer not stored separately yet)
+          os << "If(exec_op(" << ref.globalIdx << ", '" << ref.op->taskName
+             << "', " << ref.op->position << "), " << ref.op->expectedBytes
+             << ", 0)";
+          first = false;
+        }
+      }
+      os << "\n";
+
+      // Add byte deficit as additional blocking condition for waits on this
+      // slot
+      os << "byte_deficit_" << sk << " = total_loaded_" << sk
+         << " < total_expected_" << sk << "\n";
+      os << "# (byte_deficit is implicitly part of blocked for this slot)\n\n";
+    }
+  }
+
+  // Deadlock query: at least one task is stuck
+  os << "# Deadlock query: at least one task stuck\n";
+  os << "s.add(Or(";
+  first = true;
+  for (const auto &task : taskTraces) {
+    if (!first)
+      os << ", ";
+    os << "c_" << task.taskName << " < " << task.ops.size();
+    first = false;
+  }
+  os << "))\n\n";
+
+  // --- Solve and diagnose ---
+  os << "# ---- Solve ----\n\n";
+  os << "result = s.check()\n";
+  os << "print(f'Result: {result}')\n\n";
+  os << "if result == sat:\n";
+  os << "    m = s.model()\n";
+  os << "    print('\\nDeadlock detected!')\n";
+  os << "    print('Task cut-points:')\n";
+  for (const auto &task : taskTraces) {
+    os << "    c_val = m.eval(c_" << task.taskName << ").as_long()\n";
+    os << "    print(f'  " << task.taskName << ": c={c_val} / "
+       << task.ops.size() << "', end='')\n";
+    os << "    if c_val < " << task.ops.size() << ":\n";
+    os << "        print(' [STUCK]', end='')\n";
+    os << "    print()\n";
+  }
+  os << "else:\n";
+  os << "    print('No deadlock found (UNSAT).')\n";
 }
 
 } // namespace mlir::triton

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonAnalysis
   AxisInfo.cpp
   Allocation.cpp
+  BarrierAnalysis.cpp
   Membar.cpp
   Alias.cpp
   Utility.cpp

--- a/lib/Dialect/TritonGPU/Transforms/BarrierDeadlockDetection.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/BarrierDeadlockDetection.cpp
@@ -1,0 +1,85 @@
+//===-- BarrierDeadlockDetection.cpp - Deadlock detection pass ---*- C++
+//-*-===//
+//
+// Pass entry point for barrier deadlock detection. Instantiates
+// BarrierDeadlockAnalysis, runs trace extraction, and dumps a standalone
+// Python Z3 script encoding the barrier constraints.
+//
+// See docs/barrier_deadlock_detection_design.md for design details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/BarrierAnalysis.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Process.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir::triton::gpu {
+
+#define GEN_PASS_DEF_TRITONGPUBARRIERDEADLOCKDETECTION
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+struct BarrierDeadlockDetectionPass
+    : public impl::TritonGPUBarrierDeadlockDetectionBase<
+          BarrierDeadlockDetectionPass> {
+  using TritonGPUBarrierDeadlockDetectionBase::
+      TritonGPUBarrierDeadlockDetectionBase;
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    moduleOp.walk([&](FunctionOpInterface funcOp) {
+      BarrierDeadlockAnalysis analysis(funcOp, unrollBound);
+      analysis.run();
+
+      if (analysis.getTaskTraces().empty())
+        return;
+
+      // Dump Z3 script to file or stderr.
+      if (!outputPath.empty()) {
+        std::error_code ec;
+        llvm::raw_fd_ostream fileOs(outputPath, ec);
+        if (ec) {
+          funcOp.emitWarning()
+              << "Failed to open output file: " << ec.message();
+          return;
+        }
+        analysis.dumpPythonZ3Script(fileOs);
+
+        // Optionally run the solver.
+        if (runSolver) {
+          auto python = llvm::sys::findProgramByName("python3");
+          if (!python) {
+            funcOp.emitWarning() << "python3 not found; skipping solver";
+            return;
+          }
+          llvm::StringRef args[] = {*python, outputPath};
+          int exitCode = llvm::sys::ExecuteAndWait(*python, args);
+          if (exitCode != 0)
+            funcOp.emitWarning() << "Z3 solver exited with code " << exitCode;
+        }
+      } else {
+        // Print to stderr with a summary header.
+        llvm::errs() << "=== Barrier Deadlock Detection: " << funcOp.getName()
+                     << " ===\n";
+        analysis.printSummary(llvm::errs());
+        llvm::errs() << "\n--- Z3 Script ---\n";
+        analysis.dumpPythonZ3Script(llvm::errs());
+        llvm::errs() << "--- End Z3 Script ---\n\n";
+      }
+    });
+  }
+};
+
+} // namespace
+} // namespace mlir::triton::gpu

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonGPUTransforms
   AccelerateMatmul.cpp
+  BarrierDeadlockDetection.cpp
   Coalesce.cpp
   F32DotTC.cpp
   FuseNestedLoops.cpp

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -365,6 +365,7 @@ class compilation_knobs(base_knobs):
     disable_line_info: env_bool = env_bool("TRITON_DISABLE_LINE_INFO")
     front_end_debugging: env_bool = env_bool("TRITON_FRONT_END_DEBUGGING")
     allow_non_constexpr_globals: env_bool = env_bool("TRITON_ALLOW_NON_CONSTEXPR_GLOBALS")
+    static_analysis: env_bool = env_bool("TRITON_ENABLE_STATIC_ANALYSIS")
     # Instrumentation mode is checked on every run, which is expensive.
     # We cache the value here to avoid the expensive check on every run.
     instrumentation_mode: str = env_str("TRITON_INSTRUMENTATION_MODE", "").get()

--- a/scripts/dump_hopper_fa.py
+++ b/scripts/dump_hopper_fa.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Dump TTIR for Hopper FA kernels."""
+import os
+import sys
+import torch
+
+sys.path.insert(0, os.path.expanduser("~/triton-fb/triton"))
+
+os.environ["TRITON_KERNEL_DUMP"] = "1"
+os.environ["TRITON_DUMP_DIR"] = os.path.expanduser("~/triton_ir_dump_hopper_fa")
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+
+B, H, N_CTX, D_HEAD = 1, 1, 256, 64
+sm_scale = 1.0 / (D_HEAD ** 0.5)
+q = torch.randn(B, H, N_CTX, D_HEAD, device='cuda', dtype=torch.float16)
+k = torch.randn(B, H, N_CTX, D_HEAD, device='cuda', dtype=torch.float16)
+v = torch.randn(B, H, N_CTX, D_HEAD, device='cuda', dtype=torch.float16)
+
+kernels = [
+    ("hopper_fa_ws", "third_party.tlx.tutorials.hopper_fa_ws"),
+    ("hopper_fa_ws_pipelined", "third_party.tlx.tutorials.hopper_fa_ws_pipelined"),
+    ("hopper_fa_ws_pipelined_pingpong", "third_party.tlx.tutorials.hopper_fa_ws_pipelined_pingpong"),
+    ("hopper_fa_ws_pipelined_pingpong_persistent", "third_party.tlx.tutorials.hopper_fa_ws_pipelined_pingpong_persistent"),
+]
+
+for name, mod_path in kernels:
+    print(f"=== {name} ===")
+    try:
+        mod = __import__(mod_path, fromlist=["attention"])
+        fn = getattr(mod, "attention")
+        o = fn(q, k, v, sm_scale)
+        print(f"  OK: output shape={o.shape}")
+    except Exception as e:
+        print(f"  Error: {e}")

--- a/scripts/dump_hopper_gemm_ws.py
+++ b/scripts/dump_hopper_gemm_ws.py
@@ -1,0 +1,30 @@
+"""Compile a single TLX Hopper kernel and dump IR for deadlock analysis."""
+import os
+import sys
+import torch
+
+DUMP_DIR = os.path.expanduser("~/triton_ir_dump")
+os.environ["TRITON_KERNEL_DUMP"] = "1"
+os.environ["TRITON_DUMP_DIR"] = DUMP_DIR
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+os.makedirs(DUMP_DIR, exist_ok=True)
+
+REPO = os.path.expanduser("~/triton-fb/triton")
+sys.path.insert(0, os.path.join(REPO, "third_party/tlx/tutorials"))
+
+from hopper_gemm_ws import matmul  # noqa: E402
+
+M, N, K = 256, 256, 256
+a = torch.randn(M, K, dtype=torch.float16, device="cuda")
+b = torch.randn(K, N, dtype=torch.float16, device="cuda")
+c = matmul(a, b)
+print(f"Done: output shape {c.shape}")
+
+# Find first ttir file
+for d in sorted(os.listdir(DUMP_DIR)):
+    subdir = os.path.join(DUMP_DIR, d)
+    if os.path.isdir(subdir):
+        ttir = os.path.join(subdir, "matmul_kernel_tlx_ws.ttir")
+        if os.path.exists(ttir):
+            print(f"TTIR: {ttir}")
+            break

--- a/scripts/dump_hopper_kernels.py
+++ b/scripts/dump_hopper_kernels.py
@@ -1,0 +1,58 @@
+"""Compile Hopper TLX kernels and dump IR for deadlock analysis."""
+import os
+import sys
+import torch
+
+DUMP_DIR = os.path.expanduser("~/triton_ir_dump_hopper")
+os.environ["TRITON_KERNEL_DUMP"] = "1"
+os.environ["TRITON_DUMP_DIR"] = DUMP_DIR
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+os.makedirs(DUMP_DIR, exist_ok=True)
+
+REPO = os.path.expanduser("~/triton-fb/triton")
+sys.path.insert(0, os.path.join(REPO, "third_party/tlx/tutorials"))
+
+# hopper_fa_ws
+print("=== hopper_fa_ws ===")
+try:
+    from hopper_fa_ws import attention as fa_ws_attention
+    q = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    k = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    v = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    o = fa_ws_attention(q, k, v, 1.0 / (64**0.5))
+    print(f"  Done: output shape {o.shape}")
+except Exception as e:
+    print(f"  Error: {e}")
+
+# hopper_fa_ws_pipelined
+print("=== hopper_fa_ws_pipelined ===")
+try:
+    from hopper_fa_ws_pipelined import attention as fa_ws_pipe_attention
+    q = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    k = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    v = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    o = fa_ws_pipe_attention(q, k, v, 1.0 / (64**0.5))
+    print(f"  Done: output shape {o.shape}")
+except Exception as e:
+    print(f"  Error: {e}")
+
+# hopper_fa_ws_pipelined_pingpong
+print("=== hopper_fa_ws_pipelined_pingpong ===")
+try:
+    from hopper_fa_ws_pipelined_pingpong import attention as fa_ws_pp_attention
+    q = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    k = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    v = torch.randn(1, 16, 64, 64, dtype=torch.float16, device="cuda")
+    o = fa_ws_pp_attention(q, k, v, 1.0 / (64**0.5))
+    print(f"  Done: output shape {o.shape}")
+except Exception as e:
+    print(f"  Error: {e}")
+
+# List dumped files
+print("\n=== Dumped TTIR files ===")
+for d in sorted(os.listdir(DUMP_DIR)):
+    subdir = os.path.join(DUMP_DIR, d)
+    if os.path.isdir(subdir):
+        for f in os.listdir(subdir):
+            if f.endswith(".ttir"):
+                print(f"  {f}: {os.path.join(subdir, f)}")

--- a/scripts/test_hopper_deadlock.py
+++ b/scripts/test_hopper_deadlock.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Dump TTIR for all Hopper TLX kernels and run barrier deadlock detection.
+
+Usage: python3 scripts/test_hopper_deadlock.py
+"""
+
+import os
+import sys
+import glob
+import subprocess
+import shutil
+
+TRITON_OPT = os.path.expanduser(
+    "~/triton-fb/triton/build/cmake.linux-x86_64-cpython-3.12/bin/triton-opt"
+)
+DUMP_DIR = os.path.expanduser("~/triton_ir_dump_hopper")
+Z3_DIR = "/tmp/z3_hopper_scripts"
+
+# Clean and recreate dump dirs
+for d in [DUMP_DIR, Z3_DIR]:
+    if os.path.exists(d):
+        shutil.rmtree(d)
+    os.makedirs(d)
+
+os.environ["TRITON_KERNEL_DUMP"] = "1"
+os.environ["TRITON_DUMP_DIR"] = DUMP_DIR
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+
+# Hopper kernels and their entry points
+KERNELS = {
+    "hopper_gemm_ws": {
+        "module": "third_party.tlx.tutorials.hopper_gemm_ws",
+        "func": "matmul",
+        "args": "M=256, N=256, K=256",
+    },
+    "hopper_gemm_pipelined": {
+        "module": "third_party.tlx.tutorials.hopper_gemm_pipelined",
+        "func": "matmul",
+        "args": "M=256, N=256, K=256",
+    },
+    "hopper_fa_ws": {
+        "module": "third_party.tlx.tutorials.hopper_fa_ws",
+        "func": "attention",
+        "args": "B=1, H=1, N_CTX=256, D_HEAD=64",
+    },
+    "hopper_fa_ws_pipelined": {
+        "module": "third_party.tlx.tutorials.hopper_fa_ws_pipelined",
+        "func": "attention",
+        "args": "B=1, H=1, N_CTX=256, D_HEAD=64",
+    },
+    "hopper_fa_ws_pipelined_pingpong": {
+        "module": "third_party.tlx.tutorials.hopper_fa_ws_pipelined_pingpong",
+        "func": "attention",
+        "args": "B=1, H=1, N_CTX=256, D_HEAD=64",
+    },
+    "hopper_fa_ws_pipelined_pingpong_persistent": {
+        "module": "third_party.tlx.tutorials.hopper_fa_ws_pipelined_pingpong_persistent",
+        "func": "attention",
+        "args": "B=1, H=1, N_CTX=256, D_HEAD=64",
+    },
+}
+
+# Step 1: Dump TTIR for each kernel
+print("=" * 60)
+print("Step 1: Dumping TTIR for Hopper kernels")
+print("=" * 60)
+
+for name, info in KERNELS.items():
+    print(f"\n--- Dumping {name} ---")
+    script = f"""
+import sys
+sys.path.insert(0, '.')
+import torch
+from {info['module']} import {info['func']}
+{info['args'].replace(', ', '; ')}
+"""
+    # Build a proper invocation script
+    script_path = f"/tmp/dump_{name}.py"
+    with open(script_path, "w") as f:
+        if "gemm" in name:
+            f.write(f"""
+import sys, os, torch
+sys.path.insert(0, '{os.path.expanduser("~/triton-fb/triton")}')
+os.environ['TRITON_KERNEL_DUMP'] = '1'
+os.environ['TRITON_DUMP_DIR'] = '{DUMP_DIR}'
+os.environ['TRITON_ALWAYS_COMPILE'] = '1'
+from {info['module']} import {info['func']}
+a = torch.randn(256, 256, device='cuda', dtype=torch.float16)
+b = torch.randn(256, 256, device='cuda', dtype=torch.float16)
+c = {info['func']}(a, b)
+print(f'{name}: done, output shape={{c.shape}}')
+""")
+        else:
+            # Flash attention
+            f.write(f"""
+import sys, os, torch
+sys.path.insert(0, '{os.path.expanduser("~/triton-fb/triton")}')
+os.environ['TRITON_KERNEL_DUMP'] = '1'
+os.environ['TRITON_DUMP_DIR'] = '{DUMP_DIR}'
+os.environ['TRITON_ALWAYS_COMPILE'] = '1'
+from {info['module']} import {info['func']}
+B, H, N_CTX, D_HEAD = 1, 1, 256, 64
+q = torch.randn(B, H, N_CTX, D_HEAD, device='cuda', dtype=torch.float16)
+k = torch.randn(B, H, N_CTX, D_HEAD, device='cuda', dtype=torch.float16)
+v = torch.randn(B, H, N_CTX, D_HEAD, device='cuda', dtype=torch.float16)
+sm_scale = 1.0 / (D_HEAD ** 0.5)
+o = {info['func']}(q, k, v, sm_scale)
+print(f'{name}: done, output shape={{o.shape}}')
+""")
+    try:
+        result = subprocess.run(
+            [sys.executable, script_path],
+            capture_output=True, text=True, timeout=120,
+            cwd=os.path.expanduser("~/triton-fb/triton"),
+        )
+        if result.returncode == 0:
+            print(f"  OK: {result.stdout.strip().split(chr(10))[-1]}")
+        else:
+            print(f"  FAILED: {result.stderr.strip()[-200:]}")
+    except subprocess.TimeoutExpired:
+        print(f"  TIMEOUT")
+
+# Step 2: Find TTIR files and run deadlock detection
+print("\n" + "=" * 60)
+print("Step 2: Running barrier deadlock detection")
+print("=" * 60)
+
+ttir_files = glob.glob(f"{DUMP_DIR}/**/*.ttir", recursive=True)
+print(f"Found {len(ttir_files)} TTIR files")
+
+results = {}
+for ttir in sorted(ttir_files):
+    kernel_name = os.path.basename(ttir).replace(".ttir", "")
+    z3_script = f"{Z3_DIR}/{kernel_name}.py"
+    print(f"\n--- {kernel_name} ({ttir}) ---")
+
+    # Run triton-opt to generate Z3 script
+    cmd = [
+        TRITON_OPT, ttir,
+        f"--pass-pipeline=builtin.module(tritongpu-barrier-deadlock-detection{{output-path={z3_script}}})",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        print(f"  triton-opt FAILED: {result.stderr.strip()[-200:]}")
+        results[kernel_name] = "TRITON-OPT-FAIL"
+        continue
+
+    if not os.path.exists(z3_script):
+        print(f"  No Z3 script generated (no warp_specialize?)")
+        results[kernel_name] = "NO-WS"
+        continue
+
+    # Check syntax
+    try:
+        with open(z3_script) as f:
+            compile(f.read(), z3_script, "exec")
+    except SyntaxError as e:
+        print(f"  Z3 script syntax error: {e}")
+        results[kernel_name] = "SYNTAX-ERROR"
+        continue
+
+    # Run Z3 solver
+    z3_result = subprocess.run(
+        [sys.executable, z3_script],
+        capture_output=True, text=True, timeout=120,
+    )
+    output = z3_result.stdout.strip()
+    print(f"  {output}")
+    if "unsat" in output.lower():
+        results[kernel_name] = "UNSAT (safe)"
+    elif "sat" in output.lower():
+        results[kernel_name] = "SAT (deadlock?!)"
+    else:
+        results[kernel_name] = f"UNKNOWN: {output[:100]}"
+
+# Summary
+print("\n" + "=" * 60)
+print("Summary")
+print("=" * 60)
+for k, v in sorted(results.items()):
+    status = "PASS" if "UNSAT" in v else ("FALSE POSITIVE!" if "SAT" in v else "?")
+    print(f"  {k:50s} {v:20s} [{status}]")

--- a/test/Analysis/test-barrier-analysis.mlir
+++ b/test/Analysis/test-barrier-analysis.mlir
@@ -1,0 +1,169 @@
+// RUN: triton-opt %s -split-input-file -test-print-barrier-analysis="unroll-bound=5" 2>&1 | FileCheck %s
+
+// Test: Simple producer-consumer pipeline with 4 stages.
+// Producer: wait(empty), expect(full), tma_load(full)
+// Consumer: wait(full), arrive(empty)
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Analysis: simple_pipeline ===
+// CHECK: Barrier allocations:
+// CHECK:   bars_empty: 4 slots, arrive_count=1
+// CHECK:   bars_full: 4 slots, arrive_count=1
+// CHECK: Task traces:
+// CHECK:   default (task 0): 15 barrier ops
+// CHECK:     [0] wait_barrier bars_empty[0] phase=0 (iter 0)
+// CHECK:     [1] barrier_expect bars_full[0] bytes=8192 (iter 0)
+// CHECK:     [2] tma_load bars_full[0] (iter 0)
+// CHECK:     [3] wait_barrier bars_empty[1] phase=0 (iter 1)
+// CHECK:     [4] barrier_expect bars_full[1] bytes=8192 (iter 1)
+// CHECK:     [5] tma_load bars_full[1] (iter 1)
+// CHECK:     [6] wait_barrier bars_empty[2] phase=0 (iter 2)
+// CHECK:     [7] barrier_expect bars_full[2] bytes=8192 (iter 2)
+// CHECK:     [8] tma_load bars_full[2] (iter 2)
+// CHECK:     [9] wait_barrier bars_empty[3] phase=0 (iter 3)
+// CHECK:     [10] barrier_expect bars_full[3] bytes=8192 (iter 3)
+// CHECK:     [11] tma_load bars_full[3] (iter 3)
+// CHECK:     [12] wait_barrier bars_empty[0] phase=1 (iter 4)
+// CHECK:     [13] barrier_expect bars_full[0] bytes=8192 (iter 4)
+// CHECK:     [14] tma_load bars_full[0] (iter 4)
+// CHECK:   partition0 (task 1): 10 barrier ops
+// CHECK:     [0] wait_barrier bars_full[0] phase=0 (iter 0)
+// CHECK:     [1] arrive_barrier bars_empty[0] (iter 0)
+// CHECK:     [2] wait_barrier bars_full[1] phase=0 (iter 1)
+// CHECK:     [3] arrive_barrier bars_empty[1] (iter 1)
+// CHECK:     [4] wait_barrier bars_full[2] phase=0 (iter 2)
+// CHECK:     [5] arrive_barrier bars_empty[2] (iter 2)
+// CHECK:     [6] wait_barrier bars_full[3] phase=0 (iter 3)
+// CHECK:     [7] arrive_barrier bars_empty[3] (iter 3)
+// CHECK:     [8] wait_barrier bars_full[0] phase=1 (iter 4)
+// CHECK:     [9] arrive_barrier bars_empty[0] (iter 4)
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @simple_pipeline(%K: i32, %desc: !tt.tensordesc<tensor<64x64xf16>>) {
+    %true = arith.constant true
+    %c4_i32 = arith.constant 4 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %data = ttg.local_alloc : () -> !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable>
+    %bars_empty = ttg.local_alloc : () -> !ttg.memdesc<4xi64, #shared1, #smem, mutable> loc("bars_empty")
+    %be0 = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be1 = ttg.memdesc_index %bars_empty[%c1_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be2 = ttg.memdesc_index %bars_empty[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be3 = ttg.memdesc_index %bars_empty[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    %bars_full = ttg.local_alloc : () -> !ttg.memdesc<4xi64, #shared1, #smem, mutable> loc("bars_full")
+    %bf0 = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf1 = ttg.memdesc_index %bars_full[%c1_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf2 = ttg.memdesc_index %bars_full[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf3 = ttg.memdesc_index %bars_full[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
+    default {
+      // Producer: wait(empty[buf]), expect(full[buf]), tma_load(full[buf])
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c4_i32 : i32
+        %empty_bar = ttg.memdesc_index %bars_empty[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %full_bar = ttg.memdesc_index %bars_full[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %data_buf = ttg.memdesc_index %data[%buf] : !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+
+        ttng.wait_barrier %empty_bar, %phase, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.barrier_expect %full_bar, 8192, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %data_buf, %full_bar, %true : !tt.tensordesc<tensor<64x64xf16>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+
+        // phase ^= (buf == 3)
+        %is_last = arith.cmpi eq, %buf, %c3_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<4xi64, #shared1, #smem, mutable>, %arg3: !ttg.memdesc<4xi64, #shared1, #smem, mutable>, %arg4: !tt.tensordesc<tensor<64x64xf16>>) num_warps(4) {
+      // Consumer: wait(full[buf]), arrive(empty[buf])
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c3 = arith.constant 3 : i32
+      %c4 = arith.constant 4 : i32
+      %t = arith.constant true
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%phase = %c0) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c4 : i32
+        %full_bar = ttg.memdesc_index %arg3[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %empty_bar = ttg.memdesc_index %arg2[%buf] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+        ttng.wait_barrier %full_bar, %phase, %t : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.arrive_barrier %empty_bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+        %is_last = arith.cmpi eq, %buf, %c3 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<4x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<4xi64, #shared1, #smem, mutable>, !ttg.memdesc<4xi64, #shared1, #smem, mutable>, !tt.tensordesc<tensor<64x64xf16>>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Phase tracking correctness with 2 stages (phases flip every 2 iterations).
+
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem2 = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Analysis: two_stage_pipeline ===
+// CHECK: Barrier allocations:
+// CHECK:   bars: 2 slots, arrive_count=1
+// CHECK: Task traces:
+// CHECK:   default (task 0): 5 barrier ops
+// Phase flips at buf==1, so: iter0=phase0, iter1=phase0->flip, iter2=phase1, iter3=phase1->flip, iter4=phase0
+// CHECK:     [0] wait_barrier bars[0] phase=0 (iter 0)
+// CHECK:     [1] wait_barrier bars[1] phase=0 (iter 1)
+// CHECK:     [2] wait_barrier bars[0] phase=1 (iter 2)
+// CHECK:     [3] wait_barrier bars[1] phase=1 (iter 3)
+// CHECK:     [4] wait_barrier bars[0] phase=0 (iter 4)
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @two_stage_pipeline(%K: i32) {
+    %true = arith.constant true
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared3, #smem2, mutable> loc("bars")
+    %b0 = ttg.memdesc_index %bars[%c0_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %b0, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    %b1 = ttg.memdesc_index %bars[%c1_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %b1, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+
+    ttg.warp_specialize(%K, %bars)
+    default {
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2_i32 : i32
+        %bar = ttg.memdesc_index %bars[%buf] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        ttng.wait_barrier %bar, %phase, %true : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        // phase ^= (buf == 1)
+        %is_last = arith.cmpi eq, %buf, %c1_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    } : (i32, !ttg.memdesc<2xi64, #shared3, #smem2, mutable>) -> ()
+    tt.return
+  }
+}

--- a/test/Analysis/test-barrier-analysis.mlir
+++ b/test/Analysis/test-barrier-analysis.mlir
@@ -46,6 +46,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %true = arith.constant true
     %c4_i32 = arith.constant 4 : i32
     %c3_i32 = arith.constant 3 : i32
+    %c2_i32 = arith.constant 2 : i32
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
 
@@ -55,7 +56,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.init_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %be1 = ttg.memdesc_index %bars_empty[%c1_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    %be2 = ttg.memdesc_index %bars_empty[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be2 = ttg.memdesc_index %bars_empty[%c2_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %be2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %be3 = ttg.memdesc_index %bars_empty[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %be3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -65,10 +66,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %bf1 = ttg.memdesc_index %bars_full[%c1_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bf1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    %bf2 = ttg.memdesc_index %bars_full[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf2 = ttg.memdesc_index %bars_full[%c2_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bf2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %bf3 = ttg.memdesc_index %bars_full[%c3_i32] : !ttg.memdesc<4xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bf3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    // Pre-arrive empty barriers so producer can start (buffers are initially empty/available)
+    ttng.arrive_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.arrive_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.arrive_barrier %be2, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.arrive_barrier %be3, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
 
     ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
     default {

--- a/test/Analysis/test-barrier-deadlock-detection.mlir
+++ b/test/Analysis/test-barrier-deadlock-detection.mlir
@@ -1,0 +1,181 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-barrier-deadlock-detection 2>&1 | FileCheck %s
+
+// Test: Correct producer-consumer pipeline → UNSAT
+// Producer: wait(empty), expect(full), tma_load(full)
+// Consumer: wait(full), arrive(empty)
+// Pre-arrives on empty barriers so producer can start.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Deadlock Detection: correct_pipeline ===
+// CHECK: Initial arrives (pre-task):
+// CHECK:   bars_empty_0: 1
+// CHECK:   bars_empty_1: 1
+// CHECK: --- Z3 Script ---
+// CHECK: from z3 import *
+// CHECK: initial_arrives = {
+// CHECK: def arrive_count(slot_key):
+// CHECK: def arrive_count_before(slot_key, t):
+// CHECK: def blocked_parity(slot_key, parity, ac):
+// CHECK: # Phi_ord: intra-task operation ordering
+// CHECK: # Phi_stall: stall only at WAIT positions
+// CHECK: # Phi_B: stalled at WAIT -> barrier is blocked
+// CHECK: # Phi_R: passed-through WAIT -> barrier was ready when reached
+// CHECK: # Deadlock query: at least one task stuck
+// CHECK: --- End Z3 Script ---
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @correct_pipeline(%K: i32, %desc: !tt.tensordesc<tensor<64x64xf16>>) {
+    %true = arith.constant true
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %data = ttg.local_alloc : () -> !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>
+    %bars_empty = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable> loc("bars_empty")
+    %be0 = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %be1 = ttg.memdesc_index %bars_empty[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    %bars_full = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable> loc("bars_full")
+    %bf0 = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bf1 = ttg.memdesc_index %bars_full[%c1_i32] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bf1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    // Pre-arrive empty barriers (buffers initially available)
+    ttng.arrive_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.arrive_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
+    default {
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2_i32 : i32
+        %empty_bar = ttg.memdesc_index %bars_empty[%buf] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %full_bar = ttg.memdesc_index %bars_full[%buf] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %data_buf = ttg.memdesc_index %data[%buf] : !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+
+        ttng.wait_barrier %empty_bar, %phase, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.barrier_expect %full_bar, 8192, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %data_buf, %full_bar, %true : !tt.tensordesc<tensor<64x64xf16>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+
+        // phase ^= (buf == 1)
+        %is_last = arith.cmpi eq, %buf, %c1_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<2xi64, #shared1, #smem, mutable>, %arg3: !ttg.memdesc<2xi64, #shared1, #smem, mutable>, %arg4: !tt.tensordesc<tensor<64x64xf16>>) num_warps(4) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %t = arith.constant true
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%phase = %c0) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2 : i32
+        %full_bar = ttg.memdesc_index %arg3[%buf] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        %empty_bar = ttg.memdesc_index %arg2[%buf] : !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+        ttng.wait_barrier %full_bar, %phase, %t : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+        ttng.arrive_barrier %empty_bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+        %is_last = arith.cmpi eq, %buf, %c1 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<2xi64, #shared1, #smem, mutable>, !ttg.memdesc<2xi64, #shared1, #smem, mutable>, !tt.tensordesc<tensor<64x64xf16>>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Missing arrive on empty barrier → SAT (deadlock)
+// Consumer does NOT arrive on empty barrier, so producer blocks forever
+// on wait(empty) after the first iteration.
+
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem2 = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Deadlock Detection: missing_arrive ===
+// CHECK: --- Z3 Script ---
+// CHECK: # Phi_B: stalled at WAIT -> barrier is blocked
+// The producer waits on bars_empty but consumer never arrives on it.
+// Z3 should find a deadlock (SAT).
+// CHECK: # Deadlock query: at least one task stuck
+// CHECK: --- End Z3 Script ---
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @missing_arrive(%K: i32, %desc: !tt.tensordesc<tensor<64x64xf16>>) {
+    %true = arith.constant true
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %data = ttg.local_alloc : () -> !ttg.memdesc<2x64x64xf16, #shared2, #smem2, mutable>
+    %bars_empty = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared3, #smem2, mutable> loc("bars_empty")
+    %be0 = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    %be1 = ttg.memdesc_index %bars_empty[%c1_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+
+    %bars_full = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared3, #smem2, mutable> loc("bars_full")
+    %bf0 = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    %bf1 = ttg.memdesc_index %bars_full[%c1_i32] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.init_barrier %bf1, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+
+    // Pre-arrive empty barriers
+    ttng.arrive_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+    ttng.arrive_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+
+    ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
+    default {
+      // Producer: wait(empty), expect(full), tma_load(full)
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2_i32 : i32
+        %empty_bar = ttg.memdesc_index %bars_empty[%buf] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        %full_bar = ttg.memdesc_index %bars_full[%buf] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        %data_buf = ttg.memdesc_index %data[%buf] : !ttg.memdesc<2x64x64xf16, #shared2, #smem2, mutable> -> !ttg.memdesc<64x64xf16, #shared2, #smem2, mutable>
+
+        ttng.wait_barrier %empty_bar, %phase, %true : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        ttng.barrier_expect %full_bar, 8192, %true : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %data_buf, %full_bar, %true : !tt.tensordesc<tensor<64x64xf16>>, !ttg.memdesc<1xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<64x64xf16, #shared2, #smem2, mutable>
+
+        %is_last = arith.cmpi eq, %buf, %c1_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<2x64x64xf16, #shared2, #smem2, mutable>, %arg2: !ttg.memdesc<2xi64, #shared3, #smem2, mutable>, %arg3: !ttg.memdesc<2xi64, #shared3, #smem2, mutable>, %arg4: !tt.tensordesc<tensor<64x64xf16>>) num_warps(4) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %t = arith.constant true
+      // Consumer: wait(full) but NO arrive(empty) — BUG!
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%phase = %c0) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2 : i32
+        %full_bar = ttg.memdesc_index %arg3[%buf] : !ttg.memdesc<2xi64, #shared3, #smem2, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+
+        ttng.wait_barrier %full_bar, %phase, %t : !ttg.memdesc<1xi64, #shared3, #smem2, mutable>
+        // Missing: ttng.arrive_barrier %empty_bar, 1
+
+        %is_last = arith.cmpi eq, %buf, %c1 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<2x64x64xf16, #shared2, #smem2, mutable>, !ttg.memdesc<2xi64, #shared3, #smem2, mutable>, !ttg.memdesc<2xi64, #shared3, #smem2, mutable>, !tt.tensordesc<tensor<64x64xf16>>) -> ()
+    tt.return
+  }
+}

--- a/test/Analysis/test-barrier-deadlock-detection.mlir
+++ b/test/Analysis/test-barrier-deadlock-detection.mlir
@@ -179,3 +179,325 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Test: Missing pre-arrive on empty barriers → SAT (deadlock)
+// Without pre-arrives, producer immediately blocks on wait(empty[0]) at phase=0
+// because A(empty_0) = 0, parity 0 == phase 0 → blocked.
+
+#shared4 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared5 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem4 = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Deadlock Detection: missing_pre_arrive ===
+// No initial arrives should appear.
+// CHECK-NOT: Initial arrives (pre-task):
+// CHECK: --- Z3 Script ---
+// CHECK: initial_arrives = {}
+// CHECK: # Phi_B: stalled at WAIT -> barrier is blocked
+// CHECK: # Deadlock query: at least one task stuck
+// CHECK: --- End Z3 Script ---
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @missing_pre_arrive(%K: i32, %desc: !tt.tensordesc<tensor<64x64xf16>>) {
+    %true = arith.constant true
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %data = ttg.local_alloc : () -> !ttg.memdesc<2x64x64xf16, #shared4, #smem4, mutable>
+    %bars_empty = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared5, #smem4, mutable> loc("bars_empty")
+    %be0 = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+    ttng.init_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+    %be1 = ttg.memdesc_index %bars_empty[%c1_i32] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+    ttng.init_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+
+    %bars_full = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared5, #smem4, mutable> loc("bars_full")
+    %bf0 = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+    ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+    %bf1 = ttg.memdesc_index %bars_full[%c1_i32] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+    ttng.init_barrier %bf1, 1 : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+
+    // BUG: No pre-arrives on empty barriers! Producer will block immediately.
+
+    ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
+    default {
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2_i32 : i32
+        %empty_bar = ttg.memdesc_index %bars_empty[%buf] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+        %full_bar = ttg.memdesc_index %bars_full[%buf] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+        %data_buf = ttg.memdesc_index %data[%buf] : !ttg.memdesc<2x64x64xf16, #shared4, #smem4, mutable> -> !ttg.memdesc<64x64xf16, #shared4, #smem4, mutable>
+
+        ttng.wait_barrier %empty_bar, %phase, %true : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+        ttng.barrier_expect %full_bar, 8192, %true : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+        ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %data_buf, %full_bar, %true : !tt.tensordesc<tensor<64x64xf16>>, !ttg.memdesc<1xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<64x64xf16, #shared4, #smem4, mutable>
+
+        %is_last = arith.cmpi eq, %buf, %c1_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<2x64x64xf16, #shared4, #smem4, mutable>, %arg2: !ttg.memdesc<2xi64, #shared5, #smem4, mutable>, %arg3: !ttg.memdesc<2xi64, #shared5, #smem4, mutable>, %arg4: !tt.tensordesc<tensor<64x64xf16>>) num_warps(4) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %t = arith.constant true
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%phase = %c0) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2 : i32
+        %full_bar = ttg.memdesc_index %arg3[%buf] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+        %empty_bar = ttg.memdesc_index %arg2[%buf] : !ttg.memdesc<2xi64, #shared5, #smem4, mutable> -> !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+
+        ttng.wait_barrier %full_bar, %phase, %t : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+        ttng.arrive_barrier %empty_bar, 1 : !ttg.memdesc<1xi64, #shared5, #smem4, mutable>
+
+        %is_last = arith.cmpi eq, %buf, %c1 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<2x64x64xf16, #shared4, #smem4, mutable>, !ttg.memdesc<2xi64, #shared5, #smem4, mutable>, !ttg.memdesc<2xi64, #shared5, #smem4, mutable>, !tt.tensordesc<tensor<64x64xf16>>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Circular wait → SAT (deadlock)
+// Two tasks cross-wait on each other's barriers with no pre-arrives.
+// Task 0 (default): wait(bar_a), arrive(bar_b)
+// Task 1 (partition0): wait(bar_b), arrive(bar_a)
+// Neither can make progress since both are blocked at their first wait.
+
+#shared6 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem6 = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Deadlock Detection: circular_wait ===
+// CHECK: --- Z3 Script ---
+// CHECK: initial_arrives = {}
+// CHECK: # Phi_B: stalled at WAIT -> barrier is blocked
+// CHECK: # Deadlock query: at least one task stuck
+// CHECK: --- End Z3 Script ---
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @circular_wait(%K: i32) {
+    %true = arith.constant true
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %bar_a = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable> loc("bar_a")
+    %ba0 = ttg.memdesc_index %bar_a[%c0_i32] : !ttg.memdesc<1xi64, #shared6, #smem6, mutable> -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+    ttng.init_barrier %ba0, 1 : !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+
+    %bar_b = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable> loc("bar_b")
+    %bb0 = ttg.memdesc_index %bar_b[%c0_i32] : !ttg.memdesc<1xi64, #shared6, #smem6, mutable> -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+    ttng.init_barrier %bb0, 1 : !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+
+    // No pre-arrives: classic circular dependency.
+
+    ttg.warp_specialize(%K, %bar_a, %bar_b)
+    default {
+      // Task 0: wait(bar_a) then arrive(bar_b)
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %a = ttg.memdesc_index %bar_a[%c0_i32] : !ttg.memdesc<1xi64, #shared6, #smem6, mutable> -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+        %b = ttg.memdesc_index %bar_b[%c0_i32] : !ttg.memdesc<1xi64, #shared6, #smem6, mutable> -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+
+        ttng.wait_barrier %a, %phase, %true : !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+        ttng.arrive_barrier %b, 1 : !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+
+        scf.yield %phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<1xi64, #shared6, #smem6, mutable>, %arg2: !ttg.memdesc<1xi64, #shared6, #smem6, mutable>) num_warps(4) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %t = arith.constant true
+      // Task 1: wait(bar_b) then arrive(bar_a)
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%phase = %c0) -> (i32) : i32 {
+        %b = ttg.memdesc_index %arg2[%c0] : !ttg.memdesc<1xi64, #shared6, #smem6, mutable> -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+        %a = ttg.memdesc_index %arg1[%c0] : !ttg.memdesc<1xi64, #shared6, #smem6, mutable> -> !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+
+        ttng.wait_barrier %b, %phase, %t : !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+        ttng.arrive_barrier %a, 1 : !ttg.memdesc<1xi64, #shared6, #smem6, mutable>
+
+        scf.yield %phase : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<1xi64, #shared6, #smem6, mutable>, !ttg.memdesc<1xi64, #shared6, #smem6, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Arrive count mismatch → SAT (deadlock)
+// Barrier initialized with count=2 (needs 2 arrives per phase), but only
+// 1 pre-arrive and 1 arrive per cycle from the consumer.
+// With ac=2: blocked_parity = (A/2) % 2 == phase.
+// Pre-arrive gives A=1, (1/2)=0, 0%2==0 == phase(0) → blocked immediately.
+
+#shared7 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared8 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem7 = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Deadlock Detection: arrive_count_mismatch ===
+// CHECK: Initial arrives (pre-task):
+// CHECK:   bars_empty_0: 1
+// CHECK: --- Z3 Script ---
+// CHECK: # Phi_B: stalled at WAIT -> barrier is blocked
+// CHECK: # Deadlock query: at least one task stuck
+// CHECK: --- End Z3 Script ---
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @arrive_count_mismatch(%K: i32, %desc: !tt.tensordesc<tensor<64x64xf16>>) {
+    %true = arith.constant true
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %data = ttg.local_alloc : () -> !ttg.memdesc<1x64x64xf16, #shared7, #smem7, mutable>
+
+    // BUG: init_barrier with count=2, but we only have 1 arrive source.
+    %bars_empty = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable> loc("bars_empty")
+    %be0 = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<1xi64, #shared8, #smem7, mutable> -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+    ttng.init_barrier %be0, 2 : !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+
+    %bars_full = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable> loc("bars_full")
+    %bf0 = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<1xi64, #shared8, #smem7, mutable> -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+    ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+
+    // Only 1 pre-arrive, but count=2 needed.
+    ttng.arrive_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+
+    ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
+    default {
+      // Producer: wait(empty[0]), expect(full[0]), tma_load(full[0])
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %empty_bar = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<1xi64, #shared8, #smem7, mutable> -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+        %full_bar = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<1xi64, #shared8, #smem7, mutable> -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+        %data_buf = ttg.memdesc_index %data[%c0_i32] : !ttg.memdesc<1x64x64xf16, #shared7, #smem7, mutable> -> !ttg.memdesc<64x64xf16, #shared7, #smem7, mutable>
+
+        ttng.wait_barrier %empty_bar, %phase, %true : !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+        ttng.barrier_expect %full_bar, 8192, %true : !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+        ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %data_buf, %full_bar, %true : !tt.tensordesc<tensor<64x64xf16>>, !ttg.memdesc<1xi64, #shared8, #smem7, mutable> -> !ttg.memdesc<64x64xf16, #shared7, #smem7, mutable>
+
+        // Single buffer: phase flips every iteration.
+        %one = arith.constant 1 : i32
+        %next_phase = arith.xori %phase, %one : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<1x64x64xf16, #shared7, #smem7, mutable>, %arg2: !ttg.memdesc<1xi64, #shared8, #smem7, mutable>, %arg3: !ttg.memdesc<1xi64, #shared8, #smem7, mutable>, %arg4: !tt.tensordesc<tensor<64x64xf16>>) num_warps(4) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %t = arith.constant true
+      // Consumer: wait(full[0]), arrive(empty[0], count=1) — only 1 of 2 needed!
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%phase = %c0) -> (i32) : i32 {
+        %full_bar = ttg.memdesc_index %arg3[%c0] : !ttg.memdesc<1xi64, #shared8, #smem7, mutable> -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+        %empty_bar = ttg.memdesc_index %arg2[%c0] : !ttg.memdesc<1xi64, #shared8, #smem7, mutable> -> !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+
+        ttng.wait_barrier %full_bar, %phase, %t : !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+        ttng.arrive_barrier %empty_bar, 1 : !ttg.memdesc<1xi64, #shared8, #smem7, mutable>
+
+        %one = arith.constant 1 : i32
+        %next_phase = arith.xori %phase, %one : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<1x64x64xf16, #shared7, #smem7, mutable>, !ttg.memdesc<1xi64, #shared8, #smem7, mutable>, !ttg.memdesc<1xi64, #shared8, #smem7, mutable>, !tt.tensordesc<tensor<64x64xf16>>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test: Phase mismatch → SAT (deadlock)
+// Consumer uses constant phase=0 (never flips), while producer correctly tracks
+// phase. After 2 iterations (buf wraps around), consumer waits on full[0] at
+// phase=0 again, but by then the barrier has flipped to phase=1.
+
+#shared9 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared10 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem9 = #ttg.shared_memory
+
+// CHECK-LABEL: === Barrier Deadlock Detection: phase_mismatch ===
+// CHECK: Initial arrives (pre-task):
+// CHECK:   bars_empty_0: 1
+// CHECK:   bars_empty_1: 1
+// CHECK: --- Z3 Script ---
+// CHECK: # Phi_B: stalled at WAIT -> barrier is blocked
+// CHECK: # Phi_R: passed-through WAIT -> barrier was ready when reached
+// CHECK: # Deadlock query: at least one task stuck
+// CHECK: --- End Z3 Script ---
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @phase_mismatch(%K: i32, %desc: !tt.tensordesc<tensor<64x64xf16>>) {
+    %true = arith.constant true
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+
+    %data = ttg.local_alloc : () -> !ttg.memdesc<2x64x64xf16, #shared9, #smem9, mutable>
+    %bars_empty = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared10, #smem9, mutable> loc("bars_empty")
+    %be0 = ttg.memdesc_index %bars_empty[%c0_i32] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+    ttng.init_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+    %be1 = ttg.memdesc_index %bars_empty[%c1_i32] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+    ttng.init_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+
+    %bars_full = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared10, #smem9, mutable> loc("bars_full")
+    %bf0 = ttg.memdesc_index %bars_full[%c0_i32] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+    ttng.init_barrier %bf0, 1 : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+    %bf1 = ttg.memdesc_index %bars_full[%c1_i32] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+    ttng.init_barrier %bf1, 1 : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+
+    // Pre-arrive empty barriers
+    ttng.arrive_barrier %be0, 1 : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+    ttng.arrive_barrier %be1, 1 : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+
+    ttg.warp_specialize(%K, %data, %bars_empty, %bars_full, %desc)
+    default {
+      // Producer correctly tracks phase
+      %p = scf.for %k = %c0_i32 to %K step %c1_i32 iter_args(%phase = %c0_i32) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2_i32 : i32
+        %empty_bar = ttg.memdesc_index %bars_empty[%buf] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+        %full_bar = ttg.memdesc_index %bars_full[%buf] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+        %data_buf = ttg.memdesc_index %data[%buf] : !ttg.memdesc<2x64x64xf16, #shared9, #smem9, mutable> -> !ttg.memdesc<64x64xf16, #shared9, #smem9, mutable>
+
+        ttng.wait_barrier %empty_bar, %phase, %true : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+        ttng.barrier_expect %full_bar, 8192, %true : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+        ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %data_buf, %full_bar, %true : !tt.tensordesc<tensor<64x64xf16>>, !ttg.memdesc<1xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<64x64xf16, #shared9, #smem9, mutable>
+
+        %is_last = arith.cmpi eq, %buf, %c1_i32 : i32
+        %is_last_ext = arith.extui %is_last : i1 to i32
+        %next_phase = arith.xori %phase, %is_last_ext : i32
+        scf.yield %next_phase : i32
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32, %arg1: !ttg.memdesc<2x64x64xf16, #shared9, #smem9, mutable>, %arg2: !ttg.memdesc<2xi64, #shared10, #smem9, mutable>, %arg3: !ttg.memdesc<2xi64, #shared10, #smem9, mutable>, %arg4: !tt.tensordesc<tensor<64x64xf16>>) num_warps(4) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %t = arith.constant true
+      // BUG: Consumer always uses phase=0 (never flips)!
+      // After 2 iterations, full[0] parity flips but consumer still expects phase=0.
+      %p2 = scf.for %k = %c0 to %arg0 step %c1 iter_args(%unused = %c0) -> (i32) : i32 {
+        %buf = arith.remsi %k, %c2 : i32
+        %full_bar = ttg.memdesc_index %arg3[%buf] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+        %empty_bar = ttg.memdesc_index %arg2[%buf] : !ttg.memdesc<2xi64, #shared10, #smem9, mutable> -> !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+
+        // Always wait with phase=0 — BUG!
+        ttng.wait_barrier %full_bar, %c0, %t : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+        ttng.arrive_barrier %empty_bar, 1 : !ttg.memdesc<1xi64, #shared10, #smem9, mutable>
+
+        scf.yield %unused : i32
+      }
+      ttg.warp_return
+    } : (i32, !ttg.memdesc<2x64x64xf16, #shared9, #smem9, mutable>, !ttg.memdesc<2xi64, #shared10, #smem9, mutable>, !ttg.memdesc<2xi64, #shared10, #smem9, mutable>, !tt.tensordesc<tensor<64x64xf16>>) -> ()
+    tt.return
+  }
+}

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_library(TritonTestAnalysis
   TestAlias.cpp
   TestAxisInfo.cpp
   TestAllocation.cpp
+  TestBarrierAnalysis.cpp
   TestMembar.cpp
   TestPrintNesting.cpp
 

--- a/test/lib/Analysis/TestBarrierAnalysis.cpp
+++ b/test/lib/Analysis/TestBarrierAnalysis.cpp
@@ -1,0 +1,51 @@
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Analysis/BarrierAnalysis.h"
+
+using namespace mlir;
+
+namespace {
+
+struct TestBarrierAnalysisPass
+    : public PassWrapper<TestBarrierAnalysisPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestBarrierAnalysisPass);
+
+  TestBarrierAnalysisPass() = default;
+  TestBarrierAnalysisPass(const TestBarrierAnalysisPass &other)
+      : PassWrapper<TestBarrierAnalysisPass, OperationPass<ModuleOp>>(other) {}
+
+  StringRef getArgument() const final { return "test-print-barrier-analysis"; }
+  StringRef getDescription() const final {
+    return "print the result of the barrier deadlock trace extraction";
+  }
+
+  Option<int> unrollBound{*this, "unroll-bound",
+                          llvm::cl::desc("Loop unrolling bound"),
+                          llvm::cl::init(0)};
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    moduleOp.walk([&](FunctionOpInterface funcOp) {
+      triton::BarrierDeadlockAnalysis analysis(funcOp, unrollBound);
+      analysis.run();
+
+      if (analysis.getTaskTraces().empty())
+        return;
+
+      llvm::outs() << "=== Barrier Analysis: " << funcOp.getName() << " ===\n";
+      analysis.printSummary(llvm::outs());
+    });
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestBarrierAnalysisPass() {
+  PassRegistration<TestBarrierAnalysisPass>();
+}
+} // namespace test
+} // namespace mlir

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -316,6 +316,10 @@ class CUDABackend(BaseBackend):
         passes.common.add_symbol_dce(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
+
+        if knobs.compilation.static_analysis:
+            CUDABackend.run_static_analysis(mod)
+
         return mod
 
     @staticmethod
@@ -666,6 +670,12 @@ please share the reproducer above with Triton project.
             if os.path.exists(fbin):
                 os.remove(fbin)
         return cubin
+
+    @staticmethod
+    def run_static_analysis(mod):
+        # Optional static analyses gated by TRITON_ENABLE_STATIC_ANALYSIS.
+        # TODO: Add barrier deadlock detection pass (PR 2).
+        pass
 
     def add_stages(self, stages, options, language):
         capability = self._parse_arch(options.arch)


### PR DESCRIPTION
## Summary                                                                                                            
  Adds a pass (`tritongpu-barrier-deadlock-detection`) that encodes barrier                                             
  execution traces as Z3 constraints and checks for deadlocks in                                                        
  warp-specialized kernels. Builds on the trace extraction from PR #1157.                                               
                                                                                                                        
  The Z3 encoding covers:                                                                                               
  - **Φ_ord**: intra-task operation ordering                                                                            
  - **Φ_async**: causal ordering for async ops (TMA, barrier_expect)                                                    
  - **Φ_stall**: tasks stall only at wait operations                                                                    
  - **Φ_B**: blocked semantics via parity-based mbarrier phase tracking                                                 
  - **Φ_R**: release semantics (passed-through waits were ready)                                                        
                                                                                                                        
  Also collects pre-task barrier arrives to correctly model initial state.                                              
                                                                                                                        
  Authored with Claude.                                                                                                 
                                                                  
  ## Test plan                                                                                                          
  - LIT test with FileCheck: `test/Analysis/test-barrier-deadlock-detection.mlir`
  - Two test cases verified end-to-end with Z3:                                                                         
    - Correct 2-stage pipeline → **UNSAT** (no deadlock)                                                                
    - Missing arrive pipeline → **SAT** (deadlock at producer's 2nd wait)