### PR TITLE
[autoWS] fixes to make FA work after rebasing

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -22,6 +22,7 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/StrUtil.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MathExtras.h"
@@ -3783,8 +3784,11 @@ LogicalResult TritonGPUDialect::verifyOperationAttribute(Operation *op,
   // Verify that op partitions include partitions of all child ops.
   // Skip for ReduceOp and MapElementwiseOp whose regions contain function-like
   // bodies where individual ops don't need partition annotations.
+  // Meta's partition scheduler intentionally leaves some ops unpartitioned for
+  // doTaskIdPropagate).
   if (attr.getName() == kPartitionAttrName && op->getNumRegions() != 0 &&
-      !isa<triton::ReduceOp, triton::MapElementwiseOp>(op)) {
+      !isa<triton::ReduceOp, triton::MapElementwiseOp>(op) &&
+      !triton::tools::getBoolEnv("TRITON_USE_META_PARTITION")) {
     SetVector<int> expectedIds;
     for (auto &region : op->getRegions()) {
       for (auto &block : region.getBlocks()) {

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -913,10 +913,11 @@ void init_gluon_ir(py::module &&m) {
            [](GluonOpBuilder &self, Value memDesc, Value phase) {
              self.create<ttag::WaitBarrierOp>(memDesc, phase);
            })
-      .def("create_lds_barrier_arrive", [](GluonOpBuilder &self, Value memDesc,
-                                           int count, int expectedCount) {
-        self.create<ttag::ArriveBarrierOp>(memDesc, count, expectedCount);
-      })
+      .def("create_lds_barrier_arrive",
+           [](GluonOpBuilder &self, Value memDesc, int count,
+              int expectedCount) {
+             self.create<ttag::ArriveBarrierOp>(memDesc, count, expectedCount);
+           })
       .def("create_warp_pipeline_border",
            [](GluonOpBuilder &self, const std::string &marker) {
              auto border = self.create<ROCDL::SchedBarrier>(0);

--- a/python/test/unit/language/test_autows_addmm.py
+++ b/python/test/unit/language/test_autows_addmm.py
@@ -65,6 +65,7 @@ def addmm_kernel_tma_persistent_ws(
             disallow_acc_multi_buffer=True,
             data_partition_factor=DATA_PARTITION_FACTOR,
             smem_alloc_algo=SMEM_ALLOC_ALGO,
+            separate_epilogue_store=True,
     ):
         pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         offs_am = pid_m * BLOCK_SIZE_M

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -68,7 +68,7 @@ def matmul_kernel_tma_ws(
 
     # Always use warp_specialize=True
     for k in tl.range(k_tiles, warp_specialize=True, data_partition_factor=DATA_PARTITION_FACTOR,
-                      smem_alloc_algo=SMEM_ALLOC_ALGO):
+                      smem_alloc_algo=SMEM_ALLOC_ALGO, separate_epilogue_store=False):
         offs_k = k * BLOCK_SIZE_K
         if A_COL_MAJOR:
             a = a_desc.load([offs_k, offs_am]).T
@@ -131,6 +131,7 @@ def matmul_kernel_tma_persistent_ws(
             warp_specialize=True,
             data_partition_factor=DATA_PARTITION_FACTOR,
             smem_alloc_algo=SMEM_ALLOC_ALGO,
+            separate_epilogue_store=True,
     ):
         pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         offs_am = pid_m * BLOCK_SIZE_M
@@ -263,6 +264,7 @@ def matmul_kernel_descriptor_persistent_ws(
             warp_specialize=True,
             data_partition_factor=DATA_PARTITION_FACTOR,
             smem_alloc_algo=SMEM_ALLOC_ALGO,
+            separate_epilogue_store=True,
     ):
         pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         offs_am = pid_m * BLOCK_SIZE_M

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1258,6 +1258,9 @@ class CodeGenerator(ast.NodeVisitor):
         disallow_acc_multi_buffer = False
         data_partition_factor = None
         merge_epilogue = False
+        merge_epilogue_to_computation = False
+        merge_correction = False
+        separate_epilogue_store = False
         tmem_alloc_algo = None
         smem_alloc_algo = None
         smem_budget = None
@@ -1279,6 +1282,9 @@ class CodeGenerator(ast.NodeVisitor):
             disallow_acc_multi_buffer = iterator.disallow_acc_multi_buffer
             data_partition_factor = iterator.data_partition_factor
             merge_epilogue = iterator.merge_epilogue
+            merge_epilogue_to_computation = iterator.merge_epilogue_to_computation
+            merge_correction = iterator.merge_correction
+            separate_epilogue_store = iterator.separate_epilogue_store
             tmem_alloc_algo = iterator.tmem_alloc_algo
             smem_alloc_algo = iterator.smem_alloc_algo
             smem_budget = iterator.smem_budget
@@ -1355,6 +1361,12 @@ class CodeGenerator(ast.NodeVisitor):
                 for_op.set_attr("tt.multi_cta", self.builder.get_unit_attr())
             if merge_epilogue:
                 for_op.set_attr("tt.merge_epilogue", self.builder.get_bool_attr(True))
+            if merge_correction:
+                for_op.set_attr("tt.merge_correction", self.builder.get_bool_attr(True))
+            if merge_epilogue_to_computation:
+                for_op.set_attr("tt.merge_epilogue_to_computation", self.builder.get_bool_attr(True))
+            if separate_epilogue_store:
+                for_op.set_attr("tt.separate_epilogue_store", self.builder.get_bool_attr(True))
             if tmem_alloc_algo is not None:
                 for_op.set_attr("tt.tmem_alloc_algo", self.builder.get_int32_attr(tmem_alloc_algo))
             if smem_alloc_algo is not None:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3339,8 +3339,9 @@ class range(base_value):
 
     def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None,
                  disallow_acc_multi_buffer=False, flatten=False, warp_specialize=False, multi_cta=False,
-                 disable_licm=False, data_partition_factor=None, merge_epilogue=False, tmem_alloc_algo=None,
-                 smem_alloc_algo=None, smem_budget=None, smem_circular_reuse=None):
+                 disable_licm=False, data_partition_factor=None, merge_epilogue=False,
+                 merge_epilogue_to_computation=False, merge_correction=False, separate_epilogue_store=False,
+                 tmem_alloc_algo=None, smem_alloc_algo=None, smem_budget=None, smem_circular_reuse=None):
         if step is None:
             self.step = constexpr(1)
         else:
@@ -3356,6 +3357,9 @@ class range(base_value):
         self.disallow_acc_multi_buffer = disallow_acc_multi_buffer
         self.data_partition_factor = data_partition_factor
         self.merge_epilogue = merge_epilogue
+        self.merge_epilogue_to_computation = merge_epilogue_to_computation
+        self.merge_correction = merge_correction
+        self.separate_epilogue_store = separate_epilogue_store
         self.tmem_alloc_algo = tmem_alloc_algo
         self.smem_alloc_algo = smem_alloc_algo
         self.smem_budget = smem_budget

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -146,6 +146,8 @@ def _attn_fwd_inner_oss_dp(
             hi,
             BLOCK_N,
             warp_specialize=warp_specialize,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
             # disallow_acc_multi_buffer=True,
             data_partition_factor=DP_FACTOR,
     ):
@@ -565,6 +567,8 @@ def _attn_fwd_persist(
             0,
             tiles_per_sm,
             warp_specialize=warp_specialize and OUTER_LOOP,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
             data_partition_factor=DP_FACTOR,
     ):
         pid = tile_idx % n_tile_num
@@ -790,8 +794,8 @@ def _attn_bwd_dkdv(
     curr_m = start_m
     step_m = BLOCK_M1
     if warp_specialize:
-        for blk_idx in tl.range(0, num_steps, warp_specialize=True, merge_epilogue=True, tmem_alloc_algo=2,
-                                smem_alloc_algo=1, smem_budget=200000):
+        for blk_idx in tl.range(0, num_steps, warp_specialize=True, merge_epilogue_to_computation=True,
+                                tmem_alloc_algo=2, smem_alloc_algo=1, smem_budget=200000):
             dk, dv, curr_m = _attn_bwd_dkdv_inner(
                 dk,
                 dv,
@@ -1166,8 +1170,8 @@ def _attn_bwd_persist(
         block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
     )
 
-    for _ in tl.range(0, tiles_per_sm, warp_specialize=True, merge_epilogue=True, tmem_alloc_algo=2, smem_alloc_algo=1,
-                      smem_budget=200000):
+    for _ in tl.range(0, tiles_per_sm, warp_specialize=True, merge_epilogue_to_computation=True, tmem_alloc_algo=2,
+                      smem_alloc_algo=1, smem_budget=200000):
         pid = tile_idx % n_tile_num
         bhid = tile_idx // n_tile_num
         _attn_bwd_core(
@@ -1259,7 +1263,7 @@ class _attention_opt(torch.autograd.Function):
                 extra_kern_args["maxnreg"] = 128
             else:
                 extra_kern_args["maxnreg"] = 128
-        if True:  # persistent: forward non-persistent has some issues
+        if persistent:
             _attn_fwd_persist[grid_persist](
                 sm_scale,
                 M,  #
@@ -1475,20 +1479,30 @@ attention = _attention_opt.apply
 @pytest.mark.parametrize("Z", [8])
 @pytest.mark.parametrize("H", [16])
 @pytest.mark.parametrize("N_CTX", [1024])  #, 2048])
-@pytest.mark.parametrize("HEAD_DIM", [128])
+@pytest.mark.parametrize("HEAD_DIM", [64, 128])
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("mode", ["fwd", "bwd"])
-@pytest.mark.parametrize("baseVariant", ["ws_persistent"])
+@pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
 @pytest.mark.parametrize("provider", ["triton-fp16"])
 @pytest.mark.parametrize("SUBTILING", [False, True])
 @pytest.mark.parametrize("VECT_MUL", [0])  #, 1, 2, 3])
 @pytest.mark.parametrize("FADD2_REDUCE", [False])
+@pytest.mark.parametrize("bwd_config_idx", range(len(configs_bwd_persist)))
 def test_op(Z, H, N_CTX, HEAD_DIM, causal, mode, baseVariant, provider, SUBTILING, VECT_MUL, FADD2_REDUCE,
-            dtype=torch.float16):
+            bwd_config_idx, dtype=torch.float16):
+    # For fwd mode, only run once (bwd_config_idx=0) to avoid redundant tests
+    if mode == "fwd" and bwd_config_idx > 0:
+        pytest.skip("bwd_config_idx only applies to bwd mode")
     if mode == "bwd" and "fp8" in provider:
         pytest.skip("Backward pass with FP8 is not supported.")
-    if SUBTILING and baseVariant == "ws_persistent":
-        pytest.skip("SUBTILING with ws_persistent exceeds shared memory budget")
+    if mode == "bwd" and HEAD_DIM == 64 and bwd_config_idx == 1:
+        pytest.skip("bwd_config_idx of 1 does not work with hDim 64")
+    if mode == "bwd" and baseVariant == "ws_persistent":
+        _attn_bwd_persist.configs = [configs_bwd_persist[bwd_config_idx]]
+        _attn_bwd_persist.cache = {}
+    if mode == "bwd" and baseVariant == "ws":
+        _attn_bwd.configs = [configs_bwd_persist[bwd_config_idx]]
+        _attn_bwd.cache = {}
     torch.manual_seed(20)
     q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
     k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())

--- a/test/Hopper/WarpSpecialization/blackwell_fa_fwd_persist_code_partition.mlir
+++ b/test/Hopper/WarpSpecialization/blackwell_fa_fwd_persist_code_partition.mlir
@@ -1,0 +1,363 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1" | FileCheck %s
+// CHECK-LABEL: _attn_fwd_persist
+// CHECK: ttg.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["correction", "gemm", "load", "epilogue_store", "computation", "computation"]
+// CHECK: default
+//
+// partition0 = gemm
+//
+// Outer loop carries i64 counters initialized to 0.
+// q0 phase uses divui by 1 (single-buffer, outer-loop-only counter).
+// k/v phase uses divui by 3 (triple-buffer, inner-loop counter).
+// Counter increments by 1 each outer iteration.
+//
+// CHECK: partition0
+// CHECK: arith.constant {{.*}} 0 : i64
+// Outer loop with i64 iter_args, first initialized to 0
+// CHECK: scf.for %arg{{[0-9]+}} = {{.*}} iter_args(%[[ARG0:arg[0-9]+]] = %c0_i64, %[[ARG1:arg[0-9]+]] = %c0_i64{{.*}}, %[[ARG2:arg[0-9]+]] = %c0_i64{{.*}}) -> (i64, i64, i64)
+//
+// q0 phase: full data dependency chain from ARG0 to wait_barrier
+//   ARG0 -> divui -> DIV -> andi -> PHASE_BIT -> trunci -> PHASE_I1 -> extui -> PHASE_I32 -> wait_barrier
+// CHECK:   [[DIV0:%.*]] = arith.divui %[[ARG0]],
+// CHECK-SAME: : i64
+// CHECK:   [[PHASE_BIT0:%.*]] = arith.andi [[DIV0]],
+// CHECK-SAME: : i64
+// CHECK:   [[PHASE_I1_0:%.*]] = arith.trunci [[PHASE_BIT0]]
+// CHECK-SAME: : i64 to i1
+// Second q0 channel: also from ARG0
+// CHECK:   [[DIV1:%.*]] = arith.divui %[[ARG0]],
+// CHECK-SAME: : i64
+// CHECK:   [[PHASE_BIT1:%.*]] = arith.andi [[DIV1]],
+// CHECK-SAME: : i64
+// CHECK:   [[PHASE_I1_1:%.*]] = arith.trunci [[PHASE_BIT1]]
+// CHECK-SAME: : i64 to i1
+//
+// q0 consumer wait: extui(PHASE_I1) -> wait_barrier (no xori)
+// CHECK:   [[PHASE_I32_1:%.*]] = arith.extui [[PHASE_I1_1]]
+// CHECK-SAME: : i1 to i32
+// CHECK-NOT: arith.xori
+// CHECK:   ttng.wait_barrier {{.*}}, [[PHASE_I32_1]]
+// CHECK:   [[PHASE_I32_0:%.*]] = arith.extui [[PHASE_I1_0]]
+// CHECK-SAME: : i1 to i32
+// CHECK-NOT: arith.xori
+// CHECK:   ttng.wait_barrier {{.*}}, [[PHASE_I32_0]]
+//
+// Inner loop: k/v phase uses divui by 3 (buffer.copy=3)
+// Inner loop iter_args: ARG3 for acc counter, ARG4 for k/v counter
+// CHECK:   scf.for %arg{{[0-9]+}} = {{.*}} iter_args(%[[ARG3:arg[0-9]+]] = {{.*}}, %[[ARG4:arg[0-9]+]] = {{.*}}) -> (i64, i64)
+// k/v phase: full data dependency chain from ARG4 to wait_barrier
+//   ARG4 -> divui by 3 -> DIV_KV -> andi -> PHASE_KV -> trunci -> PHASE_KV_I1 -> extui -> wait_barrier
+// CHECK:     [[C3:%.*]] = arith.constant {{.*}} 3 : i64
+// CHECK:     [[DIV_KV:%.*]] = arith.divui %[[ARG4]], [[C3]]
+// CHECK-SAME: : i64
+// CHECK:     [[PHASE_KV_BIT:%.*]] = arith.andi [[DIV_KV]],
+// CHECK-SAME: : i64
+// CHECK:     [[PHASE_KV_I1:%.*]] = arith.trunci [[PHASE_KV_BIT]]
+// CHECK-SAME: : i64 to i1
+// k consumer wait with phase from ARG4
+// CHECK:     [[PHASE_KV_I32:%.*]] = arith.extui [[PHASE_KV_I1]]
+// CHECK-SAME: : i1 to i32
+// CHECK:     ttng.wait_barrier {{.*}}, [[PHASE_KV_I32]]
+// k/v counter update: ARG4 incremented by 2 (k+v each consume one buffer slot)
+// CHECK:     [[KV_INC:%.*]] = arith.constant {{.*}} 2 : i64
+// CHECK:     [[NEW_KV:%.*]] = arith.addi %[[ARG4]], [[KV_INC]]
+// CHECK-SAME: : i64
+// Inner acc counter update: ARG3 incremented by 1
+// CHECK:     [[NEW_ACC:%.*]] = arith.addi %[[ARG3]],
+// CHECK-SAME: : i64
+// CHECK:     scf.yield {{.*}}[[NEW_ACC]], [[NEW_KV]]
+//
+// Outer counter update: ARG0 incremented by 1, yielded as first result
+// CHECK:   [[NEW_CNT:%.*]] = arith.addi %[[ARG0]],
+// CHECK-SAME: : i64
+// CHECK:   scf.yield {{.*}}[[NEW_CNT]],
+//
+// partition1 = load: q0 producer uses inverted phase (xori)
+// CHECK: partition1
+// CHECK: scf.for
+// CHECK:   arith.trunci {{.*}} : i64 to i1
+// CHECK:   arith.xori
+// CHECK:   arith.extui {{.*}} : i1 to i32
+// CHECK:   ttng.wait_barrier
+// CHECK:   ttng.async_tma_copy_global_to_local
+// CHECK:   arith.trunci {{.*}} : i64 to i1
+// CHECK:   arith.xori
+// CHECK:   arith.extui {{.*}} : i1 to i32
+// CHECK:   ttng.wait_barrier
+// CHECK:   ttng.async_tma_copy_global_to_local
+//
+// CHECK: partition2
+// CHECK: partition3
+// CHECK: partition4
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 128, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [2, 0, 1]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 2, 128], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [1, 0, 2]}>
+#linear = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16]], warp = [[32], [64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1, 0], [0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [128, 0, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 64], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 1, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.maxnreg = 128 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_fwd_persist(%sm_scale: f32, %M: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %Z: i32, %H: i32 {tt.divisibility = 16 : i32}, %desc_q: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_k: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_v: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_o: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant {async_task_id = array<i32: 0, 4, 5>} dense<1.000000e+00> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %cst_0 = arith.constant {async_task_id = array<i32: 0, 4, 5>} dense<0xFF800000> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %cst_1 = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %cst_2 = arith.constant {async_task_id = array<i32: 4, 5>} 1.44269502 : f32
+    %c256_i32 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 256 : i32
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} 0 : i32
+    %c1_i64 = arith.constant {async_task_id = array<i32: 2, 3>} 1 : i64
+    %c128_i64 = arith.constant {async_task_id = array<i32: 2, 3>} 128 : i64
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} 128 : i32
+    %c4096_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} 4096 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} 1 : i32
+    %n_tile_num = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} 16 : i32
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %false = arith.constant {async_task_id = array<i32: 1>} false
+    %_0 = ttg.local_alloc {async_task_id = array<i32: 0>, buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %_1 = ttg.local_alloc {async_task_id = array<i32: 0>, buffer.copy = 1 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %acc_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %acc_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %alpha_1, %alpha_1_3 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 64 : i32} : () -> (!ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %alpha_0, %alpha_0_4 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 64 : i32} : () -> (!ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %qk_1, %qk_1_5 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %qk_0, %qk_0_6 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %v = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 2 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %k = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 2 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %m_ij_0, %m_ij_0_7 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 65 : i32} : () -> (!ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %l_i0_1, %l_i0_1_8 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 66 : i32} : () -> (!ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %m_ij_1, %m_ij_1_9 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 65 : i32} : () -> (!ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %l_i0_0, %l_i0_0_10 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 66 : i32} : () -> (!ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %acc_1_11, %acc_1_12 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 6 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %acc_0_13, %acc_0_14 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %q0_1 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %q0_0 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %prog_id = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+    %num_progs = tt.get_num_programs x {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+    %total_tiles = arith.muli %Z, %n_tile_num {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+    %total_tiles_15 = arith.muli %total_tiles, %H {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+    %tiles_per_sm = arith.divsi %total_tiles_15, %num_progs {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+    %0 = arith.remsi %total_tiles_15, %num_progs {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+    %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+    %2 = scf.if %1 -> (i32) {
+      %tiles_per_sm_27 = arith.addi %tiles_per_sm, %c1_i32 {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} : i32
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} %tiles_per_sm_27 : i32
+    } else {
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>} %tiles_per_sm : i32
+    } {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>}
+    %desc_q_16 = arith.muli %Z, %H {async_task_id = array<i32: 2, 3>} : i32
+    %desc_q_17 = arith.muli %desc_q_16, %c4096_i32 {async_task_id = array<i32: 2, 3>} : i32
+    %desc_q_18 = tt.make_tensor_descriptor %desc_q, [%desc_q_17, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_q_19 = tt.make_tensor_descriptor %desc_q, [%desc_q_17, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_k_20 = tt.make_tensor_descriptor %desc_k, [%desc_q_17, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_v_21 = tt.make_tensor_descriptor %desc_v, [%desc_q_17, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_o_22 = tt.make_tensor_descriptor %desc_o, [%desc_q_17, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_o_23 = tt.make_tensor_descriptor %desc_o, [%desc_q_17, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %offset_y = arith.muli %H, %c4096_i32 {async_task_id = array<i32: 2, 3>} : i32
+    %offs_m0 = tt.make_range {async_task_id = array<i32: 0>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked1>
+    %offs_m0_24 = tt.make_range {async_task_id = array<i32: 0>, end = 256 : i32, start = 128 : i32} : tensor<128xi32, #blocked1>
+    %qk_scale = arith.mulf %sm_scale, %cst_2 {async_task_id = array<i32: 4, 5>} : f32
+    %m_ij = tt.splat %qk_scale {async_task_id = array<i32: 5>} : f32 -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %m_ij_25 = tt.splat %qk_scale {async_task_id = array<i32: 4>} : f32 -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %qk = tt.splat %qk_scale {async_task_id = array<i32: 5>} : f32 -> tensor<128x128xf32, #blocked>
+    %qk_26 = tt.splat %qk_scale {async_task_id = array<i32: 4>} : f32 -> tensor<128x128xf32, #blocked>
+    %tile_idx = scf.for %_ = %c0_i32 to %2 step %c1_i32 iter_args(%tile_idx_27 = %prog_id) -> (i32)  : i32 {
+      %pid = arith.remsi %tile_idx_27, %n_tile_num {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_hz = arith.divsi %tile_idx_27, %n_tile_num {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_z = arith.divsi %off_hz, %H {async_task_id = array<i32: 2, 3>} : i32
+      %off_h = arith.remsi %off_hz, %H {async_task_id = array<i32: 2, 3>} : i32
+      %offset_y_28 = arith.muli %off_z, %offset_y {async_task_id = array<i32: 2, 3>} : i32
+      %offset_y_29 = arith.muli %off_h, %c4096_i32 {async_task_id = array<i32: 2, 3>} : i32
+      %offset_y_30 = arith.addi %offset_y_28, %offset_y_29 {async_task_id = array<i32: 2, 3>} : i32
+      %qo_offset_y = arith.muli %pid, %c256_i32 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %qo_offset_y_31 = arith.addi %offset_y_30, %qo_offset_y {async_task_id = array<i32: 2, 3>} : i32
+      %3 = arith.addi %qo_offset_y_31, %c128_i32 {async_task_id = array<i32: 3>} : i32
+      %q0 = arith.addi %qo_offset_y_31, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      %offs_m0_32 = tt.splat %qo_offset_y {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #blocked1>
+      %offs_m0_33 = tt.splat %qo_offset_y {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #blocked1>
+      %offs_m0_34 = arith.addi %offs_m0_32, %offs_m0 {async_task_id = array<i32: 0>} : tensor<128xi32, #blocked1>
+      %offs_m0_35 = arith.addi %offs_m0_33, %offs_m0_24 {async_task_id = array<i32: 0>} : tensor<128xi32, #blocked1>
+      %q0_36 = tt.descriptor_load %desc_q_18[%qo_offset_y_31, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked2>
+      %q0_37 = tt.descriptor_load %desc_q_19[%q0, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked2>
+      ttg.local_store %q0_36, %q0_0 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked2> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      ttg.local_store %q0_37, %q0_1 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked2> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %acc = ttng.tmem_store %cst_1, %acc_0_13[%acc_0_14], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %acc_38 = ttng.tmem_store %cst_1, %acc_1_11[%acc_1_12], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %offsetkv_y:9 = scf.for %offsetkv_y_81 = %c0_i32 to %c4096_i32 step %c128_i32 iter_args(%offset_y_82 = %offset_y_30, %arg12 = %cst, %arg13 = %cst_0, %qk_0_83 = %qk_0_6, %acc_84 = %acc, %arg16 = %cst, %arg17 = %cst_0, %qk_1_85 = %qk_1_5, %acc_86 = %acc_38) -> (i32, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.async.token, !ttg.async.token, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.async.token, !ttg.async.token)  : i32 {
+        %k_87 = tt.descriptor_load %desc_k_20[%offset_y_82, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked2>
+        %v_88 = tt.descriptor_load %desc_v_21[%offset_y_82, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked2>
+        ttg.local_store %k_87, %k {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked2> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %k_89 = ttg.memdesc_trans %k {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared1, #smem, mutable>
+        ttg.local_store %v_88, %v {async_task_id = array<i32: 2>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked2> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %qk_90 = ttng.tc_gen5_mma %q0_0, %k_89, %qk_0[%qk_0_83], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %qk_91 = ttng.tc_gen5_mma %q0_1, %k_89, %qk_1[%qk_1_85], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %qk_92, %qk_93 = ttng.tmem_load %qk_0[%qk_90] {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %qk_94, %qk_95 = ttng.tmem_load %qk_1[%qk_91] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %m_ij_96 = "tt.reduce"(%qk_92) <{axis = 1 : i32}> ({
+        ^bb0(%m_ij_162: f32, %m_ij_163: f32):
+          %m_ij_164 = arith.maxnumf %m_ij_162, %m_ij_163 {async_task_id = array<i32: 5>} : f32
+          tt.reduce.return %m_ij_164 {async_task_id = array<i32: 5>} : f32
+        }) {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %m_ij_97 = "tt.reduce"(%qk_94) <{axis = 1 : i32}> ({
+        ^bb0(%m_ij_162: f32, %m_ij_163: f32):
+          %m_ij_164 = arith.maxnumf %m_ij_162, %m_ij_163 {async_task_id = array<i32: 4>} : f32
+          tt.reduce.return %m_ij_164 {async_task_id = array<i32: 4>} : f32
+        }) {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %m_ij_98 = arith.mulf %m_ij_96, %m_ij {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %m_ij_99 = arith.mulf %m_ij_97, %m_ij_25 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %m_ij_100 = arith.maxnumf %arg13, %m_ij_98 {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %m_ij_101 = arith.maxnumf %arg17, %m_ij_99 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %qk_102 = arith.mulf %qk_92, %qk {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+        %qk_103 = arith.mulf %qk_94, %qk_26 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked>
+        %qk_104 = tt.expand_dims %m_ij_100 {async_task_id = array<i32: 5>, axis = 1 : i32, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+        %qk_105 = tt.expand_dims %m_ij_101 {async_task_id = array<i32: 4>, axis = 1 : i32, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+        %qk_106 = tt.broadcast %qk_104 {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+        %qk_107 = tt.broadcast %qk_105 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+        %qk_108 = arith.subf %qk_102, %qk_106 {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+        %qk_109 = arith.subf %qk_103, %qk_107 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked>
+        %p = math.exp2 %qk_108 {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+        %p_110 = math.exp2 %qk_109 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked>
+        %alpha = arith.subf %arg13, %m_ij_100 {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %alpha_111 = arith.subf %arg17, %m_ij_101 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %alpha_112 = math.exp2 %alpha {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %alpha_113 = tt.expand_dims %alpha_112 {async_task_id = array<i32: 5>, axis = 1 : i32, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+        %alpha_114 = ttg.convert_layout %alpha_113 {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked3>
+        ttng.tmem_store %alpha_114, %alpha_0, %true {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked3> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %alpha_115 = math.exp2 %alpha_111 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %alpha_116 = tt.expand_dims %alpha_115 {async_task_id = array<i32: 4>, axis = 1 : i32, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+        %alpha_117 = ttg.convert_layout %alpha_116 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked3>
+        ttng.tmem_store %alpha_117, %alpha_1, %true {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x1xf32, #blocked3> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %l_ij = "tt.reduce"(%p) <{axis = 1 : i32}> ({
+        ^bb0(%l_ij_162: f32, %l_ij_163: f32):
+          %l_ij_164 = arith.addf %l_ij_162, %l_ij_163 {async_task_id = array<i32: 5>} : f32
+          tt.reduce.return %l_ij_164 {async_task_id = array<i32: 5>} : f32
+        }) {async_task_id = array<i32: 5>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %l_ij_118 = "tt.reduce"(%p_110) <{axis = 1 : i32}> ({
+        ^bb0(%l_ij_162: f32, %l_ij_163: f32):
+          %l_ij_164 = arith.addf %l_ij_162, %l_ij_163 {async_task_id = array<i32: 4>} : f32
+          tt.reduce.return %l_ij_164 {async_task_id = array<i32: 4>} : f32
+        }) {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %acc_119, %acc_120 = ttng.tmem_load %acc_0_13[%acc_84] {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %acc_121, %acc_122 = ttng.tmem_load %acc_1_11[%acc_86] {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %12 = tt.reshape %acc_119 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+        %13 = tt.reshape %acc_121 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+        %14 = tt.trans %12 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+        %15 = tt.trans %13 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+        %outLHS, %outRHS = tt.split %14 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+        %outLHS_123, %outRHS_124 = tt.split %15 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+        %16 = ttg.convert_layout %outRHS {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x64xf32, #blocked>
+        %17 = ttg.convert_layout %outRHS_124 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x64xf32, #blocked>
+        %18 = ttg.convert_layout %outLHS {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x64xf32, #blocked>
+        %19 = ttg.convert_layout %outLHS_123 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x64xf32, #blocked>
+        %acc0_125, %acc0_126 = ttng.tmem_load %alpha_0[] {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x1xf32, #blocked3>
+        %acc0_127 = tt.reshape %acc0_125 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked3> -> tensor<128xf32, #linear>
+        %acc0_128 = ttg.convert_layout %acc0_127 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #linear> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %acc0_129 = tt.expand_dims %acc0_128 {async_task_id = array<i32: 0>, axis = 1 : i32, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+        %acc0_130, %acc0_131 = ttng.tmem_load %alpha_1[] {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x1xf32, #blocked3>
+        %acc0_132 = tt.reshape %acc0_130 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x1xf32, #blocked3> -> tensor<128xf32, #linear>
+        %acc0_133 = ttg.convert_layout %acc0_132 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #linear> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %acc0_134 = tt.expand_dims %acc0_133 {async_task_id = array<i32: 0>, axis = 1 : i32, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+        %acc0_135 = tt.broadcast %acc0_129 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x64xf32, #blocked>
+        %acc0_136 = tt.broadcast %acc0_134 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x64xf32, #blocked>
+        %acc0_137 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {async_task_id = array<i32: 0>, constraints = "=r,=r,r,r,r,r", loop.cluster = 3 : i32, loop.stage = 1 : i32, packed_element = 2 : i32, pure = true} %18, %acc0_135 : tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked> -> tensor<128x64xf32, #blocked>
+        %acc0_138 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {async_task_id = array<i32: 0>, constraints = "=r,=r,r,r,r,r", loop.cluster = 1 : i32, loop.stage = 2 : i32, packed_element = 2 : i32, pure = true} %19, %acc0_136 : tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked> -> tensor<128x64xf32, #blocked>
+        %acc1 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {async_task_id = array<i32: 0>, constraints = "=r,=r,r,r,r,r", loop.cluster = 3 : i32, loop.stage = 1 : i32, packed_element = 2 : i32, pure = true} %16, %acc0_135 : tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked> -> tensor<128x64xf32, #blocked>
+        %acc1_139 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {async_task_id = array<i32: 0>, constraints = "=r,=r,r,r,r,r", loop.cluster = 1 : i32, loop.stage = 2 : i32, packed_element = 2 : i32, pure = true} %17, %acc0_136 : tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked> -> tensor<128x64xf32, #blocked>
+        %acc_140 = tt.join %acc0_137, %acc1 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked> -> tensor<128x64x2xf32, #blocked7>
+        %acc_141 = tt.join %acc0_138, %acc1_139 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x64xf32, #blocked> -> tensor<128x64x2xf32, #blocked7>
+        %acc_142 = tt.trans %acc_140 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x64x2xf32, #blocked7> -> tensor<128x2x64xf32, #blocked8>
+        %acc_143 = tt.trans %acc_141 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32, order = array<i32: 0, 2, 1>} : tensor<128x64x2xf32, #blocked7> -> tensor<128x2x64xf32, #blocked8>
+        %acc_144 = ttg.convert_layout %acc_142 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x2x64xf32, #blocked8> -> tensor<128x2x64xf32, #linear1>
+        %acc_145 = ttg.convert_layout %acc_143 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x2x64xf32, #blocked8> -> tensor<128x2x64xf32, #linear1>
+        %acc_146 = tt.reshape %acc_144 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x2x64xf32, #linear1> -> tensor<128x128xf32, #linear2>
+        %acc_147 = tt.reshape %acc_145 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x2x64xf32, #linear1> -> tensor<128x128xf32, #linear2>
+        %p_148 = arith.truncf %p {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+        %p_149 = arith.truncf %p_110 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+        %acc_150 = ttg.convert_layout %p_148 {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked> -> tensor<128x128xf16, #blocked>
+        ttng.tmem_store %acc_150, %acc_0, %true {async_task_id = array<i32: 5>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %acc_151 = ttg.convert_layout %p_149 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf16, #blocked> -> tensor<128x128xf16, #blocked>
+        ttng.tmem_store %acc_151, %acc_1, %true {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf16, #blocked> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %acc_152 = ttg.convert_layout %acc_146 {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #linear2> -> tensor<128x128xf32, #blocked>
+        %acc_153 = ttg.convert_layout %acc_147 {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #linear2> -> tensor<128x128xf32, #blocked>
+        %acc_154 = ttng.tmem_store %acc_152, %acc_0_13[%acc_120], %true {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 1 : i32, tmem.start = array<i32: 16>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %acc_155 = ttng.tmem_store %acc_153, %acc_1_11[%acc_122], %true {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 2 : i32, tmem.start = array<i32: 14>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %acc_156 = ttng.tc_gen5_mma %acc_0, %v, %acc_0_13[%acc_154], %true, %true {async_task_id = array<i32: 1>, loop.cluster = 3 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 16>, tmem.start = array<i32: 17>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %acc_157 = ttng.tc_gen5_mma %acc_1, %v, %acc_1_11[%acc_155], %true, %true {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 2 : i32, tmem.end = array<i32: 14>, tmem.start = array<i32: 15>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %l_i0 = arith.mulf %arg12, %alpha_112 {async_task_id = array<i32: 5>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %l_i0_158 = arith.mulf %arg16, %alpha_115 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %l_i0_159 = arith.addf %l_i0, %l_ij {async_task_id = array<i32: 5>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %l_i0_160 = arith.addf %l_i0_158, %l_ij_118 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+        %offsetkv_y_161 = arith.addi %offset_y_82, %c128_i32 {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 1 : i32} : i32
+        scf.yield {async_task_id = array<i32: 0, 1, 2, 4, 5>} %offsetkv_y_161, %l_i0_159, %m_ij_100, %qk_93, %acc_156, %l_i0_160, %m_ij_101, %qk_95, %acc_157 : i32, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.async.token, !ttg.async.token, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.async.token, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>, tt.data_partition_factor = 2 : i32, tt.merge_epilogue = true, tt.scheduled_max_stage = 2 : i32, tt.separate_epilogue_store = true}
+      %offsetkv_y_39 = tt.expand_dims %offsetkv_y#6 {async_task_id = array<i32: 4>, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+      %offsetkv_y_40 = ttg.convert_layout %offsetkv_y_39 {async_task_id = array<i32: 4>} : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked3>
+      ttng.tmem_store %offsetkv_y_40, %m_ij_0, %true {async_task_id = array<i32: 4>} : tensor<128x1xf32, #blocked3> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %offsetkv_y_41 = tt.expand_dims %offsetkv_y#5 {async_task_id = array<i32: 4>, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+      %offsetkv_y_42 = ttg.convert_layout %offsetkv_y_41 {async_task_id = array<i32: 4>} : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked3>
+      ttng.tmem_store %offsetkv_y_42, %l_i0_1, %true {async_task_id = array<i32: 4>} : tensor<128x1xf32, #blocked3> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %offsetkv_y_43 = tt.expand_dims %offsetkv_y#2 {async_task_id = array<i32: 5>, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+      %offsetkv_y_44 = ttg.convert_layout %offsetkv_y_43 {async_task_id = array<i32: 5>} : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked3>
+      ttng.tmem_store %offsetkv_y_44, %m_ij_1, %true {async_task_id = array<i32: 5>} : tensor<128x1xf32, #blocked3> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %offsetkv_y_45 = tt.expand_dims %offsetkv_y#1 {async_task_id = array<i32: 5>, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+      %offsetkv_y_46 = ttg.convert_layout %offsetkv_y_45 {async_task_id = array<i32: 5>} : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked3>
+      ttng.tmem_store %offsetkv_y_46, %l_i0_0, %true {async_task_id = array<i32: 5>} : tensor<128x1xf32, #blocked3> -> !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %m_i0, %m_i0_47 = ttng.tmem_load %l_i0_0[] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x1xf32, #blocked3>
+      %m_i0_48 = tt.reshape %m_i0 {async_task_id = array<i32: 0>} : tensor<128x1xf32, #blocked3> -> tensor<128xf32, #linear>
+      %m_i0_49 = ttg.convert_layout %m_i0_48 {async_task_id = array<i32: 0>} : tensor<128xf32, #linear> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %m_i0_50 = math.log2 %m_i0_49 {async_task_id = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %m_i0_51, %m_i0_52 = ttng.tmem_load %m_ij_1[] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x1xf32, #blocked3>
+      %m_i0_53 = tt.reshape %m_i0_51 {async_task_id = array<i32: 0>} : tensor<128x1xf32, #blocked3> -> tensor<128xf32, #linear>
+      %m_i0_54 = ttg.convert_layout %m_i0_53 {async_task_id = array<i32: 0>} : tensor<128xf32, #linear> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %m_i0_55 = arith.addf %m_i0_54, %m_i0_50 {async_task_id = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %4 = ttg.convert_layout %m_i0_55 {async_task_id = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128xf32, #blocked1>
+      %m_ptrs0 = arith.muli %off_hz, %c4096_i32 {async_task_id = array<i32: 0>} : i32
+      %m_ptrs0_56 = tt.addptr %M, %m_ptrs0 {async_task_id = array<i32: 0>} : !tt.ptr<f32>, i32
+      %m_ptrs0_57 = tt.splat %m_ptrs0_56 {async_task_id = array<i32: 0>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked1>
+      %m_ptrs0_58 = tt.addptr %m_ptrs0_57, %offs_m0_34 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked1>, tensor<128xi32, #blocked1>
+      tt.store %m_ptrs0_58, %4 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked1>
+      %acc0 = tt.expand_dims %m_i0_49 {async_task_id = array<i32: 0>, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+      %acc0_59 = tt.broadcast %acc0 {async_task_id = array<i32: 0>} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+      %acc_60, %acc_61 = ttng.tmem_load %acc_0_13[%offsetkv_y#4] {async_task_id = array<i32: 0>, tmem.end = array<i32: 17>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %acc0_62 = arith.divf %acc_60, %acc0_59 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked>
+      %5 = arith.truncf %acc0_62 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+      %6 = ttg.convert_layout %5 {async_task_id = array<i32: 0>} : tensor<128x128xf16, #blocked> -> tensor<128x128xf16, #blocked2>
+      ttg.local_store %6, %_1 {async_task_id = array<i32: 0>} : tensor<128x128xf16, #blocked2> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %7 = ttg.local_load %_1 {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #blocked2>
+      tt.descriptor_store %desc_o_22[%qo_offset_y_31, %c0_i32], %7 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, tensor<128x128xf16, #blocked2>
+      %m_i0_63, %m_i0_64 = ttng.tmem_load %l_i0_1[] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x1xf32, #blocked3>
+      %m_i0_65 = tt.reshape %m_i0_63 {async_task_id = array<i32: 0>} : tensor<128x1xf32, #blocked3> -> tensor<128xf32, #linear>
+      %m_i0_66 = ttg.convert_layout %m_i0_65 {async_task_id = array<i32: 0>} : tensor<128xf32, #linear> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %m_i0_67 = math.log2 %m_i0_66 {async_task_id = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %m_i0_68, %m_i0_69 = ttng.tmem_load %m_ij_0[] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x1xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x1xf32, #blocked3>
+      %m_i0_70 = tt.reshape %m_i0_68 {async_task_id = array<i32: 0>} : tensor<128x1xf32, #blocked3> -> tensor<128xf32, #linear>
+      %m_i0_71 = ttg.convert_layout %m_i0_70 {async_task_id = array<i32: 0>} : tensor<128xf32, #linear> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %m_i0_72 = arith.addf %m_i0_71, %m_i0_67 {async_task_id = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+      %8 = ttg.convert_layout %m_i0_72 {async_task_id = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128xf32, #blocked1>
+      %m_ptrs0_73 = tt.splat %m_ptrs0_56 {async_task_id = array<i32: 0>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked1>
+      %m_ptrs0_74 = tt.addptr %m_ptrs0_73, %offs_m0_35 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked1>, tensor<128xi32, #blocked1>
+      tt.store %m_ptrs0_74, %8 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked1>
+      %acc0_75 = tt.expand_dims %m_i0_66 {async_task_id = array<i32: 0>, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+      %acc0_76 = tt.broadcast %acc0_75 {async_task_id = array<i32: 0>} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+      %acc_77, %acc_78 = ttng.tmem_load %acc_1_11[%offsetkv_y#8] {async_task_id = array<i32: 0>, tmem.end = array<i32: 15>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %acc0_79 = arith.divf %acc_77, %acc0_76 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked>
+      %9 = arith.truncf %acc0_79 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+      %10 = ttg.convert_layout %9 {async_task_id = array<i32: 0>} : tensor<128x128xf16, #blocked> -> tensor<128x128xf16, #blocked2>
+      ttg.local_store %10, %_0 {async_task_id = array<i32: 0>} : tensor<128x128xf16, #blocked2> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %11 = ttg.local_load %_0 {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #blocked2>
+      tt.descriptor_store %desc_o_23[%3, %c0_i32], %11 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, tensor<128x128xf16, #blocked2>
+      %tile_idx_80 = arith.addi %tile_idx_27, %num_progs {async_task_id = array<i32: 0, 2, 3>} : i32
+      scf.yield {async_task_id = array<i32: 0, 2, 3>} %tile_idx_80 : i32
+    } {async_task_id = array<i32: 0, 1, 2, 3, 4, 5>, tt.data_partition_factor = 2 : i32, tt.merge_epilogue = true, tt.separate_epilogue_store = true, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["correction", "gemm", "load", "epilogue_store", "computation", "computation"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
@@ -1,0 +1,353 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation" | FileCheck %s
+
+// Tests that the full FA BWD persistent kernel (bwd.part.prior) gets the correct
+// 4-partition layout: reduction + gemm + load + computation.
+// This is a real BWD FA kernel dumped from fused-attention-ws-device-tma.py.
+//
+// Partition structure:
+//   0 = reduction: dq tmem_load, reshape/split, descriptor_reduce, dk/dv init
+//   1 = gemm:      all 5 MMAs (QK, dpT, dv, dq, dk) + memdesc_trans
+//   2 = load:      descriptor_load (K, V, Q, dO) + local_alloc
+//   3 = computation: QK tmem_load, softmax, dpT tmem_load, dsT computation,
+//                    p tmem_alloc, post-loop tmem_load/reshape/split/descriptor_store
+
+// CHECK-LABEL: @_attn_bwd_persist
+//
+// --- Pre-loop: address computation -> reduction partition ---
+// (scalar ops may be unscheduled since they can be rematerialized)
+// CHECK: arith.divsi {{.*}}ttg.partition = array<i32: [[RED:[0-9]+]]>
+// CHECK: arith.remsi {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.muli {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.divsi {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.muli {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.addi {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.extsi {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.divsi {{.*}}ttg.partition = array<i32: [[RED]]>
+// --- Pre-loop: K, V descriptor_load -> load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.splat {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
+// CHECK: tt.splat {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Pre-loop: dq tmem_alloc, dk/dv init → reduction partition ---
+// CHECK: ttng.tmem_alloc {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[RED]]>
+// --- In-loop: address computation → reduction partition ---
+// CHECK: arith.extsi {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.addi {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.trunci {{.*}}ttg.partition = array<i32: [[RED]]>
+// --- In-loop: Q descriptor_load, local_alloc → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- In-loop: Q memdesc_trans → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// --- In-loop: QK MMA → gemm partition ---
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: QK tmem_load, softmax → computation partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.subf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: math.exp2 {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- In-loop: dO descriptor_load, local_alloc → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- In-loop: ppT truncf, tmem_alloc → computation partition ---
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttng.tmem_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- In-loop: dO memdesc_trans → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: dpT MMA, dv MMA → gemm partition ---
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: dpT tmem_load, dsT computation → computation partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.subf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- In-loop: dsT memdesc_trans → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: dq MMA, dk MMA → gemm partition ---
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: dq tmem_load, reshape/split → reduction partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[RED]]>
+// --- In-loop: dq descriptor_reduce (×4) → reduction partition ---
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.descriptor_reduce {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.descriptor_reduce {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.descriptor_reduce {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[RED]]>
+// CHECK: tt.descriptor_reduce {{.*}}ttg.partition = array<i32: [[RED]]>
+//
+// --- Post-loop: dv tmem_load, reshape/split → computation partition (via mergeEpilogueToComputation) ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Post-loop: dv truncf, convert, descriptor_store (×4) → computation partition (via mergeEpilogueToComputation) ---
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Post-loop: dk tmem_load, reshape/split → computation partition (via mergeEpilogueToComputation) ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Post-loop: dk mulf, truncf, convert, descriptor_store (×4) → computation partition (via mergeEpilogueToComputation) ---
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+//
+// --- Partition types ---
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["reduction", "gemm", "load", "computation"]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 32], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 32, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked9 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked10 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_bwd_persist(%desc_q: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_q_0: i32, %desc_q_1: i32, %desc_q_2: i64, %desc_q_3: i64, %desc_k: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_k_4: i32, %desc_k_5: i32, %desc_k_6: i64, %desc_k_7: i64, %desc_v: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_v_8: i32, %desc_v_9: i32, %desc_v_10: i64, %desc_v_11: i64, %sm_scale: f32, %desc_do: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_do_12: i32, %desc_do_13: i32, %desc_do_14: i64, %desc_do_15: i64, %desc_dq: !tt.tensordesc<tensor<128x32xf32, #shared1>>, %desc_dq_16: i32, %desc_dq_17: i32, %desc_dq_18: i64, %desc_dq_19: i64, %desc_dk: !tt.tensordesc<tensor<128x32xf16, #shared2>>, %desc_dk_20: i32, %desc_dk_21: i32, %desc_dk_22: i64, %desc_dk_23: i64, %desc_dv: !tt.tensordesc<tensor<128x32xf16, #shared2>>, %desc_dv_24: i32, %desc_dv_25: i32, %desc_dv_26: i64, %desc_dv_27: i64, %M: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %D: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32 {tt.divisibility = 16 : i32}, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %n_tile_num = arith.constant 127 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c96_i32 = arith.constant 96 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %cst_28 = arith.constant dense<0.693147182> : tensor<128x32xf32, #blocked1>
+    %n_tile_num_29 = arith.addi %N_CTX, %n_tile_num : i32
+    %n_tile_num_30 = arith.divsi %n_tile_num_29, %c128_i32 : i32
+    %prog_id = tt.get_program_id x : i32
+    %num_progs = tt.get_num_programs x : i32
+    %total_tiles = arith.muli %n_tile_num_30, %BATCH : i32
+    %total_tiles_31 = arith.muli %total_tiles, %H : i32
+    %tiles_per_sm = arith.divsi %total_tiles_31, %num_progs : i32
+    %0 = arith.remsi %total_tiles_31, %num_progs : i32
+    %1 = arith.cmpi slt, %prog_id, %0 : i32
+    %2 = scf.if %1 -> (i32) {
+      %tiles_per_sm_32 = arith.addi %tiles_per_sm, %c1_i32 : i32
+      scf.yield %tiles_per_sm_32 : i32
+    } else {
+      scf.yield %tiles_per_sm : i32
+    }
+    %off_bh = arith.extsi %stride_tok : i32 to i64
+    %num_steps = arith.divsi %N_CTX, %c128_i32 : i32
+    %offs_m = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked2>
+    %dkN = tt.splat %sm_scale : f32 -> tensor<128x32xf32, #blocked1>
+    %tile_idx = scf.for %_ = %c0_i32 to %2 step %c1_i32 iter_args(%tile_idx_32 = %prog_id) -> (i32)  : i32 {
+      %pid = arith.remsi %tile_idx_32, %n_tile_num_30 : i32
+      %bhid = arith.divsi %tile_idx_32, %n_tile_num_30 : i32
+      %off_chz = arith.muli %bhid, %N_CTX : i32
+      %off_chz_33 = arith.extsi %off_chz : i32 to i64
+      %off_bh_34 = arith.remsi %bhid, %H : i32
+      %off_bh_35 = arith.muli %stride_h, %off_bh_34 : i32
+      %off_bh_36 = arith.divsi %bhid, %H : i32
+      %off_bh_37 = arith.muli %stride_z, %off_bh_36 : i32
+      %off_bh_38 = arith.addi %off_bh_35, %off_bh_37 : i32
+      %off_bh_39 = arith.extsi %off_bh_38 : i32 to i64
+      %off_bh_40 = arith.divsi %off_bh_39, %off_bh : i64
+      %M_41 = tt.addptr %M, %off_chz_33 : !tt.ptr<f32>, i64
+      %D_42 = tt.addptr %D, %off_chz_33 : !tt.ptr<f32>, i64
+      %start_n = arith.muli %pid, %c128_i32 : i32
+      %k = arith.extsi %start_n : i32 to i64
+      %k_43 = arith.addi %off_bh_40, %k : i64
+      %k_44 = arith.trunci %k_43 : i64 to i32
+      %k_45 = tt.descriptor_load %desc_k[%k_44, %c0_i32] : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+      %k_46 = ttg.local_alloc %k_45 : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %v = tt.descriptor_load %desc_v[%k_44, %c0_i32] : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+      %v_47 = ttg.local_alloc %v : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %m = tt.splat %M_41 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %Di = tt.splat %D_42 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %qkT, %qkT_48 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dpT, %dpT_49 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dv, %dv_50 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dq, %dq_51 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dk, %dk_52 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dk_53 = ttng.tmem_store %cst, %dk[%dk_52], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dv_54 = ttng.tmem_store %cst, %dv[%dv_50], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %curr_m:7 = scf.for %curr_m_86 = %c0_i32 to %num_steps step %c1_i32 iter_args(%arg47 = %c0_i32, %arg48 = %false, %qkT_87 = %qkT_48, %dpT_88 = %dpT_49, %dv_89 = %dv_54, %dq_90 = %dq_51, %dk_91 = %dk_53) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+        %q = arith.extsi %arg47 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32 to i64
+        %q_92 = arith.addi %off_bh_40, %q {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+        %q_93 = arith.trunci %q_92 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+        %q_94 = tt.descriptor_load %desc_q[%q_93, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+        %q_95 = ttg.local_alloc %q_94 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %qT = ttg.memdesc_trans %q_95 {loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared3, #smem>
+        %offs_m_96 = tt.splat %arg47 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32 -> tensor<128xi32, #blocked2>
+        %offs_m_97 = arith.addi %offs_m_96, %offs_m {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128xi32, #blocked2>
+        %m_98 = tt.addptr %m, %offs_m_97 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %m_99 = tt.load %m_98 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %qkT_100 = ttng.tc_gen5_mma %k_46, %qT, %qkT[%qkT_87], %false, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,2,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %pT = ttg.convert_layout %m_99 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+        %pT_101 = tt.expand_dims %pT {axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xf32, #blocked>
+        %pT_102 = tt.broadcast %pT_101 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #blocked> -> tensor<128x128xf32, #blocked>
+        %qkT_103, %qkT_104 = ttng.tmem_load %qkT[%qkT_100] {loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %pT_105 = arith.subf %qkT_103, %pT_102 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked>
+        %pT_106 = math.exp2 %pT_105 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked>
+        %do = tt.descriptor_load %desc_do[%q_93, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+        %do_107 = ttg.local_alloc %do {loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %ppT = arith.truncf %pT_106 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+        %dv_108 = ttng.tmem_alloc %ppT {loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+        %dpT_109 = ttg.memdesc_trans %do_107 {loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared3, #smem>
+        %dpT_110 = ttng.tc_gen5_mma %v_47, %dpT_109, %dpT[%dpT_88], %false, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %Di_111 = tt.addptr %Di, %offs_m_97 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %Di_112 = tt.load %Di_111 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %dv_113 = ttng.tc_gen5_mma %dv_108, %do_107, %dv[%dv_89], %arg48, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dsT = ttg.convert_layout %Di_112 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+        %dsT_114 = tt.expand_dims %dsT {axis = 0 : i32, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xf32, #blocked>
+        %dsT_115 = tt.broadcast %dsT_114 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked> -> tensor<128x128xf32, #blocked>
+        %dpT_116, %dpT_117 = ttng.tmem_load %dpT[%dpT_110] {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %dsT_118 = arith.subf %dpT_116, %dsT_115 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+        %dsT_119 = arith.mulf %pT_106, %dsT_118 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+        %dsT_120 = arith.truncf %dsT_119 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+        %dsT_121 = ttg.local_alloc %dsT_120 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %dq_122 = ttg.memdesc_trans %dsT_121 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared3, #smem>
+        %dq_123 = ttng.tc_gen5_mma %dq_122, %k_46, %dq[%dq_90], %false, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}"} : !ttg.memdesc<128x128xf16, #shared3, #smem>, !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dk_124 = ttng.tc_gen5_mma %dsT_121, %q_95, %dk[%dk_91], %arg48, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndD,tmem,1,10\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dq_125, %dq_126 = ttng.tmem_load %dq[%dq_123] {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %dqs = tt.reshape %dq_125 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+        %dqs_127 = tt.trans %dqs {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+        %dqs_128, %dqs_129 = tt.split %dqs_127 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+        %dqs_130 = tt.reshape %dqs_128 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_131 = tt.trans %dqs_130 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_132, %dqs_133 = tt.split %dqs_131 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+        %dqs_134 = tt.reshape %dqs_129 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_135 = tt.trans %dqs_134 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_136, %dqs_137 = tt.split %dqs_135 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+        %dqN = arith.mulf %dqs_132, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_138 = ttg.convert_layout %dqN {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c0_i32], %dqN_138 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_139 = arith.mulf %dqs_133, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_140 = ttg.convert_layout %dqN_139 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c32_i32], %dqN_140 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_141 = arith.mulf %dqs_136, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_142 = ttg.convert_layout %dqN_141 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c64_i32], %dqN_142 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_143 = arith.mulf %dqs_137, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_144 = ttg.convert_layout %dqN_143 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c96_i32], %dqN_144 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %curr_m_145 = arith.addi %arg47, %c128_i32 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+        scf.yield %curr_m_145, %true, %qkT_104, %dpT_117, %dv_113, %dq_126, %dk_124 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+      } {tt.scheduled_max_stage = 1 : i32}
+      %dv_55, %dv_56 = ttng.tmem_load %dv[%curr_m#4] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %dvs = tt.reshape %dv_55 : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+      %dvs_57 = tt.trans %dvs {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dvs_58, %dvs_59 = tt.split %dvs_57 : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dvs_60 = tt.reshape %dvs_58 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_61 = tt.trans %dvs_60 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_62, %dvs_63 = tt.split %dvs_61 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %dvs_64 = tt.reshape %dvs_59 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_65 = tt.trans %dvs_64 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_66, %dvs_67 = tt.split %dvs_65 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %3 = arith.truncf %dvs_62 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %4 = ttg.convert_layout %3 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c0_i32], %4 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %5 = arith.truncf %dvs_63 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %6 = ttg.convert_layout %5 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c32_i32], %6 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %7 = arith.truncf %dvs_66 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %8 = ttg.convert_layout %7 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c64_i32], %8 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %9 = arith.truncf %dvs_67 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %10 = ttg.convert_layout %9 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c96_i32], %10 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dk_68, %dk_69 = ttng.tmem_load %dk[%curr_m#6] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %dks = tt.reshape %dk_68 : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+      %dks_70 = tt.trans %dks {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dks_71, %dks_72 = tt.split %dks_70 : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dks_73 = tt.reshape %dks_71 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_74 = tt.trans %dks_73 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_75, %dks_76 = tt.split %dks_74 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %dks_77 = tt.reshape %dks_72 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_78 = tt.trans %dks_77 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_79, %dks_80 = tt.split %dks_78 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %dkN_81 = arith.mulf %dks_75, %dkN : tensor<128x32xf32, #blocked1>
+      %11 = arith.truncf %dkN_81 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %12 = ttg.convert_layout %11 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c0_i32], %12 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dkN_82 = arith.mulf %dks_76, %dkN : tensor<128x32xf32, #blocked1>
+      %13 = arith.truncf %dkN_82 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %14 = ttg.convert_layout %13 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c32_i32], %14 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dkN_83 = arith.mulf %dks_79, %dkN : tensor<128x32xf32, #blocked1>
+      %15 = arith.truncf %dkN_83 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %16 = ttg.convert_layout %15 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c64_i32], %16 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dkN_84 = arith.mulf %dks_80, %dkN : tensor<128x32xf32, #blocked1>
+      %17 = arith.truncf %dkN_84 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %18 = ttg.convert_layout %17 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c96_i32], %18 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %tile_idx_85 = arith.addi %tile_idx_32, %num_progs : i32
+      scf.yield %tile_idx_85 : i32
+    } {tt.merge_epilogue = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 200000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation" | FileCheck %s
+// RUN: TRITON_USE_META_PARTITION=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation" | FileCheck %s
 
 // Tests that the full FA BWD persistent kernel (bwd.part.prior) gets the correct
 // 4-partition layout: reduction + gemm + load + computation.

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-forward.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-forward.mlir
@@ -1,0 +1,323 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue separate-epilogue-store" | FileCheck %s
+
+// Tests that flash attention forward (dpFactor=2, with epilogue descriptor
+// stores) gets the correct 6-partition layout:
+//   default (correction), gemm, load, epilogue, computation, computation
+//
+// Key differences from flex attention:
+// - FA uses DescriptorStoreOp for output → creates an epilogue partition
+// - Correction ops (acc rescaling) go to the default partition
+// - No scf.if masking (no IfOp splitting needed)
+// - Global stores (descriptor_store) are post-loop epilogue ops
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @fa_forward_data_partition_split
+//
+// --- Pre-loop: Q descriptor_loads and local_allocs → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- Pre-loop: acc init → correction partition ---
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[CORR:[0-9]+]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[CORR]]>
+//
+// --- In-loop: K, V descriptor_loads → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- In-loop: QK MMAs → gemm partition ---
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: QK tmem_loads → computation partitions ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP0:[0-9]+]]>
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP1:[0-9]+]]>
+// --- In-loop: softmax m_ij reduction → computation partitions ---
+// CHECK: "tt.reduce"
+// CHECK: ttg.partition = array<i32: [[COMP0]]>
+// CHECK: "tt.reduce"
+// CHECK: ttg.partition = array<i32: [[COMP1]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: arith.maxnumf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.maxnumf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// --- In-loop: QK scaling and softmax → computation partitions ---
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: tt.expand_dims {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: tt.broadcast {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: tt.expand_dims {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: tt.broadcast {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: arith.subf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.subf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: math.exp2 {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: math.exp2 {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// --- In-loop: alpha = exp2(m_i - new_m) → computation partitions ---
+// CHECK: arith.subf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.subf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: math.exp2 {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: math.exp2 {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// --- In-loop: l_ij = sum(p) → computation partitions ---
+// CHECK: "tt.reduce"
+// CHECK: ttg.partition = array<i32: [[COMP0]]>
+// CHECK: "tt.reduce"
+// CHECK: ttg.partition = array<i32: [[COMP1]]>
+// --- In-loop: rescale acc → correction partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.expand_dims {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.broadcast {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.expand_dims {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.broadcast {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[CORR]]>
+// --- In-loop: p → bf16 → tmem → computation partitions ---
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: ttng.tmem_alloc {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: ttng.tmem_alloc {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// --- In-loop: PV MMAs → gemm partition ---
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: l_i update → computation partitions ---
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+// CHECK: arith.addf {{.*}}ttg.partition = array<i32: [[COMP0]]>
+// CHECK: arith.addf {{.*}}ttg.partition = array<i32: [[COMP1]]>
+//
+// --- Partition types ---
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["correction", "gemm", "load", "epilogue_store", "computation", "computation"]
+//
+// --- Post-loop: acc tmem_load, normalize → correction partition (via mergeEpilogue) ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.expand_dims {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.broadcast {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.expand_dims {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: tt.broadcast {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: arith.divf {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: arith.divf {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[CORR]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[CORR]]>
+// --- Post-loop: descriptor_store → epilogue_store partition ---
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[EPIL_STORE:[0-9]+]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
+
+tt.func public @fa_forward_data_partition_split(
+  %Q: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %K: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %V: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %Out: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %stride_qm: i32 {tt.divisibility = 16 : i32},
+  %stride_kn: i32 {tt.divisibility = 16 : i32},
+  %stride_vn: i32 {tt.divisibility = 16 : i32},
+  %stride_om: i32 {tt.divisibility = 16 : i32},
+  %Q_LEN: i32 {tt.divisibility = 16 : i32},
+  %KV_LEN: i32 {tt.divisibility = 16 : i32},
+  %SM_SCALE: f32
+) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %cst_neg_inf = arith.constant dense<0xFF800000> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  %cst_one = arith.constant dense<1.000000e+00> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  %cst_zero_2d = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+  %cst_scale = arith.constant dense<1.44269502> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  %cst_scale_2d = arith.constant dense<1.44269502> : tensor<128x128xf32, #blocked>
+  %n_iters = arith.constant 8 : i32
+
+  // Q descriptor and loads for two data partitions
+  %desc_q_stride = arith.extsi %stride_qm : i32 to i64
+  %desc_q = tt.make_tensor_descriptor %Q, [%Q_LEN, %c128_i32], [%desc_q_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+  %desc_q_2 = tt.make_tensor_descriptor %Q, [%Q_LEN, %c128_i32], [%desc_q_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+  %q_0_data = tt.descriptor_load %desc_q[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+  %q_1_data = tt.descriptor_load %desc_q_2[%c128_i32, %c0_i32] : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+  %q_0 = ttg.local_alloc %q_0_data : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+  %q_1 = ttg.local_alloc %q_1_data : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+
+  // K/V descriptors
+  %desc_k_stride = arith.extsi %stride_kn : i32 to i64
+  %desc_k = tt.make_tensor_descriptor %K, [%KV_LEN, %c128_i32], [%desc_k_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+  %desc_v_stride = arith.extsi %stride_vn : i32 to i64
+  %desc_v = tt.make_tensor_descriptor %V, [%KV_LEN, %c128_i32], [%desc_v_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+
+  // Output descriptor (TMA store — creates epilogue partition)
+  %desc_o_stride = arith.extsi %stride_om : i32 to i64
+  %desc_o = tt.make_tensor_descriptor %Out, [%Q_LEN, %c128_i32], [%desc_o_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+  %desc_o_2 = tt.make_tensor_descriptor %Out, [%Q_LEN, %c128_i32], [%desc_o_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+
+  // QK and ACC TMEM allocations
+  %qk_0, %qk_0_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %qk_1, %qk_1_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %acc_0, %acc_0_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %acc_1, %acc_1_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+
+  // Init accumulators
+  %acc_0_init = ttng.tmem_store %cst_zero_2d, %acc_0[%acc_0_tok], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %acc_1_init = ttng.tmem_store %cst_zero_2d, %acc_1[%acc_1_tok], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+  // Main attention loop
+  %loop:8 = scf.for %i = %c0_i32 to %n_iters step %c1_i32
+      iter_args(
+        %l_i_0 = %cst_one, %m_i_0 = %cst_neg_inf,
+        %qk_tok_0 = %qk_0_tok, %acc_tok_0 = %acc_0_init,
+        %l_i_1 = %cst_one, %m_i_1 = %cst_neg_inf,
+        %qk_tok_1 = %qk_1_tok, %acc_tok_1 = %acc_1_init
+      ) -> (
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token
+      ) : i32 {
+
+    // Load K and V
+    %kv_offset = arith.muli %i, %c128_i32 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i32
+    %k_data = tt.descriptor_load %desc_k[%kv_offset, %c0_i32] {loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+    %v_data = tt.descriptor_load %desc_v[%kv_offset, %c0_i32] {loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+    %k_smem = ttg.local_alloc %k_data {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+    %k_trans = ttg.memdesc_trans %k_smem {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared1, #smem>
+    %v_smem = ttg.local_alloc %v_data {loop.cluster = 3 : i32, loop.stage = 1 : i32} : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+
+    // QK MMA for both data partitions
+    %qk_mma_0 = ttng.tc_gen5_mma %q_0, %k_trans, %qk_0[%qk_tok_0], %false, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %qk_mma_1 = ttng.tc_gen5_mma %q_1, %k_trans, %qk_1[%qk_tok_1], %false, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // Load QK results
+    %qk_val_0, %qk_val_0_tok = ttng.tmem_load %qk_0[%qk_mma_0] {loop.cluster = 3 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %qk_val_1, %qk_val_1_tok = ttng.tmem_load %qk_1[%qk_mma_1] {loop.cluster = 1 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+
+    // Reduce for m_ij
+    %m_ij_0 = "tt.reduce"(%qk_val_0) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %b0: f32):
+      %max0 = arith.maxnumf %a0, %b0 : f32
+      tt.reduce.return %max0 : f32
+    }) {loop.cluster = 3 : i32, loop.stage = 1 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %m_ij_1 = "tt.reduce"(%qk_val_1) <{axis = 1 : i32}> ({
+    ^bb0(%a1: f32, %b1: f32):
+      %max1 = arith.maxnumf %a1, %b1 : f32
+      tt.reduce.return %max1 : f32
+    }) {loop.cluster = 1 : i32, loop.stage = 2 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    // Scale m_ij
+    %m_ij_scaled_0 = arith.mulf %m_ij_0, %cst_scale {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %m_ij_scaled_1 = arith.mulf %m_ij_1, %cst_scale {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    // new_m = max(m_i, m_ij)
+    %new_m_0 = arith.maxnumf %m_i_0, %m_ij_scaled_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %new_m_1 = arith.maxnumf %m_i_1, %m_ij_scaled_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    // Scale QK
+    %scores_0 = arith.mulf %qk_val_0, %cst_scale_2d {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %scores_1 = arith.mulf %qk_val_1, %cst_scale_2d {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked>
+
+    // p = exp2(scores - m)
+    %m_bcast_0 = tt.expand_dims %new_m_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %m_bcast2d_0 = tt.broadcast %m_bcast_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %m_bcast_1 = tt.expand_dims %new_m_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %m_bcast2d_1 = tt.broadcast %m_bcast_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %p_sub_0 = arith.subf %scores_0, %m_bcast2d_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %p_sub_1 = arith.subf %scores_1, %m_bcast2d_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked>
+    %p_0 = math.exp2 %p_sub_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %p_1 = math.exp2 %p_sub_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked>
+
+    // alpha = exp2(m_i - new_m)
+    %alpha_0 = arith.subf %m_i_0, %new_m_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %alpha_1 = arith.subf %m_i_1, %new_m_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %alpha_exp_0 = math.exp2 %alpha_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %alpha_exp_1 = math.exp2 %alpha_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    // l_ij = sum(p)
+    %l_ij_0 = "tt.reduce"(%p_0) <{axis = 1 : i32}> ({
+    ^bb0(%a2: f32, %b2: f32):
+      %s0 = arith.addf %a2, %b2 : f32
+      tt.reduce.return %s0 : f32
+    }) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %l_ij_1 = "tt.reduce"(%p_1) <{axis = 1 : i32}> ({
+    ^bb0(%a3: f32, %b3: f32):
+      %s1 = arith.addf %a3, %b3 : f32
+      tt.reduce.return %s1 : f32
+    }) {loop.cluster = 1 : i32, loop.stage = 2 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    // Rescale acc: acc_old * alpha
+    %acc_old_0, %acc_old_0_tok = ttng.tmem_load %acc_0[%acc_tok_0] {loop.cluster = 3 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %acc_old_1, %acc_old_1_tok = ttng.tmem_load %acc_1[%acc_tok_1] {loop.cluster = 1 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %alpha_1d_0 = tt.expand_dims %alpha_exp_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %alpha_2d_0 = tt.broadcast %alpha_1d_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %alpha_1d_1 = tt.expand_dims %alpha_exp_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %alpha_2d_1 = tt.broadcast %alpha_1d_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %acc_scaled_0 = arith.mulf %acc_old_0, %alpha_2d_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %acc_scaled_1 = arith.mulf %acc_old_1, %alpha_2d_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked>
+    %acc_store_0 = ttng.tmem_store %acc_scaled_0, %acc_0[%acc_old_0_tok], %true {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %acc_store_1 = ttng.tmem_store %acc_scaled_1, %acc_1[%acc_old_1_tok], %true {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // p → bf16 → tmem for PV MMA
+    %p_bf16_0 = arith.truncf %p_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+    %p_bf16_1 = arith.truncf %p_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+    %p_tmem_0 = ttng.tmem_alloc %p_bf16_0 {loop.cluster = 3 : i32, loop.stage = 1 : i32} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>
+    %p_tmem_1 = ttng.tmem_alloc %p_bf16_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>
+
+    // PV MMA
+    %pv_0 = ttng.tc_gen5_mma %p_tmem_0, %v_smem, %acc_0[%acc_store_0], %true, %true {loop.cluster = 3 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %pv_1 = ttng.tc_gen5_mma %p_tmem_1, %v_smem, %acc_1[%acc_store_1], %true, %true {loop.cluster = 1 : i32, loop.stage = 2 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // l_i update
+    %l_scaled_0 = arith.mulf %l_i_0, %alpha_exp_0 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %l_scaled_1 = arith.mulf %l_i_1, %alpha_exp_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %new_l_0 = arith.addf %l_scaled_0, %l_ij_0 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %new_l_1 = arith.addf %l_scaled_1, %l_ij_1 {loop.cluster = 1 : i32, loop.stage = 2 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    scf.yield %new_l_0, %new_m_0, %qk_val_0_tok, %pv_0,
+              %new_l_1, %new_m_1, %qk_val_1_tok, %pv_1
+      : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token
+  } {tt.data_partition_factor = 2 : i32, tt.warp_specialize}
+
+  // Post-loop: normalize acc and write with descriptor_store (epilogue)
+  %final_acc_0, %fa0_tok = ttng.tmem_load %acc_0[%loop#3] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+  %final_acc_1, %fa1_tok = ttng.tmem_load %acc_1[%loop#7] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+  %l_bcast_0 = tt.expand_dims %loop#0 {axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+  %l_bcast2d_0 = tt.broadcast %l_bcast_0 : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+  %l_bcast_1 = tt.expand_dims %loop#4 {axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+  %l_bcast2d_1 = tt.broadcast %l_bcast_1 : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+  %acc_norm_0 = arith.divf %final_acc_0, %l_bcast2d_0 : tensor<128x128xf32, #blocked>
+  %acc_norm_1 = arith.divf %final_acc_1, %l_bcast2d_1 : tensor<128x128xf32, #blocked>
+  %out_bf16_0 = arith.truncf %acc_norm_0 : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+  %out_bf16_1 = arith.truncf %acc_norm_1 : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+  %out_conv_0 = ttg.convert_layout %out_bf16_0 : tensor<128x128xbf16, #blocked> -> tensor<128x128xbf16, #blocked1>
+  %out_conv_1 = ttg.convert_layout %out_bf16_1 : tensor<128x128xbf16, #blocked> -> tensor<128x128xbf16, #blocked1>
+
+  // Descriptor stores — this is the KEY difference from flex attention.
+  // These create an epilogue partition.
+  tt.descriptor_store %desc_o[%c0_i32, %c0_i32], %out_conv_0 : !tt.tensordesc<tensor<128x128xbf16, #shared>>, tensor<128x128xbf16, #blocked1>
+  tt.descriptor_store %desc_o_2[%c128_i32, %c0_i32], %out_conv_1 : !tt.tensordesc<tensor<128x128xbf16, #shared>>, tensor<128x128xbf16, #blocked1>
+
+  tt.return
+}
+
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue" | FileCheck %s
+// RUN: TRITON_USE_META_PARTITION=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue" | FileCheck %s
 
 // Tests that flex attention (dpFactor=2, no epilogue stores, scf.if masking)
 // gets two separate computation partitions with symmetric split.

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
@@ -1,0 +1,260 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue" | FileCheck %s
+
+// Tests that flex attention (dpFactor=2, no epilogue stores, scf.if masking)
+// gets two separate computation partitions with symmetric split.
+// Without the fix, the pass collapses all computation ops into a single
+// partition because:
+// 1. No epilogue stores → hasEpilogue=false → no defaultPartition created
+// 2. Without defaultPartition, Phase 4 load user propagation is skipped
+// 3. Phase 5's greedy scheduleUsers absorbs all ops through the scf.if merge
+// 4. Shared ops (scf.if) form cross-partition clusters in propagatePartitions
+//
+// The fix:
+// 1. Creates defaultPartition when numDataPartitions > 1
+// 2. Pre-assigns DataPartition ops to separate computation partitions
+// 3. Pre-assigns shared MMA backward-slice ops to the default partition
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 1, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @flex_attention_data_partition_split
+//
+// --- Anchor ops: loads → load partition, MMAs → gemm partition ---
+// CHECK: tt.descriptor_load {{.*}} ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}} ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttng.tc_gen5_mma {{.*}} ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// CHECK: ttng.tc_gen5_mma {{.*}} ttg.partition = array<i32: [[GEMM]]>
+//
+// --- QK tmem_loads go to two DIFFERENT computation partitions ---
+// CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: [[COMP_A:[0-9]+]]>
+// CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: [[COMP_B:[0-9]+]]>
+//
+// --- Correction/rescale ops (acc tmem_load, tmem_store) go to correction (partition 0) ---
+// CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: 0>
+// CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: 0>
+// CHECK: ttng.tmem_store {{.*}} ttg.partition = array<i32: 0>
+// CHECK: ttng.tmem_store {{.*}} ttg.partition = array<i32: 0>
+//
+// --- PV MMAs go to gemm partition ---
+// CHECK: ttng.tc_gen5_mma {{.*}} ttg.partition = array<i32: [[GEMM]]>
+// CHECK: ttng.tc_gen5_mma {{.*}} ttg.partition = array<i32: [[GEMM]]>
+//
+// --- Partition types: correction + gemm + load + two computation partitions ---
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types =
+// CHECK-SAME: "correction"
+// CHECK-SAME: "gemm"
+// CHECK-SAME: "load"
+// CHECK-SAME: "computation"
+// CHECK-SAME: "computation"
+//
+// --- Post-loop ops go to correction partition (partition 0) ---
+// CHECK: tmem_load {{.*}}ttg.partition = array<i32: 0>
+// CHECK: tmem_load {{.*}}ttg.partition = array<i32: 0>
+// CHECK: tt.store {{.*}}ttg.partition = array<i32: 0>
+
+tt.func public @flex_attention_data_partition_split(
+  %Q: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %K: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %V: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %Out: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+  %LSE: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+  %KV_IDX: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+  %stride_qm: i32 {tt.divisibility = 16 : i32},
+  %stride_kn: i32 {tt.divisibility = 16 : i32},
+  %stride_vn: i32 {tt.divisibility = 16 : i32},
+  %stride_om: i32 {tt.divisibility = 16 : i32},
+  %Q_LEN: i32 {tt.divisibility = 16 : i32},
+  %KV_LEN: i32 {tt.divisibility = 16 : i32},
+  %SM_SCALE: f32
+) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %cst_neg_inf = arith.constant dense<0xFF800000> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  %cst_zero_f = arith.constant dense<0.000000e+00> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  %cst_zero_2d = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+  %cst_neg_inf_2d = arith.constant dense<0xFF800000> : tensor<128x128xf32, #blocked>
+  %cst_scale = arith.constant dense<1.44269502> : tensor<128x128xf32, #blocked>
+  %n_iters = arith.constant 8 : i32
+
+  // Q descriptor and loads for two data partitions
+  %desc_q_stride = arith.extsi %stride_qm : i32 to i64
+  %desc_q = tt.make_tensor_descriptor %Q, [%Q_LEN, %c128_i32], [%desc_q_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+  %q_0_data = tt.descriptor_load %desc_q[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+  %q_1_data = tt.descriptor_load %desc_q[%c128_i32, %c0_i32] : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+  %q_0 = ttg.local_alloc %q_0_data : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+  %q_1 = ttg.local_alloc %q_1_data : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+
+  // K/V descriptors
+  %desc_k_stride = arith.extsi %stride_kn : i32 to i64
+  %desc_k = tt.make_tensor_descriptor %K, [%KV_LEN, %c128_i32], [%desc_k_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+  %desc_v_stride = arith.extsi %stride_vn : i32 to i64
+  %desc_v = tt.make_tensor_descriptor %V, [%KV_LEN, %c128_i32], [%desc_v_stride, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+
+  // QK and ACC TMEM allocations
+  %qk_0, %qk_0_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %qk_1, %qk_1_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %acc_0, %acc_0_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %acc_1, %acc_1_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+
+  // Init accumulators
+  %acc_0_init = ttng.tmem_store %cst_zero_2d, %acc_0[%acc_0_tok], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %acc_1_init = ttng.tmem_store %cst_zero_2d, %acc_1[%acc_1_tok], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+  // Sparse block index load (outside loop, used for masking)
+  %kv_idx_val = tt.load %KV_IDX : !tt.ptr<i32>
+
+  // Main attention loop — no epilogue stores inside, pointer-based stores
+  // after the loop (like flex attention).
+  %loop:8 = scf.for %i = %c0_i32 to %n_iters step %c1_i32
+      iter_args(
+        %l_i_0 = %cst_zero_f, %m_i_0 = %cst_neg_inf,
+        %qk_tok_0 = %qk_0_tok, %acc_tok_0 = %acc_0_init,
+        %l_i_1 = %cst_zero_f, %m_i_1 = %cst_neg_inf,
+        %qk_tok_1 = %qk_1_tok, %acc_tok_1 = %acc_1_init
+      ) -> (
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token
+      ) : i32 {
+
+    // Load K and V
+    %kv_offset = arith.muli %i, %c128_i32 {loop.cluster = 3 : i32, loop.stage = 0 : i32} : i32
+    %k_data = tt.descriptor_load %desc_k[%kv_offset, %c0_i32] {loop.cluster = 3 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+    %v_data = tt.descriptor_load %desc_v[%kv_offset, %c0_i32] {loop.cluster = 3 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+    %k_smem = ttg.local_alloc %k_data {loop.cluster = 3 : i32, loop.stage = 0 : i32} : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+    %k_trans = ttg.memdesc_trans %k_smem {loop.cluster = 3 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared1, #smem>
+    %v_smem = ttg.local_alloc %v_data {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+
+    // QK MMA for both data partitions
+    %qk_mma_0 = ttng.tc_gen5_mma %q_0, %k_trans, %qk_0[%qk_tok_0], %false, %true {loop.cluster = 3 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %qk_mma_1 = ttng.tc_gen5_mma %q_1, %k_trans, %qk_1[%qk_tok_1], %false, %true {loop.cluster = 3 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // Load QK results
+    %qk_val_0, %qk_val_0_tok = ttng.tmem_load %qk_0[%qk_mma_0] {loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %qk_val_1, %qk_val_1_tok = ttng.tmem_load %qk_1[%qk_mma_1] {loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+
+    // Scale QK
+    %scores_0 = arith.mulf %qk_val_0, %cst_scale {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %scores_1 = arith.mulf %qk_val_1, %cst_scale {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+
+    // scf.if for masking — this is the merge point that causes both data
+    // partitions to collapse into one computation partition without the fix
+    %is_full = arith.cmpi sge, %i, %c1_i32 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : i32
+    %masked:2 = scf.if %is_full -> (tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>) {
+      scf.yield %scores_0, %scores_1 : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
+    } else {
+      %mask_0 = arith.select %false, %scores_0, %cst_neg_inf_2d {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+      %mask_1 = arith.select %false, %scores_1, %cst_neg_inf_2d {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+      scf.yield %mask_0, %mask_1 : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
+    } {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+
+    // Online softmax: m_ij, alpha, p, l_i — per data partition
+    %m_ij_0 = "tt.reduce"(%masked#0) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %b0: f32):
+      %max0 = arith.maxnumf %a0, %b0 : f32
+      tt.reduce.return %max0 : f32
+    }) {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %m_ij_1 = "tt.reduce"(%masked#1) <{axis = 1 : i32}> ({
+    ^bb0(%a1: f32, %b1: f32):
+      %max1 = arith.maxnumf %a1, %b1 : f32
+      tt.reduce.return %max1 : f32
+    }) {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    %new_m_0 = arith.maxnumf %m_i_0, %m_ij_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %new_m_1 = arith.maxnumf %m_i_1, %m_ij_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %alpha_0 = arith.subf %m_i_0, %new_m_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %alpha_1 = arith.subf %m_i_1, %new_m_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %alpha_exp_0 = math.exp2 %alpha_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %alpha_exp_1 = math.exp2 %alpha_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    // p = exp2(scores - m)
+    %m_bcast_0 = tt.expand_dims %new_m_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %m_bcast2d_0 = tt.broadcast %m_bcast_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %m_bcast_1 = tt.expand_dims %new_m_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %m_bcast2d_1 = tt.broadcast %m_bcast_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %p_sub_0 = arith.subf %masked#0, %m_bcast2d_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %p_sub_1 = arith.subf %masked#1, %m_bcast2d_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %p_0 = math.exp2 %p_sub_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %p_1 = math.exp2 %p_sub_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+
+    // l_i update
+    %l_scaled_0 = arith.mulf %l_i_0, %alpha_exp_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %l_scaled_1 = arith.mulf %l_i_1, %alpha_exp_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %l_sum_0 = "tt.reduce"(%p_0) <{axis = 1 : i32}> ({
+    ^bb0(%a2: f32, %b2: f32):
+      %s0 = arith.addf %a2, %b2 : f32
+      tt.reduce.return %s0 : f32
+    }) {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %l_sum_1 = "tt.reduce"(%p_1) <{axis = 1 : i32}> ({
+    ^bb0(%a3: f32, %b3: f32):
+      %s1 = arith.addf %a3, %b3 : f32
+      tt.reduce.return %s1 : f32
+    }) {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %new_l_0 = arith.addf %l_scaled_0, %l_sum_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %new_l_1 = arith.addf %l_scaled_1, %l_sum_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+
+    // Rescale acc and accumulate P*V
+    %alpha_1d_0 = tt.expand_dims %alpha_exp_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %alpha_2d_0 = tt.broadcast %alpha_1d_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %alpha_1d_1 = tt.expand_dims %alpha_exp_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32, axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %alpha_2d_1 = tt.broadcast %alpha_1d_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x1xf32, #blocked> -> tensor<128x128xf32, #blocked>
+    %acc_old_0, %acc_old_0_tok = ttng.tmem_load %acc_0[%acc_tok_0] {loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %acc_old_1, %acc_old_1_tok = ttng.tmem_load %acc_1[%acc_tok_1] {loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %acc_scaled_0 = arith.mulf %acc_old_0, %alpha_2d_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %acc_scaled_1 = arith.mulf %acc_old_1, %alpha_2d_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+    %acc_store_0 = ttng.tmem_store %acc_scaled_0, %acc_0[%acc_old_0_tok], %true {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %acc_store_1 = ttng.tmem_store %acc_scaled_1, %acc_1[%acc_old_1_tok], %true {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // p → bf16 → tmem for PV MMA
+    %p_bf16_0 = arith.truncf %p_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+    %p_bf16_1 = arith.truncf %p_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+    %p_tmem_0 = ttng.tmem_alloc %p_bf16_0 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>
+    %p_tmem_1 = ttng.tmem_alloc %p_bf16_1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>
+
+    // PV MMA
+    %pv_0 = ttng.tc_gen5_mma %p_tmem_0, %v_smem, %acc_0[%acc_store_0], %true, %true {loop.cluster = 1 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %pv_1 = ttng.tc_gen5_mma %p_tmem_1, %v_smem, %acc_1[%acc_store_1], %true, %true {loop.cluster = 1 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    scf.yield %new_l_0, %new_m_0, %qk_val_0_tok, %pv_0,
+              %new_l_1, %new_m_1, %qk_val_1_tok, %pv_1
+      : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>,
+        !ttg.async.token, !ttg.async.token
+  } {tt.data_partition_factor = 2 : i32, tt.warp_specialize}
+
+  // Post-loop: pointer-based stores (NOT descriptor stores)
+  // This is the key difference from FA — no epilogue stores.
+  %final_acc_0, %_ = ttng.tmem_load %acc_0[%loop#3] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+  %final_acc_1, %__ = ttng.tmem_load %acc_1[%loop#7] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+  %out_bf16_0 = arith.truncf %final_acc_0 : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+  %out_bf16_1 = arith.truncf %final_acc_1 : tensor<128x128xf32, #blocked> to tensor<128x128xbf16, #blocked>
+  // Use pointer-based store (tt.store), not descriptor store
+  %out_ptr = tt.splat %Out : !tt.ptr<bf16> -> tensor<128x128x!tt.ptr<bf16>, #blocked>
+  tt.store %out_ptr, %out_bf16_0 : tensor<128x128x!tt.ptr<bf16>, #blocked>
+  tt.store %out_ptr, %out_bf16_1 : tensor<128x128x!tt.ptr<bf16>, #blocked>
+
+  tt.return
+}
+
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-data-partition.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-data-partition.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="separate-epilogue-store" | FileCheck %s
 
 // Tests that when #MMAs == data_partition_factor, the GEMM template is selected
 // (not UnifiedFA). With dpFactor=2 and BLOCK_SIZE_M=256, the accumulator is
@@ -15,8 +15,40 @@
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // CHECK-LABEL: @data_partitioned_gemm_uses_gemm_template
+//
+// --- Pre-loop: acc inits → epilogue partition (no default partition) ---
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[EPIL:[0-9]+]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[EPIL]]>
+//
+// --- Inner k-loop: all descriptor_loads and local_allocs → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- Inner k-loop: memdesc_trans and both MMAs → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+//
+// --- Epilogue: tmem_load, truncf, local_alloc → computation partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Epilogue: TMA store → epilogue partition ---
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}}ttg.partition = array<i32: [[EPIL_STORE:[0-9]+]]>
+// CHECK: ttng.async_tma_store_token_wait {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
+// --- Second half: tmem_load, truncf, local_alloc → computation; TMA store → epilogue ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
+// CHECK: ttng.async_tma_store_token_wait {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
+//
+// --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["default", "gemm", "load", "epilogue"]
+// CHECK-SAME: ttg.partition.types = ["gemm", "load", "epilogue", "epilogue_store", "computation"]
 tt.func public @data_partitioned_gemm_uses_gemm_template(
   %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
   %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta="separate-epilogue-store" | FileCheck %s
 
 // Tests that GEMM partition scheduling does not create a separate "computation"
 // partition. Multi-def/sink clusters should merge into the default partition.
@@ -17,8 +17,41 @@
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // CHECK-LABEL: @persistent_gemm_no_computation_partition
+//
+// --- Pre-loop: acc init → epilogue partition (no default partition) ---
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[EPIL:[0-9]+]]>
+//
+// --- Inner k-loop: loads → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- Inner k-loop: memdesc_trans and MMA → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+//
+// --- Epilogue: tmem_load, reshape, trans, split → computation partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Epilogue: truncf, convert_layout, local_alloc → computation partition ---
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Epilogue: TMA store → epilogue partition ---
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}}ttg.partition = array<i32: [[EPIL_STORE:[0-9]+]]>
+// CHECK: ttng.async_tma_store_token_wait {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
+// --- Second half: truncf, convert_layout, local_alloc → computation; TMA store → epilogue ---
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
+// CHECK: ttng.async_tma_store_token_wait {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
+//
+// --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["default", "gemm", "load", "epilogue"]
+// CHECK-SAME: ttg.partition.types = ["gemm", "load", "epilogue", "epilogue_store", "computation"]
 tt.func public @persistent_gemm_no_computation_partition(
   %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
   %b_desc: !tt.tensordesc<tensor<256x64xf16, #shared>>,

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-post-loop-epilogue.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-post-loop-epilogue.mlir
@@ -1,0 +1,123 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+
+// Tests that post-loop tmem_load and arithmetic ops are scheduled to the
+// default partition (not the epilogue), while only epilogue store ops go to
+// the epilogue partition. This prevents TMEM ops from landing in the epilogue,
+// which would force it to use 4 warps (TMEM lane coverage hardware constraint).
+//
+// Before the fix, schedulePostLoopOps put ALL post-loop consumers of loop
+// results into the epilogue, including tmem_load (accumulator reads). This
+// forced the epilogue to 4 warps, causing non-persistent FA forward to exceed
+// the 512-thread hardware limit (20 warps × 32 = 640 > 512).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @post_loop_tmem_load_not_in_epilogue
+//
+// --- Pre-loop: acc inits → epilogue partition (no default partition) ---
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[EPIL:[0-9]+]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[EPIL]]>
+//
+// --- In-loop: loads → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- In-loop: memdesc_trans and MMAs → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: correction ops → computation partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: [[COMP]]>
+//
+// --- Partition types ---
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["gemm", "load", "epilogue", "computation"]
+//
+// --- Post-loop: tmem_load → epilogue ---
+// CHECK: ttng.tmem_load
+// CHECK-SAME: ttg.partition = array<i32: [[EPIL]]>
+// --- Post-loop: truncf → epilogue ---
+// CHECK: arith.truncf
+// CHECK-SAME: ttg.partition = array<i32: [[EPIL]]>
+// --- Post-loop: local_alloc → epilogue ---
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// --- Post-loop: TMA store → epilogue partition ---
+// CHECK: ttng.async_tma_copy_local_to_global
+// CHECK-SAME: ttg.partition = array<i32: [[EPIL]]>
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-SAME: ttg.partition = array<i32: [[EPIL]]>
+tt.func public @post_loop_tmem_load_not_in_epilogue(
+  %A_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+  %B_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+  %C_desc: !tt.tensordesc<tensor<128x128xf16, #shared>>,
+  %k_tiles: i32
+) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+
+  // Accumulators for two data-partitioned MMAs
+  %acc0_mem, %acc0_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %acc0_tok2 = ttng.tmem_store %cst, %acc0_mem[%acc0_tok], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %acc1_mem, %acc1_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+  %acc1_tok2 = ttng.tmem_store %cst, %acc1_mem[%acc1_tok], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+  // Inner KV loop (non-persistent FA forward pattern) with correction ops.
+  // Two MMAs + their results are yielded AND have non-yield users that feed
+  // the yield (accumulator rescaling), which triggers hasCorrection → UnifiedFA.
+  %loop_out:4 = scf.for %i = %c0_i32 to %k_tiles step %c1_i32
+      iter_args(%use_acc = %false, %loop_tok0 = %acc0_tok2, %loop_tok1 = %acc1_tok2,
+                %prev_scale = %cst) -> (i1, !ttg.async.token, !ttg.async.token,
+                tensor<128x128xf32, #blocked>) : i32 {
+    %offs_k = arith.muli %i, %c64_i32 : i32
+
+    // Load A
+    %a0 = tt.descriptor_load %A_desc[%c0_i32, %offs_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+    %a0_smem = ttg.local_alloc %a0 : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+
+    // Load B
+    %b = tt.descriptor_load %B_desc[%c0_i32, %offs_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+    %b_smem = ttg.local_alloc %b : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_trans = ttg.memdesc_trans %b_smem {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+
+    // MMA 0
+    %mma_tok0 = ttng.tc_gen5_mma %a0_smem, %b_trans, %acc0_mem[%loop_tok0], %use_acc, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // MMA 1 (second data partition)
+    %mma_tok1 = ttng.tc_gen5_mma %a0_smem, %b_trans, %acc1_mem[%loop_tok1], %use_acc, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // Correction: read MMA result, compute rescaling, yield back
+    // (This is the online softmax pattern that triggers hasCorrection)
+    %mma_result, %mma_result_tok = ttng.tmem_load %acc0_mem[%mma_tok0] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %scale = arith.mulf %mma_result, %prev_scale : tensor<128x128xf32, #blocked>
+    %store_tok = ttng.tmem_store %scale, %acc0_mem[%mma_result_tok], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    scf.yield %true, %store_tok, %mma_tok1, %scale : i1, !ttg.async.token, !ttg.async.token, tensor<128x128xf32, #blocked>
+  } {tt.warp_specialize}
+
+  // Post-loop epilogue: tmem_load → truncf → TMA store
+  // The tmem_load should go to default partition (not epilogue)
+  // Only the TMA store should go to epilogue partition
+  %result, %result_tok = ttng.tmem_load %acc0_mem[%loop_out#1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+  %result_f16 = arith.truncf %result : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+  %result_smem = ttg.local_alloc %result_f16 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+  %store_tok = ttng.async_tma_copy_local_to_global %C_desc[%c0_i32, %c0_i32] %result_smem : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+  ttng.async_tma_store_token_wait %store_tok : !ttg.async.token
+
+  tt.return
+}
+
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-types.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-types.mlir
@@ -14,11 +14,24 @@
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
-// Test: Verify partition types attribute is serialized
-// The partition scheduling pass should add ttg.partition.types attribute to the ForOp
+// Test: Verify partition types attribute is serialized and all tensor ops get partition IDs
 // CHECK-LABEL: @simple_gemm_partition_types
-// CHECK: scf.for
-// CHECK: ttg.partition.types
+//
+// --- In-loop: descriptor_load and local_alloc → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- In-loop: memdesc_trans and MMA → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+// --- In-loop: tmem_load and addf → computation partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
+// CHECK: arith.addf {{.*}}ttg.partition = array<i32: [[COMP]]>
+//
+// --- Partition types ---
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["gemm", "load", "computation"]
+//
+// --- Post-loop: use → no partition annotation (unregistered dialect op) ---
 tt.func public @simple_gemm_partition_types(
   %A_shared: !ttg.memdesc<128x64xf16, #shared, #smem>,
   %B_desc: !tt.tensordesc<tensor<64x64xf16, #shared>>,

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -271,10 +271,23 @@ def NVGPUPartitionSchedulingMeta : Pass<"nvgpu-partition-scheduling-meta", "mlir
   }];
 
   let options = [
-    Option<"mergeEpilogueIntoComputation", "merge-epilogue-into-computation",
+    Option<"mergeEpilogue", "merge-epilogue",
            "bool", /*default*/"false",
-           "If true, merge epilogue stores into the computation partition "
-           "instead of creating a separate epilogue partition">
+           "If true, merge epilogue ops into the correction/reduction partition "
+           "(or computation partition if neither exists)">,
+    Option<"mergeEpilogueToComputation", "merge-epilogue-to-computation",
+           "bool", /*default*/"false",
+           "If true, merge epilogue ops directly into computation[dpId] "
+           "partitions, even if correction/reduction exists">,
+    Option<"mergeCorrection", "merge-correction",
+           "bool", /*default*/"false",
+           "If true, merge correction ops into computation[dpId] partitions">,
+    Option<"mergeReduction", "merge-reduction",
+           "bool", /*default*/"false",
+           "If true, merge reduction ops into computation[dpId] partitions">,
+    Option<"separateEpilogueStore", "separate-epilogue-store",
+           "bool", /*default*/"false",
+           "If true, place epilogue store ops in a dedicated 1-warp partition">
   ];
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -19,6 +19,14 @@
 using namespace mlir;
 using namespace triton;
 using namespace triton::gpu;
+
+// Safe wrapper around getPartitionIds that handles ops without partition attrs.
+static SetVector<int> safeGetPartitionIds(Operation *op) {
+  if (!op->hasAttr(kPartitionAttrName))
+    return {};
+  return getPartitionIds(op);
+}
+
 namespace ttng = triton::nvidia_gpu;
 
 #define DEBUG_TYPE "tritongpu-partition-scheduling"
@@ -28,6 +36,12 @@ namespace {
 
 inline bool isEpilogueStoreOp(Operation *op) {
   return isa<DescriptorStoreOp, ttng::AsyncTMACopyLocalToGlobalOp>(op);
+}
+
+/// Check if an operation is an MMA-like operation (MMAv5 or WarpGroupDot).
+/// Used for backward slice analysis and data partition detection.
+inline bool isMMAOp(Operation *op) {
+  return isa<ttng::MMAv5OpInterface>(op) || isa<ttng::WarpGroupDotOp>(op);
 }
 
 //===----------------------------------------------------------------------===//
@@ -50,6 +64,9 @@ enum class OpCategory {
   Correction,    // Cross-iteration MMA users
   Default        // Everything else
 };
+
+/// Sentinel value for ops shared across multiple data partition groups.
+static constexpr unsigned SHARED_DPID = UINT_MAX;
 
 /// Get a string representation of an OpCategory.
 static llvm::StringRef toString(OpCategory category) {
@@ -79,18 +96,67 @@ static llvm::StringRef toString(OpCategory category) {
 //===----------------------------------------------------------------------===//
 
 /// Collect backward slice for an MMA operation.
-static SetVector<Operation *>
-collectMMABackwardSlice(scf::ForOp loop, ttng::MMAv5OpInterface mmaOp) {
+/// Enhanced to enter scf.if regions: when an scf.if op is in the slice,
+/// follow yield operands in the then/else blocks backward. This captures
+/// ops like tmem_load QK and mulf(QK*scale) in flex attention that feed
+/// into scf.if yield operands but are missed by standard getBackwardSlice.
+static SetVector<Operation *> collectMMABackwardSlice(scf::ForOp loop,
+                                                      Operation *mmaOp) {
   SetVector<Operation *> slice;
   BackwardSliceOptions options;
   options.omitBlockArguments = true;
   options.inclusive = false;
   options.filter = [&](Operation *op) {
-    return loop->isAncestor(op) && !isa<ttng::MMAv5OpInterface>(op);
+    return loop->isAncestor(op) && !isMMAOp(op);
   };
   for (Value operand : mmaOp->getOperands()) {
     (void)getBackwardSlice(operand, &slice, options);
   }
+
+  // Enter scf.if regions: follow yield operands backward until fixpoint.
+  // getBackwardSlice adds scf.if ops to the slice but does NOT enter their
+  // regions. Only follow yield operands that correspond to scf.if results
+  // actually consumed by ops already in the slice. This prevents pulling in
+  // ops from other data partitions (e.g., in flex attention, scf.if yields
+  // values for both dp0 and dp1 — we only want the one used by this MMA).
+  DenseSet<Operation *> visitedIfs;
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Operation *op : llvm::to_vector(slice)) {
+      auto ifOp = dyn_cast<scf::IfOp>(op);
+      if (!ifOp || !visitedIfs.insert(ifOp).second)
+        continue;
+      // Find which scf.if results are actually used by ops in the slice.
+      DenseSet<unsigned> usedResultIndices;
+      for (unsigned i = 0; i < ifOp.getNumResults(); ++i) {
+        for (Operation *user : ifOp.getResult(i).getUsers()) {
+          if (slice.contains(user) ||
+              llvm::any_of(mmaOp->getOperands(), [&](Value v) {
+                return v.getDefiningOp() == user;
+              })) {
+            usedResultIndices.insert(i);
+            break;
+          }
+        }
+      }
+      // Follow only the yield operands for used results.
+      for (Region *region : {&ifOp.getThenRegion(), &ifOp.getElseRegion()}) {
+        if (region->empty())
+          continue;
+        auto *yieldOp = region->front().getTerminator();
+        for (unsigned idx : usedResultIndices) {
+          if (idx < yieldOp->getNumOperands()) {
+            unsigned prevSize = slice.size();
+            (void)getBackwardSlice(yieldOp->getOperand(idx), &slice, options);
+            if (slice.size() > prevSize)
+              changed = true;
+          }
+        }
+      }
+    }
+  }
+
   return slice;
 }
 
@@ -166,212 +232,52 @@ static std::string prettyOp(Operation *op) {
 }
 
 //===----------------------------------------------------------------------===//
-// Scheduling Templates (Unified Approach)
+// Scheduling Options and Partition Layout
 //===----------------------------------------------------------------------===//
 //
-// Abstract partition types based on operation semantics:
-// - gemm: gen5 mma operations (core compute)
-// - correction: cross-iteration correction ops (online softmax)
-// - epilogue: epilogue store operations (descriptor_store)
-// - load: TMA load operations (descriptor_load, descriptor_gather)
-// - reduction: TMA reduction operations (descriptor_reduce)
-// - computation[N]: per-data-partition computation tensor ops
-//
-// Templates control how abstract partitions map to physical partitions.
+// Tuning knobs control how categories map to partitions.
+// The partition layout is determined by the categorizer results + options.
 
-/// Abstract partition type for semantic categorization.
-enum class AbstractPartition {
-  Gemm,        // gen5 mma operations
-  Correction,  // cross-iteration correction ops
-  Epilogue,    // epilogue store operations
-  Load,        // TMA load operations
-  Reduction,   // TMA reduction operations
-  Computation, // computation tensor ops (per data partition)
-  Default      // fallback for uncategorized ops
+/// Tuning knobs for partition scheduling.
+struct SchedulingOptions {
+  bool mergeCorrection = false;
+  bool mergeEpilogue = false;
+  bool mergeEpilogueToComputation = false;
+  bool mergeReduction = false;
+  bool separateEpilogueStore = false;
 };
 
-/// Template options for controlling partition placement.
-struct TemplateOptions {
-  /// If true, merge epilogue into computation partition.
-  /// If false, epilogue gets its own partition.
-  bool mergeEpilogueIntoComputation = false;
-
-  /// If true, merge reduction into computation partition.
-  /// If false, reduction gets its own partition.
-  bool mergeReductionIntoComputation = false;
-
-  /// Whether correction ops exist. If false, correction partition is skipped
-  /// and correction requests fall back to the default partition.
-  bool hasCorrection = false;
-
-  /// Whether TMA reduction ops exist. If false, reduction partition is skipped
-  /// and reduction requests fall back to the default partition.
-  bool hasReduction = false;
-
-  /// Whether epilogue stores exist. If false, epilogue partition is skipped.
-  bool hasEpilogue = false;
-
-  /// Number of data partitions (for parallel computation chains).
-  unsigned numDataPartitions = 1;
-};
-
-/// Base class for scheduling templates.
-class SchedulingTemplate {
-public:
-  virtual ~SchedulingTemplate() = default;
-
-  /// Create the partitions for this template in the schedule.
-  virtual void createPartitions(PartitionSet &schedule) = 0;
-
-  /// Get the partition for a given abstract partition type and data partition
-  /// ID.
-  virtual Partition *getPartition(AbstractPartition absPart,
-                                  unsigned dpId = 0) = 0;
-
-  /// Get the template name for debugging.
-  virtual StringRef getName() const = 0;
-};
-
-/// Unified Flash Attention template using general partition rules.
-/// Works for both forward and backward passes.
-class UnifiedFATemplate : public SchedulingTemplate {
-public:
-  explicit UnifiedFATemplate(TemplateOptions opts) : options(std::move(opts)) {}
-
-  void createPartitions(PartitionSet &schedule) override {
-    // Build up partitions based on what's actually needed.
-    // For fwd: default+correction / gemm / load / epilogue
-    //   → MMA users create dynamic computation partitions
-    // For bwd: reduction / gemm / load / computation
-    //   → reduction is at index 0 (default position) with num_warps=4
-    //   → gemm gets num_warps=1
-    //   → MMA users create a single shared computation partition with
-    //   num_warps=8
-
-    // For bwd (hasReduction): create reduction FIRST at index 0.
-    // This makes reduction the "default" partition in warp_specialize.
-    if (options.hasReduction) {
-      reductionPartition = schedule.addPartition(0);
-      reductionPartition->setType("reduction");
-      defaultPartition = nullptr; // No separate default for bwd
-    } else {
-      reductionPartition = nullptr;
-      // Default partition: needed when we have correction or epilogue.
-      bool needDefault = options.hasCorrection || options.hasEpilogue;
-      if (needDefault) {
-        defaultPartition = schedule.addPartition(0);
-        defaultPartition->setType("default");
-      } else {
-        defaultPartition = nullptr;
-      }
-    }
-
-    gemmPartition = schedule.addPartition(1); // stage 1 for MMA
-    gemmPartition->setType("gemm");
-    loadPartition = schedule.addPartition(0);
-    loadPartition->setType("load");
-
-    // Correction: merge into default partition.
-    if (options.hasCorrection)
-      correctionPartition = defaultPartition;
-    else
-      correctionPartition = nullptr;
-
-    // Epilogue: only if there are epilogue stores and not merged into
-    // computation.
-    if (options.hasEpilogue && !options.mergeEpilogueIntoComputation) {
-      epiloguePartition = schedule.addPartition(0);
-      epiloguePartition->setType("epilogue");
-    } else {
-      epiloguePartition = nullptr;
-    }
-
-    // Note: computation partitions are NOT pre-allocated here.
-    // They are created dynamically by scheduleUsers() in Phase 5.
-  }
-
-  Partition *getPartition(AbstractPartition absPart,
-                          unsigned dpId = 0) override {
-    switch (absPart) {
-    case AbstractPartition::Gemm:
-      return gemmPartition;
-    case AbstractPartition::Load:
-      return loadPartition;
-    case AbstractPartition::Correction:
-      return correctionPartition;
-    case AbstractPartition::Epilogue:
-      return epiloguePartition;
-    case AbstractPartition::Reduction:
-      return reductionPartition;
-    case AbstractPartition::Computation:
-      return dpId < computationPartitions.size() ? computationPartitions[dpId]
-                                                 : defaultPartition;
-    case AbstractPartition::Default:
-      return defaultPartition;
-    }
-    llvm_unreachable("Unknown abstract partition");
-  }
-
-  StringRef getName() const override { return "UnifiedFA"; }
-
-private:
-  TemplateOptions options;
-  Partition *gemmPartition = nullptr;
-  Partition *loadPartition = nullptr;
+/// Holds all partition pointers created by createPartitionLayout.
+struct PartitionLayout {
   Partition *correctionPartition = nullptr;
   Partition *reductionPartition = nullptr;
-  Partition *epiloguePartition = nullptr;
-  Partition *defaultPartition = nullptr;
-  SmallVector<Partition *> computationPartitions;
-};
-
-/// Simple GEMM template (no data partitioning).
-class GEMMTemplate : public SchedulingTemplate {
-public:
-  void createPartitions(PartitionSet &schedule) override {
-    defaultPartition = schedule.addPartition(0);
-    defaultPartition->setType("default");
-    gemmPartition = schedule.addPartition(1);
-    gemmPartition->setType("gemm");
-    loadPartition = schedule.addPartition(0);
-    loadPartition->setType("load");
-    epiloguePartition = schedule.addPartition(0);
-    epiloguePartition->setType("epilogue");
-  }
-
-  Partition *getPartition(AbstractPartition absPart,
-                          unsigned dpId = 0) override {
-    switch (absPart) {
-    case AbstractPartition::Gemm:
-      return gemmPartition;
-    case AbstractPartition::Load:
-      return loadPartition;
-    case AbstractPartition::Epilogue:
-      return epiloguePartition;
-    default:
-      return defaultPartition;
-    }
-  }
-
-  StringRef getName() const override { return "GEMM"; }
-
-private:
-  Partition *defaultPartition = nullptr;
   Partition *gemmPartition = nullptr;
   Partition *loadPartition = nullptr;
   Partition *epiloguePartition = nullptr;
+  Partition *epilogueStorePartition = nullptr;
+  Partition *defaultPartition = nullptr; // computed alias
+  SmallVector<Partition *, 2> computationPartitions;
+
+  /// Fallback: correction -> reduction -> epilogue -> first computation.
+  Partition *getDefaultPartition() const {
+    if (correctionPartition)
+      return correctionPartition;
+    if (reductionPartition)
+      return reductionPartition;
+    if (epiloguePartition)
+      return epiloguePartition;
+    if (!computationPartitions.empty())
+      return computationPartitions.back();
+    return nullptr;
+  }
+
+  /// Get the opToDpId map (for schedulePostLoopOps).
+  bool hasGemm() const { return gemmPartition != nullptr; }
 };
 
 //===----------------------------------------------------------------------===//
-// OpCategorizer - Categorizes operations for scheduling (Analysis Only)
+// OpCategorizer - Categorizes operations for scheduling
 //===----------------------------------------------------------------------===//
-//
-// This class implements Phase 1 of the two-phase scheduling approach:
-// 1. Categorize all ops based on their role
-// 2. Apply scheduling template based on categories (future)
-//
-// Currently this is used for analysis/logging only - the actual scheduling
-// logic in getInitialSchedule() is unchanged.
 
 /// Information about a categorized operation.
 struct CategorizedOp {
@@ -384,7 +290,7 @@ struct CategorizedOp {
 /// Categorizes operations in a loop for partition scheduling.
 class OpCategorizer {
 public:
-  OpCategorizer(scf::ForOp mainLoop, ArrayRef<ttng::MMAv5OpInterface> mmaOps)
+  OpCategorizer(scf::ForOp mainLoop, ArrayRef<Operation *> mmaOps)
       : mainLoop(mainLoop), mmas(mmaOps.begin(), mmaOps.end()) {
     // Collect all loops (nested + main)
     for (auto nestedLoop : mainLoop.getOps<scf::ForOp>())
@@ -399,8 +305,8 @@ public:
     categorizeMMAs();
     categorizeEpilogueStores();
     categorizeTMAReductions();
+    categorizeCorrectionOps(); // Before DataPartition to prevent stealing
     categorizeDataPartitionOps();
-    categorizeCorrectionOps();
   }
 
   /// Get operations in a specific category.
@@ -417,7 +323,27 @@ public:
   unsigned getDataPartitionFactor() const { return dataPartitionFactor; }
 
   /// Get all MMAs.
-  ArrayRef<ttng::MMAv5OpInterface> getMMAs() const { return mmas; }
+  ArrayRef<Operation *> getMMAs() const { return mmas; }
+
+  /// Check if any MMAs are MMAv5 (Blackwell).
+  bool hasMMAv5() const {
+    return llvm::any_of(
+        mmas, [](Operation *op) { return isa<ttng::MMAv5OpInterface>(op); });
+  }
+
+  /// Get the shared ops (ops appearing in multiple MMA backward slices).
+  const DenseSet<Operation *> &getSharedOps() const { return sharedOps; }
+
+  /// Get the dpId for an op. Returns SHARED_DPID if the op is shared across
+  /// groups, or 0 if the op has no dpId assigned.
+  unsigned getDpId(Operation *op) const {
+    auto it = opToDpId.find(op);
+    return it != opToDpId.end() ? it->second : 0;
+  }
+
+  const DenseMap<Operation *, unsigned> &getOpToDpIdMap() const {
+    return opToDpId;
+  }
 
   /// Pretty-print all categorized ops grouped by category.
   void printCategorizedOps(llvm::raw_ostream &os) const {
@@ -457,7 +383,7 @@ private:
     // Only process innermost loop's MMAs for data partitioning
     scf::ForOp innermostLoop = loops.empty() ? mainLoop : loops[0];
 
-    SmallVector<ttng::MMAv5OpInterface> loopMmas;
+    SmallVector<Operation *> loopMmas;
     for (auto mmaOp : mmas) {
       if (mmaOp->getParentOp() == innermostLoop.getOperation())
         loopMmas.push_back(mmaOp);
@@ -470,8 +396,7 @@ private:
 
     // Collect backward slice for each MMA
     for (auto mmaOp : loopMmas) {
-      mmaToSlice[mmaOp.getOperation()] =
-          collectMMABackwardSlice(innermostLoop, mmaOp);
+      mmaToSlice[mmaOp] = collectMMABackwardSlice(innermostLoop, mmaOp);
     }
 
     // Find shared ops (appear in multiple slices)
@@ -501,7 +426,7 @@ private:
 
     // Build forward reachability from each MMA result (through iter args too)
     for (unsigned i = 0; i < n; ++i) {
-      Operation *mmaOp = loopMmas[i].getOperation();
+      Operation *mmaOp = loopMmas[i];
       // Collect all ops reachable from this MMA's results
       DenseSet<Operation *> forwardSet;
       SmallVector<Value> worklist;
@@ -521,7 +446,7 @@ private:
         for (Operation *user : val.getUsers()) {
           if (!innermostLoop->isAncestor(user))
             continue;
-          if (isa<ttng::MMAv5OpInterface>(user))
+          if (isMMAOp(user))
             continue; // Don't traverse through other MMAs
           if (!forwardSet.insert(user).second)
             continue; // Already visited
@@ -534,7 +459,7 @@ private:
       for (unsigned j = 0; j < n; ++j) {
         if (i == j || find(i) == find(j))
           continue;
-        auto &slice = mmaToSlice[loopMmas[j].getOperation()];
+        auto &slice = mmaToSlice[loopMmas[j]];
         for (Operation *op : slice) {
           if (forwardSet.contains(op)) {
             unite(i, j);
@@ -547,7 +472,7 @@ private:
     // Count distinct groups that have exclusive (non-shared) ops
     DenseSet<unsigned> groupsWithExclusiveOps;
     for (unsigned i = 0; i < n; ++i) {
-      auto &slice = mmaToSlice[loopMmas[i].getOperation()];
+      auto &slice = mmaToSlice[loopMmas[i]];
       for (Operation *op : slice) {
         if (!sharedOps.contains(op) && !isa<arith::ConstantOp>(op)) {
           groupsWithExclusiveOps.insert(find(i));
@@ -563,6 +488,132 @@ private:
                             << groupsWithExclusiveOps.size()
                             << " independent groups (dpFactor="
                             << dataPartitionFactor << ")\n");
+
+    // Build opToDpId map for ALL ops reachable from MMAs.
+    // This is the single source of truth for data partition ID assignment.
+    if (dataPartitionFactor > 1) {
+      // Normalize group IDs to contiguous 0..dpFactor-1 range.
+      DenseMap<unsigned, unsigned> rootToGroupId;
+      unsigned nextGroupId = 0;
+      for (unsigned i = 0; i < n; ++i) {
+        unsigned root = find(i);
+        if (!rootToGroupId.count(root))
+          rootToGroupId[root] = nextGroupId++;
+      }
+
+      // Assign dpId to MMAs themselves.
+      for (unsigned i = 0; i < n; ++i) {
+        unsigned groupId = rootToGroupId[find(i)];
+        opToDpId[loopMmas[i]] = groupId;
+      }
+
+      // Assign dpId to all backward slice ops.
+      for (unsigned i = 0; i < n; ++i) {
+        unsigned groupId = rootToGroupId[find(i)];
+        for (Operation *op : mmaToSlice[loopMmas[i]]) {
+          auto it = opToDpId.find(op);
+          if (it == opToDpId.end()) {
+            opToDpId[op] = groupId;
+          } else if (it->second != groupId) {
+            it->second = SHARED_DPID;
+          }
+        }
+      }
+
+      // Assign dpId to pre-loop ops: follow MMA operands backward across
+      // the loop boundary. Ops defined outside the innermost loop that
+      // feed exclusively into one MMA group get that group's dpId.
+      for (unsigned i = 0; i < n; ++i) {
+        unsigned groupId = rootToGroupId[find(i)];
+        Operation *mmaOp = loopMmas[i];
+        SmallVector<Operation *> worklist;
+        for (Value operand : mmaOp->getOperands()) {
+          if (auto *defOp = operand.getDefiningOp()) {
+            if (!innermostLoop->isAncestor(defOp))
+              worklist.push_back(defOp);
+          }
+        }
+        // Also follow pre-loop ops from the backward slice.
+        for (Operation *op : mmaToSlice[mmaOp]) {
+          for (Value operand : op->getOperands()) {
+            if (auto *defOp = operand.getDefiningOp()) {
+              if (!innermostLoop->isAncestor(defOp) &&
+                  mainLoop->isAncestor(defOp))
+                worklist.push_back(defOp);
+            }
+          }
+        }
+        DenseSet<Operation *> visited;
+        while (!worklist.empty()) {
+          Operation *op = worklist.pop_back_val();
+          if (!visited.insert(op).second)
+            continue;
+          auto it = opToDpId.find(op);
+          if (it == opToDpId.end()) {
+            opToDpId[op] = groupId;
+          } else if (it->second != groupId) {
+            it->second = SHARED_DPID;
+          }
+          for (Value operand : op->getOperands()) {
+            if (auto *defOp = operand.getDefiningOp()) {
+              if (mainLoop->isAncestor(defOp) &&
+                  !innermostLoop->isAncestor(defOp))
+                worklist.push_back(defOp);
+            }
+          }
+        }
+      }
+
+      // Assign dpId to post-loop ops: follow loop results forward.
+      // Each loop result traces back to a specific MMA group's yield.
+      auto yieldOp = innermostLoop.getBody()->getTerminator();
+      for (unsigned argIdx = 0; argIdx < innermostLoop.getNumResults();
+           ++argIdx) {
+        Value yieldVal = yieldOp->getOperand(argIdx);
+        Operation *yieldDef = yieldVal.getDefiningOp();
+        if (!yieldDef)
+          continue;
+        auto it = opToDpId.find(yieldDef);
+        if (it == opToDpId.end())
+          continue;
+        unsigned yieldDpId = it->second;
+        if (yieldDpId == SHARED_DPID)
+          continue;
+        // Follow the loop result to post-loop consumers.
+        Value loopResult = innermostLoop.getResult(argIdx);
+        SmallVector<Operation *> postWorklist;
+        for (Operation *user : loopResult.getUsers())
+          postWorklist.push_back(user);
+        DenseSet<Operation *> postVisited;
+        while (!postWorklist.empty()) {
+          Operation *op = postWorklist.pop_back_val();
+          if (!postVisited.insert(op).second)
+            continue;
+          if (innermostLoop->isAncestor(op))
+            continue;
+          auto pit = opToDpId.find(op);
+          if (pit == opToDpId.end()) {
+            opToDpId[op] = yieldDpId;
+          } else if (pit->second != yieldDpId) {
+            pit->second = SHARED_DPID;
+          }
+          for (Value result : op->getResults())
+            for (Operation *user : result.getUsers())
+              postWorklist.push_back(user);
+        }
+      }
+
+      LLVM_DEBUG({
+        llvm::dbgs() << "[data-partition] opToDpId map (" << opToDpId.size()
+                     << " entries):\n";
+        unsigned sharedCount = 0;
+        for (auto &[op, dpId] : opToDpId) {
+          if (dpId == SHARED_DPID)
+            sharedCount++;
+        }
+        llvm::dbgs() << "  shared ops: " << sharedCount << "\n";
+      });
+    }
   }
 
   void categorizeLoads() {
@@ -578,7 +629,8 @@ private:
 
   void categorizeMMAs() {
     for (auto mmaOp : mmas) {
-      addCategorizedOp(mmaOp, OpCategory::MMA, 0, mmaOp);
+      unsigned dpId = getDpId(mmaOp);
+      addCategorizedOp(mmaOp, OpCategory::MMA, dpId, mmaOp);
 
       // Categorize memory descriptor views feeding into MMA
       SmallVector<Operation *> worklist;
@@ -592,7 +644,7 @@ private:
           continue;
         if (opCategories.contains(op))
           continue;
-        addCategorizedOp(op, OpCategory::MemDescView, 0, mmaOp);
+        addCategorizedOp(op, OpCategory::MemDescView, getDpId(op), mmaOp);
         if (Operation *defOp = op->getOperand(0).getDefiningOp())
           worklist.push_back(defOp);
       }
@@ -629,22 +681,23 @@ private:
     if (dataPartitionFactor <= 1)
       return;
 
-    // Map exclusive ops to their MMA's partition ID
-    unsigned partitionId = 0;
+    // Map exclusive ops to their MMA group's dpId using opToDpId.
     for (auto &[mma, slice] : mmaToSlice) {
       for (Operation *op : slice) {
         if (!sharedOps.contains(op) && !opCategories.contains(op) &&
             !isa<arith::ConstantOp>(op)) {
-          addCategorizedOp(op, OpCategory::DataPartition, partitionId, mma);
+          unsigned dpId = getDpId(op);
+          if (dpId != SHARED_DPID)
+            addCategorizedOp(op, OpCategory::DataPartition, dpId, mma);
         }
       }
-      partitionId++;
     }
   }
 
   void categorizeCorrectionOps() {
     for (auto mmaOp : mmas) {
       scf::ForOp loop = mmaOp->getParentOfType<scf::ForOp>();
+      unsigned dpId = getDpId(mmaOp);
       for (OpOperand &use : mmaOp->getUses()) {
         if (use.getOwner() != loop.getBody()->getTerminator())
           continue;
@@ -653,7 +706,7 @@ private:
              loop.getRegionIterArg(use.getOperandNumber()).getUses()) {
           Operation *user = iterUse.getOwner();
           if (!opCategories.contains(user)) {
-            addCategorizedOp(user, OpCategory::Correction);
+            addCategorizedOp(user, OpCategory::Correction, dpId, mmaOp);
           }
         }
         break;
@@ -685,114 +738,93 @@ private:
   void addCategorizedOp(Operation *op, OpCategory cat,
                         unsigned dataPartitionId = 0,
                         Operation *parentMMA = nullptr) {
+    // If no explicit dpId provided, look up from opToDpId map.
+    if (dataPartitionId == 0) {
+      auto it = opToDpId.find(op);
+      if (it != opToDpId.end() && it->second != SHARED_DPID)
+        dataPartitionId = it->second;
+    }
     opCategories[op] = CategorizedOp{op, cat, dataPartitionId, parentMMA};
   }
 
   scf::ForOp mainLoop;
   SmallVector<scf::ForOp> loops;
-  SmallVector<ttng::MMAv5OpInterface> mmas;
+  SmallVector<Operation *> mmas;
   DenseMap<Operation *, CategorizedOp> opCategories;
   DenseMap<Operation *, SetVector<Operation *>> mmaToSlice;
   DenseSet<Operation *> sharedOps;
+  DenseMap<Operation *, unsigned> opToDpId;
   unsigned dataPartitionFactor = 1;
 };
 
-/// Select the appropriate scheduling template based on the categorized ops.
-/// Uses unified template approach - no forward/backward distinction needed.
-/// The UnifiedFATemplate creates partitions based on abstract operation roles:
-/// - gemm: gen5 mma operations
-/// - load: TMA load operations
-/// - correction: cross-iteration correction ops
-/// - computation[N]: per-data-partition tensor ops
-/// - epilogue: descriptor store operations
-/// - reduction: TMA reduction operations
-/// Template options control merging behavior (e.g., epilogue into computation).
-static std::unique_ptr<SchedulingTemplate>
-selectTemplate(const OpCategorizer &categorizer,
-               bool mergeEpilogueIntoComputation = false) {
+/// Create partitions based on the categorizer results and scheduling options.
+/// This replaces the old template system (UnifiedFATemplate, GEMMTemplate,
+/// selectTemplate).
+static PartitionLayout createPartitionLayout(PartitionSet &schedule,
+                                             const OpCategorizer &categorizer,
+                                             const SchedulingOptions &options) {
+  PartitionLayout layout;
   unsigned dpFactor = categorizer.getDataPartitionFactor();
   bool hasCorrection =
       !categorizer.getOpsInCategory(OpCategory::Correction).empty();
+  bool hasReduction =
+      !categorizer.getOpsInCategory(OpCategory::TMAReduction).empty();
+  bool hasEpilogue =
+      !categorizer.getOpsInCategory(OpCategory::EpilogueStore).empty();
+  bool hasMMAv5 = categorizer.hasMMAv5();
 
-  auto epilogueStores = categorizer.getOpsInCategory(OpCategory::EpilogueStore);
-  auto mmas = categorizer.getMMAs();
-
-  // Debug output for template selection
-  LLVM_DEBUG(llvm::dbgs() << "[selectTemplate] dpFactor=" << dpFactor
+  LLVM_DEBUG(llvm::dbgs() << "[partition-layout] dpFactor=" << dpFactor
                           << ", hasCorrection=" << hasCorrection
-                          << ", epilogueStores=" << epilogueStores.size()
-                          << ", mmas=" << mmas.size() << "\n");
+                          << ", hasReduction=" << hasReduction
+                          << ", hasEpilogue=" << hasEpilogue
+                          << ", hasMMAv5=" << hasMMAv5 << "\n");
 
-  // Use UnifiedFA for patterns with more MMAs than data partitions (FA fwd,
-  // FA bwd, etc.) or with correction ops. When #MMAs == dpFactor, each MMA
-  // maps 1:1 to a data partition — use the simpler GEMM template.
-  if (hasCorrection ||
-      ((mmas.size() > 1 || dpFactor > 1) && mmas.size() != dpFactor)) {
-    bool hasReduction =
-        !categorizer.getOpsInCategory(OpCategory::TMAReduction).empty();
-
-    // Detect correction even if categorizer missed it (correction ops may
-    // already be categorized as DataPartition). Correction is when the SAME
-    // MMA has BOTH a direct yield (accumulator) AND non-yield users that
-    // eventually feed the yield (rescaling chain). A pure non-yield MMA
-    // (intermediate computation) or pure yield MMA (simple accumulator)
-    // does NOT indicate correction.
-    if (!hasCorrection) {
-      for (auto mmaOp : mmas) {
-        scf::ForOp loop = mmaOp->getParentOfType<scf::ForOp>();
-        bool hasDirectYield = false;
-        bool hasNonYieldUserToYield = false;
-        for (OpOperand &use : mmaOp->getUses()) {
-          Operation *user = use.getOwner();
-          if (user == loop.getBody()->getTerminator()) {
-            hasDirectYield = true;
-            continue;
-          }
-          // Check if this non-yield user eventually feeds the yield.
-          SmallVector<Operation *> worklist;
-          worklist.push_back(user);
-          DenseSet<Operation *> visited;
-          while (!worklist.empty()) {
-            Operation *curr = worklist.pop_back_val();
-            if (!visited.insert(curr).second)
-              continue;
-            if (curr == loop.getBody()->getTerminator()) {
-              hasNonYieldUserToYield = true;
-              break;
-            }
-            for (Operation *u : curr->getUsers())
-              if (u->getBlock() == loop.getBody())
-                worklist.push_back(u);
-          }
-          if (hasNonYieldUserToYield)
-            break;
-        }
-        // Correction: same MMA yields directly AND has rescaling users.
-        if (hasDirectYield && hasNonYieldUserToYield) {
-          hasCorrection = true;
-          break;
-        }
-      }
-    }
-
-    TemplateOptions opts;
-    opts.numDataPartitions = dpFactor;
-    opts.hasCorrection = hasCorrection;
-    opts.hasReduction = hasReduction;
-    opts.hasEpilogue = !epilogueStores.empty();
-    opts.mergeEpilogueIntoComputation = mergeEpilogueIntoComputation;
-    opts.mergeReductionIntoComputation = false;
-    LLVM_DEBUG(
-        llvm::dbgs()
-        << "[tritongpu-partition-scheduling] Selected template: UnifiedFA"
-        << " (dpFactor=" << dpFactor << ", hasCorrection=" << hasCorrection
-        << ", hasReduction=" << hasReduction << ")\n");
-    return std::make_unique<UnifiedFATemplate>(opts);
+  // Correction partition: needed when we have correction ops and not merging.
+  if (hasCorrection && !options.mergeCorrection) {
+    layout.correctionPartition = schedule.addPartition(0);
+    layout.correctionPartition->setType("correction");
   }
 
-  LLVM_DEBUG(llvm::dbgs()
-             << "[tritongpu-partition-scheduling] Selected template: GEMM\n");
-  return std::make_unique<GEMMTemplate>();
+  // Reduction partition: for bwd.
+  if (hasReduction && !options.mergeReduction) {
+    layout.reductionPartition = schedule.addPartition(0);
+    layout.reductionPartition->setType("reduction");
+  }
+
+  // Gemm partition: only when MMAv5 ops exist.
+  if (hasMMAv5) {
+    layout.gemmPartition = schedule.addPartition(1);
+    layout.gemmPartition->setType("gemm");
+  }
+
+  // Load partition: always.
+  layout.loadPartition = schedule.addPartition(0);
+  layout.loadPartition->setType("load");
+
+  // Epilogue partition: for non-store epilogue ops when not merging.
+  if (hasEpilogue && !options.mergeEpilogue &&
+      !options.mergeEpilogueToComputation) {
+    layout.epiloguePartition = schedule.addPartition(0);
+    layout.epiloguePartition->setType("epilogue");
+  }
+
+  // Epilogue store partition: dedicated 1-warp partition for epilogue stores.
+  if (options.separateEpilogueStore && hasEpilogue) {
+    layout.epilogueStorePartition = schedule.addPartition(0);
+    layout.epilogueStorePartition->setType("epilogue_store");
+  }
+
+  // Set default partition alias using fallback chain.
+  layout.defaultPartition = layout.getDefaultPartition();
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "[partition-layout] Created partitions:";
+    for (Partition &p : schedule.getPartitions())
+      llvm::dbgs() << " " << p.getType() << "(" << p.getIndex() << ")";
+    llvm::dbgs() << "\n";
+  });
+
+  return layout;
 }
 
 } // namespace
@@ -842,11 +874,37 @@ static void iterateDefs(scf::ForOp loop, Operation *op,
 static void iterateUsers(scf::ForOp loop, Operation *op,
                          function_ref<void(Operation *)> callback) {
   SmallVector<OpOperand *> uses;
+  DenseSet<OpOperand *> visited;
   for (OpOperand &use : op->getUses())
     uses.push_back(&use);
   while (!uses.empty()) {
     OpOperand *use = uses.pop_back_val();
+    if (!visited.insert(use).second)
+      continue;
     Operation *owner = loop.getBody()->findAncestorOpInBlock(*use->getOwner());
+    if (auto nestedFor = dyn_cast<scf::ForOp>(owner)) {
+      // For captured values used inside nested loops, walk the use
+      // chain inside the loop to find partitioned consumers.
+      SmallVector<Operation *> innerWorklist;
+      DenseSet<Operation *> innerVisited;
+      for (OpOperand &innerUse : use->get().getUses())
+        if (nestedFor->isAncestor(innerUse.getOwner()))
+          innerWorklist.push_back(innerUse.getOwner());
+      while (!innerWorklist.empty()) {
+        Operation *innerOp = innerWorklist.pop_back_val();
+        if (!innerVisited.insert(innerOp).second)
+          continue;
+        if (hasPartition(innerOp)) {
+          callback(innerOp);
+        } else {
+          for (Value result : innerOp->getResults())
+            for (OpOperand &u : result.getUses())
+              if (nestedFor->isAncestor(u.getOwner()))
+                innerWorklist.push_back(u.getOwner());
+        }
+      }
+      continue;
+    }
     if (!isa<scf::YieldOp>(owner)) {
       callback(owner);
       continue;
@@ -915,55 +973,133 @@ static Partition *scheduleUsers(scf::ForOp loop, PartitionSet &schedule,
 }
 
 // Schedule post-loop operations (operations outside and after the loop) into
-// the epilogue partition. This recursively schedules operations that consume
-// loop results and their transitive users.
-static void schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
-                                Partition *epiloguePartition) {
-  if (!epiloguePartition)
-    return;
+// the appropriate partition. Epilogue store ops and their transitive users
+// (e.g., TMAStoreTokenWaitOp) go to the epilogue partition. All other post-loop
+// ops (e.g., tmem_load for accumulator reads, arithmetic for normalization) go
+// to the default partition. This prevents TMEM ops from landing in the
+// epilogue, which would force it to use 4 warps (TMEM lane coverage hardware
+
+static void
+schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
+                    const PartitionLayout &layout,
+                    const SchedulingOptions &options,
+                    const DenseMap<Operation *, unsigned> &opToDpId,
+                    const DenseMap<unsigned, Partition *> &dpIdToPartition) {
+  auto findDpId = [&](Operation *op) -> unsigned {
+    auto it = opToDpId.find(op);
+    if (it != opToDpId.end())
+      return it->second;
+    for (Value operand : op->getOperands()) {
+      if (auto *defOp = operand.getDefiningOp()) {
+        auto defIt = opToDpId.find(defOp);
+        if (defIt != opToDpId.end())
+          return defIt->second;
+      }
+    }
+    return SHARED_DPID;
+  };
+
+  auto getEpilogueTarget = [&](Operation *op) -> Partition * {
+    if (options.mergeEpilogueToComputation) {
+      unsigned dpId = findDpId(op);
+      if (dpId != SHARED_DPID) {
+        auto it = dpIdToPartition.find(dpId);
+        if (it != dpIdToPartition.end())
+          return it->second;
+      }
+      if (!dpIdToPartition.empty())
+        return dpIdToPartition.begin()->second;
+    }
+    if (options.mergeEpilogue) {
+      if (layout.correctionPartition)
+        return layout.correctionPartition;
+      if (layout.reductionPartition)
+        if (layout.reductionPartition)
+          return layout.reductionPartition;
+      // When no correction/reduction partition exists (e.g., mergeCorrection +
+      // mergeEpilogue on Hopper), route epilogue ops to their dpId-based
+      // computation partition so each data partition's epilogue stays local.
+      unsigned dpId = findDpId(op);
+      if (dpId != SHARED_DPID) {
+        auto it = dpIdToPartition.find(dpId);
+        if (it != dpIdToPartition.end())
+          return it->second;
+      }
+      if (!dpIdToPartition.empty())
+        return dpIdToPartition.begin()->second;
+    }
+    if (layout.epiloguePartition)
+      return layout.epiloguePartition;
+    return layout.defaultPartition;
+  };
+
+  auto getStoreTarget = [&](Operation *op) -> Partition * {
+    if (layout.epilogueStorePartition)
+      return layout.epilogueStorePartition;
+    return getEpilogueTarget(op);
+  };
 
   SmallVector<OpOperand *> uses;
-
-  // Collect all uses of the loop's results.
-  for (OpResult result : loop.getResults()) {
+  // For persistent kernels, seed from nested inner loop results.
+  for (auto &op : loop.getOps())
+    if (auto innerLoop = dyn_cast<scf::ForOp>(op))
+      for (OpResult result : innerLoop.getResults())
+        for (OpOperand &use : result.getUses())
+          uses.push_back(&use);
+  for (OpResult result : loop.getResults())
     for (OpOperand &use : result.getUses())
       uses.push_back(&use);
-  }
 
-  // Recursively schedule all post-loop users.
   DenseSet<Operation *> visited;
   while (!uses.empty()) {
     OpOperand *use = uses.pop_back_val();
     Operation *user = use->getOwner();
-
-    // Skip if already visited.
     if (!visited.insert(user).second)
       continue;
+    // Skip ops inside nested inner loops. Ops directly in the ws-loop
+    // body (post-inner-loop) or outside the ws-loop are processed.
+    if (auto parentLoop = user->getParentOfType<scf::ForOp>())
+      if (parentLoop != loop)
+        continue;
 
-    // Only schedule operations that are outside the loop.
-    if (loop->isAncestor(user))
-      continue;
+    { // Schedule post-loop op (override earlier phase assignments)
+      Partition *target = nullptr;
+      if (isEpilogueStoreOp(user)) {
+        target = getStoreTarget(user);
+      } else {
+        bool hasStoreInput = false;
+        if (layout.epilogueStorePartition) {
+          hasStoreInput = llvm::any_of(user->getOperands(), [&](Value v) {
+            if (auto *defOp = v.getDefiningOp()) {
+              auto ids = safeGetPartitionIds(defOp);
+              return !ids.empty() &&
+                     llvm::is_contained(
+                         ids, layout.epilogueStorePartition->getIndex());
+            }
+            return false;
+          });
+        }
+        if (hasStoreInput)
+          target = layout.epilogueStorePartition;
+        else
+          target = getEpilogueTarget(user);
+      }
+      if (target)
+        setPartition(user, target);
+    }
 
-    // Schedule this post-loop operation to the epilogue partition
-    // (skip if already scheduled, e.g. categorized as an epilogue store).
-    if (!hasPartition(user))
-      tryScheduleOp(epiloguePartition, user);
-
-    // Add all users of this operation to process transitively, even if the
-    // op was already scheduled. This ensures ops reachable only through
-    // already-scheduled ops (e.g. TMAStoreTokenWaitOp reachable through
-    // AsyncTMACopyLocalToGlobalOp) still get visited and scheduled.
     for (OpResult result : user->getResults())
       for (OpOperand &nextUse : result.getUses())
         uses.push_back(&nextUse);
   }
 }
-
-// Result of getInitialSchedule, including the schedule and the epilogue
-// partition pointer (may be null if merged into computation).
+// Result of getInitialSchedule.
 struct ScheduleResult {
   PartitionSet schedule;
-  Partition *epiloguePartition = nullptr;
+  PartitionLayout layout;
+  SchedulingOptions options;
+  DenseMap<Operation *, unsigned> opToDpId;
+  DenseMap<unsigned, Partition *> dpIdToPartition;
   bool createComputePartitions;
 };
 
@@ -971,14 +1107,16 @@ struct ScheduleResult {
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.
 static std::optional<ScheduleResult>
-getInitialSchedule(scf::ForOp mainLoop,
-                   bool mergeEpilogueIntoComputation = false) {
+getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // Check for an existing schedule.
   if (FailureOr<PartitionSet> scheduleOr = PartitionSet::fromLoop(mainLoop);
       succeeded(scheduleOr))
-    // Deserialized schedule: epilogue partition is unknown, use null.
+    // Deserialized schedule: layout/options unknown, use defaults.
     return ScheduleResult{std::move(*scheduleOr),
-                          /*epiloguePartition=*/nullptr,
+                          PartitionLayout{},
+                          schedOpts,
+                          DenseMap<Operation *, unsigned>(),
+                          DenseMap<unsigned, Partition *>(),
                           /*createComputePartitions=*/true};
 
   // Collect all loops (nested + main)
@@ -986,10 +1124,12 @@ getInitialSchedule(scf::ForOp mainLoop,
   loops.push_back(mainLoop);
 
   // Collect all MMAs
-  SmallVector<ttng::MMAv5OpInterface> mmas;
+  SmallVector<Operation *> mmas;
   for (auto loop : loops) {
-    for (auto mmaOp : loop.getOps<ttng::MMAv5OpInterface>())
-      mmas.push_back(mmaOp);
+    for (auto &op : loop.getOps()) {
+      if (isMMAOp(&op))
+        mmas.push_back(&op);
+    }
   }
 
   //===--------------------------------------------------------------------===//
@@ -1007,29 +1147,21 @@ getInitialSchedule(scf::ForOp mainLoop,
                    << dataPartitionFactor << "\n");
 
   //===--------------------------------------------------------------------===//
-  // Phase 2: Select and create template
+  // Phase 2: Create partition layout using tuning knobs
   //===--------------------------------------------------------------------===//
-  std::unique_ptr<SchedulingTemplate> tmpl =
-      selectTemplate(categorizer, mergeEpilogueIntoComputation);
-  LLVM_DEBUG(
-      llvm::dbgs() << "[tritongpu-partition-scheduling] Selected template: "
-                   << tmpl->getName() << "\n");
-
   PartitionSet schedule;
-  tmpl->createPartitions(schedule);
+  PartitionLayout layout =
+      createPartitionLayout(schedule, categorizer, schedOpts);
 
-  // Get partition references from template using AbstractPartition
-  Partition *defaultPartition = tmpl->getPartition(AbstractPartition::Default);
-  Partition *mmaPartition = tmpl->getPartition(AbstractPartition::Gemm);
-  Partition *loadPartition = tmpl->getPartition(AbstractPartition::Load);
-  Partition *epiloguePartition =
-      tmpl->getPartition(AbstractPartition::Epilogue);
-  Partition *correctionPartition =
-      tmpl->getPartition(AbstractPartition::Correction);
-  Partition *reductionPartition =
-      tmpl->getPartition(AbstractPartition::Reduction);
+  // Extract partition references from layout
+  Partition *defaultPartition = layout.defaultPartition;
+  Partition *mmaPartition = layout.gemmPartition;
+  Partition *loadPartition = layout.loadPartition;
+  Partition *epiloguePartition = layout.epiloguePartition;
+  Partition *correctionPartition = layout.correctionPartition;
+  Partition *reductionPartition = layout.reductionPartition;
 
-  // Use default partition as fallback for correction/reduction if not set
+  // For backward compatibility: use default as fallback
   if (!correctionPartition)
     correctionPartition = defaultPartition;
   if (!reductionPartition)
@@ -1176,55 +1308,63 @@ getInitialSchedule(scf::ForOp mainLoop,
 
   // Schedule MMAs and their associated stores
   for (auto loop : loops) {
-    for (auto mmaOp : loop.getOps<ttng::MMAv5OpInterface>()) {
-      tryScheduleOp(mmaPartition, mmaOp);
+    for (auto &op : loop.getOps()) {
+      if (!isMMAOp(&op))
+        continue;
+      if (mmaPartition)
+        tryScheduleOp(mmaPartition, &op);
 
-      // If the store is unrelated to the use of the MMA, place in MMA
-      // partition. Exception: in BWD (hasReduction), keep TMEMStoreOp out of
-      // the gemm partition so that gemm can run with fewer warps (TMEM ops
-      // require >=4).
-      auto storeOp = dyn_cast_or_null<ttng::TMEMStoreOp>(
-          findDefOpInLoop(loop, mmaOp.getAccDep()));
-      if (reductionPartition == nullptr &&
-          !ttng::hasAccReadModifyWrite(mmaOp, loop) && storeOp &&
-          loop.isDefinedOutsideOfLoop(storeOp.getSrc()))
-        tryScheduleOp(mmaPartition, storeOp);
+      // For MMAv5: if the store is unrelated to the use of the MMA, place
+      // in MMA partition. Exception: in BWD (hasReduction), keep TMEMStoreOp
+      // out of the gemm partition so that gemm can run with fewer warps.
+      if (auto mmaOp = dyn_cast<ttng::MMAv5OpInterface>(&op)) {
+        auto storeOp = dyn_cast_or_null<ttng::TMEMStoreOp>(
+            findDefOpInLoop(loop, mmaOp.getAccDep()));
+        if (mmaPartition && reductionPartition == nullptr &&
+            !ttng::hasAccReadModifyWrite(mmaOp, loop) && storeOp &&
+            loop.isDefinedOutsideOfLoop(storeOp.getSrc()))
+          tryScheduleOp(mmaPartition, storeOp);
+      }
     }
   }
 
-  // Schedule memory descriptor views feeding into MMAs
-  for (auto loop : loops) {
-    for (auto mmaOp : loop.getOps<ttng::MMAv5OpInterface>()) {
-      SmallVector<Operation *> operandViews;
-      for (Value operand : mmaOp->getOperands()) {
-        if (Operation *defOp = operand.getDefiningOp())
-          operandViews.push_back(defOp);
-      }
-      while (!operandViews.empty()) {
-        Operation *op = operandViews.pop_back_val();
-        if (!op->hasTrait<OpTrait::MemDescViewTrait>())
+  // Schedule memory descriptor views feeding into MMAs (MMAv5 only —
+  // memdesc views are a Blackwell TMEM concept, not used on Hopper).
+  if (mmaPartition) {
+    for (auto loop : loops) {
+      for (auto &mmaOp : loop.getOps()) {
+        if (!isMMAOp(&mmaOp))
           continue;
-
-        // Duplicate the op if necessary to ensure MMA partition is only user
-        if (!llvm::all_of(op->getUsers(), [&](Operation *user) {
-              return hasPartition(user) &&
-                     getPartitionIds(user).contains(mmaPartition->getIndex());
-            })) {
-          Operation *newOp = OpBuilder(op).clone(*op);
-          op->replaceUsesWithIf(newOp->getResults(), [&](OpOperand &use) {
-            return hasPartition(use.getOwner()) &&
-                   getPartitionIds(use.getOwner())
-                       .contains(mmaPartition->getIndex());
-          });
-          op = newOp;
+        SmallVector<Operation *> operandViews;
+        for (Value operand : mmaOp.getOperands()) {
+          if (Operation *defOp = operand.getDefiningOp())
+            operandViews.push_back(defOp);
         }
+        while (!operandViews.empty()) {
+          Operation *op = operandViews.pop_back_val();
+          if (!op->hasTrait<OpTrait::MemDescViewTrait>())
+            continue;
 
-        tryScheduleOp(mmaPartition, op);
-        if (Operation *defOp = op->getOperand(0).getDefiningOp())
-          operandViews.push_back(defOp);
+          // Duplicate the op if necessary to ensure MMA partition is only user
+          if (!llvm::all_of(op->getUsers(), [&](Operation *user) {
+                auto ids = safeGetPartitionIds(user);
+                return !ids.empty() && ids.contains(mmaPartition->getIndex());
+              })) {
+            Operation *newOp = OpBuilder(op).clone(*op);
+            op->replaceUsesWithIf(newOp->getResults(), [&](OpOperand &use) {
+              auto ids = safeGetPartitionIds(use.getOwner());
+              return !ids.empty() && ids.contains(mmaPartition->getIndex());
+            });
+            op = newOp;
+          }
+
+          tryScheduleOp(mmaPartition, op);
+          if (Operation *defOp = op->getOperand(0).getDefiningOp())
+            operandViews.push_back(defOp);
+        }
       }
     }
-  }
+  } // if (mmaPartition)
 
   // If there are no loads or MMAs, don't warp specialize.
   if (loadsAndAllocs.empty() && mmas.empty())
@@ -1307,12 +1447,12 @@ getInitialSchedule(scf::ForOp mainLoop,
     }
 
     // For BWD (hasReduction): tag pre-loop TMEMStoreOp with the reduction
-    // partition index. These ops initialize accumulators (e.g., zeroing dK/dV)
-    // before the loop. Without explicit assignment, they would get pulled
-    // into the gemm partition via token chains to the in-loop MMA, causing
-    // gemm to require >=4 warps (TMEM ops need 4 warps).
-    // We set the attribute directly rather than using schedule.trySchedule
-    // because pre-loop ops must not be added to the partition's ops list
+    // partition index. These ops initialize accumulators (e.g., zeroing
+    // dK/dV) before the loop. Without explicit assignment, they would get
+    // pulled into the gemm partition via token chains to the in-loop MMA,
+    // causing gemm to require >=4 warps (TMEM ops need 4 warps). We set the
+    // attribute directly rather than using schedule.trySchedule because
+    // pre-loop ops must not be added to the partition's ops list
     // (optimizeSchedule only handles in-loop ops).
     if (reductionPartition) {
       Builder b(mainLoop->getContext());
@@ -1349,12 +1489,128 @@ getInitialSchedule(scf::ForOp mainLoop,
     sharedComputePartition = nullptr; // lazy-created on first use
   }
 
+  // When dpFactor > 1 and there is no defaultPartition, pre-assign
+  // DataPartition-categorized ops to their respective computation partitions
+  // BEFORE scheduleUsers runs. Without a defaultPartition, Phase 4 (load user
+  // propagation) is skipped, so shared/correction ops are not pre-claimed.
+  // This causes the first MMA's scheduleUsers to greedily absorb all
+  // computation ops into a single partition (e.g., when an scf.if merges both
+  // partitions' values). The categorizer already knows which ops belong to
+  // which data partition via backward slice analysis.
+  //
+  // When defaultPartition exists (e.g., FA with epilogue stores), the
+  // original Phase 4 → Phase 5 flow works correctly — skip pre-assignment to
+  // avoid changing the partition creation order that downstream passes
+  // expect.
+  DenseMap<unsigned, Partition *> dpIdToPartition;
+  DenseMap<Operation *, Partition *> mmaToPreassignedPartition;
+  if (dataPartitionFactor > 1) {
+    // Pre-assign exclusive DataPartition ops to per-dpId computation
+    // partitions.
+    auto dpOps = categorizer.getOpsInCategory(OpCategory::DataPartition);
+
+    // Collect which dpIds actually have ops.
+    DenseSet<unsigned> usedDpIds;
+    for (const auto &catOp : dpOps)
+      usedDpIds.insert(catOp.dataPartitionId);
+
+    // Pre-create computation partitions in reverse dpId order to match
+    // the original partition creation order.
+    SmallVector<unsigned> sortedDpIds(usedDpIds.begin(), usedDpIds.end());
+    llvm::sort(sortedDpIds, std::greater<unsigned>());
+    for (unsigned dpId : sortedDpIds) {
+      dpIdToPartition[dpId] = schedule.addPartition(0);
+      dpIdToPartition[dpId]->setType("computation");
+    }
+
+    for (const auto &catOp : dpOps) {
+      unsigned dpId = catOp.dataPartitionId;
+      auto it = dpIdToPartition.find(dpId);
+      if (it != dpIdToPartition.end()) {
+        tryScheduleOp(it->second, catOp.op);
+        if (catOp.parentMMA)
+          mmaToPreassignedPartition[catOp.parentMMA] = it->second;
+      }
+    }
+    // Pre-assign shared ops (ops appearing in multiple MMA backward slices,
+    // e.g., scf.if for masking) to the default partition. Without this,
+    // propagatePartitions forms clusters around the unscheduled scf.if with
+    // multiple sink partitions (one per data partition), collapsing them
+    // into a single partition.
+    if (defaultPartition) {
+      for (Operation *sharedOp : categorizer.getSharedOps()) {
+        if (!isa<arith::ConstantOp>(sharedOp))
+          tryScheduleOp(defaultPartition, sharedOp);
+      }
+    }
+  }
+
   for (auto mmaOp : llvm::reverse(mmas)) {
     if (mmaOp->getParentOfType<scf::ForOp>() == loops[0]) {
       Partition *targetPart = nullptr;
+      LDBG("[phase5] Processing MMA: "
+           << prettyOp(mmaOp) << " dpId=" << categorizer.getDpId(mmaOp)
+           << " inPreassigned=" << mmaToPreassignedPartition.count(mmaOp));
       if (dataPartitionFactor > 1) {
-        // fwd: each MMA group gets its own dynamic partition
-        targetPart = nullptr;
+        // Check if this MMA has a pre-assigned partition (flex path).
+        auto it = mmaToPreassignedPartition.find(mmaOp);
+        if (it != mmaToPreassignedPartition.end()) {
+          targetPart = it->second;
+        } else {
+          // This MMA (e.g., a QK MMA) has no pre-assigned partition, but
+          // its users may already be pre-assigned to a computation partition
+          // (e.g., tmem_load and mulf(QK*scale) are DataPartition ops).
+          // Use that existing partition to avoid creating extra computation
+          // partitions that inflate TMEM channel count.
+          for (OpOperand &use : mmaOp->getUses()) {
+            Operation *user = use.getOwner();
+            {
+              auto ids = safeGetPartitionIds(user);
+              for (int id : ids) {
+                Partition *p = schedule.getPartition(id);
+                if (p && p->getType() == "computation") {
+                  targetPart = p;
+                  break;
+                }
+              }
+            }
+            if (targetPart)
+              break;
+          }
+          // If no user has a computation partition, look up the MMA's dpId
+          // and use the corresponding pre-created computation partition.
+          // This handles the case where the MMA itself has a dpId but its
+          // users aren't pre-assigned (e.g., Hopper QK MMA whose users are
+          // softmax ops that will be scheduled later by scheduleUsers).
+          if (!targetPart) {
+            unsigned dpId = categorizer.getDpId(mmaOp);
+            LDBG("[phase5]   dpId fallback: dpId="
+                 << dpId
+                 << " dpIdToPartition.count=" << dpIdToPartition.count(dpId));
+            if (dpId != SHARED_DPID) {
+              auto it = dpIdToPartition.find(dpId);
+              if (it != dpIdToPartition.end())
+                targetPart = it->second;
+            }
+          }
+          LDBG("[phase5]   targetPart after fallback: "
+               << (targetPart ? targetPart->getType() : "null"));
+          // If we found a pre-assigned computation partition, skip
+          // scheduleUsers entirely — all MMA users are already pre-assigned
+          // and calling scheduleUsers would create extra partitions from
+          // unscheduled transitive users (yield ops, loop-carried args).
+          if (targetPart) {
+            // For non-MMAv5 ops without a gemm partition, also schedule the
+            // MMA op itself into the computation partition.
+            if (!mmaPartition)
+              tryScheduleOp(targetPart, mmaOp);
+            mmaToPartition[mmaOp] = targetPart;
+            inFirstLoop.push_back(mmaOp);
+            continue;
+          }
+        }
+        // Otherwise nullptr → scheduleUsers creates a new partition (FA
+        // path).
       } else {
         // bwd: all MMA users share one partition
         targetPart = sharedComputePartition;
@@ -1363,12 +1619,35 @@ getInitialSchedule(scf::ForOp mainLoop,
                                 targetPart, mmaOp);
       if (dataPartitionFactor <= 1 && !sharedComputePartition)
         sharedComputePartition = part;
-      mmaToPartition[mmaOp.getOperation()] = part;
-      inFirstLoop.push_back(mmaOp.getOperation());
+      if (!part)
+        part = targetPart;
+      // For non-MMAv5 ops without a gemm partition, also schedule the
+      // MMA op itself into the computation partition.
+      if (!mmaPartition && part)
+        tryScheduleOp(part, mmaOp);
+      mmaToPartition[mmaOp] = part;
+      inFirstLoop.push_back(mmaOp);
     }
   }
 
-  // For causal attention with 3 loops, match MMAs in second loop to first loop
+  // For dpFactor<=1 (BWD), populate dpIdToPartition so
+  // schedulePostLoopOps can route via mergeEpilogueToComputation.
+  if (dataPartitionFactor <= 1 && dpIdToPartition.empty()) {
+    if (sharedComputePartition) {
+      dpIdToPartition[0] = sharedComputePartition;
+    } else {
+      // Fallback: find any computation partition in the schedule.
+      for (Partition &p : schedule.getPartitions()) {
+        if (p.getType() == "computation") {
+          dpIdToPartition[0] = &p;
+          break;
+        }
+      }
+    }
+  }
+
+  // For causal attention with 3 loops, match MMAs in second loop to first
+  // loop
   unsigned Idx = 0;
   for (auto mmaOp : llvm::reverse(mmas)) {
     if (loops.size() == 3 && mmaOp->getParentOfType<scf::ForOp>() == loops[1]) {
@@ -1379,18 +1658,95 @@ getInitialSchedule(scf::ForOp mainLoop,
     }
   }
 
-  // When epilogue is merged into computation, post-loop ops should be
-  // assigned to the computation partition (not the default partition).
-  // For bwd (dpFactor<=1), sharedComputePartition is the single computation
-  // partition. For fwd (dpFactor>1), fall back to defaultPartition since
-  // there are multiple per-group computation partitions.
-  Partition *postLoopPartition = epiloguePartition;
-  if (!postLoopPartition)
-    postLoopPartition = sharedComputePartition;
-  if (!postLoopPartition)
-    postLoopPartition = defaultPartition;
-  return ScheduleResult{std::move(schedule), postLoopPartition,
-                        tmpl->getName() != "GEMM"};
+  // Assign remaining unscheduled inner-loop ops using their dpId.
+  // Only assign to computation partitions that already exist in
+  // dpIdToPartition (don't create new ones).
+  // For ops not in opToDpId (e.g., l_i update chain: l_i*alpha, l_i+l_ij),
+  // trace through operands to find the dpId from an operand that IS in
+  // opToDpId.
+  if (dataPartitionFactor > 1 && !dpIdToPartition.empty()) {
+    // Helper to find dpId by tracing operands.
+    auto findDpIdFromOperands = [&](Operation *op) -> unsigned {
+      unsigned dpId = categorizer.getDpId(op);
+      if (dpId != 0 && dpId != SHARED_DPID)
+        return dpId;
+      // Trace through operands to find a non-zero dpId.
+      SmallVector<Operation *> worklist;
+      DenseSet<Operation *> visited;
+      for (Value operand : op->getOperands()) {
+        if (auto *defOp = operand.getDefiningOp())
+          worklist.push_back(defOp);
+      }
+      while (!worklist.empty()) {
+        Operation *curr = worklist.pop_back_val();
+        if (!visited.insert(curr).second)
+          continue;
+        unsigned currDpId = categorizer.getDpId(curr);
+        if (currDpId != 0 && currDpId != SHARED_DPID)
+          return currDpId;
+        // Also check if the op has a partition assignment that maps to
+        // a computation partition.
+        {
+          auto ids = safeGetPartitionIds(curr);
+          if (!ids.empty())
+            for (int id : ids) {
+              Partition *p = schedule.getPartition(id);
+              if (p && p->getType() == "computation") {
+                // Find which dpId maps to this partition.
+                for (auto &[did, part] : dpIdToPartition) {
+                  if (part == p)
+                    return did;
+                }
+              }
+            }
+        }
+        for (Value operand : curr->getOperands()) {
+          if (auto *defOp = operand.getDefiningOp())
+            worklist.push_back(defOp);
+        }
+      }
+      return dpId; // fallback to original (may be 0)
+    };
+
+    scf::ForOp innermostLoop = loops[0];
+    for (Operation &op : innermostLoop.getOps()) {
+      if (hasPartition(&op))
+        continue;
+      if (isa<arith::ConstantOp, scf::YieldOp>(&op))
+        continue;
+      // Skip loop counter increment ops (scalar integer arithmetic that
+      // feeds the yield). These are loop-control ops, not data-partition
+      // computation ops.
+      if (op.getNumResults() == 1 && op.getResult(0).getType().isIntOrIndex() &&
+          !isa<RankedTensorType>(op.getResult(0).getType()))
+        continue;
+      unsigned dpId = findDpIdFromOperands(&op);
+      if (dpId != SHARED_DPID) {
+        auto it = dpIdToPartition.find(dpId);
+        if (it != dpIdToPartition.end())
+          tryScheduleOp(it->second, &op);
+      }
+    }
+  }
+
+  // Pre-schedule post-loop ops before propagatePartitions claims them.
+  schedulePostLoopOps(mainLoop, schedule, layout, schedOpts,
+                      categorizer.getOpToDpIdMap(), dpIdToPartition);
+
+  // Update defaultPartition after computation partitions are created.
+  layout.defaultPartition = layout.getDefaultPartition();
+
+  bool createComputePartitions =
+      (layout.correctionPartition != nullptr ||
+       layout.reductionPartition != nullptr || dataPartitionFactor > 1) &&
+      layout.defaultPartition != nullptr;
+
+  return ScheduleResult{std::move(schedule),
+                        layout,
+                        schedOpts,
+                        categorizer.getOpToDpIdMap(),
+                        std::move(dpIdToPartition),
+                        createComputePartitions};
 }
 
 namespace {
@@ -1405,18 +1761,19 @@ struct OpCluster {
   // These are the operations in the cluster.
   SetVector<Operation *> ops;
   // The definition partitions are the partitions from which inputs of the
-  // operation are reachable. When the cluster is fully formed, the defining op
-  // in the loop of any input to any operation in the cluster is either in the
-  // root partition or one of these partitions.
+  // operation are reachable. When the cluster is fully formed, the defining
+  // op in the loop of any input to any operation in the cluster is either in
+  // the root partition or one of these partitions.
   SetVector<Partition *> defPartitions;
   // The sink partitions which consume the outputs of operations in this
-  // cluster. When the cluster is fully formed, all uses in the loop of outputs
-  // of any operation in the cluster belong to one of these partitions.
+  // cluster. When the cluster is fully formed, all uses in the loop of
+  // outputs of any operation in the cluster belong to one of these
+  // partitions.
   SetVector<Partition *> sinkPartitions;
 };
 
-// Owning class for a bunch of clusters. This class manages the lifetimes of the
-// clusters and has some helper functions.
+// Owning class for a bunch of clusters. This class manages the lifetimes of
+// the clusters and has some helper functions.
 struct OpClusters : public llvm::MapVector<Operation *, OpCluster *> {
   using MapVector::MapVector;
 
@@ -1451,8 +1808,17 @@ namespace {
 
 // Operations that require partition assignment are those reachable from an
 // operation in a partition. This function propagates partitions by first
-// forming contiguous clusters from the unassigned operations and then deciding
-// what to do with the operations in that cluster.
+// forming contiguous clusters from the unassigned operations and then
+// deciding what to do with the operations in that cluster.
+// Check if an op produces only scalar results (can be rematerialized).
+static bool isScalarOp(Operation *op) {
+  if (op->getNumResults() == 0)
+    return false;
+  return llvm::all_of(op->getResults(), [](Value v) {
+    return !isa<RankedTensorType, triton::gpu::MemDescType>(v.getType());
+  });
+}
+
 void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
                          bool createComputePartitions) {
   OpClusters opClusters;
@@ -1469,11 +1835,12 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
     };
     partition.iterateDefs(loop, defCallback);
 
-    // For each partition, place users of its outputs in a cluster if it is not
-    // already assigned to a partition.
+    // For each partition, place users of its outputs in a cluster if it is
+    // not already assigned to a partition.
     auto useCallback = [&](OpResult result, OpOperand &use, unsigned distance) {
       Operation *user = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
-      // Skip users outside the loop — they are handled by schedulePostLoopOps.
+      // Skip users outside the loop — they are handled by
+      // schedulePostLoopOps.
       if (!user)
         return;
       if (!hasPartition(user)) {
@@ -1485,8 +1852,8 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
   }
 
   // Now we have a pile of single-operation clusters directly adjacent to the
-  // operations in a partition. Grow the clusters by adding adjacent operations
-  // clusters and merging clusters when possible.
+  // operations in a partition. Grow the clusters by adding adjacent
+  // operations clusters and merging clusters when possible.
   SmallVector<Operation *> worklist =
       llvm::to_vector(llvm::make_first_range(opClusters));
   while (!worklist.empty()) {
@@ -1499,7 +1866,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
       if (hasPartition(defOp)) {
         // The input originates from an operation already assigned to a
         // partition. Add this as a def partition.
-        for (auto id : getPartitionIds(defOp)) {
+        for (auto id : safeGetPartitionIds(defOp)) {
           cluster->defPartitions.insert(schedule.getPartition(id));
         }
       } else {
@@ -1524,9 +1891,9 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
     // Check the users of the operation.
     iterateUsers(loop, op, [&](Operation *user) {
       if (hasPartition(user)) {
-        // If the user is already assigned to a partition, add that partition as
-        // one of the sink partitions.
-        for (auto id : getPartitionIds(user)) {
+        // If the user is already assigned to a partition, add that partition
+        // as one of the sink partitions.
+        for (auto id : safeGetPartitionIds(user)) {
           cluster->sinkPartitions.insert(schedule.getPartition(id));
         }
         return;
@@ -1552,17 +1919,19 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
     // Skip dead clusters.
     if (cluster.ops.empty())
       continue;
-    assert(!cluster.defPartitions.empty());
+    // Skip clusters with no def partitions (all scalar ops).
+    if (cluster.defPartitions.empty())
+      continue;
     assert(llvm::all_of(cluster.ops,
                         [&](Operation *op) { return !hasPartition(op); }));
 
     // If there are multiple def or sink partitions, don't know what to do.
     // Assign the whole cluster to its own partition.
     if (cluster.defPartitions.size() > 1 || cluster.sinkPartitions.size() > 1) {
-      // For BWD-like kernels (has reduction partition, no epilogue partition),
-      // avoid creating extra partitions which can split pointer-typed ops
-      // across partitions and crash createLocalAlloc. Reuse the existing
-      // computation partition instead.
+      // For BWD-like kernels (has reduction partition, no epilogue
+      // partition), avoid creating extra partitions which can split
+      // pointer-typed ops across partitions and crash createLocalAlloc. Reuse
+      // the existing computation partition instead.
       Partition *existingComputation = nullptr;
       bool hasReduction = false;
       bool hasEpilogue = false;
@@ -1575,40 +1944,76 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
           existingComputation = &p;
       }
       if (hasReduction && !hasEpilogue && existingComputation) {
-        for (Operation *op : cluster.ops)
+        for (Operation *op : cluster.ops) {
+          if (isScalarOp(op))
+            continue;
           setPartition(op, existingComputation);
+        }
         continue;
       }
       // For GEMM with data partitioning, merge into the default partition
       // instead of creating a separate computation partition.
       // TODO: Fix issues with DataPartitioning.
       if (!createComputePartitions) {
-        Partition *defaultPartition = nullptr;
+        Partition *fallbackPartition = nullptr;
         for (Partition &p : schedule.getPartitions()) {
           if (p.getType() == "default") {
-            defaultPartition = &p;
+            fallbackPartition = &p;
             break;
           }
         }
-        if (defaultPartition) {
-          for (Operation *op : cluster.ops)
-            setPartition(op, defaultPartition);
+        // When no default partition exists (e.g., Hopper with all categories
+        // merged), use the first computation partition as fallback.
+        if (!fallbackPartition) {
+          for (Partition &p : schedule.getPartitions()) {
+            if (p.getType() == "computation") {
+              fallbackPartition = &p;
+              break;
+            }
+          }
+        }
+        if (fallbackPartition) {
+          for (Operation *op : cluster.ops) {
+            if (isScalarOp(op))
+              continue;
+            setPartition(op, fallbackPartition);
+          }
           continue;
         }
       }
+      // For data-partitioned kernels: if a single computation partition is
+      // in the sinks, assign the cluster there instead of creating extra
+      // computation partitions. This prevents partition inflation (e.g., 4
+      // computation partitions instead of 2) when intermediate ops between
+      // the gemm and computation partitions form a cluster.
+      if (cluster.sinkPartitions.size() == 1 &&
+          cluster.sinkPartitions.front()->getType() == "computation") {
+        for (Operation *op : cluster.ops) {
+          if (isScalarOp(op))
+            continue;
+          setPartition(op, cluster.sinkPartitions.front());
+        }
+        continue;
+      }
       Partition *newPartition = schedule.addPartition(0);
       newPartition->setType("computation");
-      for (Operation *op : cluster.ops)
+      for (Operation *op : cluster.ops) {
+        if (isScalarOp(op))
+          continue;
         setPartition(op, newPartition);
+      }
       continue;
     }
 
-    // If there is no sink partition, this means there is a backedge somewhere,
-    // for now assign the cluster to the def partition.
+    // If there is no sink partition, this means there is a backedge
+    // somewhere, for now assign the cluster to the def partition.
     Partition *defPartition = cluster.defPartitions.front();
     if (cluster.sinkPartitions.empty()) {
-      for (Operation *op : cluster.ops)
+      for (Operation *op : cluster.ops) {
+        if (isScalarOp(op))
+          continue;
         setPartition(op, defPartition);
+      }
       continue;
     }
 
@@ -1633,8 +2038,11 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
 
     // If all ops are on the critical path, assign them to the def partition.
     if (critPath.size() == cluster.ops.size()) {
-      for (Operation *op : cluster.ops)
+      for (Operation *op : cluster.ops) {
+        if (isScalarOp(op))
+          continue;
         setPartition(op, defPartition);
+      }
       continue;
     }
 
@@ -1653,23 +2061,65 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
       sinkOps.insert(clone);
       setPartition(clone, sinkPartition);
     }
-    for (Operation *op : cluster.ops)
+    for (Operation *op : cluster.ops) {
+      if (isScalarOp(op))
+        continue;
       setPartition(op, defPartition);
+    }
   }
 }
 
 /// Walk over \p loop and clone Broadcast/ExpandDims ops into each
 /// partition that they have users in. This reduces the amount of data that
 /// needs to be transferred through memory.
+///
+/// When a ConvertLayoutOp sits between an ExpandDimsOp/BroadcastOp and its
+/// consumer (e.g., due to upstream layout choices producing different
+/// encodings), also walk backward and clone the operand chain
+/// (ConvertLayoutOp, ExpandDimsOp, BroadcastOp) to avoid creating an
+/// unintended cross-partition boundary.
 void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
   // Helper to get partition for an op, returning null if unscheduled.
   auto getPartition = [&](Operation *op) -> Partition * {
     if (!hasPartition(op))
       return nullptr;
-    auto ids = getPartitionIds(op);
+    auto ids = safeGetPartitionIds(op);
     if (ids.size() != 1)
       return nullptr;
     return schedule.getPartition(static_cast<unsigned>(ids[0]));
+  };
+
+  // After cloning a BroadcastOp/ExpandDimsOp into a user partition, walk
+  // backward through the cloned op's operand chain and also clone any
+  // ConvertLayoutOp/BroadcastOp/ExpandDimsOp that feeds it from a different
+  // partition. This handles the pattern where upstream layout passes insert
+  // a ConvertLayoutOp between ExpandDimsOp and BroadcastOp, which would
+  // otherwise break the cloning chain and create a cross-partition boundary.
+  auto cloneOperandChain = [&](Operation *clonedOp, Partition *userPartition) {
+    Operation *current = clonedOp;
+    while (true) {
+      Operation *toPull = nullptr;
+      unsigned operandIdx = 0;
+      for (auto [idx, operand] : llvm::enumerate(current->getOperands())) {
+        auto *defOp = operand.getDefiningOp();
+        if (!defOp)
+          continue;
+        Partition *defPartition = getPartition(defOp);
+        if (!defPartition || defPartition == userPartition)
+          continue;
+        if (!isa<ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(defOp))
+          continue;
+        toPull = defOp;
+        operandIdx = idx;
+        break;
+      }
+      if (!toPull)
+        break;
+      Operation *pullClone = OpBuilder(toPull).clone(*toPull);
+      setPartition(pullClone, userPartition);
+      current->setOperand(operandIdx, pullClone->getResult(0));
+      current = pullClone;
+    }
   };
 
   // Walk everything in reverse so that operations are visited before their
@@ -1699,15 +2149,190 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
       op->replaceUsesWithIf(clone->getResults(), [&](OpOperand &otherUse) {
         return getPartition(otherUse.getOwner()) == userPartition;
       });
+      // Walk backward and clone any cheap layout ops feeding the clone.
+      cloneOperandChain(clone, userPartition);
     }
   });
 }
 
-} // namespace
+/// Split scf.if ops whose results feed different computation partitions
+/// into separate per-partition scf.if ops. This is needed for
+/// data-partitioned kernels (like flex attention) where an scf.if for masking
+/// returns both data partitions' results as a tuple. Without splitting, the
+/// downstream WSCodePartition pass creates channels from the single scf.if
+/// producer to consumers in different tasks, violating the "channels sharing
+/// the same producer must be in the same task" invariant.
+///
+/// Before:
+///   %r:2 = scf.if %cond -> (T, T) {
+///     yield %a, %b          // %a for dp0, %b for dp1
+///   } else {
+///     yield %c, %d          // %c for dp0, %d for dp1
+///   } {ttg.partition = [0]}  // default partition
+///   use(%r#0) {ttg.partition = [3]}  // computation partition dp0
+///   use(%r#1) {ttg.partition = [4]}  // computation partition dp1
+///
+/// After:
+///   %r0 = scf.if %cond -> (T) {
+///     yield %a
+///   } else {
+///     yield %c
+///   } {ttg.partition = [3]}  // dp0 computation partition
+///   %r1 = scf.if %cond -> (T) {
+///     yield %b
+///   } else {
+///     yield %d
+///   } {ttg.partition = [4]}  // dp1 computation partition
+///   use(%r0) {ttg.partition = [3]}
+///   use(%r1) {ttg.partition = [4]}
+void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
+  SmallVector<scf::IfOp> ifsToSplit;
 
-//===----------------------------------------------------------------------===//
-// Pass Definition
-//===----------------------------------------------------------------------===//
+  loop.walk([&](scf::IfOp ifOp) {
+    if (ifOp.getNumResults() < 2)
+      return;
+
+    // Check if results feed different partitions.
+    DenseSet<int> resultPartitions;
+    bool hasDifferentPartitions = false;
+    for (OpResult result : ifOp.getResults()) {
+      for (Operation *user : result.getUsers()) {
+        auto ids = safeGetPartitionIds(user);
+        for (int id : ids)
+          resultPartitions.insert(id);
+      }
+    }
+    // Only split if results feed more than one computation partition.
+    unsigned computationCount = 0;
+    for (Partition &p : schedule.getPartitions()) {
+      if (p.getType() == "computation" &&
+          resultPartitions.contains(p.getIndex()))
+        computationCount++;
+    }
+    if (computationCount >= 2)
+      ifsToSplit.push_back(ifOp);
+  });
+
+  for (scf::IfOp ifOp : ifsToSplit) {
+    unsigned numResults = ifOp.getNumResults();
+    OpBuilder builder(ifOp);
+
+    // For each result, determine which computation partition its users belong
+    // to, then find which yield operands in the then/else blocks map to it.
+    // Group results by their consumer partition.
+    DenseMap<int, SmallVector<unsigned>> partitionToResultIndices;
+    for (unsigned i = 0; i < numResults; i++) {
+      int partId = -1;
+      for (Operation *user : ifOp.getResult(i).getUsers()) {
+        auto ids = safeGetPartitionIds(user);
+        if (!ids.empty()) {
+          // Find a computation partition among the user's partitions.
+          for (int id : ids) {
+            Partition *p = schedule.getPartition(id);
+            if (p && p->getType() == "computation") {
+              partId = id;
+              break;
+            }
+          }
+        }
+        if (partId >= 0)
+          break;
+      }
+      if (partId >= 0)
+        partitionToResultIndices[partId].push_back(i);
+    }
+
+    // Only split if we have at least 2 groups.
+    if (partitionToResultIndices.size() < 2)
+      continue;
+
+    // Create one scf.if per partition group.
+    for (auto &[partId, resultIndices] : partitionToResultIndices) {
+      auto *origThenBlock = ifOp.thenBlock();
+      auto *origElseBlock = ifOp.elseBlock();
+      auto *origThenYield = origThenBlock->getTerminator();
+      auto *origElseYield =
+          origElseBlock ? origElseBlock->getTerminator() : nullptr;
+
+      // Collect needed ops for the else block via backward reachability.
+      DenseSet<Operation *> neededElseOps;
+      if (origElseBlock) {
+        for (unsigned idx : resultIndices) {
+          SmallVector<Operation *> worklist;
+          if (auto *def = origElseYield->getOperand(idx).getDefiningOp())
+            worklist.push_back(def);
+          while (!worklist.empty()) {
+            Operation *curr = worklist.pop_back_val();
+            if (!curr || curr->getBlock() != origElseBlock)
+              continue;
+            if (!neededElseOps.insert(curr).second)
+              continue;
+            for (Value operand : curr->getOperands())
+              if (auto *def = operand.getDefiningOp())
+                worklist.push_back(def);
+          }
+        }
+      }
+
+      // Build result types for this split.
+      SmallVector<Type> splitResultTypes;
+      for (unsigned idx : resultIndices)
+        splitResultTypes.push_back(ifOp.getResult(idx).getType());
+
+      // Use the callback-based builder to populate then/else blocks.
+      auto thenBuilder = [&](OpBuilder &b, Location loc) {
+        IRMapping mapping;
+        for (Operation &op : origThenBlock->without_terminator()) {
+          bool needed = false;
+          for (unsigned idx : resultIndices) {
+            if (origThenYield->getOperand(idx).getDefiningOp() == &op)
+              needed = true;
+          }
+          if (needed)
+            b.clone(op, mapping);
+        }
+        SmallVector<Value> yieldVals;
+        for (unsigned idx : resultIndices)
+          yieldVals.push_back(
+              mapping.lookupOrDefault(origThenYield->getOperand(idx)));
+        scf::YieldOp::create(b, loc, yieldVals);
+      };
+
+      auto elseBuilder = [&](OpBuilder &b, Location loc) {
+        IRMapping mapping;
+        for (Operation &op : origElseBlock->without_terminator()) {
+          if (neededElseOps.contains(&op))
+            b.clone(op, mapping);
+        }
+        SmallVector<Value> yieldVals;
+        for (unsigned idx : resultIndices)
+          yieldVals.push_back(
+              mapping.lookupOrDefault(origElseYield->getOperand(idx)));
+        scf::YieldOp::create(b, loc, yieldVals);
+      };
+
+      auto newIf = scf::IfOp::create(
+          builder, ifOp.getLoc(), ifOp.getCondition(), thenBuilder,
+          origElseBlock
+              ? elseBuilder
+              : static_cast<function_ref<void(OpBuilder &, Location)>>(
+                    nullptr));
+
+      // Assign the new scf.if to this computation partition.
+      setPartition(newIf, schedule.getPartition(partId));
+
+      // Replace uses of the original results with the new scf.if results.
+      for (unsigned i = 0; i < resultIndices.size(); i++) {
+        ifOp.getResult(resultIndices[i]).replaceAllUsesWith(newIf.getResult(i));
+      }
+    }
+
+    // Erase the original scf.if (all uses should be replaced).
+    ifOp.erase();
+  }
+}
+
+} // namespace
 
 namespace mlir {
 #define GEN_PASS_DEF_NVGPUPARTITIONSCHEDULINGMETA
@@ -1731,84 +2356,50 @@ void PartitionSchedulingMeta::runOnOperation() {
       loops.push_back(loop);
   });
   for (auto [idx, loop] : llvm::enumerate(loops)) {
-    // Check for per-loop tt.merge_epilogue attribute on the forOp,
-    // falling back to the pass option.
-    bool mergeEpilogue = mergeEpilogueIntoComputation;
-    if (auto attr = loop->getAttrOfType<BoolAttr>("tt.merge_epilogue"))
-      mergeEpilogue = attr.getValue();
+    // Build SchedulingOptions from pass options and per-loop attributes.
+    SchedulingOptions schedOpts;
+    schedOpts.mergeEpilogue = mergeEpilogue;
+    schedOpts.mergeEpilogueToComputation = mergeEpilogueToComputation;
+    schedOpts.mergeCorrection = mergeCorrection;
+    schedOpts.mergeReduction = mergeReduction;
+    schedOpts.separateEpilogueStore = separateEpilogueStore;
+
+    // Per-loop tt.merge_epilogue_to_computation overrides pass option.
+    if (auto attr =
+            loop->getAttrOfType<BoolAttr>("tt.merge_epilogue_to_computation"))
+      schedOpts.mergeEpilogueToComputation = attr.getValue();
+
+    // Per-loop tt.separate_epilogue_store overrides pass option.
+    if (auto attr = loop->getAttrOfType<BoolAttr>("tt.separate_epilogue_store"))
+      schedOpts.separateEpilogueStore = attr.getValue();
+
+    // Per-loop tt.merge_correction overrides pass option.
+    if (auto attr = loop->getAttrOfType<BoolAttr>("tt.merge_correction"))
+      schedOpts.mergeCorrection = attr.getValue();
+
+    // Per-loop tt.merge_epilogue overrides pass option.
+    if (auto attr2 = loop->getAttrOfType<BoolAttr>("tt.merge_epilogue"))
+      schedOpts.mergeEpilogue = attr2.getValue();
 
     if (std::optional<ScheduleResult> result =
-            getInitialSchedule(loop, mergeEpilogue)) {
+            getInitialSchedule(loop, schedOpts)) {
       PartitionSet &schedule = result->schedule;
       propagatePartitions(loop, schedule, result->createComputePartitions);
 
-      // Schedule post-loop operations into the epilogue partition after
-      // propagatePartitions completes. When mergeEpilogueIntoComputation is
-      // true, epiloguePartition is null and post-loop ops are handled by
-      // propagation instead.
-      schedulePostLoopOps(loop, schedule, result->epiloguePartition);
-
       optimizeSchedule(loop, schedule);
+
+      // Split scf.if ops whose results feed different computation partitions.
+      // This must run after all partition assignments are finalized (after
+      // propagatePartitions + optimizeSchedule) but before serialization.
+      splitDataPartitionedIfOps(loop, schedule);
+
       schedule.serialize(loop);
       loop->setAttr(
           kWarpSpecializeTagAttrName,
           IntegerAttr::get(IntegerType::get(loop.getContext(), 32), idx));
-      // Assign partition IDs to all remaining ops inside the loop that don't
-      // have one yet. This mirrors upstream's assignRegionBodyPartition and
-      // assignRegionOpPartitions to satisfy the partition verifier which
-      // requires ALL ops inside a WS loop to have partition attributes.
-
-      // Step 1: For ops nested inside regions (e.g. tt.reduce body, scf.if
-      // body), inherit the partition from the nearest ancestor op that has one.
-      Operation *loopOp = loop.getOperation();
-      loop->walk([&](Operation *op) {
-        if (isa<scf::YieldOp, scf::ForOp>(op) || hasPartition(op))
-          return WalkResult::advance();
-
-        // Find the nearest ancestor in the loop body that has a partition.
-        Operation *ancestor = op->getParentOp();
-        while (ancestor && ancestor != loopOp) {
-          if (hasPartition(ancestor)) {
-            setPartition(op, getPartitionIds(ancestor));
-            break;
-          }
-          ancestor = ancestor->getParentOp();
-        }
-        return WalkResult::advance();
-      });
-
-      // Step 2: Remove partition attribute from non-ForOp ops that have
-      // regions (e.g. tt.reduce, scf.if), but only when the parent op
-      // does not itself have a partition attribute. If the parent is
-      // partitioned the dialect verifier will require all its children
-      // to carry the attribute, so we must keep it.
-      loop->walk([&](Operation *op) {
-        if (!isa<scf::ForOp>(op) && hasPartition(op) &&
-            op->getNumRegions() > 0) {
-          auto *parent = op->getParentOp();
-          if (!parent || !hasPartition(parent))
-            op->removeAttr(kPartitionAttrName);
-        }
-      });
-
-      // Step 3: Handle ops without results that still need partition
-      // assignments (e.g. llvm.intr.assume, debug intrinsics). These inherit
-      // from their parent operation.
-      loop.walk([&](Operation *op) {
-        if (op->getNumResults() > 0 || hasPartition(op))
-          return WalkResult::advance();
-        if (op->getNumRegions() > 0 ||
-            isa<scf::YieldOp, triton::ReduceReturnOp>(op))
-          return WalkResult::advance();
-        auto parentOp = op->getParentOp();
-        if (hasPartition(parentOp))
-          setPartition(op, getPartitionIds(parentOp));
-        return WalkResult::advance();
-      });
-
-      // Clean Broadcast/ExpandDims/ConvertLayout that were left with no users
-      // after optimizeSchedule. We wait until after the schedule is serialized
-      // to avoid invalidating pointers stored in the schedule.
+      // Clean Broadcast/ExpandDims that were left with no users
+      // after optimizeSchedule. We wait until after the schedule is
+      // serialized to avoid invalidating pointers stored in the schedule.
       loop.walk<WalkOrder::PostOrder, ReverseIterator>([](Operation *op) {
         // By default, the walk is in postorder so it is safe to delete ops
         // while we walk.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -816,7 +816,7 @@ parseChannelAnnotations(Operation *parentOp) {
   std::map<unsigned, std::pair<unsigned, Operation *>> bufferIdToInfo;
 
   parentOp->walk([&](Operation *op) {
-    if (!isa<ttng::MMAv5OpInterface>(op))
+    if (!op->hasAttr("tt.autows"))
       return;
     auto attr = op->getAttrOfType<StringAttr>("tt.autows");
     if (!attr)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -1,0 +1,383 @@
+# Partition Scheduling Meta
+
+This document covers the `PartitionSchedulingMeta` pass, which assigns partition
+IDs to operations for warp specialization. This is the first pass in the AutoWS
+pipeline — it determines which warp group each operation will execute on.
+
+**File**: `PartitionSchedulingMeta.cpp`
+
+## Overview
+
+The pass walks all `scf.for` loops with the `tt.warp_specialize` attribute and
+assigns each operation inside the loop (and post-loop consumers) to a
+**partition**. Each partition maps to a warp group at runtime.
+
+```
+Phase 1: Categorize operations         (OpCategorizer + collectMMABackwardSlices)
+Phase 2: Create partition layout       (createPartitionLayout with tuning knobs)
+Phase 3: Schedule anchor ops           (loads, epilogue stores, MMAs)
+Phase 4: Propagate users               (load users, correction, reductions)
+Phase 5: Create computation partitions (per-MMA user scheduling + dpId assignment)
+Post:    propagatePartitions + schedulePostLoopOps + optimizeSchedule
+         + splitDataPartitionedIfOps
+```
+
+## Tuning Knobs
+
+Partition layout is controlled by `SchedulingOptions`, exposed as pass options
+in `Passes.td`:
+
+| Knob | Pass Option | Default | Effect |
+|------|-------------|---------|--------|
+| `mergeCorrection` | `--merge-correction` | false | Correction ops → computation[dpId] |
+| `mergeEpilogue` | `--merge-epilogue` | false | Epilogue ops → correction/reduction/computation |
+| `mergeEpilogueToComputation` | `--merge-epilogue-to-computation` | false | Epilogue ops → computation[dpId] directly |
+| `mergeReduction` | `--merge-reduction` | false | Reduction ops → computation[dpId] |
+| `separateEpilogueStore` | `--separate-epilogue-store` | false | Epilogue store ops → own 1-warp partition |
+
+Per-loop `tt.merge_epilogue` attribute overrides the `mergeEpilogue` pass option.
+
+### Epilogue Terminology
+
+Post-loop operations are split into two categories:
+
+- **Epilogue ops**: Non-store post-loop operations (tmem_load acc, normalize,
+  truncf, convert_layout). These are computation that must happen after the
+  main loop before the final store.
+- **Epilogue store ops**: Post-loop TMA store operations (DescriptorStoreOp,
+  AsyncTMACopyLocalToGlobalOp). These write the final results to global memory.
+
+The epilogue tuning knobs control where these go:
+
+**`mergeEpilogue` routing**: When true, epilogue ops go to the correction
+partition (if it exists), else the reduction partition, else computation[dpId].
+This preserves the priority: correction > reduction > computation. Used by
+FA forward where epilogue ops (normalize acc) belong in the correction
+partition.
+
+**`mergeEpilogueToComputation` routing**: When true, epilogue ops go directly
+to computation[dpId], even if a correction or reduction partition exists. This
+is used by FA backward where post-loop ops (tmem_load dK/dV, reshape, split,
+truncf) are data-partitioned and should stay with their corresponding
+computation partition rather than being merged into the reduction partition.
+
+`mergeEpilogueToComputation` takes priority over `mergeEpilogue` when both are
+set.
+
+Epilogue store ops are independent of these knobs — they always go to
+`epilogue_store` (when `separateEpilogueStore`) or `epilogue` partition.
+
+### Target Partition Layouts
+
+| Case | Knobs | Partitions |
+|------|-------|------------|
+| Blackwell FA fwd | mergeEpilogue + separateEpilogueStore | correction, gemm, load, epilogue_store, comp×2 |
+| Blackwell FA bwd | mergeEpilogueToComputation (merge_epilogue=true) | reduction, gemm, load, computation |
+| Blackwell flex fwd | mergeEpilogue | correction, gemm, load, comp×2 |
+| Hopper FA fwd | mergeCorrection + mergeEpilogue | load, comp×2 |
+| Simple GEMM | separateEpilogueStore | gemm, load, epilogue, epilogue_store |
+
+## Phase 1: Operation Categorization (`OpCategorizer`)
+
+### Categories
+
+| Category | Ops | Purpose |
+|----------|-----|---------|
+| `Load` | `DescriptorLoadOp`, `DescriptorGatherOp` | TMA loads |
+| `MMA` | `MMAv5OpInterface`, `WarpGroupDotOp` | Tensor core operations |
+| `MemDescView` | ops with `MemDescViewTrait` | Memory descriptor views feeding MMA |
+| `EpilogueStore` | `DescriptorStoreOp`, `AsyncTMACopyLocalToGlobalOp` | Epilogue store ops (TMA output stores) |
+| `TMAReduction` | `DescriptorReduceOp`, `AsyncTMAReduceOp` | Atomic reductions |
+| `Correction` | Cross-iteration MMA users | Online softmax rescaling |
+| `DataPartition` | Exclusive ops in one MMA's backward slice | Per-MMA-group computation |
+
+### MMA Type Support
+
+The pass supports both Blackwell and Hopper MMA types via the `isMMAOp()`
+helper:
+- **MMAv5** (`tc_gen5_mma`): Blackwell tensor cores. Gets its own `gemm`
+  partition for TMEM-based accumulation.
+- **WarpGroupDot** (`warp_group_dot`): Hopper tensor cores. No separate `gemm`
+  partition — MMA ops go directly into computation partitions.
+
+### Categorization Order
+
+```
+categorizeLoads()
+categorizeMMAs()
+categorizeEpilogueStores()
+categorizeTMAReductions()
+categorizeCorrectionOps()       ← runs before DataPartition
+categorizeDataPartitionOps()    ← skips already-categorized ops
+```
+
+Correction runs before DataPartition so that correction ops (accumulator
+rescaling) are not stolen by the data partition categorizer.
+
+### Central dpId Assignment (`collectMMABackwardSlices`)
+
+`collectMMABackwardSlices` is the single source of truth for data partition ID
+(dpId) assignment. It:
+
+1. **Collects backward slices** for each MMA, **entering `scf.if` regions**
+   selectively — only following yield operands that correspond to results
+   consumed by the current slice. This captures ops like `tmem_load QK` and
+   `mulf(QK*scale)` in flex attention without pulling in ops from the other
+   data partition.
+2. **Groups dependent MMAs** via union-find. MMA B depends on MMA A if A's
+   forward user set overlaps B's backward slice (e.g., QK MMA feeds PV MMA).
+3. **Builds `opToDpId` map** for ALL reachable ops:
+   - **Inner-loop ops**: From backward slices, using normalized group IDs.
+     Ops appearing in multiple groups get `SHARED_DPID` sentinel.
+   - **Pre-loop ops**: Following MMA operands backward across the loop
+     boundary (Q loads, allocs).
+   - **Post-loop ops**: Following loop results forward to post-loop consumers
+     (descriptor stores, normalization).
+
+All `categorize*` functions look up dpId from `opToDpId` via `addCategorizedOp`,
+which auto-resolves the dpId when not explicitly provided.
+
+### Data Partition Factor Detection
+
+1. **Collect backward slices** for each MMA.
+2. **Identify shared ops** — ops appearing in multiple slices.
+3. **Union-find grouping** — MMAs whose forward user sets overlap another MMA's
+   backward slice are grouped together.
+4. **Count groups with exclusive ops** — only groups with at least one
+   non-shared, non-constant op count. This becomes `dataPartitionFactor`.
+
+For FA forward with `data_partition_factor=2`, this yields `dpFactor=2`.
+For FA backward, MMAs are data-dependent (QK feeds PV via the same accumulator),
+so all MMAs group together → `dpFactor=1`.
+
+## Phase 2: Partition Layout (`createPartitionLayout`)
+
+Creates partitions based on the categorizer results and `SchedulingOptions`.
+Replaces the old template system (`UnifiedFATemplate`, `GEMMTemplate`,
+`selectTemplate`).
+
+Partition creation order determines the partition index. The first partition
+created gets index 0, which becomes the "default" warp group in
+`tt.warp_specialize` (receives 4 warps):
+
+1. **Correction** — when `!mergeCorrection && hasCorrection`. Serves as default
+   for FA/flex (shared ops, load users go here). Created first → index 0.
+2. **Reduction** — when `!mergeReduction && hasReduction`. Serves as default for
+   bwd. Created first → index 0.
+3. **Gemm** — only when MMAv5 ops exist (Blackwell). Hopper `warp_group_dot`
+   is not MMAv5, so no gemm partition is created for Hopper.
+4. **Load** — always.
+5. **Epilogue** — when `!mergeEpilogue && !mergeEpilogueToComputation &&
+   hasEpilogue`. Holds epilogue ops (non-store post-loop computation).
+6. **Epilogue store** — when `separateEpilogueStore && hasEpilogue`. Gets 1
+   warp. Holds epilogue store ops (TMA stores). When no separate epilogue store
+   partition exists, epilogue store ops go to the epilogue partition instead.
+7. **Computation** — pre-created in Phase 5 per data partition (reverse dpId
+   order for consistent partition index assignment).
+
+There is no dedicated "default" partition. Uncategorized ops (e.g., pre-loop
+acc inits, shared ops, load users) that are not assigned by any phase are
+routed to existing partitions with the fallback priority:
+correction → reduction → epilogue → computation.
+
+When merged (`mergeCorrection=true`), no correction partition is created and
+those ops go to the next available partition in the fallback chain.
+
+## Phase 3–5: Partition Assignment
+
+### Phase 3: Anchor Ops
+
+1. **Loads** → `load` partition. Includes `LocalAllocOp` users with matching
+   shared encoding and `TMEMAllocOp` users.
+2. **Epilogue store ops** → `epilogue_store` partition (when it exists), else
+   follow the same routing as regular epilogue ops.
+3. **MMAs** → `gemm` partition (MMAv5 only). Non-MMAv5 MMAs (WarpGroupDot) are
+   left for Phase 5 where they go to computation partitions.
+4. **MemDesc views** → `gemm` partition (MMAv5 only). Skipped when no gemm
+   partition exists.
+
+### Phase 4: Propagate Users
+
+1. **Load users** → routed with the uncategorized op fallback priority:
+   correction → reduction → epilogue → computation.
+2. **Correction ops** → correction partition (+ `scheduleUsers` for transitive
+   users). `scheduleUsers` walks **forward only** through the use chain
+   starting from the correction-categorized op (the `tmem_load` of the PV
+   accumulator). It claims all transitive forward users — reshape, trans,
+   split, convert_layout, inline_asm (the mul with alpha), join, trans,
+   reshape, convert_layout, tmem_store — for the correction partition.
+   However, it does **not** walk backward to claim co-operands of visited ops.
+   For example, when `inline_asm(mul %acc_split, %alpha_broadcast)` is
+   claimed for correction, `scheduleUsers` does not trace back to
+   `%alpha_broadcast` or `expand_dims %alpha`. These ops are left for
+   Phase 5 (computation) and later `optimizeSchedule` (cloning).
+3. **TMA reduction ops** → reduction partition (+ backward slice producers).
+
+### Phase 5: Computation Partitions
+
+Pre-creates computation partitions for each dpId that has `DataPartition`-
+categorized ops (in reverse dpId order to match legacy partition index ordering).
+Then iterates over MMAs:
+
+- **Pre-assigned MMAs** (PV MMAs): Use the pre-assigned computation partition.
+- **Non-pre-assigned MMAs** (QK MMAs): First check user partitions, then look up
+  dpId from `opToDpId` to find the correct existing computation partition. This
+  prevents creating extra partitions.
+- **Non-MMAv5** (Hopper): MMA ops themselves are scheduled into the computation
+  partition (not gemm, since no gemm partition exists).
+
+### dpId-Based Inner-Loop Assignment
+
+After Phase 5, some inner-loop ops may remain unscheduled (e.g., `l_ij` reduce,
+`tmem_alloc` p, `l_i*alpha`, `l_i+l_ij`). These ops have dpIds but aren't
+reached by `scheduleUsers` because they're downstream of correction ops
+(already scheduled in Phase 4) whose use chains `scheduleUsers` skips.
+
+For each unscheduled inner-loop op with a tensor result:
+1. Look up dpId from `opToDpId`.
+2. If no entry, **trace through operands** to find the dpId from an operand
+   that IS in `opToDpId` or already assigned to a computation partition.
+3. Assign to the corresponding `dpIdToPartition` computation partition.
+
+Scalar integer ops (loop counters) and `scf.yield` are excluded from this
+assignment since they are loop-control ops, not data-partition computation ops.
+
+## Post-Processing
+
+### `propagatePartitions`
+
+Handles unscheduled ops by forming **clusters** — groups of adjacent
+unscheduled ops connected via the SSA def-use graph. Each cluster tracks:
+
+- **defPartitions**: Partitions of already-scheduled ops that feed into the
+  cluster (upstream).
+- **sinkPartitions**: Partitions of already-scheduled ops that consume the
+  cluster's outputs (downstream).
+
+**Nested loop visibility**: `iterateUsers` follows use chains into nested
+inner loops to find partitioned consumers. When a captured value (e.g.,
+`tt.splat` producing `tensor<!tt.ptr>`) is used inside a nested `scf.for`,
+`iterateUsers` walks the use chain inside the nested loop until it finds an
+op with a partition annotation. This ensures the cluster gets the correct
+sink partition (e.g., computation) rather than falling back to the def
+partition (e.g., reduction). Without this, `propagatePartitions` would
+assign pointer tensor ops to reduction, creating cross-partition channels
+for pointer types that crash `WSCodePartition`.
+
+**Scalar op exclusion**: During cluster assignment, ops that produce only
+scalar results (non-tensor, non-memdesc) are skipped. These ops can be
+rematerialized in any partition and should not force partition assignment.
+Clusters with empty `defPartitions` (containing only scalar ops) are also
+skipped.
+
+Cluster assignment rules:
+
+1. **Multiple def or sink partitions**: The cluster sits between multiple
+   partitions. For BWD-like kernels (has reduction, no epilogue, has
+   computation), assign to the existing computation partition. Otherwise
+   create a new computation partition (unless `createComputePartitions=false`,
+   in which case merge into existing computation).
+2. **No sink partition** (no downstream consumers with partitions): Assign
+   the entire cluster to its def partition.
+3. **Single def and single sink**: Assign to the sink partition (downstream
+   consumer), or to the def partition if they're the same.
+
+### `schedulePostLoopOps`
+
+Schedules post-loop operations:
+
+- **Epilogue store ops** → `epilogue_store` partition (when it exists), else
+  follow the same routing as regular epilogue ops.
+- **Epilogue ops** (non-store) → routing depends on tuning knobs:
+  - `mergeEpilogueToComputation`: → computation[dpId] directly
+  - `mergeEpilogue`: → correction (if exists) → reduction → computation[dpId]
+  - Neither: → `epiloguePartition` (if exists) → correction/reduction →
+    computation
+
+The `postLoopPartition` fallback order (for epilogue ops when no merge knob
+is active) is:
+1. `epiloguePartition` (when it exists)
+2. Correction/reduction partition (whichever serves as default)
+3. First `dpIdToPartition` entry (Hopper with all merges, last resort)
+
+### `optimizeSchedule`
+
+Clones `BroadcastOp` and `ExpandDimsOp` into each partition that has users.
+This allows cheap element-rearranging ops to be rematerialized in consumer
+partitions rather than creating cross-partition channels.
+
+The cloning walks in reverse post-order so that an `ExpandDimsOp` feeding a
+`BroadcastOp` is visited after the broadcast has already been cloned. When
+`BroadcastOp` B is cloned into partition P (because B's user is in P), and
+`ExpandDimsOp` E feeds B, then E is also cloned into P in the same pass
+(because E's user — the cloned B — is now in P).
+
+**Operand chain cloning**: After cloning a `BroadcastOp`/`ExpandDimsOp`,
+`optimizeSchedule` walks backward through the clone's operand chain and
+also clones any `ConvertLayoutOp`, `BroadcastOp`, or `ExpandDimsOp` that
+feeds it from a different partition. This handles the case where upstream
+layout passes insert a `ConvertLayoutOp` between `ExpandDimsOp` and
+`BroadcastOp` (e.g., `expand_dims → convert_layout → broadcast`). Without
+this backward walk, the `ConvertLayoutOp` would break the cloning chain
+and create an unintended cross-partition boundary, forcing the value
+through an smem channel instead of keeping it within the partition.
+
+### `splitDataPartitionedIfOps`
+
+Splits `scf.if` ops whose results feed different computation partitions into
+separate per-partition `scf.if` ops. Required for flex attention masking where
+a single `scf.if` yields values for both data partitions.
+
+## Partition Type Summary
+
+For FA forward with `dpFactor=2`, `mergeEpilogue` + `separateEpilogueStore`
+(Blackwell):
+```
+partition 0: correction      — correction ops, load users, epilogue ops (normalize acc)
+partition 1: gemm            — MMA operations + mem desc views
+partition 2: load            — TMA loads + associated allocs
+partition 3: epilogue_store  — descriptor stores
+partition 4: computation     — MMA user group 1 (PV_1 chain)
+partition 5: computation     — MMA user group 0 (PV_0 chain)
+```
+
+For FA backward with `dpFactor=1`, `mergeEpilogueToComputation` (Blackwell):
+```
+partition 0: reduction   — TMA reduction ops, pre-loop tmem_stores
+partition 1: gemm        — MMA operations + mem desc views
+partition 2: load        — TMA loads + associated allocs
+partition 3: computation — all MMA users + epilogue ops (tmem_load dK/dV,
+                           reshape, split, truncf, descriptor_store)
+```
+
+For flex attention forward with `dpFactor=2`, `mergeEpilogue` (Blackwell):
+```
+partition 0: correction  — correction ops, load users, sparse indexing,
+                           epilogue ops (normalize acc)
+partition 1: gemm        — MMA operations + mem desc views
+partition 2: load        — TMA loads + associated allocs
+partition 3: computation — MMA user group 0 (includes QK tmem_load + scale)
+partition 4: computation — MMA user group 1 (includes QK tmem_load + scale)
+```
+
+For FA forward with `dpFactor=2` (Hopper, mergeCorrection + mergeEpilogue):
+```
+partition 0: load        — TMA loads + associated allocs
+partition 1: computation — MMA group 0 (QK + PV + softmax + correction + epilogue)
+partition 2: computation — MMA group 1 (QK + PV + softmax + correction + epilogue)
+```
+
+For GEMM with `separateEpilogueStore` (no correction/reduction):
+```
+partition 0: gemm           — MMA operations + mem desc views
+partition 1: load           — TMA loads + associated allocs
+partition 2: epilogue       — epilogue ops (post-loop tmem_load, truncf)
+partition 3: epilogue_store — TMA stores (descriptor_store, async_tma_copy)
+```
+
+## Debug
+
+- `TRITON_LLVM_DEBUG_ONLY="tritongpu-partition-scheduling"` enables debug logging.
+- The categorizer prints all ops grouped by category with dpId.
+- `createPartitionLayout` logs which partitions are created.
+- Phase 5 logs MMA processing with dpId and pre-assignment status.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/partition_scheduling_meta_redesign.plan.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/partition_scheduling_meta_redesign.plan.md
@@ -1,0 +1,243 @@
+## Context
+
+The current `PartitionSchedulingMeta` pass has accumulated several design issues:
+
+1. **Hacky secondary correction detection**: `selectTemplate()` has ~35 lines re-detecting correction ops that the categorizer missed because `categorizeDataPartitionOps()` runs first and claims them.
+2. **dpId only on DataPartition**: Only `DataPartition`-categorized ops carry a `dataPartitionId`. Other categories (Load, MMA, Correction, EpilogueStore) don't, making it impossible to merge them into the correct per-dpId computation partition.
+3. **Template system is over-engineered**: `UnifiedFATemplate` vs `GEMMTemplate` selection adds indirection. The partition layout should be driven by tuning knobs, not by detecting which "pattern" the kernel matches.
+4. **Default partition semantics are inconsistent**: The "default" partition is sometimes created, sometimes not, and serves multiple unrelated roles (correction, load users, post-loop ops, uncategorized ops).
+5. **`getBackwardSlice` stops at `scf.if` boundaries**: MLIR's `getBackwardSlice` adds an `scf.if` op to the slice and follows its condition, but does NOT enter the then/else regions to follow yield operands. This causes QK `tmem_load` and `mulf(QK*scale)` ops in flex attention to be missed, requiring the post-hoc merge workaround.
+6. **New Hopper case impossible**: FA on Hopper wants 3 partitions (load + computation×2), requiring `mergeCorrection` and `mergeEpilogue` — none of which exist today.
+7. **No control over epilogue store placement**: On Blackwell, `DescriptorStoreOp` benefits from a dedicated 1-warp partition.
+
+### Target partition layouts
+
+| Case | Knobs | Partitions |
+|------|-------|------------|
+| Blackwell FA fwd (current) | default | correction, gemm, load, epilogue, comp×2 |
+| Blackwell FA fwd (optimized) | separateEpilogueStore | correction, gemm, load, epilogue_store (1-warp), comp×2 |
+| Blackwell FA fwd (merged epi) | mergeEpilogue | correction (+ epilogue ops), gemm, load, comp×2 |
+| Blackwell FA bwd | default | reduction, gemm, load, epilogue, comp |
+| Blackwell flex fwd | default (no epilogue) | correction, gemm, load, comp×2 |
+| Hopper FA fwd | mergeCorrection+mergeEpilogue | load, comp×2 |
+| Simple GEMM (dpFactor=1) | default | default, gemm, load, epilogue |
+| Data-partitioned GEMM (dpFactor=2) | default | default, gemm, load, epilogue |
+
+Note: Both GEMM cases produce identical partition layouts. With dpFactor=2, each MMA's exclusive backward slice only contains loads/memdesc_views (already categorized as Load), so no DataPartition or computation entries are created. Post-loop ops (tmem_load, truncf for output conversion) go to the uncategorized partition, labeled "default".
+
+---
+
+## Phase 1: Enhance `collectMMABackwardSlices` as central dpId assignment
+
+**File**: `PartitionSchedulingMeta.cpp`
+
+The core change: `collectMMABackwardSlices` becomes the single source of truth for dpId assignment. It already computes backward slices and union-find groups. Enhance it to (a) enter `scf.if` regions, (b) build an `opToDpId` map for ALL reachable ops, and (c) extend beyond the innermost loop boundary.
+
+### 1a. Enter `scf.if` regions in backward slice analysis
+
+Enhance `collectMMABackwardSlice` so that when an `scf.if` op is added to the slice, its yield operands in the then/else blocks are also followed backward. This captures ops like `tmem_load QK` and `mulf(QK*scale)` that feed into `scf.if` yield operands in flex attention.
+
+Implementation: after the initial `getBackwardSlice` call, iterate over any `scf::IfOp` in the slice and recursively call `getBackwardSlice` on their yield operands:
+
+```
+collectMMABackwardSlice(loop, mmaOp):
+  slice = getBackwardSlice(mmaOp operands, options)
+  // Enter scf.if regions: follow yield operands backward
+  repeat until no new ops:
+    for each scf.IfOp in slice:
+      for each region (then, else):
+        for each yield operand:
+          getBackwardSlice(operand, &slice, options)
+  return slice
+```
+
+This eliminates the root cause of the flex attention issue. The post-hoc merge-extra-computation-partitions logic and compaction step can be removed.
+
+### 1b. Assign dpId to all ops (inside and outside innermost loop)
+
+After union-find grouping, build `opToDpId` for every reachable op:
+
+**Inside innermost loop** — iterate over all MMAs and their (now-complete) backward slices:
+```
+For each MMA group g:
+  For each MMA m in group g:
+    opToDpId[m] = g
+    For each op in backwardSlice[m]:
+      if op not in opToDpId:
+        opToDpId[op] = g
+      else if opToDpId[op] != g:
+        opToDpId[op] = SHARED_DPID
+```
+
+**Pre-loop ops** (Q loads, allocs): Follow MMA operands backward across the loop boundary. Assign dpId based on which MMA group they feed exclusively into, or `SHARED_DPID` if shared.
+
+**Post-loop ops** (descriptor_stores, normalization): Follow loop results forward. Each result traces back to a specific MMA group's yield value. The post-loop consumer chain gets that group's dpId.
+
+### 1c. Expose dpId map from OpCategorizer
+
+Add `opToDpId` as a member of `OpCategorizer`. All `categorize*` functions look up dpId from this map when creating `CategorizedOp` entries, instead of computing dpId independently. `CategorizedOp.dataPartitionId` is populated for ALL categories.
+
+### 1d. Fix categorization order
+
+Move `categorizeCorrectionOps()` BEFORE `categorizeDataPartitionOps()`:
+```
+categorizeLoads();            // dpId from opToDpId
+categorizeMMAs();             // dpId from opToDpId
+categorizeEpilogueStores();   // dpId from opToDpId
+categorizeTMAReductions();    // dpId from opToDpId
+categorizeCorrectionOps();    // dpId from opToDpId ← moved up
+categorizeDataPartitionOps(); // dpId from opToDpId, skips already-categorized
+```
+
+This eliminates the root cause of the secondary correction detection hack.
+
+---
+
+## Phase 2: Replace template system with tuning knobs
+
+**File**: `PartitionSchedulingMeta.cpp`
+
+### 2a. Tuning knobs
+
+```cpp
+struct SchedulingOptions {
+  bool mergeCorrection = false;        // correction → computation[dpId]
+  bool mergeEpilogue = false;          // non-store epilogue ops → see routing below
+  bool mergeReduction = false;         // reduction → computation[dpId]
+  bool separateEpilogueStore = false;  // descriptor_store → own 1-warp partition
+  unsigned numDataPartitions = 1;
+};
+```
+
+No `mergeGemm` — MMAv5 always gets its own gemm partition.
+
+**`mergeEpilogue` routing logic** (for non-store epilogue ops):
+1. If a **correction** partition exists (`!mergeCorrection && hasCorrection`): merge into correction partition.
+2. Else if a **reduction** partition exists (`!mergeReduction && hasReduction`): merge into reduction partition.
+3. Else: merge into `computation[dpId]`.
+
+Rationale: correction ops (acc rescaling) and epilogue ops (acc normalization, output writes) are part of the same accumulator pipeline. When correction has its own partition, epilogue naturally belongs there. Same logic applies for reduction in bwd.
+
+**`separateEpilogueStore`**: When true, `DescriptorStoreOp`/`AsyncTMACopyLocalToGlobalOp` always get their own 1-warp partition, regardless of `mergeEpilogue`.
+
+**Full interaction matrix** (non-store epilogue ops):
+
+| `mergeCorrection` | `mergeEpilogue` | correction exists? | non-store epilogue → |
+|---|---|---|---|
+| false | false | yes | epilogue partition |
+| false | true | yes | **correction partition** |
+| true | false | no | epilogue partition |
+| true | true | no | computation[dpId] |
+
+**Full interaction matrix** (descriptor_store ops):
+
+| `mergeEpilogue` | `separateEpilogueStore` | descriptor_store → |
+|---|---|---|
+| false | false | epilogue partition |
+| false | true | **epilogue_store (1-warp)** |
+| true | false | follows non-store epilogue routing above |
+| true | true | **epilogue_store (1-warp)** |
+
+Expose as pass options and/or `scf.for` attributes.
+
+### 2b. Simplify partition creation
+
+Remove `UnifiedFATemplate`, `GEMMTemplate`, and `selectTemplate()`. Replace with direct partition creation:
+
+1. **Always** create `computation[0..dpFactor-1]` partitions (when dpFactor > 1).
+2. Create `gemm` only if there are MMA-categorized ops (MMAv5). When present, MMAv5 always gets its own partition.
+3. **Always** create `load` partition.
+4. Create `correction` only if `!mergeCorrection && hasCorrection`.
+5. Create `reduction` only if `!mergeReduction && hasReduction`.
+6. Create `epilogue` only if `!mergeEpilogue && hasEpilogue && !separateEpilogueStore`. (Also create when `!mergeEpilogue` and there are non-store epilogue ops even when `separateEpilogueStore` is true.)
+7. Create `epilogue_store` only if `separateEpilogueStore && hasEpilogueStores`. This partition gets 1 warp.
+8. Create `uncategorized` partition for leftovers → label as `"default"` at the end if it has ops, or remove it.
+
+### 2c. Remove secondary correction detection
+
+Delete the ~35 lines in `selectTemplate()` that re-detect correction by walking MMA forward users.
+
+---
+
+## Phase 3: Refactor partition assignment
+
+**File**: `PartitionSchedulingMeta.cpp`
+
+### 3a. Category-to-partition routing with dpId
+
+Replace current Phase 3-5 logic with category-based assignment using dpId:
+
+```
+For each categorized op:
+  switch (category):
+    Load          → loadPartition (shared; dpId is informational)
+    MMA           → gemmPartition (always separate for MMAv5)
+    MemDescView   → gemmPartition (same as MMA)
+    Correction    → correctionPartition (or computation[dpId] if mergeCorrection)
+    EpilogueStore → if separateEpilogueStore: epilogueStorePartition (1-warp)
+                    else: follow Epilogue routing below
+    Epilogue      → if !mergeEpilogue: epiloguePartition
+                    else if correctionPartition exists: correctionPartition
+                    else if reductionPartition exists: reductionPartition
+                    else: computation[dpId]
+    Reduction     → reductionPartition (or computation[dpId] if mergeReduction)
+    DataPartition → computation[dpId]
+    Default       → uncategorizedPartition
+```
+
+For ops with `dpId = SHARED_DPID`, route to the uncategorized/default partition.
+
+### 3c. Partition reordering — select the default partition
+
+After all ops are assigned, reorder partitions so that the **default partition** (partition index 0 in `tt.warp_specialize`) is one that requires 4 warps. The `tt.warp_specialize` lowering assigns 4 warps to the first partition and distributes remaining warps to others.
+
+Selection priority:
+1. If a **reduction** partition exists → make it partition 0 (bwd: reduction needs 4 warps for TMEM coverage).
+2. Else if a **correction** partition exists → make it partition 0 (fwd: correction/rescaling needs 4 warps for TMEM ops).
+3. Else → make `computation[0]` partition 0 (fallback: e.g., Hopper with all categories merged).
+
+Implementation: after partition assignment is complete, swap the chosen partition to index 0 and update all ops' `ttg.partition` attributes to reflect the new numbering.
+
+With the `scf.if` region fix (Phase 1a) and dpId-aware routing:
+- Merge-extra-computation-partitions step is **removed** (no extra partitions created).
+- Compaction step is **removed** (no empty partitions to compact).
+- `splitDataPartitionedIfOps` remains for flex attention.
+- `propagatePartitions` and `schedulePostLoopOps` still needed for uncategorized ops.
+
+---
+
+## Phase 4: Add Hopper FA lit test
+
+**File**: `test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-fa.mlir`
+
+Create from `hopper.part.prior`:
+- 3 partitions: `load`, `computation`, `computation`
+- Pass options: `--nvgpu-partition-scheduling-meta="merge-correction merge-epilogue"`
+- Hopper uses `warp_group_dot` (not MMAv5), so no MMA-categorized ops → no gemm partition created
+- Correction ops + epilogue ops → computation[dpId] (both merged, no correction/reduction partition exists)
+- Loads → shared load partition
+- Result: load + comp×2 = 3 partitions
+
+---
+
+## Phase 5: Verify all existing lit tests
+
+Run all existing `partition-scheduling-meta-*.mlir` tests with default knobs (no merging) to verify backward compatibility.
+
+---
+
+## Verification
+
+1. `ninja -j$(nproc) triton-opt` to rebuild
+2. Run all partition-scheduling-meta lit tests with FileCheck
+3. Run `triton-opt` on `fa.part.prior`, `flex.part.prior`, `hopper.part.prior` and verify partition types
+4. Run FA fwd tutorial: `TRITON_USE_META_PARTITION=1 TRITON_USE_META_WS=1 python python/tutorials/fused-attention-ws-device-tma.py`
+
+---
+
+## Critical files
+
+- `PartitionSchedulingMeta.cpp` — main pass implementation (all phases)
+- `docs/PartitionSchedulingMeta.md` — documentation updates
+- `test/Hopper/WarpSpecialization/partition-scheduling-meta-*.mlir` — lit tests
+- `include/nvidia/hopper/include/Transforms/Passes.td` — pass option definitions for merge/separation knobs

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -606,8 +606,8 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func) {
   }
 
   bool isTlxPairedMMA = tlx::tlxEnablePairedMMA(mod);
-  bool useTwoCTAs = mlir::triton::nvidia_gpu::getModuleTwoCTAs(mod) ||
-                    isTlxPairedMMA;
+  bool useTwoCTAs =
+      mlir::triton::nvidia_gpu::getModuleTwoCTAs(mod) || isTlxPairedMMA;
   // This code is only executed by the default warp group.
   Value threadId = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
   Value pred = b.icmp_ult(threadId, b.i32_val(32));


### PR DESCRIPTION
PartitionSchedulingMeta refactoring, see the md files for details
Add per-loop annotations for partition scheduling knobs:
```
| `mergeCorrection` | `--merge-correction` | false | Correction ops → computation[dpId] |
| `mergeEpilogue` | `--merge-epilogue` | false | Epilogue ops → correction/reduction/computation |
| `mergeEpilogueToComputation` | `--merge-epilogue-to-computation` | false | Epilogue ops → computation[dpId] directly |
| `mergeReduction` | `--merge-reduction` | false | Reduction ops → computation[dpId] |
| `separateEpilogueStore` | `--separate-epilogue-store` | false | Epilogue store ops → own 1-warp partition |
```

fused-attention-ws-device-tma.py: expand pytest to cover hDim of 64 and various other configs

