### PR TITLE
 D101017879: [triton][PR] [AutoWS] Add SubtiledRegion Generation (SubtiledOperator 2/N) (#1261)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -197,6 +197,27 @@ def TritonNvidiaGPULowerSubtiledRegionPass
   ];
 }
 
+def TritonNvidiaGPUTestGenerateSubtiledRegionPass
+    : Pass<"triton-nvidia-gpu-test-generate-subtiled-region", "mlir::ModuleOp"> {
+  let summary = "Test pass: generate subtiled_region ops from split patterns";
+
+  let description = [{
+    This pass finds the GEMM epilogue subtiling pattern:
+      tmem_load -> reshape -> trans{[0,2,1]} -> split
+    followed by per-tile code (truncf, convert_layout, TMA store), and wraps
+    it in a `ttng.subtiled_region` op.
+
+    The pass runs after the memory planner and before code partition in the WS
+    pipeline. It captures the setup chain (tmem_load through split) in the
+    setup region and the per-tile code in the tile region body.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 def TritonNvidiaGPURemoveTMEMTokensPass : Pass<"triton-nvidia-gpu-remove-tmem-tokens", "mlir::ModuleOp"> {
   let summary = "remove TMEM tokens";
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1108,8 +1108,7 @@ LogicalResult SubtiledRegionOp::verify() {
                        "'ttng.subtiled_region_yield'");
 
   // 4. Teardown results must match op results
-  auto teardownOp =
-      cast<SubtiledRegionYieldOp>(teardownBlock.getTerminator());
+  auto teardownOp = cast<SubtiledRegionYieldOp>(teardownBlock.getTerminator());
   if (teardownOp.getResults().size() != getNumResults())
     return emitOpError("teardown yields ")
            << teardownOp.getResults().size() << " values but op has "

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonNvidiaGPUTransforms
   CheckMatmulTwoCTAs.cpp
   FenceInsertion.cpp
+  GenerateSubtiledRegion.cpp
   InterleaveTMem.cpp
   LowerSubtiledRegion.cpp
   MMALowering.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/GenerateSubtiledRegion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/GenerateSubtiledRegion.cpp
@@ -1,0 +1,262 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/IRMapping.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUTESTGENERATESUBTILEDREGIONPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Strip convert_layout ops wrapping a value.
+static Value stripConvertLayout(Value v) {
+  while (auto cvt = v.getDefiningOp<gpu::ConvertLayoutOp>())
+    v = cvt.getSrc();
+  return v;
+}
+
+/// Trace the setup chain backward from a SplitOp:
+///   split <- trans{[0,2,1]} <- reshape <- (convert_layout)* <- tmem_load
+/// Returns the tmem_load op, or nullptr if the pattern doesn't match.
+static TMEMLoadOp traceSetupChain(triton::SplitOp splitOp) {
+  Value src = stripConvertLayout(splitOp.getSrc());
+  auto transOp = src.getDefiningOp<triton::TransOp>();
+  if (!transOp || transOp.getOrder() != ArrayRef<int>({0, 2, 1}))
+    return nullptr;
+  auto reshapeOp = transOp.getSrc().getDefiningOp<triton::ReshapeOp>();
+  if (!reshapeOp)
+    return nullptr;
+  Value reshapeSrc = stripConvertLayout(reshapeOp.getSrc());
+  return reshapeSrc.getDefiningOp<TMEMLoadOp>();
+}
+
+/// Check if two per-tile op chains are structurally equivalent.
+/// Returns a list of (operand_from_chain0, operand_from_chain1) pairs
+/// for operands that differ between the two chains.
+/// Returns nullopt if the chains are not structurally equivalent.
+static std::optional<SmallVector<std::pair<Value, Value>>>
+checkStructuralEquivalence(ArrayRef<Operation *> chain0,
+                           ArrayRef<Operation *> chain1) {
+  if (chain0.size() != chain1.size())
+    return std::nullopt;
+
+  llvm::DenseMap<Value, Value> valueMap;
+  SmallVector<std::pair<Value, Value>> differingOperands;
+
+  for (auto [op0, op1] : llvm::zip(chain0, chain1)) {
+    if (op0->getName() != op1->getName())
+      return std::nullopt;
+    if (op0->getNumOperands() != op1->getNumOperands())
+      return std::nullopt;
+    if (op0->getNumResults() != op1->getNumResults())
+      return std::nullopt;
+    for (auto [r0, r1] : llvm::zip(op0->getResults(), op1->getResults())) {
+      if (r0.getType() != r1.getType())
+        return std::nullopt;
+    }
+    if (op0->getAttrDictionary() != op1->getAttrDictionary())
+      return std::nullopt;
+
+    for (auto [v0, v1] : llvm::zip(op0->getOperands(), op1->getOperands())) {
+      auto it = valueMap.find(v0);
+      if (it != valueMap.end()) {
+        if (it->second != v1)
+          return std::nullopt;
+        continue;
+      }
+      if (v0 == v1)
+        continue;
+      differingOperands.push_back({v0, v1});
+      valueMap[v0] = v1;
+    }
+
+    for (auto [r0, r1] : llvm::zip(op0->getResults(), op1->getResults()))
+      valueMap[r0] = r1;
+  }
+
+  return differingOperands;
+}
+
+/// Collect the per-tile op chain for a split result: all ops in the block
+/// that transitively depend on `splitResult`, plus any ops needed exclusively
+/// by those (e.g., offset computations).
+static SmallVector<Operation *>
+collectPerTileChain(Value splitResult, Operation *splitOp, Block *block) {
+  SmallVector<Operation *> chain;
+  llvm::DenseSet<Operation *> visited;
+  SmallVector<Value> worklist;
+  worklist.push_back(splitResult);
+
+  // Forward walk: find all transitive users of the split result.
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    for (Operation *user : v.getUsers()) {
+      if (user->getBlock() != block)
+        continue;
+      if (user->isBeforeInBlock(splitOp) || user == splitOp)
+        continue;
+      if (!visited.insert(user).second)
+        continue;
+      chain.push_back(user);
+      for (Value result : user->getResults())
+        worklist.push_back(result);
+    }
+  }
+
+  // Also collect ops that are needed by the chain but don't depend on the
+  // split result (e.g., offset computations like arith.addi %col, %half_n).
+  llvm::DenseSet<Operation *> chainSet(chain.begin(), chain.end());
+  for (Operation *op : chain) {
+    for (Value operand : op->getOperands()) {
+      auto defOp = operand.getDefiningOp();
+      if (!defOp || defOp->getBlock() != block)
+        continue;
+      if (defOp->isBeforeInBlock(splitOp) || defOp == splitOp)
+        continue;
+      if (!chainSet.contains(defOp) && visited.insert(defOp).second)
+        chainSet.insert(defOp);
+    }
+  }
+
+  // Rebuild as sorted list.
+  SmallVector<Operation *> fullChain;
+  for (Operation *op : chainSet)
+    fullChain.push_back(op);
+  llvm::sort(fullChain,
+             [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
+  return fullChain;
+}
+
+} // anonymous namespace
+
+void tryGenerateForSplit(triton::SplitOp splitOp) {
+  auto tmemLoad = traceSetupChain(splitOp);
+  if (!tmemLoad)
+    return;
+
+  Block *block = splitOp->getBlock();
+  Value lhs = splitOp.getOutLHS();
+  Value rhs = splitOp.getOutRHS();
+
+  SmallVector<Operation *> chain0 = collectPerTileChain(lhs, splitOp, block);
+  SmallVector<Operation *> chain1 = collectPerTileChain(rhs, splitOp, block);
+
+  if (chain0.empty() || chain1.empty())
+    return;
+
+  auto differing = checkStructuralEquivalence(chain0, chain1);
+  if (!differing)
+    return;
+
+  // --- Build the SubtiledRegionOp ---
+  OpBuilder builder(tmemLoad);
+  Location loc = splitOp.getLoc();
+
+  // Collect setup ops: everything from tmemLoad to splitOp (inclusive).
+  SmallVector<Operation *> setupOps;
+  for (auto it = Block::iterator(tmemLoad); it != Block::iterator(splitOp);
+       ++it)
+    setupOps.push_back(&*it);
+  setupOps.push_back(splitOp);
+
+  // Tile arg types and mappings.
+  SmallVector<Type> tileArgTypes;
+  SmallVector<int32_t> tile0Mapping, tile1Mapping;
+
+  // Tile arg 0: split result.
+  tileArgTypes.push_back(lhs.getType());
+  tile0Mapping.push_back(0);
+  tile1Mapping.push_back(1);
+
+  // Additional tile args from differing operands.
+  for (auto [i, pair] : llvm::enumerate(*differing)) {
+    tileArgTypes.push_back(pair.first.getType());
+    tile0Mapping.push_back(2 + 2 * i);
+    tile1Mapping.push_back(2 + 2 * i + 1);
+  }
+
+  auto tileMappingsAttr = builder.getArrayAttr(
+      {DenseI32ArrayAttr::get(builder.getContext(), tile0Mapping),
+       DenseI32ArrayAttr::get(builder.getContext(), tile1Mapping)});
+  auto barrierAnnotationsAttr = builder.getArrayAttr({});
+
+  auto regionOp = SubtiledRegionOp::create(
+      builder, loc, /*resultTypes=*/TypeRange{},
+      /*barriers=*/ValueRange{}, /*barrierPhases=*/ValueRange{},
+      tileMappingsAttr, barrierAnnotationsAttr);
+
+  // --- Setup Region ---
+  Block *setupBlock = &regionOp.getSetupRegion().emplaceBlock();
+  OpBuilder setupBuilder = OpBuilder::atBlockEnd(setupBlock);
+  IRMapping setupMapping;
+  for (Operation *op : setupOps)
+    setupBuilder.clone(*op, setupMapping);
+
+  SmallVector<Value> setupYieldValues;
+  setupYieldValues.push_back(setupMapping.lookupOrDefault(lhs));
+  setupYieldValues.push_back(setupMapping.lookupOrDefault(rhs));
+  for (auto [v0, v1] : *differing) {
+    setupYieldValues.push_back(setupMapping.lookupOrDefault(v0));
+    setupYieldValues.push_back(setupMapping.lookupOrDefault(v1));
+  }
+  SubtiledRegionYieldOp::create(setupBuilder, loc, setupYieldValues);
+
+  // --- Tile Region ---
+  Block *tileBlock = &regionOp.getTileRegion().emplaceBlock();
+  for (Type ty : tileArgTypes)
+    tileBlock->addArgument(ty, loc);
+
+  OpBuilder tileBuilder = OpBuilder::atBlockEnd(tileBlock);
+  IRMapping tileMapping;
+  tileMapping.map(lhs, tileBlock->getArgument(0));
+  for (auto [i, pair] : llvm::enumerate(*differing))
+    tileMapping.map(pair.first, tileBlock->getArgument(1 + i));
+
+  for (Operation *op : chain0)
+    tileBuilder.clone(*op, tileMapping);
+  SubtiledRegionYieldOp::create(tileBuilder, loc, ValueRange{});
+
+  // --- Teardown Region ---
+  Block *teardownBlock = &regionOp.getTeardownRegion().emplaceBlock();
+  OpBuilder teardownBuilder = OpBuilder::atBlockEnd(teardownBlock);
+  SubtiledRegionYieldOp::create(teardownBuilder, loc, ValueRange{});
+
+  // --- Erase original ops (reverse program order) ---
+  for (Operation *op : llvm::reverse(chain1))
+    op->erase();
+  for (Operation *op : llvm::reverse(chain0))
+    op->erase();
+  for (Operation *op : llvm::reverse(setupOps)) {
+    if (op->use_empty())
+      op->erase();
+  }
+}
+
+namespace {
+
+class TritonNvidiaGPUTestGenerateSubtiledRegionPass
+    : public impl::TritonNvidiaGPUTestGenerateSubtiledRegionPassBase<
+          TritonNvidiaGPUTestGenerateSubtiledRegionPass> {
+public:
+  using TritonNvidiaGPUTestGenerateSubtiledRegionPassBase::
+      TritonNvidiaGPUTestGenerateSubtiledRegionPassBase;
+
+  void runOnOperation() override {
+    SmallVector<triton::SplitOp> splitOps;
+    getOperation().walk([&](triton::SplitOp op) { splitOps.push_back(op); });
+    for (auto splitOp : splitOps)
+      tryGenerateForSplit(splitOp);
+  }
+};
+
+} // anonymous namespace
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/python/src/passes.h
+++ b/python/src/passes.h
@@ -41,3 +41,9 @@
   m.def(name,                                                                  \
         [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2, ty3 val3,      \
            ty4 val4) { pm.addPass(builder({val0, val1, val2, val3, val4})); })
+
+#define ADD_PASS_OPTION_WRAPPER_6(name, builder, ty0, ty1, ty2, ty3, ty4, ty5) \
+  m.def(name, [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2,          \
+                 ty3 val3, ty4 val4, ty5 val5) {                               \
+    pm.addPass(builder({val0, val1, val2, val3, val4, val5}));                 \
+  })

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -516,6 +516,7 @@ class nvidia_knobs(base_knobs):
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
+    generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
 
 
 class amd_knobs(base_knobs):

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -380,7 +380,7 @@ class CUDABackend(BaseBackend):
             nvidia.passes.hopper.add_tma_store_lowering(pm)
             smem_budget = _max_shared_mem_for_capability(capability)
             nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS, dump_enabled,
-                                                     smem_budget)
+                                                     smem_budget, knobs.nvidia.generate_subtiled_region)
             passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
@@ -408,7 +408,8 @@ class CUDABackend(BaseBackend):
                     passes.ttgpuir.add_partition_scheduling(pm)
                 smem_budget = _max_shared_mem_for_capability(capability)
                 nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS,
-                                                         dump_enabled, smem_budget)
+                                                         dump_enabled, smem_budget,
+                                                         knobs.nvidia.generate_subtiled_region)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_optimize_partition_warps(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -31,7 +31,10 @@ def NVGPUWarpSpecialization : Pass<"nvgpu-warp-specialization", "mlir::ModuleOp"
              "Dump intermediate steps">,
     Option<"smemBudget", "smem-budget",
              "int32_t", /*default*/"0",
-             "SMEM budget in bytes (0 = auto-detect from target)">
+             "SMEM budget in bytes (0 = auto-detect from target)">,
+    Option<"generateSubtiledRegion", "generate-subtiled-region",
+             "bool", /*default*/"false",
+             "Generate SubtiledRegionOp from epilogue split patterns">
     ];
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/Support/LogicalResult.h"
 
 #define DEBUG_TYPE "nvgpu-warp-specialization"
@@ -50,6 +51,14 @@ void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
 void doTMAStoreWaitReorder(triton::FuncOp &funcOp);
 void doAnnotateTMAStoreWaits(triton::FuncOp &funcOp);
 void doValidateTMAStoreAnnotations(triton::FuncOp &funcOp);
+
+void doGenerateSubtiledRegion(triton::FuncOp &funcOp) {
+  auto moduleOp = funcOp->getParentOfType<ModuleOp>();
+  PassManager pm(moduleOp.getContext());
+  pm.addPass(triton::nvidia_gpu::
+                 createTritonNvidiaGPUTestGenerateSubtiledRegionPass());
+  (void)pm.run(moduleOp);
+}
 
 #define GEN_PASS_DEF_NVGPUWARPSPECIALIZATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
@@ -219,6 +228,16 @@ public:
           << "// -----// WarpSpec internal IR Dump After: doMemoryPlanner\n";
       moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
       llvm::dbgs() << "\n\n\n";
+    }
+
+    if (generateSubtiledRegion) {
+      doGenerateSubtiledRegion(funcOp);
+      if (dumpIntermediateSteps) {
+        llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
+                        "doGenerateSubtiledRegion\n";
+        moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
+        llvm::dbgs() << "\n\n\n";
+      }
     }
 
     doAnnotateTMAStoreWaits(funcOp);

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -94,9 +94,9 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
 
 void init_triton_hopper_passes(py::module &&m) {
   // Meta's autoWS
-  ADD_PASS_OPTION_WRAPPER_5("add_hopper_warpspec",
+  ADD_PASS_OPTION_WRAPPER_6("add_hopper_warpspec",
                             mlir::createNVGPUWarpSpecialization, int, int, bool,
-                            bool, int);
+                            bool, int, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_data_partitioning",
                             mlir::createNVGPUWSDataPartition, int);
   ADD_PASS_WRAPPER_0("add_tma_store_lowering",


### PR DESCRIPTION
Summary:
Adds the framework for generating an initial subtiled region. Gates behind a knob since this shouldn't work yet. This is placed after the memory planner to allow all buffers to be resolved/unified before this step.


Reviewed By: jananisriram

Differential Revision: D101190981

Pulled By: njriasan


