### PR TITLE
[TLX] Guard remote and local bars init together to simplify cluster sync op insertion 

### DIFF
--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -135,7 +135,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
       %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
       %c0_i32 = arith.constant 0 : i32
       %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-      // expected-error @+1 {{Barrier init outside of the first block in function is not supported for remote barriers}}
+      // expected-error @+1 {{Barrier init outside of the first block in function is not supported}}
       ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
       %9 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
       ttg.warp_yield

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -126,6 +126,73 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
 
 // -----
 
+// Test that cluster sync is placed after the last barrier init, even when the
+// last init is for a local-only barrier. The first barrier is used remotely
+// (via map_to_remote_buffer), the second is used locally only.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @mixed_remote_local_bar_sync_after_last
+  tt.func public @mixed_remote_local_bar_sync_after_last() attributes {noinline = false} {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %c1_i32 = arith.constant 1 : i32
+    %2 = ttg.memdesc_index %0[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // The second init is for a local-only barrier, but cluster sync should
+    // still be placed after it (i.e., after the last init).
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: nvvm.mapa
+    ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    // First barrier used remotely
+    %3 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    ttng.arrive_barrier %3, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    // Second barrier used locally only
+    ttng.arrive_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test that a local-only barrier init in a non-first block triggers an error
+// when remote barriers exist elsewhere in the module. The remote barrier is
+// in the first block, but the local init inside the WS region is not allowed.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  tt.func public @local_bar_init_non_first_block_with_remote() attributes {noinline = false} {
+    // Remote barrier setup in the first block
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    ttg.warp_specialize(%0)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg0: !ttg.memdesc<1xi64, #shared, #smem, mutable>) num_warps(4) {
+      // Local-only barrier init in non-first block should error
+      %3 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      %c0 = arith.constant 0 : i32
+      %4 = ttg.memdesc_index %3[%c0] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      // expected-error @+1 {{Barrier init outside of the first block in function is not supported}}
+      ttng.init_barrier %4, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttng.arrive_barrier %4, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -233,56 +233,8 @@ private:
         static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared));
   }
 
-  void getBackwardSliceWithWS(Value target,
-                              SetVector<Operation *> *backwardSlice) {
-    SetVector<Value> worklist;
-    worklist.insert(target);
-
-    BackwardSliceOptions options;
-    options.omitUsesFromAbove = false;
-    options.omitBlockArguments = true;
-    options.inclusive = true;
-
-    while (!worklist.empty()) {
-      Value nextTarget = worklist.back();
-      worklist.pop_back();
-
-      if (auto arg = dyn_cast<BlockArgument>(nextTarget)) {
-        if (auto wsPartitionOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(
-                arg.getOwner()->getParentOp())) {
-          auto argIndex = arg.getArgNumber();
-          auto wsOp = wsPartitionOp->getParentOfType<ttg::WarpSpecializeOp>();
-          // map to WSOp's operand at the same index
-          nextTarget = wsOp.getOperand(argIndex);
-        } else {
-          // ttg::WarpSpecializeOp's default region just captures
-          // from trunk so no need to special handle the defining block args.
-          // We should omit block args for other block structures like scf.For,
-          // and the captures would still be handled automatically
-          continue;
-        }
-      }
-
-      SetVector<Operation *> ops;
-      if (failed(getBackwardSlice(nextTarget, &ops, options))) {
-        llvm_unreachable("getBackwardSlice failed");
-      }
-
-      for (auto op : ops) {
-        if (backwardSlice->insert(op)) {
-          for (auto operand : op->getOperands()) {
-            if (isa<BlockArgument>(operand)) {
-              worklist.insert(operand);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  LogicalResult
-  ensureEarlyRemoteBarInit(ModuleOp &mod,
-                           SetVector<Operation *> &remoteBarInitOps) {
+  LogicalResult ensureEarlyBarInit(ModuleOp &mod,
+                                   SetVector<Operation *> &barInitOps) {
     triton::FuncOp funcOp = nullptr;
     mod.walk([&](triton::FuncOp op) {
       if (triton::isKernel(op)) {
@@ -292,10 +244,10 @@ private:
       return WalkResult::advance();
     });
     assert(funcOp && "Expecting to find a kernel func but got none.");
-    for (auto op : remoteBarInitOps) {
+    for (auto op : barInitOps) {
       if (op->getBlock() != &funcOp.front()) {
         op->emitError() << "Barrier init outside of the first block in "
-                           "function is not supported for remote barriers";
+                           "function is not supported for CTA clusters";
         return failure();
       }
     }
@@ -404,48 +356,29 @@ private:
     }
 
     bool hasRemoteBar = false;
-    SetVector<Operation *> barAllocOps;
-    // Find all bar alloc op in the back slice of a remote bar
+    // Find if we have a remote bar
     mod.walk([&](Operation *op) {
       SetVector<Operation *> ops;
       auto remoteBar = getRemoteBarrier(op);
       if (remoteBar.has_value()) {
         hasRemoteBar = true;
-        for (auto bar : remoteBar.value()) {
-          getBackwardSliceWithWS(bar, &ops);
-
-          for (auto opInSlice : ops) {
-            if (isa<ttg::LocalAllocOp>(opInSlice)) {
-              barAllocOps.insert(opInSlice);
-            }
-          }
-        }
+        return WalkResult::interrupt();
       }
+      return WalkResult::advance();
     });
-
-    // If there's no remote barrier,
-    // skipping
+    // If there's no remote barrier, skipping
     if (!hasRemoteBar) {
       return success();
     }
 
-    assert(!barAllocOps.empty() &&
-           "Failed to find bar alloc op for remote bar");
-
-    // Find the init op for remote barriers
-    SetVector<Operation *> remoteBarInitOps;
+    // Find all bar init ops
+    SetVector<Operation *> remoteOrLocalBarInitOps;
     mod.walk([&](ttng::InitBarrierOp barInitOp) {
-      SetVector<Operation *> ops;
-      getBackwardSliceWithWS(barInitOp.getAlloc(), &ops);
-      if (llvm::any_of(
-              ops, [&](Operation *op) { return barAllocOps.contains(op); })) {
-        // barInitOp is for remote bar
-        remoteBarInitOps.insert(barInitOp);
-      }
+      remoteOrLocalBarInitOps.insert(barInitOp);
     });
 
-    assert(!remoteBarInitOps.empty() &&
-           "Failed to find bar init op for remote bar");
+    assert(!remoteOrLocalBarInitOps.empty() &&
+           "Failed to find bar init op when we know there's remote bar");
 
     // Enforcing front end for 2cta kernels:
     // All remote barrier init ops need to happen at the first block of
@@ -453,7 +386,7 @@ private:
     // case. If in the future there's a need to really alloc/init barriers after
     // a WS op, we can seek to relax this limitation and fix cluster sync
     // insertions.
-    if (failed(ensureEarlyRemoteBarInit(mod, remoteBarInitOps))) {
+    if (failed(ensureEarlyBarInit(mod, remoteOrLocalBarInitOps))) {
       return failure();
     }
 
@@ -462,10 +395,10 @@ private:
     // block of the kernel func op, as we currently enforce earlier in this
     // pass. If that assumption changes, we should revisit this heuristic here.
     ttng::InitBarrierOp lastBarInitOp;
-    auto firstBlock = remoteBarInitOps.front()->getBlock();
+    auto firstBlock = remoteOrLocalBarInitOps.front()->getBlock();
     for (auto it = firstBlock->rbegin(), e = firstBlock->rend(); it != e;
          ++it) {
-      if (remoteBarInitOps.contains(&*it)) {
+      if (remoteOrLocalBarInitOps.contains(&*it)) {
         lastBarInitOp = cast<ttng::InitBarrierOp>(*it);
         break;
       }


### PR DESCRIPTION
What we tried to do before:
- Identify remote bars
- Identify their init ops via `getBackwardSliceWithWS`
- Enforce these init ops to be at first block of func
- Insert a cluster sync after the last init op

However, making `getBackwardSliceWithWS` generic and robust is challenging and not worth it at the moment. There's at least one bug where if a block arg comes from previous blocks instead of parent WS partition Op, we'd still blindly map it to the WS Op's operand at the same index, which is wrong. In the example below, it would incorrectly map `bar_idx` to `arg0/other_bar`

```mlir
    %cta_bars = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // cta-bars-def
    %other_bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>  // other-bar-def

    ttg.warp_specialize(%other_bar, %cta_bars) attributes {warpGroupStartIds = array<i32: 4>}
    default {
      ttg.warp_yield
    }
    partition0(%arg0: !ttg.memdesc<2xi64, #shared, #smem, mutable>, %arg1: !ttg.memdesc<2xi64, #shared, #smem, mutable>) num_warps(1) {
      %c0 = arith.constant 0 : i32
      ...
      cf.br ^bb1(%c0 : i32)

    ^bb1(%bar_idx: i32):
      %cmp = arith.cmpi slt, %bar_idx, %c10 : i32
      cf.cond_br %cmp, ^bb2, ^bb3

    ^bb2:
      %idx = arith.remsi %bar_idx, %c2 : i32
      %bar = ttg.memdesc_index %arg1[%idx] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>  // bar-def
      %remote = ttng.map_to_remote_buffer %bar, %c0 {slice_target} : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>  // remote-def
      
```


To minimize the chance of inserting cluster sync too early, we do not differentiate remote or local bars when find the last bar init. So the flow looks like:

- Identify remote bars
- Identify init ops of *all bars*
- Enforce these init ops to be at first block of func
- Insert a cluster sync after the last init op

This means we could possibly delay the cluster sync very slightly to after some local bar init ops in exchange for more safety. There should be very minimal disruption to existing kernels (unless they have local bar init not located in the first block), and we believe the perf cost should be very minimal as well. Plus TLX users can always move the bar alloc API calls to earlier in the kernel to recover some perf.

Test plan: lit test