### PR TITLE
[TLX] Add blockscaled softmax to MXFP8 FA kernel

### DIFF
--- a/third_party/tlx/language/tlx/mxfp8_utils.py
+++ b/third_party/tlx/language/tlx/mxfp8_utils.py
@@ -124,3 +124,91 @@ def _to_mxfp8_block(
 
     # Step 3: Store scales
     tlx.local_store(scale_out_tile, scale_e8m0)
+
+
+@triton.jit
+def _amax_to_e8m0_and_quantize(
+    data_input,
+    block_amax,
+    VEC_SIZE: tl.constexpr,
+    dtype: tl.constexpr,
+):
+    """
+    Compute E8M0 scales from pre-computed block amaxes and quantize data to FP8.
+
+    Instead of computing max(abs(data)) per block (128 max ops per row), this
+    function accepts pre-computed block amaxes derived from the raw QK values
+    via monotonicity of exp2: max(exp2(x)) == exp2(max(x)).
+
+    Args:
+        data_input: Input tensor [BLOCK_M, BLOCK_K] in float32
+        block_amax: Pre-computed block amaxes [BLOCK_M, NUM_SCALES]
+        VEC_SIZE: MX block size (32)
+        dtype: tl.float8e4nv or tl.float8e5
+
+    Returns:
+        scale_e8m0: E8M0 biased exponent scales [BLOCK_M, NUM_SCALES]
+        data_fp8: Quantized FP8 data [BLOCK_M, BLOCK_K]
+    """
+    BLOCK_M: tl.constexpr = data_input.shape[0]
+    BLOCK_K: tl.constexpr = data_input.shape[1]
+    NUM_SCALES: tl.constexpr = BLOCK_K // VEC_SIZE
+
+    if dtype == tl.float8e4nv:
+        FLOAT_MAX: tl.constexpr = 448.0
+    else:
+        tl.static_assert(dtype == tl.float8e5)
+        FLOAT_MAX: tl.constexpr = 57344.0
+
+    max_abs = block_amax
+
+    descale = max_abs / FLOAT_MAX
+    descale_exponent = (descale.to(tl.uint32, bitcast=True) + 0x007FFFFF) & 0x7F800000
+    descale_rounded = descale_exponent.to(tl.float32, bitcast=True)
+    scale_e8m0 = (descale_exponent >> 23).to(tl.uint8)
+    quant_scale = tl.where(descale_rounded == 0, 0.0, 1.0 / descale_rounded)
+
+    data_reshaped = tl.reshape(data_input, [BLOCK_M, NUM_SCALES, VEC_SIZE])
+    quant_scale_expanded = tl.reshape(quant_scale, [BLOCK_M, NUM_SCALES, 1])
+    scaled_data = data_reshaped * quant_scale_expanded
+    scaled_data = tl.clamp(scaled_data, -FLOAT_MAX, FLOAT_MAX)
+    data_scaled_flat = tl.reshape(scaled_data, [BLOCK_M, BLOCK_K])
+    data_fp8 = data_scaled_flat.to(dtype)
+
+    return scale_e8m0, data_fp8
+
+
+@triton.jit
+def _to_mxfp8_block_with_block_amax(
+    data_input,
+    block_amax,
+    data_out_tile,
+    scale_out_tile,
+    VEC_SIZE: tl.constexpr,
+    dtype: tl.constexpr,
+):
+    """
+    Convert float32 data to MXFP8 using pre-computed block amaxes.
+
+    This is the blockscaled variant of _to_mxfp8_block that skips the expensive
+    max(abs(data)) computation per 32-element block by accepting pre-computed
+    block amaxes derived from raw QK values.
+
+    Args:
+        data_input: Input tensor [BLOCK_M, BLOCK_K] in float32
+        block_amax: Pre-computed block amaxes [BLOCK_M, NUM_SCALES]
+        data_out_tile: Preallocated buffer for FP8 data output
+        scale_out_tile: Preallocated buffer for E8M0 scale output
+        VEC_SIZE: MX block size (32)
+        dtype: tl.float8e4nv or tl.float8e5
+    """
+    BLOCK_M: tl.constexpr = data_input.shape[0]
+    BLOCK_K: tl.constexpr = data_input.shape[1]
+    tl.static_assert(BLOCK_M == 128)
+    tl.static_assert(BLOCK_K == 128)
+    tl.static_assert(VEC_SIZE == 32)
+
+    scale_e8m0, data_fp8 = _amax_to_e8m0_and_quantize(data_input, block_amax, VEC_SIZE, dtype)
+
+    tlx.local_store(data_out_tile, data_fp8)
+    tlx.local_store(scale_out_tile, scale_e8m0)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -46,7 +46,6 @@ mxfp8_configs = [
             "NUM_Q_SCALE_TMEM_BUFFERS": 1,
             "NUM_KV_SCALE_TMEM_BUFFERS": 2,
             "GROUP_SIZE_N": 1,
-            "RESCALE_OPT": False,
         },
         num_stages=1,
         num_warps=4,
@@ -207,7 +206,6 @@ def _softmax_inner_loop(
     NUM_MMA_GROUPS: tl.constexpr,
     VEC_SIZE: tl.constexpr,
     STAGE: tl.constexpr,
-    RESCALE_OPT: tl.constexpr,
 ):
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // 2
     NUM_BLOCKS: tl.constexpr = BLOCK_N // VEC_SIZE
@@ -224,43 +222,24 @@ def _softmax_inner_loop(
             col_limit_right = (offs_m - start_n + 1)[:, None]
             qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
 
-        # Blockscaled row-max: compute per-32-element block maxes, then derive
-        # row max from the 4 block maxes. Saves 128 max ops later in MXFP8
-        # conversion since we reuse these block maxes for E8M0 scale computation.
         qk_reshaped = tl.reshape(qk, [BLOCK_M_SPLIT, NUM_BLOCKS, VEC_SIZE])
         block_maxes = tl.max(qk_reshaped, 2)
         row_max = tl.max(block_maxes, 1)
 
-        if RESCALE_OPT:
-            m_ij = tl.maximum(m_i, row_max)
-            alpha_ = (m_i - m_ij) * qk_scale
-            alpha = tl.math.exp2(alpha_)
-            rescale_mask = alpha_ >= -8.0
-            alpha = tl.where(rescale_mask, 1.0, alpha)
-            m_ij = tl.where(rescale_mask, m_i, m_ij)
-        else:
-            m_ij = tl.maximum(m_i, row_max * qk_scale)
-            alpha = tl.math.exp2(m_i - m_ij)
+        m_ij = tl.maximum(m_i, row_max * qk_scale)
+        alpha = tl.math.exp2(m_i - m_ij)
 
-        # -- compute correction factor
         tlx.barrier_wait(tlx.local_view(alpha_empties, cid), qk_phase ^ 1)
         tlx.local_store(tlx.local_view(alpha_tiles, cid), alpha[:, None])
         tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
 
-        if RESCALE_OPT:
-            m_scaled = m_ij * qk_scale
-            qk = _fma_f32x2(qk, qk_scale, -m_scaled[:, None])
-        else:
-            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+        qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
         p_i = tl.math.exp2(qk)
 
         # Derive block amax from pre-computed block maxes via monotonicity
         # of exp2: max(exp2(x)) == exp2(max(x)), avoiding 128 max(abs())
         # ops per row in the MXFP8 conversion.
-        if RESCALE_OPT:
-            block_amax = tl.math.exp2((block_maxes - m_ij[:, None]) * qk_scale)
-        else:
-            block_amax = tl.math.exp2(block_maxes * qk_scale - m_ij[:, None])
+        block_amax = tl.math.exp2(block_maxes * qk_scale - m_ij[:, None])
 
         tlx.barrier_wait(tlx.local_view(p_empties, cid), qk_phase ^ 1)
         _to_mxfp8_block_with_block_amax(
@@ -300,7 +279,6 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                       NUM_Q_SCALE_TMEM_BUFFERS: tl.constexpr,  #
                       NUM_KV_SCALE_TMEM_BUFFERS: tl.constexpr,  #
                       GROUP_SIZE_N: tl.constexpr,  #
-                      RESCALE_OPT: tl.constexpr,  #
                       ):
     """
     This kernel is adapted from the Blackwell FA kernel for MXFP8.
@@ -555,16 +533,8 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                         tlx.barrier_wait(alpha_fulls[cid], phase)
                         alpha_1 = tlx.local_load(alpha_tiles[cid])
                         tlx.barrier_arrive(alpha_empties[cid])
-                        if RESCALE_OPT:
-                            pred = alpha_1 < 1.0
-                            ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
-                            should_rescale = ballot_result != 0
                         acc = tlx.local_load(acc_tiles[cid])
-                        if RESCALE_OPT:
-                            scaled_acc = _mul_f32x2(acc, alpha_1)
-                            acc = tl.where(should_rescale, scaled_acc, acc)
-                        else:
-                            acc = _mul_f32x2(acc, alpha_1)
+                        acc = _mul_f32x2(acc, alpha_1)
                         tlx.local_store(acc_tiles[cid], acc)
                         tlx.barrier_arrive(acc_fulls[cid])
                     accum_cnt += 1
@@ -576,8 +546,6 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                     l = tlx.local_load(l_tiles[cid])
                     m = tlx.local_load(m_tiles[cid])
                     tlx.barrier_arrive(l_empties[cid])
-                    if RESCALE_OPT:
-                        m = m * sm_scale * 1.44269504
                     m += tl.math.log2(l)
                     offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
                     m_ptrs = M + off_hz * N_CTX + offs_m
@@ -645,7 +613,6 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                         NUM_MMA_GROUPS,
                         VEC_SIZE,
                         STAGE=4 - STAGE,
-                        RESCALE_OPT=RESCALE_OPT,
                     )
 
                 if STAGE & 2:
@@ -675,7 +642,6 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                         NUM_MMA_GROUPS,
                         VEC_SIZE,
                         STAGE=2,
-                        RESCALE_OPT=RESCALE_OPT,
                     )
 
                 # prepare l_i for the epilog

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
-from triton.language.extra.tlx.mxfp8_utils import _to_mxfp8_block
+from triton.language.extra.tlx.mxfp8_utils import _to_mxfp8_block_with_block_amax
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -46,6 +46,7 @@ mxfp8_configs = [
             "NUM_Q_SCALE_TMEM_BUFFERS": 1,
             "NUM_KV_SCALE_TMEM_BUFFERS": 2,
             "GROUP_SIZE_N": 1,
+            "RESCALE_OPT": False,
         },
         num_stages=1,
         num_warps=4,
@@ -206,7 +207,11 @@ def _softmax_inner_loop(
     NUM_MMA_GROUPS: tl.constexpr,
     VEC_SIZE: tl.constexpr,
     STAGE: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
 ):
+    BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // 2
+    NUM_BLOCKS: tl.constexpr = BLOCK_N // VEC_SIZE
+
     lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
 
     for start_n in tl.range(lo, hi, BLOCK_N):
@@ -219,22 +224,48 @@ def _softmax_inner_loop(
             col_limit_right = (offs_m - start_n + 1)[:, None]
             qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
 
-        # compute m_i, p in registers
-        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+        # Blockscaled row-max: compute per-32-element block maxes, then derive
+        # row max from the 4 block maxes. Saves 128 max ops later in MXFP8
+        # conversion since we reuse these block maxes for E8M0 scale computation.
+        qk_reshaped = tl.reshape(qk, [BLOCK_M_SPLIT, NUM_BLOCKS, VEC_SIZE])
+        block_maxes = tl.max(qk_reshaped, 2)
+        row_max = tl.max(block_maxes, 1)
+
+        if RESCALE_OPT:
+            m_ij = tl.maximum(m_i, row_max)
+            alpha_ = (m_i - m_ij) * qk_scale
+            alpha = tl.math.exp2(alpha_)
+            rescale_mask = alpha_ >= -8.0
+            alpha = tl.where(rescale_mask, 1.0, alpha)
+            m_ij = tl.where(rescale_mask, m_i, m_ij)
+        else:
+            m_ij = tl.maximum(m_i, row_max * qk_scale)
+            alpha = tl.math.exp2(m_i - m_ij)
 
         # -- compute correction factor
-        alpha = tl.math.exp2(m_i - m_ij)
         tlx.barrier_wait(tlx.local_view(alpha_empties, cid), qk_phase ^ 1)
-        # Use alpha[0] for cid=0, and alpha[BLOCK_N] for cid=1
         tlx.local_store(tlx.local_view(alpha_tiles, cid), alpha[:, None])
         tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
 
-        qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+        if RESCALE_OPT:
+            m_scaled = m_ij * qk_scale
+            qk = _fma_f32x2(qk, qk_scale, -m_scaled[:, None])
+        else:
+            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
         p_i = tl.math.exp2(qk)
+
+        # Derive block amax from pre-computed block maxes via monotonicity
+        # of exp2: max(exp2(x)) == exp2(max(x)), avoiding 128 max(abs())
+        # ops per row in the MXFP8 conversion.
+        if RESCALE_OPT:
+            block_amax = tl.math.exp2((block_maxes - m_ij[:, None]) * qk_scale)
+        else:
+            block_amax = tl.math.exp2(block_maxes * qk_scale - m_ij[:, None])
+
         tlx.barrier_wait(tlx.local_view(p_empties, cid), qk_phase ^ 1)
-        # Convert p_i to mxFP8 + write out the scales.
-        _to_mxfp8_block(
+        _to_mxfp8_block_with_block_amax(
             p_i,
+            block_amax,
             tlx.local_view(p_tiles, cid),
             tlx.local_view(p_scale_tiles, cid),
             VEC_SIZE,
@@ -269,6 +300,7 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                       NUM_Q_SCALE_TMEM_BUFFERS: tl.constexpr,  #
                       NUM_KV_SCALE_TMEM_BUFFERS: tl.constexpr,  #
                       GROUP_SIZE_N: tl.constexpr,  #
+                      RESCALE_OPT: tl.constexpr,  #
                       ):
     """
     This kernel is adapted from the Blackwell FA kernel for MXFP8.
@@ -521,11 +553,18 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                     for cid in tl.static_range(0, NUM_MMA_GROUPS):
                         # -- update output accumulator --
                         tlx.barrier_wait(alpha_fulls[cid], phase)
-                        # Use alpha[0] for cid=0, and alpha[BLOCK_N] for cid=1
                         alpha_1 = tlx.local_load(alpha_tiles[cid])
                         tlx.barrier_arrive(alpha_empties[cid])
+                        if RESCALE_OPT:
+                            pred = alpha_1 < 1.0
+                            ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
+                            should_rescale = ballot_result != 0
                         acc = tlx.local_load(acc_tiles[cid])
-                        acc = _mul_f32x2(acc, alpha_1)
+                        if RESCALE_OPT:
+                            scaled_acc = _mul_f32x2(acc, alpha_1)
+                            acc = tl.where(should_rescale, scaled_acc, acc)
+                        else:
+                            acc = _mul_f32x2(acc, alpha_1)
                         tlx.local_store(acc_tiles[cid], acc)
                         tlx.barrier_arrive(acc_fulls[cid])
                     accum_cnt += 1
@@ -537,6 +576,8 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                     l = tlx.local_load(l_tiles[cid])
                     m = tlx.local_load(m_tiles[cid])
                     tlx.barrier_arrive(l_empties[cid])
+                    if RESCALE_OPT:
+                        m = m * sm_scale * 1.44269504
                     m += tl.math.log2(l)
                     offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
                     m_ptrs = M + off_hz * N_CTX + offs_m
@@ -604,6 +645,7 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                         NUM_MMA_GROUPS,
                         VEC_SIZE,
                         STAGE=4 - STAGE,
+                        RESCALE_OPT=RESCALE_OPT,
                     )
 
                 if STAGE & 2:
@@ -633,6 +675,7 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                         NUM_MMA_GROUPS,
                         VEC_SIZE,
                         STAGE=2,
+                        RESCALE_OPT=RESCALE_OPT,
                     )
 
                 # prepare l_i for the epilog

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -240,6 +240,7 @@ class FlashAttention:
             "NUM_Q_SCALE_TMEM_BUFFERS": 1,
             "NUM_KV_SCALE_TMEM_BUFFERS": 2,
             "GROUP_SIZE_N": 1,
+            "RESCALE_OPT": False,
         },
         "hopper_fa_ws": {
             "BLOCK_M": 128,

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -240,7 +240,6 @@ class FlashAttention:
             "NUM_Q_SCALE_TMEM_BUFFERS": 1,
             "NUM_KV_SCALE_TMEM_BUFFERS": 2,
             "GROUP_SIZE_N": 1,
-            "RESCALE_OPT": False,
         },
         "hopper_fa_ws": {
             "BLOCK_M": 128,


### PR DESCRIPTION
Port blockscaled softmax optimization from the cuteDSL FA4 implementation: compute per-32-element block maxes during the row-max reduction, then derive E8M0 block amaxes via monotonicity of exp2 (max(exp2(x)) == exp2(max(x))). This avoids 128 max(abs()) ops per row per N-block iteration in the MXFP8 conversion.


before:
```
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                              311.049198
1  2048.0                              400.762092
2  4096.0                              419.102984
3  8192.0                              424.666167
```

after:
```
flash-attention-performance-mxfp8:
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                              325.179232
1  2048.0                              418.205172
2  4096.0                              438.206078
3  8192.0                              444.106454
```