### PR TITLE
[AutoWS] Step 3: derive ScheduleBuffer counts from cycle-level lifetime

### DIFF
--- a/test/TritonGPU/modulo-schedule-graph-buffers.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-buffers.mlir
@@ -2,7 +2,9 @@
 // RUN: triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule -debug-only=nvgpu-modulo-schedule 2>&1 | FileCheck %s
 
 //===----------------------------------------------------------------------===//
-// Test: Basic ScheduleGraph — graph structure, nodes, and edges
+// Test: Buffer allocations and barrier pairing
+//   SMEM buffers for A (128x64xf16) and B (64x128xf16) tiles,
+//   TMEM buffer for accumulator (128x128xf32), each with paired barriers.
 //===----------------------------------------------------------------------===//
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -13,40 +15,38 @@
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
-// --- Graph structure: II=1038, max_stage=2, trip_count=32 ---
-// CHECK: [PASS-A] === Inner Loop ScheduleGraph ===
-// CHECK-NEXT: modulo.schedule @loop0 {
-// CHECK-NEXT:   ii = 1038, max_stage = 2, prologue_latency = 1038, trip_count = 32
+// --- SMEM buffers: count=2, shapes match tiles, live=[start, end) per
+//     design doc §215 worked example. ---
+// CHECK: %buf0 = modulo.alloc SMEM [2 x 128x64 x f16]
+// CHECK-SAME: live=[
+// CHECK-SAME: bytes total
+// CHECK: %buf1 = modulo.alloc SMEM [2 x 64x128 x f16]
+// CHECK-SAME: live=[
+// CHECK-SAME: bytes total
 //
-// --- Nodes: loads+allocs@s0, MMA@s1, tmem_load@s2 with cluster IDs ---
-// CHECK: modulo.stage @s0 {
-// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 0, cluster: 0, latency: 1218, selfLatency: 518}
-// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 518, cluster: 1, latency: 1218, selfLatency: 518}
-// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1036, cluster: 2, latency: 700
-// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1037, cluster: 3, latency: 700
-// CHECK: }
-// CHECK: modulo.stage @s1 {
-// CHECK:   ttng.tc_gen5_mma  {pipe: TC, cycle: 1737, cluster: 0, latency: 900, selfLatency: 900
-// CHECK: }
-// CHECK: modulo.stage @s2 {
-// CHECK:   ttng.tmem_load  {pipe: CUDA, cycle: 2637, cluster: 0, latency: 130, selfLatency: 130
-// CHECK: }
+// --- TMEM buffer: count=3 for accumulator ---
+// CHECK: %buf2 = modulo.alloc TMEM [3 x 128x128 x f32]
+// CHECK-SAME: live=[
+// CHECK-SAME: 196608 bytes total
 //
-// --- Edges: SSA + loop-carried ---
-// CHECK: edges {
-// CHECK-DAG: N0 -> N1  lat=0  dist=0
-// CHECK-DAG: N0 -> N2  lat=0  dist=0
-// CHECK-DAG: N1 -> N3  lat=518  dist=0
-// CHECK-DAG: N2 -> N4  lat=518  dist=0
-// CHECK-DAG: N3 -> N6  lat=700  dist=0
-// CHECK-DAG: N4 -> N6  lat=700  dist=0
-// CHECK-DAG: N5 -> N6  lat=0  dist=0
-// CHECK-DAG: N5 -> N7  lat=0  dist=0
-// CHECK-DAG: N6 -> N7  lat=900  dist=0
-// CHECK-DAG: N7 -> N5  lat=130  dist=1
-// CHECK: }
-// CHECK: }
-tt.func @test_basic_graph(
+// --- Paired barriers carry the same live interval as their data buffer ---
+// CHECK: %bar3 = modulo.alloc BARRIER [2] for buf0
+// CHECK-SAME: live=[
+// CHECK: %bar4 = modulo.alloc BARRIER [2] for buf1
+// CHECK-SAME: live=[
+// CHECK: %bar5 = modulo.alloc BARRIER [3] for buf2
+// CHECK-SAME: live=[
+//
+// --- Producers: local_alloc → ->buf ---
+// CHECK: ttg.local_alloc  {pipe: MEM, {{.*}}->buf0}
+// CHECK: ttg.local_alloc  {pipe: MEM, {{.*}}->buf1}
+//
+// --- Consumer: MMA consumes all three buffers ---
+// CHECK: ttng.tc_gen5_mma  {pipe: TC, {{.*}}<-buf0, <-buf1, <-buf2}
+//
+// --- tmem_load consumes TMEM buffer ---
+// CHECK: ttng.tmem_load  {pipe: CUDA, {{.*}}<-buf2}
+tt.func @test_buffers(
   %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
   %b_desc: !tt.tensordesc<tensor<64x128xf16>>
 ) {

--- a/test/TritonGPU/modulo-schedule-graph-edge.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-edge.mlir
@@ -1,4 +1,5 @@
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect "-nvgpu-modulo-schedule=print-schedule-graph=true" 2>&1 | FileCheck %s
+// REQUIRES: asserts
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule -debug-only=nvgpu-modulo-schedule 2>&1 | FileCheck %s
 
 //===----------------------------------------------------------------------===//
 // Edge case 0: Single-stage schedule (maxStage=0).

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
@@ -105,7 +105,27 @@ static void dumpLoop(const ScheduleGraph &graph, const ScheduleLoop &loop,
   }
   os << "\n";
 
-  // Buffer declarations
+  // Buffer declarations.
+  // Format per design doc §1546-1556:
+  //   %buf<id> = modulo.alloc <KIND> [<count> x <shape> x <dtype>]
+  //     live=[<start>, <end>)  // <size> bytes total
+  //   %bar<id> = modulo.alloc BARRIER [<count>] for buf<paired_id>
+  auto dtypeName = [](unsigned bits) -> const char * {
+    switch (bits) {
+    case 1:
+      return "i1";
+    case 8:
+      return "i8";
+    case 16:
+      return "f16";
+    case 32:
+      return "f32";
+    case 64:
+      return "f64";
+    default:
+      return "?";
+    }
+  };
   if (!loop.buffers.empty()) {
     os << "\n";
     for (const auto &buf : loop.buffers) {
@@ -123,9 +143,28 @@ static void dumpLoop(const ScheduleGraph &graph, const ScheduleLoop &loop,
             os << "x";
           os << buf.shape[i];
         }
-        os << " x " << (buf.elementBitWidth <= 16 ? "f16" : "f32") << "]";
+        os << " x " << dtypeName(buf.elementBitWidth) << "]";
       }
+      // Live range (per design doc §215 Step 3 example).
+      if (buf.liveStart != 0 || buf.liveEnd != 0)
+        os << "  live=[" << buf.liveStart << ", " << buf.liveEnd << ")";
+      // Merge group (filled by Step 4.5).
+      if (buf.mergeGroupId != UINT_MAX)
+        os << "  merged=" << buf.mergeGroupId;
       os << "  // " << buf.sizeBytes() * buf.count << " bytes total\n";
+    }
+
+    // Merge groups (per design doc §1555-1556).
+    for (const auto &pb : loop.physicalBuffers) {
+      dumpIndent(os, inner);
+      os << "modulo.merge_group " << pb.id << " {";
+      for (size_t i = 0; i < pb.memberBufferIds.size(); ++i) {
+        if (i > 0)
+          os << ", ";
+        os << "buf" << pb.memberBufferIds[i];
+      }
+      os << "}  // physical: " << pb.sizeBytes << " bytes x " << pb.count
+         << "\n";
     }
   }
 

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -37,12 +37,33 @@ enum class MemoryKind { SMEM, TMEM, Register, BARRIER };
 
 /// A multi-buffered memory allocation.
 /// Represents SMEM or TMEM that needs multiple copies for pipelining.
+///
+/// Per design doc §125 (type table) and §215 (Step 3 worked example): each
+/// buffer carries the absolute live-range cycles (`liveStart`/`liveEnd`)
+/// derived from `producer.cycle` and `last_consumer.cycle + selfLatency`.
+/// The `count` is then `floor((liveEnd - liveStart) / II) + 1`, and Step 4.5
+/// projects `[liveStart, liveEnd) % II` for the modular overlap check.
+///
+/// `mergeGroupId` is filled by Step 4.5 — buffers in the same group share a
+/// physical allocation (size = max(sizeBytes), count = max(count)).
 struct ScheduleBuffer {
   unsigned id{};
   MemoryKind kind{MemoryKind::SMEM};
   llvm::SmallVector<int64_t, 4> shape; // e.g., {128, 64}
   unsigned elementBitWidth{16};        // e.g., 16 for f16
-  unsigned count{1};                   // number of buffers (from stageDiff + 1)
+  unsigned count{1};                   // floor((liveEnd-liveStart)/II) + 1
+
+  // Live interval in absolute cycles within the loop's modulo schedule.
+  // liveStart = producer.cycle.
+  // liveEnd   = max over consumers of (consumer.cycle + consumer.selfLatency
+  //             + edge.distance * II).
+  // Step 4.5 takes these mod II to build the modular overlap intervals.
+  int liveStart{0};
+  int liveEnd{0};
+
+  // Step 4.5 buffer merging: buffers with the same mergeGroupId share a
+  // physical allocation. UINT_MAX = ungrouped (own physical allocation).
+  unsigned mergeGroupId{UINT_MAX};
 
   // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if
   // none) For barrier buffers: index of the data buffer this barrier guards
@@ -59,6 +80,25 @@ struct ScheduleBuffer {
       elems *= d;
     return elems * elementBitWidth / 8;
   }
+
+  // Total bytes including multi-buffering. For a merge group, callers should
+  // sum max(sizeBytes) × max(count) across the group instead.
+  int64_t totalBytes() const { return sizeBytes() * count; }
+};
+
+/// A merge group materialised by Step 4.5. Buffers with the same
+/// mergeGroupId share a physical allocation of `size × count` bytes.
+/// Doc §1140-1147: "physical_buffers[color] = PhysicalBuffer{
+///   size = max(intervals[r].size for r in resources),
+///   depth = max(intervals[r].depth for r in resources), ... }"
+struct PhysicalBuffer {
+  unsigned id{};
+  MemoryKind kind{MemoryKind::SMEM};
+  int64_t sizeBytes{0};
+  unsigned count{1};
+  llvm::SmallVector<unsigned, 4> memberBufferIds;
+
+  int64_t totalBytes() const { return sizeBytes * count; }
 };
 
 // ============================================================================
@@ -151,8 +191,19 @@ struct ScheduleLoop {
   llvm::SmallVector<MemPort, 4> inputs;  // consumed from outer scope
   llvm::SmallVector<MemPort, 4> outputs; // produced for outer scope
 
-  // Multi-buffered allocations within this loop
+  // Multi-buffered allocations within this loop (logical buffers).
   llvm::SmallVector<ScheduleBuffer, 4> buffers;
+
+  // Physical buffer groups produced by Step 4.5 merging. Empty until
+  // mergeBuffers runs. Each PhysicalBuffer.memberBufferIds lists the
+  // ScheduleBuffer ids that share that physical allocation.
+  llvm::SmallVector<PhysicalBuffer, 4> physicalBuffers;
+
+  // Absolute kernel-time interval for this loop (set by Step 4.6's
+  // compute_region_intervals). Used for cross-region buffer lifetime
+  // analysis. liveStart=liveEnd=0 means "not yet computed".
+  int regionStart{0};
+  int regionEnd{0};
 
   // Lookup
   llvm::DenseMap<Operation *, unsigned> opToNodeId;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -115,12 +115,12 @@ static void emitScheduleAttributes(scf::ForOp loop,
 // Blackwell sm_100 SMEM budget (reserve some for barriers/scratch).
 constexpr int kSmemBudgetBytes = 228 * 1024;
 
-// Fallback trip count used when the loop bounds are not constant.
-// Marked via `tripCountIsEstimated = true` so callers can detect it.
-// Chosen as a small but non-trivial number (e.g., a 256x256 GEMM with
-// BLOCK_K=64 has K_TILES=4) — keeps stage/buffer-depth heuristics from
-// degenerating, but downstream code that needs a precise trip count
-// must check the `tripCountIsEstimated` flag.
+// Blackwell TMEM budget: 256KB total tensor memory (128 lanes × 512 cols × 4B).
+constexpr int kTmemBudgetBytes = 256 * 1024;
+
+// Fallback trip count when the loop bounds aren't constant-foldable.
+// Used so kernel_time_cost can give a finite (rather than div-by-zero)
+// answer for cost-based depth reduction.
 constexpr int kEstimatedTripCount = 4;
 
 // computeBufferDepths removed — buffer allocation is now done via
@@ -339,14 +339,207 @@ static unsigned buildScheduleLoop(scf::ForOp loop,
   return loopId;
 }
 
+// ============================================================================
+// Phase 1: Buffer Allocation
+// ============================================================================
+
+static ttg::MemoryKind classifyMemoryKind(Operation *op) {
+  if (isa<ttng::TMEMAllocOp>(op))
+    return ttg::MemoryKind::TMEM;
+  // Both local_alloc (pre-lowering) and async_tma_copy (post-lowering)
+  // produce SMEM buffers that need multi-buffering.
+  if (isa<ttg::LocalAllocOp, ttng::AsyncTMACopyGlobalToLocalOp>(op))
+    return ttg::MemoryKind::SMEM;
+  return ttg::MemoryKind::Register;
+}
+
+static void extractBufferShape(Operation *op, ttg::ScheduleBuffer &buf) {
+  Type resultType;
+  if (auto alloc = dyn_cast<ttg::LocalAllocOp>(op))
+    resultType = alloc.getType();
+  else if (auto tmemAlloc = dyn_cast<ttng::TMEMAllocOp>(op))
+    resultType = tmemAlloc.getType();
+  else if (auto tmaCopy = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op))
+    resultType = tmaCopy.getResult().getType();
+  else if (op->getNumResults() > 0)
+    resultType = op->getResult(0).getType();
+
+  auto extractFromShapedType = [&](llvm::ArrayRef<int64_t> shape, Type elemTy) {
+    for (auto dim : shape) {
+      if (dim <= 0 || ShapedType::isDynamic(dim))
+        return;
+    }
+    if (!elemTy.isIntOrFloat())
+      return;
+    for (auto dim : shape)
+      buf.shape.push_back(dim);
+    buf.elementBitWidth = elemTy.getIntOrFloatBitWidth();
+  };
+
+  if (auto memDesc = dyn_cast_or_null<ttg::MemDescType>(resultType)) {
+    extractFromShapedType(memDesc.getShape(), memDesc.getElementType());
+  } else if (auto tensorType = dyn_cast_or_null<RankedTensorType>(resultType)) {
+    extractFromShapedType(tensorType.getShape(), tensorType.getElementType());
+  }
+}
+
+/// Step 3: Compute buffer count from cycle-level lifetime.
+///
+/// Design doc formula (§Step 3):
+///   lifetime(R) = lastConsumerEnd - producerStart
+///   num_buffers(R) = floor(lifetime(R) / II) + 1
+///
+/// For loop-carried edges (distance > 0), the consumer in iteration i+d
+/// effectively ends at: consumerEnd + d * II (in absolute time).
+/// This is equivalent to adding d * II to the lifetime.
+///
+/// Returns the absolute cycle range the buffer is live for. The hold time is
+/// `selfLatency` (pipeline occupancy of the consumer) per design doc §414;
+/// `latency` (when the consumer's *output* becomes available) is the edge
+/// weight, not the buffer hold. We fall back to `latency` when `selfLatency`
+/// is 0 (synthetic local_load nodes have selfLat=0 but still need a non-zero
+/// hold time = latency).
+struct LifetimeRange {
+  int liveStart{0};
+  int liveEnd{0};
+  unsigned count{1};
+};
+
+static LifetimeRange computeLifetimeAndCount(const ttg::ScheduleLoop &loop,
+                                              unsigned producerNodeId) {
+  const auto &producer = loop.getNode(producerNodeId);
+  int prodCycle = producer.cycle;
+  int II = loop.II;
+  if (II <= 0)
+    return {prodCycle, prodCycle, 1};
+
+  // Find the latest DIRECT consumer end cycle.
+  int lastConsumerEnd = prodCycle;
+  for (const auto &edge : loop.edges) {
+    if (edge.srcId != producerNodeId)
+      continue;
+    const auto &consumer = loop.getNode(edge.dstId);
+    int hold = consumer.selfLatency > 0 ? consumer.selfLatency : consumer.latency;
+    int consumerEnd = consumer.cycle + hold + edge.distance * II;
+    lastConsumerEnd = std::max(lastConsumerEnd, consumerEnd);
+  }
+
+  int lifetime = lastConsumerEnd - prodCycle;
+  unsigned numBuffers = static_cast<unsigned>(std::max(lifetime / II + 1, 1));
+  return {prodCycle, lastConsumerEnd, numBuffers};
+}
+
+static void allocateBuffersForLoop(ttg::ScheduleLoop &loop) {
+  llvm::SmallVector<unsigned, 4> dataBufferIds;
+  for (auto &node : loop.nodes) {
+    if (!node.op)
+      continue;
+
+    auto kind = classifyMemoryKind(node.op);
+    if (kind == ttg::MemoryKind::Register)
+      continue;
+
+    unsigned bufId = loop.buffers.size();
+    ttg::ScheduleBuffer buf;
+    buf.id = bufId;
+    buf.kind = kind;
+    buf.defOp = node.op;
+    extractBufferShape(node.op, buf);
+
+    auto life = computeLifetimeAndCount(loop, node.id);
+    buf.liveStart = life.liveStart;
+    buf.liveEnd = life.liveEnd;
+    buf.count = life.count;
+
+    loop.buffers.push_back(buf);
+    node.producesBuffer = bufId;
+
+    if (buf.count > 1)
+      dataBufferIds.push_back(bufId);
+
+    llvm::DenseSet<unsigned> markedConsumers;
+    for (const auto &edge : loop.edges) {
+      if (edge.srcId == node.id && markedConsumers.insert(edge.dstId).second)
+        loop.nodes[edge.dstId].consumesBuffers.push_back(bufId);
+    }
+  }
+
+  for (unsigned dataBufId : dataBufferIds) {
+    unsigned barId = loop.buffers.size();
+    ttg::ScheduleBuffer bar;
+    bar.id = barId;
+    bar.kind = ttg::MemoryKind::BARRIER;
+    bar.count = loop.buffers[dataBufId].count;
+    bar.liveStart = loop.buffers[dataBufId].liveStart;
+    bar.liveEnd = loop.buffers[dataBufId].liveEnd;
+    bar.defOp = loop.buffers[dataBufId].defOp;
+    bar.pairedBufferId = dataBufId;
+    loop.buffers[dataBufId].pairedBufferId = barId;
+    loop.buffers.push_back(bar);
+  }
+}
+
+// ============================================================================
+// Step 4: SMEM/TMEM Budget Check
+// ============================================================================
+
+/// Per design doc §Step 4 (lines 1029-1063): each loop's buffer footprint
+/// must fit within the per-tile SMEM/TMEM budgets. This is the per-loop
+/// check; Step 4.6 (next diff) adds the kernel-wide cross-region check.
+///
+/// Sums `sizeBytes() × count` for each buffer (excluding mergeGroupId
+/// duplicates — though Phase 1 doesn't merge yet, accept the field for
+/// forward compat). BARRIER buffers are charged to SMEM (mbarriers live in
+/// SMEM). Returns true if within budget.
+static bool checkLoopMemoryBudget(const ttg::ScheduleLoop &loop) {
+  int64_t smemBytes = 0;
+  int64_t tmemBytes = 0;
+  llvm::DenseSet<unsigned> seenGroups;
+  for (const auto &buf : loop.buffers) {
+    // For merged groups, charge once at max(size×count). Step 4.5 fills
+    // mergeGroupId; before then this just walks every buffer individually.
+    if (buf.mergeGroupId != UINT_MAX &&
+        !seenGroups.insert(buf.mergeGroupId).second)
+      continue;
+    int64_t bytes = buf.totalBytes();
+    if (buf.kind == ttg::MemoryKind::TMEM)
+      tmemBytes += bytes;
+    else // SMEM and BARRIER both use SMEM space
+      smemBytes += bytes;
+  }
+  bool ok = true;
+  if (smemBytes > kSmemBudgetBytes) {
+    LDBG("[Step4] SMEM over budget: " << smemBytes << " > "
+                                       << kSmemBudgetBytes << " bytes");
+    ok = false;
+  }
+  if (tmemBytes > kTmemBudgetBytes) {
+    LDBG("[Step4] TMEM over budget: " << tmemBytes << " > "
+                                       << kTmemBudgetBytes << " bytes");
+    ok = false;
+  }
+  if (ok)
+    LDBG("[Step4] Budget OK: SMEM=" << smemBytes << "B, TMEM=" << tmemBytes
+                                     << "B");
+  return ok;
+}
+
 /// Top-level: build a ScheduleGraph from DDG + schedule result.
-/// Phase 0 only (DDG→nodes/edges). Buffer allocation is a separate step.
+/// Includes Phase 0 (DDG→nodes/edges) and Phase 1 (buffer allocation).
 static ttg::ScheduleGraph
 buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
                    const ttg::ModuloScheduleResult &sched,
                    const ttg::LatencyModel &model) {
   ttg::ScheduleGraph graph;
   buildScheduleLoop(loop, ddg, sched, graph, model);
+
+  for (auto &schedLoop : graph.loops) {
+    allocateBuffersForLoop(schedLoop);
+    // Step 4: per-loop budget check (Step 4.5 merging + Step 4.6 cross-
+    // region budget come in the next stack diff).
+    checkLoopMemoryBudget(schedLoop);
+  }
+
   return graph;
 }
 


### PR DESCRIPTION
Summary:
Implements Step 3 of the modulo scheduling algorithm (per design doc §215 and Phase 1 row of §131): derive each multi-buffered allocation's depth from its cycle-level live range, then pair every multi-buffered data buffer with a matching BARRIER buffer. The result is rendered through a refreshed `ScheduleGraph::dump()` so the worked example in the doc lines up with what the pass actually emits.

`ScheduleBuffer` (in `ModuloScheduleGraph.h`) gains the fields the doc's §125 type table lists: `liveStart`/`liveEnd` (absolute cycles), `mergeGroupId` (reserved for Step 4.5), `pairedBufferId`, and `defOp`. Helper accessors `sizeBytes()` and `totalBytes()` centralize the per-buffer footprint computation. A new `PhysicalBuffer` struct and `ScheduleLoop::physicalBuffers`/`region{Start,End}` reserve the slots Step 4.5 and Step 4.6 will fill in subsequent diffs.

In `ModuloSchedulePass.cpp`, the new buffer-allocation pipeline runs immediately after the DDG-driven schedule build. `classifyMemoryKind` maps `LocalAllocOp`/`AsyncTMACopyGlobalToLocalOp` to SMEM and `TMEMAllocOp` to TMEM; `extractBufferShape` reads the result `MemDescType`/`RankedTensorType`. `computeLifetimeAndCount` walks each producer's outgoing edges, picks `consumer.cycle + selfLatency + edge.distance * II` as the consumer end (falling back to `latency` when `selfLatency == 0`), and applies `floor(lifetime / II) + 1` per the §215 formula. `allocateBuffersForLoop` orchestrates this and emits a sibling BARRIER for every `count > 1` data buffer.

A new per-loop budget check (`checkLoopMemoryBudget`) enforces the Blackwell sm_100 limits: `kSmemBudgetBytes = 228 KiB` and `kTmemBudgetBytes = 256 KiB` (128 lanes × 512 cols × 4 B). It charges BARRIER bytes against SMEM and is `mergeGroupId`-aware so Step 4.5 plugs in without changing the call site. A `kEstimatedTripCount = 4` named constant is used as the fallback when loop bounds aren't constant-foldable, so `kernel_time_cost` (Step 4.6) gets a finite tripCount rather than zero.

`ModuloScheduleGraph.cpp::dump()` is updated to print the format used in the design doc's worked example: `live=[start, end)` annotations, `merged=<id>` when set, dtype names from a small lookup, and a trailing `modulo.merge_group` block driven by `physicalBuffers`.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D101252136


