### PR TITLE
[AutoWS] Revert AutoWS cache key perf regression

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -584,8 +584,11 @@ class JitFunctionInfo:
 
 
 def compute_cache_key(kernel_key_cache, specialization, options):
-    env_vars = get_cache_invalidating_env_vars()
-    key = (tuple(specialization), str(options), tuple(sorted(env_vars.items())))
+    # TODO: Handle runtime knob swapping. This is currently too slow on the Python
+    # critial path.
+    # The original change was for testing, but we can invalidate caches explicitly if
+    # tests break.
+    key = (tuple(specialization), str(options))
     cache_key = kernel_key_cache.get(key, None)
     if cache_key is not None:
         return cache_key
@@ -603,7 +606,7 @@ def compute_cache_key(kernel_key_cache, specialization, options):
             return obj.cache_key
         return obj
 
-    cache_key = str(replace_callables(specialization)) + str(options) + str(sorted(env_vars.items()))
+    cache_key = str(replace_callables(specialization)) + str(options)
     kernel_key_cache[key] = cache_key
     return cache_key
 


### PR DESCRIPTION
Summary: Reverts a change that updated the cache key to check for knob changes (necessarily if you want to be able to swap knob values dynamically). This was used solely for testing, so it should be okay to revert.

Differential Revision: D101748719


