### PR TITLE
[AutoWS] Step 4.5/4.6: interval graph coloring for buffer merging + budget reduction (#1294)

### DIFF
--- a/test/TritonGPU/modulo-schedule-graph-budget.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-budget.mlir
@@ -1,0 +1,52 @@
+// REQUIRES: asserts
+// RUN: triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule -debug-only=nvgpu-modulo-schedule 2>&1 | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Test: Step 4 (budget check) + Step 4.5 (buffer merging)
+//   Verify budget passes for a standard GEMM and that buffers with
+//   overlapping lifetimes are NOT merged (separate physical groups).
+//===----------------------------------------------------------------------===//
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// Step 4.5: Merge first (before budget check — reduces memory footprint)
+// Step 4.6: Budget check passes (SMEM ~65KB << 232KB, TMEM ~196KB << 256KB)
+//
+// CHECK: [Step4.5] 6 buffers -> 3 physical groups
+// CHECK: [Step4.6] Budget: SMEM {{[0-9]+}}/{{[0-9]+}} OK, TMEM {{[0-9]+}}/{{[0-9]+}} OK
+tt.func @test_budget_and_merge(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x128xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked>
+
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+
+    scf.yield %c : tensor<128x128xf32, #acc_layout>
+  }
+
+  tt.return
+}
+
+}

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.cpp
@@ -56,8 +56,7 @@ static void dumpNodeOneLine(const ScheduleNode &node, llvm::raw_ostream &os,
       os << "(" << innerName << ")";
   }
   os << "  {pipe: " << getPipelineName(node.pipeline)
-     << ", cycle: " << node.cycle
-     << ", cluster: " << node.cluster;
+     << ", cycle: " << node.cycle << ", cluster: " << node.cluster;
   if (node.latency)
     os << ", latency: " << node.latency;
   if (node.selfLatency)

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -37,37 +37,24 @@ enum class MemoryKind { SMEM, TMEM, Register, BARRIER };
 
 /// A multi-buffered memory allocation.
 /// Represents SMEM or TMEM that needs multiple copies for pipelining.
-///
-/// Per design doc §125 (type table) and §215 (Step 3 worked example): each
-/// buffer carries the absolute live-range cycles (`liveStart`/`liveEnd`)
-/// derived from `producer.cycle` and `last_consumer.cycle + selfLatency`.
-/// The `count` is then `floor((liveEnd - liveStart) / II) + 1`, and Step 4.5
-/// projects `[liveStart, liveEnd) % II` for the modular overlap check.
-///
-/// `mergeGroupId` is filled by Step 4.5 — buffers in the same group share a
-/// physical allocation (size = max(sizeBytes), count = max(count)).
 struct ScheduleBuffer {
   unsigned id{};
   MemoryKind kind{MemoryKind::SMEM};
   llvm::SmallVector<int64_t, 4> shape; // e.g., {128, 64}
   unsigned elementBitWidth{16};        // e.g., 16 for f16
-  unsigned count{1};                   // floor((liveEnd-liveStart)/II) + 1
-
-  // Live interval in absolute cycles within the loop's modulo schedule.
-  // liveStart = producer.cycle.
-  // liveEnd   = max over consumers of (consumer.cycle + consumer.selfLatency
-  //             + edge.distance * II).
-  // Step 4.5 takes these mod II to build the modular overlap intervals.
-  int liveStart{0};
-  int liveEnd{0};
-
-  // Step 4.5 buffer merging: buffers with the same mergeGroupId share a
-  // physical allocation. UINT_MAX = ungrouped (own physical allocation).
-  unsigned mergeGroupId{UINT_MAX};
+  unsigned count{1};                   // number of buffers (from stageDiff + 1)
 
   // For data buffers: index of the corresponding BARRIER buffer (UINT_MAX if
   // none) For barrier buffers: index of the data buffer this barrier guards
   unsigned pairedBufferId{UINT_MAX};
+
+  // Step 4.5: Buffer merging. Buffers with the same mergeGroupId share a
+  // physical allocation. UINT_MAX = not merged (own physical buffer).
+  unsigned mergeGroupId{UINT_MAX};
+
+  // Live interval (cycle-level, for merging analysis)
+  int liveStart{0}; // producer cycle
+  int liveEnd{0};   // last consumer end cycle
 
   // The MLIR op that originally defines this buffer (e.g., local_alloc)
   Operation *defOp{nullptr};
@@ -80,25 +67,23 @@ struct ScheduleBuffer {
       elems *= d;
     return elems * elementBitWidth / 8;
   }
-
-  // Total bytes including multi-buffering. For a merge group, callers should
-  // sum max(sizeBytes) × max(count) across the group instead.
   int64_t totalBytes() const { return sizeBytes() * count; }
 };
 
-/// A merge group materialised by Step 4.5. Buffers with the same
-/// mergeGroupId share a physical allocation of `size × count` bytes.
-/// Doc §1140-1147: "physical_buffers[color] = PhysicalBuffer{
-///   size = max(intervals[r].size for r in resources),
-///   depth = max(intervals[r].depth for r in resources), ... }"
+/// A physical buffer materialized from one or more logical ScheduleBuffers
+/// that share storage via lifetime-aware merging (Step 4.5 / 4.6).
+///
+/// Per design doc §1140-1147: physical size = max(member.sizeBytes),
+/// physical count = max(member.count). Shape is opaque (we only track
+/// bytes — the lowering pass will allocate uint8 storage and reinterpret).
 struct PhysicalBuffer {
   unsigned id{};
   MemoryKind kind{MemoryKind::SMEM};
-  int64_t sizeBytes{0};
-  unsigned count{1};
+  int64_t sizeBytes{0}; // max over members
+  unsigned count{1};    // max over members
   llvm::SmallVector<unsigned, 4> memberBufferIds;
 
-  int64_t totalBytes() const { return sizeBytes * count; }
+  int64_t totalBytes() const { return sizeBytes * static_cast<int64_t>(count); }
 };
 
 // ============================================================================
@@ -191,19 +176,19 @@ struct ScheduleLoop {
   llvm::SmallVector<MemPort, 4> inputs;  // consumed from outer scope
   llvm::SmallVector<MemPort, 4> outputs; // produced for outer scope
 
-  // Multi-buffered allocations within this loop (logical buffers).
+  // Multi-buffered allocations within this loop
   llvm::SmallVector<ScheduleBuffer, 4> buffers;
 
-  // Physical buffer groups produced by Step 4.5 merging. Empty until
-  // mergeBuffers runs. Each PhysicalBuffer.memberBufferIds lists the
-  // ScheduleBuffer ids that share that physical allocation.
+  // Physical buffers materialized from merge groups (populated by Step 4.5).
+  // Each PhysicalBuffer's id matches the mergeGroupId of its member buffers.
   llvm::SmallVector<PhysicalBuffer, 4> physicalBuffers;
 
-  // Absolute kernel-time interval for this loop (set by Step 4.6's
-  // compute_region_intervals). Used for cross-region buffer lifetime
-  // analysis. liveStart=liveEnd=0 means "not yet computed".
-  int regionStart{0};
-  int regionEnd{0};
+  // Absolute kernel-timeline interval for this loop region (Step 4.6).
+  // 0 = unset; populated by computeRegionIntervals before kernel-wide
+  // budget checks. For a non-persistent kernel: prologue + steady-state +
+  // epilogue (all in cycles).
+  int64_t regionStart{0};
+  int64_t regionEnd{0};
 
   // Lookup
   llvm::DenseMap<Operation *, unsigned> opToNodeId;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -24,6 +24,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 
+#include <limits>
+
 #define DEBUG_TYPE "nvgpu-modulo-schedule"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
@@ -114,9 +116,6 @@ static void emitScheduleAttributes(scf::ForOp loop,
 
 // Blackwell sm_100 SMEM budget (reserve some for barriers/scratch).
 constexpr int kSmemBudgetBytes = 228 * 1024;
-
-// Blackwell TMEM budget: 256KB total tensor memory (128 lanes × 512 cols × 4B).
-constexpr int kTmemBudgetBytes = 256 * 1024;
 
 // Fallback trip count when the loop bounds aren't constant-foldable.
 // Used so kernel_time_cost can give a finite (rather than div-by-zero)
@@ -385,48 +384,41 @@ static void extractBufferShape(Operation *op, ttg::ScheduleBuffer &buf) {
 
 /// Step 3: Compute buffer count from cycle-level lifetime.
 ///
-/// Design doc formula (§Step 3):
+/// Design doc formula:
 ///   lifetime(R) = lastConsumerEnd - producerStart
 ///   num_buffers(R) = floor(lifetime(R) / II) + 1
 ///
 /// For loop-carried edges (distance > 0), the consumer in iteration i+d
 /// effectively ends at: consumerEnd + d * II (in absolute time).
 /// This is equivalent to adding d * II to the lifetime.
-///
-/// Returns the absolute cycle range the buffer is live for. The hold time is
-/// `selfLatency` (pipeline occupancy of the consumer) per design doc §414;
-/// `latency` (when the consumer's *output* becomes available) is the edge
-/// weight, not the buffer hold. We fall back to `latency` when `selfLatency`
-/// is 0 (synthetic local_load nodes have selfLat=0 but still need a non-zero
-/// hold time = latency).
-struct LifetimeRange {
-  int liveStart{0};
-  int liveEnd{0};
-  unsigned count{1};
-};
-
-static LifetimeRange computeLifetimeAndCount(const ttg::ScheduleLoop &loop,
-                                              unsigned producerNodeId) {
+static unsigned computeBufferCount(const ttg::ScheduleLoop &loop,
+                                   unsigned producerNodeId) {
   const auto &producer = loop.getNode(producerNodeId);
   int prodCycle = producer.cycle;
   int II = loop.II;
   if (II <= 0)
-    return {prodCycle, prodCycle, 1};
+    return 1;
 
-  // Find the latest DIRECT consumer end cycle.
+  // Find the latest consumer end cycle among direct successors.
+  // The DDG has edges from this producer to every op that reads its
+  // result, so walking outgoing edges covers all consumers.
   int lastConsumerEnd = prodCycle;
   for (const auto &edge : loop.edges) {
     if (edge.srcId != producerNodeId)
       continue;
     const auto &consumer = loop.getNode(edge.dstId);
-    int hold = consumer.selfLatency > 0 ? consumer.selfLatency : consumer.latency;
+    // Consumer hold time: use selfLatency (pipeline occupancy) when
+    // available, falling back to latency (result-ready time). This
+    // matches computeBufferLifetimes so that count and lifetime are
+    // computed consistently.
+    int hold = consumer.selfLatency ? consumer.selfLatency : consumer.latency;
     int consumerEnd = consumer.cycle + hold + edge.distance * II;
     lastConsumerEnd = std::max(lastConsumerEnd, consumerEnd);
   }
 
   int lifetime = lastConsumerEnd - prodCycle;
-  unsigned numBuffers = static_cast<unsigned>(std::max(lifetime / II + 1, 1));
-  return {prodCycle, lastConsumerEnd, numBuffers};
+  int numBuffers = lifetime / II + 1;
+  return static_cast<unsigned>(std::max(numBuffers, 1));
 }
 
 static void allocateBuffersForLoop(ttg::ScheduleLoop &loop) {
@@ -446,10 +438,7 @@ static void allocateBuffersForLoop(ttg::ScheduleLoop &loop) {
     buf.defOp = node.op;
     extractBufferShape(node.op, buf);
 
-    auto life = computeLifetimeAndCount(loop, node.id);
-    buf.liveStart = life.liveStart;
-    buf.liveEnd = life.liveEnd;
-    buf.count = life.count;
+    buf.count = computeBufferCount(loop, node.id);
 
     loop.buffers.push_back(buf);
     node.producesBuffer = bufId;
@@ -470,8 +459,6 @@ static void allocateBuffersForLoop(ttg::ScheduleLoop &loop) {
     bar.id = barId;
     bar.kind = ttg::MemoryKind::BARRIER;
     bar.count = loop.buffers[dataBufId].count;
-    bar.liveStart = loop.buffers[dataBufId].liveStart;
-    bar.liveEnd = loop.buffers[dataBufId].liveEnd;
     bar.defOp = loop.buffers[dataBufId].defOp;
     bar.pairedBufferId = dataBufId;
     loop.buffers[dataBufId].pairedBufferId = barId;
@@ -480,52 +467,499 @@ static void allocateBuffersForLoop(ttg::ScheduleLoop &loop) {
 }
 
 // ============================================================================
-// Step 4: SMEM/TMEM Budget Check
+// Step 4.6: Global Memory Budget Check and Reduction
 // ============================================================================
 
-/// Per design doc §Step 4 (lines 1029-1063): each loop's buffer footprint
-/// must fit within the per-tile SMEM/TMEM budgets. This is the per-loop
-/// check; Step 4.6 (next diff) adds the kernel-wide cross-region check.
-///
-/// Sums `sizeBytes() × count` for each buffer (excluding mergeGroupId
-/// duplicates — though Phase 1 doesn't merge yet, accept the field for
-/// forward compat). BARRIER buffers are charged to SMEM (mbarriers live in
-/// SMEM). Returns true if within budget.
-static bool checkLoopMemoryBudget(const ttg::ScheduleLoop &loop) {
-  int64_t smemBytes = 0;
-  int64_t tmemBytes = 0;
-  llvm::DenseSet<unsigned> seenGroups;
+// Blackwell sm_100 TMEM budget. Logical capacity is 128 lanes × 512 cols ×
+// 4 bytes/col = 256KB.
+constexpr int64_t kTmemBudgetBytes = 128 * 512 * 4;
+
+// Forward decl — defined under Step 4.5 below; called by reduceBuffersForBudget
+// to refresh PhysicalBuffer sizes after a depth reduction.
+static void buildPhysicalBuffers(ttg::ScheduleLoop &loop);
+
+/// Compute total SMEM/TMEM usage. Buffers in the same merge group share
+/// a physical allocation sized to the largest member at the deepest
+/// count, so we charge each group exactly once via its PhysicalBuffer.
+/// Unmerged data buffers and all BARRIER buffers (always SMEM) are
+/// charged individually.
+static int64_t computeTotalMemory(const ttg::ScheduleLoop &loop,
+                                  ttg::MemoryKind targetKind) {
+  int64_t total = 0;
+
+  // Charge each materialized physical buffer once.
+  for (const auto &pb : loop.physicalBuffers) {
+    bool isTarget = (pb.kind == targetKind);
+    if (targetKind == ttg::MemoryKind::SMEM &&
+        pb.kind == ttg::MemoryKind::BARRIER)
+      isTarget = true;
+    if (isTarget)
+      total += pb.totalBytes();
+  }
+
+  // Charge unmerged buffers (mergeGroupId == UINT_MAX) directly.
   for (const auto &buf : loop.buffers) {
-    // For merged groups, charge once at max(size×count). Step 4.5 fills
-    // mergeGroupId; before then this just walks every buffer individually.
-    if (buf.mergeGroupId != UINT_MAX &&
-        !seenGroups.insert(buf.mergeGroupId).second)
+    if (buf.mergeGroupId != UINT_MAX)
       continue;
-    int64_t bytes = buf.totalBytes();
-    if (buf.kind == ttg::MemoryKind::TMEM)
-      tmemBytes += bytes;
-    else // SMEM and BARRIER both use SMEM space
-      smemBytes += bytes;
+    bool isTarget = (buf.kind == targetKind);
+    if (targetKind == ttg::MemoryKind::SMEM &&
+        buf.kind == ttg::MemoryKind::BARRIER)
+      isTarget = true;
+    if (!isTarget)
+      continue;
+    if (buf.kind != ttg::MemoryKind::BARRIER &&
+        (buf.shape.empty() || buf.elementBitWidth == 0))
+      continue;
+    total += buf.totalBytes();
   }
-  bool ok = true;
-  if (smemBytes > kSmemBudgetBytes) {
-    LDBG("[Step4] SMEM over budget: " << smemBytes << " > "
-                                       << kSmemBudgetBytes << " bytes");
-    ok = false;
+  return total;
+}
+
+static int64_t computeTotalSmem(const ttg::ScheduleLoop &loop) {
+  return computeTotalMemory(loop, ttg::MemoryKind::SMEM);
+}
+static int64_t computeTotalTmem(const ttg::ScheduleLoop &loop) {
+  return computeTotalMemory(loop, ttg::MemoryKind::TMEM);
+}
+
+/// Cost (design doc §1437-1477): kernel time increase per byte saved by
+/// reducing this buffer's depth by 1. Lower = greedily reduce first.
+///
+/// new_lifetime_bound = (count - 1) × II. If lifetime exceeds it, the
+/// producer must stall and effective II grows; otherwise depth reduction
+/// is free of latency impact (ii_increase = 0).
+///
+/// time_increase = ii_increase × tripCount  (loop region)
+///               = ii_increase             (non-loop region — single pass)
+/// cost          = time_increase / size_bytes_saved
+static double kernelTimeCost(const ttg::ScheduleLoop &loop,
+                             const ttg::ScheduleBuffer &buf) {
+  if (buf.count <= 1 || buf.kind == ttg::MemoryKind::BARRIER)
+    return std::numeric_limits<double>::infinity();
+  if (loop.II <= 0)
+    return std::numeric_limits<double>::infinity();
+  int lifetime = buf.liveEnd - buf.liveStart;
+  int newCount = static_cast<int>(buf.count) - 1;
+  int newLifetimeBound = newCount * loop.II;
+  int iiIncrease = 0;
+  if (lifetime > newLifetimeBound) {
+    int newII = (lifetime + newCount - 1) / newCount;
+    iiIncrease = newII - loop.II;
   }
-  if (tmemBytes > kTmemBudgetBytes) {
-    LDBG("[Step4] TMEM over budget: " << tmemBytes << " > "
-                                       << kTmemBudgetBytes << " bytes");
-    ok = false;
+  // tripCount of 0 (unknown) → assume 1 to avoid div-by-zero biasing.
+  int tc = loop.tripCount > 0 ? loop.tripCount : 1;
+  double timeIncrease = static_cast<double>(iiIncrease) * tc;
+  // For merged buffers, reducing one member's count may not reduce the
+  // physical allocation if another member has a higher count. This is
+  // a known approximation — the greedy loop still terminates correctly
+  // (all counts reach 1), and buildPhysicalBuffers re-materializes
+  // the true physical sizes after each reduction.
+  int64_t saved = buf.sizeBytes();
+  if (saved <= 0)
+    return std::numeric_limits<double>::infinity();
+  return timeIncrease / static_cast<double>(saved);
+}
+
+/// Step 4.6: Reduce buffer depths until SMEM and TMEM fit. Greedy: at
+/// each step, pick the buffer with the lowest kernel_time_cost per byte
+/// saved. Returns true if within budget.
+static bool reduceBuffersForBudget(ttg::ScheduleLoop &loop) {
+  auto pickWorst = [&](ttg::MemoryKind kind) -> int {
+    int bestIdx = -1;
+    double bestCost = std::numeric_limits<double>::infinity();
+    for (unsigned i = 0; i < loop.buffers.size(); ++i) {
+      const auto &buf = loop.buffers[i];
+      if (buf.kind != kind || buf.count <= 1)
+        continue;
+      double c = kernelTimeCost(loop, buf);
+      if (c < bestCost) {
+        bestCost = c;
+        bestIdx = static_cast<int>(i);
+      }
+    }
+    return bestIdx;
+  };
+
+  auto reduceOne = [&](int idx) {
+    auto &buf = loop.buffers[idx];
+    buf.count--;
+    unsigned barId = buf.pairedBufferId;
+    if (barId != UINT_MAX)
+      loop.buffers[barId].count = buf.count;
+    LLVM_DEBUG(llvm::dbgs()
+               << "[Step4.6] Reduced "
+               << (buf.kind == ttg::MemoryKind::SMEM ? "SMEM" : "TMEM")
+               << " buf" << idx << " to count=" << buf.count
+               << " (cost=" << kernelTimeCost(loop, buf) << ")\n");
+    // Re-materialize merge groups since member depths changed.
+    buildPhysicalBuffers(loop);
+  };
+
+  // Safety bound: total reductions ≤ sum of all buffer counts.
+  unsigned maxIters = 0;
+  for (const auto &buf : loop.buffers)
+    maxIters += buf.count;
+
+  unsigned iters = 0;
+  while (computeTotalSmem(loop) > kSmemBudgetBytes && iters < maxIters) {
+    int idx = pickWorst(ttg::MemoryKind::SMEM);
+    if (idx < 0)
+      break;
+    reduceOne(idx);
+    ++iters;
   }
-  if (ok)
-    LDBG("[Step4] Budget OK: SMEM=" << smemBytes << "B, TMEM=" << tmemBytes
-                                     << "B");
-  return ok;
+  while (computeTotalTmem(loop) > kTmemBudgetBytes && iters < maxIters) {
+    int idx = pickWorst(ttg::MemoryKind::TMEM);
+    if (idx < 0)
+      break;
+    reduceOne(idx);
+    ++iters;
+  }
+
+  int64_t smemUsed = computeTotalSmem(loop);
+  int64_t tmemUsed = computeTotalTmem(loop);
+  bool smemOk = smemUsed <= kSmemBudgetBytes;
+  bool tmemOk = tmemUsed <= kTmemBudgetBytes;
+  LLVM_DEBUG(llvm::dbgs() << "[Step4.6] Budget: SMEM " << smemUsed << "/"
+                          << kSmemBudgetBytes << (smemOk ? " OK" : " EXCEEDED")
+                          << ", TMEM " << tmemUsed << "/" << kTmemBudgetBytes
+                          << (tmemOk ? " OK" : " EXCEEDED") << "\n");
+  if (!smemOk || !tmemOk) {
+    llvm::errs() << "[Step4.6] WARNING: memory budget exceeded after " << iters
+                 << " reductions (all reducible buffers at count=1). "
+                 << "SMEM: " << smemUsed << "/" << kSmemBudgetBytes
+                 << ", TMEM: " << tmemUsed << "/" << kTmemBudgetBytes << "\n";
+  }
+  return smemOk && tmemOk;
+}
+
+// ============================================================================
+// Step 4.5: Lifetime-Aware Buffer Merging
+// ============================================================================
+
+/// Faithful port of design doc §1156-1177 `intervals_overlap_modular`:
+/// project each interval onto [0, II), split if it wraps, then test all
+/// (a-half, b-half) pairs for plain interval overlap.
+static bool intervalsOverlapModularSingle(int aStart, int aEnd, int bStart,
+                                          int bEnd, int II) {
+  if (II <= 0)
+    return true;
+  // Empty intervals can't overlap anything.
+  if (aEnd <= aStart || bEnd <= bStart)
+    return false;
+
+  auto mod = [II](int x) {
+    int r = x % II;
+    return r < 0 ? r + II : r;
+  };
+  int aS = mod(aStart);
+  int aE = mod(aEnd);
+  int bS = mod(bStart);
+  int bE = mod(bEnd);
+  // A live interval whose duration is >= II covers the entire ring.
+  if (aEnd - aStart >= II || bEnd - bStart >= II)
+    return true;
+
+  llvm::SmallVector<std::pair<int, int>, 2> aHalves;
+  if (aS < aE)
+    aHalves.push_back({aS, aE});
+  else if (aS > aE) {
+    aHalves.push_back({aS, II});
+    aHalves.push_back({0, aE});
+  } else {
+    // aS == aE with non-empty original ⇒ wraps fully.
+    return true;
+  }
+  llvm::SmallVector<std::pair<int, int>, 2> bHalves;
+  if (bS < bE)
+    bHalves.push_back({bS, bE});
+  else if (bS > bE) {
+    bHalves.push_back({bS, II});
+    bHalves.push_back({0, bE});
+  } else {
+    return true;
+  }
+  for (auto [s1, e1] : aHalves)
+    for (auto [s2, e2] : bHalves)
+      if (s1 < e2 && s2 < e1)
+        return true;
+  return false;
+}
+
+/// Faithful port of design doc §1180-1203 `any_instances_overlap`.
+/// For each (d1, d2) pair of in-flight buffer instances, shift interval B
+/// by (d2 - d1) * II and test for modular overlap. Two resources can share
+/// a physical buffer only if NO (d1, d2) pair produces overlap.
+static bool anyInstancesOverlap(int aStart, int aEnd, int bStart, int bEnd,
+                                unsigned aDepth, unsigned bDepth, int II) {
+  if (II <= 0)
+    return true;
+  for (unsigned d1 = 0; d1 < std::max(1u, aDepth); ++d1) {
+    for (unsigned d2 = 0; d2 < std::max(1u, bDepth); ++d2) {
+      int offset = (static_cast<int>(d2) - static_cast<int>(d1)) * II;
+      if (intervalsOverlapModularSingle(aStart, aEnd, bStart + offset,
+                                        bEnd + offset, II))
+        return true;
+    }
+  }
+  return false;
+}
+
+/// Compute and store [liveStart, liveEnd) for every data buffer in the loop.
+/// Lifetime is producer cycle → max(consumer.cycle + consumer.selfLatency)
+/// across direct consumer edges, with loop-carried edges adjusted by
+/// distance × II. Paired barriers inherit the data buffer's interval
+/// (per design doc §215).
+static void computeBufferLifetimes(ttg::ScheduleLoop &loop) {
+  if (loop.II <= 0)
+    return;
+  for (auto &buf : loop.buffers) {
+    if (buf.kind == ttg::MemoryKind::BARRIER ||
+        buf.kind == ttg::MemoryKind::Register)
+      continue;
+    for (const auto &node : loop.nodes) {
+      if (node.producesBuffer != buf.id)
+        continue;
+      buf.liveStart = node.cycle;
+      int lastEnd = node.cycle;
+      for (const auto &edge : loop.edges) {
+        if (edge.srcId != node.id)
+          continue;
+        const auto &consumer = loop.getNode(edge.dstId);
+        // Use selfLatency (occupancy) over latency (result-ready) for
+        // the consumer's hold time on the resource.
+        int hold =
+            consumer.selfLatency ? consumer.selfLatency : consumer.latency;
+        int end =
+            consumer.cycle + hold + static_cast<int>(edge.distance) * loop.II;
+        lastEnd = std::max(lastEnd, end);
+      }
+      buf.liveEnd = lastEnd;
+      break;
+    }
+  }
+  // Mirror data-buffer intervals onto their paired barriers.
+  for (auto &bar : loop.buffers) {
+    if (bar.kind != ttg::MemoryKind::BARRIER)
+      continue;
+    if (bar.pairedBufferId == UINT_MAX)
+      continue;
+    const auto &data = loop.buffers[bar.pairedBufferId];
+    bar.liveStart = data.liveStart;
+    bar.liveEnd = data.liveEnd;
+  }
+}
+
+/// Cycle-freedom check (design doc §1129-1137 / §1216): merging buffers A
+/// and B adds an implicit edge "last_consumer_of_A happens-before
+/// producer_of_B". Reject the merge if it would create a cycle in the
+/// node-level dependency graph.
+///
+/// We model the merge as a candidate edge (last_consumer(B'), producer(A))
+/// added per pair, where (A, B') ranges over (existing group members,
+/// candidate). Run a forward reachability from producer(A) over all real
+/// edges PLUS the prospective merge edges; if producer(B') is reachable
+/// before the new edge is added the other direction, we'd close a cycle.
+static bool mergeIntroducesCycle(const ttg::ScheduleLoop &loop,
+                                 llvm::ArrayRef<unsigned> groupMembers,
+                                 unsigned candidate) {
+  // Collect (producer, lastConsumer) per buffer in {groupMembers + candidate}.
+  auto findProducer = [&](unsigned bufId) -> unsigned {
+    for (const auto &n : loop.nodes)
+      if (n.producesBuffer == bufId)
+        return n.id;
+    return UINT_MAX;
+  };
+  auto lastConsumers = [&](unsigned bufId) {
+    llvm::SmallVector<unsigned, 4> result;
+    unsigned prodId = findProducer(bufId);
+    if (prodId == UINT_MAX)
+      return result;
+    for (const auto &e : loop.edges)
+      if (e.srcId == prodId)
+        result.push_back(e.dstId);
+    return result;
+  };
+
+  // Build adjacency for plain DDG (intra-iteration edges only — cross-
+  // iteration edges close their own loops, which is fine).
+  llvm::DenseMap<unsigned, llvm::SmallVector<unsigned, 4>> adj;
+  for (const auto &e : loop.edges)
+    if (e.distance == 0)
+      adj[e.srcId].push_back(e.dstId);
+
+  // Collect candidate-induced edges: for every existing member M and the
+  // candidate C, both directions of "last_consumer happens-before producer"
+  // are added as additional edges to test. Coloring will pick a serial
+  // order, but for the cycle test, both possibilities are checked.
+  llvm::SmallVector<std::pair<unsigned, unsigned>, 8> proposed;
+  auto addPair = [&](unsigned aBuf, unsigned bBuf) {
+    unsigned bProd = findProducer(bBuf);
+    if (bProd == UINT_MAX)
+      return;
+    for (unsigned cons : lastConsumers(aBuf))
+      proposed.push_back({cons, bProd});
+  };
+  for (unsigned m : groupMembers) {
+    addPair(m, candidate);
+    addPair(candidate, m);
+  }
+
+  // BFS from each proposed edge's source over (real edges + all proposed
+  // edges except itself); a cycle exists iff we can reach back to itself.
+  for (size_t i = 0; i < proposed.size(); ++i) {
+    auto [src, dst] = proposed[i];
+    llvm::DenseSet<unsigned> visited;
+    llvm::SmallVector<unsigned, 16> stack{dst};
+    while (!stack.empty()) {
+      unsigned u = stack.pop_back_val();
+      if (!visited.insert(u).second)
+        continue;
+      if (u == src)
+        return true;
+      for (unsigned v : adj.lookup(u))
+        stack.push_back(v);
+      for (size_t j = 0; j < proposed.size(); ++j)
+        if (j != i && proposed[j].first == u)
+          stack.push_back(proposed[j].second);
+    }
+  }
+  return false;
+}
+
+/// Cost guard (design doc §1418-1429): merging is only beneficial when
+/// max(size) × max(count) < sum(size × count). Otherwise, the physical
+/// buffer (sized to the largest member with the deepest count) wastes
+/// more memory than separate allocations.
+static bool shouldMerge(const ttg::ScheduleLoop &loop,
+                        llvm::ArrayRef<unsigned> groupMembers,
+                        unsigned candidate) {
+  int64_t separateCost = 0;
+  int64_t maxSize = 0;
+  unsigned maxCount = 0;
+  auto accum = [&](unsigned bufId) {
+    const auto &b = loop.buffers[bufId];
+    int64_t sz = b.sizeBytes();
+    separateCost += sz * static_cast<int64_t>(b.count);
+    maxSize = std::max(maxSize, sz);
+    maxCount = std::max(maxCount, b.count);
+  };
+  for (unsigned m : groupMembers)
+    accum(m);
+  accum(candidate);
+  int64_t mergedCost = maxSize * static_cast<int64_t>(maxCount);
+  return mergedCost < separateCost;
+}
+
+/// Materialize PhysicalBuffer entries from each merge group. Per design
+/// doc §1140-1147: physical size = max(member.sizeBytes), physical count =
+/// max(member.count).
+static void buildPhysicalBuffers(ttg::ScheduleLoop &loop) {
+  loop.physicalBuffers.clear();
+  llvm::DenseMap<unsigned, unsigned> groupToPhys;
+  for (const auto &buf : loop.buffers) {
+    if (buf.mergeGroupId == UINT_MAX)
+      continue;
+    auto it = groupToPhys.find(buf.mergeGroupId);
+    if (it == groupToPhys.end()) {
+      ttg::PhysicalBuffer pb;
+      pb.id = buf.mergeGroupId;
+      pb.kind = buf.kind;
+      pb.sizeBytes = buf.sizeBytes();
+      pb.count = buf.count;
+      pb.memberBufferIds.push_back(buf.id);
+      groupToPhys[buf.mergeGroupId] = loop.physicalBuffers.size();
+      loop.physicalBuffers.push_back(std::move(pb));
+    } else {
+      auto &pb = loop.physicalBuffers[it->second];
+      pb.sizeBytes = std::max(pb.sizeBytes, buf.sizeBytes());
+      pb.count = std::max(pb.count, buf.count);
+      pb.memberBufferIds.push_back(buf.id);
+    }
+  }
+}
+
+/// Step 4.5: Merge buffers with non-overlapping lifetimes.
+/// Greedy interval-graph coloring with three guards:
+///   1. Same storage kind (SMEM only merges with SMEM).
+///   2. No modular interval overlap across all (d1, d2) buffer instances.
+///   3. should_merge cost guard — never inflate memory by merging.
+///   4. Cycle-freedom — never introduce a deadlock-prone dependency.
+static void mergeNonOverlappingBuffers(ttg::ScheduleLoop &loop) {
+  if (loop.II <= 0)
+    return;
+  computeBufferLifetimes(loop);
+
+  unsigned nextGroupId = 0;
+  llvm::SmallVector<llvm::SmallVector<unsigned, 4>, 4> groups;
+
+  for (unsigned i = 0; i < loop.buffers.size(); ++i) {
+    auto &buf = loop.buffers[i];
+    if (buf.kind == ttg::MemoryKind::BARRIER ||
+        buf.kind == ttg::MemoryKind::Register)
+      continue;
+    // Skip buffers with zero-length lifetime — they have no producer/
+    // consumer pattern we can reason about and shouldn't be merged blindly.
+    if (buf.liveEnd == buf.liveStart)
+      continue;
+
+    bool merged = false;
+    for (unsigned g = 0; g < groups.size(); ++g) {
+      bool canMerge = true;
+      for (unsigned memberIdx : groups[g]) {
+        const auto &member = loop.buffers[memberIdx];
+        if (member.kind != buf.kind) {
+          canMerge = false;
+          break;
+        }
+        if (anyInstancesOverlap(member.liveStart, member.liveEnd, buf.liveStart,
+                                buf.liveEnd, member.count, buf.count,
+                                loop.II)) {
+          canMerge = false;
+          break;
+        }
+      }
+      if (!canMerge)
+        continue;
+      if (!shouldMerge(loop, groups[g], i)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[Step4.5] Skip merge buf" << i << " into group " << g
+                   << " (cost guard: would inflate)\n");
+        continue;
+      }
+      if (mergeIntroducesCycle(loop, groups[g], i)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[Step4.5] Skip merge buf" << i << " into group " << g
+                   << " (would create dependency cycle)\n");
+        continue;
+      }
+      buf.mergeGroupId = g;
+      groups[g].push_back(i);
+      merged = true;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[Step4.5] Merged buf" << i << " into group " << g
+                 << " (live=[" << buf.liveStart << "," << buf.liveEnd << "), "
+                 << (buf.kind == ttg::MemoryKind::SMEM ? "SMEM" : "TMEM")
+                 << ")\n");
+      break;
+    }
+    if (!merged) {
+      buf.mergeGroupId = nextGroupId;
+      groups.push_back({i});
+      nextGroupId++;
+    }
+  }
+
+  buildPhysicalBuffers(loop);
+
+  LLVM_DEBUG(llvm::dbgs() << "[Step4.5] " << loop.buffers.size()
+                          << " buffers -> " << loop.physicalBuffers.size()
+                          << " physical groups\n");
 }
 
 /// Top-level: build a ScheduleGraph from DDG + schedule result.
-/// Includes Phase 0 (DDG→nodes/edges) and Phase 1 (buffer allocation).
+/// Includes Phase 0 (DDG→nodes/edges), Step 2.5 (clusters),
+/// Step 3 (buffer allocation), Step 4.5 (merging), Step 4.6 (budget).
 static ttg::ScheduleGraph
 buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
                    const ttg::ModuloScheduleResult &sched,
@@ -534,10 +968,15 @@ buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
   buildScheduleLoop(loop, ddg, sched, graph, model);
 
   for (auto &schedLoop : graph.loops) {
+    // Step 3: Buffer allocation (cycle-based depths)
     allocateBuffersForLoop(schedLoop);
-    // Step 4: per-loop budget check (Step 4.5 merging + Step 4.6 cross-
-    // region budget come in the next stack diff).
-    checkLoopMemoryBudget(schedLoop);
+
+    // Step 4.5: Merge non-overlapping buffers (before budget check —
+    // merging reduces memory footprint, giving tighter budget).
+    mergeNonOverlappingBuffers(schedLoop);
+
+    // Step 4.6: Global memory budget check and reduction.
+    reduceBuffersForBudget(schedLoop);
   }
 
   return graph;
@@ -574,7 +1013,6 @@ struct ModuloSchedulePass
   void runOnOperation() override {
     auto moduleOp = getOperation();
     ttg::LatencyModel model;
-
 
     // Find innermost loops with TMA loads or MMA ops.
     SmallVector<scf::ForOp> innerLoops;
@@ -629,9 +1067,9 @@ struct ModuloSchedulePass
             continue;
           int cycle = it->second;
           int stage = cycle / schedResult->II;
-          llvm::dbgs() << "[PASS-A]   N" << node.idx
-                       << "  cycle=" << cycle << "  stage=" << stage
-                       << "  " << ttg::getPipelineName(node.pipeline)
+          llvm::dbgs() << "[PASS-A]   N" << node.idx << "  cycle=" << cycle
+                       << "  stage=" << stage << "  "
+                       << ttg::getPipelineName(node.pipeline)
                        << "  selfLat=" << node.selfLatency << "  ";
           node.op->print(
               llvm::dbgs(),
@@ -660,8 +1098,7 @@ struct ModuloSchedulePass
           buildScheduleGraph(innerLoop, ddg, *schedResult, model);
 
       LLVM_DEBUG({
-        llvm::dbgs()
-            << "[PASS-A] === Inner Loop ScheduleGraph ===\n";
+        llvm::dbgs() << "[PASS-A] === Inner Loop ScheduleGraph ===\n";
         pipelineGraph.dump();
       });
       if (printScheduleGraph) {
@@ -715,9 +1152,9 @@ struct ModuloSchedulePass
             continue;
           int cycle = it->second;
           int stage = cycle / outerSched->II;
-          llvm::dbgs() << "[PASS-A]   N" << node.idx
-                       << "  cycle=" << cycle << "  stage=" << stage
-                       << "  " << ttg::getPipelineName(node.pipeline)
+          llvm::dbgs() << "[PASS-A]   N" << node.idx << "  cycle=" << cycle
+                       << "  stage=" << stage << "  "
+                       << ttg::getPipelineName(node.pipeline)
                        << "  selfLat=" << node.selfLatency << "  "
                        << node.op->getName().getStringRef() << "\n";
         }
@@ -744,7 +1181,6 @@ struct ModuloSchedulePass
       for (auto &op : outerLoop.getBody()->without_terminator())
         op.removeAttr("tt.modulo_cycle");
     }
-
   }
 };
 


### PR DESCRIPTION
Summary:

Implements design doc Step 4.5 (lifetime-aware buffer merging) and Step 4.6 (global memory budget check with kernel-time-cost-driven reduction) on the ScheduleGraph. The two passes run in order — merge first to shrink the footprint, then check the budget against the post-merge total — matching §1208: "Merging strictly reduces memory usage, so configurations that previously required depth reduction may now fit within budget."

Step 4.5 is a faithful port of `merge_buffers` (§1080-1150). Lifetimes are computed in cycles (`producer.cycle` to `max(consumer.cycle + selfLatency + distance × II)`), then projected onto `[0, II)` and checked for modular overlap by `intervalsOverlapModularSingle` (port of §1156-1177) and `anyInstancesOverlap`, which iterates the `(d1, d2)` in-flight instance pairs and shifts the second interval by `(d2 - d1) × II` (port of §1180-1203). Earlier revisions of this code projected incorrectly and iterated the wrong offset range; this revision matches the design doc exactly.

The merge assignment itself is **classic greedy first-fit interval graph coloring** (§1124-1127): each buffer is a node, conflicting modular intervals are edges, and `mergeNonOverlappingBuffers` walks buffers in order, assigning each to the first existing color whose members all pass three guards — same storage kind, no `anyInstancesOverlap`, and `shouldMerge` (§1418-1429: only merge when `max(size) × max(count) < sum(size × count)`, otherwise the physical allocation wastes more than separate ones). A fourth guard, `mergeIntroducesCycle` (§1129-1137 / §1216), runs a BFS over real edges plus the prospective implicit "last_consumer(A) happens-before producer(B)" edges in both directions; the merge is rejected if it would close a cycle. Each color materializes one `PhysicalBuffer` with `sizeBytes = max(member.sizeBytes())`, `count = max(member.count)`, and a list of contributing buffer ids (§1140-1147). Paired barriers inherit the data buffer's lifetime per §215.

Step 4.6 (`reduceBuffersForBudget`) implements the doc's `kernel_time_cost`-driven greedy reducer (§1437-1477). When SMEM (228 KB) or TMEM (256 KB) is exceeded, it picks the buffer with the lowest cost = `(II_increase × tripCount) / size_bytes_saved`, decrements its `count`, mirrors the change onto the paired barrier, and rebuilds physical buffers. Reducing a buffer with slack (`lifetime ≤ (count-1) × II`) costs zero II; otherwise the new II is `ceil(lifetime / (count-1))`. Multiplying by `tripCount` automatically prioritises low-trip-count regions (epilogue, prologue) over hot K-loop buffers.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D101263328


