### PR TITLE
[triton][beta] Backport '[Gluon] Expose finer grained cluster fences (#9076)'

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -75,13 +75,29 @@ def TTNG_FenceOp : TTNG_Op<"fence"> {
   }];
 }
 
+def TTNG_FenceMBarrierInitReleaseClusterOp : TTNG_Op<
+    "fence_mbarrier_init_release_cluster"> {
+  let summary = "fence mbarrier init release.cluster";
+
+  let assemblyFormat = "attr-dict";
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    static bool isSupported(int computeCapability) {
+      return computeCapability >= 90;
+    }
+  }];
+}
+
 def TTNG_ClusterArriveOp : TTNG_Op<"cluster_arrive", []> {
   let arguments = (ins I1Attr:$relaxed);
   let assemblyFormat = "attr-dict";
+  let hasVerifier = 1;
 }
 
 def TTNG_ClusterWaitOp : TTNG_Op<"cluster_wait", []> {
   let assemblyFormat = "attr-dict";
+  let hasVerifier = 1;
 }
 
 def TTNG_ClusterSize1DOp : TTNG_Op<"cluster_size_1d", [Pure]> {

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -202,6 +202,54 @@ LogicalResult InvalBarrierOp::verify() {
   return success();
 }
 
+// -- FenceMBarrierInitReleaseClusterOp --
+LogicalResult FenceMBarrierInitReleaseClusterOp::verify() {
+  int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
+  if (numCTAs <= 1){
+    // upstream numCTA is 1, check TLX cluster size
+    const SmallVector<int> tlxClusterDims =
+      triton::gpu::TritonGPUDialect::getClusterDims(getOperation()->getParentOfType<ModuleOp>());
+    int tlxClusterSize = 1;
+    for (int d : tlxClusterDims)
+      tlxClusterSize *= d;
+      if(tlxClusterSize <= 1)
+        return emitOpError("requires ttg.num-ctas > 1 or TLX cluster size > 1");
+  }
+  return success();
+}
+
+// -- ClusterArriveOp --
+LogicalResult ClusterArriveOp::verify() {
+  int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
+  if (numCTAs <= 1){
+    // upstream numCTA is 1, check TLX cluster size
+    const SmallVector<int> tlxClusterDims =
+      triton::gpu::TritonGPUDialect::getClusterDims(getOperation()->getParentOfType<ModuleOp>());
+    int tlxClusterSize = 1;
+    for (int d : tlxClusterDims)
+      tlxClusterSize *= d;
+      if(tlxClusterSize <= 1)
+        return emitOpError("requires ttg.num-ctas > 1 or TLX cluster size > 1");
+  }
+  return success();
+}
+
+// -- ClusterWaitOp --
+LogicalResult ClusterWaitOp::verify() {
+  int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
+  if (numCTAs <= 1){
+    // upstream numCTA is 1, check TLX cluster size
+    const SmallVector<int> tlxClusterDims =
+      triton::gpu::TritonGPUDialect::getClusterDims(getOperation()->getParentOfType<ModuleOp>());
+    int tlxClusterSize = 1;
+    for (int d : tlxClusterDims)
+      tlxClusterSize *= d;
+      if(tlxClusterSize <= 1)
+        return emitOpError("requires ttg.num-ctas > 1 or TLX cluster size > 1");
+  }
+  return success();
+}
+
 // -- BarrierExpectOp --
 LogicalResult BarrierExpectOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -748,6 +748,16 @@ void init_gluon_ir(py::module &&m) {
            [](GluonOpBuilder &self, Value memDesc, int count, Value pred) {
              self.create<ttng::ArriveBarrierOp>(memDesc, count, pred);
            })
+      .def("create_fence_mbarrier_init_release_cluster",
+           [](GluonOpBuilder &self) {
+             self.create<ttng::FenceMBarrierInitReleaseClusterOp>();
+           })
+      .def("create_cluster_arrive",
+           [](GluonOpBuilder &self, bool relaxed) {
+             self.create<ttng::ClusterArriveOp>(relaxed);
+           })
+      .def("create_cluster_wait",
+           [](GluonOpBuilder &self) { self.create<ttng::ClusterWaitOp>(); })
       .def("create_tcgen05_mma",
            [](GluonOpBuilder &self, Value a, Value b, Value acc, Value useAcc,
               Value pred, std::vector<Value> &mbarriers,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -7,6 +7,7 @@ from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia import blackwell
 from triton.experimental.gluon.language.nvidia import hopper
+from triton.experimental.gluon.language.nvidia.hopper import cluster
 from triton.experimental.gluon.language.nvidia.blackwell import mbarrier, tma, TensorMemoryLayout, TensorMemoryScalesLayout, async_copy
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.amd import _layouts as amd_layouts
@@ -580,6 +581,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %true_1 = arith.constant true
     ttng.wait_barrier %0, %c0_i32, %true_1 deps %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.inval_barrier %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+""")
+
+
+@gluon.jit
+def mbarrier_sync_cluster_init_kernel():
+    mbarrier.sync_cluster_init()
+
+
+def test_mbarrier_sync_cluster_init():
+    mod = run_parser(mbarrier_sync_cluster_init_kernel, *make_args(num_ctas=2), target=HOPPER_TARGET)
+    expecttest.assert_expected_inline(
+        anonymize_ir(mod.str_nodebug()), """\
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @mbarrier_sync_cluster_init_kernel() attributes {noinline = false} {
+    tt.call @triton.experimental.gluon.language.nvidia.hopper.mbarrier.sync_cluster_init__() : () -> ()
+    tt.return
+  }
+  tt.func private @triton.experimental.gluon.language.nvidia.hopper.mbarrier.sync_cluster_init__() attributes {noinline = false} {
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
     tt.return
   }
 }
@@ -1531,6 +1556,26 @@ def test_fence_async_shared():
 
     # CHECK-NEXT: ttng.fence_async_shared {bCluster = true}
     blackwell.fence_async_shared(cluster=True)
+
+
+@gluon.jit
+def cluster_arrive_wait_ops_kernel():
+    cluster.arrive()
+    cluster.wait()
+
+
+def test_cluster_arrive_wait_ops():
+    mod = run_parser(cluster_arrive_wait_ops_kernel, *make_args(num_ctas=2), target=HOPPER_TARGET)
+    expecttest.assert_expected_inline(
+        anonymize_ir(mod.str_nodebug()), """\
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @cluster_arrive_wait_ops_kernel() attributes {noinline = false} {
+    ttng.cluster_arrive {relaxed = false}
+    ttng.cluster_wait
+    tt.return
+  }
+}
+""")
 
 
 @filecheck_test

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -8,7 +8,9 @@ from typing import List, Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from triton._C.libtriton import ir
 
-__all__ = ["async_copy", "cluster", "fence_async_shared", "mbarrier", "mma_v2", "tma", "warpgroup_mma", "warpgroup_mma_wait"]
+__all__ = [
+    "async_copy", "cluster", "fence_async_shared", "mbarrier", "mma_v2", "tma", "warpgroup_mma", "warpgroup_mma_wait"
+]
 
 
 @_core.builtin

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 from triton.compiler.code_generator import unflatten_ir_values
 from ..ampere import async_copy, mma_v2
-from . import mbarrier, tma
+from . import cluster, mbarrier, tma
 from ... import _core
 
 from typing import List, Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from triton._C.libtriton import ir
 
-__all__ = ["async_copy", "fence_async_shared", "mbarrier", "mma_v2", "tma", "warpgroup_mma", "warpgroup_mma_wait"]
+__all__ = ["async_copy", "cluster", "fence_async_shared", "mbarrier", "mma_v2", "tma", "warpgroup_mma", "warpgroup_mma_wait"]
 
 
 @_core.builtin

--- a/python/triton/experimental/gluon/language/nvidia/hopper/cluster.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/cluster.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from triton.experimental.gluon.language._core import builtin, _unwrap_if_constexpr
+
+__all__ = ["arrive", "wait"]
+
+
+@builtin
+def arrive(relaxed: bool = False, _semantic=None):
+    """
+    Arrive at a barrier that synchronizes across the CTA cluster.
+
+    Args:
+        relaxed (bool): Whether to use relaxed semantics. Defaults to False.
+    """
+    relaxed = _unwrap_if_constexpr(relaxed)
+    _semantic.builder.create_cluster_arrive(relaxed)
+
+
+@builtin
+def wait(_semantic=None):
+    """
+    Wait for all CTAs in the cluster to arrive at the cluster barrier.
+    """
+    _semantic.builder.create_cluster_wait()

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -1,7 +1,18 @@
 from ..ampere.mbarrier import MBarrierLayout, init, invalidate, wait
+from triton.experimental.gluon._runtime import jit
 from ..._core import _unwrap_if_constexpr, builtin
+from . import cluster
 
-__all__ = ["arrive", "expect", "init", "invalidate", "MBarrierLayout", "wait"]
+__all__ = [
+    "arrive",
+    "expect",
+    "sync_cluster_init",
+    "fence_init_release_cluster",
+    "init",
+    "invalidate",
+    "MBarrierLayout",
+    "wait",
+]
 
 
 @builtin
@@ -32,3 +43,23 @@ def arrive(mbarrier, *, count=1, pred=True, _semantic=None):
     count = _unwrap_if_constexpr(count)
     pred = _semantic.to_tensor(pred)
     _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)
+
+
+@builtin
+def fence_init_release_cluster(_semantic=None):
+    """
+    Fence that makes prior mbarrier initialization visible across the CTA cluster.
+
+    Needs to be called together with cluster.arrive(relaxed=True) and cluster.wait.
+    """
+    _semantic.builder.create_fence_mbarrier_init_release_cluster()
+
+
+@jit
+def sync_cluster_init():
+    """
+    Ensure mbarrier initialization is visible across the CTA cluster.
+    """
+    fence_init_release_cluster()
+    cluster.arrive(relaxed=True)
+    cluster.wait()

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -426,3 +426,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+// CHECK-LABEL: mbarrier_sync_cluster_init
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @mbarrier_sync_cluster_init() {
+    // CHECK: fence.mbarrier_init.release.cluster
+    // CHECK: nvvm.cluster.arrive.relaxed
+    // CHECK: nvvm.cluster.wait
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = 1 : i1}
+    ttng.cluster_wait
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -144,3 +144,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @fence_mbarrier_init_release_cluster_invalid() {
+    // expected-error @below {{requires ttg.num-ctas > 1}}
+    ttng.fence_mbarrier_init_release_cluster
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @cluster_arrive_invalid() {
+    // expected-error @below {{requires ttg.num-ctas > 1}}
+    ttng.cluster_arrive {relaxed = false}
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @cluster_wait_invalid() {
+    // expected-error @below {{requires ttg.num-ctas > 1}}
+    ttng.cluster_wait
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -73,6 +73,35 @@ struct FenceOpConversion
   }
 };
 
+struct FenceMBarrierInitReleaseClusterOpConversion
+    : public ConvertOpToLLVMPattern<
+          triton::nvidia_gpu::FenceMBarrierInitReleaseClusterOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::FenceMBarrierInitReleaseClusterOp>::
+      ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::FenceMBarrierInitReleaseClusterOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Only one thread needs to issue the fence, just like mbarrier.init.
+    Value tid = getThreadId(rewriter, loc);
+    Value pred = b.icmp_eq(tid, b.i32_val(0));
+
+    PTXBuilder ptxBuilder;
+    auto &fence = *ptxBuilder.create("fence.mbarrier_init.release.cluster");
+    fence().predicate(pred);
+    auto voidTy = void_ty(op->getContext());
+    ptxBuilder.launch(rewriter, loc, voidTy);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct InitBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::InitBarrierOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -515,6 +544,8 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
     PatternBenefit benefit, NVIDIA::TargetInfo &targetInfo) {
   patterns.add<FenceAsyncSharedOpConversion>(typeConverter, benefit);
   patterns.add<FenceOpConversion>(typeConverter, benefit);
+  patterns.add<FenceMBarrierInitReleaseClusterOpConversion>(typeConverter,
+                                                            benefit);
   patterns.add<InitBarrierOpConversion, InvalBarrierOpConversion>(typeConverter,
                                                                   benefit);
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo);


### PR DESCRIPTION
Summary:
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9076

## Changes made on top of the PR:
- Resolve merge conflict - due to gaps in earlier PRs that have not been picked, we drop the changes in `python/test/gluon/test_core.py`. 
- Relax the verifiers in `lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp` to support tlx cluster size too


Upstream commit message:
```
> [Gluon] Expose finer grained cluster fences (#9076)

> We also expose the utility `fence_cluster_init` that ensures that all
> the CTAs see the initialisation of the mbarriers before multiCTA ops.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: e5122680758899eff52a5b8ab54021e902e40187
---


Differential Revision: D100065300


