### PR TITLE
[AutoWS] Add inner loop super-node modeling and outer loop scheduling (#1233)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -1,6 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "DataDependenceGraph.h"
+#include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -20,6 +21,106 @@
 namespace mlir::triton::gpu {
 
 namespace ttng = mlir::triton::nvidia_gpu;
+
+// Default estimated trip count for inner loops with dynamic bounds.
+constexpr int kDefaultInnerTripCount = 4;
+
+// Fallback latency constants from Blackwell SM100 microbenchmarks.
+// Used when inner loop scheduling fails or stageLoads are empty.
+constexpr int kFallbackTMASelfLatency = 518;   // TMA load pipeline occupancy
+constexpr int kFallbackTMATotalLatency = 1218; // TMA self + async overhead
+constexpr int kFallbackMMALatency = 900;       // MMA 128x128x128 TC latency
+
+/// Per-stage pipeline load summary from inner loop schedule.
+struct StageLoad {
+  int memSelfLatency{0};
+  int tcSelfLatency{0};
+  int cudaSelfLatency{0};
+  int totalLatency{0};
+};
+
+/// Info extracted from inner loop modulo scheduling.
+struct InnerLoopInfo {
+  int II;
+  int prologueLatency;
+  int tripCount;
+  bool tripCountIsEstimated{true};
+  SmallVector<StageLoad, 4> stageLoads;
+  int maxStage{0};
+};
+
+static InnerLoopInfo computeInnerLoopInfo(scf::ForOp innerLoop,
+                                          const LatencyModel &model) {
+  InnerLoopInfo info;
+  info.tripCount = kDefaultInnerTripCount;
+  info.tripCountIsEstimated = true;
+
+  auto innerDDG = DataDependenceGraph::build(innerLoop, model);
+  if (innerDDG.getNumNodes() == 0) {
+    info.II = kFallbackMMALatency;
+    info.prologueLatency = 0;
+    return info;
+  }
+  auto result = runModuloScheduling(innerDDG);
+  if (failed(result)) {
+    info.II = std::max(innerDDG.computeResMII(), kFallbackMMALatency);
+    info.prologueLatency = 0;
+    return info;
+  }
+
+  info.II = result->II;
+  info.maxStage = result->getMaxStage();
+
+  auto lb = innerLoop.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
+  auto ub = innerLoop.getUpperBound().getDefiningOp<arith::ConstantIntOp>();
+  auto step = innerLoop.getStep().getDefiningOp<arith::ConstantIntOp>();
+  if (lb && ub && step && step.value() > 0) {
+    int64_t tc =
+        (ub.value() - lb.value() + step.value() - 1) / step.value();
+    if (tc > 0) {
+      info.tripCount = static_cast<int>(tc);
+      info.tripCountIsEstimated = false;
+    }
+  }
+
+  int tcStart = result->II;
+  for (const auto &node : innerDDG.getNodes()) {
+    if (node.pipeline == HWPipeline::TC) {
+      auto it = result->nodeToCycle.find(node.idx);
+      if (it != result->nodeToCycle.end())
+        tcStart = std::min(tcStart, it->second);
+    }
+  }
+  info.prologueLatency = tcStart;
+
+  info.stageLoads.resize(info.maxStage + 1);
+  for (const auto &node : innerDDG.getNodes()) {
+    auto it = result->nodeToCycle.find(node.idx);
+    if (it == result->nodeToCycle.end())
+      continue;
+    int stage = it->second / info.II;
+    if (stage > info.maxStage)
+      continue;
+    auto &sl = info.stageLoads[stage];
+    switch (node.pipeline) {
+    case HWPipeline::MEM:
+      sl.memSelfLatency += node.selfLatency;
+      break;
+    case HWPipeline::TC:
+      sl.tcSelfLatency += node.selfLatency;
+      break;
+    case HWPipeline::CUDA:
+    case HWPipeline::SFU:
+      sl.cudaSelfLatency += node.selfLatency;
+      break;
+    default:
+      break;
+    }
+    sl.totalLatency = std::max(sl.totalLatency, node.latency);
+  }
+
+  return info;
+}
 
 unsigned DataDependenceGraph::addNode(Operation *op,
                                       const LatencyModel &model) {
@@ -52,11 +153,115 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   for (auto &op : body) {
     if (op.hasTrait<OpTrait::IsTerminator>())
       continue;
-    // Skip inner scf.for loops — this DDG handles flat loop bodies only.
-    // Inner loop super-node modeling is added in a follow-up diff for
-    // outer loop (persistent kernel) scheduling.
-    if (isa<scf::ForOp>(op))
+    // Model inner scf.for as a super-node for outer loop scheduling.
+    if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
+      auto info = computeInnerLoopInfo(innerLoop, model);
+
+      if (info.maxStage == 0) {
+        unsigned idx = ddg.nodes.size();
+        DDGNode node;
+        node.op = &op;
+        node.idx = idx;
+        node.pipeline = HWPipeline::TC;
+        int totalLatency = info.prologueLatency + info.tripCount * info.II;
+        node.latency = std::max(totalLatency, 1);
+        node.selfLatency = std::max(totalLatency, 1);
+        node.isSuperNode = true;
+        node.innerII = info.II;
+        node.prologueLatency = info.prologueLatency;
+        ddg.nodes.push_back(node);
+        ddg.opToIdx[&op] = idx;
+        continue;
+      }
+
+      // Multi-stage: split into prologue/kloop/epilogue.
+      unsigned prologueIdx = ddg.nodes.size();
+      {
+        DDGNode node;
+        node.op = &op;
+        node.idx = prologueIdx;
+        node.pipeline = HWPipeline::MEM;
+        int memLat =
+            info.stageLoads.empty() ? kFallbackTMATotalLatency : info.stageLoads[0].totalLatency;
+        node.latency = std::max(memLat, 1);
+        node.selfLatency =
+            info.stageLoads.empty() ? kFallbackTMASelfLatency : info.stageLoads[0].memSelfLatency;
+        node.selfLatency = std::max(node.selfLatency, 1);
+        ddg.nodes.push_back(node);
+      }
+
+      unsigned kloopIdx = ddg.nodes.size();
+      {
+        DDGNode node;
+        node.op = &op;
+        node.idx = kloopIdx;
+        node.pipeline = HWPipeline::TC;
+        int steadyIters = std::max(info.tripCount - info.maxStage, 1);
+        node.latency = steadyIters * info.II;
+        int tcPerIter = info.stageLoads.size() > (unsigned)info.maxStage
+                            ? info.stageLoads[info.maxStage].tcSelfLatency
+                            : kFallbackMMALatency;
+        node.selfLatency = std::max(steadyIters * tcPerIter, 1);
+        node.isSuperNode = true;
+        node.innerII = info.II;
+        node.prologueLatency = info.prologueLatency;
+        ddg.nodes.push_back(node);
+      }
+
+      unsigned epilogueIdx = ddg.nodes.size();
+      {
+        DDGNode node;
+        node.op = &op;
+        node.idx = epilogueIdx;
+        node.pipeline = HWPipeline::TC;
+        int tcLat = info.stageLoads.size() > (unsigned)info.maxStage
+                        ? info.stageLoads[info.maxStage].tcSelfLatency
+                        : kFallbackMMALatency;
+        node.latency = std::max(tcLat, 1);
+        node.selfLatency = std::max(tcLat, 1);
+        ddg.nodes.push_back(node);
+      }
+
+      ddg.opToIdx[&op] = epilogueIdx;        // producer: results come from epilogue
+      ddg.consumerOpToIdx[&op] = prologueIdx; // consumer: data enters at prologue
+      ddg.addEdge(prologueIdx, kloopIdx, ddg.nodes[prologueIdx].latency,
+                  /*distance=*/0);
+      ddg.addEdge(kloopIdx, epilogueIdx, ddg.nodes[kloopIdx].latency,
+                  /*distance=*/0);
       continue;
+    }
+    // Handle scf.if: walk regions to find pipeline-relevant ops.
+    // Persistent kernels put TMA loads inside conditional prefetch blocks
+    // (scf.if i < num_iter). Without this, those ops are invisible to
+    // the scheduler.
+    if (isa<scf::IfOp>(op)) {
+      HWPipeline bestPipeline = HWPipeline::NONE;
+      int bestLatency = 0;
+      int bestSelfLatency = 0;
+      op.walk([&](Operation *nested) {
+        if (nested == &op)
+          return;
+        auto info = model.getLatency(nested);
+        if (info.pipeline != HWPipeline::NONE &&
+            info.selfLatency > bestSelfLatency) {
+          bestPipeline = info.pipeline;
+          bestLatency = info.latency;
+          bestSelfLatency = info.selfLatency;
+        }
+      });
+      if (bestPipeline != HWPipeline::NONE) {
+        unsigned idx = ddg.nodes.size();
+        DDGNode node;
+        node.op = &op;
+        node.idx = idx;
+        node.pipeline = bestPipeline;
+        node.latency = bestLatency;
+        node.selfLatency = bestSelfLatency;
+        ddg.nodes.push_back(node);
+        ddg.opToIdx[&op] = idx;
+        continue;
+      }
+    }
     ddg.addNode(&op, model);
   }
 
@@ -84,6 +289,46 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
     }
   }
 
+  // Phase 2.5: Implicit MEM-load → TC/super-node edges.
+  // In persistent kernels using lowered TMA (async_tma_copy), the MEM→TC
+  // dependency goes through SMEM buffers and barriers, not SSA. Without
+  // these edges the scheduler places MEM and TC at the same cycle.
+  {
+    SmallVector<unsigned> memLoadNodes, tcNodes;
+    for (const auto &node : ddg.nodes) {
+      if (node.pipeline == HWPipeline::MEM) {
+        bool isStore = isa<triton::DescriptorStoreOp>(node.op) ||
+                       isa<ttng::AsyncTMACopyLocalToGlobalOp>(node.op);
+        if (!isStore && isa<scf::IfOp>(node.op)) {
+          node.op->walk([&](Operation *nested) {
+            if (isa<triton::DescriptorStoreOp>(nested) ||
+                isa<ttng::AsyncTMACopyLocalToGlobalOp>(nested))
+              isStore = true;
+          });
+        }
+        if (!isStore)
+          memLoadNodes.push_back(node.idx);
+      }
+      if (node.pipeline == HWPipeline::TC || node.isSuperNode)
+        tcNodes.push_back(node.idx);
+    }
+    for (unsigned memIdx : memLoadNodes) {
+      for (unsigned tcIdx : tcNodes) {
+        bool hasEdge = false;
+        for (const auto &e : ddg.edges) {
+          if (e.srcIdx == memIdx && e.dstIdx == tcIdx) {
+            hasEdge = true;
+            break;
+          }
+        }
+        if (!hasEdge) {
+          ddg.addEdge(memIdx, tcIdx, ddg.nodes[memIdx].latency,
+                      /*distance=*/0);
+        }
+      }
+    }
+  }
+
   // Phase 3: Loop-carried edges via scf.yield → iter_args.
   auto yieldOp = loop.getBody()->getTerminator();
   auto iterArgs = loop.getRegionIterArgs();
@@ -103,10 +348,19 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
     for (auto *user : iterArg.getUsers()) {
       if (user->hasTrait<OpTrait::IsTerminator>())
         continue;
-      auto userIt = ddg.opToIdx.find(user);
-      if (userIt == ddg.opToIdx.end())
-        continue;
-      ddg.addEdge(srcIdx, userIt->second, ddg.nodes[srcIdx].latency,
+      // For multi-stage super-nodes, loop-carried edges should target
+      // the prologue (data enters at the start), not the epilogue.
+      auto consIt = ddg.consumerOpToIdx.find(user);
+      unsigned dstIdx;
+      if (consIt != ddg.consumerOpToIdx.end()) {
+        dstIdx = consIt->second;
+      } else {
+        auto userIt = ddg.opToIdx.find(user);
+        if (userIt == ddg.opToIdx.end())
+          continue;
+        dstIdx = userIt->second;
+      }
+      ddg.addEdge(srcIdx, dstIdx, ddg.nodes[srcIdx].latency,
                   /*distance=*/1);
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -40,6 +40,9 @@ public:
   llvm::ArrayRef<DDGEdge> getEdges() const { return edges; }
   const DDGNode &getNode(unsigned idx) const { return nodes[idx]; }
   unsigned getNumNodes() const { return nodes.size(); }
+  const llvm::DenseMap<Operation *, unsigned> &getOpToIdx() const {
+    return opToIdx;
+  }
 
   /// Get all incoming edges for a node.
   llvm::SmallVector<const DDGEdge *> getInEdges(unsigned nodeIdx) const;
@@ -66,6 +69,10 @@ private:
   llvm::SmallVector<DDGNode> nodes;
   llvm::SmallVector<DDGEdge> edges;
   llvm::DenseMap<Operation *, unsigned> opToIdx;
+  // For multi-stage super-nodes (prologue/kloop/epilogue sharing the same
+  // Operation*), opToIdx maps to the epilogue (producer). consumerOpToIdx
+  // maps to the prologue so loop-carried edges target the correct node.
+  llvm::DenseMap<Operation *, unsigned> consumerOpToIdx;
 
   unsigned addNode(Operation *op, const LatencyModel &model);
   void addEdge(unsigned src, unsigned dst, int latency, unsigned distance);

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -70,6 +70,12 @@ static void emitScheduleAttributes(scf::ForOp loop,
     auto it = schedule.nodeToCycle.find(node.idx);
     if (it == schedule.nodeToCycle.end())
       continue;
+    // For multi-stage super-nodes (prologue/kloop/epilogue sharing the same
+    // Operation*), only write attrs from the node registered in opToIdx
+    // (the epilogue) to avoid overwrites.
+    auto opIt = ddg.getOpToIdx().find(node.op);
+    if (opIt != ddg.getOpToIdx().end() && opIt->second != node.idx)
+      continue;
     int stage = it->second / II;
     int cycle = it->second;
     int clusterId = stageAndCycleToCluster[stage][cycle];
@@ -165,6 +171,42 @@ struct ModuloSchedulePass
 
       // Emit loop.stage / loop.cluster on all ops.
       emitScheduleAttributes(innerLoop, ddg, *schedResult);
+    }
+
+    // Step 2: Schedule outer loops (persistent kernels).
+    SmallVector<scf::ForOp> outerLoops;
+    moduleOp.walk([&](scf::ForOp loop) {
+      bool hasInnerLoop = false;
+      loop.getBody()->walk([&](scf::ForOp) { hasInnerLoop = true; });
+      if (!hasInnerLoop)
+        return;
+      if (loop->getParentOfType<scf::ForOp>())
+        return;
+      outerLoops.push_back(loop);
+    });
+
+    LDBG("Found " << outerLoops.size() << " outer loop(s)");
+
+    for (auto outerLoop : outerLoops) {
+      auto outerDDG = ttg::DataDependenceGraph::build(outerLoop, model);
+      if (outerDDG.getNumNodes() == 0)
+        continue;
+
+      LDBG("Outer DDG: " << outerDDG.getNumNodes() << " nodes, "
+                          << outerDDG.getEdges().size() << " edges");
+
+      auto outerSched = ttg::runModuloScheduling(outerDDG);
+      if (failed(outerSched)) {
+        LDBG("Outer scheduling FAILED");
+        continue;
+      }
+
+      LDBG("Outer schedule: II=" << outerSched->II
+                                 << " ResMII=" << outerDDG.computeResMII()
+                                 << " RecMII=" << outerDDG.computeRecMII()
+                                 << " maxStage=" << outerSched->getMaxStage());
+
+      emitScheduleAttributes(outerLoop, outerDDG, *outerSched);
     }
   }
 };


### PR DESCRIPTION
Summary:

Extend the DDG to model inner scf.for loops as super-nodes for outer
loop (persistent kernel) scheduling. The inner loop is scheduled
recursively via modulo scheduling; its II and per-stage pipeline loads
determine the super-node's latency in the outer DDG.

For multi-stage inner loops, the super-node is split into 3 synthetic
nodes (prologue/kloop/epilogue) to expose the MEM→TC pipeline overlap
to the outer scheduler.

Also adds scf.if handling: persistent kernels put TMA loads inside
conditional prefetch blocks (scf.if i < num_iter). The DDG inspects
scf.if regions and assigns the dominant pipeline/latency to the node.

Extends ModuloSchedulePass with Step 2: after scheduling inner loops,
find top-level outer loops, build an outer DDG with the inner loop as
a super-node, and run modulo scheduling on the outer loop.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D99956720
