### PR TITLE
[AutoWS] Add Modulo Reservation Table (MRT) (#1224)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/WSTaskPartition.cpp
   WarpSpecialization/PartitionSchedulingMeta.cpp
   ModuloScheduling/LatencyModel.cpp
+  ModuloScheduling/DataDependenceGraph.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/PartitionSchedulingMeta.cpp
   ModuloScheduling/LatencyModel.cpp
   ModuloScheduling/DataDependenceGraph.cpp
+  ModuloScheduling/ModuloReservationTable.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/WSTaskIdPropagate.cpp
   WarpSpecialization/WSTaskPartition.cpp
   WarpSpecialization/PartitionSchedulingMeta.cpp
+  ModuloScheduling/LatencyModel.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -1,0 +1,284 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "DataDependenceGraph.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <cmath>
+#include <queue>
+
+#define DEBUG_TYPE "modulo-scheduling-ddg"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+namespace mlir::triton::gpu {
+
+namespace ttng = mlir::triton::nvidia_gpu;
+
+
+unsigned DataDependenceGraph::addNode(Operation *op,
+                                      const LatencyModel &model) {
+  auto info = model.getLatency(op);
+  unsigned idx = nodes.size();
+  DDGNode node;
+  node.op = op;
+  node.idx = idx;
+  node.pipeline = info.pipeline;
+  node.latency = info.latency;
+  node.selfLatency = info.selfLatency;
+  nodes.push_back(node);
+  opToIdx[op] = idx;
+  return idx;
+}
+
+void DataDependenceGraph::addEdge(unsigned src, unsigned dst, int latency,
+                                  unsigned distance) {
+  edges.push_back(DDGEdge{src, dst, latency, distance});
+  nodes[src].succs.push_back(dst);
+  nodes[dst].preds.push_back(src);
+}
+
+DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
+                                               const LatencyModel &model) {
+  DataDependenceGraph ddg;
+
+  // Phase 1: Create nodes for every op in the loop body (except terminator).
+  auto &body = loop.getBody()->getOperations();
+  for (auto &op : body) {
+    if (op.hasTrait<OpTrait::IsTerminator>())
+      continue;
+    // Skip inner scf.for loops — this DDG handles flat loop bodies only.
+    // Inner loop super-node modeling is added in a follow-up diff for
+    // outer loop (persistent kernel) scheduling.
+    if (isa<scf::ForOp>(op))
+      continue;
+    ddg.addNode(&op, model);
+  }
+
+  // Phase 2: Intra-iteration edges from SSA def-use chains.
+  for (auto &node : ddg.nodes) {
+    for (auto operand : node.op->getOperands()) {
+      auto *defOp = operand.getDefiningOp();
+      if (!defOp || defOp->getNumResults() == 0)
+        continue;
+      auto it = ddg.opToIdx.find(defOp);
+      if (it == ddg.opToIdx.end())
+        continue;
+      unsigned srcIdx = it->second;
+      // Edge latency = producer's latency (time until result available).
+      // Exception: for MEM → local_alloc edges, use selfLatency instead of
+      // the full async latency. local_alloc is a format conversion (registers
+      // → SMEM) that must stay at the same pipeline stage as its load.
+      // The async overhead only applies to the MMA consumer, not local_alloc.
+      int edgeLatency = ddg.nodes[srcIdx].latency;
+      if (ddg.nodes[srcIdx].pipeline == HWPipeline::MEM &&
+          isa<triton::gpu::LocalAllocOp>(node.op)) {
+        edgeLatency = ddg.nodes[srcIdx].selfLatency;
+      }
+      ddg.addEdge(srcIdx, node.idx, edgeLatency, /*distance=*/0);
+    }
+  }
+
+  // Phase 3: Loop-carried edges via scf.yield → iter_args.
+  auto yieldOp = loop.getBody()->getTerminator();
+  auto iterArgs = loop.getRegionIterArgs();
+  for (unsigned i = 0; i < yieldOp->getNumOperands(); ++i) {
+    auto yieldVal = yieldOp->getOperand(i);
+    auto *yieldDef = yieldVal.getDefiningOp();
+    if (!yieldDef || yieldDef->getNumResults() == 0 ||
+        ddg.opToIdx.count(yieldDef) == 0)
+      continue;
+    unsigned srcIdx = ddg.opToIdx[yieldDef];
+
+    // The iter_arg at position i receives yieldVal in the next iteration.
+    // Find all users of that iter_arg within the loop body.
+    if (i >= iterArgs.size())
+      continue;
+    auto iterArg = iterArgs[i];
+    for (auto *user : iterArg.getUsers()) {
+      if (user->hasTrait<OpTrait::IsTerminator>())
+        continue;
+      auto userIt = ddg.opToIdx.find(user);
+      if (userIt == ddg.opToIdx.end())
+        continue;
+      ddg.addEdge(srcIdx, userIt->second, ddg.nodes[srcIdx].latency,
+                  /*distance=*/1);
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "[DDG] Built DDG with " << ddg.nodes.size() << " nodes, "
+                 << ddg.edges.size() << " edges\n";
+    ddg.dump();
+  });
+
+  return ddg;
+}
+
+llvm::SmallVector<const DDGEdge *>
+DataDependenceGraph::getInEdges(unsigned nodeIdx) const {
+  llvm::SmallVector<const DDGEdge *> result;
+  for (const auto &e : edges)
+    if (e.dstIdx == nodeIdx)
+      result.push_back(&e);
+  return result;
+}
+
+llvm::SmallVector<const DDGEdge *>
+DataDependenceGraph::getOutEdges(unsigned nodeIdx) const {
+  llvm::SmallVector<const DDGEdge *> result;
+  for (const auto &e : edges)
+    if (e.srcIdx == nodeIdx)
+      result.push_back(&e);
+  return result;
+}
+
+llvm::DenseMap<unsigned, int>
+DataDependenceGraph::computeCriticalPathHeights() const {
+  llvm::DenseMap<unsigned, int> heights;
+  llvm::DenseSet<unsigned> visiting; // cycle detection
+  // Reverse topological order: process sinks first.
+  // Use DFS-based approach since graph is small.
+  std::function<int(unsigned)> computeHeight = [&](unsigned idx) -> int {
+    auto it = heights.find(idx);
+    if (it != heights.end())
+      return it->second;
+    // Guard against cycles in distance-0 edges. DDG construction guarantees
+    // acyclicity, but this prevents infinite recursion if invariant is broken.
+    if (!visiting.insert(idx).second)
+      return 0;
+    int maxSuccHeight = 0;
+    for (const auto *edge : getOutEdges(idx)) {
+      if (edge->distance > 0)
+        continue; // skip loop-carried for critical path
+      int succHeight = computeHeight(edge->dstIdx);
+      maxSuccHeight = std::max(maxSuccHeight, edge->latency + succHeight);
+    }
+    visiting.erase(idx);
+    heights[idx] = maxSuccHeight;
+    return maxSuccHeight;
+  };
+  for (unsigned i = 0; i < nodes.size(); ++i)
+    computeHeight(i);
+  return heights;
+}
+
+int DataDependenceGraph::computeResMII() const {
+  llvm::DenseMap<HWPipeline, int> pipeLoad;
+  for (const auto &node : nodes) {
+    if (node.pipeline == HWPipeline::NONE)
+      continue;
+    pipeLoad[node.pipeline] += node.selfLatency;
+  }
+  int maxLoad = 0;
+  for (auto &[pipe, load] : pipeLoad) {
+    LLVM_DEBUG(llvm::dbgs() << "[DDG] Pipeline " << getPipelineName(pipe)
+                            << " load: " << load << " cycles\n");
+    maxLoad = std::max(maxLoad, load);
+  }
+  return maxLoad;
+}
+
+int DataDependenceGraph::computeRecMII() const {
+  // Compute RecMII = max over all recurrence circuits of ceil(sum_lat /
+  // sum_dist).
+  //
+  // For each back-edge (distance > 0), find the longest forward path from
+  // dst back to src. The recurrence latency = forward_path + back_edge_latency,
+  // and distance = forward_distance + back_edge_distance. RecMII for that
+  // circuit = ceil(total_lat / total_dist).
+  //
+  // We use Floyd-Warshall to compute longest forward paths (distance=0 edges
+  // only), then combine with each back-edge.
+  const unsigned N = nodes.size();
+  if (N == 0)
+    return 0;
+
+  // Forward-path longest latencies (only distance=0 edges).
+  constexpr int NEG_INF = -1;
+  std::vector<std::vector<int>> fwdLat(N, std::vector<int>(N, NEG_INF));
+
+  // Initialize with distance=0 edges only.
+  for (const auto &e : edges) {
+    if (e.distance == 0) {
+      fwdLat[e.srcIdx][e.dstIdx] =
+          std::max(fwdLat[e.srcIdx][e.dstIdx], e.latency);
+    }
+  }
+  // Self-loops with distance 0.
+  for (unsigned i = 0; i < N; ++i)
+    fwdLat[i][i] = std::max(fwdLat[i][i], 0);
+
+  // Floyd-Warshall on forward paths.
+  for (unsigned k = 0; k < N; ++k) {
+    for (unsigned i = 0; i < N; ++i) {
+      for (unsigned j = 0; j < N; ++j) {
+        if (fwdLat[i][k] == NEG_INF || fwdLat[k][j] == NEG_INF)
+          continue;
+        int newLat = fwdLat[i][k] + fwdLat[k][j];
+        if (newLat > fwdLat[i][j])
+          fwdLat[i][j] = newLat;
+      }
+    }
+  }
+
+  // For each back-edge, compute the recurrence ratio.
+  int recMII = 0;
+  for (const auto &e : edges) {
+    if (e.distance == 0)
+      continue;
+    // Back-edge: src → dst with distance > 0.
+    // Forward path: dst →...→ src (distance=0 edges).
+    // Total recurrence: forward_lat + back_edge_lat, total_dist = e.distance.
+    int forwardLat = fwdLat[e.dstIdx][e.srcIdx];
+    if (forwardLat == NEG_INF)
+      continue; // no forward path completes the circuit
+    int totalLat = forwardLat + e.latency;
+    int totalDist = e.distance;
+    int rec = (totalLat + totalDist - 1) / totalDist; // ceil
+    LLVM_DEBUG(llvm::dbgs() << "[DDG] Recurrence: back-edge " << e.srcIdx
+                            << " -> " << e.dstIdx << " (dist=" << e.distance
+                            << ") fwdLat=" << forwardLat << " totalLat="
+                            << totalLat << " RecMII=" << rec << "\n");
+    recMII = std::max(recMII, rec);
+  }
+  return recMII;
+}
+
+int DataDependenceGraph::computeMinII() const {
+  int resMII = computeResMII();
+  int recMII = computeRecMII();
+  int minII = std::max(resMII, recMII);
+  LLVM_DEBUG(llvm::dbgs() << "[DDG] ResMII=" << resMII << " RecMII=" << recMII
+                          << " MinII=" << minII << "\n");
+  return minII;
+}
+
+void DataDependenceGraph::dump() const {
+  llvm::dbgs() << "=== DDG Dump ===\n";
+  for (const auto &node : nodes) {
+    llvm::dbgs() << "  Node " << node.idx
+                 << ": pipeline=" << getPipelineName(node.pipeline)
+                 << " latency=" << node.latency
+                 << " selfLatency=" << node.selfLatency;
+    if (node.isSuperNode)
+      llvm::dbgs() << " [SUPER-NODE innerII=" << node.innerII << "]";
+    llvm::dbgs() << " op=";
+    node.op->print(llvm::dbgs(), OpPrintingFlags().skipRegions());
+    llvm::dbgs() << "\n";
+  }
+  for (const auto &edge : edges) {
+    llvm::dbgs() << "  Edge " << edge.srcIdx << " -> " << edge.dstIdx
+                 << " latency=" << edge.latency << " distance=" << edge.distance
+                 << "\n";
+  }
+  llvm::dbgs() << "=== End DDG ===\n";
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -1,0 +1,76 @@
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_DDG_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_DDG_H
+
+#include "LatencyModel.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::triton::gpu {
+
+struct DDGEdge {
+  unsigned srcIdx{};
+  unsigned dstIdx{};
+  int latency{};
+  unsigned distance{}; // 0 = intra-iteration, 1+ = loop-carried
+};
+
+struct DDGNode {
+  Operation *op{};
+  unsigned idx{};
+  HWPipeline pipeline{HWPipeline::NONE};
+  int latency{};
+  int selfLatency{};
+  bool isSuperNode{false}; // True if this node represents an inner loop
+  int innerII{0};           // If super-node, the inner loop's II
+  int prologueLatency{0};   // If super-node, cycles before TC starts (MEM busy)
+  llvm::SmallVector<unsigned> succs;
+  llvm::SmallVector<unsigned> preds;
+};
+
+/// Data Dependence Graph for one scf.for loop body.
+/// Captures both intra-iteration and loop-carried (distance-1) edges.
+class DataDependenceGraph {
+public:
+  static DataDependenceGraph build(scf::ForOp loop, const LatencyModel &model);
+
+  llvm::ArrayRef<DDGNode> getNodes() const { return nodes; }
+  llvm::ArrayRef<DDGEdge> getEdges() const { return edges; }
+  const DDGNode &getNode(unsigned idx) const { return nodes[idx]; }
+  unsigned getNumNodes() const { return nodes.size(); }
+
+  /// Get all incoming edges for a node.
+  llvm::SmallVector<const DDGEdge *> getInEdges(unsigned nodeIdx) const;
+
+  /// Get all outgoing edges for a node.
+  llvm::SmallVector<const DDGEdge *> getOutEdges(unsigned nodeIdx) const;
+
+  /// Compute critical-path height (bottom-up) from each node to any sink.
+  llvm::DenseMap<unsigned, int> computeCriticalPathHeights() const;
+
+  /// Compute ResMII: max over all pipelines of total self-latency.
+  int computeResMII() const;
+
+  /// Compute RecMII: max over all recurrence circuits of sum_lat / sum_dist.
+  int computeRecMII() const;
+
+  /// Compute MinII = max(ResMII, RecMII).
+  int computeMinII() const;
+
+  /// Dump the DDG to llvm::dbgs() for debugging.
+  void dump() const;
+
+private:
+  llvm::SmallVector<DDGNode> nodes;
+  llvm::SmallVector<DDGEdge> edges;
+  llvm::DenseMap<Operation *, unsigned> opToIdx;
+
+  unsigned addNode(Operation *op, const LatencyModel &model);
+  void addEdge(unsigned src, unsigned dst, int latency, unsigned distance);
+};
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_DDG_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -1,0 +1,305 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "LatencyModel.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "modulo-scheduling-latency"
+
+namespace tt = mlir::triton;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace mlir::triton::gpu {
+
+llvm::StringRef getPipelineName(HWPipeline pipeline) {
+  switch (pipeline) {
+  case HWPipeline::MEM:
+    return "MEM";
+  case HWPipeline::TC:
+    return "TC";
+  case HWPipeline::CUDA:
+    return "CUDA";
+  case HWPipeline::SFU:
+    return "SFU";
+  case HWPipeline::NONE:
+    return "NONE";
+  }
+  llvm_unreachable("unknown pipeline");
+}
+
+// Estimate total elements in the result tensor of an op.
+int64_t LatencyModel::getTensorElements(Operation *op) const {
+  if (op->getNumResults() == 0)
+    return 0;
+  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType)
+    return 0;
+  int64_t elements = 1;
+  for (auto dim : resultType.getShape())
+    elements *= dim;
+  return elements;
+}
+
+// TMA load latencies from B200 microbenchmarks (cycles).
+// Key = total bytes, value = pipeline occupancy cycles.
+// Entries from NVIDIA_B200_latency_table.json.
+struct TMALatencyEntry {
+  int64_t bytes;
+  int cycles;
+};
+static constexpr TMALatencyEntry kTMALoadTable[] = {
+    {128 * 64 * 2, 518},   // 128x64 or 64x128 bf16/fp16 = 16KB
+    {128 * 128 * 2, 654},  // 128x128 bf16/fp16 = 32KB
+    {256 * 64 * 2, 653},   // 256x64 bf16 = 32KB
+    {256 * 128 * 2, 918},  // 256x128 bf16 = 64KB
+};
+
+// Async overhead: additional cycles for data to travel through the memory
+// hierarchy (L2/DRAM) and arrive in SMEM. On top of pipeline occupancy.
+constexpr int kTMAAsyncOverhead = 700;
+
+/// Look up TMA load occupancy by total bytes. Table lookup first, then
+/// linear interpolation from 128x64 baseline as fallback.
+static int lookupTMALoadOccupancy(int64_t totalBytes) {
+  for (const auto &entry : kTMALoadTable) {
+    if (entry.bytes == totalBytes)
+      return entry.cycles;
+  }
+  // Fallback: linear interpolation from 128x64 baseline.
+  constexpr int64_t kBaseBytes = 128 * 64 * 2;
+  constexpr int kBaseCycles = 518;
+  return static_cast<int>(kBaseCycles *
+                          static_cast<double>(totalBytes) / kBaseBytes);
+}
+
+int LatencyModel::getTMALoadLatency(Operation *op) const {
+  if (op->getNumResults() == 0)
+    return lookupTMALoadOccupancy(128 * 64 * 2); // default: 128x64
+  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType)
+    return lookupTMALoadOccupancy(128 * 64 * 2);
+
+  int64_t elements = 1;
+  for (auto dim : resultType.getShape())
+    elements *= dim;
+  int64_t bytesPerElement = resultType.getElementTypeBitWidth() / 8;
+  return lookupTMALoadOccupancy(elements * bytesPerElement);
+}
+
+int LatencyModel::getTMAStoreLatency(Operation *op) const {
+  // TMA stores have similar latency profile to loads
+  return getTMALoadLatency(op);
+}
+
+// MMA latencies from design doc microbenchmarks (Blackwell tcgen05.mma).
+// Scales with the product M*N*K.
+constexpr int kMMALatency128x128x128 = 900;
+constexpr int kMMALatency128x128x64 = 559;
+
+int LatencyModel::getMMALatency(Operation *op) const {
+  if (op->getNumResults() == 0)
+    return kMMALatency128x128x128; // conservative default
+  // Try to extract the MMA shape from the MMAv5 interface
+  if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
+    auto aType = dyn_cast<RankedTensorType>(mma->getOperand(0).getType());
+    auto bType = dyn_cast<RankedTensorType>(mma->getOperand(1).getType());
+    if (aType && bType) {
+      auto aShape = aType.getShape(); // [M, K]
+      int64_t K = aShape.size() >= 2 ? aShape[1] : 64;
+      // Use K to select between known latencies
+      if (K >= 128)
+        return kMMALatency128x128x128;
+      return kMMALatency128x128x64;
+    }
+  }
+  return kMMALatency128x128x128; // conservative default
+}
+
+int LatencyModel::getCUDALatency(Operation *op) const {
+  int64_t elements = getTensorElements(op);
+  if (elements == 0)
+    return 0; // scalar
+
+  // Reductions: differentiate by reduction kind.
+  if (auto reduceOp = dyn_cast<tt::ReduceOp>(op)) {
+    // RowMax ~336 cycles, RowSum ~508 cycles for 128-wide (from microbench).
+    // Heuristic: check if the reduction body contains an AddF (sum) or MaxF.
+    bool isSum = false;
+    reduceOp.getBody()->walk([&](Operation *inner) {
+      if (isa<arith::AddFOp>(inner))
+        isSum = true;
+    });
+    return isSum ? 508 : 336; // RowSum vs RowMax
+  }
+
+  // Type conversions (truncf, extf): ~105 cycles for 128x128.
+  if (isa<arith::TruncFOp, arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp,
+          tt::FpToFpOp, tt::BitcastOp>(op))
+    return 105;
+
+  // Multiply (Acc x Alpha): ~105 cycles for 128x128.
+  if (isa<arith::MulFOp>(op))
+    return 105;
+
+  // Scale & Subtract, AddF: ~130 cycles.
+  return 130;
+}
+
+int LatencyModel::getSFULatency(Operation *op) const {
+  int64_t elements = getTensorElements(op);
+  if (elements == 0)
+    return 43; // scalar exp2 (Alpha = Exp2(scalar))
+  return 662;  // elementwise exp2 for 128x128
+}
+
+HWPipeline LatencyModel::classifyPipeline(Operation *op) const {
+  // MEM: TMA loads, regular loads, and stores
+  if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
+    return HWPipeline::MEM;
+  // MEM: Lowered TMA loads (TLX kernels use async_tma_copy instead of descriptor_load)
+  if (isa<ttng::AsyncTMACopyGlobalToLocalOp>(op))
+    return HWPipeline::MEM;
+  if (isa<tt::LoadOp>(op)) {
+    // Regular tt.load (before TMA lowering) — classify as MEM if tensor
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::MEM;
+  }
+  if (isa<tt::DescriptorStoreOp>(op))
+    return HWPipeline::MEM;
+  // MEM: Lowered TMA stores (TLX path)
+  if (isa<ttng::AsyncTMACopyLocalToGlobalOp>(op))
+    return HWPipeline::MEM;
+
+  // TC: Tensor Core MMA operations
+  if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op))
+    return HWPipeline::TC;
+  if (isa<ttng::WarpGroupDotOp>(op))
+    return HWPipeline::TC;
+  // TC: tt.dot (before lowering to TCGen5MMAOp / WarpGroupDotOp)
+  if (isa<tt::DotOp>(op))
+    return HWPipeline::TC;
+
+  // CUDA: TMEM load (reads accumulator from TMEM to registers — epilogue op)
+  if (isa<ttng::TMEMLoadOp>(op))
+    return HWPipeline::CUDA;
+
+  // SFU: Transcendental math operations on tensors
+  if (isa<math::Exp2Op, math::ExpOp, math::Log2Op, math::LogOp, math::SqrtOp,
+          math::RsqrtOp, math::TanhOp>(op)) {
+    // Only classify as SFU if operating on tensors
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::SFU;
+    return HWPipeline::NONE; // scalar math is free
+  }
+
+  // CUDA: Reductions
+  if (isa<tt::ReduceOp>(op))
+    return HWPipeline::CUDA;
+
+  // CUDA: Tensor arithmetic (elementwise operations on tensors)
+  if (isa<arith::AddFOp, arith::SubFOp, arith::MulFOp, arith::DivFOp,
+          arith::MaximumFOp, arith::MinimumFOp, arith::NegFOp>(op)) {
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::CUDA;
+  }
+
+  // CUDA: Type conversions on tensors
+  if (isa<arith::TruncFOp, arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp,
+          tt::FpToFpOp, tt::BitcastOp>(op)) {
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::CUDA;
+  }
+
+  // MEM: local_alloc fed by a MEM load represents the async data arrival.
+  // It stays at the same stage as the load (edge uses selfLatency), but
+  // carries the async overhead latency to its consumers (MMA).
+  if (isa<triton::gpu::LocalAllocOp>(op)) {
+    // Check if operand comes from a load
+    if (op->getNumOperands() > 0) {
+      auto *srcOp = op->getOperand(0).getDefiningOp();
+      if (srcOp && (isa<tt::LoadOp, tt::DescriptorLoadOp>(srcOp)))
+        return HWPipeline::MEM;
+    }
+  }
+
+  // NONE: Scalar ops, index arithmetic, control flow, barriers, etc.
+  return HWPipeline::NONE;
+}
+
+OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
+  auto pipeline = classifyPipeline(op);
+
+  int latency = 0;
+  int selfLatency = 0;
+  switch (pipeline) {
+  case HWPipeline::MEM: {
+    // For async MEM ops, selfLatency (pipeline occupancy) and latency
+    // (time until data available for consumers) are different.
+    // selfLatency = how long the MEM pipeline is busy dispatching.
+    // latency = selfLatency + async overhead (DRAM round-trip).
+    int occupancy;
+    if (isa<tt::DescriptorStoreOp>(op))
+      occupancy = getTMAStoreLatency(op);
+    else if (isa<ttng::AsyncTMACopyLocalToGlobalOp>(op)) {
+      // Lowered TMA store — use same logic as descriptor_store.
+      occupancy = lookupTMALoadOccupancy(128 * 64 * 2);
+    } else if (isa<triton::gpu::LocalAllocOp>(op)) {
+      // local_alloc fed by a load: represents async data arrival.
+      // selfLatency = 0 (no pipeline occupancy, it's a bookkeeping op).
+      // latency = async overhead (DRAM round-trip time).
+      selfLatency = 0;
+      latency = kTMAAsyncOverhead;
+      break;
+    } else if (auto tmaCopy = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+      // Lowered TMA load (TLX path). Get size from the SMEM result type.
+      auto resultMemDesc =
+          dyn_cast<triton::gpu::MemDescType>(tmaCopy.getResult().getType());
+      if (resultMemDesc) {
+        int64_t elements = 1;
+        for (auto dim : resultMemDesc.getShape())
+          elements *= dim;
+        int64_t bytesPerElement =
+            resultMemDesc.getElementType().getIntOrFloatBitWidth() / 8;
+        occupancy = lookupTMALoadOccupancy(elements * bytesPerElement);
+      } else {
+        occupancy = lookupTMALoadOccupancy(128 * 64 * 2);
+      }
+    } else
+      occupancy = getTMALoadLatency(op);
+    selfLatency = occupancy;
+    latency = occupancy + kTMAAsyncOverhead;
+    break;
+  }
+  case HWPipeline::TC:
+    latency = getMMALatency(op);
+    selfLatency = latency;
+    break;
+  case HWPipeline::CUDA:
+    latency = getCUDALatency(op);
+    selfLatency = latency;
+    break;
+  case HWPipeline::SFU:
+    latency = getSFULatency(op);
+    selfLatency = latency;
+    break;
+  case HWPipeline::NONE:
+    latency = 0;
+    selfLatency = 0;
+    break;
+  }
+
+  return OpLatencyInfo{pipeline, latency, selfLatency};
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
@@ -1,0 +1,64 @@
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_LATENCY_MODEL_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_LATENCY_MODEL_H
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::triton::gpu {
+
+/// Hardware pipeline classification for Blackwell SM100.
+/// Each op executes on exactly one pipeline; distinct pipelines overlap.
+enum class HWPipeline {
+  MEM,  // TMA loads/stores (descriptor_load, descriptor_store, descriptor_gather)
+  TC,   // Tensor Core (tc_gen05_mma, warp_group_dot)
+  CUDA, // General CUDA cores (arith.*, tt.reduce, type conversions)
+  SFU,  // Special Function Unit (math.exp2, math.log2, math.rsqrt)
+  NONE  // Scalar/index ops, control flow — zero latency, no resource
+};
+
+/// Return a human-readable name for a pipeline.
+llvm::StringRef getPipelineName(HWPipeline pipeline);
+
+/// Latency info for a single operation.
+struct OpLatencyInfo {
+  HWPipeline pipeline{HWPipeline::NONE};
+  int latency{0};     // Total latency: cycles from op start to result available.
+                      // Used for dependency analysis (RecMII — how long a
+                      // consumer must wait for the result).
+  int selfLatency{0}; // Pipeline occupancy: cycles this op blocks its pipeline.
+                      // Used for resource conflict analysis (ResMII — how much
+                      // pipeline bandwidth is consumed).
+};
+
+/// Hardware latency model for Blackwell SM100.
+///
+/// Classifies TTGIR operations into hardware pipelines and assigns
+/// cycle-accurate latencies from microbenchmark data. Initially hardcoded
+/// for Blackwell; designed to be subclassed for other architectures.
+///
+/// Latency values are from the WS Global Instruction Scheduling design doc
+/// (D95269626) and validated by the latency microbenchmark harness.
+class LatencyModel {
+public:
+  virtual ~LatencyModel() = default;
+
+  /// Classify an operation and return its pipeline + latency.
+  virtual OpLatencyInfo getLatency(Operation *op) const;
+
+  /// Classify which hardware pipeline an operation uses.
+  HWPipeline classifyPipeline(Operation *op) const;
+
+private:
+  int getTMALoadLatency(Operation *op) const;
+  int getTMAStoreLatency(Operation *op) const;
+  int getMMALatency(Operation *op) const;
+  int getCUDALatency(Operation *op) const;
+  int getSFULatency(Operation *op) const;
+
+  /// Estimate tensor size in elements from an op's result type.
+  int64_t getTensorElements(Operation *op) const;
+};
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_LATENCY_MODEL_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
@@ -1,0 +1,253 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "ModuloReservationTable.h"
+
+#include "llvm/Support/Debug.h"
+#include <algorithm>
+#include <climits>
+#include <numeric>
+
+#define DEBUG_TYPE "modulo-scheduling-rau"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+namespace mlir::triton::gpu {
+
+// ── ModuloReservationTable ──────────────────────────────────────────────────
+
+ModuloReservationTable::ModuloReservationTable(int II) : II{II} {
+  for (auto pipe :
+       {HWPipeline::MEM, HWPipeline::TC, HWPipeline::CUDA, HWPipeline::SFU}) {
+    table[pipe].assign(II, -1);
+  }
+}
+
+bool ModuloReservationTable::isFree(int cycle, HWPipeline pipeline) const {
+  if (pipeline == HWPipeline::NONE)
+    return true;
+  auto it = table.find(pipeline);
+  if (it == table.end())
+    return true;
+  return it->second[cycle % II] < 0;
+}
+
+bool ModuloReservationTable::isIntervalFree(int cycle, HWPipeline pipeline,
+                                            int duration) const {
+  if (pipeline == HWPipeline::NONE)
+    return true;
+  for (int t = cycle; t < cycle + duration; ++t) {
+    if (!isFree(t, pipeline))
+      return false;
+  }
+  return true;
+}
+
+void ModuloReservationTable::reserve(int cycle, HWPipeline pipeline,
+                                     unsigned nodeIdx, int duration) {
+  if (pipeline == HWPipeline::NONE)
+    return;
+  for (int t = cycle; t < cycle + duration; ++t) {
+    table[pipeline][t % II] = static_cast<int>(nodeIdx);
+  }
+}
+
+void ModuloReservationTable::unreserve(int cycle, HWPipeline pipeline,
+                                       int duration) {
+  if (pipeline == HWPipeline::NONE)
+    return;
+  for (int t = cycle; t < cycle + duration; ++t) {
+    table[pipeline][t % II] = -1;
+  }
+}
+
+int ModuloReservationTable::getOccupant(int cycle, HWPipeline pipeline) const {
+  if (pipeline == HWPipeline::NONE)
+    return -1;
+  auto it = table.find(pipeline);
+  if (it == table.end())
+    return -1;
+  return it->second[cycle % II];
+}
+
+int ModuloReservationTable::findFreeSlot(int earliest, HWPipeline pipeline,
+                                         int duration) const {
+  if (pipeline == HWPipeline::NONE)
+    return earliest;
+  for (int t = earliest; t < earliest + II; ++t) {
+    if (isIntervalFree(t, pipeline, duration))
+      return t;
+  }
+  return -1;
+}
+
+// ── Rau's Iterative Modulo Scheduling ───────────────────────────────────────
+
+/// Compute the earliest start time for a node given its predecessors'
+/// scheduled cycles, respecting loop-carried distances.
+static int computeEarliestStart(unsigned nodeIdx,
+                                const DataDependenceGraph &ddg,
+                                const llvm::DenseMap<unsigned, int> &scheduled,
+                                int II) {
+  int earliest = 0;
+  for (const auto *edge : ddg.getInEdges(nodeIdx)) {
+    auto it = scheduled.find(edge->srcIdx);
+    if (it == scheduled.end())
+      continue;
+    // constraint: dst_start >= src_start + latency - distance * II
+    int constraint =
+        it->second + edge->latency - static_cast<int>(edge->distance) * II;
+    earliest = std::max(earliest, constraint);
+  }
+  return earliest;
+}
+
+FailureOr<ModuloScheduleResult>
+runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
+                    int maxBacktracks) {
+  LLVM_DEBUG(DBGS() << "Computing MinII...\n");
+  const int minII = ddg.computeMinII();
+  LLVM_DEBUG(DBGS() << "MinII=" << minII << "\n");
+  if (minII <= 0)
+    return failure();
+
+  if (maxII <= 0)
+    maxII = 2 * minII;
+
+  LLVM_DEBUG(DBGS() << "Computing critical path heights...\n");
+  auto heights = ddg.computeCriticalPathHeights();
+  LLVM_DEBUG(DBGS() << "Heights computed for " << heights.size() << " nodes\n");
+
+  // Sort ALL nodes (including NONE-pipeline) by decreasing critical-path
+  // height. NONE ops must be scheduled together with pipeline ops so that
+  // dependency constraints (e.g., load → local_alloc → MMA) are respected.
+  llvm::SmallVector<unsigned> priorityOrder;
+  for (unsigned i = 0; i < ddg.getNumNodes(); ++i)
+    priorityOrder.push_back(i);
+  llvm::sort(priorityOrder,
+             [&](unsigned a, unsigned b) {
+               if (heights[a] != heights[b])
+                 return heights[a] > heights[b];
+               // Tiebreaker: lower index first (producers before consumers
+               // in program order). This ensures that when a predecessor and
+               // successor have equal heights, the predecessor is scheduled
+               // first so its cycle is known when the successor is placed.
+               return a < b;
+             });
+
+  LLVM_DEBUG({
+    DBGS() << "MinII=" << minII << " MaxII=" << maxII
+           << " Nodes=" << priorityOrder.size() << "\n";
+    DBGS() << "ResMII=" << ddg.computeResMII()
+           << " RecMII=" << ddg.computeRecMII() << "\n";
+  });
+  // Show per-pipeline resource usage for ResMII breakdown
+  LLVM_DEBUG({
+    llvm::DenseMap<HWPipeline, int> pipeLoad;
+    for (const auto &node : ddg.getNodes()) {
+      if (node.pipeline != HWPipeline::NONE)
+        pipeLoad[node.pipeline] += std::max(node.selfLatency, 1);
+    }
+    for (auto &[pipe, load] : pipeLoad) {
+      DBGS() << "  " << getPipelineName(pipe) << " total_load=" << load << "\n";
+    }
+  });
+
+  for (int II = minII; II <= maxII; ++II) {
+    ModuloReservationTable table{II};
+    llvm::DenseMap<unsigned, int> scheduled;
+    bool success = true;
+    int backtracks = 0;
+
+    // Use index-based iteration instead of range-for because ejection
+    // may insert evicted nodes back into priorityOrder for re-scheduling.
+    // Range-for would be UB (iterator invalidation on SmallVector insert).
+    for (unsigned i = 0; i < priorityOrder.size(); ++i) {
+      unsigned nodeIdx = priorityOrder[i];
+      const auto &node = ddg.getNode(nodeIdx);
+      int duration = std::max(node.selfLatency, 1); // at least 1 slot
+      if (node.pipeline == HWPipeline::NONE)
+        duration = 1; // NONE ops don't occupy any pipeline
+
+      int earliest = computeEarliestStart(nodeIdx, ddg, scheduled, II);
+      int slot = table.findFreeSlot(earliest, node.pipeline, duration);
+
+      if (slot < 0 && backtracks < maxBacktracks) {
+        // Rau's ejection: find the least-critical occupant in a
+        // conflicting slot, evict it, place current node, then
+        // re-schedule the evicted node later.
+        int bestVictim = -1;
+        int bestVictimHeight = INT_MAX;
+        int currentHeight = heights.lookup(nodeIdx);
+        for (int t = earliest; t < earliest + II; ++t) {
+          int occupant = table.getOccupant(t, node.pipeline);
+          if (occupant < 0)
+            continue;
+          int occHeight = heights.lookup(static_cast<unsigned>(occupant));
+          // Only eject nodes with strictly lower priority (smaller height)
+          // than the current node. This prevents priority inversion where
+          // a less-critical node evicts a more-critical one.
+          if (occHeight < currentHeight && occHeight < bestVictimHeight) {
+            bestVictimHeight = occHeight;
+            bestVictim = occupant;
+          }
+        }
+        if (bestVictim >= 0) {
+          // Evict the victim.
+          const auto &victim = ddg.getNode(bestVictim);
+          int victimDur = std::max(victim.selfLatency, 1);
+          if (victim.pipeline == HWPipeline::NONE)
+            victimDur = 1;
+          int victimCycle = scheduled[bestVictim];
+          table.unreserve(victimCycle, victim.pipeline, victimDur);
+          scheduled.erase(bestVictim);
+
+          // Place current node at the freed slot.
+          slot = table.findFreeSlot(earliest, node.pipeline, duration);
+          if (slot >= 0) {
+            // Insert evicted node right after current position for
+            // re-scheduling. Index-based iteration handles the growth
+            // safely (no iterator invalidation).
+            priorityOrder.insert(priorityOrder.begin() + i + 1,
+                                 static_cast<unsigned>(bestVictim));
+            ++backtracks;
+            LLVM_DEBUG(DBGS() << "  Ejected N" << bestVictim
+                              << " (height=" << bestVictimHeight
+                              << ") to place N" << nodeIdx << "\n");
+          } else {
+            // Could not place even after ejection — restore victim.
+            table.reserve(victimCycle, victim.pipeline,
+                          static_cast<unsigned>(bestVictim), victimDur);
+            scheduled[bestVictim] = victimCycle;
+          }
+        }
+      }
+      if (slot < 0) {
+        success = false;
+        break;
+      }
+
+      table.reserve(slot, node.pipeline, nodeIdx, duration);
+      scheduled[nodeIdx] = slot;
+      LLVM_DEBUG(DBGS() << "  II=" << II << " Placed N" << nodeIdx << " ("
+                        << getPipelineName(node.pipeline) << " dur=" << duration
+                        << ") at cycle=" << slot << " stage=" << slot / II
+                        << "\n");
+    }
+
+    if (success) {
+      LLVM_DEBUG(DBGS() << "SUCCESS at II=" << II << "\n");
+
+      ModuloScheduleResult result;
+      result.II = II;
+      result.nodeToCycle = std::move(scheduled);
+      return result;
+    }
+
+    LLVM_DEBUG(DBGS() << "FAILED at II=" << II << "\n");
+  }
+
+  LLVM_DEBUG(DBGS() << "EXHAUSTED: failed to schedule within maxII=" << maxII
+                    << "\n");
+  return failure();
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
@@ -1,0 +1,66 @@
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_RESERVATION_TABLE_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_RESERVATION_TABLE_H
+
+#include "DataDependenceGraph.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::triton::gpu {
+
+/// Modulo reservation table: II time slots × one row per HWPipeline.
+/// A slot [cycle % II][pipeline] holds at most one op.
+class ModuloReservationTable {
+public:
+  explicit ModuloReservationTable(int II);
+
+  int getII() const { return II; }
+
+  bool isFree(int cycle, HWPipeline pipeline) const;
+  bool isIntervalFree(int cycle, HWPipeline pipeline, int duration) const;
+  void reserve(int cycle, HWPipeline pipeline, unsigned nodeIdx,
+               int duration = 1);
+  void unreserve(int cycle, HWPipeline pipeline, int duration = 1);
+
+  /// Find earliest free slot at or after `earliest` on pipeline, within II.
+  /// Checks that `duration` consecutive slots are all free.
+  /// Returns -1 if no slot found.
+  int findFreeSlot(int earliest, HWPipeline pipeline, int duration = 1) const;
+
+  /// Get the node index occupying a slot, or -1 if free.
+  int getOccupant(int cycle, HWPipeline pipeline) const;
+
+private:
+  int II{};
+  // table[pipeline][slot] = nodeIdx or -1
+  llvm::DenseMap<HWPipeline, llvm::SmallVector<int>> table;
+};
+
+/// Result of modulo scheduling for one loop.
+struct ModuloScheduleResult {
+  int II{};
+  llvm::DenseMap<unsigned, int> nodeToCycle; // DDG node idx -> absolute cycle
+
+  int getStage(unsigned nodeIdx) const {
+    auto it = nodeToCycle.find(nodeIdx);
+    return it != nodeToCycle.end() ? it->second / II : 0;
+  }
+
+  int getMaxStage() const {
+    int maxStage = 0;
+    for (auto &[idx, cycle] : nodeToCycle)
+      maxStage = std::max(maxStage, cycle / II);
+    return maxStage;
+  }
+};
+
+/// Run Rau's iterative modulo scheduling on the DDG.
+/// maxII defaults to 2 * MinII. maxBacktracks limits ejection attempts per II.
+FailureOr<ModuloScheduleResult>
+runModuloScheduling(const DataDependenceGraph &ddg, int maxII = 0,
+                    int maxBacktracks = 20);
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_RESERVATION_TABLE_H


### PR DESCRIPTION
Summary:

Add the reservation table data structure for modulo scheduling's
resource-conflict analysis. The MRT tracks per-pipeline (MEM, TC, CUDA,
SFU) cycle occupancy across the initiation interval (II).

Used to compute ResMII (resource-constrained minimum II) and to check
for resource conflicts when placing operations in Rau's iterative
modulo scheduling algorithm.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D99879739
