### PR TITLE
[autoWS] fix OOR shared memory from ReshapeMemDesc

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -165,6 +165,13 @@ public:
             getContext(), allocOp.getLoc(), allocType, srcShape, innerTy)))
       return failure();
 
+    // Only apply this optimization when the inferred encoding preserves the
+    // original encoding type (e.g. NVMMAShared). If inference fell back to
+    // SharedLinearEncodingAttr, the resulting 3D allocation can be
+    // significantly larger than the original 2D one, causing OOR errors.
+    if (isa<SharedLinearEncodingAttr>(innerTy.getEncoding()))
+      return failure();
+
     auto newAlloc = rewriter.create<LocalAllocOp>(allocOp.getLoc(), innerTy,
                                                   reshapeOp.getSrc());
     rewriter.replaceOpWithNewOp<MemDescReshapeOp>(allocOp, allocOp.getType(),

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -276,3 +276,28 @@ module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num
     tt.return %a: !ttg.memdesc<128x64xf16, #shared, #smem>
   }
 }
+
+// -----
+
+// Verify that ReshapeMemDesc does NOT fire when the reshape changes the
+// innermost dimension (e.g. 128x2x64 -> 128x128, inner dim 64 != 128).
+// Encoding inference falls back to SharedLinearEncodingAttr in this case,
+// and creating a 3D local_alloc with that encoding would bloat SMEM
+// allocation, potentially causing OOR errors.
+#blocked = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [1, 0, 2]}>
+#linear = #ttg.linear<{register = [[0, 64], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @reshape_memdesc_inner_dim_change
+  tt.func @reshape_memdesc_inner_dim_change(%arg: tensor<128x2x64xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem> {
+    // The reshape changes the inner dim (64 -> 128), so the pattern must NOT
+    // fire. We should see tt.reshape + local_alloc, NOT local_alloc + memdesc_reshape.
+    // CHECK: tt.reshape
+    // CHECK-NEXT: ttg.local_alloc
+    // CHECK-NOT: ttg.memdesc_reshape
+    %r = tt.reshape %arg : tensor<128x2x64xbf16, #blocked> -> tensor<128x128xbf16, #linear>
+    %a = ttg.local_alloc %r : (tensor<128x128xbf16, #linear>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+    tt.return %a: !ttg.memdesc<128x128xbf16, #shared, #smem>
+  }
+}


### PR DESCRIPTION
Subtiling p in [FA kernel](https://github.com/meta-pytorch/tritonbench/blob/main/tritonbench/kernels/blackwell_triton_fused_attention_dp.py) ran into Triton OOR error. The root cause is that it introduces `tt.reshape` (128x2x64 → 128x128), and upstream tries to optimize the reshape from registers into SMEM which introduces additional SMEM usage. This PR tries to guard the optimization from happening when inner dimension changes and the `NVMMAShared` encoding falls back to `SharedLinearEncodingAttr`.

### Test plan
The tritonbench FA with `subtile_p=True` runs without OOR issue:
```
cd tritonbench && CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/triton_dumps TRITON_USE_META_WS=1 TRITON_USE_META_PARTITION=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --mode fwd --causal --rep 3000 --sleep 1.0 --metrics tflops --simple-output --only triton_tutorial_flash_dp_persistent_blackwell --force
```
and lit test:
```
triton-opt test/TritonGPU/dot-operands.mlir -split-input-file -tritongpu-optimize-dot-operands -canonicalize | FileCheck test/TritonGPU/dot-operands.mlir
```
