### PR TITLE
[AutoWS][ModuloSchedule] Model async TMA/MMA issue latency (#1324)

### DIFF
--- a/docs/design/ws_global_instruction_scheduling.md
+++ b/docs/design/ws_global_instruction_scheduling.md
@@ -474,14 +474,20 @@ Here `local_store` is a real DDG node (not synthetic) with `pipeline = MEM` and 
 
 #### selfLatency / latency Summary (Blackwell)
 
-| TTGIR Op | DDG Node(s) | selfLatency | latency | Pipeline |
-|----------|------------|----------:|--------:|----------|
-| `tt.descriptor_load` | `tma_load` (→buf) + `local_load` (←buf, synthetic) | 20 / 0 | 520 / 0 | MEM / NONE |
-| `tt.descriptor_store` | `tma_store` (←buf) | 20 | 600 | MEM |
-| `ttg.local_store` | `local_store` (→buf, real IR op) | 150 | 150 | MEM |
-| `ttng.tc_gen5_mma` | `mma` | 900 | 900 | TC |
-| `ttng.tmem_load` | `tmem_load` | 200 | 200 | TC |
-| CUDA/SFU ops | 1:1 | varies | = selfLatency | CUDA/SFU |
+| TTGIR Op | DDG Node(s) | selfLatency | transferLatency | latency | Pipeline |
+|----------|------------|----------:|----------------:|--------:|----------|
+| `tt.descriptor_load` | `tma_load` (→buf) + `local_load` (←buf, synthetic) | 30 / 0 | 520 / — | 1220 / 0 | MEM / NONE |
+| `tt.descriptor_store` | `tma_store` (←buf) | 30 | 520 | 1220 | MEM |
+| `ttg.local_store` | `local_store` (→buf, real IR op) | 150 | 150 | 150 | MEM |
+| `ttng.tc_gen5_mma` | `mma` | 30 | — | 900 | TC |
+| `ttng.tmem_load` | `tmem_load` | 200 | — | 200 | TC |
+| CUDA/SFU ops | 1:1 | varies | — | = selfLatency | CUDA/SFU |
+
+**selfLatency** is the issue cost — how long the SM's dispatch pipeline is busy before it can accept the next operation. For async ops (TMA loads/stores, MMA), this is much smaller than the full execution time because the hardware unit (TMA engine, tensor cores) runs independently after the SM issues the command.
+
+**transferLatency** is the full transfer/execution time on the hardware unit. For MEM ops, this is used as the edge weight from `tma_load` to `local_alloc` so that the alloc is placed at the correct cycle (when data actually arrives in SMEM), independent of the SM's dispatch cost.
+
+**latency** is the total time from op issue to result availability for consumers. For TMA loads: `transferLatency + kTMAAsyncOverhead` (DRAM round-trip). For MMA: the full tensor core execution time.
 
 ### 3. Functional Unit Mapping
 
@@ -515,7 +521,7 @@ Execution time per operation in cycles (from microbenchmarks):
 
 - Each pipeline can execute **one op at a time** per warpgroup
 - Distinct pipelines **can overlap** (MEM + TC + CUDA + SFU all concurrent)
-- An op **occupies** its pipeline for its full latency duration
+- An op **occupies** its pipeline for its **selfLatency** (issue cost), not its full execution time. For async ops (TMA, MMA), the hardware unit executes independently after the SM issues the command, so the pipeline is free to accept the next op after the issue cost
 
 ---
 

--- a/test/TritonGPU/modulo-schedule-graph.mlir
+++ b/test/TritonGPU/modulo-schedule-graph.mlir
@@ -16,7 +16,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // --- Graph structure: II=1005, max_stage=1, trip_count=32 ---
 // With selfLatency=1, loads issue every cycle (not every 518 cycles),
 // so II is driven by RecMII (loop-carried dep: MMA→tmem_load→tmem_alloc→MMA).
-// CHECK: [PASS-A] === Inner Loop ScheduleGraph ===
+// CHECK: [PASS-A] === Loop ScheduleGraph ===
 // CHECK-NEXT: modulo.schedule @loop0 {
 // CHECK-NEXT:   ii = 1005, max_stage = 1, prologue_latency = 703, trip_count = 32
 //

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -18,7 +18,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK-NOT: loop.stage
 // CHECK-NOT: loop.cluster
 // CHECK-NOT: tt.autows
-// CHECK: tt.num_stages = 2 : i32
+// CHECK: tt.num_stages = 3 : i32
 tt.func @gemm_inner_loop(
   %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
   %b_desc: !tt.tensordesc<tensor<64x128xf16>>

--- a/test/TritonGPU/modulo-ws-partition.mlir
+++ b/test/TritonGPU/modulo-ws-partition.mlir
@@ -17,7 +17,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK: scf.for
 // Inner loop has tt.num_stages from modulo schedule
 // CHECK: scf.for
-// CHECK: tt.num_stages = 2 : i32
+// CHECK: tt.num_stages = 3 : i32
 // Outer loop has tt.warp_specialize
 // CHECK: tt.warp_specialize
 tt.func @persistent_gemm_ws_partition(

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -31,6 +31,7 @@ unsigned DataDependenceGraph::addNode(Operation *op,
   node.pipeline = info.pipeline;
   node.latency = info.latency;
   node.selfLatency = info.selfLatency;
+  node.transferLatency = info.transferLatency;
   nodes.push_back(node);
   opToIdx[op] = idx;
   return idx;
@@ -71,14 +72,15 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         continue;
       unsigned srcIdx = it->second;
       // Edge latency = producer's latency (time until result available).
-      // Exception: for MEM → local_alloc edges, use selfLatency instead of
-      // the full async latency. local_alloc is a format conversion (registers
-      // → SMEM) that must stay at the same pipeline stage as its load.
-      // The async overhead only applies to the MMA consumer, not local_alloc.
+      // Exception: for MEM → local_alloc edges, use transferLatency (the TMA
+      // transfer time) instead of the full async latency. local_alloc is a
+      // bookkeeping op that represents data arrival — it must wait for the
+      // transfer to complete, but not for the async DRAM overhead that only
+      // applies to the MMA consumer.
       int edgeLatency = ddg.nodes[srcIdx].latency;
       if (ddg.nodes[srcIdx].pipeline == HWPipeline::MEM &&
           isa<triton::gpu::LocalAllocOp>(node.op)) {
-        edgeLatency = ddg.nodes[srcIdx].selfLatency;
+        edgeLatency = ddg.nodes[srcIdx].transferLatency;
       }
       ddg.addEdge(srcIdx, node.idx, edgeLatency, /*distance=*/0);
     }
@@ -106,7 +108,16 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       auto userIt = ddg.opToIdx.find(user);
       if (userIt == ddg.opToIdx.end())
         continue;
-      ddg.addEdge(srcIdx, userIt->second, ddg.nodes[srcIdx].latency,
+      // For async ops (TC, MEM), the loop-carried recurrence latency
+      // is the issue cost (selfLatency), not the full execution time.
+      // The hardware pipelines successive iterations internally — e.g.,
+      // tcgen05.mma with useAcc=true pipelines accumulator updates in
+      // TMEM, so the next MMA can issue after the dispatch cost.
+      int backEdgeLat = ddg.nodes[srcIdx].latency;
+      if (ddg.nodes[srcIdx].pipeline == HWPipeline::TC ||
+          ddg.nodes[srcIdx].pipeline == HWPipeline::MEM)
+        backEdgeLat = ddg.nodes[srcIdx].selfLatency;
+      ddg.addEdge(srcIdx, userIt->second, backEdgeLat,
                   /*distance=*/1);
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -23,6 +23,7 @@ struct DDGNode {
   HWPipeline pipeline{HWPipeline::NONE};
   int latency{};
   int selfLatency{};
+  int transferLatency{};
   bool isSuperNode{false}; // True if this node represents an inner loop
   int innerII{0};          // If super-node, the inner loop's II
   int prologueLatency{0};  // If super-node, cycles before TC starts (MEM busy)

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -65,6 +65,19 @@ static constexpr TMALatencyEntry kTMALoadTable[] = {
 // hierarchy (L2/DRAM) and arrive in SMEM. On top of pipeline occupancy.
 constexpr int kTMAAsyncOverhead = 700;
 
+// Issue latency for async TMA operations. The SM spends this many cycles
+// programming the TMA descriptor and triggering the copy, then the TMA engine
+// runs independently. This is the MEM pipeline occupancy (selfLatency), NOT
+// the full transfer time — the transfer time only affects edge weights (when
+// data becomes available to consumers).
+constexpr int kTMAIssueLatency = 30;
+
+// Issue latency for async MMA operations (tcgen05.mma on Blackwell).
+// The SM issues the MMA instruction to the tensor cores asynchronously,
+// then the TC hardware executes independently. The SM can issue subsequent
+// instructions (including more MMAs) after the issue cost.
+constexpr int kMMAIssueLatency = 30;
+
 /// Look up TMA load occupancy by total bytes. Table lookup first, then
 /// linear interpolation from 128x64 baseline as fallback.
 static int lookupTMALoadOccupancy(int64_t totalBytes) {
@@ -349,7 +362,7 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
     // loads (e.g., FA backward with 6 MEM ops would need ResMII=3400+).
     selfLatency = 1;
     latency = occupancy + kTMAAsyncOverhead;
-    break;
+    return OpLatencyInfo{pipeline, latency, selfLatency, occupancy};
   }
   case HWPipeline::TC:
     latency = getMMALatency(op);
@@ -377,7 +390,7 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
     break;
   }
 
-  return OpLatencyInfo{pipeline, latency, selfLatency};
+  return OpLatencyInfo{pipeline, latency, selfLatency, selfLatency};
 }
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
@@ -29,6 +29,11 @@ struct OpLatencyInfo {
   int selfLatency{0}; // Pipeline occupancy: cycles this op blocks its pipeline.
                       // Used for resource conflict analysis (ResMII — how much
                       // pipeline bandwidth is consumed).
+  int transferLatency{0}; // For async MEM ops: the full TMA transfer time
+                          // (pipeline occupancy from the TMA engine's
+                          // perspective). Used as edge weight from load to
+                          // local_alloc so the alloc stays at the right stage.
+                          // For non-async ops, equals selfLatency.
 };
 
 /// Hardware latency model for Blackwell SM100.


### PR DESCRIPTION
Summary:

Depends on D100655309

The modulo scheduling algorithm was modeling TMA loads and MMA operations with their full transfer/execution time as pipeline occupancy (selfLatency), preventing the scheduler from discovering multi-stage pipelines. On Blackwell, both TMA loads and tc_gen5_mma are async fire-and-forget — the SM spends ~30 cycles issuing them, then the hardware unit runs independently.

This diff separates issue latency from transfer/execution latency:

1. Async latency modeling: TMA loads and MMA now use selfLatency=30 (issue cost) for ResMII/reservation table, while preserving the full transfer time in a new transferLatency field for DDG edge weights. This drops ResMII from ~1300 to ~60, allowing the scheduler to explore deeper pipelines.

2. DDG edge fix: Load-to-local_alloc edges now use transferLatency (the actual TMA transfer time) instead of selfLatency (issue cost), so the data availability chain is correctly modeled even with the reduced pipeline occupancy.

3. Loop-carried edges for async ops (TC, MEM) now use selfLatency instead of latency, reflecting that hardware pipelines successive iterations internally (e.g., tcgen05.mma with useAcc pipelines accumulator updates in TMEM).

Reviewed By: wlei-llvm

Differential Revision: D101587923


