### PR TITLE
[backend] Preserve original num_warps in metadata before warp-specialization overwrite

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -449,6 +449,10 @@ class HIPBackend(BaseBackend):
             amd.add_scalarize_packed_fops_llvm_pass(fns[0])
 
         # Get some metadata
+        total_num_warps = src.get_int_attr("ttg.total-num-warps")
+        if total_num_warps is not None and total_num_warps != metadata["num_warps"]:
+            metadata["num_warps_base"] = metadata["num_warps"]
+            metadata["num_warps"] = total_num_warps
         metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["profile_scratch_size"] = src.get_int_attr("ttg.profile_scratch_memory_size") or 0
         metadata["profile_scratch_align"] = src.get_int_attr("ttg.profile_scratch_memory_alignment") or 1

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -449,9 +449,9 @@ class HIPBackend(BaseBackend):
             amd.add_scalarize_packed_fops_llvm_pass(fns[0])
 
         # Get some metadata
+        metadata["num_warps_base"] = metadata["num_warps"]
         total_num_warps = src.get_int_attr("ttg.total-num-warps")
-        if total_num_warps is not None and total_num_warps != metadata["num_warps"]:
-            metadata["num_warps_base"] = metadata["num_warps"]
+        if total_num_warps is not None:
             metadata["num_warps"] = total_num_warps
         metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["profile_scratch_size"] = src.get_int_attr("ttg.profile_scratch_memory_size") or 0

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -549,7 +549,8 @@ class CUDABackend(BaseBackend):
         # Get some metadata
         # warp-specialization mutates num_warps
         total_num_warps = src.get_int_attr("ttg.total-num-warps")
-        if total_num_warps is not None:
+        if total_num_warps is not None and total_num_warps != metadata["num_warps"]:
+            metadata["num_warps_base"] = metadata["num_warps"]
             metadata["num_warps"] = total_num_warps
         metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["tmem_size"] = src.get_int_attr("ttg.tensor_memory_size")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -548,9 +548,9 @@ class CUDABackend(BaseBackend):
 
         # Get some metadata
         # warp-specialization mutates num_warps
+        metadata["num_warps_base"] = metadata["num_warps"]
         total_num_warps = src.get_int_attr("ttg.total-num-warps")
-        if total_num_warps is not None and total_num_warps != metadata["num_warps"]:
-            metadata["num_warps_base"] = metadata["num_warps"]
+        if total_num_warps is not None:
             metadata["num_warps"] = total_num_warps
         metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["tmem_size"] = src.get_int_attr("ttg.tensor_memory_size")


### PR DESCRIPTION

  When warp-specialization is enabled, AllocateWarpGroups overwrites metadata["num_warps"] with the inflated total, discarding the user-specified value. This breaks downstream
  consumers like tritonparse and Proton profiler.

  Upstream PR (https://github.com/triton-lang/triton/pull/9597) was not accepted because the maintainer suggested using jit_cache_hook to capture num_warps before compilation. However, tritonparse only
  uses post_compile_hook — adding jit_cache_hook would introduce significant overhead in both execution time and trace size. Storing num_warps_base in the metadata is the most
  practical solution for our use case.

  This PR saves the original value as metadata["num_warps_base"] before the overwrite, only when the count actually changes. Both NVIDIA and AMD backends are updated.

  No breaking changes — metadata["num_warps"] continues to hold the post-transformation value for the dispatcher.

  Test plan

  - This is a metadata-only change; no functional behavior is altered.
  - Verified with tritonparse on a TLX warp-specialization kernel that num_warps_base correctly reflects the user-specified value.

cc @wychi @srivatsan-ramesh