### PR TITLE
[triton] Hopper AutoWS GEMM: enable warp specialization end-to-end (#1278)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -452,6 +452,20 @@ static std::optional<int> dotCanBeProperlyAsync(ttng::WarpGroupDotOp dotOp,
            transitiveOperand.getDefiningOp<ttg::MemDescIndexOp>();
   };
 
+  // Rule 0: If there are arrive_barrier ops, the dot can't be async.
+  // An arrive_barrier signals "SMEM is free for reuse"; with pendings > 0 the
+  // arrive could fire while the dot is still asynchronously reading SMEM,
+  // letting the producer overwrite the buffer mid-read.
+  // wait_barrier alone (used by TMA pipelining) is safe — it only blocks until
+  // data is ready and does not signal buffer ownership.
+  bool hasCrossWarpBarriers =
+      !forOp.getBody()->getOps<ttng::ArriveBarrierOp>().empty();
+  if (hasCrossWarpBarriers) {
+    LDBG("Can't make dot async because there are arrive_barrier ops in the "
+         "loop.");
+    return std::nullopt;
+  }
+
   // Rule 1: All shmem operands are multi-buffered.
   // We don't have to call checkOperand on getC() because it's always in
   // registers, never in shmem.

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -2,15 +2,15 @@
 Explicit unit tests for all warp-specialized variations of Tutorial 09 (Persistent Matmul).
 
 These tests validate the warp specialization feature for persistent matmul kernels
-with both Flatten=True and Flatten=False configurations. Tests are restricted to
-Blackwell GPUs only.
+with both Flatten=True and Flatten=False configurations. Tests cover both
+Blackwell and Hopper GPUs.
 """
 
 import pytest
 import torch
 import triton
 import triton.language as tl
-from triton._internal_testing import is_blackwell
+from triton._internal_testing import is_blackwell, is_hopper
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 
@@ -791,5 +791,346 @@ def test_tutorial09_multi_epilogue_subtile():
         assert "ttng.tc_gen5_mma" in ttgir, "Expected Blackwell MMA instruction"
 
         # Verify correctness
+        ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
+        torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
+
+
+# ============================================================================
+# Hopper Tests
+# ============================================================================
+
+
+# ============================================================================
+# Hopper Test 1: matmul_kernel_tma warp specialization (K-loop based)
+# ============================================================================
+@pytest.mark.parametrize("M, N, K", [(128, 128, 128), (512, 512, 256), (8192, 8192, 1024)])
+@pytest.mark.parametrize("BLOCK_SIZE_M", [64, 128])
+@pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
+@pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
+@pytest.mark.parametrize("num_stages", [2, 3])
+@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("A_col_major", [False, True])
+@pytest.mark.parametrize("B_col_major", [False, True])
+@pytest.mark.parametrize("use_early_tma_store_lowering", [True, False])
+@pytest.mark.parametrize("DATA_PARTITION_FACTOR", [1, 2])
+@pytest.mark.parametrize("SMEM_ALLOC_ALGO", [0, 1])
+@pytest.mark.parametrize("enable_pingpong", [False, True])
+@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper")
+def test_hopper_matmul_tma_warp_specialize(
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    num_stages,
+    num_warps,
+    A_col_major,
+    B_col_major,
+    use_early_tma_store_lowering,
+    DATA_PARTITION_FACTOR,
+    SMEM_ALLOC_ALGO,
+    enable_pingpong,
+):
+    """Test matmul_kernel_tma with warp_specialize=True on Hopper (K-loop based)."""
+    if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 128:
+        pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 128")
+    if BLOCK_SIZE_N == 256 and BLOCK_SIZE_K == 128 and not (BLOCK_SIZE_M == 64 and num_stages == 2):
+        pytest.skip("OOM: shared memory exceeds H100 limit")
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+
+        dtype = torch.float16
+        GROUP_SIZE_M = 8
+        device = "cuda"
+
+        torch.manual_seed(42)
+        if A_col_major:
+            A = torch.randn((K, M), dtype=dtype, device=device).t()
+        else:
+            A = torch.randn((M, K), dtype=dtype, device=device)
+        if B_col_major:
+            B = torch.randn((K, N), dtype=dtype, device=device).t()
+        else:
+            B = torch.randn((N, K), dtype=dtype, device=device)
+        C = torch.empty((M, N), dtype=dtype, device=device)
+
+        def alloc_fn(size, align, stream):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        if A_col_major:
+            a_desc = TensorDescriptor(A, [K, M], [M, 1], [BLOCK_SIZE_K, BLOCK_SIZE_M])
+        else:
+            a_desc = TensorDescriptor(A, [M, K], [K, 1], [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        if B_col_major:
+            b_desc = TensorDescriptor(B, [K, N], [N, 1], [BLOCK_SIZE_K, BLOCK_SIZE_N])
+        else:
+            b_desc = TensorDescriptor(B, [N, K], [K, 1], [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor(C, C.shape, C.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_N])
+
+        grid = lambda META: (triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]), )
+
+        kernel = matmul_kernel_tma_ws[grid](
+            a_desc,
+            b_desc,
+            c_desc,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            A_COL_MAJOR=A_col_major,
+            B_COL_MAJOR=B_col_major,
+            DATA_PARTITION_FACTOR=DATA_PARTITION_FACTOR,
+            SMEM_ALLOC_ALGO=SMEM_ALLOC_ALGO,
+            num_stages=num_stages,
+            num_warps=num_warps,
+            early_tma_store_lowering=use_early_tma_store_lowering,
+            pingpongAutoWS=enable_pingpong,
+        )
+
+        ttgir = kernel.asm["ttgir"]
+        assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
+        assert "ttng.warp_group_dot" in ttgir, "Expected Hopper MMA instruction"
+        assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
+
+        ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
+        torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
+
+
+# ============================================================================
+# Hopper Test 2: matmul_kernel_tma_persistent warp specialization (tile-loop)
+# Hopper constraints: FLATTEN=False, EPILOGUE_SUBTILE=1
+# ============================================================================
+@pytest.mark.parametrize("M, N, K", [(128, 128, 128), (512, 512, 256), (8192, 8192, 1024)])
+@pytest.mark.parametrize("BLOCK_SIZE_M", [64, 128])
+@pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
+@pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
+@pytest.mark.parametrize("num_stages", [2, 3])
+@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("A_col_major", [False, True])
+@pytest.mark.parametrize("B_col_major", [False, True])
+@pytest.mark.parametrize("use_early_tma_store_lowering", [True, False])
+@pytest.mark.parametrize("DATA_PARTITION_FACTOR", [1, 2])
+@pytest.mark.parametrize("SMEM_ALLOC_ALGO", [0, 1])
+@pytest.mark.parametrize("enable_pingpong", [False, True])
+@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper")
+def test_hopper_matmul_tma_persistent_warp_specialize(
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    num_stages,
+    num_warps,
+    A_col_major,
+    B_col_major,
+    use_early_tma_store_lowering,
+    DATA_PARTITION_FACTOR,
+    SMEM_ALLOC_ALGO,
+    enable_pingpong,
+):
+    """Test matmul_kernel_tma_persistent with warp_specialize=True on Hopper.
+
+    Hopper constraints: FLATTEN=False (not supported with WS), EPILOGUE_SUBTILE=1 (no TMEM).
+    """
+    if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 128:
+        pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 128")
+    if BLOCK_SIZE_N == 256 and BLOCK_SIZE_K == 128 and not (BLOCK_SIZE_M == 64 and num_stages == 2):
+        pytest.skip("OOM: shared memory exceeds H100 limit")
+
+    FLATTEN = False
+    EPILOGUE_SUBTILE = 1
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+
+        dtype = torch.float16
+        GROUP_SIZE_M = 8
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        device = "cuda"
+
+        torch.manual_seed(42)
+        if A_col_major:
+            A = torch.randn((K, M), dtype=dtype, device=device).t()
+        else:
+            A = torch.randn((M, K), dtype=dtype, device=device)
+        if B_col_major:
+            B = torch.randn((K, N), dtype=dtype, device=device).t()
+        else:
+            B = torch.randn((N, K), dtype=dtype, device=device)
+        C = torch.empty((M, N), dtype=dtype, device=device)
+
+        def alloc_fn(size, align, stream):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        if A_col_major:
+            a_desc = TensorDescriptor(A, [K, M], [M, 1], [BLOCK_SIZE_K, BLOCK_SIZE_M])
+        else:
+            a_desc = TensorDescriptor(A, [M, K], [K, 1], [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        if B_col_major:
+            b_desc = TensorDescriptor(B, [K, N], [N, 1], [BLOCK_SIZE_K, BLOCK_SIZE_N])
+        else:
+            b_desc = TensorDescriptor(B, [N, K], [K, 1], [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor(
+            C,
+            C.shape,
+            C.stride(),
+            [BLOCK_SIZE_M, BLOCK_SIZE_N],
+        )
+
+        grid = lambda META: (min(
+            NUM_SMS,
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        ), )
+
+        kernel = matmul_kernel_tma_persistent_ws[grid](
+            a_desc,
+            b_desc,
+            c_desc,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
+            NUM_SMS=NUM_SMS,
+            FLATTEN=FLATTEN,
+            A_COL_MAJOR=A_col_major,
+            B_COL_MAJOR=B_col_major,
+            DATA_PARTITION_FACTOR=DATA_PARTITION_FACTOR,
+            SMEM_ALLOC_ALGO=SMEM_ALLOC_ALGO,
+            num_stages=num_stages,
+            num_warps=num_warps,
+            early_tma_store_lowering=use_early_tma_store_lowering,
+            pingpongAutoWS=enable_pingpong,
+        )
+
+        ttgir = kernel.asm["ttgir"]
+        assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
+        assert "ttng.warp_group_dot" in ttgir, "Expected Hopper MMA instruction"
+        assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
+
+        ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
+        torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
+
+
+# ============================================================================
+# Hopper Test 3: matmul_kernel_descriptor_persistent warp specialization
+# (device-side TMA descriptors)
+# Hopper constraints: FLATTEN=False, EPILOGUE_SUBTILE=1
+# ============================================================================
+@pytest.mark.parametrize("M, N, K", [(128, 128, 128), (512, 512, 256), (8192, 8192, 1024)])
+@pytest.mark.parametrize("BLOCK_SIZE_M", [64, 128])
+@pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
+@pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
+@pytest.mark.parametrize("num_stages", [2, 3])
+@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("A_col_major", [False, True])
+@pytest.mark.parametrize("B_col_major", [False, True])
+@pytest.mark.parametrize("use_early_tma_store_lowering", [True, False])
+@pytest.mark.parametrize("DATA_PARTITION_FACTOR", [1, 2])
+@pytest.mark.parametrize("SMEM_ALLOC_ALGO", [0, 1])
+@pytest.mark.parametrize("enable_pingpong", [False, True])
+@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper")
+def test_hopper_matmul_descriptor_persistent_warp_specialize(
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    num_stages,
+    num_warps,
+    A_col_major,
+    B_col_major,
+    use_early_tma_store_lowering,
+    DATA_PARTITION_FACTOR,
+    SMEM_ALLOC_ALGO,
+    enable_pingpong,
+):
+    """Test matmul_kernel_descriptor_persistent with warp_specialize=True on Hopper.
+
+    Hopper constraints: FLATTEN=False (not supported with WS), EPILOGUE_SUBTILE=1 (no TMEM).
+    """
+    if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 128:
+        pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 128")
+    if BLOCK_SIZE_N == 256 and BLOCK_SIZE_K == 128 and not (BLOCK_SIZE_M == 64 and num_stages == 2):
+        pytest.skip("OOM: shared memory exceeds H100 limit")
+
+    FLATTEN = False
+    EPILOGUE_SUBTILE = 1
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+
+        dtype = torch.float16
+        GROUP_SIZE_M = 8
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        device = "cuda"
+
+        torch.manual_seed(42)
+        if A_col_major:
+            A = torch.randn((K, M), dtype=dtype, device=device).t()
+        else:
+            A = torch.randn((M, K), dtype=dtype, device=device)
+        if B_col_major:
+            B = torch.randn((K, N), dtype=dtype, device=device).t()
+        else:
+            B = torch.randn((N, K), dtype=dtype, device=device)
+        C = torch.empty((M, N), dtype=dtype, device=device)
+
+        def alloc_fn(size, align, stream):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        grid = lambda META: (min(
+            NUM_SMS,
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        ), )
+
+        kernel = matmul_kernel_descriptor_persistent_ws[grid](
+            A,
+            B,
+            C,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
+            NUM_SMS=NUM_SMS,
+            FLATTEN=FLATTEN,
+            A_COL_MAJOR=A_col_major,
+            B_COL_MAJOR=B_col_major,
+            DATA_PARTITION_FACTOR=DATA_PARTITION_FACTOR,
+            SMEM_ALLOC_ALGO=SMEM_ALLOC_ALGO,
+            num_stages=num_stages,
+            num_warps=num_warps,
+            early_tma_store_lowering=use_early_tma_store_lowering,
+            pingpongAutoWS=enable_pingpong,
+        )
+
+        ttgir = kernel.asm["ttgir"]
+        assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
+        assert "ttng.warp_group_dot" in ttgir, "Expected Hopper MMA instruction"
+        assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
+
         ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
         torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-forward.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-forward.mlir
@@ -101,7 +101,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["correction", "gemm", "load", "epilogue_store", "computation", "computation"]
+// CHECK-SAME: ttg.partition.types = ["correction", "gemm", "epilogue_store", "load", "computation", "computation"]
 //
 // --- Post-loop: acc tmem_load, normalize → correction partition (via mergeEpilogue) ---
 // CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[CORR]]>

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-data-partition.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-data-partition.mlir
@@ -48,7 +48,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["gemm", "load", "epilogue", "epilogue_store", "computation"]
+// CHECK-SAME: ttg.partition.types = ["gemm", "epilogue", "epilogue_store", "load", "computation"]
 tt.func public @data_partitioned_gemm_uses_gemm_template(
   %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
   %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
@@ -51,7 +51,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["gemm", "load", "epilogue", "epilogue_store", "computation"]
+// CHECK-SAME: ttg.partition.types = ["gemm", "epilogue", "epilogue_store", "load", "computation"]
 tt.func public @persistent_gemm_no_computation_partition(
   %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
   %b_desc: !tt.tensordesc<tensor<256x64xf16, #shared>>,

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-post-loop-epilogue.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-post-loop-epilogue.mlir
@@ -41,7 +41,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["gemm", "load", "epilogue", "computation"]
+// CHECK-SAME: ttg.partition.types = ["gemm", "epilogue", "load", "computation"]
 //
 // --- Post-loop: tmem_load → epilogue ---
 // CHECK: ttng.tmem_load

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -391,6 +391,8 @@ class CUDABackend(BaseBackend):
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
+            if knobs.nvidia.use_meta_ws:
+                passes.ttgpuir.add_optimize_partition_warps(pm)
         elif capability // 10 >= 10:
             passes.ttgpuir.add_fuse_nested_loops(pm)
             passes.common.add_canonicalizer(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -828,10 +828,6 @@ static PartitionLayout createPartitionLayout(PartitionSet &schedule,
     layout.gemmPartition->setType("gemm");
   }
 
-  // Load partition: always.
-  layout.loadPartition = schedule.addPartition(0);
-  layout.loadPartition->setType("load");
-
   // Epilogue partition: for non-store epilogue ops when not merging.
   if (hasEpilogue && !options.mergeEpilogue &&
       !options.mergeEpilogueToComputation) {
@@ -844,6 +840,11 @@ static PartitionLayout createPartitionLayout(PartitionSet &schedule,
     layout.epilogueStorePartition = schedule.addPartition(0);
     layout.epilogueStorePartition->setType("epilogue_store");
   }
+
+  // Load partition: always created last so it gets the highest partition index,
+  // which maps to the default (producer) warp group at runtime.
+  layout.loadPartition = schedule.addPartition(0);
+  layout.loadPartition->setType("load");
 
   // Set default partition alias using fallback chain.
   layout.defaultPartition = layout.getDefaultPartition();


### PR DESCRIPTION
Summary:

End-to-end enablement of warp specialization for Hopper GEMM kernels in the
Triton AutoWS pipeline.

Compiler/runtime changes:
1. Reorder partition creation in PartitionSchedulingMeta so the load partition
   is always the last task (highest index), mapping it to the default warp group.
2. Enable OptimizePartitionWarps on the Hopper pipeline path (was Blackwell-only).
   This allows per-warp-group register budgeting via setmaxnreg, fixing all
   PTXAS register pressure failures for BLOCK_SIZE_N=256 persistent kernels.
3. WGMMAPipeline: skip the properly-async wgmma optimization when the loop body
   contains cross-warp barriers (ttng.arrive_barrier / ttng.wait_barrier).
   The pendings>0 wait would otherwise let an arrive_barrier signaling SMEM-free
   fire while wgmma is still asynchronously reading SMEM, allowing the producer
   to overwrite the buffer mid-read. Forces wait {pendings=0} after every wgmma
   in WS kernels.
4. Add OOM shared memory skips for Hopper tests where large tile sizes exceed
   the H100's 232KB shared memory limit.

Reviewed By: manman-ren

Differential Revision: D101639060


