### PR TITLE
[lint-autofix] Fix pre-commit formatting issues

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -722,7 +722,8 @@ static LogicalResult verifyTMEMOperand(Operation *op, RankedTensorType type,
   // getTmemCompatibleLayouts.
   SmallVector<DistributedEncodingTrait> layouts =
       getTmemCompatibleLayouts(op, type, memdesc);
-  auto encoding = dyn_cast<triton::gpu::LayoutEncodingTrait>(type.getEncoding());
+  auto encoding =
+      dyn_cast<triton::gpu::LayoutEncodingTrait>(type.getEncoding());
   if (encoding) {
     for (auto &layout : layouts) {
       if (triton::gpu::areLayoutsEquivalent(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -60,7 +60,8 @@ public:
     funcOp->walk([&](Operation *op) {
       if (auto attr = op->getAttrOfType<DenseI32ArrayAttr>("async_task_id"))
         enabled = true;
-      if (auto attr = op->getAttrOfType<DenseI32ArrayAttr>(triton::gpu::kPartitionAttrName))
+      if (auto attr = op->getAttrOfType<DenseI32ArrayAttr>(
+              triton::gpu::kPartitionAttrName))
         enabled = true;
     });
     if (!enabled) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -89,8 +89,8 @@ void TMEM1DAllocator::TMEMStore1D(OpResult producer, AsyncTaskId producerTaskId,
   auto newLayout = oldLayout;
   if (!layoutTmemCompatible) {
     auto tmemEnc = cast<ttng::TensorMemoryEncodingAttr>(tmemDesc.getEncoding());
-    auto compatibleLayouts = ttng::getTmemCompatibleLayouts(
-        expandDims, expandType, tmemDesc);
+    auto compatibleLayouts =
+        ttng::getTmemCompatibleLayouts(expandDims, expandType, tmemDesc);
     assert(!compatibleLayouts.empty() && "No TMEM-compatible layout found");
     newLayout = compatibleLayouts.front();
   }
@@ -118,8 +118,8 @@ Value TMEM1DAllocator::TMEMLoad1D(OpResult producer, Operation *consumer) {
   auto oldExpandType = getExpandedInput().getType();
   auto allocDesc = dyn_cast<ttg::MemDescType>(allocOp->getResult(0).getType());
   auto tmemEnc = cast<ttng::TensorMemoryEncodingAttr>(allocDesc.getEncoding());
-  auto compatibleLayouts = ttng::getTmemCompatibleLayouts(
-      allocOp, oldExpandType, allocDesc);
+  auto compatibleLayouts =
+      ttng::getTmemCompatibleLayouts(allocOp, oldExpandType, allocDesc);
   assert(!compatibleLayouts.empty() && "No TMEM-compatible layout found");
   auto newDistributedEncoding = compatibleLayouts.front();
   auto newExpandType = oldExpandType.cloneWithEncoding(newDistributedEncoding);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
@@ -21,8 +21,8 @@ SmallVector<AsyncTaskId> getAsyncTaskIds(Operation *op) {
           asyncTaskIds[asyncTaskIds.size() - 1] != asyncTaskId)
         asyncTaskIds.push_back(asyncTaskId);
     }
-  } else if (auto attr =
-                 op->getAttrOfType<DenseI32ArrayAttr>(tt::gpu::kPartitionAttrName)) {
+  } else if (auto attr = op->getAttrOfType<DenseI32ArrayAttr>(
+                 tt::gpu::kPartitionAttrName)) {
     for (AsyncTaskId asyncTaskId : attr.asArrayRef()) {
       asyncTaskIds.push_back(asyncTaskId);
     }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -913,7 +913,8 @@ void createToken(
         Value v;
         if (it->second.front()->getSrcOp()->getParentOfType<scf::ForOp>())
           v = ttnvws::CreateTokenOp::create(builder, funcOp.getLoc(),
-                                            channel->getNumBuffers(), tokenLoadType);
+                                            channel->getNumBuffers(),
+                                            tokenLoadType);
         else
           v = ttnvws::CreateTokenOp::create(builder, funcOp.getLoc(), 1,
                                             tokenLoadType);
@@ -1623,9 +1624,9 @@ static ttng::TMEMAllocOp createTMemAllocPost(OpBuilder &builder,
   Type accMemDescType = triton::gpu::MemDescType::get(
       shape, oldRetType.getElementType(), oldRetType.getEncoding(),
       oldRetType.getMemorySpace(), /*mutableMemory=*/true);
-  return ttng::TMEMAllocOp::create(builder, oldTMemAllocOp.getLoc(),
-                                   accMemDescType,
-                                   builder.getType<ttg::AsyncTokenType>(), /*src=*/Value());
+  return ttng::TMEMAllocOp::create(
+      builder, oldTMemAllocOp.getLoc(), accMemDescType,
+      builder.getType<ttg::AsyncTokenType>(), /*src=*/Value());
 }
 
 // Create a buffer array for each producer op, if the producer is in a ForOp,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -1038,8 +1038,8 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     // The source op is already sliced at this point, so srcTy, type, tmem is
     // sliced. We use getTmemCompatibleLayout to get a block layout that is
     // for the sliced tmem here.
-    auto compatibleLayouts = nvidia_gpu::getTmemCompatibleLayouts(
-        op, oldSrcType, type);
+    auto compatibleLayouts =
+        nvidia_gpu::getTmemCompatibleLayouts(op, oldSrcType, type);
     assert(!compatibleLayouts.empty() && "No TMEM-compatible layout found");
     auto newDistributedEncoding = compatibleLayouts.front();
     // oldRetType is the desired output, we slice it and convert from the

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -196,13 +196,13 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
     // Helper function for extracting one index from bufferFullArray.
     auto extractBufferFull = [&](Location loc, Value idx) -> Value {
       return ttg::MemDescIndexOp::create(builder, loc, singleBarrierMemDescType,
-                                                 bufferFullArray, idx);
+                                         bufferFullArray, idx);
     };
 
     // Helper function for extracting one index from bufferEmptyArray.
     auto extractBufferEmpty = [&](Location loc, Value idx) -> Value {
       return ttg::MemDescIndexOp::create(builder, loc, singleBarrierMemDescType,
-                                                 bufferEmptyArray, idx);
+                                         bufferEmptyArray, idx);
     };
     auto handleOneUser = [&](Operation *user) -> bool {
       // Here builder is at the user, make sure usage of values outside of

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -421,8 +421,8 @@ static void logOpStillHasUsers(Operation *op) {
         llvm::errs() << "  User: " << user->getName();
         // llvm::errs() << "  Full IR: ";
         // user->print(llvm::errs());
-        if (auto userPartitionAttr =
-                user->getAttrOfType<DenseI32ArrayAttr>(ttg::kPartitionAttrName)) {
+        if (auto userPartitionAttr = user->getAttrOfType<DenseI32ArrayAttr>(
+                ttg::kPartitionAttrName)) {
           llvm::errs() << " (partition: " << userPartitionAttr << ")";
         }
         auto userTaskIds = getAsyncTaskIds(user);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
@@ -146,7 +146,8 @@ int doTaskIdPropagate(triton::FuncOp &funcOp) {
   // Compute the min partition to normalize to 0
   int64_t minPartition = INT64_MAX;
   funcOp.walk([&](mlir::Operation *op) {
-    if (auto attr = op->getAttrOfType<DenseI32ArrayAttr>(ttg::kPartitionAttrName)) {
+    if (auto attr =
+            op->getAttrOfType<DenseI32ArrayAttr>(ttg::kPartitionAttrName)) {
       assert(attr.size() == 1 && "expected exactly 1 partition element");
       int64_t idx = attr[0];
       assert(idx >= 0);
@@ -156,7 +157,8 @@ int doTaskIdPropagate(triton::FuncOp &funcOp) {
   DenseSet<AsyncTaskId> totalTaskIds;
   // Convert ttg.partition to async_task_id
   funcOp.walk([&](mlir::Operation *op) {
-    if (auto attr = op->getAttrOfType<DenseI32ArrayAttr>(ttg::kPartitionAttrName)) {
+    if (auto attr =
+            op->getAttrOfType<DenseI32ArrayAttr>(ttg::kPartitionAttrName)) {
       assert(attr.size() == 1 && "expected exactly 1 partition element");
       int64_t idx = attr[0] - minPartition;
       totalTaskIds.insert(idx);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -272,10 +272,9 @@ void createTMALoad(triton::nvws::DescriptorLoadOp op, PatternRewriter &rewriter,
                          getStageCluster(op), rewriter);
     }
   }
-  auto newLoadOp =
-      triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
-          rewriter, op.getLoc(), /*multicastTargets*/ Value(), op.getDesc(),
-          indices, barrierAlloc, op.getResult(), pred);
+  auto newLoadOp = triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
+      rewriter, op.getLoc(), /*multicastTargets*/ Value(), op.getDesc(),
+      indices, barrierAlloc, op.getResult(), pred);
   assignStageCluster(newLoadOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
 };

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -154,8 +154,8 @@ public:
         return WalkResult::advance();
 
       auto srcTy = cast<RankedTensorType>(requireOp.getResult().getType());
-      auto compatibleLayouts = ttng::getTmemCompatibleLayouts(
-          storeOp, srcTy, memTy);
+      auto compatibleLayouts =
+          ttng::getTmemCompatibleLayouts(storeOp, srcTy, memTy);
       assert(!compatibleLayouts.empty() &&
              "No TMEM-compatible layout found for scales");
       auto newEncoding = compatibleLayouts.front();

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -84,8 +84,8 @@ static Attribute resolveRegisterLayout(DummyRegisterLayoutAttr dummyLayout,
     auto blockedEnc = ttg::BlockedEncodingAttr::get(
         ctx, shape, spt, order, numWarps, threadsPerWarp, numCTAs);
     auto tmpType = RankedTensorType::get(shape, elementType, blockedEnc);
-    auto compatibleLayouts = ttng::getTmemCompatibleLayouts(
-        contextOp, tmpType, memDescType);
+    auto compatibleLayouts =
+        ttng::getTmemCompatibleLayouts(contextOp, tmpType, memDescType);
     assert(!compatibleLayouts.empty() && "No TMEM-compatible layout found");
     return compatibleLayouts.front();
   }


### PR DESCRIPTION
Summary:
Automated formatting fix generated by running `pre-commit run --all-files`
and `pre-commit run clang-format --all-files` on the GitHub mirror
(facebookexperimental/triton). 12 file(s) fixed.

Reviewed By: dshi7

Differential Revision: D98708610


