### PR TITLE
Fix C++17 structured binding capture in PartitionSchedulingMeta

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1701,13 +1701,14 @@ void PartitionSchedulingMeta::runOnOperation() {
 
       // Step 1: For ops nested inside regions (e.g. tt.reduce body, scf.if
       // body), inherit the partition from the nearest ancestor op that has one.
+      Operation *loopOp = loop.getOperation();
       loop->walk([&](Operation *op) {
         if (isa<scf::YieldOp, scf::ForOp>(op) || hasPartition(op))
           return WalkResult::advance();
 
         // Find the nearest ancestor in the loop body that has a partition.
         Operation *ancestor = op->getParentOp();
-        while (ancestor && ancestor != loop.getOperation()) {
+        while (ancestor && ancestor != loopOp) {
           if (hasPartition(ancestor)) {
             setPartition(op, getPartitionIds(ancestor));
             break;


### PR DESCRIPTION
The cherry-pick in https://github.com/facebookexperimental/triton/commit/6ddd9be279c54636b0817c474ea869bb2d6c86f3 introduced lambdas that capture loop, a structured binding declared as:

```
  for (auto [idx, loop] : llvm::enumerate(loops)) {
```
In C++17, structured bindings cannot be captured in lambdas — this is a C++20 extension. Clang rejects it with -Werror on my GB200 builds where the toolchain probably enforces C++17:
```
  error: captured structured bindings are a C++20 extension
         [-Werror,-Wc++20-extensions]
```
The fix extracts loop.getOperation() into a local Operation* variable (loopOp) before the lambda that needs it. The structured binding itself is no longer referenced inside the lambda, so no capture occurs.


Authored with Claude