### PR TITLE
[AutoWS] Add lowerLoops + PipelineGraph expansion to ModuloSchedulePass (#1229)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -137,6 +137,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // NVGPU transform passes
   mlir::registerNVHopperTransformsPasses();
   mlir::registerNVGPUModuloSchedule();
+  mlir::registerNVGPUModuloWSPartition();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -138,6 +138,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVHopperTransformsPasses();
   mlir::registerNVGPUModuloSchedule();
   mlir::registerNVGPUModuloWSPartition();
+  mlir::registerNVGPUModuloBufferAlloc();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -139,6 +139,8 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVGPUModuloSchedule();
   mlir::registerNVGPUModuloWSPartition();
   mlir::registerNVGPUModuloBufferAlloc();
+  mlir::registerNVGPUModuloExpand();
+  mlir::registerNVGPUModuloLower();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -136,6 +136,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
 
   // NVGPU transform passes
   mlir::registerNVHopperTransformsPasses();
+  mlir::registerNVGPUModuloSchedule();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -830,7 +830,26 @@ void scheduleLoops(ModuleOp moduleOp, int defaultNumStages, bool useMetaWS) {
   moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
   if (loops.empty())
     return;
+  // If any loop has tt.modulo_ii, skip ALL loops — the modulo schedule
+  // handles scheduling globally. This module-wide skip is needed because
+  // the WS pass's PartitionLoops creates partition loop clones inside
+  // warp_specialize regions that don't inherit tt.modulo_ii from the
+  // original loop. Without the module-wide skip, these clones get
+  // re-scheduled by the heuristic, overwriting the modulo stage assignments.
+  // TODO: Propagate tt.modulo_ii to partition clones in WS pass so we can
+  // skip only annotated loops instead of all loops in the module.
+  bool moduleHasModuloSchedule = false;
   for (auto forOp : loops) {
+    if (forOp->hasAttr("tt.modulo_ii")) {
+      moduleHasModuloSchedule = true;
+      break;
+    }
+  }
+  for (auto forOp : loops) {
+    if (forOp->hasAttr("tt.modulo_ii") || moduleHasModuloSchedule) {
+      LDBG("Skipping loop (modulo-scheduled)");
+      continue;
+    }
     scheduleLoop(forOp, opLatency, defaultNumStages, useMetaWS);
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -101,6 +101,9 @@ static void expandLoops(ModuleOp moduleOp) {
   auto metaWS = triton::tools::getBoolEnv("TRITON_USE_META_WS");
 
   for (scf::ForOp forOp : loops) {
+    // Skip loops already expanded by modulo scheduling.
+    if (forOp->hasAttr("tt.modulo_ii"))
+      continue;
     CoarseSchedule schedule;
     if (failed(schedule.deSerialize(forOp))) {
       continue;

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -509,6 +509,7 @@ class nvidia_knobs(base_knobs):
     libcuda_path: env_opt_str = env_opt_str("TRITON_LIBCUDA_PATH")
     use_meta_ws: env_bool = env_bool("TRITON_USE_META_WS")
     use_meta_partition: env_bool = env_bool("TRITON_USE_META_PARTITION")
+    use_modulo_schedule: env_bool = env_bool("TRITON_USE_MODULO_SCHEDULE")
     # Force OAI SWP schedule even when using Meta's WS implementation.
     force_trunk_swp_schedule: env_bool = env_bool("TRITON_FORCE_TRUNK_SWP_SCHEDULE")
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -12,10 +12,13 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // and sets tt.modulo_ii on the loop.
 //
 // CHECK-LABEL: @gemm_inner_loop
+// Cluster IDs are dense ranks of modulo cycles within each stage (Step 2.5).
+// Stages processed in reverse order: higher stage -> lower cluster ID.
+// Same cycle -> same cluster; different cycle -> different cluster.
 // CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32}
 // CHECK: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK: tt.modulo_ii

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -1,0 +1,52 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// Verify that the modulo schedule pass annotates ops with loop.stage/loop.cluster
+// and sets tt.modulo_ii on the loop.
+//
+// CHECK-LABEL: @gemm_inner_loop
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK: tt.modulo_ii
+// CHECK: tt.scheduled_max_stage
+tt.func @gemm_inner_loop(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x128xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked>
+
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+
+    scf.yield %c : tensor<128x128xf32, #acc_layout>
+  }
+
+  tt.return
+}
+
+}

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -17,12 +17,13 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // Same cycle -> same cluster; different cycle -> different cluster.
 // CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
 // CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} loop.cluster = 2 : i32, loop.stage = 0 : i32{{.*}}tt.num_buffers =
+// CHECK: ttg.local_alloc {{.*}} loop.cluster = 3 : i32, loop.stage = 0 : i32{{.*}}tt.num_buffers =
 // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32}
 // CHECK: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK: tt.modulo_ii
-// CHECK: tt.scheduled_max_stage
+// CHECK: tt.num_stages
+// CHECK-SAME: tt.scheduled_max_stage
 tt.func @gemm_inner_loop(
   %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
   %b_desc: !tt.tensordesc<tensor<64x128xf16>>

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -385,8 +385,11 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_hoist_tmem_alloc(pm, False)
             nvidia.passes.ttnvgpuir.add_promote_lhs_to_tmem(pm)
             nvidia.passes.hopper.add_data_partitioning(pm, 1)
-            passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
-            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
+            if knobs.nvidia.use_modulo_schedule:
+                nvidia.passes.hopper.add_modulo_schedule(pm)
+            else:
+                passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
+                passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             if not knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_warp_specialize(pm, opt.num_stages)
             else:

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -21,6 +21,10 @@ std::unique_ptr<Pass> createNVGPUModuloWSPartition();
 void registerNVGPUModuloWSPartition();
 std::unique_ptr<Pass> createNVGPUModuloBufferAlloc();
 void registerNVGPUModuloBufferAlloc();
+std::unique_ptr<Pass> createNVGPUModuloExpand();
+void registerNVGPUModuloExpand();
+std::unique_ptr<Pass> createNVGPUModuloLower();
+void registerNVGPUModuloLower();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -14,5 +14,8 @@ namespace mlir {
 #define GEN_PASS_REGISTRATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
 
+// Modulo scheduling pass (manual registration, not tablegen-generated).
+std::unique_ptr<Pass> createNVGPUModuloSchedule();
+
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -19,6 +19,8 @@ std::unique_ptr<Pass> createNVGPUModuloSchedule();
 void registerNVGPUModuloSchedule();
 std::unique_ptr<Pass> createNVGPUModuloWSPartition();
 void registerNVGPUModuloWSPartition();
+std::unique_ptr<Pass> createNVGPUModuloBufferAlloc();
+void registerNVGPUModuloBufferAlloc();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -14,9 +14,11 @@ namespace mlir {
 #define GEN_PASS_REGISTRATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
 
-// Modulo scheduling pass (manual registration, not tablegen-generated).
+// Modulo scheduling passes (manual registration, not tablegen-generated).
 std::unique_ptr<Pass> createNVGPUModuloSchedule();
 void registerNVGPUModuloSchedule();
+std::unique_ptr<Pass> createNVGPUModuloWSPartition();
+void registerNVGPUModuloWSPartition();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -16,6 +16,7 @@ namespace mlir {
 
 // Modulo scheduling pass (manual registration, not tablegen-generated).
 std::unique_ptr<Pass> createNVGPUModuloSchedule();
+void registerNVGPUModuloSchedule();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/WSTaskPartition.cpp
   WarpSpecialization/PartitionSchedulingMeta.cpp
   ModuloScheduling/LatencyModel.cpp
+  ModuloScheduling/DataDependenceGraph.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/PartitionSchedulingMeta.cpp
   ModuloScheduling/LatencyModel.cpp
   ModuloScheduling/DataDependenceGraph.cpp
+  ModuloScheduling/ModuloReservationTable.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/WSTaskIdPropagate.cpp
   WarpSpecialization/WSTaskPartition.cpp
   WarpSpecialization/PartitionSchedulingMeta.cpp
+  ModuloScheduling/LatencyModel.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/DataDependenceGraph.cpp
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/ModuloSchedulePass.cpp
+  ModuloScheduling/ModuloWSPartitionPass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/ModuloSchedulePass.cpp
   ModuloScheduling/ModuloWSPartitionPass.cpp
+  ModuloScheduling/ModuloPipelineIR.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/LatencyModel.cpp
   ModuloScheduling/DataDependenceGraph.cpp
   ModuloScheduling/ModuloReservationTable.cpp
+  ModuloScheduling/ModuloSchedulePass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloSchedulePass.cpp
   ModuloScheduling/ModuloWSPartitionPass.cpp
   ModuloScheduling/ModuloPipelineIR.cpp
+  ModuloScheduling/ModuloBufferAllocPass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -23,6 +23,8 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloWSPartitionPass.cpp
   ModuloScheduling/ModuloPipelineIR.cpp
   ModuloScheduling/ModuloBufferAllocPass.cpp
+  ModuloScheduling/ModuloExpandPass.cpp
+  ModuloScheduling/ModuloLowerPass.cpp
 
   DEPENDS
   NVHopperTransformsIncGen

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -1,0 +1,284 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "DataDependenceGraph.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <cmath>
+#include <queue>
+
+#define DEBUG_TYPE "modulo-scheduling-ddg"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+namespace mlir::triton::gpu {
+
+namespace ttng = mlir::triton::nvidia_gpu;
+
+
+unsigned DataDependenceGraph::addNode(Operation *op,
+                                      const LatencyModel &model) {
+  auto info = model.getLatency(op);
+  unsigned idx = nodes.size();
+  DDGNode node;
+  node.op = op;
+  node.idx = idx;
+  node.pipeline = info.pipeline;
+  node.latency = info.latency;
+  node.selfLatency = info.selfLatency;
+  nodes.push_back(node);
+  opToIdx[op] = idx;
+  return idx;
+}
+
+void DataDependenceGraph::addEdge(unsigned src, unsigned dst, int latency,
+                                  unsigned distance) {
+  edges.push_back(DDGEdge{src, dst, latency, distance});
+  nodes[src].succs.push_back(dst);
+  nodes[dst].preds.push_back(src);
+}
+
+DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
+                                               const LatencyModel &model) {
+  DataDependenceGraph ddg;
+
+  // Phase 1: Create nodes for every op in the loop body (except terminator).
+  auto &body = loop.getBody()->getOperations();
+  for (auto &op : body) {
+    if (op.hasTrait<OpTrait::IsTerminator>())
+      continue;
+    // Skip inner scf.for loops — this DDG handles flat loop bodies only.
+    // Inner loop super-node modeling is added in a follow-up diff for
+    // outer loop (persistent kernel) scheduling.
+    if (isa<scf::ForOp>(op))
+      continue;
+    ddg.addNode(&op, model);
+  }
+
+  // Phase 2: Intra-iteration edges from SSA def-use chains.
+  for (auto &node : ddg.nodes) {
+    for (auto operand : node.op->getOperands()) {
+      auto *defOp = operand.getDefiningOp();
+      if (!defOp || defOp->getNumResults() == 0)
+        continue;
+      auto it = ddg.opToIdx.find(defOp);
+      if (it == ddg.opToIdx.end())
+        continue;
+      unsigned srcIdx = it->second;
+      // Edge latency = producer's latency (time until result available).
+      // Exception: for MEM → local_alloc edges, use selfLatency instead of
+      // the full async latency. local_alloc is a format conversion (registers
+      // → SMEM) that must stay at the same pipeline stage as its load.
+      // The async overhead only applies to the MMA consumer, not local_alloc.
+      int edgeLatency = ddg.nodes[srcIdx].latency;
+      if (ddg.nodes[srcIdx].pipeline == HWPipeline::MEM &&
+          isa<triton::gpu::LocalAllocOp>(node.op)) {
+        edgeLatency = ddg.nodes[srcIdx].selfLatency;
+      }
+      ddg.addEdge(srcIdx, node.idx, edgeLatency, /*distance=*/0);
+    }
+  }
+
+  // Phase 3: Loop-carried edges via scf.yield → iter_args.
+  auto yieldOp = loop.getBody()->getTerminator();
+  auto iterArgs = loop.getRegionIterArgs();
+  for (unsigned i = 0; i < yieldOp->getNumOperands(); ++i) {
+    auto yieldVal = yieldOp->getOperand(i);
+    auto *yieldDef = yieldVal.getDefiningOp();
+    if (!yieldDef || yieldDef->getNumResults() == 0 ||
+        ddg.opToIdx.count(yieldDef) == 0)
+      continue;
+    unsigned srcIdx = ddg.opToIdx[yieldDef];
+
+    // The iter_arg at position i receives yieldVal in the next iteration.
+    // Find all users of that iter_arg within the loop body.
+    if (i >= iterArgs.size())
+      continue;
+    auto iterArg = iterArgs[i];
+    for (auto *user : iterArg.getUsers()) {
+      if (user->hasTrait<OpTrait::IsTerminator>())
+        continue;
+      auto userIt = ddg.opToIdx.find(user);
+      if (userIt == ddg.opToIdx.end())
+        continue;
+      ddg.addEdge(srcIdx, userIt->second, ddg.nodes[srcIdx].latency,
+                  /*distance=*/1);
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "[DDG] Built DDG with " << ddg.nodes.size() << " nodes, "
+                 << ddg.edges.size() << " edges\n";
+    ddg.dump();
+  });
+
+  return ddg;
+}
+
+llvm::SmallVector<const DDGEdge *>
+DataDependenceGraph::getInEdges(unsigned nodeIdx) const {
+  llvm::SmallVector<const DDGEdge *> result;
+  for (const auto &e : edges)
+    if (e.dstIdx == nodeIdx)
+      result.push_back(&e);
+  return result;
+}
+
+llvm::SmallVector<const DDGEdge *>
+DataDependenceGraph::getOutEdges(unsigned nodeIdx) const {
+  llvm::SmallVector<const DDGEdge *> result;
+  for (const auto &e : edges)
+    if (e.srcIdx == nodeIdx)
+      result.push_back(&e);
+  return result;
+}
+
+llvm::DenseMap<unsigned, int>
+DataDependenceGraph::computeCriticalPathHeights() const {
+  llvm::DenseMap<unsigned, int> heights;
+  llvm::DenseSet<unsigned> visiting; // cycle detection
+  // Reverse topological order: process sinks first.
+  // Use DFS-based approach since graph is small.
+  std::function<int(unsigned)> computeHeight = [&](unsigned idx) -> int {
+    auto it = heights.find(idx);
+    if (it != heights.end())
+      return it->second;
+    // Guard against cycles in distance-0 edges. DDG construction guarantees
+    // acyclicity, but this prevents infinite recursion if invariant is broken.
+    if (!visiting.insert(idx).second)
+      return 0;
+    int maxSuccHeight = 0;
+    for (const auto *edge : getOutEdges(idx)) {
+      if (edge->distance > 0)
+        continue; // skip loop-carried for critical path
+      int succHeight = computeHeight(edge->dstIdx);
+      maxSuccHeight = std::max(maxSuccHeight, edge->latency + succHeight);
+    }
+    visiting.erase(idx);
+    heights[idx] = maxSuccHeight;
+    return maxSuccHeight;
+  };
+  for (unsigned i = 0; i < nodes.size(); ++i)
+    computeHeight(i);
+  return heights;
+}
+
+int DataDependenceGraph::computeResMII() const {
+  llvm::DenseMap<HWPipeline, int> pipeLoad;
+  for (const auto &node : nodes) {
+    if (node.pipeline == HWPipeline::NONE)
+      continue;
+    pipeLoad[node.pipeline] += node.selfLatency;
+  }
+  int maxLoad = 0;
+  for (auto &[pipe, load] : pipeLoad) {
+    LLVM_DEBUG(llvm::dbgs() << "[DDG] Pipeline " << getPipelineName(pipe)
+                            << " load: " << load << " cycles\n");
+    maxLoad = std::max(maxLoad, load);
+  }
+  return maxLoad;
+}
+
+int DataDependenceGraph::computeRecMII() const {
+  // Compute RecMII = max over all recurrence circuits of ceil(sum_lat /
+  // sum_dist).
+  //
+  // For each back-edge (distance > 0), find the longest forward path from
+  // dst back to src. The recurrence latency = forward_path + back_edge_latency,
+  // and distance = forward_distance + back_edge_distance. RecMII for that
+  // circuit = ceil(total_lat / total_dist).
+  //
+  // We use Floyd-Warshall to compute longest forward paths (distance=0 edges
+  // only), then combine with each back-edge.
+  const unsigned N = nodes.size();
+  if (N == 0)
+    return 0;
+
+  // Forward-path longest latencies (only distance=0 edges).
+  constexpr int NEG_INF = -1;
+  std::vector<std::vector<int>> fwdLat(N, std::vector<int>(N, NEG_INF));
+
+  // Initialize with distance=0 edges only.
+  for (const auto &e : edges) {
+    if (e.distance == 0) {
+      fwdLat[e.srcIdx][e.dstIdx] =
+          std::max(fwdLat[e.srcIdx][e.dstIdx], e.latency);
+    }
+  }
+  // Self-loops with distance 0.
+  for (unsigned i = 0; i < N; ++i)
+    fwdLat[i][i] = std::max(fwdLat[i][i], 0);
+
+  // Floyd-Warshall on forward paths.
+  for (unsigned k = 0; k < N; ++k) {
+    for (unsigned i = 0; i < N; ++i) {
+      for (unsigned j = 0; j < N; ++j) {
+        if (fwdLat[i][k] == NEG_INF || fwdLat[k][j] == NEG_INF)
+          continue;
+        int newLat = fwdLat[i][k] + fwdLat[k][j];
+        if (newLat > fwdLat[i][j])
+          fwdLat[i][j] = newLat;
+      }
+    }
+  }
+
+  // For each back-edge, compute the recurrence ratio.
+  int recMII = 0;
+  for (const auto &e : edges) {
+    if (e.distance == 0)
+      continue;
+    // Back-edge: src → dst with distance > 0.
+    // Forward path: dst →...→ src (distance=0 edges).
+    // Total recurrence: forward_lat + back_edge_lat, total_dist = e.distance.
+    int forwardLat = fwdLat[e.dstIdx][e.srcIdx];
+    if (forwardLat == NEG_INF)
+      continue; // no forward path completes the circuit
+    int totalLat = forwardLat + e.latency;
+    int totalDist = e.distance;
+    int rec = (totalLat + totalDist - 1) / totalDist; // ceil
+    LLVM_DEBUG(llvm::dbgs() << "[DDG] Recurrence: back-edge " << e.srcIdx
+                            << " -> " << e.dstIdx << " (dist=" << e.distance
+                            << ") fwdLat=" << forwardLat << " totalLat="
+                            << totalLat << " RecMII=" << rec << "\n");
+    recMII = std::max(recMII, rec);
+  }
+  return recMII;
+}
+
+int DataDependenceGraph::computeMinII() const {
+  int resMII = computeResMII();
+  int recMII = computeRecMII();
+  int minII = std::max(resMII, recMII);
+  LLVM_DEBUG(llvm::dbgs() << "[DDG] ResMII=" << resMII << " RecMII=" << recMII
+                          << " MinII=" << minII << "\n");
+  return minII;
+}
+
+void DataDependenceGraph::dump() const {
+  llvm::dbgs() << "=== DDG Dump ===\n";
+  for (const auto &node : nodes) {
+    llvm::dbgs() << "  Node " << node.idx
+                 << ": pipeline=" << getPipelineName(node.pipeline)
+                 << " latency=" << node.latency
+                 << " selfLatency=" << node.selfLatency;
+    if (node.isSuperNode)
+      llvm::dbgs() << " [SUPER-NODE innerII=" << node.innerII << "]";
+    llvm::dbgs() << " op=";
+    node.op->print(llvm::dbgs(), OpPrintingFlags().skipRegions());
+    llvm::dbgs() << "\n";
+  }
+  for (const auto &edge : edges) {
+    llvm::dbgs() << "  Edge " << edge.srcIdx << " -> " << edge.dstIdx
+                 << " latency=" << edge.latency << " distance=" << edge.distance
+                 << "\n";
+  }
+  llvm::dbgs() << "=== End DDG ===\n";
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -1,6 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "DataDependenceGraph.h"
+#include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -21,6 +22,105 @@ namespace mlir::triton::gpu {
 
 namespace ttng = mlir::triton::nvidia_gpu;
 
+// Default estimated trip count for inner loops with dynamic bounds.
+constexpr int kDefaultInnerTripCount = 4;
+
+// Fallback latency constants from Blackwell SM100 microbenchmarks.
+// Used when inner loop scheduling fails or stageLoads are empty.
+constexpr int kFallbackTMASelfLatency = 518;   // TMA load pipeline occupancy
+constexpr int kFallbackTMATotalLatency = 1218; // TMA self + async overhead
+constexpr int kFallbackMMALatency = 900;       // MMA 128x128x128 TC latency
+
+/// Per-stage pipeline load summary from inner loop schedule.
+struct StageLoad {
+  int memSelfLatency{0};
+  int tcSelfLatency{0};
+  int cudaSelfLatency{0};
+  int totalLatency{0};
+};
+
+/// Info extracted from inner loop modulo scheduling.
+struct InnerLoopInfo {
+  int II;
+  int prologueLatency;
+  int tripCount;
+  bool tripCountIsEstimated{true};
+  SmallVector<StageLoad, 4> stageLoads;
+  int maxStage{0};
+};
+
+static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
+                                          const LatencyModel &model) {
+  InnerLoopInfo info;
+  info.tripCount = kDefaultInnerTripCount;
+  info.tripCountIsEstimated = true;
+
+  auto innerDDG = DataDependenceGraph::build(innerLoop, model);
+  if (innerDDG.getNumNodes() == 0) {
+    info.II = kFallbackMMALatency;
+    info.prologueLatency = 0;
+    return info;
+  }
+  auto result = runModuloScheduling(innerDDG);
+  if (failed(result)) {
+    info.II = std::max(innerDDG.computeResMII(), kFallbackMMALatency);
+    info.prologueLatency = 0;
+    return info;
+  }
+
+  info.II = result->II;
+  info.maxStage = result->getMaxStage();
+
+  auto lb = innerLoop.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
+  auto ub = innerLoop.getUpperBound().getDefiningOp<arith::ConstantIntOp>();
+  auto step = innerLoop.getStep().getDefiningOp<arith::ConstantIntOp>();
+  if (lb && ub && step && step.value() > 0) {
+    int64_t tc =
+        (ub.value() - lb.value() + step.value() - 1) / step.value();
+    if (tc > 0) {
+      info.tripCount = static_cast<int>(tc);
+      info.tripCountIsEstimated = false;
+    }
+  }
+
+  int tcStart = result->II;
+  for (const auto &node : innerDDG.getNodes()) {
+    if (node.pipeline == HWPipeline::TC) {
+      auto it = result->nodeToCycle.find(node.idx);
+      if (it != result->nodeToCycle.end())
+        tcStart = std::min(tcStart, it->second);
+    }
+  }
+  info.prologueLatency = tcStart;
+
+  info.stageLoads.resize(info.maxStage + 1);
+  for (const auto &node : innerDDG.getNodes()) {
+    auto it = result->nodeToCycle.find(node.idx);
+    if (it == result->nodeToCycle.end())
+      continue;
+    int stage = it->second / info.II;
+    if (stage > info.maxStage)
+      continue;
+    auto &sl = info.stageLoads[stage];
+    switch (node.pipeline) {
+    case HWPipeline::MEM:
+      sl.memSelfLatency += node.selfLatency;
+      break;
+    case HWPipeline::TC:
+      sl.tcSelfLatency += node.selfLatency;
+      break;
+    case HWPipeline::CUDA:
+    case HWPipeline::SFU:
+      sl.cudaSelfLatency += node.selfLatency;
+      break;
+    default:
+      break;
+    }
+    sl.totalLatency = std::max(sl.totalLatency, node.latency);
+  }
+
+  return info;
+}
 
 unsigned DataDependenceGraph::addNode(Operation *op,
                                       const LatencyModel &model) {
@@ -53,11 +153,115 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   for (auto &op : body) {
     if (op.hasTrait<OpTrait::IsTerminator>())
       continue;
-    // Skip inner scf.for loops — this DDG handles flat loop bodies only.
-    // Inner loop super-node modeling is added in a follow-up diff for
-    // outer loop (persistent kernel) scheduling.
-    if (isa<scf::ForOp>(op))
+    // Model inner scf.for as a super-node for outer loop scheduling.
+    if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
+      auto info = computeInnerLoopInfo(innerLoop, model);
+
+      if (info.maxStage == 0) {
+        unsigned idx = ddg.nodes.size();
+        DDGNode node;
+        node.op = &op;
+        node.idx = idx;
+        node.pipeline = HWPipeline::TC;
+        int totalLatency = info.prologueLatency + info.tripCount * info.II;
+        node.latency = std::max(totalLatency, 1);
+        node.selfLatency = std::max(totalLatency, 1);
+        node.isSuperNode = true;
+        node.innerII = info.II;
+        node.prologueLatency = info.prologueLatency;
+        ddg.nodes.push_back(node);
+        ddg.opToIdx[&op] = idx;
+        continue;
+      }
+
+      // Multi-stage: split into prologue/kloop/epilogue.
+      unsigned prologueIdx = ddg.nodes.size();
+      {
+        DDGNode node;
+        node.op = &op;
+        node.idx = prologueIdx;
+        node.pipeline = HWPipeline::MEM;
+        int memLat =
+            info.stageLoads.empty() ? kFallbackTMATotalLatency : info.stageLoads[0].totalLatency;
+        node.latency = std::max(memLat, 1);
+        node.selfLatency =
+            info.stageLoads.empty() ? kFallbackTMASelfLatency : info.stageLoads[0].memSelfLatency;
+        node.selfLatency = std::max(node.selfLatency, 1);
+        ddg.nodes.push_back(node);
+      }
+
+      unsigned kloopIdx = ddg.nodes.size();
+      {
+        DDGNode node;
+        node.op = &op;
+        node.idx = kloopIdx;
+        node.pipeline = HWPipeline::TC;
+        int steadyIters = std::max(info.tripCount - info.maxStage, 1);
+        node.latency = steadyIters * info.II;
+        int tcPerIter = info.stageLoads.size() > (unsigned)info.maxStage
+                            ? info.stageLoads[info.maxStage].tcSelfLatency
+                            : kFallbackMMALatency;
+        node.selfLatency = std::max(steadyIters * tcPerIter, 1);
+        node.isSuperNode = true;
+        node.innerII = info.II;
+        node.prologueLatency = info.prologueLatency;
+        ddg.nodes.push_back(node);
+      }
+
+      unsigned epilogueIdx = ddg.nodes.size();
+      {
+        DDGNode node;
+        node.op = &op;
+        node.idx = epilogueIdx;
+        node.pipeline = HWPipeline::TC;
+        int tcLat = info.stageLoads.size() > (unsigned)info.maxStage
+                        ? info.stageLoads[info.maxStage].tcSelfLatency
+                        : kFallbackMMALatency;
+        node.latency = std::max(tcLat, 1);
+        node.selfLatency = std::max(tcLat, 1);
+        ddg.nodes.push_back(node);
+      }
+
+      ddg.opToIdx[&op] = epilogueIdx;        // producer: results come from epilogue
+      ddg.consumerOpToIdx[&op] = prologueIdx; // consumer: data enters at prologue
+      ddg.addEdge(prologueIdx, kloopIdx, ddg.nodes[prologueIdx].latency,
+                  /*distance=*/0);
+      ddg.addEdge(kloopIdx, epilogueIdx, ddg.nodes[kloopIdx].latency,
+                  /*distance=*/0);
       continue;
+    }
+    // Handle scf.if: walk regions to find pipeline-relevant ops.
+    // Persistent kernels put TMA loads inside conditional prefetch blocks
+    // (scf.if i < num_iter). Without this, those ops are invisible to
+    // the scheduler.
+    if (isa<scf::IfOp>(op)) {
+      HWPipeline bestPipeline = HWPipeline::NONE;
+      int bestLatency = 0;
+      int bestSelfLatency = 0;
+      op.walk([&](Operation *nested) {
+        if (nested == &op)
+          return;
+        auto info = model.getLatency(nested);
+        if (info.pipeline != HWPipeline::NONE &&
+            info.selfLatency > bestSelfLatency) {
+          bestPipeline = info.pipeline;
+          bestLatency = info.latency;
+          bestSelfLatency = info.selfLatency;
+        }
+      });
+      if (bestPipeline != HWPipeline::NONE) {
+        unsigned idx = ddg.nodes.size();
+        DDGNode node;
+        node.op = &op;
+        node.idx = idx;
+        node.pipeline = bestPipeline;
+        node.latency = bestLatency;
+        node.selfLatency = bestSelfLatency;
+        ddg.nodes.push_back(node);
+        ddg.opToIdx[&op] = idx;
+        continue;
+      }
+    }
     ddg.addNode(&op, model);
   }
 
@@ -85,6 +289,46 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
     }
   }
 
+  // Phase 2.5: Implicit MEM-load → TC/super-node edges.
+  // In persistent kernels using lowered TMA (async_tma_copy), the MEM→TC
+  // dependency goes through SMEM buffers and barriers, not SSA. Without
+  // these edges the scheduler places MEM and TC at the same cycle.
+  {
+    SmallVector<unsigned> memLoadNodes, tcNodes;
+    for (const auto &node : ddg.nodes) {
+      if (node.pipeline == HWPipeline::MEM) {
+        bool isStore = isa<triton::DescriptorStoreOp>(node.op) ||
+                       isa<ttng::AsyncTMACopyLocalToGlobalOp>(node.op);
+        if (!isStore && isa<scf::IfOp>(node.op)) {
+          node.op->walk([&](Operation *nested) {
+            if (isa<triton::DescriptorStoreOp>(nested) ||
+                isa<ttng::AsyncTMACopyLocalToGlobalOp>(nested))
+              isStore = true;
+          });
+        }
+        if (!isStore)
+          memLoadNodes.push_back(node.idx);
+      }
+      if (node.pipeline == HWPipeline::TC || node.isSuperNode)
+        tcNodes.push_back(node.idx);
+    }
+    for (unsigned memIdx : memLoadNodes) {
+      for (unsigned tcIdx : tcNodes) {
+        bool hasEdge = false;
+        for (const auto &e : ddg.edges) {
+          if (e.srcIdx == memIdx && e.dstIdx == tcIdx) {
+            hasEdge = true;
+            break;
+          }
+        }
+        if (!hasEdge) {
+          ddg.addEdge(memIdx, tcIdx, ddg.nodes[memIdx].latency,
+                      /*distance=*/0);
+        }
+      }
+    }
+  }
+
   // Phase 3: Loop-carried edges via scf.yield → iter_args.
   auto yieldOp = loop.getBody()->getTerminator();
   auto iterArgs = loop.getRegionIterArgs();
@@ -104,10 +348,19 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
     for (auto *user : iterArg.getUsers()) {
       if (user->hasTrait<OpTrait::IsTerminator>())
         continue;
-      auto userIt = ddg.opToIdx.find(user);
-      if (userIt == ddg.opToIdx.end())
-        continue;
-      ddg.addEdge(srcIdx, userIt->second, ddg.nodes[srcIdx].latency,
+      // For multi-stage super-nodes, loop-carried edges should target
+      // the prologue (data enters at the start), not the epilogue.
+      auto consIt = ddg.consumerOpToIdx.find(user);
+      unsigned dstIdx;
+      if (consIt != ddg.consumerOpToIdx.end()) {
+        dstIdx = consIt->second;
+      } else {
+        auto userIt = ddg.opToIdx.find(user);
+        if (userIt == ddg.opToIdx.end())
+          continue;
+        dstIdx = userIt->second;
+      }
+      ddg.addEdge(srcIdx, dstIdx, ddg.nodes[srcIdx].latency,
                   /*distance=*/1);
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -23,6 +23,7 @@ namespace mlir::triton::gpu {
 namespace ttng = mlir::triton::nvidia_gpu;
 
 // Default estimated trip count for inner loops with dynamic bounds.
+// Used to compute super-node latency = prologue + K_est * II.
 constexpr int kDefaultInnerTripCount = 4;
 
 // Fallback latency constants from Blackwell SM100 microbenchmarks.
@@ -33,18 +34,19 @@ constexpr int kFallbackMMALatency = 900;       // MMA 128x128x128 TC latency
 
 /// Per-stage pipeline load summary from inner loop schedule.
 struct StageLoad {
-  int memSelfLatency{0};
-  int tcSelfLatency{0};
-  int cudaSelfLatency{0};
-  int totalLatency{0};
+  int memSelfLatency{0};  // total MEM pipeline occupancy
+  int tcSelfLatency{0};   // total TC pipeline occupancy
+  int cudaSelfLatency{0}; // total CUDA pipeline occupancy
+  int totalLatency{0};    // max end-to-end latency across all ops
 };
 
 /// Info extracted from inner loop modulo scheduling.
 struct InnerLoopInfo {
   int II;
-  int prologueLatency;
-  int tripCount;
+  int prologueLatency; // cycles before TC starts
+  int tripCount;       // known or estimated trip count
   bool tripCountIsEstimated{true};
+  // Per-stage load (stage 0 = prologue ops, stage maxStage = epilogue ops)
   SmallVector<StageLoad, 4> stageLoads;
   int maxStage{0};
 };
@@ -71,6 +73,7 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
   info.II = result->II;
   info.maxStage = result->getMaxStage();
 
+  // Try to extract constant trip count from scf.for bounds.
   auto lb = innerLoop.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
   auto ub = innerLoop.getUpperBound().getDefiningOp<arith::ConstantIntOp>();
   auto step = innerLoop.getStep().getDefiningOp<arith::ConstantIntOp>();
@@ -83,6 +86,7 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
     }
   }
 
+  // Find the earliest TC cycle — that's where MMA starts (= prologueLatency)
   int tcStart = result->II;
   for (const auto &node : innerDDG.getNodes()) {
     if (node.pipeline == HWPipeline::TC) {
@@ -93,6 +97,7 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
   }
   info.prologueLatency = tcStart;
 
+  // Collect per-stage pipeline loads from the inner schedule.
   info.stageLoads.resize(info.maxStage + 1);
   for (const auto &node : innerDDG.getNodes()) {
     auto it = result->nodeToCycle.find(node.idx);
@@ -119,6 +124,19 @@ static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
     sl.totalLatency = std::max(sl.totalLatency, node.latency);
   }
 
+  LLVM_DEBUG(DBGS() << "Inner loop: II=" << info.II
+                    << " maxStage=" << info.maxStage
+                    << " prologueLat=" << info.prologueLatency
+                    << " tripCount=" << info.tripCount
+                    << (info.tripCountIsEstimated ? "(est)" : "(const)")
+                    << " stages=" << info.stageLoads.size() << "\n");
+  for (int s = 0; s <= info.maxStage; ++s) {
+    LLVM_DEBUG(DBGS() << "  stage " << s
+                      << ": MEM=" << info.stageLoads[s].memSelfLatency
+                      << " TC=" << info.stageLoads[s].tcSelfLatency
+                      << " CUDA=" << info.stageLoads[s].cudaSelfLatency
+                      << "\n");
+  }
   return info;
 }
 
@@ -149,14 +167,20 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   DataDependenceGraph ddg;
 
   // Phase 1: Create nodes for every op in the loop body (except terminator).
+  // Inner scf.for loops become super-nodes with latency = inner loop's II.
+  // scf.if ops are inspected: if they contain pipeline-relevant ops (TMA
+  // loads/stores), the scf.if node inherits the dominant pipeline/latency
+  // from its contents (e.g., conditional prefetch blocks).
   auto &body = loop.getBody()->getOperations();
   for (auto &op : body) {
     if (op.hasTrait<OpTrait::IsTerminator>())
       continue;
-    // Model inner scf.for as a super-node for outer loop scheduling.
+    // Handle inner scf.for as a super-node
     if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
       auto info = computeInnerLoopInfo(innerLoop, model);
 
+      // If inner loop is single-stage (already expanded or trivial),
+      // create a single super-node — no prologue/epilogue split needed.
       if (info.maxStage == 0) {
         unsigned idx = ddg.nodes.size();
         DDGNode node;
@@ -171,10 +195,35 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         node.prologueLatency = info.prologueLatency;
         ddg.nodes.push_back(node);
         ddg.opToIdx[&op] = idx;
+        LLVM_DEBUG(DBGS() << "Single-stage inner loop: N" << idx
+                         << " = super-node (TC, lat=" << node.latency
+                         << " II=" << info.II << ")\n");
         continue;
       }
 
-      // Multi-stage: split into prologue/kloop/epilogue.
+      // Multi-stage: split inner loop into 3 synthetic nodes in the outer DDG:
+      //   prologue: MEM loads (stage 0 ops) — runs once before steady state
+      //   kloop:    steady-state scf.for — TC+MEM interleaved, K iterations
+      //   epilogue: last MMA (highest stage ops) — drains after loop exits
+      //
+      // Only kloop is a super-node (still an scf.for). Prologue/epilogue
+      // are synthetic DDG nodes — they don't correspond to a real loop.
+
+      LLVM_DEBUG({
+        DBGS() << "Inner loop scheduled: II=" << info.II
+               << " maxStage=" << info.maxStage
+               << " tripCount=" << info.tripCount
+               << (info.tripCountIsEstimated ? "(est)" : "(const)") << "\n";
+        for (int s = 0; s <= info.maxStage; ++s) {
+          DBGS() << "  stage " << s
+                 << ": MEM=" << info.stageLoads[s].memSelfLatency
+                 << " TC=" << info.stageLoads[s].tcSelfLatency
+                 << " CUDA=" << info.stageLoads[s].cudaSelfLatency
+                 << " totalLat=" << info.stageLoads[s].totalLatency << "\n";
+        }
+      });
+
+      // --- Node 1: inner_prologue (MEM pipeline, synthetic) ---
       unsigned prologueIdx = ddg.nodes.size();
       {
         DDGNode node;
@@ -187,9 +236,14 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         node.selfLatency =
             info.stageLoads.empty() ? kFallbackTMASelfLatency : info.stageLoads[0].memSelfLatency;
         node.selfLatency = std::max(node.selfLatency, 1);
+        // NOT a super-node — synthetic prologue, no backing loop
         ddg.nodes.push_back(node);
+        LLVM_DEBUG(DBGS() << "Split inner loop: N" << prologueIdx
+                         << " = inner_prologue (MEM, lat=" << node.latency
+                         << " selfLat=" << node.selfLatency << ")\n");
       }
 
+      // --- Node 2: inner_kloop (TC pipeline, super-node) ---
       unsigned kloopIdx = ddg.nodes.size();
       {
         DDGNode node;
@@ -202,12 +256,17 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
                             ? info.stageLoads[info.maxStage].tcSelfLatency
                             : kFallbackMMALatency;
         node.selfLatency = std::max(steadyIters * tcPerIter, 1);
-        node.isSuperNode = true;
+        node.isSuperNode = true; // this IS the scf.for
         node.innerII = info.II;
         node.prologueLatency = info.prologueLatency;
         ddg.nodes.push_back(node);
+        LLVM_DEBUG(DBGS() << "Split inner loop: N" << kloopIdx
+                         << " = inner_kloop (TC, lat=" << node.latency
+                         << " selfLat=" << node.selfLatency
+                         << " steadyIters=" << steadyIters << ")\n");
       }
 
+      // --- Node 3: inner_epilogue (TC pipeline, synthetic) ---
       unsigned epilogueIdx = ddg.nodes.size();
       {
         DDGNode node;
@@ -219,7 +278,11 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
                         : kFallbackMMALatency;
         node.latency = std::max(tcLat, 1);
         node.selfLatency = std::max(tcLat, 1);
+        // NOT a super-node — synthetic epilogue
         ddg.nodes.push_back(node);
+        LLVM_DEBUG(DBGS() << "Split inner loop: N" << epilogueIdx
+                         << " = inner_epilogue (TC, lat=" << node.latency
+                         << " selfLat=" << node.selfLatency << ")\n");
       }
 
       ddg.opToIdx[&op] = epilogueIdx;        // producer: results come from epilogue
@@ -231,9 +294,9 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       continue;
     }
     // Handle scf.if: walk regions to find pipeline-relevant ops.
-    // Persistent kernels put TMA loads inside conditional prefetch blocks
-    // (scf.if i < num_iter). Without this, those ops are invisible to
-    // the scheduler.
+    // TLX kernels put TMA loads inside conditional prefetch blocks
+    // (scf.if i < num_iter). Without this, those ops are invisible
+    // to the scheduler and the loop gets a trivial single-stage schedule.
     if (isa<scf::IfOp>(op)) {
       HWPipeline bestPipeline = HWPipeline::NONE;
       int bestLatency = 0;
@@ -259,6 +322,9 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         node.selfLatency = bestSelfLatency;
         ddg.nodes.push_back(node);
         ddg.opToIdx[&op] = idx;
+        LLVM_DEBUG(DBGS() << "scf.if node " << idx
+                          << ": pipeline=" << getPipelineName(bestPipeline)
+                          << " latency=" << bestLatency << "\n");
         continue;
       }
     }
@@ -290,13 +356,20 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   }
 
   // Phase 2.5: Implicit MEM-load → TC/super-node edges.
-  // In persistent kernels using lowered TMA (async_tma_copy), the MEM→TC
-  // dependency goes through SMEM buffers and barriers, not SSA. Without
-  // these edges the scheduler places MEM and TC at the same cycle.
+  // TMA loads write to SMEM buffers consumed by MMA ops. This producer-consumer
+  // relationship isn't visible in SSA (they communicate through barriers and
+  // shared memory). Without these edges, the scheduler places MEM and TC at the
+  // same cycle, missing the opportunity for multi-stage pipelining where MEM
+  // ops run ahead to prefetch data for future iterations.
+  // NOTE: Only MEM *load* ops get implicit edges to TC. MEM *store* ops
+  // (descriptor_store) consume the K-loop result — adding store→TC edges
+  // creates false cycles (store → super-node → ... → store).
   {
     SmallVector<unsigned> memLoadNodes, tcNodes;
     for (const auto &node : ddg.nodes) {
       if (node.pipeline == HWPipeline::MEM) {
+        // Only loads, not stores. For scf.if nodes, check if the
+        // contained op is a store.
         bool isStore = isa<triton::DescriptorStoreOp>(node.op) ||
                        isa<ttng::AsyncTMACopyLocalToGlobalOp>(node.op);
         if (!isStore && isa<scf::IfOp>(node.op)) {
@@ -314,6 +387,7 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
     }
     for (unsigned memIdx : memLoadNodes) {
       for (unsigned tcIdx : tcNodes) {
+        // Skip if an SSA edge already exists (avoid duplicates).
         bool hasEdge = false;
         for (const auto &e : ddg.edges) {
           if (e.srcIdx == memIdx && e.dstIdx == tcIdx) {
@@ -324,6 +398,9 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         if (!hasEdge) {
           ddg.addEdge(memIdx, tcIdx, ddg.nodes[memIdx].latency,
                       /*distance=*/0);
+          LLVM_DEBUG(DBGS() << "Implicit edge: MEM node " << memIdx
+                            << " -> TC node " << tcIdx << " (latency="
+                            << ddg.nodes[memIdx].latency << ")\n");
         }
       }
     }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -1,0 +1,76 @@
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_DDG_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_DDG_H
+
+#include "LatencyModel.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::triton::gpu {
+
+struct DDGEdge {
+  unsigned srcIdx{};
+  unsigned dstIdx{};
+  int latency{};
+  unsigned distance{}; // 0 = intra-iteration, 1+ = loop-carried
+};
+
+struct DDGNode {
+  Operation *op{};
+  unsigned idx{};
+  HWPipeline pipeline{HWPipeline::NONE};
+  int latency{};
+  int selfLatency{};
+  bool isSuperNode{false}; // True if this node represents an inner loop
+  int innerII{0};           // If super-node, the inner loop's II
+  int prologueLatency{0};   // If super-node, cycles before TC starts (MEM busy)
+  llvm::SmallVector<unsigned> succs;
+  llvm::SmallVector<unsigned> preds;
+};
+
+/// Data Dependence Graph for one scf.for loop body.
+/// Captures both intra-iteration and loop-carried (distance-1) edges.
+class DataDependenceGraph {
+public:
+  static DataDependenceGraph build(scf::ForOp loop, const LatencyModel &model);
+
+  llvm::ArrayRef<DDGNode> getNodes() const { return nodes; }
+  llvm::ArrayRef<DDGEdge> getEdges() const { return edges; }
+  const DDGNode &getNode(unsigned idx) const { return nodes[idx]; }
+  unsigned getNumNodes() const { return nodes.size(); }
+
+  /// Get all incoming edges for a node.
+  llvm::SmallVector<const DDGEdge *> getInEdges(unsigned nodeIdx) const;
+
+  /// Get all outgoing edges for a node.
+  llvm::SmallVector<const DDGEdge *> getOutEdges(unsigned nodeIdx) const;
+
+  /// Compute critical-path height (bottom-up) from each node to any sink.
+  llvm::DenseMap<unsigned, int> computeCriticalPathHeights() const;
+
+  /// Compute ResMII: max over all pipelines of total self-latency.
+  int computeResMII() const;
+
+  /// Compute RecMII: max over all recurrence circuits of sum_lat / sum_dist.
+  int computeRecMII() const;
+
+  /// Compute MinII = max(ResMII, RecMII).
+  int computeMinII() const;
+
+  /// Dump the DDG to llvm::dbgs() for debugging.
+  void dump() const;
+
+private:
+  llvm::SmallVector<DDGNode> nodes;
+  llvm::SmallVector<DDGEdge> edges;
+  llvm::DenseMap<Operation *, unsigned> opToIdx;
+
+  unsigned addNode(Operation *op, const LatencyModel &model);
+  void addEdge(unsigned src, unsigned dst, int latency, unsigned distance);
+};
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_DDG_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -40,6 +40,9 @@ public:
   llvm::ArrayRef<DDGEdge> getEdges() const { return edges; }
   const DDGNode &getNode(unsigned idx) const { return nodes[idx]; }
   unsigned getNumNodes() const { return nodes.size(); }
+  const llvm::DenseMap<Operation *, unsigned> &getOpToIdx() const {
+    return opToIdx;
+  }
 
   /// Get all incoming edges for a node.
   llvm::SmallVector<const DDGEdge *> getInEdges(unsigned nodeIdx) const;
@@ -66,6 +69,10 @@ private:
   llvm::SmallVector<DDGNode> nodes;
   llvm::SmallVector<DDGEdge> edges;
   llvm::DenseMap<Operation *, unsigned> opToIdx;
+  // For multi-stage super-nodes (prologue/kloop/epilogue sharing the same
+  // Operation*), opToIdx maps to the epilogue (producer). consumerOpToIdx
+  // maps to the prologue so loop-carried edges target the correct node.
+  llvm::DenseMap<Operation *, unsigned> consumerOpToIdx;
 
   unsigned addNode(Operation *op, const LatencyModel &model);
   void addEdge(unsigned src, unsigned dst, int latency, unsigned distance);

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -1,0 +1,311 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "LatencyModel.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "modulo-scheduling-latency"
+
+namespace tt = mlir::triton;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace mlir::triton::gpu {
+
+llvm::StringRef getPipelineName(HWPipeline pipeline) {
+  switch (pipeline) {
+  case HWPipeline::MEM:
+    return "MEM";
+  case HWPipeline::TC:
+    return "TC";
+  case HWPipeline::CUDA:
+    return "CUDA";
+  case HWPipeline::SFU:
+    return "SFU";
+  case HWPipeline::NONE:
+    return "NONE";
+  }
+  llvm_unreachable("unknown pipeline");
+}
+
+// Estimate total elements in the result tensor of an op.
+int64_t LatencyModel::getTensorElements(Operation *op) const {
+  if (op->getNumResults() == 0)
+    return 0;
+  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType)
+    return 0;
+  int64_t elements = 1;
+  for (auto dim : resultType.getShape())
+    elements *= dim;
+  return elements;
+}
+
+// TMA load latencies from B200 microbenchmarks (cycles).
+// Key = total bytes, value = pipeline occupancy cycles.
+// Entries from NVIDIA_B200_latency_table.json.
+struct TMALatencyEntry {
+  int64_t bytes;
+  int cycles;
+};
+static constexpr TMALatencyEntry kTMALoadTable[] = {
+    {128 * 64 * 2, 518},   // 128x64 or 64x128 bf16/fp16 = 16KB
+    {128 * 128 * 2, 654},  // 128x128 bf16/fp16 = 32KB
+    {256 * 64 * 2, 653},   // 256x64 bf16 = 32KB
+    {256 * 128 * 2, 918},  // 256x128 bf16 = 64KB
+};
+
+// Async overhead: additional cycles for data to travel through the memory
+// hierarchy (L2/DRAM) and arrive in SMEM. On top of pipeline occupancy.
+constexpr int kTMAAsyncOverhead = 700;
+
+int LatencyModel::getTMALoadLatency(Operation *op) const {
+  if (op->getNumResults() == 0)
+    return 518; // default for ops without results (e.g. stores)
+  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType)
+    return 518; // default: 128x64
+
+  int64_t elements = 1;
+  for (auto dim : resultType.getShape())
+    elements *= dim;
+  int64_t bytesPerElement = resultType.getElementTypeBitWidth() / 8;
+  int64_t totalBytes = elements * bytesPerElement;
+
+  // Look up in the microbenchmark table.
+  for (const auto &entry : kTMALoadTable) {
+    if (entry.bytes == totalBytes)
+      return entry.cycles;
+  }
+
+  // Fallback: linear interpolation from 128x64 baseline.
+  constexpr int64_t kBaseBytes = 128 * 64 * 2;
+  constexpr int kBaseCycles = 518;
+  return static_cast<int>(kBaseCycles *
+                          static_cast<double>(totalBytes) / kBaseBytes);
+}
+
+int LatencyModel::getTMAStoreLatency(Operation *op) const {
+  // TMA stores have similar latency profile to loads
+  return getTMALoadLatency(op);
+}
+
+// MMA latencies from design doc microbenchmarks (Blackwell tcgen05.mma).
+// Scales with the product M*N*K.
+constexpr int kMMALatency128x128x128 = 900;
+constexpr int kMMALatency128x128x64 = 559;
+
+int LatencyModel::getMMALatency(Operation *op) const {
+  if (op->getNumResults() == 0)
+    return kMMALatency128x128x128; // conservative default
+  // Try to extract the MMA shape from the MMAv5 interface
+  if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
+    auto aType = dyn_cast<RankedTensorType>(mma->getOperand(0).getType());
+    auto bType = dyn_cast<RankedTensorType>(mma->getOperand(1).getType());
+    if (aType && bType) {
+      auto aShape = aType.getShape(); // [M, K]
+      int64_t K = aShape.size() >= 2 ? aShape[1] : 64;
+      // Use K to select between known latencies
+      if (K >= 128)
+        return kMMALatency128x128x128;
+      return kMMALatency128x128x64;
+    }
+  }
+  return kMMALatency128x128x128; // conservative default
+}
+
+int LatencyModel::getCUDALatency(Operation *op) const {
+  int64_t elements = getTensorElements(op);
+  if (elements == 0)
+    return 0; // scalar
+
+  // Reductions: differentiate by reduction kind.
+  if (auto reduceOp = dyn_cast<tt::ReduceOp>(op)) {
+    // RowMax ~336 cycles, RowSum ~508 cycles for 128-wide (from microbench).
+    // Heuristic: check if the reduction body contains an AddF (sum) or MaxF.
+    bool isSum = false;
+    reduceOp.getBody()->walk([&](Operation *inner) {
+      if (isa<arith::AddFOp>(inner))
+        isSum = true;
+    });
+    return isSum ? 508 : 336; // RowSum vs RowMax
+  }
+
+  // Type conversions (truncf, extf): ~105 cycles for 128x128.
+  if (isa<arith::TruncFOp, arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp,
+          tt::FpToFpOp, tt::BitcastOp>(op))
+    return 105;
+
+  // Multiply (Acc x Alpha): ~105 cycles for 128x128.
+  if (isa<arith::MulFOp>(op))
+    return 105;
+
+  // Scale & Subtract, AddF: ~130 cycles.
+  return 130;
+}
+
+int LatencyModel::getSFULatency(Operation *op) const {
+  int64_t elements = getTensorElements(op);
+  if (elements == 0)
+    return 43; // scalar exp2 (Alpha = Exp2(scalar))
+  return 662;  // elementwise exp2 for 128x128
+}
+
+HWPipeline LatencyModel::classifyPipeline(Operation *op) const {
+  // MEM: TMA loads, regular loads, and stores
+  if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
+    return HWPipeline::MEM;
+  // MEM: Lowered TMA loads (TLX kernels use async_tma_copy instead of descriptor_load)
+  if (isa<ttng::AsyncTMACopyGlobalToLocalOp>(op))
+    return HWPipeline::MEM;
+  if (isa<tt::LoadOp>(op)) {
+    // Regular tt.load (before TMA lowering) — classify as MEM if tensor
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::MEM;
+  }
+  if (isa<tt::DescriptorStoreOp>(op))
+    return HWPipeline::MEM;
+  // MEM: Lowered TMA stores (TLX path)
+  if (isa<ttng::AsyncTMACopyLocalToGlobalOp>(op))
+    return HWPipeline::MEM;
+
+  // TC: Tensor Core MMA operations
+  if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op))
+    return HWPipeline::TC;
+  if (isa<ttng::WarpGroupDotOp>(op))
+    return HWPipeline::TC;
+  // TC: tt.dot (before lowering to TCGen5MMAOp / WarpGroupDotOp)
+  if (isa<tt::DotOp>(op))
+    return HWPipeline::TC;
+
+  // CUDA: TMEM load (reads accumulator from TMEM to registers — epilogue op)
+  if (isa<ttng::TMEMLoadOp>(op))
+    return HWPipeline::CUDA;
+
+  // SFU: Transcendental math operations on tensors
+  if (isa<math::Exp2Op, math::ExpOp, math::Log2Op, math::LogOp, math::SqrtOp,
+          math::RsqrtOp, math::TanhOp>(op)) {
+    // Only classify as SFU if operating on tensors
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::SFU;
+    return HWPipeline::NONE; // scalar math is free
+  }
+
+  // CUDA: Reductions
+  if (isa<tt::ReduceOp>(op))
+    return HWPipeline::CUDA;
+
+  // CUDA: Tensor arithmetic (elementwise operations on tensors)
+  if (isa<arith::AddFOp, arith::SubFOp, arith::MulFOp, arith::DivFOp,
+          arith::MaximumFOp, arith::MinimumFOp, arith::NegFOp>(op)) {
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::CUDA;
+  }
+
+  // CUDA: Type conversions on tensors
+  if (isa<arith::TruncFOp, arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp,
+          tt::FpToFpOp, tt::BitcastOp>(op)) {
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return HWPipeline::CUDA;
+  }
+
+  // MEM: local_alloc fed by a MEM load represents the async data arrival.
+  // It stays at the same stage as the load (edge uses selfLatency), but
+  // carries the async overhead latency to its consumers (MMA).
+  if (isa<triton::gpu::LocalAllocOp>(op)) {
+    // Check if operand comes from a load
+    if (op->getNumOperands() > 0) {
+      auto *srcOp = op->getOperand(0).getDefiningOp();
+      if (srcOp && (isa<tt::LoadOp, tt::DescriptorLoadOp>(srcOp)))
+        return HWPipeline::MEM;
+    }
+  }
+
+  // NONE: Scalar ops, index arithmetic, control flow, barriers, etc.
+  return HWPipeline::NONE;
+}
+
+OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
+  auto pipeline = classifyPipeline(op);
+
+  int latency = 0;
+  int selfLatency = 0;
+  switch (pipeline) {
+  case HWPipeline::MEM: {
+    // For async MEM ops, selfLatency (pipeline occupancy) and latency
+    // (time until data available for consumers) are different.
+    // selfLatency = how long the MEM pipeline is busy dispatching.
+    // latency = selfLatency + async overhead (DRAM round-trip).
+    int occupancy;
+    if (isa<tt::DescriptorStoreOp>(op))
+      occupancy = getTMAStoreLatency(op);
+    else if (isa<ttng::AsyncTMACopyLocalToGlobalOp>(op)) {
+      // Lowered TMA store — use default store latency
+      occupancy = 518;
+    } else if (isa<triton::gpu::LocalAllocOp>(op)) {
+      // local_alloc fed by a load: represents async data arrival.
+      // selfLatency = 0 (no pipeline occupancy, it's a bookkeeping op).
+      // latency = async overhead (DRAM round-trip time).
+      selfLatency = 0;
+      latency = kTMAAsyncOverhead;
+      break;
+    } else if (auto tmaCopy = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+      // Lowered TMA load (TLX path). Get size from the SMEM result operand.
+      auto resultMemDesc =
+          dyn_cast<triton::gpu::MemDescType>(tmaCopy.getResult().getType());
+      if (resultMemDesc) {
+        int64_t elements = 1;
+        for (auto dim : resultMemDesc.getShape())
+          elements *= dim;
+        int64_t bytesPerElement =
+            resultMemDesc.getElementType().getIntOrFloatBitWidth() / 8;
+        int64_t totalBytes = elements * bytesPerElement;
+        // Look up in microbenchmark table
+        occupancy = 518; // default
+        for (const auto &entry : kTMALoadTable) {
+          if (entry.bytes == totalBytes) {
+            occupancy = entry.cycles;
+            break;
+          }
+        }
+      } else {
+        occupancy = 518;
+      }
+    } else
+      occupancy = getTMALoadLatency(op);
+    selfLatency = occupancy;
+    latency = occupancy + kTMAAsyncOverhead;
+    break;
+  }
+  case HWPipeline::TC:
+    latency = getMMALatency(op);
+    selfLatency = latency;
+    break;
+  case HWPipeline::CUDA:
+    latency = getCUDALatency(op);
+    selfLatency = latency;
+    break;
+  case HWPipeline::SFU:
+    latency = getSFULatency(op);
+    selfLatency = latency;
+    break;
+  case HWPipeline::NONE:
+    latency = 0;
+    selfLatency = 0;
+    break;
+  }
+
+  return OpLatencyInfo{pipeline, latency, selfLatency};
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
@@ -1,0 +1,64 @@
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_LATENCY_MODEL_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_LATENCY_MODEL_H
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::triton::gpu {
+
+/// Hardware pipeline classification for Blackwell SM100.
+/// Each op executes on exactly one pipeline; distinct pipelines overlap.
+enum class HWPipeline {
+  MEM,  // TMA loads/stores (descriptor_load, descriptor_store, descriptor_gather)
+  TC,   // Tensor Core (tc_gen05_mma, warp_group_dot)
+  CUDA, // General CUDA cores (arith.*, tt.reduce, type conversions)
+  SFU,  // Special Function Unit (math.exp2, math.log2, math.rsqrt)
+  NONE  // Scalar/index ops, control flow — zero latency, no resource
+};
+
+/// Return a human-readable name for a pipeline.
+llvm::StringRef getPipelineName(HWPipeline pipeline);
+
+/// Latency info for a single operation.
+struct OpLatencyInfo {
+  HWPipeline pipeline{HWPipeline::NONE};
+  int latency{0};     // Total latency: cycles from op start to result available.
+                      // Used for dependency analysis (RecMII — how long a
+                      // consumer must wait for the result).
+  int selfLatency{0}; // Pipeline occupancy: cycles this op blocks its pipeline.
+                      // Used for resource conflict analysis (ResMII — how much
+                      // pipeline bandwidth is consumed).
+};
+
+/// Hardware latency model for Blackwell SM100.
+///
+/// Classifies TTGIR operations into hardware pipelines and assigns
+/// cycle-accurate latencies from microbenchmark data. Initially hardcoded
+/// for Blackwell; designed to be subclassed for other architectures.
+///
+/// Latency values are from the WS Global Instruction Scheduling design doc
+/// (D95269626) and validated by the latency microbenchmark harness.
+class LatencyModel {
+public:
+  virtual ~LatencyModel() = default;
+
+  /// Classify an operation and return its pipeline + latency.
+  virtual OpLatencyInfo getLatency(Operation *op) const;
+
+  /// Classify which hardware pipeline an operation uses.
+  HWPipeline classifyPipeline(Operation *op) const;
+
+private:
+  int getTMALoadLatency(Operation *op) const;
+  int getTMAStoreLatency(Operation *op) const;
+  int getMMALatency(Operation *op) const;
+  int getCUDALatency(Operation *op) const;
+  int getSFULatency(Operation *op) const;
+
+  /// Estimate tensor size in elements from an op's result type.
+  int64_t getTensorElements(Operation *op) const;
+};
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_LATENCY_MODEL_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloBufferAllocPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloBufferAllocPass.cpp
@@ -1,0 +1,53 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Buffer Allocation Pass (placeholder)
+//
+// Phase boundary marker between Pass A's schedule computation and the
+// loop expansion phase. Currently a no-op — the actual buffer allocation
+// is performed by lowerLoops() in ModuloExpandPass, which derives
+// multi-buffer depths from loop.stage differences.
+//
+// TODO: Move PipelineGraph-based buffer allocation here once the
+// PipelineGraph expansion path replaces lowerLoops().
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-buffer-alloc"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+
+namespace {
+
+struct ModuloBufferAllocPass
+    : public PassWrapper<ModuloBufferAllocPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloBufferAllocPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-buffer-alloc"; }
+
+  StringRef getDescription() const override {
+    return "Buffer allocation for modulo scheduling (placeholder)";
+  }
+
+  void runOnOperation() override {
+    LDBG("Phase 1 analysis complete "
+         "(buffer allocation deferred to ModuloExpand/lowerLoops)");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloBufferAlloc() {
+  return std::make_unique<ModuloBufferAllocPass>();
+}
+
+void registerNVGPUModuloBufferAlloc() {
+  PassRegistration<ModuloBufferAllocPass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloExpandPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloExpandPass.cpp
@@ -1,0 +1,210 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Loop Expansion Pass (Phase 2 + Phase 3 combined)
+//
+// This pass takes the modulo-scheduled loop (with loop.stage attrs from
+// ModuloSchedulePass) and performs the full software pipelining
+// transformation:
+//   1. lowerLoops() — transform loads into async copies, insert barriers,
+//      allocate multi-buffered SMEM/TMEM (same as existing Pipeline pass)
+//   2. expandLoops() — generate prologue/kernel/epilogue via PipelineExpander
+//
+// The key difference from the standard Pipeline pass is that our schedule
+// comes from Rau's iterative modulo scheduling (Phase 0) rather than
+// the heuristic-based assign_latencies + schedule_loops.
+//
+// NOTE: lowerLoops() processes ALL loops in the module, not just
+// modulo-scheduled ones. When integrating with the standard Pipeline pass,
+// ensure they don't both run lowerLoops() on the same module.
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-expand"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+
+namespace {
+
+/// Check if the loop has MMAv5 waits in its last stage — if so, we need
+/// custom epilogue peeling (same logic as SoftwarePipeliner.cpp).
+static bool hasMMAv5WaitsInLastStage(scf::ForOp forOp,
+                                     triton::CoarseSchedule &schedule) {
+  int maxStage = schedule.getNumStages() - 1;
+  bool hasMMAv5 = false;
+  bool hasWaitInLastStage = false;
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    if (isa<ttng::WaitBarrierOp>(op) && schedule[&op].first == maxStage)
+      hasWaitInLastStage = true;
+    if (isa<ttng::MMAv5OpInterface>(op))
+      hasMMAv5 = true;
+  }
+  return hasMMAv5 && hasWaitInLastStage;
+}
+
+/// Replicate the expandLoops() logic from SoftwarePipeliner.cpp.
+/// Deserializes the schedule, calls pipelineForLoop(), handles epilogue
+/// peeling for MMAv5 loops.
+static void moduloExpandLoops(ModuleOp moduleOp) {
+  DenseSet<ttg::MaskOp> peeledMaskOps;
+  auto processPeeledEpilogueOp = [&](RewriterBase &rewriter, Operation *op,
+                                     bool isEpilogue) -> Operation * {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    if (auto predOp = dyn_cast<ttg::PredicateStageOp>(op)) {
+      if (isEpilogue) {
+        return mlir::arith::ConstantIntOp::create(
+            rewriter, predOp.getLoc(), predOp.getResult().getType(), 0);
+      }
+      if (predOp.getStage() == predOp.getMaxStage() - 1) {
+        return mlir::arith::ConstantIntOp::create(
+            rewriter, predOp.getLoc(), predOp.getResult().getType(), 1);
+      }
+      return triton::emitPredicateForStage(
+                 rewriter, predOp.getIv(), predOp.getUb(), predOp.getStep(),
+                 predOp.getMaxStage(), predOp.getStage())
+          .getDefiningOp();
+    }
+    if (auto maskOp = dyn_cast<ttg::MaskOp>(op)) {
+      if (isEpilogue)
+        peeledMaskOps.insert(maskOp);
+    }
+    return op;
+  };
+
+  // Collect loops with their nesting depth. We must expand inner loops first
+  // (bottom-up) so that after inner expansion, the inner loop is a "black box"
+  // for outer expansion. moduleOp->walk uses pre-order (outer before inner),
+  // so we explicitly sort by descending depth.
+  SmallVector<std::pair<scf::ForOp, unsigned>> loopsWithDepth;
+  moduleOp->walk([&](scf::ForOp forOp) {
+    unsigned depth = 0;
+    for (auto *parent = forOp->getParentOp(); parent;
+         parent = parent->getParentOp()) {
+      if (isa<scf::ForOp>(parent))
+        ++depth;
+    }
+    loopsWithDepth.push_back({forOp, depth});
+  });
+  // Sort by descending depth — innermost loops first.
+  llvm::sort(loopsWithDepth,
+             [](const auto &a, const auto &b) { return a.second > b.second; });
+
+  for (auto &[forOp, depth] : loopsWithDepth) {
+    // Safety: inner loop expansion may have erased or replaced this op.
+    if (!forOp || !forOp->getBlock())
+      continue;
+
+    triton::CoarseSchedule schedule;
+    if (failed(schedule.deSerialize(forOp)))
+      continue;
+
+    // Skip loops with only 1 stage — no pipelining needed.
+    if (schedule.getNumStages() <= 1) {
+      LDBG("Skipping loop at depth " << depth << " with "
+                                     << schedule.getNumStages()
+                                     << " stage(s) — no expansion needed");
+      continue;
+    }
+
+    LDBG("Expanding loop at depth " << depth << " with "
+                                    << schedule.getNumStages() << " stages");
+
+    std::vector<std::pair<Operation *, unsigned>> finalSchedule =
+        schedule.createFinalSchedule(forOp);
+    triton::PipeliningOption options;
+    options.supportDynamicLoops = true;
+    options.peelEpilogue = false;
+    options.predicateFn = triton::wrapInMaskOp;
+    options.getScheduleFn =
+        [&](scf::ForOp, std::vector<std::pair<Operation *, unsigned>> &sched) {
+          sched = finalSchedule;
+        };
+
+    bool customEpiloguePeeling =
+        hasMMAv5WaitsInLastStage(forOp, schedule) &&
+        !forOp->getParentOfType<ttg::WarpSpecializeOp>();
+    if (customEpiloguePeeling) {
+      options.emitPredicateStageFn = [](RewriterBase &rewriter,
+                                        Value inductionVar, Value upperBound,
+                                        Value step, uint64_t maxStage,
+                                        uint64_t stage) {
+        return ttg::PredicateStageOp::create(rewriter, inductionVar.getLoc(),
+                                             inductionVar, upperBound, step,
+                                             maxStage, stage);
+      };
+    }
+
+    IRRewriter rewriter(forOp);
+    FailureOr<scf::ForOp> newForOp =
+        triton::pipelineForLoop(rewriter, forOp, options);
+
+    if (failed(newForOp)) {
+      LDBG("pipelineForLoop FAILED for a loop");
+      continue;
+    }
+    forOp = *newForOp;
+    if (customEpiloguePeeling)
+      triton::peelLoopEpilogue(forOp, processPeeledEpilogueOp);
+  }
+
+  assert(moduleOp.getOps<ttg::PredicateStageOp>().empty() &&
+         "PredicateStageOp should be resolved after pipeline expansion");
+  LLVM_DEBUG({
+    if (failed(verify(moduleOp)))
+      DBGS() << "WARNING: IR verification failed after expansion\n";
+  });
+  triton::resolveMaskOp(moduleOp);
+}
+
+struct ModuloExpandPass
+    : public PassWrapper<ModuloExpandPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloExpandPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-expand"; }
+
+  StringRef getDescription() const override {
+    return "Modulo loop expansion (lowerLoops + pipelineForLoop)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    LDBG("=== Phase 2+3: Loop Expansion ===");
+
+    LDBG("Step 1: lowerLoops");
+    triton::gpu::lowerLoops(moduleOp);
+
+    LDBG("Step 2: expandLoops");
+    moduloExpandLoops(moduleOp);
+
+    LDBG("Expansion complete");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloExpand() {
+  return std::make_unique<ModuloExpandPass>();
+}
+
+void registerNVGPUModuloExpand() {
+  PassRegistration<ModuloExpandPass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloLowerPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloLowerPass.cpp
@@ -1,0 +1,105 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Modulo Lowering Pass (post-expansion cleanup)
+//
+// Runs after ModuloExpandPass. Performs the same post-expansion steps
+// as the standard PipelinePass:
+//   1. removePipeliningAttributes — strip loop.stage/loop.cluster attrs
+//   2. asyncLaunchDots — pipeline wgmma ops (mark async, insert waits)
+//   3. updateWaits — adjust AsyncWaitOp pending counts
+//   4. pipelineTMAStores — pipeline TMA store operations
+//   5. arith canonicalization — clean up arithmetic
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-lower"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = triton;
+
+namespace {
+
+struct ModuloLowerPass
+    : public PassWrapper<ModuloLowerPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloLowerPass)
+
+  StringRef getArgument() const override { return "nvgpu-modulo-lower"; }
+
+  StringRef getDescription() const override {
+    return "Post-expansion cleanup (asyncLaunchDots, updateWaits, TMA stores)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    LDBG("=== Post-expansion cleanup ===");
+
+    // Step 1: Remove pipelining attributes (loop.stage, loop.cluster, etc.)
+    LDBG("Step 1: removePipeliningAttributes");
+    tt::removePipeliningAttributes(moduleOp);
+
+    // Verify all loop.stage attrs were consumed and removed.
+    LLVM_DEBUG({
+      bool hasStaleAttrs = false;
+      moduleOp->walk([&](Operation *op) {
+        if (op->hasAttr(tt::kLoopStageAttrName)) {
+          hasStaleAttrs = true;
+          DBGS() << "WARNING: stale loop.stage on: " << *op << "\n";
+        }
+      });
+      if (hasStaleAttrs)
+        DBGS() << "WARNING: loop.stage attributes remain after "
+               << "removePipeliningAttributes\n";
+    });
+
+    // Step 2: Pipeline wgmma ops — mark dots as async, insert waits.
+    LDBG("Step 2: asyncLaunchDots");
+    SmallVector<scf::ForOp> loops;
+    moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      tt::asyncLaunchDots(forOp);
+
+    // Step 3: Update wait ops with correct pending counts.
+    LDBG("Step 3: updateWaits");
+    tt::updateWaits(moduleOp);
+
+    // Step 4: Canonicalize arith to simplify index arithmetic from expansion.
+    auto *arithDialect =
+        moduleOp.getContext()->getLoadedDialect<arith::ArithDialect>();
+    RewritePatternSet patterns(moduleOp.getContext());
+    arithDialect->getCanonicalizationPatterns(patterns);
+    if (applyPatternsGreedily(moduleOp, std::move(patterns)).failed())
+      return signalPassFailure();
+
+    // Step 5: Pipeline TMA stores.
+    LDBG("Step 5: pipelineTMAStores");
+    loops.clear();
+    moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      tt::pipelineTMAStores(forOp);
+
+    LDBG("Post-expansion cleanup complete");
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloLower() {
+  return std::make_unique<ModuloLowerPass>();
+}
+
+void registerNVGPUModuloLower() {
+  PassRegistration<ModuloLowerPass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.cpp
@@ -1,0 +1,238 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "ModuloPipelineIR.h"
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir::triton::gpu {
+
+static llvm::StringRef memKindName(MemoryKind k) {
+  switch (k) {
+  case MemoryKind::SMEM:
+    return "SMEM";
+  case MemoryKind::TMEM:
+    return "TMEM";
+  case MemoryKind::Register:
+    return "Reg";
+  case MemoryKind::BARRIER:
+    return "BARRIER";
+  }
+  llvm_unreachable("unknown MemoryKind");
+}
+
+static void dumpIndent(llvm::raw_ostream &os, unsigned depth) {
+  for (unsigned i = 0; i < depth; ++i)
+    os << "  ";
+}
+
+static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
+                            unsigned depth) {
+  dumpIndent(os, depth);
+  if (node.op && node.op->getNumResults() > 0)
+    os << "%N" << node.id << " = ";
+  if (node.op)
+    os << node.op->getName().getStringRef();
+  else
+    os << "<null>";
+  // Label synthetic inner loop nodes
+  if (node.isSuperNode())
+    os << " [K-loop]";
+  // For ttg.mask: show the first real op inside (1-level unwrap)
+  if (node.op && node.op->getNumRegions() > 0 &&
+      node.op->getName().getStringRef() == "ttg.mask") {
+    auto innerName = [&]() -> llvm::StringRef {
+      for (auto &region : node.op->getRegions())
+        for (auto &block : region)
+          for (auto &inner : block) {
+            auto name = inner.getName().getStringRef();
+            if (name != "scf.yield" && name != "arith.constant")
+              return name;
+          }
+      return {};
+    }();
+    if (!innerName.empty())
+      os << "(" << innerName << ")";
+  }
+  os << "  {pipe: " << getPipelineName(node.pipeline) << ", cycle: "
+     << node.cycle;
+  if (node.latency)
+    os << ", latency: " << node.latency;
+  if (node.selfLatency)
+    os << ", selfLatency: " << node.selfLatency;
+  if (node.warpGroup >= 0)
+    os << ", wg: " << node.warpGroup;
+  if (node.producesBuffer != UINT_MAX)
+    os << ", ->buf" << node.producesBuffer;
+  for (auto cb : node.consumesBuffers)
+    os << ", <-buf" << cb;
+  os << "}\n";
+}
+
+static void dumpPort(const PipelineLoop::MemPort &port,
+                     llvm::raw_ostream &os) {
+  if (!port.op) {
+    if (port.bufferId != UINT_MAX)
+      os << "buf" << port.bufferId;
+    else
+      os << "?";
+    return;
+  }
+  if (port.op->getNumResults() > 0) {
+    port.op->getResult(0).printAsOperand(os, OpPrintingFlags());
+    os << " : " << port.op->getName().getStringRef();
+  } else {
+    os << port.op->getName().getStringRef();
+  }
+}
+
+static void dumpLoop(const PipelineGraph &graph, const PipelineLoop &loop,
+                     llvm::raw_ostream &os, unsigned depth) {
+  dumpIndent(os, depth);
+  os << "modulo.pipeline @loop" << loop.id << " {\n";
+  unsigned inner = depth + 1;
+
+  // Schedule parameters
+  dumpIndent(os, inner);
+  os << "ii = " << loop.II << ", max_stage = " << loop.maxStage;
+  if (loop.prologueLatency)
+    os << ", prologue_latency = " << loop.prologueLatency;
+  if (loop.tripCount > 0) {
+    os << ", trip_count = " << loop.tripCount;
+    if (loop.tripCountIsEstimated)
+      os << " (estimated)";
+  }
+  os << "\n";
+
+  // Buffer declarations
+  if (!loop.buffers.empty()) {
+    os << "\n";
+    for (const auto &buf : loop.buffers) {
+      dumpIndent(os, inner);
+      if (buf.kind == MemoryKind::BARRIER) {
+        os << "%bar" << buf.id << " = modulo.alloc BARRIER [" << buf.count
+           << "]";
+        if (buf.pairedBufferId != UINT_MAX)
+          os << " for buf" << buf.pairedBufferId;
+      } else {
+        os << "%buf" << buf.id << " = modulo.alloc " << memKindName(buf.kind)
+           << " [" << buf.count << " x ";
+        for (unsigned i = 0; i < buf.shape.size(); ++i) {
+          if (i > 0)
+            os << "x";
+          os << buf.shape[i];
+        }
+        os << " x " << (buf.elementBitWidth <= 16 ? "f16" : "f32") << "]";
+      }
+      os << "  // " << buf.sizeBytes() * buf.count << " bytes total\n";
+    }
+  }
+
+  // Inputs
+  if (!loop.inputs.empty()) {
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "inputs:\n";
+    for (const auto &port : loop.inputs) {
+      dumpIndent(os, inner + 1);
+      dumpPort(port, os);
+      os << "\n";
+    }
+  }
+
+  // Outputs
+  if (!loop.outputs.empty()) {
+    dumpIndent(os, inner);
+    os << "outputs:\n";
+    for (const auto &port : loop.outputs) {
+      dumpIndent(os, inner + 1);
+      dumpPort(port, os);
+      os << "\n";
+    }
+  }
+
+  // Expanded prologue/epilogue (if expanded)
+  if (loop.isExpanded) {
+    if (!loop.prologueNodes.empty()) {
+      os << "\n";
+      dumpIndent(os, inner);
+      os << "modulo.prologue {\n";
+      for (const auto &node : loop.prologueNodes)
+        dumpNodeOneLine(node, os, inner + 1);
+      dumpIndent(os, inner);
+      os << "}\n";
+    }
+  }
+
+  // Stages (grouped)
+  for (int s = 0; s <= loop.maxStage; ++s) {
+    auto stageNodes = loop.getNodesInStage(s);
+    if (stageNodes.empty())
+      continue;
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "modulo.stage @s" << s << " {\n";
+    for (const auto *node : stageNodes) {
+      if (node->isSuperNode()) {
+        dumpLoop(graph, graph.getLoop(node->childPipelineId), os, inner + 1);
+      } else {
+        dumpNodeOneLine(*node, os, inner + 1);
+      }
+    }
+    dumpIndent(os, inner);
+    os << "}\n";
+  }
+
+  // Expanded epilogue (if expanded)
+  if (loop.isExpanded && !loop.epilogueNodes.empty()) {
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "modulo.epilogue {\n";
+    for (const auto &node : loop.epilogueNodes)
+      dumpNodeOneLine(node, os, inner + 1);
+    dumpIndent(os, inner);
+    os << "}\n";
+  }
+
+  // Edges
+  if (!loop.edges.empty()) {
+    os << "\n";
+    dumpIndent(os, inner);
+    os << "edges {\n";
+    for (const auto &edge : loop.edges) {
+      dumpIndent(os, inner + 1);
+      // Mark super-node endpoints
+      auto printNode = [&](unsigned id) {
+        os << "N" << id;
+        if (id < loop.nodes.size() && loop.nodes[id].isSuperNode())
+          os << "(K-loop)";
+      };
+      printNode(edge.srcId);
+      os << " -> ";
+      printNode(edge.dstId);
+      os << "  lat=" << edge.latency << "  dist=" << edge.distance << "\n";
+    }
+    dumpIndent(os, inner);
+    os << "}\n";
+  }
+
+  dumpIndent(os, depth);
+  os << "}\n";
+}
+
+void PipelineGraph::dump() const {
+  llvm::DenseSet<unsigned> childIds;
+  for (const auto &loop : loops)
+    for (const auto &node : loop.nodes)
+      if (node.isSuperNode())
+        childIds.insert(node.childPipelineId);
+
+  for (const auto &loop : loops) {
+    if (childIds.count(loop.id))
+      continue;
+    dumpLoop(*this, loop, llvm::dbgs(), 0);
+    llvm::dbgs() << "\n";
+  }
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloPipelineIR.h
@@ -1,0 +1,259 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// ModuloPipeline IR — abstract representation of a modulo-scheduled
+// loop nest with multi-buffered memory, pipeline stages, and optional
+// warp specialization.
+//
+// The IR is a side data structure (not MLIR ops). It references MLIR
+// Operations but adds scheduling metadata (cycles, stages, buffers,
+// edges) that drive the lowering passes.
+//
+// Transformation phases:
+//   Phase 0: SCHEDULE  — DDG + Rau's → populate PipelineNode cycle/stage
+//   Phase 1: BUFFERS   — stage diffs → populate PipelineBuffer count
+//   Phase 1.5: WS      — utilization → assign warp_group per stage
+//   Phase 2: EXPAND    — bottom-up prologue/kernel/epilogue per loop
+//   Phase 3: LOWER     — replace MLIR ops with async copies + barriers
+
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H
+#define TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H
+
+#include "LatencyModel.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include <cassert>
+
+namespace mlir::triton::gpu {
+
+// ============================================================================
+// Memory abstraction
+// ============================================================================
+
+enum class MemoryKind { SMEM, TMEM, Register, BARRIER };
+
+/// A multi-buffered memory allocation.
+/// Represents SMEM or TMEM that needs multiple copies for pipelining.
+struct PipelineBuffer {
+  unsigned id{};
+  MemoryKind kind{MemoryKind::SMEM};
+  llvm::SmallVector<int64_t, 4> shape;  // e.g., {128, 64}
+  unsigned elementBitWidth{16};       // e.g., 16 for f16
+  unsigned count{1};                  // number of buffers (from stageDiff + 1)
+
+  // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if none)
+  // For barrier buffers: index of the data buffer this barrier guards
+  unsigned pairedBufferId{UINT_MAX};
+
+  // The MLIR op that originally defines this buffer (e.g., local_alloc)
+  Operation *defOp{nullptr};
+
+  int64_t sizeBytes() const {
+    if (kind == MemoryKind::BARRIER)
+      return 8; // mbarrier object is 8 bytes in SMEM
+    int64_t elems = 1;
+    for (auto d : shape)
+      elems *= d;
+    return elems * elementBitWidth / 8;
+  }
+};
+
+// ============================================================================
+// Pipeline node — a scheduled operation
+// ============================================================================
+
+/// A node in the pipeline graph. Wraps an MLIR Operation with scheduling info.
+struct PipelineNode {
+  unsigned id{};
+  Operation *op{nullptr};
+
+  // Schedule assignment (from Phase 0)
+  HWPipeline pipeline{HWPipeline::NONE};
+  int cycle{0};          // absolute cycle within the II
+  int stage{0};          // cycle / II
+  int latency{0};        // cycles until result available
+  int selfLatency{0};    // cycles this op occupies its pipeline
+
+  // Super-node: if this node represents a child pipeline (inner loop)
+  unsigned childPipelineId{UINT_MAX}; // index into PipelineGraph::pipelines
+  int prologueLatency{0};             // cycles before TC starts in child
+
+  // Buffer references
+  unsigned producesBuffer{UINT_MAX};  // index into PipelineLoop::buffers
+  llvm::SmallVector<unsigned, 2> consumesBuffers; // indices into buffers
+
+  // Warp specialization (from Phase 1.5)
+  int warpGroup{-1}; // -1 = unassigned
+
+  bool isSuperNode() const { return childPipelineId != UINT_MAX; }
+  bool hasBuffer() const {
+    return producesBuffer != UINT_MAX || !consumesBuffers.empty();
+  }
+};
+
+// ============================================================================
+// Pipeline edge — producer-consumer dependency
+// ============================================================================
+
+struct PipelineEdge {
+  unsigned srcId{};
+  unsigned dstId{};
+  int latency{};
+  unsigned distance{}; // 0 = intra-iteration, 1+ = loop-carried
+};
+
+// ============================================================================
+// Pipeline loop — a single pipelined scf.for
+// ============================================================================
+
+/// A pipelined loop with its schedule, nodes, edges, and buffers.
+/// Analogous to a function: has inputs (consumed from outer scope),
+/// outputs (produced for outer scope), and a body (nodes + edges).
+struct PipelineLoop {
+  unsigned id{};
+  scf::ForOp forOp;
+
+  // Schedule parameters
+  int II{0};
+  int maxStage{0};
+  int prologueLatency{0}; // cycles before TC starts (for parent's super-node)
+  int tripCount{0};        // loop trip count (0 = unknown/not set)
+  bool tripCountIsEstimated{false}; // true if tripCount is estimated, not constant
+
+  // Body (kernel loop steady state)
+  llvm::SmallVector<PipelineNode, 16> nodes;
+  llvm::SmallVector<PipelineEdge, 16> edges;
+
+  // Expanded structure (populated after expansion, empty before)
+  // Prologue: ops cloned before the loop (stage 0 of first iterations)
+  // Epilogue: ops cloned after the loop (drain of last stage)
+  llvm::SmallVector<PipelineNode, 8> prologueNodes;
+  llvm::SmallVector<PipelineNode, 8> epilogueNodes;
+  bool isExpanded{false}; // true after expandPipelineGraph
+
+  // Memory interface (inputs/outputs crossing loop boundary)
+  // These drive multi-buffering at the parent level.
+  //
+  // isInput is intentionally kept alongside the separate inputs/outputs vectors:
+  // it allows generic iteration over all ports (e.g., when building the parent's
+  // buffer map) without needing to know which vector a port came from.
+  struct MemPort {
+    unsigned bufferId{UINT_MAX}; // index into parent's buffers
+    Operation *op{nullptr};      // the MLIR op at the boundary
+    bool isInput{true};
+  };
+  llvm::SmallVector<MemPort, 4> inputs;  // consumed from outer scope
+  llvm::SmallVector<MemPort, 4> outputs; // produced for outer scope
+
+  // Multi-buffered allocations within this loop
+  llvm::SmallVector<PipelineBuffer, 4> buffers;
+
+  // Lookup
+  llvm::DenseMap<Operation *, unsigned> opToNodeId;
+
+  // Helpers
+  const PipelineNode &getNode(unsigned id) const {
+    assert(id < nodes.size() && "node id out of range");
+    return nodes[id];
+  }
+  /// Find the node for an MLIR op, or nullptr if not in this loop.
+  const PipelineNode *findNode(Operation *op) const {
+    auto it = opToNodeId.find(op);
+    if (it == opToNodeId.end())
+      return nullptr;
+    return &nodes[it->second];
+  }
+  int numStages() const { return maxStage + 1; }
+
+  /// Get all nodes in a given stage.
+  llvm::SmallVector<const PipelineNode *> getNodesInStage(int stage) const {
+    llvm::SmallVector<const PipelineNode *> result;
+    for (const auto &n : nodes)
+      if (n.stage == stage)
+        result.push_back(&n);
+    return result;
+  }
+};
+
+// ============================================================================
+// Pipeline graph — the top-level container
+// ============================================================================
+
+/// The complete pipeline graph for a kernel. Contains all pipelined loops
+/// (potentially nested) and their relationships.
+struct PipelineGraph {
+  llvm::SmallVector<PipelineLoop, 4> loops;
+
+  /// Add a new loop and return its id.
+  unsigned addLoop(scf::ForOp forOp) {
+    unsigned id = loops.size();
+    PipelineLoop loop;
+    loop.id = id;
+    loop.forOp = forOp;
+    loops.push_back(std::move(loop));
+    return id;
+  }
+
+  PipelineLoop &getLoop(unsigned id) {
+    assert(id < loops.size() && "loop id out of range");
+    return loops[id];
+  }
+  const PipelineLoop &getLoop(unsigned id) const {
+    assert(id < loops.size() && "loop id out of range");
+    return loops[id];
+  }
+
+  /// Find the innermost loops (leaves) — process these first (bottom-up).
+  llvm::SmallVector<unsigned> getInnermostLoops() const {
+    llvm::SmallVector<unsigned> result;
+    for (const auto &loop : loops) {
+      bool isInnermost = true;
+      for (const auto &node : loop.nodes) {
+        if (node.isSuperNode()) {
+          isInnermost = false;
+          break;
+        }
+      }
+      // A loop with no super-nodes is innermost
+      // (but it might still not be a leaf if it has no nodes at all)
+      if (isInnermost && !loop.nodes.empty())
+        result.push_back(loop.id);
+    }
+    return result;
+  }
+
+  /// Get loops in bottom-up order (innermost first, outermost last).
+  llvm::SmallVector<unsigned> getBottomUpOrder() const {
+    llvm::SmallVector<unsigned> order;
+    llvm::DenseSet<unsigned> visited;
+
+    std::function<void(unsigned)> visit = [&](unsigned id) {
+      if (visited.count(id))
+        return;
+      // Visit children first
+      for (const auto &node : loops[id].nodes) {
+        if (node.isSuperNode()) {
+          assert(node.childPipelineId < loops.size() &&
+                 "childPipelineId out of range");
+          visit(node.childPipelineId);
+        }
+      }
+      visited.insert(id);
+      order.push_back(id);
+    };
+
+    for (unsigned i = 0; i < loops.size(); ++i)
+      visit(i);
+    return order;
+  }
+
+  /// Dump the graph for debugging.
+  void dump() const;
+};
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
@@ -1,0 +1,253 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "ModuloReservationTable.h"
+
+#include "llvm/Support/Debug.h"
+#include <algorithm>
+#include <climits>
+#include <numeric>
+
+#define DEBUG_TYPE "modulo-scheduling-rau"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+namespace mlir::triton::gpu {
+
+// ── ModuloReservationTable ──────────────────────────────────────────────────
+
+ModuloReservationTable::ModuloReservationTable(int II) : II{II} {
+  for (auto pipe :
+       {HWPipeline::MEM, HWPipeline::TC, HWPipeline::CUDA, HWPipeline::SFU}) {
+    table[pipe].assign(II, -1);
+  }
+}
+
+bool ModuloReservationTable::isFree(int cycle, HWPipeline pipeline) const {
+  if (pipeline == HWPipeline::NONE)
+    return true;
+  auto it = table.find(pipeline);
+  if (it == table.end())
+    return true;
+  return it->second[cycle % II] < 0;
+}
+
+bool ModuloReservationTable::isIntervalFree(int cycle, HWPipeline pipeline,
+                                            int duration) const {
+  if (pipeline == HWPipeline::NONE)
+    return true;
+  for (int t = cycle; t < cycle + duration; ++t) {
+    if (!isFree(t, pipeline))
+      return false;
+  }
+  return true;
+}
+
+void ModuloReservationTable::reserve(int cycle, HWPipeline pipeline,
+                                     unsigned nodeIdx, int duration) {
+  if (pipeline == HWPipeline::NONE)
+    return;
+  for (int t = cycle; t < cycle + duration; ++t) {
+    table[pipeline][t % II] = static_cast<int>(nodeIdx);
+  }
+}
+
+void ModuloReservationTable::unreserve(int cycle, HWPipeline pipeline,
+                                       int duration) {
+  if (pipeline == HWPipeline::NONE)
+    return;
+  for (int t = cycle; t < cycle + duration; ++t) {
+    table[pipeline][t % II] = -1;
+  }
+}
+
+int ModuloReservationTable::getOccupant(int cycle, HWPipeline pipeline) const {
+  if (pipeline == HWPipeline::NONE)
+    return -1;
+  auto it = table.find(pipeline);
+  if (it == table.end())
+    return -1;
+  return it->second[cycle % II];
+}
+
+int ModuloReservationTable::findFreeSlot(int earliest, HWPipeline pipeline,
+                                         int duration) const {
+  if (pipeline == HWPipeline::NONE)
+    return earliest;
+  for (int t = earliest; t < earliest + II; ++t) {
+    if (isIntervalFree(t, pipeline, duration))
+      return t;
+  }
+  return -1;
+}
+
+// ── Rau's Iterative Modulo Scheduling ───────────────────────────────────────
+
+/// Compute the earliest start time for a node given its predecessors'
+/// scheduled cycles, respecting loop-carried distances.
+static int computeEarliestStart(unsigned nodeIdx,
+                                const DataDependenceGraph &ddg,
+                                const llvm::DenseMap<unsigned, int> &scheduled,
+                                int II) {
+  int earliest = 0;
+  for (const auto *edge : ddg.getInEdges(nodeIdx)) {
+    auto it = scheduled.find(edge->srcIdx);
+    if (it == scheduled.end())
+      continue;
+    // constraint: dst_start >= src_start + latency - distance * II
+    int constraint =
+        it->second + edge->latency - static_cast<int>(edge->distance) * II;
+    earliest = std::max(earliest, constraint);
+  }
+  return earliest;
+}
+
+FailureOr<ModuloScheduleResult>
+runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
+                    int maxBacktracks) {
+  LLVM_DEBUG(DBGS() << "Computing MinII...\n");
+  const int minII = ddg.computeMinII();
+  LLVM_DEBUG(DBGS() << "MinII=" << minII << "\n");
+  if (minII <= 0)
+    return failure();
+
+  if (maxII <= 0)
+    maxII = 2 * minII;
+
+  LLVM_DEBUG(DBGS() << "Computing critical path heights...\n");
+  auto heights = ddg.computeCriticalPathHeights();
+  LLVM_DEBUG(DBGS() << "Heights computed for " << heights.size() << " nodes\n");
+
+  // Sort ALL nodes (including NONE-pipeline) by decreasing critical-path
+  // height. NONE ops must be scheduled together with pipeline ops so that
+  // dependency constraints (e.g., load → local_alloc → MMA) are respected.
+  llvm::SmallVector<unsigned> priorityOrder;
+  for (unsigned i = 0; i < ddg.getNumNodes(); ++i)
+    priorityOrder.push_back(i);
+  llvm::sort(priorityOrder,
+             [&](unsigned a, unsigned b) {
+               if (heights[a] != heights[b])
+                 return heights[a] > heights[b];
+               // Tiebreaker: lower index first (producers before consumers
+               // in program order). This ensures that when a predecessor and
+               // successor have equal heights, the predecessor is scheduled
+               // first so its cycle is known when the successor is placed.
+               return a < b;
+             });
+
+  LLVM_DEBUG({
+    DBGS() << "MinII=" << minII << " MaxII=" << maxII
+           << " Nodes=" << priorityOrder.size() << "\n";
+    DBGS() << "ResMII=" << ddg.computeResMII()
+           << " RecMII=" << ddg.computeRecMII() << "\n";
+  });
+  // Show per-pipeline resource usage for ResMII breakdown
+  LLVM_DEBUG({
+    llvm::DenseMap<HWPipeline, int> pipeLoad;
+    for (const auto &node : ddg.getNodes()) {
+      if (node.pipeline != HWPipeline::NONE)
+        pipeLoad[node.pipeline] += std::max(node.selfLatency, 1);
+    }
+    for (auto &[pipe, load] : pipeLoad) {
+      DBGS() << "  " << getPipelineName(pipe) << " total_load=" << load << "\n";
+    }
+  });
+
+  for (int II = minII; II <= maxII; ++II) {
+    ModuloReservationTable table{II};
+    llvm::DenseMap<unsigned, int> scheduled;
+    bool success = true;
+    int backtracks = 0;
+
+    // Use index-based iteration instead of range-for because ejection
+    // may insert evicted nodes back into priorityOrder for re-scheduling.
+    // Range-for would be UB (iterator invalidation on SmallVector insert).
+    for (unsigned i = 0; i < priorityOrder.size(); ++i) {
+      unsigned nodeIdx = priorityOrder[i];
+      const auto &node = ddg.getNode(nodeIdx);
+      int duration = std::max(node.selfLatency, 1); // at least 1 slot
+      if (node.pipeline == HWPipeline::NONE)
+        duration = 1; // NONE ops don't occupy any pipeline
+
+      int earliest = computeEarliestStart(nodeIdx, ddg, scheduled, II);
+      int slot = table.findFreeSlot(earliest, node.pipeline, duration);
+
+      if (slot < 0 && backtracks < maxBacktracks) {
+        // Rau's ejection: find the least-critical occupant in a
+        // conflicting slot, evict it, place current node, then
+        // re-schedule the evicted node later.
+        int bestVictim = -1;
+        int bestVictimHeight = INT_MAX;
+        int currentHeight = heights.lookup(nodeIdx);
+        for (int t = earliest; t < earliest + II; ++t) {
+          int occupant = table.getOccupant(t, node.pipeline);
+          if (occupant < 0)
+            continue;
+          int occHeight = heights.lookup(static_cast<unsigned>(occupant));
+          // Only eject nodes with strictly lower priority (smaller height)
+          // than the current node. This prevents priority inversion where
+          // a less-critical node evicts a more-critical one.
+          if (occHeight < currentHeight && occHeight < bestVictimHeight) {
+            bestVictimHeight = occHeight;
+            bestVictim = occupant;
+          }
+        }
+        if (bestVictim >= 0) {
+          // Evict the victim.
+          const auto &victim = ddg.getNode(bestVictim);
+          int victimDur = std::max(victim.selfLatency, 1);
+          if (victim.pipeline == HWPipeline::NONE)
+            victimDur = 1;
+          int victimCycle = scheduled[bestVictim];
+          table.unreserve(victimCycle, victim.pipeline, victimDur);
+          scheduled.erase(bestVictim);
+
+          // Place current node at the freed slot.
+          slot = table.findFreeSlot(earliest, node.pipeline, duration);
+          if (slot >= 0) {
+            // Insert evicted node right after current position for
+            // re-scheduling. Index-based iteration handles the growth
+            // safely (no iterator invalidation).
+            priorityOrder.insert(priorityOrder.begin() + i + 1,
+                                 static_cast<unsigned>(bestVictim));
+            ++backtracks;
+            LLVM_DEBUG(DBGS() << "  Ejected N" << bestVictim
+                              << " (height=" << bestVictimHeight
+                              << ") to place N" << nodeIdx << "\n");
+          } else {
+            // Could not place even after ejection — restore victim.
+            table.reserve(victimCycle, victim.pipeline,
+                          static_cast<unsigned>(bestVictim), victimDur);
+            scheduled[bestVictim] = victimCycle;
+          }
+        }
+      }
+      if (slot < 0) {
+        success = false;
+        break;
+      }
+
+      table.reserve(slot, node.pipeline, nodeIdx, duration);
+      scheduled[nodeIdx] = slot;
+      LLVM_DEBUG(DBGS() << "  II=" << II << " Placed N" << nodeIdx << " ("
+                        << getPipelineName(node.pipeline) << " dur=" << duration
+                        << ") at cycle=" << slot << " stage=" << slot / II
+                        << "\n");
+    }
+
+    if (success) {
+      LLVM_DEBUG(DBGS() << "SUCCESS at II=" << II << "\n");
+
+      ModuloScheduleResult result;
+      result.II = II;
+      result.nodeToCycle = std::move(scheduled);
+      return result;
+    }
+
+    LLVM_DEBUG(DBGS() << "FAILED at II=" << II << "\n");
+  }
+
+  LLVM_DEBUG(DBGS() << "EXHAUSTED: failed to schedule within maxII=" << maxII
+                    << "\n");
+  return failure();
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
@@ -1,0 +1,66 @@
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_RESERVATION_TABLE_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_RESERVATION_TABLE_H
+
+#include "DataDependenceGraph.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::triton::gpu {
+
+/// Modulo reservation table: II time slots × one row per HWPipeline.
+/// A slot [cycle % II][pipeline] holds at most one op.
+class ModuloReservationTable {
+public:
+  explicit ModuloReservationTable(int II);
+
+  int getII() const { return II; }
+
+  bool isFree(int cycle, HWPipeline pipeline) const;
+  bool isIntervalFree(int cycle, HWPipeline pipeline, int duration) const;
+  void reserve(int cycle, HWPipeline pipeline, unsigned nodeIdx,
+               int duration = 1);
+  void unreserve(int cycle, HWPipeline pipeline, int duration = 1);
+
+  /// Find earliest free slot at or after `earliest` on pipeline, within II.
+  /// Checks that `duration` consecutive slots are all free.
+  /// Returns -1 if no slot found.
+  int findFreeSlot(int earliest, HWPipeline pipeline, int duration = 1) const;
+
+  /// Get the node index occupying a slot, or -1 if free.
+  int getOccupant(int cycle, HWPipeline pipeline) const;
+
+private:
+  int II{};
+  // table[pipeline][slot] = nodeIdx or -1
+  llvm::DenseMap<HWPipeline, llvm::SmallVector<int>> table;
+};
+
+/// Result of modulo scheduling for one loop.
+struct ModuloScheduleResult {
+  int II{};
+  llvm::DenseMap<unsigned, int> nodeToCycle; // DDG node idx -> absolute cycle
+
+  int getStage(unsigned nodeIdx) const {
+    auto it = nodeToCycle.find(nodeIdx);
+    return it != nodeToCycle.end() ? it->second / II : 0;
+  }
+
+  int getMaxStage() const {
+    int maxStage = 0;
+    for (auto &[idx, cycle] : nodeToCycle)
+      maxStage = std::max(maxStage, cycle / II);
+    return maxStage;
+  }
+};
+
+/// Run Rau's iterative modulo scheduling on the DDG.
+/// maxII defaults to 2 * MinII. maxBacktracks limits ejection attempts per II.
+FailureOr<ModuloScheduleResult>
+runModuloScheduling(const DataDependenceGraph &ddg, int maxII = 0,
+                    int maxBacktracks = 20);
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_RESERVATION_TABLE_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -83,6 +83,9 @@ static void emitScheduleAttributes(scf::ForOp loop,
                      IntegerAttr::get(IntegerType::get(ctx, 32), stage));
     node.op->setAttr(tt::kLoopClusterAttrName,
                      IntegerAttr::get(IntegerType::get(ctx, 32), clusterId));
+    // Emit raw cycle for downstream buffer depth computation (Step 3).
+    node.op->setAttr("tt.modulo_cycle",
+                     IntegerAttr::get(IntegerType::get(ctx, 32), cycle));
   }
 
   // Ensure ALL ops in the loop body have loop.stage/loop.cluster attrs.
@@ -102,6 +105,129 @@ static void emitScheduleAttributes(scf::ForOp loop,
                 IntegerAttr::get(IntegerType::get(ctx, 32), II));
   loop->setAttr(tt::kScheduledMaxStageAttrName,
                 IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
+}
+
+// ============================================================================
+// Step 3: Derive per-resource buffer depths from modulo schedule
+// ============================================================================
+
+// Blackwell sm_100 SMEM budget (reserve some for barriers/scratch).
+constexpr int kSmemBudgetBytes = 228 * 1024;
+
+static int getMemDescSizeBytes(ttg::MemDescType memDescType) {
+  int numElements = 1;
+  for (auto dim : memDescType.getShape())
+    numElements *= dim;
+  return numElements * memDescType.getElementType().getIntOrFloatBitWidth() / 8;
+}
+
+/// Compute per-resource buffer depths from the modulo schedule.
+///
+/// For each local_alloc (SMEM buffer) in the loop body:
+///   1. Find its producer's cycle (tt.modulo_cycle on the load)
+///   2. Find the last consumer's end cycle (cycle + latency)
+///   3. lifetime = last_consumer_end - producer_cycle
+///   4. num_buffers = floor(lifetime / II) + 1
+///
+/// Then check SMEM budget: if total exceeds limit, reduce depths.
+/// Returns the max buffer depth, or 0 if no buffers found.
+static int computeBufferDepths(scf::ForOp loop,
+                               const ttg::LatencyModel &model) {
+  auto ctx = loop.getContext();
+  auto iiAttr = loop->getAttrOfType<IntegerAttr>("tt.modulo_ii");
+  if (!iiAttr)
+    return 0;
+  int II = iiAttr.getInt();
+  if (II <= 0)
+    return 0;
+
+  struct BufferInfo {
+    Operation *allocOp;
+    int sizeBytes;
+    int numBuffers;
+  };
+  SmallVector<BufferInfo> buffers;
+
+  for (auto &op : loop.getBody()->without_terminator()) {
+    auto alloc = dyn_cast<ttg::LocalAllocOp>(op);
+    if (!alloc || !alloc.getSrc())
+      continue;
+
+    auto memDescType = dyn_cast<ttg::MemDescType>(alloc.getType());
+    if (!memDescType)
+      continue;
+
+    // Find producer cycle from the source op.
+    auto *producer = alloc.getSrc().getDefiningOp();
+    if (!producer)
+      continue;
+    auto prodCycleAttr =
+        producer->getAttrOfType<IntegerAttr>("tt.modulo_cycle");
+    if (!prodCycleAttr)
+      continue;
+    int prodCycle = prodCycleAttr.getInt();
+
+    // Find last consumer end cycle.
+    int lastConsumerEnd = prodCycle;
+    for (auto *user : alloc->getUsers()) {
+      auto userCycleAttr =
+          user->getAttrOfType<IntegerAttr>("tt.modulo_cycle");
+      if (!userCycleAttr)
+        continue;
+      int userCycle = userCycleAttr.getInt();
+      auto info = model.getLatency(user);
+      lastConsumerEnd = std::max(lastConsumerEnd, userCycle + info.latency);
+    }
+
+    int lifetime = lastConsumerEnd - prodCycle;
+    int numBuffers = std::max(lifetime / II + 1, 1);
+    int sizeBytes = getMemDescSizeBytes(memDescType);
+    buffers.push_back({alloc, sizeBytes, numBuffers});
+
+    LDBG("Buffer: producer_cycle=" << prodCycle
+                                   << " last_consumer_end=" << lastConsumerEnd
+                                   << " lifetime=" << lifetime << " II=" << II
+                                   << " -> num_buffers=" << numBuffers
+                                   << " (" << sizeBytes << " bytes)");
+  }
+
+  if (buffers.empty())
+    return 0;
+
+  // SMEM budget check: reduce depths if total exceeds limit.
+  auto computeTotalSmem = [&]() {
+    int total = 0;
+    for (auto &b : buffers)
+      total += b.sizeBytes * b.numBuffers;
+    return total;
+  };
+
+  while (computeTotalSmem() > kSmemBudgetBytes) {
+    int worstIdx = 0, worstCost = 0;
+    for (int i = 0; i < (int)buffers.size(); ++i) {
+      int cost = buffers[i].sizeBytes * buffers[i].numBuffers;
+      if (cost > worstCost) {
+        worstCost = cost;
+        worstIdx = i;
+      }
+    }
+    if (buffers[worstIdx].numBuffers <= 1)
+      break;
+    buffers[worstIdx].numBuffers--;
+    LDBG("Reduced buffer depth for SMEM budget");
+  }
+
+  // Emit tt.num_buffers on each local_alloc.
+  int maxNumBuffers = 1;
+  for (auto &b : buffers) {
+    b.allocOp->setAttr("tt.num_buffers",
+                       IntegerAttr::get(IntegerType::get(ctx, 32), b.numBuffers));
+    maxNumBuffers = std::max(maxNumBuffers, b.numBuffers);
+  }
+
+  LDBG("Buffer depths: max=" << maxNumBuffers
+                              << " totalSmem=" << computeTotalSmem() << "B");
+  return maxNumBuffers;
 }
 
 // ============================================================================
@@ -171,6 +297,25 @@ struct ModuloSchedulePass
 
       // Emit loop.stage / loop.cluster on all ops.
       emitScheduleAttributes(innerLoop, ddg, *schedResult);
+
+      // Step 3: Derive SMEM buffer depths from cycle-level lifetimes.
+      // Only set tt.num_stages if the user didn't specify one (no
+      // tt.num_stages attr on the loop already).
+      if (!innerLoop->hasAttr(tt::kNumStagesAttrName)) {
+        int numStages = computeBufferDepths(innerLoop, model);
+        if (numStages > 0) {
+          auto ctx = innerLoop.getContext();
+          innerLoop->setAttr(
+              tt::kNumStagesAttrName,
+              IntegerAttr::get(IntegerType::get(ctx, 32), numStages));
+          LDBG("Set tt.num_stages=" << numStages << " from modulo schedule");
+        }
+      }
+
+      // Clean up tt.modulo_cycle — internal attr used only to pass cycle
+      // info from emitScheduleAttributes to computeBufferDepths.
+      for (auto &op : innerLoop.getBody()->without_terminator())
+        op.removeAttr("tt.modulo_cycle");
     }
 
     // Step 2: Schedule outer loops (persistent kernels).

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -70,6 +70,12 @@ static void emitScheduleAttributes(scf::ForOp loop,
     auto it = schedule.nodeToCycle.find(node.idx);
     if (it == schedule.nodeToCycle.end())
       continue;
+    // For multi-stage super-nodes (prologue/kloop/epilogue sharing the same
+    // Operation*), only write attrs from the node registered in opToIdx
+    // (the epilogue) to avoid overwrites.
+    auto opIt = ddg.getOpToIdx().find(node.op);
+    if (opIt != ddg.getOpToIdx().end() && opIt->second != node.idx)
+      continue;
     int stage = it->second / II;
     int cycle = it->second;
     int clusterId = stageAndCycleToCluster[stage][cycle];
@@ -165,6 +171,42 @@ struct ModuloSchedulePass
 
       // Emit loop.stage / loop.cluster on all ops.
       emitScheduleAttributes(innerLoop, ddg, *schedResult);
+    }
+
+    // Step 2: Schedule outer loops (persistent kernels).
+    SmallVector<scf::ForOp> outerLoops;
+    moduleOp.walk([&](scf::ForOp loop) {
+      bool hasInnerLoop = false;
+      loop.getBody()->walk([&](scf::ForOp) { hasInnerLoop = true; });
+      if (!hasInnerLoop)
+        return;
+      if (loop->getParentOfType<scf::ForOp>())
+        return;
+      outerLoops.push_back(loop);
+    });
+
+    LDBG("Found " << outerLoops.size() << " outer loop(s)");
+
+    for (auto outerLoop : outerLoops) {
+      auto outerDDG = ttg::DataDependenceGraph::build(outerLoop, model);
+      if (outerDDG.getNumNodes() == 0)
+        continue;
+
+      LDBG("Outer DDG: " << outerDDG.getNumNodes() << " nodes, "
+                          << outerDDG.getEdges().size() << " edges");
+
+      auto outerSched = ttg::runModuloScheduling(outerDDG);
+      if (failed(outerSched)) {
+        LDBG("Outer scheduling FAILED");
+        continue;
+      }
+
+      LDBG("Outer schedule: II=" << outerSched->II
+                                 << " ResMII=" << outerDDG.computeResMII()
+                                 << " RecMII=" << outerDDG.computeRecMII()
+                                 << " maxStage=" << outerSched->getMaxStage());
+
+      emitScheduleAttributes(outerLoop, outerDDG, *outerSched);
     }
   }
 };

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -1,0 +1,29 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Stub for createNVGPUModuloSchedule — provides the symbol so that
+// triton_nvidia.cc (ADD_PASS_WRAPPER_0) links before the real
+// implementation lands in a child diff.
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace {
+struct ModuloSchedulePass
+    : public PassWrapper<ModuloSchedulePass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloSchedulePass)
+  StringRef getArgument() const override { return "nvgpu-modulo-schedule"; }
+  StringRef getDescription() const override {
+    return "Modulo scheduling for warp specialization (stub)";
+  }
+  void runOnOperation() override {}
+};
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloSchedule() {
+  return std::make_unique<ModuloSchedulePass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -45,15 +45,38 @@ static void emitScheduleAttributes(scf::ForOp loop,
   const int maxStage = schedule.getMaxStage();
   auto ctx = loop.getContext();
 
+  // Step 2.5: Compute per-stage cluster IDs from modulo cycles.
+  // Ops in the same stage are ordered by cycle: lower cycle → lower cluster ID.
+  // This preserves the modulo schedule's within-stage ordering for downstream
+  // pipelining, instead of relying on IR program order.
+  llvm::DenseMap<int, SmallVector<int>> stageToCycles;
   for (const auto &node : ddg.getNodes()) {
     auto it = schedule.nodeToCycle.find(node.idx);
     if (it == schedule.nodeToCycle.end())
       continue;
     int stage = it->second / II;
+    stageToCycles[stage].push_back(it->second);
+  }
+  // Deduplicate and sort cycles per stage to assign dense cluster IDs.
+  llvm::DenseMap<int, llvm::DenseMap<int, int>> stageAndCycleToCluster;
+  for (auto &[stage, cycles] : stageToCycles) {
+    llvm::sort(cycles);
+    cycles.erase(llvm::unique(cycles), cycles.end());
+    for (int i = 0, e = cycles.size(); i < e; ++i)
+      stageAndCycleToCluster[stage][cycles[i]] = i;
+  }
+
+  for (const auto &node : ddg.getNodes()) {
+    auto it = schedule.nodeToCycle.find(node.idx);
+    if (it == schedule.nodeToCycle.end())
+      continue;
+    int stage = it->second / II;
+    int cycle = it->second;
+    int clusterId = stageAndCycleToCluster[stage][cycle];
     node.op->setAttr(tt::kLoopStageAttrName,
                      IntegerAttr::get(IntegerType::get(ctx, 32), stage));
     node.op->setAttr(tt::kLoopClusterAttrName,
-                     IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+                     IntegerAttr::get(IntegerType::get(ctx, 32), clusterId));
   }
 
   // Ensure ALL ops in the loop body have loop.stage/loop.cluster attrs.

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -1,29 +1,159 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// Stub for createNVGPUModuloSchedule — provides the symbol so that
-// triton_nvidia.cc (ADD_PASS_WRAPPER_0) links before the real
-// implementation lands in a child diff.
+// Pass A: Modulo Schedule Pass
+//
+// Builds a DDG from scf.for loop bodies, computes MinII, runs Rau's iterative
+// modulo scheduling, and annotates ops with loop.stage and loop.cluster
+// attributes for downstream pipelining passes.
 
+#include "DataDependenceGraph.h"
+#include "LatencyModel.h"
+#include "ModuloReservationTable.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Format.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-schedule"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 using namespace mlir;
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
 
 namespace {
+
+// ============================================================================
+// Emit loop.stage / loop.cluster attributes from modulo schedule
+// ============================================================================
+
+static void emitScheduleAttributes(scf::ForOp loop,
+                                   const ttg::DataDependenceGraph &ddg,
+                                   const ttg::ModuloScheduleResult &schedule) {
+  const int II = schedule.II;
+  const int maxStage = schedule.getMaxStage();
+  auto ctx = loop.getContext();
+
+  for (const auto &node : ddg.getNodes()) {
+    auto it = schedule.nodeToCycle.find(node.idx);
+    if (it == schedule.nodeToCycle.end())
+      continue;
+    int stage = it->second / II;
+    node.op->setAttr(tt::kLoopStageAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), stage));
+    node.op->setAttr(tt::kLoopClusterAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+  }
+
+  // Ensure ALL ops in the loop body have loop.stage/loop.cluster attrs.
+  // Downstream passes assert every op is in the schedule.
+  for (auto &op : loop.getBody()->without_terminator()) {
+    if (!op.hasAttr(tt::kLoopStageAttrName))
+      op.setAttr(tt::kLoopStageAttrName,
+                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+    if (!op.hasAttr(tt::kLoopClusterAttrName))
+      op.setAttr(tt::kLoopClusterAttrName,
+                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+  }
+
+  LDBG("Emitted schedule: II=" << II << " maxStage=" << maxStage);
+
+  loop->setAttr("tt.modulo_ii",
+                IntegerAttr::get(IntegerType::get(ctx, 32), II));
+  loop->setAttr(tt::kScheduledMaxStageAttrName,
+                IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
+}
+
+// ============================================================================
+// Pass A: Modulo Scheduling
+// ============================================================================
+
+/// The main pass.
 struct ModuloSchedulePass
     : public PassWrapper<ModuloSchedulePass, OperationPass<ModuleOp>> {
+
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloSchedulePass)
+
   StringRef getArgument() const override { return "nvgpu-modulo-schedule"; }
+
   StringRef getDescription() const override {
-    return "Modulo scheduling for warp specialization (stub)";
+    return "Modulo scheduling for warp specialization (Pass A)";
   }
-  void runOnOperation() override {}
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    ttg::LatencyModel model;
+
+    // Find innermost loops with TMA loads or MMA ops.
+    SmallVector<scf::ForOp> innerLoops;
+    moduleOp.walk([&](scf::ForOp loop) {
+      bool hasInnerLoop = false;
+      loop.getBody()->walk([&](scf::ForOp) { hasInnerLoop = true; });
+      if (hasInnerLoop)
+        return;
+      bool hasTMALoad = false;
+      bool hasMMAv5 = false;
+      loop.getBody()->walk([&](Operation *op) {
+        if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
+          hasTMALoad = true;
+        if (isa<ttng::AsyncTMACopyGlobalToLocalOp>(op))
+          hasTMALoad = true;
+        if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op))
+          hasMMAv5 = true;
+      });
+      if (!hasTMALoad && !hasMMAv5)
+        return;
+      innerLoops.push_back(loop);
+    });
+
+    LDBG("Found " << innerLoops.size() << " innermost loop(s)");
+
+    for (auto innerLoop : innerLoops) {
+      // Build DDG for this inner loop.
+      auto ddg = ttg::DataDependenceGraph::build(innerLoop, model);
+      if (ddg.getNumNodes() == 0)
+        continue;
+
+      LDBG("DDG: " << ddg.getNumNodes() << " nodes, "
+                    << ddg.getEdges().size() << " edges");
+
+      // Run Rau's modulo scheduling.
+      auto schedResult = ttg::runModuloScheduling(ddg);
+      if (failed(schedResult)) {
+        LDBG("Scheduling FAILED");
+        continue;
+      }
+
+      LDBG("Schedule: II=" << schedResult->II
+                           << " ResMII=" << ddg.computeResMII()
+                           << " RecMII=" << ddg.computeRecMII()
+                           << " maxStage=" << schedResult->getMaxStage());
+
+      // Emit loop.stage / loop.cluster on all ops.
+      emitScheduleAttributes(innerLoop, ddg, *schedResult);
+    }
+  }
 };
+
 } // namespace
 
 namespace mlir {
 std::unique_ptr<Pass> createNVGPUModuloSchedule() {
   return std::make_unique<ModuloSchedulePass>();
+}
+
+void registerNVGPUModuloSchedule() {
+  PassRegistration<ModuloSchedulePass>();
 }
 } // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -3,19 +3,36 @@
 // Pass A: Modulo Schedule Pass
 //
 // Builds a DDG from scf.for loop bodies, computes MinII, runs Rau's iterative
-// modulo scheduling, and annotates ops with loop.stage and loop.cluster
-// attributes for downstream pipelining passes.
+// modulo scheduling, and annotates ops with loop.stage, loop.cluster, and
+// latency attributes for downstream pipelining passes.
+//
+// Outer loop wiring for persistent kernels:
+//   The pass handles nested loops by modeling inner K-loops as super-nodes
+//   in the outer tile loop's DDG. The outer loop schedule sets tt.modulo_ii
+//   which survives through assign_latencies (per-loop skip in ScheduleLoops)
+//   and through WarpSpecialization (which consumes the loops into partition
+//   regions). The epilogue pipelining analysis computes overlap depth for
+//   tile-to-tile pipelining.
 
 #include "DataDependenceGraph.h"
 #include "LatencyModel.h"
+#include "ModuloPipelineIR.h"
 #include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -34,82 +51,17 @@ namespace ttng = triton::nvidia_gpu;
 
 namespace {
 
-// ============================================================================
-// Emit loop.stage / loop.cluster attributes from modulo schedule
-// ============================================================================
-
-static void emitScheduleAttributes(scf::ForOp loop,
-                                   const ttg::DataDependenceGraph &ddg,
-                                   const ttg::ModuloScheduleResult &schedule) {
-  const int II = schedule.II;
-  const int maxStage = schedule.getMaxStage();
-  auto ctx = loop.getContext();
-
-  // Step 2.5: Compute per-stage cluster IDs from modulo cycles.
-  // Ops in the same stage are ordered by cycle: lower cycle → lower cluster ID.
-  // This preserves the modulo schedule's within-stage ordering for downstream
-  // pipelining, instead of relying on IR program order.
-  llvm::DenseMap<int, SmallVector<int>> stageToCycles;
-  for (const auto &node : ddg.getNodes()) {
-    auto it = schedule.nodeToCycle.find(node.idx);
-    if (it == schedule.nodeToCycle.end())
-      continue;
-    int stage = it->second / II;
-    stageToCycles[stage].push_back(it->second);
-  }
-  // Deduplicate and sort cycles per stage to assign dense cluster IDs.
-  llvm::DenseMap<int, llvm::DenseMap<int, int>> stageAndCycleToCluster;
-  for (auto &[stage, cycles] : stageToCycles) {
-    llvm::sort(cycles);
-    cycles.erase(llvm::unique(cycles), cycles.end());
-    for (int i = 0, e = cycles.size(); i < e; ++i)
-      stageAndCycleToCluster[stage][cycles[i]] = i;
-  }
-
-  for (const auto &node : ddg.getNodes()) {
-    auto it = schedule.nodeToCycle.find(node.idx);
-    if (it == schedule.nodeToCycle.end())
-      continue;
-    // For multi-stage super-nodes (prologue/kloop/epilogue sharing the same
-    // Operation*), only write attrs from the node registered in opToIdx
-    // (the epilogue) to avoid overwrites.
-    auto opIt = ddg.getOpToIdx().find(node.op);
-    if (opIt != ddg.getOpToIdx().end() && opIt->second != node.idx)
-      continue;
-    int stage = it->second / II;
-    int cycle = it->second;
-    int clusterId = stageAndCycleToCluster[stage][cycle];
-    node.op->setAttr(tt::kLoopStageAttrName,
-                     IntegerAttr::get(IntegerType::get(ctx, 32), stage));
-    node.op->setAttr(tt::kLoopClusterAttrName,
-                     IntegerAttr::get(IntegerType::get(ctx, 32), clusterId));
-    // Emit raw cycle for downstream buffer depth computation (Step 3).
-    node.op->setAttr("tt.modulo_cycle",
-                     IntegerAttr::get(IntegerType::get(ctx, 32), cycle));
-  }
-
-  // Ensure ALL ops in the loop body have loop.stage/loop.cluster attrs.
-  // Downstream passes assert every op is in the schedule.
-  for (auto &op : loop.getBody()->without_terminator()) {
-    if (!op.hasAttr(tt::kLoopStageAttrName))
-      op.setAttr(tt::kLoopStageAttrName,
-                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
-    if (!op.hasAttr(tt::kLoopClusterAttrName))
-      op.setAttr(tt::kLoopClusterAttrName,
-                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
-  }
-
-  LDBG("Emitted schedule: II=" << II << " maxStage=" << maxStage);
-
-  loop->setAttr("tt.modulo_ii",
-                IntegerAttr::get(IntegerType::get(ctx, 32), II));
-  loop->setAttr(tt::kScheduledMaxStageAttrName,
-                IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
-}
-
-// ============================================================================
-// Step 3: Derive per-resource buffer depths from modulo schedule
-// ============================================================================
+/// Step 3: Derive per-resource SMEM buffer depths from modulo schedule.
+///
+/// For each local_alloc (SMEM buffer) in the loop body:
+///   1. Find its producer's cycle (tt.modulo_cycle on the load)
+///   2. Find the last consumer's end cycle (cycle + latency)
+///   3. lifetime = last_consumer_end - producer_cycle
+///   4. num_buffers = floor(lifetime / II) + 1
+///
+/// Then check SMEM budget (228KB): if total exceeds limit, reduce depths
+/// starting from the largest resource.
+/// Returns the max buffer depth, or 0 if no buffers found.
 
 // Blackwell sm_100 SMEM budget (reserve some for barriers/scratch).
 constexpr int kSmemBudgetBytes = 228 * 1024;
@@ -121,16 +73,6 @@ static int getMemDescSizeBytes(ttg::MemDescType memDescType) {
   return numElements * memDescType.getElementType().getIntOrFloatBitWidth() / 8;
 }
 
-/// Compute per-resource buffer depths from the modulo schedule.
-///
-/// For each local_alloc (SMEM buffer) in the loop body:
-///   1. Find its producer's cycle (tt.modulo_cycle on the load)
-///   2. Find the last consumer's end cycle (cycle + latency)
-///   3. lifetime = last_consumer_end - producer_cycle
-///   4. num_buffers = floor(lifetime / II) + 1
-///
-/// Then check SMEM budget: if total exceeds limit, reduce depths.
-/// Returns the max buffer depth, or 0 if no buffers found.
 static int computeBufferDepths(scf::ForOp loop,
                                const ttg::LatencyModel &model) {
   auto ctx = loop.getContext();
@@ -170,13 +112,13 @@ static int computeBufferDepths(scf::ForOp loop,
     // Find last consumer end cycle.
     int lastConsumerEnd = prodCycle;
     for (auto *user : alloc->getUsers()) {
-      auto userCycleAttr =
+      auto uCycleAttr =
           user->getAttrOfType<IntegerAttr>("tt.modulo_cycle");
-      if (!userCycleAttr)
+      if (!uCycleAttr)
         continue;
-      int userCycle = userCycleAttr.getInt();
       auto info = model.getLatency(user);
-      lastConsumerEnd = std::max(lastConsumerEnd, userCycle + info.latency);
+      lastConsumerEnd = std::max(lastConsumerEnd,
+                                 (int)(uCycleAttr.getInt() + info.latency));
     }
 
     int lifetime = lastConsumerEnd - prodCycle;
@@ -217,10 +159,13 @@ static int computeBufferDepths(scf::ForOp loop,
     LDBG("Reduced buffer depth for SMEM budget");
   }
 
-  // Emit tt.num_buffers on each local_alloc.
+  // Emit buffer.copy on each local_alloc so the WS pass's
+  // ChannelPost::getNumBuffers() picks up the per-buffer depth.
   int maxNumBuffers = 1;
   for (auto &b : buffers) {
     b.allocOp->setAttr("tt.num_buffers",
+                       IntegerAttr::get(IntegerType::get(ctx, 32), b.numBuffers));
+    b.allocOp->setAttr("buffer.copy",
                        IntegerAttr::get(IntegerType::get(ctx, 32), b.numBuffers));
     maxNumBuffers = std::max(maxNumBuffers, b.numBuffers);
   }
@@ -230,9 +175,857 @@ static int computeBufferDepths(scf::ForOp loop,
   return maxNumBuffers;
 }
 
+// TODO(Phase2/3): Remove emitScheduleAttributes once ModuloExpand and
+// ModuloLower consume the PipelineGraph directly. Until then, downstream
+// passes (TritonGPUPipeline, WarpSpecialization) need loop.stage attrs.
+static void emitScheduleAttributes(scf::ForOp loop,
+                                   const ttg::DataDependenceGraph &ddg,
+                                   const ttg::ModuloScheduleResult &schedule) {
+  const int II = schedule.II;
+  const int maxStage = schedule.getMaxStage();
+  auto ctx = loop.getContext();
+  auto moduleOp = loop->getParentOfType<ModuleOp>();
+
+  // Step 2.5: Compute per-stage cluster IDs from modulo cycles.
+  // Ops in the same stage are ordered by cycle: lower cycle → lower cluster ID.
+  llvm::DenseMap<int, SmallVector<int>> stageToCycles;
+  for (const auto &node : ddg.getNodes()) {
+    auto it = schedule.nodeToCycle.find(node.idx);
+    if (it == schedule.nodeToCycle.end())
+      continue;
+    int stage = it->second / II;
+    stageToCycles[stage].push_back(it->second);
+  }
+  llvm::DenseMap<int, llvm::DenseMap<int, int>> stageAndCycleToCluster;
+  for (auto &[stage, cycles] : stageToCycles) {
+    llvm::sort(cycles);
+    cycles.erase(llvm::unique(cycles), cycles.end());
+    for (int i = 0, e = cycles.size(); i < e; ++i)
+      stageAndCycleToCluster[stage][cycles[i]] = i;
+  }
+
+  // Collect selfLatency values for serialization.
+  DenseMap<Operation *, int> selfLatencies;
+
+  for (const auto &node : ddg.getNodes()) {
+    auto it = schedule.nodeToCycle.find(node.idx);
+    if (it == schedule.nodeToCycle.end())
+      continue;
+    int stage = it->second / II;
+    int cycle = it->second;
+    int clusterId = stageAndCycleToCluster[stage][cycle];
+    node.op->setAttr(tt::kLoopStageAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), stage));
+    node.op->setAttr(tt::kLoopClusterAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), clusterId));
+    node.op->setAttr("tt.modulo_cycle",
+                     IntegerAttr::get(IntegerType::get(ctx, 32), cycle));
+
+    // Record selfLatency for ops that need it (MMAv5, loads with latency).
+    // Convert from cycles to stages: lowerMMAs uses this as a stage count,
+    // not a cycle count. selfLatency_stages = ceil(cycles / II).
+    if (node.selfLatency > 0) {
+      int selfLatStages =
+          (node.selfLatency + schedule.II - 1) / schedule.II;
+      selfLatencies[node.op] = selfLatStages;
+    }
+  }
+
+  // Serialize selfLatency attrs so lowerMMAs/lowerLoads can read them.
+  tt::serializeSelfLatencies(moduleOp, selfLatencies);
+
+  // Ensure ALL ops in the loop body have loop.stage/loop.cluster attrs.
+  // Downstream TritonGPUPipeline asserts every op is in the schedule.
+  for (auto &op : loop.getBody()->without_terminator()) {
+    if (!op.hasAttr(tt::kLoopStageAttrName))
+      op.setAttr(tt::kLoopStageAttrName,
+                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+    if (!op.hasAttr(tt::kLoopClusterAttrName))
+      op.setAttr(tt::kLoopClusterAttrName,
+                 IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+  }
+
+  LDBG("Emitted schedule: II=" << II << " maxStage=" << maxStage);
+
+  loop->setAttr("tt.modulo_ii",
+                IntegerAttr::get(IntegerType::get(ctx, 32), II));
+  if (maxStage > 0) {
+    loop->setAttr(tt::kScheduledMaxStageAttrName,
+                  IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
+  }
+
+  // === Warp Group Partitioning analysis (informational logging) ===
+  {
+    llvm::DenseMap<ttg::HWPipeline, int> pipeLoad;
+    llvm::DenseMap<ttg::HWPipeline, int> pipeOpCount;
+    for (const auto &node : ddg.getNodes()) {
+      if (node.pipeline == ttg::HWPipeline::NONE)
+        continue;
+      pipeLoad[node.pipeline] += node.selfLatency;
+      pipeOpCount[node.pipeline]++;
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Warp group partitioning analysis (II=" << II
+                 << "):\n");
+
+    SmallVector<ttg::HWPipeline> ownGroup;
+    SmallVector<ttg::HWPipeline> mergeGroup;
+    for (auto pipe : {ttg::HWPipeline::MEM, ttg::HWPipeline::TC,
+                      ttg::HWPipeline::CUDA, ttg::HWPipeline::SFU}) {
+      int load = pipeLoad.lookup(pipe);
+      int ops = pipeOpCount.lookup(pipe);
+      if (load == 0 && ops == 0)
+        continue;
+      double util = II > 0 ? static_cast<double>(load) / II : 0.0;
+      bool gets_own = util > 0.3;
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A]   " << ttg::getPipelineName(pipe)
+                   << ": load=" << load
+                   << " util=" << llvm::format("%.1f%%", util * 100)
+                   << " ops=" << ops
+                   << (gets_own ? " -> OWN warp group" : " -> MERGE") << "\n");
+      if (gets_own)
+        ownGroup.push_back(pipe);
+      else
+        mergeGroup.push_back(pipe);
+    }
+
+    int numGroups = ownGroup.size();
+    bool memHasOwn = false;
+    for (auto p : ownGroup)
+      if (p == ttg::HWPipeline::MEM)
+        memHasOwn = true;
+    if (!memHasOwn && pipeLoad.lookup(ttg::HWPipeline::MEM) > 0) {
+      numGroups++;
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A]   MEM promoted to own group "
+                   << "(TMA producer needs dedicated warp)\n");
+    }
+    if (!mergeGroup.empty())
+      numGroups++;
+
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Recommended: " << numGroups << " warp groups");
+    if (numGroups >= 2)
+      LLVM_DEBUG(llvm::dbgs() << " (");
+    bool first = true;
+    for (auto p : ownGroup) {
+      if (!first)
+        LLVM_DEBUG(llvm::dbgs() << " + ");
+      LLVM_DEBUG(llvm::dbgs() << ttg::getPipelineName(p));
+      first = false;
+    }
+    if (!memHasOwn && pipeLoad.lookup(ttg::HWPipeline::MEM) > 0) {
+      if (!first)
+        LLVM_DEBUG(llvm::dbgs() << " + ");
+      LLVM_DEBUG(llvm::dbgs() << "MEM(producer)");
+      first = false;
+    }
+    if (!mergeGroup.empty()) {
+      if (!first)
+        LLVM_DEBUG(llvm::dbgs() << " + ");
+      LLVM_DEBUG(llvm::dbgs() << "default(");
+      for (unsigned i = 0; i < mergeGroup.size(); i++) {
+        if (i > 0)
+          LLVM_DEBUG(llvm::dbgs() << "+");
+        LLVM_DEBUG(llvm::dbgs() << ttg::getPipelineName(mergeGroup[i]));
+      }
+      LLVM_DEBUG(llvm::dbgs() << ")");
+    }
+    if (numGroups >= 2)
+      LLVM_DEBUG(llvm::dbgs() << ")");
+    LLVM_DEBUG(llvm::dbgs() << "\n");
+  }
+}
+
+// ============================================================================
+// Phase 0d: Build PipelineGraph from DDG + Schedule
+// ============================================================================
+
+static ttg::PipelineNode
+convertDDGNode(const ttg::DDGNode &ddgNode, unsigned pipeNodeId,
+               const ttg::ModuloScheduleResult &sched) {
+  ttg::PipelineNode pn;
+  pn.id = pipeNodeId;
+  pn.op = ddgNode.op;
+  pn.pipeline = ddgNode.pipeline;
+  pn.latency = ddgNode.latency;
+  pn.selfLatency = ddgNode.selfLatency;
+
+  auto cycleIt = sched.nodeToCycle.find(ddgNode.idx);
+  if (cycleIt != sched.nodeToCycle.end()) {
+    pn.cycle = cycleIt->second;
+    pn.stage = cycleIt->second / sched.II;
+  }
+
+  if (ddgNode.isSuperNode) {
+    pn.prologueLatency = ddgNode.prologueLatency;
+    // childPipelineId set by caller after child loop is created
+  }
+  return pn;
+}
+
+/// Build a child PipelineLoop for an inner scf.for loop (super-node).
+/// Recursively builds DDG, schedules it, and populates nodes/edges.
+static unsigned buildChildPipelineLoop(scf::ForOp innerLoop,
+                                       ttg::PipelineGraph &graph,
+                                       const ttg::LatencyModel &model) {
+  auto innerDDG = ttg::DataDependenceGraph::build(innerLoop, model);
+  unsigned loopId = graph.addLoop(innerLoop);
+  auto &pipeLoop = graph.getLoop(loopId);
+
+  if (innerDDG.getNumNodes() == 0)
+    return loopId;
+
+  auto innerSched = ttg::runModuloScheduling(innerDDG);
+  if (failed(innerSched))
+    return loopId;
+
+  pipeLoop.II = innerSched->II;
+  pipeLoop.maxStage = innerSched->getMaxStage();
+
+  // Find prologue latency (earliest TC cycle)
+  int tcStart = innerSched->II;
+  for (const auto &node : innerDDG.getNodes()) {
+    if (node.pipeline == ttg::HWPipeline::TC) {
+      auto it = innerSched->nodeToCycle.find(node.idx);
+      if (it != innerSched->nodeToCycle.end())
+        tcStart = std::min(tcStart, it->second);
+    }
+  }
+  pipeLoop.prologueLatency = tcStart;
+
+  // Extract trip count from scf.for bounds (constant or estimated).
+  pipeLoop.tripCount = 4; // default estimate
+  pipeLoop.tripCountIsEstimated = true;
+  {
+    auto lb = innerLoop.getLowerBound()
+                  .getDefiningOp<arith::ConstantIntOp>();
+    auto ub = innerLoop.getUpperBound()
+                  .getDefiningOp<arith::ConstantIntOp>();
+    auto step = innerLoop.getStep()
+                    .getDefiningOp<arith::ConstantIntOp>();
+    if (lb && ub && step && step.value() > 0) {
+      int64_t tc =
+          (ub.value() - lb.value() + step.value() - 1) / step.value();
+      if (tc > 0) {
+        pipeLoop.tripCount = static_cast<int>(tc);
+        pipeLoop.tripCountIsEstimated = false;
+      }
+    }
+  }
+
+  // Convert DDG nodes → PipelineNodes
+  llvm::DenseMap<unsigned, unsigned> ddgToPipe; // ddgIdx → pipeNodeId
+  for (const auto &ddgNode : innerDDG.getNodes()) {
+    unsigned pipeNodeId = pipeLoop.nodes.size();
+    ddgToPipe[ddgNode.idx] = pipeNodeId;
+    auto pn = convertDDGNode(ddgNode, pipeNodeId, *innerSched);
+
+    // Handle nested super-nodes (arbitrary depth)
+    if (ddgNode.isSuperNode) {
+      if (auto nestedLoop = dyn_cast<scf::ForOp>(ddgNode.op)) {
+        unsigned childId = buildChildPipelineLoop(nestedLoop, graph, model);
+        pn.childPipelineId = childId;
+      }
+    }
+
+    pipeLoop.nodes.push_back(pn);
+    pipeLoop.opToNodeId[ddgNode.op] = pipeNodeId;
+  }
+
+  // Convert DDG edges → PipelineEdges
+  for (const auto &ddgEdge : innerDDG.getEdges()) {
+    auto srcIt = ddgToPipe.find(ddgEdge.srcIdx);
+    auto dstIt = ddgToPipe.find(ddgEdge.dstIdx);
+    if (srcIt == ddgToPipe.end() || dstIt == ddgToPipe.end())
+      continue;
+    ttg::PipelineEdge pe;
+    pe.srcId = srcIt->second;
+    pe.dstId = dstIt->second;
+    pe.latency = ddgEdge.latency;
+    pe.distance = ddgEdge.distance;
+    pipeLoop.edges.push_back(pe);
+  }
+
+  // Populate inputs: values from outside the inner loop used by DDG nodes.
+  // (1) iter_args (loop-carried values, e.g., accumulator)
+  for (auto arg : innerLoop.getRegionIterArgs()) {
+    for (auto *user : arg.getUsers()) {
+      if (user->hasTrait<OpTrait::IsTerminator>())
+        continue;
+      auto it = pipeLoop.opToNodeId.find(user);
+      if (it != pipeLoop.opToNodeId.end()) {
+        ttg::PipelineLoop::MemPort port;
+        port.op = user;
+        port.isInput = true;
+        pipeLoop.inputs.push_back(port);
+        break; // one input entry per iter_arg
+      }
+    }
+  }
+
+  // (2) Captured values from outer scope (e.g., TMA descriptors, offsets).
+  // Walk all DDG nodes and check if any operand is defined outside the loop.
+  llvm::DenseSet<Operation *> capturedDefs;
+  for (const auto &node : pipeLoop.nodes) {
+    if (!node.op)
+      continue;
+    // Walk the op (and nested regions for scf.if) to find outer operands
+    node.op->walk([&](Operation *nested) {
+      for (auto operand : nested->getOperands()) {
+        // Skip block arguments of the inner loop (induction var, iter_args)
+        if (auto blockArg = dyn_cast<BlockArgument>(operand))
+          if (blockArg.getOwner() == innerLoop.getBody())
+            continue;
+        auto *defOp = operand.getDefiningOp();
+        if (!defOp)
+          continue;
+        // If defOp is inside the inner loop, it's not captured
+        if (innerLoop->isAncestor(defOp))
+          continue;
+        // Deduplicate by defining op
+        if (!capturedDefs.insert(defOp).second)
+          continue;
+        ttg::PipelineLoop::MemPort port;
+        port.op = defOp;
+        port.isInput = true;
+        pipeLoop.inputs.push_back(port);
+      }
+    });
+  }
+
+  // Populate outputs: values yielded by the loop (via scf.yield)
+  auto *yieldOp = innerLoop.getBody()->getTerminator();
+  for (unsigned i = 0; i < yieldOp->getNumOperands(); ++i) {
+    auto *defOp = yieldOp->getOperand(i).getDefiningOp();
+    if (!defOp)
+      continue;
+    auto it = pipeLoop.opToNodeId.find(defOp);
+    if (it != pipeLoop.opToNodeId.end()) {
+      ttg::PipelineLoop::MemPort port;
+      port.op = defOp;
+      port.isInput = false;
+      pipeLoop.outputs.push_back(port);
+    }
+  }
+
+  return loopId;
+}
+
+/// Build the top-level PipelineLoop for a scheduled outer/main loop.
+static unsigned buildPipelineLoop(scf::ForOp loop,
+                                  const ttg::DataDependenceGraph &ddg,
+                                  const ttg::ModuloScheduleResult &sched,
+                                  ttg::PipelineGraph &graph,
+                                  const ttg::LatencyModel &model) {
+  unsigned loopId = graph.addLoop(loop);
+  auto &pipeLoop = graph.getLoop(loopId);
+  pipeLoop.II = sched.II;
+  pipeLoop.maxStage = sched.getMaxStage();
+
+  // Find prologue latency (earliest TC cycle)
+  int tcStart = sched.II;
+  for (const auto &node : ddg.getNodes()) {
+    if (node.pipeline == ttg::HWPipeline::TC || node.isSuperNode) {
+      auto it = sched.nodeToCycle.find(node.idx);
+      if (it != sched.nodeToCycle.end())
+        tcStart = std::min(tcStart, it->second);
+    }
+  }
+  pipeLoop.prologueLatency = tcStart;
+
+  // Convert DDG nodes → PipelineNodes
+  llvm::DenseMap<unsigned, unsigned> ddgToPipe;
+  for (const auto &ddgNode : ddg.getNodes()) {
+    unsigned pipeNodeId = pipeLoop.nodes.size();
+    ddgToPipe[ddgNode.idx] = pipeNodeId;
+    auto pn = convertDDGNode(ddgNode, pipeNodeId, sched);
+
+    // For super-nodes, build child PipelineLoop recursively
+    if (ddgNode.isSuperNode) {
+      if (auto innerLoop = dyn_cast<scf::ForOp>(ddgNode.op)) {
+        unsigned childId = buildChildPipelineLoop(innerLoop, graph, model);
+        pn.childPipelineId = childId;
+        // Copy prologue latency from child
+        pn.prologueLatency = graph.getLoop(childId).prologueLatency;
+      }
+    }
+
+    pipeLoop.nodes.push_back(pn);
+    pipeLoop.opToNodeId[ddgNode.op] = pipeNodeId;
+  }
+
+  // Convert DDG edges → PipelineEdges
+  for (const auto &ddgEdge : ddg.getEdges()) {
+    auto srcIt = ddgToPipe.find(ddgEdge.srcIdx);
+    auto dstIt = ddgToPipe.find(ddgEdge.dstIdx);
+    if (srcIt == ddgToPipe.end() || dstIt == ddgToPipe.end())
+      continue;
+    ttg::PipelineEdge pe;
+    pe.srcId = srcIt->second;
+    pe.dstId = dstIt->second;
+    pe.latency = ddgEdge.latency;
+    pe.distance = ddgEdge.distance;
+    pipeLoop.edges.push_back(pe);
+  }
+
+  return loopId;
+}
+
+/// Top-level: build a PipelineGraph from DDG + schedule result.
+static ttg::PipelineGraph
+buildPipelineGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
+                   const ttg::ModuloScheduleResult &sched,
+                   const ttg::LatencyModel &model) {
+  ttg::PipelineGraph graph;
+  buildPipelineLoop(loop, ddg, sched, graph, model);
+  return graph;
+}
+
+// ============================================================================
+// Phase 1: Buffer Allocation
+// ============================================================================
+
+static ttg::MemoryKind classifyMemoryKind(Operation *op) {
+  if (isa<ttng::TMEMAllocOp>(op))
+    return ttg::MemoryKind::TMEM;
+  if (isa<ttg::LocalAllocOp>(op))
+    return ttg::MemoryKind::SMEM;
+  return ttg::MemoryKind::Register;
+}
+
+static void extractBufferShape(Operation *op, ttg::PipelineBuffer &buf) {
+  Type resultType;
+  if (auto alloc = dyn_cast<ttg::LocalAllocOp>(op))
+    resultType = alloc.getType();
+  else if (auto tmemAlloc = dyn_cast<ttng::TMEMAllocOp>(op))
+    resultType = tmemAlloc.getType();
+  else if (op->getNumResults() > 0)
+    resultType = op->getResult(0).getType();
+
+  auto extractFromShapedType = [&](llvm::ArrayRef<int64_t> shape, Type elemTy) {
+    // Guard against dynamic/unknown dimensions
+    for (auto dim : shape) {
+      if (dim <= 0 || ShapedType::isDynamic(dim))
+        return; // leave buf.shape empty → caller will skip budget
+    }
+    // Guard against non-int/float element types
+    if (!elemTy.isIntOrFloat())
+      return;
+    for (auto dim : shape)
+      buf.shape.push_back(dim);
+    buf.elementBitWidth = elemTy.getIntOrFloatBitWidth();
+  };
+
+  if (auto memDesc = dyn_cast_or_null<ttg::MemDescType>(resultType)) {
+    extractFromShapedType(memDesc.getShape(), memDesc.getElementType());
+  } else if (auto tensorType = dyn_cast_or_null<RankedTensorType>(resultType)) {
+    extractFromShapedType(tensorType.getShape(), tensorType.getElementType());
+  }
+}
+
+/// Compute the maximum "effective consumer stage" for a producer node.
+/// For distance-0 edges: effective = consumer.stage
+/// For distance-d edges: effective = consumer.stage + d * numStages
+/// This ensures buffer lifetime covers cross-iteration dependencies.
+/// Returns the max effective consumer stage across all outgoing edges.
+static int findMaxEffectiveConsumerStage(const ttg::PipelineLoop &loop,
+                                         unsigned nodeId) {
+  int maxStage = loop.getNode(nodeId).stage;
+  const int numStages = loop.numStages();
+  for (const auto &edge : loop.edges) {
+    if (edge.srcId == nodeId) {
+      int effective =
+          loop.getNode(edge.dstId).stage + edge.distance * numStages;
+      maxStage = std::max(maxStage, effective);
+    }
+  }
+  return maxStage;
+}
+
+static void allocateBuffersForLoop(ttg::PipelineLoop &loop) {
+  // First pass: allocate data buffers (SMEM/TMEM)
+  llvm::SmallVector<unsigned, 4> dataBufferIds;
+  for (auto &node : loop.nodes) {
+    if (!node.op)
+      continue;
+
+    auto kind = classifyMemoryKind(node.op);
+    if (kind == ttg::MemoryKind::Register)
+      continue;
+
+    unsigned bufId = loop.buffers.size();
+    ttg::PipelineBuffer buf;
+    buf.id = bufId;
+    buf.kind = kind;
+    buf.defOp = node.op;
+    extractBufferShape(node.op, buf);
+
+    // Skip budget accounting for buffers with invalid shapes
+    if (buf.shape.empty() || buf.elementBitWidth == 0) {
+      LLVM_DEBUG(llvm::dbgs() << "[Phase1] WARNING: skipped budget for buf" << bufId
+                   << ": unknown shape/type\n");
+    }
+
+    int effectiveConsumer = findMaxEffectiveConsumerStage(loop, node.id);
+    int stageDiff = effectiveConsumer - node.stage;
+    buf.count = static_cast<unsigned>(std::max(stageDiff + 1, 1));
+
+    loop.buffers.push_back(buf);
+    node.producesBuffer = bufId;
+
+    // Track data buffers that need barriers (multi-buffered only)
+    if (buf.count > 1)
+      dataBufferIds.push_back(bufId);
+
+    // Mark all consumers (including distance>0) — deduplicate by dstId.
+    llvm::DenseSet<unsigned> markedConsumers;
+    for (const auto &edge : loop.edges) {
+      if (edge.srcId == node.id && markedConsumers.insert(edge.dstId).second)
+        loop.nodes[edge.dstId].consumesBuffers.push_back(bufId);
+    }
+  }
+
+  // Second pass: allocate a BARRIER buffer for each multi-buffered data buffer.
+  // Each barrier has the same count as its paired data buffer.
+  for (unsigned dataBufId : dataBufferIds) {
+    unsigned barId = loop.buffers.size();
+    ttg::PipelineBuffer bar;
+    bar.id = barId;
+    bar.kind = ttg::MemoryKind::BARRIER;
+    bar.count = loop.buffers[dataBufId].count;
+    bar.defOp = loop.buffers[dataBufId].defOp;
+    bar.pairedBufferId = dataBufId;
+    // Barriers have no shape/elementBitWidth — sizeBytes() returns 8 for BARRIER
+    loop.buffers[dataBufId].pairedBufferId = barId;
+    loop.buffers.push_back(bar);
+  }
+}
+
+static bool checkSmemBudget(const ttg::PipelineGraph &graph) {
+  constexpr int64_t kSmemBudget = 232 * 1024; // Blackwell B200
+  int64_t totalSmem = 0;
+  for (const auto &loop : graph.loops) {
+    for (const auto &buf : loop.buffers) {
+      if (buf.kind != ttg::MemoryKind::SMEM &&
+          buf.kind != ttg::MemoryKind::BARRIER)
+        continue;
+      // Skip buffers with unknown shape (already warned in allocation)
+      // Barriers have no shape but sizeBytes() handles them correctly
+      if (buf.kind != ttg::MemoryKind::BARRIER &&
+          (buf.shape.empty() || buf.elementBitWidth == 0))
+        continue;
+      totalSmem += buf.sizeBytes() * buf.count;
+    }
+  }
+  LLVM_DEBUG(llvm::dbgs() << "[Phase1] SMEM budget: " << totalSmem << " / " << kSmemBudget
+               << " bytes"
+               << (totalSmem > kSmemBudget ? " EXCEEDED\n" : " OK\n"));
+  return totalSmem <= kSmemBudget;
+}
+
+static bool checkTmemBudget(const ttg::PipelineGraph &graph) {
+  constexpr int64_t kTmemBudget = 128 * 512 * 4;
+  int64_t totalTmem = 0;
+  for (const auto &loop : graph.loops) {
+    for (const auto &buf : loop.buffers) {
+      if (buf.kind != ttg::MemoryKind::TMEM)
+        continue;
+      if (buf.shape.empty() || buf.elementBitWidth == 0)
+        continue;
+      totalTmem += buf.sizeBytes() * buf.count;
+    }
+  }
+  LLVM_DEBUG(llvm::dbgs() << "[Phase1] TMEM budget: " << totalTmem << " / " << kTmemBudget
+               << " bytes"
+               << (totalTmem > kTmemBudget ? " EXCEEDED\n" : " OK\n"));
+  return totalTmem <= kTmemBudget;
+}
+
+/// Dump Phase 1 buffer declarations per loop, matching examples.txt format.
+static void dumpPhase1Buffers(const ttg::PipelineGraph &graph) {
+  for (unsigned loopId = 0; loopId < graph.loops.size(); ++loopId) {
+    const auto &loop = graph.loops[loopId];
+    if (loop.buffers.empty())
+      continue;
+    LLVM_DEBUG(llvm::dbgs() << "[Phase1] Loop " << loopId << " (II=" << loop.II
+                 << " maxStage=" << loop.maxStage << "): "
+                 << loop.buffers.size() << " buffers\n");
+    for (const auto &buf : loop.buffers) {
+      const char *kindStr = buf.kind == ttg::MemoryKind::SMEM      ? "SMEM"
+                            : buf.kind == ttg::MemoryKind::TMEM    ? "TMEM"
+                            : buf.kind == ttg::MemoryKind::BARRIER ? "BARRIER"
+                                                                    : "Reg";
+
+      if (buf.kind == ttg::MemoryKind::BARRIER) {
+        // Barrier buffers: compact format matching examples.txt
+        // e.g., %bar_ld = modulo.alloc BARRIER [2]
+        LLVM_DEBUG(llvm::dbgs() << "[Phase1]   buf" << buf.id << " = alloc BARRIER ["
+                     << buf.count << "]");
+        if (buf.pairedBufferId != UINT_MAX)
+          LLVM_DEBUG(llvm::dbgs() << "  // for buf" << buf.pairedBufferId);
+        LLVM_DEBUG(llvm::dbgs() << ", " << buf.sizeBytes() * buf.count << " bytes total\n");
+        continue;
+      }
+
+      // Find producer node for this buffer
+      int producerStage = -1;
+      int effectiveConsumer = -1;
+      for (const auto &node : loop.nodes) {
+        if (node.producesBuffer == buf.id) {
+          producerStage = node.stage;
+          effectiveConsumer = findMaxEffectiveConsumerStage(loop, node.id);
+          break;
+        }
+      }
+      int stageDiff =
+          (producerStage >= 0 && effectiveConsumer >= 0)
+              ? effectiveConsumer - producerStage
+              : 0;
+
+      LLVM_DEBUG(llvm::dbgs() << "[Phase1]   buf" << buf.id << " = alloc " << kindStr
+                   << " [" << buf.count << "x");
+      for (size_t i = 0; i < buf.shape.size(); ++i) {
+        if (i > 0)
+          LLVM_DEBUG(llvm::dbgs() << "x");
+        LLVM_DEBUG(llvm::dbgs() << buf.shape[i]);
+      }
+      if (buf.elementBitWidth > 0) {
+        LLVM_DEBUG(llvm::dbgs() << " x " << (buf.elementBitWidth <= 16 ? "f16" : "f32"));
+      }
+      LLVM_DEBUG(llvm::dbgs() << "]");
+      LLVM_DEBUG(llvm::dbgs() << "  // stageDiff=" << stageDiff << " -> "
+                   << buf.count << " bufs");
+      if (buf.shape.size() > 0 && buf.elementBitWidth > 0)
+        LLVM_DEBUG(llvm::dbgs() << ", " << buf.sizeBytes() * buf.count << " bytes total");
+      LLVM_DEBUG(llvm::dbgs() << "\n");
+    }
+  }
+}
+
+/// Allocate multi-buffers for all loops. Returns false if budget exceeded.
+static bool allocateBuffers(ttg::PipelineGraph &graph) {
+  LLVM_DEBUG(llvm::dbgs() << "[Phase1] === Buffer Allocation ===\n");
+  for (auto &loop : graph.loops)
+    allocateBuffersForLoop(loop);
+
+  // Dump detailed buffer info (compare against Phase 1 in examples.txt)
+  dumpPhase1Buffers(graph);
+
+  bool smemOk = checkSmemBudget(graph);
+  bool tmemOk = checkTmemBudget(graph);
+  if (!smemOk)
+    LLVM_DEBUG(llvm::dbgs() << "[Phase1] ERROR: SMEM budget exceeded — reduce "
+                 << "buffer depths or tile size\n");
+  if (!tmemOk)
+    LLVM_DEBUG(llvm::dbgs() << "[Phase1] ERROR: TMEM budget exceeded — reduce "
+                 << "accumulator size or disable multi-buffering\n");
+  return smemOk && tmemOk;
+}
+
+// ============================================================================
+// Phase 2: Loop Expansion Plan (Software Pipelining Analysis)
+// ============================================================================
+
+static void logExpansionPlanForLoop(const ttg::PipelineLoop &loop,
+                                    unsigned loopId,
+                                    const ttg::PipelineGraph &graph) {
+  if (loop.maxStage == 0)
+    return;
+
+  const int prologueIters = loop.maxStage;
+  const int epilogueIters = loop.maxStage;
+
+  LLVM_DEBUG(llvm::dbgs() << "[Phase2] Loop " << loopId << ": maxStage=" << loop.maxStage
+               << " II=" << loop.II << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "[Phase2]   Prologue: " << prologueIters
+               << " iterations (stages 0.." << loop.maxStage - 1 << ")\n");
+
+  for (int iter = 0; iter < prologueIters; ++iter) {
+    LLVM_DEBUG(llvm::dbgs() << "[Phase2]     Iter " << iter << ": stages [0.." << iter
+                 << "] — ");
+    int opCount = 0;
+    for (const auto &node : loop.nodes) {
+      if (node.stage <= iter) {
+        ++opCount;
+      }
+    }
+    LLVM_DEBUG(llvm::dbgs() << opCount << " ops, bufIdx=" << iter << "\n");
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "[Phase2]   Kernel loop: all " << loop.maxStage + 1
+               << " stages active\n");
+  LLVM_DEBUG(llvm::dbgs() << "[Phase2]     Stage-to-buffer mapping:\n");
+  for (const auto &buf : loop.buffers) {
+    LLVM_DEBUG(llvm::dbgs() << "[Phase2]       buf" << buf.id << " ("
+                 << (buf.kind == ttg::MemoryKind::SMEM   ? "SMEM"
+                     : buf.kind == ttg::MemoryKind::TMEM ? "TMEM"
+                                                         : "Reg")
+                 << "): count=" << buf.count << " index=iter%" << buf.count
+                 << "\n");
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "[Phase2]   Epilogue: " << epilogueIters
+               << " iterations (drain stages " << loop.maxStage << "..0)\n");
+
+  for (int iter = 0; iter < epilogueIters; ++iter) {
+    int minStage = iter + 1;
+    LLVM_DEBUG(llvm::dbgs() << "[Phase2]     Drain " << iter << ": stages [" << minStage
+                 << ".." << loop.maxStage << "] — ");
+    int opCount = 0;
+    for (const auto &node : loop.nodes) {
+      if (node.stage >= minStage)
+        ++opCount;
+    }
+    LLVM_DEBUG(llvm::dbgs() << opCount << " ops\n");
+  }
+
+  // Log super-node expansion order
+  for (const auto &node : loop.nodes) {
+    if (!node.isSuperNode())
+      continue;
+    const auto &child = graph.getLoop(node.childPipelineId);
+    LLVM_DEBUG(llvm::dbgs() << "[Phase2]   Super-node N" << node.id << " → child loop "
+                 << node.childPipelineId << " (II=" << child.II
+                 << " maxStage=" << child.maxStage
+                 << " prologueLat=" << child.prologueLatency << ")\n");
+  }
+}
+
+static void logExpansionPlan(const ttg::PipelineGraph &graph) {
+  LLVM_DEBUG(llvm::dbgs() << "[Phase2] === Loop Expansion Plan ===\n");
+
+  auto order = graph.getBottomUpOrder();
+  LLVM_DEBUG(llvm::dbgs() << "[Phase2] Processing order (bottom-up):");
+  for (auto id : order)
+    LLVM_DEBUG(llvm::dbgs() << " loop" << id);
+  LLVM_DEBUG(llvm::dbgs() << "\n");
+
+  for (auto id : order)
+    logExpansionPlanForLoop(graph.getLoop(id), id, graph);
+}
+
 // ============================================================================
 // Pass A: Modulo Scheduling
 // ============================================================================
+
+// ============================================================================
+// Pipeline Graph Expansion
+// ============================================================================
+
+/// Expand a PipelineGraph: PipelineGraph in → IR transform → PipelineGraph out.
+/// 1. Extract {op, stage} schedule from the input graph
+/// 2. Call pipelineForLoop() to do the mechanical IR rewrite
+/// 3. Build a new PipelineGraph from the expanded loop
+/// Returns the new PipelineGraph and the new scf::ForOp, or failure.
+static FailureOr<std::pair<ttg::PipelineGraph, scf::ForOp>>
+expandPipelineGraph(const ttg::PipelineGraph &inputGraph,
+                    scf::ForOp forOp, const ttg::LatencyModel &model) {
+  auto &pipeLoop = inputGraph.getLoop(0);
+  if (pipeLoop.numStages() <= 1)
+    return failure(); // nothing to expand
+
+  // Step 1: Build schedule from loop.stage attrs on the IR (post-lowering).
+  // This ensures we pick up any ops added by lowerLoops (async copies,
+  // barriers) with their correct stage assignments.
+  triton::CoarseSchedule coarseSched;
+  if (failed(coarseSched.deSerialize(forOp)))
+    return failure(); // no schedule on this loop
+
+  std::vector<std::pair<Operation *, unsigned>> schedule =
+      coarseSched.createFinalSchedule(forOp);
+
+  // Step 2: Call pipelineForLoop (reuse existing expander).
+  triton::PipeliningOption options;
+  options.supportDynamicLoops = true;
+  options.peelEpilogue = false;
+  options.predicateFn = triton::wrapInMaskOp;
+  options.getScheduleFn =
+      [&](scf::ForOp,
+          std::vector<std::pair<Operation *, unsigned>> &sched) {
+        sched = schedule;
+      };
+
+  IRRewriter rewriter(forOp);
+  auto newForOp = triton::pipelineForLoop(rewriter, forOp, options);
+  if (failed(newForOp))
+    return failure();
+
+  // Step 3: Build new PipelineGraph from expanded loop.
+  auto expandedDDG = ttg::DataDependenceGraph::build(*newForOp, model);
+  if (expandedDDG.getNumNodes() == 0) {
+    // Expanded loop has no pipeline-relevant ops — return trivial graph.
+    ttg::PipelineGraph result;
+    result.addLoop(*newForOp);
+    return std::make_pair(std::move(result), *newForOp);
+  }
+
+  auto expandedSched = ttg::runModuloScheduling(expandedDDG);
+  if (failed(expandedSched)) {
+    // Single-stage after expansion is expected — build trivial graph.
+    ttg::PipelineGraph result;
+    auto loopId = result.addLoop(*newForOp);
+    auto &loop = result.getLoop(loopId);
+    loop.II = 0;
+    loop.maxStage = 0;
+    // Add all DDG nodes at stage 0
+    for (const auto &node : expandedDDG.getNodes()) {
+      ttg::PipelineNode pn;
+      pn.id = loop.nodes.size();
+      pn.op = node.op;
+      pn.pipeline = node.pipeline;
+      pn.latency = node.latency;
+      pn.selfLatency = node.selfLatency;
+      pn.stage = 0;
+      pn.cycle = 0;
+      loop.nodes.push_back(pn);
+    }
+    return std::make_pair(std::move(result), *newForOp);
+  }
+
+  auto expandedGraph =
+      buildPipelineGraph(*newForOp, expandedDDG, *expandedSched, model);
+
+  // Step 4: Populate prologue/epilogue nodes by walking the parent block.
+  // After pipelineForLoop, the parent block has:
+  //   [original ops before inner loop]
+  //   [prologue ops inserted by expander (ttg.mask, arith, etc.)]
+  //   [new scf.for]
+  //   [epilogue ops (if peelEpilogue=true, empty otherwise)]
+  //   [original ops after inner loop]
+  // We identify prologue ops as those between the last "original" op
+  // before the loop and the loop itself. Since we used predicateFn,
+  // the prologue ops are ttg.mask + supporting arith ops.
+  auto &resultLoop = expandedGraph.getLoop(0);
+  resultLoop.isExpanded = true;
+
+  if (auto *parentBlock = (*newForOp)->getBlock()) {
+    // Find prologue: ops before the new scf.for that are ttg.mask or
+    // were not in the original outer body (i.e., inserted by expander).
+    // Walk backwards from the scf.for to find prologue ops.
+    auto *forOpPtr = (*newForOp).getOperation();
+    for (auto it = Block::iterator(forOpPtr); it != parentBlock->begin();) {
+      --it;
+      Operation *op = &*it;
+      // Stop when we hit an op that's clearly from the outer loop
+      // (tmem_alloc, tmem_store, divsi, etc.)
+      if (isa<ttng::TMEMAllocOp, ttng::TMEMStoreOp>(op))
+        break;
+      // ttg.mask and supporting arith ops are prologue
+      ttg::PipelineNode pn;
+      pn.id = resultLoop.prologueNodes.size();
+      pn.op = op;
+      auto info = model.getLatency(op);
+      pn.pipeline = info.pipeline;
+      pn.latency = info.latency;
+      pn.selfLatency = info.selfLatency;
+      resultLoop.prologueNodes.push_back(pn);
+    }
+    // Reverse since we walked backwards.
+    std::reverse(resultLoop.prologueNodes.begin(),
+                 resultLoop.prologueNodes.end());
+  }
+
+  return std::make_pair(std::move(expandedGraph), *newForOp);
+}
 
 /// The main pass.
 struct ModuloSchedulePass
@@ -250,13 +1043,15 @@ struct ModuloSchedulePass
     auto moduleOp = getOperation();
     ttg::LatencyModel model;
 
-    // Find innermost loops with TMA loads or MMA ops.
+    // Step 1: Find innermost loops (K-loops) and schedule them.
     SmallVector<scf::ForOp> innerLoops;
     moduleOp.walk([&](scf::ForOp loop) {
+      // Only innermost loops (no nested scf.for inside).
       bool hasInnerLoop = false;
       loop.getBody()->walk([&](scf::ForOp) { hasInnerLoop = true; });
       if (hasInnerLoop)
         return;
+      // Must have TMA loads or MMA.
       bool hasTMALoad = false;
       bool hasMMAv5 = false;
       loop.getBody()->walk([&](Operation *op) {
@@ -272,44 +1067,163 @@ struct ModuloSchedulePass
       innerLoops.push_back(loop);
     });
 
-    LDBG("Found " << innerLoops.size() << " innermost loop(s)");
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] ========================================\n");
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Step 1: Schedule INNER loops (bottom-up)\n");
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] ========================================\n");
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Found " << innerLoops.size()
+                 << " innermost loop(s)\n");
 
     for (auto innerLoop : innerLoops) {
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] --- Inner loop ---\n");
+
       // Build DDG for this inner loop.
       auto ddg = ttg::DataDependenceGraph::build(innerLoop, model);
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] DDG: " << ddg.getNumNodes() << " nodes, "
+                   << ddg.getEdges().size() << " edges\n");
       if (ddg.getNumNodes() == 0)
         continue;
-
-      LDBG("DDG: " << ddg.getNumNodes() << " nodes, "
-                    << ddg.getEdges().size() << " edges");
 
       // Run Rau's modulo scheduling.
       auto schedResult = ttg::runModuloScheduling(ddg);
       if (failed(schedResult)) {
-        LDBG("Scheduling FAILED");
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Scheduling FAILED\n");
         continue;
       }
 
-      LDBG("Schedule: II=" << schedResult->II
-                           << " ResMII=" << ddg.computeResMII()
-                           << " RecMII=" << ddg.computeRecMII()
-                           << " maxStage=" << schedResult->getMaxStage());
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Schedule: II=" << schedResult->II
+                   << " ResMII=" << ddg.computeResMII()
+                   << " RecMII=" << ddg.computeRecMII()
+                   << " maxStage=" << schedResult->getMaxStage() << "\n");
 
-      // Emit loop.stage / loop.cluster on all ops.
-      emitScheduleAttributes(innerLoop, ddg, *schedResult);
+      // Log per-node schedule.
+      for (const auto &node : ddg.getNodes()) {
+        auto it = schedResult->nodeToCycle.find(node.idx);
+        if (it == schedResult->nodeToCycle.end())
+          continue;
+        int cycle = it->second;
+        int stage = cycle / schedResult->II;
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A]   N" << node.idx << "  cycle=" << cycle
+                     << "  stage=" << stage << "  "
+                     << ttg::getPipelineName(node.pipeline)
+                     << "  selfLat=" << node.selfLatency << "  ");
+        node.op->print(LLVM_DEBUG(llvm::dbgs(),
+                       OpPrintingFlags().skipRegions().elideLargeElementsAttrs()));
+        LLVM_DEBUG(llvm::dbgs() << "\n");
+      }
 
-      // Step 3: Derive SMEM buffer depths from cycle-level lifetimes.
-      // Only set tt.num_stages if the user didn't specify one (no
-      // tt.num_stages attr on the loop already).
-      if (!innerLoop->hasAttr(tt::kNumStagesAttrName)) {
-        int numStages = computeBufferDepths(innerLoop, model);
-        if (numStages > 0) {
-          auto ctx = innerLoop.getContext();
-          innerLoop->setAttr(
-              tt::kNumStagesAttrName,
-              IntegerAttr::get(IntegerType::get(ctx, 32), numStages));
-          LDBG("Set tt.num_stages=" << numStages << " from modulo schedule");
+      // Build PipelineGraph for this inner loop.
+      auto pipelineGraph =
+          buildPipelineGraph(innerLoop, ddg, *schedResult, model);
+
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] === Inner Loop PipelineGraph (BEFORE expand) ===\n");
+      pipelineGraph.dump();
+
+      // Serialize modulo schedule as loop.stage/loop.cluster attrs on ops.
+      // lowerLoops needs these to compute buffer depths and insert async ops.
+      // Derive stage from modulo schedule lifetime analysis:
+      //   bufferDepth = max consumer end-cycle / II
+      // For loads: stage 0 (prefetched).
+      // For non-loads: stage = max(consumer end-cycle) / II, at least 1.
+      // This ensures lowerLoads sees the correct stageDiff for buffer depth.
+      {
+        triton::CoarseSchedule coarseSched;
+        auto cluster = coarseSched.clusters.newAtBack();
+
+        // First pass: compute max end-cycle across all consumers (MMA).
+        int maxEndCycle = 0;
+        for (const auto &node : ddg.getNodes()) {
+          auto it = schedResult->nodeToCycle.find(node.idx);
+          if (it == schedResult->nodeToCycle.end())
+            continue;
+          int endCycle = it->second + node.selfLatency;
+          maxEndCycle = std::max(maxEndCycle, endCycle);
         }
+        int consumerStage = std::max(1, maxEndCycle / schedResult->II);
+
+        // Second pass: assign stages.
+        for (const auto &node : ddg.getNodes()) {
+          auto it = schedResult->nodeToCycle.find(node.idx);
+          if (it == schedResult->nodeToCycle.end() || !node.op)
+            continue;
+          int stage;
+          if (isa<triton::DescriptorLoadOp, triton::LoadOp>(node.op)) {
+            stage = 0; // loads are prefetched
+          } else {
+            // All non-load ops get the consumer stage so that
+            // getDefUseStageDiff sees the full buffer lifetime.
+            stage = consumerStage;
+          }
+          coarseSched.insert(node.op, stage, cluster);
+        }
+        coarseSched.serialize(innerLoop);
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Serialized CoarseSchedule ("
+                     << coarseSched.getNumStages() << " stages)\n");
+        // Verify: check loop.stage on ops
+        int opsWithStage = 0;
+        innerLoop.getBody()->walk([&](Operation *op) {
+          if (op->hasAttr("loop.stage"))
+            opsWithStage++;
+        });
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] ops with loop.stage: " << opsWithStage
+                     << ", scheduled_max_stage="
+                     << (innerLoop->hasAttr("tt.scheduled_max_stage") ? "yes" : "no")
+                     << "\n");
+      }
+
+      // Step 1: lowerLoops — convert descriptor_load → async TMA, allocate
+      // SMEM buffers. Must run before expand while loop.stage attrs are valid.
+      // Note: lowerLoops may replace the ForOp, so re-find it afterward.
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] lowerLoops (inner)\n");
+      ttg::lowerLoops(moduleOp);
+
+      // Debug: check if descriptor_load ops survive after lowerLoops
+      {
+        int descLoadCount = 0;
+        moduleOp.walk([&](triton::DescriptorLoadOp) { descLoadCount++; });
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] descriptor_load ops remaining: "
+                     << descLoadCount << "\n");
+      }
+
+      // Re-find the innermost loop (lowerLoops may have replaced the ForOp).
+      innerLoop = scf::ForOp();
+      moduleOp.walk([&](scf::ForOp loop) {
+        bool hasChild = false;
+        loop.getBody()->walk([&](scf::ForOp) { hasChild = true; });
+        if (!hasChild)
+          innerLoop = loop;
+      });
+      if (!innerLoop) {
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Lost inner loop after lowerLoops\n");
+        continue;
+      }
+
+      // Step 2: Expand — prologue/kernel/epilogue via pipelineForLoop.
+      auto expandResult = expandPipelineGraph(pipelineGraph, innerLoop, model);
+      if (failed(expandResult)) {
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Expansion failed or not needed\n");
+        continue;
+      }
+      auto &[expandedGraph, newForOp] = *expandResult;
+
+      // Mark expanded loop so ScheduleLoops (inside AutoWS) skips it.
+      auto builder = OpBuilder(newForOp);
+      newForOp->setAttr("tt.modulo_ii",
+                        builder.getI32IntegerAttr(schedResult->II));
+
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] === Inner Loop PipelineGraph (AFTER expand) ===\n");
+      expandedGraph.dump();
+
+      // Clean stale inner loop scheduling attrs from the expanded IR.
+      // Keep tt.modulo_ii so ScheduleLoops (inside AutoWS) skips these loops.
+      if (auto parentLoop = newForOp.getOperation()->getParentOfType<scf::ForOp>()) {
+        parentLoop.getBody()->walk([](Operation *op) {
+          op->removeAttr("loop.stage");
+          op->removeAttr("loop.cluster");
+          op->removeAttr("tt.modulo_cycle");
+          op->removeAttr("tt.self_latency");
+        });
+        parentLoop->removeAttr("tt.scheduled_max_stage");
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Cleaned stale inner loop attrs from outer body\n");
       }
 
       // Clean up tt.modulo_cycle — internal attr used only to pass cycle
@@ -318,41 +1232,168 @@ struct ModuloSchedulePass
         op.removeAttr("tt.modulo_cycle");
     }
 
-    // Step 2: Schedule outer loops (persistent kernels).
+    // Step 2: Schedule OUTER loop (now with expanded inner loop).
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] ========================================\n");
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Step 2: Schedule OUTER loop\n");
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] ========================================\n");
+
+    // Find the outer loop (has an inner scf.for but is not itself nested).
     SmallVector<scf::ForOp> outerLoops;
     moduleOp.walk([&](scf::ForOp loop) {
+      // Must have an inner scf.for child.
       bool hasInnerLoop = false;
       loop.getBody()->walk([&](scf::ForOp) { hasInnerLoop = true; });
       if (!hasInnerLoop)
         return;
+      // Must not be inside another scf.for (top-level).
       if (loop->getParentOfType<scf::ForOp>())
         return;
       outerLoops.push_back(loop);
     });
 
-    LDBG("Found " << outerLoops.size() << " outer loop(s)");
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Found " << outerLoops.size()
+                 << " outer loop(s)\n");
 
     for (auto outerLoop : outerLoops) {
+      // Build DDG for outer loop. Inner K-loop is now expanded, so
+      // its prologue ops (ttg.mask wrapping descriptor_load) are visible.
       auto outerDDG = ttg::DataDependenceGraph::build(outerLoop, model);
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Outer DDG: " << outerDDG.getNumNodes()
+                   << " nodes, " << outerDDG.getEdges().size() << " edges\n");
       if (outerDDG.getNumNodes() == 0)
         continue;
 
-      LDBG("Outer DDG: " << outerDDG.getNumNodes() << " nodes, "
-                          << outerDDG.getEdges().size() << " edges");
-
       auto outerSched = ttg::runModuloScheduling(outerDDG);
       if (failed(outerSched)) {
-        LDBG("Outer scheduling FAILED");
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Outer scheduling FAILED\n");
         continue;
       }
 
-      LDBG("Outer schedule: II=" << outerSched->II
-                                 << " ResMII=" << outerDDG.computeResMII()
-                                 << " RecMII=" << outerDDG.computeRecMII()
-                                 << " maxStage=" << outerSched->getMaxStage());
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Outer schedule: II=" << outerSched->II
+                   << " ResMII=" << outerDDG.computeResMII()
+                   << " RecMII=" << outerDDG.computeRecMII()
+                   << " maxStage=" << outerSched->getMaxStage() << "\n");
 
-      emitScheduleAttributes(outerLoop, outerDDG, *outerSched);
+      // Log per-node outer DDG schedule.
+      for (const auto &node : outerDDG.getNodes()) {
+        auto it = outerSched->nodeToCycle.find(node.idx);
+        if (it == outerSched->nodeToCycle.end())
+          continue;
+        int cycle = it->second;
+        int stage = cycle / outerSched->II;
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A]   N" << node.idx << "  cycle=" << cycle
+                     << "  stage=" << stage << "  "
+                     << ttg::getPipelineName(node.pipeline)
+                     << "  selfLat=" << node.selfLatency << "  "
+                     << node.op->getName().getStringRef() << "\n");
+      }
+
+      auto outerGraph =
+          buildPipelineGraph(outerLoop, outerDDG, *outerSched, model);
+
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] === Outer Loop PipelineGraph (BEFORE expand) ===\n");
+      outerGraph.dump();
+
+      // Serialize outer schedule — same lifetime-based stage assignment.
+      {
+        triton::CoarseSchedule coarseSched;
+        auto cluster = coarseSched.clusters.newAtBack();
+
+        int maxEndCycle = 0;
+        for (const auto &node : outerDDG.getNodes()) {
+          auto it = outerSched->nodeToCycle.find(node.idx);
+          if (it == outerSched->nodeToCycle.end())
+            continue;
+          int endCycle = it->second + node.selfLatency;
+          maxEndCycle = std::max(maxEndCycle, endCycle);
+        }
+        int consumerStage = std::max(1, maxEndCycle / outerSched->II);
+
+        for (const auto &node : outerDDG.getNodes()) {
+          auto it = outerSched->nodeToCycle.find(node.idx);
+          if (it == outerSched->nodeToCycle.end() || !node.op)
+            continue;
+          int stage;
+          if (isa<triton::DescriptorLoadOp, triton::LoadOp>(node.op)) {
+            stage = 0;
+          } else {
+            stage = consumerStage;
+          }
+          coarseSched.insert(node.op, stage, cluster);
+        }
+        coarseSched.serialize(outerLoop);
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Serialized outer CoarseSchedule ("
+                     << coarseSched.getNumStages() << " stages)\n");
+      }
+
+      // lowerLoops for outer loop (buffer alloc, async TMA).
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] lowerLoops (outer)\n");
+      ttg::lowerLoops(moduleOp);
+
+      // Re-find the outer loop (lowerLoops may have replaced the ForOp).
+      outerLoop = scf::ForOp();
+      moduleOp.walk([&](scf::ForOp loop) {
+        bool hasChild = false;
+        loop.getBody()->walk([&](scf::ForOp) { hasChild = true; });
+        if (hasChild && !loop->getParentOfType<scf::ForOp>())
+          outerLoop = loop;
+      });
+      if (!outerLoop) {
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Lost outer loop after lowerLoops\n");
+        continue;
+      }
+
+      // Expand the outer loop: PipelineGraph in → IR transform → PipelineGraph out.
+      auto outerExpandResult =
+          expandPipelineGraph(outerGraph, outerLoop, model);
+      if (failed(outerExpandResult)) {
+        LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Outer expansion failed or not needed\n");
+        continue;
+      }
+      auto &[expandedOuterGraph, newOuterForOp] = *outerExpandResult;
+
+      // Mark expanded outer loop so ScheduleLoops skips it.
+      {
+        auto builder = OpBuilder(newOuterForOp);
+        newOuterForOp->setAttr("tt.modulo_ii",
+                               builder.getI32IntegerAttr(outerSched->II));
+      }
+
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] === Outer Loop PipelineGraph (AFTER expand) ===\n");
+      expandedOuterGraph.dump();
+
+      // Dump TTGIR after full two-loop expansion.
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] === TTGIR after outer loop expansion ===\n");
+      moduleOp.print(LLVM_DEBUG(llvm::dbgs()));
+      LLVM_DEBUG(llvm::dbgs() << "\n");
+
+      // Clean stale outer loop scheduling attrs from the expanded IR.
+      // Walk the entire module because prologue ops are outside the for loop.
+      // Keep tt.modulo_ii so ScheduleLoops (inside AutoWS) skips these loops.
+      moduleOp->walk([](Operation *op) {
+        op->removeAttr("loop.stage");
+        op->removeAttr("loop.cluster");
+        op->removeAttr("tt.modulo_cycle");
+        op->removeAttr("tt.self_latency");
+        op->removeAttr("tt.scheduled_max_stage");
+      });
+      LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Cleaned stale outer loop attrs\n");
     }
+
+    // Final cleanup: remove any residual scheduling attrs from the module.
+    // This ensures add_pipeline's lowerLoops/expandLoops are no-ops.
+    moduleOp->walk([](Operation *op) {
+      op->removeAttr("loop.stage");
+      op->removeAttr("loop.cluster");
+      op->removeAttr("tt.modulo_cycle");
+      op->removeAttr("tt.self_latency");
+      op->removeAttr("tt.scheduled_max_stage");
+    });
+
+    // Resolve ttg.mask ops created by pipelineForLoop expansion.
+    DenseSet<ttg::MaskOp> emptySet;
+    triton::resolveMaskOp(moduleOp);
+    LLVM_DEBUG(llvm::dbgs() << "[PASS-A] Resolved mask ops\n");
   }
 };
 
@@ -362,7 +1403,6 @@ namespace mlir {
 std::unique_ptr<Pass> createNVGPUModuloSchedule() {
   return std::make_unique<ModuloSchedulePass>();
 }
-
 void registerNVGPUModuloSchedule() {
   PassRegistration<ModuloSchedulePass>();
 }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
@@ -1,13 +1,16 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// Pass B: Schedule Integration (Warp Specialization Reconstruction)
+// Pass B: Schedule Integration + Modulo Partition Scheduling
 //
-// Configures IR attributes so downstream passes (schedule_loops,
-// warp_specialize, pipeline) use the modulo schedule from Pass A.
-//
-// Buffer depths (tt.num_buffers) are already computed by Pass A (Steps 3-4.5).
-// This pass reads them and sets tt.num_stages, tt.scheduled_max_stage,
-// and strips tt.latency attrs for WS loops.
+// Two responsibilities:
+// 1. Configure IR attributes so downstream passes use the modulo schedule.
+// 2. Assign WS partitions (ttg.partition) using DDG pipe classification
+//    and utilization analysis. Supports nested loops via bottom-up traversal.
+//    Replaces PartitionScheduling for modulo-scheduled kernels.
+
+#include "DataDependenceGraph.h"
+#include "LatencyModel.h"
+#include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -15,6 +18,7 @@
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/Support/Debug.h"
@@ -29,6 +33,283 @@ namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
 
 namespace {
+
+// ============================================================================
+// Modulo Partition Scheduling — utilization-driven warp group assignment
+// ============================================================================
+
+// Pipelines with utilization > this threshold get dedicated warp groups.
+// 30% is chosen empirically: below this, the pipeline is idle most of the
+// time and doesn't benefit from a dedicated warp group.
+constexpr double kUtilizationThreshold = 0.3;
+
+/// Partition a loop's ops into warp groups based on DDG pipe classification.
+/// Returns number of partitions created, or 0 if not applicable.
+static int partitionLoopByUtilization(scf::ForOp loop,
+                                       const ttg::LatencyModel &model,
+                                       bool isWSLoop = false) {
+  // Read II from tt.modulo_ii if already set by Pass A, otherwise
+  // build DDG and schedule to compute it.
+  int II = 0;
+  if (auto iiAttr = loop->getAttrOfType<IntegerAttr>("tt.modulo_ii"))
+    II = iiAttr.getInt();
+
+  auto ddg = ttg::DataDependenceGraph::build(loop, model);
+  if (II <= 0) {
+    auto schedResult = ttg::runModuloScheduling(ddg);
+    if (failed(schedResult))
+      return 0;
+    II = schedResult->II;
+  }
+  if (II <= 0)
+    return 0;
+
+  LDBG("Building partition for loop with "
+       << std::distance(loop.getBody()->begin(), loop.getBody()->end())
+       << " ops, II=" << II);
+
+  // Compute per-pipeline utilization.
+  llvm::DenseMap<ttg::HWPipeline, int> pipeLoad;
+  for (const auto &node : ddg.getNodes()) {
+    if (node.pipeline == ttg::HWPipeline::NONE)
+      continue;
+    pipeLoad[node.pipeline] += node.selfLatency;
+  }
+
+  // Determine which pipelines get their own warp group.
+  SmallVector<ttg::HWPipeline> ownGroup;
+  SmallVector<ttg::HWPipeline> mergeGroup;
+  for (auto pipe : {ttg::HWPipeline::MEM, ttg::HWPipeline::TC,
+                    ttg::HWPipeline::CUDA, ttg::HWPipeline::SFU}) {
+    int load = pipeLoad.lookup(pipe);
+    if (load == 0)
+      continue;
+    double util = static_cast<double>(load) / II;
+    if (util > kUtilizationThreshold)
+      ownGroup.push_back(pipe);
+    else
+      mergeGroup.push_back(pipe);
+  }
+
+  // MEM always gets its own group (TMA producer needs dedicated warp).
+  // Remove from mergeGroup if it was placed there by the threshold check.
+  if (!llvm::is_contained(ownGroup, ttg::HWPipeline::MEM) &&
+      pipeLoad.lookup(ttg::HWPipeline::MEM) > 0) {
+    ownGroup.insert(ownGroup.begin(), ttg::HWPipeline::MEM);
+    llvm::erase(mergeGroup, ttg::HWPipeline::MEM);
+  }
+
+  if (ownGroup.size() < 2)
+    return 0; // Need at least 2 groups for WS.
+
+  // Build pipe → partition ID mapping.
+  llvm::DenseMap<ttg::HWPipeline, int> pipeToPartition;
+  int nextId = 0;
+  for (auto pipe : ownGroup)
+    pipeToPartition[pipe] = nextId++;
+  int defaultPartId = -1;
+  if (!mergeGroup.empty()) {
+    defaultPartId = nextId++;
+    for (auto pipe : mergeGroup)
+      pipeToPartition[pipe] = defaultPartId;
+  }
+  int numPartitions = nextId;
+
+  // All-partitions list for shared/scalar ops.
+  SmallVector<int> allParts;
+  for (int i = 0; i < numPartitions; i++)
+    allParts.push_back(i);
+
+  LLVM_DEBUG({
+    DBGS() << numPartitions << " groups (II=" << II << "): ";
+    for (auto pipe : ownGroup)
+      llvm::dbgs() << ttg::getPipelineName(pipe) << "="
+                   << pipeToPartition[pipe] << " ";
+    if (!mergeGroup.empty())
+      llvm::dbgs() << "default=" << defaultPartId;
+    llvm::dbgs() << "\n";
+  });
+
+  // Step 1: Seed assignment — DDG-classified ops get their specific partition.
+  // Skip ops with regions (scf.for, scf.if) — their child ops may get different
+  // partitions, and the verifier requires parent partitions to be a superset of
+  // all children. These ops get allParts in Step 3 instead.
+  llvm::DenseMap<Operation *, int> opPartitionMap;
+  for (const auto &node : ddg.getNodes()) {
+    if (node.op->getNumRegions() > 0)
+      continue; // Skip ForOps, IfOps — handled later.
+    auto it = pipeToPartition.find(node.pipeline);
+    if (it != pipeToPartition.end()) {
+      opPartitionMap[node.op] = it->second;
+      ttg::setPartition(node.op, ArrayRef<int>{it->second});
+    }
+  }
+
+  // Step 2: Propagate partitions through use-def chains.
+  // For unassigned ops, inherit partition from users (demand-driven).
+  // Iterate until convergence.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (isa<scf::ForOp>(op) || opPartitionMap.count(&op))
+        continue;
+      // Collect partitions from all users within this loop body.
+      SetVector<int> userParts;
+      for (auto *user : op.getUsers()) {
+        // Find the ancestor op in the loop body block.
+        Operation *ancestor = loop.getBody()->findAncestorOpInBlock(*user);
+        if (!ancestor)
+          continue;
+        auto uit = opPartitionMap.find(ancestor);
+        if (uit != opPartitionMap.end())
+          userParts.insert(uit->second);
+      }
+      if (userParts.size() == 1) {
+        int part = *userParts.begin();
+        opPartitionMap[&op] = part;
+        ttg::setPartition(&op, ArrayRef<int>{part});
+        changed = true;
+      }
+    }
+  }
+
+  // Step 2.5: TMEM consistency — TMEMStoreOp and TMEMLoadOp sharing a
+  // TMEMAllocOp must be in the same partition. PartitionScheduling asserts this.
+  loop.walk([&](ttng::TMEMAllocOp allocOp) {
+    std::optional<int> simtPartition;
+    for (auto *user : allocOp->getUsers()) {
+      if (isa<ttng::TMEMLoadOp>(user)) {
+        auto uit = opPartitionMap.find(user);
+        if (uit != opPartitionMap.end())
+          simtPartition = uit->second;
+      }
+    }
+    if (!simtPartition) {
+      for (auto *user : allocOp->getUsers()) {
+        if (isa<ttng::TMEMStoreOp>(user)) {
+          auto uit = opPartitionMap.find(user);
+          if (uit != opPartitionMap.end())
+            simtPartition = uit->second;
+        }
+      }
+    }
+    if (!simtPartition)
+      return WalkResult::advance();
+    for (auto *user : allocOp->getUsers()) {
+      if (isa<ttng::TMEMStoreOp, ttng::TMEMLoadOp>(user)) {
+        opPartitionMap[user] = *simtPartition;
+        ttg::setPartition(user, ArrayRef<int>{*simtPartition});
+      }
+    }
+    return WalkResult::advance();
+  });
+
+  // Step 3: Remaining unassigned ops → allParts. Walk recursively to cover
+  // ops inside scf.if regions (flattened persistent kernels have tile-boundary
+  // conditionals). Skip inner ForOps (handled by inner loop processing).
+  loop.walk([&](Operation *op) {
+    if (isa<scf::ForOp>(op) && op != loop.getOperation())
+      return WalkResult::skip(); // Don't recurse into inner ForOps.
+    if (!ttg::hasPartition(op))
+      ttg::setPartition(op, allParts);
+    return WalkResult::advance();
+  });
+
+  // Inner ForOps: set partition on the ForOp itself via raw setAttr (don't
+  // propagate to region terminators — body ops are handled by inner loop
+  // processing). The ForOp gets allParts since both MEM and TC run inside it.
+  Builder b(loop.getContext());
+  {
+    auto sorted = llvm::to_vector(allParts);
+    llvm::sort(sorted);
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (isa<scf::ForOp>(op))
+        op.setAttr(ttg::kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
+    }
+  }
+
+  // Set ttg.partition on the WS loop itself (required by verifier if
+  // ttg.partition.outputs is set). Use raw setAttr to avoid propagating.
+  if (isWSLoop) {
+    auto sorted = llvm::to_vector(allParts);
+    llvm::sort(sorted);
+    loop->setAttr(ttg::kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
+  }
+
+  // Yield → all partitions.
+  ttg::setPartition(cast<scf::YieldOp>(loop.getBody()->getTerminator()),
+                    allParts);
+
+  // Only serialize WS metadata on the actual WS loop (not inner K-loops).
+  // PartitionSet::fromLoop reads these attrs and will get confused if inner
+  // loops have them too.
+  if (isWSLoop) {
+    Builder b(loop.getContext());
+    SmallVector<Attribute> stages;
+    for (int i = 0; i < numPartitions; i++) {
+      int stage = 0;
+      // TC partition gets stage 1 (consumer, pipelined after MEM producer).
+      for (auto pipe : ownGroup)
+        if (pipeToPartition[pipe] == i && pipe == ttg::HWPipeline::TC)
+          stage = 1;
+      stages.push_back(b.getI32IntegerAttr(stage));
+    }
+    loop->setAttr(ttg::kPartitionStagesAttrName, b.getArrayAttr(stages));
+    ttg::setWarpSpecializeTag(loop, 0);
+
+    // Set partition outputs — for now all results go to all partitions.
+    SmallVector<SetVector<int>> outputParts;
+    for (unsigned i = 0; i < loop.getNumResults(); i++) {
+      SetVector<int> ids;
+      for (int p : allParts)
+        ids.insert(p);
+      outputParts.push_back(ids);
+    }
+    ttg::setPartitionOutputs(loop, outputParts);
+  }
+
+  return numPartitions;
+}
+
+/// Bottom-up partition scheduling for nested WS loops.
+/// Inner loops are partitioned first with specific per-op partitions,
+/// then the outer WS loop. For flattened loops (no inner loops), skip
+/// partition assignment and let PartitionScheduling handle it.
+static void moduloPartitionScheduling(scf::ForOp wsLoop,
+                                       const ttg::LatencyModel &model) {
+  // Collect inner loops (deepest first).
+  SmallVector<scf::ForOp> innerLoops;
+  wsLoop.getBody()->walk([&](scf::ForOp inner) {
+    if (inner != wsLoop)
+      innerLoops.push_back(inner);
+  });
+
+  // Flattened case: no inner loops. The WS loop IS the only loop.
+  // Skip our partition assignment — PartitionScheduling's getInitialPartitions
+  // already handles flattened loops with DescriptorLoadOp/MMA pattern matching.
+  // Our contribution is the modulo schedule (loop.stage/loop.cluster).
+  if (innerLoops.empty()) {
+    LDBG("Flattened WS loop — skipping partition, using PartitionScheduling default");
+    return;
+  }
+
+  // Partition inner loops bottom-up.
+  for (auto inner : llvm::reverse(innerLoops)) {
+    int n = partitionLoopByUtilization(inner, model, /*isWSLoop=*/false);
+    if (n > 0)
+      LDBG("Inner loop: " << n << " groups");
+  }
+
+  // Partition the outer WS loop itself.
+  int n = partitionLoopByUtilization(wsLoop, model, /*isWSLoop=*/true);
+  if (n > 0)
+    LDBG("Outer WS loop: " << n << " groups");
+}
+
+// ============================================================================
+// processScheduledLoop — existing Pass B logic (schedule integration)
+// ============================================================================
 
 static void processScheduledLoop(scf::ForOp loop) {
   auto ctx = loop.getContext();
@@ -99,7 +380,15 @@ struct ModuloWSPartitionPass
 
   void runOnOperation() override {
     auto moduleOp = getOperation();
+    ttg::LatencyModel model;
 
+    // Step 1: Modulo partition scheduling for WS loops (bottom-up).
+    moduleOp.walk([&](scf::ForOp loop) {
+      if (loop->hasAttr(tt::kWarpSpecializeAttrName))
+        moduloPartitionScheduling(loop, model);
+    });
+
+    // Step 2: Schedule integration (existing Pass B logic).
     moduleOp.walk([&](scf::ForOp loop) {
       bool hasMMAv5 = false;
       bool hasTMALoad = false;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
@@ -1,0 +1,137 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Pass B: Schedule Integration (Warp Specialization Reconstruction)
+//
+// Configures IR attributes so downstream passes (schedule_loops,
+// warp_specialize, pipeline) use the modulo schedule from Pass A.
+//
+// Buffer depths (tt.num_buffers) are already computed by Pass A (Steps 3-4.5).
+// This pass reads them and sets tt.num_stages, tt.scheduled_max_stage,
+// and strips tt.latency attrs for WS loops.
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "nvgpu-modulo-ws-partition"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+
+namespace {
+
+static void processScheduledLoop(scf::ForOp loop) {
+  auto ctx = loop.getContext();
+  bool isWS = loop->hasAttr(tt::kWarpSpecializeAttrName);
+
+  // Read num_stages if already set by Pass A Step 3 (computeBufferDepths).
+  int numStages = 0;
+  if (auto ns = loop->getAttrOfType<IntegerAttr>(tt::kNumStagesAttrName))
+    numStages = ns.getInt();
+
+  if (isWS || loop->hasAttr("tt.modulo_ii")) {
+    // WS loops or modulo-scheduled loops: keep loop.stage/loop.cluster attrs.
+    // For modulo-scheduled non-WS loops, the schedule must survive to
+    // downstream ScheduleLoops (which skips them via tt.modulo_ii check).
+    int maxStage = 0;
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (auto stageAttr =
+              op.getAttrOfType<IntegerAttr>(tt::kLoopStageAttrName))
+        maxStage = std::max(maxStage, (int)stageAttr.getInt());
+    }
+
+    // Derive num_stages from the schedule when Pass A Step 3 found no
+    // LocalAllocOp (e.g. outer tile loops of persistent kernels where
+    // SMEM buffers are allocated outside the loop).
+    if (numStages == 0 && maxStage > 0) {
+      numStages = maxStage + 1;
+      LDBG("Derived num_stages=" << numStages
+                                 << " from maxStage=" << maxStage);
+    }
+
+    if (numStages > 0) {
+      loop->setAttr(tt::kNumStagesAttrName,
+                    IntegerAttr::get(IntegerType::get(ctx, 32), numStages));
+      // scheduled_max_stage reflects the actual schedule, not buffer depth.
+      loop->setAttr(tt::kScheduledMaxStageAttrName,
+                    IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
+      LDBG("Set num_stages=" << numStages
+                             << " scheduled_max_stage=" << maxStage);
+    }
+    LDBG("Modulo/WS loop: kept loop.stage/loop.cluster");
+  } else {
+    for (auto &op : loop.getBody()->without_terminator()) {
+      op.removeAttr(tt::kLoopStageAttrName);
+      op.removeAttr(tt::kLoopClusterAttrName);
+      op.walk([](Operation *nestedOp) {
+        nestedOp->removeAttr(triton::kLoopStageAttrName);
+        nestedOp->removeAttr(triton::kLoopClusterAttrName);
+      });
+    }
+    LDBG("Non-WS loop: stripped loop.stage/loop.cluster");
+  }
+  // Keep tt.modulo_ii on the loop so downstream ScheduleLoops (inside AutoWS)
+  // knows to skip re-scheduling this loop and its partition clones.
+}
+
+struct ModuloWSPartitionPass
+    : public PassWrapper<ModuloWSPartitionPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloWSPartitionPass)
+
+  StringRef getArgument() const override {
+    return "nvgpu-modulo-ws-partition";
+  }
+
+  StringRef getDescription() const override {
+    return "Schedule integration for warp specialization (Pass B)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    moduleOp.walk([&](scf::ForOp loop) {
+      bool hasMMAv5 = false;
+      bool hasTMALoad = false;
+      bool hasSchedule = false;
+      loop.getBody()->walk([&](Operation *op) {
+        if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op))
+          hasMMAv5 = true;
+        if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp,
+                ttng::AsyncTMACopyGlobalToLocalOp>(op))
+          hasTMALoad = true;
+        if (op->hasAttr(tt::kLoopStageAttrName))
+          hasSchedule = true;
+        if (hasSchedule && (hasMMAv5 || hasTMALoad))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      });
+      if (!hasSchedule || (!hasMMAv5 && !hasTMALoad))
+        return;
+
+      processScheduledLoop(loop);
+    });
+  }
+};
+
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createNVGPUModuloWSPartition() {
+  return std::make_unique<ModuloWSPartitionPass>();
+}
+
+void registerNVGPUModuloWSPartition() {
+  PassRegistration<ModuloWSPartitionPass>();
+}
+} // namespace mlir

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -105,6 +105,8 @@ void init_triton_hopper_passes(py::module &&m) {
                      mlir::createNVGPUMultiCTAReduction);
   ADD_PASS_WRAPPER_0("add_modulo_schedule",
                      mlir::createNVGPUModuloSchedule);
+  ADD_PASS_WRAPPER_0("add_modulo_ws_partition",
+                     mlir::createNVGPUModuloWSPartition);
 }
 
 static void checkMatmulConstraints(const std::string &A_dtype,

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -103,6 +103,8 @@ void init_triton_hopper_passes(py::module &&m) {
                      mlir::createNVGPUPartitionSchedulingMeta);
   ADD_PASS_WRAPPER_0("add_multi_cta_reduction",
                      mlir::createNVGPUMultiCTAReduction);
+  ADD_PASS_WRAPPER_0("add_modulo_schedule",
+                     mlir::createNVGPUModuloSchedule);
 }
 
 static void checkMatmulConstraints(const std::string &A_dtype,


### PR DESCRIPTION
Summary:

Update ModuloSchedulePass to the full version with lowerLoops
integration and PipelineGraph expansion infrastructure.

**Step 2.5 (computeClusterIds)**: Cycle-based cluster IDs — within
each stage, ops are assigned dense cluster IDs sorted by their
modulo cycle. Same cycle = same cluster (can emit in any order).
Stages processed in reverse order so higher stages (consumers)
execute first in the loop body.

**Step 3 (computeBufferDepths)**: Derives per-resource SMEM buffer
depths from cycle-level lifetimes: num_buffers = floor(lifetime/II)
+ 1. Checks SMEM budget (228KB for Blackwell) and reduces depths
if needed. Sets both tt.num_buffers and buffer.copy on each
local_alloc for downstream WS pass consumption.

**emitScheduleAttributes**: Emits loop.stage, loop.cluster (from
Step 2.5), tt.modulo_cycle on each scheduled op. Serializes
selfLatency attrs so lowerMMAs/lowerLoads create correct barriers.
Includes warp group partitioning analysis logging.

**buildPipelineGraph**: Constructs PipelineGraph from DDG + schedule.
For nested loops, inner K-loops become child PipelineLoops linked
via super-nodes. Includes child loop input/output port detection
for cross-loop-boundary memory interfaces.

**Phase 1 buffer allocation**: SMEM/TMEM buffer depth from stage
differences, paired barrier allocation, budget checks (232KB SMEM,
256KB TMEM for Blackwell B200).

**lowerLoops + expandPipelineGraph**: For kernels without warp
specialization, the pass runs lowerLoops() to convert descriptor_load
to async TMA copies, then expandPipelineGraph() to generate
prologue/kernel/epilogue via PipelineExpander. For WS kernels, this
path is skipped — only loop.stage/loop.cluster attrs are emitted.

Authored with Claude.

Differential Revision: D100125075
