### PR TITLE
[lint] Add TRITON_ENABLE_EXTRA_ANALYSIS_PASSES knob with outer-loop pipelining check

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -390,10 +390,10 @@ def TritonGPUPipeliningAnalysis: Pass<"tritongpu-pipelining-analysis", "mlir::Mo
   let summary = "Analyze pipelining failures and emit diagnostics";
 
   let description = [{
-    The `tritongpu-pipelining-analysis` pass runs after the software pipeliner
-    and analyzes which scf.ForOp loops were not pipelined. For each unpipelined
-    loop, it emits an MLIR remark explaining the reason (e.g., num_stages <= 1,
-    distance > 1, outer loop, barrier ops, no latency assigned).
+    The `tritongpu-pipelining-analysis` pass runs before the software pipeliner
+    (after loop fusion) and diagnoses scf.ForOp loops that request pipelining
+    (num_stages > 1) but will be skipped. It emits MLIR remarks explaining the
+    reason (e.g., outer loop containing nested loops).
 
     This is a read-only analysis pass that does not modify the IR.
   }];

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -386,4 +386,23 @@ def TritonGPUCoalesceAsyncCopy: Pass<"tritongpu-coalesce-async-copy", "mlir::Mod
                            "mlir::triton::TritonDialect"];
 }
 
+def TritonGPUPipeliningAnalysis: Pass<"tritongpu-pipelining-analysis", "mlir::ModuleOp"> {
+  let summary = "Analyze pipelining failures and emit diagnostics";
+
+  let description = [{
+    The `tritongpu-pipelining-analysis` pass runs after the software pipeliner
+    and analyzes which scf.ForOp loops were not pipelined. For each unpipelined
+    loop, it emits an MLIR remark explaining the reason (e.g., num_stages <= 1,
+    distance > 1, outer loop, barrier ops, no latency assigned).
+
+    This is a read-only analysis pass that does not modify the IR.
+  }];
+
+  let options = [
+    Option<"numStages", "num-stages",
+           "int32_t", /*default*/"3",
+           "number of pipeline stages">
+  ];
+}
+
 #endif

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -59,7 +59,7 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
 
 inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
     // clang-format off
-    "TRITON_ENABLE_PIPELINING_ANALYSIS",
+    "TRITON_ENABLE_EXTRA_ANALYSIS_PASSES",
     "TRITON_REPRODUCER_PATH",
     "TRITON_ENABLE_PYTHON_STACKTRACE",
     "TRITON_TLX_DUMP_DIR",

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -59,6 +59,7 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
 
 inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
     // clang-format off
+    "TRITON_ENABLE_PIPELINING_ANALYSIS",
     "TRITON_REPRODUCER_PATH",
     "TRITON_ENABLE_PYTHON_STACKTRACE",
     "TRITON_TLX_DUMP_DIR",

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_triton_library(TritonGPUTransforms
   Pipeliner/WGMMAPipeline.cpp
   Pipeliner/PipelineExpander.cpp
   Pipeliner/TestPipelineLowerLoop.cpp
+  Pipeliner/PipeliningAnalysis.cpp
   Pipeliner/SoftwarePipeliner.cpp
   Pipeliner/TMAStoresPipeline.cpp
   Pipeliner/MMAv5PipelineUtility.cpp

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningAnalysis.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningAnalysis.cpp
@@ -1,0 +1,73 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define GEN_PASS_DEF_TRITONGPUPIPELININGANALYSIS
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+class PipeliningAnalysisPass
+    : public impl::TritonGPUPipeliningAnalysisBase<PipeliningAnalysisPass> {
+public:
+  using TritonGPUPipeliningAnalysisBase::TritonGPUPipeliningAnalysisBase;
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    moduleOp.walk([&](scf::ForOp forOp) {
+      // Skip successfully pipelined loops.
+      if (forOp->hasAttr(kScheduledMaxStageAttrName))
+        return;
+
+      // Check common failure reasons.
+      int stages = getNumStagesOrDefault(forOp, numStages);
+      if (stages <= 1) {
+        forOp.emitRemark("pipelining not applied: num_stages is ")
+            << stages << ", no pipelining requested";
+        return;
+      }
+
+      if (loopHasDistGreaterThanOne(forOp)) {
+        forOp.emitRemark(
+            "pipelining not applied: loop has distance > 1 (not supported)");
+        return;
+      }
+
+      if (isOuterLoop(forOp)) {
+        forOp.emitRemark(
+            "pipelining not applied: outer loop (contains nested loop)");
+        return;
+      }
+
+      // Check if any op in the loop body has a latency attribute, indicating
+      // the assign-latencies pass identified pipelineable ops.
+      bool hasLatencyOp = false;
+      forOp.getBody()->walk([&](Operation *op) {
+        if (op->hasAttr(kLoopStageAttrName)) {
+          hasLatencyOp = true;
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+      if (!hasLatencyOp) {
+        forOp.emitRemark(
+            "pipelining not applied: no latency assigned to any op in loop");
+        return;
+      }
+
+      // If none of the above, emit a generic remark.
+      forOp.emitRemark("pipelining not applied: unknown reason");
+    });
+
+    // This is a read-only analysis pass; do not modify the IR.
+    markAllAnalysesPreserved();
+  }
+};
+
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningAnalysis.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningAnalysis.cpp
@@ -19,48 +19,15 @@ public:
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
     moduleOp.walk([&](scf::ForOp forOp) {
-      // Skip successfully pipelined loops.
-      if (forOp->hasAttr(kScheduledMaxStageAttrName))
-        return;
-
-      // Check common failure reasons.
       int stages = getNumStagesOrDefault(forOp, numStages);
-      if (stages <= 1) {
-        forOp.emitRemark("pipelining not applied: num_stages is ")
-            << stages << ", no pipelining requested";
+      if (stages <= 1)
         return;
-      }
-
-      if (loopHasDistGreaterThanOne(forOp)) {
-        forOp.emitRemark(
-            "pipelining not applied: loop has distance > 1 (not supported)");
-        return;
-      }
 
       if (isOuterLoop(forOp)) {
         forOp.emitRemark(
             "pipelining not applied: outer loop (contains nested loop)");
         return;
       }
-
-      // Check if any op in the loop body has a latency attribute, indicating
-      // the assign-latencies pass identified pipelineable ops.
-      bool hasLatencyOp = false;
-      forOp.getBody()->walk([&](Operation *op) {
-        if (op->hasAttr(kLoopStageAttrName)) {
-          hasLatencyOp = true;
-          return WalkResult::interrupt();
-        }
-        return WalkResult::advance();
-      });
-      if (!hasLatencyOp) {
-        forOp.emitRemark(
-            "pipelining not applied: no latency assigned to any op in loop");
-        return;
-      }
-
-      // If none of the above, emit a generic remark.
-      forOp.emitRemark("pipelining not applied: unknown reason");
     });
 
     // This is a read-only analysis pass; do not modify the IR.

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -100,6 +100,8 @@ void init_triton_passes_ttgpuir(py::module &&m) {
                      createTritonGPUOptimizePartitionWarps);
   ADD_PASS_WRAPPER_0("add_partition_scheduling",
                      createTritonGPUPartitionScheduling);
+  ADD_PASS_OPTION_WRAPPER_1("add_pipelining_analysis",
+                            createTritonGPUPipeliningAnalysis, int);
 }
 
 void init_plugin_passes(py::module &&m) {

--- a/python/test/unit/test_pipelining_analysis.py
+++ b/python/test/unit/test_pipelining_analysis.py
@@ -1,0 +1,50 @@
+"""End-to-end test for the PipeliningAnalysis diagnostic pass."""
+import os
+from contextlib import contextmanager
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+from triton._internal_testing import is_cuda, is_hip
+
+
+@contextmanager
+def pipelining_analysis_context():
+    """Enable pipelining analysis diagnostics."""
+    old_diag = os.environ.get("MLIR_ENABLE_DIAGNOSTICS", "")
+    old_analysis = os.environ.get("TRITON_ENABLE_EXTRA_ANALYSIS_PASSES", "")
+    try:
+        os.environ["MLIR_ENABLE_DIAGNOSTICS"] = "remarks"
+        os.environ["TRITON_ENABLE_EXTRA_ANALYSIS_PASSES"] = "1"
+        yield
+    finally:
+        os.environ["MLIR_ENABLE_DIAGNOSTICS"] = old_diag
+        os.environ["TRITON_ENABLE_EXTRA_ANALYSIS_PASSES"] = old_analysis
+
+
+def test_outer_loop_remark(capfd, fresh_triton_cache):
+    """An outer loop containing a nested loop should emit 'outer loop' remark."""
+    if is_hip():
+        pytest.skip("CUDA specific test")
+    if not is_cuda():
+        pytest.skip("Requires CUDA GPU")
+
+    @triton.jit
+    def kernel(in_ptr, out_ptr, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        acc = tl.zeros((N, ), dtype=tl.float32)
+        for i in tl.range(0, 4, num_stages=3):
+            for j in tl.range(0, 16):
+                x = tl.load(in_ptr + offs + (i * 16 + j) * N)
+                acc += x
+        tl.store(out_ptr + offs, acc)
+
+    inp = torch.randn(64 * 64, device="cuda")
+    out = torch.empty(64, device="cuda")
+
+    with pipelining_analysis_context():
+        kernel[(1, )](inp, out, N=64)
+
+    _, err = capfd.readouterr()
+    assert "outer loop" in err, (f"Expected 'outer loop' remark, got:\n{err}")

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -516,6 +516,7 @@ class nvidia_knobs(base_knobs):
     force_trunk_swp_schedule: env_bool = env_bool("TRITON_FORCE_TRUNK_SWP_SCHEDULE")
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
+    enable_pipelining_analysis: env_bool = env_bool("TRITON_ENABLE_PIPELINING_ANALYSIS")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     enable_tileir: env_bool = env_bool("ENABLE_TILE")

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -370,6 +370,7 @@ class compilation_knobs(base_knobs):
     # We cache the value here to avoid the expensive check on every run.
     instrumentation_mode: str = env_str("TRITON_INSTRUMENTATION_MODE", "").get()
     listener: Union[CompilationListener, None] = None
+    enable_extra_analysis_passes: env_bool = env_bool("TRITON_ENABLE_EXTRA_ANALYSIS_PASSES")
 
 
 class autotuning_knobs(base_knobs):
@@ -516,7 +517,6 @@ class nvidia_knobs(base_knobs):
     force_trunk_swp_schedule: env_bool = env_bool("TRITON_FORCE_TRUNK_SWP_SCHEDULE")
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
-    enable_pipelining_analysis: env_bool = env_bool("TRITON_ENABLE_PIPELINING_ANALYSIS")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     enable_tileir: env_bool = env_bool("ENABLE_TILE")

--- a/test/TritonGPU/pipelining-analysis.mlir
+++ b/test/TritonGPU/pipelining-analysis.mlir
@@ -1,0 +1,82 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-pipelining-analysis=num-stages=3 -verify-diagnostics=only-expected -o /dev/null
+
+// Test: loop with num_stages=1 should emit "no pipelining requested" remark.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @num_stages_one(%lb : index, %ub : index, %step : index,
+                        %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
+  %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
+  // expected-remark @below {{pipelining not applied: num_stages is 1, no pipelining requested}}
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
+    %v = tt.load %p : tensor<128x32x!tt.ptr<f16>, #blocked>
+    %np = tt.addptr %p, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
+    scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
+  } {tt.num_stages = 1 : i32}
+  tt.return
+}
+}
+
+// -----
+
+// Test: successfully pipelined loop (has tt.scheduled_max_stage) should NOT emit any remark.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @already_pipelined(%lb : index, %ub : index, %step : index,
+                           %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
+  %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
+  // No remark expected here.
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
+    %v = tt.load %p : tensor<128x32x!tt.ptr<f16>, #blocked>
+    %np = tt.addptr %p, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
+    scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
+  } {tt.scheduled_max_stage = 2 : i32}
+  tt.return
+}
+}
+
+// -----
+
+// Test: outer loop (contains nested loop) should emit "outer loop" remark.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @outer_loop(%lb : index, %ub : index, %step : index,
+                    %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
+  %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
+  // expected-remark @below {{pipelining not applied: outer loop (contains nested loop)}}
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
+    %inner = scf.for %jv = %lb to %ub step %step iter_args(%ip = %p) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
+      %v = tt.load %ip : tensor<128x32x!tt.ptr<f16>, #blocked>
+      %np = tt.addptr %ip, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
+      scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
+    }
+    scf.yield %inner : tensor<128x32x!tt.ptr<f16>, #blocked>
+  }
+  tt.return
+}
+}
+
+// -----
+
+// Test: loop with no latency-assigned ops should emit "no latency assigned" remark.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @no_latency(%lb : index, %ub : index, %step : index,
+                    %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
+  %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
+  // expected-remark @below {{pipelining not applied: no latency assigned to any op in loop}}
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
+    %v = tt.load %p : tensor<128x32x!tt.ptr<f16>, #blocked>
+    %np = tt.addptr %p, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
+    scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
+  }
+  tt.return
+}
+}

--- a/test/TritonGPU/pipelining-analysis.mlir
+++ b/test/TritonGPU/pipelining-analysis.mlir
@@ -1,45 +1,5 @@
 // RUN: triton-opt %s -split-input-file -tritongpu-pipelining-analysis=num-stages=3 -verify-diagnostics=only-expected -o /dev/null
 
-// Test: loop with num_stages=1 should emit "no pipelining requested" remark.
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
-tt.func @num_stages_one(%lb : index, %ub : index, %step : index,
-                        %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
-  %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
-  // expected-remark @below {{pipelining not applied: num_stages is 1, no pipelining requested}}
-  %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
-    %v = tt.load %p : tensor<128x32x!tt.ptr<f16>, #blocked>
-    %np = tt.addptr %p, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
-    scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
-  } {tt.num_stages = 1 : i32}
-  tt.return
-}
-}
-
-// -----
-
-// Test: successfully pipelined loop (has tt.scheduled_max_stage) should NOT emit any remark.
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
-tt.func @already_pipelined(%lb : index, %ub : index, %step : index,
-                           %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
-  %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
-  // No remark expected here.
-  %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
-    %v = tt.load %p : tensor<128x32x!tt.ptr<f16>, #blocked>
-    %np = tt.addptr %p, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
-    scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
-  } {tt.scheduled_max_stage = 2 : i32}
-  tt.return
-}
-}
-
-// -----
-
 // Test: outer loop (contains nested loop) should emit "outer loop" remark.
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -56,27 +16,47 @@ tt.func @outer_loop(%lb : index, %ub : index, %step : index,
       scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
     }
     scf.yield %inner : tensor<128x32x!tt.ptr<f16>, #blocked>
-  }
+  } {tt.num_stages = 3 : i32}
   tt.return
 }
 }
 
 // -----
 
-// Test: loop with no latency-assigned ops should emit "no latency assigned" remark.
+// Test: non-outer loop with num_stages=3 should NOT emit any remark.
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
-tt.func @no_latency(%lb : index, %ub : index, %step : index,
-                    %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
+tt.func @simple_loop(%lb : index, %ub : index, %step : index,
+                     %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
   %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
-  // expected-remark @below {{pipelining not applied: no latency assigned to any op in loop}}
+  // No remark expected here.
   %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
     %v = tt.load %p : tensor<128x32x!tt.ptr<f16>, #blocked>
     %np = tt.addptr %p, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
     scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
-  }
+  } {tt.num_stages = 3 : i32}
+  tt.return
+}
+}
+
+// -----
+
+// Test: loop with num_stages=1 should NOT emit any remark (pipelining not requested).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @num_stages_one(%lb : index, %ub : index, %step : index,
+                        %ptr : tensor<128x32x!tt.ptr<f16>, #blocked>) {
+  %c = arith.constant dense<4> : tensor<128x32xi32, #blocked>
+  // No remark expected here.
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%p = %ptr) -> (tensor<128x32x!tt.ptr<f16>, #blocked>) {
+    %v = tt.load %p : tensor<128x32x!tt.ptr<f16>, #blocked>
+    %np = tt.addptr %p, %c : tensor<128x32x!tt.ptr<f16>, #blocked>, tensor<128x32xi32, #blocked>
+    scf.yield %np : tensor<128x32x!tt.ptr<f16>, #blocked>
+  } {tt.num_stages = 1 : i32}
   tt.return
 }
 }

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -378,6 +378,8 @@ class CUDABackend(BaseBackend):
             passes.ttir.add_triton_licm(pm)
             passes.common.add_canonicalizer(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
+            if knobs.compilation.enable_extra_analysis_passes:
+                passes.ttgpuir.add_pipelining_analysis(pm, opt.num_stages)
             if knobs.nvidia.use_meta_ws:
                 nvidia.passes.hopper.add_data_partitioning(pm, 1)
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
@@ -393,8 +395,6 @@ class CUDABackend(BaseBackend):
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
-            if knobs.nvidia.enable_pipelining_analysis:
-                passes.ttgpuir.add_pipelining_analysis(pm, opt.num_stages)
         elif capability // 10 >= 10:
             if not knobs.nvidia.use_modulo_schedule:
                 passes.ttgpuir.add_fuse_nested_loops(pm)
@@ -411,6 +411,10 @@ class CUDABackend(BaseBackend):
                 # TRITON_USE_MODULO_SCHEDULE=sms|exhaustive|random
                 nvidia.passes.hopper.add_modulo_schedule(pm)
             nvidia.passes.hopper.add_data_partitioning(pm, 1)
+
+            if knobs.compilation.enable_extra_analysis_passes:
+                passes.ttgpuir.add_pipelining_analysis(pm, opt.num_stages)
+
             # assign_latencies sets tt.latency on loads/MMAs (stage-distance
             # latencies). schedule_loops reads tt.latency AND tt.autows:
             # when MMA ops have tt.autows, scheduleKeyOpsAnnotation places
@@ -435,8 +439,6 @@ class CUDABackend(BaseBackend):
                 nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS,
                                                          dump_enabled, smem_budget, generate_subtiled)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
-            if knobs.nvidia.enable_pipelining_analysis:
-                passes.ttgpuir.add_pipelining_analysis(pm, opt.num_stages)
             passes.ttgpuir.add_optimize_partition_warps(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             # hoist again and allow hoisting out of if statements

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -393,6 +393,8 @@ class CUDABackend(BaseBackend):
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
+            if knobs.nvidia.enable_pipelining_analysis:
+                passes.ttgpuir.add_pipelining_analysis(pm, opt.num_stages)
         elif capability // 10 >= 10:
             if not knobs.nvidia.use_modulo_schedule:
                 passes.ttgpuir.add_fuse_nested_loops(pm)
@@ -433,6 +435,8 @@ class CUDABackend(BaseBackend):
                 nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS,
                                                          dump_enabled, smem_budget, generate_subtiled)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
+            if knobs.nvidia.enable_pipelining_analysis:
+                passes.ttgpuir.add_pipelining_analysis(pm, opt.num_stages)
             passes.ttgpuir.add_optimize_partition_warps(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             # hoist again and allow hoisting out of if statements


### PR DESCRIPTION
## Summary

Add a new opt-in knob `TRITON_ENABLE_EXTRA_ANALYSIS_PASSES` that gates extra static analysis passes in the compiler pipeline. This establishes the infrastructure for **compiler-induced lint** — a series of read-only analysis passes that emit MLIR remarks to help diagnose compiler behavior.

## What this PR does

- Adds `TRITON_ENABLE_EXTRA_ANALYSIS_PASSES` env var and `knobs.nvidia.enable_extra_analysis_passes` knob
- Adds a `PipeliningAnalysis` pass that runs after loop fusion but before the pipeliner
- As a first example, diagnoses outer loops that request pipelining (`num_stages > 1`) but will be skipped because they contain nested loops
- Includes lit tests and an end-to-end Python test

## Why a separate knob?

These analysis passes are opt-in diagnostic tools, not part of the default compilation pipeline. They emit MLIR remarks (visible when `MLIR_ENABLE_DIAGNOSTICS=remarks` is set) to help users and compiler developers understand why certain optimizations were not applied.

## Follow-up work

More analysis checks will be added under the same knob in follow-up PRs. For example, a complete and sound diagnosis on the loop pipelining, barrier analysis and more static analyses.

Mostly authored with Claude.
