### PR TITLE
[AutoWS] Fix AutoWS Hopper GEMM partition structure with DP=2

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -164,6 +164,7 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
   SmallVector<unsigned> maxTensorRegs;
   for (Region *partition : wsOp.getPartitionRegions()) {
     unsigned &tensorRegs = maxTensorRegs.emplace_back(0);
+
     partition->walk([&](Operation *op) {
       for (Type type :
            llvm::concat<Type>(op->getOperandTypes(), op->getResultTypes())) {
@@ -308,7 +309,6 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
   for (auto [partition, newNumWarps, prevNumWarps, tensorRegs, estRegs] :
        llvm::zip(wsOp.getPartitionRegions(), partitionNumWarps,
                  wsOp.getPartitionNumWarps(), maxTensorRegs, estRegUsage)) {
-
     // "Guess" the register usage for each partition.
     estRegs = tensorRegs ? maxRegAutoWS : minRegAutoWS;
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -207,7 +207,9 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
       if (isa<ttng::AsyncTMAGatherOp, ttng::AsyncTMAScatterOp>(op))
         *minWarps = 2;
       // TMEM ops require at least 4 warps to be able to read all lanes.
-      else if (isa<ttng::TMEMLoadOp, ttng::TMEMStoreOp, ttng::TMEMAllocOp>(op))
+      // WarpGroupDotOp requires a full warp group (4 warps).
+      else if (isa<ttng::TMEMLoadOp, ttng::TMEMStoreOp, ttng::TMEMAllocOp,
+                   ttng::WarpGroupDotOp>(op))
         *minWarps = 4;
     });
   }

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -1157,6 +1157,7 @@ def test_hopper_matmul_tma_warp_specialize(
             num_warps=num_warps,
             early_tma_store_lowering=use_early_tma_store_lowering,
             pingpongAutoWS=enable_pingpong,
+            maxRegAutoWS=208 if DATA_PARTITION_FACTOR > 1 else 252,
         )
 
         ttgir = kernel.asm["ttgir"]
@@ -1283,6 +1284,7 @@ def test_hopper_matmul_tma_persistent_warp_specialize(
             num_warps=num_warps,
             early_tma_store_lowering=use_early_tma_store_lowering,
             pingpongAutoWS=enable_pingpong,
+            maxRegAutoWS=208 if DATA_PARTITION_FACTOR > 1 else 252,
         )
 
         ttgir = kernel.asm["ttgir"]
@@ -1395,6 +1397,7 @@ def test_hopper_matmul_descriptor_persistent_warp_specialize(
             num_warps=num_warps,
             early_tma_store_lowering=use_early_tma_store_lowering,
             pingpongAutoWS=enable_pingpong,
+            maxRegAutoWS=208 if DATA_PARTITION_FACTOR > 1 else 252,
         )
 
         ttgir = kernel.asm["ttgir"]

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -1098,6 +1098,7 @@ def test_hopper_matmul_tma_warp_specialize(
     """Test matmul_kernel_tma with warp_specialize=True on Hopper (K-loop based)."""
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 128:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 128")
+
     if BLOCK_SIZE_N == 256 and BLOCK_SIZE_K == 128 and not (BLOCK_SIZE_M == 64 and num_stages == 2):
         pytest.skip("OOM: shared memory exceeds H100 limit")
 
@@ -1210,6 +1211,7 @@ def test_hopper_matmul_tma_persistent_warp_specialize(
     """
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 128:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 128")
+
     if BLOCK_SIZE_N == 256 and BLOCK_SIZE_K == 128 and not (BLOCK_SIZE_M == 64 and num_stages == 2):
         pytest.skip("OOM: shared memory exceeds H100 limit")
 
@@ -1338,6 +1340,7 @@ def test_hopper_matmul_descriptor_persistent_warp_specialize(
     """
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 128:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 128")
+
     if BLOCK_SIZE_N == 256 and BLOCK_SIZE_K == 128 and not (BLOCK_SIZE_M == 64 and num_stages == 2):
         pytest.skip("OOM: shared memory exceeds H100 limit")
 

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-gemm-data-partition.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-gemm-data-partition.mlir
@@ -1,0 +1,134 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta --verify-each=false | FileCheck %s
+
+// Tests that on Hopper (cuda:90) with DATA_PARTITION_FACTOR=2 and
+// WarpGroupDotOp, the partition scheduler correctly creates per-dpId
+// computation partitions using the WarpGroupDotOp fallback (since
+// WSDataPartition already split the dots, leaving no DataPartition-
+// categorized ops in backward slices). Epilogue is merged into
+// computation partitions so each MMA's truncf + TMA store lives
+// alongside it.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: hopper_data_partitioned_gemm
+//
+// --- Inner k-loop: descriptor_loads and local_allocs → load partition ---
+// CHECK: descriptor_load{{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: descriptor_load{{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: descriptor_load{{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: local_alloc{{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: local_alloc{{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: local_alloc{{.*}}ttg.partition = array<i32: [[LOAD]]>
+//
+// --- Inner k-loop: each warp_group_dot in its own computation partition ---
+// CHECK: warp_group_dot{{.*}}ttg.partition = array<i32: [[COMP_A:[0-9]+]]>
+// CHECK: warp_group_dot{{.*}}ttg.partition = array<i32: [[COMP_B:[0-9]+]]>
+//
+// --- Epilogue: each half's truncf + TMA store in same partition as its MMA ---
+// CHECK: truncf{{.*}}ttg.partition = array<i32: [[COMP_A]]>
+// CHECK: truncf{{.*}}ttg.partition = array<i32: [[COMP_B]]>
+// CHECK: async_tma_copy_local_to_global{{.*}}ttg.partition = array<i32: [[COMP_A]]>
+// CHECK: async_tma_copy_local_to_global{{.*}}ttg.partition = array<i32: [[COMP_B]]>
+//
+// --- Partition types: computation partitions before load ---
+// CHECK: partition.types = ["computation", "computation", "load"
+tt.func public @hopper_data_partitioned_gemm(
+    %a_desc: !tt.tensordesc<tensor<64x64xf16, #shared>>,
+    %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+    %c_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>,
+    %M: i32 {tt.divisibility = 16 : i32},
+    %N: i32 {tt.divisibility = 16 : i32},
+    %K: i32 {tt.divisibility = 16 : i32}
+) {
+  %c132_i32 = arith.constant 132 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c127_i32 = arith.constant 127 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #mma>
+
+  %start_pid = tt.get_program_id x : i32
+  %num_pid_m = arith.addi %M, %c127_i32 : i32
+  %num_pid_m_div = arith.divsi %num_pid_m, %c128_i32 : i32
+  %num_pid_n = arith.addi %N, %c127_i32 : i32
+  %num_pid_n_div = arith.divsi %num_pid_n, %c128_i32 : i32
+  %k_tiles = arith.addi %K, %c64_i32 : i32
+  %k_tiles_div = arith.divsi %k_tiles, %c64_i32 : i32
+  %num_tiles = arith.muli %num_pid_m_div, %num_pid_n_div : i32
+  %tile_id_c_init = arith.subi %start_pid, %c132_i32 : i32
+  %num_pid_in_group = arith.muli %num_pid_n_div, %c8_i32 : i32
+
+  %tile_id_c_out = scf.for %tile_id = %start_pid to %num_tiles step %c132_i32
+      iter_args(%tile_id_c = %tile_id_c_init) -> (i32) : i32 {
+    %group_id = arith.divsi %tile_id, %num_pid_in_group : i32
+    %first_pid_m = arith.muli %group_id, %c8_i32 : i32
+    %group_size_m = arith.subi %num_pid_m_div, %first_pid_m : i32
+    %group_size_m_clamped = arith.minsi %group_size_m, %c8_i32 : i32
+    %pid_m = arith.remsi %tile_id, %group_size_m_clamped : i32
+    %pid_m_final = arith.addi %first_pid_m, %pid_m : i32
+    %pid_n_tmp = arith.remsi %tile_id, %num_pid_in_group : i32
+    %pid_n = arith.divsi %pid_n_tmp, %group_size_m_clamped : i32
+    %offs_am = arith.muli %pid_m_final, %c128_i32 : i32
+    %offs_am_1 = arith.addi %offs_am, %c64_i32 : i32
+    %offs_bn = arith.muli %pid_n, %c128_i32 : i32
+
+    // Inner k-loop with two WarpGroupDotOps (data-partitioned)
+    %acc:2 = scf.for %ki = %c0_i32 to %k_tiles_div step %c1_i32
+        iter_args(%acc0 = %cst, %acc1 = %cst) -> (tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>) : i32 {
+      %offs_k = arith.muli %ki, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+
+      %a0 = tt.descriptor_load %a_desc[%offs_am, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #blocked>
+      %a1 = tt.descriptor_load %a_desc[%offs_am_1, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #blocked>
+      %b = tt.descriptor_load %b_desc[%offs_bn, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+
+      %a0_smem = ttg.local_alloc %a0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+      %a1_smem = ttg.local_alloc %a1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+      %b_smem = ttg.local_alloc %b {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %b_trans = ttg.memdesc_trans %b_smem {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+
+      %dot0 = ttng.warp_group_dot %a0_smem, %b_trans, %acc0 {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared1, #smem> -> tensor<64x128xf32, #mma>
+      %dot1 = ttng.warp_group_dot %a1_smem, %b_trans, %acc1 {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared1, #smem> -> tensor<64x128xf32, #mma>
+
+      scf.yield %dot0, %dot1 : tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>
+    } {tt.scheduled_max_stage = 1 : i32}
+
+    // Epilogue
+    %tile_id_c_next = arith.addi %tile_id_c, %c132_i32 : i32
+    %group_id_c = arith.divsi %tile_id_c_next, %num_pid_in_group : i32
+    %first_pid_m_c = arith.muli %group_id_c, %c8_i32 : i32
+    %group_size_m_c = arith.subi %num_pid_m_div, %first_pid_m_c : i32
+    %group_size_m_c_clamped = arith.minsi %group_size_m_c, %c8_i32 : i32
+    %pid_m_c = arith.remsi %tile_id_c_next, %group_size_m_c_clamped : i32
+    %pid_m_c_final = arith.addi %first_pid_m_c, %pid_m_c : i32
+    %pid_n_c_tmp = arith.remsi %tile_id_c_next, %num_pid_in_group : i32
+    %pid_n_c = arith.divsi %pid_n_c_tmp, %group_size_m_c_clamped : i32
+    %offs_am_c = arith.muli %pid_m_c_final, %c128_i32 : i32
+    %offs_am_c_1 = arith.addi %offs_am_c, %c64_i32 : i32
+    %offs_bn_c = arith.muli %pid_n_c, %c128_i32 : i32
+
+    %c0_f16 = arith.truncf %acc#0 : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %c1_f16 = arith.truncf %acc#1 : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %c0_cvt = ttg.convert_layout %c0_f16 : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked1>
+    %c1_cvt = ttg.convert_layout %c1_f16 : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked1>
+    %c0_smem = ttg.local_alloc %c0_cvt : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    %store_tok0 = ttng.async_tma_copy_local_to_global %c_desc[%offs_am_c, %offs_bn_c] %c0_smem : !tt.tensordesc<tensor<64x128xf16, #shared>>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %store_tok0 : !ttg.async.token
+    %c1_smem = ttg.local_alloc %c1_cvt : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    %store_tok1 = ttng.async_tma_copy_local_to_global %c_desc[%offs_am_c_1, %offs_bn_c] %c1_smem : !tt.tensordesc<tensor<64x128xf16, #shared>>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %store_tok1 : !ttg.async.token
+
+    scf.yield %tile_id_c_next : i32
+  } {tt.data_partition_factor = 2 : i32, tt.smem_alloc_algo = 0 : i32, tt.warp_specialize}
+  tt.return
+}
+
+} // module

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -393,8 +393,6 @@ class CUDABackend(BaseBackend):
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
-            if knobs.nvidia.use_meta_ws:
-                passes.ttgpuir.add_optimize_partition_warps(pm)
         elif capability // 10 >= 10:
             passes.ttgpuir.add_fuse_nested_loops(pm)
             passes.common.add_canonicalizer(pm)
@@ -462,7 +460,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_symbol_dce(pm)
         # Optimize the number of warps and registers after TMA lowering, so
         # that any local loads eliminated by TMA lowering do not inflate them.
-        if capability // 10 >= 10 and knobs.nvidia.use_meta_ws:
+        if capability // 10 >= 9 and knobs.nvidia.use_meta_ws:
             passes.ttgpuir.add_optimize_partition_warps(pm)
         nvidia.passes.ttnvgpuir.add_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_lower_mma(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -393,8 +393,8 @@ class CUDABackend(BaseBackend):
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
-            #if knobs.nvidia.use_meta_ws:
-            #    passes.ttgpuir.add_optimize_partition_warps(pm)
+            if knobs.nvidia.use_meta_ws:
+                passes.ttgpuir.add_optimize_partition_warps(pm)
         elif capability // 10 >= 10:
             passes.ttgpuir.add_fuse_nested_loops(pm)
             passes.common.add_canonicalizer(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -393,8 +393,8 @@ class CUDABackend(BaseBackend):
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, use_meta_swp_schedule)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
-            if knobs.nvidia.use_meta_ws:
-                passes.ttgpuir.add_optimize_partition_warps(pm)
+            #if knobs.nvidia.use_meta_ws:
+            #    passes.ttgpuir.add_optimize_partition_warps(pm)
         elif capability // 10 >= 10:
             passes.ttgpuir.add_fuse_nested_loops(pm)
             passes.common.add_canonicalizer(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -2731,18 +2731,22 @@ static void createChannelPost(Operation *allocOp, mlir::DominanceInfo &dom,
 
   // When a producer has multiple task IDs (e.g., a shared local_alloc
   // consumed by data-partitioned computation groups), no channel is needed
-  // if every consumer task matches one of the producer tasks — producer and
-  // consumer are co-located.
-  if (producerTaskIds.size() > 1) {
-    DenseSet<int> producerSet(producerTaskIds.begin(), producerTaskIds.end());
-    bool allConsumersMatch = llvm::all_of(
-        consumerTaskIds, [&](int id) { return producerSet.contains(id); });
-    if (allConsumersMatch)
-      return;
+  // for any producer that is co-located with a consumer. It is unclear if
+  // is sufficient when there are multiple consumers.
+  AsyncTaskId producerTaskId = -1;
+  if (producerTaskIds.size() > 1 && consumerTaskIds.size() == 1) {
+    auto consumerTaskId = consumerTaskIds.front();
+    for (auto id : producerTaskIds) {
+      if (id != consumerTaskId) {
+        assert(producerTaskId == -1 &&
+               "Multiple producers encountered for 1 consumer");
+        producerTaskId = id;
+      }
+    }
+  } else {
+    assert(producerTaskIds.size() == 1);
+    producerTaskId = producerTaskIds.front();
   }
-
-  assert(producerTaskIds.size() == 1);
-  auto producerTaskId = producerTaskIds.front();
   // Remove producer task id from consumerTaskIds.
   auto iter = std::remove(consumerTaskIds.begin(), consumerTaskIds.end(),
                           producerTaskId);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -2717,8 +2717,6 @@ static void createChannelPost(Operation *allocOp, mlir::DominanceInfo &dom,
   if (!producerOp)
     return;
   auto producerTaskIds = getAsyncTaskIds(producerOp);
-  assert(producerTaskIds.size() == 1);
-  auto producerTaskId = producerTaskIds.front();
   // Collect consumer task IDs from all consumers. With data partitioning,
   // different consumers may have different task IDs (e.g., K/V buffers
   // consumed by multiple computation partitions).
@@ -2730,6 +2728,21 @@ static void createChannelPost(Operation *allocOp, mlir::DominanceInfo &dom,
         consumerTaskIds.push_back(id);
     }
   }
+
+  // When a producer has multiple task IDs (e.g., a shared local_alloc
+  // consumed by data-partitioned computation groups), no channel is needed
+  // if every consumer task matches one of the producer tasks — producer and
+  // consumer are co-located.
+  if (producerTaskIds.size() > 1) {
+    DenseSet<int> producerSet(producerTaskIds.begin(), producerTaskIds.end());
+    bool allConsumersMatch = llvm::all_of(
+        consumerTaskIds, [&](int id) { return producerSet.contains(id); });
+    if (allConsumersMatch)
+      return;
+  }
+
+  assert(producerTaskIds.size() == 1);
+  auto producerTaskId = producerTaskIds.front();
   // Remove producer task id from consumerTaskIds.
   auto iter = std::remove(consumerTaskIds.begin(), consumerTaskIds.end(),
                           producerTaskId);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1166,6 +1166,36 @@ struct ScheduleResult {
   bool createComputePartitions;
 };
 
+// Pre-schedule DataPartition-categorized ops and shared ops to their
+// respective partitions. Loads and allocs are skipped (Phase 3 handles them).
+// Shared ops go to the default partition unless on the Hopper DP schedule
+// path where Phase 3/4 handles routing.
+static void
+preScheduleDpOps(SmallVector<CategorizedOp> &dpOps,
+                 DenseMap<unsigned, Partition *> &dpIdToPartition,
+                 DenseMap<Operation *, Partition *> &mmaToPreassignedPartition,
+                 PartitionLayout &layout, const OpCategorizer &categorizer,
+                 bool useHopperDpSchedule) {
+  for (const auto &catOp : dpOps) {
+    if (isa<DescriptorLoadOp, DescriptorGatherOp, LocalAllocOp>(catOp.op))
+      continue;
+    unsigned dpId = catOp.dataPartitionId;
+    auto it = dpIdToPartition.find(dpId);
+    if (it != dpIdToPartition.end()) {
+      tryScheduleOp(it->second, catOp.op);
+      if (catOp.parentMMA)
+        mmaToPreassignedPartition[catOp.parentMMA] = it->second;
+    }
+  }
+
+  if (layout.defaultPartition && !dpOps.empty() && !useHopperDpSchedule) {
+    for (Operation *sharedOp : categorizer.getSharedOps()) {
+      if (!isa<arith::ConstantOp>(sharedOp))
+        tryScheduleOp(layout.defaultPartition, sharedOp);
+    }
+  }
+}
+
 // Given a partitioning scheme, determine an initial schedule by performing a
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.
@@ -1208,6 +1238,9 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       llvm::dbgs() << "[tritongpu-partition-scheduling] Using template-based "
                       "scheduling with data partition factor: "
                    << dataPartitionFactor << "\n");
+
+  int cc = getNVIDIAComputeCapability(mainLoop->getParentOfType<ModuleOp>());
+  bool isHopper = cc / 10 == 9;
 
   // For Hopper data-partitioned GEMM with WarpGroupDotOps, the epilogue
   // must be merged into the computation partitions so each can store its
@@ -1298,33 +1331,13 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       }
     }
 
-    for (const auto &catOp : dpOps) {
-      // Don't pre-schedule loads or allocs to computation partitions —
-      // they belong in the load partition. Phase 3 will place them there.
-      if (isa<DescriptorLoadOp, DescriptorGatherOp, LocalAllocOp>(catOp.op))
-        continue;
-      unsigned dpId = catOp.dataPartitionId;
-      auto it = dpIdToPartition.find(dpId);
-      if (it != dpIdToPartition.end()) {
-        tryScheduleOp(it->second, catOp.op);
-        if (catOp.parentMMA)
-          mmaToPreassignedPartition[catOp.parentMMA] = it->second;
-      }
-    }
-
-    // Pre-assign shared ops to the default partition so that
-    // propagatePartitions doesn't merge computation partitions.
-    // Skip for Hopper data-partitioned WarpGroupDotOps — Phase 3/4
-    // will correctly route loads to the load partition and other
-    // shared ops to the default partition. Pre-scheduling shared ops
-    // here would claim descriptor_loads before Phase 3, putting B
-    // loads in the computation partition instead of the load partition.
-    if (layout.defaultPartition && !dpOps.empty() && !useHopperDpSchedule) {
-      for (Operation *sharedOp : categorizer.getSharedOps()) {
-        if (!isa<arith::ConstantOp>(sharedOp))
-          tryScheduleOp(layout.defaultPartition, sharedOp);
-      }
-    }
+    // On Hopper (sm_9x), schedule dpOps now (Phase 2b) since MMA ops
+    // are already pre-scheduled and won't be stolen by Phase 4.
+    // On Blackwell (sm_10x+), defer to Phase 5 so correction scheduling
+    // in Phase 4 gets first pick of rescaling ops (acc * alpha).
+    if (isHopper)
+      preScheduleDpOps(dpOps, dpIdToPartition, mmaToPreassignedPartition,
+                       layout, categorizer, useHopperDpSchedule);
   }
 
   // Extract partition references from layout (after Phase 2b which may
@@ -1664,7 +1677,13 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     sharedComputePartition = nullptr; // lazy-created on first use
   }
 
-  // Data partition pre-assignment is handled in Phase 2b above.
+  // On Blackwell, schedule dpOps here (Phase 5, after Phase 4 correction)
+  // so correction scheduling gets first pick of rescaling ops.
+  if (dataPartitionFactor > 1 && !isHopper) {
+    auto dpOps = categorizer.getOpsInCategory(OpCategory::DataPartition);
+    preScheduleDpOps(dpOps, dpIdToPartition, mmaToPreassignedPartition, layout,
+                     categorizer, useHopperDpSchedule);
+  }
 
   for (auto mmaOp : llvm::reverse(mmas)) {
     if (mmaOp->getParentOfType<scf::ForOp>() == loops[0]) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1214,9 +1214,10 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // own MMA result directly, and computation partitions must be created
   // before Phase 3/4 to prevent load-user propagation from claiming MMAs.
   bool useHopperDpSchedule =
-      dataPartitionFactor > 1 && llvm::all_of(mmas, [](Operation *op) {
-        return isa<ttng::WarpGroupDotOp>(op);
-      });
+      dataPartitionFactor > 1 &&
+      categorizer.getOpsInCategory(OpCategory::Correction).empty() &&
+      llvm::all_of(mmas,
+                   [](Operation *op) { return isa<ttng::WarpGroupDotOp>(op); });
   SchedulingOptions localSchedOpts = schedOpts;
   if (useHopperDpSchedule)
     localSchedOpts.mergeEpilogueToComputation = true;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1297,8 +1297,11 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
         dpIdToPartition[dpId] = layout.makeDefaultPartition(schedule);
 
       // Create epilogue_store after computation partitions so it doesn't
-      // become the default.
-      if (localSchedOpts.separateEpilogueStore) {
+      // become the default. Mirror the hasEpilogue guard from
+      // createPartitionLayout to avoid creating a stray partition.
+      bool hasEpilogue =
+          !categorizer.getOpsInCategory(OpCategory::EpilogueStore).empty();
+      if (localSchedOpts.separateEpilogueStore && hasEpilogue) {
         layout.epilogueStorePartition = schedule.addPartition(0);
         layout.epilogueStorePartition->setType("epilogue_store");
       }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -274,6 +274,19 @@ struct PartitionLayout {
 
   /// Get the opToDpId map (for schedulePostLoopOps).
   bool hasGemm() const { return gemmPartition != nullptr; }
+
+  /// Create a computation partition and set it as the default.
+  /// Used by the WarpGroupDotOp data partition fallback to ensure
+  /// computation partitions get lower indices than the load partition,
+  /// making one of them the default (index 0) warp group.
+  Partition *makeDefaultPartition(PartitionSet &schedule) {
+    auto *part = schedule.addPartition(0);
+    part->setType("computation");
+    computationPartitions.push_back(part);
+    if (!defaultPartition)
+      defaultPartition = part;
+    return part;
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -793,7 +806,8 @@ private:
 /// selectTemplate).
 static PartitionLayout createPartitionLayout(PartitionSet &schedule,
                                              const OpCategorizer &categorizer,
-                                             const SchedulingOptions &options) {
+                                             const SchedulingOptions &options,
+                                             bool deferLoadPartition = false) {
   PartitionLayout layout;
   unsigned dpFactor = categorizer.getDataPartitionFactor();
   bool hasCorrection =
@@ -841,10 +855,14 @@ static PartitionLayout createPartitionLayout(PartitionSet &schedule,
     layout.epilogueStorePartition->setType("epilogue_store");
   }
 
-  // Load partition: always created last so it gets the highest partition index,
+  // Load partition: created last so it gets the highest partition index,
   // which maps to the default (producer) warp group at runtime.
-  layout.loadPartition = schedule.addPartition(0);
-  layout.loadPartition->setType("load");
+  // When deferLoadPartition is true, the caller creates it after
+  // computation partitions so they get lower indices (= default region).
+  if (!deferLoadPartition) {
+    layout.loadPartition = schedule.addPartition(0);
+    layout.loadPartition->setType("load");
+  }
 
   // Set default partition alias using fallback chain.
   layout.defaultPartition = layout.getDefaultPartition();
@@ -1189,14 +1207,114 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
                       "scheduling with data partition factor: "
                    << dataPartitionFactor << "\n");
 
+  // When WSDataPartition has already split WarpGroupDotOps but left no
+  // DataPartition-categorized ops, the epilogue must be merged into the
+  // computation partitions so each can store its own MMA result directly.
+  bool useWgmmaDpFallback =
+      dataPartitionFactor > 1 &&
+      categorizer.getOpsInCategory(OpCategory::DataPartition).empty() &&
+      llvm::all_of(mmas, [](Operation *op) {
+        return isa<ttng::WarpGroupDotOp>(op);
+      });
+  SchedulingOptions localSchedOpts = schedOpts;
+  if (useWgmmaDpFallback)
+    localSchedOpts.mergeEpilogueToComputation = true;
+
   //===--------------------------------------------------------------------===//
   // Phase 2: Create partition layout using tuning knobs
   //===--------------------------------------------------------------------===//
   PartitionSet schedule;
-  PartitionLayout layout =
-      createPartitionLayout(schedule, categorizer, schedOpts);
+  PartitionLayout layout = createPartitionLayout(schedule, categorizer,
+                                                 localSchedOpts,
+                                                 useWgmmaDpFallback);
 
-  // Extract partition references from layout
+  //===--------------------------------------------------------------------===//
+  // Phase 2b: Pre-create per-dpId computation partitions and pre-schedule
+  // WarpGroupDotOps when data partitioning is active. This must run before
+  // Phase 3/4 so that load-user propagation doesn't pull the MMA ops into
+  // the default partition.
+  //===--------------------------------------------------------------------===//
+  DenseMap<unsigned, Partition *> dpIdToPartition;
+  DenseMap<Operation *, Partition *> mmaToPreassignedPartition;
+  if (dataPartitionFactor > 1) {
+    auto dpOps = categorizer.getOpsInCategory(OpCategory::DataPartition);
+
+    DenseSet<unsigned> usedDpIds;
+    for (const auto &catOp : dpOps)
+      usedDpIds.insert(catOp.dataPartitionId);
+
+    // When WSDataPartition has already split the dot ops, the backward
+    // slices may contain only ops that are already categorized (e.g.,
+    // descriptor_loads as Load), leaving no DataPartition-categorized ops.
+    // Fall back to the WarpGroupDotOp dpIds directly, using
+    // makeDefaultPartition so computation partitions get lower indices
+    // than the load partition (making them the default warp group).
+    if (useWgmmaDpFallback) {
+      for (auto mmaOp : mmas) {
+        if (!isa<ttng::WarpGroupDotOp>(mmaOp))
+          continue;
+        unsigned dpId = categorizer.getDpId(mmaOp);
+        if (dpId != SHARED_DPID)
+          usedDpIds.insert(dpId);
+      }
+
+      SmallVector<unsigned> sortedDpIds(usedDpIds.begin(), usedDpIds.end());
+      llvm::sort(sortedDpIds, std::greater<unsigned>());
+      for (unsigned dpId : sortedDpIds)
+        dpIdToPartition[dpId] = layout.makeDefaultPartition(schedule);
+
+      // Create the load partition last so it gets the highest index
+      // (producer warp group).
+      layout.loadPartition = schedule.addPartition(0);
+      layout.loadPartition->setType("load");
+
+      // Pre-schedule MMA ops into their computation partitions.
+      for (auto mmaOp : mmas) {
+        if (!isa<ttng::WarpGroupDotOp>(mmaOp))
+          continue;
+        unsigned dpId = categorizer.getDpId(mmaOp);
+        if (dpId != SHARED_DPID) {
+          auto it = dpIdToPartition.find(dpId);
+          if (it != dpIdToPartition.end()) {
+            mmaToPreassignedPartition[mmaOp] = it->second;
+            tryScheduleOp(it->second, mmaOp);
+          }
+        }
+      }
+    } else {
+      SmallVector<unsigned> sortedDpIds(usedDpIds.begin(), usedDpIds.end());
+      llvm::sort(sortedDpIds, std::greater<unsigned>());
+      for (unsigned dpId : sortedDpIds) {
+        dpIdToPartition[dpId] = schedule.addPartition(0);
+        dpIdToPartition[dpId]->setType("computation");
+      }
+    }
+
+    for (const auto &catOp : dpOps) {
+      unsigned dpId = catOp.dataPartitionId;
+      auto it = dpIdToPartition.find(dpId);
+      if (it != dpIdToPartition.end()) {
+        tryScheduleOp(it->second, catOp.op);
+        if (catOp.parentMMA)
+          mmaToPreassignedPartition[catOp.parentMMA] = it->second;
+      }
+    }
+
+    // Pre-assign shared ops to the default partition so that
+    // propagatePartitions doesn't merge computation partitions.
+    // Skip this for the WarpGroupDotOp fallback path — Phase 3/4
+    // will correctly route loads to the load partition and other
+    // shared ops to the default partition.
+    if (layout.defaultPartition && !dpOps.empty()) {
+      for (Operation *sharedOp : categorizer.getSharedOps()) {
+        if (!isa<arith::ConstantOp>(sharedOp))
+          tryScheduleOp(layout.defaultPartition, sharedOp);
+      }
+    }
+  }
+
+  // Extract partition references from layout (after Phase 2b which may
+  // create computation and load partitions for the wgmma fallback path).
   Partition *defaultPartition = layout.defaultPartition;
   Partition *mmaPartition = layout.gemmPartition;
   Partition *loadPartition = layout.loadPartition;
@@ -1532,61 +1650,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     sharedComputePartition = nullptr; // lazy-created on first use
   }
 
-  // When dpFactor > 1 and there is no defaultPartition, pre-assign
-  // DataPartition-categorized ops to their respective computation partitions
-  // BEFORE scheduleUsers runs. Without a defaultPartition, Phase 4 (load user
-  // propagation) is skipped, so shared/correction ops are not pre-claimed.
-  // This causes the first MMA's scheduleUsers to greedily absorb all
-  // computation ops into a single partition (e.g., when an scf.if merges both
-  // partitions' values). The categorizer already knows which ops belong to
-  // which data partition via backward slice analysis.
-  //
-  // When defaultPartition exists (e.g., FA with epilogue stores), the
-  // original Phase 4 → Phase 5 flow works correctly — skip pre-assignment to
-  // avoid changing the partition creation order that downstream passes
-  // expect.
-  DenseMap<unsigned, Partition *> dpIdToPartition;
-  DenseMap<Operation *, Partition *> mmaToPreassignedPartition;
-  if (dataPartitionFactor > 1) {
-    // Pre-assign exclusive DataPartition ops to per-dpId computation
-    // partitions.
-    auto dpOps = categorizer.getOpsInCategory(OpCategory::DataPartition);
-
-    // Collect which dpIds actually have ops.
-    DenseSet<unsigned> usedDpIds;
-    for (const auto &catOp : dpOps)
-      usedDpIds.insert(catOp.dataPartitionId);
-
-    // Pre-create computation partitions in reverse dpId order to match
-    // the original partition creation order.
-    SmallVector<unsigned> sortedDpIds(usedDpIds.begin(), usedDpIds.end());
-    llvm::sort(sortedDpIds, std::greater<unsigned>());
-    for (unsigned dpId : sortedDpIds) {
-      dpIdToPartition[dpId] = schedule.addPartition(0);
-      dpIdToPartition[dpId]->setType("computation");
-    }
-
-    for (const auto &catOp : dpOps) {
-      unsigned dpId = catOp.dataPartitionId;
-      auto it = dpIdToPartition.find(dpId);
-      if (it != dpIdToPartition.end()) {
-        tryScheduleOp(it->second, catOp.op);
-        if (catOp.parentMMA)
-          mmaToPreassignedPartition[catOp.parentMMA] = it->second;
-      }
-    }
-    // Pre-assign shared ops (ops appearing in multiple MMA backward slices,
-    // e.g., scf.if for masking) to the default partition. Without this,
-    // propagatePartitions forms clusters around the unscheduled scf.if with
-    // multiple sink partitions (one per data partition), collapsing them
-    // into a single partition.
-    if (defaultPartition) {
-      for (Operation *sharedOp : categorizer.getSharedOps()) {
-        if (!isa<arith::ConstantOp>(sharedOp))
-          tryScheduleOp(defaultPartition, sharedOp);
-      }
-    }
-  }
+  // Data partition pre-assignment is handled in Phase 2b above.
 
   for (auto mmaOp : llvm::reverse(mmas)) {
     if (mmaOp->getParentOfType<scf::ForOp>() == loops[0]) {
@@ -1773,7 +1837,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   }
 
   // Pre-schedule post-loop ops before propagatePartitions claims them.
-  schedulePostLoopOps(mainLoop, schedule, layout, schedOpts,
+  schedulePostLoopOps(mainLoop, schedule, layout, localSchedOpts,
                       categorizer.getOpToDpIdMap(), dpIdToPartition);
 
   // Update defaultPartition after computation partitions are created.
@@ -1786,7 +1850,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   return ScheduleResult{std::move(schedule),
                         layout,
-                        schedOpts,
+                        localSchedOpts,
                         categorizer.getOpToDpIdMap(),
                         std::move(dpIdToPartition),
                         createComputePartitions};

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -850,7 +850,9 @@ static PartitionLayout createPartitionLayout(PartitionSet &schedule,
   }
 
   // Epilogue store partition: dedicated 1-warp partition for epilogue stores.
-  if (options.separateEpilogueStore && hasEpilogue) {
+  // When deferLoadPartition is true, defer creation so computation
+  // partitions get lower indices (= default region).
+  if (options.separateEpilogueStore && hasEpilogue && !deferLoadPartition) {
     layout.epilogueStorePartition = schedule.addPartition(0);
     layout.epilogueStorePartition->setType("epilogue_store");
   }
@@ -1260,6 +1262,13 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       llvm::sort(sortedDpIds, std::greater<unsigned>());
       for (unsigned dpId : sortedDpIds)
         dpIdToPartition[dpId] = layout.makeDefaultPartition(schedule);
+
+      // Create epilogue_store after computation partitions so it doesn't
+      // become the default.
+      if (localSchedOpts.separateEpilogueStore) {
+        layout.epilogueStorePartition = schedule.addPartition(0);
+        layout.epilogueStorePartition->setType("epilogue_store");
+      }
 
       // Create the load partition last so it gets the highest index
       // (producer warp group).

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1213,9 +1213,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   bool useWgmmaDpFallback =
       dataPartitionFactor > 1 &&
       categorizer.getOpsInCategory(OpCategory::DataPartition).empty() &&
-      llvm::all_of(mmas, [](Operation *op) {
-        return isa<ttng::WarpGroupDotOp>(op);
-      });
+      llvm::all_of(mmas,
+                   [](Operation *op) { return isa<ttng::WarpGroupDotOp>(op); });
   SchedulingOptions localSchedOpts = schedOpts;
   if (useWgmmaDpFallback)
     localSchedOpts.mergeEpilogueToComputation = true;
@@ -1224,9 +1223,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // Phase 2: Create partition layout using tuning knobs
   //===--------------------------------------------------------------------===//
   PartitionSet schedule;
-  PartitionLayout layout = createPartitionLayout(schedule, categorizer,
-                                                 localSchedOpts,
-                                                 useWgmmaDpFallback);
+  PartitionLayout layout = createPartitionLayout(
+      schedule, categorizer, localSchedOpts, useWgmmaDpFallback);
 
   //===--------------------------------------------------------------------===//
   // Phase 2b: Pre-create per-dpId computation partitions and pre-schedule

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1209,16 +1209,16 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
                       "scheduling with data partition factor: "
                    << dataPartitionFactor << "\n");
 
-  // When WSDataPartition has already split WarpGroupDotOps but left no
-  // DataPartition-categorized ops, the epilogue must be merged into the
-  // computation partitions so each can store its own MMA result directly.
-  bool useWgmmaDpFallback =
-      dataPartitionFactor > 1 &&
-      categorizer.getOpsInCategory(OpCategory::DataPartition).empty() &&
-      llvm::all_of(mmas,
-                   [](Operation *op) { return isa<ttng::WarpGroupDotOp>(op); });
+  // For Hopper data-partitioned GEMM with WarpGroupDotOps, the epilogue
+  // must be merged into the computation partitions so each can store its
+  // own MMA result directly, and computation partitions must be created
+  // before Phase 3/4 to prevent load-user propagation from claiming MMAs.
+  bool useHopperDpSchedule =
+      dataPartitionFactor > 1 && llvm::all_of(mmas, [](Operation *op) {
+        return isa<ttng::WarpGroupDotOp>(op);
+      });
   SchedulingOptions localSchedOpts = schedOpts;
-  if (useWgmmaDpFallback)
+  if (useHopperDpSchedule)
     localSchedOpts.mergeEpilogueToComputation = true;
 
   //===--------------------------------------------------------------------===//
@@ -1226,7 +1226,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   //===--------------------------------------------------------------------===//
   PartitionSet schedule;
   PartitionLayout layout = createPartitionLayout(
-      schedule, categorizer, localSchedOpts, useWgmmaDpFallback);
+      schedule, categorizer, localSchedOpts, useHopperDpSchedule);
 
   //===--------------------------------------------------------------------===//
   // Phase 2b: Pre-create per-dpId computation partitions and pre-schedule
@@ -1243,13 +1243,10 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     for (const auto &catOp : dpOps)
       usedDpIds.insert(catOp.dataPartitionId);
 
-    // When WSDataPartition has already split the dot ops, the backward
-    // slices may contain only ops that are already categorized (e.g.,
-    // descriptor_loads as Load), leaving no DataPartition-categorized ops.
-    // Fall back to the WarpGroupDotOp dpIds directly, using
-    // makeDefaultPartition so computation partitions get lower indices
-    // than the load partition (making them the default warp group).
-    if (useWgmmaDpFallback) {
+    // For Hopper WarpGroupDotOps: also collect dpIds from the MMA ops
+    // directly, since backward slices may miss exclusive ops due to
+    // inclusive=false or prior categorization.
+    if (useHopperDpSchedule) {
       for (auto mmaOp : mmas) {
         if (!isa<ttng::WarpGroupDotOp>(mmaOp))
           continue;
@@ -1258,6 +1255,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
           usedDpIds.insert(dpId);
       }
 
+      // Create computation partitions first via makeDefaultPartition so
+      // they get lower indices than load (= default warp group).
       SmallVector<unsigned> sortedDpIds(usedDpIds.begin(), usedDpIds.end());
       llvm::sort(sortedDpIds, std::greater<unsigned>());
       for (unsigned dpId : sortedDpIds)
@@ -1275,7 +1274,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       layout.loadPartition = schedule.addPartition(0);
       layout.loadPartition->setType("load");
 
-      // Pre-schedule MMA ops into their computation partitions.
+      // Pre-schedule MMA ops into their computation partitions so
+      // Phase 3/4 load-user propagation doesn't claim them.
       for (auto mmaOp : mmas) {
         if (!isa<ttng::WarpGroupDotOp>(mmaOp))
           continue;
@@ -1298,6 +1298,10 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     }
 
     for (const auto &catOp : dpOps) {
+      // Don't pre-schedule loads or allocs to computation partitions —
+      // they belong in the load partition. Phase 3 will place them there.
+      if (isa<DescriptorLoadOp, DescriptorGatherOp, LocalAllocOp>(catOp.op))
+        continue;
       unsigned dpId = catOp.dataPartitionId;
       auto it = dpIdToPartition.find(dpId);
       if (it != dpIdToPartition.end()) {
@@ -1309,10 +1313,12 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
     // Pre-assign shared ops to the default partition so that
     // propagatePartitions doesn't merge computation partitions.
-    // Skip this for the WarpGroupDotOp fallback path — Phase 3/4
+    // Skip for Hopper data-partitioned WarpGroupDotOps — Phase 3/4
     // will correctly route loads to the load partition and other
-    // shared ops to the default partition.
-    if (layout.defaultPartition && !dpOps.empty()) {
+    // shared ops to the default partition. Pre-scheduling shared ops
+    // here would claim descriptor_loads before Phase 3, putting B
+    // loads in the computation partition instead of the load partition.
+    if (layout.defaultPartition && !dpOps.empty() && !useHopperDpSchedule) {
       for (Operation *sharedOp : categorizer.getSharedOps()) {
         if (!isa<arith::ConstantOp>(sharedOp))
           tryScheduleOp(layout.defaultPartition, sharedOp);


### PR DESCRIPTION
Fixes the partition structure with DP=2. Previously these were being mapped to the same partition so there was no benefit. Now these are mapped to separate partitions, allowing greater parallelism and the opportunity to use ping pong.

This also fixes several structural bugs in the compiler.
