### PR TITLE
[TLX] Force crash if we see a sync dot for Blackwell

### DIFF
--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -131,6 +131,9 @@ def async_dot(
         acc_handle = require_tmem_layout_col_stride(acc, 1, _semantic.builder)
         handles = [t.handle for t in mBarriers]
         is_async = force_async or len(handles) > 0
+        # Sync semantic gen5 dot is rarely a good idea in TLX. It usually comes with perf penalty around bar init/inval.
+        # We're deprecating it, but as a first step let's force a crash in case we do have a use case.
+        assert is_async, "Blackwell dot with sync semantics is disabled. Please pass in proper mBarriers and wait for the barrier explicitly."
         use_acc_handle = None
         if use_acc is not None:
             assert isinstance(use_acc, tl.tensor) or isinstance(


### PR DESCRIPTION
When user issues a "sync" async-dot for Blackwell by providing empty list of `mBarriers` and not `force_async`, the compiler will 
generate an mbarrier init before it and bar wait/invalidate after it.  https://github.com/facebookexperimental/triton/blob/2afad864175c889be36a60d5554f94c993ca1250/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp#L38-L49

This will hurt perf if it's in a loop. Also in 2cta it has a risk of missing cluster barrier protection for mbar init, meaning one CTA could arrive another CTA's mbar before it's properly initialized. 

We're deprecating this "sync" semantic for TLX API. However, directly mapping it to async version will break existing kernels (semi-silently) because the kernel would be written with assumptions that the dot op is sync. Our assumption is there's almost no real user of sync dot, so we put an explicit crash in the API for now just in case. After some time, we'll just remove the 
entrypoint from front end.