### PR TITLE
[triton][beta] Fix WGMMA descriptor register pressure regression

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -52,8 +52,9 @@ class DotOpMmaSmemLoader : public DotOpMmaMemLoader {
 public:
   DotOpMmaSmemLoader() = default;
 
-  DotOpMmaSmemLoader(MMASMEMDescriptor desc, Value baseb128, LinearLayout llInv)
-      : desc(desc), baseb128(baseb128), ll(std::move(llInv)) {}
+  DotOpMmaSmemLoader(MMASMEMDescriptor desc, Value baseSrcb128,
+                     LinearLayout llInv)
+      : desc(desc), baseSrcb128(baseSrcb128), ll(std::move(llInv)) {}
 
   static FailureOr<DotOpMmaSmemLoader>
   build(Location loc, RewriterBase &rewriter, gpu::MemDescType memTy,
@@ -148,8 +149,7 @@ public:
     if (failed(desc))
       return failure();
 
-    Value baseb128 = b.zext(i64_ty, b.and_(baseSrcb128, b.i32_val(0x3FFF)));
-    return DotOpMmaSmemLoader{*desc, baseb128, ll};
+    return DotOpMmaSmemLoader{*desc, baseSrcb128, ll};
   }
 
   Value smemLoad(int a, int b, ConversionPatternRewriter &rewriter,
@@ -169,11 +169,17 @@ public:
     // Take the next 0/1/2/3 bits after the 128b tile
     uint32_t mask = (desc.swizzlingByteWidth >> 4) - 1;
     currDesc.matrixBaseOffset = (smemByteOffsetb8 / 128) & mask;
+    currDesc.baseAddress = 0;
     int32_t smemByteOffsetb128 = smemByteOffsetb8 >> 4;
-    Value descValBase =
-        tb.int_val(64, currDesc.descriptor + smemByteOffsetb128);
-    // Add the base address to the descriptor
-    Value descVal = tb.add(descValBase, baseb128);
+    // Compute the base address at runtime to prevent LLVM from folding the
+    // per-tile offset into a unique 64-bit constant. This produces a short
+    // dependency chain (add→and→zext→add) that helps hide WGMMA latency.
+    Value fullAddrb128 =
+        tb.add(baseSrcb128, tb.i32_val(smemByteOffsetb128));
+    Value addrMasked = tb.and_(fullAddrb128, tb.i32_val(0x3FFF));
+    Value addr64 = tb.zext(i64_ty, addrMasked);
+    Value descVal =
+        tb.add(tb.int_val(64, currDesc.descriptor), addr64);
     return descVal;
   }
   MemDescOperand memLoad(int a, int b, ConversionPatternRewriter &rewriter,
@@ -185,7 +191,7 @@ public:
 
 private:
   MMASMEMDescriptor desc;
-  Value baseb128;
+  Value baseSrcb128;
   LinearLayout ll;
 
   static FailureOr<MMASMEMDescriptor>


### PR DESCRIPTION
Summary:
D96882777 introduced a regression where per-tile WGMMA shared memory
descriptor offsets are folded into unique 64-bit compile-time constants.
For kernels like hstu_attn_bwd with 5 tl.dot operations and ~8 tiles each,
this produces ~60-80 unique i64 constants that exhaust the register file
(already at 255 max) and cause +48 bytes average additional stack spill.

The fix computes the base address at runtime (add→and→zext→add) instead of
baking it into per-tile constants. This keeps the descriptor base constant
shared across tiles while computing only the 14-bit baseAddress field at
runtime. ptxas register pressure is restored to parent-level (350 bytes avg
spill, matching parent exactly).

Benchmark: hstu backward on H100 with Triton beta showed ~18% latency
regression from D96882777. This fix recovers the regression.

Authored with Claude.

Reviewed By: agron911

Differential Revision: D101188595


