### PR TITLE
[triton] Fix internal code for LLVM bump API changes

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -570,9 +570,9 @@ public:
       newResultTypes.push_back(newType);
     }
 
-    auto newOp = rewriter.create<WarpSpecializeOp>(
-        op.getLoc(), newResultTypes, op.getPartitionNumWarps(),
-        op.getPartitionRegions().size());
+    auto newOp = WarpSpecializeOp::create(rewriter, op.getLoc(), newResultTypes,
+                                          op.getPartitionNumWarps(),
+                                          op.getPartitionRegions().size());
 
     // Update the operands and types.
     newOp->setOperands(adaptor.getOperands());
@@ -888,7 +888,7 @@ static OwningOpRef<ModuleOp> takeIntoFunction(Region *partition, int numWarps) {
 
   auto b = OpBuilder::atBlockBegin(containerBlock);
   FunctionType funcType = b.getFunctionType(partition->getArgumentTypes(), {});
-  auto containerFunc = b.create<FuncOp>(mod.getLoc(), "container", funcType);
+  auto containerFunc = FuncOp::create(b, mod.getLoc(), "container", funcType);
   containerFunc.getBody().takeBody(*partition);
   container.get()->setAttrs(mod->getAttrs());
   container.get()->setAttr(AttrNumWarpsName, b.getI32IntegerAttr(numWarps));
@@ -896,7 +896,7 @@ static OwningOpRef<ModuleOp> takeIntoFunction(Region *partition, int numWarps) {
   // Replace `ttg.warp_return` with `tt.return` to make the IR valid.
   containerFunc.walk([&](WarpReturnOp op) {
     b.setInsertionPoint(op);
-    b.create<ReturnOp>(op.getLoc());
+    ReturnOp::create(b, op.getLoc());
     op.erase();
   });
 
@@ -914,7 +914,7 @@ static void extractPartitionBody(OwningOpRef<ModuleOp> container,
   // Rewrite the returns.
   containerFunc.walk([](ReturnOp op) {
     OpBuilder b(op);
-    b.create<WarpReturnOp>(op.getLoc());
+    WarpReturnOp::create(b, op.getLoc());
     op.erase();
   });
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -97,15 +97,15 @@ static std::pair<Value, Value> postIncrementModulo(ImplicitLocOpBuilder &b,
                                                    Value index, Value phase,
                                                    unsigned numStages) {
   auto intCst = [&](int value) {
-    return b.create<arith::ConstantIntOp>(value, 32);
+    return arith::ConstantIntOp::create(b, value, 32);
   };
-  Value nextIndex = b.create<arith::AddIOp>(index, intCst(1));
-  Value nextPhase = b.create<arith::XOrIOp>(phase, intCst(1));
+  Value nextIndex = arith::AddIOp::create(b, index, intCst(1));
+  Value nextPhase = arith::XOrIOp::create(b, phase, intCst(1));
 
-  Value rollover = b.create<arith::CmpIOp>(arith::CmpIPredicate::eq, nextIndex,
-                                           intCst(numStages));
-  nextIndex = b.create<arith::SelectOp>(rollover, intCst(0), nextIndex);
-  nextPhase = b.create<arith::SelectOp>(rollover, nextPhase, phase);
+  Value rollover = arith::CmpIOp::create(b, arith::CmpIPredicate::eq, nextIndex,
+                                         intCst(numStages));
+  nextIndex = arith::SelectOp::create(b, rollover, intCst(0), nextIndex);
+  nextPhase = arith::SelectOp::create(b, rollover, nextPhase, phase);
 
   return {nextIndex, nextPhase};
 }
@@ -128,8 +128,8 @@ addIndexAndPhase(PartitionBuilder &b, scf::ForOp &loop, unsigned numStages,
 
   auto [nextIndex, nextPhase] = postIncrementModulo(b, index, phase, numStages);
   if (epilogue) {
-    nextIndex = b.create<arith::SelectOp>(epilogue, nextIndex, index);
-    nextPhase = b.create<arith::SelectOp>(epilogue, nextPhase, phase);
+    nextIndex = arith::SelectOp::create(b, epilogue, nextIndex, index);
+    nextPhase = arith::SelectOp::create(b, epilogue, nextPhase, phase);
   }
   yield->insertOperands(yield.getNumOperands(), {nextIndex, nextPhase});
 
@@ -148,7 +148,7 @@ static Value getUserPrecondition(ImplicitLocOpBuilder &b, scf::ForOp loop,
 
   OpBuilder::InsertionGuard guard(b);
   b.setInsertionPoint(loop);
-  Value trueVal = b.create<arith::ConstantOp>(b.getBoolAttr(true));
+  Value trueVal = arith::ConstantOp::create(b, b.getBoolAttr(true));
 
   Value userPred = trueVal;
   Operation *parentOp = domOp;
@@ -162,8 +162,8 @@ static Value getUserPrecondition(ImplicitLocOpBuilder &b, scf::ForOp loop,
     }
     Value cond = ifOp.getCondition();
     if (domOp->getParentRegion() == &ifOp.getElseRegion())
-      cond = b.create<arith::XOrIOp>(cond, trueVal);
-    userPred = b.create<arith::AndIOp>(userPred, cond);
+      cond = arith::XOrIOp::create(b, cond, trueVal);
+    userPred = arith::AndIOp::create(b, userPred, cond);
   }
 
   return userPred;
@@ -337,7 +337,7 @@ void PipelinedLoadGroup::allocateAref(scf::ForOp &loop, int numStages) {
   PartitionBuilder b(getLoc(), loop);
   for (auto i : llvm::seq(numStages)) {
     Value emptyBar = createSingleBufferView(b, emptyBars, i);
-    b.create<ttng::ArriveBarrierOp>(emptyBar, arriveCount);
+    ttng::ArriveBarrierOp::create(b, emptyBar, arriveCount);
   }
 
   std::tie(index, phase) = addIndexAndPhase(b, loop, numStages);
@@ -582,7 +582,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     for (auto i : llvm::seq(numMmaStages)) {
       b.setInsertionPoint(loop);
       Value bar = createSingleBufferView(b, nodes.front().barPrev, i);
-      b.create<ttng::ArriveBarrierOp>(bar, /*arriveCount=*/1);
+      ttng::ArriveBarrierOp::create(b, bar, /*arriveCount=*/1);
     }
   }
 
@@ -594,14 +594,15 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
       b.setInsertionPoint(loop);
       return getLastInductionValue(b, loop);
     }();
-    userPred = b.create<arith::CmpIOp>(
-        arith::CmpIPredicate::eq, loop.getInductionVar(), lastInductionValue);
+    userPred =
+        arith::CmpIOp::create(b, arith::CmpIPredicate::eq,
+                              loop.getInductionVar(), lastInductionValue);
     nodes.back().barNext = createBarrierAlloc(loop, /*numBarriers=*/1);
   }
 
   Value curIndex = index, curPhase = phase;
   b.setInsertionPoint(loop);
-  Value replTok = b.create<ub::PoisonOp>(b.getType<AsyncTokenType>());
+  Value replTok = ub::PoisonOp::create(b, b.getType<AsyncTokenType>());
   DenseSet<Operation *> seen;
   std::optional<OpBuilder::InsertPoint> incrementPt;
   Node *firstAfterInc = nullptr;
@@ -635,8 +636,8 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
       b.setInsertionPointAfter(inBody(readOp));
       auto [nextIndex, nextPhase] =
           postIncrementModulo(b, index, phase, numMmaStages);
-      curIndex = b.create<arith::SelectOp>(userPred, nextIndex, index);
-      curPhase = b.create<arith::SelectOp>(userPred, nextPhase, phase);
+      curIndex = arith::SelectOp::create(b, userPred, nextIndex, index);
+      curPhase = arith::SelectOp::create(b, userPred, nextPhase, phase);
       incrementPt = b.saveInsertionPoint();
     }
   }
@@ -644,12 +645,12 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     b.setInsertionPoint(loop);
     if (firstAfterInc->op == mmaOp) {
       Value firstBar = createSingleBufferView(b, firstAfterInc->barPrev, 0);
-      b.create<ttng::ArriveBarrierOp>(firstBar, /*arriveCount=*/1);
+      ttng::ArriveBarrierOp::create(b, firstBar, /*arriveCount=*/1);
     } else {
       assert(firstAfterInc->op == dyn_cast<ttng::TMEMStoreOp>(overwriteOp));
       for (auto i : llvm::seq(numMmaStages)) {
         Value firstBar = createSingleBufferView(b, firstAfterInc->barPrev, i);
-        b.create<ttng::ArriveBarrierOp>(firstBar, /*arriveCount=*/1);
+        ttng::ArriveBarrierOp::create(b, firstBar, /*arriveCount=*/1);
       }
     }
   }
@@ -794,7 +795,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     PartitionBuilder b(defs.front()->getLoc(), loop);
     // For Nx1 barrier allocations, pass a 1D view into barrier ops.
     Value emptyView0 = createSingleBufferView(b, emptyBar, b.intCst(0));
-    b.create<ttng::ArriveBarrierOp>(emptyView0, /*arriveCount=*/1);
+    ttng::ArriveBarrierOp::create(b, emptyView0, /*arriveCount=*/1);
 
     Operation *domOp = findNearestCommonDominator(defs, domInfo);
     Operation *lastOp = findNearestCommonPostDominator(defs, postDomInfo);
@@ -833,7 +834,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     Value lastIndex = loop.getResult(index.getArgNumber() - 1);
     Value lastPhase = loop.getResult(phase.getArgNumber() - 1);
     Value lastBar = createSingleBufferView(b, nodes.back().barNext, lastIndex);
-    b.create<ttng::WaitBarrierOp>(lastBar, lastPhase);
+    ttng::WaitBarrierOp::create(b, lastBar, lastPhase);
   }
 
   llvm::SetVector<Operation *> predOps;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAStoreBufferReuse.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAStoreBufferReuse.cpp
@@ -130,8 +130,8 @@ static void processBlock(Block &block) {
       OpBuilder builder(first.alloc);
       Value src = first.alloc.getSrc();
       auto buf =
-          builder.create<ttg::LocalAllocOp>(first.alloc.getLoc(), mutableTy);
-      builder.create<ttg::LocalStoreOp>(first.alloc.getLoc(), src, buf);
+          ttg::LocalAllocOp::create(builder, first.alloc.getLoc(), mutableTy);
+      ttg::LocalStoreOp::create(builder, first.alloc.getLoc(), src, buf);
       first.alloc.replaceAllUsesWith(buf.getResult());
       first.alloc.erase();
 
@@ -142,7 +142,7 @@ static void processBlock(Block &block) {
         auto &cand = candidates[chain[i]];
         OpBuilder b(cand.alloc);
         Value srcN = cand.alloc.getSrc();
-        b.create<ttg::LocalStoreOp>(cand.alloc.getLoc(), srcN, buf);
+        ttg::LocalStoreOp::create(b, cand.alloc.getLoc(), srcN, buf);
         cand.alloc.replaceAllUsesWith(buf.getResult());
         cand.alloc.erase();
       }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpConversion.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpConversion.cpp
@@ -125,8 +125,8 @@ struct ArriveBarrierOpConversion
     Block *phaseFlipBlock = rewriter.createBlock(afterPhaseFlipBlock);
     rewriter.setInsertionPointToEnd(currentBlock);
 
-    rewriter.create<LLVM::CondBrOp>(loc, allArrived, phaseFlipBlock,
-                                    afterPhaseFlipBlock);
+    LLVM::CondBrOp::create(rewriter, loc, allArrived, phaseFlipBlock,
+                           afterPhaseFlipBlock);
 
     rewriter.setInsertionPointToStart(phaseFlipBlock);
     GCNBuilder phaseFlipBuilder;
@@ -143,7 +143,7 @@ struct ArriveBarrierOpConversion
     auto xor_op = phaseFlipBuilder.launch(rewriter, loc, void_ty(ctx),
                                           true /*hasSideEffects*/);
 
-    auto br = rewriter.create<LLVM::BrOp>(loc, afterPhaseFlipBlock);
+    auto br = LLVM::BrOp::create(rewriter, loc, afterPhaseFlipBlock);
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -1239,9 +1239,9 @@ public:
     }
 #endif
 
-    auto newWsOp = rewriter.create<ttg::WarpSpecializeOp>(
-        wsOp.getLoc(), wsOp.getResultTypes(), wsOp.getPartitionNumWarps(),
-        wsOp.getPartitionRegions().size());
+    auto newWsOp = ttg::WarpSpecializeOp::create(
+        rewriter, wsOp.getLoc(), wsOp.getResultTypes(),
+        wsOp.getPartitionNumWarps(), wsOp.getPartitionRegions().size());
     newWsOp->setAttrs(wsOp->getAttrs());
     newWsOp->setOperands(flattenValues(remappedOperands));
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerBarrierOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerBarrierOps.cpp
@@ -45,15 +45,15 @@ void lowerArriveBarrierOps(ModuleOp m,
       auto ctx = op.getContext();
       // Create if condition for the arrive
       auto i32ty = builder.getIntegerType(32);
-      auto threadId = builder.create<ROCDL::ThreadIdXOp>(loc, i32ty);
+      auto threadId = ROCDL::ThreadIdXOp::create(builder, loc, i32ty);
       auto threadsPerWave =
-          builder.create<arith::ConstantIntOp>(loc, THREADS_PER_WAVE, 32);
-      auto mod = builder.create<arith::RemSIOp>(loc, threadId, threadsPerWave);
-      auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-      cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, mod,
-                                           zero);
+          arith::ConstantIntOp::create(builder, loc, THREADS_PER_WAVE, 32);
+      auto mod = arith::RemSIOp::create(builder, loc, threadId, threadsPerWave);
+      auto zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+      cond = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::eq, mod,
+                                   zero);
     }
-    auto ifOp = builder.create<scf::IfOp>(loc, cond);
+    auto ifOp = scf::IfOp::create(builder, loc, cond);
     auto thenBuilder = ifOp.getThenBodyBuilder();
     if (auto defOp = dyn_cast<triton::gpu::MemDescIndexOp>(
             op.getAlloc().getDefiningOp())) {
@@ -65,8 +65,8 @@ void lowerArriveBarrierOps(ModuleOp m,
           auto incrementCount = op.getCount();
           LDBG("srcOp: " << srcOp << " inc: " << incrementCount
                          << "expected: " << expectedCount << "\n");
-          thenBuilder.create<triton::amdgpu::ArriveBarrierOp>(
-              loc, op.getAlloc(), incrementCount, expectedCount);
+          triton::amdgpu::ArriveBarrierOp::create(
+              thenBuilder, loc, op.getAlloc(), incrementCount, expectedCount);
         } else {
           assert(false && "Cannot find LocalAlllocOp for ArriveBarrierOp");
         }
@@ -88,34 +88,35 @@ void lowerWaitBarrierOps(ModuleOp m) {
     auto loc = op.getLoc();
     OpBuilder builder(op);
     auto waitPhase = op.getPhase();
-    auto whileOp = builder.create<scf::WhileOp>(loc, TypeRange{}, ValueRange{});
+    auto whileOp =
+        scf::WhileOp::create(builder, loc, TypeRange{}, ValueRange{});
     // Spin Wait
     // while - Before block
     Block *beforeBlock = builder.createBlock(&whileOp.getBefore());
     builder.setInsertionPointToEnd(beforeBlock);
     auto i32ty = builder.getIntegerType(32);
     // TODO: Lower this to a LocalLoad
-    Value barrierPhase = builder.create<triton::amdgpu::ReadBarrierPhaseOp>(
-        loc, i32ty, op.getAlloc());
-    Value phaseCond = builder.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::eq, barrierPhase, waitPhase);
-    builder.create<scf::ConditionOp>(loc, phaseCond, ValueRange{});
+    Value barrierPhase = triton::amdgpu::ReadBarrierPhaseOp::create(
+        builder, loc, i32ty, op.getAlloc());
+    Value phaseCond = arith::CmpIOp::create(
+        builder, loc, arith::CmpIPredicate::eq, barrierPhase, waitPhase);
+    scf::ConditionOp::create(builder, loc, phaseCond, ValueRange{});
     // while - after block
     Block *afterBlock = builder.createBlock(&whileOp.getAfter());
     builder.setInsertionPointToEnd(afterBlock);
-    auto five = builder.create<arith::ConstantIntOp>(loc, 5, 32);
+    auto five = arith::ConstantIntOp::create(builder, loc, 5, 32);
     auto sleepInstrinsic = "llvm.amdgcn.s.sleep";
     auto sleepOp = LLVM::createLLVMIntrinsicCallOp(
         builder, loc, sleepInstrinsic, TypeRange{}, ValueRange{five});
-    builder.create<scf::YieldOp>(loc, ValueRange{});
+    scf::YieldOp::create(builder, loc, ValueRange{});
     builder.setInsertionPointAfter(whileOp);
 
     const char *asmStr = "s_wakeup";
     const char *constraints = "";
     auto asmDialectAttr = LLVM::AsmDialectAttr::get(builder.getContext(),
                                                     LLVM::AsmDialect::AD_ATT);
-    builder.create<LLVM::InlineAsmOp>(
-        loc,
+    LLVM::InlineAsmOp::create(
+        builder, loc,
         /*resultTypes=*/TypeRange(), /*operands=*/ValueRange(),
         /*asm_string=*/asmStr, constraints, /*has_side_effects=*/true,
         /*is_align_stack=*/false, LLVM::TailCallKind::None,
@@ -142,15 +143,15 @@ void lowerInitBarrierOps(ModuleOp m,
       auto ctx = op.getContext();
       // Create if tid == 0 condition for the arrive
       auto i32ty = builder.getIntegerType(32);
-      auto threadId = builder.create<ROCDL::ThreadIdXOp>(loc, i32ty);
-      auto zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-      cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                           threadId, zero);
+      auto threadId = ROCDL::ThreadIdXOp::create(builder, loc, i32ty);
+      auto zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+      cond = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::eq,
+                                   threadId, zero);
     }
-    auto ifOp = builder.create<scf::IfOp>(loc, cond);
+    auto ifOp = scf::IfOp::create(builder, loc, cond);
     auto thenBuilder = ifOp.getThenBodyBuilder();
-    thenBuilder.create<triton::amdgpu::InitBarrierOp>(loc, op.getAlloc(),
-                                                      op.getCount());
+    triton::amdgpu::InitBarrierOp::create(thenBuilder, loc, op.getAlloc(),
+                                          op.getCount());
     if (auto defOp = dyn_cast<triton::gpu::MemDescIndexOp>(
             op.getAlloc().getDefiningOp())) {
       if (auto srcOp = dyn_cast<triton::gpu::LocalAllocOp>(

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
@@ -39,12 +39,13 @@ Operation *streamPredication(RewriterBase &rewriter, Operation *op,
   // to optimize the select away as redundant.
   if (auto dotOp = dyn_cast<tt::DotOpInterface>(op)) {
     auto loc = dotOp->getLoc();
-    auto ifOp = rewriter.create<scf::IfOp>(loc, dotOp->getResult(0).getType(),
-                                           pred, /*withElseRegion=*/true);
+    auto ifOp = scf::IfOp::create(rewriter, loc, dotOp->getResult(0).getType(),
+                                  pred, /*withElseRegion=*/true);
     auto thenB = ifOp.getThenBodyBuilder();
-    auto yield = thenB.create<scf::YieldOp>(loc, dotOp->getResult(0));
+    auto yield = scf::YieldOp::create(thenB, loc, dotOp->getResult(0));
     dotOp->moveBefore(yield);
-    ifOp.getElseBodyBuilder().create<scf::YieldOp>(loc, dotOp->getOperand(2));
+    auto elseB = ifOp.getElseBodyBuilder();
+    scf::YieldOp::create(elseB, loc, dotOp->getOperand(2));
     return ifOp;
   }
   return tt::wrapInMaskOp(rewriter, op, pred);

--- a/third_party/nvidia/hopper/lib/Transforms/MultiCTAReduction.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/MultiCTAReduction.cpp
@@ -143,22 +143,22 @@ static LogicalResult transformMultiCTALoop(scf::ForOp forOp,
   auto ivType = lb.getType();
 
   // Step 1: Get CTA rank within the cluster.
-  Value ctaRankI32 = builder.create<triton::nvgpu::ClusterCTAIdOp>(loc, i32Ty);
-  Value numCTAsI32 = builder.create<arith::ConstantIntOp>(
-      loc, static_cast<int64_t>(numClusterCTAs), /*width=*/32);
+  Value ctaRankI32 = triton::nvgpu::ClusterCTAIdOp::create(builder, loc, i32Ty);
+  Value numCTAsI32 = arith::ConstantIntOp::create(
+      builder, loc, static_cast<int64_t>(numClusterCTAs), /*width=*/32);
 
   // Cast to the loop IV type if needed.
   Value ctaRank = (ivType == i32Ty)
                       ? ctaRankI32
-                      : static_cast<Value>(builder.create<arith::IndexCastOp>(
-                            loc, ivType, ctaRankI32));
+                      : static_cast<Value>(arith::IndexCastOp::create(
+                            builder, loc, ivType, ctaRankI32));
   Value numCTAs = (ivType == i32Ty)
                       ? numCTAsI32
-                      : static_cast<Value>(builder.create<arith::IndexCastOp>(
-                            loc, ivType, numCTAsI32));
+                      : static_cast<Value>(arith::IndexCastOp::create(
+                            builder, loc, ivType, numCTAsI32));
 
   // Step 2: Partition loop range across CTAs.
-  Value range = builder.create<arith::SubIOp>(loc, ub, lb);
+  Value range = arith::SubIOp::create(builder, loc, ub, lb);
 
   // Verify divisibility: floor division drops remainder iterations.
   APInt rangeConst;
@@ -170,10 +170,10 @@ static LogicalResult transformMultiCTALoop(scf::ForOp forOp,
            << "); remainder iterations would be silently dropped";
   }
 
-  Value chunkSize = builder.create<arith::DivUIOp>(loc, range, numCTAs);
-  Value offset = builder.create<arith::MulIOp>(loc, ctaRank, chunkSize);
-  Value myLB = builder.create<arith::AddIOp>(loc, lb, offset);
-  Value myUB = builder.create<arith::AddIOp>(loc, myLB, chunkSize);
+  Value chunkSize = arith::DivUIOp::create(builder, loc, range, numCTAs);
+  Value offset = arith::MulIOp::create(builder, loc, ctaRank, chunkSize);
+  Value myLB = arith::AddIOp::create(builder, loc, lb, offset);
+  Value myUB = arith::AddIOp::create(builder, loc, myLB, chunkSize);
 
   forOp.setLowerBound(myLB);
   forOp.setUpperBound(myUB);
@@ -252,62 +252,63 @@ static LogicalResult transformMultiCTALoop(scf::ForOp forOp,
         /*order=*/{1, 0}, ctaLayout2d);
     auto bufType = ttg::MemDescType::get({numClusterCTAs, resultSize}, elemType,
                                          smemEncoding2d, smemSpace, true);
-    Value dsmBuf = builder.create<ttg::LocalAllocOp>(loc, bufType, Value());
+    Value dsmBuf = ttg::LocalAllocOp::create(builder, loc, bufType, Value());
 
     // b) Allocate barrier.
     auto barBufType = ttg::MemDescType::get({1}, builder.getI64Type(),
                                             smemEncoding1d, smemSpace, true);
-    Value barrier = builder.create<ttg::LocalAllocOp>(loc, barBufType, Value());
+    Value barrier =
+        ttg::LocalAllocOp::create(builder, loc, barBufType, Value());
     // init_barrier count = 1: only BarrierExpectOp counts as an arrival.
     // The st.async.mbarrier::complete_tx::bytes ops deliver bytes but do NOT
     // count as arrivals. Using numClusterCTAs-1 here causes deadlock for >2
     // CTAs.
-    builder.create<ttng::InitBarrierOp>(loc, barrier, 1);
+    ttng::InitBarrierOp::create(builder, loc, barrier, 1);
 
     // c) Wrap/convert the partial result into the exchange tensor type.
     Value partialTensor;
     if (isScalar) {
       partialTensor =
-          builder.create<triton::SplatOp>(loc, exchangeTy, partialResult);
+          triton::SplatOp::create(builder, loc, exchangeTy, partialResult);
     } else {
       partialTensor =
-          builder.create<ttg::ConvertLayoutOp>(loc, exchangeTy, partialResult);
+          ttg::ConvertLayoutOp::create(builder, loc, exchangeTy, partialResult);
     }
 
     // d) Get my slot in dsmBuf: memdesc<resultSize x elemType> (rank-1).
     auto dsmSlotType = ttg::MemDescType::get({resultSize}, elemType,
                                              smemEncoding1d, smemSpace, true);
-    Value mySlot = builder.create<ttg::MemDescIndexOp>(loc, dsmSlotType, dsmBuf,
-                                                       ctaRankI32);
+    Value mySlot = ttg::MemDescIndexOp::create(builder, loc, dsmSlotType,
+                                               dsmBuf, ctaRankI32);
 
     // Match TLX ordering exactly:
     //   barrier_expect -> cluster_arrive/wait -> local_store -> async_remote ->
     //   wait_barrier
-    Value predTrue = builder.create<arith::ConstantIntOp>(loc, 1, 1);
-    builder.create<ttng::BarrierExpectOp>(loc, barrier, expectedBytes,
-                                          predTrue);
-    builder.create<ttng::ClusterArriveOp>(loc, false);
-    builder.create<ttng::ClusterWaitOp>(loc);
+    Value predTrue = arith::ConstantIntOp::create(builder, loc, 1, 1);
+    ttng::BarrierExpectOp::create(builder, loc, barrier, expectedBytes,
+                                  predTrue);
+    ttng::ClusterArriveOp::create(builder, loc, false);
+    ttng::ClusterWaitOp::create(builder, loc);
 
     // e) Store my partial to my slot AFTER cluster sync (matching TLX).
-    builder.create<ttg::LocalStoreOp>(loc, partialTensor, mySlot);
+    ttg::LocalStoreOp::create(builder, loc, partialTensor, mySlot);
 
     // f) Send partial to other CTAs (skip self).
     for (int i = 0; i < numClusterCTAs; ++i) {
-      Value iVal = builder.create<arith::ConstantIntOp>(loc, i, 32);
-      Value isNotMe = builder.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::ne, ctaRankI32, iVal);
-      auto ifOp = builder.create<scf::IfOp>(loc, TypeRange{}, isNotMe,
-                                            /*withElseRegion=*/false);
+      Value iVal = arith::ConstantIntOp::create(builder, loc, i, 32);
+      Value isNotMe = arith::CmpIOp::create(
+          builder, loc, arith::CmpIPredicate::ne, ctaRankI32, iVal);
+      auto ifOp = scf::IfOp::create(builder, loc, TypeRange{}, isNotMe,
+                                    /*withElseRegion=*/false);
       builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
-      builder.create<ttg::AsyncRemoteShmemStoreOp>(loc, partialTensor, mySlot,
-                                                   iVal, barrier);
+      ttg::AsyncRemoteShmemStoreOp::create(builder, loc, partialTensor, mySlot,
+                                           iVal, barrier);
       builder.setInsertionPointAfter(ifOp);
     }
 
     // g) Wait for all remote stores.
-    Value phaseZero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-    builder.create<ttng::WaitBarrierOp>(loc, barrier, phaseZero, predTrue);
+    Value phaseZero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+    ttng::WaitBarrierOp::create(builder, loc, barrier, phaseZero, predTrue);
 
     // h) Accumulate: load each slot, add with arith.addf.
     if (!isa<FloatType>(elemType)) {
@@ -316,25 +317,25 @@ static LogicalResult transformMultiCTALoop(scf::ForOp forOp,
                                 "reductions, got ")
              << elemType;
     }
-    Value firstSlotIdx = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-    Value firstSlot = builder.create<ttg::MemDescIndexOp>(loc, dsmSlotType,
-                                                          dsmBuf, firstSlotIdx);
+    Value firstSlotIdx = arith::ConstantIntOp::create(builder, loc, 0, 32);
+    Value firstSlot = ttg::MemDescIndexOp::create(builder, loc, dsmSlotType,
+                                                  dsmBuf, firstSlotIdx);
     Value combined =
-        builder.create<ttg::LocalLoadOp>(loc, exchangeTy, firstSlot);
+        ttg::LocalLoadOp::create(builder, loc, exchangeTy, firstSlot);
     for (int i = 1; i < numClusterCTAs; ++i) {
-      Value iVal = builder.create<arith::ConstantIntOp>(loc, i, 32);
+      Value iVal = arith::ConstantIntOp::create(builder, loc, i, 32);
       Value slot =
-          builder.create<ttg::MemDescIndexOp>(loc, dsmSlotType, dsmBuf, iVal);
-      Value loaded = builder.create<ttg::LocalLoadOp>(loc, exchangeTy, slot);
-      combined = builder.create<arith::AddFOp>(loc, combined, loaded);
+          ttg::MemDescIndexOp::create(builder, loc, dsmSlotType, dsmBuf, iVal);
+      Value loaded = ttg::LocalLoadOp::create(builder, loc, exchangeTy, slot);
+      combined = arith::AddFOp::create(builder, loc, combined, loaded);
     }
 
     // i) Extract the final result from the accumulated exchange tensor.
     Value finalResult;
     if (isScalar) {
       // Scalar case: extract from tensor<1xelemType> via tt.reduce(axis=0).
-      auto finalReduce = builder.create<triton::ReduceOp>(
-          loc, SmallVector<Value>{combined}, 0);
+      auto finalReduce = triton::ReduceOp::create(
+          builder, loc, SmallVector<Value>{combined}, 0);
       IRMapping finalMapping;
       reduceOp.getCombineOp().cloneInto(&finalReduce.getCombineOp(),
                                         finalMapping);
@@ -342,7 +343,7 @@ static LogicalResult transformMultiCTALoop(scf::ForOp forOp,
     } else {
       // Tensor case: convert back from exchange encoding to original encoding.
       finalResult =
-          builder.create<ttg::ConvertLayoutOp>(loc, resultType, combined);
+          ttg::ConvertLayoutOp::create(builder, loc, resultType, combined);
     }
 
     // j) Replace uses of the original reduce result with the final result.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -565,7 +565,7 @@ Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
   // These operations don't participate in buffer cycling, so return constant 0.
   if (!parentForOp) {
     LDBG("getAccumCount: operation outside loop, returning constant 0");
-    return builder.create<arith::ConstantIndexOp>(op->getLoc(), 0);
+    return arith::ConstantIndexOp::create(builder, op->getLoc(), 0);
   }
 
   auto *pOp = op->getParentOp();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -590,21 +590,21 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp, int computeCapability) {
     auto pingRegionLoc = pingRegionBlock.front().getLoc();
     // Prepare values
     Value pingBarrier =
-        builder.create<arith::ConstantIntOp>(pingRegionLoc, pingBarrierId, 32);
+        arith::ConstantIntOp::create(builder, pingRegionLoc, pingBarrierId, 32);
     Value pongBarrier =
-        builder.create<arith::ConstantIntOp>(pingRegionLoc, pongBarrierId, 32);
+        arith::ConstantIntOp::create(builder, pingRegionLoc, pongBarrierId, 32);
     Value pingNumThreads =
-        builder.create<arith::ConstantIntOp>(pingRegionLoc, numThreads, 32);
+        arith::ConstantIntOp::create(builder, pingRegionLoc, numThreads, 32);
     // Insert arrive barrier for the ping partition to allow the initial entry
-    builder.create<ttng::NamedBarrierArriveOp>(pingRegionLoc, pongBarrier,
-                                               pingNumThreads);
+    ttng::NamedBarrierArriveOp::create(builder, pingRegionLoc, pongBarrier,
+                                       pingNumThreads);
     builder.setInsertionPoint(pingStart);
-    builder.create<ttng::NamedBarrierWaitOp>(pingStart->getLoc(), pingBarrier,
-                                             pingNumThreads);
+    ttng::NamedBarrierWaitOp::create(builder, pingStart->getLoc(), pingBarrier,
+                                     pingNumThreads);
     // Insert AFTER the pingEnd op
     builder.setInsertionPointAfter(pingEnd);
-    builder.create<ttng::NamedBarrierArriveOp>(pingEnd->getLoc(), pongBarrier,
-                                               pingNumThreads);
+    ttng::NamedBarrierArriveOp::create(builder, pingEnd->getLoc(), pongBarrier,
+                                       pingNumThreads);
 
     // Insert barriers for the pong partition
     Operation *pongStart = pongBoundOps[0];
@@ -613,19 +613,19 @@ static void handleWarpSpec(ttg::WarpSpecializeOp wsOp, int computeCapability) {
     Block &pongRegionBlock = pongRegion->front();
     OpBuilder builder2(&pongRegionBlock, pongRegionBlock.begin());
     auto pongRegionLoc = pongRegionBlock.front().getLoc();
-    Value pingBarrier2 =
-        builder2.create<arith::ConstantIntOp>(pongRegionLoc, pingBarrierId, 32);
-    Value pongBarrier2 =
-        builder2.create<arith::ConstantIntOp>(pongRegionLoc, pongBarrierId, 32);
+    Value pingBarrier2 = arith::ConstantIntOp::create(builder2, pongRegionLoc,
+                                                      pingBarrierId, 32);
+    Value pongBarrier2 = arith::ConstantIntOp::create(builder2, pongRegionLoc,
+                                                      pongBarrierId, 32);
     Value pingNumThreads2 =
-        builder2.create<arith::ConstantIntOp>(pongRegionLoc, numThreads, 32);
+        arith::ConstantIntOp::create(builder2, pongRegionLoc, numThreads, 32);
     builder2.setInsertionPoint(pongStart);
-    builder2.create<ttng::NamedBarrierWaitOp>(pongStart->getLoc(), pongBarrier2,
-                                              pingNumThreads2);
+    ttng::NamedBarrierWaitOp::create(builder2, pongStart->getLoc(),
+                                     pongBarrier2, pingNumThreads2);
     // Insert AFTER the pongEnd op
     builder2.setInsertionPointAfter(pongEnd);
-    builder2.create<ttng::NamedBarrierArriveOp>(pongEnd->getLoc(), pingBarrier2,
-                                                pingNumThreads2);
+    ttng::NamedBarrierArriveOp::create(builder2, pongEnd->getLoc(),
+                                       pingBarrier2, pingNumThreads2);
   }
 }
 } // anonymous namespace

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -20,9 +20,10 @@ ttng::TMEMAllocOp TMEM1DAllocator::alloc1DTMEMBuffer() {
   auto oldRetType = getResultTensorType(expandedInput->getResult(0), 2);
   auto shape = oldRetType.getShape();
   auto tmemDesc = createTMEMDesc(builder, oldRetType, shape[0], shape[1]);
-  auto allocCall = builder.create<ttng::TMEMAllocOp>(
-      expandedInput->getLoc(), tmemDesc, builder.getType<ttg::AsyncTokenType>(),
-      /*src=*/Value());
+  auto allocCall =
+      ttng::TMEMAllocOp::create(builder, expandedInput->getLoc(), tmemDesc,
+                                builder.getType<ttg::AsyncTokenType>(),
+                                /*src=*/Value());
   return allocCall;
 }
 
@@ -232,15 +233,15 @@ sliceAndReinterpretMDTMEM(OpBuilderWithAsyncTaskIds &builder,
   auto elemTyWidth = newType.getElementType().getIntOrFloatBitWidth();
   auto oldElemTyWidth = allocType.getElementType().getIntOrFloatBitWidth();
   if (oldElemTyWidth == elemTyWidth * 2) {
-    auto subSlice = builder.create<ttng::TMEMSubSliceOp>(
-        allocOp->getLoc(), allocResult, offset, blockN / 2);
-    return builder.create<ttg::MemDescReinterpretOp>(allocOp->getLoc(),
-                                                     tmemDesc, subSlice);
+    auto subSlice = ttng::TMEMSubSliceOp::create(
+        builder, allocOp->getLoc(), allocResult, offset, blockN / 2);
+    return ttg::MemDescReinterpretOp::create(builder, allocOp->getLoc(),
+                                             tmemDesc, subSlice);
   } else if (elemTyWidth == oldElemTyWidth) {
-    auto subSlice = builder.create<ttng::TMEMSubSliceOp>(
-        allocOp->getLoc(), allocResult, offset, blockN);
-    return builder.create<ttg::MemDescReinterpretOp>(allocOp->getLoc(),
-                                                     tmemDesc, subSlice);
+    auto subSlice = ttng::TMEMSubSliceOp::create(builder, allocOp->getLoc(),
+                                                 allocResult, offset, blockN);
+    return ttg::MemDescReinterpretOp::create(builder, allocOp->getLoc(),
+                                             tmemDesc, subSlice);
   } else {
     // Unsupported element type conversion
     return nullptr;
@@ -268,10 +269,10 @@ ttg::MemDescReinterpretOp sliceAndReinterpretTMEMBuffer(OpBuilder &builder,
 
   auto tmemDesc =
       createTMEMDesc(builder, allocType, shape[shape.size() - 2], 1);
-  auto subSlice = builder.create<ttng::TMEMSubSliceOp>(
-      allocOp->getLoc(), allocResult, offset, blockN);
-  return builder.create<ttg::MemDescReinterpretOp>(allocOp->getLoc(), tmemDesc,
-                                                   subSlice);
+  auto subSlice = ttng::TMEMSubSliceOp::create(builder, allocOp->getLoc(),
+                                               allocResult, offset, blockN);
+  return ttg::MemDescReinterpretOp::create(builder, allocOp->getLoc(), tmemDesc,
+                                           subSlice);
 }
 
 ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,
@@ -306,10 +307,9 @@ ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,
   size_t CTASplitN;
   bool twoCTAs = false;
   if (auto ttgLayout = mlir::dyn_cast<ttg::LayoutEncodingTrait>(encoding)) {
-    ArrayRef<unsigned> CTASplitNum =
-        ttg::getCTALayout(encoding).getCTASplitNum();
-    CTASplitM = CTASplitNum[0];
-    CTASplitN = CTASplitNum[1];
+    auto ctaLayoutAttr = ttg::getCTALayout(encoding);
+    CTASplitM = ctaLayoutAttr.getCTASplitNum()[0];
+    CTASplitN = ctaLayoutAttr.getCTASplitNum()[1];
   } else if (auto tmemLayout =
                  mlir::dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
                      encoding)) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1335,8 +1335,8 @@ void createTokenPost(
           llvm_unreachable("Unexpected load type");
         }
         Value v;
-        v = builder.create<ttnvws::CreateTokenOp>(
-            funcOp.getLoc(), channel->getNumBuffers(), tokenLoadType);
+        v = ttnvws::CreateTokenOp::create(
+            builder, funcOp.getLoc(), channel->getNumBuffers(), tokenLoadType);
         commChannel.tokens[consumerAsyncTaskId] = v;
       }
 
@@ -1404,15 +1404,15 @@ static Value hoistLocalAlloc(OpBuilderWithAsyncTaskIds &builder,
   Operation *newAlloc;
   if (auto localAlloc = dyn_cast<ttg::LocalAllocOp>(oldAlloc)) {
     newAlloc =
-        builder.create<ttg::LocalAllocOp>(oldAlloc->getLoc(), memdescType);
+        ttg::LocalAllocOp::create(builder, oldAlloc->getLoc(), memdescType);
   } else if (auto tmemAlloc = dyn_cast<ttng::TMEMAllocOp>(oldAlloc)) {
     if (tmemAlloc.getToken()) {
-      newAlloc = builder.create<ttng::TMEMAllocOp>(
-          oldAlloc->getLoc(), memdescType, tmemAlloc.getToken().getType(),
-          Value());
+      newAlloc =
+          ttng::TMEMAllocOp::create(builder, oldAlloc->getLoc(), memdescType,
+                                    tmemAlloc.getToken().getType(), Value());
     } else {
-      newAlloc = builder.create<ttng::TMEMAllocOp>(
-          oldAlloc->getLoc(), memdescType, mlir::Type(), Value());
+      newAlloc = ttng::TMEMAllocOp::create(builder, oldAlloc->getLoc(),
+                                           memdescType, mlir::Type(), Value());
     }
   } else {
     llvm_unreachable("Unexpected alloc type");
@@ -1496,8 +1496,8 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
         channel->srcName.empty()
             ? srcOp->getLoc()
             : replaceOutermostNameLoc(srcOp->getLoc(), channel->srcName);
-    auto allocOp = builder.create<ttng::TMEMAllocOp>(
-        allocLoc, memdescType, builder.getType<ttg::AsyncTokenType>(),
+    auto allocOp = ttng::TMEMAllocOp::create(
+        builder, allocLoc, memdescType, builder.getType<ttg::AsyncTokenType>(),
         /*src=*/Value());
     newProducer = TMEM1DAllocator(builder).replaceWith1DTMEM(
         dyn_cast<mlir::OpResult>(srcResult), channel->relation.first, dstOp,
@@ -1565,7 +1565,7 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
         channel->srcName.empty()
             ? srcOp->getLoc()
             : replaceOutermostNameLoc(srcOp->getLoc(), channel->srcName);
-    auto allocOp = builder.create<ttg::LocalAllocOp>(allocLoc, memdescType);
+    auto allocOp = ttg::LocalAllocOp::create(builder, allocLoc, memdescType);
     buffer = allocOp->getResult(0);
 
     if (isPost) {
@@ -1605,7 +1605,7 @@ static ttg::LocalAllocOp hoistLocalAllocPost(OpBuilder &builder,
   Type memdescType = ttg::MemDescType::get(
       shape, allocDescType.getElementType(), allocDescType.getEncoding(),
       allocDescType.getMemorySpace(), allocDescType.getMutableMemory());
-  return builder.create<ttg::LocalAllocOp>(oldAlloc.getLoc(), memdescType);
+  return ttg::LocalAllocOp::create(builder, oldAlloc.getLoc(), memdescType);
 }
 
 static ttng::TMEMAllocOp createTMemAllocPost(OpBuilder &builder,
@@ -3108,8 +3108,8 @@ void foldLocalLoads(triton::FuncOp funcOp) {
 // Compare against TritonNvidiaGPURemoveTMEMTokensPass.
 static void cleanupTmemTokens(triton::FuncOp funcOp) {
   auto b = OpBuilder::atBlockBegin(&funcOp.getBody().front());
-  Value replTok =
-      b.create<ub::PoisonOp>(funcOp.getLoc(), b.getType<ttg::AsyncTokenType>());
+  Value replTok = ub::PoisonOp::create(b, funcOp.getLoc(),
+                                       b.getType<ttg::AsyncTokenType>());
   funcOp.walk([&](Operation *op) {
     if (auto storeOp = dyn_cast<ttng::TMEMStoreOp>(op)) {
       storeOp.getDepMutable().clear();
@@ -3150,7 +3150,7 @@ static void separateLocalAllocWithSrc(triton::FuncOp &funcOp) {
 
     builder.setInsertionPoint(allocOp);
     auto newAlloc =
-        builder.create<ttg::LocalAllocOp>(allocOp.getLoc(), memdescType);
+        ttg::LocalAllocOp::create(builder, allocOp.getLoc(), memdescType);
 
     auto originTaskIds = builder.getAsyncTaskIds();
     auto originLoopScheduleInfo = builder.getLoopScheduleInfo();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -1062,7 +1062,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
                      "backward-sliced in getSliceToPartition?");
     if (newSrc.getType() != newSrcType) {
       auto cvtOp =
-          builder.create<ConvertLayoutOp>(op->getLoc(), newSrcType, newSrc);
+          ConvertLayoutOp::create(builder, op->getLoc(), newSrcType, newSrc);
       mappings.map(tmemStOp.getSrc(), cvtOp->getResult(0));
     }
     newOp = cloneAndSetResultType(op);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -460,9 +460,9 @@ struct VoteBallotSyncOpConversion
 
     // Scalar case: simple pass-through to NVVM
     if (!isa<RankedTensorType>(predType)) {
-      Value result = rewriter.create<NVVM::VoteSyncOp>(
-          loc, rewriter.getI32Type(), adaptor.getMask(), adaptor.getPred(),
-          NVVM::VoteSyncKind::ballot);
+      Value result = NVVM::VoteSyncOp::create(
+          rewriter, loc, rewriter.getI32Type(), adaptor.getMask(),
+          adaptor.getPred(), NVVM::VoteSyncKind::ballot);
       rewriter.replaceOp(op, result);
       return success();
     }
@@ -494,8 +494,8 @@ struct VoteBallotSyncOpConversion
     }
 
     // Perform the warp-level ballot with the combined predicate
-    Value ballot = rewriter.create<NVVM::VoteSyncOp>(
-        loc, rewriter.getI32Type(), adaptor.getMask(), combinedPred,
+    Value ballot = NVVM::VoteSyncOp::create(
+        rewriter, loc, rewriter.getI32Type(), adaptor.getMask(), combinedPred,
         NVVM::VoteSyncKind::ballot);
 
     // Replicate the ballot result to all elements of the output tensor

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -108,8 +108,8 @@ struct MapToRemoteBufferOpConversion
     Type convertedPtrTy = convertedRetTy.getBody()[0];
 
     // map an SMEM ptr in mem space 3 to a ptr in mem space 7
-    auto remotePtr = rewriter.create<NVVM::MapaOp>(
-        loc, convertedPtrTy, srcSmemPtr, adaptor.getCtaRank());
+    auto remotePtr = NVVM::MapaOp::create(rewriter, loc, convertedPtrTy,
+                                          srcSmemPtr, adaptor.getCtaRank());
 
     // everything stays the same except base ptr comparing to srcSmemObj
     auto dstSmemObj = SharedMemoryObject(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -92,8 +92,8 @@ static void createBarrier(TritonLLVMIRRewriter &b, unsigned barIdx,
   if (numThreads == 32)
     LLVM::NVIDIA::createSyncWarp(b.getLoc(), b);
   else
-    NVVM::BarrierOp::create(b, b.getLoc(), mlir::TypeRange{},
-                            b.i32_val(barIdx), b.i32_val(numThreads),
+    NVVM::BarrierOp::create(b, b.getLoc(), mlir::TypeRange{}, b.i32_val(barIdx),
+                            b.i32_val(numThreads),
                             /*reductionOp=*/nullptr,
                             /*reductionPredicate=*/nullptr);
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -601,8 +601,8 @@ struct ConvertWarpSpecializeToLLVM
           // active and should not have exited."
           auto unitAttr = UnitAttr::get(ctx);
           rewriter.setInsertionPoint(ret);
-          rewriter.create<NVVM::ClusterArriveOp>(loc, unitAttr);
-          rewriter.create<NVVM::ClusterWaitOp>(loc, unitAttr);
+          NVVM::ClusterArriveOp::create(rewriter, loc, unitAttr);
+          NVVM::ClusterWaitOp::create(rewriter, loc, unitAttr);
         });
       }
     }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -309,8 +309,8 @@ static void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
     // be broadcasted into CTAid 0 and 1
     // If there're more than 2 CTAs in a cluster, it should be CTAid x and x+1
     // where x is even
-    Value clusterCTARank = rewriter.create<triton::nvgpu::ClusterCTAIdOp>(
-        loc, rewriter.getI32Type());
+    Value clusterCTARank = triton::nvgpu::ClusterCTAIdOp::create(
+        rewriter, loc, rewriter.getI32Type());
     // mask the least bit
     Value leaderCTARank = b.and_(clusterCTARank, b.i32_val(~1));
     // "3 << leaderCTARank" means " (1<<leaderCTARank) | (1 << (leaderCTARank +

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -571,10 +571,10 @@ struct FpToFpOpConversion
       for (unsigned j = 1; j < rbitsPack.size(); ++j) {
         // Shift r[j] by j positions to decorrelate bit patterns
         Value shiftAmount = b.i32_val(j);
-        Value shifted =
-            rewriter.create<LLVM::ShlOp>(loc, i32Ty, rbitsPack[j], shiftAmount);
+        Value shifted = LLVM::ShlOp::create(rewriter, loc, i32Ty, rbitsPack[j],
+                                            shiftAmount);
         // XOR with accumulated rbits to mix entropy sources
-        rbits = rewriter.create<LLVM::XOrOp>(loc, i32Ty, rbits, shifted);
+        rbits = LLVM::XOrOp::create(rewriter, loc, i32Ty, rbits, shifted);
       }
 
       // Emit PTX inline assembly for stochastic rounding

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1168,8 +1168,9 @@ struct AsyncCopyGlobalToLocalOpConversion
       ptxBuilder.launch(rewriter, loc, voidTy);
 
       // Replace op with dummy token (same as non-bulk path)
-      Value zero = rewriter.create<LLVM::ConstantOp>(
-          loc, IntegerType::get(ctx, 32), rewriter.getI32IntegerAttr(0));
+      Value zero =
+          LLVM::ConstantOp::create(rewriter, loc, IntegerType::get(ctx, 32),
+                                   rewriter.getI32IntegerAttr(0));
       rewriter.replaceOp(op, zero);
       return success();
     }
@@ -2132,7 +2133,7 @@ struct AsyncStoreOpConversion
     ptxBuilder.launch(rewriter, loc, voidTy);
 
     // Emit commit group so completion can be tracked via wait_group
-    rewriter.create<NVVM::CpAsyncBulkCommitGroupOp>(loc);
+    NVVM::CpAsyncBulkCommitGroupOp::create(rewriter, loc);
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
@@ -60,7 +60,7 @@ struct Clock64OpConversion
   matchAndRewrite(triton::gpu::Clock64Op op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto readClock =
-        rewriter.create<NVVM::Clock64Op>(op.getLoc(), rewriter.getI64Type());
+        NVVM::Clock64Op::create(rewriter, op.getLoc(), rewriter.getI64Type());
     rewriter.replaceOp(op, readClock.getResult());
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
@@ -327,8 +327,8 @@ struct PrefetchTensormapOpConversion
     // Device side TMA desc gets initialized in SMEM and copied to GMEM
     // We use Generic Address state space here to support both
     auto genericPtrTy = LLVM::LLVMPointerType::get(ctx, 0);
-    Value addr = rewriter.create<LLVM::AddrSpaceCastOp>(loc, genericPtrTy,
-                                                        adaptor.getDesc());
+    Value addr = LLVM::AddrSpaceCastOp::create(rewriter, loc, genericPtrTy,
+                                               adaptor.getDesc());
     // Note: not lowering to NVVM::PrefetchOp as it seems to have a bug where
     // if I don't set `$in_param_space` (leading to prefetch.param.tensormap)
     // it's emitting both `prefetch.tensormap` and `prefetch.param.tensormap` at

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -378,9 +378,9 @@ private:
     // need to insert cluster arrive and wait to prevent CTA_X from arriving
     // CTA_Y's bar before CTA_Y inits it, as shown in ptx doc examples:
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-try-wait
-    builder.create<ttng::ClusterArriveOp>(lastBarInitOp.getLoc(),
-                                          /*relaxed*/ false);
-    builder.create<ttng::ClusterWaitOp>(lastBarInitOp.getLoc());
+    ttng::ClusterArriveOp::create(builder, lastBarInitOp.getLoc(),
+                                  /*relaxed*/ false);
+    ttng::ClusterWaitOp::create(builder, lastBarInitOp.getLoc());
 
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -141,11 +141,11 @@ Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter) {
 
 Value createLeaderCTAPredicate(Location loc, RewriterBase &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value clusterCTARank = rewriter.create<triton::nvgpu::ClusterCTAIdOp>(
-      loc, rewriter.getI32Type());
+  Value clusterCTARank = triton::nvgpu::ClusterCTAIdOp::create(
+      rewriter, loc, rewriter.getI32Type());
   // Always pick the even numbered CTA in the CTA pair to be the leader
   Value rem =
-      rewriter.create<mlir::arith::RemUIOp>(loc, clusterCTARank, b.i32_val(2));
+      mlir::arith::RemUIOp::create(rewriter, loc, clusterCTARank, b.i32_val(2));
   return b.icmp_eq(rem, b.i32_val(0));
 }
 

--- a/third_party/proton/Dialect/lib/Dialect/ProtonGPU/Transforms/MppStoreBarrierInfoPass.cpp
+++ b/third_party/proton/Dialect/lib/Dialect/ProtonGPU/Transforms/MppStoreBarrierInfoPass.cpp
@@ -182,19 +182,19 @@ private:
           initIndexValue
               ? (initIndexValue.getType().isInteger(32)
                      ? initIndexValue
-                     : builder.create<arith::IndexCastOp>(
-                           loc, builder.getI32Type(), initIndexValue))
-              : builder.create<arith::ConstantOp>(loc, builder.getI32Type(),
-                                                  builder.getI32IntegerAttr(0));
+                     : arith::IndexCastOp::create(
+                           builder, loc, builder.getI32Type(), initIndexValue))
+              : arith::ConstantOp::create(builder, loc, builder.getI32Type(),
+                                          builder.getI32IntegerAttr(0));
       if (pos <= newInitArgs.size())
         newInitArgs.insert(newInitArgs.begin() + pos, initValue);
     }
 
     // Create new for loop
     builder.setInsertionPoint(forOp);
-    auto newForOp = builder.create<scf::ForOp>(loc, forOp.getLowerBound(),
-                                               forOp.getUpperBound(),
-                                               forOp.getStep(), newInitArgs);
+    auto newForOp =
+        scf::ForOp::create(builder, loc, forOp.getLowerBound(),
+                           forOp.getUpperBound(), forOp.getStep(), newInitArgs);
 
     Block *newBlock = newForOp.getBody();
     Block *oldBlock = forOp.getBody();
@@ -227,7 +227,7 @@ private:
     for (Value v : newYieldOperands)
       mappedYieldOperands.push_back(mapping.lookupOrDefault(v));
 
-    builder.create<scf::YieldOp>(loc, mappedYieldOperands);
+    scf::YieldOp::create(builder, loc, mappedYieldOperands);
 
     numInserted = 0;
     newIdx = 0;
@@ -335,13 +335,13 @@ private:
               builder.setInsertionPoint(terminator);
               if (idx.getType().isInteger(32))
                 return idx;
-              return builder.create<arith::IndexCastOp>(
-                  terminator->getLoc(), builder.getI32Type(), idx);
+              return arith::IndexCastOp::create(builder, terminator->getLoc(),
+                                                builder.getI32Type(), idx);
             }
             builder.setInsertionPoint(terminator);
-            return builder.create<arith::ConstantOp>(
-                terminator->getLoc(), builder.getI32Type(),
-                builder.getI32IntegerAttr(0));
+            return arith::ConstantOp::create(builder, terminator->getLoc(),
+                                             builder.getI32Type(),
+                                             builder.getI32IntegerAttr(0));
           };
 
           if (auto branchOp = dyn_cast<cf::BranchOp>(terminator)) {
@@ -355,8 +355,8 @@ private:
                                  newIndexValue);
 
               builder.setInsertionPoint(branchOp);
-              builder.create<cf::BranchOp>(branchOp.getLoc(), block,
-                                           newOperands);
+              cf::BranchOp::create(builder, branchOp.getLoc(), block,
+                                   newOperands);
               branchOp.erase();
             }
           } else if (auto condBranchOp =
@@ -385,8 +385,8 @@ private:
             }
 
             builder.setInsertionPoint(condBranchOp);
-            builder.create<cf::CondBranchOp>(
-                condBranchOp.getLoc(), condBranchOp.getCondition(),
+            cf::CondBranchOp::create(
+                builder, condBranchOp.getLoc(), condBranchOp.getCondition(),
                 condBranchOp.getTrueDest(), newTrueOperands,
                 condBranchOp.getFalseDest(), newFalseOperands);
             condBranchOp.erase();
@@ -636,8 +636,8 @@ private:
       if (v.getType().isInteger(32))
         return v;
       builder.setInsertionPoint(op);
-      return builder
-          .create<arith::IndexCastOp>(op->getLoc(), builder.getI32Type(), v)
+      return arith::IndexCastOp::create(builder, op->getLoc(),
+                                        builder.getI32Type(), v)
           .getResult();
     };
 
@@ -745,7 +745,7 @@ private:
     auto toCounterType = [&](Value v) -> Value {
       return v.getType() == counterType
                  ? v
-                 : builder.create<arith::IndexCastOp>(loc, counterType, v)
+                 : arith::IndexCastOp::create(builder, loc, counterType, v)
                        .getResult();
     };
 

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
@@ -676,9 +676,9 @@ private:
     // Add the 'else' block and the condition.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
-    rewriter.create<cf::CondBranchOp>(loc, isFirstThread, ifBlock, thenBlock);
+    cf::CondBranchOp::create(rewriter, loc, isFirstThread, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);
-    rewriter.create<cf::BranchOp>(loc, thenBlock);
+    cf::BranchOp::create(rewriter, loc, thenBlock);
   }
 
 protected:

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -121,7 +121,7 @@ public:
         Location loc = op.getLoc();
         for (auto barrier : barriers) {
           if (domInfo.properlyDominates(barrier, op)) {
-            builder.create<ttng::InvalBarrierOp>(loc, barrier);
+            ttng::InvalBarrierOp::create(builder, loc, barrier);
           }
         }
       });

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -67,8 +67,8 @@ LogicalResult insertRequireLayout(ModuleOp m) {
             auto newType = ttg::MemDescType::get(
                 type.getShape(), type.getElementType(), encodingAttr,
                 type.getMemorySpace(), type.getMutableMemory());
-            auto converLayoutOp = builder.create<tlx::RequireLayoutOp>(
-                op->getLoc(), newType, loadMemDescTy);
+            auto converLayoutOp = tlx::RequireLayoutOp::create(
+                builder, op->getLoc(), newType, loadMemDescTy);
             localLoadOp->setOperand(0, converLayoutOp.getResult());
           }
         } else {

--- a/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
@@ -138,11 +138,11 @@ LogicalResult rewriteLocalAlias(ModuleOp m) {
       Operation *newAllocOp = nullptr;
       if (isa<ttg::LocalAllocOp>(baseAllocOp)) {
         newAllocOp =
-            builder.create<ttg::LocalAllocOp>(baseAllocOp->getLoc(), maxType);
+            ttg::LocalAllocOp::create(builder, baseAllocOp->getLoc(), maxType);
       } else {
         assert(isa<ttng::TMEMAllocOp>(baseAllocOp) && "Unexpected alloc op");
-        newAllocOp = builder.create<ttng::TMEMAllocOp>(baseAllocOp->getLoc(),
-                                                       maxType, nullptr);
+        newAllocOp = ttng::TMEMAllocOp::create(builder, baseAllocOp->getLoc(),
+                                               maxType, nullptr);
       }
       // Save mapping so we can rewrite uses later.
       allocToNewAlloc[baseAllocOp] = newAllocOp;
@@ -170,8 +170,9 @@ LogicalResult rewriteLocalAlias(ModuleOp m) {
           dyn_cast<ttg::MemDescType>(newAllocOp->getResult(0).getType());
       auto baseAllocType =
           dyn_cast<ttg::MemDescType>(baseAllocOp->getResult(0).getType());
-      auto newAllocToBaseAllocOp = builder.create<ttg::MemDescReinterpretOp>(
-          baseAllocOp->getLoc(), baseAllocType, newAllocOp->getResult(0));
+      auto newAllocToBaseAllocOp = ttg::MemDescReinterpretOp::create(
+          builder, baseAllocOp->getLoc(), baseAllocType,
+          newAllocOp->getResult(0));
       baseAllocOp->getResult(0).replaceAllUsesWith(
           newAllocToBaseAllocOp.getResult());
       baseAllocOp->erase();
@@ -188,8 +189,8 @@ LogicalResult rewriteLocalAlias(ModuleOp m) {
       });
       builder.setInsertionPoint(aliasOp);
       auto aliasType = aliasOp.getResult().getType();
-      auto baseAllocToAliasOp = builder.create<ttg::MemDescReinterpretOp>(
-          baseAllocOp->getLoc(), aliasType, baseAllocOp->getResult(0));
+      auto baseAllocToAliasOp = ttg::MemDescReinterpretOp::create(
+          builder, baseAllocOp->getLoc(), aliasType, baseAllocOp->getResult(0));
       aliasOp.getResult().replaceAllUsesWith(baseAllocToAliasOp.getResult());
       aliasOp->erase();
     }

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
@@ -131,7 +131,7 @@ LogicalResult materializeStorageAliasAllocations(
           ttg::MemDescType::get(shape, elemType, sharedEncoding, memorySpace,
                                 /*mutableMemory=*/true);
       auto allocOp =
-          builder.create<ttg::LocalAllocOp>(specOp.getLoc(), memDescType);
+          ttg::LocalAllocOp::create(builder, specOp.getLoc(), memDescType);
       allocResult = allocOp.getResult();
     } else {
       // TMEM: 2D allocation
@@ -158,8 +158,8 @@ LogicalResult materializeStorageAliasAllocations(
       auto memDescType =
           ttg::MemDescType::get(tmemShape, tmemElemType, tmemEncoding,
                                 memorySpace, /*mutableMemory=*/true);
-      auto allocOp = builder.create<ttng::TMEMAllocOp>(specOp.getLoc(),
-                                                       memDescType, nullptr);
+      auto allocOp = ttng::TMEMAllocOp::create(builder, specOp.getLoc(),
+                                               memDescType, nullptr);
       allocResult = allocOp.getResult();
     }
 
@@ -278,7 +278,7 @@ LogicalResult materializeStorageAliasAllocations(
     // Create a LocalAliasOp to reinterpret the allocation with the
     // (possibly expanded) type
     auto localAliasOp =
-        builder.create<LocalAliasOp>(allocOp.getLoc(), resultType, it->second);
+        LocalAliasOp::create(builder, allocOp.getLoc(), resultType, it->second);
 
     // Replace all uses and erase the old operation
     allocOp.getResult().replaceAllUsesWith(localAliasOp.getResult());
@@ -335,25 +335,25 @@ LogicalResult materializeStorageAliasAllocations(
           Value newIndex = originalIndex;
 
           if (scaleFactor > 1) {
-            Value scaleVal = builder.create<arith::ConstantOp>(
-                loc, builder.getI32IntegerAttr(scaleFactor));
+            Value scaleVal = arith::ConstantOp::create(
+                builder, loc, builder.getI32IntegerAttr(scaleFactor));
             newIndex =
-                builder.create<arith::MulIOp>(loc, originalIndex, scaleVal);
+                arith::MulIOp::create(builder, loc, originalIndex, scaleVal);
           }
 
           if (offsetSlots > 0) {
-            Value offsetVal = builder.create<arith::ConstantOp>(
-                loc, builder.getI32IntegerAttr(offsetSlots));
-            newIndex = builder.create<arith::AddIOp>(loc, newIndex, offsetVal);
+            Value offsetVal = arith::ConstantOp::create(
+                builder, loc, builder.getI32IntegerAttr(offsetSlots));
+            newIndex = arith::AddIOp::create(builder, loc, newIndex, offsetVal);
           }
 
           // Add (originalIndex % groupSize) for subtiling
           if (groupSize > 1) {
-            Value groupSizeVal = builder.create<arith::ConstantOp>(
-                loc, builder.getI32IntegerAttr(groupSize));
-            Value modVal = builder.create<arith::RemSIOp>(loc, originalIndex,
-                                                          groupSizeVal);
-            newIndex = builder.create<arith::AddIOp>(loc, newIndex, modVal);
+            Value groupSizeVal = arith::ConstantOp::create(
+                builder, loc, builder.getI32IntegerAttr(groupSize));
+            Value modVal = arith::RemSIOp::create(builder, loc, originalIndex,
+                                                  groupSizeVal);
+            newIndex = arith::AddIOp::create(builder, loc, newIndex, modVal);
           }
 
           // Update the index operand

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -305,8 +305,8 @@ void init_triton_tlx_ir(py::module &&m) {
              //  Init barrier in each slot
              for (auto i = 0; i < numBarriers; i++) {
                // Obtain the single buffer view
-               Value idx = self.getBuilder().create<arith::ConstantIntOp>(
-                   bufferViews.getLoc(), i, 32);
+               Value idx = arith::ConstantIntOp::create(
+                   self.getBuilder(), bufferViews.getLoc(), i, 32);
                mlir::Value buf = self.create<ttg::MemDescIndexOp>(
                    singleBarrierMemDescType, bufferViews, idx);
 


### PR DESCRIPTION
Migrate deprecated `builder.create<OpTy>(...)` to `OpTy::create(builder, ...)` across 33 internal files to match the new MLIR API from the LLVM bump in https://github.com/triton-lang/triton/pull/8766. Also fix RegionSuccessor constructor changes in RangeAnalysis and Ops.cpp, NVVM::BarrierOp signature change, and a dangling ArrayRef in TMEMAlloc1D.
