### PR TITLE
[TLX] Extract util `getBackwardSliceWithWS` and test with a test pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -61,6 +61,7 @@ void registerAMDTestAlignmentPass();
 void registerTestAllocationPass();
 void registerTestMembarPass();
 void registerTestPrintNestingPass();
+void registerTestBackwardSliceWithWSPass();
 void registerTestAMDGPUMembarPass();
 void registerTestTritonAMDGPURangeAnalysis();
 void registerTestLoopPeelingPass();
@@ -83,6 +84,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
   mlir::test::registerTestPrintNestingPass();
+  mlir::test::registerTestBackwardSliceWithWSPass();
   mlir::test::registerTestLoopPeelingPass();
   mlir::test::registerTestAMDGPUMembarPass();
   mlir::test::registerTestTritonAMDGPURangeAnalysis();

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h
@@ -1,9 +1,11 @@
 #ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_UTILITY_H_
 #define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_UTILITY_H_
 
+#include "mlir/IR/Value.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/SetVector.h"
 
 namespace mlir::triton::nvidia_gpu {
 
@@ -12,6 +14,12 @@ LogicalResult verifyBarrierType(Operation *op,
 int allocateTMemWithInterval(
     DenseMap<Operation *, Interval<int>> &allocToIntervals,
     SmallVector<Operation *> &allocOrder);
+
+/// Like mlir::getBackwardSlice, but also traverses through
+/// WarpSpecializePartitionsOp block arguments by mapping them back to the
+/// corresponding WarpSpecializeOp operands.
+void getBackwardSliceWithWS(Value target,
+                            SetVector<Operation *> *backwardSlice);
 
 } // namespace mlir::triton::nvidia_gpu
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   TMALowering.cpp
   TMAStoreBufferReuse.cpp
   TMAUtilities.cpp
+  Utility.cpp
 
   DEPENDS
   TritonNvidiaGPUTransformsIncGen

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
@@ -17,6 +17,12 @@ void getBackwardSliceWithWS(Value target,
   options.omitUsesFromAbove = false;
   options.omitBlockArguments = true;
   options.inclusive = true;
+  // Exclude RegionBranchOpInterface ops from getBackwardSlice so it doesn't
+  // pull in all their operands indiscriminately. We handle them precisely
+  // in the operand loop, tracing only the specific result index.
+  options.filter = [](Operation *op) {
+    return !isa<RegionBranchOpInterface>(op);
+  };
 
   while (!worklist.empty()) {
     Value nextTarget = worklist.back();
@@ -119,21 +125,48 @@ void getBackwardSliceWithWS(Value target,
         for (auto operand : op->getOperands()) {
           if (isa<BlockArgument>(operand)) {
             worklist.insert(operand);
-          }
-        }
-        // If this op is a RegionBranchOpInterface, trace its results back
-        // through region terminators to find the values that produce them
-        // (e.g. scf.while results come from scf.condition operands).
-        // NOTE: This traces all results, not just those used in the slice,
-        // so it may over-approximate. This is safe (conservative) but could
-        // be tightened to only trace results used by ops in the slice.
-        if (auto regionBranch = dyn_cast<RegionBranchOpInterface>(op)) {
-          RegionSuccessor parentSuccessor(op, op->getResults());
-          for (unsigned i = 0, e = op->getNumResults(); i < e; ++i) {
-            SmallVector<Value> predValues;
-            regionBranch.getPredecessorValues(parentSuccessor, i, predValues);
-            for (auto val : predValues)
-              worklist.insert(val);
+          } else if (auto opResult = dyn_cast<OpResult>(operand)) {
+            if (auto regionBranch =
+                    dyn_cast<RegionBranchOpInterface>(opResult.getOwner())) {
+              // Trace through region terminators at this specific result
+              // index (e.g. scf.for result #1 → init #1 and yield #1).
+              auto *branchOp = regionBranch.getOperation();
+              RegionSuccessor parentSuccessor(branchOp, branchOp->getResults());
+              SmallVector<Value> predValues;
+              regionBranch.getPredecessorValues(
+                  parentSuccessor, opResult.getResultNumber(), predValues);
+              for (auto val : predValues)
+                worklist.insert(val);
+              // The filter excluded this op from getBackwardSlice, so add
+              // it and its control operands (e.g. lb, ub, step for scf.for)
+              // manually. Skip entry/init operands — they're already traced
+              // precisely by getPredecessorValues at the right index.
+              if (backwardSlice->insert(branchOp)) {
+                unsigned entryBegin = 0, entryEnd = 0;
+                SmallVector<RegionSuccessor> successors;
+                regionBranch.getSuccessorRegions(RegionBranchPoint::parent(),
+                                                 successors);
+                for (auto &succ : successors) {
+                  if (succ.getSuccessor()) {
+                    auto entryOps =
+                        regionBranch.getEntrySuccessorOperands(succ);
+                    if (!entryOps.empty()) {
+                      entryBegin = entryOps.getBeginOperandIndex();
+                      entryEnd = entryBegin + entryOps.size();
+                    }
+                    break;
+                  }
+                }
+                for (auto [idx, branchOperand] :
+                     llvm::enumerate(branchOp->getOperands())) {
+                  if (idx >= entryBegin && idx < entryEnd)
+                    continue;
+                  worklist.insert(branchOperand);
+                }
+              }
+            }
+            // Non-RegionBranchOpInterface results are already in ops
+            // via getBackwardSlice — no action needed.
           }
         }
       }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
@@ -1,0 +1,57 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
+
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir::triton::nvidia_gpu {
+
+void getBackwardSliceWithWS(Value target,
+                            SetVector<Operation *> *backwardSlice) {
+  SetVector<Value> worklist;
+  worklist.insert(target);
+
+  BackwardSliceOptions options;
+  options.omitUsesFromAbove = false;
+  options.omitBlockArguments = true;
+  options.inclusive = true;
+
+  while (!worklist.empty()) {
+    Value nextTarget = worklist.back();
+    worklist.pop_back();
+
+    if (auto arg = dyn_cast<BlockArgument>(nextTarget)) {
+      if (auto wsPartitionOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(
+              arg.getOwner()->getParentOp())) {
+        auto argIndex = arg.getArgNumber();
+        auto wsOp = wsPartitionOp->getParentOfType<ttg::WarpSpecializeOp>();
+        // map to WSOp's operand at the same index
+        nextTarget = wsOp.getOperand(argIndex);
+      } else {
+        // ttg::WarpSpecializeOp's default region just captures
+        // from trunk so no need to special handle the defining block args.
+        // We should omit block args for other block structures like scf.For,
+        // and the captures would still be handled automatically
+        continue;
+      }
+    }
+
+    SetVector<Operation *> ops;
+    if (failed(getBackwardSlice(nextTarget, &ops, options))) {
+      llvm_unreachable("getBackwardSlice failed");
+    }
+
+    for (auto op : ops) {
+      if (backwardSlice->insert(op)) {
+        for (auto operand : op->getOperands()) {
+          if (isa<BlockArgument>(operand)) {
+            worklist.insert(operand);
+          }
+        }
+      }
+    }
+  }
+}
+
+} // namespace mlir::triton::nvidia_gpu

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
@@ -24,8 +24,8 @@ void getBackwardSliceWithWS(Value target,
 
     if (auto arg = dyn_cast<BlockArgument>(nextTarget)) {
       auto *block = arg.getOwner();
-      if (auto wsPartitionOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(
-              block->getParentOp());
+      if (auto wsPartitionOp =
+              dyn_cast<ttg::WarpSpecializePartitionsOp>(block->getParentOp());
           wsPartitionOp && block->isEntryBlock()) {
         auto argIndex = arg.getArgNumber();
         auto wsOp = wsPartitionOp->getParentOfType<ttg::WarpSpecializeOp>();
@@ -72,13 +72,12 @@ void getBackwardSliceWithWS(Value target,
           // Some regions are only reachable from siblings, not from the
           // parent (e.g. scf.while's "after" region).
           if (!searchSuccessors([&](auto &s) {
-                regionBranch.getSuccessorRegions(
-                    RegionBranchPoint::parent(), s);
+                regionBranch.getSuccessorRegions(RegionBranchPoint::parent(),
+                                                 s);
               })) {
             for (auto &r : parentOp->getRegions()) {
-              if (searchSuccessors([&](auto &s) {
-                    regionBranch.getSuccessorRegions(r, s);
-                  }))
+              if (searchSuccessors(
+                      [&](auto &s) { regionBranch.getSuccessorRegions(r, s); }))
                 break;
             }
           }
@@ -128,8 +127,7 @@ void getBackwardSliceWithWS(Value target,
         // NOTE: This traces all results, not just those used in the slice,
         // so it may over-approximate. This is safe (conservative) but could
         // be tightened to only trace results used by ops in the slice.
-        if (auto regionBranch =
-                dyn_cast<RegionBranchOpInterface>(op)) {
+        if (auto regionBranch = dyn_cast<RegionBranchOpInterface>(op)) {
           RegionSuccessor parentSuccessor(op, op->getResults());
           for (unsigned i = 0, e = op->getNumResults(); i < e; ++i) {
             SmallVector<Value> predValues;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
@@ -28,15 +28,15 @@ void getBackwardSliceWithWS(Value target,
     Value nextTarget = worklist.back();
     worklist.pop_back();
 
+    // --- Handle block arguments ---
     if (auto arg = dyn_cast<BlockArgument>(nextTarget)) {
       auto *block = arg.getOwner();
       if (auto wsPartitionOp =
               dyn_cast<ttg::WarpSpecializePartitionsOp>(block->getParentOp());
           wsPartitionOp && block->isEntryBlock()) {
-        auto argIndex = arg.getArgNumber();
+        // WS partition entry block arg → map to WarpSpecializeOp operand.
         auto wsOp = wsPartitionOp->getParentOfType<ttg::WarpSpecializeOp>();
-        // map to WSOp's operand at the same index
-        nextTarget = wsOp.getOperand(argIndex);
+        worklist.insert(wsOp.getOperand(arg.getArgNumber()));
       } else if (block->isEntryBlock()) {
         // Entry block arg of a region-based control flow op (e.g. scf.for,
         // scf.while). Use RegionBranchOpInterface to find all values that
@@ -45,21 +45,21 @@ void getBackwardSliceWithWS(Value target,
                 dyn_cast<RegionBranchOpInterface>(block->getParentOp())) {
           // Find a RegionSuccessor for our region by querying all possible
           // branch points (parent op + each region). We must check all
-          // because some regions are only reachable from sibling regions,
-          // not from the parent (e.g. scf.while's "after" region).
-          // The RegionSuccessor's inputs may be a subset of block args
-          // (e.g. scf.for drops the induction variable), so we find the
-          // arg's index within those inputs.
+          // because some regions are only reachable from siblings, not
+          // from the parent (e.g. scf.while's "after" region).
           auto *parentOp = block->getParentOp();
           auto *region = block->getParent();
 
-          // Helper to search successors from a given branch point.
+          // Helper: search successors from a given branch point for our
+          // region, then call getPredecessorValues at the matching index.
           auto searchSuccessors = [&](auto getSuccessorsFn) -> bool {
             SmallVector<RegionSuccessor> successors;
             getSuccessorsFn(successors);
             for (auto &successor : successors) {
               if (successor.getSuccessor() != region)
                 continue;
+              // Successor inputs may be a subset of block args (e.g.
+              // scf.for drops the IV), so match by identity, not index.
               auto inputs = successor.getSuccessorInputs();
               for (auto [i, input] : llvm::enumerate(inputs)) {
                 if (input == arg) {
@@ -88,11 +88,11 @@ void getBackwardSliceWithWS(Value target,
             }
           }
         }
-        continue;
       } else {
         // Non-entry CF block arg: trace through predecessor terminators.
         auto argIdx = arg.getArgNumber();
         for (auto *pred : block->getPredecessors()) {
+          // terminator can be e.g. cf.br/cf.cond_br
           auto branchOp = dyn_cast<BranchOpInterface>(pred->getTerminator());
           if (!branchOp)
             continue;
@@ -100,10 +100,6 @@ void getBackwardSliceWithWS(Value target,
             if (branchOp->getSuccessor(i) != block)
               continue;
             auto succOperands = branchOp.getSuccessorOperands(i);
-            // SuccessorOperands splits block args into "produced" (implicit,
-            // defined by the block) and "forwarded" (explicit operands from
-            // the branch). For standard cf/scf ops produced count is always
-            // 0, but we handle the general case for correctness.
             auto produced = succOperands.getProducedOperandCount();
             if (argIdx >= produced) {
               auto forwarded = succOperands.getForwardedOperands();
@@ -111,7 +107,53 @@ void getBackwardSliceWithWS(Value target,
             }
           }
         }
-        continue;
+      }
+      continue; // end of --- Handle block arguments ---
+    }
+
+    // If nextTarget is a result of a RegionBranchOpInterface, handle it
+    // directly — the filter would exclude it from getBackwardSlice.
+    if (auto opResult = dyn_cast<OpResult>(nextTarget)) {
+      if (auto regionBranch =
+              dyn_cast<RegionBranchOpInterface>(opResult.getOwner())) {
+        auto *branchOp = regionBranch.getOperation();
+        RegionSuccessor parentSuccessor(branchOp, branchOp->getResults());
+        SmallVector<Value> predValues;
+        regionBranch.getPredecessorValues(
+            parentSuccessor, opResult.getResultNumber(), predValues);
+        for (auto val : predValues)
+          worklist.insert(val);
+        // Also add control operands (e.g. lb, ub, step for scf.for).
+        // These aren't predecessor values — they don't flow through
+        // results — but results depend on them, and no op inside the
+        // region uses them, so omitUsesFromAbove won't trace them.
+        // Skip entry/init operands; those are traced precisely above.
+        if (backwardSlice->insert(branchOp)) { // first time seeing this op
+          // Find the init operand range to skip (already traced precisely).
+          // Default empty range = skip nothing = all operands are control.
+          unsigned entryBegin = 0, entryEnd = 0;
+          SmallVector<RegionSuccessor> successors;
+          regionBranch.getSuccessorRegions( // which regions can parent enter?
+              RegionBranchPoint::parent(), successors);
+          for (auto &succ : successors) {
+            if (!succ.getSuccessor()) // skip parent-to-parent successor
+              continue;
+            // operands forwarded into this region (e.g. initArgs for scf.for)
+            auto entryOps = regionBranch.getEntrySuccessorOperands(succ);
+            if (!entryOps.empty()) {
+              entryBegin = entryOps.getBeginOperandIndex();
+              entryEnd = entryBegin + entryOps.size();
+            }
+            break; // one region successor is enough to determine the range
+          }
+          for (auto [idx, branchOperand] :
+               llvm::enumerate(branchOp->getOperands())) {
+            if (idx >= entryBegin && idx < entryEnd)
+              continue; // init arg — traced by getPredecessorValues above
+            worklist.insert(branchOperand); // control operand (lb, ub, step)
+          }
+        }
+        continue; // end of handling OpResult of RegionBranchOpInterface
       }
     }
 
@@ -123,51 +165,13 @@ void getBackwardSliceWithWS(Value target,
     for (auto op : ops) {
       if (backwardSlice->insert(op)) {
         for (auto operand : op->getOperands()) {
-          if (isa<BlockArgument>(operand)) {
+          // Block args and RegionBranchOpInterface results are not in ops
+          // (omitBlockArguments / filter). Add them to the worklist so the
+          // top-of-loop handlers trace them precisely.
+          if (isa<BlockArgument>(operand) ||
+              (isa<OpResult>(operand) &&
+               isa<RegionBranchOpInterface>(operand.getDefiningOp())))
             worklist.insert(operand);
-          } else if (auto opResult = dyn_cast<OpResult>(operand)) {
-            if (auto regionBranch =
-                    dyn_cast<RegionBranchOpInterface>(opResult.getOwner())) {
-              // Trace through region terminators at this specific result
-              // index (e.g. scf.for result #1 → init #1 and yield #1).
-              auto *branchOp = regionBranch.getOperation();
-              RegionSuccessor parentSuccessor(branchOp, branchOp->getResults());
-              SmallVector<Value> predValues;
-              regionBranch.getPredecessorValues(
-                  parentSuccessor, opResult.getResultNumber(), predValues);
-              for (auto val : predValues)
-                worklist.insert(val);
-              // The filter excluded this op from getBackwardSlice, so add
-              // it and its control operands (e.g. lb, ub, step for scf.for)
-              // manually. Skip entry/init operands — they're already traced
-              // precisely by getPredecessorValues at the right index.
-              if (backwardSlice->insert(branchOp)) {
-                unsigned entryBegin = 0, entryEnd = 0;
-                SmallVector<RegionSuccessor> successors;
-                regionBranch.getSuccessorRegions(RegionBranchPoint::parent(),
-                                                 successors);
-                for (auto &succ : successors) {
-                  if (succ.getSuccessor()) {
-                    auto entryOps =
-                        regionBranch.getEntrySuccessorOperands(succ);
-                    if (!entryOps.empty()) {
-                      entryBegin = entryOps.getBeginOperandIndex();
-                      entryEnd = entryBegin + entryOps.size();
-                    }
-                    break;
-                  }
-                }
-                for (auto [idx, branchOperand] :
-                     llvm::enumerate(branchOp->getOperands())) {
-                  if (idx >= entryBegin && idx < entryEnd)
-                    continue;
-                  worklist.insert(branchOperand);
-                }
-              }
-            }
-            // Non-RegionBranchOpInterface results are already in ops
-            // via getBackwardSlice — no action needed.
-          }
         }
       }
     }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
@@ -1,6 +1,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
 
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace ttg = mlir::triton::gpu;
@@ -22,17 +23,89 @@ void getBackwardSliceWithWS(Value target,
     worklist.pop_back();
 
     if (auto arg = dyn_cast<BlockArgument>(nextTarget)) {
+      auto *block = arg.getOwner();
       if (auto wsPartitionOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(
-              arg.getOwner()->getParentOp())) {
+              block->getParentOp());
+          wsPartitionOp && block->isEntryBlock()) {
         auto argIndex = arg.getArgNumber();
         auto wsOp = wsPartitionOp->getParentOfType<ttg::WarpSpecializeOp>();
         // map to WSOp's operand at the same index
         nextTarget = wsOp.getOperand(argIndex);
+      } else if (block->isEntryBlock()) {
+        // Entry block arg of a region-based control flow op (e.g. scf.for,
+        // scf.while). Use RegionBranchOpInterface to find all values that
+        // can flow into this block arg position.
+        if (auto regionBranch =
+                dyn_cast<RegionBranchOpInterface>(block->getParentOp())) {
+          // Find a RegionSuccessor for our region by querying all possible
+          // branch points (parent op + each region). We must check all
+          // because some regions are only reachable from sibling regions,
+          // not from the parent (e.g. scf.while's "after" region).
+          // The RegionSuccessor's inputs may be a subset of block args
+          // (e.g. scf.for drops the induction variable), so we find the
+          // arg's index within those inputs.
+          auto *parentOp = block->getParentOp();
+          auto *region = block->getParent();
+
+          // Helper to search successors from a given branch point.
+          auto searchSuccessors = [&](auto getSuccessorsFn) -> bool {
+            SmallVector<RegionSuccessor> successors;
+            getSuccessorsFn(successors);
+            for (auto &successor : successors) {
+              if (successor.getSuccessor() != region)
+                continue;
+              auto inputs = successor.getSuccessorInputs();
+              for (auto [i, input] : llvm::enumerate(inputs)) {
+                if (input == arg) {
+                  SmallVector<Value> predValues;
+                  regionBranch.getPredecessorValues(successor, i, predValues);
+                  for (auto val : predValues)
+                    worklist.insert(val);
+                  return true;
+                }
+              }
+            }
+            return false;
+          };
+
+          // Check from parent op first, then from each sibling region.
+          // Some regions are only reachable from siblings, not from the
+          // parent (e.g. scf.while's "after" region).
+          if (!searchSuccessors([&](auto &s) {
+                regionBranch.getSuccessorRegions(
+                    RegionBranchPoint::parent(), s);
+              })) {
+            for (auto &r : parentOp->getRegions()) {
+              if (searchSuccessors([&](auto &s) {
+                    regionBranch.getSuccessorRegions(r, s);
+                  }))
+                break;
+            }
+          }
+        }
+        continue;
       } else {
-        // ttg::WarpSpecializeOp's default region just captures
-        // from trunk so no need to special handle the defining block args.
-        // We should omit block args for other block structures like scf.For,
-        // and the captures would still be handled automatically
+        // Non-entry CF block arg: trace through predecessor terminators.
+        auto argIdx = arg.getArgNumber();
+        for (auto *pred : block->getPredecessors()) {
+          auto branchOp = dyn_cast<BranchOpInterface>(pred->getTerminator());
+          if (!branchOp)
+            continue;
+          for (unsigned i = 0, e = branchOp->getNumSuccessors(); i < e; ++i) {
+            if (branchOp->getSuccessor(i) != block)
+              continue;
+            auto succOperands = branchOp.getSuccessorOperands(i);
+            // SuccessorOperands splits block args into "produced" (implicit,
+            // defined by the block) and "forwarded" (explicit operands from
+            // the branch). For standard cf/scf ops produced count is always
+            // 0, but we handle the general case for correctness.
+            auto produced = succOperands.getProducedOperandCount();
+            if (argIdx >= produced) {
+              auto forwarded = succOperands.getForwardedOperands();
+              worklist.insert(forwarded[argIdx - produced]);
+            }
+          }
+        }
         continue;
       }
     }
@@ -47,6 +120,22 @@ void getBackwardSliceWithWS(Value target,
         for (auto operand : op->getOperands()) {
           if (isa<BlockArgument>(operand)) {
             worklist.insert(operand);
+          }
+        }
+        // If this op is a RegionBranchOpInterface, trace its results back
+        // through region terminators to find the values that produce them
+        // (e.g. scf.while results come from scf.condition operands).
+        // NOTE: This traces all results, not just those used in the slice,
+        // so it may over-approximate. This is safe (conservative) but could
+        // be tightened to only trace results used by ops in the slice.
+        if (auto regionBranch =
+                dyn_cast<RegionBranchOpInterface>(op)) {
+          RegionSuccessor parentSuccessor(op, op->getResults());
+          for (unsigned i = 0, e = op->getNumResults(); i < e; ++i) {
+            SmallVector<Value> predValues;
+            regionBranch.getPredecessorValues(parentSuccessor, i, predValues);
+            for (auto val : predValues)
+              worklist.insert(val);
           }
         }
       }

--- a/test/Analysis/test-backward-slice-with-ws.mlir
+++ b/test/Analysis/test-backward-slice-with-ws.mlir
@@ -1,19 +1,28 @@
-// RUN: triton-opt %s -test-print-backward-slice-with-ws 2>&1 | FileCheck %s
+// RUN: triton-opt %s -split-input-file -test-print-backward-slice-with-ws 2>&1 | FileCheck %s
 
+// Test 1: CF block args are traced through predecessors.
+// %a feeds ^bb1 via cf.br. The slice of %add should include both %a and %b.
 
-// Test that getBackwardSliceWithWS correctly traces through
-// WarpSpecializePartitionsOp entry block args but does NOT confuse
-// non-entry CF block args (like loop induction vars) with partition args.
-//
-// %other_bar is operand#0 and %cta_bars is operand#1 of warp_specialize.
-// Inside partition0, %arg1 maps to %cta_bars, and is used to index the
-// remote barrier. The backward slice of map_to_remote_buffer should
-// include %cta_bars's local_alloc but NOT %other_bar's.
-//
-// FIXME: Currently getBackwardSliceWithWS incorrectly maps non-entry CF
-// block args (^bb1's %bar_idx, which is arg#0 of a cf.br target block)
-// to wsOp.getOperand(0) = %other_bar, causing a spurious inclusion.
-// Remove XFAIL once the bug is fixed.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_no_ws_cf_block_args() {
+    %a = arith.constant 1 : i32          // a-def
+    %b = arith.constant 2 : i32          // b-def
+    cf.br ^bb1(%a : i32)
+
+  ^bb1(%x: i32):
+    %add = arith.addi %x, %b {slice_target} : i32   // add-def
+    tt.return
+  }
+}
+
+// CHECK-DAG: a-def
+// CHECK-DAG: b-def
+// CHECK-DAG: add-def
+
+// -----
+
+// Test 2: WS partition entry block args are traced through to the
+// corresponding WarpSpecializeOp operands.
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -22,8 +31,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
 
-    %cta_bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
-    %other_bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %cta_bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // cta-bars-def
+    %other_bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // other-bar-def
 
     ttg.warp_specialize(%other_bar, %cta_bars) attributes {warpGroupStartIds = array<i32: 4>}
     default {
@@ -42,8 +51,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     ^bb2:
       %idx = arith.remsi %bar_idx, %c2 : i32
-      %bar = ttg.memdesc_index %arg1[%idx] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-      %remote = ttng.map_to_remote_buffer %bar, %c0 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+      %bar = ttg.memdesc_index %arg1[%idx] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>  // bar-def
+      %remote = ttng.map_to_remote_buffer %bar, %c0 {slice_target} : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>  // remote-def
       %next = arith.addi %bar_idx, %c1 : i32
       cf.br ^bb1(%next : i32)
 
@@ -55,10 +64,248 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
 
-// The slice should include %cta_bars's alloc and the ops leading to %remote.
-// CHECK-DAG: in_slice: ttg.local_alloc %0
-// CHECK-DAG: in_slice: ttg.memdesc_index
-// CHECK-DAG: in_slice: ttng.map_to_remote_buffer
+// CHECK-DAG: cta-bars-def
+// CHECK-DAG: bar-def
+// CHECK-DAG: remote-def
+// CHECK-NOT: other-bar-def
 
-// The slice must NOT include %other_bar's alloc (%1).
-// CHECK-NOT: in_slice: ttg.local_alloc %1
+// -----
+
+// Test 3: cf.cond_br — slice includes values from both branches.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_cf_cond_br() {
+    %cond = arith.constant true     // condbr-cond
+    %a = arith.constant 1 : i32    // condbr-a
+    %b = arith.constant 2 : i32    // condbr-b
+    %c = arith.constant 3 : i32    // condbr-c
+    cf.cond_br %cond, ^bb1(%a : i32), ^bb1(%b : i32)
+
+  ^bb1(%x: i32):
+    %r = arith.addi %x, %c {slice_target} : i32  // condbr-r
+    tt.return
+  }
+}
+
+// CHECK-DAG: condbr-a
+// CHECK-DAG: condbr-b
+// CHECK-DAG: condbr-c
+// CHECK-DAG: condbr-r
+
+// -----
+
+// Test 4: scf.if — slice includes yields from both branches.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_if() {
+    %cond = arith.constant true    // if-cond
+    %a = arith.constant 1 : i32   // if-a
+    %b = arith.constant 2 : i32   // if-b
+    %r = scf.if %cond -> i32 {
+      scf.yield %a : i32
+    } else {
+      scf.yield %b : i32
+    }
+    %out = arith.addi %r, %r {slice_target} : i32  // if-out
+    tt.return
+  }
+}
+
+// CHECK-DAG: if-a
+// CHECK-DAG: if-b
+// CHECK-DAG: if-out
+
+// -----
+
+// Test 5: scf.while — slice includes inits and condition forwarded args.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_while() {
+    %init = arith.constant 0 : i32          // while-init
+    %step = arith.constant 1 : i32          // while-step
+    %limit = arith.constant 10 : i32
+    %r = scf.while (%arg = %init) : (i32) -> i32 {
+      %cmp = arith.cmpi slt, %arg, %limit : i32
+      scf.condition(%cmp) %arg : i32
+    } do {
+    ^bb0(%val: i32):
+      %next = arith.addi %val, %step : i32  // while-next
+      scf.yield %next : i32
+    }
+    %out = arith.addi %r, %r {slice_target} : i32  // while-out
+    tt.return
+  }
+}
+
+// CHECK-DAG: while-init
+// CHECK-DAG: while-step
+// CHECK-DAG: while-next
+// CHECK-DAG: while-out
+
+// -----
+
+// Test 6: scf.while with slice target inside the "after" region — the
+// after region is only reachable from the before region (via scf.condition),
+// not from the parent op.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_while_after_body() {
+    %init = arith.constant 0 : i32          // whilebody-init
+    %step = arith.constant 1 : i32          // whilebody-step
+    %limit = arith.constant 10 : i32
+    %r = scf.while (%arg = %init) : (i32) -> i32 {
+      %cmp = arith.cmpi slt, %arg, %limit : i32
+      scf.condition(%cmp) %arg : i32
+    } do {
+    ^bb0(%val: i32):
+      %next = arith.addi %val, %step {slice_target} : i32  // whilebody-next
+      scf.yield %next : i32
+    }
+    tt.return
+  }
+}
+
+// CHECK-DAG: whilebody-init
+// CHECK-DAG: whilebody-step
+// CHECK-DAG: whilebody-next
+
+// -----
+
+// Test 7: scf.for with slice target inside the loop body — slice traces
+// the iter_arg back to both the init value and the previous yield.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_for_body() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %init = arith.constant 0 : i32           // forbody-init
+    %step = arith.constant 1 : i32           // forbody-step
+    %r = scf.for %iv = %c0 to %c4 step %c1 iter_args(%acc = %init) -> i32 {
+      %next = arith.addi %acc, %step {slice_target} : i32  // forbody-next
+      scf.yield %next : i32
+    }
+    tt.return
+  }
+}
+
+// CHECK-DAG: forbody-init
+// CHECK-DAG: forbody-step
+// CHECK-DAG: forbody-next
+
+// -----
+
+// Test 8: scf.for with slice target after the loop — slice includes
+// the init value and the loop body yield.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_for() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %init = arith.constant 0 : i32           // for-init
+    %step = arith.constant 1 : i32           // for-step
+    %r = scf.for %iv = %c0 to %c4 step %c1 iter_args(%acc = %init) -> i32 {
+      %next = arith.addi %acc, %step : i32   // for-next
+      scf.yield %next : i32
+    }
+    %out = arith.addi %r, %r {slice_target} : i32  // for-out
+    tt.return
+  }
+}
+
+// CHECK-DAG: for-init
+// CHECK-DAG: for-step
+// CHECK-DAG: for-next
+// CHECK-DAG: for-out
+
+// -----
+
+// Test 9: WS partition containing scf.for — both WS entry arg and
+// scf.for iter_arg are traced through.
+
+#shared3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem3 = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_ws_scf_for() {
+    %bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared3, #smem3, mutable>  // wsfor-bars
+
+    ttg.warp_specialize(%bars) attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg0: !ttg.memdesc<2xi64, #shared3, #smem3, mutable>) num_warps(1) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      %c0_i32 = arith.constant 0 : i32       // wsfor-init
+      %r = scf.for %iv = %c0 to %c4 step %c1 iter_args(%acc = %c0_i32) -> i32 {
+        %bar = ttg.memdesc_index %arg0[%acc] : !ttg.memdesc<2xi64, #shared3, #smem3, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem3, mutable>  // wsfor-bar
+        %remote = ttng.map_to_remote_buffer %bar, %acc {slice_target} : !ttg.memdesc<1xi64, #shared3, #smem3, mutable> -> !ttg.memdesc<1xi64, #shared3, #ttng.shared_cluster_memory, mutable>  // wsfor-remote
+        %next = arith.addi %acc, %acc : i32
+        scf.yield %next : i32
+      }
+      ttg.warp_return
+    } : (!ttg.memdesc<2xi64, #shared3, #smem3, mutable>) -> ()
+
+    tt.return
+  }
+}
+
+// CHECK-DAG: wsfor-bars
+// CHECK-DAG: wsfor-init
+// CHECK-DAG: wsfor-bar
+// CHECK-DAG: wsfor-remote
+
+// -----
+
+// Test 10: scf.for with multiple iter_args — the second iter_arg's
+// index must be adjusted correctly.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_for_multi_iter() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %initA = arith.constant 0 : i32          // multi-initA
+    %initB = arith.constant 10 : i32         // multi-initB
+    %step = arith.constant 1 : i32           // multi-step
+    %rA, %rB = scf.for %iv = %c0 to %c4 step %c1
+        iter_args(%a = %initA, %b = %initB) -> (i32, i32) {
+      %nextA = arith.addi %a, %step : i32
+      %nextB = arith.addi %b, %step {slice_target} : i32  // multi-nextB
+      scf.yield %nextA, %nextB : i32, i32
+    }
+    tt.return
+  }
+}
+
+// Slice of %nextB should include %initB (second init) and %step,
+// but NOT %initA (first init).
+// CHECK-DAG: multi-initB
+// CHECK-DAG: multi-step
+// CHECK-DAG: multi-nextB
+// CHECK-NOT: multi-initA
+
+// -----
+
+// Test 11: Uses-from-above inside scf.for — a value defined outside
+// the loop is used directly inside without being a block arg.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_uses_from_above() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %init = arith.constant 0 : i32
+    %bias = arith.constant 42 : i32          // above-bias
+    %r = scf.for %iv = %c0 to %c4 step %c1 iter_args(%acc = %init) -> i32 {
+      %next = arith.addi %acc, %bias {slice_target} : i32  // above-next
+      scf.yield %next : i32
+    }
+    tt.return
+  }
+}
+
+// CHECK-DAG: above-bias
+// CHECK-DAG: above-next

--- a/test/Analysis/test-backward-slice-with-ws.mlir
+++ b/test/Analysis/test-backward-slice-with-ws.mlir
@@ -1,0 +1,64 @@
+// RUN: triton-opt %s -test-print-backward-slice-with-ws 2>&1 | FileCheck %s
+
+
+// Test that getBackwardSliceWithWS correctly traces through
+// WarpSpecializePartitionsOp entry block args but does NOT confuse
+// non-entry CF block args (like loop induction vars) with partition args.
+//
+// %other_bar is operand#0 and %cta_bars is operand#1 of warp_specialize.
+// Inside partition0, %arg1 maps to %cta_bars, and is used to index the
+// remote barrier. The backward slice of map_to_remote_buffer should
+// include %cta_bars's local_alloc but NOT %other_bar's.
+//
+// FIXME: Currently getBackwardSliceWithWS incorrectly maps non-entry CF
+// block args (^bb1's %bar_idx, which is arg#0 of a cf.br target block)
+// to wsOp.getOperand(0) = %other_bar, causing a spurious inclusion.
+// Remove XFAIL once the bug is fixed.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_ws_cf_block_arg() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+
+    %cta_bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %other_bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+
+    ttg.warp_specialize(%other_bar, %cta_bars) attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg0: !ttg.memdesc<2xi64, #shared, #smem, mutable>, %arg1: !ttg.memdesc<2xi64, #shared, #smem, mutable>) num_warps(1) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %c10 = arith.constant 10 : i32
+      cf.br ^bb1(%c0 : i32)
+
+    ^bb1(%bar_idx: i32):
+      %cmp = arith.cmpi slt, %bar_idx, %c10 : i32
+      cf.cond_br %cmp, ^bb2, ^bb3
+
+    ^bb2:
+      %idx = arith.remsi %bar_idx, %c2 : i32
+      %bar = ttg.memdesc_index %arg1[%idx] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      %remote = ttng.map_to_remote_buffer %bar, %c0 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+      %next = arith.addi %bar_idx, %c1 : i32
+      cf.br ^bb1(%next : i32)
+
+    ^bb3:
+      ttg.warp_return
+    } : (!ttg.memdesc<2xi64, #shared, #smem, mutable>, !ttg.memdesc<2xi64, #shared, #smem, mutable>) -> ()
+
+    tt.return
+  }
+}
+
+// The slice should include %cta_bars's alloc and the ops leading to %remote.
+// CHECK-DAG: in_slice: ttg.local_alloc %0
+// CHECK-DAG: in_slice: ttg.memdesc_index
+// CHECK-DAG: in_slice: ttng.map_to_remote_buffer
+
+// The slice must NOT include %other_bar's alloc (%1).
+// CHECK-NOT: in_slice: ttg.local_alloc %1

--- a/test/Analysis/test-backward-slice-with-ws.mlir
+++ b/test/Analysis/test-backward-slice-with-ws.mlir
@@ -31,8 +31,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @test_ws_cf_block_arg() attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32
-    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32         // NOT-IN-SLICE-trunk-c0
+    %c1_i32 = arith.constant 1 : i32         // NOT-IN-SLICE-trunk-c1
 
     %cta_bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // cta-bars-def
     %other_bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // NOT-IN-SLICE-other-bar-def
@@ -42,9 +42,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       ttg.warp_yield
     }
     partition0(%arg0: !ttg.memdesc<2xi64, #shared, #smem, mutable>, %arg1: !ttg.memdesc<2xi64, #shared, #smem, mutable>) num_warps(1) {
-      %c0 = arith.constant 0 : i32
+      %c0 = arith.constant 0 : i32             // ws2-c0
       %c1 = arith.constant 1 : i32
-      %c2 = arith.constant 2 : i32
+      %c2 = arith.constant 2 : i32             // ws2-c2
       %c10 = arith.constant 10 : i32
       cf.br ^bb1(%c0 : i32)
 
@@ -53,10 +53,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       cf.cond_br %cmp, ^bb2, ^bb3
 
     ^bb2:
-      %idx = arith.remsi %bar_idx, %c2 : i32
+      %idx = arith.remsi %bar_idx, %c2 : i32   // ws2-idx
       %bar = ttg.memdesc_index %arg1[%idx] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>  // bar-def
       %remote = ttng.map_to_remote_buffer %bar, %c0 {slice_target} : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>  // remote-def
-      %next = arith.addi %bar_idx, %c1 : i32
+      %next = arith.addi %bar_idx, %c1 : i32   // ws2-next
       cf.br ^bb1(%next : i32)
 
     ^bb3:
@@ -70,6 +70,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-DAG: cta-bars-def
 // CHECK-DAG: bar-def
 // CHECK-DAG: remote-def
+// CHECK-DAG: ws2-c0
+// CHECK-DAG: ws2-c2
+// CHECK-DAG: ws2-idx
+// CHECK-DAG: ws2-next
 
 // -----
 
@@ -178,9 +182,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @test_scf_for_body() {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index           // NOT-IN-SLICE-forbody-lb
+    %c1 = arith.constant 1 : index           // NOT-IN-SLICE-forbody-step-idx
+    %c4 = arith.constant 4 : index           // NOT-IN-SLICE-forbody-ub
     %init = arith.constant 0 : i32           // forbody-init
     %step = arith.constant 1 : i32           // forbody-step
     %r = scf.for %iv = %c0 to %c4 step %c1 iter_args(%acc = %init) -> i32 {
@@ -237,9 +241,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       ttg.warp_yield
     }
     partition0(%arg0: !ttg.memdesc<2xi64, #shared3, #smem3, mutable>) num_warps(1) {
-      %c0 = arith.constant 0 : index
-      %c1 = arith.constant 1 : index
-      %c4 = arith.constant 4 : index
+      %c0 = arith.constant 0 : index         // NOT-IN-SLICE-wsfor-lb
+      %c1 = arith.constant 1 : index         // NOT-IN-SLICE-wsfor-step-idx
+      %c4 = arith.constant 4 : index         // NOT-IN-SLICE-wsfor-ub
       %c0_i32 = arith.constant 0 : i32       // wsfor-init
       %r = scf.for %iv = %c0 to %c4 step %c1 iter_args(%acc = %c0_i32) -> i32 {
         %bar = ttg.memdesc_index %arg0[%acc] : !ttg.memdesc<2xi64, #shared3, #smem3, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem3, mutable>  // wsfor-bar
@@ -266,9 +270,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @test_scf_for_multi_iter() {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index           // NOT-IN-SLICE-multi-lb
+    %c1 = arith.constant 1 : index           // NOT-IN-SLICE-multi-step-idx
+    %c4 = arith.constant 4 : index           // NOT-IN-SLICE-multi-ub
     %initA = arith.constant 0 : i32          // NOT-IN-SLICE-multi-initA
     %initB = arith.constant 10 : i32         // multi-initB
     %step = arith.constant 1 : i32           // multi-step
@@ -295,9 +299,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @test_uses_from_above() {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index           // NOT-IN-SLICE-above-lb
+    %c1 = arith.constant 1 : index           // NOT-IN-SLICE-above-step-idx
+    %c4 = arith.constant 4 : index           // NOT-IN-SLICE-above-ub
     %init = arith.constant 0 : i32
     %bias = arith.constant 42 : i32          // above-bias
     %r = scf.for %iv = %c0 to %c4 step %c1 iter_args(%acc = %init) -> i32 {
@@ -339,3 +343,69 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-DAG: forres-step
 // CHECK-DAG: forres-nextB
 // CHECK-DAG: forres-out
+
+// -----
+
+// Test 13: scf.for's upper bound is an scf.if result (a RegionBranchOp
+// result used as a control operand). The scf.if result enters the worklist
+// from the control-operand path; getBackwardSlice must not filter it out.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_nested_region_branch() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cond = arith.constant true
+    %lo = arith.constant 4 : index           // nested-lo
+    %hi = arith.constant 8 : index           // nested-hi
+    %bound = scf.if %cond -> index {
+      scf.yield %lo : index
+    } else {
+      scf.yield %hi : index
+    }
+    %init = arith.constant 0 : i32           // nested-init
+    %step = arith.constant 1 : i32           // nested-step
+    %r = scf.for %iv = %c0 to %bound step %c1 iter_args(%acc = %init) -> i32 {
+      %next = arith.addi %acc, %step : i32   // nested-next
+      scf.yield %next : i32
+    }
+    %out = arith.addi %r, %r {slice_target} : i32  // nested-out
+    tt.return
+  }
+}
+
+// CHECK-DAG: nested-lo
+// CHECK-DAG: nested-hi
+// CHECK-DAG: nested-init
+// CHECK-DAG: nested-step
+// CHECK-DAG: nested-next
+// CHECK-DAG: nested-out
+
+// -----
+
+// Test 14: scf.while with multiple iter_args — slice target uses only
+// result #1. Result #0's init should not be in the slice.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_while_multi() {
+    %initA = arith.constant 0 : i32          // NOT-IN-SLICE-while-initA
+    %initB = arith.constant 10 : i32         // while-multi-initB
+    %step = arith.constant 1 : i32           // while-multi-step
+    %limit = arith.constant 100 : i32
+    %rA, %rB = scf.while (%a = %initA, %b = %initB) : (i32, i32) -> (i32, i32) {
+      %cmp = arith.cmpi slt, %a, %limit : i32
+      scf.condition(%cmp) %a, %b : i32, i32
+    } do {
+    ^bb0(%valA: i32, %valB: i32):
+      %nextA = arith.addi %valA, %step : i32
+      %nextB = arith.addi %valB, %step : i32  // while-multi-nextB
+      scf.yield %nextA, %nextB : i32, i32
+    }
+    %out = arith.addi %rB, %rB {slice_target} : i32  // while-multi-out
+    tt.return
+  }
+}
+
+// CHECK-DAG: while-multi-initB
+// CHECK-DAG: while-multi-step
+// CHECK-DAG: while-multi-nextB
+// CHECK-DAG: while-multi-out

--- a/test/Analysis/test-backward-slice-with-ws.mlir
+++ b/test/Analysis/test-backward-slice-with-ws.mlir
@@ -1,4 +1,7 @@
 // RUN: triton-opt %s -split-input-file -test-print-backward-slice-with-ws 2>&1 | FileCheck %s
+// CHECK-NOT/CHECK-DAG cannot reliably exclude patterns that appear between
+// out-of-order DAG matches. Use grep to assert NOT-IN-SLICE tags never appear.
+// RUN: triton-opt %s -split-input-file -test-print-backward-slice-with-ws 2>&1 | not grep "NOT-IN-SLICE"
 
 // Test 1: CF block args are traced through predecessors.
 // %a feeds ^bb1 via cf.br. The slice of %add should include both %a and %b.
@@ -32,7 +35,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c1_i32 = arith.constant 1 : i32
 
     %cta_bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // cta-bars-def
-    %other_bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // other-bar-def
+    %other_bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // NOT-IN-SLICE-other-bar-def
 
     ttg.warp_specialize(%other_bar, %cta_bars) attributes {warpGroupStartIds = array<i32: 4>}
     default {
@@ -67,7 +70,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-DAG: cta-bars-def
 // CHECK-DAG: bar-def
 // CHECK-DAG: remote-def
-// CHECK-NOT: other-bar-def
 
 // -----
 
@@ -267,7 +269,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index
-    %initA = arith.constant 0 : i32          // multi-initA
+    %initA = arith.constant 0 : i32          // NOT-IN-SLICE-multi-initA
     %initB = arith.constant 10 : i32         // multi-initB
     %step = arith.constant 1 : i32           // multi-step
     %rA, %rB = scf.for %iv = %c0 to %c4 step %c1
@@ -285,7 +287,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-DAG: multi-initB
 // CHECK-DAG: multi-step
 // CHECK-DAG: multi-nextB
-// CHECK-NOT: multi-initA
 
 // -----
 
@@ -309,3 +310,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // CHECK-DAG: above-bias
 // CHECK-DAG: above-next
+
+// -----
+
+// Test 12: scf.for with multiple results — slice target uses only
+// result #1, so result #0's init and yield should NOT be in the slice.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_for_multi_result() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %initA = arith.constant 0 : i32          // NOT-IN-SLICE-forres-initA
+    %initB = arith.constant 10 : i32         // forres-initB
+    %step = arith.constant 1 : i32           // forres-step
+    %rA, %rB = scf.for %iv = %c0 to %c4 step %c1
+        iter_args(%a = %initA, %b = %initB) -> (i32, i32) {
+      %nextA = arith.addi %a, %step : i32    // NOT-IN-SLICE-forres-nextA
+      %nextB = arith.addi %b, %step : i32   // forres-nextB
+      scf.yield %nextA, %nextB : i32, i32
+    }
+    %out = arith.addi %rB, %rB {slice_target} : i32  // forres-out
+    tt.return
+  }
+}
+
+// CHECK-DAG: forres-initB
+// CHECK-DAG: forres-step
+// CHECK-DAG: forres-nextB
+// CHECK-DAG: forres-out

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -2,10 +2,12 @@ add_mlir_library(TritonTestAnalysis
   TestAlias.cpp
   TestAxisInfo.cpp
   TestAllocation.cpp
+  TestBackwardSliceWithWS.cpp
   TestMembar.cpp
   TestPrintNesting.cpp
 
   LINK_LIBS PUBLIC
   MLIRPass
   TritonAnalysis
+  TritonNvidiaGPUTransforms
 )

--- a/test/lib/Analysis/TestBackwardSliceWithWS.cpp
+++ b/test/lib/Analysis/TestBackwardSliceWithWS.cpp
@@ -1,6 +1,4 @@
-#include "mlir/IR/AsmState.h"
 #include "mlir/Pass/Pass.h"
-#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
 
 using namespace mlir;
@@ -16,27 +14,23 @@ struct TestBackwardSliceWithWSPass
     return "test-print-backward-slice-with-ws";
   }
   StringRef getDescription() const final {
-    return "print the backward slice (WS-aware) for each "
-           "map_to_remote_buffer result";
+    return "print the backward slice (WS-aware) for ops marked with "
+           "a 'slice_target' attribute";
   }
 
   void runOnOperation() override {
     ModuleOp mod = getOperation();
-    AsmState state(mod);
 
-    mod.walk([&](triton::nvidia_gpu::MapToRemoteBufferOp mapaOp) {
-      SetVector<Operation *> slice;
-      triton::nvidia_gpu::getBackwardSliceWithWS(mapaOp.getResult(), &slice);
+    mod.walk([&](Operation *op) {
+      if (!op->hasAttr("slice_target"))
+        return;
 
-      for (auto *op : slice) {
-        std::string resultStr;
-        llvm::raw_string_ostream os(resultStr);
-        for (auto result : op->getResults()) {
-          os << " ";
-          result.printAsOperand(os, state);
-        }
-        mlir::emitRemark(op->getLoc())
-            << "in_slice: " << op->getName() << resultStr;
+      for (auto result : op->getResults()) {
+        SetVector<Operation *> slice;
+        triton::nvidia_gpu::getBackwardSliceWithWS(result, &slice);
+
+        for (auto *sliceOp : slice)
+          mlir::emitRemark(sliceOp->getLoc()) << "in_slice";
       }
     });
   }

--- a/test/lib/Analysis/TestBackwardSliceWithWS.cpp
+++ b/test/lib/Analysis/TestBackwardSliceWithWS.cpp
@@ -1,0 +1,53 @@
+#include "mlir/IR/AsmState.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
+
+using namespace mlir;
+
+namespace {
+
+struct TestBackwardSliceWithWSPass
+    : public PassWrapper<TestBackwardSliceWithWSPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestBackwardSliceWithWSPass);
+
+  StringRef getArgument() const final {
+    return "test-print-backward-slice-with-ws";
+  }
+  StringRef getDescription() const final {
+    return "print the backward slice (WS-aware) for each "
+           "map_to_remote_buffer result";
+  }
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    AsmState state(mod);
+
+    mod.walk([&](triton::nvidia_gpu::MapToRemoteBufferOp mapaOp) {
+      SetVector<Operation *> slice;
+      triton::nvidia_gpu::getBackwardSliceWithWS(mapaOp.getResult(), &slice);
+
+      for (auto *op : slice) {
+        std::string resultStr;
+        llvm::raw_string_ostream os(resultStr);
+        for (auto result : op->getResults()) {
+          os << " ";
+          result.printAsOperand(os, state);
+        }
+        mlir::emitRemark(op->getLoc())
+            << "in_slice: " << op->getName() << resultStr;
+      }
+    });
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestBackwardSliceWithWSPass() {
+  PassRegistration<TestBackwardSliceWithWSPass>();
+}
+} // namespace test
+} // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -24,6 +24,7 @@
 #include "tlx/dialect/include/IR/Dialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
 
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
@@ -233,53 +234,6 @@ private:
         static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared));
   }
 
-  void getBackwardSliceWithWS(Value target,
-                              SetVector<Operation *> *backwardSlice) {
-    SetVector<Value> worklist;
-    worklist.insert(target);
-
-    BackwardSliceOptions options;
-    options.omitUsesFromAbove = false;
-    options.omitBlockArguments = true;
-    options.inclusive = true;
-
-    while (!worklist.empty()) {
-      Value nextTarget = worklist.back();
-      worklist.pop_back();
-
-      if (auto arg = dyn_cast<BlockArgument>(nextTarget)) {
-        if (auto wsPartitionOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(
-                arg.getOwner()->getParentOp())) {
-          auto argIndex = arg.getArgNumber();
-          auto wsOp = wsPartitionOp->getParentOfType<ttg::WarpSpecializeOp>();
-          // map to WSOp's operand at the same index
-          nextTarget = wsOp.getOperand(argIndex);
-        } else {
-          // ttg::WarpSpecializeOp's default region just captures
-          // from trunk so no need to special handle the defining block args.
-          // We should omit block args for other block structures like scf.For,
-          // and the captures would still be handled automatically
-          continue;
-        }
-      }
-
-      SetVector<Operation *> ops;
-      if (failed(getBackwardSlice(nextTarget, &ops, options))) {
-        llvm_unreachable("getBackwardSlice failed");
-      }
-
-      for (auto op : ops) {
-        if (backwardSlice->insert(op)) {
-          for (auto operand : op->getOperands()) {
-            if (isa<BlockArgument>(operand)) {
-              worklist.insert(operand);
-            }
-          }
-        }
-      }
-    }
-  }
-
   LogicalResult
   ensureEarlyRemoteBarInit(ModuleOp &mod,
                            SetVector<Operation *> &remoteBarInitOps) {
@@ -436,7 +390,7 @@ private:
     SetVector<Operation *> remoteBarInitOps;
     mod.walk([&](ttng::InitBarrierOp barInitOp) {
       SetVector<Operation *> ops;
-      getBackwardSliceWithWS(barInitOp.getAlloc(), &ops);
+      ttng::getBackwardSliceWithWS(barInitOp.getAlloc(), &ops);
       if (llvm::any_of(
               ops, [&](Operation *op) { return barAllocOps.contains(op); })) {
         // barInitOp is for remote bar

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -366,7 +366,7 @@ private:
       if (remoteBar.has_value()) {
         hasRemoteBar = true;
         for (auto bar : remoteBar.value()) {
-          getBackwardSliceWithWS(bar, &ops);
+          ttng::getBackwardSliceWithWS(bar, &ops);
 
           for (auto opInSlice : ops) {
             if (isa<ttg::LocalAllocOp>(opInSlice)) {


### PR DESCRIPTION
To reliably find the right place to insert a cluster sync op, we need a `getBackwardSliceWithWS` util helper to go from ops like `mapa` to the corresponding mbar alloc and init ops.

The existing implementation has at least one bug where if a block arg comes from previous block instead of parent op we would incorrectly map to irrelevant arg of the enclosing WS op (see "other-bar-def" in Test 2 of `test-backward-slice-with-ws.mlir`)

In this PR we separate it out, make the helper function more robust and easy to test such that it will be reusable across the codebase. Concretely:
- Move the helper to a separate file
- Create a test pass for it
- Fix the bug above
- Add support for more generic scf and cf ops
- Add many lit tests to check for remarks emitted by the test pass

Test plan: `make test-lit`, all passing except pre-existing failures