### PR TITLE
[TLX] disable the cluster sync ops verifier

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -204,49 +204,28 @@ LogicalResult InvalBarrierOp::verify() {
 
 // -- FenceMBarrierInitReleaseClusterOp --
 LogicalResult FenceMBarrierInitReleaseClusterOp::verify() {
-  int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
-  if (numCTAs <= 1){
-    // upstream numCTA is 1, check TLX cluster size
-    const SmallVector<int> tlxClusterDims =
-      triton::gpu::TritonGPUDialect::getClusterDims(getOperation()->getParentOfType<ModuleOp>());
-    int tlxClusterSize = 1;
-    for (int d : tlxClusterDims)
-      tlxClusterSize *= d;
-      if(tlxClusterSize <= 1)
-        return emitOpError("requires ttg.num-ctas > 1 or TLX cluster size > 1");
-  }
+  // FB: comment out these because we allow the op in frontend/ttir, where the
+  // ir does not have tlx cluster dim yet int numCTAs =
+  // triton::gpu::lookupNumCTAs(getOperation()); if (numCTAs <= 1)
+  //   return emitOpError("requires ttg.num-ctas > 1");
   return success();
 }
 
 // -- ClusterArriveOp --
 LogicalResult ClusterArriveOp::verify() {
-  int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
-  if (numCTAs <= 1){
-    // upstream numCTA is 1, check TLX cluster size
-    const SmallVector<int> tlxClusterDims =
-      triton::gpu::TritonGPUDialect::getClusterDims(getOperation()->getParentOfType<ModuleOp>());
-    int tlxClusterSize = 1;
-    for (int d : tlxClusterDims)
-      tlxClusterSize *= d;
-      if(tlxClusterSize <= 1)
-        return emitOpError("requires ttg.num-ctas > 1 or TLX cluster size > 1");
-  }
+  // FB: comment out these because we allow the op in frontend/ttir, where the
+  // ir does not have tlx cluster dim yet int numCTAs =
+  // triton::gpu::lookupNumCTAs(getOperation()); if (numCTAs <= 1)
+  //   return emitOpError("requires ttg.num-ctas > 1");
   return success();
 }
 
 // -- ClusterWaitOp --
 LogicalResult ClusterWaitOp::verify() {
-  int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
-  if (numCTAs <= 1){
-    // upstream numCTA is 1, check TLX cluster size
-    const SmallVector<int> tlxClusterDims =
-      triton::gpu::TritonGPUDialect::getClusterDims(getOperation()->getParentOfType<ModuleOp>());
-    int tlxClusterSize = 1;
-    for (int d : tlxClusterDims)
-      tlxClusterSize *= d;
-      if(tlxClusterSize <= 1)
-        return emitOpError("requires ttg.num-ctas > 1 or TLX cluster size > 1");
-  }
+  // FB: comment out these because we allow the op in frontend/ttir, where the
+  // ir does not have tlx cluster dim yet int numCTAs =
+  // triton::gpu::lookupNumCTAs(getOperation()); if (numCTAs <= 1)
+  //   return emitOpError("requires ttg.num-ctas > 1");
   return success();
 }
 


### PR DESCRIPTION
TLX has num_ctas to be 1. TLX adds the cluster dim to mod attr before making ttgir, but this verifier runs since the very first pass so it would not work until we make ttgir.

Disable them for now to minimize merge conflict.

Test Plan: `pytest -vs /data/users/pchen7e4/triton/third_party/tlx/tutorials/blackwell-multi-cta-layernorm_test.py && pytest -vs python/test/unit/language/test_tlx_cluster.py`