### PR TITLE
[AutoWS] Skip ScheduleLoops and pipeline expansion for modulo-scheduled loops (#1223)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -139,6 +139,8 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVGPUModuloSchedule();
   mlir::registerNVGPUModuloWSPartition();
   mlir::registerNVGPUModuloBufferAlloc();
+  mlir::registerNVGPUModuloExpand();
+  mlir::registerNVGPUModuloLower();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -830,7 +830,26 @@ void scheduleLoops(ModuleOp moduleOp, int defaultNumStages, bool useMetaWS) {
   moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
   if (loops.empty())
     return;
+  // If any loop has tt.modulo_ii, skip ALL loops — the modulo schedule
+  // handles scheduling globally. This module-wide skip is needed because
+  // the WS pass's PartitionLoops creates partition loop clones inside
+  // warp_specialize regions that don't inherit tt.modulo_ii from the
+  // original loop. Without the module-wide skip, these clones get
+  // re-scheduled by the heuristic, overwriting the modulo stage assignments.
+  // TODO: Propagate tt.modulo_ii to partition clones in WS pass so we can
+  // skip only annotated loops instead of all loops in the module.
+  bool moduleHasModuloSchedule = false;
   for (auto forOp : loops) {
+    if (forOp->hasAttr("tt.modulo_ii")) {
+      moduleHasModuloSchedule = true;
+      break;
+    }
+  }
+  for (auto forOp : loops) {
+    if (forOp->hasAttr("tt.modulo_ii") || moduleHasModuloSchedule) {
+      LDBG("Skipping loop (modulo-scheduled)");
+      continue;
+    }
     scheduleLoop(forOp, opLatency, defaultNumStages, useMetaWS);
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -101,6 +101,9 @@ static void expandLoops(ModuleOp moduleOp) {
   auto metaWS = triton::tools::getBoolEnv("TRITON_USE_META_WS");
 
   for (scf::ForOp forOp : loops) {
+    // Skip loops already expanded by modulo scheduling.
+    if (forOp->hasAttr("tt.modulo_ii"))
+      continue;
     CoarseSchedule schedule;
     if (failed(schedule.deSerialize(forOp))) {
       continue;

--- a/test/TritonGPU/modulo-ws-partition.mlir
+++ b/test/TritonGPU/modulo-ws-partition.mlir
@@ -1,0 +1,62 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule -nvgpu-modulo-ws-partition | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// Verify that Pass B assigns utilization-driven ttg.partition attrs on a
+// persistent kernel with a WS outer loop containing an inner K-loop.
+// Expected partitions: MEM=0, TC=1, CUDA(tmem_load)=2.
+// Shared/scalar ops get allParts [0,1,2].
+//
+// CHECK-LABEL: @persistent_gemm_ws_partition
+// MEM ops (descriptor_load, local_alloc) → partition 0
+// CHECK: tt.descriptor_load {{.*}} ttg.partition = array<i32: 0>
+// CHECK: tt.descriptor_load {{.*}} ttg.partition = array<i32: 0>
+// CHECK: ttg.local_alloc {{.*}} ttg.partition = array<i32: 0>
+// CHECK: ttg.local_alloc {{.*}} ttg.partition = array<i32: 0>
+// TC ops (tc_gen5_mma) → partition 1
+// CHECK: ttng.tc_gen5_mma {{.*}} ttg.partition = array<i32: 1>
+// CUDA ops (tmem_load) → partition 2
+// CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: 2>
+tt.func @persistent_gemm_ws_partition(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16>>,
+  %num_tiles: i32
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+
+  // Outer tile loop with tt.warp_specialize — triggers partition assignment
+  scf.for %tile = %c0_i32 to %num_tiles step %c1_i32 : i32 {
+    // Inner K-loop (GEMM accumulation)
+    scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x128xf32, #acc_layout>) : i32 {
+      %off_k = arith.muli %k, %c1_i32 : i32
+
+      %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+      %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked>
+
+      %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+      %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+      %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+
+      scf.yield %c : tensor<128x128xf32, #acc_layout>
+    }
+
+    scf.yield
+  } {tt.warp_specialize}
+
+  tt.return
+}
+
+}

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -21,6 +21,10 @@ std::unique_ptr<Pass> createNVGPUModuloWSPartition();
 void registerNVGPUModuloWSPartition();
 std::unique_ptr<Pass> createNVGPUModuloBufferAlloc();
 void registerNVGPUModuloBufferAlloc();
+std::unique_ptr<Pass> createNVGPUModuloExpand();
+void registerNVGPUModuloExpand();
+std::unique_ptr<Pass> createNVGPUModuloLower();
+void registerNVGPUModuloLower();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -23,6 +23,8 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloWSPartitionPass.cpp
   ModuloScheduling/ModuloPipelineIR.cpp
   ModuloScheduling/ModuloBufferAllocPass.cpp
+  ModuloScheduling/ModuloExpandPass.cpp
+  ModuloScheduling/ModuloLowerPass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -23,6 +23,7 @@ namespace mlir::triton::gpu {
 namespace ttng = mlir::triton::nvidia_gpu;
 
 // Default estimated trip count for inner loops with dynamic bounds.
+// Used to compute super-node latency = prologue + K_est * II.
 constexpr int kDefaultInnerTripCount = 4;
 
 // Fallback latency constants from Blackwell SM100 microbenchmarks.
@@ -33,18 +34,19 @@ constexpr int kFallbackMMALatency = 900;       // MMA 128x128x128 TC latency
 
 /// Per-stage pipeline load summary from inner loop schedule.
 struct StageLoad {
-  int memSelfLatency{0};
-  int tcSelfLatency{0};
-  int cudaSelfLatency{0};
-  int totalLatency{0};
+  int memSelfLatency{0};  // total MEM pipeline occupancy
+  int tcSelfLatency{0};   // total TC pipeline occupancy
+  int cudaSelfLatency{0}; // total CUDA pipeline occupancy
+  int totalLatency{0};    // max end-to-end latency across all ops
 };
 
 /// Info extracted from inner loop modulo scheduling.
 struct InnerLoopInfo {
   int II;
-  int prologueLatency;
-  int tripCount;
+  int prologueLatency; // cycles before TC starts
+  int tripCount;       // known or estimated trip count
   bool tripCountIsEstimated{true};
+  // Per-stage load (stage 0 = prologue ops, stage maxStage = epilogue ops)
   SmallVector<StageLoad, 4> stageLoads;
   int maxStage{0};
 };
@@ -71,6 +73,7 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
   info.II = result->II;
   info.maxStage = result->getMaxStage();
 
+  // Try to extract constant trip count from scf.for bounds.
   auto lb = innerLoop.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
   auto ub = innerLoop.getUpperBound().getDefiningOp<arith::ConstantIntOp>();
   auto step = innerLoop.getStep().getDefiningOp<arith::ConstantIntOp>();
@@ -82,6 +85,7 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
     }
   }
 
+  // Find the earliest TC cycle — that's where MMA starts (= prologueLatency)
   int tcStart = result->II;
   for (const auto &node : innerDDG.getNodes()) {
     if (node.pipeline == HWPipeline::TC) {
@@ -92,6 +96,7 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
   }
   info.prologueLatency = tcStart;
 
+  // Collect per-stage pipeline loads from the inner schedule.
   info.stageLoads.resize(info.maxStage + 1);
   for (const auto &node : innerDDG.getNodes()) {
     auto it = result->nodeToCycle.find(node.idx);
@@ -118,6 +123,19 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
     sl.totalLatency = std::max(sl.totalLatency, node.latency);
   }
 
+  LLVM_DEBUG(DBGS() << "Inner loop: II=" << info.II
+                    << " maxStage=" << info.maxStage
+                    << " prologueLat=" << info.prologueLatency
+                    << " tripCount=" << info.tripCount
+                    << (info.tripCountIsEstimated ? "(est)" : "(const)")
+                    << " stages=" << info.stageLoads.size() << "\n");
+  for (int s = 0; s <= info.maxStage; ++s) {
+    LLVM_DEBUG(DBGS() << "  stage " << s
+                      << ": MEM=" << info.stageLoads[s].memSelfLatency
+                      << " TC=" << info.stageLoads[s].tcSelfLatency
+                      << " CUDA=" << info.stageLoads[s].cudaSelfLatency
+                      << "\n");
+  }
   return info;
 }
 
@@ -148,14 +166,20 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   DataDependenceGraph ddg;
 
   // Phase 1: Create nodes for every op in the loop body (except terminator).
+  // Inner scf.for loops become super-nodes with latency = inner loop's II.
+  // scf.if ops are inspected: if they contain pipeline-relevant ops (TMA
+  // loads/stores), the scf.if node inherits the dominant pipeline/latency
+  // from its contents (e.g., conditional prefetch blocks).
   auto &body = loop.getBody()->getOperations();
   for (auto &op : body) {
     if (op.hasTrait<OpTrait::IsTerminator>())
       continue;
-    // Model inner scf.for as a super-node for outer loop scheduling.
+    // Handle inner scf.for as a super-node
     if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
       auto info = computeInnerLoopInfo(innerLoop, model);
 
+      // If inner loop is single-stage (already expanded or trivial),
+      // create a single super-node — no prologue/epilogue split needed.
       if (info.maxStage == 0) {
         unsigned idx = ddg.nodes.size();
         DDGNode node;
@@ -170,10 +194,35 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         node.prologueLatency = info.prologueLatency;
         ddg.nodes.push_back(node);
         ddg.opToIdx[&op] = idx;
+        LLVM_DEBUG(DBGS() << "Single-stage inner loop: N" << idx
+                         << " = super-node (TC, lat=" << node.latency
+                         << " II=" << info.II << ")\n");
         continue;
       }
 
-      // Multi-stage: split into prologue/kloop/epilogue.
+      // Multi-stage: split inner loop into 3 synthetic nodes in the outer DDG:
+      //   prologue: MEM loads (stage 0 ops) — runs once before steady state
+      //   kloop:    steady-state scf.for — TC+MEM interleaved, K iterations
+      //   epilogue: last MMA (highest stage ops) — drains after loop exits
+      //
+      // Only kloop is a super-node (still an scf.for). Prologue/epilogue
+      // are synthetic DDG nodes — they don't correspond to a real loop.
+
+      LLVM_DEBUG({
+        DBGS() << "Inner loop scheduled: II=" << info.II
+               << " maxStage=" << info.maxStage
+               << " tripCount=" << info.tripCount
+               << (info.tripCountIsEstimated ? "(est)" : "(const)") << "\n";
+        for (int s = 0; s <= info.maxStage; ++s) {
+          DBGS() << "  stage " << s
+                 << ": MEM=" << info.stageLoads[s].memSelfLatency
+                 << " TC=" << info.stageLoads[s].tcSelfLatency
+                 << " CUDA=" << info.stageLoads[s].cudaSelfLatency
+                 << " totalLat=" << info.stageLoads[s].totalLatency << "\n";
+        }
+      });
+
+      // --- Node 1: inner_prologue (MEM pipeline, synthetic) ---
       unsigned prologueIdx = ddg.nodes.size();
       {
         DDGNode node;
@@ -187,9 +236,14 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
                                ? kFallbackTMASelfLatency
                                : info.stageLoads[0].memSelfLatency;
         node.selfLatency = std::max(node.selfLatency, 1);
+        // NOT a super-node — synthetic prologue, no backing loop
         ddg.nodes.push_back(node);
+        LLVM_DEBUG(DBGS() << "Split inner loop: N" << prologueIdx
+                         << " = inner_prologue (MEM, lat=" << node.latency
+                         << " selfLat=" << node.selfLatency << ")\n");
       }
 
+      // --- Node 2: inner_kloop (TC pipeline, super-node) ---
       unsigned kloopIdx = ddg.nodes.size();
       {
         DDGNode node;
@@ -202,12 +256,17 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
                             ? info.stageLoads[info.maxStage].tcSelfLatency
                             : kFallbackMMALatency;
         node.selfLatency = std::max(steadyIters * tcPerIter, 1);
-        node.isSuperNode = true;
+        node.isSuperNode = true; // this IS the scf.for
         node.innerII = info.II;
         node.prologueLatency = info.prologueLatency;
         ddg.nodes.push_back(node);
+        LLVM_DEBUG(DBGS() << "Split inner loop: N" << kloopIdx
+                         << " = inner_kloop (TC, lat=" << node.latency
+                         << " selfLat=" << node.selfLatency
+                         << " steadyIters=" << steadyIters << ")\n");
       }
 
+      // --- Node 3: inner_epilogue (TC pipeline, synthetic) ---
       unsigned epilogueIdx = ddg.nodes.size();
       {
         DDGNode node;
@@ -219,7 +278,11 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
                         : kFallbackMMALatency;
         node.latency = std::max(tcLat, 1);
         node.selfLatency = std::max(tcLat, 1);
+        // NOT a super-node — synthetic epilogue
         ddg.nodes.push_back(node);
+        LLVM_DEBUG(DBGS() << "Split inner loop: N" << epilogueIdx
+                         << " = inner_epilogue (TC, lat=" << node.latency
+                         << " selfLat=" << node.selfLatency << ")\n");
       }
 
       ddg.opToIdx[&op] = epilogueIdx; // producer: results come from epilogue
@@ -232,9 +295,9 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       continue;
     }
     // Handle scf.if: walk regions to find pipeline-relevant ops.
-    // Persistent kernels put TMA loads inside conditional prefetch blocks
-    // (scf.if i < num_iter). Without this, those ops are invisible to
-    // the scheduler.
+    // TLX kernels put TMA loads inside conditional prefetch blocks
+    // (scf.if i < num_iter). Without this, those ops are invisible
+    // to the scheduler and the loop gets a trivial single-stage schedule.
     if (isa<scf::IfOp>(op)) {
       HWPipeline bestPipeline = HWPipeline::NONE;
       int bestLatency = 0;
@@ -260,6 +323,9 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         node.selfLatency = bestSelfLatency;
         ddg.nodes.push_back(node);
         ddg.opToIdx[&op] = idx;
+        LLVM_DEBUG(DBGS() << "scf.if node " << idx
+                          << ": pipeline=" << getPipelineName(bestPipeline)
+                          << " latency=" << bestLatency << "\n");
         continue;
       }
     }
@@ -291,13 +357,20 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   }
 
   // Phase 2.5: Implicit MEM-load → TC/super-node edges.
-  // In persistent kernels using lowered TMA (async_tma_copy), the MEM→TC
-  // dependency goes through SMEM buffers and barriers, not SSA. Without
-  // these edges the scheduler places MEM and TC at the same cycle.
+  // TMA loads write to SMEM buffers consumed by MMA ops. This producer-consumer
+  // relationship isn't visible in SSA (they communicate through barriers and
+  // shared memory). Without these edges, the scheduler places MEM and TC at the
+  // same cycle, missing the opportunity for multi-stage pipelining where MEM
+  // ops run ahead to prefetch data for future iterations.
+  // NOTE: Only MEM *load* ops get implicit edges to TC. MEM *store* ops
+  // (descriptor_store) consume the K-loop result — adding store→TC edges
+  // creates false cycles (store → super-node → ... → store).
   {
     SmallVector<unsigned> memLoadNodes, tcNodes;
     for (const auto &node : ddg.nodes) {
       if (node.pipeline == HWPipeline::MEM) {
+        // Only loads, not stores. For scf.if nodes, check if the
+        // contained op is a store.
         bool isStore = isa<triton::DescriptorStoreOp>(node.op) ||
                        isa<ttng::AsyncTMACopyLocalToGlobalOp>(node.op);
         if (!isStore && isa<scf::IfOp>(node.op)) {
@@ -315,6 +388,7 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
     }
     for (unsigned memIdx : memLoadNodes) {
       for (unsigned tcIdx : tcNodes) {
+        // Skip if an SSA edge already exists (avoid duplicates).
         bool hasEdge = false;
         for (const auto &e : ddg.edges) {
           if (e.srcIdx == memIdx && e.dstIdx == tcIdx) {
@@ -325,6 +399,9 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         if (!hasEdge) {
           ddg.addEdge(memIdx, tcIdx, ddg.nodes[memIdx].latency,
                       /*distance=*/0);
+          LLVM_DEBUG(DBGS() << "Implicit edge: MEM node " << memIdx
+                            << " -> TC node " << tcIdx << " (latency="
+                            << ddg.nodes[memIdx].latency << ")\n");
         }
       }
     }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloExpandPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloExpandPass.cpp
@@ -1,0 +1,227 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Loop Expansion Pass (Phase 2 + Phase 3 combined)
+//
+// This pass takes the modulo-scheduled loop (with loop.stage attrs from
+// ModuloSchedulePass) and performs the full software pipelining
+// transformation:
+//   1. lowerLoops() — transform loads into async copies, insert barriers,
+//      allocate multi-buffered SMEM/TMEM (same as existing Pipeline pass)
+//   2. expandLoops() — generate prologue/kernel/epilogue via PipelineExpander
+//
+// The key difference from the standard Pipeline pass is that our schedule
+// comes from Rau's iterative modulo scheduling (Phase 0) rather than
+// the heuristic-based assign_latencies + schedule_loops.
+//
+// NOTE: lowerLoops() processes ALL loops in the module, not just
+// modulo-scheduled ones. When integrating with the standard Pipeline pass,
+// ensure they don't both run lowerLoops() on the same module.
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-expand"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+
+namespace {
+
+/// Check if the loop has MMAv5 waits in its last stage — if so, we need
+/// custom epilogue peeling (same logic as SoftwarePipeliner.cpp).
+static bool hasMMAv5WaitsInLastStage(scf::ForOp forOp,
+                                     triton::CoarseSchedule &schedule) {
+  int maxStage = schedule.getNumStages() - 1;
+  bool hasMMAv5 = false;
+  bool hasWaitInLastStage = false;
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    if (isa<ttng::WaitBarrierOp>(op) && schedule[&op].first == maxStage)
+      hasWaitInLastStage = true;
+    if (isa<ttng::MMAv5OpInterface>(op))
+      hasMMAv5 = true;
+  }
+  return hasMMAv5 && hasWaitInLastStage;
+}
+
+/// Replicate the expandLoops() logic from SoftwarePipeliner.cpp.
+/// Deserializes the schedule, calls pipelineForLoop(), handles epilogue
+/// peeling for MMAv5 loops.
+static void moduloExpandLoops(ModuleOp moduleOp) {
+  DenseSet<ttg::MaskOp> peeledMaskOps;
+  auto processPeeledEpilogueOp = [&](RewriterBase &rewriter, Operation *op,
+                                     bool isEpilogue) -> Operation * {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    if (auto predOp = dyn_cast<ttg::PredicateStageOp>(op)) {
+      if (isEpilogue) {
+        return mlir::arith::ConstantIntOp::create(
+            rewriter, predOp.getLoc(), predOp.getResult().getType(), 0);
+      }
+      if (predOp.getStage() == predOp.getMaxStage() - 1) {
+        return mlir::arith::ConstantIntOp::create(
+            rewriter, predOp.getLoc(), predOp.getResult().getType(), 1);
+      }
+      return triton::emitPredicateForStage(
+                 rewriter, predOp.getIv(), predOp.getUb(), predOp.getStep(),
+                 predOp.getMaxStage(), predOp.getStage())
+          .getDefiningOp();
+    }
+    if (auto maskOp = dyn_cast<ttg::MaskOp>(op)) {
+      if (isEpilogue)
+        peeledMaskOps.insert(maskOp);
+    }
+    return op;
+  };
+
+  // Collect loops with their nesting depth. We must expand inner loops first
+  // (bottom-up) so that after inner expansion, the inner loop is a "black box"
+  // for outer expansion. moduleOp->walk uses pre-order (outer before inner),
+  // so we explicitly sort by descending depth.
+  SmallVector<std::pair<scf::ForOp, unsigned>> loopsWithDepth;
+  moduleOp->walk([&](scf::ForOp forOp) {
+    unsigned depth = 0;
+    for (auto *parent = forOp->getParentOp(); parent;
+         parent = parent->getParentOp()) {
+      if (isa<scf::ForOp>(parent))
+        ++depth;
+    }
+    loopsWithDepth.push_back({forOp, depth});
+  });
+  // Sort by descending depth — innermost loops first.
+  llvm::sort(loopsWithDepth,
+             [](const auto &a, const auto &b) { return a.second > b.second; });
+
+  for (auto &[forOp, depth] : loopsWithDepth) {
+    // Safety: inner loop expansion may have erased or replaced this op.
+    if (!forOp || !forOp->getBlock())
+      continue;
+
+    triton::CoarseSchedule schedule;
+    if (failed(schedule.deSerialize(forOp)))
+      continue;
+
+    // Skip loops with only 1 stage — no pipelining needed.
+    if (schedule.getNumStages() <= 1) {
+      LDBG("Skipping loop at depth " << depth << " with "
+                                     << schedule.getNumStages()
+                                     << " stage(s) — no expansion needed");
+      continue;
+    }
+
+    LDBG("Expanding loop at depth " << depth << " with "
+                                    << schedule.getNumStages() << " stages");
+
+    std::vector<std::pair<Operation *, unsigned>> finalSchedule =
+        schedule.createFinalSchedule(forOp);
+    triton::PipeliningOption options;
+    options.supportDynamicLoops = true;
+    options.peelEpilogue = false;
+    options.predicateFn = triton::wrapInMaskOp;
+    options.getScheduleFn =
+        [&](scf::ForOp, std::vector<std::pair<Operation *, unsigned>> &sched) {
+          sched = finalSchedule;
+        };
+
+    bool customEpiloguePeeling =
+        hasMMAv5WaitsInLastStage(forOp, schedule) &&
+        !forOp->getParentOfType<ttg::WarpSpecializeOp>();
+    if (customEpiloguePeeling) {
+      options.emitPredicateStageFn = [](RewriterBase &rewriter,
+                                        Value inductionVar, Value upperBound,
+                                        Value step, uint64_t maxStage,
+                                        uint64_t stage) {
+        return ttg::PredicateStageOp::create(rewriter, inductionVar.getLoc(),
+                                             inductionVar, upperBound, step,
+                                             maxStage, stage);
+      };
+    }
+
+    IRRewriter rewriter(forOp);
+    FailureOr<scf::ForOp> newForOp =
+        triton::pipelineForLoop(rewriter, forOp, options);
+
+    if (failed(newForOp)) {
+      LDBG("pipelineForLoop FAILED for a loop");
+      continue;
+    }
+    forOp = *newForOp;
+    if (customEpiloguePeeling)
+      triton::peelLoopEpilogue(forOp, processPeeledEpilogueOp);
+
+    // Prune statically dead mask ops in the epilogue. When the predicate is
+    // constant false, replace the mask op's results with poison values and
+    // erase it. This matches SoftwarePipeliner.cpp's post-peeling cleanup.
+    for (auto maskOp : peeledMaskOps) {
+      rewriter.setInsertionPoint(maskOp);
+      if (isConstantIntValue(maskOp.getPred(), 0)) {
+        SmallVector<Value> results;
+        for (auto result : maskOp->getResults()) {
+          auto poisonOp = mlir::ub::PoisonOp::create(rewriter, maskOp->getLoc(),
+                                                     result.getType());
+          results.push_back(poisonOp);
+        }
+        maskOp->replaceAllUsesWith(results);
+        maskOp->erase();
+      }
+    }
+    peeledMaskOps.clear();
+  }
+
+  assert(moduleOp.getOps<ttg::PredicateStageOp>().empty() &&
+         "PredicateStageOp should be resolved after pipeline expansion");
+  LLVM_DEBUG({
+    if (failed(verify(moduleOp)))
+      DBGS() << "WARNING: IR verification failed after expansion\n";
+  });
+  triton::resolveMaskOp(moduleOp);
+}
+
+struct ModuloExpandPass
+    : public PassWrapper<ModuloExpandPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloExpandPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-expand"; }
+
+  StringRef getDescription() const override {
+    return "Modulo loop expansion (lowerLoops + pipelineForLoop)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    LDBG("=== Phase 2+3: Loop Expansion ===");
+
+    LDBG("Step 1: lowerLoops");
+    triton::gpu::lowerLoops(moduleOp);
+
+    LDBG("Step 2: expandLoops");
+    moduloExpandLoops(moduleOp);
+
+    LDBG("Expansion complete");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloExpand() {
+  return std::make_unique<ModuloExpandPass>();
+}
+
+void registerNVGPUModuloExpand() { PassRegistration<ModuloExpandPass>(); }
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloLowerPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloLowerPass.cpp
@@ -1,0 +1,103 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Lowering Pass (post-expansion cleanup)
+//
+// Runs after ModuloExpandPass. Performs the same post-expansion steps
+// as the standard PipelinePass:
+//   1. removePipeliningAttributes — strip loop.stage/loop.cluster attrs
+//   2. asyncLaunchDots — pipeline wgmma ops (mark async, insert waits)
+//   3. updateWaits — adjust AsyncWaitOp pending counts
+//   4. pipelineTMAStores — pipeline TMA store operations
+//   5. arith canonicalization — clean up arithmetic
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-lower"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = triton;
+
+namespace {
+
+struct ModuloLowerPass
+    : public PassWrapper<ModuloLowerPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloLowerPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-lower"; }
+
+  StringRef getDescription() const override {
+    return "Post-expansion cleanup (asyncLaunchDots, updateWaits, TMA stores)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    LDBG("=== Post-expansion cleanup ===");
+
+    // Step 1: Remove pipelining attributes (loop.stage, loop.cluster, etc.)
+    LDBG("Step 1: removePipeliningAttributes");
+    tt::removePipeliningAttributes(moduleOp);
+
+    // Verify all loop.stage attrs were consumed and removed.
+    LLVM_DEBUG({
+      bool hasStaleAttrs = false;
+      moduleOp->walk([&](Operation *op) {
+        if (op->hasAttr(tt::kLoopStageAttrName)) {
+          hasStaleAttrs = true;
+          DBGS() << "WARNING: stale loop.stage on: " << *op << "\n";
+        }
+      });
+      if (hasStaleAttrs)
+        DBGS() << "WARNING: loop.stage attributes remain after "
+               << "removePipeliningAttributes\n";
+    });
+
+    // Step 2: Pipeline wgmma ops — mark dots as async, insert waits.
+    LDBG("Step 2: asyncLaunchDots");
+    SmallVector<scf::ForOp> loops;
+    moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      tt::asyncLaunchDots(forOp);
+
+    // Step 3: Update wait ops with correct pending counts.
+    LDBG("Step 3: updateWaits");
+    tt::updateWaits(moduleOp);
+
+    // Step 4: Canonicalize arith to simplify index arithmetic from expansion.
+    auto *arithDialect =
+        moduleOp.getContext()->getLoadedDialect<arith::ArithDialect>();
+    RewritePatternSet patterns(moduleOp.getContext());
+    arithDialect->getCanonicalizationPatterns(patterns);
+    if (applyPatternsGreedily(moduleOp, std::move(patterns)).failed())
+      return signalPassFailure();
+
+    // Step 5: Pipeline TMA stores.
+    LDBG("Step 5: pipelineTMAStores");
+    loops.clear();
+    moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      tt::pipelineTMAStores(forOp);
+
+    LDBG("Post-expansion cleanup complete");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloLower() {
+  return std::make_unique<ModuloLowerPass>();
+}
+
+void registerNVGPUModuloLower() { PassRegistration<ModuloLowerPass>(); }
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
@@ -55,8 +55,8 @@ static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
     if (!innerName.empty())
       os << "(" << innerName << ")";
   }
-  os << "  {pipe: " << getPipelineName(node.pipeline) << ", cycle: "
-     << node.cycle;
+  os << "  {pipe: " << getPipelineName(node.pipeline)
+     << ", cycle: " << node.cycle;
   if (node.latency)
     os << ", latency: " << node.latency;
   if (node.selfLatency)
@@ -70,8 +70,7 @@ static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
   os << "}\n";
 }
 
-static void dumpPort(const PipelineLoop::MemPort &port,
-                     llvm::raw_ostream &os) {
+static void dumpPort(const PipelineLoop::MemPort &port, llvm::raw_ostream &os) {
   if (!port.op) {
     if (port.bufferId != UINT_MAX)
       os << "buf" << port.bufferId;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
@@ -40,12 +40,12 @@ enum class MemoryKind { SMEM, TMEM, Register, BARRIER };
 struct PipelineBuffer {
   unsigned id{};
   MemoryKind kind{MemoryKind::SMEM};
-  llvm::SmallVector<int64_t, 4> shape;  // e.g., {128, 64}
-  unsigned elementBitWidth{16};       // e.g., 16 for f16
-  unsigned count{1};                  // number of buffers (from stageDiff + 1)
+  llvm::SmallVector<int64_t, 4> shape; // e.g., {128, 64}
+  unsigned elementBitWidth{16};        // e.g., 16 for f16
+  unsigned count{1};                   // number of buffers (from stageDiff + 1)
 
-  // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if none)
-  // For barrier buffers: index of the data buffer this barrier guards
+  // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if
+  // none) For barrier buffers: index of the data buffer this barrier guards
   unsigned pairedBufferId{UINT_MAX};
 
   // The MLIR op that originally defines this buffer (e.g., local_alloc)
@@ -72,17 +72,17 @@ struct PipelineNode {
 
   // Schedule assignment (from Phase 0)
   HWPipeline pipeline{HWPipeline::NONE};
-  int cycle{0};          // absolute cycle within the II
-  int stage{0};          // cycle / II
-  int latency{0};        // cycles until result available
-  int selfLatency{0};    // cycles this op occupies its pipeline
+  int cycle{0};       // absolute cycle within the II
+  int stage{0};       // cycle / II
+  int latency{0};     // cycles until result available
+  int selfLatency{0}; // cycles this op occupies its pipeline
 
   // Super-node: if this node represents a child pipeline (inner loop)
   unsigned childPipelineId{UINT_MAX}; // index into PipelineGraph::pipelines
   int prologueLatency{0};             // cycles before TC starts in child
 
   // Buffer references
-  unsigned producesBuffer{UINT_MAX};  // index into PipelineLoop::buffers
+  unsigned producesBuffer{UINT_MAX}; // index into PipelineLoop::buffers
   llvm::SmallVector<unsigned, 2> consumesBuffers; // indices into buffers
 
   // Warp specialization (from Phase 1.5)
@@ -120,8 +120,9 @@ struct PipelineLoop {
   int II{0};
   int maxStage{0};
   int prologueLatency{0}; // cycles before TC starts (for parent's super-node)
-  int tripCount{0};        // loop trip count (0 = unknown/not set)
-  bool tripCountIsEstimated{false}; // true if tripCount is estimated, not constant
+  int tripCount{0};       // loop trip count (0 = unknown/not set)
+  bool tripCountIsEstimated{
+      false}; // true if tripCount is estimated, not constant
 
   // Body (kernel loop steady state)
   llvm::SmallVector<PipelineNode, 16> nodes;
@@ -137,9 +138,10 @@ struct PipelineLoop {
   // Memory interface (inputs/outputs crossing loop boundary)
   // These drive multi-buffering at the parent level.
   //
-  // isInput is intentionally kept alongside the separate inputs/outputs vectors:
-  // it allows generic iteration over all ports (e.g., when building the parent's
-  // buffer map) without needing to know which vector a port came from.
+  // isInput is intentionally kept alongside the separate inputs/outputs
+  // vectors: it allows generic iteration over all ports (e.g., when building
+  // the parent's buffer map) without needing to know which vector a port came
+  // from.
   struct MemPort {
     unsigned bufferId{UINT_MAX}; // index into parent's buffers
     Operation *op{nullptr};      // the MLIR op at the boundary

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
@@ -1,13 +1,16 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// Pass B: Schedule Integration (Warp Specialization Reconstruction)
+// Pass B: Schedule Integration + Modulo Partition Scheduling
 //
-// Configures IR attributes so downstream passes (schedule_loops,
-// warp_specialize, pipeline) use the modulo schedule from Pass A.
-//
-// Buffer depths (tt.num_buffers) are already computed by Pass A (Steps 3-4.5).
-// This pass reads them and sets tt.num_stages, tt.scheduled_max_stage,
-// and strips tt.latency attrs for WS loops.
+// Two responsibilities:
+// 1. Configure IR attributes so downstream passes use the modulo schedule.
+// 2. Assign WS partitions (ttg.partition) using DDG pipe classification
+//    and utilization analysis. Supports nested loops via bottom-up traversal.
+//    Replaces PartitionScheduling for modulo-scheduled kernels.
+
+#include "DataDependenceGraph.h"
+#include "LatencyModel.h"
+#include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -15,6 +18,7 @@
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/Support/Debug.h"
@@ -29,6 +33,283 @@ namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
 
 namespace {
+
+// ============================================================================
+// Modulo Partition Scheduling — utilization-driven warp group assignment
+// ============================================================================
+
+// Pipelines with utilization > this threshold get dedicated warp groups.
+// 30% is chosen empirically: below this, the pipeline is idle most of the
+// time and doesn't benefit from a dedicated warp group.
+constexpr double kUtilizationThreshold = 0.3;
+
+/// Partition a loop's ops into warp groups based on DDG pipe classification.
+/// Returns number of partitions created, or 0 if not applicable.
+static int partitionLoopByUtilization(scf::ForOp loop,
+                                       const ttg::LatencyModel &model,
+                                       bool isWSLoop = false) {
+  // Read II from tt.modulo_ii if already set by Pass A, otherwise
+  // build DDG and schedule to compute it.
+  int II = 0;
+  if (auto iiAttr = loop->getAttrOfType<IntegerAttr>("tt.modulo_ii"))
+    II = iiAttr.getInt();
+
+  auto ddg = ttg::DataDependenceGraph::build(loop, model);
+  if (II <= 0) {
+    auto schedResult = ttg::runModuloScheduling(ddg);
+    if (failed(schedResult))
+      return 0;
+    II = schedResult->II;
+  }
+  if (II <= 0)
+    return 0;
+
+  LDBG("Building partition for loop with "
+       << std::distance(loop.getBody()->begin(), loop.getBody()->end())
+       << " ops, II=" << II);
+
+  // Compute per-pipeline utilization.
+  llvm::DenseMap<ttg::HWPipeline, int> pipeLoad;
+  for (const auto &node : ddg.getNodes()) {
+    if (node.pipeline == ttg::HWPipeline::NONE)
+      continue;
+    pipeLoad[node.pipeline] += node.selfLatency;
+  }
+
+  // Determine which pipelines get their own warp group.
+  SmallVector<ttg::HWPipeline> ownGroup;
+  SmallVector<ttg::HWPipeline> mergeGroup;
+  for (auto pipe : {ttg::HWPipeline::MEM, ttg::HWPipeline::TC,
+                    ttg::HWPipeline::CUDA, ttg::HWPipeline::SFU}) {
+    int load = pipeLoad.lookup(pipe);
+    if (load == 0)
+      continue;
+    double util = static_cast<double>(load) / II;
+    if (util > kUtilizationThreshold)
+      ownGroup.push_back(pipe);
+    else
+      mergeGroup.push_back(pipe);
+  }
+
+  // MEM always gets its own group (TMA producer needs dedicated warp).
+  // Remove from mergeGroup if it was placed there by the threshold check.
+  if (!llvm::is_contained(ownGroup, ttg::HWPipeline::MEM) &&
+      pipeLoad.lookup(ttg::HWPipeline::MEM) > 0) {
+    ownGroup.insert(ownGroup.begin(), ttg::HWPipeline::MEM);
+    llvm::erase(mergeGroup, ttg::HWPipeline::MEM);
+  }
+
+  if (ownGroup.size() < 2)
+    return 0; // Need at least 2 groups for WS.
+
+  // Build pipe → partition ID mapping.
+  llvm::DenseMap<ttg::HWPipeline, int> pipeToPartition;
+  int nextId = 0;
+  for (auto pipe : ownGroup)
+    pipeToPartition[pipe] = nextId++;
+  int defaultPartId = -1;
+  if (!mergeGroup.empty()) {
+    defaultPartId = nextId++;
+    for (auto pipe : mergeGroup)
+      pipeToPartition[pipe] = defaultPartId;
+  }
+  int numPartitions = nextId;
+
+  // All-partitions list for shared/scalar ops.
+  SmallVector<int> allParts;
+  for (int i = 0; i < numPartitions; i++)
+    allParts.push_back(i);
+
+  LLVM_DEBUG({
+    DBGS() << numPartitions << " groups (II=" << II << "): ";
+    for (auto pipe : ownGroup)
+      llvm::dbgs() << ttg::getPipelineName(pipe) << "="
+                   << pipeToPartition[pipe] << " ";
+    if (!mergeGroup.empty())
+      llvm::dbgs() << "default=" << defaultPartId;
+    llvm::dbgs() << "\n";
+  });
+
+  // Step 1: Seed assignment — DDG-classified ops get their specific partition.
+  // Skip ops with regions (scf.for, scf.if) — their child ops may get different
+  // partitions, and the verifier requires parent partitions to be a superset of
+  // all children. These ops get allParts in Step 3 instead.
+  llvm::DenseMap<Operation *, int> opPartitionMap;
+  for (const auto &node : ddg.getNodes()) {
+    if (node.op->getNumRegions() > 0)
+      continue; // Skip ForOps, IfOps — handled later.
+    auto it = pipeToPartition.find(node.pipeline);
+    if (it != pipeToPartition.end()) {
+      opPartitionMap[node.op] = it->second;
+      ttg::setPartition(node.op, ArrayRef<int>{it->second});
+    }
+  }
+
+  // Step 2: Propagate partitions through use-def chains.
+  // For unassigned ops, inherit partition from users (demand-driven).
+  // Iterate until convergence.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (isa<scf::ForOp>(op) || opPartitionMap.count(&op))
+        continue;
+      // Collect partitions from all users within this loop body.
+      SetVector<int> userParts;
+      for (auto *user : op.getUsers()) {
+        // Find the ancestor op in the loop body block.
+        Operation *ancestor = loop.getBody()->findAncestorOpInBlock(*user);
+        if (!ancestor)
+          continue;
+        auto uit = opPartitionMap.find(ancestor);
+        if (uit != opPartitionMap.end())
+          userParts.insert(uit->second);
+      }
+      if (userParts.size() == 1) {
+        int part = *userParts.begin();
+        opPartitionMap[&op] = part;
+        ttg::setPartition(&op, ArrayRef<int>{part});
+        changed = true;
+      }
+    }
+  }
+
+  // Step 2.5: TMEM consistency — TMEMStoreOp and TMEMLoadOp sharing a
+  // TMEMAllocOp must be in the same partition. PartitionScheduling asserts this.
+  loop.walk([&](ttng::TMEMAllocOp allocOp) {
+    std::optional<int> simtPartition;
+    for (auto *user : allocOp->getUsers()) {
+      if (isa<ttng::TMEMLoadOp>(user)) {
+        auto uit = opPartitionMap.find(user);
+        if (uit != opPartitionMap.end())
+          simtPartition = uit->second;
+      }
+    }
+    if (!simtPartition) {
+      for (auto *user : allocOp->getUsers()) {
+        if (isa<ttng::TMEMStoreOp>(user)) {
+          auto uit = opPartitionMap.find(user);
+          if (uit != opPartitionMap.end())
+            simtPartition = uit->second;
+        }
+      }
+    }
+    if (!simtPartition)
+      return WalkResult::advance();
+    for (auto *user : allocOp->getUsers()) {
+      if (isa<ttng::TMEMStoreOp, ttng::TMEMLoadOp>(user)) {
+        opPartitionMap[user] = *simtPartition;
+        ttg::setPartition(user, ArrayRef<int>{*simtPartition});
+      }
+    }
+    return WalkResult::advance();
+  });
+
+  // Step 3: Remaining unassigned ops → allParts. Walk recursively to cover
+  // ops inside scf.if regions (flattened persistent kernels have tile-boundary
+  // conditionals). Skip inner ForOps (handled by inner loop processing).
+  loop.walk([&](Operation *op) {
+    if (isa<scf::ForOp>(op) && op != loop.getOperation())
+      return WalkResult::skip(); // Don't recurse into inner ForOps.
+    if (!ttg::hasPartition(op))
+      ttg::setPartition(op, allParts);
+    return WalkResult::advance();
+  });
+
+  // Inner ForOps: set partition on the ForOp itself via raw setAttr (don't
+  // propagate to region terminators — body ops are handled by inner loop
+  // processing). The ForOp gets allParts since both MEM and TC run inside it.
+  Builder b(loop.getContext());
+  {
+    auto sorted = llvm::to_vector(allParts);
+    llvm::sort(sorted);
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (isa<scf::ForOp>(op))
+        op.setAttr(ttg::kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
+    }
+  }
+
+  // Set ttg.partition on the WS loop itself (required by verifier if
+  // ttg.partition.outputs is set). Use raw setAttr to avoid propagating.
+  if (isWSLoop) {
+    auto sorted = llvm::to_vector(allParts);
+    llvm::sort(sorted);
+    loop->setAttr(ttg::kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
+  }
+
+  // Yield → all partitions.
+  ttg::setPartition(cast<scf::YieldOp>(loop.getBody()->getTerminator()),
+                    allParts);
+
+  // Only serialize WS metadata on the actual WS loop (not inner K-loops).
+  // PartitionSet::fromLoop reads these attrs and will get confused if inner
+  // loops have them too.
+  if (isWSLoop) {
+    Builder b(loop.getContext());
+    SmallVector<Attribute> stages;
+    for (int i = 0; i < numPartitions; i++) {
+      int stage = 0;
+      // TC partition gets stage 1 (consumer, pipelined after MEM producer).
+      for (auto pipe : ownGroup)
+        if (pipeToPartition[pipe] == i && pipe == ttg::HWPipeline::TC)
+          stage = 1;
+      stages.push_back(b.getI32IntegerAttr(stage));
+    }
+    loop->setAttr(ttg::kPartitionStagesAttrName, b.getArrayAttr(stages));
+    ttg::setWarpSpecializeTag(loop, 0);
+
+    // Set partition outputs — for now all results go to all partitions.
+    SmallVector<SetVector<int>> outputParts;
+    for (unsigned i = 0; i < loop.getNumResults(); i++) {
+      SetVector<int> ids;
+      for (int p : allParts)
+        ids.insert(p);
+      outputParts.push_back(ids);
+    }
+    ttg::setPartitionOutputs(loop, outputParts);
+  }
+
+  return numPartitions;
+}
+
+/// Bottom-up partition scheduling for nested WS loops.
+/// Inner loops are partitioned first with specific per-op partitions,
+/// then the outer WS loop. For flattened loops (no inner loops), skip
+/// partition assignment and let PartitionScheduling handle it.
+static void moduloPartitionScheduling(scf::ForOp wsLoop,
+                                       const ttg::LatencyModel &model) {
+  // Collect inner loops (deepest first).
+  SmallVector<scf::ForOp> innerLoops;
+  wsLoop.getBody()->walk([&](scf::ForOp inner) {
+    if (inner != wsLoop)
+      innerLoops.push_back(inner);
+  });
+
+  // Flattened case: no inner loops. The WS loop IS the only loop.
+  // Skip our partition assignment — PartitionScheduling's getInitialPartitions
+  // already handles flattened loops with DescriptorLoadOp/MMA pattern matching.
+  // Our contribution is the modulo schedule (loop.stage/loop.cluster).
+  if (innerLoops.empty()) {
+    LDBG("Flattened WS loop — skipping partition, using PartitionScheduling default");
+    return;
+  }
+
+  // Partition inner loops bottom-up.
+  for (auto inner : llvm::reverse(innerLoops)) {
+    int n = partitionLoopByUtilization(inner, model, /*isWSLoop=*/false);
+    if (n > 0)
+      LDBG("Inner loop: " << n << " groups");
+  }
+
+  // Partition the outer WS loop itself.
+  int n = partitionLoopByUtilization(wsLoop, model, /*isWSLoop=*/true);
+  if (n > 0)
+    LDBG("Outer WS loop: " << n << " groups");
+}
+
+// ============================================================================
+// processScheduledLoop — existing Pass B logic (schedule integration)
+// ============================================================================
 
 static void processScheduledLoop(scf::ForOp loop) {
   auto ctx = loop.getContext();
@@ -96,7 +377,15 @@ struct ModuloWSPartitionPass
 
   void runOnOperation() override {
     auto moduleOp = getOperation();
+    ttg::LatencyModel model;
 
+    // Step 1: Modulo partition scheduling for WS loops (bottom-up).
+    moduleOp.walk([&](scf::ForOp loop) {
+      if (loop->hasAttr(tt::kWarpSpecializeAttrName))
+        moduloPartitionScheduling(loop, model);
+    });
+
+    // Step 2: Schedule integration (existing Pass B logic).
     moduleOp.walk([&](scf::ForOp loop) {
       bool hasMMAv5 = false;
       bool hasTMALoad = false;


### PR DESCRIPTION
Summary:

Prevent downstream passes from overwriting the modulo schedule's
stage/cluster assignments. Three changes:

**ScheduleLoops skip**: When any loop in the module has tt.modulo_ii
(set by Pass A), skip ALL loops in scheduleLoops() — not just the
annotated loop. This is necessary because the WS pass's internal
PartitionLoops creates partition loops inside warp_specialize that
don't inherit tt.modulo_ii from the original loop. Without the
module-wide skip, these partition loops get re-scheduled by the
upstream heuristic, overwriting our cycle-based stage assignments.

**SoftwarePipeliner skip**: Skip loops with tt.modulo_ii in the
pipeline expander (expandLoops). The modulo schedule's loop.stage
attrs drive the expansion — re-deserializing and re-expanding would
produce incorrect prologue/epilogue structure since the expander
doesn't understand the modulo schedule's cross-iteration semantics.

**DataDependenceGraph update**: Final version with improved inner
loop super-node handling (3-way split into prologue/kloop/epilogue
for multi-stage inner loops), scf.if conditional prefetch support
(persistent kernels wrap TMA loads in conditional blocks), and
implicit MEM→TC edge insertion for lowered TMA paths where the
producer-consumer dependency goes through SMEM barriers rather than
SSA def-use chains.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D100189224
