### PR TITLE
[triton][tileir] Add backend autotuning support and enable TileIR in beta build (#1312)

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -591,3 +591,547 @@ def test_dump_best_config_ir(device, tmp_path):
         knobs.autotuning.dump_best_config_ir = original_dump_best
         knobs.compilation.dump_ir = original_dump_ir
         knobs.cache.dump_dir = original_dump_dir
+
+
+# =============================================================================
+# Config.get_effective_backend tests (no GPU required)
+# =============================================================================
+
+class TestGetEffectiveBackend:
+    """Tests for Config.get_effective_backend() with single/multiple backend scenarios."""
+
+    def test_explicit_backend_with_multiple_backends(self):
+        """Explicit backend is returned when multiple backends are registered."""
+        from unittest.mock import patch
+        fake_backends = {"nvidia": object(), "cutile": object()}
+        with patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = None
+            config = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir")
+            with patch("triton.backends.backends", fake_backends):
+                assert config.get_effective_backend() == "tileir"
+
+    def test_knob_default_with_multiple_backends(self):
+        """TRITON_DEFAULT_BACKEND knob is used when config.backend is None."""
+        from unittest.mock import patch
+        fake_backends = {"nvidia": object(), "cutile": object()}
+        with patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = "tileir"
+            config = triton.Config(kwargs={"BLOCK_SIZE": 128})
+            with patch("triton.backends.backends", fake_backends):
+                assert config.get_effective_backend() == "tileir"
+
+    def test_no_override_returns_none(self):
+        """Returns None when no backend override and no knob set."""
+        from unittest.mock import patch
+        fake_backends = {"nvidia": object(), "cutile": object()}
+        with patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = None
+            config = triton.Config(kwargs={"BLOCK_SIZE": 128})
+            with patch("triton.backends.backends", fake_backends):
+                assert config.get_effective_backend() is None
+
+    def test_single_backend_ignores_explicit_override(self, caplog):
+        """With only 1 backend registered, explicit backend is ignored and logged."""
+        import logging
+        from unittest.mock import patch
+        fake_backends = {"nvidia": object()}
+        with patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = None
+            config = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir")
+            with patch("triton.backends.backends", fake_backends):
+                with caplog.at_level(logging.INFO, logger="triton"):
+                    result = config.get_effective_backend()
+                assert result is None
+                assert "Ignoring backend override 'tileir'" in caplog.text
+                assert "1 backend(s) available" in caplog.text
+
+    def test_single_backend_ignores_knob_override(self, caplog):
+        """With only 1 backend registered, TRITON_DEFAULT_BACKEND knob is ignored and logged."""
+        import logging
+        from unittest.mock import patch
+        fake_backends = {"nvidia": object()}
+        with patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = "tileir"
+            config = triton.Config(kwargs={"BLOCK_SIZE": 128})
+            with patch("triton.backends.backends", fake_backends):
+                with caplog.at_level(logging.INFO, logger="triton"):
+                    result = config.get_effective_backend()
+                assert result is None
+                assert "Ignoring backend override 'tileir'" in caplog.text
+
+    def test_explicit_backend_overrides_knob(self):
+        """Explicit config.backend takes precedence over TRITON_DEFAULT_BACKEND knob."""
+        from unittest.mock import patch
+        fake_backends = {"nvidia": object(), "cutile": object()}
+        with patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = "cuda"
+            config = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir")
+            with patch("triton.backends.backends", fake_backends):
+                assert config.get_effective_backend() == "tileir"
+
+    def test_backend_in_config_hash(self):
+        """Configs with different backends have different hashes."""
+        c1 = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="cuda")
+        c2 = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir")
+        c3 = triton.Config(kwargs={"BLOCK_SIZE": 128})
+        assert hash(c1) != hash(c2)
+        assert hash(c1) != hash(c3)
+        assert c1 != c2
+        assert c1 != c3
+
+    def test_backend_in_config_str(self):
+        """Backend appears in Config string representation when set."""
+        c_with = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir")
+        c_without = triton.Config(kwargs={"BLOCK_SIZE": 128})
+        assert "backend: tileir" in str(c_with)
+        assert "backend" not in str(c_without)
+
+
+def _has_multiple_backends():
+    """Check if both nvidia and cutile/tileir backends are registered."""
+    from triton.backends import backends
+    return len(backends) > 1
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not _has_multiple_backends(), reason="Only 1 backend registered; need both nvidia and cutile")
+def test_autotune_filters_backend_when_single_available(device: str):
+    """End-to-end: autotuner with backend configs filters correctly when both backends exist.
+
+    With multiple backends registered, configs specifying different backends should
+    each be benchmarked independently. The autotuner should pick the best config
+    (which may be from either backend), and the result should be numerically correct.
+    """
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+
+    from triton.backends import backends
+    backend_names = list(backends.keys())
+
+    # Create configs that autotune across all available backends
+    configs = []
+    for backend_name in backend_names:
+        configs.append(triton.Config(kwargs={"BLOCK_SIZE": 128}, backend=backend_name))
+        configs.append(triton.Config(kwargs={"BLOCK_SIZE": 256}, backend=backend_name))
+
+    @triton.autotune(
+        configs=configs,
+        key=["N"],
+        do_bench=lambda kernel, quantiles: do_bench(kernel, quantiles),
+    )
+    @triton.jit
+    def _copy_kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        x = tl.load(src + offsets, mask=mask)
+        tl.store(dst + offsets, x, mask=mask)
+
+    grid = lambda META: (triton.cdiv(N, META["BLOCK_SIZE"]),)
+    _copy_kernel[grid](dst, src, N=N)
+
+    triton.testing.assert_close(dst, src)
+
+    # Verify the best config was selected and has a backend set
+    best = _copy_kernel.best_config
+    assert best.backend in backend_names, (
+        f"Best config backend '{best.backend}' not in registered backends {backend_names}"
+    )
+
+
+# =============================================================================
+# check_disk_cache multi-backend tests (mocked, no GPU required)
+# =============================================================================
+
+class TestCheckDiskCacheMultiBackend:
+    """Tests for check_disk_cache() behaviour when configs span multiple backends."""
+
+    def _make_autotuner(self, configs):
+        """Helper: create an Autotuner around a trivial JIT stub."""
+        from unittest.mock import MagicMock
+        fn = MagicMock(spec=triton.runtime.jit.JITFunction)
+        fn.cache_key = "stub_cache_key"
+        fn.__name__ = "stub_kernel"
+        # Mark fn as a JITFunction so the while-loop in check_disk_cache terminates
+        fn.__class__ = triton.runtime.jit.JITFunction
+        autotuner = triton.runtime.autotuner.Autotuner(
+            fn=fn,
+            arg_names=["x"],
+            configs=configs,
+            key=["N"],
+            reset_to_zero=None,
+            restore_value=None,
+        )
+        return autotuner
+
+    def test_cache_key_differs_across_backend_sets(self):
+        """The disk-cache key should change when configs reference different backend sets."""
+        import hashlib
+        from unittest.mock import patch, MagicMock
+
+        class FakeBackend:
+            def __init__(self, name):
+                self._name = name
+            def hash(self):
+                return f"hash-{self._name}"
+
+        def fake_make_backend(target):
+            return FakeBackend(target.backend)
+
+        fake_target = MagicMock()
+        fake_target.backend = "cuda"
+        fake_target.arch = 80
+        fake_target.warp_size = 32
+
+        fake_driver = MagicMock()
+        fake_driver.active.get_current_target.return_value = fake_target
+
+        # Configs that all use cuda
+        configs_single = [
+            triton.Config(kwargs={"BLOCK_SIZE": 128}),
+            triton.Config(kwargs={"BLOCK_SIZE": 256}),
+        ]
+        # Configs that span cuda + tileir
+        configs_multi = [
+            triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="cuda"),
+            triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir"),
+        ]
+
+        fake_backends = {"nvidia": object(), "cutile": object()}
+
+        keys = []
+        for configs in [configs_single, configs_multi]:
+            at = self._make_autotuner(configs)
+            captured_key = {}
+
+            def fake_get_cache_manager(key):
+                captured_key["key"] = key
+                mgr = MagicMock()
+                mgr.get_file.return_value = None  # cache miss
+                return mgr
+
+            with patch("triton.compiler.compiler.make_backend", fake_make_backend), \
+                 patch("triton.runtime.autotuner.driver", fake_driver), \
+                 patch("triton.runtime.autotuner.triton_key", return_value="triton_v1"), \
+                 patch("triton.runtime.autotuner.get_cache_invalidating_env_vars", return_value={}), \
+                 patch("triton.runtime.autotuner.get_cache_manager", fake_get_cache_manager), \
+                 patch("triton.backends.backends", fake_backends), \
+                 patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+                mock_runtime.default_backend = None
+                at.check_disk_cache(
+                    tuning_key=(1024,),
+                    configs=configs,
+                    bench_fn=lambda: setattr(at, "configs_timings", {c: 1.0 for c in configs}),
+                )
+            keys.append(captured_key["key"])
+
+        assert keys[0] != keys[1], "Cache key should differ when configs span different backends"
+
+    def test_multi_backend_calls_make_backend_for_each(self):
+        """make_backend should be called once per unique effective backend in the config set."""
+        from unittest.mock import patch, MagicMock, call
+
+        class FakeBackend:
+            def __init__(self, name):
+                self._name = name
+            def hash(self):
+                return f"hash-{self._name}"
+
+        make_backend_calls = []
+        def fake_make_backend(target):
+            make_backend_calls.append(target.backend)
+            return FakeBackend(target.backend)
+
+        fake_target = MagicMock()
+        fake_target.backend = "cuda"
+        fake_target.arch = 80
+        fake_target.warp_size = 32
+
+        fake_driver = MagicMock()
+        fake_driver.active.get_current_target.return_value = fake_target
+
+        configs = [
+            triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="cuda"),
+            triton.Config(kwargs={"BLOCK_SIZE": 256}, backend="cuda"),
+            triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir"),
+        ]
+
+        fake_backends = {"nvidia": object(), "cutile": object()}
+        at = self._make_autotuner(configs)
+
+        def fake_get_cache_manager(key):
+            mgr = MagicMock()
+            mgr.get_file.return_value = None
+            return mgr
+
+        with patch("triton.compiler.compiler.make_backend", fake_make_backend), \
+             patch("triton.runtime.autotuner.driver", fake_driver), \
+             patch("triton.runtime.autotuner.triton_key", return_value="triton_v1"), \
+             patch("triton.runtime.autotuner.get_cache_invalidating_env_vars", return_value={}), \
+             patch("triton.runtime.autotuner.get_cache_manager", fake_get_cache_manager), \
+             patch("triton.backends.backends", fake_backends), \
+             patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = None
+            at.check_disk_cache(
+                tuning_key=(1024,),
+                configs=configs,
+                bench_fn=lambda: setattr(at, "configs_timings", {c: 1.0 for c in configs}),
+            )
+
+        # Should have called make_backend for exactly 2 unique backends: cuda and tileir
+        assert sorted(make_backend_calls) == ["cuda", "tileir"], (
+            f"Expected make_backend called for ['cuda', 'tileir'], got {sorted(make_backend_calls)}"
+        )
+
+    def test_disk_cache_round_trip_preserves_backend(self, tmp_path):
+        """Serialized configs with backend field should deserialize correctly."""
+        import json
+
+        config_cuda = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="cuda")
+        config_tileir = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="tileir")
+
+        timings = {config_cuda: [1.0, 1.1, 1.2], config_tileir: [0.9, 1.0, 1.1]}
+
+        # Simulate the serialization path from check_disk_cache
+        serialized = json.dumps({
+            "key": (1024,),
+            "configs_timings": [
+                (config.__dict__, timing) for config, timing in timings.items()
+                if not config.pre_hook
+            ],
+        })
+
+        # Simulate the deserialization path
+        loaded = json.loads(serialized)["configs_timings"]
+        restored = {triton.Config(**cfg): t for cfg, t in loaded}
+
+        # Verify backends round-tripped
+        backends_found = {c.backend for c in restored.keys()}
+        assert "cuda" in backends_found
+        assert "tileir" in backends_found
+
+        # Verify the best config is correctly identified
+        import builtins
+        best = builtins.min(restored, key=restored.get)
+        assert best.backend == "tileir"  # tileir had lower timings
+
+    def test_disk_cache_hit_returns_correct_backend(self, tmp_path):
+        """When check_disk_cache hits, the restored best config should have the right backend."""
+        import json
+        from unittest.mock import patch, MagicMock
+
+        config_cuda = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend="cuda")
+        config_tileir = triton.Config(kwargs={"BLOCK_SIZE": 256}, backend="tileir")
+
+        # Write a fake cache file
+        cache_data = json.dumps({
+            "key": (1024,),
+            "configs_timings": [
+                (config_cuda.__dict__, [2.0, 2.1, 2.2]),
+                (config_tileir.__dict__, [1.0, 1.1, 1.2]),
+            ],
+        })
+        cache_file = tmp_path / "stub_kernel.autotune.json"
+        cache_file.write_text(cache_data)
+
+        configs = [config_cuda, config_tileir]
+        at = self._make_autotuner(configs)
+
+        class FakeBackend:
+            def __init__(self, name):
+                self._name = name
+            def hash(self):
+                return f"hash-{self._name}"
+
+        def fake_make_backend(target):
+            return FakeBackend(target.backend)
+
+        fake_target = MagicMock()
+        fake_target.backend = "cuda"
+        fake_target.arch = 80
+        fake_target.warp_size = 32
+
+        fake_driver = MagicMock()
+        fake_driver.active.get_current_target.return_value = fake_target
+
+        fake_backends = {"nvidia": object(), "cutile": object()}
+
+        def fake_get_cache_manager(key):
+            mgr = MagicMock()
+            mgr.get_file.return_value = str(cache_file)
+            return mgr
+
+        tuning_key = (1024,)
+        with patch("triton.compiler.compiler.make_backend", fake_make_backend), \
+             patch("triton.runtime.autotuner.driver", fake_driver), \
+             patch("triton.runtime.autotuner.triton_key", return_value="triton_v1"), \
+             patch("triton.runtime.autotuner.get_cache_invalidating_env_vars", return_value={}), \
+             patch("triton.runtime.autotuner.get_cache_manager", fake_get_cache_manager), \
+             patch("triton.backends.backends", fake_backends), \
+             patch("triton.runtime.autotuner.knobs.runtime") as mock_runtime:
+            mock_runtime.default_backend = None
+            hit = at.check_disk_cache(tuning_key, configs, bench_fn=lambda: None)
+
+        assert hit is True
+        best = at.cache[tuning_key]
+        assert best.backend == "tileir", f"Expected tileir (lower timings), got {best.backend}"
+        assert best.kwargs["BLOCK_SIZE"] == 256
+
+
+# =============================================================================
+# GPU integration tests for multi-backend autotuning + caching
+# =============================================================================
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not _has_multiple_backends(), reason="Only 1 backend registered; need both nvidia and cutile")
+def test_autotune_multi_backend_device_cache_isolation(device: str):
+    """Each backend should get its own entry in device_caches.
+
+    After autotuning, the JITFunction's device_caches should contain separate
+    entries for each (device, backend) pair that was benchmarked.
+    """
+    from triton.backends import backends
+    backend_names = list(backends.keys())
+
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+
+    configs = []
+    for bn in backend_names:
+        configs.append(triton.Config(kwargs={"BLOCK_SIZE": 128}, backend=bn))
+
+    @triton.autotune(
+        configs=configs,
+        key=["N"],
+        do_bench=lambda kernel, quantiles: do_bench(kernel, quantiles),
+    )
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        x = tl.load(src + offsets, mask=mask)
+        tl.store(dst + offsets, x, mask=mask)
+
+    grid = lambda META: (triton.cdiv(N, META["BLOCK_SIZE"]),)
+    _kernel[grid](dst, src, N=N)
+    triton.testing.assert_close(dst, src)
+
+    # After autotuning + final launch, device_caches should have entries
+    # for the backends that were actually used
+    jit_fn = _kernel.fn
+    while not isinstance(jit_fn, triton.runtime.jit.JITFunction):
+        jit_fn = jit_fn.fn
+    cache_keys = list(jit_fn.device_caches.keys())
+    # Each key is (device, backend_override) — check we have multiple backend entries
+    backends_in_cache = {k[1] for k in cache_keys if k[1] is not None}
+    assert len(backends_in_cache) >= 2, (
+        f"Expected device_caches to have entries for multiple backends, "
+        f"got keys: {cache_keys}"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not _has_multiple_backends(), reason="Only 1 backend registered; need both nvidia and cutile")
+def test_autotune_multi_backend_disk_cache(device: str, tmp_path, monkeypatch):
+    """Autotuning results across backends should be saved to and loaded from disk cache.
+
+    Run 1: cache miss → benchmarks run → results saved to disk.
+    Run 2: cache hit → no benchmarks → same best config restored.
+    """
+    from triton.backends import backends
+    backend_names = list(backends.keys())
+
+    cache_dir = tmp_path / "triton_cache"
+    cache_dir.mkdir()
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(cache_dir))
+
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+
+    configs = []
+    for bn in backend_names:
+        configs.append(triton.Config(kwargs={"BLOCK_SIZE": 128}, backend=bn))
+        configs.append(triton.Config(kwargs={"BLOCK_SIZE": 256}, backend=bn))
+
+    # --- Run 1: cache miss, benchmarks execute ---
+    @triton.autotune(
+        configs=configs,
+        key=["N"],
+        do_bench=lambda kernel, quantiles: do_bench(kernel, quantiles),
+        cache_results=True,
+    )
+    @triton.jit
+    def _kernel_r1(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        x = tl.load(src + offsets, mask=mask)
+        tl.store(dst + offsets, x, mask=mask)
+
+    grid = lambda META: (triton.cdiv(N, META["BLOCK_SIZE"]),)
+    _kernel_r1[grid](dst, src, N=N)
+    triton.testing.assert_close(dst, src)
+    best_run1 = _kernel_r1.best_config
+
+    # Verify cache file was written
+    cache_files = list(cache_dir.rglob("*.autotune.json"))
+    assert len(cache_files) >= 1, "Expected disk cache file to be written"
+
+    # --- Run 2: new autotuner instance, should hit disk cache ---
+    bench_called = {"count": 0}
+
+    @triton.autotune(
+        configs=configs,
+        key=["N"],
+        do_bench=lambda kernel, quantiles: do_bench(kernel, quantiles),
+        cache_results=True,
+    )
+    @triton.jit
+    def _kernel_r2(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        x = tl.load(src + offsets, mask=mask)
+        tl.store(dst + offsets, x, mask=mask)
+
+    # Monkey-patch _bench to detect if benchmarks actually run
+    original_bench = _kernel_r2._bench
+    def counting_bench(*a, **kw):
+        bench_called["count"] += 1
+        return original_bench(*a, **kw)
+    _kernel_r2._bench = counting_bench
+
+    dst2 = torch.empty(N, device=device)
+    _kernel_r2[grid](dst2, src, N=N)
+    triton.testing.assert_close(dst2, src)
+
+    best_run2 = _kernel_r2.best_config
+    assert best_run1.kwargs == best_run2.kwargs, (
+        f"Disk-cached best config kwargs mismatch: {best_run1.kwargs} vs {best_run2.kwargs}"
+    )
+    assert best_run1.backend == best_run2.backend, (
+        f"Disk-cached best config backend mismatch: {best_run1.backend} vs {best_run2.backend}"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not _has_multiple_backends(), reason="Only 1 backend registered; need both nvidia and cutile")
+def test_autotune_backend_configs_are_distinct(device: str):
+    """Configs with different backends but same kwargs should be treated as distinct entries."""
+    from triton.backends import backends
+    backend_names = list(backends.keys())
+    assert len(backend_names) >= 2
+
+    # Same kwargs, different backends — should produce different cache entries
+    c1 = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend=backend_names[0])
+    c2 = triton.Config(kwargs={"BLOCK_SIZE": 128}, backend=backend_names[1])
+    assert c1 != c2
+    assert hash(c1) != hash(c2)
+
+    # Effective backend should return the explicit value
+    assert c1.get_effective_backend() == backend_names[0]
+    assert c2.get_effective_backend() == backend_names[1]

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -233,7 +233,7 @@ def test_annotation(device):
     kernel[(1, )](x, 8)
     kernel[(1, )](x, 16)
     kernel[(1, )](x, 17)
-    assert len(kernel.device_caches[device][0]) == 3
+    assert len(kernel.device_caches[(device, None)][0]) == 3
 
 
 GLOBAL_DEFAULT_ARG = 1
@@ -257,7 +257,7 @@ def test_kernel_default_arg(device):
     assert x == torch.ones_like(x)
 
     device = getattr(torch, device).current_device()
-    assert len(kernel.device_caches[device][0]) == 1
+    assert len(kernel.device_caches[(device, None)][0]) == 1
 
 
 GLOBAL_VAR = tl.constexpr(1)
@@ -469,13 +469,13 @@ def test_jit_warmup_cache(device) -> None:
         32,
     ]
     device = getattr(torch, device).current_device()
-    assert len(kernel_add.device_caches[device][0]) == 0
+    assert len(kernel_add.device_caches[(device, None)][0]) == 0
     kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
-    assert len(kernel_add.device_caches[device][0]) == 1
+    assert len(kernel_add.device_caches[(device, None)][0]) == 1
     kernel_add.warmup(*args, grid=(1, ))
-    assert len(kernel_add.device_caches[device][0]) == 1
+    assert len(kernel_add.device_caches[(device, None)][0]) == 1
     kernel_add.warmup(*args, grid=(1, ))
-    assert len(kernel_add.device_caches[device][0]) == 1
+    assert len(kernel_add.device_caches[(device, None)][0]) == 1
 
 
 def test_jit_debug(device) -> None:
@@ -486,12 +486,12 @@ def test_jit_debug(device) -> None:
 
     device = getattr(torch, device).current_device()
     tmp = torch.tensor([1], dtype=torch.int32, device=device)
-    assert len(kernel.device_caches[device][0]) == 0
+    assert len(kernel.device_caches[(device, None)][0]) == 0
     kernel[(1, )](tmp, debug=False)
-    assert len(kernel.device_caches[device][0]) == 1
+    assert len(kernel.device_caches[(device, None)][0]) == 1
     kernel[(1, )](tmp, debug=True)
-    assert len(kernel.device_caches[device][0]) == 2
-    bins = list(kernel.device_caches[device][0].values())
+    assert len(kernel.device_caches[(device, None)][0]) == 2
+    bins = list(kernel.device_caches[(device, None)][0].values())
     assert bins[0].asm['ttir'] != bins[1].asm['ttir']
 
 
@@ -508,18 +508,18 @@ def test_jit_noinline(device) -> None:
         add_fn(a, b, o, N)
 
     device = getattr(torch, device).current_device()
-    assert len(kernel_add_device.device_caches[device][0]) == 0
+    assert len(kernel_add_device.device_caches[(device, None)][0]) == 0
     kernel_add_device.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
-    assert len(kernel_add_device.device_caches[device][0]) == 1
-    bins = list(kernel_add_device.device_caches[device][0].values())
+    assert len(kernel_add_device.device_caches[(device, None)][0]) == 1
+    bins = list(kernel_add_device.device_caches[(device, None)][0].values())
     inline_ttir = bins[0].asm['ttir']
     add_fn.noinline = True
     add_fn.hash = None
     kernel_add_device.hash = None
-    kernel_add_device.device_caches[device][0].clear()
+    kernel_add_device.device_caches[(device, None)][0].clear()
     kernel_add_device.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1, ))
-    assert len(kernel_add_device.device_caches[device][0]) == 1
-    bins = list(kernel_add_device.device_caches[device][0].values())
+    assert len(kernel_add_device.device_caches[(device, None)][0]) == 1
+    bins = list(kernel_add_device.device_caches[(device, None)][0].values())
     noinline_ttir = bins[0].asm['ttir']
     assert inline_ttir != noinline_ttir
 
@@ -554,12 +554,12 @@ def test_preload(device, fresh_triton_cache) -> None:
 
     # clear the cache
     shutil.rmtree(fresh_triton_cache)
-    kernel_add.device_caches[device][0].clear()
+    kernel_add.device_caches[(device, None)][0].clear()
 
     # preload the kernel
     kernel_preload = kernel_add.preload(specialization_data)
     assert kernel_preload.hash == hash
-    assert len(kernel_add.device_caches[device][0]) == 1
+    assert len(kernel_add.device_caches[(device, None)][0]) == 1
 
     # we should hit the cache and not compile anything
     counter = 0
@@ -571,7 +571,7 @@ def test_preload(device, fresh_triton_cache) -> None:
     triton.knobs.runtime.jit_cache_hook = inc_counter
     final_kernel = kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, tl.float32, grid=(1, ))
     assert counter == 0
-    assert len(kernel_add.device_caches[device][0]) == 1
+    assert len(kernel_add.device_caches[(device, None)][0]) == 1
     assert final_kernel.hash == hash
 
     # test that we can't preload a mismatched kernel
@@ -614,7 +614,7 @@ def test_hooks(device, fresh_triton_cache) -> None:
     kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, tl.float32, grid=(1, ))
     assert specialization_data is not None and specialization_data_compiled == specialization_data
     assert is_warmup is True
-    assert key in kernel_add.device_caches[getattr(torch, device).current_device()][0]
+    assert key in kernel_add.device_caches[(getattr(torch, device).current_device(), None)][0]
     assert name == "test_hooks.<locals>.kernel_add"
 
 
@@ -680,7 +680,7 @@ def test_function_arguments(device):
     kernel[(1, )](y[2], func3, (3, ))
     kernel[(1, )](y[3], func4, (3, 4))
     kernel[(1, )](y[4], func1, tuple())
-    assert len(kernel.device_caches[0][0]) == 4
+    assert len(kernel.device_caches[(0, None)][0]) == 4
     assert y.tolist() == [1, 2, 3, 7, 1]
 
 
@@ -735,18 +735,18 @@ def test_async_compile_mock(device, fresh_triton_cache):
         kernel.warmup(b, 1, grid=(1, ))
 
         # Nothing has actually compiled yet
-        assert len(kernel.device_caches[0][0]) == 0
+        assert len(kernel.device_caches[(0, None)][0]) == 0
         assert len(pool.work_queue) == 4
 
         # Duplicates are only submitted once
         kernel.warmup(a, 0, grid=(1, ))
         kernel.warmup(a, 1, grid=(1, ))
-        assert len(kernel.device_caches[0][0]) == 0
+        assert len(kernel.device_caches[(0, None)][0]) == 0
         assert len(pool.work_queue) == 4
 
         pool.run_one()
         kernel[(1, )](a, 0)
-        assert len(kernel.device_caches[0][0]) == 1
+        assert len(kernel.device_caches[(0, None)][0]) == 1
         assert a[0, 0] == 0.0
 
         pool.run_all()
@@ -769,7 +769,7 @@ def test_async_compile(device, fresh_triton_cache):
         kernel.warmup(b, 0, grid=(1, ))
         kernel.warmup(b, 1, grid=(1, ))
 
-        assert len(kernel.device_caches[0][0]) == 0
+        assert len(kernel.device_caches[(0, None)][0]) == 0
 
         kernel[(1, )](b, 1)
         assert b[0, 0] == 1

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -473,6 +473,9 @@ class runtime_knobs(base_knobs):
     # sanitize_overflow enables overflow checking for integer operations
     sanitize_overflow: bool = env_bool("TRITON_SANITIZE_OVERFLOW").get()
     override_arch: env_opt_str = env_opt_str("TRITON_OVERRIDE_ARCH")
+    # default_backend overrides the backend used for compilation (e.g. "cuda", "tileir")
+    # when not explicitly specified by a Config or @triton.jit decorator.
+    default_backend: env_opt_str = env_opt_str("TRITON_DEFAULT_BACKEND")
 
     launch_enter_hook: HookChain[LaunchHook] = HookChain()
     launch_exit_hook: HookChain[LaunchHook] = HookChain(reversed=True)

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -151,6 +151,8 @@ class Autotuner(KernelInterface):
         # augment meta-parameters with tunable ones
         current = dict(meta, **config.all_kwargs())
         full_nargs = {**self.nargs, **current}
+        # Resolve the effective backend for this config
+        effective_backend = config.get_effective_backend()
 
         def kernel_call():
             if config.pre_hook:
@@ -160,6 +162,7 @@ class Autotuner(KernelInterface):
                 self.fn.run(
                     *args,
                     **current,
+                    _backend_override=effective_backend,
                 )
             except Exception as e:
                 try:
@@ -184,15 +187,31 @@ class Autotuner(KernelInterface):
             return False
 
         from triton.compiler.compiler import make_backend
+        from ..backends.compiler import GPUTarget
 
         fn = self.fn
         while not isinstance(fn, JITFunction):
             fn = fn.fn
 
+        # Collect backend hashes for all backends referenced by configs.
+        # When autotuning across multiple backends, the disk cache key must
+        # reflect all of them so that results are invalidated when any
+        # backend's compiler changes.
+        target = driver.active.get_current_target()
+        effective_backends = {c.get_effective_backend() for c in configs}
+        backend_hashes = []
+        for eb in sorted(effective_backends, key=lambda x: (x is None, x)):
+            if eb is not None:
+                t = GPUTarget(eb, target.arch, target.warp_size)
+            else:
+                t = target
+            backend_hashes.append(make_backend(t).hash())
+        backend_hash = "+".join(backend_hashes)
+
         env_vars = get_cache_invalidating_env_vars()
         cache_key = [
             triton_key(),
-            make_backend(driver.active.get_current_target()).hash(),
+            backend_hash,
             fn.cache_key,
             str(sorted(env_vars.items())),
             str(tuning_key),
@@ -297,6 +316,7 @@ class Autotuner(KernelInterface):
                 *args,
                 **kwargs,
                 **config.all_kwargs(),
+                _backend_override=config.get_effective_backend(),
             )
         finally:
             if dump_best:
@@ -374,6 +394,9 @@ class Config:
         required, this is a hint: the driver may use a smaller cluster if resources are constrained.
         Maps to CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION. The per dim grid size must be divisible by this per dim cluster size.
     :type preferred_ctas_per_cga: tuple[int, int, int]
+    :ivar backend: the backend to use for compilation (e.g. "cuda", "tileir"). If None, uses the
+                   TRITON_DEFAULT_BACKEND knob, or falls back to the driver's default target.
+    :type backend: Optional[str]
     """
 
     def __init__(
@@ -395,6 +418,7 @@ class Config:
         ctas_per_cga=None,
         early_tma_store_lowering=None,
         preferred_ctas_per_cga=None,
+        backend=None,
     ):
         self.kwargs = kwargs
         self.num_warps = num_warps
@@ -409,6 +433,27 @@ class Config:
         self.ctas_per_cga = ctas_per_cga
         self.early_tma_store_lowering = early_tma_store_lowering
         self.preferred_ctas_per_cga = preferred_ctas_per_cga
+        self.backend = backend
+
+    def get_effective_backend(self):
+        """Resolve the backend to use: explicit config > TRITON_DEFAULT_BACKEND knob > None (driver default).
+
+        If only one backend is registered, the override is ignored with a log message.
+        """
+        from ..backends import backends as registered_backends
+
+        effective = self.backend if self.backend is not None else knobs.runtime.default_backend
+        if effective is not None and len(registered_backends) <= 1:
+            import logging
+            logger = logging.getLogger("triton")
+            logger.info(
+                "Ignoring backend override '%s' because only %d backend(s) available: %s",
+                effective,
+                len(registered_backends),
+                list(registered_backends.keys()),
+            )
+            return None
+        return effective
 
     def __setstate__(self, state):
         self.kwargs = state.get("kwargs", {})
@@ -424,6 +469,7 @@ class Config:
         self.ctas_per_cga = state.get("ctas_per_cga", None)
         self.early_tma_store_lowering = state.get("early_tma_store_lowering", None)
         self.preferred_ctas_per_cga = state.get("preferred_ctas_per_cga", None)
+        self.backend = state.get("backend", None)
 
     def all_kwargs(self):
         return {
@@ -460,19 +506,23 @@ class Config:
         res.append(f"ctas_per_cga: {self.ctas_per_cga}")
         res.append(f"early_tma_store_lowering: {self.early_tma_store_lowering}")
         res.append(f"preferred_ctas_per_cga: {self.preferred_ctas_per_cga}")
+        if self.backend is not None:
+            res.append(f"backend: {self.backend}")
         return ", ".join(res)
 
     def __hash__(self):
-        return hash((*self.all_kwargs().items(), self.pre_hook))
+        return hash((*self.all_kwargs().items(), self.pre_hook, self.backend))
 
     def __eq__(self, other):
         self_tuple = tuple((
             *self.all_kwargs().items(),
             self.pre_hook,
+            self.backend,
         ))
         other_tuple = tuple((
             *other.all_kwargs().items(),
             other.pre_hook,
+            other.backend,
         ))
         return self_tuple == other_tuple
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -784,12 +784,20 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 return None
         return tuple(parts)
 
-    def create_binder(self):
+    def create_binder(self, backend_override=None):
         """
         Precompute as much as possible.
+
+        Args:
+            backend_override: Optional backend name (e.g. "tileir") to override the
+                driver's default target backend. When set, the GPUTarget's backend
+                field is replaced before calling make_backend().
         """
         from ..compiler import CompiledKernel, compile, ASTSource, make_backend
         target = driver.active.get_current_target()
+        if backend_override is not None:
+            from ..backends.compiler import GPUTarget
+            target = GPUTarget(backend_override, target.arch, target.warp_size)
         backend = make_backend(target)
         self.CompiledKernel = CompiledKernel
         self.compile = compile
@@ -859,9 +867,12 @@ class JITFunction(JITCallable, KernelInterface[T]):
         self._run_cache.clear()
 
     def run(self, *args, grid, warmup, **kwargs):
+        # Extract backend override before it reaches the kernel kwargs
+        backend_override = kwargs.pop("_backend_override", None)
+
         # Fast path: if cache is populated, try identity/signature check
         # (separate method to keep run() bytecode compact).
-        if not warmup and self._last_call is not None and not self.pre_run_hooks and not knobs.compilation.always_compile:
+        if not warmup and not backend_override and self._last_call is not None and not self.pre_run_hooks and not knobs.compilation.always_compile:
             result = self._try_fast_path(args, grid, kwargs)
             if result is not None:
                 return result
@@ -879,7 +890,12 @@ class JITFunction(JITCallable, KernelInterface[T]):
         for hook in self.pre_run_hooks:
             hook(*args, **kwargs)
 
-        kernel_cache, kernel_key_cache, target, backend, binder = self.device_caches[device]
+        # Use (device, backend_override) as cache key so each backend gets its own
+        # kernel_cache, target, backend, and binder.
+        cache_key = (device, backend_override)
+        if cache_key not in self.device_caches:
+            self.device_caches[cache_key] = self.create_binder(backend_override)
+        kernel_cache, kernel_key_cache, target, backend, binder = self.device_caches[cache_key]
         bound_args, specialization, options = binder(*args, **kwargs)
 
         if knobs.runtime.add_stages_inspection_hook is not None:
@@ -900,7 +916,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 except Exception:
                     pass
 
-            kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup)
+            kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup, backend_override)
             if kernel is None:
                 return None
 
@@ -1118,7 +1134,10 @@ class JITFunction(JITCallable, KernelInterface[T]):
             for key, value in deserialized_obj['options'].items()
         }
         key = deserialized_obj['key']
-        _, _, _, backend, _ = self.device_caches[device]
+        cache_key = (device, None)
+        if cache_key not in self.device_caches:
+            self.device_caches[cache_key] = self.create_binder()
+        _, _, _, backend, _ = self.device_caches[cache_key]
         options = backend.parse_options(options)
         return self._do_compile(
             key,
@@ -1130,8 +1149,9 @@ class JITFunction(JITCallable, KernelInterface[T]):
             warmup=True,
         )
 
-    def _do_compile(self, key, signature, device, constexprs, options, attrs, warmup):
-        kernel_cache, _, target, backend, _ = self.device_caches[device]
+    def _do_compile(self, key, signature, device, constexprs, options, attrs, warmup, backend_override=None):
+        cache_key = (device, backend_override)
+        kernel_cache, _, target, backend, _ = self.device_caches[cache_key]
 
         if self._call_hook(knobs.runtime.jit_cache_hook, key, signature, device, constexprs, options, [attrs], warmup):
             return None


### PR DESCRIPTION
Summary:

- Enable TileIR/cutile unconditionally in beta build (BUCK, BUCK.template, cmake2buck.toml)
- Update backend selection to support Ampere (cc 80-89) with CUDA >= 13.2, in addition to Blackwell
- Hopper (cc 90-99) remains explicitly excluded
- Add `backend` parameter to autotuner `Config` for cross-backend autotuning
- Add `TRITON_DEFAULT_BACKEND` knob/env var for global backend override
- `get_effective_backend()` resolves: explicit config > env var > driver default
- Log and ignore backend override when only 1 backend is registered
- Add unit tests (mocked, no GPU) and integration tests (requires GPU + multiple backends)

Reviewed By: jananisriram

Differential Revision: D100481081
