### PR TITLE
[triton][tileir] Apply Meta-specific patches to TileIR backend in Triton Beta (#1301)

### DIFF
--- a/python/examples/gluon/01-attention-forward.py
+++ b/python/examples/gluon/01-attention-forward.py
@@ -952,7 +952,7 @@ def attention_forward(q, k, v, causal, sm_scale):
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def is_blackwell():

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -82,7 +82,7 @@ def get_disassembler_command_and_debug_line_format():
     """
     backend = triton.runtime.driver.active.get_current_target().backend
 
-    if backend == "cuda":
+    if triton.runtime.driver.active.get_current_target().is_cuda_backend():
         nvdisasm = triton.knobs.nvidia.nvdisasm.path
         return ("cubin", [nvdisasm, "-g"], "## File", ",")
 

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -121,7 +121,7 @@ def test_hooks(device):
     # shared memory bytes = N_STAGES * BLOCK_SIZE * sizeof(float)
     # On AMD GPUs:
     # `num_stages` is a fixed value of 2, so it won't cause out of resources
-    if triton.runtime.driver.active.get_current_target().backend == "cuda":
+    if triton.runtime.driver.active.get_current_target().is_cuda_backend():
         assert values["has_exception"] is True
     else:
         assert values["has_exception"] is False

--- a/python/test/unit/tools/test_disasm.py
+++ b/python/test/unit/tools/test_disasm.py
@@ -6,7 +6,7 @@ import triton.language as tl
 
 
 def test_disam_cubin():
-    if not triton.runtime.driver.active.get_current_target().backend == "cuda":
+    if not triton.runtime.driver.active.get_current_target().is_cuda_backend():
         pytest.skip("Test requires CUDA.")
 
     @triton.jit

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -38,7 +38,7 @@ def get_current_target():
 
 def is_cuda():
     target = get_current_target()
-    return False if target is None else target.backend == "cuda"
+    return False if target is None else target.is_cuda_backend()
 
 
 def is_ampere_or_newer():

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -7,11 +7,15 @@ from types import ModuleType
 
 @dataclass(frozen=True)
 class GPUTarget(object):
-    # Target backend, e.g., cuda, hip
+    # Target backend, e.g., cuda, tileir, hip
     backend: str
     # Target architecture, e.g., 90 (for cuda compute capability), gfx940 (for hip)
     arch: Union[int, str]
     warp_size: int
+
+    def is_cuda_backend(self) -> bool:
+        """Returns True if this target uses a CUDA-compatible backend (cuda or tileir)."""
+        return self.backend in ("cuda", "tileir")
 
 
 class Language(Enum):

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -517,6 +517,7 @@ class nvidia_knobs(base_knobs):
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
+    enable_tileir: env_bool = env_bool("ENABLE_TILE")
 
 
 class amd_knobs(base_knobs):

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1198,7 +1198,7 @@ class TritonSemantic(Generic[TensorTy]):
 
     def _has_native_tma(self, ):
         target = driver.active.get_current_target()
-        return target.backend == "cuda" and target.arch >= 90
+        return target.is_cuda_backend() and target.arch >= 90
 
     def _descriptor_atomic_min_max_supported(self, dtype):
         assert dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64, tl.float16, tl.bfloat16}, "Unsupported dtype"

--- a/python/triton/language/target_info.py
+++ b/python/triton/language/target_info.py
@@ -19,7 +19,7 @@ current_target.__triton_builtin__ = True
 @constexpr_function
 def is_cuda():
     target = current_target()
-    return target is not None and target.backend == "cuda"
+    return target is not None and target.is_cuda_backend()
 
 
 @constexpr_function
@@ -30,7 +30,7 @@ def cuda_capability_geq(major, minor=0):
     inline asm implementations that require a certain compute capability.
     """
     target = current_target()
-    if target is None or target.backend != "cuda":
+    if target is None or not target.is_cuda_backend():
         return False
     assert isinstance(target.arch, int)
     return target.arch >= major * 10 + minor

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -391,6 +391,6 @@ def make_opt_flags(
     backend = triton.runtime.driver.active.get_current_target().backend
     if backend == "hip":
         return make_default_opt_flags_amd(*args)
-    if backend == "cuda":
+    if triton.runtime.driver.active.get_current_target().is_cuda_backend():
         return make_default_opt_flags_nvidia(*args)
     assert False

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -158,7 +158,7 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def get_cuda_autotune_config():

--- a/python/tutorials/06-fused-attention-ws.py
+++ b/python/tutorials/06-fused-attention-ws.py
@@ -25,7 +25,7 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def supports_host_descriptor():

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -29,7 +29,7 @@ def is_hip():
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def supports_host_descriptor():

--- a/python/tutorials/07-extern-functions.py
+++ b/python/tutorials/07-extern-functions.py
@@ -69,7 +69,7 @@ print(f'The maximum difference between torch and triton is '
 # -------------------------------------
 # We can also customize the libdevice library path by passing the path to the `libdevice` library to the `asin` kernel.
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def is_hip():

--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -36,7 +36,7 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def supports_tma():

--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -128,7 +128,7 @@ from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def is_hip_cdna4():

--- a/python/tutorials/11-programmatic-dependent-launch.py
+++ b/python/tutorials/11-programmatic-dependent-launch.py
@@ -16,7 +16,7 @@ import triton.language as tl
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def supports_pdl():

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -14,7 +14,7 @@ def is_hip():
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def supports_host_descriptor():

--- a/python/tutorials/fused-attention-ws.py
+++ b/python/tutorials/fused-attention-ws.py
@@ -13,7 +13,7 @@ def is_hip():
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def supports_host_descriptor():

--- a/python/tutorials/gluon/03-async-copy.py
+++ b/python/tutorials/gluon/03-async-copy.py
@@ -23,7 +23,7 @@ from triton.experimental.gluon.language.nvidia.ampere import async_copy as cp
 
 def is_ampere_or_newer():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] >= 8
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] >= 8
 
 
 if __name__ == "__main__" and not is_ampere_or_newer():

--- a/python/tutorials/gluon/04-tma.py
+++ b/python/tutorials/gluon/04-tma.py
@@ -36,7 +36,7 @@ t3 = importlib.import_module("03-async-copy")
 
 def is_hopper_or_newer():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] >= 9
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] >= 9
 
 
 if __name__ == "__main__" and not is_hopper_or_newer():

--- a/python/tutorials/gluon/05-wgmma.py
+++ b/python/tutorials/gluon/05-wgmma.py
@@ -31,7 +31,7 @@ from triton.experimental.gluon.language.nvidia.hopper import (
 
 def is_hopper():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] == 9
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] == 9
 
 
 if __name__ == "__main__" and not is_hopper():

--- a/python/tutorials/gluon/06-tcgen05.py
+++ b/python/tutorials/gluon/06-tcgen05.py
@@ -34,7 +34,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
 
 def is_blackwell():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] == 10
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] == 10
 
 
 if __name__ == "__main__" and not is_blackwell():

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -65,7 +65,7 @@ t5 = importlib.import_module("05-wgmma")
 
 def is_hopper_or_newer():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] >= 9
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] >= 9
 
 
 if __name__ == "__main__" and not is_hopper_or_newer():

--- a/python/tutorials/gluon/08-warp-specialization.py
+++ b/python/tutorials/gluon/08-warp-specialization.py
@@ -54,12 +54,12 @@ t4 = importlib.import_module("04-tma")
 
 def is_hopper_or_newer():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] >= 9
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] >= 9
 
 
 def is_blackwell():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] == 10
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] == 10
 
 
 if __name__ == "__main__" and not is_hopper_or_newer():

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -117,8 +117,8 @@ def _interpret_mode(mode_obj: Union[str, mode.InstrumentationMode]) -> mode.Inst
 
 
 def _get_backend_name() -> str:
-    backend = triton.runtime.driver.active.get_current_target().backend
-    if backend == "cuda":
+    target = triton.runtime.driver.active.get_current_target()
+    if target.is_cuda_backend():
         return "nvidia"
     elif backend == "hip":
         return "amd"

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -13,7 +13,7 @@ DEFAULT_PROFILE_NAME = "proton"
 
 def _select_backend() -> str:
     backend = triton.runtime.driver.active.get_current_target().backend
-    if backend == "cuda":
+    if triton.runtime.driver.active.get_current_target().is_cuda_backend():
         return "cupti"
     elif backend == "hip":
         return "roctracer"

--- a/third_party/proton/tutorials/intra_kernel/example_dsl.py
+++ b/third_party/proton/tutorials/intra_kernel/example_dsl.py
@@ -29,7 +29,7 @@ NUM_WARPS = 8
 
 def is_hopper():
     target = triton.runtime.driver.active.get_current_target()
-    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] == 9
+    return target.is_cuda_backend() and torch.cuda.get_device_capability()[0] == 9
 
 
 def config_helper(description: str):

--- a/third_party/tileir/backend/code_generator.py
+++ b/third_party/tileir/backend/code_generator.py
@@ -7,7 +7,7 @@ import warnings
 import triton
 import triton.knobs as knobs
 import triton.language as language
-from triton.language import constexpr, str_to_ty
+from triton.language import constexpr
 from triton._utils import (
     find_paths_if,
     get_iterable_path,
@@ -34,6 +34,7 @@ from triton.runtime.jit import (
 )
 
 from triton.backends.tileir.conf import TileIREnvConf
+from .fb.language import tileir_tensor_descriptor_type
 
 
 def mangle_fn(name, arg_tys, caller_context):
@@ -61,4 +62,219 @@ def tileir_mangle_fn(name, arg_tys, constants):
     # [ and ] are not allowed in LLVM identifiers
     mangled_constants = mangled_constants.replace('[', '_').replace(']', '_')
     ret = f'{name}__{mangled_arg_names}__{mangled_constants}'
+    return ret
+
+
+
+# TODO: FIXME HACK: META INTEGRATION CODE GENERATOR.
+# TileIRCodeGenerator, str_to_ty, and ast_to_ttir provide the Meta-specific
+# code generation path for the TileIR backend. These override the default
+# Triton code generator to handle TileIR-specific types (e.g. tensordesc)
+# and plug into the ast_to_ttir property on TileIROptions.
+
+class TileIRCodeGenerator(CodeGenerator):
+
+    def __init__(
+        self,
+        context,
+        prototype,
+        gscope,
+        function_name,
+        jit_fn: JITFunction,
+        options,
+        codegen_fns,
+        module_map,
+        is_gluon=False,
+        module=None,
+        is_kernel=False,
+        function_types: Optional[Dict] = None,
+        noinline=False,
+        file_name: Optional[str] = None,
+        begin_line=0,
+    ):
+        super().__init__(
+            context=context,
+            prototype=prototype,
+            gscope=gscope,
+            function_name=function_name,
+            jit_fn=jit_fn,
+            options=options,
+            codegen_fns=codegen_fns,
+            module_map=module_map,
+            is_gluon=is_gluon,
+            module=module,
+            is_kernel=is_kernel,
+            function_types=function_types,
+            noinline=noinline,
+            file_name=file_name,
+            begin_line=begin_line,
+        )
+
+    def get_used_vars(self, stmt):
+        used_vars = dict()
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.FunctionDef):
+                continue
+            if isinstance(node, ast.With):
+                continue
+            if isinstance(node, ast.AugAssign):
+                used_vars[node.target.id] = node.target
+                continue
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                used_vars[node.id] = node
+        return used_vars
+
+    def call_JitFunction(self, fn: JITFunction, args, kwargs):
+        args = inspect.getcallargs(fn.fn, *args, **kwargs)
+        args = [args[name] for name in fn.arg_names]
+        for i, arg in enumerate(args):
+            if isinstance(arg, (language.dtype, float, int, bool)):
+                args[i] = language.core.constexpr(arg)
+        args_cst = find_paths_if(args, lambda _, x: _is_constexpr(x))
+        args_cst = {path: get_iterable_path(args, path) for path in args_cst}
+        args_path = find_paths_if(args, lambda _, x: not _is_constexpr(x))
+        args_val = [get_iterable_path(args, path) for path in args_path]
+        # mangle
+        fn_name = tileir_mangle_fn(
+            get_full_name(fn), [arg.type for arg in args_val], args_cst
+        )
+        # generate function def if necessary
+        if not self.module.has_function(fn_name):
+            # If the callee is not set, we use the same debug setting as the caller
+            file_name, begin_line = get_jit_fn_file_line(fn)
+            arg_types = [
+                language.core.constexpr if arg is None or isinstance(arg,
+                                                                     (bool, int, language.core.dtype)) else arg.type
+                for arg in args
+            ]
+            prototype = ASTFunction([], arg_types, args_cst, dict())
+            # TileIR backend does not support noinline mode currently
+            if fn.noinline:
+                import warnings
+
+                warnings.warn(
+                    "Current backend does not support noinline mode, noinline will be turn off.",
+                    RuntimeWarning,
+                )
+                fn.noinline = False
+            generator = TileIRCodeGenerator(
+                self.context,
+                prototype,
+                fn.get_capture_scope(),
+                module=self.module,
+                jit_fn=fn,
+                function_name=fn_name,
+                function_types=self.function_ret_types,
+                noinline=fn.noinline,
+                file_name=file_name,
+                begin_line=begin_line,
+                options=self.builder.options,
+                codegen_fns=self.builder.codegen_fns,
+                module_map=self.builder.module_map,
+                is_gluon=False,
+            )
+            try:
+                generator.visit(fn.parse())
+            except Exception as e:
+                # Wrap the error in the callee with the location of the call.
+                if knobs.compilation.front_end_debugging:
+                    raise
+                raise CompilationError(self.jit_fn.src, self.cur_node, None) from e
+
+            callee_ret_type = generator.ret_type
+            self.function_ret_types[fn_name] = callee_ret_type
+        else:
+            callee_ret_type = self.function_ret_types[fn_name]
+        symbol = self.module.get_function(fn_name)
+        args_val = flatten_values_to_ir(args_val)
+        call_op = self.builder.call(symbol, args_val)
+        if callee_ret_type == language.void:
+            return None
+        handles = [call_op.get_result(i) for i in range(call_op.get_num_results())]
+        return next(unflatten_ir_values(handles, [callee_ret_type]))
+
+
+def str_to_ty(name, c):
+    from builtins import tuple
+    from triton.language.core import (
+        pointer_type,
+        tuple_type,
+        block_type,
+        int32,
+        int64,
+    )
+
+    # Ensure we recurse properly to this implementation.
+    if isinstance(name, tuple):
+        fields = type(name).__dict__.get("_fields", None)
+        return tuple_type([str_to_ty(x, c) for x in name], fields)
+
+    if name[0] == "*":
+        name = name[1:]
+        const = False
+        if name[0] == "k":
+            name = name[1:]
+            const = True
+        ty = str_to_ty(name, c)
+        return pointer_type(element_ty=ty, const=const)
+
+    if name.startswith("tensordesc"):
+        inner = name.split("<")[1].rstrip(">")
+        dtype, rest = inner.split("[", maxsplit=1)
+        block_shape, rest = rest.split("]", maxsplit=1)
+        block_shape = [int(s.strip()) for s in block_shape.rstrip("]").split(",")]
+        dtype = str_to_ty(dtype, None)
+        ndim = len(block_shape)
+        shape_type = tuple_type([int32] * ndim)
+        stride_type = tuple_type(([int64] * ndim))
+        block = block_type(dtype, block_shape)
+        return tileir_tensor_descriptor_type(block, shape_type, stride_type)
+
+    # Fall back to language's default for non-tensor descriptor types.
+    return language.str_to_ty(name, c)
+
+
+def ast_to_ttir(fn, src, context, options, codegen_fns, module_map, module=None):
+    arg_types = [None] * len(fn.arg_names)
+    const_iter = iter(src.constants.items())
+    kc, vc = next(const_iter, (None, None))
+
+    for i, (ks, v) in enumerate(src.signature.items()):
+        idx = fn.arg_names.index(ks)
+        cexpr = None
+        if kc is not None and kc[0] == i:
+            cexpr = vc
+            kc, vc = next(const_iter, (None, None))
+        arg_types[idx] = str_to_ty(v, cexpr)
+
+    prototype = ASTFunction([], arg_types, src.constants, src.attrs)
+    file_name, begin_line = get_jit_fn_file_line(fn)
+    # query function representation
+    from collections import namedtuple
+    leaves = filter(lambda v: len(v) == 1, src.constants)
+    constants = {fn.arg_names[i[0]]: src.constants[i] for i in leaves}
+    signature = src.signature
+
+    tileir_additional_suffix = ""
+    proxy = namedtuple("SpecializationProxy", ["constants", "signature",])(constants, signature)
+    generator = TileIRCodeGenerator(
+        context,
+        prototype,
+        gscope=fn.get_capture_scope(),
+        function_name=fn.repr(proxy) + tileir_additional_suffix,
+        jit_fn=fn,
+        is_kernel=True,
+        file_name=file_name,
+        begin_line=begin_line,
+        options=options,
+        codegen_fns=codegen_fns,
+        module_map=module_map,
+        is_gluon=False,
+    )
+    generator.visit(fn.parse())
+
+    ret = generator.module
+    # module takes ownership of the context
+    ret.context = context
+    ret.name = generator.function_name
     return ret

--- a/third_party/tileir/backend/compiler.py
+++ b/third_party/tileir/backend/compiler.py
@@ -4,6 +4,7 @@ from triton.runtime.cache import get_cache_manager
 from triton.backends.compiler import BaseBackend, GPUTarget, Language
 from triton.backends.tileir.conf import TileIREnvConf
 from triton._C.libtriton import ir, passes, tileir
+from triton import knobs
 
 from dataclasses import dataclass
 import functools
@@ -121,6 +122,11 @@ class TileIROptions:
         key = "_".join([f"{name}-{val}" for name, val in sorted(hash_dict.items()) if name != "num_warps"])
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
+    @property
+    def ast_to_ttir(self):
+        from .code_generator import ast_to_ttir
+        return ast_to_ttir
+
 
 def get_tileir_version():
     return "13.1"
@@ -134,8 +140,10 @@ class TileIRBackend(BaseBackend):
         return {"triton.language.extra.libdevice": libdevice}
 
     @staticmethod
-    def supports_target(target: GPUTarget):
-        return target.backend == "tileir"
+    def supports_target(target: GPUTarget) -> bool:
+        # Only supported on Blackwell with Cuda
+        # TODO: Enable Ampere with Cuda 13.2
+        return knobs.nvidia.enable_tileir and target.backend == "tileir" and target.arch >= 100 and target.arch < 110
 
     def _parse_arch(self, arch):
         pattern = r"^sm(\d+)$"
@@ -191,6 +199,11 @@ class TileIRBackend(BaseBackend):
 
     @staticmethod
     def call_tileiras(mod, metadata, opt: TileIROptions, capability):
+        # HACK: TileIR does not report shared memory usage, but the Triton runtime
+        # expects metadata["shared"] to be set. Default to 0 to satisfy the calling
+        # convention. This should be replaced with actual shared memory reporting
+        # once tileiras supports it.
+        metadata["shared"] = 0
         tileiras = opt.tileir_tileiras_path
         tileiras_cmd = [
             tileiras,
@@ -211,7 +224,11 @@ class TileIRBackend(BaseBackend):
             tileiras_cmd.append(fbin)
 
             try:
-                subprocess.run(tileiras_cmd, check=True, close_fds=False, stderr=flog)
+                # Workaround: Buck injects environment variables that break
+                # the tileiras subprocess. Clear env when running in fbcode.
+                from triton.runtime.fbcode_gating import is_fbcode_dependant
+                env = {} if is_fbcode_dependant() else None
+                subprocess.run(tileiras_cmd, check=True, close_fds=False, stderr=flog, env=env)
                 if os.path.exists(fbytecode.name):
                     os.remove(fbytecode.name)
             except subprocess.CalledProcessError as e:
@@ -310,3 +327,5 @@ class TileIRBackend(BaseBackend):
     def hash(self):
         version = get_tileir_version()
         return f"{'tileir'}-{version}-{self.target.arch}"
+
+__all__ = ["TileIROptions", "TileIRBackend"]

--- a/third_party/tileir/backend/conf.py
+++ b/third_party/tileir/backend/conf.py
@@ -1,7 +1,28 @@
 from contextlib import contextmanager
 import os
+import warnings
 import triton
 import functools
+
+
+_tileir_info_msg = """
+The Triton-TileIR backend is an experimental feature and is not supported for production use.
+If you would like to use this for benchmarking/investigation purposes, please set
+TRITON_TILEIRAS_PATH to the path of the tileiras binary. This can be found in the
+Cuda 13.1 toolkit under bin and is available by default on most devservers.
+
+If you find substantial performance results when benchmarking please report your results
+to the Triton team.
+"""
+
+_tileir_enabled_msg = """
+The Triton-TileIR backend is enabled. This is an experimental feature and is
+not supported for production use.
+
+If you are using this solely for benchmarking purposes you can ignore this message.
+If you find substantial performance results when benchmarking please report your results
+to the Triton team.
+"""
 
 
 class TileIREnvConf:
@@ -30,6 +51,7 @@ class TileIREnvConf:
     def get_tileiras_path():
         env_path = os.getenv("TRITON_TILEIRAS_PATH")
         if env_path:
+            warnings.warn(_tileir_enabled_msg)
             return os.path.join(env_path, "tileiras")
         cuda_home = os.getenv("CUDA_HOME")
         if cuda_home:
@@ -39,11 +61,20 @@ class TileIREnvConf:
                 version_output = subprocess.check_output([path, "--version"], encoding="utf-8",
                                                          stderr=subprocess.STDOUT)
                 if "release 13.1" in version_output:
+                    warnings.warn(_tileir_enabled_msg)
                     return path
         from shutil import which
         tileiras_path = which("tileiras")
         if tileiras_path:
+            warnings.warn(_tileir_enabled_msg)
             return tileiras_path
+        # TODO: FIXME HACK: FBCODE FALLBACK.
+        # Buck does not always propagate environment variables to subprocesses,
+        # so fall back to a well-known devserver path when no tileiras is found.
+        from triton.runtime.fbcode_gating import is_fbcode_dependant
+        if is_fbcode_dependant():
+            warnings.warn(_tileir_info_msg)
+            return "/usr/local/cuda/bin/tileiras"
         return None
 
     # todo: DKG CI related, need to be removed

--- a/third_party/tileir/backend/driver.py
+++ b/third_party/tileir/backend/driver.py
@@ -44,7 +44,17 @@ class TileIRUtils(object):
         self.init_tileir_function(tile_mod)
 
     def init_tileir_function(self, mod):
-        self.load_binary = mod.load_tileir_binary
+        # TODO: FIXME HACK: ADAPT LOAD_BINARY SIGNATURE.
+        # The underlying load_tileir_binary returns 6 values including
+        # static_smem_bytes, but Triton's runtime expects 5. Wrap to drop
+        # the extra value and ignore the shared memory arg from the caller.
+        self._load_binary_impl = mod.load_tileir_binary
+
+    def load_binary(self, name, kernel, shared, device):
+        mod, func, n_reg, n_spills, static_smem_bytes, n_max_threads = self._load_binary_impl(
+            name, kernel, device
+        )
+        return (mod, func, n_reg, n_spills, n_max_threads)
 
     def init_nvidia_function(self, mod):
         self.get_device_properties = mod.get_device_properties
@@ -509,10 +519,12 @@ class TileIRDriver(GPUDriver):
 
     @staticmethod
     def is_active():
+        if not knobs.nvidia.enable_tileir:
+            return False
+
         try:
-            from triton.backends.tileir.conf import TileIREnvConf
-            tileiras = TileIREnvConf.get_tileiras_path()
-            return tileiras is not None and (torch.cuda.is_available() and (torch.version.hip is None))
+            import torch
+            return torch.cuda.is_available() and (torch.version.hip is None)
         except ImportError:
             return False
 
@@ -535,5 +547,8 @@ class TileIRDriver(GPUDriver):
     def clear_cache(self, cache):
         cache.zero_()
 
+    def tensor_descriptor(self, handle, shape, strides, type, base):
+        from .fb.language import tileir_tensor_descriptor
+        return tileir_tensor_descriptor(handle, shape, strides, type, base)
 
-GlobalTileIRDriver = TileIRDriver()
+__all__ = ["TileIRUtils", "TileIRLauncher", "TileIRDriver"]

--- a/third_party/tlx/tutorials/blackwell-gdpa.py
+++ b/third_party/tlx/tutorials/blackwell-gdpa.py
@@ -1693,7 +1693,7 @@ def profile_tlx_gdpa(config):
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 if __name__ == "__main__":

--- a/third_party/tlx/tutorials/blackwell-grouped-gemm_test.py
+++ b/third_party/tlx/tutorials/blackwell-grouped-gemm_test.py
@@ -39,7 +39,7 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def supports_tma():

--- a/third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py
+++ b/third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py
@@ -13,7 +13,7 @@ M, N, K = (2176, 2176, 2176)
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def is_hip_cdna2():

--- a/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong.py
+++ b/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong.py
@@ -13,7 +13,7 @@ M, N, K = (8192, 8192, 8192)  # (2176, 2176, 2176)
 
 
 def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+    return triton.runtime.driver.active.get_current_target().is_cuda_backend()
 
 
 def is_hip_cdna2():


### PR DESCRIPTION
Summary:

Apply integration patches from stable TileIR diffs (D89700252, D90068010,
D90511733, D90544543) to the beta copy of the TileIR backend source.

Changes:
- compiler.py: ast_to_ttir property, ENABLE_TILE gate, CUDABackend
  monkeypatch, metadata["shared"]=0 hack, env={} for fbcode
- driver.py: GPUTarget "cuda", ENABLE_TILE gate, load_binary wrapper,
  tensor_descriptor method, CudaDriver monkeypatch
- conf.py: warning messages, fbcode fallback path for tileiras
- code_generator.py: TileIRCodeGenerator class, str_to_ty for tensordesc
  types, ast_to_ttir function

All Meta-specific hacks are marked with TODO: FIXME HACK comments.

Reviewed By: jananisriram

Differential Revision: D100481087
