### PR TITLE
[TLX][AMD] Fix async_load, local_load, and async_token for AMD pipelines

### DIFF
--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -1,0 +1,187 @@
+"""
+Tests for TLX AMD support (async_load, local_load with relaxed, async_token in loops).
+
+These tests compile kernels targeting gfx950 via triton.compile() with an
+explicit GPUTarget and verify the generated TTGIR/AMDGCN. No AMD hardware is
+required for the compilation checks. Correctness checks (actual execution) run
+only when gfx950 hardware is available.
+"""
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton._internal_testing import is_hip
+from triton.compiler.compiler import ASTSource, compile as triton_compile
+from triton.backends.compiler import GPUTarget
+
+# Skip the entire module if no HIP runtime is available.
+pytestmark = pytest.mark.skipif(not is_hip(), reason="Requires HIP runtime")
+
+GFX950 = GPUTarget("hip", "gfx950", 64)
+
+
+def compile_for_gfx950(fn, signature, constexprs):
+    """Compile a TLX kernel for gfx950 and return the compiled object."""
+    src = ASTSource(fn=fn, signature=signature, constexprs=constexprs)
+    return triton_compile(src, target=GFX950)
+
+
+def is_gfx950_available():
+    """Check if the current device is gfx950."""
+    try:
+        target = triton.runtime.driver.active.get_current_target()
+        return target.arch == "gfx950"
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Test: async_load compiles on gfx950 and produces the expected ops.
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _async_load_kernel(
+    x_ptr, y_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    buffers = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 2)
+
+    buf0 = tlx.local_view(buffers, 0)
+    buf1 = tlx.local_view(buffers, 1)
+    tok_x = tlx.async_load(x_ptr + offs, buf0, mask=mask)
+    tok_y = tlx.async_load(y_ptr + offs, buf1, mask=mask)
+    tlx.async_load_commit_group([tok_x, tok_y])
+    tlx.async_load_wait_group(0)
+
+    x = tlx.local_load(buf0)
+    y = tlx.local_load(buf1)
+    tl.store(output_ptr + offs, x + y, mask=mask)
+
+
+def test_async_load_compiles_gfx950(device):
+    """async_load should produce async_copy_global_to_local in TTGIR on gfx950."""
+    compiled = compile_for_gfx950(
+        _async_load_kernel,
+        signature={"x_ptr": "*fp32", "y_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
+        constexprs={"BLOCK_SIZE": 64},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "async_copy_global_to_local" in ttgir or "buffer_load_to_local" in ttgir
+    assert "async_commit_group" in ttgir
+    assert "async_wait" in ttgir
+    assert "local_load" in ttgir
+
+    # Verify the kernel compiled all the way to AMDGCN.
+    assert "amdgcn" in compiled.asm
+    assert len(compiled.asm["amdgcn"]) > 0
+
+
+def test_async_load_correctness(device):
+    """async_load produces correct results on gfx950 hardware."""
+    if not is_gfx950_available():
+        pytest.skip("Requires gfx950 hardware")
+    size = 256
+    x = torch.rand(size, dtype=torch.float32, device=device)
+    y = torch.rand(size, dtype=torch.float32, device=device)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(size, 64),)
+    _async_load_kernel[grid](x, y, output, size, BLOCK_SIZE=64)
+    torch.testing.assert_close(x + y, output)
+
+
+# ---------------------------------------------------------------------------
+# Test: local_load with relaxed=True sets the syncedViaAsyncWait attribute.
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _relaxed_load_kernel(
+    x_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    buf = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 1)
+    buf0 = tlx.local_view(buf, 0)
+    tok = tlx.async_load(x_ptr + offs, buf0, mask=mask)
+    tlx.async_load_commit_group([tok])
+    tlx.async_load_wait_group(0)
+
+    x = tlx.local_load(buf0, relaxed=True)
+    tl.store(output_ptr + offs, x, mask=mask)
+
+
+def test_relaxed_local_load_compiles_gfx950(device):
+    """local_load(relaxed=True) should compile and produce local_load in TTGIR."""
+    compiled = compile_for_gfx950(
+        _relaxed_load_kernel,
+        signature={"x_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
+        constexprs={"BLOCK_SIZE": 64},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "local_load" in ttgir
+
+
+def test_relaxed_local_load_correctness(device):
+    """local_load(relaxed=True) produces correct results on gfx950 hardware."""
+    if not is_gfx950_available():
+        pytest.skip("Requires gfx950 hardware")
+    size = 256
+    x = torch.rand(size, dtype=torch.float32, device=device)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(size, 64),)
+    _relaxed_load_kernel[grid](x, output, size, BLOCK_SIZE=64)
+    torch.testing.assert_close(x, output)
+
+
+# ---------------------------------------------------------------------------
+# Test: async_token survives in scope around tl.range without crashing.
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _token_in_loop_kernel(
+    x_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_ITERS: tl.constexpr,
+):
+    """async_token from async_load_commit_group is live when tl.range is
+    entered. If async_token._flatten_ir is broken, the code generator
+    crashes with NotImplementedError when collecting carries."""
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    buf = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 1)
+    buf0 = tlx.local_view(buf, 0)
+
+    tok = tlx.async_load(x_ptr + offs, buf0, mask=mask)
+    tlx.async_load_commit_group([tok])
+
+    acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+    # tok is in scope here -- that's what we're testing.
+    for i in tl.range(0, NUM_ITERS, num_stages=0):
+        tlx.async_load_wait_group(0)
+        x = tlx.local_load(buf0)
+        acc += x
+
+    tl.store(output_ptr + offs, acc, mask=mask)
+
+
+def test_async_token_loop_compiles_gfx950(device):
+    """async_token in scope around tl.range should compile without crashing."""
+    compiled = compile_for_gfx950(
+        _token_in_loop_kernel,
+        signature={"x_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
+        constexprs={"BLOCK_SIZE": 64, "NUM_ITERS": 4},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "local_load" in ttgir
+    assert "async_wait" in ttgir

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -749,13 +749,10 @@ void init_triton_tlx_ir(py::module &&m) {
               mlir::triton::CacheModifier cacheModifier, mlir::triton::EvictionPolicy evictionPolicy,
               bool isVolatile, std::optional<Value> bulkSize,
               std::optional<Value> barrier, bool useBulk) -> mlir::Value {
-             // TODO: upstream AsyncCopyGlobalToLocalOp signature changed
-             // self.create<ttg::AsyncCopyGlobalToLocalOp>(
-             //     ptrTensor, result, mask.value_or(Value()),
-             //     other.value_or(Value()), bulkSize.value_or(Value()),
-             //     barrier.value_or(Value()), cacheModifier, evictionPolicy,
-             //     isVolatile, useBulk);
-             return Value();
+             return self.create<ttg::AsyncCopyGlobalToLocalOp>(
+                 ptrTensor, result, mask.value_or(Value()),
+                 other.value_or(Value()), cacheModifier, evictionPolicy,
+                 isVolatile);
            })
       .def("create_clock64",
            [](TritonOpBuilder &self) -> mlir::Value {

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -598,8 +598,15 @@ def async_load(
         # unsupported for now
         raise NotImplementedError("async_load by block pointer is not supported yet")
     else:
-        # Load by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
-        _, src, mask, other, _ = _semantic._prepare_legacy_load(src, mask, other, None, None)
+        # Load by a tensor of pointers or a pointer of scalar.
+        if src.type.is_block():
+            if mask is not None:
+                src, mask = _semantic.broadcast_impl_value(src, mask)
+            if other is not None:
+                src, other = _semantic.broadcast_impl_value(src, other)
+        elt_ty = src.type.scalar.element_ty
+        if other is not None:
+            other = _semantic.cast(other, elt_ty)
 
     cache = _semantic._str_to_load_cache_modifier(cache_modifier)
     eviction = _semantic._str_to_eviction_policy(eviction_policy)
@@ -650,10 +657,16 @@ def async_load_wait_group(
 def local_load(
     src: tlx.buffered_tensor,
     token: tlx.async_token = None,
+    relaxed: bool = False,
     _semantic=None,
 ) -> tl.tensor:
     """
     Loads buffer from local or tensor memory into a distributed tensor.
+
+    When relaxed=True, the load is annotated as synchronized via async_wait,
+    telling the AMD backend that no additional vmcnt wait is needed before
+    this LDS read. Use this when the load is preceded by an async_wait +
+    barrier that guarantees the data is ready.
     """
     block_type = tl.block_type(src.type.element_ty, src.type.shape)
     storage = src.type.storage
@@ -666,7 +679,11 @@ def local_load(
         return tl.tensor(output, block_type)
     else:
         output = _semantic.builder.create_local_load(src.handle, token.handle if token else None)
-        return tl.tensor(output, block_type)
+        result = tl.tensor(output, block_type)
+        if relaxed:
+            result.handle.set_attr("ttg.amdg.syncedViaAsyncWait",
+                                   _semantic.builder.get_bool_attr(True))
+        return result
 
 
 @tl.builtin

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -985,10 +985,10 @@ class async_token(tl.base_value):
         self.type = async_token_type(handle)
 
     def _flatten_ir(self, handles) -> None:
-        handles.append(self.handle)
-
-    def _unflatten_ir(self, handles, cursor):
-        raise NotImplementedError
+        # Async tokens are zero-width: they are not carried across loop
+        # iterations. Do not append to handles so _flatten_ir_types (which
+        # also emits nothing) stays consistent.
+        pass
 
 
 class async_token_type(tl.base_type):


### PR DESCRIPTION
Three fixes for TLX AMD async pipeline support:

1. Fix async_load C++ binding for upstream AsyncCopyGlobalToLocalOp API change (removed bulkSize/barrier/useBulk parameters). Inline broadcast+cast logic on the Python side to replace the removed _prepare_legacy_load method.

2. Add relaxed parameter to local_load that sets the ttg.amdg.syncedViaAsyncWait attribute, telling the AMD backend that no additional vmcnt wait is needed before the LDS read. This avoids spurious s_waitcnt vmcnt(0) in 3-stage pipelines.

3. Fix async_token._flatten_ir to be zero-width (consistent with async_token_type._flatten_ir_types), preventing NotImplementedError when an async_token is in scope around a tl.range loop.

Add test_tlx_amd.py with three compilation tests targeting gfx950.