### PR TITLE
[TLX] Implement implicit/explicit mbar init cluster fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,17 @@ Binary wheels are available for CPython 3.10-3.14.
   tlx.async_descriptor_store(desc, smem_buf, offsets)
   ```
 
+- `tlx.fence_mbarrier_init_cluster(scope)` issues a memory fence to make mbarrier init visible to cluster.
 
+  Example:
+  ```python
+  bars = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+  tlx.fence_mbarrier_init_cluster()
+  tlx.cluster_barrier()
+
+  # now bars is ready for cross CTA use
+  tlx.barrier_arrive(bar=bars[0], remote_cta_rank=1)
+  ```
 
 ### Cluster Launch Control (CLC)
 

--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -651,6 +651,8 @@ def test_explicit_cluster_sync_ws(device):
         BLOCK_SIZE: tl.constexpr,
     ):
         bars = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+        # need this fence to make mbar init visible to cluster
+        tlx.fence_mbarrier_init_cluster()
         cta_rank = tlx.cluster_cta_rank()
 
         # Explicit cluster sync placed by user – compiler must not auto-insert
@@ -693,10 +695,14 @@ def test_explicit_cluster_sync_ws(device):
     assert "tlx.explicit_cluster_sync = true" in ttgir, (
         f"Expected tlx.explicit_cluster_sync module attr in TTGIR:\n{ttgir}")
     # User placed exactly one cluster arrive+wait pair for each task (from cluster_barrier)
+    assert ttgir.count("ttng.fence_mbarrier_init_release_cluster") == 1, (
+        f"Expected exactly 1 fence_mbarrier_init_release_cluster in TTGIR:\n{ttgir}")
     assert ttgir.count("ttng.cluster_arrive") == 3, (f"Expected exactly 3 cluster_arrive in TTGIR:\n{ttgir}")
     assert ttgir.count("ttng.cluster_wait") == 3, (f"Expected exactly 3 cluster_wait in TTGIR:\n{ttgir}")
 
     ptx = kernel.asm["ptx"]
+    assert ptx.count("fence.mbarrier_init.release.cluster") == 1, (
+        f"Expected exactly 1 fence.mbarrier_init.release.cluster in PTX:\n{ptx}")
     # The user's cluster_barrier should produce exactly one
     # barrier.cluster.arrive.aligned and one barrier.cluster.wait.aligned
     # No extra heuristic ones should be inserted

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -409,6 +409,7 @@ def run_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
         cluster_cta_rank = tlx.cluster_cta_rank()
         pred_cta0 = cluster_cta_rank == 0
         cta_bars = tlx.alloc_barriers(num_barriers=1, arrive_count=2)  # CTA0 waits for signals from both CTAs
+        mma_bars = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
 
         desc_a = tl.make_tensor_descriptor(
             a_ptr,
@@ -452,10 +453,12 @@ def run_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
             buf_alloc_a_tmem = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, tl.constexpr(1), tlx.storage_kind.tmem)
             a_reg = tlx.local_load(a_smem)
             tlx.local_store(buf_alloc_a_tmem[0], a_reg)
-            tlx.async_dot(buf_alloc_a_tmem[0], b_smem, acc_tmem, use_acc=False, mBarriers=[], two_ctas=True,
+            tlx.async_dot(buf_alloc_a_tmem[0], b_smem, acc_tmem, use_acc=False, mBarriers=[mma_bars[0]], two_ctas=True,
                           out_dtype=OUT_DTYPE)
         else:
-            tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=False, mBarriers=[], two_ctas=True, out_dtype=OUT_DTYPE)
+            tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=False, mBarriers=[mma_bars[0]], two_ctas=True,
+                          out_dtype=OUT_DTYPE)
+        tlx.barrier_wait(mma_bars[0], 0)
         result = tlx.local_load(acc_tmem)
 
         c = result.to(tl.float16)
@@ -595,9 +598,9 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
                 tlx.barrier_wait(cta_bars[0], phase=0, pred=pred_cta0)
 
                 # difference from 1cta: set two_ctas. Compiler auto generates pred to issue mma only from CTA0
-                tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=False, mBarriers=[], two_ctas=True, out_dtype=OUT_DTYPE)
+                tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=False, mBarriers=[tmem_full_bars[0]], two_ctas=True,
+                              out_dtype=OUT_DTYPE)
 
-                tlx.barrier_arrive(tmem_full_bars[0], 1)
             with tlx.async_task(num_warps=1, num_regs=232):  # producer
                 # difference from 1cta: size
                 tlx.barrier_expect_bytes(smem_full_bars[0],

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -509,6 +509,7 @@ def run_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
     assert ttgir.count("ttng.map_to_remote_buffer") == 1
 
     ptx = kernel.asm["ptx"]
+    assert ptx.count("fence.mbarrier_init.release.cluster") == 1
     assert ptx.count("barrier.cluster.arrive.aligned") == 1  # one for remote bar init
     assert ptx.count("barrier.cluster.wait.aligned") == 1  # one for remote bar init
     assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
@@ -649,6 +650,7 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
     assert ttgir.count("ttng.map_to_remote_buffer") == 1
 
     ptx = kernel.asm["ptx"]
+    assert ptx.count("fence.mbarrier_init.release.cluster") == 1
     # two for trunk remote bar init: one for default wg, one for non default
     assert ptx.count("barrier.cluster.arrive.aligned") == 2
     # one for trunk remote bar init: non default WGs just arrive anyway, then it's equivalent to a sync between

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -104,6 +104,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %c1_i32 = arith.constant 1 : i32
     %2 = ttg.memdesc_index %0[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: fence.mbarrier_init.release.cluster
     // CHECK-NEXT: nvvm.cluster.arrive {aligned}
     // CHECK-NEXT: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -473,6 +473,8 @@ private:
 
     OpBuilder builder(lastBarInitOp);
     builder.setInsertionPointAfter(lastBarInitOp);
+    ttng::FenceMBarrierInitReleaseClusterOp::create(builder,
+                                                    lastBarInitOp.getLoc());
     // need to insert cluster arrive and wait to prevent CTA_X from arriving
     // CTA_Y's bar before CTA_Y inits it, as shown in ptx doc examples:
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-try-wait

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -473,6 +473,7 @@ private:
 
     OpBuilder builder(lastBarInitOp);
     builder.setInsertionPointAfter(lastBarInitOp);
+    // need to insert fence to make mbar init visible to cluster
     ttng::FenceMBarrierInitReleaseClusterOp::create(builder,
                                                     lastBarInitOp.getLoc());
     // need to insert cluster arrive and wait to prevent CTA_X from arriving

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -362,6 +362,10 @@ void init_triton_tlx_ir(py::module &&m) {
              self.create<triton::nvidia_gpu::ClusterArriveOp>(false);
              self.create<triton::nvidia_gpu::ClusterWaitOp>();
            })
+      .def("create_fence_mbarrier_init_cluster",
+           [](TritonOpBuilder &self) -> void {
+             self.create<ttng::FenceMBarrierInitReleaseClusterOp>();
+           })
       .def("create_tmem_alloc",
            [](TritonOpBuilder &self, std::vector<int64_t> shape,
               Type &elementType, Attribute &encoding,

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -7,6 +7,7 @@ from .barrier import (
     barrier_expect_bytes,
     barrier_wait,
     cluster_barrier,
+    fence_mbarrier_init_cluster,
     named_barrier_arrive,
     named_barrier_wait,
 )
@@ -148,6 +149,7 @@ __all__ = [
     "barrier_expect_bytes",
     "barrier_wait",
     "barrier_arrive",
+    "fence_mbarrier_init_cluster",
     "named_barrier_wait",
     "named_barrier_arrive",
     # mma_ops

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -10,6 +10,18 @@ def cluster_barrier(_semantic=None):
 
 
 @tl.builtin
+def fence_mbarrier_init_cluster(_semantic=None):
+    """
+    Emit a fence.mbarrier_init.release.cluster instruction.
+
+    This fence ensures that prior mbarrier.init operations (from alloc_barriers)
+    are visible to all CTAs in the cluster before any cross-CTA barrier
+    operations (barrier_arrive with remote_cta_rank, etc.).
+    """
+    _semantic.builder.create_fence_mbarrier_init_cluster()
+
+
+@tl.builtin
 def alloc_barriers(
         num_barriers: tl.constexpr,
         arrive_count: tl.constexpr = tl.constexpr(1),

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -12,7 +12,7 @@ def cluster_barrier(_semantic=None):
 @tl.builtin
 def fence_mbarrier_init_cluster(_semantic=None):
     """
-    Emit a fence.mbarrier_init.release.cluster instruction.
+    Emit a cluster fence instruction for mbarrier init.
 
     This fence ensures that prior mbarrier.init operations (from alloc_barriers)
     are visible to all CTAs in the cluster before any cross-CTA barrier


### PR DESCRIPTION
When an mbar is used cross CTA, we need a fence to ensure its init is visible to the whole cluster. 

We follow cutlass and Gluon to insert the fence between mbar init and cluster arrive/wait ops.

https://github.com/NVIDIA/cutlass/blob/0d2b201e8c1c4a03efa6e9c468161916e2334725/examples/88_hopper_fmha/kernel/fmha_kernel_tma_warpspecialized.hpp#L274-L284

https://github.com/facebookexperimental/triton/blob/acee6eb8472c8de73166668c9e6e541ec7c45019/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py#L63


For explicit cluster sync, we expose the API to front end. Users need to insert it. We do not bundle with tlx.cluster_barrer() because the cluster barrier could be used for other purposes.