### PR TITLE
Back out "[triton][PR] [Triton beta] Do not use different ptxas for blackwell"

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -497,7 +497,7 @@ class nvidia_knobs(base_knobs):
     cuobjdump: env_nvidia_tool = env_nvidia_tool("cuobjdump")
     nvdisasm: env_nvidia_tool = env_nvidia_tool("nvdisasm")
     ptxas: env_nvidia_tool = env_nvidia_tool("ptxas")
-    ptxas_blackwell: env_nvidia_tool = env_nvidia_tool("ptxas")  # FB: we keep using ptxas bin for all archs
+    ptxas_blackwell: env_nvidia_tool = env_nvidia_tool("ptxas-blackwell")
 
     dump_nvptx: env_bool = env_bool("NVPTX_ENABLE_DUMP")
     disable_ptxas_opt: env_bool = env_bool("DISABLE_PTXAS_OPT")


### PR DESCRIPTION
Summary: D99344869 was unnecessary. The issue should already be resolved by previous diff removing the problematic ptxas binary D98829669

Differential Revision: D99499599


