### PR TITLE
[TLX] Unify cluster sync

### DIFF
--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -633,3 +633,77 @@ def test_cluster_launch_control_multi_cta_delayed_exit(device):
     )
 
     torch.testing.assert_close(output, ref_out)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer for cluster sync")
+def test_explicit_cluster_sync_ws(device):
+    """Test that explicit cluster_barrier() in WS mode sets the
+    tlx.explicit_cluster_sync module attribute and suppresses heuristic
+    cluster sync insertion.  The kernel uses two CTAs in a cluster with
+    warp specialization: the default task does a remote barrier arrive
+    to signal CTA 1, and a partition task waits on the barrier.
+    """
+
+    @triton.jit
+    def explicit_cluster_sync_ws_kernel(
+        x_ptr,
+        y_ptr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        bars = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+        cta_rank = tlx.cluster_cta_rank()
+
+        # Explicit cluster sync placed by user – compiler must not auto-insert
+        with tlx.async_tasks():
+            with tlx.async_task("default"):
+                # This has to be inside default task, because at WS entry there'd be task syncs
+                tlx.cluster_barrier()
+
+                # CTA 0 arrives on remote barrier in CTA 1
+                if cta_rank == 0:
+                    tlx.barrier_arrive(bar=bars[0], remote_cta_rank=1)
+
+            with tlx.async_task(num_warps=2):
+                # This has to be in async task because trunk path belongs to default task
+                tlx.cluster_barrier()
+                offsets = tl.arange(0, BLOCK_SIZE) + cta_rank * BLOCK_SIZE
+                data = tl.load(x_ptr + offsets)
+                # CTA 1 waits for the remote arrive from CTA 0
+                if cta_rank == 1:
+                    tlx.barrier_wait(bars[0], phase=0)
+                tl.store(y_ptr + offsets, data)
+            with tlx.async_task(num_warps=2):
+                # idle warps also have to participate in cluster wide sync
+                tlx.cluster_barrier()
+
+    BLOCK_SIZE = 128
+    x = torch.arange(BLOCK_SIZE * 2, device=device, dtype=torch.float32)
+    y = torch.empty_like(x)
+
+    kernel = explicit_cluster_sync_ws_kernel[(2, )](
+        x,
+        y,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=4,
+        ctas_per_cga=(2, 1, 1),
+    )
+
+    ttgir = kernel.asm["ttgir"]
+    # The Fixup pass should have detected the user cluster_barrier and set this
+    assert "tlx.explicit_cluster_sync = true" in ttgir, (
+        f"Expected tlx.explicit_cluster_sync module attr in TTGIR:\n{ttgir}")
+    # User placed exactly one cluster arrive+wait pair for each task (from cluster_barrier)
+    assert ttgir.count("ttng.cluster_arrive") == 3, (f"Expected exactly 3 cluster_arrive in TTGIR:\n{ttgir}")
+    assert ttgir.count("ttng.cluster_wait") == 3, (f"Expected exactly 3 cluster_wait in TTGIR:\n{ttgir}")
+
+    ptx = kernel.asm["ptx"]
+    # The user's cluster_barrier should produce exactly one
+    # barrier.cluster.arrive.aligned and one barrier.cluster.wait.aligned
+    # No extra heuristic ones should be inserted
+    assert ptx.count("barrier.cluster.arrive.aligned") == 3, (
+        f"Expected exactly 3 barrier.cluster.arrive.aligned in PTX:\n{ptx}")
+    assert ptx.count("barrier.cluster.wait.aligned") == 3, (
+        f"Expected exactly 3 barrier.cluster.wait.aligned in PTX:\n{ptx}")
+
+    # --- Check correctness ---
+    torch.testing.assert_close(y, x)

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -509,8 +509,8 @@ def run_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
     assert ttgir.count("ttng.map_to_remote_buffer") == 1
 
     ptx = kernel.asm["ptx"]
-    assert ptx.count("barrier.cluster.arrive.aligned") == 2  # one for remote bar init, one for tmem dealloc
-    assert ptx.count("barrier.cluster.wait.aligned") == 2  # one for remote bar init, one for tmem dealloc
+    assert ptx.count("barrier.cluster.arrive.aligned") == 1  # one for remote bar init
+    assert ptx.count("barrier.cluster.wait.aligned") == 1  # one for remote bar init
     assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
     assert ptx.count("tcgen05.mma.cta_group::2") == 8  # BK=128 divided into steps of 16
 
@@ -650,12 +650,10 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
 
     ptx = kernel.asm["ptx"]
     # two for trunk remote bar init: one for default wg, one for non default
-    # two for tmem dealloc (two returns)
-    assert ptx.count("barrier.cluster.arrive.aligned") == 4
+    assert ptx.count("barrier.cluster.arrive.aligned") == 2
     # one for trunk remote bar init: non default WGs just arrive anyway, then it's equivalent to a sync between
     #   default WGs in all CTAs
-    # two for tmem dealloc (two returns)
-    assert ptx.count("barrier.cluster.wait.aligned") == 3
+    assert ptx.count("barrier.cluster.wait.aligned") == 1
     assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
     assert ptx.count("tcgen05.mma.cta_group::2") == 8  # BK=128 divided into steps of 16
 

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -386,14 +386,17 @@ tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<128x32xi8, #shared2, #ttg.
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttng.two-ctas" = true} {
 
 tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
-                             %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
-		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
+                             %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
+  %c0_i32 = arith.constant 0 : i32
+  %bar_alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
+  %barrier = ttg.memdesc_index %bar_alloc[%c0_i32] : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
+  ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
   // CHECK: %[[CTAID:.+]] = nvg.cluster_id
   // CHECK: %[[TWO:.+]] = llvm.mlir.constant(2 : i32) : i32
   // CHECK: llvm.urem %[[CTAID]], %[[TWO]]
   // CHECK-COUNT-8: tcgen05.cp.cta_group::2.warpx4.32x128b
   // CHECK: tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64
-  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
   tt.return
 }
 

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -856,3 +856,34 @@ llvm.func @paired_cta_cluster_sync(%a: !llvm.ptr<3>, %b: i1) attributes {allocat
   llvm.return
 }
 }
+
+// -----
+
+// Test that explicit_cluster_sync suppresses the auto-inserted
+// barrier.cluster.arrive.aligned for non-default warps. When the user manages
+// cluster sync manually, the compiler must not inject the predicated arrive
+// before the default/partition branch.
+module attributes {tlx.enable_paired_cta_mma = true, tlx.explicit_cluster_sync = true, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 6 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+
+llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
+// CHECK-LABEL: @explicit_cluster_sync_no_ws_arrive
+
+// No cluster arrive for non-default warps, because of explicit cluster sync mod attr
+// CHECK-NOT: barrier.cluster.arrive
+// CHECK-NOT: nvvm.cluster.arrive
+
+llvm.func @explicit_cluster_sync_no_ws_arrive(%a: !llvm.ptr<3>, %b: i1) attributes {allocation.offset = 0 : i32} {
+  %c = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 mbarrier.init.shared::cta.b64 [$1], 2;", "b,r" %b, %a : (i1, !llvm.ptr<3>) -> !llvm.void
+  nvvm.cluster.wait {aligned}
+  ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 4>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(1) {
+    %1 = llvm.mlir.constant(32 : i32) : i32
+    ttg.warp_return
+  } : () -> ()
+  llvm.return
+}
+}

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -836,20 +836,11 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 // CHECK-SAME: @!$0 barrier.cluster.arrive.aligned
 // CHECK-NEXT: llvm.cond_br
 
-// sync before return for tmem dealloc
-// CHECK: nvvm.cluster.arrive {aligned}
-// CHECK-NEXT: nvvm.cluster.wait {aligned}
-// CHECK-NEXT: llvm.return
-
 // default warps keep arrive/wait after bar init
 // CHECK: mbarrier.init.shared::cta.b64
 // CHECK-NEXT: nvvm.cluster.arrive {aligned}
 // CHECK-NEXT: nvvm.cluster.wait {aligned}
 
-// sync before return for tmem dealloc
-// CHECK: nvvm.cluster.arrive {aligned}
-// CHECK-NEXT: nvvm.cluster.wait {aligned}
-// CHECK-NEXT: llvm.return
 llvm.func @paired_cta_cluster_sync(%a: !llvm.ptr<3>, %b: i1) attributes {allocation.offset = 0 : i32} {
   %c = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 mbarrier.init.shared::cta.b64 [$1], 2;", "b,r" %b, %a : (i1, !llvm.ptr<3>) -> !llvm.void
   nvvm.cluster.arrive {aligned}

--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -195,3 +195,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttng.tw
     tt.return
   }
 }
+
+// -----
+
+// Test that Fixup sets tlx.explicit_cluster_sync when ClusterArriveOp is present.
+// At Fixup time, cluster arrive/wait ops can only come from user frontend code.
+// CHECK: module attributes {
+// CHECK-SAME: tlx.explicit_cluster_sync = true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  tt.func public @explicit_cluster_sync_arrive() attributes {noinline = false} {
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    tt.return
+  }
+}
+
+// -----
+
+// Test that Fixup does NOT set tlx.explicit_cluster_sync when no cluster
+// arrive/wait ops are present.
+// CHECK: module attributes {
+// CHECK-NOT: tlx.explicit_cluster_sync
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  tt.func public @no_explicit_cluster_sync() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -12,6 +12,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK: nvvm.cluster.arrive {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
 
     %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
@@ -33,6 +34,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK: nvvm.cluster.arrive {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttg.warp_specialize(%0) attributes {warpGroupStartIds = array<i32: 4>}
     default {
@@ -66,6 +68,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK: nvvm.cluster.arrive {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttg.warp_specialize()
     default {
@@ -103,6 +106,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK-NEXT: nvvm.cluster.arrive {aligned}
     // CHECK-NEXT: nvvm.cluster.wait {aligned}
+    // CHECK: nvvm.mapa
     ttng.init_barrier %2, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %c0_i32_0 = arith.constant 0 : i32
     %c300_i32 = arith.constant 300 : i32
@@ -160,10 +164,309 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK: nvvm.cluster.arrive {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
 
     %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
     ttng.arrive_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tc_gen5_commit with {two_ctas} triggers cluster sync after init_barrier.
+// The two_ctas flag means the barrier signal is multicast to other CTAs in the cluster.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tc_gen5_commit_two_ctas_bar_init
+  tt.func public @tc_gen5_commit_two_ctas_bar_init() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: tcgen05.commit
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.tc_gen5_commit %1 {two_ctas} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that async_clc_try_cancel triggers cluster sync after init_barrier.
+// The CLC try_cancel always multicasts the barrier signal to all CTAs in the cluster.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @clc_try_cancel_bar_init
+  tt.func public @clc_try_cancel_bar_init() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %2 = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    ttng.async_clc_try_cancel %1, %2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that async_tma_copy_global_to_local with multicast_targets triggers cluster
+// sync after init_barrier. The multicast bitmask causes the barrier signal to be
+// sent to multiple CTAs in the cluster.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tma_multicast_bar_init
+  tt.func public @tma_multicast_bar_init(%desc: !tt.tensordesc<tensor<128x64xbf16, #nvmma>>, %alloc: !ttg.memdesc<128x64xbf16, #nvmma, #smem, mutable>, %x: i32, %mcast: i32, %pred: i1) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%x, %x] %alloc, %1, %pred, %mcast : !tt.tensordesc<tensor<128x64xbf16, #nvmma>>, !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<128x64xbf16, #nvmma, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tc_gen5_commit WITHOUT {two_ctas} does NOT trigger cluster sync.
+// The barrier signal stays local, so no cluster bootstrap is needed.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tc_gen5_commit_no_two_ctas_no_sync
+  tt.func public @tc_gen5_commit_no_two_ctas_no_sync() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK-NOT: nvvm.cluster.wait
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.tc_gen5_commit %1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that async_tma_copy_global_to_local WITHOUT multicast_targets does NOT
+// trigger cluster sync, even in a clustered kernel.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tma_no_multicast_no_sync
+  tt.func public @tma_no_multicast_no_sync(%desc: !tt.tensordesc<tensor<128x64xbf16, #nvmma>>, %alloc: !ttg.memdesc<128x64xbf16, #nvmma, #smem, mutable>, %x: i32, %pred: i1) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK-NOT: nvvm.cluster.wait
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%x, %x] %alloc, %1, %pred : !tt.tensordesc<tensor<128x64xbf16, #nvmma>>, !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<128x64xbf16, #nvmma, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tmem_copy with barrier in paired CTA MMA mode triggers cluster sync.
+// The barrier on tmem_copy will generate a tcgen05.commit with multicast in 2cta mode.
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared_scales = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttng.two-ctas" = true} {
+  // CHECK-LABEL: @tmem_copy_barrier_paired_cta
+  tt.func public @tmem_copy_barrier_paired_cta(
+      %src: !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>,
+      %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: tcgen05.cp
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tmem_copy %src, %dst, %1 : !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tmem_copy with barrier but WITHOUT paired CTA MMA does NOT trigger
+// cluster sync. The commit stays local without multicast.
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared_scales = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tmem_copy_barrier_no_paired_cta_no_sync
+  tt.func public @tmem_copy_barrier_no_paired_cta_no_sync(
+      %src: !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>,
+      %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK-NOT: nvvm.cluster.wait
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tmem_copy %src, %dst, %1 : !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tc_gen5_mma with multiple barriers in paired CTA MMA mode triggers
+// cluster sync. The MMA's commit will multicast barrier signals to other CTAs
+// in 2cta mode. Both barriers must be initialized before the cluster sync.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 2>
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_barrier_paired_cta
+  tt.func public @tc_gen5_mma_barrier_paired_cta(
+      %a: !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x256xf16, #tmem, #ttng.tensor_memory, mutable>,
+      %useAcc: i1, %pred: i1, %barrierPred: i1) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared_bar, #ttg.shared_memory, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<2xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    %2 = ttg.memdesc_index %0[%c1_i32] : !ttg.memdesc<2xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: tcgen05.mma
+    ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %1[%barrierPred], %2[%barrierPred] {is_async, two_ctas} :
+       !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<128x256xf16, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tc_gen5_mma with barrier but WITHOUT paired CTA MMA does NOT trigger
+// cluster sync, even in a clustered kernel.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 2>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_barrier_no_paired_cta_no_sync
+  tt.func public @tc_gen5_mma_barrier_no_paired_cta_no_sync(
+      %a: !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x256xf16, #tmem, #ttng.tensor_memory, mutable>,
+      %useAcc: i1, %pred: i1, %barrierPred: i1) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK-NOT: nvvm.cluster.wait
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %1[%barrierPred] {is_async} :
+       !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<128x256xf16, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tc_gen5_mma_scaled with barrier in paired CTA MMA mode triggers
+// cluster sync. The scaled MMA's commit multicasts barrier signals in 2cta mode.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_scaled_barrier_paired_cta
+  tt.func public @tc_gen5_mma_scaled_barrier_paired_cta(
+      %a: !ttg.memdesc<128x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<64x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+      %useAcc: i1, %pred: i1, %barrierPred: i1) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: tcgen05.mma
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e4m3, %1[%barrierPred] {is_async, two_ctas} :
+       !ttg.memdesc<128x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<64x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+       !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+       !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that tc_gen5_mma_scaled with barrier but WITHOUT paired CTA MMA does NOT
+// trigger cluster sync, even in a clustered kernel.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_scaled_barrier_no_paired_cta_no_sync
+  tt.func public @tc_gen5_mma_scaled_barrier_no_paired_cta_no_sync(
+      %a: !ttg.memdesc<128x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<64x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+      %useAcc: i1, %pred: i1, %barrierPred: i1) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK-NOT: nvvm.cluster.wait
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e4m3, %1[%barrierPred] {is_async} :
+       !ttg.memdesc<128x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<64x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+       !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+       !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     tt.return
   }
 }

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -470,3 +470,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// Test that explicit_cluster_sync suppresses heuristic cluster sync insertion.
+// Even though there is a remote barrier (map_to_remote_buffer + arrive_barrier),
+// the compiler must not auto-insert cluster arrive/wait because the user is
+// responsible for placing them manually.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {tlx.enable_paired_cta_mma = true, tlx.explicit_cluster_sync = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @explicit_cluster_sync_no_auto_insert
+  tt.func public @explicit_cluster_sync_no_auto_insert() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK-NOT: nvvm.cluster.wait
+    // CHECK: nvvm.mapa
+    ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    ttng.arrive_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -379,15 +379,26 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
   // Tell PTXAS this value is warp-uniform.
   wid = targetInfo.shuffleIdx(b, b.getLoc(), wid, 0);
   Value isDefault = b.icmp_ult(wid, b.i32_val(defaultNumWarps));
-  if (tlx::tlxIsClustered(func)) {
-    // Non default warps should just do a cluster arrive unconditionally
-    PTXBuilder ptxBuilder;
-    auto clusterArriveOp =
-        *ptxBuilder.create("@!$0 barrier.cluster.arrive.aligned;");
-    clusterArriveOp({ptxBuilder.newOperand(isDefault, "b")},
-                    /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(ctx);
-    ptxBuilder.launch(b, func.getLoc(), voidTy);
+  if (tlx::tlxIsClustered(func) && !tlx::tlxExplicitClusterSync(func)) {
+    // All these have to be true before we can insert an arrive here:
+    // - The kernel is in clustered mode
+    // - There's no user controlled explicit cluster sync
+    // - There's an ClusterWaitOp (then it had to be inserted by compiler)
+    bool hasClusterBarWait =
+        func.walk([&](NVVM::ClusterWaitOp) { return WalkResult::interrupt(); })
+            .wasInterrupted();
+    if (hasClusterBarWait) {
+      // Non default warps should just do a cluster arrive unconditionally.
+      // Note this instruction is at kernel beginning shared by all warps, and
+      // we use `isDefault` as predicate here to select only non default warps
+      PTXBuilder ptxBuilder;
+      auto clusterArriveOp =
+          *ptxBuilder.create("@!$0 barrier.cluster.arrive.aligned;");
+      clusterArriveOp({ptxBuilder.newOperand(isDefault, "b")},
+                      /*onlyAttachMLIRArgs=*/true);
+      auto voidTy = void_ty(ctx);
+      ptxBuilder.launch(b, func.getLoc(), voidTy);
+    }
   }
   LLVM::CondBrOp::create(b, b.getLoc(), isDefault, entry, switchLoop);
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -584,28 +584,6 @@ struct ConvertWarpSpecializeToLLVM
     for (LLVM::LLVMFuncOp kernel : kernels)
       if (failed(lowerWarpSpecialize(kernel, targetInfo)))
         return signalPassFailure();
-
-    // Insert cluster sync right before every return op after ws lowering to
-    // make sure all warps execute it. Note: we put this piece of code here to
-    // make sure it's executed right after WS lowering, but it's not part of WS
-    // lowering, so without WS ops this piece should still execute
-    if (tlx::tlxEnablePairedMMA(mod)) {
-      for (LLVM::LLVMFuncOp kernel : kernels) {
-        kernel.walk([&](LLVM::ReturnOp ret) {
-          auto ctx = ret->getContext();
-          auto loc = ret.getLoc();
-          IRRewriter rewriter(kernel.getContext());
-
-          // for 2cta, this is needed
-          // "When the current CTA issues the operation, the peer CTA should be
-          // active and should not have exited."
-          auto unitAttr = UnitAttr::get(ctx);
-          rewriter.setInsertionPoint(ret);
-          rewriter.create<NVVM::ClusterArriveOp>(loc, unitAttr);
-          rewriter.create<NVVM::ClusterWaitOp>(loc, unitAttr);
-        });
-      }
-    }
   }
 };
 } // namespace

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -303,6 +303,93 @@ private:
     return success();
   }
 
+  // Return the operand or result Value of a given op if the Value is used for
+  // cross CTA mbarrier arrival. This function assumes the kernel has cluster
+  // size larger than 1.
+  std::optional<SetVector<Value>> getRemoteBarrier(Operation *op) {
+    if (auto mapaOp = llvm::dyn_cast<ttng::MapToRemoteBufferOp>(op)) {
+      // plain cross CTA mbarrier arrive and cross CTA DSMEM store/copy need
+      // mapa to map mbarrier addr explicitly
+      llvm::SetVector<Value> bars;
+      bars.insert(mapaOp.getResult());
+      return bars;
+    } else if (auto tmaLoadOp =
+                   llvm::dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+      // If it's a TMA load with multicast, the mbar signal is multicasted too
+      if (tmaLoadOp.getMulticastTargets()) {
+        llvm::SetVector<Value> bars;
+        bars.insert(tmaLoadOp.getBarrier());
+        return bars;
+      }
+    } else if (auto asyncCLCTryCancelOp =
+                   llvm::dyn_cast<ttng::AsyncCLCTryCancelOp>(op)) {
+      // If it's AsyncCLCTryCancelOp, the signal will be broadcasted to other
+      // CTAs only when .multicast::cluster::all is specified, which is true now
+      // no matter what cluster size is. Since we're assuming cluster size > 1,
+      // we should consider the barrier here as remote barrier.
+      llvm::SetVector<Value> bars;
+      bars.insert(asyncCLCTryCancelOp.getMbarAlloc());
+      return bars;
+    } else if (auto tcgen5CommitOp = llvm::dyn_cast<ttng::TCGen5CommitOp>(op)) {
+      // As of now, there're only three sources to have a tcgen05.commit
+      // instruction:
+      // 1. Front end supplied a TCGen5CommitOp directly
+      // 2. When lowering gen5 TMEMCopy to llvm, compiler inserts inline ptx
+      // 3. When lowering gen5 MMA to llvm, compiler inserts inline ptx
+      // And the eventual tcgen05.commit has .multicast::cluster to broadcast
+      // mbar signals to multiple CTAs only under 2cta mode.
+      // https://github.com/facebookexperimental/triton/blob/70d488dc45ca7e75432b0352cb9dd07b602a82cf/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp#L327
+      // Although it's valid
+      // to have .multicast::cluster for 1cta mode too, there's currently no
+      // support for it.
+
+      // Cases 1 and 2 will read module attribute for 2cta mode, case 3 will
+      // read module attr or op arg for 2cta mode, which are equivalent since
+      // all tcgen05 ops have to be consistent with module attr on this.
+
+      // Case 1: explicit TCGen5CommitOp from front end or earlier passes
+      if (tcgen5CommitOp.getTwoCtas()) {
+        llvm::SetVector<Value> bars;
+        bars.insert(tcgen5CommitOp.getBarrier());
+        return bars;
+      }
+    } else if (auto tmemCopyOp = llvm::dyn_cast<ttng::TMEMCopyOp>(op)) {
+      // case 2 for gen5 commit: a commit inline ptx is generated for a tmem cp
+      // op if it has a barrier arg. If the mod is in 2cta mode, the commit op
+      // can multicast bar signals.
+      if (auto bar = tmemCopyOp.getBarrier()) {
+        if (tlx::tlxEnablePairedMMA(op)) {
+          llvm::SetVector<Value> bars;
+          bars.insert(bar);
+          return bars;
+        }
+      }
+    } else if (llvm::isa<ttng::MMAv5OpInterface>(op)) {
+      // case 3 for gen5 commit: a commit inline ptx will be generated for each
+      // barrier on the gen5 MMA op. If the mod is in 2cta mode, the commit op
+      // can multicast bar signals.
+      if (tlx::tlxEnablePairedMMA(op)) {
+        llvm::SetVector<Value> bars;
+        // TODO: move getBarriers() into MMAv5OpInterface to simplify this
+        if (auto mma = llvm::dyn_cast<ttng::TCGen5MMAOp>(op)) {
+          for (auto bar : mma.getBarriers()) {
+            bars.insert(bar);
+          }
+        } else {
+          // "assert" it's a scaled MMA op so that we crash explicitly if new
+          // MMAv5OpInterface is added
+          auto scaledMMA = llvm::cast<ttng::TCGen5MMAScaledOp>(op);
+          for (auto bar : scaledMMA.getBarriers()) {
+            bars.insert(bar);
+          }
+        }
+        return bars;
+      }
+    }
+
+    return std::nullopt;
+  }
+
   // If the kernel is clustered, insert cluster sync properly to
   // bootstrap remote bars
   LogicalResult maybeInsertClusterSync(ModuleOp &mod) {
@@ -310,24 +397,29 @@ private:
       return success();
     }
 
-    bool hasMapaOp = false;
+    bool hasRemoteBar = false;
     SetVector<Operation *> barAllocOps;
-    // Find all bar alloc op in the back slice of mapa ops
-    mod.walk([&](ttng::MapToRemoteBufferOp mapaOp) {
-      hasMapaOp = true;
+    // Find all bar alloc op in the back slice of a remote bar
+    mod.walk([&](Operation *op) {
       SetVector<Operation *> ops;
-      getBackwardSliceWithWS(mapaOp.getResult(), &ops);
+      auto remoteBar = getRemoteBarrier(op);
+      if (remoteBar.has_value()) {
+        hasRemoteBar = true;
+        for (auto bar : remoteBar.value()) {
+          getBackwardSliceWithWS(bar, &ops);
 
-      for (auto op : ops) {
-        if (isa<ttg::LocalAllocOp>(op)) {
-          barAllocOps.insert(op);
+          for (auto opInSlice : ops) {
+            if (isa<ttg::LocalAllocOp>(opInSlice)) {
+              barAllocOps.insert(opInSlice);
+            }
+          }
         }
       }
     });
 
-    // If there's no mapa, it's not possible to access remote barrier so
+    // If there's no remote barrier,
     // skipping
-    if (!hasMapaOp) {
+    if (!hasRemoteBar) {
       return success();
     }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -397,6 +397,12 @@ private:
       return success();
     }
 
+    // If the kernel is in explicit(manual) cluster sync mode, users will be
+    // responsible for inserting cluster sync correctly from front end.
+    if (tlx::tlxExplicitClusterSync(mod)) {
+      return success();
+    }
+
     bool hasRemoteBar = false;
     SetVector<Operation *> barAllocOps;
     // Find all bar alloc op in the back slice of a remote bar

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -27,8 +27,12 @@ constexpr static char AttrHasTLXOpsName[] = "tlx.has_tlx_ops";
 constexpr static char AttrHasWarpSpecOpsName[] = "tlx.has_warp_spec_ops";
 constexpr static char AttrTLXEnablePairedCTAMMAName[] =
     "tlx.enable_paired_cta_mma";
+constexpr static char AttrTLXExplicitClusterSyncName[] =
+    "tlx.explicit_cluster_sync";
 
 bool tlxEnablePairedMMA(Operation *op);
+
+bool tlxExplicitClusterSync(Operation *op);
 
 // Returns true if the kernel uses clusters (clusterDims product > 1).
 // Subsumes tlxEnablePairedMMA: paired CTA MMA always implies clustering.

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -42,6 +42,19 @@ bool mlir::triton::tlx::tlxEnablePairedMMA(Operation *op) {
   return attr != nullptr && attr.getValue() == true;
 }
 
+bool mlir::triton::tlx::tlxExplicitClusterSync(Operation *op) {
+  assert(op != nullptr &&
+         "expecting nonnull op for checking explicit cluster sync");
+  auto module = op;
+  if (!isa<ModuleOp>(module)) {
+    module = op->getParentOfType<ModuleOp>();
+  }
+  assert(module != nullptr &&
+         "expecting op nested in a module for checking explicit cluster sync");
+  auto attr = module->getAttrOfType<BoolAttr>(AttrTLXExplicitClusterSyncName);
+  return attr != nullptr && attr.getValue() == true;
+}
+
 bool mlir::triton::tlx::tlxIsClustered(Operation *op) {
   assert(op != nullptr && "expecting nonnull op for checking cluster dims");
   auto moduleOp = op;

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -197,8 +197,17 @@ public:
                                return WalkResult::advance();
                              })
                               .wasInterrupted();
+    auto hasExplicitClusterSync =
+        mod.walk([&](Operation *op) {
+             if (isa<ttng::ClusterArriveOp, ttng::ClusterWaitOp>(op)) {
+               return WalkResult::interrupt();
+             }
+             return WalkResult::advance();
+           })
+            .wasInterrupted();
+
     if (!hasTLXOps && !hasExplicitLocalMemAccess && !hasWarpSpecOps &&
-        !hasTLXTwoCTAs) {
+        !hasTLXTwoCTAs && !hasExplicitClusterSync) {
       return;
     }
 
@@ -217,6 +226,9 @@ public:
       mod->setAttr(AttrHasWarpSpecOpsName, b.getBoolAttr(true));
     if (hasTLXTwoCTAs) {
       mod->setAttr(AttrTLXEnablePairedCTAMMAName, b.getBoolAttr(true));
+    }
+    if (hasExplicitClusterSync) {
+      mod->setAttr(AttrTLXExplicitClusterSyncName, b.getBoolAttr(true));
     }
   }
 };


### PR DESCRIPTION
Unifying cluster sync op for different cluster level use cases, and clarify compiler and user responsibilites.

## High level
This change is based on this assumption:

If a kernel is written correctly, there is no trailing redundant cross CTA SMEM/TMEM access (every such access would have corresponding synchronizations, like a bar wait). If there is one, we should try to remove it because it's redundant, and comes at a cost.

Then we don't need to insert cluster sync around the end of kernel to prevent invalid cross CTA access when one CTA already exits.

TLX compiler will provide guarantees that mbarriers are properly set up for CTA or cluster wide use, by inserting cluster sync (arrive+wait) to guard mbarrier init. User will need to provide guarantee for correct use of mbarriers for synchronizations. User generally should not need to use cluster sync API.

## Implementation details
Mostly inheriting https://github.com/facebookexperimental/triton/pull/652.

We find all the "remote barriers", and insert a cluster sync after the last mbarrier init among them. If we see a cluster wait in the func when lowering WS, we have non default warps unconditionally do a cluster arrive. Then syncing the whole cluster is equivalent to syncing default warps of the whole cluster, which is responsible for all mbarrier init.

Note: https://github.com/facebookexperimental/triton/pull/1159 already landed to extend the coverage from 2cta to any multi-cta for some "remote barriers". This PR covers all remote bars.

## Commit review
For easy reviews, this PR is organized such that every single commit is doing an atomic meaningful thing:
1. Remove the unnecessary cluster sync inserted at the end of kernel. This could possibly expose more issues with existing kernels if they have one cross CTA access when target CTA exited, and we should go fix those kernels.
2. Extend the definition of "remote barrier" when we insert cluster sync to guard init. This is based on a review of currently TLX API involving cross CTA barriers. Some of them require explicit `mapa` to convert mbar address while the rest is doing implicit cross CTA barrier access like TMA multicasting or CLC. tcgen5 commit op is the most special, because it can come from front end, or from ttgir to llvm lowering, by which time our sync op insertion was done, so we had to check mma and tcgen5 cp op instead (i.e. Will this MMA op later generate a commit op that could multicast mbar signals?)
3. Improve co-op between compiler insertion and user insertions. There might be very rare cases when we do allow users to explicitly call cluster sync on front end. In that case, we should disable compiler sync insertion to not mess up. This is done by checking TLX front end and set a mod attr.

TODO: fine tune the explicit use of cluster sync in reduction kernel.