### PR TITLE
[TLX] Relax BM=64 tile gate for unsaturated GEMM shapes

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -501,10 +501,9 @@ def preprocess_configs(configs, named_args, **kwargs):
         num_tiles_n = math.ceil(N / BLOCK_N)
         num_mn_tiles = num_tiles_m * num_tiles_n
 
-        # BM=64 tiles only help when MN is too small with larger tiles.
-        # Skip them for shapes that already have enough spatial tiles
-        # to avoid bloating the autotuner search space.
-        if BLOCK_M == 64 and math.ceil(M / 128) * math.ceil(N / 128) > 16:
+        # BM=64 tiles help unsaturated shapes by providing more spatial tiles.
+        # Skip them when the shape is already GPU-saturated with 128-tiles.
+        if BLOCK_M == 64 and math.ceil(M / 128) * math.ceil(N / 128) >= NUM_SMS:
             continue
 
         # --- Split-K gating: only allow SPLIT_K > 1 for small shapes ---


### PR DESCRIPTION
Summary:
Relax the BM=64 tile gate from `mn128 > 16` to `mn128 >= NUM_SMS`. This allows the autotuner to try BM=64 tiles for all GPU-unsaturated shapes, not just very small ones.

For shapes like (128, 4096, 8192), BM=64 provides 128 spatial tiles with SK=1, eliminating the need for split-K reduction. Previously, the gate blocked BM=64 (mn128=32 > 16), forcing the autotuner to use BM=256 with SK=8 + a separate reduction kernel.

cuBLAS uses 64×64 tiles for these shapes (confirmed via NCU: `nvjet_hsh_64x64_64x16_2x2_2cta`), achieving 128 tiles without split-K overhead.

(128, 4096, 8192): 0.79x → 0.85x cuBLAS (+7.5%)

Authored with Claude.

Reviewed By: wangyang59

Differential Revision: D100892207


