### PR TITLE
[AutoWS] Fix relayout condition for non-default partitions when num_warps != 4

### DIFF
--- a/test/TritonGPU/optimize-partition-warps-num-warps8.mlir
+++ b/test/TritonGPU/optimize-partition-warps-num-warps8.mlir
@@ -1,0 +1,58 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-optimize-partition-warps | FileCheck %s
+
+// Test that non-default partitions are capped at the base warp group size (4)
+// when the module's num_warps is greater than 4. Only the default partition
+// should use the user's num_warps setting.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#shared_1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK: module attributes {{.*}}"ttg.num-warps" = 8
+module attributes {ttg.target = "cuda:100", "ttg.num-warps" = 8 : i32} {
+
+// CHECK-LABEL: @non_default_partitions_capped_to_base_warps
+tt.func @non_default_partitions_capped_to_base_warps(%arg0: i32) {
+  ttg.warp_specialize(%arg0)
+    attributes {"ttg.partition.types" = ["default", "gemm", "load", "computation"]}
+  default {
+    ttg.warp_yield
+  }
+  // Partitions initialized at 8 warps should be shrunk.
+  // gemm: scalar-only, shrinks to 1
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // load: scalar-only, shrinks to 1
+  // CHECK: partition1({{.*}}) num_warps(1)
+  partition1(%arg1: i32) num_warps(8) {
+    %0 = arith.muli %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // computation: scalar-only, shrinks to 1
+  // CHECK: partition2({{.*}}) num_warps(1)
+  partition2(%arg1: i32) num_warps(8) {
+    %0 = arith.subi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+// Verify that num_warps=4 behaves the same as before (no regression).
+// CHECK-LABEL: @num_warps_4_unchanged
+tt.func @num_warps_4_unchanged(%arg0: i32) {
+  ttg.warp_specialize(%arg0)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(4) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -561,16 +561,12 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
 
   // Instead of a new IfOp for each task, we create one partitionRegion.
   auto nTaskIds = getNestedAsyncTaskIds(funcOp);
+  int defaultNumWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
   SmallVector<int32_t> partitionNumWarps;
   for (AsyncTaskId asyncTaskId : nTaskIds) {
     if (asyncTaskId == 0)
       continue;
-    // HACK: hardcode 1,2,3 with 1 warp
-    // TODO: check TritonGPUAllocateWarpGroups
-    if (asyncTaskId == 1 || asyncTaskId == 2 || asyncTaskId == 3)
-      partitionNumWarps.push_back(4);
-    else
-      partitionNumWarps.push_back(4);
+    partitionNumWarps.push_back(defaultNumWarps);
   }
   ArrayRef<Type> dummyTypes;
   ImplicitLocOpBuilder impB(opList[0]->getLoc(), opList[0]);


### PR DESCRIPTION
In cases in which `num_warps != 4`, the default partition is assigned the user-defined `num_warps`, while other partitions start with the minimum number of warps (4) required to satisfy 1 warp group. When `num_warps > 4`, partitions were assigned 4 warps (1 warp group), but ops in non-default partitions were assigned layouts with the user-defined number of warps, causing a mismatch.

This PR assigns the default number of warps to every op at the beginning and changes the relayout condition to trigger when non-default partitions have fewer warps than the op layouts expect.

The new lit test `optimize-partition-warps-num-warps8.mlir` confirms that each non-default partition is assigned no more than 4 warps, and that the default partition contains 8 warps.