### PR TITLE
[triton][beta] Fix CI failures: PKG-INFO version, split-file exec, proton test (#1284)

### DIFF
--- a/test/Proton/proton_to_protongpu.mlir
+++ b/test/Proton/proton_to_protongpu.mlir
@@ -82,27 +82,25 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     // CHECK: scf.for
     // CHECK: %[[START1:.*]] = proton_gpu.read_counter : i32
     // CHECK: proton_gpu.circular_store start %[[SEGMENT]], %[[START1]] {scopeId = 1 : i32}
-    // CHECK: scf.for
     // CHECK: %[[END1:.*]] = proton_gpu.read_counter : i32
     // CHECK: proton_gpu.circular_store end %[[SEGMENT]], %[[END1]] {scopeId = 1 : i32}
     // CHECK: }
     // CHECK: %[[END0:.*]] = proton_gpu.read_counter : i32
     // CHECK: proton_gpu.circular_store end %[[SEGMENT]], %[[END0]] {scopeId = 0 : i32}
-    // CHECK: }
     // CHECK: %[[START2:.*]] = proton_gpu.read_counter : i32
     // CHECK: proton_gpu.circular_store start %[[SEGMENT]], %[[START2]] {scopeId = 2 : i32}
     // CHECK: %[[END2:.*]] = proton_gpu.read_counter : i32
     // CHECK: proton_gpu.circular_store end %[[SEGMENT]], %[[END2]] {scopeId = 2 : i32}
     // CHECK: gpu.barrier
     // CHECK: proton_gpu.finalize %[[SEGMENT]], %[[SCRATCH]]
-    proton.record start "name1"
+    proton.record start "name0"
     scf.for %arg0 = %i to %c4 step %c1 {
-      proton.record start "name0"
+      proton.record start "name1"
       scf.for %arg1 = %i to %c4 step %c1 {
-        proton.record end "name0"
       }
       proton.record end "name1"
     }
+    proton.record end "name0"
     proton.record start "name2"
     proton.record end "name2"
     tt.return
@@ -167,7 +165,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32} {
 // -----
 
 module attributes {"ttg.num-warps" = 8 : i32} {
-  // CHECK-LABEL: global_mem_buffer
+  // CHECK-GMEM-LABEL: global_mem_buffer
   // CHECK-GMEM: %[[SCRATCH:.*]] = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
   // CHECK-GMEM: proton_gpu.initialize %[[SCRATCH]] : !tt.ptr<i32>
   // CHECK-GMEM: %[[PTR:.*]] = tt.addptr %[[SCRATCH]]
@@ -189,7 +187,7 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 // -----
 
 module attributes {"ttg.num-warps" = 8 : i32} {
-  // CHECK-LABEL: global_mem_buffer
+  // CHECK-GMEM-LABEL: global_mem_buffer
   // CHECK-GMEM: %[[SCRATCH:.*]] = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
   // CHECK-GMEM: proton_gpu.initialize %[[SCRATCH]] : !tt.ptr<i32>
   // CHECK-GMEM: %[[PTR:.*]] = tt.addptr %[[SCRATCH]]


### PR DESCRIPTION
Summary:

Mirror the same fixes from the stable channel:

1. PKG-INFO version: 3.4.0 -> 3.6.0 to match actual triton version.

2. Missing split-file in lit test execs for accelerate-amd-matmul-mfma.mlir.

3. Proton lit test (proton_to_protongpu.mlir):
   - nested_record: rewrote to use properly nested scopes compatible with
     the ScopeIdAllocation reachability analysis.
   - CHECK-LABEL -> CHECK-GMEM-LABEL for global_mem_buffer sections.

Note: the beta proton test was disabled in CI so this bug was latent.

Authored with Claude.

Reviewed By: fywkevin

Differential Revision: D101267061


