### PR TITLE
[AutoWS] Add ModuloExpandPass and ModuloLowerPass for loop pipelining (#1228)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -139,6 +139,8 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVGPUModuloSchedule();
   mlir::registerNVGPUModuloWSPartition();
   mlir::registerNVGPUModuloBufferAlloc();
+  mlir::registerNVGPUModuloExpand();
+  mlir::registerNVGPUModuloLower();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -21,6 +21,10 @@ std::unique_ptr<Pass> createNVGPUModuloWSPartition();
 void registerNVGPUModuloWSPartition();
 std::unique_ptr<Pass> createNVGPUModuloBufferAlloc();
 void registerNVGPUModuloBufferAlloc();
+std::unique_ptr<Pass> createNVGPUModuloExpand();
+void registerNVGPUModuloExpand();
+std::unique_ptr<Pass> createNVGPUModuloLower();
+void registerNVGPUModuloLower();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -23,6 +23,8 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloWSPartitionPass.cpp
   ModuloScheduling/ModuloPipelineIR.cpp
   ModuloScheduling/ModuloBufferAllocPass.cpp
+  ModuloScheduling/ModuloExpandPass.cpp
+  ModuloScheduling/ModuloLowerPass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloExpandPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloExpandPass.cpp
@@ -1,0 +1,227 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Loop Expansion Pass (Phase 2 + Phase 3 combined)
+//
+// This pass takes the modulo-scheduled loop (with loop.stage attrs from
+// ModuloSchedulePass) and performs the full software pipelining
+// transformation:
+//   1. lowerLoops() — transform loads into async copies, insert barriers,
+//      allocate multi-buffered SMEM/TMEM (same as existing Pipeline pass)
+//   2. expandLoops() — generate prologue/kernel/epilogue via PipelineExpander
+//
+// The key difference from the standard Pipeline pass is that our schedule
+// comes from Rau's iterative modulo scheduling (Phase 0) rather than
+// the heuristic-based assign_latencies + schedule_loops.
+//
+// NOTE: lowerLoops() processes ALL loops in the module, not just
+// modulo-scheduled ones. When integrating with the standard Pipeline pass,
+// ensure they don't both run lowerLoops() on the same module.
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-expand"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+
+namespace {
+
+/// Check if the loop has MMAv5 waits in its last stage — if so, we need
+/// custom epilogue peeling (same logic as SoftwarePipeliner.cpp).
+static bool hasMMAv5WaitsInLastStage(scf::ForOp forOp,
+                                     triton::CoarseSchedule &schedule) {
+  int maxStage = schedule.getNumStages() - 1;
+  bool hasMMAv5 = false;
+  bool hasWaitInLastStage = false;
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    if (isa<ttng::WaitBarrierOp>(op) && schedule[&op].first == maxStage)
+      hasWaitInLastStage = true;
+    if (isa<ttng::MMAv5OpInterface>(op))
+      hasMMAv5 = true;
+  }
+  return hasMMAv5 && hasWaitInLastStage;
+}
+
+/// Replicate the expandLoops() logic from SoftwarePipeliner.cpp.
+/// Deserializes the schedule, calls pipelineForLoop(), handles epilogue
+/// peeling for MMAv5 loops.
+static void moduloExpandLoops(ModuleOp moduleOp) {
+  DenseSet<ttg::MaskOp> peeledMaskOps;
+  auto processPeeledEpilogueOp = [&](RewriterBase &rewriter, Operation *op,
+                                     bool isEpilogue) -> Operation * {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    if (auto predOp = dyn_cast<ttg::PredicateStageOp>(op)) {
+      if (isEpilogue) {
+        return mlir::arith::ConstantIntOp::create(
+            rewriter, predOp.getLoc(), predOp.getResult().getType(), 0);
+      }
+      if (predOp.getStage() == predOp.getMaxStage() - 1) {
+        return mlir::arith::ConstantIntOp::create(
+            rewriter, predOp.getLoc(), predOp.getResult().getType(), 1);
+      }
+      return triton::emitPredicateForStage(
+                 rewriter, predOp.getIv(), predOp.getUb(), predOp.getStep(),
+                 predOp.getMaxStage(), predOp.getStage())
+          .getDefiningOp();
+    }
+    if (auto maskOp = dyn_cast<ttg::MaskOp>(op)) {
+      if (isEpilogue)
+        peeledMaskOps.insert(maskOp);
+    }
+    return op;
+  };
+
+  // Collect loops with their nesting depth. We must expand inner loops first
+  // (bottom-up) so that after inner expansion, the inner loop is a "black box"
+  // for outer expansion. moduleOp->walk uses pre-order (outer before inner),
+  // so we explicitly sort by descending depth.
+  SmallVector<std::pair<scf::ForOp, unsigned>> loopsWithDepth;
+  moduleOp->walk([&](scf::ForOp forOp) {
+    unsigned depth = 0;
+    for (auto *parent = forOp->getParentOp(); parent;
+         parent = parent->getParentOp()) {
+      if (isa<scf::ForOp>(parent))
+        ++depth;
+    }
+    loopsWithDepth.push_back({forOp, depth});
+  });
+  // Sort by descending depth — innermost loops first.
+  llvm::sort(loopsWithDepth,
+             [](const auto &a, const auto &b) { return a.second > b.second; });
+
+  for (auto &[forOp, depth] : loopsWithDepth) {
+    // Safety: inner loop expansion may have erased or replaced this op.
+    if (!forOp || !forOp->getBlock())
+      continue;
+
+    triton::CoarseSchedule schedule;
+    if (failed(schedule.deSerialize(forOp)))
+      continue;
+
+    // Skip loops with only 1 stage — no pipelining needed.
+    if (schedule.getNumStages() <= 1) {
+      LDBG("Skipping loop at depth " << depth << " with "
+                                     << schedule.getNumStages()
+                                     << " stage(s) — no expansion needed");
+      continue;
+    }
+
+    LDBG("Expanding loop at depth " << depth << " with "
+                                    << schedule.getNumStages() << " stages");
+
+    std::vector<std::pair<Operation *, unsigned>> finalSchedule =
+        schedule.createFinalSchedule(forOp);
+    triton::PipeliningOption options;
+    options.supportDynamicLoops = true;
+    options.peelEpilogue = false;
+    options.predicateFn = triton::wrapInMaskOp;
+    options.getScheduleFn =
+        [&](scf::ForOp, std::vector<std::pair<Operation *, unsigned>> &sched) {
+          sched = finalSchedule;
+        };
+
+    bool customEpiloguePeeling =
+        hasMMAv5WaitsInLastStage(forOp, schedule) &&
+        !forOp->getParentOfType<ttg::WarpSpecializeOp>();
+    if (customEpiloguePeeling) {
+      options.emitPredicateStageFn = [](RewriterBase &rewriter,
+                                        Value inductionVar, Value upperBound,
+                                        Value step, uint64_t maxStage,
+                                        uint64_t stage) {
+        return ttg::PredicateStageOp::create(rewriter, inductionVar.getLoc(),
+                                             inductionVar, upperBound, step,
+                                             maxStage, stage);
+      };
+    }
+
+    IRRewriter rewriter(forOp);
+    FailureOr<scf::ForOp> newForOp =
+        triton::pipelineForLoop(rewriter, forOp, options);
+
+    if (failed(newForOp)) {
+      LDBG("pipelineForLoop FAILED for a loop");
+      continue;
+    }
+    forOp = *newForOp;
+    if (customEpiloguePeeling)
+      triton::peelLoopEpilogue(forOp, processPeeledEpilogueOp);
+
+    // Prune statically dead mask ops in the epilogue. When the predicate is
+    // constant false, replace the mask op's results with poison values and
+    // erase it. This matches SoftwarePipeliner.cpp's post-peeling cleanup.
+    for (auto maskOp : peeledMaskOps) {
+      rewriter.setInsertionPoint(maskOp);
+      if (isConstantIntValue(maskOp.getPred(), 0)) {
+        SmallVector<Value> results;
+        for (auto result : maskOp->getResults()) {
+          auto poisonOp = mlir::ub::PoisonOp::create(rewriter, maskOp->getLoc(),
+                                                     result.getType());
+          results.push_back(poisonOp);
+        }
+        maskOp->replaceAllUsesWith(results);
+        maskOp->erase();
+      }
+    }
+    peeledMaskOps.clear();
+  }
+
+  assert(moduleOp.getOps<ttg::PredicateStageOp>().empty() &&
+         "PredicateStageOp should be resolved after pipeline expansion");
+  LLVM_DEBUG({
+    if (failed(verify(moduleOp)))
+      DBGS() << "WARNING: IR verification failed after expansion\n";
+  });
+  triton::resolveMaskOp(moduleOp);
+}
+
+struct ModuloExpandPass
+    : public PassWrapper<ModuloExpandPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloExpandPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-expand"; }
+
+  StringRef getDescription() const override {
+    return "Modulo loop expansion (lowerLoops + pipelineForLoop)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    LDBG("=== Phase 2+3: Loop Expansion ===");
+
+    LDBG("Step 1: lowerLoops");
+    triton::gpu::lowerLoops(moduleOp);
+
+    LDBG("Step 2: expandLoops");
+    moduloExpandLoops(moduleOp);
+
+    LDBG("Expansion complete");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloExpand() {
+  return std::make_unique<ModuloExpandPass>();
+}
+
+void registerNVGPUModuloExpand() { PassRegistration<ModuloExpandPass>(); }
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloLowerPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloLowerPass.cpp
@@ -1,0 +1,103 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Lowering Pass (post-expansion cleanup)
+//
+// Runs after ModuloExpandPass. Performs the same post-expansion steps
+// as the standard PipelinePass:
+//   1. removePipeliningAttributes — strip loop.stage/loop.cluster attrs
+//   2. asyncLaunchDots — pipeline wgmma ops (mark async, insert waits)
+//   3. updateWaits — adjust AsyncWaitOp pending counts
+//   4. pipelineTMAStores — pipeline TMA store operations
+//   5. arith canonicalization — clean up arithmetic
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-lower"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = triton;
+
+namespace {
+
+struct ModuloLowerPass
+    : public PassWrapper<ModuloLowerPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloLowerPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-lower"; }
+
+  StringRef getDescription() const override {
+    return "Post-expansion cleanup (asyncLaunchDots, updateWaits, TMA stores)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    LDBG("=== Post-expansion cleanup ===");
+
+    // Step 1: Remove pipelining attributes (loop.stage, loop.cluster, etc.)
+    LDBG("Step 1: removePipeliningAttributes");
+    tt::removePipeliningAttributes(moduleOp);
+
+    // Verify all loop.stage attrs were consumed and removed.
+    LLVM_DEBUG({
+      bool hasStaleAttrs = false;
+      moduleOp->walk([&](Operation *op) {
+        if (op->hasAttr(tt::kLoopStageAttrName)) {
+          hasStaleAttrs = true;
+          DBGS() << "WARNING: stale loop.stage on: " << *op << "\n";
+        }
+      });
+      if (hasStaleAttrs)
+        DBGS() << "WARNING: loop.stage attributes remain after "
+               << "removePipeliningAttributes\n";
+    });
+
+    // Step 2: Pipeline wgmma ops — mark dots as async, insert waits.
+    LDBG("Step 2: asyncLaunchDots");
+    SmallVector<scf::ForOp> loops;
+    moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      tt::asyncLaunchDots(forOp);
+
+    // Step 3: Update wait ops with correct pending counts.
+    LDBG("Step 3: updateWaits");
+    tt::updateWaits(moduleOp);
+
+    // Step 4: Canonicalize arith to simplify index arithmetic from expansion.
+    auto *arithDialect =
+        moduleOp.getContext()->getLoadedDialect<arith::ArithDialect>();
+    RewritePatternSet patterns(moduleOp.getContext());
+    arithDialect->getCanonicalizationPatterns(patterns);
+    if (applyPatternsGreedily(moduleOp, std::move(patterns)).failed())
+      return signalPassFailure();
+
+    // Step 5: Pipeline TMA stores.
+    LDBG("Step 5: pipelineTMAStores");
+    loops.clear();
+    moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      tt::pipelineTMAStores(forOp);
+
+    LDBG("Post-expansion cleanup complete");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloLower() {
+  return std::make_unique<ModuloLowerPass>();
+}
+
+void registerNVGPUModuloLower() { PassRegistration<ModuloLowerPass>(); }
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
@@ -55,8 +55,8 @@ static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
     if (!innerName.empty())
       os << "(" << innerName << ")";
   }
-  os << "  {pipe: " << getPipelineName(node.pipeline) << ", cycle: "
-     << node.cycle;
+  os << "  {pipe: " << getPipelineName(node.pipeline)
+     << ", cycle: " << node.cycle;
   if (node.latency)
     os << ", latency: " << node.latency;
   if (node.selfLatency)
@@ -70,8 +70,7 @@ static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
   os << "}\n";
 }
 
-static void dumpPort(const PipelineLoop::MemPort &port,
-                     llvm::raw_ostream &os) {
+static void dumpPort(const PipelineLoop::MemPort &port, llvm::raw_ostream &os) {
   if (!port.op) {
     if (port.bufferId != UINT_MAX)
       os << "buf" << port.bufferId;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
@@ -40,12 +40,12 @@ enum class MemoryKind { SMEM, TMEM, Register, BARRIER };
 struct PipelineBuffer {
   unsigned id{};
   MemoryKind kind{MemoryKind::SMEM};
-  llvm::SmallVector<int64_t, 4> shape;  // e.g., {128, 64}
-  unsigned elementBitWidth{16};       // e.g., 16 for f16
-  unsigned count{1};                  // number of buffers (from stageDiff + 1)
+  llvm::SmallVector<int64_t, 4> shape; // e.g., {128, 64}
+  unsigned elementBitWidth{16};        // e.g., 16 for f16
+  unsigned count{1};                   // number of buffers (from stageDiff + 1)
 
-  // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if none)
-  // For barrier buffers: index of the data buffer this barrier guards
+  // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if
+  // none) For barrier buffers: index of the data buffer this barrier guards
   unsigned pairedBufferId{UINT_MAX};
 
   // The MLIR op that originally defines this buffer (e.g., local_alloc)
@@ -72,17 +72,17 @@ struct PipelineNode {
 
   // Schedule assignment (from Phase 0)
   HWPipeline pipeline{HWPipeline::NONE};
-  int cycle{0};          // absolute cycle within the II
-  int stage{0};          // cycle / II
-  int latency{0};        // cycles until result available
-  int selfLatency{0};    // cycles this op occupies its pipeline
+  int cycle{0};       // absolute cycle within the II
+  int stage{0};       // cycle / II
+  int latency{0};     // cycles until result available
+  int selfLatency{0}; // cycles this op occupies its pipeline
 
   // Super-node: if this node represents a child pipeline (inner loop)
   unsigned childPipelineId{UINT_MAX}; // index into PipelineGraph::pipelines
   int prologueLatency{0};             // cycles before TC starts in child
 
   // Buffer references
-  unsigned producesBuffer{UINT_MAX};  // index into PipelineLoop::buffers
+  unsigned producesBuffer{UINT_MAX}; // index into PipelineLoop::buffers
   llvm::SmallVector<unsigned, 2> consumesBuffers; // indices into buffers
 
   // Warp specialization (from Phase 1.5)
@@ -120,8 +120,9 @@ struct PipelineLoop {
   int II{0};
   int maxStage{0};
   int prologueLatency{0}; // cycles before TC starts (for parent's super-node)
-  int tripCount{0};        // loop trip count (0 = unknown/not set)
-  bool tripCountIsEstimated{false}; // true if tripCount is estimated, not constant
+  int tripCount{0};       // loop trip count (0 = unknown/not set)
+  bool tripCountIsEstimated{
+      false}; // true if tripCount is estimated, not constant
 
   // Body (kernel loop steady state)
   llvm::SmallVector<PipelineNode, 16> nodes;
@@ -137,9 +138,10 @@ struct PipelineLoop {
   // Memory interface (inputs/outputs crossing loop boundary)
   // These drive multi-buffering at the parent level.
   //
-  // isInput is intentionally kept alongside the separate inputs/outputs vectors:
-  // it allows generic iteration over all ports (e.g., when building the parent's
-  // buffer map) without needing to know which vector a port came from.
+  // isInput is intentionally kept alongside the separate inputs/outputs
+  // vectors: it allows generic iteration over all ports (e.g., when building
+  // the parent's buffer map) without needing to know which vector a port came
+  // from.
   struct MemPort {
     unsigned bufferId{UINT_MAX}; // index into parent's buffers
     Operation *op{nullptr};      // the MLIR op at the boundary


### PR DESCRIPTION
Summary:

Add the loop expansion and post-expansion lowering passes for the
modulo scheduling pipeline.

**ModuloExpandPass** (Phase 2+3 combined): Takes a modulo-scheduled
loop (with loop.stage/loop.cluster attrs from Pass A) and performs
the full software pipelining transformation:

1. **lowerLoops()**: Transforms descriptor_load into async TMA copies,
   inserts mbarrier wait/arrive ops, allocates multi-buffered SMEM
   based on stage differences. Reads loop.stage to determine buffer
   depths — loads at stage 0 and consumers at stage N get
   (N+1)-buffered SMEM.

2. **expandLoops()**: Generates prologue (ramp up pipeline stages),
   kernel body (all stages active), and epilogue (drain) via
   PipelineExpander. Handles MMAv5 epilogue peeling for Blackwell
   tc_gen5_mma wait semantics.

3. **resolveMaskOp()**: Resolves predicated ops (ttg.mask) inserted
   by the expander for dynamic trip count handling.

The key difference from the standard Pipeline pass is that the
schedule comes from Rau's iterative modulo scheduling rather than the
heuristic assign_latencies + schedule_loops path.

**ModuloLowerPass** (post-expansion cleanup): Runs after expansion
and performs the same steps as the standard Pipeline pass:

1. removePipeliningAttributes — strip loop.stage/loop.cluster attrs
2. asyncLaunchDots — pipeline wgmma ops (mark async, insert waits)
3. updateWaits — adjust AsyncWaitOp pending counts
4. pipelineTMAStores — pipeline TMA store operations
5. arith canonicalization — clean up arithmetic from expansion

Neither pass is wired into the compiler pipeline by default.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D100122316


