### PR TITLE
Add ModuloSchedulePass: inner loop scheduling (#1221)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -136,6 +136,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
 
   // NVGPU transform passes
   mlir::registerNVHopperTransformsPasses();
+  mlir::registerNVGPUModuloSchedule();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -509,6 +509,7 @@ class nvidia_knobs(base_knobs):
     libcuda_path: env_opt_str = env_opt_str("TRITON_LIBCUDA_PATH")
     use_meta_ws: env_bool = env_bool("TRITON_USE_META_WS")
     use_meta_partition: env_bool = env_bool("TRITON_USE_META_PARTITION")
+    use_modulo_schedule: env_bool = env_bool("TRITON_USE_MODULO_SCHEDULE")
     # Force OAI SWP schedule even when using Meta's WS implementation.
     force_trunk_swp_schedule: env_bool = env_bool("TRITON_FORCE_TRUNK_SWP_SCHEDULE")
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -1,0 +1,52 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// Verify that the modulo schedule pass annotates ops with loop.stage/loop.cluster
+// and sets tt.modulo_ii on the loop.
+//
+// CHECK-LABEL: @gemm_inner_loop
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK: tt.modulo_ii
+// CHECK: tt.scheduled_max_stage
+tt.func @gemm_inner_loop(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x128xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked>
+
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+
+    scf.yield %c : tensor<128x128xf32, #acc_layout>
+  }
+
+  tt.return
+}
+
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -385,8 +385,11 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_hoist_tmem_alloc(pm, False)
             nvidia.passes.ttnvgpuir.add_promote_lhs_to_tmem(pm)
             nvidia.passes.hopper.add_data_partitioning(pm, 1)
-            passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
-            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
+            if knobs.nvidia.use_modulo_schedule:
+                nvidia.passes.hopper.add_modulo_schedule(pm)
+            else:
+                passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
+                passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             if not knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_warp_specialize(pm, opt.num_stages)
             else:

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -14,5 +14,8 @@ namespace mlir {
 #define GEN_PASS_REGISTRATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
 
+// Modulo scheduling pass (manual registration, not tablegen-generated).
+std::unique_ptr<Pass> createNVGPUModuloSchedule();
+
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -16,6 +16,7 @@ namespace mlir {
 
 // Modulo scheduling pass (manual registration, not tablegen-generated).
 std::unique_ptr<Pass> createNVGPUModuloSchedule();
+void registerNVGPUModuloSchedule();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/LatencyModel.cpp
   ModuloScheduling/DataDependenceGraph.cpp
   ModuloScheduling/ModuloReservationTable.cpp
+  ModuloScheduling/ModuloSchedulePass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -1,0 +1,29 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Stub for createNVGPUModuloSchedule — provides the symbol so that
+// triton_nvidia.cc (ADD_PASS_WRAPPER_0) links before the real
+// implementation lands in a child diff.
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace {
+struct ModuloSchedulePass
+    : public PassWrapper<ModuloSchedulePass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloSchedulePass)
+  StringRef getArgument() const override { return "nvgpu-modulo-schedule"; }
+  StringRef getDescription() const override {
+    return "Modulo scheduling for warp specialization (stub)";
+  }
+  void runOnOperation() override {}
+};
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloSchedule() {
+  return std::make_unique<ModuloSchedulePass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -1,29 +1,159 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// Stub for createNVGPUModuloSchedule — provides the symbol so that
-// triton_nvidia.cc (ADD_PASS_WRAPPER_0) links before the real
-// implementation lands in a child diff.
+// Pass A: Modulo Schedule Pass
+//
+// Builds a DDG from scf.for loop bodies, computes MinII, runs Rau's iterative
+// modulo scheduling, and annotates ops with loop.stage and loop.cluster
+// attributes for downstream pipelining passes.
 
+#include "DataDependenceGraph.h"
+#include "LatencyModel.h"
+#include "ModuloReservationTable.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Format.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-schedule"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 using namespace mlir;
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
 
 namespace {
+
+// ============================================================================
+// Emit loop.stage / loop.cluster attributes from modulo schedule
+// ============================================================================
+
+static void emitScheduleAttributes(scf::ForOp loop,
+                                   const ttg::DataDependenceGraph &ddg,
+                                   const ttg::ModuloScheduleResult &schedule) {
+  const int II = schedule.II;
+  const int maxStage = schedule.getMaxStage();
+  auto ctx = loop.getContext();
+
+  for (const auto &node : ddg.getNodes()) {
+    auto it = schedule.nodeToCycle.find(node.idx);
+    if (it == schedule.nodeToCycle.end())
+      continue;
+    int stage = it->second / II;
+    node.op->setAttr(tt::kLoopStageAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), stage));
+    node.op->setAttr(tt::kLoopClusterAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+  }
+
+  // Ensure ALL ops in the loop body have loop.stage/loop.cluster attrs.
+  // Downstream passes assert every op is in the schedule.
+  for (auto &op : loop.getBody()->without_terminator()) {
+    if (!op.hasAttr(tt::kLoopStageAttrName))
+      op.setAttr(tt::kLoopStageAttrName,
+                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+    if (!op.hasAttr(tt::kLoopClusterAttrName))
+      op.setAttr(tt::kLoopClusterAttrName,
+                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+  }
+
+  LDBG("Emitted schedule: II=" << II << " maxStage=" << maxStage);
+
+  loop->setAttr("tt.modulo_ii",
+                IntegerAttr::get(IntegerType::get(ctx, 32), II));
+  loop->setAttr(tt::kScheduledMaxStageAttrName,
+                IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
+}
+
+// ============================================================================
+// Pass A: Modulo Scheduling
+// ============================================================================
+
+/// The main pass.
 struct ModuloSchedulePass
     : public PassWrapper<ModuloSchedulePass, OperationPass<ModuleOp>> {
+
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloSchedulePass)
+
   StringRef getArgument() const override { return "nvgpu-modulo-schedule"; }
+
   StringRef getDescription() const override {
-    return "Modulo scheduling for warp specialization (stub)";
+    return "Modulo scheduling for warp specialization (Pass A)";
   }
-  void runOnOperation() override {}
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    ttg::LatencyModel model;
+
+    // Find innermost loops with TMA loads or MMA ops.
+    SmallVector<scf::ForOp> innerLoops;
+    moduleOp.walk([&](scf::ForOp loop) {
+      bool hasInnerLoop = false;
+      loop.getBody()->walk([&](scf::ForOp) { hasInnerLoop = true; });
+      if (hasInnerLoop)
+        return;
+      bool hasTMALoad = false;
+      bool hasMMAv5 = false;
+      loop.getBody()->walk([&](Operation *op) {
+        if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
+          hasTMALoad = true;
+        if (isa<ttng::AsyncTMACopyGlobalToLocalOp>(op))
+          hasTMALoad = true;
+        if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op))
+          hasMMAv5 = true;
+      });
+      if (!hasTMALoad && !hasMMAv5)
+        return;
+      innerLoops.push_back(loop);
+    });
+
+    LDBG("Found " << innerLoops.size() << " innermost loop(s)");
+
+    for (auto innerLoop : innerLoops) {
+      // Build DDG for this inner loop.
+      auto ddg = ttg::DataDependenceGraph::build(innerLoop, model);
+      if (ddg.getNumNodes() == 0)
+        continue;
+
+      LDBG("DDG: " << ddg.getNumNodes() << " nodes, "
+                    << ddg.getEdges().size() << " edges");
+
+      // Run Rau's modulo scheduling.
+      auto schedResult = ttg::runModuloScheduling(ddg);
+      if (failed(schedResult)) {
+        LDBG("Scheduling FAILED");
+        continue;
+      }
+
+      LDBG("Schedule: II=" << schedResult->II
+                           << " ResMII=" << ddg.computeResMII()
+                           << " RecMII=" << ddg.computeRecMII()
+                           << " maxStage=" << schedResult->getMaxStage());
+
+      // Emit loop.stage / loop.cluster on all ops.
+      emitScheduleAttributes(innerLoop, ddg, *schedResult);
+    }
+  }
 };
+
 } // namespace
 
 namespace mlir {
 std::unique_ptr<Pass> createNVGPUModuloSchedule() {
   return std::make_unique<ModuloSchedulePass>();
+}
+
+void registerNVGPUModuloSchedule() {
+  PassRegistration<ModuloSchedulePass>();
 }
 } // namespace mlir

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -103,6 +103,8 @@ void init_triton_hopper_passes(py::module &&m) {
                      mlir::createNVGPUPartitionSchedulingMeta);
   ADD_PASS_WRAPPER_0("add_multi_cta_reduction",
                      mlir::createNVGPUMultiCTAReduction);
+  ADD_PASS_WRAPPER_0("add_modulo_schedule",
+                     mlir::createNVGPUModuloSchedule);
 }
 
 static void checkMatmulConstraints(const std::string &A_dtype,


### PR DESCRIPTION
Summary:

Add Pass A of the modulo scheduling pipeline. For each innermost loop
with TMA loads or MMA ops, the pass:

1. Builds a DDG and runs Rau's iterative modulo scheduling
2. Serializes the schedule as loop.stage/loop.cluster attributes
3. Sets tt.modulo_ii and tt.scheduled_max_stage on the loop

The pass replaces assign_latencies + schedule_loops when
TRITON_USE_MODULO_SCHEDULE=1 is set. Default off, no behavior change
to existing pipelines.

Includes a TTGIR lit test (modulo-schedule.mlir) verifying that a GEMM
inner loop gets correct stage assignments (loads at stage 0, MMA at
stage 1, tmem_load at stage 2).

Authored with Claude.

Reviewed By: htyu

Differential Revision: D99879741


