### PR TITLE
[autoWS] support Hopper + FA + SWP via annotation

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -427,6 +427,10 @@ public:
           rewriter, dotOp.getLoc(), mmaResult.newRetType, a, b,
           mmaResult.newAcc, nullptr, dotOp.getInputPrecision(),
           dotOp.getMaxNumImpreciseAcc(), false);
+      // Propagate discardable attributes (e.g. tt.autows) from the original
+      // dot.
+      for (auto attr : dotOp->getDiscardableAttrs())
+        newDot->setDiscardableAttr(attr.getName(), attr.getValue());
     } else {
       int minBitwidth =
           std::min(computeOrigBitWidth(a), computeOrigBitWidth(b));

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -223,12 +223,6 @@ void setPartition(Operation *op, ArrayRef<int> partitionIds) {
   auto sorted = llvm::to_vector(partitionIds);
   llvm::sort(sorted);
   op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
-  for (auto &region : op->getRegions()) {
-    for (auto &block : region.getBlocks()) {
-      auto terminator = block.getTerminator();
-      terminator->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
-    }
-  }
 }
 
 void setPartitionOutputs(Operation *op,

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -223,6 +223,12 @@ void setPartition(Operation *op, ArrayRef<int> partitionIds) {
   auto sorted = llvm::to_vector(partitionIds);
   llvm::sort(sorted);
   op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
+  for (auto &region : op->getRegions()) {
+    for (auto &block : region.getBlocks()) {
+      auto terminator = block.getTerminator();
+      terminator->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(sorted));
+    }
+  }
 }
 
 void setPartitionOutputs(Operation *op,

--- a/python/tutorials/fused-attention-ws-device-tma-hopper.py
+++ b/python/tutorials/fused-attention-ws-device-tma-hopper.py
@@ -1,0 +1,1729 @@
+import json
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+import os
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+USE_SWP = os.environ.get("TRITON_HOPPER_SWP", "1") == "1"
+
+
+def is_hip():
+    return triton.runtime.driver.active.get_current_target().backend == "hip"
+
+
+def is_cuda():
+    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+
+
+def supports_host_descriptor():
+    return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def is_blackwell():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 10
+
+
+def is_hopper():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 9
+
+
+@triton.jit
+def _attn_fwd_subtile(
+    q,
+    k,
+    offs_m,
+    start_n,
+    offs_n,
+    qk_scale,
+    l_i0,
+    l_i1,  # used when FADD2_REDUCE is true
+    m_i,
+    acc,
+    v,
+    dtype: tl.constexpr,
+    STAGE: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    FWD_DOT_ATTRS: tl.constexpr = None,
+):
+    qk = tl.dot(q, k, attrs=FWD_DOT_ATTRS.get("qk"))
+    if STAGE == 2:
+        mask = offs_m[:, None] >= (start_n + offs_n[None, :])
+        qk = qk * qk_scale + tl.where(mask, 0, -1.0e6)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        qk -= m_ij[:, None]
+    else:
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+        if VECT_MUL == 2 or VECT_MUL == 3:
+            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+        else:
+            qk = qk * qk_scale - m_ij[:, None]
+    p = tl.math.exp2(qk)
+    # -- compute correction factor
+    alpha = tl.math.exp2(m_i - m_ij)
+    if not FADD2_REDUCE:
+        l_ij = tl.sum(p, 1)
+
+    # -- update output accumulator --
+    BM: tl.constexpr = acc.shape[0]
+    BN: tl.constexpr = acc.shape[1]
+
+    if SUBTILING:
+        acc0, acc1 = acc.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
+        if VECT_MUL == 1 or VECT_MUL == 3:
+            acc0 = _mul_f32x2(acc0, alpha[:, None])
+            acc1 = _mul_f32x2(acc1, alpha[:, None])
+        else:
+            acc0 = acc0 * alpha[:, None]
+            acc1 = acc1 * alpha[:, None]
+        acc = tl.join(acc0, acc1).permute(0, 2, 1).reshape([BM, BN])
+    else:
+        acc = acc * alpha[:, None]
+
+    PM: tl.constexpr = p.shape[0]
+    PN: tl.constexpr = p.shape[1]
+    if FADD2_REDUCE:
+        p0, p1 = p.reshape([PM, 2, PN // 2]).permute(0, 2, 1).split()
+        l_ij0, l_ij1 = tl.reduce((p0, p1), axis=1, combine_fn=_reduce_fadd2)
+        l_i0 = l_i0 * alpha + l_ij0
+        l_i1 = l_i1 * alpha + l_ij1
+
+    # prepare p and v for the dot
+    p = p.to(dtype)
+    # note that this non transposed v for FP8 is only supported on Blackwell
+    acc = tl.dot(p, v, acc, attrs=FWD_DOT_ATTRS.get("pv"))
+    # update m_i and l_i
+    # place this at the end of the loop to reduce register pressure
+    if not FADD2_REDUCE:
+        l_i0 = l_i0 * alpha + l_ij
+    m_i = m_ij
+
+    return l_i0, l_i1, m_i, acc
+
+
+@triton.jit
+def _attn_fwd_inner_oss_dp(
+    acc0,
+    l_i0,
+    l_i0_1,
+    m_i0,
+    q0,
+    desc_k,
+    desc_v,  #
+    offset_y,
+    dtype: tl.constexpr,
+    start_m,
+    qk_scale,  #
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,
+    offs_m0: tl.constexpr,
+    offs_n: tl.constexpr,  #
+    N_CTX: tl.constexpr,
+    warp_specialize: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+    FWD_DOT_ATTRS: tl.constexpr = None,
+):
+    # range of values handled by this stage
+    if STAGE == 1:
+        lo, hi = 0, start_m * BLOCK_M
+    elif STAGE == 2:
+        lo, hi = start_m * BLOCK_M, (start_m + 1) * BLOCK_M
+        lo = tl.multiple_of(lo, BLOCK_M)
+    # causal = False
+    else:
+        lo, hi = 0, N_CTX
+    offsetkv_y = offset_y + lo
+
+    # loop over k, v and update accumulator
+    for start_n in tl.range(
+            lo,
+            hi,
+            BLOCK_N,
+            warp_specialize=warp_specialize,
+            merge_epilogue=True,
+            merge_correction=True,
+            smem_alloc_algo=1,
+            # disallow_acc_multi_buffer=True,
+            data_partition_factor=DP_FACTOR,
+    ):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+
+        k = desc_k.load([offsetkv_y, 0]).T
+        v = desc_v.load([offsetkv_y, 0])
+
+        l_i0, l_i0_1, m_i0, acc0 = _attn_fwd_subtile(
+            q0,
+            k,
+            offs_m0,
+            start_n,
+            offs_n,
+            qk_scale,
+            l_i0,
+            l_i0_1,
+            m_i0,
+            acc0,
+            v,
+            dtype,
+            STAGE,
+            SUBTILING,
+            VECT_MUL,
+            FADD2_REDUCE,
+            FWD_DOT_ATTRS,
+        )
+
+        offsetkv_y += BLOCK_N
+
+    return acc0, l_i0, l_i0_1, m_i0
+
+
+def _host_descriptor_pre_hook(nargs):
+    BLOCK_M = nargs["BLOCK_M"]
+    BLOCK_N = nargs["BLOCK_N"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    if not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+    nargs["desc_q"].block_shape = [BLOCK_M, HEAD_DIM]  # due to data partitioning
+    if nargs["FP8_OUTPUT"]:
+        nargs["desc_v"].block_shape = [HEAD_DIM, BLOCK_N]
+    else:
+        nargs["desc_v"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_k"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_o"].block_shape = [BLOCK_M, HEAD_DIM]
+
+
+if is_hip():
+    NUM_STAGES_OPTIONS = [1]
+elif supports_host_descriptor():
+    NUM_STAGES_OPTIONS = [2]
+else:
+    NUM_STAGES_OPTIONS = [2]
+
+configs = [
+    triton.Config(
+        {
+            "BLOCK_M": BM,
+            "BLOCK_N": BN,
+            "DP_FACTOR": 2,
+        },
+        num_stages=s,
+        num_warps=w,
+        pre_hook=_host_descriptor_pre_hook,
+    ) for BM in [128] for BN in [128] for s in NUM_STAGES_OPTIONS for w in [4]
+]
+
+
+def keep(conf):
+    BLOCK_M = conf.kwargs["BLOCK_M"]
+    BLOCK_N = conf.kwargs["BLOCK_N"]
+    return not (is_cuda() and torch.cuda.get_device_capability()[0] == 9 and BLOCK_M * BLOCK_N < 128 * 128
+                and conf.num_warps == 8)
+
+
+def prune_invalid_configs(configs, named_args, **kwargs):
+    N_CTX = kwargs["N_CTX"]
+
+    # Filter out configs where BLOCK_M > N_CTX
+    return [conf for conf in configs if conf.kwargs.get("BLOCK_M", 0) <= N_CTX]
+
+
+@triton.jit
+def _maybe_make_tensor_desc(desc_or_ptr, shape, strides, block_shape):
+    if isinstance(desc_or_ptr, tl.tensor_descriptor):
+        return desc_or_ptr
+    else:
+        return tl.make_tensor_descriptor(desc_or_ptr, shape, strides, block_shape)
+
+
+@triton.jit
+def _mul_f32x2(a, b):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mul.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [a, b],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def _fma_f32x2(a, b, c):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc, rd;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mov.b64 rc, { $6, $7 };
+            fma.rn.f32x2 rd, ra, rb, rc;
+            mov.b64 { $0, $1 }, rd;
+        }
+        """,
+        "=r,=r,r,r,r,r,r,r",
+        [a, b, c],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def _reduce_fadd2(p0a, p1a, p0b, p1b):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 rc, ra, rb;
+            mov.b64 ra, { $2, $4 };
+            mov.b64 rb, { $3, $5 };
+            add.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [p0a, p0b, p1a, p1b],
+        dtype=[tl.float32, tl.float32],
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _attn_fwd_tma_dp(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    pid,
+    off_hz,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+    FWD_DOT_ATTRS: tl.constexpr = None,
+):
+    start_m = pid  # tl.program_id(0)
+    # off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    offset_y = off_z * (N_CTX * H) + off_h * N_CTX
+    qo_offset_y = offset_y + start_m * BLOCK_M
+    # initialize offsets
+    offs_m0 = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+
+    m_i0 = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i0_0 = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc0 = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    qk_scale = sm_scale
+    qk_scale *= 1.44269504  # 1/log(2)
+
+    q0 = desc_q.load([qo_offset_y, 0])
+
+    if FADD2_REDUCE:
+        l_i0_1 = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+    else:
+        l_i0_1 = 0
+
+    if STAGE & 1:
+        acc0, l_i0_0, l_i0_1, m_i0 = _attn_fwd_inner_oss_dp(
+            acc0,
+            l_i0_0,
+            l_i0_1,
+            m_i0,
+            q0,
+            desc_k,
+            desc_v,  #
+            offset_y,
+            dtype,
+            start_m,
+            qk_scale,  #
+            BLOCK_M,
+            HEAD_DIM,
+            BLOCK_N,  #
+            4 - STAGE,
+            offs_m0,
+            offs_n,
+            N_CTX,  #
+            warp_specialize,
+            SUBTILING,
+            VECT_MUL,
+            FADD2_REDUCE,
+            DP_FACTOR,
+            FWD_DOT_ATTRS,
+        )
+    if STAGE & 2:
+        acc0, l_i0_0, l_i0_1, m_i0 = _attn_fwd_inner_oss_dp(
+            acc0,
+            l_i0_0,
+            l_i0_1,
+            m_i0,
+            q0,
+            desc_k,
+            desc_v,  #
+            offset_y,
+            dtype,
+            start_m,
+            qk_scale,  #
+            BLOCK_M,
+            HEAD_DIM,
+            BLOCK_N,  #
+            2,
+            offs_m0,
+            offs_n,
+            N_CTX,  #
+            warp_specialize,
+            SUBTILING,
+            VECT_MUL,
+            FADD2_REDUCE,
+            DP_FACTOR,
+            FWD_DOT_ATTRS,
+        )
+
+    if FADD2_REDUCE:
+        l_i0 = l_i0_0 + l_i0_1
+    else:
+        l_i0 = l_i0_0
+
+    m_i0 += tl.math.log2(l_i0)
+    acc0 = acc0 / l_i0[:, None]
+    m_ptrs0 = M + off_hz * N_CTX + offs_m0
+    tl.store(m_ptrs0, m_i0)
+    desc_o.store([qo_offset_y, 0], acc0.to(dtype))
+
+
+@triton.autotune(
+    configs=list(filter(keep, configs)),
+    key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
+    prune_configs_by={"early_config_prune": prune_invalid_configs},
+)
+@triton.jit
+def _attn_fwd(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+    FWD_DOT_ATTRS: tl.constexpr = None,
+):
+    pid = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    y_dim = Z * H * N_CTX
+    desc_q = _maybe_make_tensor_desc(
+        desc_q,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M, HEAD_DIM],
+    )
+    desc_v = _maybe_make_tensor_desc(
+        desc_v,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N, HEAD_DIM],
+    )
+    desc_k = _maybe_make_tensor_desc(
+        desc_k,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N, HEAD_DIM],
+    )
+    desc_o = _maybe_make_tensor_desc(
+        desc_o,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M, HEAD_DIM],
+    )
+
+    _attn_fwd_tma_dp(
+        sm_scale,
+        M,
+        Z,
+        H,
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_o,
+        pid,
+        off_hz,
+        N_CTX,
+        HEAD_DIM,
+        BLOCK_M,
+        BLOCK_N,
+        FP8_OUTPUT,
+        STAGE,
+        warp_specialize,
+        dtype,
+        SUBTILING,
+        VECT_MUL,
+        FADD2_REDUCE,
+        DP_FACTOR,
+        FWD_DOT_ATTRS,
+    )
+
+
+@triton.autotune(
+    configs=list(filter(keep, configs)),
+    key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
+    prune_configs_by={"early_config_prune": prune_invalid_configs},
+)
+@triton.jit
+def _attn_fwd_persist(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    OUTER_LOOP: tl.constexpr,
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+    FWD_DOT_ATTRS: tl.constexpr = None,
+):
+    n_tile_num = tl.cdiv(N_CTX, BLOCK_M)
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    total_tiles = n_tile_num * Z * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
+    desc_q = tl.make_tensor_descriptor(
+        desc_q,
+        shape=[Z * H * N_CTX, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M, HEAD_DIM],
+    )
+    desc_k = tl.make_tensor_descriptor(
+        desc_k,
+        shape=[Z * H * N_CTX, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N, HEAD_DIM],
+    )
+    desc_v = tl.make_tensor_descriptor(
+        desc_v,
+        shape=[Z * H * N_CTX, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N, HEAD_DIM],
+    )
+    desc_o = tl.make_tensor_descriptor(
+        desc_o,
+        shape=[Z * H * N_CTX, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M, HEAD_DIM],
+    )
+
+    # inner loop warpspec vs. outer loop warpspec
+    for _ in tl.range(
+            0,
+            tiles_per_sm,
+            warp_specialize=warp_specialize and OUTER_LOOP,
+            merge_epilogue=True,
+            merge_correction=True,
+            smem_alloc_algo=1,
+            data_partition_factor=DP_FACTOR,
+    ):
+        pid = tile_idx % n_tile_num
+        off_hz = tile_idx // n_tile_num
+        _attn_fwd_tma_dp(
+            sm_scale,
+            M,
+            Z,
+            H,
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,
+            pid,
+            off_hz,
+            N_CTX,
+            HEAD_DIM,
+            BLOCK_M,
+            BLOCK_N,
+            FP8_OUTPUT,
+            STAGE,
+            warp_specialize and not OUTER_LOOP,
+            dtype,
+            SUBTILING,
+            VECT_MUL,
+            FADD2_REDUCE,
+            DP_FACTOR,
+            FWD_DOT_ATTRS,
+        )
+        tile_idx += num_progs
+
+
+def torch_dtype_to_triton(dtype):
+    if dtype == torch.float8_e5m2:
+        return tl.float8e5
+    return getattr(tl, str(dtype).split(".")[1])
+
+
+@triton.jit
+def _split_n(x, SPLIT_FACTOR: tl.constexpr):
+    if SPLIT_FACTOR == 1:
+        return (x, )
+    else:
+        x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
+        return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
+
+
+@triton.jit
+def _attn_bwd_preprocess(O, DO,  #
+                         Delta,  #
+                         Z, H, N_CTX,  #
+                         BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr,  #
+                         ):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_hz = tl.program_id(1)
+    off_n = tl.arange(0, HEAD_DIM)
+    # load
+    o = tl.load(O + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :])
+    do = tl.load(DO + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :]).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_hz * N_CTX + off_m, delta)
+
+
+# Frozen (hashable) wrapper for dot attrs configuration, usable in triton.Config.
+# Supports .get(key) like a dict but is hashable for Triton's JIT cache key.
+class FrozenDotAttrs:
+
+    def __init__(self, d):
+        self._data = d
+        self._hash = hash(json.dumps(d, sort_keys=True)) if d else hash(None)
+
+    def get(self, key, default=None):
+        return self._data.get(key, default) if self._data else default
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        if isinstance(other, FrozenDotAttrs):
+            return self._data == other._data
+        return NotImplemented
+
+    def __repr__(self):
+        return f"FrozenDotAttrs({self._data})"
+
+    def __bool__(self):
+        return bool(self._data)
+
+
+# FWD dot attrs: 2 copies for K and V, no reuse (separate buffer IDs)
+#FWD_DOT_ATTRS = FrozenDotAttrs({
+#    "qk": {"channels": ["opndB,smem,2,0"]},
+#    "pv": {"channels": ["opndB,smem,2,1"]},
+#})
+_FWD_DOT_ATTRS_SWP = FrozenDotAttrs({
+    "qk": {"stage": "0", "order": "0", "channels": ["opndB,smem,2,0"]},
+    "pv": {"stage": "1", "order": "1", "channels": ["opndB,smem,2,1"]},
+})
+_FWD_DOT_ATTRS_NO_SWP = FrozenDotAttrs({
+    "qk": {"channels": ["opndB,smem,2,0"]},
+    "pv": {"channels": ["opndB,smem,2,1"]},
+})
+_FWD_DOT_ATTRS = _FWD_DOT_ATTRS_SWP if USE_SWP else _FWD_DOT_ATTRS_NO_SWP
+
+# Default dot attrs configuration for the BWD kernel.
+# Each key corresponds to a dot operation in _attn_bwd_dkdv_inner.
+# Set to None to disable attrs for a given dot (heuristic allocation).
+# Format: {"stage": str, "order": str, "channels": [str, ...]}
+_DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs({
+    "qkT": {
+        "stage": "0",
+        "order": "0",
+        "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"],
+    },
+    "dpT": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+    },
+    "dv": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"],
+    },
+    "dq": {
+        "stage": "1",
+        "order": "1",
+        "channels": ["opndA,smem,1,8", "opndD,tmem,1,5"],
+    },
+    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+})
+
+_BWD_DOT_ATTRS_BM64 = FrozenDotAttrs({
+    # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
+    # no need to reuse between dq and dpT
+    "qkT": {
+        "stage": "0",
+        "order": "0",
+        "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"],
+    },  # k, q
+    "dpT": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+    },  # v, do
+    "dv": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"],
+    },  # ppT
+    "dq": {
+        "stage": "1",
+        "order": "1",
+        "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"],
+    },  # dsT
+    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+})
+
+_BWD_DOT_ATTRS_SCHED = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0"},
+    "dpT": {"stage": "0", "order": "2"},
+    "dv": {"stage": "0", "order": "2"},
+    "dq": {"stage": "1", "order": "1"},
+    "dk": {"stage": "1", "order": "1"},
+})
+
+
+@triton.jit
+def _attn_bwd_dkdv_inner(
+    dk,
+    dv,
+    desc_q,
+    k,
+    v,
+    desc_do,
+    desc_dq,
+    M,
+    D,
+    off_bh,
+    curr_m,
+    step_m,
+    start_n,
+    offs_n,
+    BLOCK_M1: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    MASK: tl.constexpr,
+    dtype: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+    LN2: tl.constexpr,
+    RESCHED: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+):
+    q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
+    qT = tl.trans(q)
+    offs_m = curr_m + tl.arange(0, BLOCK_M1)
+    m = tl.load(M + offs_m)
+    if RESCHED:
+        qkT = tl.dot(k, qT, attrs=BWD_DOT_ATTRS.get("qkT"))
+    else:
+        qkT = tl.dot(k, qT)
+    pT = tl.math.exp2(qkT - m[None, :])
+    if MASK:
+        mask = offs_m[None, :] >= offs_n[:, None]
+        pT = tl.where(mask, pT, 0.0)
+    do = desc_do.load([(off_bh + curr_m).to(tl.int32), 0])
+    ppT = pT
+    ppT = ppT.to(dtype)
+    if RESCHED:
+        dpT = tl.dot(v, tl.trans(do), attrs=BWD_DOT_ATTRS.get("dpT")).to(tl.float32)
+        Di = tl.load(D + offs_m)
+        dv += tl.dot(ppT, do, attrs=BWD_DOT_ATTRS.get("dv"))
+    else:
+        dv += tl.dot(ppT, do)
+        Di = tl.load(D + offs_m)
+        dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
+    dsT = pT * (dpT - Di[None, :])
+    dsT = dsT.to(dtype)
+    if RESCHED:
+        dq = tl.dot(tl.trans(dsT), k, attrs=BWD_DOT_ATTRS.get("dq"))
+        dk += tl.dot(dsT, tl.trans(qT), attrs=BWD_DOT_ATTRS.get("dk"))
+    else:
+        dk += tl.dot(dsT, tl.trans(qT))
+        dq = tl.dot(tl.trans(dsT), k)
+    dqs = _split_n(dq, EPILOGUE_SUBTILE)
+    slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+    for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
+        dqN = dqs[slice_id] * LN2
+        desc_dq.atomic_add([(off_bh + curr_m).to(tl.int32), slice_id * slice_size], dqN)
+    curr_m += step_m
+    return dk, dv, curr_m
+
+
+@triton.jit
+def _attn_bwd_dkdv(
+    dk,
+    dv,  #
+    desc_q,
+    k,
+    v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    M,
+    D,  #
+    # shared by Q/K/V/DO.
+    stride_tok,
+    stride_d,  #
+    off_bh,
+    H,
+    N_CTX,
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    # Filled in by the wrapper.
+    start_n,
+    start_m,
+    num_steps,  #
+    MASK: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+):
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+
+    LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
+
+    # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+    curr_m = start_m
+    step_m = BLOCK_M1
+    if warp_specialize:
+        for blk_idx in tl.range(
+                0,
+                num_steps,
+                warp_specialize=True,
+                merge_epilogue_to_computation=True,
+        ):
+            dk, dv, curr_m = _attn_bwd_dkdv_inner(
+                dk,
+                dv,
+                desc_q,
+                k,
+                v,
+                desc_do,
+                desc_dq,
+                M,
+                D,
+                off_bh,
+                curr_m,
+                step_m,
+                start_n,
+                offs_n,
+                BLOCK_M1,
+                HEAD_DIM,
+                MASK,
+                dtype,
+                EPILOGUE_SUBTILE,
+                LN2,
+                True,
+                BWD_DOT_ATTRS,
+            )
+    else:
+        for blk_idx in tl.range(0, num_steps):
+            dk, dv, curr_m = _attn_bwd_dkdv_inner(
+                dk,
+                dv,
+                desc_q,
+                k,
+                v,
+                desc_do,
+                desc_dq,
+                M,
+                D,
+                off_bh,
+                curr_m,
+                step_m,
+                start_n,
+                offs_n,
+                BLOCK_M1,
+                HEAD_DIM,
+                MASK,
+                dtype,
+                EPILOGUE_SUBTILE,
+                LN2,
+                True,
+                BWD_DOT_ATTRS,
+            )
+
+    return dk, dv
+
+
+def _bwd_host_descriptor_pre_hook(nargs):
+    BLOCK_M1 = nargs["BLOCK_M1"]
+    BLOCK_N1 = nargs["BLOCK_N1"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    EPILOGUE_SUBTILE = nargs["EPILOGUE_SUBTILE"]
+    if not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+
+    # Reset dq accumulator to zeros before each autotuner warmup run.
+    # Without this, dq accumulates across autotuner benchmark runs when
+    # multiple configs are present (e.g., USE_WARP_BARRIER in [False, True]).
+    nargs["desc_dq"].base.zero_()
+
+    nargs["desc_q"].block_shape = [BLOCK_M1, HEAD_DIM]
+    nargs["desc_do"].block_shape = [BLOCK_M1, HEAD_DIM]
+    nargs["desc_dq"].block_shape = [BLOCK_M1, HEAD_DIM // EPILOGUE_SUBTILE]
+    nargs["desc_v"].block_shape = [BLOCK_N1, HEAD_DIM]
+    nargs["desc_k"].block_shape = [BLOCK_N1, HEAD_DIM]
+    nargs["desc_dv"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
+    nargs["desc_dk"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
+
+
+configs_bwd = [
+    triton.Config(
+        {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 4,
+            "BWD_DOT_ATTRS": FrozenDotAttrs(None),
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    )
+]
+
+configs_bwd_persist = [
+    triton.Config(
+        {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _DEFAULT_BWD_DOT_ATTRS,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128, "EPILOGUE_SUBTILE": 4, "BWD_DOT_ATTRS":
+            _BWD_DOT_ATTRS_SCHED,  # use memory planner heuristics
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM64,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+]
+
+
+@triton.jit
+def _attn_bwd_core(
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    M,
+    D,  #
+    stride_tok,
+    stride_d,  #
+    stride_z,
+    stride_h,  #
+    pid,
+    bhid,
+    BATCH: tl.constexpr,
+    H: tl.constexpr,
+    N_CTX: tl.constexpr,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+):
+    off_chz = (bhid * N_CTX).to(tl.int64)
+    off_bh = ((stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)) // stride_tok
+
+    M += off_chz
+    D += off_chz
+
+    dv = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+
+    start_n = pid * BLOCK_N1
+    start_m = 0
+
+    k = desc_k.load([(off_bh + start_n).to(tl.int32), 0])
+    v = desc_v.load([(off_bh + start_n).to(tl.int32), 0])
+    num_steps = (N_CTX - start_m) // BLOCK_M1
+    dk, dv = _attn_bwd_dkdv(  #
+        dk,
+        dv,  #
+        desc_q,
+        k,
+        v,
+        sm_scale,  #
+        desc_do,  #
+        desc_dq,
+        M,
+        D,  #
+        stride_tok,
+        stride_d,  #
+        off_bh,
+        H,
+        N_CTX,  #
+        BLOCK_M1,
+        BLOCK_N1,
+        HEAD_DIM,  #
+        start_n,
+        start_m,
+        num_steps,  #
+        MASK=False,  #
+        dtype=dtype,
+        warp_specialize=warp_specialize,
+        EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
+        BWD_DOT_ATTRS=BWD_DOT_ATTRS,
+    )
+
+    dvs = _split_n(dv, EPILOGUE_SUBTILE)
+    slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+    for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
+        dvN = dvs[slice_id]
+        desc_dv.store(
+            [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+            dvN.to(dtype),
+        )
+
+    dks = _split_n(dk, EPILOGUE_SUBTILE)
+    for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
+        dkN = dks[slice_id] * sm_scale
+        desc_dk.store(
+            [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+            dkN.to(dtype),
+        )
+
+
+@triton.autotune(configs=configs_bwd, key=["N_CTX", "HEAD_DIM"])
+@triton.jit
+def _attn_bwd(
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    M,
+    D,
+    # shared by Q/K/V/DO.
+    stride_z,
+    stride_h,
+    stride_tok,
+    stride_d,  #
+    BATCH,
+    H,
+    N_CTX,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+):
+    bhid = tl.program_id(2)
+    pid = tl.program_id(0)
+
+    _attn_bwd_core(
+        desc_q,
+        desc_k,
+        desc_v,
+        sm_scale,
+        desc_do,
+        desc_dq,
+        desc_dk,
+        desc_dv,
+        M,
+        D,
+        stride_tok,
+        stride_d,
+        stride_z,
+        stride_h,
+        pid,
+        bhid,
+        BATCH,
+        H,
+        N_CTX,
+        BLOCK_M1,
+        BLOCK_N1,
+        HEAD_DIM,
+        dtype,
+        warp_specialize,
+        EPILOGUE_SUBTILE,
+        BWD_DOT_ATTRS,
+    )
+
+
+@triton.autotune(configs=configs_bwd_persist, key=["N_CTX", "HEAD_DIM"])
+@triton.jit
+def _attn_bwd_persist(
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    M,
+    D,
+    # shared by Q/K/V/DO.
+    stride_z,
+    stride_h,
+    stride_tok,
+    stride_d,  #
+    BATCH,
+    H,
+    N_CTX,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+):
+    n_tile_num = tl.cdiv(N_CTX, BLOCK_N1)
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    total_tiles = n_tile_num * BATCH * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
+    y_dim = BATCH * H * N_CTX
+    desc_q = _maybe_make_tensor_desc(
+        desc_q,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M1, HEAD_DIM],
+    )
+    desc_do = _maybe_make_tensor_desc(
+        desc_do,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M1, HEAD_DIM],
+    )
+    desc_dq = _maybe_make_tensor_desc(
+        desc_dq,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M1, HEAD_DIM // EPILOGUE_SUBTILE],
+    )
+    desc_v = _maybe_make_tensor_desc(
+        desc_v,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM],
+    )
+    desc_k = _maybe_make_tensor_desc(
+        desc_k,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM],
+    )
+    desc_dv = _maybe_make_tensor_desc(
+        desc_dv,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+    )
+    desc_dk = _maybe_make_tensor_desc(
+        desc_dk,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+    )
+
+    for _ in tl.range(
+            0,
+            tiles_per_sm,
+            warp_specialize=True,
+            merge_epilogue_to_computation=True,
+    ):
+        pid = tile_idx % n_tile_num
+        bhid = tile_idx // n_tile_num
+        _attn_bwd_core(
+            desc_q,
+            desc_k,
+            desc_v,
+            sm_scale,
+            desc_do,
+            desc_dq,
+            desc_dk,
+            desc_dv,
+            M,
+            D,
+            stride_tok,
+            stride_d,
+            stride_z,
+            stride_h,
+            pid,
+            bhid,
+            BATCH,
+            H,
+            N_CTX,
+            BLOCK_M1,
+            BLOCK_N1,
+            HEAD_DIM,
+            dtype,
+            False,
+            EPILOGUE_SUBTILE,
+            BWD_DOT_ATTRS,
+        )
+        tile_idx += num_progs
+
+
+class _attention_opt(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE):
+        # shape constraints
+        HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
+        # when v is in float8_e5m2 it is transposed.
+        HEAD_DIM_V = v.shape[-1]
+        assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+        assert HEAD_DIM_K in {16, 32, 64, 128, 256}
+        o = torch.empty_like(q)
+        stage = 3 if causal else 1
+        extra_kern_args = {}
+
+        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        warp_specialize = True
+        desc_q = q
+        desc_v = v
+        desc_k = k
+        desc_o = o
+
+        def alloc_fn(size: int, align: int, _):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        def grid(META):
+            return (
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
+
+        def grid_persist(META):
+            return (
+                min(
+                    NUM_SMS,
+                    triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1],
+                ),
+                1,
+                1,
+            )
+
+        def grid_debug(META):
+            return (
+                1,
+                1,
+                1,
+            )
+
+        ctx.grid = grid
+        persistent = baseVariant == "persistent" or baseVariant == "ws_persistent"
+        if is_blackwell() and warp_specialize:
+            if HEAD_DIM_K == 128 and (q.dtype == torch.float16 or q.dtype == torch.bfloat16):
+                extra_kern_args["maxnreg"] = 128
+            else:
+                extra_kern_args["maxnreg"] = 128
+        if persistent:
+            _attn_fwd_persist[grid_persist](
+                sm_scale,
+                M,  #
+                q.shape[0],
+                q.shape[1],  #
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,  #
+                N_CTX=q.shape[2],  #
+                HEAD_DIM=HEAD_DIM_K,  #
+                FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                STAGE=stage,  #
+                warp_specialize=warp_specialize,
+                OUTER_LOOP=True,
+                dtype=torch_dtype_to_triton(q.dtype),
+                SUBTILING=SUBTILING,
+                VECT_MUL=VECT_MUL,
+                FADD2_REDUCE=FADD2_REDUCE,
+                FWD_DOT_ATTRS=_FWD_DOT_ATTRS,
+                **extra_kern_args,
+            )
+        else:
+            _attn_fwd[grid](
+                sm_scale,
+                M,  #
+                q.shape[0],
+                q.shape[1],  #
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,  #
+                N_CTX=q.shape[2],  #
+                HEAD_DIM=HEAD_DIM_K,  #
+                FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                STAGE=stage,  #
+                warp_specialize=warp_specialize,
+                dtype=torch_dtype_to_triton(q.dtype),
+                SUBTILING=SUBTILING,
+                VECT_MUL=VECT_MUL,
+                FADD2_REDUCE=FADD2_REDUCE,
+                FWD_DOT_ATTRS=_FWD_DOT_ATTRS,
+                **extra_kern_args,
+            )
+
+        ctx.save_for_backward(q, k, v, o, M)
+
+        ctx.sm_scale = sm_scale
+        ctx.HEAD_DIM = HEAD_DIM_K
+        ctx.causal = causal
+        ctx.persistent = persistent
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        q, k, v, o, M = ctx.saved_tensors
+        assert do.is_contiguous()
+        assert q.stride() == k.stride() == v.stride() == o.stride() == do.stride()
+        dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        BATCH, N_HEAD, N_CTX = q.shape[:3]
+        PRE_BLOCK = 128
+        BLK_SLICE_FACTOR = 2
+        RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
+        arg_k = k
+        arg_k = arg_k * (ctx.sm_scale * RCP_LN2)
+        PRE_BLOCK = 128
+        assert N_CTX % PRE_BLOCK == 0
+        pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
+        delta = torch.empty_like(M)
+        _attn_bwd_preprocess[pre_grid](
+            o, do,  #
+            delta,  #
+            BATCH, N_HEAD, N_CTX,  #
+            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
+        )
+        warp_specialize = True
+
+        dummy_block = [1, 1]
+        HEAD_DIM = ctx.HEAD_DIM
+
+        def alloc_fn(size: int, align: int, _):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        # NOTE: persistent backward (_attn_bwd_persist) is not yet usable:
+        # the kernel body exceeds the 512-unit TMEM hardware limit (needs 704)
+        # and the pipeliner cannot predicate tt.descriptor_reduce (atomic_add
+        # via TMA). Use non-persistent backward until compiler support improves.
+        desc_k = TensorDescriptor(
+            arg_k,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_v = TensorDescriptor(
+            v,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_q = TensorDescriptor(
+            q,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_do = TensorDescriptor(
+            do,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_dq = TensorDescriptor(
+            dq,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_dk = TensorDescriptor(
+            dk,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_dv = TensorDescriptor(
+            dv,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+
+        def grid(meta):
+            return (
+                triton.cdiv(N_CTX, meta["BLOCK_N1"]),  # tiles along N (K/V)
+                1,  # (or cdiv over M if you need)
+                BATCH * N_HEAD,
+            )  # batch*heads
+
+        if ctx.persistent:
+            NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+            def grid_persist_bwd(meta):
+                return (
+                    min(
+                        NUM_SMS,
+                        triton.cdiv(N_CTX, meta["BLOCK_N1"]) * BATCH * N_HEAD,
+                    ),
+                    1,
+                    1,
+                )
+
+            _attn_bwd_persist[grid_persist_bwd](
+                desc_q,
+                desc_k,
+                desc_v,
+                ctx.sm_scale,
+                desc_do,
+                desc_dq,
+                desc_dk,
+                desc_dv,  #
+                M,
+                delta,  #
+                q.stride(0),
+                q.stride(1),
+                q.stride(2),
+                q.stride(3),  #
+                BATCH,
+                N_HEAD,
+                N_CTX,  #
+                BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+                HEAD_DIM=ctx.HEAD_DIM,  #
+                dtype=torch_dtype_to_triton(q.dtype),
+                warp_specialize=warp_specialize,
+                maxRegAutoWS=192,
+            )
+        else:
+            _attn_bwd[grid](
+                desc_q,
+                desc_k,
+                desc_v,
+                ctx.sm_scale,
+                desc_do,
+                desc_dq,
+                desc_dk,
+                desc_dv,  #
+                M,
+                delta,  #
+                q.stride(0),
+                q.stride(1),
+                q.stride(2),
+                q.stride(3),  #
+                BATCH,
+                N_HEAD,
+                N_CTX,  #
+                BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+                HEAD_DIM=ctx.HEAD_DIM,  #
+                dtype=torch_dtype_to_triton(q.dtype),
+                warp_specialize=warp_specialize,
+                maxRegAutoWS=192,
+            )
+
+        return dq, dk, dv, None, None, None, None, None, None
+
+
+attention = _attention_opt.apply
+
+
+@pytest.mark.skipif(
+    not (is_hopper() or is_blackwell()),
+    reason="Requires Hopper or Blackwell GPU",
+)
+@pytest.mark.parametrize("Z", [8])
+@pytest.mark.parametrize("H", [16])
+@pytest.mark.parametrize("N_CTX", [1024])  # , 2048])
+@pytest.mark.parametrize("HEAD_DIM", [128])
+@pytest.mark.parametrize("causal", [False])
+@pytest.mark.parametrize("mode", ["fwd"])
+@pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
+@pytest.mark.parametrize("provider", ["triton-fp16"])
+@pytest.mark.parametrize("SUBTILING", [False])  #, True])
+@pytest.mark.parametrize("VECT_MUL", [0])  # , 1, 2, 3])
+@pytest.mark.parametrize("FADD2_REDUCE", [False])
+@pytest.mark.parametrize("bwd_config_idx", range(len(configs_bwd_persist)))
+def test_op(
+    Z,
+    H,
+    N_CTX,
+    HEAD_DIM,
+    causal,
+    mode,
+    baseVariant,
+    provider,
+    SUBTILING,
+    VECT_MUL,
+    FADD2_REDUCE,
+    bwd_config_idx,
+    dtype=torch.float16,
+):
+    # For fwd mode, only run once (bwd_config_idx=0) to avoid redundant tests
+    if mode == "fwd" and bwd_config_idx > 0:
+        pytest.skip("bwd_config_idx only applies to bwd mode")
+    if mode == "bwd" and "fp8" in provider:
+        pytest.skip("Backward pass with FP8 is not supported.")
+    if mode == "bwd" and HEAD_DIM == 64 and bwd_config_idx == 1:
+        pytest.skip("bwd_config_idx of 1 does not work with hDim 64")
+    if mode == "bwd" and baseVariant == "ws_persistent":
+        _attn_bwd_persist.configs = [configs_bwd_persist[bwd_config_idx]]
+        _attn_bwd_persist.cache = {}
+    if mode == "bwd" and baseVariant == "ws":
+        _attn_bwd.configs = [configs_bwd_persist[bwd_config_idx]]
+        _attn_bwd.cache = {}
+    torch.manual_seed(20)
+    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    sm_scale = 0.5
+    # reference implementation
+    ref_dtype = dtype
+    if mode == "fwd" and "fp8" in provider:
+        ref_dtype = torch.float32
+    q = q.to(ref_dtype)
+    k = k.to(ref_dtype)
+    v = v.to(ref_dtype)
+    M = torch.tril(torch.ones((N_CTX, N_CTX), device=DEVICE))
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    if causal:
+        p[:, :, M == 0] = float("-inf")
+    p = torch.softmax(p.float(), dim=-1)
+    p = p.to(ref_dtype)
+    # p = torch.exp(p)
+    ref_out = torch.matmul(p, v).half()
+    if mode == "bwd":
+        dout = torch.randn_like(q)
+        ref_out.backward(dout)
+        ref_dv, v.grad = v.grad.clone(), None
+        ref_dk, k.grad = k.grad.clone(), None
+        ref_dq, q.grad = q.grad.clone(), None
+    # triton implementation
+    if mode == "fwd" and "fp8" in provider:
+        q = q.to(torch.float8_e5m2)
+        k = k.to(torch.float8_e5m2)
+        v = v.permute(0, 1, 3, 2).contiguous()
+        v = v.permute(0, 1, 3, 2)
+        v = v.to(torch.float8_e5m2)
+    tri_out = attention(q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE).half()
+    if mode == "fwd":
+        atol = 3 if "fp8" in provider else 1e-2
+        torch.testing.assert_close(tri_out, ref_out, atol=atol, rtol=0)
+        return
+    tri_out.backward(dout)
+    tri_dv, v.grad = v.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dq, q.grad = q.grad.clone(), None
+    # compare
+    torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
+    rtol = 0.0
+    # Relative tolerance workaround for known hardware limitation of CDNA2 GPU.
+    # For details see https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices
+    if (torch.version.hip is not None and triton.runtime.driver.active.get_current_target().arch == "gfx90a"):
+        rtol = 1e-2
+    torch.testing.assert_close(tri_dv, ref_dv, atol=1e-2, rtol=rtol)
+    torch.testing.assert_close(tri_dk, ref_dk, atol=1e-2, rtol=rtol)
+    torch.testing.assert_close(tri_dq, ref_dq, atol=1e-2, rtol=rtol)
+
+
+try:
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func, )
+
+    HAS_FLASH = True
+except BaseException:
+    HAS_FLASH = False
+
+TORCH_HAS_FP8 = False
+BATCH, N_HEADS = 2, 4  #8
+# vary seq length for fixed head and batch=4
+configs = []
+for HEAD_DIM in [128]:  # 64, 128]:
+    for baseVariant in ["ws_persistent"]:
+        for mode in ["fwd"]:  # , "bwd"]:
+            configs.append(
+                triton.testing.Benchmark(
+                    x_names=["N_CTX"],
+                    x_vals=[2**i for i in range(11, 12)],  # 0, 15)],
+                    line_arg="provider",
+                    line_vals=["triton-fp16"] + (["flash"] if HAS_FLASH else []),
+                    line_names=["Triton [FP16]"] + (["Flash-2"] if HAS_FLASH else []),
+                    styles=[("red", "-"), ("blue", "-"), ("green", "-")],
+                    ylabel="TFLOPS",
+                    plot_name=f"fused-attention-{baseVariant}-{mode}-batch{BATCH}-head{N_HEADS}-d{HEAD_DIM}",
+                    args={
+                        "H": N_HEADS,
+                        "BATCH": BATCH,
+                        "HEAD_DIM": HEAD_DIM,
+                        "mode": mode,
+                        "baseVariant": baseVariant,
+                    },
+                ))
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, baseVariant, provider, device=DEVICE):
+    assert mode in ["fwd"]  #, "bwd"]
+    dtype = torch.float16
+    if "triton" in provider:
+        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        if mode == "fwd" and "fp8" in provider:
+            q = q.to(torch.float8_e5m2)
+            k = k.to(torch.float8_e5m2)
+            v = v.permute(0, 1, 3, 2).contiguous()
+            v = v.permute(0, 1, 3, 2)
+            v = v.to(torch.float8_e5m2)
+        sm_scale = 1.3
+        SUBTILING = False
+        VECT_MUL = 0
+        FADD2_REDUCE = False
+        fn = lambda: attention(q, k, v, False, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE)
+        if mode == "bwd":
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn)
+
+    if provider == "flash":
+        qkv = torch.randn(
+            (BATCH, N_CTX, 3, H, HEAD_DIM),
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
+        fn = lambda: flash_attn_func(qkv)
+        if mode == "bwd":
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn)
+    flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * HEAD_DIM
+    total_flops = 2 * flops_per_matmul
+    if mode == "bwd":
+        total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
+    return total_flops * 1e-12 / (ms * 1e-3)
+
+
+if __name__ == "__main__":
+    if is_hopper() or is_blackwell():
+        print("Running benchmarks...")
+        bench_flash_attention.run(print_data=True)
+    else:
+        print("Skipping benchmarks, no Hopper or Blackwell GPU found.")

--- a/python/tutorials/test_hopper_fwd_autows_vs_tlx.py
+++ b/python/tutorials/test_hopper_fwd_autows_vs_tlx.py
@@ -1,0 +1,174 @@
+"""
+Test: Compare Hopper autoWS FA forward against all 4 TLX reference kernels.
+
+Runs:
+  1. Accuracy comparison (autoWS vs TLX hopper_fa_ws vs PyTorch)
+  2. Performance benchmark (autoWS SWP on/off vs all 4 TLX variants)
+
+Usage:
+  TRITON_USE_META_PARTITION=1 TRITON_USE_META_WS=1 python test_hopper_fwd_autows_vs_tlx.py
+  TRITON_USE_META_PARTITION=1 TRITON_USE_META_WS=1 python test_hopper_fwd_autows_vs_tlx.py --bench
+"""
+
+import os
+import sys
+import torch
+import triton
+import importlib.util
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+def is_hopper():
+    return torch.cuda.get_device_capability()[0] == 9
+
+
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+_tlx_dir = os.path.join(_this_dir, "..", "..", "third_party", "tlx", "tutorials")
+
+
+def _import(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# TLX kernels
+tlx_ws = _import("hopper_fa_ws", os.path.join(_tlx_dir, "hopper_fa_ws.py"))
+tlx_pipe = _import("hopper_fa_ws_pipelined", os.path.join(_tlx_dir, "hopper_fa_ws_pipelined.py"))
+tlx_pp = _import("hopper_fa_ws_pipelined_pingpong", os.path.join(_tlx_dir, "hopper_fa_ws_pipelined_pingpong.py"))
+tlx_pp_persist = _import(
+    "hopper_fa_ws_pipelined_pingpong_persistent",
+    os.path.join(_tlx_dir, "hopper_fa_ws_pipelined_pingpong_persistent.py"),
+)
+
+
+def load_autows(swp=True):
+    os.environ["TRITON_HOPPER_SWP"] = "1" if swp else "0"
+    os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+    return _import(f"autows_swp{int(swp)}", os.path.join(_this_dir, "fused-attention-ws-device-tma-hopper.py"))
+
+
+def pytorch_ref(q, k, v, sm_scale):
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    p = torch.softmax(p.float(), dim=-1).to(q.dtype)
+    return torch.matmul(p, v)
+
+
+# ── Accuracy ──────────────────────────────────────────────────────────────
+
+
+def test_accuracy(Z, H, N_CTX, D, dtype=torch.float16, atol=2e-2):
+    torch.manual_seed(20)
+    sm = 0.5
+    q = torch.randn((Z, H, N_CTX, D), dtype=dtype, device=DEVICE)
+    k = torch.randn((Z, H, N_CTX, D), dtype=dtype, device=DEVICE)
+    v = torch.randn((Z, H, N_CTX, D), dtype=dtype, device=DEVICE)
+
+    ref = pytorch_ref(q, k, v, sm)
+    tlx_out = tlx_ws.attention(q, k, v, sm).to(dtype)
+    autows = load_autows(swp=True)
+    aws_out = autows.attention(q, k, v, False, sm, "ws_persistent", False, 0, False).to(dtype)
+
+    td = (tlx_out - ref).abs().max().item()
+    ad = (aws_out - ref).abs().max().item()
+    at = (aws_out - tlx_out).abs().max().item()
+
+    print(f"  Z={Z} H={H} N={N_CTX} D={D}")
+    print(f"  TLX-PyTorch={td:.6f}  AutoWS-PyTorch={ad:.6f}  AutoWS-TLX={at:.6f}")
+
+    nan = torch.isnan(aws_out).sum().item()
+    if nan:
+        print(f"  FAILED: {nan} NaN")
+        return False
+    try:
+        torch.testing.assert_close(aws_out, ref, atol=atol, rtol=0)
+        print("  PASSED")
+        return True
+    except AssertionError as e:
+        print(f"  FAILED: {e}")
+        return False
+
+
+# ── Benchmark ─────────────────────────────────────────────────────────────
+
+
+def bench_one(fn, warmup=5, rep=20):
+    return triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+
+def run_benchmark():
+    print("\n" + "=" * 100)
+    print("Performance Benchmark: AutoWS (SWP on/off) vs 4 TLX variants")
+    print("=" * 100)
+
+    aws_swp = load_autows(swp=True)
+    aws_no = load_autows(swp=False)
+
+    labels = ["AutoWS+SWP", "AutoWS-SWP", "TLX-ws", "TLX-pipe", "TLX-pp", "TLX-pp-persist"]
+    header = f"{'Config':<28}" + "".join(f"{l:>14}" for l in labels)
+    print(header)
+    print("-" * (28 + 14 * len(labels)))
+
+    for BATCH, H, N_CTX in [(4, 48, 2048), (4, 48, 4096), (4, 48, 8192)]:
+        D = 128
+        dtype = torch.float16
+        q = torch.randn((BATCH, H, N_CTX, D), dtype=dtype, device=DEVICE)
+        k = torch.randn((BATCH, H, N_CTX, D), dtype=dtype, device=DEVICE)
+        v = torch.randn((BATCH, H, N_CTX, D), dtype=dtype, device=DEVICE)
+        flops = 2 * 2.0 * BATCH * H * N_CTX * N_CTX * D
+        sm = 0.5
+
+        fns = [
+            lambda: aws_swp.attention(q, k, v, False, sm, "ws_persistent", False, 0, False),
+            lambda: aws_no.attention(q, k, v, False, sm, "ws_persistent", False, 0, False),
+            lambda: tlx_ws.attention(q, k, v, sm),
+            lambda: tlx_pipe.attention(q, k, v, sm),
+            lambda: tlx_pp.attention(q, k, v, sm),
+            lambda: tlx_pp_persist.attention(q, k, v, sm),
+        ]
+
+        tflops = []
+        for fn in fns:
+            try:
+                ms = bench_one(fn)
+                tflops.append(flops * 1e-12 / (ms * 1e-3))
+            except Exception:
+                tflops.append(0.0)
+
+        config = f"B={BATCH} H={H} N={N_CTX} D={D}"
+        vals = "".join(f"{t:>11.1f} TF" for t in tflops)
+        print(f"{config:<28}{vals}")
+
+    print()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    if not is_hopper():
+        print("Skipping: requires Hopper GPU")
+        sys.exit(0)
+
+    do_bench = "--bench" in sys.argv
+
+    ok = True
+    if not do_bench:
+        print("=" * 60)
+        print("Hopper AutoWS FA Forward: Accuracy Test")
+        print("=" * 60)
+
+        for Z, H, N, D in [(1, 1, 1024, 128), (1, 1, 2048, 128), (1, 1, 4096, 128), (2, 4, 1024, 128)]:
+            print(f"\nTest: Z={Z} H={H} N_CTX={N} HEAD_DIM={D}")
+            if not test_accuracy(Z, H, N, D):
+                ok = False
+
+        print("\n" + "=" * 60)
+        print("ALL ACCURACY TESTS PASSED" if ok else "SOME ACCURACY TESTS FAILED")
+        print("=" * 60)
+
+    if do_bench:
+        run_benchmark()
+
+    sys.exit(0 if ok else 1)

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-fa.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-fa.mlir
@@ -1,0 +1,191 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="merge-correction merge-epilogue" | FileCheck %s
+
+// Tests that Hopper FA forward (dpFactor=2, warp_group_dot, mergeCorrection +
+// mergeEpilogue) gets 3 partitions: load + computation×2.
+//
+// Key differences from Blackwell FA:
+// - Uses warp_group_dot (not MMAv5/tc_gen5_mma) → no gemm partition
+// - mergeCorrection: correction ops → computation[dpId]
+// - mergeEpilogue: epilogue ops → computation[dpId]
+// - Result: load + comp×2 = 3 partitions
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+
+// CHECK-LABEL: @hopper_fa_forward_3_partitions
+//
+// --- Partition types: load + two computation partitions ---
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types =
+// CHECK-SAME: "load"
+// CHECK-SAME: "computation"
+// CHECK-SAME: "computation"
+
+tt.func public @hopper_fa_forward_3_partitions(
+  %Q: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+  %K: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+  %V: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+  %Out: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+  %stride_qm: i32 {tt.divisibility = 16 : i32},
+  %stride_kn: i32 {tt.divisibility = 16 : i32},
+  %stride_vn: i32 {tt.divisibility = 16 : i32},
+  %stride_om: i32 {tt.divisibility = 16 : i32},
+  %Q_LEN: i32 {tt.divisibility = 16 : i32},
+  %KV_LEN: i32 {tt.divisibility = 16 : i32},
+  %SM_SCALE: f32
+) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c128_i64 = arith.constant 128 : i64
+  %cst_neg_inf = arith.constant dense<0xFF800000> : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+  %cst_one = arith.constant dense<1.000000e+00> : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+  %cst_zero_2d = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #mma>
+  %cst_scale = arith.constant dense<1.44269502> : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+  %cst_scale_2d = arith.constant dense<1.44269502> : tensor<64x128xf32, #mma>
+  %n_iters = arith.constant 8 : i32
+
+  // Q descriptor and loads for two data partitions
+  %desc_q_stride = arith.extsi %stride_qm : i32 to i64
+  %desc_q = tt.make_tensor_descriptor %Q, [%Q_LEN, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<64x128xf16, #shared>>
+  %desc_q_2 = tt.make_tensor_descriptor %Q, [%Q_LEN, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<64x128xf16, #shared>>
+  %q_0_data = tt.descriptor_load %desc_q[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<64x128xf16, #shared>> -> tensor<64x128xf16, #blocked>
+  %q_1_data = tt.descriptor_load %desc_q_2[%c64_i32, %c0_i32] : !tt.tensordesc<tensor<64x128xf16, #shared>> -> tensor<64x128xf16, #blocked>
+  %q_0 = ttg.local_alloc %q_0_data : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+  %q_1 = ttg.local_alloc %q_1_data : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+  // K/V descriptors
+  %desc_k = tt.make_tensor_descriptor %K, [%KV_LEN, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+  %desc_v = tt.make_tensor_descriptor %V, [%KV_LEN, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+
+  // Output descriptor (TMA store — epilogue)
+  %desc_o = tt.make_tensor_descriptor %Out, [%Q_LEN, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<64x128xf16, #shared>>
+  %desc_o_2 = tt.make_tensor_descriptor %Out, [%Q_LEN, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<tensor<64x128xf16, #shared>>
+
+  // Main attention loop — uses warp_group_dot (Hopper MMA, not MMAv5)
+  %loop:6 = scf.for %i = %c0_i32 to %n_iters step %c1_i32
+      iter_args(
+        %acc_0 = %cst_zero_2d, %l_i_0 = %cst_one, %m_i_0 = %cst_neg_inf,
+        %acc_1 = %cst_zero_2d, %l_i_1 = %cst_one, %m_i_1 = %cst_neg_inf
+      ) -> (
+        tensor<64x128xf32, #mma>, tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>,
+        tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>,
+        tensor<64x128xf32, #mma>, tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>,
+        tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      ) : i32 {
+
+    // Load K and V
+    %kv_offset = arith.muli %i, %c128_i32 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
+    %k_data = tt.descriptor_load %desc_k[%kv_offset, %c0_i32] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked>
+    %v_data = tt.descriptor_load %desc_v[%kv_offset, %c0_i32] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked>
+    %k_smem = ttg.local_alloc %k_data {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %k_trans = ttg.memdesc_trans %k_smem {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared1, #smem>
+    %v_smem = ttg.local_alloc %v_data {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+
+    // QK warp_group_dot for both data partitions (Hopper MMA)
+    %qk_0 = ttng.warp_group_dot %q_0, %k_trans, %cst_zero_2d {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x128xf16, #shared, #smem> * !ttg.memdesc<128x128xf16, #shared1, #smem> -> tensor<64x128xf32, #mma>
+    %qk_1 = ttng.warp_group_dot %q_1, %k_trans, %cst_zero_2d {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x128xf16, #shared, #smem> * !ttg.memdesc<128x128xf16, #shared1, #smem> -> tensor<64x128xf32, #mma>
+
+    // Online softmax
+    %m_ij_0 = "tt.reduce"(%qk_0) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %b0: f32):
+      %max0 = arith.maxnumf %a0, %b0 : f32
+      tt.reduce.return %max0 : f32
+    }) {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x128xf32, #mma>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %m_ij_1 = "tt.reduce"(%qk_1) <{axis = 1 : i32}> ({
+    ^bb0(%a1: f32, %b1: f32):
+      %max1 = arith.maxnumf %a1, %b1 : f32
+      tt.reduce.return %max1 : f32
+    }) {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x128xf32, #mma>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+
+    %m_scaled_0 = arith.mulf %m_ij_0, %cst_scale {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %m_scaled_1 = arith.mulf %m_ij_1, %cst_scale {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %new_m_0 = arith.maxnumf %m_i_0, %m_scaled_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %new_m_1 = arith.maxnumf %m_i_1, %m_scaled_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+
+    // Scale QK and compute p
+    %scores_0 = arith.mulf %qk_0, %cst_scale_2d {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+    %scores_1 = arith.mulf %qk_1, %cst_scale_2d {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+    %m_bcast_0 = tt.expand_dims %new_m_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+    %m_bcast2d_0 = tt.broadcast %m_bcast_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x1xf32, #mma> -> tensor<64x128xf32, #mma>
+    %m_bcast_1 = tt.expand_dims %new_m_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+    %m_bcast2d_1 = tt.broadcast %m_bcast_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x1xf32, #mma> -> tensor<64x128xf32, #mma>
+    %p_sub_0 = arith.subf %scores_0, %m_bcast2d_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+    %p_sub_1 = arith.subf %scores_1, %m_bcast2d_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+    %p_0 = math.exp2 %p_sub_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+    %p_1 = math.exp2 %p_sub_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+
+    // alpha = exp2(m_i - new_m)
+    %alpha_0 = arith.subf %m_i_0, %new_m_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %alpha_1 = arith.subf %m_i_1, %new_m_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %alpha_exp_0 = math.exp2 %alpha_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %alpha_exp_1 = math.exp2 %alpha_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+
+    // Rescale acc
+    %alpha_1d_0 = tt.expand_dims %alpha_exp_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+    %alpha_2d_0 = tt.broadcast %alpha_1d_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x1xf32, #mma> -> tensor<64x128xf32, #mma>
+    %alpha_1d_1 = tt.expand_dims %alpha_exp_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+    %alpha_2d_1 = tt.broadcast %alpha_1d_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x1xf32, #mma> -> tensor<64x128xf32, #mma>
+    %acc_scaled_0 = arith.mulf %acc_0, %alpha_2d_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+    %acc_scaled_1 = arith.mulf %acc_1, %alpha_2d_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma>
+
+    // p → f16 for PV dot
+    %p_f16_0 = arith.truncf %p_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %p_f16_1 = arith.truncf %p_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %p_dot_0 = ttg.convert_layout %p_f16_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    %p_dot_1 = ttg.convert_layout %p_f16_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+
+    // PV warp_group_dot
+    %pv_0 = ttng.warp_group_dot %p_dot_0, %v_smem, %acc_scaled_0 {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * !ttg.memdesc<128x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %pv_1 = ttng.warp_group_dot %p_dot_1, %v_smem, %acc_scaled_1 {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * !ttg.memdesc<128x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+
+    // l_i update
+    %l_ij_0 = "tt.reduce"(%p_0) <{axis = 1 : i32}> ({
+    ^bb0(%a2: f32, %b2: f32):
+      %s0 = arith.addf %a2, %b2 : f32
+      tt.reduce.return %s0 : f32
+    }) {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x128xf32, #mma>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %l_ij_1 = "tt.reduce"(%p_1) <{axis = 1 : i32}> ({
+    ^bb0(%a3: f32, %b3: f32):
+      %s1 = arith.addf %a3, %b3 : f32
+      tt.reduce.return %s1 : f32
+    }) {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x128xf32, #mma>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %l_scaled_0 = arith.mulf %l_i_0, %alpha_exp_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %l_scaled_1 = arith.mulf %l_i_1, %alpha_exp_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %new_l_0 = arith.addf %l_scaled_0, %l_ij_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %new_l_1 = arith.addf %l_scaled_1, %l_ij_1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+
+    scf.yield %pv_0, %new_l_0, %new_m_0, %pv_1, %new_l_1, %new_m_1
+      : tensor<64x128xf32, #mma>, tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>,
+        tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>,
+        tensor<64x128xf32, #mma>, tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>,
+        tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+  } {tt.data_partition_factor = 2 : i32, tt.warp_specialize}
+
+  // Post-loop: normalize and store with descriptor_store (epilogue)
+  %l_bcast_0 = tt.expand_dims %loop#1 {axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+  %l_bcast2d_0 = tt.broadcast %l_bcast_0 : tensor<64x1xf32, #mma> -> tensor<64x128xf32, #mma>
+  %l_bcast_1 = tt.expand_dims %loop#4 {axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+  %l_bcast2d_1 = tt.broadcast %l_bcast_1 : tensor<64x1xf32, #mma> -> tensor<64x128xf32, #mma>
+  %acc_norm_0 = arith.divf %loop#0, %l_bcast2d_0 : tensor<64x128xf32, #mma>
+  %acc_norm_1 = arith.divf %loop#3, %l_bcast2d_1 : tensor<64x128xf32, #mma>
+  %out_f16_0 = arith.truncf %acc_norm_0 : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+  %out_f16_1 = arith.truncf %acc_norm_1 : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+  %out_conv_0 = ttg.convert_layout %out_f16_0 : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked>
+  %out_conv_1 = ttg.convert_layout %out_f16_1 : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked>
+  tt.descriptor_store %desc_o[%c0_i32, %c0_i32], %out_conv_0 : !tt.tensordesc<tensor<64x128xf16, #shared>>, tensor<64x128xf16, #blocked>
+  tt.descriptor_store %desc_o_2[%c64_i32, %c0_i32], %out_conv_1 : !tt.tensordesc<tensor<64x128xf16, #shared>>, tensor<64x128xf16, #blocked>
+
+  tt.return
+}
+
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-fa.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-fa.mlir
@@ -19,12 +19,24 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 
 // CHECK-LABEL: @hopper_fa_forward_3_partitions
 //
+// --- memdesc_trans must be cloned: one copy per computation partition ---
+// CHECK: ttg.memdesc_trans {{.*}} ttg.partition = array<i32: 1>
+// CHECK: ttg.memdesc_trans {{.*}} ttg.partition = array<i32: 2>
+//
 // --- Partition types: load + two computation partitions ---
 // CHECK: tt.warp_specialize
 // CHECK-SAME: ttg.partition.types =
 // CHECK-SAME: "load"
 // CHECK-SAME: "computation"
 // CHECK-SAME: "computation"
+//
+// --- Post-loop epilogue: each data partition's ops must stay in its own
+//     computation partition (dp0 → partition 2, dp1 → partition 1).
+//     Verifies the dpId backward walk assigns the correct partition to
+//     post-loop consumers of yield values not in MMA backward slices
+//     (e.g. l_i sum accumulation).
+// CHECK: tt.expand_dims {{.*}}#1 {{.*}} ttg.partition = array<i32: 2>
+// CHECK: tt.expand_dims {{.*}}#4 {{.*}} ttg.partition = array<i32: 1>
 
 tt.func public @hopper_fa_forward_3_partitions(
   %Q: !tt.ptr<f16> {tt.divisibility = 16 : i32},

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -377,12 +377,19 @@ class CUDABackend(BaseBackend):
             passes.ttir.add_triton_licm(pm)
             passes.common.add_canonicalizer(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
+            if knobs.nvidia.use_meta_ws:
+                nvidia.passes.hopper.add_data_partitioning(pm, 1)
+                passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
+                passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             nvidia.passes.hopper.add_tma_store_lowering(pm)
+            if knobs.nvidia.use_meta_ws and knobs.nvidia.use_meta_partition:
+                nvidia.passes.hopper.add_partition_scheduling_meta(pm)
             smem_budget = _max_shared_mem_for_capability(capability)
             nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS, dump_enabled,
                                                      smem_budget, knobs.nvidia.generate_subtiled_region)
-            passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
-            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
+            if not knobs.nvidia.use_meta_ws:
+                passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
+                passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
         elif capability // 10 >= 10:
             passes.ttgpuir.add_fuse_nested_loops(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -129,53 +129,15 @@ public:
     // FIXME: skip data partitioning for Blackwell.
     bool ForBlackWell = (capability / 10) > 9;
     unsigned numWarpGroups = ForBlackWell ? 2 : 3;
-    if (!ForBlackWell) {
-      bool success = false;
-      for (; numWarpGroups >= 2; numWarpGroups--) {
-        // Partition key ops into multiple async tasks.
-        doTaskPartition(funcOp, numWarpGroups);
-        if (dumpIntermediateSteps) {
-          llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
-                          "doTaskPartition\n";
-          moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
-          llvm::dbgs() << "\n\n\n";
-        }
-        // Propagate taskId.
-        int retCode = doTaskIdPropagate(funcOp);
-        if (retCode == -1)
-          continue;
-        if (dumpIntermediateSteps) {
-          llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
-                          "doTaskIdPropagate\n";
-          moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
-          llvm::dbgs() << "\n\n\n";
-        }
 
-        // Partition ops into parallel sub ops.
-        if (doDataPartition(funcOp, numWarpGroups - 1)) {
-          if (dumpIntermediateSteps) {
-            llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
-                            "doDataPartition\n";
-            moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
-            llvm::dbgs() << "\n\n\n";
-          }
-          success = true;
-          break;
-        }
-        // Clear async_task.
-      }
-      if (!success)
-        signalPassFailure();
-    } else {
-      int retCode = doTaskIdPropagate(funcOp);
-      if (retCode == -1)
-        signalPassFailure();
-      if (dumpIntermediateSteps) {
-        llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
-                        "doTaskIdPropagate\n";
-        moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
-        llvm::dbgs() << "\n\n\n";
-      }
+    int retCode = doTaskIdPropagate(funcOp);
+    if (retCode == -1)
+      signalPassFailure();
+    if (dumpIntermediateSteps) {
+      llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
+                      "doTaskIdPropagate\n";
+      moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
+      llvm::dbgs() << "\n\n\n";
     }
 
     if (pingpongAutoWS) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -118,12 +118,11 @@ static void getAllConsumers(ChannelPost *ch,
         !isa<ttng::AsyncTMACopyGlobalToLocalOp>(user))
       consumers.push_back(user);
   }
-  // assume all consumers are in the same block, with same taskId
-  auto taskIds = getAsyncTaskIds(consumers[0]);
-  for (unsigned i = 1; i < consumers.size(); ++i) {
-    auto taskIds2 = getAsyncTaskIds(consumers[i]);
-    assert(taskIds == taskIds2);
-    if (sameBlock)
+  // With data partitioning, consumers of shared buffers (e.g., K, V) may
+  // belong to different computation partitions and have different taskIds.
+  // Only assert same-block when requested.
+  if (sameBlock) {
+    for (unsigned i = 1; i < consumers.size(); ++i)
       assert(consumers[i]->getBlock() == consumers[0]->getBlock());
   }
 }
@@ -366,7 +365,9 @@ unsigned getAccumCnts(Operation *ctrlOp,
                       const DenseSet<Operation *> &regionsWithChannels,
                       ReuseConfig *config) {
   unsigned cnt = 0;
-  LDBG("getAccumCnts: " << ctrlOp);
+  LDBG("getAccumCnts: ctrlOp=" << ctrlOp->getName().getStringRef());
+  LLVM_DEBUG(ctrlOp->getLoc().print(llvm::dbgs()));
+  LLVM_DEBUG(llvm::dbgs() << "\n");
   for (auto *op : regionsWithChannels) {
     LDBG("-- getAccumCnts: " << ctrlOp << " regionsWithChannels " << op);
     if (ctrlOp == op) {
@@ -621,9 +622,19 @@ Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
   Value accumCnt =
       parentForOp.getBody()->getArgument(tSize - parentTCnts + accumArgId);
 
-  LDBG("getAccumCount: parentForOp " << parentForOp.getOperation() << " pOp "
-                                     << pOp << " " << tSize << " "
-                                     << parentTCnts << " " << accumArgId);
+  LDBG("getAccumCount: op=" << op->getName().getStringRef());
+  LLVM_DEBUG(op->getLoc().print(llvm::dbgs()));
+  LLVM_DEBUG(llvm::dbgs() << "\n");
+  LDBG("  parentForOp=");
+  LLVM_DEBUG(parentForOp->getLoc().print(llvm::dbgs()));
+  LLVM_DEBUG(llvm::dbgs() << "\n");
+  LDBG("  pOp=" << pOp->getName().getStringRef());
+  LLVM_DEBUG(pOp->getLoc().print(llvm::dbgs()));
+  LLVM_DEBUG(llvm::dbgs() << "\n");
+  LDBG("  tSize=" << tSize << " parentTCnts=" << parentTCnts
+                  << " accumArgId=" << accumArgId
+                  << " argNum=" << (tSize - parentTCnts + accumArgId)
+                  << " reuseGroupIdx=" << reuseGroupIdx);
   return accumCnt;
 }
 
@@ -2708,11 +2719,17 @@ static void createChannelPost(Operation *allocOp, mlir::DominanceInfo &dom,
   auto producerTaskIds = getAsyncTaskIds(producerOp);
   assert(producerTaskIds.size() == 1);
   auto producerTaskId = producerTaskIds.front();
-  // Either a single consumer op with multiple taskIds, or multiple consumer ops
-  // with the same taskId.
-  auto consumerTaskIds = getAsyncTaskIds(consumers[0]);
-  if (consumerTaskIds.size() > 1)
-    assert(consumers.size() == 1);
+  // Collect consumer task IDs from all consumers. With data partitioning,
+  // different consumers may have different task IDs (e.g., K/V buffers
+  // consumed by multiple computation partitions).
+  SmallVector<int> consumerTaskIds;
+  DenseSet<int> seenTaskIds;
+  for (auto *consumer : consumers) {
+    for (int id : getAsyncTaskIds(consumer)) {
+      if (seenTaskIds.insert(id).second)
+        consumerTaskIds.push_back(id);
+    }
+  }
   // Remove producer task id from consumerTaskIds.
   auto iter = std::remove(consumerTaskIds.begin(), consumerTaskIds.end(),
                           producerTaskId);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -263,6 +263,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Value phase, Operation *headProducer,
                             Operation *headConsumer,
                             Operation *headConsumerSameLevel,
+                            SmallVector<int> additionalConsumerTaskIds = {},
                             bool isPost = false);
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
 Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -567,6 +567,28 @@ private:
       // Assign dpId to post-loop ops: follow loop results forward.
       // Each loop result traces back to a specific MMA group's yield.
       auto yieldOp = innermostLoop.getBody()->getTerminator();
+      // Helper: find dpId for an in-loop op by walking backward through its
+      // operand chain until we find an op in opToDpId. This handles ops like
+      // l_i0 (softmax sum accumulation) that are not in any MMA's backward
+      // slice but whose operands (e.g., alpha from the correction chain) are.
+      auto findDpIdBackward = [&](Operation *startOp) -> unsigned {
+        SmallVector<Operation *> bwWorklist;
+        DenseSet<Operation *> bwVisited;
+        bwWorklist.push_back(startOp);
+        while (!bwWorklist.empty()) {
+          Operation *op = bwWorklist.pop_back_val();
+          if (!bwVisited.insert(op).second)
+            continue;
+          auto foundIt = opToDpId.find(op);
+          if (foundIt != opToDpId.end())
+            return foundIt->second;
+          for (Value operand : op->getOperands())
+            if (auto *defOp = operand.getDefiningOp())
+              if (innermostLoop->isAncestor(defOp))
+                bwWorklist.push_back(defOp);
+        }
+        return SHARED_DPID;
+      };
       for (unsigned argIdx = 0; argIdx < innermostLoop.getNumResults();
            ++argIdx) {
         Value yieldVal = yieldOp->getOperand(argIdx);
@@ -574,8 +596,16 @@ private:
         if (!yieldDef)
           continue;
         auto it = opToDpId.find(yieldDef);
-        if (it == opToDpId.end())
-          continue;
+        // If the yield def is not directly in opToDpId (e.g., softmax sum
+        // accumulation ops that don't feed any MMA), walk backward through
+        // its operand chain to find an ancestor with a known dpId.
+        if (it == opToDpId.end()) {
+          unsigned backwardDpId = findDpIdBackward(yieldDef);
+          if (backwardDpId == SHARED_DPID)
+            continue;
+          opToDpId[yieldDef] = backwardDpId;
+          it = opToDpId.find(yieldDef);
+        }
         unsigned yieldDpId = it->second;
         if (yieldDpId == SHARED_DPID)
           continue;
@@ -999,6 +1029,18 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
     return SHARED_DPID;
   };
 
+  // Deterministic fallback: pick the partition with the smallest dpId key.
+  // DenseMap iteration order is non-deterministic, so .begin() can return
+  // different entries across builds. Use min_element on the key instead.
+  auto dpIdFallbackPartition = [&]() -> Partition * {
+    if (dpIdToPartition.empty())
+      return nullptr;
+    auto minIt = std::min_element(
+        dpIdToPartition.begin(), dpIdToPartition.end(),
+        [](const auto &a, const auto &b) { return a.first < b.first; });
+    return minIt->second;
+  };
+
   auto getEpilogueTarget = [&](Operation *op) -> Partition * {
     if (options.mergeEpilogueToComputation) {
       unsigned dpId = findDpId(op);
@@ -1007,8 +1049,8 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
         if (it != dpIdToPartition.end())
           return it->second;
       }
-      if (!dpIdToPartition.empty())
-        return dpIdToPartition.begin()->second;
+      if (auto *p = dpIdFallbackPartition())
+        return p;
     }
     if (options.mergeEpilogue) {
       if (layout.correctionPartition)
@@ -1024,8 +1066,8 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
         if (it != dpIdToPartition.end())
           return it->second;
       }
-      if (!dpIdToPartition.empty())
-        return dpIdToPartition.begin()->second;
+      if (auto *p = dpIdFallbackPartition())
+        return p;
     }
     if (layout.epiloguePartition)
       return layout.epiloguePartition;
@@ -2124,8 +2166,9 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
   // Walk everything in reverse so that operations are visited before their
   // operands.
   loop.walk<WalkOrder::PostOrder, ReverseIterator>([&](Operation *op) {
-    if (op->getNumResults() != 1 || !isPure(op) ||
-        isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
+    if (!isa<MemDescTransOp, ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(op))
+      // if (op->getNumResults() != 1 || !isPure(op) ||
+      //     isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
       return;
 
     Partition *partition = getPartition(op);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1014,8 +1014,7 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
       if (layout.correctionPartition)
         return layout.correctionPartition;
       if (layout.reductionPartition)
-        if (layout.reductionPartition)
-          return layout.reductionPartition;
+        return layout.reductionPartition;
       // When no correction/reduction partition exists (e.g., mergeCorrection +
       // mergeEpilogue on Hopper), route epilogue ops to their dpId-based
       // computation partition so each data partition's epilogue stays local.
@@ -2125,7 +2124,8 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
   // Walk everything in reverse so that operations are visited before their
   // operands.
   loop.walk<WalkOrder::PostOrder, ReverseIterator>([&](Operation *op) {
-    if (!isa<BroadcastOp, ExpandDimsOp>(op))
+    if (op->getNumResults() != 1 || !isPure(op) ||
+        isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
       return;
 
     Partition *partition = getPartition(op);
@@ -2403,9 +2403,9 @@ void PartitionSchedulingMeta::runOnOperation() {
       loop.walk<WalkOrder::PostOrder, ReverseIterator>([](Operation *op) {
         // By default, the walk is in postorder so it is safe to delete ops
         // while we walk.
-        if (isa<BroadcastOp, ExpandDimsOp>(op))
-          if (op->use_empty())
-            op->erase();
+        if (op->use_empty() && isPure(op) && op->getNumResults() == 1 &&
+            !isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
+          op->erase();
       });
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -601,6 +601,7 @@ void collectRegionsWithChannelsPost(
       }
     }
     auto *dst = channel->getDstOp();
+    auto *src = channel->getSrcOp();
     auto *pOp = dst->getParentOp();
     if (!pOp)
       continue;
@@ -608,6 +609,21 @@ void collectRegionsWithChannelsPost(
       regionsWithChannels.insert(pOp);
     if (auto ifOp = dyn_cast<scf::IfOp>(pOp))
       regionsWithChannels.insert(pOp);
+    // When producer is in a different (outer) scope than consumer,
+    // also register the producer's parent. This handles Q buffers in
+    // persistent FA kernels: Q is produced in the outer tile loop but
+    // consumed inside the inner KV loop. Without this, the outer loop
+    // only gets 1 accumCnt (for the inner loop), and Q's phase uses
+    // the inner loop's K/V counter instead of a separate Q counter.
+    if (src) {
+      auto *srcParent = src->getParentOp();
+      if (srcParent && srcParent != pOp) {
+        if (isa<scf::ForOp>(srcParent))
+          regionsWithChannels.insert(srcParent);
+        if (isa<scf::IfOp>(srcParent))
+          regionsWithChannels.insert(srcParent);
+      }
+    }
   }
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -22,6 +22,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "llvm/ADT/MapVector.h"
 #include <unordered_set>
@@ -1822,8 +1823,12 @@ DenseMap<Channel *, Value> createBuffer(const SmallVector<Channel *> &channels,
         llvm_unreachable("Unexpected srcOp type");
     } else if (auto tensorType =
                    dyn_cast<RankedTensorType>(srcValue.getType())) {
+      int cc = getNVIDIAComputeCapability(funcOp->getParentOfType<ModuleOp>());
       auto res = createLocalAlloc(
-          builder, channel, isPost ? tensorType.getShape().size() == 1 : false,
+          builder, channel,
+          isPost ? (cc >= 100 && tensorType.getShape().size() == 1 &&
+                    tensorType.getElementType().isIntOrFloat())
+                 : false,
           isPost);
       buffer = res.first;
       newProducer = res.second;
@@ -2018,10 +2023,41 @@ DenseMap<Channel *, Value> createBufferPost(
               regionsWithChannels, config, reuseGrp);
         }
       } else if (auto forOp = user->getParentOfType<scf::ForOp>()) {
-        // Goes through channels here. Make sure the channel is not partilly
-        // mutated.
-        getBufferIdxAndPhase(builder, user, numBuffers, regionsWithChannels,
-                             bufferIdx, _phase, config, reuseGrp, channel);
+        // Check if the channel's producer (local_store) is in an outer loop
+        // while the user (consumer) is in an inner loop. This happens for Q
+        // buffers in persistent FA: Q is loaded in the outer tile loop but
+        // consumed inside the inner KV loop. The buffer index/phase must
+        // use the outer loop's accumCnt, not the inner KV loop's.
+        // Detect this by checking if the producer op is NOT inside the
+        // user's immediate parent ForOp.
+        Operation *producerOp = channel->getSrcOp();
+        bool producerInOuterScope =
+            producerOp && !forOp->isAncestor(producerOp);
+        LDBG("createBufferPost user: producerInOuterScope="
+             << producerInOuterScope << " channel=" << channel->uniqID
+             << " numBuffers=" << numBuffers << " user=");
+        LLVM_DEBUG(user->getLoc().print(llvm::dbgs()));
+        LLVM_DEBUG(llvm::dbgs() << "\n");
+        if (producerOp) {
+          LDBG("  producerOp=");
+          LLVM_DEBUG(producerOp->getLoc().print(llvm::dbgs()));
+          LLVM_DEBUG(llvm::dbgs() << "\n");
+        }
+        LDBG("  forOp=");
+        LLVM_DEBUG(forOp->getLoc().print(llvm::dbgs()));
+        LLVM_DEBUG(llvm::dbgs() << "\n");
+        if (producerInOuterScope) {
+          LDBG("  -> using forOp as op for getBufferIdxAndPhase");
+          // User is in a deeper loop than the producer. Pass the inner
+          // ForOp as 'op' so getAccumCount looks up to the outer loop
+          // for the accumCnt.
+          getBufferIdxAndPhase(builder, forOp.getOperation(), numBuffers,
+                               regionsWithChannels, bufferIdx, _phase, config,
+                               reuseGrp, channel);
+        } else {
+          getBufferIdxAndPhase(builder, user, numBuffers, regionsWithChannels,
+                               bufferIdx, _phase, config, reuseGrp, channel);
+        }
       } else {
         // For operations outside loops (epilogue), compute the
         // correct bufferIdx and phase based on the parent loop's final
@@ -3506,13 +3542,33 @@ void insertAsyncComm(
       builder.setAsynTaskIdsFromArray(token.first);
       // Insert ConsumerWaitOp
       if (!commChannel.producerBarrier) {
-        auto consumerWaitPoint = getSameLevelOp(headProducer, headConsumer);
+        // For channels with multiple consumer task IDs, find the correct
+        // headConsumer for this token's task ID. Each consumer partition
+        // needs its own wait point.
+        int tokenTaskId = token.first;
+        LDBG("ConsumerWaitOp: tokenTaskId=" << tokenTaskId
+                                            << " headConsumer task=");
+        Operation *tokenHeadConsumer = headConsumer;
+        for (auto &op : headConsumer->getBlock()->getOperations()) {
+          if (consumerOps.count(&op)) {
+            auto taskIds = getAsyncTaskIds(&op);
+            if (std::find(taskIds.begin(), taskIds.end(), tokenTaskId) !=
+                taskIds.end()) {
+              tokenHeadConsumer = &op;
+              LDBG("  found tokenHeadConsumer for task " << tokenTaskId);
+              break;
+            }
+          }
+        }
+        auto consumerWaitPoint =
+            getSameLevelOp(headProducer, tokenHeadConsumer);
         builder.setInsertionPoint(consumerWaitPoint);
         // Use the actual consumer's stage/cluster instead of the prep op's.
         // consumerWaitPoint may be a memdesc_trans at stage 0, but the real
         // consumer (e.g. dQ/dK MMA) may be at stage 1.
         auto *actualCons = getUniqueActualConsumer(consumerWaitPoint);
         builder.setLoopScheduleInfoFromOp(actualCons);
+        LDBG("  inserting ConsumerWaitOp for task " << tokenTaskId);
         auto waitOp = builder.createWithAsyncTaskIds<ttnvws::ConsumerWaitOp>(
             headConsumer->getLoc(), token.second, bufferIdx, phase);
         // Propagate the actual consumer's loop schedule to the phase/bufferIdx
@@ -3574,9 +3630,19 @@ void insertAsyncComm(
     if (tmaLoads.size() > 0) {
       // Instead of headConsumer, need to lift out to the same scope.
       auto consumerWaitPoint = getSameLevelOp(tmaHeadProducer, headConsumer);
+      // Collect additional consumer task IDs beyond the primary headConsumer.
+      SmallVector<int> additionalConsumerTaskIds;
+      auto primaryTaskIds = getAsyncTaskIds(headConsumer);
+      for (const auto &token : commChannel.tokens) {
+        int taskId = token.first;
+        if (std::find(primaryTaskIds.begin(), primaryTaskIds.end(), taskId) ==
+            primaryTaskIds.end())
+          additionalConsumerTaskIds.push_back(taskId);
+      }
       optimizeTMALoads(builder, tmaLoads, buffers, *commChannel.producerBarrier,
                        bufferIdx, bufferIdx, phase, tmaHeadProducer,
-                       headConsumer, consumerWaitPoint, isPost);
+                       headConsumer, consumerWaitPoint,
+                       additionalConsumerTaskIds, isPost);
     }
   }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -328,7 +328,9 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Value bufferIdx, Value bufferIdxExtract,
                             Value phase, Operation *headProducer,
                             Operation *headConsumer,
-                            Operation *headConsumerSameLevel, bool isPost) {
+                            Operation *headConsumerSameLevel,
+                            SmallVector<int> additionalConsumerTaskIds,
+                            bool isPost) {
   auto loc = barrierAlloc.getLoc();
 
   // Compute the total size of the loads.
@@ -365,21 +367,32 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
   }
 
   // Create a wait_barrier before the first consumer.
+  // For data-partitioned channels, shared ops (consBarrier, phase, pred)
+  // need ALL consumer task IDs so they survive specializeRegion.
   builder.setInsertionPoint(headConsumerSameLevel);
-  builder.setAsyncTaskIdsFromOp(headConsumer);
+  SmallVector<int> allConsumerTaskIds;
+  for (int id : getAsyncTaskIds(headConsumer))
+    allConsumerTaskIds.push_back(id);
+  for (int id : additionalConsumerTaskIds)
+    allConsumerTaskIds.push_back(id);
+  builder.setAsynTaskIdsFromArray(allConsumerTaskIds);
   builder.setLoopScheduleInfoFromOp(headConsumerSameLevel);
   auto consBarrier =
       getBarrierForPipelineStage(builder, barrierAlloc, bufferIdxExtract);
   phase = builder.createWithAsyncTaskIds<arith::ExtUIOp>(
       loc, builder.getI32Type(), phase);
-
-  // Create a constant true predicate for the wait_barrier
-  // This ensures barriers are never skipped, preventing deadlocks
   Value waitPred =
       builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);
 
+  // Create one WaitBarrierOp per consumer task ID.
+  builder.setAsyncTaskIdsFromOp(headConsumer);
   auto wait = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
       loc, consBarrier, phase, waitPred);
+  for (int extraTaskId : additionalConsumerTaskIds) {
+    builder.setAsynTaskIdsFromArray(extraTaskId);
+    builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(loc, consBarrier, phase,
+                                                        waitPred);
+  }
 
   // Convert all the consumers to local_load
   for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {

--- a/third_party/nvidia/hopper/run_all.sh
+++ b/third_party/nvidia/hopper/run_all.sh
@@ -32,3 +32,6 @@ echo "Run autoWS tutorial kernels"
 echo "Verifying correctness of FA tutorial kernels"
 TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 pytest python/tutorials/fused-attention-ws-device-tma.py
 TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 python python/tutorials/test_tlx_bwd_from_fused_attention.py
+
+echo "run for Hopper"
+TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 pytest python/tutorials/fused-attention-ws-device-tma-hopper.py


### PR DESCRIPTION
Fixes applied
- PSM (Partition Scheduling Meta)
dpIdFallbackPartition: deterministic std::min_element replacing DenseMap::begin()
findDpIdBackward: backward walk from yield defs to find dpId for ops not in MMA backward slices
- Code Partitioning
Handle channels with multiple consumers
Correctly handle channels with outer-scope producers (such as q0/q1) so bufferIdx/phase use accumCnt for the outer loop

Preliminary Perf for fwd
```
Config                          AutoWS+SWP    AutoWS-SWP        TLX-ws      TLX-pipe        TLX-ppTLX-pp-persist
----------------------------------------------------------------------------------------------------------------
B=4 H=48 N=2048 D=128             505.1 TF      505.2 TF      467.1 TF      514.0 TF      552.3 TF      574.0 TF
B=4 H=48 N=4096 D=128             535.4 TF      521.9 TF      527.2 TF      552.2 TF      489.5 TF      470.6 TF
B=4 H=48 N=8192 D=128             517.8 TF      490.7 TF      534.3 TF      587.6 TF      568.1 TF      578.4 TF
```