### PR TITLE
[lint-autofix] Fix pre-commit formatting issues

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -671,7 +671,8 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     if (!defOp || loop.isDefinedOutsideOfLoop(operand))
       continue;
 
-    if (!hasPartition(defOp) || getPartitionIds(defOp).size() == partitions.getNumPartitions()) {
+    if (!hasPartition(defOp) ||
+        getPartitionIds(defOp).size() == partitions.getNumPartitions()) {
       // If the MMA operand is coming from outside the loop, move the alloc out.
       auto allocOp = dyn_cast<LocalAllocOp>(defOp);
       if (allocOp && loop.isDefinedOutsideOfLoop(allocOp.getSrc()))

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -65,7 +65,8 @@ void Partition::iterateOutputs(
         // The user is outside the loop, so it's a post-loop operation.
         // Use the operation directly.
         owner = use.getOwner();
-        if (!hasPartition(owner) || !getPartitionIds(owner).contains(getIndex())) {
+        if (!hasPartition(owner) ||
+            !getPartitionIds(owner).contains(getIndex())) {
           callback(owner, use);
         }
         continue;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1189,11 +1189,14 @@ getInitialSchedule(scf::ForOp mainLoop,
 
         // Duplicate the op if necessary to ensure MMA partition is only user
         if (!llvm::all_of(op->getUsers(), [&](Operation *user) {
-              return hasPartition(user) && getPartitionIds(user).contains(mmaPartition->getIndex());
+              return hasPartition(user) &&
+                     getPartitionIds(user).contains(mmaPartition->getIndex());
             })) {
           Operation *newOp = OpBuilder(op).clone(*op);
           op->replaceUsesWithIf(newOp->getResults(), [&](OpOperand &use) {
-            return hasPartition(use.getOwner()) && getPartitionIds(use.getOwner()).contains(mmaPartition->getIndex());
+            return hasPartition(use.getOwner()) &&
+                   getPartitionIds(use.getOwner())
+                       .contains(mmaPartition->getIndex());
           });
           op = newOp;
         }


### PR DESCRIPTION
Summary:
Automated formatting fix generated by running `pre-commit run --all-files`
and `pre-commit run clang-format --all-files` on the GitHub mirror
(facebookexperimental/triton). 3 file(s) fixed.

Reviewed By: pchen7e2

Differential Revision: D98935448


