### PR TITLE
Register modulo scheduling passes with triton-opt

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -146,6 +146,10 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVGPUModuloExpand();
   mlir::registerNVGPUModuloLower();
 
+  // Modulo scheduling passes (manually registered, not tablegen-generated)
+  mlir::registerPass([]() { return mlir::createNVGPUModuloSchedule(); });
+  mlir::registerPass([]() { return mlir::createNVGPUModuloWSPartition(); });
+
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();
   mlir::triton::proton::registerConvertProtonToProtonGPU();

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -438,15 +438,18 @@ void LayoutPropagation::propagateLayout() {
 }
 
 // Compute a score for a layout to guide conflict resolution.
-// Currently based on sizePerThread (vectorization), but can be extended
-// with other heuristics. Higher score is preferred.
-// Returns 0 for non-blocked encodings.
+// Based on sizePerThread (vectorization) for both blocked and linear encodings.
+// Higher score is preferred — layouts with more elements per thread allow better
+// vectorized memory access (ld.shared, st.shared).
 static int64_t getLayoutScore(Attribute encoding) {
-  auto blocked = dyn_cast<BlockedEncodingAttr>(encoding);
-  if (!blocked)
+  SmallVector<unsigned> sizePerThread;
+  if (auto blocked = dyn_cast<BlockedEncodingAttr>(encoding)) {
+    sizePerThread = SmallVector<unsigned>(blocked.getSizePerThread());
+  } else if (auto linear = dyn_cast<LinearEncodingAttr>(encoding)) {
+    sizePerThread = linear.getSizePerThread();
+  }
+  if (sizePerThread.empty())
     return 0;
-  auto sizePerThread = blocked.getSizePerThread();
-  // Compute product of sizePerThread values as the vectorization score.
   int64_t score = 1;
   for (auto size : sizePerThread) {
     score *= size;
@@ -466,8 +469,10 @@ void LayoutPropagation::resolveConflicts() {
     bool isLoadOrStore =
         op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
     // Pick the layout with maximum score.
-    // This prefers layouts with larger sizePerThread values (e.g., TMEM's
-    // [1, 128] over SMEM's [1, 8]) for better memory access patterns.
+    // This prefers layouts with larger sizePerThread values for better
+    // vectorized memory access. Both blocked and linear encodings are scored,
+    // so e.g. a linear layout from TMEMLoadOp (sizePerThread=[1,32]) beats
+    // a blocked layout from local_load (sizePerThread=[1,8]).
     int64_t bestScore = getLayoutScore(encoding);
     for (Attribute e : info.encodings) {
       int64_t score = getLayoutScore(e);
@@ -476,7 +481,7 @@ void LayoutPropagation::resolveConflicts() {
         encoding = e;
       }
     }
-    // If no blocked layout with vectorization found, fall back to the original
+    // If no layout with vectorization found, fall back to the original
     // heuristic (prefer blocked for load/store, MMA for compute).
     if (bestScore == 0) {
       for (Attribute e : info.encodings) {

--- a/test/TLX/remove-layout-local-memory.mlir
+++ b/test/TLX/remove-layout-local-memory.mlir
@@ -60,3 +60,48 @@ tt.func @tmem_and_local_load_conflict_resolution(
   tt.return %z : tensor<128x128xf32, #blocked_common>
 }
 }
+
+// -----
+
+// Test that tmem_load's linear layout takes priority over local_load's blocked
+// layout. tmem_load produces a hardware-fixed linear layout that cannot be
+// changed, while local_load can adapt to any layout. Preferring the linear
+// layout avoids a convert_layout that would consume shared memory.
+
+// CHECK: #[[$LINEAR:.*]] = #ttg.linear
+// CHECK-LABEL: @tmem_linear_layout_priority
+// CHECK: ttng.tmem_load {{.*}} -> tensor<64x128xf32, #[[$LINEAR]]>
+// CHECK: ttg.local_load {{.*}} -> tensor<64x128xbf16, #[[$LINEAR]]>
+// CHECK-NOT: ttg.convert_layout
+// CHECK: arith.addf {{.*}} : tensor<64x128xf32, #[[$LINEAR]]>
+// CHECK: ttg.local_store
+
+#linear_tmem = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0], [0, 64]], block = []}>
+#blocked_smem2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#shared_nv = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem2 = #ttg.shared_memory
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tmem_linear_layout_priority(%arg_o: !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, %arg_res: !ttg.memdesc<64x128xbf16, #shared_nv, #smem2, mutable>, %arg_out: !ttg.memdesc<64x128xbf16, #shared_nv, #smem2, mutable>) {
+    %cst_eps = arith.constant dense<9.99999974E-6> : tensor<64x1xf32, #linear_tmem>
+    %o = ttng.tmem_load %arg_o : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear_tmem>
+    %sq = arith.mulf %o, %o : tensor<64x128xf32, #linear_tmem>
+    %sum = "tt.reduce"(%sq) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %s = arith.addf %a, %b : f32
+      tt.reduce.return %s : f32
+    }) : (tensor<64x128xf32, #linear_tmem>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #linear_tmem}>>
+    %sum_exp = tt.expand_dims %sum {axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #linear_tmem}>> -> tensor<64x1xf32, #linear_tmem>
+    %sum_eps = arith.addf %sum_exp, %cst_eps : tensor<64x1xf32, #linear_tmem>
+    %rrms = tt.extern_elementwise %sum_eps {libname = "", libpath = "", pure = true, symbol = "__nv_rsqrtf"} : (tensor<64x1xf32, #linear_tmem>) -> tensor<64x1xf32, #linear_tmem>
+    %rrms_bcast = tt.broadcast %rrms : tensor<64x1xf32, #linear_tmem> -> tensor<64x128xf32, #linear_tmem>
+    %result = arith.mulf %o, %rrms_bcast : tensor<64x128xf32, #linear_tmem>
+    %result_cvt = ttg.convert_layout %result : tensor<64x128xf32, #linear_tmem> -> tensor<64x128xf32, #blocked_smem2>
+    %res = ttg.local_load %arg_res : !ttg.memdesc<64x128xbf16, #shared_nv, #smem2, mutable> -> tensor<64x128xbf16, #blocked_smem2>
+    %res_f32 = arith.extf %res : tensor<64x128xbf16, #blocked_smem2> to tensor<64x128xf32, #blocked_smem2>
+    %add = arith.addf %result_cvt, %res_f32 : tensor<64x128xf32, #blocked_smem2>
+    %out = arith.truncf %add : tensor<64x128xf32, #blocked_smem2> to tensor<64x128xbf16, #blocked_smem2>
+    ttg.local_store %out, %arg_out : tensor<64x128xbf16, #blocked_smem2> -> !ttg.memdesc<64x128xbf16, #shared_nv, #smem2, mutable>
+    tt.return
+  }
+}


### PR DESCRIPTION
Summary:
Add ModuloScheduling source files to the NVHopperTransforms BUCK target
and register the passes in RegisterTritonDialects.h so they can be
invoked via triton-opt CLI:

  triton-opt --nvgpu-modulo-schedule --nvgpu-modulo-ws-partition input.ttgir

Differential Revision: D101384129


