### PR TITLE
[TLX] Move P from SMEM to TMEM in MXFP8 FA kernel

### DIFF
--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -183,14 +183,14 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
                     layout.swizzled,
                 )
         else:
-            # For 8-bit element types (uint8/int8), use a dummy TMEM layout that will
-            # be resolved during layout propagation. This is used for scales in
-            # scaled MMA operations where the final layout depends on usage context.
+            # For sub-16-bit element types:
+            # - FP8 data tiles get a proper TMEM layout (used as MMA operands)
+            # - Integer scales (uint8/int8) use a dummy layout resolved during propagation
             if dtype.primitive_bitwidth < 16:
-                if dtype == tl.uint8 or dtype == tl.int8:
-                    layout = tlx.DummyTMEMLayoutEncoding()
+                if dtype.is_fp8():
+                    layout = tlx.tensor_memory_layout_encoding.make_default(shape)
                 else:
-                    raise NotImplementedError(f"TMEM Layouts not supported for {dtype} yet")
+                    layout = tlx.DummyTMEMLayoutEncoding()
             else:
                 layout = tlx.tensor_memory_layout_encoding.make_default(shape)
             layout_handle = layout.to_ir(_semantic.builder)

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -244,7 +244,6 @@ def async_dot_scaled(
     assert version == 5, "async_dot_scaled is only available on Blackwell"
 
     assert isinstance(A, tlx.buffered_tensor), "input must be a buffered tensor"
-    assert A.type.storage == tlx.storage_kind.smem, "input must be a shared memory tensor"
     assert isinstance(B, tlx.buffered_tensor), "input must be a buffered tensor"
     assert B.type.storage == tlx.storage_kind.smem, "input must be a shared memory tensor"
 
@@ -257,19 +256,19 @@ def async_dot_scaled(
     A_type = _semantic._str_to_fp_type(A_format)
     B_type = _semantic._str_to_fp_type(B_format)
 
-    # Require the shared memory layout for A and B
-    # For fp4 (e2m1) format with mixed precision, we need fp4Padded=True for correct swizzling
-    # This follows the same logic as Triton's AccelerateMatmul.cpp:
-    # https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-packing-formats-mxf8f6f4-smem
+    # Require layout for A: SMEM or TMEM (mirroring async_dot's 3-way branch)
     is_A_fp4 = A_format == "e2m1"
     is_B_fp4 = B_format == "e2m1"
     is_mixed_precision = A_format != B_format
-    # fp4Padded is needed when:
-    # 1. The operand is FP4 and it's mixed precision (the other operand is not FP4)
-    # Note: When both operands are FP4 (not mixed precision), they use packed format
-    A_fp4Padded = is_A_fp4 and is_mixed_precision
+    if A.type.storage == tlx.storage_kind.smem:
+        A_fp4Padded = is_A_fp4 and is_mixed_precision
+        A_handle = require_nv_mma_shared_layout(A, True, _semantic.builder, fp4Padded=A_fp4Padded)
+    else:
+        assert A.type.storage == tlx.storage_kind.tmem, "A must be in SMEM or TMEM"
+        A_handle = require_tmem_layout_col_stride(A, 1, _semantic.builder)
+
+    # Require layout for B (always SMEM)
     B_fp4Padded = is_B_fp4 and is_mixed_precision
-    A_handle = require_nv_mma_shared_layout(A, True, _semantic.builder, fp4Padded=A_fp4Padded)
     B_handle = require_nv_mma_shared_layout(B, True, _semantic.builder, fp4Padded=B_fp4Padded)
 
     # Handle scale tensors - can be in SMEM or TMEM (auto-detected from storage type)

--- a/third_party/tlx/language/tlx/mxfp8_utils.py
+++ b/third_party/tlx/language/tlx/mxfp8_utils.py
@@ -102,7 +102,7 @@ def _to_mxfp8_block(
 
     Args:
         data_input: Input tensor of shape [BLOCK_M, BLOCK_K] in float32 (in registers)
-        data_out_tile: Preallocated SMEM buffer for FP8 data output
+        data_out_tile: Preallocated buffer for FP8 data output (SMEM or TMEM)
         scale_out_tile: Preallocated buffer for int8 (E8M0) scale output (SMEM or TMEM)
         VEC_SIZE: The MX block size (typically 32)
         dtype: Target output dtype, either tl.float8e4nv or tl.float8e5

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -240,7 +240,6 @@ def _softmax_inner_loop(
             VEC_SIZE,
             out_dtype,
         )
-        tlx.fence("async_shared")
         tlx.barrier_arrive(tlx.local_view(p_fulls, cid))
 
         l_ij = tl.sum(p_i, 1)
@@ -273,26 +272,10 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                       ):
     """
     This kernel is adapted from the Blackwell FA kernel for MXFP8.
-    This requires the following changes for correctness:
 
-    1. P must move to SMEM. As a result, for HEAD-DIM=64 it is no longer
-    necessary/helpful to share buffers QK (you have enough TMEM). This
-    kernel moves P, alpha, m, and l to their own individual buffers and
-    adds corresponding barriers (including for qk_empties).
-
-    2. The FP8 data is generated with scales, converting the dots to scale
-    dots. This follows the pattern of going bf16 -> torchao CuBlas format
-    -> 5D TMA format. This creates separate Tensor Descriptors which
-    currently match the load placement of the original tensors.
-
-    3. P is converted to FP8 online and both the data and scales are placed
-    in SMEM.
-
-    4. Subtiling is removed. It is an open question to explore how this will
-    work with scale dots.
-
-    This kernel has not yet been tuned in its autotuning configs and future work
-    will further modify this kernel.
+    P is converted to FP8 online with per-block E8M0 scales and stored in
+    TMEM alongside its scales, matching the BF16 kernel's pattern of keeping
+    P in TMEM for the PV scaled dot.
     """
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
@@ -363,12 +346,6 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
     kv_scale_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     kv_scale_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
 
-    p_tiles = tlx.local_alloc(
-        (BLOCK_M_SPLIT, BLOCK_N),
-        tlx.dtype_of(desc_v),
-        NUM_MMA_GROUPS,
-    )
-
     # Calculate scale bytes for barrier expect
     Q_SCALE_BYTES: tl.constexpr = REP_M * REP_HEAD * 2 * 256
     K_SCALE_BYTES: tl.constexpr = REP_N * REP_HEAD * 2 * 256
@@ -434,6 +411,13 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
             tlx.storage_kind.tmem,
             reuse=qk_storage_alias,
         )
+        p_tiles = tlx.local_alloc(
+            (BLOCK_M_SPLIT, BLOCK_N),
+            tlx.dtype_of(desc_v),
+            NUM_MMA_GROUPS,
+            tlx.storage_kind.tmem,
+            reuse=qk_storage_alias,
+        )
         p_scale_tiles = tlx.local_alloc(
             (BLOCK_M_SPLIT, BLOCK_N // VEC_SIZE),
             tl.uint8,
@@ -442,9 +426,8 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
             reuse=qk_storage_alias,
         )
         # Define the reuse strategy.
-        # Here we share 1 buffer of QK with all other buffers. However,
-        # because Q_SCALES is needed to compute QK we must store the opposite
-        # scale index.
+        # QK and P have sequential lifetimes (QK consumed by softmax before P produced),
+        # so they share the same TMEM region. P in FP8 (32 cols) fits within QK's FP32 space (128 cols).
         # QK[0] : |                              BLK_M/2 * BLOCK_N * fp32                                       |
         # Alpha[0]: |BLK_M/2*1*fp32|
         # L[0]:                    |BLK_M/2*1*fp32|
@@ -452,7 +435,8 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
         # Q_SCALES[1]:                                           |512*uint8|
         # K_SCALES[1]:                                                     |512*uint8|
         # V_SCALES[0]:                                                               |512*uint8|
-        # P_SCALES[0]:                                                                         |BLK_M/2*32*uint8|
+        # P[0]:                                                                      |BLK_M/2*BLK_N*fp8|
+        # P_SCALES[0]:                                                                         |BLK_M/2*4*uint8|
         qk_storage_alias.set_buffer_overlap(
             tlx.reuse_group(
                 qk_tiles,
@@ -463,6 +447,7 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                     q_scale_tmem,
                     v_scale_tmem,
                     k_scale_tmem,
+                    p_tiles,
                     p_scale_tiles,
                     group_type=tlx.reuse_group_type.distinct,
                 ),
@@ -496,6 +481,7 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                                        tlx.storage_kind.tmem)
         v_scale_tmem = tlx.local_alloc((HEAD_DIM, V_SCALE_TMEM_COLS), tl.uint8, NUM_KV_SCALE_TMEM_BUFFERS,
                                        tlx.storage_kind.tmem)
+        p_tiles = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N), tlx.dtype_of(desc_v), NUM_MMA_GROUPS, tlx.storage_kind.tmem)
         p_scale_tiles = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N // VEC_SIZE), tl.uint8, NUM_MMA_GROUPS,
                                         tlx.storage_kind.tmem)
 


### PR DESCRIPTION
Enable async_dot_scaled to accept TMEM-sourced A operands, matching the BF16 kernel's pattern of keeping P in TMEM for the PV dot. The C++ IR, MLIR verifier, and LLVM/PTX lowering already supported this; only the Python DSL assertion blocked it.

Three infrastructure changes:
- mma_ops.py: async_dot_scaled now accepts TMEM A (mirrors async_dot)
- mem_ops.py: FP8 types get proper TensorMemoryEncodingAttr for TMEM allocation (DummyTMEMLayout is only for integer scale types)
- mxfp8_utils.py: docstring update for TMEM-compatible data output

The kernel change moves p_tiles into the qk_storage_alias group for SHARE_SCALE_BUFFERS (HEAD_DIM=128), since QK and P have sequential lifetimes. FP8 P uses 32 TMEM columns vs QK's 128 FP32 columns.


Before:
```
flash-attention-performance-mxfp8:
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                               59.599349
1  2048.0                               71.620988
2  4096.0                               73.182124
3  8192.0                               73.842364
```

After:
```
flash-attention-performance-mxfp8:
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                              313.226901
1  2048.0                              400.799500
2  4096.0                              419.409927
3  8192.0                              424.891963
```