### PR TITLE
[TLX][AMD] Improve pipelined GEMM performance by sinking second load.

### DIFF
--- a/third_party/tlx/tutorials/amd-gemm-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-gemm-pipelined_test.py
@@ -185,7 +185,6 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
         a_k_smem_view = tlx.local_view(buffers_A, k % NUM_BUFFERS)
         b_k_smem_view = tlx.local_view(buffers_B, k % NUM_BUFFERS)
         a_load_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K)
-        b_load_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K)
 
         # do compute on data fetched ahead by NUM_STAGES - 1
         buf = (k - NUM_STAGES - 1) % NUM_BUFFERS
@@ -193,6 +192,7 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
         b_k_prev_shmem = tlx.local_view(buffers_B, buf)
         a_k_prev_reg = tlx.local_load(a_k_prev_shmem)
         b_k_prev_reg = tlx.local_load(b_k_prev_shmem)
+        b_load_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K)
         acc = tl.dot(a_k_prev_reg, b_k_prev_reg, acc)
 
         # store data for k from regs to shmem, this is NUM_STAGES - 1 ahead of the k in the prev tl.dot


### PR DESCRIPTION
We sink second load closert to dot S.T global_load instructions can be interleaved with mfmas to help hide global load issue latency.

This used to be default in AMD compiler pipeline but has been removed in With https://github.com/triton-lang/triton/pull/9119.

Perf improvements with this change:

## Without Sink Second Load

| M    | N    | K    | rocBLAS (TFLOPS) | Triton (TFLOPS) |
|------|------|------|------------------:|----------------:|
| 256  | 256  | 256  |             4.346 |           5.178 |
| 512  | 512  | 512  |            29.434 |          34.065 |
| 1024 | 1024 | 1024 |           156.522 |         178.362 |
| 2048 | 2048 | 2048 |           589.159 |         540.928 |
| 4096 | 4096 | 4096 |          1046.907 |         571.322 |

## With Sink Second Load

| M    | N    | K    | rocBLAS (TFLOPS) | Triton (TFLOPS) |
|------|------|------|------------------:|----------------:|
| 256  | 256  | 256  |             4.438 |           5.083 |
| 512  | 512  | 512  |            29.178 |          33.719 |
| 1024 | 1024 | 1024 |           158.369 |         181.990 |
| 2048 | 2048 | 2048 |           585.944 |         574.962 |
| 4096 | 4096 | 4096 |          1049.144 |         615.760 |