### PR TITLE
[AutoWS] Register ModuloSchedulePass and add TRITON_USE_MODULO_SCHEDULE knob (#1220)

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -509,6 +509,7 @@ class nvidia_knobs(base_knobs):
     libcuda_path: env_opt_str = env_opt_str("TRITON_LIBCUDA_PATH")
     use_meta_ws: env_bool = env_bool("TRITON_USE_META_WS")
     use_meta_partition: env_bool = env_bool("TRITON_USE_META_PARTITION")
+    use_modulo_schedule: env_bool = env_bool("TRITON_USE_MODULO_SCHEDULE")
     # Force OAI SWP schedule even when using Meta's WS implementation.
     force_trunk_swp_schedule: env_bool = env_bool("TRITON_FORCE_TRUNK_SWP_SCHEDULE")
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -14,5 +14,8 @@ namespace mlir {
 #define GEN_PASS_REGISTRATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
 
+// Modulo scheduling pass (manual registration, not tablegen-generated).
+std::unique_ptr<Pass> createNVGPUModuloSchedule();
+
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/LatencyModel.cpp
   ModuloScheduling/DataDependenceGraph.cpp
   ModuloScheduling/ModuloReservationTable.cpp
+  ModuloScheduling/ModuloSchedulePass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -1,0 +1,29 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Stub for createNVGPUModuloSchedule — provides the symbol so that
+// triton_nvidia.cc (ADD_PASS_WRAPPER_0) links before the real
+// implementation lands in a child diff.
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace {
+struct ModuloSchedulePass
+    : public PassWrapper<ModuloSchedulePass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloSchedulePass)
+  StringRef getArgument() const override { return "nvgpu-modulo-schedule"; }
+  StringRef getDescription() const override {
+    return "Modulo scheduling for warp specialization (stub)";
+  }
+  void runOnOperation() override {}
+};
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloSchedule() {
+  return std::make_unique<ModuloSchedulePass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -103,6 +103,8 @@ void init_triton_hopper_passes(py::module &&m) {
                      mlir::createNVGPUPartitionSchedulingMeta);
   ADD_PASS_WRAPPER_0("add_multi_cta_reduction",
                      mlir::createNVGPUMultiCTAReduction);
+  ADD_PASS_WRAPPER_0("add_modulo_schedule",
+                     mlir::createNVGPUModuloSchedule);
 }
 
 static void checkMatmulConstraints(const std::string &A_dtype,


### PR DESCRIPTION
Summary:

Add pass declaration, Python binding, and environment variable knob
for the modulo scheduling pass. Gated by TRITON_USE_MODULO_SCHEDULE=1
(default off).

Authored with Claude.

Reviewed By: htyu

Differential Revision: D99879743


