### PR TITLE
 [Triton] Fix nvmma_shared CGALayout rank mismatch after memdesc_index (#1255) (#1255)

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -202,6 +202,21 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
   auto kOffset = S("offset");
   auto tmaShape = triton::nvidia_gpu::getTMABlockShape(shared, shapePerCTA,
                                                        /*packedSize=*/true);
+  // The memdesc shape rank may exceed the encoding's CGALayout rank (the
+  // verifier allows encoding_rank == shape_rank - 1 for the leading buffer
+  // dimension from local_alloc with num_buffers). Extend the CGALayout by
+  // prepending trivial output dimensions to preserve the original layout.
+  auto cgaLayout = shared.getCGALayout();
+  if (cgaLayout.getRank() < (unsigned)rank) {
+    int extraDims = rank - cgaLayout.getRank();
+    auto bases = cgaLayout.getLinearLayout().getBases();
+    // Insert zeros at the front of each basis vector for the new leading dims.
+    for (auto &[name, bvs] : bases)
+      for (auto &bv : bvs)
+        bv.insert(bv.begin(), extraDims, 0);
+    cgaLayout =
+        CGAEncodingAttr::get(ctx, LinearLayout(bases, standardOutDimNames(ctx, rank)));
+  }
   if (shared.getSwizzlingByteWidth() == 0) {
     auto outDimNames = standardOutDimNames(ctx, rank);
     LinearLayout layout = LinearLayout::identity1D(tmaShape[rank - 1], kOffset,
@@ -210,7 +225,7 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
       layout *= LinearLayout::identity1D(tmaShape[i], kOffset, outDimNames[i]);
     }
     layout = ensureLayoutNotSmallerThan(layout, outDimNames, shapePerCTA);
-    return combineCtaCgaWithShape(layout, shared.getCGALayout(), shape);
+    return combineCtaCgaWithShape(layout, cgaLayout, shape);
   }
   assert(rank >= 2);
 
@@ -268,7 +283,7 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
   reshapedLayout = ensureLayoutNotSmallerThan(
       reshapedLayout, standardOutDimNames(ctx, shapePerCTA.size()),
       shapePerCTA);
-  return combineCtaCgaWithShape(reshapedLayout, shared.getCGALayout(), shape);
+  return combineCtaCgaWithShape(reshapedLayout, cgaLayout, shape);
 }
 
 /// Function to generate lane and warp layout for dot operands.

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -214,8 +214,8 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
     for (auto &[name, bvs] : bases)
       for (auto &bv : bvs)
         bv.insert(bv.begin(), extraDims, 0);
-    cgaLayout =
-        CGAEncodingAttr::get(ctx, LinearLayout(bases, standardOutDimNames(ctx, rank)));
+    cgaLayout = CGAEncodingAttr::get(
+        ctx, LinearLayout(bases, standardOutDimNames(ctx, rank)));
   }
   if (shared.getSwizzlingByteWidth() == 0) {
     auto outDimNames = standardOutDimNames(ctx, rank);

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -197,6 +197,52 @@ def test_async_dot(device):
     torch.testing.assert_close(z, z_ref)
 
 
+@pytest.mark.skipif(not is_hopper(), reason="Need Hopper")
+@pytest.mark.parametrize("BLOCK", [64, 128])
+def test_async_dot_local_store(BLOCK, device):
+    """Test WGMMA dot result stored to SMEM via local_store then TMA-stored out."""
+
+    @triton.jit
+    def _kernel(desc_a, desc_b, desc_c, BLOCK: tl.constexpr):
+        a_tiles = tlx.local_alloc((BLOCK, BLOCK), tlx.dtype_of(desc_a), 1)
+        b_tiles = tlx.local_alloc((BLOCK, BLOCK), tlx.dtype_of(desc_b), 1)
+        out_tiles = tlx.local_alloc((BLOCK, BLOCK), tlx.dtype_of(desc_c), 1)
+        a_fulls = tlx.alloc_barriers(num_barriers=1, arrive_count=tl.constexpr(1))
+        b_fulls = tlx.alloc_barriers(num_barriers=1, arrive_count=tl.constexpr(1))
+
+        a_full = tlx.local_view(a_fulls, 0)
+        tlx.barrier_expect_bytes(a_full, 2 * BLOCK * BLOCK)
+        tlx.async_descriptor_load(desc_a, a_tiles, [0, 0], a_full)
+        b_full = tlx.local_view(b_fulls, 0)
+        tlx.barrier_expect_bytes(b_full, 2 * BLOCK * BLOCK)
+        tlx.async_descriptor_load(desc_b, b_tiles, [0, 0], b_full)
+
+        tlx.barrier_wait(a_full, 0)
+        tlx.barrier_wait(b_full, 0)
+        a_view = tlx.local_view(a_tiles, 0)
+        b_view = tlx.local_view(b_tiles, 0)
+        acc = tlx.async_dot(a_view, b_view)
+        acc = tlx.async_dot_wait(0, acc)
+
+        acc_fp16 = acc.to(tlx.dtype_of(desc_c))
+        out_view = tlx.local_view(out_tiles, 0)
+        tlx.local_store(out_view, acc_fp16)
+        tlx.fence_async_shared()
+        tlx.async_descriptor_store(desc_c, out_view, [0, 0])
+        tlx.async_descriptor_store_wait(0)
+
+    a = torch.randn(BLOCK, BLOCK, device=device, dtype=torch.float16)
+    b = torch.randn(BLOCK, BLOCK, device=device, dtype=torch.float16)
+    c = torch.empty(BLOCK, BLOCK, device=device, dtype=torch.float16)
+    desc_a = TensorDescriptor(a, shape=[BLOCK, BLOCK], strides=[BLOCK, 1], block_shape=[BLOCK, BLOCK])
+    desc_b = TensorDescriptor(b, shape=[BLOCK, BLOCK], strides=[BLOCK, 1], block_shape=[BLOCK, BLOCK])
+    desc_c = TensorDescriptor(c, shape=[BLOCK, BLOCK], strides=[BLOCK, 1], block_shape=[BLOCK, BLOCK])
+
+    _kernel[(1, )](desc_a, desc_b, desc_c, BLOCK=BLOCK, num_stages=0, num_warps=4)
+    z_ref = torch.matmul(a, b)
+    torch.testing.assert_close(c, z_ref)
+
+
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
 def test_async_dot_blackwell(device):
     """

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -632,3 +632,28 @@ tt.func @warpgroup_dot_wait_2_inputs(%arg0: tensor<128xf32, #blocked>, %arg1: te
 }
 
 }
+
+// -----
+
+// Test that local_store from #mma to a memdesc_index'd #nvmma_shared works
+// when the shared encoding has rank 2 but the source memdesc is 3D (from
+// local_alloc with num_buffers=1). The memdesc_index result is 2D. This
+// triggered a "Dimensions must match" crash in nvmmaSharedToLinearLayout
+// because combineCtaCgaWithShape received a rank-2 CGALayout for a rank-3
+// shape.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#smem = #ttg.shared_memory
+// CHECK-LABEL: local_store_mma_to_indexed_nvmma_shared
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @local_store_mma_to_indexed_nvmma_shared(%a: tensor<128x128xf16, #mma>) {
+    // Verify the pass doesn't crash with a dimension mismatch.
+    // CHECK-COUNT-16: nvvm.stmatrix
+    //          CHECK: llvm.return
+    %c0 = arith.constant 0 : i32
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+    %view = ttg.memdesc_index %buf[%c0] : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    ttg.local_store %a, %view : tensor<128x128xf16, #mma> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1342,6 +1342,18 @@ static LinearLayout getMsgToPackedOffsetLayout(ttg::MemDescType ty) {
                                 blockShape[dim], kMsg, outDimNames[dim]);
   }
   auto cgaLayout = getCGALayout(ty.getEncoding());
+  // The memdesc shape rank may exceed the encoding's CGALayout rank (the
+  // verifier allows encoding_rank == shape_rank - 1 for the leading buffer
+  // dimension). Extend the CGALayout by prepending trivial output dimensions.
+  if (cgaLayout.getRank() < (unsigned)rank) {
+    int extraDims = rank - cgaLayout.getRank();
+    auto bases = cgaLayout.getLinearLayout().getBases();
+    for (auto &[name, bvs] : bases)
+      for (auto &bv : bvs)
+        bv.insert(bv.begin(), extraDims, 0);
+    cgaLayout =
+        ttg::CGAEncodingAttr::get(ctx, LinearLayout(bases, outDimNames));
+  }
   for (int i = 0; i < rank; ++i) {
     auto dim = cgaLayout.getCTAOrder()[i];
     msgToOffset *= LinearLayout::identity1D(cgaLayout.getCTASplitNum()[dim],


### PR DESCRIPTION
Summary:
When local_alloc creates a 3D memdesc (e.g., 1x128x128 with num_buffers=1) using a rank-2 nvmma_shared encoding, and memdesc_index later produces a 2D view, the encoding's CGALayout retains rank 2 while the 3D memdesc shape has rank 3. This caused combineCtaCgaWithShape to crash with "Dimensions must match" and getMsgToPackedOffsetLayout to hit an out-of-bounds access on getCTAOrder().

The fix detects the rank mismatch and substitutes a default CGALayout with the correct rank, in both nvmmaSharedToLinearLayout and getMsgToPackedOffsetLayout.

Pulled By:
htyu


htyu

Reviewed By: pchen7e2

Differential Revision: D100757992


