### PR TITLE
[autoWS] get FA bwd + 1D TMA load + dST in tmem working

### DIFF
--- a/.claude/skills/autows-docs/SKILL.md
+++ b/.claude/skills/autows-docs/SKILL.md
@@ -38,7 +38,7 @@ Use the file map below to match your task to the relevant doc(s):
 | Splitting ops across warp groups | `docs/DataPartition.md` |
 | Channel insertion, async copies, barriers | `docs/CodePartition.md` |
 | Code specialization / cloning into regions | `docs/CodeSpecialization.md` |
-| SMEM/TMEM allocation, multi-buffering | `docs/BufferAllocation.md`, `docs/SmemAllocationDesign.md` |
+| SMEM/TMEM allocation, multi-buffering | `docs/BufferAllocation.md`, `docs/AccumulationCounters.md`, `docs/SmemAllocationDesign.md` |
 | Memory planner liveness analysis | `docs/MemoryPlannerVisualization.md` |
 | Memory lowering (global/shared/tensor) | `docs/MemoryLowering.md` |
 | Token/barrier lowering to hardware | `docs/TokenBarrierLowering.md` |

--- a/.llms/rules/partition-scheduler-bugs.md
+++ b/.llms/rules/partition-scheduler-bugs.md
@@ -1,0 +1,69 @@
+# Partition Scheduler Known Issues & Patterns
+
+> **For full architectural context**, load the `partition-scheduler` skill which points to the design docs (PartitionSchedulingMeta.md, BufferAllocation.md, etc).
+
+> Update this file when an issue is triaged/fixed and PartitionSchedulingMeta.md if necessary
+
+## Code Location
+- Partition assignment: `third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp`
+- Buffer allocation: `WSCodePartition.cpp` → `doBufferAllocation()` → `createLocalAlloc()`
+- Code partition: `WSCodePartition.cpp` → `doCodePartition()`
+
+## Debugging Regression between directory A and B
+- If IR dumps are provided after each pass:
+  - Find the IR right before partition scheduler for the right kernel, and save as file
+- Do not guess, run triton-opt for the partition scheduler pass with debugging enabled or add debugging when needed, to check what happened at each phase (phases are defined in the PartitionSchedulingMeta.md)
+- Run directory A's triton-opt on A's IR dump, and run directory B's triton-opt on B's IR dump, and compare
+- Show the differences and figure out which phase caused the issue
+- **Important**: Check BOTH directories for the same kernel. MetaMain at `~/local/MetaMain/triton/t.dump` may have both fwd and bwd kernels.
+
+## Known Bugs & Fixes
+
+### 1. getIntOrFloatBitWidth crash on pointer-typed 1D tensors (2026-04-14)
+- **Symptom**: `Assertion 'isIntOrFloat()' failed` in `doBufferAllocation`
+- **Manifestation**: We hit this when trying to create a 1D channel for pointer tensor. In general, partition scheduler should not put produer and consumer associated with pointer tensor in different partitions. So we will not have a need for a channel that is a pointer tensor. The root cause is in PSM.
+
+### 2. Shared memory overflow from alpha cross-partition channel (2026-04-14, fixed)
+- **Symptom**: `OutOfResources: shared memory, Required: 232712, Hardware limit: 232448` in FA forward persistent with dp=2
+- **Manifestation**: After rebasing to upstream Triton, `TritonGPURemoveLayoutConversions` chose `#linear` layout instead of `#blocked` for the accumulator. This inserted a `ConvertLayoutOp` between `ExpandDimsOp` and `BroadcastOp` in the alpha correction chain.
+- **Fix applied**: Added `cloneOperandChain` in `optimizeSchedule` that walks backward from a cloned `BroadcastOp`/`ExpandDimsOp` and also clones any `ConvertLayoutOp`/`BroadcastOp`/`ExpandDimsOp` feeding it from a different partition.
+- **Commit**: `67af25ea`
+
+### 3. optimizeSchedule too broad / too narrow for Blackwell vs Hopper (2026-04-17, fixed)
+- **Symptom (Blackwell)**: `channels sharing the same producer must be in the same task` assertion in `WSCodePartition.cpp:createBuffer` when using the broad `isPure(op)` filter.
+- **Symptom (Hopper)**: `producerTaskIds.size() == 1` assertion in `CodePartitionUtility.cpp:createChannelPost` when using a restrictive filter that excludes `MemDescTransOp`.
+- **Root cause**: The `optimizeSchedule` op filter must be selective:
+  - Too broad (any pure single-result op): cascading cloning of expensive ops (`tt.reduce`, `arith.mulf`, etc.) into computation partitions on Blackwell, violating channel invariants.
+  - Too narrow (only `ConvertLayoutOp/BroadcastOp/ExpandDimsOp`): `memdesc_trans` shared by two `warp_group_dot` ops in different partitions on Hopper doesn't get cloned, creating a cross-partition memdesc dependency WS can't handle.
+- **Fix**: Added `MemDescTransOp` to the allowed op list: `isa<MemDescTransOp, ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(op)`. `MemDescTransOp` is metadata-only (reinterprets shared memory layout) so it's safe and cheap to clone.
+- **Lit test**: `partition-scheduling-meta-hopper-fa.mlir` checks for two `memdesc_trans` copies with different partitions.
+
+### 4. Non-deterministic epilogue partition assignment from DenseMap iteration (2026-04-17, fixed)
+- **Symptom**: `producerTaskIds.size() == 1` assertion — `math.log2` for dp1's result gets partition 2 (dp0's) instead of partition 1, creating a cross-partition dependency with its downstream `arith.addf` in partition 1.
+- **Root cause**: Two issues:
+  1. Yield operands for `l_i` (softmax sum) and similar non-MMA-feeding ops are NOT in `opToDpId` (they're not in any MMA's backward slice). The post-loop dpId assignment at lines 576-578 skips these results.
+  2. The fallback `dpIdToPartition.begin()->second` in `getEpilogueTarget` uses `DenseMap` iteration, which is non-deterministic across builds. Different binaries pick different partitions.
+- **Fix**:
+  1. Added `findDpIdBackward` helper that walks backward from a yield def through its operand chain to find an ancestor in `opToDpId` (e.g., finds `alpha_exp` which has the correct dpId).
+  2. Replaced `dpIdToPartition.begin()->second` with `std::min_element` on the key for deterministic fallback.
+- **Lit test**: `partition-scheduling-meta-hopper-fa.mlir` checks that `tt.expand_dims` on `#1` (dp0) gets partition 2 and `#4` (dp1) gets partition 1.
+
+### 5. BWD softmax chain assigned to reduction instead of computation (2026-04-18, fixed)
+- **Symptom**: In BWD FA with TMA descriptor_load for m/Di values, the pT chain (`convert_layout → expand_dims → broadcast → arith.subf → math.exp2 → arith.truncf → tmem_alloc`) gets partition 0 (reduction) instead of partition 3 (computation).
+- **Root cause**: The load-user scheduling (Phase 4) walks forward from every categorized `descriptor_load` and assigns all transitive users to `defaultPartition`. For BWD, `defaultPartition` falls back to `reductionPartition` (partition 0) via `getDefaultPartition()` since no correction/epilogue/computation partition exists yet. When m/Di values come through `descriptor_load` (TMA), this walk transitively pulls the entire softmax chain into the reduction partition. The lit test used `tt.load` (pointer-based) for m/Di which is NOT categorized as a Load, so the issue was hidden.
+- **Fix**: Added guard `defaultPartition != reductionPartition` to the load-user scheduling condition. When `defaultPartition` is just a fallback to reduction (BWD case), the load-user walk is skipped. Phase 5's MMA forward walk correctly assigns the softmax ops to computation instead.
+- **Key insight**: The `loops` array in `getInitialSchedule` is ordered `[inner, outer]` (not `[outer, inner]`). Phase 5's `loops[0]` check matches inner-loop MMAs, so `scheduleUsers` DOES run on them. The issue was purely in Phase 4's load-user scheduling being too aggressive.
+
+## Debugging Workflow
+- `t.dump` captures IR after each WarpSpec pass (doTaskIdPropagate → doBufferAllocation → doMemoryPlanner → doCodePartition → ...)
+- IR after PartitionSchedulingMeta uses `ttg.partition = array<i32: N>` attributes (not `async_task_id`)
+- IR after doTaskIdPropagate converts `ttg.partition` to `async_task_id` annotations
+- To check partition assignments: look at IR between `NVGPUPartitionSchedulingMeta` and `NVGPUWarpSpecialization` dump sections
+- Build: see `devmate/step1.txt`
+- To run a single pass: `triton-opt --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation=true" input.mlir`
+- To enable debug: add `-debug-only=tritongpu-partition-scheduling`
+- To add stack traces on specific ops: instrument `setPartition()` in `lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp`
+
+## Key Concepts
+- `PartitionSchedulingMeta` assigns `ttg.partition` attributes → `doTaskIdPropagate` converts to `async_task_id`
+- Pointer-typed tensors (`!tt.ptr<T>`) should not be cross-partition

--- a/.llms/rules/partition-scheduler-bugs.md
+++ b/.llms/rules/partition-scheduler-bugs.md
@@ -59,7 +59,7 @@
 - IR after PartitionSchedulingMeta uses `ttg.partition = array<i32: N>` attributes (not `async_task_id`)
 - IR after doTaskIdPropagate converts `ttg.partition` to `async_task_id` annotations
 - To check partition assignments: look at IR between `NVGPUPartitionSchedulingMeta` and `NVGPUWarpSpecialization` dump sections
-- Build: see `devmate/step1.txt`
+- Build: see xxx/build-triton.txt
 - To run a single pass: `triton-opt --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation=true" input.mlir`
 - To enable debug: add `-debug-only=tritongpu-partition-scheduling`
 - To add stack traces on specific ops: instrument `setPartition()` in `lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp`

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -7,6 +7,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/Support/JSON.h"
 
 namespace ttg = mlir::triton::gpu;
 
@@ -18,6 +19,39 @@ namespace nvidia_gpu {
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
+
+/// Extract the memory type for opndA from a tt.autows annotation.
+/// Returns "tmem", "smem", or "" if no annotation or no opndA entry.
+static StringRef getOpndAMemType(Operation *op) {
+  auto attr = op->getAttrOfType<StringAttr>("tt.autows");
+  if (!attr)
+    return "";
+  auto parsed = llvm::json::parse(attr.getValue());
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return "";
+  }
+  auto *obj = parsed->getAsObject();
+  if (!obj)
+    return "";
+  auto *channelsArr = obj->getArray("channels");
+  if (!channelsArr)
+    return "";
+  for (auto &elem : *channelsArr) {
+    auto str = elem.getAsString();
+    if (!str)
+      continue;
+    if (str->starts_with("opndA,")) {
+      // Format: "opndA,memType,numCopies,bufferId"
+      auto comma = str->find(',');
+      auto comma2 = str->find(',', comma + 1);
+      if (comma != StringRef::npos && comma2 != StringRef::npos)
+        return str->slice(comma + 1, comma2);
+    }
+  }
+  return "";
+}
+
 template <class MMAOpTy>
 Attribute getLHSTMemLayout(MMAOpTy tcGen5MMAOp, gpu::MemDescType lhsTMEMType,
                            ttg::CGAEncodingAttr cgaLayout) {
@@ -42,26 +76,37 @@ public:
     if (localAllocOp->getParentRegion() != tcGen5MMAOp->getParentRegion())
       return failure();
     Value src = localAllocOp.getSrc();
+    // Check tt.autows annotation for explicit opndA memory type.
+    // If annotated as "smem", skip promotion. If "tmem", promote directly
+    // (skip the transposed-shared-source heuristic). If no annotation,
+    // fall through to the heuristic.
+    StringRef opndAMem = getOpndAMemType(tcGen5MMAOp);
+    if (opndAMem == "smem")
+      return failure();
+    bool annotatedTmem = (opndAMem == "tmem");
+
     // If the same source value is also allocated and transposed for use as
     // operand A of another gen5 MMA, skip promotion. The transposed path
     // cannot be promoted to tmem, so keeping both in smem avoids a redundant
     // tmem allocation and copy for the same data. This covers both:
     //   1. Same local_alloc used directly + through memdesc_trans
     //   2. Separate local_allocs from the same src, one transposed
-    for (Operation *srcUser : src.getUsers()) {
-      auto otherAlloc = dyn_cast<ttg::LocalAllocOp>(srcUser);
-      if (!otherAlloc)
-        continue;
-      for (Operation *allocUser : otherAlloc->getResult(0).getUsers()) {
-        if (auto transOp = dyn_cast<ttg::MemDescTransOp>(allocUser)) {
-          for (Operation *transUser : transOp->getResult(0).getUsers()) {
-            if (auto mmaOp = dyn_cast<TCGen5MMAOp>(transUser)) {
-              if (mmaOp.getA() == transOp->getResult(0))
-                return failure();
-            } else if (auto mmaScaledOp =
-                           dyn_cast<TCGen5MMAScaledOp>(transUser)) {
-              if (mmaScaledOp.getA() == transOp->getResult(0))
-                return failure();
+    if (!annotatedTmem) {
+      for (Operation *srcUser : src.getUsers()) {
+        auto otherAlloc = dyn_cast<ttg::LocalAllocOp>(srcUser);
+        if (!otherAlloc)
+          continue;
+        for (Operation *allocUser : otherAlloc->getResult(0).getUsers()) {
+          if (auto transOp = dyn_cast<ttg::MemDescTransOp>(allocUser)) {
+            for (Operation *transUser : transOp->getResult(0).getUsers()) {
+              if (auto mmaOp = dyn_cast<TCGen5MMAOp>(transUser)) {
+                if (mmaOp.getA() == transOp->getResult(0))
+                  return failure();
+              } else if (auto mmaScaledOp =
+                             dyn_cast<TCGen5MMAScaledOp>(transUser)) {
+                if (mmaScaledOp.getA() == transOp->getResult(0))
+                  return failure();
+              }
             }
           }
         }

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -142,14 +142,14 @@ def _attn_fwd_inner_oss_dp(
 
     # loop over k, v and update accumulator
     for start_n in tl.range(
-        lo,
-        hi,
-        BLOCK_N,
-        warp_specialize=warp_specialize,
-        merge_epilogue=True,
-        separate_epilogue_store=True,
-        # disallow_acc_multi_buffer=True,
-        data_partition_factor=DP_FACTOR,
+            lo,
+            hi,
+            BLOCK_N,
+            warp_specialize=warp_specialize,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
+            # disallow_acc_multi_buffer=True,
+            data_partition_factor=DP_FACTOR,
     ):
         start_n = tl.multiple_of(start_n, BLOCK_N)
 
@@ -213,23 +213,15 @@ configs = [
         num_warps=w,
         pre_hook=_host_descriptor_pre_hook,
         # ir_override=f"/home/mren/OpenSource/tritonbench/override/_attn_fwd_persist.ttgir"
-    )
-    for BM in [256]
-    for BN in [128]
-    for s in NUM_STAGES_OPTIONS
-    for w in [4]
+    ) for BM in [256] for BN in [128] for s in NUM_STAGES_OPTIONS for w in [4]
 ]
 
 
 def keep(conf):
     BLOCK_M = conf.kwargs["BLOCK_M"]
     BLOCK_N = conf.kwargs["BLOCK_N"]
-    return not (
-        is_cuda()
-        and torch.cuda.get_device_capability()[0] == 9
-        and BLOCK_M * BLOCK_N < 128 * 128
-        and conf.num_warps == 8
-    )
+    return not (is_cuda() and torch.cuda.get_device_capability()[0] == 9 and BLOCK_M * BLOCK_N < 128 * 128
+                and conf.num_warps == 8)
 
 
 def prune_invalid_configs(configs, named_args, **kwargs):
@@ -572,12 +564,12 @@ def _attn_fwd_persist(
 
     # inner loop warpspec vs. outer loop warpspec
     for _ in tl.range(
-        0,
-        tiles_per_sm,
-        warp_specialize=warp_specialize and OUTER_LOOP,
-        merge_epilogue=True,
-        separate_epilogue_store=True,
-        data_partition_factor=DP_FACTOR,
+            0,
+            tiles_per_sm,
+            warp_specialize=warp_specialize and OUTER_LOOP,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
+            data_partition_factor=DP_FACTOR,
     ):
         pid = tile_idx % n_tile_num
         off_hz = tile_idx // n_tile_num
@@ -617,23 +609,18 @@ def torch_dtype_to_triton(dtype):
 @triton.jit
 def _split_n(x, SPLIT_FACTOR: tl.constexpr):
     if SPLIT_FACTOR == 1:
-        return (x,)
+        return (x, )
     else:
         x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
         return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
 
 
 @triton.jit
-def _attn_bwd_preprocess(
-    O,
-    DO,  #
-    Delta,  #
-    Z,
-    H,
-    N_CTX,  #
-    BLOCK_M: tl.constexpr,
-    HEAD_DIM: tl.constexpr,  #
-):
+def _attn_bwd_preprocess(O, DO,  #
+                         Delta,  #
+                         Z, H, N_CTX,  #
+                         BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr,  #
+                         ):
     off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
     off_hz = tl.program_id(1)
     off_n = tl.arange(0, HEAD_DIM)
@@ -648,6 +635,7 @@ def _attn_bwd_preprocess(
 # Frozen (hashable) wrapper for dot attrs configuration, usable in triton.Config.
 # Supports .get(key) like a dict but is hashable for Triton's JIT cache key.
 class FrozenDotAttrs:
+
     def __init__(self, d):
         self._data = d
         self._hash = hash(json.dumps(d, sort_keys=True)) if d else hash(None)
@@ -674,57 +662,49 @@ class FrozenDotAttrs:
 # Each key corresponds to a dot operation in _attn_bwd_dkdv_inner.
 # Set to None to disable attrs for a given dot (heuristic allocation).
 # Format: {"stage": str, "order": str, "channels": [str, ...]}
-_DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs(
-    {
-        "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},
-        "dpT": {"stage": "0", "order": "2", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},
-        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
-        "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,5"]},
-        "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
-    }
-)
+_DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,5"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+})
 
-_BWD_DOT_ATTRS_BM64_TMEM = FrozenDotAttrs(
-    {
-        # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
-        # no need to reuse between dq and dpT
-        "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
-        "dpT": {
-            "stage": "0",
-            "order": "2",
-            "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
-        },  # v, do
-        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
-        "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
-        "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem,1,5", "opndD,tmem,1,10"]},  # dsT in tmem
-    }
-)
+_BWD_DOT_ATTRS_BM64_TMEM = FrozenDotAttrs({
+    # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
+    # no need to reuse between dq and dpT
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
+    "dpT": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+    },  # v, do
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem,1,5", "opndD,tmem,1,10"]},  # dsT in tmem
+})
 
-_BWD_DOT_ATTRS_BM64 = FrozenDotAttrs(
-    {
-        # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
-        # no need to reuse between dq and dpT
-        "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
-        "dpT": {
-            "stage": "0",
-            "order": "2",
-            "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
-        },  # v, do
-        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
-        "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
-        "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
-    }
-)
+_BWD_DOT_ATTRS_BM64 = FrozenDotAttrs({
+    # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
+    # no need to reuse between dq and dpT
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
+    "dpT": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+    },  # v, do
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
+    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+})
 
-_BWD_DOT_ATTRS_SCHED = FrozenDotAttrs(
-    {
-        "qkT": {"stage": "0", "order": "0"},
-        "dpT": {"stage": "0", "order": "2"},
-        "dv": {"stage": "0", "order": "2"},
-        "dq": {"stage": "1", "order": "1"},
-        "dk": {"stage": "1", "order": "1"},
-    }
-)
+_BWD_DOT_ATTRS_SCHED = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0"},
+    "dpT": {"stage": "0", "order": "2"},
+    "dv": {"stage": "0", "order": "2"},
+    "dq": {"stage": "1", "order": "1"},
+    "dk": {"stage": "1", "order": "1"},
+})
 
 
 @triton.jit
@@ -836,13 +816,13 @@ def _attn_bwd_dkdv(
     step_m = BLOCK_M1
     if warp_specialize:
         for blk_idx in tl.range(
-            0,
-            num_steps,
-            warp_specialize=True,
-            merge_epilogue_to_computation=True,
-            tmem_alloc_algo=2,
-            smem_alloc_algo=1,
-            smem_budget=200000,
+                0,
+                num_steps,
+                warp_specialize=True,
+                merge_epilogue_to_computation=True,
+                tmem_alloc_algo=2,
+                smem_alloc_algo=1,
+                smem_budget=200000,
         ):
             dk, dv, curr_m = _attn_bwd_dkdv_inner(
                 dk,
@@ -1224,13 +1204,13 @@ def _attn_bwd_persist(
     )
 
     for _ in tl.range(
-        0,
-        tiles_per_sm,
-        warp_specialize=True,
-        merge_epilogue_to_computation=True,
-        tmem_alloc_algo=2,
-        smem_alloc_algo=1,
-        smem_budget=200000,
+            0,
+            tiles_per_sm,
+            warp_specialize=True,
+            merge_epilogue_to_computation=True,
+            tmem_alloc_algo=2,
+            smem_alloc_algo=1,
+            smem_budget=200000,
     ):
         pid = tile_idx % n_tile_num
         bhid = tile_idx // n_tile_num
@@ -1266,6 +1246,7 @@ def _attn_bwd_persist(
 
 
 class _attention_opt(torch.autograd.Function):
+
     @staticmethod
     def forward(ctx, q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE):
         # shape constraints
@@ -1393,14 +1374,10 @@ class _attention_opt(torch.autograd.Function):
         pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
         delta = torch.empty_like(M)
         _attn_bwd_preprocess[pre_grid](
-            o,
-            do,  #
+            o, do,  #
             delta,  #
-            BATCH,
-            N_HEAD,
-            N_CTX,  #
-            BLOCK_M=PRE_BLOCK,
-            HEAD_DIM=ctx.HEAD_DIM,  #
+            BATCH, N_HEAD, N_CTX,  #
+            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
         )
         warp_specialize = True
 
@@ -1677,8 +1654,7 @@ for HEAD_DIM in [128]:  # 64, 128]:
                         "mode": mode,
                         "baseVariant": baseVariant,
                     },
-                )
-            )
+                ))
 
 
 @triton.testing.perf_report(configs)

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -142,14 +142,14 @@ def _attn_fwd_inner_oss_dp(
 
     # loop over k, v and update accumulator
     for start_n in tl.range(
-            lo,
-            hi,
-            BLOCK_N,
-            warp_specialize=warp_specialize,
-            merge_epilogue=True,
-            separate_epilogue_store=True,
-            # disallow_acc_multi_buffer=True,
-            data_partition_factor=DP_FACTOR,
+        lo,
+        hi,
+        BLOCK_N,
+        warp_specialize=warp_specialize,
+        merge_epilogue=True,
+        separate_epilogue_store=True,
+        # disallow_acc_multi_buffer=True,
+        data_partition_factor=DP_FACTOR,
     ):
         start_n = tl.multiple_of(start_n, BLOCK_N)
 
@@ -213,15 +213,23 @@ configs = [
         num_warps=w,
         pre_hook=_host_descriptor_pre_hook,
         # ir_override=f"/home/mren/OpenSource/tritonbench/override/_attn_fwd_persist.ttgir"
-    ) for BM in [256] for BN in [128] for s in NUM_STAGES_OPTIONS for w in [4]
+    )
+    for BM in [256]
+    for BN in [128]
+    for s in NUM_STAGES_OPTIONS
+    for w in [4]
 ]
 
 
 def keep(conf):
     BLOCK_M = conf.kwargs["BLOCK_M"]
     BLOCK_N = conf.kwargs["BLOCK_N"]
-    return not (is_cuda() and torch.cuda.get_device_capability()[0] == 9 and BLOCK_M * BLOCK_N < 128 * 128
-                and conf.num_warps == 8)
+    return not (
+        is_cuda()
+        and torch.cuda.get_device_capability()[0] == 9
+        and BLOCK_M * BLOCK_N < 128 * 128
+        and conf.num_warps == 8
+    )
 
 
 def prune_invalid_configs(configs, named_args, **kwargs):
@@ -564,12 +572,12 @@ def _attn_fwd_persist(
 
     # inner loop warpspec vs. outer loop warpspec
     for _ in tl.range(
-            0,
-            tiles_per_sm,
-            warp_specialize=warp_specialize and OUTER_LOOP,
-            merge_epilogue=True,
-            separate_epilogue_store=True,
-            data_partition_factor=DP_FACTOR,
+        0,
+        tiles_per_sm,
+        warp_specialize=warp_specialize and OUTER_LOOP,
+        merge_epilogue=True,
+        separate_epilogue_store=True,
+        data_partition_factor=DP_FACTOR,
     ):
         pid = tile_idx % n_tile_num
         off_hz = tile_idx // n_tile_num
@@ -609,18 +617,23 @@ def torch_dtype_to_triton(dtype):
 @triton.jit
 def _split_n(x, SPLIT_FACTOR: tl.constexpr):
     if SPLIT_FACTOR == 1:
-        return (x, )
+        return (x,)
     else:
         x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
         return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
 
 
 @triton.jit
-def _attn_bwd_preprocess(O, DO,  #
-                         Delta,  #
-                         Z, H, N_CTX,  #
-                         BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr,  #
-                         ):
+def _attn_bwd_preprocess(
+    O,
+    DO,  #
+    Delta,  #
+    Z,
+    H,
+    N_CTX,  #
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,  #
+):
     off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
     off_hz = tl.program_id(1)
     off_n = tl.arange(0, HEAD_DIM)
@@ -635,7 +648,6 @@ def _attn_bwd_preprocess(O, DO,  #
 # Frozen (hashable) wrapper for dot attrs configuration, usable in triton.Config.
 # Supports .get(key) like a dict but is hashable for Triton's JIT cache key.
 class FrozenDotAttrs:
-
     def __init__(self, d):
         self._data = d
         self._hash = hash(json.dumps(d, sort_keys=True)) if d else hash(None)
@@ -662,31 +674,41 @@ class FrozenDotAttrs:
 # Each key corresponds to a dot operation in _attn_bwd_dkdv_inner.
 # Set to None to disable attrs for a given dot (heuristic allocation).
 # Format: {"stage": str, "order": str, "channels": [str, ...]}
-_DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},
-    "dpT": {"stage": "0", "order": "2", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
-    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,5"]},
-    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
-})
+_DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs(
+    {
+        "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},
+        "dpT": {"stage": "0", "order": "2", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},
+        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+        "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,5"]},
+        "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+    }
+)
 
-_BWD_DOT_ATTRS_BM64 = FrozenDotAttrs({
-    # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
-    # no need to reuse between dq and dpT
-    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
-    "dpT": {"stage": "0", "order": "2", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},  # v, do
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
-    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
-    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
-})
+_BWD_DOT_ATTRS_BM64 = FrozenDotAttrs(
+    {
+        # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
+        # no need to reuse between dq and dpT
+        "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
+        "dpT": {
+            "stage": "0",
+            "order": "2",
+            "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+        },  # v, do
+        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
+        "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
+        "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+    }
+)
 
-_BWD_DOT_ATTRS_SCHED = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0"},
-    "dpT": {"stage": "0", "order": "2"},
-    "dv": {"stage": "0", "order": "2"},
-    "dq": {"stage": "1", "order": "1"},
-    "dk": {"stage": "1", "order": "1"},
-})
+_BWD_DOT_ATTRS_SCHED = FrozenDotAttrs(
+    {
+        "qkT": {"stage": "0", "order": "0"},
+        "dpT": {"stage": "0", "order": "2"},
+        "dv": {"stage": "0", "order": "2"},
+        "dq": {"stage": "1", "order": "1"},
+        "dk": {"stage": "1", "order": "1"},
+    }
+)
 
 
 @triton.jit
@@ -698,9 +720,10 @@ def _attn_bwd_dkdv_inner(
     v,
     desc_do,
     desc_dq,
-    M,
-    D,
+    desc_m,
+    desc_delta,
     off_bh,
+    off_chz,
     curr_m,
     step_m,
     start_n,
@@ -716,14 +739,15 @@ def _attn_bwd_dkdv_inner(
 ):
     q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
     qT = tl.trans(q)
-    offs_m = curr_m + tl.arange(0, BLOCK_M1)
-    m = tl.load(M + offs_m)
+    offs_m_start = off_chz + curr_m
+    m = desc_m.load([offs_m_start.to(tl.int32)])
     if RESCHED:
         qkT = tl.dot(k, qT, attrs=BWD_DOT_ATTRS.get("qkT"))
     else:
         qkT = tl.dot(k, qT)
     pT = tl.math.exp2(qkT - m[None, :])
     if MASK:
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
         mask = offs_m[None, :] >= offs_n[:, None]
         pT = tl.where(mask, pT, 0.0)
     do = desc_do.load([(off_bh + curr_m).to(tl.int32), 0])
@@ -731,11 +755,11 @@ def _attn_bwd_dkdv_inner(
     ppT = ppT.to(dtype)
     if RESCHED:
         dpT = tl.dot(v, tl.trans(do), attrs=BWD_DOT_ATTRS.get("dpT")).to(tl.float32)
-        Di = tl.load(D + offs_m)
+        Di = desc_delta.load([offs_m_start.to(tl.int32)])
         dv += tl.dot(ppT, do, attrs=BWD_DOT_ATTRS.get("dv"))
     else:
         dv += tl.dot(ppT, do)
-        Di = tl.load(D + offs_m)
+        Di = desc_delta.load([offs_m_start.to(tl.int32)])
         dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
     dsT = pT * (dpT - Di[None, :])
     dsT = dsT.to(dtype)
@@ -764,12 +788,13 @@ def _attn_bwd_dkdv(
     sm_scale,  #
     desc_do,  #
     desc_dq,
-    M,
-    D,  #
+    desc_m,
+    desc_delta,  #
     # shared by Q/K/V/DO.
     stride_tok,
     stride_d,  #
     off_bh,
+    off_chz,
     H,
     N_CTX,
     BLOCK_M1: tl.constexpr,  #
@@ -794,8 +819,15 @@ def _attn_bwd_dkdv(
     curr_m = start_m
     step_m = BLOCK_M1
     if warp_specialize:
-        for blk_idx in tl.range(0, num_steps, warp_specialize=True, merge_epilogue_to_computation=True,
-                                tmem_alloc_algo=2, smem_alloc_algo=1, smem_budget=200000):
+        for blk_idx in tl.range(
+            0,
+            num_steps,
+            warp_specialize=True,
+            merge_epilogue_to_computation=True,
+            tmem_alloc_algo=2,
+            smem_alloc_algo=1,
+            smem_budget=200000,
+        ):
             dk, dv, curr_m = _attn_bwd_dkdv_inner(
                 dk,
                 dv,
@@ -804,9 +836,10 @@ def _attn_bwd_dkdv(
                 v,
                 desc_do,
                 desc_dq,
-                M,
-                D,
+                desc_m,
+                desc_delta,
                 off_bh,
+                off_chz,
                 curr_m,
                 step_m,
                 start_n,
@@ -830,9 +863,10 @@ def _attn_bwd_dkdv(
                 v,
                 desc_do,
                 desc_dq,
-                M,
-                D,
+                desc_m,
+                desc_delta,
                 off_bh,
+                off_chz,
                 curr_m,
                 step_m,
                 start_n,
@@ -870,6 +904,8 @@ def _bwd_host_descriptor_pre_hook(nargs):
     nargs["desc_k"].block_shape = [BLOCK_N1, HEAD_DIM]
     nargs["desc_dv"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
     nargs["desc_dk"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
+    nargs["desc_m"].block_shape = [BLOCK_M1]
+    nargs["desc_delta"].block_shape = [BLOCK_M1]
 
 
 configs_bwd = [
@@ -915,8 +951,8 @@ def _attn_bwd_core(
     desc_dq,
     desc_dk,
     desc_dv,  #
-    M,
-    D,  #
+    desc_m,
+    desc_delta,  #
     stride_tok,
     stride_d,  #
     stride_z,
@@ -937,9 +973,6 @@ def _attn_bwd_core(
     off_chz = (bhid * N_CTX).to(tl.int64)
     off_bh = ((stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)) // stride_tok
 
-    M += off_chz
-    D += off_chz
-
     dv = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
     dk = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
 
@@ -958,11 +991,12 @@ def _attn_bwd_core(
         sm_scale,  #
         desc_do,  #
         desc_dq,
-        M,
-        D,  #
+        desc_m,
+        desc_delta,  #
         stride_tok,
         stride_d,  #
         off_bh,
+        off_chz,
         H,
         N_CTX,  #
         BLOCK_M1,
@@ -1007,8 +1041,8 @@ def _attn_bwd(
     desc_dq,
     desc_dk,
     desc_dv,  #
-    M,
-    D,
+    desc_m,
+    desc_delta,
     # shared by Q/K/V/DO.
     stride_z,
     stride_h,
@@ -1040,8 +1074,8 @@ def _attn_bwd(
         desc_dq,
         desc_dk,
         desc_dv,
-        M,
-        D,
+        desc_m,
+        desc_delta,
         stride_tok,
         stride_d,
         stride_z,
@@ -1072,8 +1106,8 @@ def _attn_bwd_persist(
     desc_dq,
     desc_dk,
     desc_dv,  #
-    M,
-    D,
+    desc_m,
+    desc_delta,
     # shared by Q/K/V/DO.
     stride_z,
     stride_h,
@@ -1147,9 +1181,28 @@ def _attn_bwd_persist(
         strides=[HEAD_DIM, 1],
         block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
     )
+    desc_m = _maybe_make_tensor_desc(
+        desc_m,
+        shape=[y_dim],
+        strides=[1],
+        block_shape=[BLOCK_M1],
+    )
+    desc_delta = _maybe_make_tensor_desc(
+        desc_delta,
+        shape=[y_dim],
+        strides=[1],
+        block_shape=[BLOCK_M1],
+    )
 
-    for _ in tl.range(0, tiles_per_sm, warp_specialize=True, merge_epilogue_to_computation=True, tmem_alloc_algo=2,
-                      smem_alloc_algo=1, smem_budget=200000):
+    for _ in tl.range(
+        0,
+        tiles_per_sm,
+        warp_specialize=True,
+        merge_epilogue_to_computation=True,
+        tmem_alloc_algo=2,
+        smem_alloc_algo=1,
+        smem_budget=200000,
+    ):
         pid = tile_idx % n_tile_num
         bhid = tile_idx // n_tile_num
         _attn_bwd_core(
@@ -1161,8 +1214,8 @@ def _attn_bwd_persist(
             desc_dq,
             desc_dk,
             desc_dv,
-            M,
-            D,
+            desc_m,
+            desc_delta,
             stride_tok,
             stride_d,
             stride_z,
@@ -1184,7 +1237,6 @@ def _attn_bwd_persist(
 
 
 class _attention_opt(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE):
         # shape constraints
@@ -1312,10 +1364,14 @@ class _attention_opt(torch.autograd.Function):
         pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
         delta = torch.empty_like(M)
         _attn_bwd_preprocess[pre_grid](
-            o, do,  #
+            o,
+            do,  #
             delta,  #
-            BATCH, N_HEAD, N_CTX,  #
-            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
+            BATCH,
+            N_HEAD,
+            N_CTX,  #
+            BLOCK_M=PRE_BLOCK,
+            HEAD_DIM=ctx.HEAD_DIM,  #
         )
         warp_specialize = True
 
@@ -1373,6 +1429,19 @@ class _attention_opt(torch.autograd.Function):
             strides=[HEAD_DIM, 1],
             block_shape=dummy_block,
         )
+        dummy_block_1d = [1]
+        desc_m = TensorDescriptor(
+            M,
+            shape=[BATCH * N_HEAD * N_CTX],
+            strides=[1],
+            block_shape=dummy_block_1d,
+        )
+        desc_delta = TensorDescriptor(
+            delta,
+            shape=[BATCH * N_HEAD * N_CTX],
+            strides=[1],
+            block_shape=dummy_block_1d,
+        )
 
         def grid(meta):
             return (
@@ -1403,8 +1472,8 @@ class _attention_opt(torch.autograd.Function):
                 desc_dq,
                 desc_dk,
                 desc_dv,  #
-                M,
-                delta,  #
+                desc_m,
+                desc_delta,  #
                 q.stride(0),
                 q.stride(1),
                 q.stride(2),
@@ -1428,8 +1497,8 @@ class _attention_opt(torch.autograd.Function):
                 desc_dq,
                 desc_dk,
                 desc_dv,  #
-                M,
-                delta,  #
+                desc_m,
+                desc_delta,  #
                 q.stride(0),
                 q.stride(1),
                 q.stride(2),
@@ -1456,18 +1525,31 @@ attention = _attention_opt.apply
 )
 @pytest.mark.parametrize("Z", [8])
 @pytest.mark.parametrize("H", [16])
-@pytest.mark.parametrize("N_CTX", [1024])  #, 2048])
+@pytest.mark.parametrize("N_CTX", [1024])  # , 2048])
 @pytest.mark.parametrize("HEAD_DIM", [64, 128])
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("mode", ["fwd", "bwd"])
 @pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
 @pytest.mark.parametrize("provider", ["triton-fp16"])
 @pytest.mark.parametrize("SUBTILING", [False, True])
-@pytest.mark.parametrize("VECT_MUL", [0])  #, 1, 2, 3])
+@pytest.mark.parametrize("VECT_MUL", [0])  # , 1, 2, 3])
 @pytest.mark.parametrize("FADD2_REDUCE", [False])
 @pytest.mark.parametrize("bwd_config_idx", range(len(configs_bwd_persist)))
-def test_op(Z, H, N_CTX, HEAD_DIM, causal, mode, baseVariant, provider, SUBTILING, VECT_MUL, FADD2_REDUCE,
-            bwd_config_idx, dtype=torch.float16):
+def test_op(
+    Z,
+    H,
+    N_CTX,
+    HEAD_DIM,
+    causal,
+    mode,
+    baseVariant,
+    provider,
+    SUBTILING,
+    VECT_MUL,
+    FADD2_REDUCE,
+    bwd_config_idx,
+    dtype=torch.float16,
+):
     # For fwd mode, only run once (bwd_config_idx=0) to avoid redundant tests
     if mode == "fwd" and bwd_config_idx > 0:
         pytest.skip("bwd_config_idx only applies to bwd mode")
@@ -1482,9 +1564,9 @@ def test_op(Z, H, N_CTX, HEAD_DIM, causal, mode, baseVariant, provider, SUBTILIN
         _attn_bwd.configs = [configs_bwd_persist[bwd_config_idx]]
         _attn_bwd.cache = {}
     torch.manual_seed(20)
-    q = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    k = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
-    v = (torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_())
+    q = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_()
+    k = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_()
+    v = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_()
     sm_scale = 0.5
     # reference implementation
     ref_dtype = dtype
@@ -1536,8 +1618,8 @@ def test_op(Z, H, N_CTX, HEAD_DIM, causal, mode, baseVariant, provider, SUBTILIN
 
 
 try:
-    from flash_attn.flash_attn_interface import \
-        flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import flash_attn_qkvpacked_func as flash_attn_func
+
     HAS_FLASH = True
 except BaseException:
     HAS_FLASH = False
@@ -1546,13 +1628,13 @@ TORCH_HAS_FP8 = False
 BATCH, N_HEADS = 4, 32
 # vary seq length for fixed head and batch=4
 configs = []
-for HEAD_DIM in [128]:  #64, 128]:
+for HEAD_DIM in [128]:  # 64, 128]:
     for baseVariant in ["ws", "ws_persistent"]:
         for mode in ["fwd", "bwd"]:
             configs.append(
                 triton.testing.Benchmark(
                     x_names=["N_CTX"],
-                    x_vals=[2**i for i in range(12, 13)],  #0, 15)],
+                    x_vals=[2**i for i in range(12, 13)],  # 0, 15)],
                     line_arg="provider",
                     line_vals=["triton-fp16"] + (["flash"] if HAS_FLASH else []),
                     line_names=["Triton [FP16]"] + (["Flash-2"] if HAS_FLASH else []),
@@ -1566,7 +1648,8 @@ for HEAD_DIM in [128]:  #64, 128]:
                         "mode": mode,
                         "baseVariant": baseVariant,
                     },
-                ))
+                )
+            )
 
 
 @triton.testing.perf_report(configs)

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -891,28 +891,6 @@ configs_bwd = [
 configs_bwd_persist = [
     triton.Config(
         {
-            "BLOCK_M1": 128,
-            "BLOCK_N1": 128,
-            "BLOCK_M2": 128,
-            "BLOCK_N2": 128,
-            "EPILOGUE_SUBTILE": 4,
-            "BWD_DOT_ATTRS": _DEFAULT_BWD_DOT_ATTRS,
-        },
-        num_warps=4,
-        num_stages=2,
-        pre_hook=_bwd_host_descriptor_pre_hook,
-    ),
-    triton.Config(
-        {
-            "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128, "EPILOGUE_SUBTILE": 4, "BWD_DOT_ATTRS":
-            _BWD_DOT_ATTRS_SCHED,  # use memory planner heuristics
-        },
-        num_warps=4,
-        num_stages=2,
-        pre_hook=_bwd_host_descriptor_pre_hook,
-    ),
-    triton.Config(
-        {
             "BLOCK_M1": 64,
             "BLOCK_N1": 128,
             "BLOCK_M2": 128,

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -684,6 +684,22 @@ _DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs(
     }
 )
 
+_BWD_DOT_ATTRS_BM64_TMEM = FrozenDotAttrs(
+    {
+        # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
+        # no need to reuse between dq and dpT
+        "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
+        "dpT": {
+            "stage": "0",
+            "order": "2",
+            "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+        },  # v, do
+        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
+        "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
+        "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem,1,5", "opndD,tmem,1,10"]},  # dsT in tmem
+    }
+)
+
 _BWD_DOT_ATTRS_BM64 = FrozenDotAttrs(
     {
         # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
@@ -925,6 +941,19 @@ configs_bwd = [
 ]
 
 configs_bwd_persist = [
+    triton.Config(
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM64_TMEM,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
     triton.Config(
         {
             "BLOCK_M1": 64,

--- a/python/tutorials/test_tlx_bwd_from_fused_attention.py
+++ b/python/tutorials/test_tlx_bwd_from_fused_attention.py
@@ -622,7 +622,7 @@ if __name__ == "__main__":
         # (8,  16, 1024,  64,  False, "ws"),
         # (8,  16, 1024,  128, False, "ws"),
         # (8, 16, 1024, 64, False, "ws_persistent"), # data race
-        (4, 32, 4096, 128, False, "ws_persistent"),  # works
+        (8, 16, 1024, 128, False, "ws_persistent"),  # works
     ]
 
     all_pass = True
@@ -648,9 +648,9 @@ if __name__ == "__main__":
 
     bench_configs = [
         # (Z,  H,  N_CTX, HEAD_DIM, causal, baseVariant)
-        #(8, 16, 1024, 128, False, "ws_persistent"),
-        #(8, 16, 2048, 128, False, "ws_persistent"),
-        #(8, 16, 4096, 128, False, "ws_persistent"),
+        (8, 16, 1024, 128, False, "ws_persistent"),
+        (8, 16, 2048, 128, False, "ws_persistent"),
+        (8, 16, 4096, 128, False, "ws_persistent"),
         (4, 32, 4096, 128, False, "ws_persistent"),
     ]
 

--- a/python/tutorials/test_tlx_bwd_from_fused_attention.py
+++ b/python/tutorials/test_tlx_bwd_from_fused_attention.py
@@ -346,20 +346,30 @@ def run_tlx_bwd(q, k, v, o, M, do, sm_scale, causal):
     )
 
     dummy_block = [1, 1]
-    desc_q = TensorDescriptor(q, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1],
-                              block_shape=dummy_block)
-    desc_k = TensorDescriptor(arg_k, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1],
-                              block_shape=dummy_block)
-    desc_v = TensorDescriptor(v, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1],
-                              block_shape=dummy_block)
-    desc_do = TensorDescriptor(do, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1],
-                               block_shape=dummy_block)
-    desc_dq = TensorDescriptor(dq, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1],
-                               block_shape=dummy_block)
-    desc_dk = TensorDescriptor(dk, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1],
-                               block_shape=dummy_block)
-    desc_dv = TensorDescriptor(dv, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1],
-                               block_shape=dummy_block)
+    dummy_block_1d = [1]
+    desc_q = TensorDescriptor(
+        q, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
+    )
+    desc_k = TensorDescriptor(
+        arg_k, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
+    )
+    desc_v = TensorDescriptor(
+        v, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
+    )
+    desc_do = TensorDescriptor(
+        do, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
+    )
+    desc_dq = TensorDescriptor(
+        dq, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
+    )
+    desc_dk = TensorDescriptor(
+        dk, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
+    )
+    desc_dv = TensorDescriptor(
+        dv, shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
+    )
+    desc_m = TensorDescriptor(M, shape=[BATCH * N_HEAD * N_CTX], strides=[1], block_shape=dummy_block_1d)
+    desc_delta = TensorDescriptor(delta, shape=[BATCH * N_HEAD * N_CTX], strides=[1], block_shape=dummy_block_1d)
 
     def alloc_fn(size: int, align: int, _):
         return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -391,8 +401,8 @@ def run_tlx_bwd(q, k, v, o, M, do, sm_scale, causal):
         desc_dq,
         desc_dk,
         desc_dv,
-        M,
-        delta,
+        desc_m,
+        desc_delta,
         q.stride(0),
         q.stride(1),
         q.stride(2),
@@ -612,7 +622,7 @@ if __name__ == "__main__":
         # (8,  16, 1024,  64,  False, "ws"),
         # (8,  16, 1024,  128, False, "ws"),
         # (8, 16, 1024, 64, False, "ws_persistent"), # data race
-        (8, 16, 1024, 128, False, "ws_persistent"),  # works
+        (4, 32, 4096, 128, False, "ws_persistent"),  # works
     ]
 
     all_pass = True
@@ -638,9 +648,9 @@ if __name__ == "__main__":
 
     bench_configs = [
         # (Z,  H,  N_CTX, HEAD_DIM, causal, baseVariant)
-        (8, 16, 1024, 128, False, "ws_persistent"),
-        (8, 16, 2048, 128, False, "ws_persistent"),
-        (8, 16, 4096, 128, False, "ws_persistent"),
+        #(8, 16, 1024, 128, False, "ws_persistent"),
+        #(8, 16, 2048, 128, False, "ws_persistent"),
+        #(8, 16, 4096, 128, False, "ws_persistent"),
         (4, 32, 4096, 128, False, "ws_persistent"),
     ]
 

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_hd64.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_hd64.mlir
@@ -11,8 +11,8 @@
 // CHECK: %dpT, %dpT_1 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
 // CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
 // CHECK: %qkT, %qkT_2 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
-// CHECK: %dv_3, %dv_4 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
-// CHECK: %dk, %dk_5 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// CHECK: %dv_3, %dv_4 = ttng.tmem_alloc {{{.*}}buffer.copy = 2 : i32, buffer.id = 6 : i32}
+// CHECK: %dk, %dk_5 = ttng.tmem_alloc {{{.*}}buffer.copy = 2 : i32, buffer.id = 5 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -272,7 +272,6 @@ struct PartitionLayout {
     return nullptr;
   }
 
-  /// Get the opToDpId map (for schedulePostLoopOps).
   bool hasGemm() const { return gemmPartition != nullptr; }
 };
 
@@ -1018,7 +1017,8 @@ static Partition *scheduleUsers(scf::ForOp loop, PartitionSet &schedule,
 // (e.g., TMAStoreTokenWaitOp) go to the epilogue partition. All other post-loop
 // ops (e.g., tmem_load for accumulator reads, arithmetic for normalization) go
 // to the default partition. This prevents TMEM ops from landing in the
-// epilogue, which would force it to use 4 warps (TMEM lane coverage hardware
+// epilogue, which would force it to use 4 warps (TMEM lane coverage
+// requires full warp group).
 
 static void
 schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
@@ -1194,8 +1194,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   unsigned dataPartitionFactor = categorizer.getDataPartitionFactor();
   LLVM_DEBUG(
-      llvm::dbgs() << "[tritongpu-partition-scheduling] Using template-based "
-                      "scheduling with data partition factor: "
+      llvm::dbgs() << "[tritongpu-partition-scheduling] Scheduling with data "
+                      "partition factor: "
                    << dataPartitionFactor << "\n");
 
   //===--------------------------------------------------------------------===//
@@ -1220,7 +1220,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     reductionPartition = defaultPartition;
 
   //===--------------------------------------------------------------------===//
-  // Phase 3: Schedule ops using template-based partition assignment
+  // Phase 3: Schedule anchor ops (loads, epilogue stores, MMAs)
   currentPhase = "phase3";
   //===--------------------------------------------------------------------===//
 
@@ -1425,11 +1425,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   //===--------------------------------------------------------------------===//
   // Phase 4: Propagate users (load users, correction, reductions)
-  //===--------------------------------------------------------------------====//
-  currentPhase = "phase4";
   //===--------------------------------------------------------------------===//
-  // Phase 4: Propagate users (load users, correction, reductions)
-  //===--------------------------------------------------------------------====//
+  currentPhase = "phase4";
 
   // Load users go to default partition (shared computation).
   // When default is absent or equals the reduction partition (e.g., bwd),
@@ -1505,25 +1502,6 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
         }
       }
     }
-
-    // For BWD (hasReduction): tag pre-loop TMEMStoreOp with the reduction
-    // partition index. These ops initialize accumulators (e.g., zeroing
-    // dK/dV) before the loop. Without explicit assignment, they would get
-    // pulled into the gemm partition via token chains to the in-loop MMA,
-    // causing gemm to require >=4 warps (TMEM ops need 4 warps). We set the
-    // attribute directly rather than using schedule.trySchedule because
-    // pre-loop ops must not be added to the partition's ops list
-    // (optimizeSchedule only handles in-loop ops).
-    if (reductionPartition) {
-      Builder b(mainLoop->getContext());
-      for (Operation &op : *mainLoop->getBlock()) {
-        if (&op == mainLoop)
-          break;
-        if (isa<ttng::TMEMStoreOp>(op))
-          op.setAttr(kPartitionAttrName,
-                     b.getDenseI32ArrayAttr({reductionPartition->getIndex()}));
-      }
-    }
   }
 
   //===--------------------------------------------------------------------===//
@@ -1546,10 +1524,6 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // For dpFactor>1, let scheduleUsers(nullptr) create per-group partitions.
   // (sharedComputePartition tracks the BWD computation partition.)
   Partition *sharedComputePartition = nullptr;
-  if (dataPartitionFactor <= 1) {
-    // All MMA users go to one computation partition (bwd pattern).
-    // Keep whatever was set by inner-loop MMA scheduling.
-  }
 
   // When dpFactor > 1 and there is no defaultPartition, pre-assign
   // DataPartition-categorized ops to their respective computation partitions
@@ -2189,8 +2163,6 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
   // operands.
   loop.walk<WalkOrder::PostOrder, ReverseIterator>([&](Operation *op) {
     if (!isa<MemDescTransOp, ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(op))
-      // if (op->getNumResults() != 1 || !isPure(op) ||
-      //     isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
       return;
 
     Partition *partition = getPartition(op);
@@ -2259,7 +2231,6 @@ void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
 
     // Check if results feed different partitions.
     DenseSet<int> resultPartitions;
-    bool hasDifferentPartitions = false;
     for (OpResult result : ifOp.getResults()) {
       for (Operation *user : result.getUsers()) {
         auto ids = safeGetPartitionIds(user);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -948,10 +948,19 @@ static void iterateUsers(scf::ForOp loop, Operation *op,
 }
 
 // Helper: schedule an operation to a partition if it is not already scheduled.
+// Current scheduling phase name for debug logging.
+static const char *currentPhase = "";
+
+static void scheduleOp(Partition *partition, Operation *op) {
+  LDBG("[" << currentPhase << "] " << partition->getIndex() << "("
+           << partition->getType() << ") <- " << prettyOp(op));
+  setPartition(op, partition);
+}
+
 static bool tryScheduleOp(Partition *partition, Operation *op) {
   if (hasPartition(op))
     return false;
-  setPartition(op, partition);
+  scheduleOp(partition, op);
   return true;
 }
 
@@ -1128,7 +1137,7 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
           target = getEpilogueTarget(user);
       }
       if (target)
-        setPartition(user, target);
+        scheduleOp(target, user);
     }
 
     for (OpResult result : user->getResults())
@@ -1212,6 +1221,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   //===--------------------------------------------------------------------===//
   // Phase 3: Schedule ops using template-based partition assignment
+  currentPhase = "phase3";
   //===--------------------------------------------------------------------===//
 
   // Schedule loads and their associated allocs (both in-loop and pre-loop)
@@ -1416,11 +1426,18 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   //===--------------------------------------------------------------------===//
   // Phase 4: Propagate users (load users, correction, reductions)
   //===--------------------------------------------------------------------====//
+  currentPhase = "phase4";
+  //===--------------------------------------------------------------------===//
+  // Phase 4: Propagate users (load users, correction, reductions)
+  //===--------------------------------------------------------------------====//
 
   // Load users go to default partition (shared computation).
-  // When default is absent (e.g., bwd), skip — MMA user propagation in
-  // Phase 5 will capture these ops through the use chain.
-  if (defaultPartition) {
+  // When default is absent or equals the reduction partition (e.g., bwd),
+  // skip — MMA user propagation in Phase 5 will capture these ops through
+  // the use chain. Without this guard, load-user scheduling from
+  // descriptor_load (m/Di metadata) transitively pulls the entire softmax
+  // chain into the reduction partition.
+  if (defaultPartition && defaultPartition != reductionPartition) {
     for (Operation *loadOrAlloc : loadsAndAllocs) {
       scf::ForOp parentLoop = loadOrAlloc->getParentOfType<scf::ForOp>();
       if (!parentLoop) {
@@ -1510,6 +1527,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   }
 
   //===--------------------------------------------------------------------===//
+  currentPhase = "phase5";
   // Phase 5: Create per-MMA computation partitions
   //===--------------------------------------------------------------------===//
   // MMA users create computation partitions. This runs AFTER correction/load
@@ -1526,10 +1544,11 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   // For dpFactor==1, pre-create a single shared computation partition.
   // For dpFactor>1, let scheduleUsers(nullptr) create per-group partitions.
+  // (sharedComputePartition tracks the BWD computation partition.)
   Partition *sharedComputePartition = nullptr;
   if (dataPartitionFactor <= 1) {
     // All MMA users go to one computation partition (bwd pattern).
-    sharedComputePartition = nullptr; // lazy-created on first use
+    // Keep whatever was set by inner-loop MMA scheduling.
   }
 
   // When dpFactor > 1 and there is no defaultPartition, pre-assign
@@ -1772,6 +1791,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     }
   }
 
+  currentPhase = "post-loop";
   // Pre-schedule post-loop ops before propagatePartitions claims them.
   schedulePostLoopOps(mainLoop, schedule, layout, schedOpts,
                       categorizer.getOpToDpIdMap(), dpIdToPartition);
@@ -1990,7 +2010,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
         for (Operation *op : cluster.ops) {
           if (isScalarOp(op))
             continue;
-          setPartition(op, existingComputation);
+          scheduleOp(existingComputation, op);
         }
         continue;
       }
@@ -2019,7 +2039,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
           for (Operation *op : cluster.ops) {
             if (isScalarOp(op))
               continue;
-            setPartition(op, fallbackPartition);
+            scheduleOp(fallbackPartition, op);
           }
           continue;
         }
@@ -2034,7 +2054,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
         for (Operation *op : cluster.ops) {
           if (isScalarOp(op))
             continue;
-          setPartition(op, cluster.sinkPartitions.front());
+          scheduleOp(cluster.sinkPartitions.front(), op);
         }
         continue;
       }
@@ -2043,7 +2063,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
       for (Operation *op : cluster.ops) {
         if (isScalarOp(op))
           continue;
-        setPartition(op, newPartition);
+        scheduleOp(newPartition, op);
       }
       continue;
     }
@@ -2055,7 +2075,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
       for (Operation *op : cluster.ops) {
         if (isScalarOp(op))
           continue;
-        setPartition(op, defPartition);
+        scheduleOp(defPartition, op);
       }
       continue;
     }
@@ -2084,7 +2104,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
       for (Operation *op : cluster.ops) {
         if (isScalarOp(op))
           continue;
-        setPartition(op, defPartition);
+        scheduleOp(defPartition, op);
       }
       continue;
     }
@@ -2102,12 +2122,12 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
         return sinkOps.contains(use.getOwner());
       });
       sinkOps.insert(clone);
-      setPartition(clone, sinkPartition);
+      scheduleOp(sinkPartition, clone);
     }
     for (Operation *op : cluster.ops) {
       if (isScalarOp(op))
         continue;
-      setPartition(op, defPartition);
+      scheduleOp(defPartition, op);
     }
   }
 }
@@ -2189,7 +2209,7 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
     for (auto *userPartition : userPartitions) {
       // Clone the instruction into each user partition.
       Operation *clone = OpBuilder(op).clone(*op);
-      setPartition(clone, userPartition);
+      scheduleOp(userPartition, clone);
       // Replace all users in that partition with the clone.
       op->replaceUsesWithIf(clone->getResults(), [&](OpOperand &otherUse) {
         return getPartition(otherUse.getOwner()) == userPartition;
@@ -2431,8 +2451,10 @@ void PartitionSchedulingMeta::runOnOperation() {
     if (std::optional<ScheduleResult> result =
             getInitialSchedule(loop, schedOpts)) {
       PartitionSet &schedule = result->schedule;
+      currentPhase = "propagate";
       propagatePartitions(loop, schedule, result->createComputePartitions);
 
+      currentPhase = "optimize";
       optimizeSchedule(loop, schedule);
 
       // Split scf.if ops whose results feed different computation partitions.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1948,12 +1948,10 @@ DenseMap<Channel *, Value> createBuffer(const SmallVector<Channel *> &channels,
     } else if (auto tensorType =
                    dyn_cast<RankedTensorType>(srcValue.getType())) {
       int cc = getNVIDIAComputeCapability(funcOp->getParentOfType<ModuleOp>());
-      auto res = createLocalAlloc(
-          builder, channel,
-          isPost ? (cc >= 100 && tensorType.getShape().size() == 1 &&
-                    tensorType.getElementType().isIntOrFloat())
-                 : false,
-          isPost);
+      bool useTMEM = isPost && cc >= 100 && tensorType.getShape().size() == 1 &&
+                     tensorType.getElementType().isIntOrFloat() &&
+                     !isa<tt::DescriptorLoadOp>(srcOp);
+      auto res = createLocalAlloc(builder, channel, useTMEM, isPost);
       buffer = res.first;
       newProducer = res.second;
     } else {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -2085,8 +2085,34 @@ public:
                                     operationId, ctrlOp, bufferId);
       } else {
         LDBG("using tmem allocation algorithm 2 (backtracking)");
-        result = allocateTMemAllocs2(allocsForThisLoop, buffers, allocToChannel,
-                                     operationId, ctrlOp, bufferId);
+        // Build initial state from pre-assigned allocs whose liveness
+        // intersects this loop, so un-annotated allocs can reuse them.
+        AllocationState initialState;
+        size_t seedColStart = 0;
+        for (auto alloc : allocs) {
+          if (!handledAllocs.count(alloc.getOperation()))
+            continue;
+          auto *buf = getBuffer(alloc.getOperation());
+          auto allocInt = bufferRange.lookup(buf);
+          if (!ctrlInt.intersects(allocInt))
+            continue;
+          if (buf->isOwnerOfSpace) {
+            int rowGroup =
+                (buf->rowSize == 2 * kRowGroupSize) ? -1 : 0; // default rg0
+            OwnerPlacement placement{seedColStart, rowGroup};
+            addOwnerToState(initialState, buf, placement);
+            seedColStart += buf->colSize;
+            LDBG("seeding owner [" << allocInt.start() << "-" << allocInt.end()
+                                   << ") at col " << placement.colStart
+                                   << " rowGroup " << rowGroup << " size "
+                                   << buf->rowSize << "x" << buf->colSize);
+          } else {
+            initialState.assignment[buf] = {buf->reuseOwner, buf->colOffset};
+          }
+        }
+        result =
+            allocateTMemAllocs2(allocsForThisLoop, buffers, allocToChannel,
+                                operationId, ctrlOp, bufferId, initialState);
       }
       if (failed(result))
         return failure();
@@ -2118,6 +2144,9 @@ public:
 
     unsigned totalCols = 0;
     for (auto alloc : allocs) {
+      // Skip reusers — their columns are already counted via their owner
+      if (alloc->hasAttr("buffer.offset"))
+        continue;
       ttng::TMemAllocation allocSize = ttng::getTmemAllocSizes(alloc.getType());
       unsigned baseCols = allocSize.numCols;
       unsigned copy = 1;
@@ -2179,16 +2208,123 @@ public:
   // ---------------------------------------------------------------
   // allocateTMemAllocs2 — backtracking search allocation algorithm.
   // ---------------------------------------------------------------
+  // TMEM has 128 physical rows (2 row groups of 64 each) × 512 columns.
+  // A 128-row alloc occupies both row groups. A 64-row alloc occupies one.
+  // Two 64-row allocs in different row groups can co-use the same columns.
 
-  /// State for backtracking search.
-  struct AllocationState {
-    /// For each buffer, stores (reuseOwner, colOffset). nullptr means owner.
-    DenseMap<BufferT *, std::pair<BufferT *, size_t>> assignment;
-    /// Set of buffers that own their space.
-    DenseSet<BufferT *> owners;
-    /// Total rows used.
-    size_t usedRows = 0;
+  static constexpr size_t kMaxTMemCols = 512;
+  static constexpr size_t kColAlignment = 4;
+  static constexpr int kNumRowGroups = 2;
+  static constexpr size_t kRowGroupSize = 64;
+
+  /// 2D placement for an owner buffer in the TMEM grid.
+  struct OwnerPlacement {
+    size_t colStart; // starting column
+    int rowGroup;    // 0, 1, or -1 meaning "both" (128-row owner)
   };
+
+  /// State for backtracking search with 2D TMEM model.
+  struct AllocationState {
+    /// For each reuser buffer, stores (reuseOwner, colOffset).
+    DenseMap<BufferT *, std::pair<BufferT *, size_t>> assignment;
+    /// Owners with their 2D placement.
+    DenseMap<BufferT *, OwnerPlacement> owners;
+    /// Column intervals occupied per row group, sorted by start.
+    /// rowGroupCols[0] = row group 0 (rows 0-63)
+    /// rowGroupCols[1] = row group 1 (rows 64-127)
+    SmallVector<std::pair<size_t, size_t>, 8> rowGroupCols[kNumRowGroups];
+
+    bool containsOwner(BufferT *buf) const { return owners.count(buf); }
+  };
+
+  /// Add an owner with its placement to the state, updating rowGroupCols.
+  void addOwnerToState(AllocationState &state, BufferT *buf,
+                       OwnerPlacement placement) const {
+    state.owners[buf] = placement;
+    auto interval =
+        std::make_pair(placement.colStart, placement.colStart + buf->colSize);
+    auto insertSorted = [](SmallVectorImpl<std::pair<size_t, size_t>> &vec,
+                           std::pair<size_t, size_t> iv) {
+      auto it = llvm::lower_bound(
+          vec, iv,
+          [](const std::pair<size_t, size_t> &a,
+             const std::pair<size_t, size_t> &b) { return a.first < b.first; });
+      vec.insert(it, iv);
+    };
+    if (placement.rowGroup == -1) {
+      // 128-row: occupies both row groups
+      insertSorted(state.rowGroupCols[0], interval);
+      insertSorted(state.rowGroupCols[1], interval);
+    } else {
+      insertSorted(state.rowGroupCols[placement.rowGroup], interval);
+    }
+  }
+
+  /// Find the first gap of at least `size` columns (with alignment) in a
+  /// sorted interval list, not exceeding maxCol.
+  std::optional<size_t>
+  findFirstGap(const SmallVectorImpl<std::pair<size_t, size_t>> &intervals,
+               size_t size, size_t maxCol) const {
+    size_t candidate = 0;
+    for (auto &[start, end] : intervals) {
+      // Align candidate
+      if (candidate % kColAlignment != 0)
+        candidate = (candidate / kColAlignment + 1) * kColAlignment;
+      if (candidate + size <= start)
+        return (candidate + size <= maxCol) ? std::optional(candidate)
+                                            : std::nullopt;
+      candidate = std::max(candidate, end);
+    }
+    // Check after the last interval
+    if (candidate % kColAlignment != 0)
+      candidate = (candidate / kColAlignment + 1) * kColAlignment;
+    if (candidate + size <= maxCol)
+      return candidate;
+    return std::nullopt;
+  }
+
+  /// Find valid 2D placements for a new owner in the TMEM grid.
+  /// Returns a list of OwnerPlacement sorted by colStart (tightest first).
+  SmallVector<OwnerPlacement, 4> findPlacements(BufferT *buf,
+                                                const AllocationState &state,
+                                                size_t maxCols) const {
+    SmallVector<OwnerPlacement, 4> result;
+
+    if (buf->rowSize == 2 * kRowGroupSize) {
+      // 128-row: needs both row groups free at the same column range.
+      // Merge intervals from both groups and find a gap in the union.
+      SmallVector<std::pair<size_t, size_t>, 16> merged;
+      merged.append(state.rowGroupCols[0].begin(), state.rowGroupCols[0].end());
+      merged.append(state.rowGroupCols[1].begin(), state.rowGroupCols[1].end());
+      llvm::sort(merged, [](const auto &a, const auto &b) {
+        return a.first < b.first;
+      });
+      // Merge overlapping intervals
+      SmallVector<std::pair<size_t, size_t>, 16> mergedUnion;
+      for (auto &iv : merged) {
+        if (!mergedUnion.empty() && iv.first <= mergedUnion.back().second) {
+          mergedUnion.back().second =
+              std::max(mergedUnion.back().second, iv.second);
+        } else {
+          mergedUnion.push_back(iv);
+        }
+      }
+      if (auto col = findFirstGap(mergedUnion, buf->colSize, maxCols))
+        result.push_back({*col, -1});
+    } else {
+      // 64-row: try each row group
+      for (int rg = 0; rg < kNumRowGroups; ++rg) {
+        if (auto col =
+                findFirstGap(state.rowGroupCols[rg], buf->colSize, maxCols))
+          result.push_back({*col, rg});
+      }
+      // Sort by colStart so we prefer tighter packing
+      llvm::sort(result, [](const auto &a, const auto &b) {
+        return a.colStart < b.colStart;
+      });
+    }
+    return result;
+  }
 
   /// Check if candidate can potentially reuse owner's space.
   /// Returns priority: 0 = cannot reuse, 1 = can reuse, 2 = exact size match.
@@ -2260,7 +2396,7 @@ public:
 
   /// Recursive backtracking search for buffer allocation.
   bool tryAllocate(SmallVectorImpl<ttng::TMEMAllocOp> &allocs, size_t idx,
-                   AllocationState &state, size_t maxRows, Operation *ctrlOp) {
+                   AllocationState &state, size_t maxCols, Operation *ctrlOp) {
     // Base case: all buffers allocated
     if (idx == allocs.size())
       return true;
@@ -2269,7 +2405,7 @@ public:
 
     // Collect reuse candidates sorted by priority (descending)
     SmallVector<std::pair<BufferT *, int>> candidates;
-    for (BufferT *owner : state.owners) {
+    for (auto &[owner, placement] : state.owners) {
       int priority = hasPotentialReuse(owner, buf, ctrlOp);
       if (priority > 0)
         candidates.push_back({owner, priority});
@@ -2297,7 +2433,7 @@ public:
       });
 
       // Recurse
-      if (tryAllocate(allocs, idx + 1, newState, maxRows, ctrlOp)) {
+      if (tryAllocate(allocs, idx + 1, newState, maxCols, ctrlOp)) {
         state = newState;
         return true;
       }
@@ -2310,26 +2446,27 @@ public:
       });
     }
 
-    // Try allocating new space
-    if (state.usedRows + buf->rowSize <= maxRows) {
+    // Try allocating new space with 2D placement
+    auto placements = findPlacements(buf, state, maxCols);
+    for (auto &placement : placements) {
       AllocationState newState = state;
-      newState.owners.insert(buf);
-      newState.usedRows += buf->rowSize;
+      addOwnerToState(newState, buf, placement);
 
       LLVM_DEBUG({
         LDBG("tryAllocate: trying new space for ["
              << bufferRange[buf].start() << "-" << bufferRange[buf].end()
-             << ") at row " << state.usedRows);
+             << ") at col " << placement.colStart << " rowGroup "
+             << placement.rowGroup);
       });
 
-      if (tryAllocate(allocs, idx + 1, newState, maxRows, ctrlOp)) {
+      if (tryAllocate(allocs, idx + 1, newState, maxCols, ctrlOp)) {
         state = newState;
         return true;
       }
       LLVM_DEBUG({
         LDBG("tryAllocate: backtracking from new space for ["
              << bufferRange[buf].start() << "-" << bufferRange[buf].end()
-             << ")");
+             << ") at col " << placement.colStart);
       });
     }
 
@@ -2338,14 +2475,23 @@ public:
 
   /// Apply the allocation state to the actual buffers.
   void applyAllocationState(SmallVectorImpl<ttng::TMEMAllocOp> &allocs,
-                            const AllocationState &state, unsigned &bufferId) {
-    // First pass: assign owners
-    size_t rowOffset = 0;
+                            const AllocationState &state, unsigned &bufferId,
+                            const AllocationState *initialState = nullptr) {
+    // First pass: assign owners (skip pre-assigned ones from initialState)
     DenseMap<BufferT *, unsigned> ownerToBufferId;
+    // Carry over buffer IDs from pre-assigned owners in initial state
+    if (initialState) {
+      for (auto &[buf, placement] : initialState->owners) {
+        auto idAttr = buf->owner->getAttrOfType<IntegerAttr>("buffer.id");
+        if (idAttr)
+          ownerToBufferId[buf] = idAttr.getInt();
+      }
+    }
     for (auto alloc : allocs) {
       BufferT *buf = getBuffer(alloc.getOperation());
-      if (state.owners.contains(buf)) {
-        buf->rowOffset = rowOffset;
+      if (state.containsOwner(buf)) {
+        auto &placement = state.owners.find(buf)->second;
+        buf->rowOffset = placement.rowGroup == 1 ? kRowGroupSize : 0;
         buf->colOffset = 0;
         buf->isOwnerOfSpace = true;
         buf->reuseOwner = buf;
@@ -2355,16 +2501,16 @@ public:
             IntegerAttr::get(IntegerType::get(alloc->getContext(), 32),
                              bufferId));
         ++bufferId;
-        rowOffset += buf->rowSize;
       }
     }
 
-    // Second pass: assign reusers
+    // Second pass: assign reusers (skip pre-assigned ones from initialState)
     for (auto alloc : allocs) {
       BufferT *buf = getBuffer(alloc.getOperation());
-      if (!state.owners.contains(buf)) {
+      if (!state.containsOwner(buf)) {
         auto it = state.assignment.find(buf);
-        assert(it != state.assignment.end());
+        if (it == state.assignment.end())
+          continue; // pre-assigned reuser, already has attributes
         auto [owner, colOffset] = it->second;
         buf->rowOffset = owner->rowOffset;
         buf->colOffset = colOffset;
@@ -2379,10 +2525,11 @@ public:
             IntegerAttr::get(IntegerType::get(alloc->getContext(), 32),
                              colOffset));
       }
-      // Set buffer.copy attribute
-      alloc.getOperation()->setAttr(
-          "buffer.copy",
-          IntegerAttr::get(IntegerType::get(alloc->getContext(), 32), 1));
+      // Set buffer.copy attribute if not already set
+      if (!alloc.getOperation()->hasAttr("buffer.copy"))
+        alloc.getOperation()->setAttr(
+            "buffer.copy",
+            IntegerAttr::get(IntegerType::get(alloc->getContext(), 32), 1));
     }
   }
 
@@ -2390,9 +2537,12 @@ public:
       SmallVector<ttng::TMEMAllocOp> &allocs, SmallVector<BufferT *> &buffers,
       DenseMap<Operation *, ttng::TmemDataChannelPost *> &allocToChannel,
       DenseMap<Operation *, size_t> &operationId, Operation *ctrlOp,
-      unsigned bufferId) {
+      unsigned bufferId,
+      const AllocationState &initialState = AllocationState()) {
 
-    LDBG("allocateTMemAllocs2: starting with " << allocs.size() << " allocs");
+    LDBG("allocateTMemAllocs2: starting with "
+         << allocs.size() << " allocs"
+         << ", initial owners: " << initialState.owners.size());
 
     // Debug: dump allocation order and liveness
     LLVM_DEBUG({
@@ -2424,20 +2574,35 @@ public:
           }
         }
       }
+      // Also check reuse with seeded owners
+      for (auto &[seedOwner, placement] : initialState.owners) {
+        for (auto alloc : allocs) {
+          auto *buf = getBuffer(alloc.getOperation());
+          int p1 = hasPotentialReuse(seedOwner, buf, ctrlOp);
+          int p2 = hasPotentialReuse(buf, seedOwner, ctrlOp);
+          if (p1 > 0 || p2 > 0) {
+            llvm::dbgs() << "  hasPotentialReuse(seeded ["
+                         << bufferRange[seedOwner].start() << "-"
+                         << bufferRange[seedOwner].end() << "), ["
+                         << bufferRange[buf].start() << "-"
+                         << bufferRange[buf].end() << ")) = " << p1 << "/" << p2
+                         << "\n";
+          }
+        }
+      }
       llvm::dbgs() << "=== End hasPotentialReuse ===\n\n";
     });
 
-    // Initialize state and run backtracking search
-    AllocationState state;
-    constexpr size_t maxRows = 512; // TMEM has 512 rows
+    // Start from the seeded state (includes pre-assigned owners)
+    AllocationState state = initialState;
 
-    if (!tryAllocate(allocs, 0, state, maxRows, ctrlOp)) {
+    if (!tryAllocate(allocs, 0, state, kMaxTMemCols, ctrlOp)) {
       return allocs[0].emitError(
           "allocateTMemAllocs2: failed to allocate TMEM buffers");
     }
 
-    // Apply the final allocation state
-    applyAllocationState(allocs, state, bufferId);
+    // Apply the final allocation state (skip pre-assigned buffers)
+    applyAllocationState(allocs, state, bufferId, &initialState);
 
     LLVM_DEBUG({
       llvm::dbgs() << "\n=== allocateTMemAllocs2: Final Allocation ===\n";

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
@@ -1,0 +1,103 @@
+# Accumulation Counters
+
+Accumulation counter insertion threads `accumCnt` loop-carried values into
+the IR — `i64` values that track which buffer slot to use in multi-buffered
+pipelines. This runs as part of code partitioning (`doCodePartition` step 6,
+`doCodePartitionPost` step 4), after channels and buffers have been created.
+
+**File**: `WSBuffer.cpp`
+**Function**: `appendAccumCntsForOps(taskTopOps, channels, regionsWithChannels, config)`
+
+## Pipeline Context
+
+```
+doCodePartition / doCodePartitionPost
+  Step 1-3: channel discovery, grouping, buffer creation
+  ...
+  → appendAccumCntsForOps  ← THIS: inserts accumCnt loop arguments
+  ...
+  → insertAsyncCopy / insertAsyncComm  ← uses accumCnt to index buffers
+```
+
+## What Is an Accumulation Counter?
+
+An **accumulation counter** (`accumCnt`) is an `i64` loop-carried value that
+starts at 0 and increments by 1 each time a buffer slot is consumed. It is
+used to compute:
+
+```
+bufferIdx = accumCnt % numBuffers    // which buffer slot
+phase     = (accumCnt / numBuffers) & 1  // mbarrier phase bit
+```
+
+Each channel (or reuse group of channels) that is multi-buffered needs its
+own `accumCnt` argument threaded through the enclosing control flow.
+
+## Algorithm
+
+### Step 1: Identify Channels Needing AccumCnt
+
+A channel needs an accumulation counter when it has `numBuffers > 1` (is
+multi-buffered). Channels in a reuse group share a single `accumCnt`.
+
+### Step 2: Extend Loop Arguments (`createNewLoop`)
+
+For each `scf::ForOp` that contains multi-buffered channels:
+
+1. Create a new loop with additional `i64` block arguments — one per
+   accumulation counter.
+2. All arguments start at 0 (`arith::ConstantOp(0)`).
+3. The original loop body is moved into the new loop.
+
+`createNewLoopWrapper` handles the case where the loop is wrapped in an
+outer structure.
+
+### Step 3: Extend If-Op Results (`rewriteIfOp`)
+
+When `scf::IfOp` appears inside a loop with accumulation counters, its
+results must be extended to carry the `accumCnt` values through both the
+then and else branches:
+
+- `generateYieldCntsForThenBlock`: generates yield values for the then branch
+- `generateYieldCntsForIfOp`: generates yield values for both branches
+
+### Step 4: Update Counter Values (`updateAccumLoopCount`)
+
+Recursively processes nested `ForOp`/`IfOp` to thread `accumCnt` values
+correctly through all control flow. The counter is incremented at each
+point where a buffer slot is consumed (i.e., at the channel's destination
+operation).
+
+### Step 5: Generate Yield Values
+
+- `generateYieldCntsForForOp`: at each loop yield, the `accumCnt` is
+  incremented by the number of times it was consumed in the loop body.
+- For reuse groups, the counter is shared — each channel in the group
+  offsets its buffer index by its position within the group.
+
+## Interaction with Reuse Groups
+
+When channels share a reuse group (same `buffer.id`), they share a single
+`accumCnt`:
+
+- `getAccumForReuseGroup`: computes the `accumCnt` SSA value at a given
+  operation by walking back through the channel list.
+- `getBufferIdxAndPhase`: for the first channel in the group, uses
+  `accumCnt` directly. Each subsequent channel at position N adds N to
+  stagger its slot within the shared circular buffer.
+
+See [Reuse Groups](ReuseGroups.md) for more details.
+
+## Key Functions
+
+| Function | Description |
+|----------|-------------|
+| `appendAccumCntsForOps` | Entry point: identifies channels needing counters |
+| `createNewLoop` / `createNewLoopWrapper` | Extends `scf::ForOp` with extra block arguments |
+| `rewriteIfOp` | Extends `scf::IfOp` results with accumCnt outputs |
+| `updateAccumLoopCount` | Recursively threads counters through nested control flow |
+| `generateYieldCntsForForOp` | Generates loop yield values for counters |
+| `generateYieldCntsForIfOp` | Generates if-op yield values for counters |
+| `getAccumCount` | Retrieves the accumCnt value for an op from its enclosing loop |
+| `getAccumCnts` | Returns the number of accumCnt arguments for a control flow op |
+| `getAccumArgIdx` | Returns the starting index of accumCnt arguments in a block argument list |

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BufferAllocation.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BufferAllocation.md
@@ -1,101 +1,110 @@
 # Buffer Allocation
 
-Buffer allocation inserts accumulation counters (`accumCnt`) into the IR —
-loop-carried values that track which buffer slot to use in multi-buffered
-pipelines. This step runs after memory planning (which decides how many
-buffer copies each channel gets) and before code partitioning (which creates
-the actual async copies).
+Buffer allocation is a pre-pass that discovers cross-partition channels,
+creates or hoists SMEM and TMEM allocations to function scope, and
+normalizes `local_alloc` ops for downstream code partitioning passes.
 
-**File**: `WSBuffer.cpp`
-**Function**: `doBufferAllocation(funcOp, channels, ...)`
+**File**: `WSCodePartition.cpp`
+**Function**: `doBufferAllocation(funcOp)`
+**Pass**: `NVGPUTestWSBufferAllocation`
 
 ## Pipeline Context
 
 ```
-doMemoryPlanner         ← decides buffer.copy for each channel
-  → doBufferAllocation  ← THIS STEP: inserts accumCnt loop arguments
-  → doCodePartitionPost ← uses accumCnt to index into multi-buffered allocs
+doTaskIdPropagate       ← assigns async_task_id to all ops
+  → doBufferAllocation  ← THIS STEP: channels + alloc hoisting
+  → doMemoryPlanner     ← decides multi-buffering (buffer.copy)
+  → doCodePartitionPost ← inserts accumCnts, async copies, sync ops
 ```
 
-## What Is an Accumulation Counter?
-
-An **accumulation counter** (`accumCnt`) is an `i64` loop-carried value that
-starts at 0 and increments by 1 each time a buffer slot is consumed. It is
-used to compute:
-
-```
-bufferIdx = accumCnt % numBuffers    // which buffer slot
-phase     = (accumCnt / numBuffers) & 1  // mbarrier phase bit
-```
-
-Each channel (or reuse group of channels) that is multi-buffered needs its
-own `accumCnt` argument threaded through the enclosing control flow.
+`doBufferAllocation` creates single-copy buffers. Multi-buffering is
+decided later by the memory planner. Code partitioning then uses
+[accumulation counters](AccumulationCounters.md) to index into
+multi-buffered allocations.
 
 ## Algorithm
 
-### Step 1: Identify Channels Needing AccumCnt
+### Step 0: `swapTransposedLocalAllocs`
 
-A channel needs an accumulation counter when it has `numBuffers > 1` (is
-multi-buffered). Channels in a reuse group share a single `accumCnt`.
+When a `local_alloc` uses a transposed `#shared2` (NVMMAShared with
+`transposed=true`) layout and its only use is a `memdesc_trans` back to
+non-transposed `#shared` feeding MMA operand A, swap the layouts:
 
-### Step 2: Extend Loop Arguments (`createNewLoop`)
+```
+Before:  local_alloc → #shared_transposed  →  memdesc_trans → #shared
+After:   local_alloc → #shared             →  memdesc_trans → #shared_transposed
+```
 
-For each `scf::ForOp` that contains multi-buffered channels:
+This enables the alloc to share a buffer with other allocs of the same
+source that already use `#shared` layout.
 
-1. Create a new loop with additional `i64` block arguments — one per
-   accumulation counter.
-2. All arguments start at 0 (`arith::ConstantOp(0)`).
-3. The original loop body is moved into the new loop.
+### Step 0.5: `mergeDuplicateLocalAllocs`
 
-`createNewLoopWrapper` handles the case where the loop is wrapped in an
-outer structure.
+After layout normalization, merge `LocalAllocOp`s that have the same
+source value and the same `MemDescType` — replace duplicates with the
+first alloc.
 
-### Step 3: Extend If-Op Results (`rewriteIfOp`)
+### Step 1: `collectAsyncChannels`
 
-When `scf::IfOp` appears inside a loop with accumulation counters, its
-results must be extended to carry the `accumCnt` values through both the
-then and else branches:
+Walk the function to find cross-partition data dependencies. For each
+operation with a single `async_task_id` that is a **channel anchor op**
+(loads, dots, allocs with source, etc.), call `createChannel` to identify
+consumers in different partitions. All channels are created with
+`numBuffers=1` (single-buffered).
 
-- `generateYieldCntsForThenBlock`: generates yield values for the then branch
-- `generateYieldCntsForIfOp`: generates yield values for both branches
+### Step 2: `reorderEpilogOps`
 
-### Step 4: Update Counter Values (`updateAccumLoopCount`)
+Reorder epilogue operations (stores after the main loop) to align with
+the expected producer completion order. Groups stores by type
+(`DescriptorStoreOp` vs `StoreOp`) and interleaves them so
+earlier-completed producers are consumed first.
 
-Recursively processes nested `ForOp`/`IfOp` to thread `accumCnt` values
-correctly through all control flow. The counter is incremented at each
-point where a buffer slot is consumed (i.e., at the channel's destination
-operation).
+### Step 3: `createBuffer`
 
-### Step 5: Generate Yield Values
+The core step. For each channel (grouped by producer), create or hoist
+the backing allocation to function entry:
 
-- `generateYieldCntsForForOp`: at each loop yield, the `accumCnt` is
-  incremented by the number of times it was consumed in the loop body.
-- For reuse groups, the counter is shared — each channel in the group
-  offsets its buffer index by its position within the group.
+- **TMEM channels** (existing `TMEMAllocOp` or `TCGen5MMAOp` source):
+  Hoist the existing alloc to function entry via `hoistLocalAlloc`.
 
-## Interaction with Reuse Groups
+- **SMEM channels** (existing `LocalAllocOp` source):
+  Hoist the existing alloc to function entry via `hoistLocalAlloc`.
 
-When channels share a reuse group (same `buffer.id`), they share a single
-`accumCnt`:
+- **Tensor-typed channels** (no existing alloc):
+  Call `createLocalAlloc` which creates a new `LocalAllocOp` (SMEM)
+  or `TMEMAllocOp` (for 1D tensors on Blackwell ≥ cc100). For
+  post-channels (`isPost=true`), also inserts `LocalStoreOp` after
+  the producer and `LocalLoadOp` before the consumer.
 
-- `getAccumForReuseGroup`: computes the `accumCnt` SSA value at a given
-  operation by walking back through the channel list.
-- `getBufferIdxAndPhase`: for the first channel in the group, uses
-  `accumCnt` directly. Each subsequent channel at position N adds N to
-  stagger its slot within the shared circular buffer.
+Channels sharing the same producer value share the same buffer.
 
-See [Reuse Groups](ReuseGroups.md) for more details.
+### Step 4: `separateLocalAllocWithSrc`
+
+Split any remaining `local_alloc %val` (alloc-with-source) into
+`local_alloc` + `local_store %val`. This normalization exposes
+cross-partition SMEM dependencies as separate store ops, enabling
+downstream `doCodePartition`/`doCodePartitionPost` to detect them
+as channels.
+
+## Key Distinction
+
+`doBufferAllocation` does **not** insert:
+- Accumulation counters (see [Accumulation Counters](AccumulationCounters.md))
+- Async copies or TMA lowering
+- Tokens or synchronization ops (barriers, acquire/release)
+
+Those are handled by `doCodePartition` / `doCodePartitionPost`.
 
 ## Key Functions
 
-| Function | Description |
-|----------|-------------|
-| `appendAccumCntsForOps` | Entry point: identifies channels needing counters |
-| `createNewLoop` / `createNewLoopWrapper` | Extends `scf::ForOp` with extra block arguments |
-| `rewriteIfOp` | Extends `scf::IfOp` results with accumCnt outputs |
-| `updateAccumLoopCount` | Recursively threads counters through nested control flow |
-| `generateYieldCntsForForOp` | Generates loop yield values for counters |
-| `generateYieldCntsForIfOp` | Generates if-op yield values for counters |
-| `getAccumCount` | Retrieves the accumCnt value for an op from its enclosing loop |
-| `getAccumCnts` | Returns the number of accumCnt arguments for a control flow op |
-| `getAccumArgIdx` | Returns the starting index of accumCnt arguments in a block argument list |
+| Function | File | Description |
+|----------|------|-------------|
+| `doBufferAllocation` | `WSCodePartition.cpp` | Entry point |
+| `swapTransposedLocalAllocs` | `WSCodePartition.cpp` | Layout normalization for buffer sharing |
+| `mergeDuplicateLocalAllocs` | `WSCodePartition.cpp` | Dedup same-source allocs |
+| `collectAsyncChannels` | `WSCodePartition.cpp` | Channel discovery |
+| `reorderEpilogOps` | `WSCodePartition.cpp` | Epilogue store reordering |
+| `createBuffer` | `WSCodePartition.cpp` | Buffer creation / hoisting |
+| `createLocalAlloc` | `WSCodePartition.cpp` | New SMEM/TMEM alloc for tensor channels |
+| `hoistLocalAlloc` | `WSCodePartition.cpp` | Move existing alloc to function entry |
+| `separateLocalAllocWithSrc` | `WSCodePartition.cpp` | Split alloc+src into alloc + store |

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
@@ -53,7 +53,8 @@ Step 12: specializeRegion          — clone ops into WarpSpecializeOp regions
 
 **Function**: `doBufferAllocation(funcOp)`
 
-A separate entry point for pre-processing before the main pipeline:
+A separate entry point for pre-processing before the main pipeline.
+See [Buffer Allocation](BufferAllocation.md) for details.
 
 ```
 Step 0:   swapTransposedLocalAllocs   — normalize transposed alloc layouts

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -40,7 +40,8 @@ an earlier partition scheduling pass (`PartitionSchedulingMeta`).
 | `WSTaskIdPropagate.cpp` | `doTaskIdPropagate` | Runs analysis and materializes task IDs |
 | `WSDataPartition.cpp` | `doDataPartition` | Splits ops along M/N dimensions across warp groups — Hopper only |
 | `PingPong.cpp` | `doPingPongPrep` / `doPingPongSync` | Named barrier insertion for ping-pong scheduling |
-| `WSBuffer.cpp` | `doBufferAllocation` | Inserts accumulation counters for multi-buffer indexing |
+| `WSCodePartition.cpp` | `doBufferAllocation` | Channel discovery and SMEM/TMEM allocation hoisting (pre-pass) |
+| `WSBuffer.cpp` | `appendAccumCntsForOps` | Accumulation counter infrastructure for multi-buffer indexing |
 | `WSMemoryPlanner.cpp` | `doMemoryPlanner` | Plans SMEM and TMEM allocation (multi-buffering, liveness) |
 | `WSCodePartition.cpp` | `doCodePartitionPost` | Creates channels, inserts async copies and barriers |
 | `WSLowerMem.cpp` | — | Memory lowering: async copies between global/shared/tensor memory |
@@ -86,7 +87,8 @@ an earlier partition scheduling pass (`PartitionSchedulingMeta`).
 - [Code Specialization](CodeSpecialization.md) — how ops are cloned into WarpSpecializeOp regions
 - [Memory Lowering](MemoryLowering.md) — async copy creation and TMA store lowering
 - [Token & Barrier Lowering](TokenBarrierLowering.md) — lowering abstract tokens to hardware mbarriers
-- [Buffer Allocation](BufferAllocation.md) — accumulation counter infrastructure for multi-buffering
+- [Buffer Allocation](BufferAllocation.md) — channel discovery and SMEM/TMEM allocation hoisting
+- [Accumulation Counters](AccumulationCounters.md) — accumulation counter infrastructure for multi-buffering
 - [Operand D Handling](OperandDHandling.md) — MMA accumulator lifecycle through WS
 - [TMEM Allocation Heuristics](TMEMAllocationHeuristics.md) — TMEM memory planning algorithms
 - [SMEM Allocation Design](SmemAllocationDesign.md) — SMEM budget-aware allocation

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -18,8 +18,9 @@ Phase 2: Create partition layout       (createPartitionLayout with tuning knobs)
 Phase 3: Schedule anchor ops           (loads, epilogue stores, MMAs)
 Phase 4: Propagate users               (load users, correction, reductions)
 Phase 5: Create computation partitions (per-MMA user scheduling + dpId assignment)
-Post:    propagatePartitions + schedulePostLoopOps + optimizeSchedule
-         + splitDataPartitionedIfOps
+Phase 6: Schedule post-loop ops        (schedulePostLoopOps — epilogue routing)
+  ─── end of getInitialSchedule ───
+Post:    propagatePartitions + optimizeSchedule + splitDataPartitionedIfOps
 ```
 
 ## Tuning Knobs
@@ -153,8 +154,6 @@ so all MMAs group together → `dpFactor=1`.
 ## Phase 2: Partition Layout (`createPartitionLayout`)
 
 Creates partitions based on the categorizer results and `SchedulingOptions`.
-Replaces the old template system (`UnifiedFATemplate`, `GEMMTemplate`,
-`selectTemplate`).
 
 Partition creation order determines the partition index. The first partition
 created gets index 0, which becomes the "default" warp group in
@@ -222,7 +221,7 @@ those ops go to the next available partition in the fallback chain.
 
 Pre-creates computation partitions for each dpId that has `DataPartition`-
 categorized ops (in reverse dpId order to match legacy partition index ordering).
-Then iterates over MMAs:
+Then iterates over MMAs (calling `scheduleUsers` to walk forward from each):
 
 - **Pre-assigned MMAs** (PV MMAs): Use the pre-assigned computation partition.
 - **Non-pre-assigned MMAs** (QK MMAs): First check user partitions, then look up
@@ -230,6 +229,11 @@ Then iterates over MMAs:
   prevents creating extra partitions.
 - **Non-MMAv5** (Hopper): MMA ops themselves are scheduled into the computation
   partition (not gemm, since no gemm partition exists).
+- **BWD (dpFactor≤1)**: All MMA users share one `sharedComputePartition`.
+  `scheduleUsers` walks forward from each MMA: token result → tmem_load →
+  subf/exp2/mulf → truncf → tmem_alloc/local_alloc, assigning all to computation.
+- **3-loop causal**: MMAs in the second loop are matched to first-loop MMAs
+  and `scheduleUsers` reuses their partition.
 
 ### dpId-Based Inner-Loop Assignment
 
@@ -246,6 +250,25 @@ For each unscheduled inner-loop op with a tensor result:
 
 Scalar integer ops (loop counters) and `scf.yield` are excluded from this
 assignment since they are loop-control ops, not data-partition computation ops.
+
+### Phase 6: `schedulePostLoopOps`
+
+Schedules post-loop operations (called at the end of `getInitialSchedule`,
+before `propagatePartitions`):
+
+- **Epilogue store ops** → `epilogue_store` partition (when it exists), else
+  follow the same routing as regular epilogue ops.
+- **Epilogue ops** (non-store) → routing depends on tuning knobs:
+  - `mergeEpilogueToComputation`: → computation[dpId] directly
+  - `mergeEpilogue`: → correction (if exists) → reduction → computation[dpId]
+  - Neither: → `epiloguePartition` (if exists) → correction/reduction →
+    computation
+
+The `postLoopPartition` fallback order (for epilogue ops when no merge knob
+is active) is:
+1. `epiloguePartition` (when it exists)
+2. Correction/reduction partition (whichever serves as default)
+3. First `dpIdToPartition` entry (Hopper with all merges, last resort)
 
 ## Post-Processing
 
@@ -286,24 +309,6 @@ Cluster assignment rules:
    the entire cluster to its def partition.
 3. **Single def and single sink**: Assign to the sink partition (downstream
    consumer), or to the def partition if they're the same.
-
-### `schedulePostLoopOps`
-
-Schedules post-loop operations:
-
-- **Epilogue store ops** → `epilogue_store` partition (when it exists), else
-  follow the same routing as regular epilogue ops.
-- **Epilogue ops** (non-store) → routing depends on tuning knobs:
-  - `mergeEpilogueToComputation`: → computation[dpId] directly
-  - `mergeEpilogue`: → correction (if exists) → reduction → computation[dpId]
-  - Neither: → `epiloguePartition` (if exists) → correction/reduction →
-    computation
-
-The `postLoopPartition` fallback order (for epilogue ops when no merge knob
-is active) is:
-1. `epiloguePartition` (when it exists)
-2. Correction/reduction partition (whichever serves as default)
-3. First `dpIdToPartition` entry (Hopper with all merges, last resort)
 
 ### `optimizeSchedule`
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -200,6 +200,11 @@ those ops go to the next available partition in the fallback chain.
 
 1. **Load users** → routed with the uncategorized op fallback priority:
    correction → reduction → epilogue → computation.
+   **Guard**: When `defaultPartition == reductionPartition` (BWD case where
+   no real correction/epilogue/computation partition exists yet), load-user
+   scheduling is **skipped** to prevent transitively pulling the softmax
+   chain into the reduction partition. Phase 5's MMA forward walk handles
+   these ops instead.
 2. **Correction ops** → correction partition (+ `scheduleUsers` for transitive
    users). `scheduleUsers` walks **forward only** through the use chain
    starting from the correction-categorized op (the `tmem_load` of the PV

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1094,7 +1094,7 @@ configs_bwd_tlx = [
         num_warps=8,
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
-    ) for bm1 in [64] for uwb in [False]
+    ) for bm1 in [64, 128] for uwb in [False, True]
 ]
 
 

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1094,7 +1094,7 @@ configs_bwd_tlx = [
         num_warps=8,
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
-    ) for bm1 in [64, 128] for uwb in [False, True]
+    ) for bm1 in [64] for uwb in [False]
 ]
 
 


### PR DESCRIPTION
PromoteLHSToTMem: use tt.autows annotation to decide promotion
PSM cleanup: remove dead code, stale comments, duplicate logic
doBufferAllocation: use SMEM for descriptor_load 1D channels
MemoryPlanner: 2D TMEM packing with column budget enforcement
    The backtracking TMEM allocator (allocateTMemAllocs2) previously modeled
    TMEM as a 1D row stack and only enforced the 512-row limit. It did not
    track or limit total column usage. This caused BWD FA to overflow the
    512-column TMEM hardware limit (544 cols needed, 6 owners).
    
    Additionally, pre-assigned TMEM owners (from user annotations) were not
    visible to the backtracking search, so un-annotated allocs could not
    reuse pre-assigned owners' column space.
    
    Changes:
    - Replace the 1D usedRows model with a 2D row-group × column grid.
      Each owner gets an OwnerPlacement (colStart, rowGroup) and the state
      tracks column intervals per row group. Two 64-row owners in different
      row groups can co-use the same columns.
    - Add findPlacements() to find valid 2D placements for new owners,
      enforcing the 512-column budget.
    - Seed the backtracking search with pre-assigned owners so un-annotated
      allocs can reuse their space.
    - Fix totalCols accounting in multi-buffering post-processing to skip
      reusers (previously double-counted).
    
    For BWD FA: dsT_1 (32 cols) now reuses dpT's space (64 cols) at offset 0,
    reducing total columns from 544 to 512.

Fix PSM BWD softmax partition + add per-phase debug logging
    
    For BWD FA with TMA descriptor_load for m/Di values, the softmax chain
    (subf, exp2, truncf) was incorrectly assigned to the reduction partition
    instead of computation. The root cause: Phase 4 load-user scheduling
    walks forward from every categorized descriptor_load and assigns all
    transitive users to defaultPartition. For BWD, defaultPartition falls
    back to reductionPartition (via getDefaultPartition()) since no
    correction/epilogue/computation partition exists yet. When m/Di values
    come through descriptor_load (TMA), this walk transitively pulled the
    entire softmax chain into partition 0 (reduction).
   Also added per-phase debug logging: tryScheduleOp and scheduleOp now log
    `[phaseN] partition_index(type) <- op_name` when
    `-debug-only=tritongpu-partition-scheduling` is enabled, making it easy
    to trace which ops get assigned at each phase.
