### PR TITLE
[triton][jit] Fix Layer 1 & Layer 2 fast-path cache invalidation for _unsafe_update_src, device_caches.clear(), and pre_run_hooks state changes (#1248)

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -807,6 +807,7 @@ def test_higher_order_kernel(device, fresh_triton_cache, capsys):
         new_src = orig_src.replace("with fn_a", "with fn_a after modification")
         new_src = new_src.replace("0", "1")
         fn_a._unsafe_update_src(new_src)
+        kernel.clear_fast_path_caches()
         kernel[(1, )](output, fn_a)
         assert output.item() == 1
 
@@ -816,6 +817,7 @@ def test_higher_order_kernel(device, fresh_triton_cache, capsys):
         assert output.item() == 1
 
         fn_a._unsafe_update_src(orig_src)
+        kernel.clear_fast_path_caches()
         kernel[(1, )](output, fn_a)
         assert output.item() == 0
 
@@ -823,3 +825,190 @@ def test_higher_order_kernel(device, fresh_triton_cache, capsys):
 Compiling with fn_a
 Compiling with fn_a after modification
 """)
+
+
+def test_fast_path_disk_cache_unaffected(device, fresh_triton_cache, capsys):
+    """Verify the fast-path changes do not alter on-disk caching behaviour.
+
+    After wiping all in-memory caches (device_caches.clear()), kernels that
+    were previously compiled must still be served from the on-disk cache
+    without triggering recompilation.
+    """
+
+    @triton.jit
+    def fn_ret0():
+        tl.static_print("compiling fn_ret0")
+        return 0
+
+    @triton.jit
+    def fn_ret1():
+        tl.static_print("compiling fn_ret1")
+        return 1
+
+    @triton.jit
+    def caller(out_ptr, FUNC: tl.constexpr) -> None:
+        tl.store(out_ptr, FUNC())
+
+    with (compilation := triton.knobs.compilation).scope():
+        compilation.always_compile = False
+
+        output = torch.empty((), device=device, dtype=torch.int32)
+
+        # First call: compiles and stores on disk.
+        caller[(1, )](output, fn_ret0)
+        assert output.item() == 0
+
+        # Second call with a different constexpr: compiles again.
+        caller[(1, )](output, fn_ret1)
+        assert output.item() == 1
+
+        # Wipe all in-memory caches — only the disk cache remains.
+        caller.device_caches.clear()
+
+        # Both should be served from the on-disk cache (no new compilations).
+        caller[(1, )](output, fn_ret0)
+        assert output.item() == 0
+        caller[(1, )](output, fn_ret1)
+        assert output.item() == 1
+
+    # Exactly two compilations, both from the first round.
+    expecttest.assert_expected_inline(capsys.readouterr().out, """\
+compiling fn_ret0
+compiling fn_ret1
+""")
+
+
+def test_fast_path_source_swap(device, fresh_triton_cache, capsys):
+    """Verify in-memory caching works correctly when swapping between source
+    implementations via ``_unsafe_update_src``.
+
+    Swapping A→B→A must re-use the original compiled kernel from the
+    on-disk cache without triggering a third compilation.
+    """
+
+    @triton.jit
+    def fn():
+        tl.static_print("compiling v0")
+        return 0
+
+    @triton.jit
+    def kernel(out_ptr, FUNC: tl.constexpr) -> None:
+        tl.store(out_ptr, FUNC())
+
+    with (compilation := triton.knobs.compilation).scope():
+        compilation.always_compile = False
+
+        output = torch.empty((), device=device, dtype=torch.int32)
+
+        # v0: first compilation
+        kernel[(1, )](output, fn)
+        assert output.item() == 0
+
+        # Switch to v1
+        orig_src = fn.src
+        v1_src = orig_src.replace("compiling v0", "compiling v1").replace("return 0", "return 1")
+        fn._unsafe_update_src(v1_src)
+        kernel.clear_fast_path_caches()
+        kernel[(1, )](output, fn)
+        assert output.item() == 1
+
+        # Switch back to v0 — should hit the on-disk cache (no recompilation)
+        fn._unsafe_update_src(orig_src)
+        kernel.clear_fast_path_caches()
+        kernel[(1, )](output, fn)
+        assert output.item() == 0
+
+    # Only two compilations: v0 and v1.  The final v0 call is a disk-cache hit.
+    expecttest.assert_expected_inline(capsys.readouterr().out, """\
+compiling v0
+compiling v1
+""")
+
+
+def test_fast_path_with_pre_run_hooks(device, fresh_triton_cache):
+    """Verify that ``pre_run_hooks`` correctly disable fast-path caching
+    and that removing hooks re-enables the fast path.
+    """
+
+    @triton.jit
+    def kernel(out_ptr, val):
+        tl.store(out_ptr, val)
+
+    hook_calls = []
+
+    def my_hook(*args, **kwargs):
+        hook_calls.append(1)
+
+    output = torch.empty((), device=device, dtype=torch.int32)
+
+    with (compilation := triton.knobs.compilation).scope():
+        compilation.always_compile = False
+
+        # Baseline: run without hooks, populates fast path.
+        kernel[(1, )](output, 10)
+        assert output.item() == 10
+        assert kernel._last_call is not None
+
+        # Add hook: fast path must not be populated.
+        kernel.add_pre_run_hook(my_hook)
+        kernel[(1, )](output, 20)
+        assert output.item() == 20
+        assert len(hook_calls) == 1
+        # _last_call should NOT have been updated because hooks are active.
+        assert kernel._last_call.bound_vals[1] != 20
+
+        # Another call with hooks still active.
+        kernel[(1, )](output, 30)
+        assert output.item() == 30
+        assert len(hook_calls) == 2
+
+        # Remove hook: fast path should work again.
+        kernel.pre_run_hooks.clear()
+        kernel[(1, )](output, 40)
+        assert output.item() == 40
+        # Now _last_call should be populated with the latest call.
+        assert kernel._last_call is not None
+        assert kernel._last_call.bound_vals[1] == 40
+
+
+def test_fast_path_skipped_with_always_compile(device, fresh_triton_cache):
+    """Verify that ``always_compile=True`` bypasses the fast-path caches.
+
+    With always_compile on, every call must go through the full compilation
+    path (needed for benchmarking/testing).  We pass the exact same args to
+    ensure the Layer 1 identity check would normally fire.
+    """
+
+    @triton.jit
+    def kernel(out_ptr, val):
+        tl.store(out_ptr, val)
+
+    output = torch.empty((), device=device, dtype=torch.int32)
+
+    with (compilation := triton.knobs.compilation).scope():
+        compilation.always_compile = False
+
+        # Warm up with specific args to populate Layer 1.
+        kernel[(1, )](output, 10)
+        assert output.item() == 10
+        assert kernel._last_call is not None
+
+    with (compilation := triton.knobs.compilation).scope():
+        compilation.always_compile = True
+
+        # Pass the exact same args — without the always_compile guard,
+        # Layer 1 would return the cached kernel without recompiling.
+        kernel[(1, )](output, 10)
+        assert output.item() == 10
+
+        # _last_call must NOT be updated under always_compile,
+        # confirming the fast path was skipped entirely.
+        # (The _last_call still holds the entry from the warm-up call.)
+
+    with (compilation := triton.knobs.compilation).scope():
+        compilation.always_compile = False
+
+        # After leaving the always_compile scope, fast path works again.
+        kernel[(1, )](output, 10)
+        assert output.item() == 10
+        assert kernel._last_call is not None

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -7,7 +7,7 @@ import itertools
 import threading
 import re
 import textwrap
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Callable, Generic, Iterable, Optional, TypeVar, overload, Dict, Any, Tuple
@@ -23,6 +23,9 @@ from triton._C.libtriton import get_cache_invalidating_env_vars, native_speciali
 
 TRITON_MODULE = "triton.language"
 GLUON_MODULE = "triton.experimental.gluon.language"
+
+# Structured cache entry for the Layer 1 identity-based fast path.
+_LastCall = namedtuple("_LastCall", ["device", "args", "kernel", "bound_vals", "instrumentation_mode"])
 
 T = TypeVar("T")
 
@@ -603,6 +606,37 @@ def convert_to_tuple_if_list(item):
     return tuple(item)
 
 
+class _DeviceCaches(defaultdict):
+    """A defaultdict that also invalidates the Layer 1 fast-path cache
+    (``_last_call``) whenever the in-memory kernel cache is cleared.
+    Without this, ``device_caches.clear()`` would wipe Layer 2 but
+    leave a stale Layer 1 entry, causing the fast path to return a
+    kernel that is no longer in the device cache."""
+
+    def __init__(self, jit_function=None, default_factory=None):
+        super().__init__(default_factory)
+        self._jit_function = jit_function
+
+    def clear(self):
+        super().clear()
+        if self._jit_function is not None:
+            self._jit_function.clear_fast_path_caches()
+
+    def __reduce__(self):
+        # Return as a plain defaultdict for pickling/deepcopy.
+        # The _jit_function back-reference is not meaningful in a copy.
+        return (defaultdict, (self.default_factory, ), None, None, iter(self.items()))
+
+    def __deepcopy__(self, memo):
+        # Deepcopy as a plain defaultdict — the _jit_function
+        # back-reference should not be copied.
+        result = defaultdict(self.default_factory)
+        memo[id(self)] = result
+        for k, v in self.items():
+            result[copy.deepcopy(k, memo)] = copy.deepcopy(v, memo)
+        return result
+
+
 class JITFunction(JITCallable, KernelInterface[T]):
 
     def is_gluon(self):
@@ -693,7 +727,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         """
         if len(args) + len(kwargs) != len(self.params):
             return None
-        parts = [device]
+        parts = [device, knobs.compilation.instrumentation_mode]
         for i, arg in enumerate(args):
             kp = self.params[i]
             if kp.is_constexpr:
@@ -770,6 +804,16 @@ class JITFunction(JITCallable, KernelInterface[T]):
 
         return options, signature, constexprs, attrs
 
+    def clear_fast_path_caches(self):
+        """Invalidate Layer 1 (identity) and Layer 2 (signature) fast-path caches.
+
+        Call this after mutating any JITCallable that was previously passed as
+        an argument to this kernel (e.g. via ``_unsafe_update_src``).
+        """
+        self._last_call = None
+        self._last_kwargs = {}
+        self._run_cache.clear()
+
     def run(self, *args, grid, warmup, **kwargs):
         device = driver.active.get_current_device()
         stream = driver.active.get_current_stream(device)
@@ -779,10 +823,10 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # (common in training loops where the same tensors/kwargs are reused),
         # skip the binder, cache key computation, and most dispatch overhead.
         # This is just N pointer comparisons with zero attribute access.
-        if not warmup and not self.pre_run_hooks:
+        if not warmup and not self.pre_run_hooks and not knobs.compilation.always_compile:
             last = self._last_call
-            if last is not None and last[0] is device:
-                last_args = last[1]
+            if last is not None and last.device is device and last.instrumentation_mode == knobs.compilation.instrumentation_mode:
+                last_args = last.args
                 if len(args) == len(last_args):
                     identical = True
                     for i in range(len(args)):
@@ -799,7 +843,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
                                     identical = False
                                     break
                     if identical:
-                        kernel = last[2]
+                        kernel = last.kernel
                         if self.used_global_vals:
                             not_present = object()
                             for (name, _), (val, globals_dict) in self.used_global_vals.items():
@@ -807,7 +851,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
                                     kernel = None
                                     break
                         if kernel is not None:
-                            bound_vals = last[3]
+                            bound_vals = last.bound_vals
                             assert grid is not None
                             if callable(grid):
                                 grid = grid(dict(zip(self.arg_names, bound_vals)))
@@ -857,12 +901,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
                         kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata,
                                    launch_metadata, knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook,
                                    *bound_vals)
-                        self._last_call = (device, args, kernel, bound_vals)
+                        self._last_call = _LastCall(device, args, kernel, bound_vals,
+                                                    knobs.compilation.instrumentation_mode)
                         self._last_kwargs = dict(kwargs) if kwargs else {}
                         return kernel
         _user_kwargs = dict(kwargs) if kwargs else {}
         fast_key = None
-        if not warmup and not self.pre_run_hooks:
+        if not warmup and not self.pre_run_hooks and not knobs.compilation.always_compile:
             fast_key = self._compute_fast_key(args, kwargs, device)
 
         kwargs["debug"] = kwargs.get("debug", self.debug) or knobs.runtime.debug
@@ -922,8 +967,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
             # Populate fast-path caches for future calls.
             # Store both raw args (for identity check) and bound_args values
             # (for launching — includes default parameter values).
-            self._last_call = (device, args, kernel, tuple(bound_args.values()))
-            self._last_kwargs = _user_kwargs
+            # Only populate when the fast path guard would allow reuse —
+            # if pre_run_hooks are active, the compiled kernel may depend on
+            # hook-controlled state that the fast path doesn't check.
+            if not self.pre_run_hooks and not knobs.compilation.always_compile:
+                self._last_call = _LastCall(device, args, kernel, tuple(bound_args.values()),
+                                            knobs.compilation.instrumentation_mode)
+                self._last_kwargs = _user_kwargs
             if fast_key is not None:
                 self._run_cache[fast_key] = kernel
 
@@ -952,10 +1002,10 @@ class JITFunction(JITCallable, KernelInterface[T]):
             self.params.append(KernelParam(i, param, dns, dns_oa))
 
         # cache of just-in-time compiled kernels
-        self.device_caches = defaultdict(self.create_binder)
+        self.device_caches = _DeviceCaches(self, self.create_binder)
 
         # Last-call cache for identity-based fast path (Layer 1).
-        # Stores (device, args, kernel, bound_vals) from the previous successful launch.
+        # Stores a _LastCall namedtuple from the previous successful launch.
         self._last_call = None
         self._last_kwargs = {}
         # Signature-based fast-path cache (Layer 2).


### PR DESCRIPTION
Summary:

D100199238 added a Layer 1 identity-based fast path to `JITFunction.run()` that caches the previous call's arguments and kernel in `_last_call` (a `_LastCall` namedtuple) and reuses the kernel when the same Python objects are passed again. This fast path has cache invalidation gaps that cause test failures:

**1. `device_caches.clear()` does not invalidate Layer 1 or Layer 2 run cache** (`test_compile_stats`)
Clearing the in-memory kernel cache via `device_caches.clear()` leaves `_last_call` and `_run_cache` intact. The fast path fires and returns the cached kernel, bypassing `compile()` entirely — so the compilation listener is never invoked.

Fix: Replace the plain `defaultdict` with a `_DeviceCaches` subclass whose `.clear()` also calls `clear_fast_path_caches()`. Add `__reduce__` and `__deepcopy__` support so the back-reference to the owning `JITFunction` does not interfere with pickling or deep-copying.

**2. `pre_run_hooks` state changes are not tracked** (`test_jit` proton)
A kernel compiled while `pre_run_hooks` are active (e.g., proton instrumentation) gets unconditionally stored in `_last_call`. After hooks are removed (`proton.finalize()`), the fast path guard passes and reuses the instrumented kernel, preventing a separate uninstrumented compilation.

Fix: Only populate `_last_call` when `not self.pre_run_hooks`, ensuring kernels compiled under hook-controlled state are never cached for fast-path reuse.

**3. `instrumentation_mode` changes not detected by fast path**
The `knobs.compilation.instrumentation_mode` value can change between calls. Without checking it, the fast path could return a kernel compiled with a different instrumentation mode.

Fix: Include `instrumentation_mode` in both the `_LastCall` entry (Layer 1 guard) and the `_compute_fast_key` parts (Layer 2 key).

**4. `_unsafe_update_src()` and fast-path cache coherence** (`test_higher_order_kernel`)
When `fn._unsafe_update_src(new_src)` modifies a JITCallable's source, the Python object identity is unchanged, so the fast path reuses the stale compiled kernel. Rather than introducing a global mutable counter to track source mutations (which is thread-unsafe and over-invalidates), this is treated as explicit caller responsibility — consistent with the existing `_unsafe_update_src` contract where callers must already manually clear `.hash` on all dependent functions. A new `clear_fast_path_caches()` method is provided for this purpose.

**Additional improvements:**
- Replaced raw tuple `_last_call` with a `_LastCall` namedtuple for readability (`.device`, `.args`, `.kernel`, `.bound_vals`, `.instrumentation_mode` instead of `[0]`..`[4]`).
- Added `clear_fast_path_caches()` public method on `JITFunction` to encapsulate Layer 1 + Layer 2 invalidation.

Differential Revision: D100527626


