### PR TITLE
[triton][beta] [Cherry-pick] '[TritonGPU] Fix regression in warpId computation (#8868)'

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -372,12 +372,13 @@ std::pair<Value, Value> getLaneAndWarpId(OpBuilder &rewriter, Location loc) {
   // If there is only one warp, the warp ID is always 0.
   Operation *lookupPt = &rewriter.getInsertionBlock()->front();
   Value laneId;
-  Value warpId = mlir::triton::gpu::WarpIdOp::create(rewriter, loc);
+  Value warpId;
   if (triton::gpu::lookupNumWarps(lookupPt) == 1) {
     laneId = tid;
     warpId = b.i32_val(0);
   } else {
     laneId = b.urem(tid, warpSizeVal);
+    warpId = b.udiv(tid, warpSizeVal);
   }
 
   return {laneId, warpId};


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/8868

Upstream commit message:
```
> [TritonGPU] Fix regression in warpId computation (#8868)

> This was breaking ptxas pattern match

> Co-authored-by: Thomas Raoux <thomas.raoux@openai.com>
```

Diff Comparison: https://www.internalfb.com/intern/paste/P2265109736/

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 67499bad5b46728af977afe3ac68395703a1e806
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1 --no-submit
```

Reviewed By: njriasan

Differential Revision: D99910033


