### PR TITLE
[TLX] Fix pytest import

### DIFF
--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -8,7 +8,7 @@ import triton.language.extra.tlx as tlx
 from typing import Optional
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from test.unit.language.conftest import _generate_test_params, _swizzle_scale_to_5d
+from conftest import _generate_test_params, _swizzle_scale_to_5d
 
 
 # Test tl.dot wit tlx smem ops

--- a/python/test/unit/language/test_tlx_tma.py
+++ b/python/test/unit/language/test_tlx_tma.py
@@ -7,7 +7,7 @@ from triton._internal_testing import is_hopper_or_newer, is_blackwell
 import triton.language.extra.tlx as tlx
 from typing import Optional
 from triton.tools.tensor_descriptor import TensorDescriptor
-from test.unit.language.conftest import _swizzle_scale_to_5d
+from conftest import _swizzle_scale_to_5d
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")


### PR DESCRIPTION
Importing `test` module might have conflict with stdlib `test` mod, resulting in errors like

```
======================================================= ERRORS ========================================================
_____________________________ ERROR collecting python/test/unit/language/test_tlx_tma.py ______________________________
ImportError while importing test module '/data/users/pchen7e4/triton/python/test/unit/language/test_tlx_tma.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../miniconda3/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python/test/unit/language/test_tlx_tma.py:10: in <module>
    from test.unit.language.conftest import _swizzle_scale_to_5d
E   ModuleNotFoundError: No module named 'test.unit'
```

Test plan: run the modified tests. They can run now.