### PR TITLE
 [AutoWS] Subtile Operator: Support token tracking, fix barrier annotations with a proper attribute, support pushing tmem loads to body, move generate_subtiled_region to an autotune config (6/N) (#1308)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -156,4 +156,41 @@ def TTNG_BarrierAnnotationAttr : AttrDef<TritonNvidiaGPU_Dialect, "BarrierAnnota
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
+//===----------------------------------------------------------------------===//
+// TokenAnnotation attribute
+//===----------------------------------------------------------------------===//
+
+def TTNG_TokenAnnotationAttr : AttrDef<TritonNvidiaGPU_Dialect, "TokenAnnotation"> {
+  let mnemonic = "token_annotation";
+  let description = [{
+    Describes where to insert a token-based synchronization operation during
+    subtiled region lowering. This is the token-layer analog of
+    `BarrierAnnotationAttr` — it references NVWS tokens (ConsumerWaitOp /
+    ConsumerReleaseOp) instead of mbarrier ops (WaitBarrierOp /
+    ArriveBarrierOp). Token annotations are resolved to barrier annotations
+    during `doTokenLowering`.
+
+    - `tokenIdx`: index into the op's `tokenValues` operand list (the NVWS
+      token Value).
+    - `bufferIdxIdx`: index into `tokenValues` for the buffer index (i32).
+    - `phaseIdx`: index into `tokenValues` for the phase (i1). Set to -1
+      for consumer_release ops that have no phase operand.
+    - `placement`: BEFORE or AFTER the target op.
+    - `targetOpIdx`: index of the target op in the target region body.
+    - `tokenOpKind`: "consumer_wait" or "consumer_release".
+    - `region`: which region the token op targets (default TILE).
+  }];
+  let parameters = (
+    ins
+    "unsigned":$tokenIdx,
+    "unsigned":$bufferIdxIdx,
+    "int":$phaseIdx,
+    "BarrierPlacement":$placement,
+    "unsigned":$targetOpIdx,
+    "StringAttr":$tokenOpKind,
+    DefaultValuedParameter<"BarrierRegion", "BarrierRegion::TILE">:$region
+  );
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
 #endif

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -1148,7 +1148,10 @@ def TTNG_SubtiledRegionOp : TTNG_Op<"subtiled_region", [
 
     `tileMappings` is an array of arrays: one per tile, each entry is an index
     into the setup yield values. The length of each inner array must equal the
-    number of tile block arguments.
+    number of tile block arguments, or the number of tile block arguments minus
+    one if the tile region has an extra trailing `i32` block argument for the
+    tile index. When present, the tile index argument is substituted with the
+    concrete tile index (0, 1, ...) during lowering.
 
     `barrierAnnotations` describes where to insert barrier operations during
     lowering. Each annotation references a target op by index in the tile body
@@ -1158,8 +1161,10 @@ def TTNG_SubtiledRegionOp : TTNG_Op<"subtiled_region", [
   let arguments = (ins
     Variadic<TTG_MemDescType>:$barriers,
     Variadic<I64>:$accumCnts,
+    Variadic<AnyType>:$tokenValues,
     ArrayAttr:$tileMappings,
-    ArrayAttr:$barrierAnnotations
+    ArrayAttr:$barrierAnnotations,
+    ArrayAttr:$tokenAnnotations
   );
 
   let results = (outs Variadic<AnyType>:$results);

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -218,6 +218,25 @@ def TritonNvidiaGPUTestGenerateSubtiledRegionPass
   ];
 }
 
+def TritonNvidiaGPUPushSharedSetupToTilePass
+    : Pass<"triton-nvidia-gpu-push-shared-setup-to-tile", "mlir::ModuleOp"> {
+  let summary = "Push shared setup ops into tile body of subtiled_region";
+
+  let description = [{
+    For each `ttng.subtiled_region` op, identifies tile arguments that are
+    "shared" — all tiles map the argument position to the same setup yield
+    index. The ops producing those shared values are cloned into the tile
+    body and the corresponding tile arguments and yield entries are removed.
+
+    This simplifies the setup region and makes the tile body more
+    self-contained, enabling further optimizations.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 def TritonNvidiaGPURemoveTMEMTokensPass : Pass<"triton-nvidia-gpu-remove-tmem-tokens", "mlir::ModuleOp"> {
   let summary = "remove TMEM tokens";
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1167,18 +1167,29 @@ LogicalResult SubtiledRegionOp::verify() {
   if (tileMappings.empty())
     return emitOpError("tileMappings must have at least one tile");
 
-  // 6-8. Validate each tile mapping
+  // 6-8. Validate each tile mapping.
+  // The tile region may have an optional trailing i32 tile index argument,
+  // so tileMappings entries may have numTileArgs or numTileArgs-1 elements.
+  bool hasTileIndex = false;
   for (auto [i, mapping] : llvm::enumerate(tileMappings)) {
     auto indices = dyn_cast<DenseI32ArrayAttr>(mapping);
     if (!indices)
       return emitOpError("tileMappings[")
              << i << "] must be a DenseI32ArrayAttr";
 
-    // 6. Inner array length = number of tile block args
-    if (static_cast<unsigned>(indices.size()) != numTileArgs)
-      return emitOpError("tileMappings[") << i << "] has " << indices.size()
-                                          << " entries but tile region has "
-                                          << numTileArgs << " block arguments";
+    // 6. Inner array length = numTileArgs or numTileArgs-1 (tile index).
+    unsigned mappingSize = static_cast<unsigned>(indices.size());
+    if (mappingSize == numTileArgs) {
+      // No tile index arg.
+    } else if (mappingSize + 1 == numTileArgs) {
+      hasTileIndex = true;
+    } else {
+      return emitOpError("tileMappings[")
+             << i << "] has " << indices.size()
+             << " entries but tile region has " << numTileArgs
+             << " block arguments (expected " << numTileArgs << " or "
+             << numTileArgs - 1 << ")";
+    }
 
     for (auto [j, idx] : llvm::enumerate(indices.asArrayRef())) {
       // 7. Indices in range
@@ -1195,6 +1206,14 @@ LogicalResult SubtiledRegionOp::verify() {
                << idx << " has type " << setupType << " but tile block arg "
                << j << " has type " << tileArgType;
     }
+  }
+
+  // Validate the tile index argument type if present.
+  if (hasTileIndex) {
+    Type lastArgType = tileBlock.getArgument(numTileArgs - 1).getType();
+    if (!lastArgType.isInteger(32))
+      return emitOpError("tile index argument must be i32 but got ")
+             << lastArgType;
   }
 
   // Count non-terminator ops in each region for targetOpIdx validation.
@@ -1300,6 +1319,17 @@ void SubtiledRegionOp::print(OpAsmPrinter &p) {
     p << ")";
   }
 
+  // Print tokenValues
+  if (!getTokenValues().empty()) {
+    p << " token_values(";
+    llvm::interleaveComma(getTokenValues(), p,
+                          [&](Value v) { p.printOperand(v); });
+    p << " : ";
+    llvm::interleaveComma(getTokenValues().getTypes(), p,
+                          [&](Type t) { p.printType(t); });
+    p << ")";
+  }
+
   // Print tileMappings
   p << " tile_mappings = ";
   p.printAttribute(getTileMappings());
@@ -1308,10 +1338,16 @@ void SubtiledRegionOp::print(OpAsmPrinter &p) {
   p << " barrier_annotations = ";
   p.printAttribute(getBarrierAnnotations());
 
+  // Print tokenAnnotations
+  if (!getTokenAnnotations().empty()) {
+    p << " token_annotations = ";
+    p.printAttribute(getTokenAnnotations());
+  }
+
   // Print attr-dict (excluding our custom attrs and operand segment sizes)
-  p.printOptionalAttrDict(
-      (*this)->getAttrs(),
-      {"tileMappings", "barrierAnnotations", getOperandSegmentSizeAttr()});
+  p.printOptionalAttrDict((*this)->getAttrs(),
+                          {"tileMappings", "barrierAnnotations",
+                           "tokenAnnotations", getOperandSegmentSizeAttr()});
 
   // Print setup region
   p << " setup ";
@@ -1339,6 +1375,8 @@ ParseResult SubtiledRegionOp::parse(OpAsmParser &parser,
   SmallVector<Type> barrierTypes;
   SmallVector<OpAsmParser::UnresolvedOperand> phaseOperands;
   SmallVector<Type> phaseTypes;
+  SmallVector<OpAsmParser::UnresolvedOperand> tokenOperands;
+  SmallVector<Type> tokenTypes;
 
   // Parse optional barriers(...)
   if (succeeded(parser.parseOptionalKeyword("barriers"))) {
@@ -1351,6 +1389,13 @@ ParseResult SubtiledRegionOp::parse(OpAsmParser &parser,
   if (succeeded(parser.parseOptionalKeyword("accum_cnts"))) {
     if (parser.parseLParen() || parser.parseOperandList(phaseOperands) ||
         parser.parseColonTypeList(phaseTypes) || parser.parseRParen())
+      return failure();
+  }
+
+  // Parse optional token_values(...)
+  if (succeeded(parser.parseOptionalKeyword("token_values"))) {
+    if (parser.parseLParen() || parser.parseOperandList(tokenOperands) ||
+        parser.parseColonTypeList(tokenTypes) || parser.parseRParen())
       return failure();
   }
 
@@ -1368,6 +1413,17 @@ ParseResult SubtiledRegionOp::parse(OpAsmParser &parser,
     return failure();
   result.addAttribute("barrierAnnotations", barrierAnnotationsAttr);
 
+  // Parse optional token_annotations = <attr>
+  if (succeeded(parser.parseOptionalKeyword("token_annotations"))) {
+    Attribute tokenAnnotationsAttr;
+    if (parser.parseEqual() || parser.parseAttribute(tokenAnnotationsAttr))
+      return failure();
+    result.addAttribute("tokenAnnotations", tokenAnnotationsAttr);
+  } else {
+    result.addAttribute("tokenAnnotations",
+                        parser.getBuilder().getArrayAttr({}));
+  }
+
   // Parse optional attr-dict
   if (parser.parseOptionalAttrDict(result.attributes))
     return failure();
@@ -1376,6 +1432,8 @@ ParseResult SubtiledRegionOp::parse(OpAsmParser &parser,
   if (parser.resolveOperands(barrierOperands, barrierTypes,
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(phaseOperands, phaseTypes,
+                             parser.getCurrentLocation(), result.operands) ||
+      parser.resolveOperands(tokenOperands, tokenTypes,
                              parser.getCurrentLocation(), result.operands))
     return failure();
 
@@ -1383,7 +1441,8 @@ ParseResult SubtiledRegionOp::parse(OpAsmParser &parser,
   result.addAttribute(SubtiledRegionOp::getOperandSegmentSizeAttr(),
                       parser.getBuilder().getDenseI32ArrayAttr(
                           {static_cast<int32_t>(barrierOperands.size()),
-                           static_cast<int32_t>(phaseOperands.size())}));
+                           static_cast<int32_t>(phaseOperands.size()),
+                           static_cast<int32_t>(tokenOperands.size())}));
 
   // Parse setup region
   if (parser.parseKeyword("setup"))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   OptimizeDescriptorEncoding.cpp
   OptimizeTMemLayouts.cpp
   PlanCTA.cpp
+  PushSharedSetupToTile.cpp
   PromoteLHSToTMem.cpp
   PruneUnusedBarriers.cpp
   ProxFenceInsertion.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/GenerateSubtiledRegion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/GenerateSubtiledRegion.cpp
@@ -422,11 +422,13 @@ static void buildSingleSubtiledRegion(OpBuilder &builder, Location loc,
       builder.getArrayAttr({DenseI32ArrayAttr::get(ctx, tile0Mapping),
                             DenseI32ArrayAttr::get(ctx, tile1Mapping)});
   auto barrierAnnotationsAttr = builder.getArrayAttr({});
+  auto tokenAnnotationsAttr = builder.getArrayAttr({});
 
   auto regionOp = SubtiledRegionOp::create(
       builder, loc, /*resultTypes=*/TypeRange{},
-      /*barriers=*/ValueRange{}, /*accumCnts=*/ValueRange{}, tileMappingsAttr,
-      barrierAnnotationsAttr);
+      /*barriers=*/ValueRange{}, /*accumCnts=*/ValueRange{},
+      /*tokenValues=*/ValueRange{}, tileMappingsAttr, barrierAnnotationsAttr,
+      tokenAnnotationsAttr);
 
   // --- Setup Region ---
   Block *setupBlock = &regionOp.getSetupRegion().emplaceBlock();
@@ -459,15 +461,17 @@ static void buildSingleSubtiledRegion(OpBuilder &builder, Location loc,
   Block *tileBlock = &regionOp.getTileRegion().emplaceBlock();
   for (Type ty : tileArgTypes)
     tileBlock->addArgument(ty, loc);
+  tileBlock->addArgument(builder.getI32Type(), loc);
 
   OpBuilder tileBuilder = OpBuilder::atBlockEnd(tileBlock);
   IRMapping tileMapping;
-  tileMapping.map(lhs, tileBlock->getArgument(0));
+  Value tplSplitResult = (equiv.templateChainIdx == 0) ? lhs : rhs;
+  tileMapping.map(tplSplitResult, tileBlock->getArgument(0));
   unsigned argIdx = 1;
-  // Map differing operands: use chain0 values as keys (the template chain's
-  // values are resolved through the value map built during equivalence).
-  for (auto [i, pair] : llvm::enumerate(differing))
-    tileMapping.map(pair.first, tileBlock->getArgument(argIdx++));
+  for (auto [i, pair] : llvm::enumerate(differing)) {
+    Value tplVal = (equiv.templateChainIdx == 0) ? pair.first : pair.second;
+    tileMapping.map(tplVal, tileBlock->getArgument(argIdx++));
+  }
 
   // Map identity insertion operands: the template chain's op references the
   // varying operand, which is mapped to the tile arg.
@@ -688,10 +692,12 @@ static void buildMultiTaskSubtiledRegions(OpBuilder &outerBuilder, Location loc,
         outerBuilder.getArrayAttr({DenseI32ArrayAttr::get(ctx, tile0Map),
                                    DenseI32ArrayAttr::get(ctx, tile1Map)});
     auto barrierAnnotationsAttr = outerBuilder.getArrayAttr({});
+    auto tokenAnnotationsAttr = outerBuilder.getArrayAttr({});
 
     auto regionOp = SubtiledRegionOp::create(
         outerBuilder, loc, TypeRange{}, ValueRange{}, ValueRange{},
-        tileMappingsAttr, barrierAnnotationsAttr);
+        /*tokenValues=*/ValueRange{}, tileMappingsAttr, barrierAnnotationsAttr,
+        tokenAnnotationsAttr);
 
     // --- Setup Region ---
     Block *setupBlock = &regionOp.getSetupRegion().emplaceBlock();
@@ -728,6 +734,7 @@ static void buildMultiTaskSubtiledRegions(OpBuilder &outerBuilder, Location loc,
     Block *tileBlock = &regionOp.getTileRegion().emplaceBlock();
     for (Type ty : tileArgTypes)
       tileBlock->addArgument(ty, loc);
+    tileBlock->addArgument(outerBuilder.getI32Type(), loc);
 
     OpBuilder tileBuilder = OpBuilder::atBlockEnd(tileBlock);
     IRMapping tileMapping;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/LowerSubtiledRegion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/LowerSubtiledRegion.cpp
@@ -108,9 +108,9 @@ void lowerSubtiledRegion(SubtiledRegionOp op) {
   ValueRange barriers = op.getBarriers();
   ValueRange accumCnts = op.getAccumCnts();
 
-  // Pre-process barrier annotations by region and target op index.
-  // Tile annotations are stored per (opIdx, placement) and filtered by
-  // tileMask at each tile replication.
+  static constexpr const char *kSubtileOpId = "subtile_op_id";
+
+  // Pre-process barrier annotations by region and target op ID.
   llvm::DenseMap<unsigned, SmallVector<BarrierAnnotationAttr>> tileBefore,
       tileAfter;
   llvm::DenseMap<unsigned, SmallVector<BarrierAnnotationAttr>> setupBefore,
@@ -118,25 +118,24 @@ void lowerSubtiledRegion(SubtiledRegionOp op) {
 
   for (Attribute attr : op.getBarrierAnnotations()) {
     auto annotation = cast<BarrierAnnotationAttr>(attr);
-    unsigned opIdx = annotation.getTargetOpIdx();
+    unsigned targetId = annotation.getTargetOpIdx();
     BarrierRegion region = annotation.getRegion();
 
     if (region == BarrierRegion::SETUP) {
       if (annotation.getPlacement() == BarrierPlacement::BEFORE)
-        setupBefore[opIdx].push_back(annotation);
+        setupBefore[targetId].push_back(annotation);
       else
-        setupAfter[opIdx].push_back(annotation);
+        setupAfter[targetId].push_back(annotation);
     } else if (region == BarrierRegion::TEARDOWN) {
       if (annotation.getPlacement() == BarrierPlacement::BEFORE)
-        teardownBefore[opIdx].push_back(annotation);
+        teardownBefore[targetId].push_back(annotation);
       else
-        teardownAfter[opIdx].push_back(annotation);
+        teardownAfter[targetId].push_back(annotation);
     } else {
-      // TILE region — placement is BEFORE or AFTER, filtered by tileMask.
       if (annotation.getPlacement() == BarrierPlacement::BEFORE)
-        tileBefore[opIdx].push_back(annotation);
+        tileBefore[targetId].push_back(annotation);
       else
-        tileAfter[opIdx].push_back(annotation);
+        tileAfter[targetId].push_back(annotation);
     }
   }
 
@@ -161,6 +160,13 @@ void lowerSubtiledRegion(SubtiledRegionOp op) {
   unsigned numTiles = tileMappings.size();
   Block &tileBlock = op.getTileRegion().front();
 
+  // Detect optional tile index argument: present when tile block has one more
+  // arg than the tile mapping entries.
+  unsigned numTileArgs = tileBlock.getNumArguments();
+  unsigned mappingSize =
+      cast<DenseI32ArrayAttr>(tileMappings[0]).asArrayRef().size();
+  bool hasTileIndex = (numTileArgs == mappingSize + 1);
+
   // 3. For each tile, clone tile region ops with substitution.
   for (unsigned tileIdx = 0; tileIdx < numTiles; ++tileIdx) {
     auto indices = cast<DenseI32ArrayAttr>(tileMappings[tileIdx]);
@@ -169,11 +175,19 @@ void lowerSubtiledRegion(SubtiledRegionOp op) {
     for (auto [j, idx] : llvm::enumerate(indices.asArrayRef()))
       tileMapping.map(tileBlock.getArgument(j), setupOutputs[idx]);
 
-    unsigned opIdx = 0;
+    if (hasTileIndex) {
+      Value tileIdxConst = arith::ConstantOp::create(
+          builder, loc, builder.getI32IntegerAttr(tileIdx));
+      tileMapping.map(tileBlock.getArgument(numTileArgs - 1), tileIdxConst);
+    }
+
     for (Operation &tileOp : tileBlock.without_terminator()) {
-      // BEFORE: emit if tileMask allows this tile.
-      {
-        auto it = tileBefore.find(opIdx);
+      auto idAttr = tileOp.getAttrOfType<IntegerAttr>(kSubtileOpId);
+      unsigned opId = idAttr ? idAttr.getInt() : ~0u;
+
+      // BEFORE annotations.
+      if (idAttr) {
+        auto it = tileBefore.find(opId);
         if (it != tileBefore.end()) {
           for (auto &annotation : it->second) {
             if (isTileEnabled(annotation, tileIdx))
@@ -183,11 +197,15 @@ void lowerSubtiledRegion(SubtiledRegionOp op) {
         }
       }
 
+      if (idAttr)
+        tileOp.removeAttr(kSubtileOpId);
       builder.clone(tileOp, tileMapping);
+      if (idAttr)
+        tileOp.setAttr(kSubtileOpId, idAttr);
 
-      // AFTER: emit if tileMask allows this tile.
-      {
-        auto it = tileAfter.find(opIdx);
+      // AFTER annotations.
+      if (idAttr) {
+        auto it = tileAfter.find(opId);
         if (it != tileAfter.end()) {
           for (auto &annotation : it->second) {
             if (isTileEnabled(annotation, tileIdx))
@@ -196,7 +214,6 @@ void lowerSubtiledRegion(SubtiledRegionOp op) {
           }
         }
       }
-      ++opIdx;
     }
   }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PushSharedSetupToTile.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PushSharedSetupToTile.cpp
@@ -1,0 +1,555 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/IRMapping.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUPUSHSHAREDSETUPTOTILEPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+/// For each SubtiledRegionOp whose setup region contains tmem_subslice ops,
+/// extract the per-tile N offsets as i32 constants, yield them from setup,
+/// and add per-tile mapped args to the tile body.  This makes the subtile
+/// offset explicitly available in the tile body for address computations.
+void addSubsliceRangeToSetup(SubtiledRegionOp op) {
+  ArrayAttr tileMappings = op.getTileMappings();
+  unsigned numTiles = tileMappings.size();
+  if (numTiles <= 1)
+    return;
+
+  Block &setupBlock = op.getSetupRegion().front();
+  auto setupYield = cast<SubtiledRegionYieldOp>(setupBlock.getTerminator());
+
+  // Collect tmem_subslice ops in the setup, grouped by source.
+  // We expect exactly numTiles subslice ops from the same source.
+  SmallVector<TMEMSubSliceOp> subsliceOps;
+  for (Operation &setupOp : setupBlock.without_terminator()) {
+    if (auto subslice = dyn_cast<TMEMSubSliceOp>(&setupOp))
+      subsliceOps.push_back(subslice);
+  }
+
+  if (subsliceOps.size() != numTiles)
+    return;
+
+  // Verify they all share the same source.
+  Value commonSrc = subsliceOps[0].getSrc();
+  for (auto subslice : subsliceOps) {
+    if (subslice.getSrc() != commonSrc)
+      return;
+  }
+
+  // Extract per-tile N offsets and create constants in setup.
+  OpBuilder setupBuilder(setupYield);
+  Location loc = op.getLoc();
+  SmallVector<Value> offsetConstants;
+  for (auto subslice : subsliceOps) {
+    int32_t nOffset = subslice.getN();
+    Value c = arith::ConstantOp::create(
+        setupBuilder, loc, setupBuilder.getI32IntegerAttr(nOffset));
+    offsetConstants.push_back(c);
+  }
+
+  // Add offset constants to the setup yield.
+  SmallVector<Value> newYieldValues(setupYield.getResults());
+  unsigned rangeYieldBase = newYieldValues.size();
+  for (Value c : offsetConstants)
+    newYieldValues.push_back(c);
+
+  SubtiledRegionYieldOp::create(setupBuilder, setupYield.getLoc(),
+                                newYieldValues);
+  setupYield.erase();
+
+  // Add a new tile arg (i32) and extend tile mappings.
+  Block &tileBlock = op.getTileRegion().front();
+  bool hasTileIndex =
+      (tileBlock.getNumArguments() >
+       cast<DenseI32ArrayAttr>(tileMappings[0]).asArrayRef().size());
+
+  // Insert the new arg before the tile index arg (if present), otherwise
+  // append.
+  unsigned insertPos = hasTileIndex ? tileBlock.getNumArguments() - 1
+                                    : tileBlock.getNumArguments();
+  tileBlock.insertArgument(insertPos, setupBuilder.getI32Type(), loc);
+
+  // Extend tile mappings with the per-tile offset yield index.
+  MLIRContext *ctx = op.getContext();
+  SmallVector<Attribute> newMappingAttrs;
+  for (unsigned t = 0; t < numTiles; ++t) {
+    SmallVector<int32_t> indices(
+        cast<DenseI32ArrayAttr>(tileMappings[t]).asArrayRef());
+    indices.push_back(static_cast<int32_t>(rangeYieldBase + t));
+    newMappingAttrs.push_back(DenseI32ArrayAttr::get(ctx, indices));
+  }
+  op.setTileMappingsAttr(ArrayAttr::get(ctx, newMappingAttrs));
+}
+
+/// Push tmem_load ops from setup into the tile body so that loads are
+/// interleaved with per-tile compute during lowering.
+///
+/// For per-tile yield values defined by a chain of tmem_load (+ optional
+/// convert_layout) from a tmem_subslice, this replaces the yield value with
+/// the memdesc (tmem_subslice result), changes the tile arg type, and clones
+/// the tmem_load chain into the tile body.
+void pushTmemLoadsToTile(SubtiledRegionOp op) {
+  ArrayAttr tileMappings = op.getTileMappings();
+  unsigned numTiles = tileMappings.size();
+  if (numTiles <= 1)
+    return;
+
+  Block &setupBlock = op.getSetupRegion().front();
+  auto setupYield = cast<SubtiledRegionYieldOp>(setupBlock.getTerminator());
+  Block &tileBlock = op.getTileRegion().front();
+  unsigned mappingSize =
+      cast<DenseI32ArrayAttr>(tileMappings[0]).asArrayRef().size();
+
+  // Find per-tile arg positions where tile mappings differ and the yield
+  // values trace back through convert_layout* → tmem_load → tmem_subslice.
+  struct LoadChain {
+    unsigned argPosition;
+    SmallVector<unsigned> yieldIndices; // one per tile
+    SmallVector<Operation *> opsToClone;
+    Value memDescValue; // the tmem_subslice result to yield instead
+  };
+  SmallVector<LoadChain> loadChains;
+
+  for (unsigned p = 0; p < mappingSize; ++p) {
+    // Skip args with no users in the tile body.
+    BlockArgument arg = tileBlock.getArgument(p);
+    if (arg.use_empty())
+      continue;
+
+    // Check if this arg is per-tile (different yield indices across tiles).
+    SmallVector<unsigned> yieldIndices;
+    for (unsigned t = 0; t < numTiles; ++t)
+      yieldIndices.push_back(
+          cast<DenseI32ArrayAttr>(tileMappings[t]).asArrayRef()[p]);
+
+    bool allSame = llvm::all_of(
+        yieldIndices, [&](unsigned idx) { return idx == yieldIndices[0]; });
+    if (allSame)
+      continue;
+
+    // Trace back from the first tile's yield value to find tmem_load chain.
+    Value yieldVal = setupYield.getResults()[yieldIndices[0]];
+
+    // Collect the chain: (convert_layout)* → tmem_load.
+    SmallVector<Operation *> chain;
+    Value current = yieldVal;
+    while (auto cvt = current.getDefiningOp<gpu::ConvertLayoutOp>()) {
+      chain.push_back(cvt);
+      current = cvt.getSrc();
+    }
+
+    auto tmemLoad = current.getDefiningOp<TMEMLoadOp>();
+    if (!tmemLoad)
+      continue;
+    chain.push_back(tmemLoad);
+
+    // Verify the tmem_load source is a tmem_subslice.
+    auto subslice = tmemLoad.getSrc().getDefiningOp<TMEMSubSliceOp>();
+    if (!subslice)
+      continue;
+
+    // Verify all tiles have the same chain structure (just different
+    // subslice N offsets).
+    bool allValid = true;
+    for (unsigned t = 1; t < numTiles; ++t) {
+      Value otherYield = setupYield.getResults()[yieldIndices[t]];
+      Value otherCur = otherYield;
+      for (size_t i = 0; i + 1 < chain.size(); ++i) {
+        auto otherCvt = otherCur.getDefiningOp<gpu::ConvertLayoutOp>();
+        if (!otherCvt) {
+          allValid = false;
+          break;
+        }
+        otherCur = otherCvt.getSrc();
+      }
+      if (!allValid)
+        break;
+      if (!otherCur.getDefiningOp<TMEMLoadOp>()) {
+        allValid = false;
+        break;
+      }
+    }
+    if (!allValid)
+      continue;
+
+    // Reverse chain so it's in program order (tmem_load first).
+    std::reverse(chain.begin(), chain.end());
+
+    loadChains.push_back(
+        {p, std::move(yieldIndices), std::move(chain), subslice.getResult()});
+  }
+
+  if (loadChains.empty())
+    return;
+
+  MLIRContext *ctx = op.getContext();
+  Location loc = op.getLoc();
+
+  // For each load chain:
+  // 1. Replace yield values with the memdesc (tmem_subslice result)
+  // 2. Change tile arg type from tensor to memdesc
+  // 3. Clone tmem_load chain into tile body
+  for (auto &lc : loadChains) {
+    // Update yield values for all tiles: yield the memdesc instead.
+    // Each tile's yield index points to a different tmem_load result;
+    // replace with the corresponding tmem_subslice result.
+    SmallVector<Value> yieldValues(setupYield.getResults());
+    for (unsigned t = 0; t < numTiles; ++t) {
+      Value tileYield = yieldValues[lc.yieldIndices[t]];
+      // Trace back to tmem_load → tmem_subslice for this tile.
+      Value cur = tileYield;
+      while (auto cvt = cur.getDefiningOp<gpu::ConvertLayoutOp>())
+        cur = cvt.getSrc();
+      auto load = cur.getDefiningOp<TMEMLoadOp>();
+      yieldValues[lc.yieldIndices[t]] = load.getSrc();
+    }
+    OpBuilder setupBuilder(setupYield);
+    SubtiledRegionYieldOp::create(setupBuilder, setupYield.getLoc(),
+                                  yieldValues);
+    setupYield.erase();
+    setupYield = cast<SubtiledRegionYieldOp>(setupBlock.getTerminator());
+
+    // Change tile arg type from tensor to memdesc.
+    BlockArgument oldArg = tileBlock.getArgument(lc.argPosition);
+    Type memDescType = lc.memDescValue.getType();
+    BlockArgument newArg =
+        tileBlock.insertArgument(lc.argPosition, memDescType, loc);
+    // Don't replace uses yet — we need to clone the chain first.
+
+    // Clone the tmem_load chain into the tile body, right before the first
+    // user of the old arg.
+    Operation *firstUser = nullptr;
+    for (Operation *user : oldArg.getUsers()) {
+      if (!firstUser || user->isBeforeInBlock(firstUser))
+        firstUser = user;
+    }
+
+    OpBuilder tileBuilder(&tileBlock, firstUser ? Block::iterator(firstUser)
+                                                : tileBlock.begin());
+    IRMapping tileCloneMapping;
+    // Map tmem_load's source (memdesc) to the new tile arg.
+    tileCloneMapping.map(lc.opsToClone.front()->getOperand(0), newArg);
+    for (Operation *chainOp : lc.opsToClone)
+      tileBuilder.clone(*chainOp, tileCloneMapping);
+
+    // The last cloned op produces the tensor that replaces the old arg.
+    Operation *lastCloned = lc.opsToClone.back();
+    Value clonedResult =
+        tileCloneMapping.lookupOrDefault(lastCloned->getResult(0));
+    oldArg.replaceAllUsesWith(clonedResult);
+    tileBlock.eraseArgument(lc.argPosition + 1); // remove old arg (shifted)
+  }
+
+  // Clean up: remove tile args that have no users in the tile body,
+  // compact the tile mappings and yield, then erase dead setup ops.
+  tileMappings = op.getTileMappings();
+  mappingSize = cast<DenseI32ArrayAttr>(tileMappings[0]).asArrayRef().size();
+  setupYield = cast<SubtiledRegionYieldOp>(setupBlock.getTerminator());
+
+  // Detect optional tile index arg (not in mappings).
+  bool hasTileIndex =
+      (tileBlock.getNumArguments() >
+       cast<DenseI32ArrayAttr>(tileMappings[0]).asArrayRef().size());
+
+  // Find unused mapped arg positions.
+  DenseSet<unsigned> unusedPositions;
+  for (unsigned p = 0; p < mappingSize; ++p) {
+    if (tileBlock.getArgument(p).use_empty())
+      unusedPositions.insert(p);
+  }
+
+  if (!unusedPositions.empty()) {
+    // Rebuild tile mappings and yield without unused positions.
+    DenseSet<unsigned> usedYieldIndices;
+    SmallVector<SmallVector<int32_t>> newMappingsRaw(numTiles);
+    for (unsigned p = 0; p < mappingSize; ++p) {
+      if (unusedPositions.contains(p))
+        continue;
+      for (unsigned t = 0; t < numTiles; ++t) {
+        int32_t yIdx = cast<DenseI32ArrayAttr>(tileMappings[t]).asArrayRef()[p];
+        newMappingsRaw[t].push_back(yIdx);
+        usedYieldIndices.insert(yIdx);
+      }
+    }
+
+    // Compact yield values and remap indices.
+    unsigned numYieldValues = setupYield.getResults().size();
+    SmallVector<int32_t> oldToNew(numYieldValues, -1);
+    SmallVector<Value> newYieldValues;
+    int32_t newIdx = 0;
+    for (unsigned i = 0; i < numYieldValues; ++i) {
+      if (usedYieldIndices.contains(i)) {
+        oldToNew[i] = newIdx++;
+        newYieldValues.push_back(setupYield.getResults()[i]);
+      }
+    }
+    for (auto &mapping : newMappingsRaw)
+      for (auto &idx : mapping)
+        idx = oldToNew[idx];
+
+    // Erase unused tile block args (reverse order).
+    SmallVector<unsigned> toRemove(unusedPositions.begin(),
+                                   unusedPositions.end());
+    llvm::sort(toRemove, std::greater<unsigned>());
+    for (unsigned p : toRemove)
+      tileBlock.eraseArgument(p);
+
+    // Update tile mappings.
+    SmallVector<Attribute> mappingAttrs;
+    for (auto &mapping : newMappingsRaw)
+      mappingAttrs.push_back(DenseI32ArrayAttr::get(ctx, mapping));
+    op.setTileMappingsAttr(ArrayAttr::get(ctx, mappingAttrs));
+
+    // Rebuild setup yield.
+    OpBuilder setupBuilder(setupYield);
+    SubtiledRegionYieldOp::create(setupBuilder, setupYield.getLoc(),
+                                  newYieldValues);
+    setupYield.erase();
+  }
+
+  // Erase dead ops in the setup block. Collect then erase in reverse
+  // program order, repeating until no more dead ops are found.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    SmallVector<Operation *> deadOps;
+    for (Operation &setupOp : setupBlock.without_terminator()) {
+      if (setupOp.getResults().empty())
+        continue;
+      if (llvm::all_of(setupOp.getResults(),
+                       [](Value v) { return v.use_empty(); }))
+        deadOps.push_back(&setupOp);
+    }
+    for (auto *op : llvm::reverse(deadOps)) {
+      op->erase();
+      changed = true;
+    }
+  }
+}
+
+void pushSharedSetupToTile(SubtiledRegionOp op) {
+  ArrayAttr tileMappings = op.getTileMappings();
+  unsigned numTiles = tileMappings.size();
+  if (numTiles <= 1)
+    return;
+
+  Block &tileBlock = op.getTileRegion().front();
+  unsigned numArgs = tileBlock.getNumArguments();
+  Block &setupBlock = op.getSetupRegion().front();
+  auto setupYield = cast<SubtiledRegionYieldOp>(setupBlock.getTerminator());
+
+  // Detect optional tile index argument (last arg, not in tileMappings).
+  unsigned mappingSize =
+      cast<DenseI32ArrayAttr>(tileMappings[0]).asArrayRef().size();
+  unsigned numMappedArgs = mappingSize;
+
+  // Step 1: Find shared arg positions — all tiles map to the same yield index.
+  // Only scan mapped args (skip trailing tile index arg if present).
+  struct SharedArg {
+    unsigned argPosition;
+    unsigned yieldIndex;
+  };
+  SmallVector<SharedArg> sharedArgs;
+
+  for (unsigned p = 0; p < numMappedArgs; ++p) {
+    int32_t yIdx = cast<DenseI32ArrayAttr>(tileMappings[0]).asArrayRef()[p];
+    bool isShared = true;
+    for (unsigned t = 1; t < numTiles; ++t) {
+      if (cast<DenseI32ArrayAttr>(tileMappings[t]).asArrayRef()[p] != yIdx) {
+        isShared = false;
+        break;
+      }
+    }
+    if (isShared)
+      sharedArgs.push_back({p, static_cast<unsigned>(yIdx)});
+  }
+
+  if (sharedArgs.empty())
+    return;
+
+  // Step 2: Determine which shared args are movable.
+  // A shared value is movable if it and all its setup-internal dependencies
+  // are defined outside the SubtiledRegionOp or only depend on values from
+  // outside.
+  DenseSet<Operation *> opsToMove;
+  SmallVector<SharedArg> movableArgs;
+
+  for (auto &sa : sharedArgs) {
+    Value yieldVal = setupYield.getResults()[sa.yieldIndex];
+    Operation *defOp = yieldVal.getDefiningOp();
+
+    if (!defOp || defOp->getBlock() != &setupBlock) {
+      // Defined outside setup — directly usable in tile body.
+      movableArgs.push_back(sa);
+      continue;
+    }
+
+    // Backward slice within setup to find all internal dependencies.
+    SmallVector<Operation *> slice;
+    SmallVector<Operation *> worklist = {defOp};
+    DenseSet<Operation *> visited;
+    bool allMovable = true;
+
+    while (!worklist.empty() && allMovable) {
+      Operation *curr = worklist.pop_back_val();
+      if (!visited.insert(curr).second)
+        continue;
+
+      if (!isPure(curr)) {
+        allMovable = false;
+        break;
+      }
+      slice.push_back(curr);
+
+      for (Value operand : curr->getOperands()) {
+        Operation *operandDef = operand.getDefiningOp();
+        if (!operandDef) {
+          if (cast<BlockArgument>(operand).getOwner() == &setupBlock) {
+            allMovable = false;
+            break;
+          }
+          continue;
+        }
+        if (operandDef->getBlock() != &setupBlock)
+          continue;
+        worklist.push_back(operandDef);
+      }
+    }
+
+    if (allMovable) {
+      movableArgs.push_back(sa);
+      for (auto *o : slice)
+        opsToMove.insert(o);
+    }
+  }
+
+  if (movableArgs.empty())
+    return;
+
+  // Step 3: Clone ops into the tile body, sinking each shared arg's
+  // dependency chain to right before its first use. This keeps tmem_load
+  // close to its consumer rather than hoisting it above barrier waits.
+
+  // Sort ops in program order for correct cloning.
+  SmallVector<Operation *> sortedOps(opsToMove.begin(), opsToMove.end());
+  llvm::sort(sortedOps,
+             [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
+
+  // For each movable arg, find the earliest op in the tile body that uses
+  // it. This is where we will sink the shared dependency chain.
+  Operation *earliestUser = nullptr;
+  for (auto &sa : movableArgs) {
+    BlockArgument arg = tileBlock.getArgument(sa.argPosition);
+    for (Operation *user : arg.getUsers()) {
+      if (!earliestUser || user->isBeforeInBlock(earliestUser))
+        earliestUser = user;
+    }
+  }
+
+  // Clone the dependency chain right before the earliest consumer.
+  IRMapping cloneMapping;
+  if (earliestUser) {
+    OpBuilder tileBuilder(&tileBlock, Block::iterator(earliestUser));
+    for (Operation *o : sortedOps)
+      tileBuilder.clone(*o, cloneMapping);
+  }
+
+  // Replace tile block args with cloned values (or external values).
+  for (auto &sa : movableArgs) {
+    Value yieldVal = setupYield.getResults()[sa.yieldIndex];
+    Value replacement = cloneMapping.lookupOrDefault(yieldVal);
+    tileBlock.getArgument(sa.argPosition).replaceAllUsesWith(replacement);
+  }
+
+  // Step 4: Remove shared args from tile block and rebuild tileMappings/yield.
+  DenseSet<unsigned> sharedPositions;
+  for (auto &sa : movableArgs)
+    sharedPositions.insert(sa.argPosition);
+
+  // Determine which yield indices are still needed by non-shared args.
+  DenseSet<unsigned> usedYieldIndices;
+  SmallVector<SmallVector<int32_t>> newMappingsRaw(numTiles);
+
+  for (unsigned p = 0; p < numMappedArgs; ++p) {
+    if (sharedPositions.contains(p))
+      continue;
+    for (unsigned t = 0; t < numTiles; ++t) {
+      int32_t yIdx = cast<DenseI32ArrayAttr>(tileMappings[t]).asArrayRef()[p];
+      newMappingsRaw[t].push_back(yIdx);
+      usedYieldIndices.insert(yIdx);
+    }
+  }
+
+  // Build compacted yield and index remapping.
+  unsigned numYieldValues = setupYield.getResults().size();
+  SmallVector<int32_t> oldToNew(numYieldValues, -1);
+  SmallVector<Value> newYieldValues;
+  int32_t newIdx = 0;
+  for (unsigned i = 0; i < numYieldValues; ++i) {
+    if (usedYieldIndices.contains(i)) {
+      oldToNew[i] = newIdx++;
+      newYieldValues.push_back(setupYield.getResults()[i]);
+    }
+  }
+
+  // Remap indices in new mappings.
+  for (auto &mapping : newMappingsRaw) {
+    for (auto &idx : mapping)
+      idx = oldToNew[idx];
+  }
+
+  // Erase shared block args (reverse order to preserve indices).
+  SmallVector<unsigned> toRemove(sharedPositions.begin(),
+                                 sharedPositions.end());
+  llvm::sort(toRemove, std::greater<unsigned>());
+  for (unsigned p : toRemove)
+    tileBlock.eraseArgument(p);
+
+  // Update tileMappings attribute.
+  MLIRContext *ctx = op.getContext();
+  SmallVector<Attribute> mappingAttrs;
+  for (auto &mapping : newMappingsRaw)
+    mappingAttrs.push_back(DenseI32ArrayAttr::get(ctx, mapping));
+  op.setTileMappingsAttr(ArrayAttr::get(ctx, mappingAttrs));
+
+  // Rebuild setup yield with only used values.
+  OpBuilder setupBuilder(setupYield);
+  SubtiledRegionYieldOp::create(setupBuilder, setupYield.getLoc(),
+                                newYieldValues);
+  setupYield.erase();
+
+  // No barrier annotation adjustment needed — annotations use stable op IDs
+  // (subtile_op_id attributes) that survive tile body transformations.
+}
+
+class TritonNvidiaGPUPushSharedSetupToTilePass
+    : public impl::TritonNvidiaGPUPushSharedSetupToTilePassBase<
+          TritonNvidiaGPUPushSharedSetupToTilePass> {
+public:
+  using TritonNvidiaGPUPushSharedSetupToTilePassBase::
+      TritonNvidiaGPUPushSharedSetupToTilePassBase;
+
+  void runOnOperation() override {
+    SmallVector<SubtiledRegionOp> ops;
+    getOperation().walk([&](SubtiledRegionOp op) { ops.push_back(op); });
+
+    for (auto op : ops)
+      addSubsliceRangeToSetup(op);
+    for (auto op : ops)
+      pushTmemLoadsToTile(op);
+    for (auto op : ops)
+      pushSharedSetupToTile(op);
+  }
+};
+
+} // namespace
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -394,6 +394,7 @@ class Config:
         reg_inc_consumer=0,
         ctas_per_cga=None,
         early_tma_store_lowering=None,
+        generate_subtiled_region=None,
         preferred_ctas_per_cga=None,
     ):
         self.kwargs = kwargs
@@ -408,6 +409,7 @@ class Config:
         self.pingpongAutoWS = pingpongAutoWS
         self.ctas_per_cga = ctas_per_cga
         self.early_tma_store_lowering = early_tma_store_lowering
+        self.generate_subtiled_region = generate_subtiled_region
         self.preferred_ctas_per_cga = preferred_ctas_per_cga
 
     def __setstate__(self, state):
@@ -423,6 +425,7 @@ class Config:
         self.pingpongAutoWS = state.get("pingpongAutoWS", None)
         self.ctas_per_cga = state.get("ctas_per_cga", None)
         self.early_tma_store_lowering = state.get("early_tma_store_lowering", None)
+        self.generate_subtiled_region = state.get("generate_subtiled_region", None)
         self.preferred_ctas_per_cga = state.get("preferred_ctas_per_cga", None)
 
     def all_kwargs(self):
@@ -441,6 +444,7 @@ class Config:
                     ("pingpongAutoWS", self.pingpongAutoWS),
                     ("ctas_per_cga", self.ctas_per_cga),
                     ("early_tma_store_lowering", self.early_tma_store_lowering),
+                    ("generate_subtiled_region", self.generate_subtiled_region),
                     ("preferred_ctas_per_cga", self.preferred_ctas_per_cga),
                 ) if v is not None
             },
@@ -459,6 +463,7 @@ class Config:
         res.append(f"pingpongAutoWS: {self.pingpongAutoWS}")
         res.append(f"ctas_per_cga: {self.ctas_per_cga}")
         res.append(f"early_tma_store_lowering: {self.early_tma_store_lowering}")
+        res.append(f"generate_subtiled_region: {self.generate_subtiled_region}")
         res.append(f"preferred_ctas_per_cga: {self.preferred_ctas_per_cga}")
         return ", ".join(res)
 

--- a/test/TritonNvidiaGPU/generate_subtiled_region_multi_task.mlir
+++ b/test/TritonNvidiaGPU/generate_subtiled_region_multi_task.mlir
@@ -181,11 +181,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
 
   // CHECK-LABEL: @identity_insertion_addi
-  // The tile body should include the arith.addi from the longer chain:
+  // The tile body should include the arith.addi from the longer chain.
+  // The split result and differing operands must use tile block arguments.
   // CHECK: ttng.subtiled_region
   // CHECK:   } tile{
-  // CHECK:     arith.truncf
-  // CHECK:     arith.addi
+  // CHECK: ^bb0(%{{.*}}: tensor<{{.*}}>, %[[DIFF:.*]]: tensor<{{.*}}>, %[[VARY:.*]]: i32, %[[TIDX:.*]]: i32):
+  // CHECK:     arith.truncf %[[DIFF]]
+  // CHECK:     arith.addi %{{.*}}, %[[VARY]]
+  // CHECK:     tt.descriptor_store
   // CHECK:     ttng.subtiled_region_yield
   // CHECK:   }
   tt.func @identity_insertion_addi(
@@ -228,12 +231,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
 
   // CHECK-LABEL: @identity_descriptor_store_epilogue
-  // The tile body should include the full epilogue chain with arith.addi:
+  // The tile body should include the full epilogue chain with arith.addi.
+  // The split result, bias, and offset operands must be tile block arguments.
   // CHECK: ttng.subtiled_region
   // CHECK:   } tile{
-  // CHECK:     ttg.convert_layout
-  // CHECK:     arith.addi
-  // CHECK:     arith.extf
+  // CHECK: ^bb0(%{{.*}}: tensor<{{.*}}>, %[[SPLIT:.*]]: tensor<{{.*}}>, %[[BIAS:.*]]: tensor<{{.*}}>, %[[VARY:.*]]: i32, %[[TIDX:.*]]: i32):
+  // CHECK:     ttg.convert_layout %[[SPLIT]]
+  // CHECK:     arith.addi %{{.*}}, %[[VARY]]
+  // CHECK:     arith.extf %[[BIAS]]
   // CHECK:     arith.addf
   // CHECK:     arith.truncf
   // CHECK:     tt.descriptor_store

--- a/test/TritonNvidiaGPU/generate_subtiled_region_tmem_split.mlir
+++ b/test/TritonNvidiaGPU/generate_subtiled_region_tmem_split.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-test-generate-subtiled-region --triton-nvidia-optimize-tmem-layouts | FileCheck %s
+
+// Test: multi-task chain — the split in the first SubtiledRegionOp's setup
+// region is also converted to tmem_subslice + tmem_load.
+
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#blocked3d2 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked3d_perm2 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked_full2 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked2d2 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem2 = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: @multi_task_setup_tmem_split_optimized
+  // First SubtiledRegionOp setup should have subslice loads:
+  // CHECK: ttng.subtiled_region
+  // CHECK:   setup {
+  // CHECK:     ttng.tmem_subslice
+  // CHECK:     ttng.tmem_load
+  // CHECK:     ttg.convert_layout
+  // CHECK:     ttng.tmem_subslice
+  // CHECK:     ttng.tmem_load
+  // CHECK:     ttg.convert_layout
+  // CHECK-NOT: tt.split
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   } tile{
+  // CHECK:     arith.truncf
+  // CHECK:     ttg.local_store
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   }
+  tt.func @multi_task_setup_tmem_split_optimized(
+      %tmem_buf: !ttg.memdesc<128x128xf32, #tmem2, #ttng.tensor_memory, mutable>,
+      %acc_tok: !ttg.async.token,
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared2>>,
+      %off0: i32, %off1: i32, %off2: i32) {
+    %loaded:2 = ttng.tmem_load %tmem_buf[%acc_tok] : !ttg.memdesc<128x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked_full2>
+    %reshaped = tt.reshape %loaded#0 : tensor<128x128xf32, #blocked_full2> -> tensor<128x2x64xf32, #blocked3d2>
+    %transposed = tt.trans %reshaped {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked3d2> -> tensor<128x64x2xf32, #blocked3d_perm2>
+    %lhs, %rhs = tt.split %transposed : tensor<128x64x2xf32, #blocked3d_perm2> -> tensor<128x64xf32, #blocked2d2>
+
+    %trunc0 = arith.truncf %lhs {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked2d2> to tensor<128x64xf16, #blocked2d2>
+    %smem0 = ttg.local_alloc %trunc0 {async_task_id = array<i32: 3>} : (tensor<128x64xf16, #blocked2d2>) -> !ttg.memdesc<128x64xf16, #shared2, #smem2, mutable>
+    ttng.async_tma_copy_local_to_global %desc[%off0, %off1] %smem0 {async_task_id = array<i32: 4>} : !tt.tensordesc<tensor<128x64xf16, #shared2>>, !ttg.memdesc<128x64xf16, #shared2, #smem2, mutable>
+
+    %trunc1 = arith.truncf %rhs {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked2d2> to tensor<128x64xf16, #blocked2d2>
+    %smem1 = ttg.local_alloc %trunc1 {async_task_id = array<i32: 3>} : (tensor<128x64xf16, #blocked2d2>) -> !ttg.memdesc<128x64xf16, #shared2, #smem2, mutable>
+    ttng.async_tma_copy_local_to_global %desc[%off0, %off2] %smem1 {async_task_id = array<i32: 4>} : !tt.tensordesc<tensor<128x64xf16, #shared2>>, !ttg.memdesc<128x64xf16, #shared2, #smem2, mutable>
+
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/lower_subtiled_region.mlir
+++ b/test/TritonNvidiaGPU/lower_subtiled_region.mlir
@@ -62,7 +62,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c128 = arith.constant 128 : i32
         ttng.subtiled_region_yield %c0, %c128 : i32, i32
       } tile(%arg0: i32) {
-        %off = arith.addi %arg0, %row : i32
+        %off = arith.addi %arg0, %row {subtile_op_id = 0 : i32} : i32
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -96,7 +96,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c1 = arith.constant 1 : i32
         ttng.subtiled_region_yield %c0, %c1 : i32, i32
       } tile(%arg0: i32) {
-        %res = arith.addi %arg0, %arg0 : i32
+        %res = arith.addi %arg0, %arg0 {subtile_op_id = 0 : i32} : i32
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -168,7 +168,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c5 = arith.constant 5 : i32
         ttng.subtiled_region_yield %c3, %c5 : i32, i32
       } tile(%arg0: i32) {
-        %res = arith.muli %arg0, %arg0 : i32
+        %res = arith.muli %arg0, %arg0 {subtile_op_id = 0 : i32} : i32
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -200,7 +200,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c42 = arith.constant 42 : i32
         ttng.subtiled_region_yield %c42 : i32
       } tile(%arg0: i32) {
-        %res = arith.addi %arg0, %arg0 : i32
+        %res = arith.addi %arg0, %arg0 {subtile_op_id = 0 : i32} : i32
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -315,7 +315,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c1 = arith.constant 1 : i32
         ttng.subtiled_region_yield %c0, %c1 : i32, i32
       } tile(%arg0: i32) {
-        %idx = arith.index_cast %arg0 : i32 to index
+        %idx = arith.index_cast %arg0 {subtile_op_id = 0 : i32} : i32 to index
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -349,7 +349,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c1 = arith.constant 1 : i32
         ttng.subtiled_region_yield %c0, %c1 : i32, i32
       } tile(%arg0: i32) {
-        %idx = arith.index_cast %arg0 : i32 to index
+        %idx = arith.index_cast %arg0 {subtile_op_id = 0 : i32} : i32 to index
         ttng.subtiled_region_yield
       } teardown {
         %c42 = arith.constant 42 : i32
@@ -382,7 +382,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c1 = arith.constant 1 : i32
         ttng.subtiled_region_yield %c0, %c1 : i32, i32
       } tile(%arg0: i32) {
-        %idx = arith.index_cast %arg0 : i32 to index
+        %idx = arith.index_cast %arg0 {subtile_op_id = 0 : i32} : i32 to index
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -412,7 +412,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c1 = arith.constant 1 : i32
         ttng.subtiled_region_yield %c0, %c1 : i32, i32
       } tile(%arg0: i32) {
-        %idx = arith.index_cast %arg0 : i32 to index
+        %idx = arith.index_cast %arg0 {subtile_op_id = 0 : i32} : i32 to index
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -456,7 +456,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c1 = arith.constant 1 : i32
         ttng.subtiled_region_yield %c0, %c1 : i32, i32
       } tile(%arg0: i32) {
-        %idx = arith.index_cast %arg0 : i32 to index
+        %idx = arith.index_cast %arg0 {subtile_op_id = 0 : i32} : i32 to index
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+
+  // Test tile index argument: the trailing i32 arg is substituted with
+  // the tile index constant (0, 1, ...) during lowering.
+  // CHECK-LABEL: @tile_index_arg
+  tt.func @tile_index_arg() {
+    // Setup:
+    // CHECK: %[[C10:.*]] = arith.constant 10 : i32
+    // CHECK: %[[C20:.*]] = arith.constant 20 : i32
+    // Tile 0: arg0 = c10, tileIdx = 0
+    // CHECK: %[[T0:.*]] = arith.constant 0 : i32
+    // CHECK: arith.addi %[[C10]], %[[T0]]
+    // Tile 1: arg0 = c20, tileIdx = 1
+    // CHECK: %[[T1:.*]] = arith.constant 1 : i32
+    // CHECK: arith.addi %[[C20]], %[[T1]]
+    // CHECK-NOT: ttng.subtiled_region
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = []
+      setup {
+        %c10 = arith.constant 10 : i32
+        %c20 = arith.constant 20 : i32
+        ttng.subtiled_region_yield %c10, %c20 : i32, i32
+      } tile(%arg0: i32, %tileIdx: i32) {
+        %sum = arith.addi %arg0, %tileIdx : i32
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield
@@ -491,7 +521,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %c1 = arith.constant 1 : i32
         ttng.subtiled_region_yield %c0, %c1 : i32, i32
       } tile(%arg0: i32) {
-        %idx = arith.index_cast %arg0 : i32 to index
+        %idx = arith.index_cast %arg0 {subtile_op_id = 0 : i32} : i32 to index
         ttng.subtiled_region_yield
       } teardown {
         ttng.subtiled_region_yield

--- a/test/TritonNvidiaGPU/push_shared_setup_to_tile.mlir
+++ b/test/TritonNvidiaGPU/push_shared_setup_to_tile.mlir
@@ -1,0 +1,324 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-push-shared-setup-to-tile | FileCheck %s
+
+// Test: shared arg (same yield index for all tiles) is pushed into tile body.
+// Arg position 1 maps to yield[2] for both tiles → shared.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @push_shared_constant
+  // The shared value (yield[2] = %c42) should be pushed into the tile body
+  // and removed from setup yield and tile args.
+  // CHECK: ttng.subtiled_region
+  // CHECK:   tile_mappings = [array<i32: 0>, array<i32: 1>]
+  // CHECK:   setup {
+  // CHECK:     ttng.subtiled_region_yield %{{.*}}, %{{.*}} : i32, i32
+  // CHECK:   } tile{
+  // CHECK:     %[[C42:.*]] = arith.constant 42 : i32
+  // CHECK:     arith.addi %{{.*}}, %[[C42]]
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   }
+  tt.func @push_shared_constant() {
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 2>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c128 = arith.constant 128 : i32
+        %c42 = arith.constant 42 : i32
+        ttng.subtiled_region_yield %c0, %c128, %c42 : i32, i32, i32
+      } tile(%arg0: i32, %arg1: i32) {
+        %sum = arith.addi %arg0, %arg1 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Test: external value shared across tiles. No op to clone — just replace
+// the tile arg with the external value directly.
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @push_shared_external
+  // The shared external value should be used directly in the tile body.
+  // CHECK: ttng.subtiled_region
+  // CHECK:   tile_mappings = [array<i32: 0>, array<i32: 1>]
+  // CHECK:   setup {
+  // CHECK:     ttng.subtiled_region_yield %{{.*}}, %{{.*}} : i32, i32
+  // CHECK:   } tile{
+  // CHECK:     arith.addi %{{.*}}, %{{.*}}
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   }
+  tt.func @push_shared_external(%ext: i32) {
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 2>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c128 = arith.constant 128 : i32
+        ttng.subtiled_region_yield %c0, %c128, %ext : i32, i32, i32
+      } tile(%arg0: i32, %arg1: i32) {
+        %sum = arith.addi %arg0, %arg1 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Test: no shared args — nothing should change.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @no_shared_args
+  // CHECK: tile_mappings = [array<i32: 0>, array<i32: 1>]
+  // CHECK:   setup {
+  // CHECK:     ttng.subtiled_region_yield %{{.*}}, %{{.*}} : i32, i32
+  // CHECK:   } tile{
+  // CHECK:     arith.index_cast
+  tt.func @no_shared_args() {
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0>, array<i32: 1>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c1 = arith.constant 1 : i32
+        ttng.subtiled_region_yield %c0, %c1 : i32, i32
+      } tile(%arg0: i32) {
+        %idx = arith.index_cast %arg0 : i32 to index
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Test: shared arg with a chain of setup ops that need to move together.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @push_shared_chain
+  // Both ops in the chain (constant + addi) should be pushed into tile body.
+  // CHECK: ttng.subtiled_region
+  // CHECK:   tile_mappings = [array<i32: 0>, array<i32: 1>]
+  // CHECK:   setup {
+  // CHECK:     ttng.subtiled_region_yield %{{.*}}, %{{.*}} : i32, i32
+  // CHECK:   } tile{
+  // CHECK:     arith.constant 10
+  // CHECK:     arith.addi
+  // CHECK:     arith.muli
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   }
+  tt.func @push_shared_chain(%ext: i32) {
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 2>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c128 = arith.constant 128 : i32
+        %c10 = arith.constant 10 : i32
+        %shared = arith.addi %c10, %ext : i32
+        ttng.subtiled_region_yield %c0, %c128, %shared : i32, i32, i32
+      } tile(%arg0: i32, %arg1: i32) {
+        %prod = arith.muli %arg0, %arg1 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Test: barrier annotations have their targetOpIdx updated when ops are
+// inserted at the start of the tile body.
+
+#shared5 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem5 = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @barrier_annotation_reindex
+  // Barrier annotations use stable op IDs (subtile_op_id attribute), so
+  // targetOpIdx is unchanged even when ops are inserted before the target.
+  // CHECK: ttng.subtiled_region
+  // CHECK-SAME: barrier_annotations =
+  // CHECK-SAME: targetOpIdx = 0
+  tt.func @barrier_annotation_reindex(
+      %bar: !ttg.memdesc<1xi64, #shared5, #smem5, mutable>,
+      %accum_cnt: i64) {
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared5, #smem5, mutable>)
+        accum_cnts(%accum_cnt : i64)
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 2>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = before,
+              targetOpIdx = 0, barrierOpKind = "wait_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c128 = arith.constant 128 : i32
+        %c42 = arith.constant 42 : i32
+        ttng.subtiled_region_yield %c0, %c128, %c42 : i32, i32, i32
+      } tile(%arg0: i32, %arg1: i32) {
+        %sum = arith.addi %arg0, %arg1 {subtile_op_id = 0 : i32} : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Test: per-tile tmem_load is pushed from setup into tile body.
+// The setup yields memdesc (tmem_subslice result) instead of tensor
+// (tmem_load result), and the tile body receives a memdesc arg with
+// tmem_load + convert_layout cloned inside.
+
+#tmem6 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem6s = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#linear6 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: @push_tmem_load_to_tile
+  // The tile body should receive a memdesc arg and contain tmem_load + convert_layout.
+  // CHECK: ttng.subtiled_region
+  // CHECK:   setup {
+  // CHECK:     ttng.tmem_subslice
+  // CHECK:     ttng.tmem_subslice
+  // CHECK:     ttng.subtiled_region_yield {{.*}} !ttg.memdesc{{.*}}, !ttg.memdesc
+  // CHECK:   } tile{
+  // CHECK:     ttng.tmem_load %{{.*}} :
+  // CHECK:     ttg.convert_layout
+  // CHECK:     arith.truncf
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   }
+  tt.func @push_tmem_load_to_tile(
+      %tmem_buf: !ttg.memdesc<128x128xf32, #tmem6, #ttng.tensor_memory, mutable>,
+      %acc_tok: !ttg.async.token) {
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 3>]
+        barrier_annotations = []
+      setup {
+        %s0 = ttng.tmem_subslice %tmem_buf {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem6, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem6s, #ttng.tensor_memory, mutable, 128x128>
+        %l0 = ttng.tmem_load %s0 : !ttg.memdesc<128x64xf32, #tmem6s, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear6>
+        %cvt0 = ttg.convert_layout %l0 : tensor<128x64xf32, #linear6> -> tensor<128x64xf32, #blocked6>
+        %s1 = ttng.tmem_subslice %tmem_buf {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem6, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem6s, #ttng.tensor_memory, mutable, 128x128>
+        %l1 = ttng.tmem_load %s1 : !ttg.memdesc<128x64xf32, #tmem6s, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear6>
+        %cvt1 = ttg.convert_layout %l1 : tensor<128x64xf32, #linear6> -> tensor<128x64xf32, #blocked6>
+        %c0 = arith.constant 0 : i32
+        %c64 = arith.constant 64 : i32
+        ttng.subtiled_region_yield %cvt0, %cvt1, %cvt0, %cvt1, %c0, %c64 : tensor<128x64xf32, #blocked6>, tensor<128x64xf32, #blocked6>, tensor<128x64xf32, #blocked6>, tensor<128x64xf32, #blocked6>, i32, i32
+      } tile(%arg0: tensor<128x64xf32, #blocked6>, %arg1: tensor<128x64xf32, #blocked6>, %nOff: i32) {
+        %trunc = arith.truncf %arg1 : tensor<128x64xf32, #blocked6> to tensor<128x64xf16, #blocked6>
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Test: shared ops are sunk to their first consumer, not placed at tile
+// body start. The constant should appear right before the addi, not
+// before the muli.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @sink_shared_to_consumer
+  // CHECK: ttng.subtiled_region
+  // CHECK:   } tile{
+  // CHECK:     arith.muli
+  // CHECK:     arith.constant 42
+  // CHECK:     arith.addi
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   }
+  tt.func @sink_shared_to_consumer() {
+    ttng.subtiled_region
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 2>]
+        barrier_annotations = []
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c128 = arith.constant 128 : i32
+        %c42 = arith.constant 42 : i32
+        ttng.subtiled_region_yield %c0, %c128, %c42 : i32, i32, i32
+      } tile(%arg0: i32, %arg1: i32) {
+        %prod = arith.muli %arg0, %arg0 : i32
+        %sum = arith.addi %prod, %arg1 : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}
+
+// -----
+
+// Test: lowering a tile body with a barrier annotation and pushed shared
+// ops produces the barrier at the correct position (after the pushed ops,
+// before the annotated op).
+
+#shared8 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem8 = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @barrier_after_pushed_ops
+  // After pushing the shared constant, the barrier annotation on the muli
+  // (subtile_op_id=0) should still target the muli, not the pushed constant.
+  // CHECK: ttng.subtiled_region
+  // CHECK-SAME: targetOpIdx = 0
+  // CHECK:   } tile{
+  // CHECK:     arith.constant 42
+  // CHECK:     arith.muli {{.*}} {subtile_op_id = 0 : i32}
+  // CHECK:     ttng.subtiled_region_yield
+  // CHECK:   }
+  tt.func @barrier_after_pushed_ops(
+      %bar: !ttg.memdesc<1xi64, #shared8, #smem8, mutable>,
+      %accum_cnt: i64) {
+    ttng.subtiled_region
+        barriers(%bar : !ttg.memdesc<1xi64, #shared8, #smem8, mutable>)
+        accum_cnts(%accum_cnt : i64)
+        tile_mappings = [array<i32: 0, 2>, array<i32: 1, 2>]
+        barrier_annotations = [
+          #ttng.barrier_annotation<barrierIdx = 0, placement = before,
+              targetOpIdx = 0, barrierOpKind = "wait_barrier">
+        ]
+      setup {
+        %c0 = arith.constant 0 : i32
+        %c128 = arith.constant 128 : i32
+        %c42 = arith.constant 42 : i32
+        ttng.subtiled_region_yield %c0, %c128, %c42 : i32, i32, i32
+      } tile(%arg0: i32, %arg1: i32) {
+        %prod = arith.muli %arg0, %arg1 {subtile_op_id = 0 : i32} : i32
+        ttng.subtiled_region_yield
+      } teardown {
+        ttng.subtiled_region_yield
+      }
+    tt.return
+  }
+}

--- a/test_subtile_gemm.py
+++ b/test_subtile_gemm.py
@@ -1,0 +1,94 @@
+"""
+Run the autoWS addmm (beta GEMM) kernel with subtiled region generation
+and verify numerical correctness against a torch reference.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "python"))
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "python/test/unit/language"))
+from test_autows_addmm import addmm_kernel_tma_persistent_ws, _compute_pid
+
+M, N, K = 512, 512, 256
+BLOCK_SIZE_M = 128
+BLOCK_SIZE_N = 256
+BLOCK_SIZE_K = 64
+EPILOGUE_SUBTILE = 2
+DATA_PARTITION_FACTOR = 1
+FLATTEN = True
+num_stages = 2
+num_warps = 4
+GROUP_SIZE_M = 8
+SMEM_ALLOC_ALGO = 0
+
+dtype = torch.float16
+device = "cuda"
+NUM_SMS = torch.cuda.get_device_properties(device).multi_processor_count
+
+torch.manual_seed(42)
+A = torch.randn((M, K), dtype=dtype, device=device)
+B = torch.randn((N, K), dtype=dtype, device=device)
+bias = torch.randn((M, N), dtype=dtype, device=device)
+C = torch.empty((M, N), dtype=dtype, device=device)
+
+
+def alloc_fn(size, align, stream):
+    return torch.empty(size, dtype=torch.int8, device="cuda")
+
+
+triton.set_allocator(alloc_fn)
+
+a_desc = TensorDescriptor(A, [M, K], [K, 1], [BLOCK_SIZE_M, BLOCK_SIZE_K])
+b_desc = TensorDescriptor(B, [N, K], [K, 1], [BLOCK_SIZE_N, BLOCK_SIZE_K])
+c_desc = TensorDescriptor(C, C.shape, C.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_N // EPILOGUE_SUBTILE])
+bias_desc = TensorDescriptor(bias, [M, N], [N, 1], [BLOCK_SIZE_M, BLOCK_SIZE_N // EPILOGUE_SUBTILE])
+
+grid = lambda META: (min(
+    NUM_SMS,
+    triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+), )
+
+print(f"Running addmm kernel: M={M}, N={N}, K={K}, "
+      f"BLOCK_M={BLOCK_SIZE_M}, BLOCK_N={BLOCK_SIZE_N}")
+print(f"  EPILOGUE_SUBTILE={EPILOGUE_SUBTILE}, "
+      f"DATA_PARTITION_FACTOR={DATA_PARTITION_FACTOR}")
+print("  early_tma_store_lowering=True, generate_subtiled_region=True")
+
+with triton.knobs.nvidia.scope():
+    triton.knobs.nvidia.use_meta_ws = True
+    triton.knobs.nvidia.use_meta_partition = True
+
+    addmm_kernel_tma_persistent_ws[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        bias_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
+        NUM_SMS=NUM_SMS,
+        FLATTEN=FLATTEN,
+        A_COL_MAJOR=False,
+        B_COL_MAJOR=False,
+        DATA_PARTITION_FACTOR=DATA_PARTITION_FACTOR,
+        SMEM_ALLOC_ALGO=SMEM_ALLOC_ALGO,
+        num_stages=num_stages,
+        num_warps=num_warps,
+        early_tma_store_lowering=True,
+        generate_subtiled_region=True,
+    )
+
+ref = torch.matmul(A.float(), B.T.float()).to(dtype) + bias
+torch.testing.assert_close(C, ref, atol=0.03, rtol=0.03)
+print("PASS: numerical results match reference")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -170,6 +170,7 @@ class CUDAOptions:
     arch: str = None
     instrumentation_mode: str = ""
     early_tma_store_lowering: bool = False
+    generate_subtiled_region: bool = False
 
     def __post_init__(self):
         default_libdir = Path(__file__).parent / 'lib'
@@ -385,8 +386,9 @@ class CUDABackend(BaseBackend):
             if knobs.nvidia.use_meta_ws and knobs.nvidia.use_meta_partition:
                 nvidia.passes.hopper.add_partition_scheduling_meta(pm)
             smem_budget = _max_shared_mem_for_capability(capability)
+            generate_subtiled = opt.generate_subtiled_region or knobs.nvidia.generate_subtiled_region
             nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS, dump_enabled,
-                                                     smem_budget, knobs.nvidia.generate_subtiled_region)
+                                                     smem_budget, generate_subtiled)
             if not knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
@@ -416,9 +418,9 @@ class CUDABackend(BaseBackend):
                 else:
                     passes.ttgpuir.add_partition_scheduling(pm)
                 smem_budget = _max_shared_mem_for_capability(capability)
+                generate_subtiled = opt.generate_subtiled_region or knobs.nvidia.generate_subtiled_region
                 nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, capability, opt.pingpongAutoWS,
-                                                         dump_enabled, smem_budget,
-                                                         knobs.nvidia.generate_subtiled_region)
+                                                         dump_enabled, smem_budget, generate_subtiled)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_optimize_partition_warps(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -51,12 +51,18 @@ void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
 void doTMAStoreWaitReorder(triton::FuncOp &funcOp);
 void doAnnotateTMAStoreWaits(triton::FuncOp &funcOp);
 void doValidateTMAStoreAnnotations(triton::FuncOp &funcOp);
-
 void doGenerateSubtiledRegion(triton::FuncOp &funcOp) {
   auto moduleOp = funcOp->getParentOfType<ModuleOp>();
   PassManager pm(moduleOp.getContext());
   pm.addPass(triton::nvidia_gpu::
                  createTritonNvidiaGPUTestGenerateSubtiledRegionPass());
+  // Convert tmem_load → reshape → trans → split chains in SubtiledRegionOp
+  // setup regions into tmem_subslice + tmem_load pairs.
+  pm.addPass(
+      triton::nvidia_gpu::createTritonNvidiaGPUOptimizeTMemLayoutsPass());
+  // Push setup values that are shared across all tiles into the tile body.
+  pm.addPass(
+      triton::nvidia_gpu::createTritonNvidiaGPUPushSharedSetupToTilePass());
   (void)pm.run(moduleOp);
 }
 
@@ -236,10 +242,34 @@ public:
       }
     }
 
+    // Primary SubtiledRegionOp lowering path. By this point the tile body
+    // has been optimized (OptimizeTMemLayouts + PushSharedSetupToTile ran
+    // inside doGenerateSubtiledRegion), so tmem_loads are sunk close to
+    // their consumers. doTokenLowering converts token annotations to
+    // barrier annotations, then lowerSubtiledRegion unrolls the tile body
+    // with per-tile barrier materialization.
+    //
+    // Multi-task SubtiledRegionOps were already lowered as fallbacks in
+    // doCodePartition/doCodePartitionPost (before specializeRegion).
     doTokenLowering(funcOp, numWarpGroups - 1);
     if (dumpIntermediateSteps) {
       llvm::dbgs()
           << "// -----// WarpSpec internal IR Dump After: doTokenLowering\n";
+      moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
+      llvm::dbgs() << "\n\n\n";
+    }
+
+    {
+      SmallVector<triton::nvidia_gpu::SubtiledRegionOp> remaining;
+      funcOp.walk([&](triton::nvidia_gpu::SubtiledRegionOp op) {
+        remaining.push_back(op);
+      });
+      for (auto op : remaining)
+        triton::nvidia_gpu::lowerSubtiledRegion(op);
+    }
+    if (dumpIntermediateSteps) {
+      llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
+                      "lowerSubtiledRegion\n";
       moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
       llvm::dbgs() << "\n\n\n";
     }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -38,6 +38,129 @@ namespace mlir {
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+static constexpr const char *kSubtileOpId = "subtile_op_id";
+
+/// Lower token annotations by injecting inline ConsumerWaitOp/ConsumerReleaseOp
+/// into the tile body. Used for multi-task SubtiledRegionOps that are lowered
+/// before doTokenLowering runs (the inline ops survive into warp partitions
+/// and get converted to mbarriers by doTokenLowering later).
+static void lowerTokenAnnotations(ttng::SubtiledRegionOp op) {
+  ArrayAttr tokenAnnotations = op.getTokenAnnotations();
+  if (tokenAnnotations.empty())
+    return;
+
+  Block &tileBlock = op.getTileRegion().front();
+  ValueRange tokenValues = op.getTokenValues();
+
+  llvm::DenseMap<unsigned, Operation *> idToOp;
+  for (Operation &tileOp : tileBlock.without_terminator()) {
+    if (auto idAttr = tileOp.getAttrOfType<IntegerAttr>(kSubtileOpId))
+      idToOp[idAttr.getInt()] = &tileOp;
+  }
+
+  OpBuilder builder(op);
+  for (Attribute attr : tokenAnnotations) {
+    auto annotation = cast<ttng::TokenAnnotationAttr>(attr);
+    unsigned targetId = annotation.getTargetOpIdx();
+    auto it = idToOp.find(targetId);
+    assert(it != idToOp.end() && "target op ID not found in tile body");
+    Operation *targetOp = it->second;
+
+    if (annotation.getPlacement() == ttng::BarrierPlacement::BEFORE)
+      builder.setInsertionPoint(targetOp);
+    else
+      builder.setInsertionPointAfter(targetOp);
+
+    Value token = tokenValues[annotation.getTokenIdx()];
+    Value bufferIdx = tokenValues[annotation.getBufferIdxIdx()];
+    StringRef kind = annotation.getTokenOpKind().getValue();
+
+    if (kind == "consumer_wait") {
+      int phaseIdx = annotation.getPhaseIdx();
+      assert(phaseIdx >= 0);
+      Value phase = tokenValues[phaseIdx];
+      ttnvws::ConsumerWaitOp::create(builder, targetOp->getLoc(), token,
+                                     bufferIdx, phase);
+    } else {
+      assert(kind == "consumer_release");
+      ttnvws::ConsumerReleaseOp::create(builder, targetOp->getLoc(), token,
+                                        bufferIdx);
+    }
+  }
+
+  MLIRContext *ctx = op.getContext();
+  op.setTokenAnnotationsAttr(ArrayAttr::get(ctx, {}));
+  op.getTokenValuesMutable().assign(ValueRange{});
+}
+
+/// If `op` is inside a SubtiledRegionOp's tile region, return that op.
+static ttng::SubtiledRegionOp getEnclosingSubtiledRegionTile(Operation *op) {
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (auto subtiled = dyn_cast<ttng::SubtiledRegionOp>(parent)) {
+      if (op->getParentRegion() == &subtiled.getTileRegion())
+        return subtiled;
+      return nullptr;
+    }
+  }
+  return nullptr;
+}
+
+/// Assign a stable ID to `targetOp` via an integer attribute and return it.
+/// If the op already has an ID, return the existing one. The ID is unique
+/// within the tile body and survives op insertions/removals by other passes,
+/// unlike positional indices.
+static unsigned getOrAssignStableId(ttng::SubtiledRegionOp subtiled,
+                                    Operation *targetOp) {
+  if (auto existing = targetOp->getAttrOfType<IntegerAttr>(kSubtileOpId))
+    return existing.getInt();
+
+  // Find the next available ID by scanning existing IDs.
+  unsigned nextId = 0;
+  Block &tileBlock = subtiled.getTileRegion().front();
+  for (Operation &op : tileBlock.without_terminator()) {
+    if (auto idAttr = op.getAttrOfType<IntegerAttr>(kSubtileOpId))
+      nextId = std::max(nextId, static_cast<unsigned>(idAttr.getInt()) + 1);
+  }
+
+  targetOp->setAttr(
+      kSubtileOpId,
+      IntegerAttr::get(IntegerType::get(targetOp->getContext(), 32), nextId));
+  return nextId;
+}
+
+/// Add a token annotation to a SubtiledRegionOp instead of creating an
+/// inline ConsumerWaitOp or ConsumerReleaseOp.
+static void addTokenAnnotation(ttng::SubtiledRegionOp subtiled, Value token,
+                               Value bufferIdx, Value phase,
+                               ttng::BarrierPlacement placement,
+                               unsigned targetOpIdx, StringRef kind) {
+  MLIRContext *ctx = subtiled.getContext();
+
+  // Add token, bufferIdx, phase to the tokenValues operand list.
+  unsigned tokenIdx = subtiled.getTokenValues().size();
+  unsigned bufferIdxIdx = tokenIdx + 1;
+  int phaseIdx = (phase) ? static_cast<int>(tokenIdx + 2) : -1;
+
+  SmallVector<Value> newTokenValues(subtiled.getTokenValues());
+  newTokenValues.push_back(token);
+  newTokenValues.push_back(bufferIdx);
+  if (phase)
+    newTokenValues.push_back(phase);
+  subtiled.getTokenValuesMutable().assign(newTokenValues);
+
+  // Create the annotation.
+  auto kindAttr = StringAttr::get(ctx, kind);
+  auto annotation = ttng::TokenAnnotationAttr::get(
+      ctx, tokenIdx, bufferIdxIdx, phaseIdx, placement, targetOpIdx, kindAttr,
+      ttng::BarrierRegion::TILE);
+
+  SmallVector<Attribute> annotations(subtiled.getTokenAnnotations().begin(),
+                                     subtiled.getTokenAnnotations().end());
+  annotations.push_back(annotation);
+  subtiled.setTokenAnnotationsAttr(ArrayAttr::get(ctx, annotations));
+}
+
 static unsigned getNumBuffersOrDefault(scf::ForOp forOp, unsigned numBuffers) {
   // Use the attribute attached to the loop if it exists otherwise use the
   // global control.
@@ -3566,41 +3689,54 @@ void insertAsyncComm(
         }
         auto consumerWaitPoint =
             getSameLevelOp(headProducer, tokenHeadConsumer);
-        builder.setInsertionPoint(consumerWaitPoint);
-        // Use the actual consumer's stage/cluster instead of the prep op's.
-        // consumerWaitPoint may be a memdesc_trans at stage 0, but the real
-        // consumer (e.g. dQ/dK MMA) may be at stage 1.
-        auto *actualCons = getUniqueActualConsumer(consumerWaitPoint);
-        builder.setLoopScheduleInfoFromOp(actualCons);
-        LDBG("  inserting ConsumerWaitOp for task " << tokenTaskId);
-        auto waitOp = builder.createWithAsyncTaskIds<ttnvws::ConsumerWaitOp>(
-            headConsumer->getLoc(), token.second, bufferIdx, phase);
-        // Propagate the actual consumer's loop schedule to the phase/bufferIdx
-        // value ops. These were computed earlier (by getBufferIdxAndPhase) with
-        // no loop.stage/loop.cluster, but they must match the consumer_wait's
-        // stage so SWP pipelines them together.
-        auto schedInfo = builder.getLoopScheduleInfo();
-        for (Value v : {bufferIdx, phase}) {
-          SmallVector<Value> worklist = {v};
-          DenseSet<Value> visited;
-          while (!worklist.empty()) {
-            Value cur = worklist.pop_back_val();
-            if (!visited.insert(cur).second)
-              continue;
-            auto *defOp = cur.getDefiningOp();
-            if (!defOp || defOp->getBlock() != waitOp->getBlock())
-              continue;
-            if (!defOp->hasAttr(triton::kLoopStageAttrName)) {
-              if (schedInfo.stage)
-                defOp->setAttr(triton::kLoopStageAttrName, schedInfo.stage);
-              if (schedInfo.cluster)
-                defOp->setAttr(triton::kLoopClusterAttrName, schedInfo.cluster);
-              for (Value operand : defOp->getOperands())
-                worklist.push_back(operand);
+        auto subtiled = getEnclosingSubtiledRegionTile(consumerWaitPoint);
+        if (subtiled) {
+          unsigned targetOpIdx =
+              getOrAssignStableId(subtiled, consumerWaitPoint);
+          addTokenAnnotation(subtiled, token.second, bufferIdx, phase,
+                             ttng::BarrierPlacement::BEFORE, targetOpIdx,
+                             "consumer_wait");
+          LDBG("create ConsumerWait annotation on SubtiledRegionOp "
+               << masterChannel->uniqID << " ");
+        } else {
+          builder.setInsertionPoint(consumerWaitPoint);
+          // Use the actual consumer's stage/cluster instead of the prep op's.
+          // consumerWaitPoint may be a memdesc_trans at stage 0, but the real
+          // consumer (e.g. dQ/dK MMA) may be at stage 1.
+          auto *actualCons = getUniqueActualConsumer(consumerWaitPoint);
+          builder.setLoopScheduleInfoFromOp(actualCons);
+          LDBG("  inserting ConsumerWaitOp for task " << tokenTaskId);
+          auto waitOp = builder.createWithAsyncTaskIds<ttnvws::ConsumerWaitOp>(
+              headConsumer->getLoc(), token.second, bufferIdx, phase);
+          // Propagate the actual consumer's loop schedule to the
+          // phase/bufferIdx value ops. These were computed earlier (by
+          // getBufferIdxAndPhase) with no loop.stage/loop.cluster, but they
+          // must match the consumer_wait's stage so SWP pipelines them
+          // together.
+          auto schedInfo = builder.getLoopScheduleInfo();
+          for (Value v : {bufferIdx, phase}) {
+            SmallVector<Value> worklist = {v};
+            DenseSet<Value> visited;
+            while (!worklist.empty()) {
+              Value cur = worklist.pop_back_val();
+              if (!visited.insert(cur).second)
+                continue;
+              auto *defOp = cur.getDefiningOp();
+              if (!defOp || defOp->getBlock() != waitOp->getBlock())
+                continue;
+              if (!defOp->hasAttr(triton::kLoopStageAttrName)) {
+                if (schedInfo.stage)
+                  defOp->setAttr(triton::kLoopStageAttrName, schedInfo.stage);
+                if (schedInfo.cluster)
+                  defOp->setAttr(triton::kLoopClusterAttrName,
+                                 schedInfo.cluster);
+                for (Value operand : defOp->getOperands())
+                  worklist.push_back(operand);
+              }
             }
           }
+          LDBG("create ConsumerWait " << masterChannel->uniqID << " ");
         }
-        LDBG("create ConsumerWait " << masterChannel->uniqID << " ");
       }
 
       // Insert ConsumerReleaseOp, if consumer is not a TCGen5MMAOp. For
@@ -3608,24 +3744,35 @@ void insertAsyncComm(
       if (commChannel.consumerBarriers.empty()) {
         auto consumerReleasePoint =
             consumerReleaseHeuristic(tailProducer, tailConsumer, token.first);
-        builder.setLoopScheduleInfoFromOp(consumerReleasePoint);
-        if (auto tokenWaitOp =
-                dyn_cast<ttng::TMAStoreTokenWaitOp>(consumerReleasePoint)) {
-          tokenWaitOp.addToken(token.second, bufferIdx);
-          LLVM_DEBUG({
-            LDBG("attached ConsumerRelease token to TMAStoreTokenWaitOp "
-                 << masterChannel->uniqID << " ");
-            token.second.dump();
-          });
+        auto subtiled = getEnclosingSubtiledRegionTile(consumerReleasePoint);
+        if (subtiled) {
+          unsigned targetOpIdx =
+              getOrAssignStableId(subtiled, consumerReleasePoint);
+          addTokenAnnotation(subtiled, token.second, bufferIdx,
+                             /*phase=*/Value(), ttng::BarrierPlacement::AFTER,
+                             targetOpIdx, "consumer_release");
+          LDBG("create ConsumerRelease annotation on SubtiledRegionOp "
+               << masterChannel->uniqID << " ");
         } else {
-          builder.setInsertionPointAfter(consumerReleasePoint);
-          auto releaseOp =
-              builder.createWithAsyncTaskIds<ttnvws::ConsumerReleaseOp>(
-                  consumerReleasePoint->getLoc(), token.second, bufferIdx);
-          LLVM_DEBUG({
-            LDBG("create ConsumerRelease " << masterChannel->uniqID << " ");
-            token.second.dump();
-          });
+          builder.setLoopScheduleInfoFromOp(consumerReleasePoint);
+          if (auto tokenWaitOp =
+                  dyn_cast<ttng::TMAStoreTokenWaitOp>(consumerReleasePoint)) {
+            tokenWaitOp.addToken(token.second, bufferIdx);
+            LLVM_DEBUG({
+              LDBG("attached ConsumerRelease token to TMAStoreTokenWaitOp "
+                   << masterChannel->uniqID << " ");
+              token.second.dump();
+            });
+          } else {
+            builder.setInsertionPointAfter(consumerReleasePoint);
+            auto releaseOp =
+                builder.createWithAsyncTaskIds<ttnvws::ConsumerReleaseOp>(
+                    consumerReleasePoint->getLoc(), token.second, bufferIdx);
+            LLVM_DEBUG({
+              LDBG("create ConsumerRelease " << masterChannel->uniqID << " ");
+              token.second.dump();
+            });
+          }
         }
       }
     }
@@ -4205,6 +4352,8 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
         multiTaskOps.push_back(op);
     });
     for (auto op : multiTaskOps)
+      lowerTokenAnnotations(op);
+    for (auto op : multiTaskOps)
       ttng::lowerSubtiledRegion(op);
   }
 
@@ -4471,6 +4620,8 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
       if (taskIds.size() > 1)
         multiTaskOps.push_back(op);
     });
+    for (auto op : multiTaskOps)
+      lowerTokenAnnotations(op);
     for (auto op : multiTaskOps)
       ttng::lowerSubtiledRegion(op);
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -273,6 +273,92 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
                                  bufferEmptyCount);
         deprecatedOps.push_back(user);
         return true;
+      } else if (auto op = dyn_cast<ttng::SubtiledRegionOp>(user)) {
+        // Convert TokenAnnotationAttr → BarrierAnnotationAttr for annotations
+        // that reference this token.
+        Value tokenVal = createTokenOp.getResult();
+        // Find which tokenValues indices reference this token.
+        SmallVector<unsigned> tokenIndices;
+        for (unsigned i = 0; i < op.getTokenValues().size(); ++i) {
+          if (op.getTokenValues()[i] == tokenVal)
+            tokenIndices.push_back(i);
+        }
+        if (tokenIndices.empty())
+          return false;
+
+        // For each matching token annotation, convert to barrier annotation.
+        SmallVector<Attribute> remainingTokenAnnotations;
+        SmallVector<Attribute> newBarrierAnnotations(
+            op.getBarrierAnnotations().begin(),
+            op.getBarrierAnnotations().end());
+
+        for (Attribute attr : op.getTokenAnnotations()) {
+          auto annotation = cast<ttng::TokenAnnotationAttr>(attr);
+          bool matchesToken =
+              llvm::is_contained(tokenIndices, annotation.getTokenIdx());
+          if (!matchesToken) {
+            remainingTokenAnnotations.push_back(attr);
+            continue;
+          }
+
+          // Determine barrier kind and memdesc.
+          StringRef kind = annotation.getTokenOpKind().getValue();
+          Value idx = op.getTokenValues()[annotation.getBufferIdxIdx()];
+          Value barrier;
+          StringRef barrierKind;
+          unsigned count = 1;
+          if (kind == "consumer_wait") {
+            barrier = extractBufferFull(loc, idx);
+            barrierKind = "wait_barrier";
+          } else {
+            barrier = extractBufferEmpty(loc, idx);
+            barrierKind = "arrive_barrier";
+            count = bufferEmptyCount;
+          }
+
+          // Add barrier to SubtiledRegionOp's barriers/accumCnts.
+          unsigned barrierIdx = op.getBarriers().size();
+          SmallVector<Value> newBarriers(op.getBarriers());
+          newBarriers.push_back(barrier);
+          op.getBarriersMutable().assign(newBarriers);
+
+          // For consumer_wait, we need the phase/accumCnt.
+          if (kind == "consumer_wait") {
+            int phaseIdx = annotation.getPhaseIdx();
+            assert(phaseIdx >= 0);
+            Value phase = op.getTokenValues()[phaseIdx];
+            // Convert phase (i1) to accumCnt (i64) for the barrier system.
+            // phase = (accumCnt / numBuffers) & 1, so accumCnt = phase.
+            Value accumCnt = arith::ExtUIOp::create(
+                builder, loc, builder.getI64Type(), phase);
+            SmallVector<Value> newAccumCnts(op.getAccumCnts());
+            newAccumCnts.push_back(accumCnt);
+            op.getAccumCntsMutable().assign(newAccumCnts);
+          } else {
+            // For arrive_barrier, accumCnt isn't used but we need a
+            // placeholder to keep barriers/accumCnts parallel.
+            Value zero = arith::ConstantOp::create(
+                builder, loc, builder.getI64IntegerAttr(0));
+            SmallVector<Value> newAccumCnts(op.getAccumCnts());
+            newAccumCnts.push_back(zero);
+            op.getAccumCntsMutable().assign(newAccumCnts);
+          }
+
+          auto barrierAnnotation = ttng::BarrierAnnotationAttr::get(
+              op.getContext(), barrierIdx, annotation.getPlacement(),
+              annotation.getTargetOpIdx(),
+              StringAttr::get(op.getContext(), barrierKind), count,
+              annotation.getRegion(),
+              /*numBuffers=*/1, /*tileMask=*/nullptr);
+          newBarrierAnnotations.push_back(barrierAnnotation);
+        }
+
+        op.setTokenAnnotationsAttr(
+            ArrayAttr::get(op.getContext(), remainingTokenAnnotations));
+        op.setBarrierAnnotationsAttr(
+            ArrayAttr::get(op.getContext(), newBarrierAnnotations));
+        // Don't erase the SubtiledRegionOp itself.
+        return true;
       } else if (auto op = dyn_cast<ttng::TMAStoreTokenWaitOp>(user)) {
         Value truePred = arith::ConstantIntOp::create(builder, loc, 1, 1);
         for (auto [nvwsTok, nvwsIdx] :


### PR DESCRIPTION
Summary:
1. Adds support for tracking the token until it gets converted to a barrier
2. Replace the flakey index in barrier annotations with an attribute that needs to propagated to handle locations. This may be possible to simplify the current annotation in the future.
3. Allows pushing tmem loads from the setup step into the body. Since we only push the load we don't need to worry that the range has const attrs.
4. Move generate_subtiled_region to an autotune config for testing purposes. This is in response to the regression caused by the knobs caching fix that I reverted.


Reviewed By: Sibylau

Differential Revision: D101986353

Pulled By: njriasan


