### PR TITLE
[TLX] remove redundant lit test checking num ctas for cluster sync ops

### DIFF
--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -144,33 +144,3 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
-
-// -----
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-  tt.func @fence_mbarrier_init_release_cluster_invalid() {
-    // expected-error @below {{requires ttg.num-ctas > 1}}
-    ttng.fence_mbarrier_init_release_cluster
-    tt.return
-  }
-}
-
-// -----
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-  tt.func @cluster_arrive_invalid() {
-    // expected-error @below {{requires ttg.num-ctas > 1}}
-    ttng.cluster_arrive {relaxed = false}
-    tt.return
-  }
-}
-
-// -----
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-  tt.func @cluster_wait_invalid() {
-    // expected-error @below {{requires ttg.num-ctas > 1}}
-    ttng.cluster_wait
-    tt.return
-  }
-}


### PR DESCRIPTION
as title, we will have num_ctas being 1 in TLX cases