### PR TITLE
[AutoWS] Fix GEMM issues due to the default partition

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -148,7 +148,8 @@ private:
     // are inside the same WarpSpecializeOp.
     if (bool(writeWsPartitions) != bool(loopWsPartitions)) {
       auto writeWs = writeOp->getParentOfType<ttg::WarpSpecializeOp>();
-      if (writeWs && writeWs == loopOp->getParentOfType<ttg::WarpSpecializeOp>())
+      if (writeWs &&
+          writeWs == loopOp->getParentOfType<ttg::WarpSpecializeOp>())
         return true;
     }
     return false;


### PR DESCRIPTION
Fixes issues exposed by GEMM's schedule moving to the default partition. In particular the fence logic didn't seemed to work for the default partition and the fence logic didn't seem to work for multiple writers to the same buffer (though its unclear to me why this triggered this change, perhaps this was a bad partition schedule).