### PR TITLE
[triton][beta] Backport '[Backend] Add uniform hint to ttg.warp_id (#9073)' (#1217)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -705,7 +705,19 @@ def TTG_LocalBarrierOp : TTG_Op<"local_barrier"> {
 }
 
 def TTG_WarpIdOp : TTG_Op<"warp_id", [Pure]> {
+  let summary = "Return the GPU warp ID";
+
+  let description = [{
+    This operation returns the GPU warp ID. This can translate to reading
+    hardware registers if there are, or just thread ID divided by warp size.
+
+    The `omitUniformHint` attribute is indicating in NVIDIA backend whether to
+    omit emitting nvvm.shfl.sync idx 0 for LLVM.
+  }];
+
+  let arguments = (ins UnitAttr:$omitUniformHint);
   let results = (outs I32:$result);
+
   let assemblyFormat = "attr-dict";
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -378,7 +378,8 @@ std::pair<Value, Value> getLaneAndWarpId(OpBuilder &rewriter, Location loc) {
     warpId = b.i32_val(0);
   } else {
     laneId = b.urem(tid, warpSizeVal);
-    warpId = b.udiv(tid, warpSizeVal);
+    warpId = mlir::triton::gpu::WarpIdOp::create(rewriter, loc,
+                                                 /*omitUniformHint=*/true);
   }
 
   return {laneId, warpId};

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -220,10 +220,12 @@ public:
       tid = LLVM::SubOp::create(rewriter, loc, tid, b.i32_val(*startId));
 
     Value warpId = b.udiv(tid, b.i32_val(32));
-    // This indicates to PTXAS that the result and its derived values are
-    // uniform across the warp. For example, if a branch condition derives from
-    // this value, it can be proven to be non-divergent.
-    warpId = LLVM::NVIDIA::shuffleIdx(loc, rewriter, warpId, 0);
+    if (!op.getOmitUniformHint()) {
+      // This indicates to PTXAS that the result and its derived values are
+      // uniform across the warp. For example, if a branch condition derives
+      // from this value, it can be proven to be non-divergent.
+      warpId = LLVM::NVIDIA::shuffleIdx(loc, rewriter, warpId, 0);
+    }
     rewriter.replaceOp(op, warpId);
     return success();
   }


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9073

Upstream commit message:
```
> [Backend] Add uniform hint to ttg.warp_id (#9073)

> This commit adds an attribute to `omitUniformHint` for NVIDIA backend
> for controlling cases where we would like to emit nvvm.shfl.sync idx 0
> in targetted manner.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: c900213eea0a3295d9c2105132781cf974cc6424
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 9073 --version beta
```

Reviewed By: agron911

Differential Revision: D100078677
