### PR TITLE
[TLX] Respect user-provided warpGroupStartIds in AllocateWarpGroups

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -144,9 +144,9 @@ struct AllocateWarpGroups
       } else {
         // No user-provided IDs (or they cover all partitions already).
         // Sort by size descending (stable to preserve order for equal sizes).
-        llvm::stable_sort(
-            idxAndSize,
-            [&](auto lhs, auto rhs) { return lhs.second > rhs.second; });
+        llvm::stable_sort(idxAndSize, [&](auto lhs, auto rhs) {
+          return lhs.second > rhs.second;
+        });
 
         int startId = baseNumWarps;
         for (auto [i, size] : idxAndSize) {

--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -117,14 +117,42 @@ struct AllocateWarpGroups
       SmallVector<std::pair<unsigned, int32_t>> idxAndSize;
       for (auto [i, size] : llvm::enumerate(arr))
         idxAndSize.emplace_back(i, size);
-      llvm::sort(idxAndSize,
-                 [&](auto lhs, auto rhs) { return lhs.second > rhs.second; });
 
+      // If user-provided warpGroupStartIds exist, they cover only the
+      // original (non-padding) partitions. Respect the user-provided IDs
+      // for those partitions and assign IDs to padding partitions after.
       SmallVector<int32_t> startIds(arr.size());
-      int startId = baseNumWarps;
-      for (auto [i, size] : idxAndSize) {
-        startIds[i] = startId;
-        startId += size;
+      if (auto existingIds = op.getWarpGroupStartIds();
+          existingIds && existingIds->size() < arr.size()) {
+        // User provided IDs for the first N partitions. Compute the max
+        // warp used by those, then assign padding partitions after.
+        int maxWarp = 0;
+        for (auto [id, numWarps] :
+             llvm::zip(*existingIds, arr.take_front(existingIds->size())))
+          maxWarp = std::max(maxWarp, (int)(id + numWarps));
+
+        // Copy user-provided IDs.
+        for (unsigned i = 0; i < existingIds->size(); ++i)
+          startIds[i] = (*existingIds)[i];
+
+        // Assign padding partitions sequentially after the real ones.
+        int startId = maxWarp;
+        for (unsigned i = existingIds->size(); i < arr.size(); ++i) {
+          startIds[i] = startId;
+          startId += arr[i];
+        }
+      } else {
+        // No user-provided IDs (or they cover all partitions already).
+        // Sort by size descending (stable to preserve order for equal sizes).
+        llvm::stable_sort(
+            idxAndSize,
+            [&](auto lhs, auto rhs) { return lhs.second > rhs.second; });
+
+        int startId = baseNumWarps;
+        for (auto [i, size] : idxAndSize) {
+          startIds[i] = startId;
+          startId += size;
+        }
       }
       op.setWarpGroupStartIds(startIds);
 

--- a/test/Conversion/allocate_warp_groups.mlir
+++ b/test/Conversion/allocate_warp_groups.mlir
@@ -111,3 +111,35 @@ tt.func @steal_from_default() {
 }
 
 }
+
+// -----
+
+// Test that user-provided warpGroupStartIds are preserved and padding
+// partitions are assigned IDs after the real partitions. This prevents
+// padding warps from displacing real task warps to higher IDs.
+module attributes {"ttg.num-warps" = 8 : i32} {
+
+// CHECK-LABEL: tt.func @respect_user_start_ids
+tt.func @respect_user_start_ids() {
+  // User provided [8, 12, 13] for 3 real partitions (4+1+1 = 6 warps).
+  // Padding adds 2 warps to reach 8 (next multiple of 4).
+  // Padding partition should get startId=14, after the real partitions.
+  // CHECK: warpGroupStartIds = array<i32: 8, 12, 13, 14>
+  ttg.warp_specialize() attributes {requestedRegisters = array<i32: 88, 24, 24>, warpGroupStartIds = array<i32: 8, 12, 13>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
+    ttg.warp_return
+  }
+  partition1() num_warps(1) {
+    ttg.warp_return
+  }
+  partition2() num_warps(1) {
+    ttg.warp_return
+  } : () -> ()
+  // CHECK: partition3() num_warps(2)
+  tt.return
+}
+
+}


### PR DESCRIPTION
Summary:
When user-provided warpGroupStartIds exist (covering the original
non-padding partitions), preserve them and assign padding partitions
sequentially after the real ones. Previously, the pass unconditionally
recomputed all start IDs sorted by partition size, which could place
larger padding partitions before smaller real partitions. 

Also changed the fallback (no user-provided IDs) to use stable_sort
to preserve original order among equal-sized partitions.

Differential Revision: D100355323


