### PR TITLE
[AutoWS] Add ModuloBufferAllocPass for PipelineGraph buffer allocation (#1227)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -137,6 +137,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // NVGPU transform passes
   mlir::registerNVHopperTransformsPasses();
   mlir::registerNVGPUModuloSchedule();
+  mlir::registerNVGPUModuloWSPartition();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -138,6 +138,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVHopperTransformsPasses();
   mlir::registerNVGPUModuloSchedule();
   mlir::registerNVGPUModuloWSPartition();
+  mlir::registerNVGPUModuloBufferAlloc();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -19,6 +19,8 @@ std::unique_ptr<Pass> createNVGPUModuloSchedule();
 void registerNVGPUModuloSchedule();
 std::unique_ptr<Pass> createNVGPUModuloWSPartition();
 void registerNVGPUModuloWSPartition();
+std::unique_ptr<Pass> createNVGPUModuloBufferAlloc();
+void registerNVGPUModuloBufferAlloc();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -14,9 +14,11 @@ namespace mlir {
 #define GEN_PASS_REGISTRATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
 
-// Modulo scheduling pass (manual registration, not tablegen-generated).
+// Modulo scheduling passes (manual registration, not tablegen-generated).
 std::unique_ptr<Pass> createNVGPUModuloSchedule();
 void registerNVGPUModuloSchedule();
+std::unique_ptr<Pass> createNVGPUModuloWSPartition();
+void registerNVGPUModuloWSPartition();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/DataDependenceGraph.cpp
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/ModuloSchedulePass.cpp
+  ModuloScheduling/ModuloWSPartitionPass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/ModuloSchedulePass.cpp
   ModuloScheduling/ModuloWSPartitionPass.cpp
+  ModuloScheduling/ModuloPipelineIR.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloSchedulePass.cpp
   ModuloScheduling/ModuloWSPartitionPass.cpp
   ModuloScheduling/ModuloPipelineIR.cpp
+  ModuloScheduling/ModuloBufferAllocPass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -75,8 +75,7 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
   auto ub = innerLoop.getUpperBound().getDefiningOp<arith::ConstantIntOp>();
   auto step = innerLoop.getStep().getDefiningOp<arith::ConstantIntOp>();
   if (lb && ub && step && step.value() > 0) {
-    int64_t tc =
-        (ub.value() - lb.value() + step.value() - 1) / step.value();
+    int64_t tc = (ub.value() - lb.value() + step.value() - 1) / step.value();
     if (tc > 0) {
       info.tripCount = static_cast<int>(tc);
       info.tripCountIsEstimated = false;
@@ -181,11 +180,12 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         node.op = &op;
         node.idx = prologueIdx;
         node.pipeline = HWPipeline::MEM;
-        int memLat =
-            info.stageLoads.empty() ? kFallbackTMATotalLatency : info.stageLoads[0].totalLatency;
+        int memLat = info.stageLoads.empty() ? kFallbackTMATotalLatency
+                                             : info.stageLoads[0].totalLatency;
         node.latency = std::max(memLat, 1);
-        node.selfLatency =
-            info.stageLoads.empty() ? kFallbackTMASelfLatency : info.stageLoads[0].memSelfLatency;
+        node.selfLatency = info.stageLoads.empty()
+                               ? kFallbackTMASelfLatency
+                               : info.stageLoads[0].memSelfLatency;
         node.selfLatency = std::max(node.selfLatency, 1);
         ddg.nodes.push_back(node);
       }
@@ -222,8 +222,9 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         ddg.nodes.push_back(node);
       }
 
-      ddg.opToIdx[&op] = epilogueIdx;        // producer: results come from epilogue
-      ddg.consumerOpToIdx[&op] = prologueIdx; // consumer: data enters at prologue
+      ddg.opToIdx[&op] = epilogueIdx; // producer: results come from epilogue
+      ddg.consumerOpToIdx[&op] =
+          prologueIdx; // consumer: data enters at prologue
       ddg.addEdge(prologueIdx, kloopIdx, ddg.nodes[prologueIdx].latency,
                   /*distance=*/0);
       ddg.addEdge(kloopIdx, epilogueIdx, ddg.nodes[kloopIdx].latency,

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloBufferAllocPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloBufferAllocPass.cpp
@@ -1,0 +1,53 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Buffer Allocation Pass (placeholder)
+//
+// Phase boundary marker between Pass A's schedule computation and the
+// loop expansion phase. Currently a no-op — the actual buffer allocation
+// is performed by lowerLoops() in ModuloExpandPass, which derives
+// multi-buffer depths from loop.stage differences.
+//
+// TODO: Move PipelineGraph-based buffer allocation here once the
+// PipelineGraph expansion path replaces lowerLoops().
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-buffer-alloc"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+
+namespace {
+
+struct ModuloBufferAllocPass
+    : public PassWrapper<ModuloBufferAllocPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloBufferAllocPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-buffer-alloc"; }
+
+  StringRef getDescription() const override {
+    return "Buffer allocation for modulo scheduling (placeholder)";
+  }
+
+  void runOnOperation() override {
+    LDBG("Phase 1 analysis complete "
+         "(buffer allocation deferred to ModuloExpand/lowerLoops)");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloBufferAlloc() {
+  return std::make_unique<ModuloBufferAllocPass>();
+}
+
+void registerNVGPUModuloBufferAlloc() {
+  PassRegistration<ModuloBufferAllocPass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
@@ -1,0 +1,239 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "ModuloPipelineIR.h"
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir::triton::gpu {
+
+static llvm::StringRef memKindName(MemoryKind k) {
+  switch (k) {
+  case MemoryKind::SMEM:
+    return "SMEM";
+  case MemoryKind::TMEM:
+    return "TMEM";
+  case MemoryKind::Register:
+    return "Reg";
+  case MemoryKind::BARRIER:
+    return "BARRIER";
+  }
+  llvm_unreachable("unknown MemoryKind");
+}
+
+static void dumpIndent(llvm::raw_ostream &os, unsigned depth) {
+  for (unsigned i = 0; i < depth; ++i)
+    os << "  ";
+}
+
+static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
+                            unsigned depth) {
+  dumpIndent(os, depth);
+  if (node.op && node.op->getNumResults() > 0)
+    os << "%N" << node.id << " = ";
+  if (node.op)
+    os << node.op->getName().getStringRef();
+  else
+    os << "<null>";
+  // Label synthetic inner loop nodes
+  if (node.isSuperNode())
+    os << " [K-loop]";
+  // For ttg.mask: show the first real op inside (1-level unwrap)
+  if (node.op && node.op->getNumRegions() > 0 &&
+      node.op->getName().getStringRef() == "ttg.mask") {
+    auto innerName = [&]() -> llvm::StringRef {
+      for (auto &region : node.op->getRegions())
+        for (auto &block : region)
+          for (auto &inner : block) {
+            auto name = inner.getName().getStringRef();
+            if (name != "scf.yield" && name != "arith.constant")
+              return name;
+          }
+      return {};
+    }();
+    if (!innerName.empty())
+      os << "(" << innerName << ")";
+  }
+  os << "  {pipe: " << getPipelineName(node.pipeline) << ", cycle: "
+     << node.cycle;
+  if (node.latency)
+    os << ", latency: " << node.latency;
+  if (node.selfLatency)
+    os << ", selfLatency: " << node.selfLatency;
+  if (node.warpGroup >= 0)
+    os << ", wg: " << node.warpGroup;
+  if (node.producesBuffer != UINT_MAX)
+    os << ", ->buf" << node.producesBuffer;
+  for (auto cb : node.consumesBuffers)
+    os << ", <-buf" << cb;
+  os << "}\n";
+}
+
+static void dumpPort(const PipelineLoop::MemPort &port,
+                     llvm::raw_ostream &os) {
+  if (!port.op) {
+    if (port.bufferId != UINT_MAX)
+      os << "buf" << port.bufferId;
+    else
+      os << "?";
+    return;
+  }
+  if (port.op->getNumResults() > 0) {
+    port.op->getResult(0).printAsOperand(os, OpPrintingFlags());
+    os << " : " << port.op->getName().getStringRef();
+  } else {
+    os << port.op->getName().getStringRef();
+  }
+}
+
+static void dumpLoop(const PipelineGraph &graph, const PipelineLoop &loop,
+                     llvm::raw_ostream &os, unsigned depth) {
+  dumpIndent(os, depth);
+  os << "modulo.pipeline @loop" << loop.id << " {\n";
+  unsigned inner = depth + 1;
+
+  // Schedule parameters
+  dumpIndent(os, inner);
+  os << "ii = " << loop.II << ", max_stage = " << loop.maxStage;
+  if (loop.prologueLatency)
+    os << ", prologue_latency = " << loop.prologueLatency;
+  if (loop.tripCount > 0) {
+    os << ", trip_count = " << loop.tripCount;
+    if (loop.tripCountIsEstimated)
+      os << " (estimated)";
+  }
+  os << "\n";
+
+  // Buffer declarations
+  if (!loop.buffers.empty()) {
+    os << "\n";
+    for (const auto &buf : loop.buffers) {
+      dumpIndent(os, inner);
+      if (buf.kind == MemoryKind::BARRIER) {
+        os << "%bar" << buf.id << " = modulo.alloc BARRIER [" << buf.count
+           << "]";
+        if (buf.pairedBufferId != UINT_MAX)
+          os << " for buf" << buf.pairedBufferId;
+      } else {
+        os << "%buf" << buf.id << " = modulo.alloc " << memKindName(buf.kind)
+           << " [" << buf.count << " x ";
+        for (unsigned i = 0; i < buf.shape.size(); ++i) {
+          if (i > 0)
+            os << "x";
+          os << buf.shape[i];
+        }
+        os << " x " << (buf.elementBitWidth <= 16 ? "f16" : "f32") << "]";
+      }
+      os << "  // " << buf.sizeBytes() * buf.count << " bytes total\n";
+    }
+  }
+
+  // Inputs
+  if (!loop.inputs.empty()) {
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "inputs:\n";
+    for (const auto &port : loop.inputs) {
+      dumpIndent(os, inner + 1);
+      dumpPort(port, os);
+      os << "\n";
+    }
+  }
+
+  // Outputs
+  if (!loop.outputs.empty()) {
+    dumpIndent(os, inner);
+    os << "outputs:\n";
+    for (const auto &port : loop.outputs) {
+      dumpIndent(os, inner + 1);
+      dumpPort(port, os);
+      os << "\n";
+    }
+  }
+
+  // Expanded prologue/epilogue (if expanded)
+  if (loop.isExpanded) {
+    if (!loop.prologueNodes.empty()) {
+      os << "\n";
+      dumpIndent(os, inner);
+      os << "modulo.prologue {\n";
+      for (const auto &node : loop.prologueNodes)
+        dumpNodeOneLine(node, os, inner + 1);
+      dumpIndent(os, inner);
+      os << "}\n";
+    }
+  }
+
+  // Stages (grouped)
+  for (int s = 0; s <= loop.maxStage; ++s) {
+    auto stageNodes = loop.getNodesInStage(s);
+    if (stageNodes.empty())
+      continue;
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "modulo.stage @s" << s << " {\n";
+    for (const auto *node : stageNodes) {
+      if (node->isSuperNode()) {
+        dumpLoop(graph, graph.getLoop(node->childPipelineId), os, inner + 1);
+      } else {
+        dumpNodeOneLine(*node, os, inner + 1);
+      }
+    }
+    dumpIndent(os, inner);
+    os << "}\n";
+  }
+
+  // Expanded epilogue (if expanded)
+  if (loop.isExpanded && !loop.epilogueNodes.empty()) {
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "modulo.epilogue {\n";
+    for (const auto &node : loop.epilogueNodes)
+      dumpNodeOneLine(node, os, inner + 1);
+    dumpIndent(os, inner);
+    os << "}\n";
+  }
+
+  // Edges
+  if (!loop.edges.empty()) {
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "edges {\n";
+    for (const auto &edge : loop.edges) {
+      dumpIndent(os, inner + 1);
+      // Mark super-node endpoints
+      auto printNode = [&](unsigned id) {
+        os << "N" << id;
+        if (id < loop.nodes.size() && loop.nodes[id].isSuperNode())
+          os << "(K-loop)";
+      };
+      printNode(edge.srcId);
+      os << " -> ";
+      printNode(edge.dstId);
+      os << "  lat=" << edge.latency << "  dist=" << edge.distance << "\n";
+    }
+    dumpIndent(os, inner);
+    os << "}\n";
+  }
+
+  dumpIndent(os, depth);
+  os << "}\n";
+}
+
+void PipelineGraph::dump() const {
+  llvm::DenseSet<unsigned> childIds;
+  for (const auto &loop : loops)
+    for (const auto &node : loop.nodes)
+      if (node.isSuperNode())
+        childIds.insert(node.childPipelineId);
+
+  for (const auto &loop : loops) {
+    if (childIds.count(loop.id))
+      continue;
+    dumpLoop(*this, loop, llvm::dbgs(), 0);
+    llvm::dbgs() << "\n";
+  }
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
@@ -1,0 +1,259 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// ModuloPipeline IR — abstract representation of a modulo-scheduled
+// loop nest with multi-buffered memory, pipeline stages, and optional
+// warp specialization.
+//
+// The IR is a side data structure (not MLIR ops). It references MLIR
+// Operations but adds scheduling metadata (cycles, stages, buffers,
+// edges) that drive the lowering passes.
+//
+// Transformation phases:
+//   Phase 0: SCHEDULE  — DDG + Rau's → populate PipelineNode cycle/stage
+//   Phase 1: BUFFERS   — stage diffs → populate PipelineBuffer count
+//   Phase 1.5: WS      — utilization → assign warp_group per stage
+//   Phase 2: EXPAND    — bottom-up prologue/kernel/epilogue per loop
+//   Phase 3: LOWER     — replace MLIR ops with async copies + barriers
+
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H
+#define TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H
+
+#include "LatencyModel.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include <cassert>
+
+namespace mlir::triton::gpu {
+
+// ============================================================================
+// Memory abstraction
+// ============================================================================
+
+enum class MemoryKind { SMEM, TMEM, Register, BARRIER };
+
+/// A multi-buffered memory allocation.
+/// Represents SMEM or TMEM that needs multiple copies for pipelining.
+struct PipelineBuffer {
+  unsigned id{};
+  MemoryKind kind{MemoryKind::SMEM};
+  llvm::SmallVector<int64_t, 4> shape;  // e.g., {128, 64}
+  unsigned elementBitWidth{16};       // e.g., 16 for f16
+  unsigned count{1};                  // number of buffers (from stageDiff + 1)
+
+  // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if none)
+  // For barrier buffers: index of the data buffer this barrier guards
+  unsigned pairedBufferId{UINT_MAX};
+
+  // The MLIR op that originally defines this buffer (e.g., local_alloc)
+  Operation *defOp{nullptr};
+
+  int64_t sizeBytes() const {
+    if (kind == MemoryKind::BARRIER)
+      return 8; // mbarrier object is 8 bytes in SMEM
+    int64_t elems = 1;
+    for (auto d : shape)
+      elems *= d;
+    return elems * elementBitWidth / 8;
+  }
+};
+
+// ============================================================================
+// Pipeline node — a scheduled operation
+// ============================================================================
+
+/// A node in the pipeline graph. Wraps an MLIR Operation with scheduling info.
+struct PipelineNode {
+  unsigned id{};
+  Operation *op{nullptr};
+
+  // Schedule assignment (from Phase 0)
+  HWPipeline pipeline{HWPipeline::NONE};
+  int cycle{0};          // absolute cycle within the II
+  int stage{0};          // cycle / II
+  int latency{0};        // cycles until result available
+  int selfLatency{0};    // cycles this op occupies its pipeline
+
+  // Super-node: if this node represents a child pipeline (inner loop)
+  unsigned childPipelineId{UINT_MAX}; // index into PipelineGraph::pipelines
+  int prologueLatency{0};             // cycles before TC starts in child
+
+  // Buffer references
+  unsigned producesBuffer{UINT_MAX};  // index into PipelineLoop::buffers
+  llvm::SmallVector<unsigned, 2> consumesBuffers; // indices into buffers
+
+  // Warp specialization (from Phase 1.5)
+  int warpGroup{-1}; // -1 = unassigned
+
+  bool isSuperNode() const { return childPipelineId != UINT_MAX; }
+  bool hasBuffer() const {
+    return producesBuffer != UINT_MAX || !consumesBuffers.empty();
+  }
+};
+
+// ============================================================================
+// Pipeline edge — producer-consumer dependency
+// ============================================================================
+
+struct PipelineEdge {
+  unsigned srcId{};
+  unsigned dstId{};
+  int latency{};
+  unsigned distance{}; // 0 = intra-iteration, 1+ = loop-carried
+};
+
+// ============================================================================
+// Pipeline loop — a single pipelined scf.for
+// ============================================================================
+
+/// A pipelined loop with its schedule, nodes, edges, and buffers.
+/// Analogous to a function: has inputs (consumed from outer scope),
+/// outputs (produced for outer scope), and a body (nodes + edges).
+struct PipelineLoop {
+  unsigned id{};
+  scf::ForOp forOp;
+
+  // Schedule parameters
+  int II{0};
+  int maxStage{0};
+  int prologueLatency{0}; // cycles before TC starts (for parent's super-node)
+  int tripCount{0};        // loop trip count (0 = unknown/not set)
+  bool tripCountIsEstimated{false}; // true if tripCount is estimated, not constant
+
+  // Body (kernel loop steady state)
+  llvm::SmallVector<PipelineNode, 16> nodes;
+  llvm::SmallVector<PipelineEdge, 16> edges;
+
+  // Expanded structure (populated after expansion, empty before)
+  // Prologue: ops cloned before the loop (stage 0 of first iterations)
+  // Epilogue: ops cloned after the loop (drain of last stage)
+  llvm::SmallVector<PipelineNode, 8> prologueNodes;
+  llvm::SmallVector<PipelineNode, 8> epilogueNodes;
+  bool isExpanded{false}; // true after expandPipelineGraph
+
+  // Memory interface (inputs/outputs crossing loop boundary)
+  // These drive multi-buffering at the parent level.
+  //
+  // isInput is intentionally kept alongside the separate inputs/outputs vectors:
+  // it allows generic iteration over all ports (e.g., when building the parent's
+  // buffer map) without needing to know which vector a port came from.
+  struct MemPort {
+    unsigned bufferId{UINT_MAX}; // index into parent's buffers
+    Operation *op{nullptr};      // the MLIR op at the boundary
+    bool isInput{true};
+  };
+  llvm::SmallVector<MemPort, 4> inputs;  // consumed from outer scope
+  llvm::SmallVector<MemPort, 4> outputs; // produced for outer scope
+
+  // Multi-buffered allocations within this loop
+  llvm::SmallVector<PipelineBuffer, 4> buffers;
+
+  // Lookup
+  llvm::DenseMap<Operation *, unsigned> opToNodeId;
+
+  // Helpers
+  const PipelineNode &getNode(unsigned id) const {
+    assert(id < nodes.size() && "node id out of range");
+    return nodes[id];
+  }
+  /// Find the node for an MLIR op, or nullptr if not in this loop.
+  const PipelineNode *findNode(Operation *op) const {
+    auto it = opToNodeId.find(op);
+    if (it == opToNodeId.end())
+      return nullptr;
+    return &nodes[it->second];
+  }
+  int numStages() const { return maxStage + 1; }
+
+  /// Get all nodes in a given stage.
+  llvm::SmallVector<const PipelineNode *> getNodesInStage(int stage) const {
+    llvm::SmallVector<const PipelineNode *> result;
+    for (const auto &n : nodes)
+      if (n.stage == stage)
+        result.push_back(&n);
+    return result;
+  }
+};
+
+// ============================================================================
+// Pipeline graph — the top-level container
+// ============================================================================
+
+/// The complete pipeline graph for a kernel. Contains all pipelined loops
+/// (potentially nested) and their relationships.
+struct PipelineGraph {
+  llvm::SmallVector<PipelineLoop, 4> loops;
+
+  /// Add a new loop and return its id.
+  unsigned addLoop(scf::ForOp forOp) {
+    unsigned id = loops.size();
+    PipelineLoop loop;
+    loop.id = id;
+    loop.forOp = forOp;
+    loops.push_back(std::move(loop));
+    return id;
+  }
+
+  PipelineLoop &getLoop(unsigned id) {
+    assert(id < loops.size() && "loop id out of range");
+    return loops[id];
+  }
+  const PipelineLoop &getLoop(unsigned id) const {
+    assert(id < loops.size() && "loop id out of range");
+    return loops[id];
+  }
+
+  /// Find the innermost loops (leaves) — process these first (bottom-up).
+  llvm::SmallVector<unsigned> getInnermostLoops() const {
+    llvm::SmallVector<unsigned> result;
+    for (const auto &loop : loops) {
+      bool isInnermost = true;
+      for (const auto &node : loop.nodes) {
+        if (node.isSuperNode()) {
+          isInnermost = false;
+          break;
+        }
+      }
+      // A loop with no super-nodes is innermost
+      // (but it might still not be a leaf if it has no nodes at all)
+      if (isInnermost && !loop.nodes.empty())
+        result.push_back(loop.id);
+    }
+    return result;
+  }
+
+  /// Get loops in bottom-up order (innermost first, outermost last).
+  llvm::SmallVector<unsigned> getBottomUpOrder() const {
+    llvm::SmallVector<unsigned> order;
+    llvm::DenseSet<unsigned> visited;
+
+    std::function<void(unsigned)> visit = [&](unsigned id) {
+      if (visited.count(id))
+        return;
+      // Visit children first
+      for (const auto &node : loops[id].nodes) {
+        if (node.isSuperNode()) {
+          assert(node.childPipelineId < loops.size() &&
+                 "childPipelineId out of range");
+          visit(node.childPipelineId);
+        }
+      }
+      visited.insert(id);
+      order.push_back(id);
+    };
+
+    for (unsigned i = 0; i < loops.size(); ++i)
+      visit(i);
+    return order;
+  }
+
+  /// Dump the graph for debugging.
+  void dump() const;
+};
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -170,8 +170,7 @@ static int computeBufferDepths(scf::ForOp loop,
     // Find last consumer end cycle.
     int lastConsumerEnd = prodCycle;
     for (auto *user : alloc->getUsers()) {
-      auto userCycleAttr =
-          user->getAttrOfType<IntegerAttr>("tt.modulo_cycle");
+      auto userCycleAttr = user->getAttrOfType<IntegerAttr>("tt.modulo_cycle");
       if (!userCycleAttr)
         continue;
       int userCycle = userCycleAttr.getInt();
@@ -184,11 +183,10 @@ static int computeBufferDepths(scf::ForOp loop,
     int sizeBytes = getMemDescSizeBytes(memDescType);
     buffers.push_back({alloc, sizeBytes, numBuffers});
 
-    LDBG("Buffer: producer_cycle=" << prodCycle
-                                   << " last_consumer_end=" << lastConsumerEnd
-                                   << " lifetime=" << lifetime << " II=" << II
-                                   << " -> num_buffers=" << numBuffers
-                                   << " (" << sizeBytes << " bytes)");
+    LDBG("Buffer: producer_cycle="
+         << prodCycle << " last_consumer_end=" << lastConsumerEnd
+         << " lifetime=" << lifetime << " II=" << II
+         << " -> num_buffers=" << numBuffers << " (" << sizeBytes << " bytes)");
   }
 
   if (buffers.empty())
@@ -223,13 +221,14 @@ static int computeBufferDepths(scf::ForOp loop,
   // Emit tt.num_buffers on each local_alloc.
   int maxNumBuffers = 1;
   for (auto &b : buffers) {
-    b.allocOp->setAttr("tt.num_buffers",
-                       IntegerAttr::get(IntegerType::get(ctx, 32), b.numBuffers));
+    b.allocOp->setAttr(
+        "tt.num_buffers",
+        IntegerAttr::get(IntegerType::get(ctx, 32), b.numBuffers));
     maxNumBuffers = std::max(maxNumBuffers, b.numBuffers);
   }
 
   LDBG("Buffer depths: max=" << maxNumBuffers
-                              << " totalSmem=" << computeTotalSmem() << "B");
+                             << " totalSmem=" << computeTotalSmem() << "B");
   return maxNumBuffers;
 }
 
@@ -341,7 +340,7 @@ struct ModuloSchedulePass
         continue;
 
       LDBG("Outer DDG: " << outerDDG.getNumNodes() << " nodes, "
-                          << outerDDG.getEdges().size() << " edges");
+                         << outerDDG.getEdges().size() << " edges");
 
       auto outerSched = ttg::runModuloScheduling(outerDDG);
       if (failed(outerSched)) {

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
@@ -1,0 +1,137 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Pass B: Schedule Integration (Warp Specialization Reconstruction)
+//
+// Configures IR attributes so downstream passes (schedule_loops,
+// warp_specialize, pipeline) use the modulo schedule from Pass A.
+//
+// Buffer depths (tt.num_buffers) are already computed by Pass A (Steps 3-4.5).
+// This pass reads them and sets tt.num_stages, tt.scheduled_max_stage,
+// and strips tt.latency attrs for WS loops.
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-ws-partition"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+
+namespace {
+
+static void processScheduledLoop(scf::ForOp loop) {
+  auto ctx = loop.getContext();
+  bool isWS = loop->hasAttr(tt::kWarpSpecializeAttrName);
+
+  // Read num_stages if already set by Pass A Step 3 (computeBufferDepths).
+  int numStages = 0;
+  if (auto ns = loop->getAttrOfType<IntegerAttr>(tt::kNumStagesAttrName))
+    numStages = ns.getInt();
+
+  if (isWS || loop->hasAttr("tt.modulo_ii")) {
+    // WS loops or modulo-scheduled loops: keep loop.stage/loop.cluster attrs.
+    // For modulo-scheduled non-WS loops, the schedule must survive to
+    // downstream ScheduleLoops (which skips them via tt.modulo_ii check).
+    int maxStage = 0;
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (auto stageAttr =
+              op.getAttrOfType<IntegerAttr>(tt::kLoopStageAttrName))
+        maxStage = std::max(maxStage, (int)stageAttr.getInt());
+    }
+
+    // Derive num_stages from the schedule when Pass A Step 3 found no
+    // LocalAllocOp (e.g. outer tile loops of persistent kernels where
+    // SMEM buffers are allocated outside the loop).
+    if (numStages == 0 && maxStage > 0) {
+      numStages = maxStage + 1;
+      LDBG("Derived num_stages=" << numStages << " from maxStage=" << maxStage);
+    }
+
+    if (numStages > 0) {
+      loop->setAttr(tt::kNumStagesAttrName,
+                    IntegerAttr::get(IntegerType::get(ctx, 32), numStages));
+      // scheduled_max_stage reflects the actual schedule, not buffer depth.
+      loop->setAttr(tt::kScheduledMaxStageAttrName,
+                    IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
+      LDBG("Set num_stages=" << numStages
+                             << " scheduled_max_stage=" << maxStage);
+    }
+    LDBG("Modulo/WS loop: kept loop.stage/loop.cluster");
+  } else {
+    // Strip schedule attrs from direct children only — don't recurse
+    // into nested scf::ForOp regions (they have their own schedules).
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (isa<scf::ForOp>(op))
+        continue;
+      op.removeAttr(tt::kLoopStageAttrName);
+      op.removeAttr(tt::kLoopClusterAttrName);
+    }
+    LDBG("Non-WS loop: stripped loop.stage/loop.cluster");
+  }
+  // Keep tt.modulo_ii on the loop so downstream ScheduleLoops (inside AutoWS)
+  // knows to skip re-scheduling this loop and its partition clones.
+}
+
+struct ModuloWSPartitionPass
+    : public PassWrapper<ModuloWSPartitionPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloWSPartitionPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-ws-partition"; }
+
+  StringRef getDescription() const override {
+    return "Schedule integration for warp specialization (Pass B)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    moduleOp.walk([&](scf::ForOp loop) {
+      bool hasMMAv5 = false;
+      bool hasTMALoad = false;
+      bool hasSchedule = false;
+      // Only check direct children of the loop body — don't recurse into
+      // nested scf::ForOp regions. Otherwise a non-scheduled outer loop
+      // containing a scheduled inner loop would match, and processScheduledLoop
+      // would strip the inner loop's schedule attrs in pre-order traversal.
+      for (auto &op : loop.getBody()->without_terminator()) {
+        if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op))
+          hasMMAv5 = true;
+        if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp,
+                ttng::AsyncTMACopyGlobalToLocalOp>(op))
+          hasTMALoad = true;
+        if (op.hasAttr(tt::kLoopStageAttrName))
+          hasSchedule = true;
+        if (hasSchedule && (hasMMAv5 || hasTMALoad))
+          break;
+      }
+      if (!hasSchedule || (!hasMMAv5 && !hasTMALoad))
+        return;
+
+      processScheduledLoop(loop);
+    });
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloWSPartition() {
+  return std::make_unique<ModuloWSPartitionPass>();
+}
+
+void registerNVGPUModuloWSPartition() {
+  PassRegistration<ModuloWSPartitionPass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -104,6 +104,8 @@ void init_triton_hopper_passes(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_multi_cta_reduction",
                      mlir::createNVGPUMultiCTAReduction);
   ADD_PASS_WRAPPER_0("add_modulo_schedule", mlir::createNVGPUModuloSchedule);
+  ADD_PASS_WRAPPER_0("add_modulo_ws_partition",
+                     mlir::createNVGPUModuloWSPartition);
 }
 
 static void checkMatmulConstraints(const std::string &A_dtype,


### PR DESCRIPTION
Summary:

Placeholder pass for modulo buffer allocation (Phase 1 boundary marker).

Currently a no-op — the actual buffer allocation is performed by
lowerLoops() in ModuloExpandPass, which derives multi-buffer depths
from loop.stage differences. Will be populated with PipelineGraph-based
buffer allocation once that path replaces lowerLoops().

Registers the pass as --nvgpu-modulo-buffer-alloc for triton-opt.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D100122317
