### PR TITLE
[AutoWS] Fix fence generation logic with non-persistent

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -204,21 +204,32 @@ private:
         // code partitioning splits the alloc: the local_store ends up in
         // the computation partition while the TMA copy stays in the
         // epilogue partition.
-        for (auto *user : localAlloc.getResult().getUsers()) {
-          auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user);
-          if (!wsOp)
+        // Walk through memdesc view ops (e.g. memdesc_index) since the
+        // warp_specialize may capture a view of the alloc rather than the
+        // alloc directly.
+        SmallVector<Value> wsWorklist = {localAlloc.getResult()};
+        DenseSet<Value> wsSeen;
+        while (!wsWorklist.empty()) {
+          Value v = wsWorklist.pop_back_val();
+          if (!wsSeen.insert(v).second)
             continue;
-          auto captures = wsOp.getExplicitCaptures();
-          for (unsigned i = 0; i < captures.size(); i++) {
-            if (captures[i] != localAlloc.getResult())
-              continue;
-            for (Region *region : wsOp.getPartitionRegions()) {
-              Value blockArg = region->getArgument(i);
-              findLocalStoresThroughViews(blockArg, result);
-              if (!result.empty())
-                return;
+          for (auto *user : v.getUsers()) {
+            if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+              auto captures = wsOp.getExplicitCaptures();
+              for (unsigned i = 0; i < captures.size(); i++) {
+                if (captures[i] != v)
+                  continue;
+                for (Region *region : wsOp.getPartitionRegions()) {
+                  Value blockArg = region->getArgument(i);
+                  findLocalStoresThroughViews(blockArg, result);
+                  if (!result.empty())
+                    return;
+                }
+              }
+            } else if (user->hasTrait<OpTrait::MemDescViewTrait>()) {
+              for (auto res : user->getResults())
+                wsWorklist.push_back(res);
             }
-            break;
           }
         }
       }

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -67,8 +67,13 @@ def matmul_kernel_tma_ws(
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
     # Always use warp_specialize=True
-    for k in tl.range(k_tiles, warp_specialize=True, data_partition_factor=DATA_PARTITION_FACTOR,
-                      smem_alloc_algo=SMEM_ALLOC_ALGO, separate_epilogue_store=False):
+    for k in tl.range(
+            k_tiles,
+            warp_specialize=True,
+            data_partition_factor=DATA_PARTITION_FACTOR,
+            smem_alloc_algo=SMEM_ALLOC_ALGO,
+            separate_epilogue_store=True,
+    ):
         offs_k = k * BLOCK_SIZE_K
         if A_COL_MAJOR:
             a = a_desc.load([offs_k, offs_am]).T

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2247,7 +2247,9 @@ void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
       continue;
 
     // Create one scf.if per partition group.
-    for (auto &[partId, resultIndices] : partitionToResultIndices) {
+    for (auto &entry : partitionToResultIndices) {
+      auto &partId = entry.first;
+      auto &resultIndices = entry.second;
       auto *origThenBlock = ifOp.thenBlock();
       auto *origElseBlock = ifOp.elseBlock();
       auto *origThenYield = origThenBlock->getTerminator();


### PR DESCRIPTION
Fixes the fence generation logic with the non-persistent kernel. In this example the fence insertion pass is supposed to check for if the Memory location is updated by non-async proxy through warp specialization. However, the current version required an explicit argument, which the non-persistent kernel did not do. 