### PR TITLE
[AutoWS] Remove num_warps=4 restriction for WS

### DIFF
--- a/python/test/unit/language/test_autows_addmm.py
+++ b/python/test/unit/language/test_autows_addmm.py
@@ -137,7 +137,7 @@ def addmm_kernel_tma_persistent_ws(
 @pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
 @pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
 @pytest.mark.parametrize("num_stages", [2, 3])
-@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("FLATTEN", [True, False])
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
 @pytest.mark.parametrize("A_col_major", [False, True])
@@ -167,6 +167,9 @@ def test_autows_addmm_tma_persistent(
     # DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 256:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256")
+
+    if num_warps != 4 and DATA_PARTITION_FACTOR > 1:
+        pytest.skip("DATA_PARTITION_FACTOR > 1 requires num_warps == 4")
 
     # Skip configurations that exceed hardware resource limits (shared memory or tensor memory)
     if BLOCK_SIZE_M == 256 and BLOCK_SIZE_N == 256:

--- a/python/test/unit/language/test_autows_flash_attention.py
+++ b/python/test/unit/language/test_autows_flash_attention.py
@@ -6,6 +6,9 @@ The kernel is ported from tritonbench's blackwell_triton_fused_attention_dp
 to remove the external dependency.
 """
 
+import importlib.util
+import os
+
 import pytest
 import torch
 import triton
@@ -488,7 +491,7 @@ def _attn_fwd_persist(
 # =============================================================================
 
 
-def attention_forward(q, k, v, causal, sm_scale):
+def attention_forward(q, k, v, causal, sm_scale, num_warps=4):
     """Launch the persistent WS flash attention DP kernel."""
     HEAD_DIM = q.shape[-1]
     Z, H, N_CTX = q.shape[0], q.shape[1], q.shape[2]
@@ -563,7 +566,7 @@ def attention_forward(q, k, v, causal, sm_scale):
         FADD2_REDUCE=False,
         GROUP_SIZE_N=1,
         num_stages=3,
-        num_warps=4,
+        num_warps=num_warps,
         maxnreg=128,
     )
     return o
@@ -595,8 +598,12 @@ class FlashAttention:
 
 @pytest.mark.parametrize("causal", [False, True], ids=["non_causal", "causal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
-def test_blackwell_fa_autows_dp(causal, dtype):
+def test_blackwell_fa_autows_dp(causal, dtype, num_warps):
+    if num_warps != 4:
+        pytest.skip("FA kernel exceeds shared memory limits with num_warps != 4")
+
     with triton.knobs.nvidia.scope():
         triton.knobs.nvidia.use_meta_ws = True
         triton.knobs.nvidia.use_meta_partition = True
@@ -605,5 +612,62 @@ def test_blackwell_fa_autows_dp(causal, dtype):
             sm_scale = 1.0 / (HEAD_DIM**0.5)
             q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM, dtype)
             ref_out = FlashAttention.get_reference(q, k, v, sm_scale, causal)
-            tri_out = attention_forward(q, k, v, causal, sm_scale)
+            tri_out = attention_forward(q, k, v, causal, sm_scale, num_warps=num_warps)
             torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=1e-2)
+
+
+# =============================================================================
+# Backward test — imports fwd+bwd from the tutorial kernel
+# =============================================================================
+
+def _import_tutorial(name, filename):
+    tutorials_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "tutorials")
+    spec = importlib.util.spec_from_file_location(name, os.path.join(tutorials_dir, filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("causal", [False], ids=["non_causal"])
+@pytest.mark.parametrize("dtype", [torch.float16], ids=["fp16"])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_blackwell_fa_autows_bwd(causal, dtype):
+    """Test backward pass of Flash Attention with autoWS."""
+    fused_attn = _import_tutorial("fused_attention_ws_device_tma", "fused-attention-ws-device-tma.py")
+    attention = fused_attn._attention_opt.apply
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+
+        Z, H, N_CTX, HEAD_DIM = 4, 32, 1024, 128
+        sm_scale = 0.5
+        torch.manual_seed(20)
+        q = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda").normal_(mean=0.0, std=0.5).requires_grad_()
+        k = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda").normal_(mean=0.0, std=0.5).requires_grad_()
+        v = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda").normal_(mean=0.0, std=0.5).requires_grad_()
+
+        # Reference
+        M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
+        p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+        if causal:
+            p[:, :, M == 0] = float("-inf")
+        p = torch.softmax(p.float(), dim=-1).to(dtype)
+        ref_out = torch.matmul(p, v).half()
+        dout = torch.randn_like(q)
+        ref_out.backward(dout)
+        ref_dv, v.grad = v.grad.clone(), None
+        ref_dk, k.grad = k.grad.clone(), None
+        ref_dq, q.grad = q.grad.clone(), None
+
+        # Triton
+        tri_out = attention(q, k, v, causal, sm_scale, "ws_persistent", True, 0, False).half()
+        tri_out.backward(dout)
+        tri_dv, v.grad = v.grad.clone(), None
+        tri_dk, k.grad = k.grad.clone(), None
+        tri_dq, q.grad = q.grad.clone(), None
+
+        torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
+        torch.testing.assert_close(tri_dv, ref_dv, atol=1e-2, rtol=0)
+        torch.testing.assert_close(tri_dk, ref_dk, atol=1e-2, rtol=0)
+        torch.testing.assert_close(tri_dq, ref_dq, atol=1e-2, rtol=0)

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -321,7 +321,7 @@ def matmul_kernel_descriptor_persistent_ws(
 @pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
 @pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
 @pytest.mark.parametrize("num_stages", [2, 3])
-@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("A_col_major", [False, True])
 @pytest.mark.parametrize("B_col_major", [False, True])
 @pytest.mark.parametrize("use_early_tma_store_lowering", [True, False])
@@ -347,6 +347,9 @@ def test_tutorial09_matmul_tma_warp_specialize(
     # DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 256:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256")
+
+    if num_warps != 4 and DATA_PARTITION_FACTOR > 1:
+        pytest.skip("DATA_PARTITION_FACTOR > 1 requires num_warps == 4")
 
     if DATA_PARTITION_FACTOR == 1 and BLOCK_SIZE_M == 256 and BLOCK_SIZE_N == 256:
         pytest.skip("Out of resources: shared memory and/or tensor memory exceeded")
@@ -433,7 +436,7 @@ def test_tutorial09_matmul_tma_warp_specialize(
 @pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
 @pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
 @pytest.mark.parametrize("num_stages", [2, 3])
-@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("FLATTEN", [True, False])
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
 @pytest.mark.parametrize("A_col_major", [False, True])
@@ -463,6 +466,9 @@ def test_tutorial09_matmul_tma_persistent_warp_specialize(
     # DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 256:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256")
+
+    if num_warps != 4 and DATA_PARTITION_FACTOR > 1:
+        pytest.skip("DATA_PARTITION_FACTOR > 1 requires num_warps == 4")
 
     if (DATA_PARTITION_FACTOR == 1 and BLOCK_SIZE_M == 256
             and (BLOCK_SIZE_N == 256 or (BLOCK_SIZE_K == 128 and not FLATTEN))):
@@ -589,7 +595,7 @@ def test_tutorial09_matmul_tma_persistent_warp_specialize(
 @pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
 @pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
 @pytest.mark.parametrize("num_stages", [2, 3])
-@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("FLATTEN", [True, False])
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
 @pytest.mark.parametrize("A_col_major", [False, True])
@@ -619,6 +625,9 @@ def test_tutorial09_matmul_descriptor_persistent_warp_specialize(
     # DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 256:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256")
+
+    if num_warps != 4 and DATA_PARTITION_FACTOR > 1:
+        pytest.skip("DATA_PARTITION_FACTOR > 1 requires num_warps == 4")
 
     if DATA_PARTITION_FACTOR == 1 and BLOCK_SIZE_M == 256 and num_stages == 3 and FLATTEN:
         pytest.skip("Out of resources: shared memory and/or tensor memory exceeded")

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -90,13 +90,28 @@ public:
     if (!enabled)
       return;
 
-    // int numWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
-    // if (numWarps != 4) {
-    //   LDBG("Warp specialization requires num_warps=4, but got "
-    //        << numWarps << ". Skipping.");
-    //   removeWarpSpecializeAttr(funcOp);
-    //   return;
-    // }
+    int numWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
+    if (numWarps != 4) {
+      bool unsupported = false;
+      funcOp->walk([&](scf::ForOp forOp) {
+        if (auto factor = forOp->getAttrOfType<IntegerAttr>(
+                "tt.data_partition_factor")) {
+          if (factor.getInt() > 1)
+            unsupported = true;
+        }
+        if (auto tmpl = forOp->getAttrOfType<StringAttr>("tt.ws_template")) {
+          if (tmpl.getValue() == "UnifiedFA")
+            unsupported = true;
+        }
+      });
+      if (unsupported) {
+        LDBG("num_warps != 4 with UnifiedFA template or "
+             "data_partition_factor > 1 is not supported. "
+             "Falling back to non-warp-specialized path.");
+        removeWarpSpecializeAttr(funcOp);
+        return;
+      }
+    }
 
     // FIXME: skip warpspec if there is else block. Need to improve
     // CodePartitioning to correctly handle channels in else block.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -90,13 +90,13 @@ public:
     if (!enabled)
       return;
 
-    int numWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
-    if (numWarps != 4) {
-      LDBG("Warp specialization requires num_warps=4, but got "
-           << numWarps << ". Skipping.");
-      removeWarpSpecializeAttr(funcOp);
-      return;
-    }
+    // int numWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
+    // if (numWarps != 4) {
+    //   LDBG("Warp specialization requires num_warps=4, but got "
+    //        << numWarps << ". Skipping.");
+    //   removeWarpSpecializeAttr(funcOp);
+    //   return;
+    // }
 
     // FIXME: skip warpspec if there is else block. Need to improve
     // CodePartitioning to correctly handle channels in else block.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1011,6 +1011,8 @@ getInitialSchedule(scf::ForOp mainLoop,
   //===--------------------------------------------------------------------===//
   std::unique_ptr<SchedulingTemplate> tmpl =
       selectTemplate(categorizer, mergeEpilogueIntoComputation);
+  mainLoop->setAttr("tt.ws_template",
+                    StringAttr::get(mainLoop.getContext(), tmpl->getName()));
   LLVM_DEBUG(
       llvm::dbgs() << "[tritongpu-partition-scheduling] Selected template: "
                    << tmpl->getName() << "\n");

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -551,16 +551,12 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
 
   // Instead of a new IfOp for each task, we create one partitionRegion.
   auto nTaskIds = getNestedAsyncTaskIds(funcOp);
+  int numWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
   SmallVector<int32_t> partitionNumWarps;
   for (AsyncTaskId asyncTaskId : nTaskIds) {
     if (asyncTaskId == 0)
       continue;
-    // HACK: hardcode 1,2,3 with 1 warp
-    // TODO: check TritonGPUAllocateWarpGroups
-    if (asyncTaskId == 1 || asyncTaskId == 2 || asyncTaskId == 3)
-      partitionNumWarps.push_back(4);
-    else
-      partitionNumWarps.push_back(4);
+    partitionNumWarps.push_back(numWarps);
   }
   ArrayRef<Type> dummyTypes;
   ImplicitLocOpBuilder impB(opList[0]->getLoc(), opList[0]);


### PR DESCRIPTION
Remove `num_warps=4` restriction to enable warp specialization in the Meta WS path. This frees the compiler to use 8 warps during partition scheduling (currently, all 4 extra warps go to the `default` partition; we are likely to modify this in a future PR).

Note: `num_warps != 4 and DATA_PARTITION_FACTOR > 1` is not currently supported; this is fixed in a stacked PR.