### PR TITLE
[AutoWS] Build ScheduleGraph from DDG and add lit tests

### DIFF
--- a/test/TritonGPU/modulo-schedule-graph-edge.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-edge.mlir
@@ -1,0 +1,114 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect "-nvgpu-modulo-schedule=print-schedule-graph=true" 2>&1 | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Edge case 0: Single-stage schedule (maxStage=0).
+// MMA-only loop: no TMA copy, no result use. The MMA self-latency (900) is
+// the only thing on the TC pipeline, so II = 900 and the MMA lands at
+// cycle 0, stage 0 — max_stage = 0.
+//
+// Regression test for Devmate review: tt.num_stages must be set even when
+// maxStage = 0 so downstream pipelining recognises the loop as scheduled.
+//===----------------------------------------------------------------------===//
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// Verify the maxStage=0 dump and the loop's tt.num_stages=1 attribute.
+// CHECK: ii = 900, max_stage = 0
+// CHECK: @maxstage_0_mma_only
+// CHECK: tt.modulo_ii = 900 : i32
+// CHECK-SAME: tt.num_stages = 1 : i32
+// CHECK-SAME: tt.scheduled_max_stage = 0 : i32
+tt.func @maxstage_0_mma_only(
+  %a: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+  %b: !ttg.memdesc<64x128xf16, #shared, #smem, mutable>,
+  %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %k_tiles = arith.constant 4 : i32
+  %true = arith.constant true
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 : i32 {
+    ttng.tc_gen5_mma %a, %b, %c, %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  }
+
+  tt.return
+}
+
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Edge case 1: Loop with no schedulable ops (no TMA load, no MMA).
+// The pass selection filter (`hasTMALoad || hasMMAv5`) must skip this loop
+// cleanly — no schedule attrs emitted, no ScheduleGraph dump.
+//===----------------------------------------------------------------------===//
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @no_schedulable_ops
+// CHECK: scf.for
+// CHECK-NOT: tt.modulo_ii
+// CHECK-NOT: tt.scheduled_max_stage
+tt.func @no_schedulable_ops(%arg0: i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %k_tiles = arith.constant 4 : i32
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 : i32 {
+    %0 = arith.muli %k, %arg0 : i32
+    "test.use"(%0) : (i32) -> ()
+  }
+
+  tt.return
+}
+
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Edge case 2: Outer loop containing an inner loop with no schedulable ops.
+// The outer loop qualifies for scheduling (has TMA load), but the inner has
+// only scalar ops. The pass must not crash on the empty inner DDG when
+// building the child ScheduleLoop — exercises the
+// `if (innerDDG.getNumNodes() == 0) return loopId;` guard in
+// buildChildScheduleLoop.
+//===----------------------------------------------------------------------===//
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @outer_loop_with_empty_inner
+// CHECK: tt.return
+tt.func @outer_loop_with_empty_inner(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %tiles = arith.constant 4 : i32
+
+  scf.for %t = %c0_i32 to %tiles step %c1_i32 : i32 {
+    %a = tt.descriptor_load %a_desc[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    "test.use"(%a_shared) : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
+
+    // Inner loop with no schedulable ops — exercises empty-DDG guard.
+    scf.for %k = %c0_i32 to %tiles step %c1_i32 : i32 {
+      %0 = arith.addi %k, %t : i32
+      "test.use"(%0) : (i32) -> ()
+    }
+  }
+
+  tt.return
+}
+
+}

--- a/test/TritonGPU/modulo-schedule-graph.mlir
+++ b/test/TritonGPU/modulo-schedule-graph.mlir
@@ -1,4 +1,8 @@
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule | FileCheck %s
+// RUN: triton-opt %s -allow-unregistered-dialect "-nvgpu-modulo-schedule=print-schedule-graph=true" 2>&1 | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Test: Basic ScheduleGraph — graph structure, nodes, and edges
+//===----------------------------------------------------------------------===//
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
@@ -8,27 +12,40 @@
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
-// Verify that the modulo schedule pass annotates ops with loop.stage/loop.cluster
-// and sets tt.modulo_ii on the loop.
+// --- Graph structure: II=1038, max_stage=2, trip_count=32 ---
+// CHECK: [PASS-A] === Inner Loop ScheduleGraph ===
+// CHECK-NEXT: modulo.schedule @loop0 {
+// CHECK-NEXT:   ii = 1038, max_stage = 2, prologue_latency = 1038, trip_count = 32
 //
-// CHECK-LABEL: @gemm_inner_loop
-// Cluster IDs are dense ranks of modulo cycles within each stage (Step 2.5).
-// Stages processed in reverse order: higher stage -> lower cluster ID.
-// Same cycle -> same cluster; different cycle -> different cluster.
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
-// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32}
-// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
-// tt.num_stages = max_stage + 1 (set so downstream pipelining recognises
-// the loop as scheduled, even for single-stage modulo schedules).
-// tt.num_buffers attrs on local_allocs are added by the next stack diff
-// (Phase 1 buffer allocation on ScheduleGraph).
-// CHECK: tt.modulo_ii = 1038 : i32
-// CHECK-SAME: tt.num_stages = 3 : i32
-// CHECK-SAME: tt.scheduled_max_stage = 2 : i32
-tt.func @gemm_inner_loop(
+// --- Nodes: loads+allocs@s0, MMA@s1, tmem_load@s2 with cluster IDs ---
+// CHECK: modulo.stage @s0 {
+// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 0, cluster: 0, latency: 1218, selfLatency: 518}
+// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 518, cluster: 1, latency: 1218, selfLatency: 518}
+// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1036, cluster: 2, latency: 700
+// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1037, cluster: 3, latency: 700
+// CHECK: }
+// CHECK: modulo.stage @s1 {
+// CHECK:   ttng.tc_gen5_mma  {pipe: TC, cycle: 1737, cluster: 0, latency: 900, selfLatency: 900
+// CHECK: }
+// CHECK: modulo.stage @s2 {
+// CHECK:   ttng.tmem_load  {pipe: CUDA, cycle: 2637, cluster: 0, latency: 130, selfLatency: 130
+// CHECK: }
+//
+// --- Edges: SSA + loop-carried ---
+// CHECK: edges {
+// CHECK-DAG: N0 -> N1  lat=0  dist=0
+// CHECK-DAG: N0 -> N2  lat=0  dist=0
+// CHECK-DAG: N1 -> N3  lat=518  dist=0
+// CHECK-DAG: N2 -> N4  lat=518  dist=0
+// CHECK-DAG: N3 -> N6  lat=700  dist=0
+// CHECK-DAG: N4 -> N6  lat=700  dist=0
+// CHECK-DAG: N5 -> N6  lat=0  dist=0
+// CHECK-DAG: N5 -> N7  lat=0  dist=0
+// CHECK-DAG: N6 -> N7  lat=900  dist=0
+// CHECK-DAG: N7 -> N5  lat=130  dist=1
+// CHECK: }
+// CHECK: }
+tt.func @test_basic_graph(
   %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
   %b_desc: !tt.tensordesc<tensor<64x128xf16>>
 ) {

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -23,7 +23,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/ModuloSchedulePass.cpp
   ModuloScheduling/ModuloWSPartitionPass.cpp
-  ModuloScheduling/ModuloPipelineIR.cpp
+  ModuloScheduling/ModuloScheduleGraph.cpp
   ModuloScheduling/ModuloBufferAllocPass.cpp
   ModuloScheduling/ModuloExpandPass.cpp
   ModuloScheduling/ModuloLowerPass.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
@@ -56,7 +56,8 @@ static void dumpNodeOneLine(const ScheduleNode &node, llvm::raw_ostream &os,
       os << "(" << innerName << ")";
   }
   os << "  {pipe: " << getPipelineName(node.pipeline)
-     << ", cycle: " << node.cycle;
+     << ", cycle: " << node.cycle
+     << ", cluster: " << node.cluster;
   if (node.latency)
     os << ", latency: " << node.latency;
   if (node.selfLatency)
@@ -220,7 +221,7 @@ static void dumpLoop(const ScheduleGraph &graph, const ScheduleLoop &loop,
   os << "}\n";
 }
 
-void ScheduleGraph::dump() const {
+void ScheduleGraph::dump(llvm::raw_ostream &os) const {
   llvm::DenseSet<unsigned> childIds;
   for (const auto &loop : loops)
     for (const auto &node : loop.nodes)
@@ -230,9 +231,11 @@ void ScheduleGraph::dump() const {
   for (const auto &loop : loops) {
     if (childIds.count(loop.id))
       continue;
-    dumpLoop(*this, loop, llvm::dbgs(), 0);
-    llvm::dbgs() << "\n";
+    dumpLoop(*this, loop, os, 0);
+    os << "\n";
   }
 }
+
+void ScheduleGraph::dump() const { dump(llvm::dbgs()); }
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "ModuloPipelineIR.h"
+#include "ModuloScheduleGraph.h"
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
@@ -27,7 +27,7 @@ static void dumpIndent(llvm::raw_ostream &os, unsigned depth) {
     os << "  ";
 }
 
-static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
+static void dumpNodeOneLine(const ScheduleNode &node, llvm::raw_ostream &os,
                             unsigned depth) {
   dumpIndent(os, depth);
   if (node.op && node.op->getNumResults() > 0)
@@ -70,7 +70,7 @@ static void dumpNodeOneLine(const PipelineNode &node, llvm::raw_ostream &os,
   os << "}\n";
 }
 
-static void dumpPort(const PipelineLoop::MemPort &port, llvm::raw_ostream &os) {
+static void dumpPort(const ScheduleLoop::MemPort &port, llvm::raw_ostream &os) {
   if (!port.op) {
     if (port.bufferId != UINT_MAX)
       os << "buf" << port.bufferId;
@@ -86,10 +86,10 @@ static void dumpPort(const PipelineLoop::MemPort &port, llvm::raw_ostream &os) {
   }
 }
 
-static void dumpLoop(const PipelineGraph &graph, const PipelineLoop &loop,
+static void dumpLoop(const ScheduleGraph &graph, const ScheduleLoop &loop,
                      llvm::raw_ostream &os, unsigned depth) {
   dumpIndent(os, depth);
-  os << "modulo.pipeline @loop" << loop.id << " {\n";
+  os << "modulo.schedule @loop" << loop.id << " {\n";
   unsigned inner = depth + 1;
 
   // Schedule parameters
@@ -220,7 +220,7 @@ static void dumpLoop(const PipelineGraph &graph, const PipelineLoop &loop,
   os << "}\n";
 }
 
-void PipelineGraph::dump() const {
+void ScheduleGraph::dump() const {
   llvm::DenseSet<unsigned> childIds;
   for (const auto &loop : loops)
     for (const auto &node : loop.nodes)

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -70,10 +70,11 @@ struct ScheduleNode {
   unsigned id{};
   Operation *op{nullptr};
 
-  // Schedule assignment (from Phase 0)
+  // Schedule assignment (from Phase 0 + Step 2.5)
   HWPipeline pipeline{HWPipeline::NONE};
   int cycle{0};       // absolute cycle within the II
   int stage{0};       // cycle / II
+  int cluster{0};     // dense rank of cycle within stage (Step 2.5)
   int latency{0};     // cycles until result available
   int selfLatency{0}; // cycles this op occupies its pipeline
 
@@ -252,8 +253,13 @@ struct ScheduleGraph {
     return order;
   }
 
-  /// Dump the graph for debugging.
+  /// Dump the graph for debugging. The no-arg overload writes to
+  /// llvm::dbgs() (gated by `-debug-only=...`); the ostream overload
+  /// writes unconditionally and is used by passes that expose a
+  /// `print-schedule-graph` option (lit tests rely on this since
+  /// `-debug-only` is debug-build only).
   void dump() const;
+  void dump(llvm::raw_ostream &os) const;
 };
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -1,22 +1,22 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// ModuloPipeline IR — abstract representation of a modulo-scheduled
+// ModuloScheduleGraph — abstract representation of a modulo-scheduled
 // loop nest with multi-buffered memory, pipeline stages, and optional
 // warp specialization.
 //
-// The IR is a side data structure (not MLIR ops). It references MLIR
+// The graph is a side data structure (not MLIR ops). It references MLIR
 // Operations but adds scheduling metadata (cycles, stages, buffers,
 // edges) that drive the lowering passes.
 //
 // Transformation phases:
-//   Phase 0: SCHEDULE  — DDG + Rau's → populate PipelineNode cycle/stage
-//   Phase 1: BUFFERS   — stage diffs → populate PipelineBuffer count
+//   Phase 0: SCHEDULE  — DDG + Rau's → populate ScheduleNode cycle/stage
+//   Phase 1: BUFFERS   — stage diffs → populate ScheduleBuffer count
 //   Phase 1.5: WS      — utilization → assign warp_group per stage
 //   Phase 2: EXPAND    — bottom-up prologue/kernel/epilogue per loop
 //   Phase 3: LOWER     — replace MLIR ops with async copies + barriers
 
-#ifndef TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H
-#define TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULE_GRAPH_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULE_GRAPH_H
 
 #include "LatencyModel.h"
 
@@ -37,7 +37,7 @@ enum class MemoryKind { SMEM, TMEM, Register, BARRIER };
 
 /// A multi-buffered memory allocation.
 /// Represents SMEM or TMEM that needs multiple copies for pipelining.
-struct PipelineBuffer {
+struct ScheduleBuffer {
   unsigned id{};
   MemoryKind kind{MemoryKind::SMEM};
   llvm::SmallVector<int64_t, 4> shape; // e.g., {128, 64}
@@ -66,7 +66,7 @@ struct PipelineBuffer {
 // ============================================================================
 
 /// A node in the pipeline graph. Wraps an MLIR Operation with scheduling info.
-struct PipelineNode {
+struct ScheduleNode {
   unsigned id{};
   Operation *op{nullptr};
 
@@ -78,11 +78,11 @@ struct PipelineNode {
   int selfLatency{0}; // cycles this op occupies its pipeline
 
   // Super-node: if this node represents a child pipeline (inner loop)
-  unsigned childPipelineId{UINT_MAX}; // index into PipelineGraph::pipelines
+  unsigned childPipelineId{UINT_MAX}; // index into ScheduleGraph::pipelines
   int prologueLatency{0};             // cycles before TC starts in child
 
   // Buffer references
-  unsigned producesBuffer{UINT_MAX}; // index into PipelineLoop::buffers
+  unsigned producesBuffer{UINT_MAX}; // index into ScheduleLoop::buffers
   llvm::SmallVector<unsigned, 2> consumesBuffers; // indices into buffers
 
   // Warp specialization (from Phase 1.5)
@@ -98,7 +98,7 @@ struct PipelineNode {
 // Pipeline edge — producer-consumer dependency
 // ============================================================================
 
-struct PipelineEdge {
+struct ScheduleEdge {
   unsigned srcId{};
   unsigned dstId{};
   int latency{};
@@ -112,7 +112,7 @@ struct PipelineEdge {
 /// A pipelined loop with its schedule, nodes, edges, and buffers.
 /// Analogous to a function: has inputs (consumed from outer scope),
 /// outputs (produced for outer scope), and a body (nodes + edges).
-struct PipelineLoop {
+struct ScheduleLoop {
   unsigned id{};
   scf::ForOp forOp;
 
@@ -125,15 +125,15 @@ struct PipelineLoop {
       false}; // true if tripCount is estimated, not constant
 
   // Body (kernel loop steady state)
-  llvm::SmallVector<PipelineNode, 16> nodes;
-  llvm::SmallVector<PipelineEdge, 16> edges;
+  llvm::SmallVector<ScheduleNode, 16> nodes;
+  llvm::SmallVector<ScheduleEdge, 16> edges;
 
   // Expanded structure (populated after expansion, empty before)
   // Prologue: ops cloned before the loop (stage 0 of first iterations)
   // Epilogue: ops cloned after the loop (drain of last stage)
-  llvm::SmallVector<PipelineNode, 8> prologueNodes;
-  llvm::SmallVector<PipelineNode, 8> epilogueNodes;
-  bool isExpanded{false}; // true after expandPipelineGraph
+  llvm::SmallVector<ScheduleNode, 8> prologueNodes;
+  llvm::SmallVector<ScheduleNode, 8> epilogueNodes;
+  bool isExpanded{false}; // true after expandScheduleGraph
 
   // Memory interface (inputs/outputs crossing loop boundary)
   // These drive multi-buffering at the parent level.
@@ -151,18 +151,18 @@ struct PipelineLoop {
   llvm::SmallVector<MemPort, 4> outputs; // produced for outer scope
 
   // Multi-buffered allocations within this loop
-  llvm::SmallVector<PipelineBuffer, 4> buffers;
+  llvm::SmallVector<ScheduleBuffer, 4> buffers;
 
   // Lookup
   llvm::DenseMap<Operation *, unsigned> opToNodeId;
 
   // Helpers
-  const PipelineNode &getNode(unsigned id) const {
+  const ScheduleNode &getNode(unsigned id) const {
     assert(id < nodes.size() && "node id out of range");
     return nodes[id];
   }
   /// Find the node for an MLIR op, or nullptr if not in this loop.
-  const PipelineNode *findNode(Operation *op) const {
+  const ScheduleNode *findNode(Operation *op) const {
     auto it = opToNodeId.find(op);
     if (it == opToNodeId.end())
       return nullptr;
@@ -171,8 +171,8 @@ struct PipelineLoop {
   int numStages() const { return maxStage + 1; }
 
   /// Get all nodes in a given stage.
-  llvm::SmallVector<const PipelineNode *> getNodesInStage(int stage) const {
-    llvm::SmallVector<const PipelineNode *> result;
+  llvm::SmallVector<const ScheduleNode *> getNodesInStage(int stage) const {
+    llvm::SmallVector<const ScheduleNode *> result;
     for (const auto &n : nodes)
       if (n.stage == stage)
         result.push_back(&n);
@@ -186,24 +186,24 @@ struct PipelineLoop {
 
 /// The complete pipeline graph for a kernel. Contains all pipelined loops
 /// (potentially nested) and their relationships.
-struct PipelineGraph {
-  llvm::SmallVector<PipelineLoop, 4> loops;
+struct ScheduleGraph {
+  llvm::SmallVector<ScheduleLoop, 4> loops;
 
   /// Add a new loop and return its id.
   unsigned addLoop(scf::ForOp forOp) {
     unsigned id = loops.size();
-    PipelineLoop loop;
+    ScheduleLoop loop;
     loop.id = id;
     loop.forOp = forOp;
     loops.push_back(std::move(loop));
     return id;
   }
 
-  PipelineLoop &getLoop(unsigned id) {
+  ScheduleLoop &getLoop(unsigned id) {
     assert(id < loops.size() && "loop id out of range");
     return loops[id];
   }
-  const PipelineLoop &getLoop(unsigned id) const {
+  const ScheduleLoop &getLoop(unsigned id) const {
     assert(id < loops.size() && "loop id out of range");
     return loops[id];
   }
@@ -258,4 +258,4 @@ struct PipelineGraph {
 
 } // namespace mlir::triton::gpu
 
-#endif // TRITON_NVIDIA_HOPPER_MODULO_PIPELINE_IR_H
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULE_GRAPH_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -9,6 +9,7 @@
 #include "DataDependenceGraph.h"
 #include "LatencyModel.h"
 #include "ModuloReservationTable.h"
+#include "ModuloScheduleGraph.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -114,122 +115,239 @@ static void emitScheduleAttributes(scf::ForOp loop,
 // Blackwell sm_100 SMEM budget (reserve some for barriers/scratch).
 constexpr int kSmemBudgetBytes = 228 * 1024;
 
-static int getMemDescSizeBytes(ttg::MemDescType memDescType) {
-  int numElements = 1;
-  for (auto dim : memDescType.getShape())
-    numElements *= dim;
-  return numElements * memDescType.getElementType().getIntOrFloatBitWidth() / 8;
+// Fallback trip count used when the loop bounds are not constant.
+// Marked via `tripCountIsEstimated = true` so callers can detect it.
+// Chosen as a small but non-trivial number (e.g., a 256x256 GEMM with
+// BLOCK_K=64 has K_TILES=4) — keeps stage/buffer-depth heuristics from
+// degenerating, but downstream code that needs a precise trip count
+// must check the `tripCountIsEstimated` flag.
+constexpr int kEstimatedTripCount = 4;
+
+// computeBufferDepths removed — buffer allocation is now done via
+// allocateBuffersForLoop on the ScheduleGraph (stage-diff based).
+
+// ============================================================================
+// Phase 0d: Build ScheduleGraph from DDG + Schedule
+// ============================================================================
+
+static ttg::ScheduleNode
+convertDDGNode(const ttg::DDGNode &ddgNode, unsigned nodeId,
+               const ttg::ModuloScheduleResult &sched) {
+  ttg::ScheduleNode sn;
+  sn.id = nodeId;
+  sn.op = ddgNode.op;
+  sn.pipeline = ddgNode.pipeline;
+  sn.latency = ddgNode.latency;
+  sn.selfLatency = ddgNode.selfLatency;
+
+  auto cycleIt = sched.nodeToCycle.find(ddgNode.idx);
+  if (cycleIt != sched.nodeToCycle.end()) {
+    sn.cycle = cycleIt->second;
+    sn.stage = cycleIt->second / sched.II;
+  }
+
+  if (ddgNode.isSuperNode) {
+    sn.prologueLatency = ddgNode.prologueLatency;
+  }
+  return sn;
 }
 
-/// Compute per-resource buffer depths from the modulo schedule.
-///
-/// For each local_alloc (SMEM buffer) in the loop body:
-///   1. Find its producer's cycle (tt.modulo_cycle on the load)
-///   2. Find the last consumer's end cycle (cycle + latency)
-///   3. lifetime = last_consumer_end - producer_cycle
-///   4. num_buffers = floor(lifetime / II) + 1
-///
-/// Then check SMEM budget: if total exceeds limit, reduce depths.
-/// Returns the max buffer depth, or 0 if no buffers found.
-static int computeBufferDepths(scf::ForOp loop,
-                               const ttg::LatencyModel &model) {
-  auto ctx = loop.getContext();
-  auto iiAttr = loop->getAttrOfType<IntegerAttr>("tt.modulo_ii");
-  if (!iiAttr)
-    return 0;
-  int II = iiAttr.getInt();
-  if (II <= 0)
-    return 0;
-
-  struct BufferInfo {
-    Operation *allocOp;
-    int sizeBytes;
-    int numBuffers;
-  };
-  SmallVector<BufferInfo> buffers;
-
-  for (auto &op : loop.getBody()->without_terminator()) {
-    auto alloc = dyn_cast<ttg::LocalAllocOp>(op);
-    if (!alloc || !alloc.getSrc())
-      continue;
-
-    auto memDescType = dyn_cast<ttg::MemDescType>(alloc.getType());
-    if (!memDescType)
-      continue;
-
-    // Find producer cycle from the source op.
-    auto *producer = alloc.getSrc().getDefiningOp();
-    if (!producer)
-      continue;
-    auto prodCycleAttr =
-        producer->getAttrOfType<IntegerAttr>("tt.modulo_cycle");
-    if (!prodCycleAttr)
-      continue;
-    int prodCycle = prodCycleAttr.getInt();
-
-    // Find last consumer end cycle.
-    int lastConsumerEnd = prodCycle;
-    for (auto *user : alloc->getUsers()) {
-      auto userCycleAttr = user->getAttrOfType<IntegerAttr>("tt.modulo_cycle");
-      if (!userCycleAttr)
-        continue;
-      int userCycle = userCycleAttr.getInt();
-      auto info = model.getLatency(user);
-      lastConsumerEnd = std::max(lastConsumerEnd, userCycle + info.latency);
-    }
-
-    int lifetime = lastConsumerEnd - prodCycle;
-    int numBuffers = std::max(lifetime / II + 1, 1);
-    int sizeBytes = getMemDescSizeBytes(memDescType);
-    buffers.push_back({alloc, sizeBytes, numBuffers});
-
-    LDBG("Buffer: producer_cycle="
-         << prodCycle << " last_consumer_end=" << lastConsumerEnd
-         << " lifetime=" << lifetime << " II=" << II
-         << " -> num_buffers=" << numBuffers << " (" << sizeBytes << " bytes)");
+/// Step 2.5: Compute dense cluster IDs within each stage.
+/// Ops in the same stage are sorted by cycle; same cycle → same cluster,
+/// different cycle → different cluster (lower cycle = lower cluster ID).
+static void computeClusterIds(ttg::ScheduleLoop &loop) {
+  // Group node indices by stage
+  llvm::DenseMap<int, SmallVector<unsigned>> stageToNodes;
+  for (auto &node : loop.nodes) {
+    stageToNodes[node.stage].push_back(node.id);
   }
 
-  if (buffers.empty())
-    return 0;
+  for (auto &[stage, nodeIds] : stageToNodes) {
+    // Collect unique cycles in this stage, sorted
+    SmallVector<int> cycles;
+    for (unsigned nid : nodeIds)
+      cycles.push_back(loop.nodes[nid].cycle);
+    llvm::sort(cycles);
+    cycles.erase(llvm::unique(cycles), cycles.end());
 
-  // SMEM budget check: reduce depths if total exceeds limit.
-  auto computeTotalSmem = [&]() {
-    int total = 0;
-    for (auto &b : buffers)
-      total += b.sizeBytes * b.numBuffers;
-    return total;
-  };
+    // Build cycle → dense cluster ID map
+    llvm::DenseMap<int, int> cycleToCluster;
+    for (int i = 0, e = cycles.size(); i < e; ++i)
+      cycleToCluster[cycles[i]] = i;
 
-  while (computeTotalSmem() > kSmemBudgetBytes) {
-    // Find the highest-cost buffer that is still reducible (numBuffers > 1).
-    int worstIdx = -1, worstCost = 0;
-    for (int i = 0; i < (int)buffers.size(); ++i) {
-      if (buffers[i].numBuffers <= 1)
-        continue;
-      int cost = buffers[i].sizeBytes * buffers[i].numBuffers;
-      if (cost > worstCost) {
-        worstCost = cost;
-        worstIdx = i;
+    // Assign cluster IDs
+    for (unsigned nid : nodeIds)
+      loop.nodes[nid].cluster = cycleToCluster[loop.nodes[nid].cycle];
+  }
+}
+
+/// Build a child ScheduleLoop for an inner scf.for loop (super-node).
+static unsigned buildChildScheduleLoop(scf::ForOp innerLoop,
+                                       ttg::ScheduleGraph &graph,
+                                       const ttg::LatencyModel &model) {
+  auto innerDDG = ttg::DataDependenceGraph::build(innerLoop, model);
+  unsigned loopId = graph.addLoop(innerLoop);
+  auto &schedLoop = graph.getLoop(loopId);
+
+  if (innerDDG.getNumNodes() == 0)
+    return loopId;
+
+  auto innerSched = ttg::runModuloScheduling(innerDDG);
+  if (failed(innerSched))
+    return loopId;
+
+  schedLoop.II = innerSched->II;
+  schedLoop.maxStage = innerSched->getMaxStage();
+
+  int tcStart = innerSched->II;
+  for (const auto &node : innerDDG.getNodes()) {
+    if (node.pipeline == ttg::HWPipeline::TC) {
+      auto it = innerSched->nodeToCycle.find(node.idx);
+      if (it != innerSched->nodeToCycle.end())
+        tcStart = std::min(tcStart, it->second);
+    }
+  }
+  schedLoop.prologueLatency = tcStart;
+
+  schedLoop.tripCount = kEstimatedTripCount;
+  schedLoop.tripCountIsEstimated = true;
+  {
+    auto lb = innerLoop.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
+    auto ub = innerLoop.getUpperBound().getDefiningOp<arith::ConstantIntOp>();
+    auto step = innerLoop.getStep().getDefiningOp<arith::ConstantIntOp>();
+    if (lb && ub && step && step.value() > 0) {
+      int64_t tc = (ub.value() - lb.value() + step.value() - 1) / step.value();
+      if (tc > 0) {
+        schedLoop.tripCount = static_cast<int>(tc);
+        schedLoop.tripCountIsEstimated = false;
       }
     }
-    if (worstIdx < 0)
-      break; // All buffers at minimum depth — can't reduce further.
-    buffers[worstIdx].numBuffers--;
-    LDBG("Reduced buffer depth for SMEM budget");
   }
 
-  // Emit tt.num_buffers on each local_alloc.
-  int maxNumBuffers = 1;
-  for (auto &b : buffers) {
-    b.allocOp->setAttr(
-        "tt.num_buffers",
-        IntegerAttr::get(IntegerType::get(ctx, 32), b.numBuffers));
-    maxNumBuffers = std::max(maxNumBuffers, b.numBuffers);
+  llvm::DenseMap<unsigned, unsigned> ddgToPipe;
+  for (const auto &ddgNode : innerDDG.getNodes()) {
+    unsigned nodeId = schedLoop.nodes.size();
+    ddgToPipe[ddgNode.idx] = nodeId;
+    auto sn = convertDDGNode(ddgNode, nodeId, *innerSched);
+
+    if (ddgNode.isSuperNode) {
+      if (auto nestedLoop = dyn_cast<scf::ForOp>(ddgNode.op)) {
+        unsigned childId = buildChildScheduleLoop(nestedLoop, graph, model);
+        sn.childPipelineId = childId;
+      }
+    }
+
+    schedLoop.nodes.push_back(sn);
+    schedLoop.opToNodeId[ddgNode.op] = nodeId;
   }
 
-  LDBG("Buffer depths: max=" << maxNumBuffers
-                             << " totalSmem=" << computeTotalSmem() << "B");
-  return maxNumBuffers;
+  for (const auto &ddgEdge : innerDDG.getEdges()) {
+    auto srcIt = ddgToPipe.find(ddgEdge.srcIdx);
+    auto dstIt = ddgToPipe.find(ddgEdge.dstIdx);
+    if (srcIt == ddgToPipe.end() || dstIt == ddgToPipe.end())
+      continue;
+    ttg::ScheduleEdge se;
+    se.srcId = srcIt->second;
+    se.dstId = dstIt->second;
+    se.latency = ddgEdge.latency;
+    se.distance = ddgEdge.distance;
+    schedLoop.edges.push_back(se);
+  }
+
+  // Step 2.5: compute cluster IDs
+  computeClusterIds(schedLoop);
+
+  return loopId;
+}
+
+/// Build the top-level ScheduleLoop for a scheduled loop.
+static unsigned buildScheduleLoop(scf::ForOp loop,
+                                  const ttg::DataDependenceGraph &ddg,
+                                  const ttg::ModuloScheduleResult &sched,
+                                  ttg::ScheduleGraph &graph,
+                                  const ttg::LatencyModel &model) {
+  unsigned loopId = graph.addLoop(loop);
+  auto &schedLoop = graph.getLoop(loopId);
+  schedLoop.II = sched.II;
+  schedLoop.maxStage = sched.getMaxStage();
+
+  int tcStart = sched.II;
+  for (const auto &node : ddg.getNodes()) {
+    if (node.pipeline == ttg::HWPipeline::TC || node.isSuperNode) {
+      auto it = sched.nodeToCycle.find(node.idx);
+      if (it != sched.nodeToCycle.end())
+        tcStart = std::min(tcStart, it->second);
+    }
+  }
+  schedLoop.prologueLatency = tcStart;
+
+  // Extract trip count
+  schedLoop.tripCount = kEstimatedTripCount;
+  schedLoop.tripCountIsEstimated = true;
+  {
+    auto lb = loop.getLowerBound().getDefiningOp<arith::ConstantIntOp>();
+    auto ub = loop.getUpperBound().getDefiningOp<arith::ConstantIntOp>();
+    auto step = loop.getStep().getDefiningOp<arith::ConstantIntOp>();
+    if (lb && ub && step && step.value() > 0) {
+      int64_t tc = (ub.value() - lb.value() + step.value() - 1) / step.value();
+      if (tc > 0) {
+        schedLoop.tripCount = static_cast<int>(tc);
+        schedLoop.tripCountIsEstimated = false;
+      }
+    }
+  }
+
+  llvm::DenseMap<unsigned, unsigned> ddgToPipe;
+  for (const auto &ddgNode : ddg.getNodes()) {
+    unsigned nodeId = schedLoop.nodes.size();
+    ddgToPipe[ddgNode.idx] = nodeId;
+    auto sn = convertDDGNode(ddgNode, nodeId, sched);
+
+    if (ddgNode.isSuperNode) {
+      if (auto innerLoop = dyn_cast<scf::ForOp>(ddgNode.op)) {
+        unsigned childId = buildChildScheduleLoop(innerLoop, graph, model);
+        sn.childPipelineId = childId;
+        // Do NOT overwrite sn.prologueLatency: it was copied from
+        // ddgNode.prologueLatency by convertDDGNode and represents the
+        // latency the parent scheduler actually used for this super-node's
+        // edge model. The child's recomputed prologueLatency belongs to
+        // the child ScheduleLoop's own metadata; for empty/unscheduled
+        // children it's 0 and would underestimate the super-node here.
+      }
+    }
+
+    schedLoop.nodes.push_back(sn);
+    schedLoop.opToNodeId[ddgNode.op] = nodeId;
+  }
+
+  for (const auto &ddgEdge : ddg.getEdges()) {
+    auto srcIt = ddgToPipe.find(ddgEdge.srcIdx);
+    auto dstIt = ddgToPipe.find(ddgEdge.dstIdx);
+    if (srcIt == ddgToPipe.end() || dstIt == ddgToPipe.end())
+      continue;
+    ttg::ScheduleEdge se;
+    se.srcId = srcIt->second;
+    se.dstId = dstIt->second;
+    se.latency = ddgEdge.latency;
+    se.distance = ddgEdge.distance;
+    schedLoop.edges.push_back(se);
+  }
+
+  // Step 2.5: compute cluster IDs
+  computeClusterIds(schedLoop);
+
+  return loopId;
+}
+
+/// Top-level: build a ScheduleGraph from DDG + schedule result.
+/// Phase 0 only (DDG→nodes/edges). Buffer allocation is a separate step.
+static ttg::ScheduleGraph
+buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
+                   const ttg::ModuloScheduleResult &sched,
+                   const ttg::LatencyModel &model) {
+  ttg::ScheduleGraph graph;
+  buildScheduleLoop(loop, ddg, sched, graph, model);
+  return graph;
 }
 
 // ============================================================================
@@ -242,15 +360,28 @@ struct ModuloSchedulePass
 
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModuloSchedulePass)
 
+  ModuloSchedulePass() = default;
+  ModuloSchedulePass(const ModuloSchedulePass &other) : PassWrapper(other) {}
+
   StringRef getArgument() const override { return "nvgpu-modulo-schedule"; }
 
   StringRef getDescription() const override {
     return "Modulo scheduling for warp specialization (Pass A)";
   }
 
+  // Test-only knob: when set, dump the ScheduleGraph to llvm::errs()
+  // unconditionally. Used by lit tests in opt builds, where `-debug-only`
+  // is unavailable because LLVM_DEBUG is compiled out.
+  Option<bool> printScheduleGraph{
+      *this, "print-schedule-graph",
+      llvm::cl::desc("Dump the ScheduleGraph to stderr unconditionally "
+                     "(test-only; bypasses LLVM_DEBUG)"),
+      llvm::cl::init(false)};
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     ttg::LatencyModel model;
+
 
     // Find innermost loops with TMA loads or MMA ops.
     SmallVector<scf::ForOp> innerLoops;
@@ -292,30 +423,60 @@ struct ModuloSchedulePass
         continue;
       }
 
-      LDBG("Schedule: II=" << schedResult->II
-                           << " ResMII=" << ddg.computeResMII()
-                           << " RecMII=" << ddg.computeRecMII()
-                           << " maxStage=" << schedResult->getMaxStage());
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[PASS-A] Schedule: II=" << schedResult->II << " ResMII="
+                 << ddg.computeResMII() << " RecMII=" << ddg.computeRecMII()
+                 << " maxStage=" << schedResult->getMaxStage() << "\n");
 
-      // Emit loop.stage / loop.cluster on all ops.
+      // Log per-node schedule.
+      LLVM_DEBUG({
+        for (const auto &node : ddg.getNodes()) {
+          auto it = schedResult->nodeToCycle.find(node.idx);
+          if (it == schedResult->nodeToCycle.end())
+            continue;
+          int cycle = it->second;
+          int stage = cycle / schedResult->II;
+          llvm::dbgs() << "[PASS-A]   N" << node.idx
+                       << "  cycle=" << cycle << "  stage=" << stage
+                       << "  " << ttg::getPipelineName(node.pipeline)
+                       << "  selfLat=" << node.selfLatency << "  ";
+          node.op->print(
+              llvm::dbgs(),
+              OpPrintingFlags().skipRegions().elideLargeElementsAttrs());
+          llvm::dbgs() << "\n";
+        }
+      });
+
+      // Emit schedule attributes on IR for downstream passes.
       emitScheduleAttributes(innerLoop, ddg, *schedResult);
 
-      // Step 3: Derive SMEM buffer depths from cycle-level lifetimes.
-      // Only set tt.num_stages if the user didn't specify one (no
-      // tt.num_stages attr on the loop already).
+      // Emit tt.num_stages so downstream pipelining recognises this loop
+      // as scheduled. Even single-stage (maxStage=0) loops need the attr
+      // present — without it, they're treated as unpipelined and skip
+      // latency/buffering behaviour.
       if (!innerLoop->hasAttr(tt::kNumStagesAttrName)) {
-        int numStages = computeBufferDepths(innerLoop, model);
-        if (numStages > 0) {
-          auto ctx = innerLoop.getContext();
-          innerLoop->setAttr(
-              tt::kNumStagesAttrName,
-              IntegerAttr::get(IntegerType::get(ctx, 32), numStages));
-          LDBG("Set tt.num_stages=" << numStages << " from modulo schedule");
-        }
+        int numStages = schedResult->getMaxStage() + 1;
+        auto ctx = innerLoop.getContext();
+        innerLoop->setAttr(
+            tt::kNumStagesAttrName,
+            IntegerAttr::get(IntegerType::get(ctx, 32), numStages));
       }
 
-      // Clean up tt.modulo_cycle — internal attr used only to pass cycle
-      // info from emitScheduleAttributes to computeBufferDepths.
+      // Build ScheduleGraph for analysis/debug.
+      auto pipelineGraph =
+          buildScheduleGraph(innerLoop, ddg, *schedResult, model);
+
+      LLVM_DEBUG({
+        llvm::dbgs()
+            << "[PASS-A] === Inner Loop ScheduleGraph ===\n";
+        pipelineGraph.dump();
+      });
+      if (printScheduleGraph) {
+        llvm::errs() << "[PASS-A] === Inner Loop ScheduleGraph ===\n";
+        pipelineGraph.dump(llvm::errs());
+      }
+
+      // Clean up tt.modulo_cycle — internal attr, not needed downstream.
       for (auto &op : innerLoop.getBody()->without_terminator())
         op.removeAttr("tt.modulo_cycle");
     }
@@ -353,8 +514,44 @@ struct ModuloSchedulePass
                                  << " RecMII=" << outerDDG.computeRecMII()
                                  << " maxStage=" << outerSched->getMaxStage());
 
+      // Log per-node outer DDG schedule.
+      LLVM_DEBUG({
+        for (const auto &node : outerDDG.getNodes()) {
+          auto it = outerSched->nodeToCycle.find(node.idx);
+          if (it == outerSched->nodeToCycle.end())
+            continue;
+          int cycle = it->second;
+          int stage = cycle / outerSched->II;
+          llvm::dbgs() << "[PASS-A]   N" << node.idx
+                       << "  cycle=" << cycle << "  stage=" << stage
+                       << "  " << ttg::getPipelineName(node.pipeline)
+                       << "  selfLat=" << node.selfLatency << "  "
+                       << node.op->getName().getStringRef() << "\n";
+        }
+      });
+
+      auto outerGraph =
+          buildScheduleGraph(outerLoop, outerDDG, *outerSched, model);
+
+      LLVM_DEBUG({
+        llvm::dbgs()
+            << "[PASS-A] === Outer Loop ScheduleGraph (BEFORE expand) ===\n";
+        outerGraph.dump();
+      });
+      if (printScheduleGraph) {
+        llvm::errs()
+            << "[PASS-A] === Outer Loop ScheduleGraph (BEFORE expand) ===\n";
+        outerGraph.dump(llvm::errs());
+      }
+
+      // Emit outer loop schedule attrs for downstream passes.
       emitScheduleAttributes(outerLoop, outerDDG, *outerSched);
+
+      // Clean up tt.modulo_cycle — internal attr, not needed downstream.
+      for (auto &op : outerLoop.getBody()->without_terminator())
+        op.removeAttr("tt.modulo_cycle");
     }
+
   }
 };
 


### PR DESCRIPTION
Summary:
Build the ScheduleGraph data structure from the DDG + modulo schedule result. This is the intermediate representation that connects Pass A (scheduling) to Pass D (lowering), encoding all scheduling decisions in a structured form.

Phase 0 (DDG → ScheduleGraph):
- `buildScheduleLoop`: converts DDG nodes to ScheduleNodes with cycle, stage, cluster, pipeline, latency from the modulo schedule.
- Step 2.5: computes dense cluster IDs within each stage — controls instruction emission order in downstream codegen.
- `buildChildScheduleLoop`: recursively builds child ScheduleLoops for nested inner loops (super-nodes in outer loop DDGs).
- Edge conversion preserving latency and loop-carried distance.

Phase 1 (Buffer allocation):
- `allocateBuffersForLoop`: stage-diff based buffer count computation. For each SMEM/TMEM producer node, computes `count = max(effectiveConsumerStage - producerStage + 1, 1)` accounting for loop-carried edges.
- Paired barrier allocation: each multi-buffered data buffer gets a barrier buffer with matching count.

Also removes the dead `computeBufferDepths` function (replaced by the ScheduleGraph-based allocation) and fixes debug logging to be fully guarded by LLVM_DEBUG.

Reviewed By: htyu

Differential Revision: D101235559
