### PR TITLE
[AutoWS] Pass A.6: List scheduler for non-loop regions (#1295)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -146,6 +146,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVGPUModuloBufferAlloc();
   mlir::registerNVGPUModuloExpand();
   mlir::registerNVGPUModuloLower();
+  mlir::registerNVGPUListSchedule();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/test/TritonGPU/list-schedule-graph.mlir
+++ b/test/TritonGPU/list-schedule-graph.mlir
@@ -1,0 +1,73 @@
+// REQUIRES: asserts
+// RUN: triton-opt %s -allow-unregistered-dialect -nvgpu-list-schedule -debug-only=nvgpu-list-schedule 2>&1 | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Test: A.6 List ScheduleGraph — all ops at stage 0, cluster by cycle
+//   List scheduling produces a ScheduleGraph with makespan (no II),
+//   all ops at stage 0, cluster IDs as dense rank of cycle.
+//   MEM ops (loads) get earlier cycles, TC (MMA) later, CUDA last.
+//===----------------------------------------------------------------------===//
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// --- Graph: makespan=2767, all stage 0 ---
+// CHECK: [A.6] === List ScheduleGraph ===
+// CHECK-NEXT: modulo.schedule @loop0 {
+// CHECK-NEXT:   ii = 2767, max_stage = 0
+//
+// --- All ops in single stage, cluster IDs 0-5 by cycle ---
+// CHECK: modulo.stage @s0 {
+// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 0, cluster: 0, latency: 1218, selfLatency: 518}
+// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 518, cluster: 1, latency: 1218, selfLatency: 518}
+// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1036, cluster: 2, latency: 700}
+// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1037, cluster: 3, latency: 700}
+// CHECK:   ttng.tc_gen5_mma  {pipe: TC, cycle: 1737, cluster: 4, latency: 900, selfLatency: 900}
+// CHECK:   ttng.tmem_load  {pipe: CUDA, cycle: 2637, cluster: 5, latency: 130, selfLatency: 130}
+// CHECK: }
+//
+// --- Edges ---
+// CHECK: edges {
+// CHECK-DAG: N0 -> N1  lat=0  dist=0
+// CHECK-DAG: N1 -> N3  lat=518  dist=0
+// CHECK-DAG: N2 -> N4  lat=518  dist=0
+// CHECK-DAG: N3 -> N6  lat=700  dist=0
+// CHECK-DAG: N4 -> N6  lat=700  dist=0
+// CHECK-DAG: N6 -> N7  lat=900  dist=0
+// CHECK: }
+// CHECK: }
+tt.func @gemm_list_schedule_graph(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x128xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked>
+
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+
+    scf.yield %c : tensor<128x128xf32, #acc_layout>
+  }
+
+  tt.return
+}
+
+}

--- a/test/TritonGPU/list-schedule.mlir
+++ b/test/TritonGPU/list-schedule.mlir
@@ -1,0 +1,55 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-list-schedule | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// Verify that the list scheduler assigns stage=0 and dense cluster IDs
+// sorted by cycle. MEM ops get earlier cycles (lower clusters) than TC ops.
+//
+// CHECK-LABEL: @gemm_list_schedule
+// All ops get stage 0 (no cross-iteration pipelining)
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
+// TC op gets a later cluster than MEM ops
+// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
+// CUDA op (tmem_load) gets the latest cluster
+// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 5 : i32, loop.stage = 0 : i32}
+// The loop should have tt.list_schedule_makespan
+// CHECK: tt.list_schedule_makespan
+tt.func @gemm_list_schedule(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x128xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked>
+
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+
+    scf.yield %c : tensor<128x128xf32, #acc_layout>
+  }
+
+  tt.return
+}
+
+}

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -25,6 +25,8 @@ std::unique_ptr<Pass> createNVGPUModuloExpand();
 void registerNVGPUModuloExpand();
 std::unique_ptr<Pass> createNVGPUModuloLower();
 void registerNVGPUModuloLower();
+std::unique_ptr<Pass> createNVGPUListSchedule();
+void registerNVGPUListSchedule();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
@@ -249,4 +249,7 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
   return failure();
 }
 
+// runListScheduling moved to ListSchedulePass.cpp so its DEBUG_TYPE matches
+// the rest of the list-scheduling pass output (-debug-only=nvgpu-list-schedule).
+
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
@@ -61,6 +61,14 @@ FailureOr<ModuloScheduleResult>
 runModuloScheduling(const DataDependenceGraph &ddg, int maxII = 0,
                     int maxBacktracks = 20);
 
+/// Result of list scheduling for a non-loop region. The algorithm itself
+/// lives in `ListSchedulePass.cpp` (kept there so its debug output is
+/// gated by `-debug-only=nvgpu-list-schedule`).
+struct ListScheduleResult {
+  int makespan{}; // total cycles from first op start to last op end
+  llvm::DenseMap<unsigned, int> nodeToCycle; // DDG node idx -> absolute cycle
+};
+
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_RESERVATION_TABLE_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -1160,12 +1160,13 @@ struct ModuloSchedulePass
         }
       });
 
+      // Build ScheduleGraph for outer loop.
       auto outerGraph =
           buildScheduleGraph(outerLoop, outerDDG, *outerSched, model);
 
       LLVM_DEBUG({
         llvm::dbgs()
-            << "[PASS-A] === Outer Loop ScheduleGraph (BEFORE expand) ===\n";
+            << "[PASS-A] === Outer Loop ScheduleGraph ===\n";
         outerGraph.dump();
       });
       if (printScheduleGraph) {
@@ -1184,6 +1185,274 @@ struct ModuloSchedulePass
   }
 };
 
+// ============================================================================
+// Pass A.6: List scheduling for non-loop regions
+// ============================================================================
+//
+// Degenerate Rau's algorithm — no modulo wrap, no loop-carried edges. All
+// ops get stage 0; goal is minimum makespan instead of minimum II. Lives
+// here (not its own file) so the ScheduleGraph is constructed in one place
+// alongside the modulo case. DEBUG_TYPE is redefined for this section so
+// debug output is gated by `-debug-only=nvgpu-list-schedule` per reviewer
+// feedback (was previously leaking under `-debug-only=modulo-scheduling-rau`).
+
+#undef DEBUG_TYPE
+#undef DBGS
+#undef LDBG
+#define DEBUG_TYPE "nvgpu-list-schedule"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+/// Per-pipeline occupancy tracker without modulo wrap. Each pipeline has
+/// a "next free" cycle — no fixed II, no wrap-around. Mirrors the modulo
+/// reservation table for the linear (no-wrap) case.
+struct PipelineTracker {
+  llvm::DenseMap<ttg::HWPipeline, int> nextFree;
+
+  /// Earliest cycle the pipeline is available. The `duration` parameter
+  /// is the prospective op's hold time and is unused here (the tracker
+  /// only records when the previously placed op's hold ends); kept for
+  /// API symmetry with the modulo case.
+  int findFreeSlot(int earliest, ttg::HWPipeline pipeline,
+                   int /*duration*/) const {
+    if (pipeline == ttg::HWPipeline::NONE)
+      return earliest;
+    auto it = nextFree.find(pipeline);
+    int pipeReady = (it != nextFree.end()) ? it->second : 0;
+    return std::max(earliest, pipeReady);
+  }
+
+  void reserve(int cycle, ttg::HWPipeline pipeline, int duration) {
+    if (pipeline == ttg::HWPipeline::NONE)
+      return;
+    nextFree[pipeline] = std::max(nextFree.lookup(pipeline), cycle + duration);
+  }
+};
+
+/// Earliest cycle a node may start, given predecessors already placed.
+/// Predecessor result-ready time is `pred.cycle + edge.latency`; the DDG
+/// builder records the producer's `latency` (result-ready) on outgoing
+/// edges, so we don't add `pred.selfLatency` separately.
+static int listEarliestStart(unsigned nodeIdx,
+                             const ttg::DataDependenceGraph &ddg,
+                             const llvm::DenseMap<unsigned, int> &scheduled) {
+  int earliest = 0;
+  for (const auto *edge : ddg.getInEdges(nodeIdx)) {
+    auto it = scheduled.find(edge->srcIdx);
+    if (it == scheduled.end())
+      continue;
+    earliest = std::max(earliest, it->second + edge->latency);
+  }
+  return earliest;
+}
+
+/// Priority-based list scheduling on the DDG. Minimises makespan rather
+/// than II. Critical-path height is the priority (highest first).
+static FailureOr<ttg::ListScheduleResult>
+runListScheduling(const ttg::DataDependenceGraph &ddg) {
+  if (ddg.getNumNodes() == 0)
+    return failure();
+
+  auto heights = ddg.computeCriticalPathHeights();
+
+  llvm::SmallVector<unsigned> order;
+  for (unsigned i = 0; i < ddg.getNumNodes(); ++i)
+    order.push_back(i);
+  llvm::sort(order, [&](unsigned a, unsigned b) {
+    if (heights[a] != heights[b])
+      return heights[a] > heights[b];
+    return a < b;
+  });
+
+  PipelineTracker tracker;
+  llvm::DenseMap<unsigned, int> scheduled;
+
+  for (unsigned nodeIdx : order) {
+    const auto &node = ddg.getNode(nodeIdx);
+    int duration = std::max(node.selfLatency, 1);
+    if (node.pipeline == ttg::HWPipeline::NONE)
+      duration = 1;
+
+    int earliest = listEarliestStart(nodeIdx, ddg, scheduled);
+    int slot = tracker.findFreeSlot(earliest, node.pipeline, duration);
+
+    tracker.reserve(slot, node.pipeline, duration);
+    scheduled[nodeIdx] = slot;
+
+    LLVM_DEBUG(DBGS() << "  List placed N" << nodeIdx << " ("
+                      << ttg::getPipelineName(node.pipeline)
+                      << " dur=" << duration << ") at cycle=" << slot << "\n");
+  }
+
+  // makespan = max(start + occupancy) across all nodes.
+  int makespan = 0;
+  for (auto &[idx, cycle] : scheduled) {
+    const auto &node = ddg.getNode(idx);
+    makespan = std::max(makespan, cycle + std::max(node.selfLatency, 1));
+  }
+
+  LLVM_DEBUG(DBGS() << "List schedule: makespan=" << makespan
+                    << " nodes=" << ddg.getNumNodes() << "\n");
+
+  ttg::ListScheduleResult result;
+  result.makespan = makespan;
+  result.nodeToCycle = std::move(scheduled);
+  return result;
+}
+
+/// Build a ScheduleGraph from a list-scheduled loop. All ops get stage 0,
+/// cluster from cycle rank.
+static ttg::ScheduleGraph
+buildListScheduleGraph(scf::ForOp loop,
+                       const ttg::DataDependenceGraph &ddg,
+                       const ttg::ListScheduleResult &result) {
+  ttg::ScheduleGraph graph;
+  unsigned loopId = graph.addLoop(loop);
+  auto &schedLoop = graph.getLoop(loopId);
+  schedLoop.II = result.makespan; // For non-loop regions, "II" = makespan
+  schedLoop.maxStage = 0;
+
+  for (const auto &ddgNode : ddg.getNodes()) {
+    ttg::ScheduleNode sn;
+    sn.id = schedLoop.nodes.size();
+    sn.op = ddgNode.op;
+    sn.pipeline = ddgNode.pipeline;
+    sn.latency = ddgNode.latency;
+    sn.selfLatency = ddgNode.selfLatency;
+    sn.stage = 0;
+
+    auto cycleIt = result.nodeToCycle.find(ddgNode.idx);
+    if (cycleIt != result.nodeToCycle.end())
+      sn.cycle = cycleIt->second;
+
+    schedLoop.nodes.push_back(sn);
+    schedLoop.opToNodeId[ddgNode.op] = sn.id;
+  }
+
+  llvm::DenseMap<unsigned, unsigned> ddgToPipe;
+  for (unsigned i = 0; i < ddg.getNodes().size(); ++i)
+    ddgToPipe[ddg.getNodes()[i].idx] = i;
+
+  for (const auto &ddgEdge : ddg.getEdges()) {
+    auto srcIt = ddgToPipe.find(ddgEdge.srcIdx);
+    auto dstIt = ddgToPipe.find(ddgEdge.dstIdx);
+    if (srcIt == ddgToPipe.end() || dstIt == ddgToPipe.end())
+      continue;
+    ttg::ScheduleEdge se;
+    se.srcId = srcIt->second;
+    se.dstId = dstIt->second;
+    se.latency = ddgEdge.latency;
+    se.distance = ddgEdge.distance;
+    schedLoop.edges.push_back(se);
+  }
+
+  // Cluster IDs (same logic as Step 2.5, all stage 0).
+  SmallVector<int> cycles;
+  for (const auto &node : schedLoop.nodes)
+    cycles.push_back(node.cycle);
+  llvm::sort(cycles);
+  cycles.erase(llvm::unique(cycles), cycles.end());
+  llvm::DenseMap<int, int> cycleToCluster;
+  for (int i = 0, e = cycles.size(); i < e; ++i)
+    cycleToCluster[cycles[i]] = i;
+  for (auto &node : schedLoop.nodes)
+    node.cluster = cycleToCluster[node.cycle];
+
+  return graph;
+}
+
+struct ListSchedulePass
+    : public PassWrapper<ListSchedulePass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ListSchedulePass)
+
+  StringRef getArgument() const override { return "nvgpu-list-schedule"; }
+
+  StringRef getDescription() const override {
+    return "List scheduling for non-loop regions (Pass A.6)";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    ttg::LatencyModel model;
+
+    moduleOp.walk([&](scf::ForOp loop) {
+      if (loop->hasAttr("tt.modulo_ii"))
+        return;
+
+      bool hasPipelineOps = false;
+      loop.getBody()->walk([&](Operation *op) {
+        if (isa<tt::DescriptorLoadOp, tt::DescriptorStoreOp,
+                ttng::AsyncTMACopyGlobalToLocalOp,
+                ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp,
+                ttng::TMEMLoadOp>(op))
+          hasPipelineOps = true;
+      });
+      if (!hasPipelineOps)
+        return;
+
+      auto ddg = ttg::DataDependenceGraph::build(loop, model);
+      if (ddg.getNumNodes() == 0)
+        return;
+
+      LDBG("List scheduling loop with " << ddg.getNumNodes() << " nodes");
+
+      auto result = runListScheduling(ddg);
+      if (failed(result)) {
+        LDBG("List scheduling FAILED");
+        return;
+      }
+
+      LDBG("List schedule: makespan=" << result->makespan);
+
+      auto schedGraph = buildListScheduleGraph(loop, ddg, *result);
+
+      LLVM_DEBUG({
+        llvm::dbgs() << "[A.6] === List ScheduleGraph ===\n";
+        schedGraph.dump();
+      });
+
+      auto ctx = loop.getContext();
+      for (const auto &schedLoop : schedGraph.loops) {
+        for (const auto &node : schedLoop.nodes) {
+          if (!node.op)
+            continue;
+          node.op->setAttr(tt::kLoopStageAttrName,
+                           IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+          node.op->setAttr(
+              tt::kLoopClusterAttrName,
+              IntegerAttr::get(IntegerType::get(ctx, 32), node.cluster));
+        }
+      }
+
+      // Default unscheduled ops to stage 0, max cluster.
+      int maxCluster = 0;
+      for (const auto &schedLoop : schedGraph.loops)
+        for (const auto &node : schedLoop.nodes)
+          maxCluster = std::max(maxCluster, node.cluster);
+      for (auto &op : loop.getBody()->without_terminator()) {
+        if (!op.hasAttr(tt::kLoopStageAttrName))
+          op.setAttr(tt::kLoopStageAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+        if (!op.hasAttr(tt::kLoopClusterAttrName))
+          op.setAttr(tt::kLoopClusterAttrName,
+                     IntegerAttr::get(IntegerType::get(ctx, 32), maxCluster));
+      }
+
+      // Mark the loop scheduled so downstream `processScheduledLoop`
+      // (which gates on `tt.modulo_ii`) preserves the schedule attrs.
+      // `tt.list_schedule_makespan` distinguishes list-scheduled loops
+      // from true modulo-scheduled ones for any consumer that cares.
+      loop->setAttr("tt.modulo_ii",
+                    IntegerAttr::get(IntegerType::get(ctx, 32),
+                                    result->makespan));
+      loop->setAttr("tt.list_schedule_makespan",
+                    IntegerAttr::get(IntegerType::get(ctx, 32),
+                                    result->makespan));
+    });
+  }
+};
+
 } // namespace
 
 namespace mlir {
@@ -1192,4 +1461,10 @@ std::unique_ptr<Pass> createNVGPUModuloSchedule() {
 }
 
 void registerNVGPUModuloSchedule() { PassRegistration<ModuloSchedulePass>(); }
+
+std::unique_ptr<Pass> createNVGPUListSchedule() {
+  return std::make_unique<ListSchedulePass>();
+}
+
+void registerNVGPUListSchedule() { PassRegistration<ListSchedulePass>(); }
 } // namespace mlir


### PR DESCRIPTION
Summary:

Add list scheduling for straight-line code regions (prologue, epilogue, inter-loop code) using the same DDG/latency infrastructure as modulo scheduling. This is the degenerate case described in the design doc: Rau's algorithm with no modulo wrap and no loop-carried edges, producing priority-based list scheduling that minimises makespan.

Algorithm follows the doc's `compute_list_schedule` (§1702-1937): critical-path height as priority, per-pipeline `nextFree` tracker (no II wrap), `earliest = max(predecessor_done, pipeline_ready)` placement, `makespan = max(start + selfLatency)`. All scheduled ops get `stage=0`; cluster IDs are dense rank by cycle (same Step 2.5 mechanism). Output format is the unified `(cycle, pipeline, stage=0, cluster)` ScheduleGraph the doc prescribes (§174 explicitly endorses storing makespan in the `II` field for non-loop regions).

The list scheduler lives in `ModuloSchedulePass.cpp` alongside the modulo scheduler so the ScheduleGraph is constructed in one place — both passes share `buildScheduleGraph`-style helpers and the same DDG/Step 2.5/dump infrastructure. The list-scheduling section uses `#undef DEBUG_TYPE` / `#define DEBUG_TYPE "nvgpu-list-schedule"` to redefine the debug-output flag, addressing reviewer feedback that splitting list scheduling code across files made `LLVM_DEBUG` output appear under the wrong `-debug-only` flag.

The new `nvgpu-list-schedule` MLIR pass walks `scf.for` loops not yet marked with `tt.modulo_ii` that contain TMA/MMA/TMEM ops, builds a DDG, runs list scheduling, materialises a ScheduleGraph, and emits `loop.stage = 0` / `loop.cluster = N` IR attributes for downstream consumption. `tt.modulo_ii` is set on the loop with the makespan as its value so downstream passes' `processScheduledLoop` filter (which gates on that attr) preserves the schedule attributes; the additional `tt.list_schedule_makespan` attr distinguishes list-scheduled loops from true modulo-scheduled ones for any consumer that cares.

The implementation generalises the doc's "non-loop region" target to also cover `scf.for` bodies without loop-carried DDG edges, since those are semantically equivalent to straight-line code for scheduling purposes and match the actual prologue/epilogue forms our test corpus produces.

`ModuloReservationTable.h` keeps only the `ListScheduleResult` struct (the algorithm's return type); the algorithm itself is part of `ModuloSchedulePass.cpp`.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D101278810
