### PR TITLE
[triton][jit] Add identity-based fast path (Layer 1) for JIT kernel launch (#1231)

### DIFF
--- a/docs/design/triton_jit_launch_optimization.md
+++ b/docs/design/triton_jit_launch_optimization.md
@@ -1,0 +1,123 @@
+# Triton JIT Launch Latency Optimization
+
+## Problem
+
+Triton's `JITFunction.run()` dispatch path adds significant Python-side overhead on
+every kernel launch, even when the kernel is already compiled and cached. Profiling
+(via D99636574) showed the following breakdown for a 19-arg kernel:
+
+| Phase | Time (µs) | % |
+|-------|-----------|---|
+| **binder** (arg specialization) | 9.65 | 48% |
+| **launch** (launch_metadata + kernel.run) | 7.47 | 37% |
+| cache_key (tuple + str creation) | 1.30 | 7% |
+| driver (get_device + get_stream) | 0.66 | 3% |
+| rest (globals, grid, hooks) | 0.88 | 5% |
+| **TOTAL** | **19.96** | |
+
+The profiled total is inflated by `time.perf_counter()` overhead; the real
+wall-clock was **~14 µs** for `nop_triton_kernel` (19 args) vs **~3.5 µs** for
+`nop_triton_compiled_kernel_run` (which calls `CompiledKernel.run` directly) and
+**~1.1 µs** for cuteDSL (0-arg case).
+
+## Root Cause Analysis
+
+There are **two separate issues**:
+
+### Issue 1: Python-side JIT dispatch overhead (Normal Triton → Compiled Kernel)
+
+Everything that happens *before* the C launcher is called:
+
+```
+kernel[grid](*args)
+  → JITFunction.__getitem__  → creates lambda
+    → JITFunction.run()
+      → binder(*args)           ← exec()-generated function, calls specialize_impl() per arg
+      → compute_cache_key()     ← tuple() + str() allocation
+      → global variable check   ← dict iteration
+      → kernel.launch_metadata()← Python method call + *args unpacking
+      → kernel.run(...)         ← property access + CudaLauncher.__call__
+```
+
+### Issue 2: C launcher overhead (Compiled Kernel → cuteDSL)
+
+The generated C launcher is a one-size-fits-all template that always pays for:
+- `ensureCudaContext()` — `cuCtxGetCurrent()` on every launch
+- `PyArg_ParseTuple` × 2 — parses 20 fields (14 metadata + 6 packed)
+- Hook/scratch None checks — 4 branches even when unused
+- `CUlaunchAttribute[4]` setup — even for simple kernels
+- `cuLaunchKernelEx` — heavier than `cudaLaunchKernel`
+
+This series of diffs addresses **Issue 1** only. Issue 2 requires changes to the C
+code generator (`make_launcher` in `driver.py`) or the compiler-emitted launcher
+approach described in the design doc "Move CPU-side Kernel Launcher Generation
+into the Triton Compiler".
+
+## Optimizations Implemented
+
+All changes are in `third-party/triton/beta/triton/python/triton/runtime/jit.py`.
+
+### 1. Identity-based fast path (Layer 1)
+
+**The biggest win.** After the first successful launch, we cache the previous
+call's args, kwargs, and kernel. On the next call, we check if the exact same
+Python objects are being passed (`args[i] is last_args[i]` and kwargs identity).
+This is just N pointer comparisons — no `isinstance`, no `data_ptr()`, no
+string formatting, no dict lookup.
+
+This works because in typical training loops, the same tensor objects and
+integer values are reused across iterations. CPython also caches small integers
+(-5 to 256), so common constexpr values like `32` pass the identity check.
+
+**kwargs support:** Kernel calls with kwargs (e.g., `kernel[grid](*args,
+BLOCK_SIZE=128)`) are handled by the fast path. The kwargs dict is compared
+by checking that each value `is` the same object as the previous call. User
+kwargs are saved before the system kwargs (debug, sanitize_overflow) injection.
+
+When the identity check succeeds, we skip:
+- The entire binder (specialize_impl × N args)
+- Cache key computation (tuple + str allocation)
+- The global variable check (when `used_global_vals` is empty)
+
+**Correctness:** Falls through to the slow path on any mismatch. Global
+variable check is still performed when `used_global_vals` is non-empty.
+
+**bound_args handling:** The fast path stores `tuple(bound_args.values())`
+(which includes default parameter values) separately from `args`, and uses
+the stored bound values for grid resolution and kernel launch.
+
+## Benchmark Results (Layer 1 only)
+
+Benchmark command:
+```bash
+buck2 run @mode/opt -m ovr_config//triton:beta //pytorch/tritonbench:run_lite -- \
+  --op launch_latency \
+  --only nop_triton_kernel,nop_triton_kernel_kwargs,nop_triton_compiled_kernel_run \
+  --metrics walltime --simple-output
+```
+
+Hardware: NVIDIA GB200
+
+### Before (baseline)
+
+| x_val (num args) | nop_triton_kernel | nop_triton_kernel_kwargs | compiled_kernel_run |
+|-------------------|-------------------|--------------------------|---------------------|
+| 0 | 6.15 µs | 6.15 µs | 2.43 µs |
+| 19 | 12.45 µs | 12.45 µs | 3.44 µs |
+
+### After (Layer 1 identity check)
+
+| x_val (num args) | nop_triton_kernel | nop_triton_kernel_kwargs | compiled_kernel_run |
+|-------------------|-------------------|--------------------------|---------------------|
+| 0 | **4.90 µs** | **4.92 µs** | 2.49 µs |
+| 19 | **6.96 µs** | **7.78 µs** | 3.53 µs |
+
+### Summary
+
+| Args | Before | After (positional) | After (kwargs) | Speedup |
+|------|--------|--------------------|----------------|--------|
+| 0 | 6.15 µs | 4.90 µs | 4.92 µs | **20%** |
+| **19** | **12.45 µs** | **6.96 µs** | **7.78 µs** | **37-44%** |
+
+The ~0.8 µs overhead for kwargs vs positional args comes from the kwargs
+identity comparison loop (iterating dict keys + `is` checks).

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -723,15 +723,63 @@ class JITFunction(JITCallable, KernelInterface[T]):
         return options, signature, constexprs, attrs
 
     def run(self, *args, grid, warmup, **kwargs):
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+
+        # --- FAST PATH (Layer 1: Identity check) ---
+        # If the exact same Python objects are passed as the previous call
+        # (common in training loops where the same tensors/kwargs are reused),
+        # skip the binder, cache key computation, and most dispatch overhead.
+        # This is just N pointer comparisons with zero attribute access.
+        if not warmup and not self.pre_run_hooks:
+            last = self._last_call
+            if last is not None and last[0] is device:
+                last_args = last[1]
+                if len(args) == len(last_args):
+                    identical = True
+                    for i in range(len(args)):
+                        if args[i] is not last_args[i]:
+                            identical = False
+                            break
+                    if identical:
+                        last_kw = self._last_kwargs
+                        if len(kwargs) != len(last_kw):
+                            identical = False
+                        else:
+                            for k, v in kwargs.items():
+                                if k not in last_kw or v is not last_kw[k]:
+                                    identical = False
+                                    break
+                    if identical:
+                        kernel = last[2]
+                        if self.used_global_vals:
+                            not_present = object()
+                            for (name, _), (val, globals_dict) in self.used_global_vals.items():
+                                if globals_dict.get(name, not_present) != val:
+                                    kernel = None
+                                    break
+                        if kernel is not None:
+                            bound_vals = last[3]
+                            assert grid is not None
+                            if callable(grid):
+                                grid = grid(dict(zip(self.arg_names, bound_vals)))
+                            grid_size = len(grid)
+                            grid_0 = grid[0]
+                            grid_1 = grid[1] if grid_size > 1 else 1
+                            grid_2 = grid[2] if grid_size > 2 else 1
+                            launch_metadata = kernel.launch_metadata(grid, stream, *bound_vals)
+                            kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata,
+                                       launch_metadata, knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook,
+                                       *bound_vals)
+                            return kernel
+
+        # --- SLOW PATH ---
+        _user_kwargs = dict(kwargs) if kwargs else {}
         kwargs["debug"] = kwargs.get("debug", self.debug) or knobs.runtime.debug
         # Enable sanitize_overflow if explicitly set via kwarg, env var (TRITON_SANITIZE_OVERFLOW), or if debug is enabled
         kwargs["sanitize_overflow"] = kwargs.get("sanitize_overflow",
                                                  False) or knobs.runtime.sanitize_overflow or kwargs["debug"]
         kwargs["instrumentation_mode"] = knobs.compilation.instrumentation_mode
-
-        # parse options
-        device = driver.active.get_current_device()
-        stream = driver.active.get_current_stream(device)
 
         # Execute pre run hooks with args and kwargs
         for hook in self.pre_run_hooks:
@@ -780,6 +828,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
             launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
             kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
                        knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook, *bound_args.values())
+
+            # Populate Layer 1 cache for future calls.
+            # Store both raw args (for identity check) and bound_args values
+            # (for launching — includes default parameter values).
+            self._last_call = (device, args, kernel, tuple(bound_args.values()))
+            self._last_kwargs = _user_kwargs
+
         return kernel
 
     def repr(self, _):
@@ -806,6 +861,11 @@ class JITFunction(JITCallable, KernelInterface[T]):
 
         # cache of just-in-time compiled kernels
         self.device_caches = defaultdict(self.create_binder)
+
+        # Last-call cache for identity-based fast path (Layer 1).
+        # Stores (device, args, kernel, bound_vals) from the previous successful launch.
+        self._last_call = None
+        self._last_kwargs = {}
 
         # JITFunction can be instantiated as kernel
         # when called with a grid using __getitem__


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/1005


Triton's JITFunction.run() dispatch adds ~12.5 µs of Python-side overhead per
kernel launch (19 args), even when the kernel is already compiled. This is
~3.6x slower than calling the compiled kernel directly (~3.4 µs).

This diff adds an identity-based fast path (Layer 1) to JITFunction.run()
that skips the binder (arg specialization), cache key computation, and most
of the dispatch overhead on repeat calls with identical args and kwargs.

After the first successful launch, we cache the previous call's args, kwargs,
and kernel. On the next call, we check if the exact same Python objects are
being passed (args[i] is last_args[i], plus kwargs identity check). This is
just N pointer comparisons with zero attribute access — the common case in
training loops where the same tensors and BLOCK_SIZE values are reused.

kwargs support: Kernel calls like kernel[grid](*args, BLOCK_SIZE=128) now
hit the fast path. User kwargs are saved before system kwargs injection
and compared by identity on repeat calls.

bound_args correctness: The fast path stores tuple(bound_args.values())
(which includes default parameter values) and uses it for grid resolution
and kernel launch, matching the slow path's behavior.

Results (19-arg nop kernel, GB200, mode/opt -m ovr_config//triton:beta):
  Positional args: 12.45 µs → 6.96 µs (44% faster)
  With kwargs:     12.45 µs → 7.78 µs (37% faster)

Authored with Claude.

Differential Revision: D100199238


