### PR TITLE
[triton] Budget-aware layout conversion elimination to avoid SMEM OOM (#1266)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -290,10 +290,22 @@ def TritonGPURemoveLayoutConversions : Pass<"tritongpu-remove-layout-conversions
     `BlockedEncodingAttr` layout for "expensive" loads and stores
     (good for coalescing) and `NvidiaMmaEncodingAttr` otherwise
     (good for tensor ops).
+
+    When `smemBudget` is nonzero, the pass additionally checks whether the
+    chosen layout would produce a `convert_layout` whose scratch buffer
+    causes total shared memory usage to exceed the budget. In that case it
+    overrides the default heuristic and picks the layout that can be absorbed
+    by a `local_load` or `local_store` without scratch.
   }];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::TritonDialect"];
+
+  let options = [
+    Option<"smemBudget", "smem-budget", "unsigned", /*default=*/"0",
+           "When nonzero, override layout choices whose convert_layout "
+           "scratch would push shared memory usage above this budget (bytes)">
+  ];
 
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -484,7 +484,7 @@ static unsigned estimateConvertScratchCost(Value value, Attribute encoding) {
     auto dstTy = srcTy.cloneWithEncoding(encoding);
     if (cvtNeedsSharedMemory(srcTy, dstTy)) {
       unsigned elems = getNumScratchElemsSwizzledCvt(srcTy, dstTy);
-      cost += elems * srcTy.getElementTypeBitWidth() / 8;
+      cost += elems * getElementBitWidth(srcTy) / 8;
     }
   }
   return cost;
@@ -1946,9 +1946,8 @@ public:
         auto dstTy = cvt.getType();
         if (!cvtNeedsSharedMemory(srcTy, dstTy))
           return;
-        unsigned scratchBytes =
-            getNumScratchElemsSwizzledCvt(srcTy, dstTy) *
-            srcTy.getElementTypeBitWidth() / 8;
+        unsigned scratchBytes = getNumScratchElemsSwizzledCvt(srcTy, dstTy) *
+                                getElementBitWidth(srcTy) / 8;
         if (baseSmem + scratchBytes > smemBudget) {
           overBudgetConverts.push_back(cvt);
         }
@@ -1985,9 +1984,9 @@ public:
           continue;
         // Elementwise ops are layout-transparent — propagate through them.
         if (user->hasTrait<OpTrait::Elementwise>() ||
-            isa<arith::ExtFOp, arith::TruncFOp, arith::ExtUIOp,
-                arith::ExtSIOp, arith::TruncIOp, arith::SIToFPOp,
-                arith::FPToSIOp, arith::BitcastOp>(user)) {
+            isa<arith::ExtFOp, arith::TruncFOp, arith::ExtUIOp, arith::ExtSIOp,
+                arith::TruncIOp, arith::SIToFPOp, arith::FPToSIOp,
+                arith::BitcastOp>(user)) {
           for (Value result : user->getResults()) {
             if (isa<RankedTensorType>(result.getType()))
               worklist.push_back(result);
@@ -2101,8 +2100,8 @@ public:
     cvt.erase();
 
     LLVM_DEBUG({
-      DBGS() << "Eliminated over-budget convert_layout, propagated "
-             << srcEnc << " through " << opsToRewrite.size() << " ops\n";
+      DBGS() << "Eliminated over-budget convert_layout, propagated " << srcEnc
+             << " through " << opsToRewrite.size() << " ops\n";
     });
   }
 };

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -15,8 +15,10 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/RegionUtils.h"
+#include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -66,7 +68,8 @@ public:
     LayoutInfo() {}
     llvm::SmallSetVector<Attribute, 8> encodings;
   };
-  LayoutPropagation(FuncOp F) : funcOp(F) {}
+  LayoutPropagation(FuncOp F, unsigned smemBudget = 0)
+      : funcOp(F), smemBudget(smemBudget) {}
   // Find the anchor ops and set their layout in the data structure.
   void initAnchorLayout();
   // Recursively Propagate the layout to all the users of the anchor ops until
@@ -113,6 +116,7 @@ private:
   DenseMap<std::pair<Value, Attribute>, Value> rewriteMapping;
   SetVector<Operation *> opToDelete;
   FuncOp funcOp;
+  unsigned smemBudget;
 };
 
 class LayoutRematerialization {
@@ -437,6 +441,55 @@ void LayoutPropagation::propagateLayout() {
   }
 }
 
+// Compute the base shared memory usage from all existing local_alloc ops in the
+// function. This accounts for explicit buffers (data tiles, mbarriers) but not
+// scratch buffers from convert_layout ops, which are what we're trying to
+// eliminate.
+static unsigned computeBaseSmem(FuncOp funcOp) {
+  unsigned total = 0;
+  funcOp->walk([&](LocalAllocOp alloc) {
+    if (!alloc.isSharedMemoryAlloc())
+      return;
+    auto allocType = alloc.getType();
+    int64_t numElems;
+    if (auto paddedEnc =
+            dyn_cast<PaddedSharedEncodingAttr>(allocType.getEncoding())) {
+      SmallVector<int64_t> unpaddedShape = getShapePerCTA(allocType);
+      numElems = paddedEnc.getPaddedSize(unpaddedShape);
+    } else {
+      auto shapePerCTA = getAllocationShapePerCTA(allocType);
+      numElems = product<int64_t>(shapePerCTA);
+    }
+    total += numElems * allocType.getElementTypeBitWidth() / 8;
+  });
+  return total;
+}
+
+// Estimate the scratch buffer cost (in bytes) that would result from choosing
+// `encoding` for `value`. This checks each operand of value's defining op: if
+// an operand is an anchor with a different layout, a convert_layout will be
+// needed, and we estimate its scratch size.
+static unsigned estimateConvertScratchCost(Value value, Attribute encoding) {
+  Operation *op = value.getDefiningOp();
+  if (!op)
+    return 0;
+  unsigned cost = 0;
+  for (Value operand : op->getOperands()) {
+    auto srcTy = dyn_cast<RankedTensorType>(operand.getType());
+    if (!srcTy)
+      continue;
+    Attribute srcEnc = srcTy.getEncoding();
+    if (!srcEnc || srcEnc == encoding)
+      continue;
+    auto dstTy = srcTy.cloneWithEncoding(encoding);
+    if (cvtNeedsSharedMemory(srcTy, dstTy)) {
+      unsigned elems = getNumScratchElemsSwizzledCvt(srcTy, dstTy);
+      cost += elems * srcTy.getElementTypeBitWidth() / 8;
+    }
+  }
+  return cost;
+}
+
 // Compute a score for a layout to guide conflict resolution.
 // Currently based on sizePerThread (vectorization), but can be extended
 // with other heuristics. Higher score is preferred.
@@ -487,6 +540,33 @@ void LayoutPropagation::resolveConflicts() {
         }
       }
     }
+    // Budget-aware override: if the chosen encoding would introduce a
+    // convert_layout whose scratch buffer pushes SMEM over budget, pick the
+    // candidate with the lowest scratch cost instead.
+    if (smemBudget > 0) {
+      unsigned baseCost = computeBaseSmem(funcOp);
+      unsigned scratchCost = estimateConvertScratchCost(it.first, encoding);
+      if (baseCost + scratchCost > smemBudget) {
+        LDBG("Budget override: base=" << baseCost << " scratch=" << scratchCost
+                                      << " total=" << (baseCost + scratchCost)
+                                      << " budget=" << smemBudget);
+        // Try each candidate and pick the one with lowest scratch cost.
+        Attribute bestEncoding = encoding;
+        unsigned bestScratchCost = scratchCost;
+        for (Attribute e : info.encodings) {
+          unsigned cost = estimateConvertScratchCost(it.first, e);
+          if (cost < bestScratchCost) {
+            bestScratchCost = cost;
+            bestEncoding = e;
+          }
+        }
+        if (bestEncoding != encoding) {
+          LDBG("  Overriding to encoding with scratch=" << bestScratchCost);
+          encoding = bestEncoding;
+        }
+      }
+    }
+
     info.encodings.clear();
     info.encodings.insert(encoding);
   }
@@ -1766,6 +1846,9 @@ class TritonGPURemoveLayoutConversionsPass
     : public impl::TritonGPURemoveLayoutConversionsBase<
           TritonGPURemoveLayoutConversionsPass> {
 public:
+  using Base = impl::TritonGPURemoveLayoutConversionsBase<
+      TritonGPURemoveLayoutConversionsPass>;
+  using Base::Base;
   // Cleanup convert ops.
   void cleanupConvertOps() {
     MLIRContext *context = &getContext();
@@ -1787,8 +1870,8 @@ public:
     ModuleOp m = getOperation();
 
     // 1. Propagate layout forward starting from "anchor" ops.
-    m.walk([](FuncOp funcOp) {
-      LayoutPropagation layoutPropagation(funcOp);
+    m.walk([this](FuncOp funcOp) {
+      LayoutPropagation layoutPropagation(funcOp, smemBudget);
       layoutPropagation.initAnchorLayout();
       layoutPropagation.propagateLayout();
       layoutPropagation.resolveConflicts();
@@ -1837,6 +1920,189 @@ public:
     LLVM_DEBUG({
       DBGS() << "Module after final cleanups:\n";
       m.dump();
+    });
+
+    // 5. Budget-aware convert elimination. If smemBudget is set, find remaining
+    // convert_layout ops whose scratch would push SMEM over budget, and try to
+    // eliminate them by propagating the source encoding through their users.
+    if (smemBudget > 0) {
+      eliminateOverBudgetConverts(m);
+    }
+  }
+
+  // Find convert_layout ops that need SMEM scratch and would push total SMEM
+  // over budget. For each such convert, if the source is an anchor (like
+  // tmem_load) and the users are elementwise ops feeding into local_store/
+  // local_load (which can accept any layout), propagate the source layout
+  // through the convert's users and erase the convert.
+  void eliminateOverBudgetConverts(ModuleOp m) {
+    m.walk([this](FuncOp funcOp) {
+      unsigned baseSmem = computeBaseSmem(funcOp);
+
+      // Collect converts whose scratch would push SMEM over budget.
+      SmallVector<ConvertLayoutOp> overBudgetConverts;
+      funcOp->walk([&](ConvertLayoutOp cvt) {
+        auto srcTy = cvt.getSrc().getType();
+        auto dstTy = cvt.getType();
+        if (!cvtNeedsSharedMemory(srcTy, dstTy))
+          return;
+        unsigned scratchBytes =
+            getNumScratchElemsSwizzledCvt(srcTy, dstTy) *
+            srcTy.getElementTypeBitWidth() / 8;
+        if (baseSmem + scratchBytes > smemBudget) {
+          overBudgetConverts.push_back(cvt);
+        }
+      });
+
+      for (ConvertLayoutOp cvt : overBudgetConverts) {
+        Attribute srcEnc = cvt.getSrc().getType().getEncoding();
+        if (canPropagateSrcEncodingThroughUsers(cvt, srcEnc)) {
+          propagateSrcEncodingAndErase(cvt, srcEnc);
+        }
+      }
+    });
+  }
+
+  // Check whether we can propagate srcEnc through all transitive users of the
+  // convert result until we hit local_store or local_load (which accept any
+  // layout) or the value dies. Returns false if any user requires a specific
+  // layout that doesn't match srcEnc.
+  bool canPropagateSrcEncodingThroughUsers(ConvertLayoutOp cvt,
+                                           Attribute srcEnc) {
+    SmallVector<Value> worklist;
+    worklist.push_back(cvt.getResult());
+    DenseSet<Value> visited;
+
+    while (!worklist.empty()) {
+      Value v = worklist.pop_back_val();
+      if (!visited.insert(v).second)
+        continue;
+
+      for (OpOperand &use : v.getUses()) {
+        Operation *user = use.getOwner();
+        // local_store accepts any register layout — it's a sink.
+        if (isa<LocalStoreOp>(user))
+          continue;
+        // Elementwise ops are layout-transparent — propagate through them.
+        if (user->hasTrait<OpTrait::Elementwise>() ||
+            isa<arith::ExtFOp, arith::TruncFOp, arith::ExtUIOp,
+                arith::ExtSIOp, arith::TruncIOp, arith::SIToFPOp,
+                arith::FPToSIOp, arith::BitcastOp>(user)) {
+          for (Value result : user->getResults()) {
+            if (isa<RankedTensorType>(result.getType()))
+              worklist.push_back(result);
+          }
+          continue;
+        }
+        // scf.yield just passes values through — propagate.
+        if (isa<scf::YieldOp>(user))
+          continue;
+        // Any other user (dot, reduce, another convert, etc.) blocks
+        // propagation.
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Propagate the source encoding through all users of the convert result,
+  // rewriting types in place, then erase the convert. For elementwise ops
+  // whose other operands have a different encoding, change their local_load
+  // to produce the new encoding directly (local_load can produce any layout).
+  // If a non-local_load operand has a mismatched encoding, insert a
+  // convert_layout on it.
+  void propagateSrcEncodingAndErase(ConvertLayoutOp cvt, Attribute srcEnc) {
+    IRRewriter rewriter(cvt.getContext());
+    Value src = cvt.getSrc();
+    Value dst = cvt.getResult();
+
+    // Collect all ops that need type rewriting (forward from convert users).
+    SmallVector<Operation *> opsToRewrite;
+    SmallVector<Value> worklist = {dst};
+    DenseSet<Value> visited;
+
+    while (!worklist.empty()) {
+      Value v = worklist.pop_back_val();
+      if (!visited.insert(v).second)
+        continue;
+      for (OpOperand &use : v.getUses()) {
+        Operation *user = use.getOwner();
+        if (isa<LocalStoreOp>(user) || isa<scf::YieldOp>(user))
+          continue;
+        opsToRewrite.push_back(user);
+        for (Value result : user->getResults()) {
+          if (isa<RankedTensorType>(result.getType()))
+            worklist.push_back(result);
+        }
+      }
+    }
+
+    // For each op we're rewriting, fix up any operands that aren't in srcEnc.
+    // When an operand comes through a chain of elementwise ops from a
+    // local_load, rewrite the entire chain to srcEnc.
+    for (Operation *op : opsToRewrite) {
+      for (OpOperand &operand : op->getOpOperands()) {
+        auto ty = dyn_cast<RankedTensorType>(operand.get().getType());
+        if (!ty || ty.getEncoding() == srcEnc)
+          continue;
+        // Walk backward through elementwise ops to find a local_load.
+        // Rewrite each op's result type along the way.
+        SmallVector<Operation *> backwardChain;
+        Value current = operand.get();
+        bool foundLocalLoad = false;
+        while (auto defOp = current.getDefiningOp()) {
+          if (auto localLoad = dyn_cast<LocalLoadOp>(defOp)) {
+            localLoad.getResult().setType(
+                cast<RankedTensorType>(localLoad.getType())
+                    .cloneWithEncoding(srcEnc));
+            foundLocalLoad = true;
+            break;
+          }
+          if (defOp->hasTrait<OpTrait::Elementwise>() ||
+              isa<arith::ExtFOp, arith::TruncFOp, arith::ExtUIOp,
+                  arith::ExtSIOp, arith::TruncIOp>(defOp)) {
+            backwardChain.push_back(defOp);
+            // Elementwise ops have one primary input.
+            current = defOp->getOperand(0);
+            continue;
+          }
+          break;
+        }
+        if (foundLocalLoad) {
+          // Rewrite all ops in the backward chain to srcEnc.
+          for (Operation *chainOp : backwardChain) {
+            for (Value result : chainOp->getResults()) {
+              if (auto rty = dyn_cast<RankedTensorType>(result.getType()))
+                result.setType(rty.cloneWithEncoding(srcEnc));
+            }
+          }
+        } else {
+          // Fallback: insert a convert_layout on this operand.
+          rewriter.setInsertionPoint(op);
+          auto newTy = ty.cloneWithEncoding(srcEnc);
+          auto newCvt = ConvertLayoutOp::create(rewriter, op->getLoc(), newTy,
+                                                operand.get());
+          operand.set(newCvt);
+        }
+      }
+    }
+
+    // Rewrite result types to use srcEnc.
+    for (Operation *op : opsToRewrite) {
+      for (Value result : op->getResults()) {
+        if (auto ty = dyn_cast<RankedTensorType>(result.getType())) {
+          result.setType(ty.cloneWithEncoding(srcEnc));
+        }
+      }
+    }
+
+    // Replace all uses of the convert result with the convert source.
+    dst.replaceAllUsesWith(src);
+    cvt.erase();
+
+    LLVM_DEBUG({
+      DBGS() << "Eliminated over-budget convert_layout, propagated "
+             << srcEnc << " through " << opsToRewrite.size() << " ops\n";
     });
   }
 };

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -127,10 +127,10 @@ static LogicalResult relayoutWarps(ModuleAxisInfoAnalysis &axisInfo,
 
   pm.clear();
   pm.addPass(createTritonGPUCoalesce());
-  pm.addPass(createTritonGPURemoveLayoutConversions());
+  pm.addPass(createTritonGPURemoveLayoutConversions({0}));
   pm.addPass(createTritonGPUOptimizeThreadLocality());
   pm.addPass(createTritonGPUAccelerateMatmul());
-  pm.addPass(createTritonGPURemoveLayoutConversions());
+  pm.addPass(createTritonGPURemoveLayoutConversions({0}));
   if (failed(runPipeline(pm, *container)))
     return failure();
 

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -78,8 +78,8 @@ void init_triton_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_1("add_f32_dot_tc", createTritonGPUF32DotTC, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_optimize_dot_operands",
                             createTritonGPUOptimizeDotOperands, bool);
-  ADD_PASS_WRAPPER_0("add_remove_layout_conversions",
-                     createTritonGPURemoveLayoutConversions);
+  ADD_PASS_OPTION_WRAPPER_1("add_remove_layout_conversions",
+                            createTritonGPURemoveLayoutConversions, unsigned);
   ADD_PASS_WRAPPER_0("add_reduce_data_duplication",
                      createTritonGPUReduceDataDuplication);
   ADD_PASS_WRAPPER_0("add_allocate_warp_groups",

--- a/python/test/unit/language/test_autows_addmm.py
+++ b/python/test/unit/language/test_autows_addmm.py
@@ -188,9 +188,6 @@ def test_autows_addmm_tma_persistent(
     if BLOCK_SIZE_M == 256 and FLATTEN and BLOCK_SIZE_K == 128 and num_stages == 3 and EPILOGUE_SUBTILE != 4:
         pytest.skip("Out of resources: shared memory exceeded")
 
-    if not FLATTEN and SMEM_ALLOC_ALGO == 1 and BLOCK_SIZE_M == 256:
-        pytest.skip("Out of resources: shared memory exceeded")
-
     if not FLATTEN and SMEM_ALLOC_ALGO == 1 and BLOCK_SIZE_M == 128 and BLOCK_SIZE_K == 128 and num_stages == 3:
         pytest.skip("Out of resources: shared memory exceeded")
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -217,7 +217,7 @@ class HIPBackend(BaseBackend):
         emuTF32 = False
         passes.ttgpuir.add_coalesce(pm)
         passes.ttgpuir.add_f32_dot_tc(pm, emuTF32)
-        passes.ttgpuir.add_remove_layout_conversions(pm)
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         passes.ttgpuir.add_optimize_thread_locality(pm)
         amd.passes.ttgpuir.add_lower_barrier_ops(pm)
 
@@ -231,7 +231,7 @@ class HIPBackend(BaseBackend):
         tlx.tlx_passes.add_tlx_propagate_layout(pm)
         tlx.tlx_passes.add_tlx_rewrite_local_alias(pm)
 
-        passes.ttgpuir.add_remove_layout_conversions(pm)
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
         amd.passes.ttgpuir.add_optimize_dot_operands(pm, options.arch)
         amd.passes.ttgpuir.add_hoist_layout_conversions(pm)
@@ -252,11 +252,11 @@ class HIPBackend(BaseBackend):
         if options.schedule_hint.lower() != "none":
             for hint in options.schedule_hint.split(","):
                 amd.passes.ttgpuir.insert_instruction_sched_hints(pm, hint)
-        passes.ttgpuir.add_remove_layout_conversions(pm)
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         if is_in_thread_transpose_enabled(options.arch):
             amd.passes.ttgpuir.add_in_thread_transpose(pm)
-            passes.ttgpuir.add_remove_layout_conversions(pm)
+            passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         amd.passes.ttgpuir.add_reorder_instructions(pm)
         if use_block_pingpong and options.num_stages > 1:
             amd.passes.ttgpuir.add_block_pingpong(pm, options.num_stages)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -363,10 +363,10 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_f32_dot_tc(pm, emuTF32)
         # TODO(Qingyi): Move PlanCTAPass to the front of CoalescePass
         nvidia.passes.ttnvgpuir.add_plan_cta(pm)
-        passes.ttgpuir.add_remove_layout_conversions(pm)
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         passes.ttgpuir.add_optimize_thread_locality(pm)
         passes.ttgpuir.add_accelerate_matmul(pm)
-        passes.ttgpuir.add_remove_layout_conversions(pm)
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         passes.ttgpuir.add_optimize_dot_operands(pm, capability >= 80)
         nvidia.passes.ttnvgpuir.add_optimize_descriptor_encoding(pm)
         passes.ttir.add_loop_aware_cse(pm)
@@ -427,7 +427,8 @@ class CUDABackend(BaseBackend):
         if capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
             nvidia.passes.ttnvgpuir.add_tma_store_buffer_reuse(pm)
-        passes.ttgpuir.add_remove_layout_conversions(pm)
+        smem_budget = _max_shared_mem_for_capability(capability)
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
         nvidia.passes.hopper.add_multi_cta_reduction(pm)
         # TODO: Find the optimal place in the pipeline for this pass.
         nvidia.passes.ttnvgpuir.add_prune_unused_barriers(pm)
@@ -445,6 +446,10 @@ class CUDABackend(BaseBackend):
         passes.common.add_sccp(pm)
         passes.common.add_cse(pm)
         passes.common.add_canonicalizer(pm)
+        # Budget-aware layout conversion elimination — runs last to ensure
+        # converts whose scratch would exceed SMEM budget are eliminated
+        # after all other passes that may introduce layout conversions.
+        passes.ttgpuir.add_remove_layout_conversions(pm, smem_budget)
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2247,7 +2247,9 @@ void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
       continue;
 
     // Create one scf.if per partition group.
-    for (auto &[partId, resultIndices] : partitionToResultIndices) {
+    for (auto &entry : partitionToResultIndices) {
+      auto &partId = entry.first;
+      auto &resultIndices = entry.second;
       auto *origThenBlock = ifOp.thenBlock();
       auto *origElseBlock = ifOp.elseBlock();
       auto *origThenYield = origThenBlock->getTerminator();


### PR DESCRIPTION
Summary:
Add an smemBudget option to TritonGPURemoveLayoutConversions. When nonzero, the pass eliminates convert_layout ops whose scratch buffer would push shared memory usage above the hardware budget. It does this by propagating the source layout (e.g. #linear from tmem_load) through elementwise users to local_store/local_load sinks, which can accept any layout without scratch.

This fixes OOM for configs like BLOCK_SIZE_M=256, FLATTEN=False in the addmm warp-specialized kernel, where a convert_layout from #linear to #blocked required an 8KB scratch buffer that pushed total SMEM from 229KB to 238KB, exceeding the 232KB Blackwell limit.

The budget-aware pass is added as a 4th invocation at the end of the NVIDIA TTGIR pipeline, after all other passes that may introduce layout conversions.

Authored with Claude.


Differential Revision: D101052652

Pulled By: njriasan
