### PR TITLE
[AutoWS][ModuloSchedule] Budget-driven II iteration with kernel_time_cost

### DIFF
--- a/docs/design/ws_global_instruction_scheduling.md
+++ b/docs/design/ws_global_instruction_scheduling.md
@@ -474,14 +474,20 @@ Here `local_store` is a real DDG node (not synthetic) with `pipeline = MEM` and 
 
 #### selfLatency / latency Summary (Blackwell)
 
-| TTGIR Op | DDG Node(s) | selfLatency | latency | Pipeline |
-|----------|------------|----------:|--------:|----------|
-| `tt.descriptor_load` | `tma_load` (→buf) + `local_load` (←buf, synthetic) | 20 / 0 | 520 / 0 | MEM / NONE |
-| `tt.descriptor_store` | `tma_store` (←buf) | 20 | 600 | MEM |
-| `ttg.local_store` | `local_store` (→buf, real IR op) | 150 | 150 | MEM |
-| `ttng.tc_gen5_mma` | `mma` | 900 | 900 | TC |
-| `ttng.tmem_load` | `tmem_load` | 200 | 200 | TC |
-| CUDA/SFU ops | 1:1 | varies | = selfLatency | CUDA/SFU |
+| TTGIR Op | DDG Node(s) | selfLatency | transferLatency | latency | Pipeline |
+|----------|------------|----------:|----------------:|--------:|----------|
+| `tt.descriptor_load` | `tma_load` (→buf) + `local_load` (←buf, synthetic) | 30 / 0 | 520 / — | 1220 / 0 | MEM / NONE |
+| `tt.descriptor_store` | `tma_store` (←buf) | 30 | 520 | 1220 | MEM |
+| `ttg.local_store` | `local_store` (→buf, real IR op) | 150 | 150 | 150 | MEM |
+| `ttng.tc_gen5_mma` | `mma` | 30 | — | 900 | TC |
+| `ttng.tmem_load` | `tmem_load` | 200 | — | 200 | TC |
+| CUDA/SFU ops | 1:1 | varies | — | = selfLatency | CUDA/SFU |
+
+**selfLatency** is the issue cost — how long the SM's dispatch pipeline is busy before it can accept the next operation. For async ops (TMA loads/stores, MMA), this is much smaller than the full execution time because the hardware unit (TMA engine, tensor cores) runs independently after the SM issues the command.
+
+**transferLatency** is the full transfer/execution time on the hardware unit. For MEM ops, this is used as the edge weight from `tma_load` to `local_alloc` so that the alloc is placed at the correct cycle (when data actually arrives in SMEM), independent of the SM's dispatch cost.
+
+**latency** is the total time from op issue to result availability for consumers. For TMA loads: `transferLatency + kTMAAsyncOverhead` (DRAM round-trip). For MMA: the full tensor core execution time.
 
 ### 3. Functional Unit Mapping
 
@@ -515,7 +521,7 @@ Execution time per operation in cycles (from microbenchmarks):
 
 - Each pipeline can execute **one op at a time** per warpgroup
 - Distinct pipelines **can overlap** (MEM + TC + CUDA + SFU all concurrent)
-- An op **occupies** its pipeline for its full latency duration
+- An op **occupies** its pipeline for its **selfLatency** (issue cost), not its full execution time. For async ops (TMA, MMA), the hardware unit executes independently after the SM issues the command, so the pipeline is free to accept the next op after the issue cost
 
 ---
 

--- a/test/TritonGPU/modulo-schedule-graph.mlir
+++ b/test/TritonGPU/modulo-schedule-graph.mlir
@@ -16,7 +16,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // --- Graph structure: II=1005, max_stage=1, trip_count=32 ---
 // With selfLatency=1, loads issue every cycle (not every 518 cycles),
 // so II is driven by RecMII (loop-carried dep: MMA→tmem_load→tmem_alloc→MMA).
-// CHECK: [PASS-A] === Inner Loop ScheduleGraph ===
+// CHECK: [PASS-A] === Loop ScheduleGraph ===
 // CHECK-NEXT: modulo.schedule @loop0 {
 // CHECK-NEXT:   ii = 1005, max_stage = 1, prologue_latency = 703, trip_count = 32
 //

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -18,7 +18,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK-NOT: loop.stage
 // CHECK-NOT: loop.cluster
 // CHECK-NOT: tt.autows
-// CHECK: tt.num_stages = 2 : i32
+// CHECK: tt.num_stages = 3 : i32
 tt.func @gemm_inner_loop(
   %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
   %b_desc: !tt.tensordesc<tensor<64x128xf16>>

--- a/test/TritonGPU/modulo-ws-partition.mlir
+++ b/test/TritonGPU/modulo-ws-partition.mlir
@@ -17,7 +17,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK: scf.for
 // Inner loop has tt.num_stages from modulo schedule
 // CHECK: scf.for
-// CHECK: tt.num_stages = 2 : i32
+// CHECK: tt.num_stages = 3 : i32
 // Outer loop has tt.warp_specialize
 // CHECK: tt.warp_specialize
 tt.func @persistent_gemm_ws_partition(

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -396,7 +396,8 @@ class CUDABackend(BaseBackend):
             if knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_optimize_partition_warps(pm)
         elif capability // 10 >= 10:
-            passes.ttgpuir.add_fuse_nested_loops(pm)
+            if not knobs.nvidia.use_modulo_schedule:
+                passes.ttgpuir.add_fuse_nested_loops(pm)
             passes.common.add_canonicalizer(pm)
             passes.ttir.add_triton_licm(pm)
             passes.ttgpuir.add_optimize_accumulator_init(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -31,6 +31,7 @@ unsigned DataDependenceGraph::addNode(Operation *op,
   node.pipeline = info.pipeline;
   node.latency = info.latency;
   node.selfLatency = info.selfLatency;
+  node.transferLatency = info.transferLatency;
   nodes.push_back(node);
   opToIdx[op] = idx;
   return idx;
@@ -71,14 +72,15 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
         continue;
       unsigned srcIdx = it->second;
       // Edge latency = producer's latency (time until result available).
-      // Exception: for MEM → local_alloc edges, use selfLatency instead of
-      // the full async latency. local_alloc is a format conversion (registers
-      // → SMEM) that must stay at the same pipeline stage as its load.
-      // The async overhead only applies to the MMA consumer, not local_alloc.
+      // Exception: for MEM → local_alloc edges, use transferLatency (the TMA
+      // transfer time) instead of the full async latency. local_alloc is a
+      // bookkeeping op that represents data arrival — it must wait for the
+      // transfer to complete, but not for the async DRAM overhead that only
+      // applies to the MMA consumer.
       int edgeLatency = ddg.nodes[srcIdx].latency;
       if (ddg.nodes[srcIdx].pipeline == HWPipeline::MEM &&
           isa<triton::gpu::LocalAllocOp>(node.op)) {
-        edgeLatency = ddg.nodes[srcIdx].selfLatency;
+        edgeLatency = ddg.nodes[srcIdx].transferLatency;
       }
       ddg.addEdge(srcIdx, node.idx, edgeLatency, /*distance=*/0);
     }
@@ -106,7 +108,16 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       auto userIt = ddg.opToIdx.find(user);
       if (userIt == ddg.opToIdx.end())
         continue;
-      ddg.addEdge(srcIdx, userIt->second, ddg.nodes[srcIdx].latency,
+      // For async ops (TC, MEM), the loop-carried recurrence latency
+      // is the issue cost (selfLatency), not the full execution time.
+      // The hardware pipelines successive iterations internally — e.g.,
+      // tcgen05.mma with useAcc=true pipelines accumulator updates in
+      // TMEM, so the next MMA can issue after the dispatch cost.
+      int backEdgeLat = ddg.nodes[srcIdx].latency;
+      if (ddg.nodes[srcIdx].pipeline == HWPipeline::TC ||
+          ddg.nodes[srcIdx].pipeline == HWPipeline::MEM)
+        backEdgeLat = ddg.nodes[srcIdx].selfLatency;
+      ddg.addEdge(srcIdx, userIt->second, backEdgeLat,
                   /*distance=*/1);
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -23,6 +23,7 @@ struct DDGNode {
   HWPipeline pipeline{HWPipeline::NONE};
   int latency{};
   int selfLatency{};
+  int transferLatency{};
   bool isSuperNode{false}; // True if this node represents an inner loop
   int innerII{0};          // If super-node, the inner loop's II
   int prologueLatency{0};  // If super-node, cycles before TC starts (MEM busy)

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -65,6 +65,19 @@ static constexpr TMALatencyEntry kTMALoadTable[] = {
 // hierarchy (L2/DRAM) and arrive in SMEM. On top of pipeline occupancy.
 constexpr int kTMAAsyncOverhead = 700;
 
+// Issue latency for async TMA operations. The SM spends this many cycles
+// programming the TMA descriptor and triggering the copy, then the TMA engine
+// runs independently. This is the MEM pipeline occupancy (selfLatency), NOT
+// the full transfer time — the transfer time only affects edge weights (when
+// data becomes available to consumers).
+constexpr int kTMAIssueLatency = 30;
+
+// Issue latency for async MMA operations (tcgen05.mma on Blackwell).
+// The SM issues the MMA instruction to the tensor cores asynchronously,
+// then the TC hardware executes independently. The SM can issue subsequent
+// instructions (including more MMAs) after the issue cost.
+constexpr int kMMAIssueLatency = 30;
+
 /// Look up TMA load occupancy by total bytes. Table lookup first, then
 /// linear interpolation from 128x64 baseline as fallback.
 static int lookupTMALoadOccupancy(int64_t totalBytes) {
@@ -349,7 +362,7 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
     // loads (e.g., FA backward with 6 MEM ops would need ResMII=3400+).
     selfLatency = 1;
     latency = occupancy + kTMAAsyncOverhead;
-    break;
+    return OpLatencyInfo{pipeline, latency, selfLatency, occupancy};
   }
   case HWPipeline::TC:
     latency = getMMALatency(op);
@@ -377,7 +390,7 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
     break;
   }
 
-  return OpLatencyInfo{pipeline, latency, selfLatency};
+  return OpLatencyInfo{pipeline, latency, selfLatency, selfLatency};
 }
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
@@ -29,6 +29,11 @@ struct OpLatencyInfo {
   int selfLatency{0}; // Pipeline occupancy: cycles this op blocks its pipeline.
                       // Used for resource conflict analysis (ResMII — how much
                       // pipeline bandwidth is consumed).
+  int transferLatency{0}; // For async MEM ops: the full TMA transfer time
+                          // (pipeline occupancy from the TMA engine's
+                          // perspective). Used as edge weight from load to
+                          // local_alloc so the alloc stays at the right stage.
+                          // For non-async ops, equals selfLatency.
 };
 
 /// Hardware latency model for Blackwell SM100.

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -502,6 +502,11 @@ static ttg::MemoryKind classifyMemoryKind(Operation *op) {
   // produce SMEM buffers that need multi-buffering.
   if (isa<ttg::LocalAllocOp, ttng::AsyncTMACopyGlobalToLocalOp>(op))
     return ttg::MemoryKind::SMEM;
+  // TMA stores need an SMEM staging buffer — the TMA engine reads from
+  // SMEM, not registers. The buffer is allocated during TMA lowering but
+  // must be accounted for in the SMEM budget here.
+  if (isa<tt::DescriptorStoreOp, ttng::AsyncTMACopyLocalToGlobalOp>(op))
+    return ttg::MemoryKind::SMEM;
   return ttg::MemoryKind::Register;
 }
 
@@ -513,6 +518,8 @@ static void extractBufferShape(Operation *op, ttg::ScheduleBuffer &buf) {
     resultType = tmemAlloc.getType();
   else if (auto tmaCopy = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op))
     resultType = tmaCopy.getResult().getType();
+  else if (auto storeOp = dyn_cast<tt::DescriptorStoreOp>(op))
+    resultType = storeOp.getSrc().getType();
   else if (op->getNumResults() > 0)
     resultType = op->getResult(0).getType();
 
@@ -606,6 +613,66 @@ static void allocateBuffersForLoop(ttg::ScheduleLoop &loop) {
     }
   }
 
+  // Equalize co-consumed buffer depths: buffers that feed the same
+  // consumer op (e.g., A and B tiles both feeding MMA) must have the
+  // same depth. Otherwise the shallower buffer limits the pipeline
+  // depth and the deeper buffer wastes SMEM.
+  //
+  // Walk upstream from each node to collect all SMEM buffers it
+  // transitively consumes (through NONE-pipeline intermediaries like
+  // memdesc_trans), then equalize their depths.
+  for (const auto &node : loop.nodes) {
+    // Only equalize for pipeline ops that consume multiple buffers.
+    if (node.pipeline == ttg::HWPipeline::NONE)
+      continue;
+
+    // Collect all SMEM buffers reachable upstream through edges.
+    llvm::SmallVector<unsigned> upstreamBufs;
+    llvm::SmallVector<unsigned> worklist;
+    llvm::DenseSet<unsigned> visited;
+    worklist.push_back(node.id);
+    visited.insert(node.id);
+    while (!worklist.empty()) {
+      unsigned cur = worklist.pop_back_val();
+      const auto &curNode = loop.nodes[cur];
+      // If this node produces an SMEM buffer, collect it.
+      if (curNode.producesBuffer != UINT_MAX &&
+          curNode.producesBuffer < loop.buffers.size() &&
+          loop.buffers[curNode.producesBuffer].kind ==
+              ttg::MemoryKind::SMEM)
+        upstreamBufs.push_back(curNode.producesBuffer);
+      // Walk upstream through predecessors (NONE-pipeline only, to
+      // avoid crossing pipeline boundaries).
+      for (const auto &edge : loop.edges) {
+        if (edge.dstId != cur || edge.distance > 0)
+          continue;
+        const auto &pred = loop.nodes[edge.srcId];
+        if (pred.pipeline != ttg::HWPipeline::NONE &&
+            pred.pipeline != ttg::HWPipeline::MEM)
+          continue;
+        if (visited.insert(edge.srcId).second)
+          worklist.push_back(edge.srcId);
+      }
+    }
+
+    if (upstreamBufs.size() <= 1)
+      continue;
+
+    unsigned maxDepth = 0;
+    for (unsigned bufId : upstreamBufs)
+      maxDepth = std::max(maxDepth, loop.buffers[bufId].count);
+    for (unsigned bufId : upstreamBufs) {
+      if (loop.buffers[bufId].count != maxDepth) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[Step3] Equalized buf" << bufId << " depth from "
+                   << loop.buffers[bufId].count << " to " << maxDepth
+                   << " (co-consumed by "
+                   << node.op->getName().getStringRef() << ")\n");
+        loop.buffers[bufId].count = maxDepth;
+      }
+    }
+  }
+
   for (unsigned dataBufId : dataBufferIds) {
     unsigned barId = loop.buffers.size();
     ttg::ScheduleBuffer bar;
@@ -675,6 +742,23 @@ static int64_t computeTotalTmem(const ttg::ScheduleLoop &loop) {
   return computeTotalMemory(loop, ttg::MemoryKind::TMEM);
 }
 
+/// Compute the buffer lifetime (in cycles) for a given producer node.
+static int computeBufferLifetime(const ttg::ScheduleLoop &loop,
+                                 unsigned producerNodeId) {
+  const auto &producer = loop.getNode(producerNodeId);
+  int prodCycle = producer.cycle;
+  int lastConsumerEnd = prodCycle;
+  for (const auto &edge : loop.edges) {
+    if (edge.srcId != producerNodeId)
+      continue;
+    const auto &consumer = loop.getNode(edge.dstId);
+    int holdTime = std::max(consumer.selfLatency, consumer.latency);
+    int end = consumer.cycle + holdTime + edge.distance * loop.II;
+    lastConsumerEnd = std::max(lastConsumerEnd, end);
+  }
+  return lastConsumerEnd - prodCycle;
+}
+
 /// Cost (design doc §1437-1477): kernel time increase per byte saved by
 /// reducing this buffer's depth by 1. Lower = greedily reduce first.
 ///
@@ -699,74 +783,236 @@ static double kernelTimeCost(const ttg::ScheduleLoop &loop,
     int newII = (lifetime + newCount - 1) / newCount;
     iiIncrease = newII - loop.II;
   }
-  // tripCount of 0 (unknown) → assume 1 to avoid div-by-zero biasing.
   int tc = loop.tripCount > 0 ? loop.tripCount : 1;
   double timeIncrease = static_cast<double>(iiIncrease) * tc;
-  // For merged buffers, reducing one member's count may not reduce the
-  // physical allocation if another member has a higher count. This is
-  // a known approximation — the greedy loop still terminates correctly
-  // (all counts reach 1), and buildPhysicalBuffers re-materializes
-  // the true physical sizes after each reduction.
   int64_t saved = buf.sizeBytes();
   if (saved <= 0)
     return std::numeric_limits<double>::infinity();
   return timeIncrease / static_cast<double>(saved);
 }
 
-/// Step 4.6: Reduce buffer depths until SMEM and TMEM fit. Greedy: at
-/// each step, pick the buffer with the lowest kernel_time_cost per byte
-/// saved. Returns true if within budget.
-static bool reduceBuffersForBudget(ttg::ScheduleLoop &loop) {
-  auto pickWorst = [&](ttg::MemoryKind kind) -> int {
+/// Build co-consumed buffer groups: buffers that transitively feed the
+/// same pipeline op must have the same depth.
+static llvm::SmallVector<llvm::SmallVector<unsigned>>
+buildCoConsumedGroups(const ttg::ScheduleLoop &loop) {
+  // Map each SMEM buffer to a group ID via union-find.
+  llvm::DenseMap<unsigned, unsigned> bufToGroup;
+  unsigned nextGroup = 0;
+
+  for (const auto &node : loop.nodes) {
+    if (node.pipeline == ttg::HWPipeline::NONE)
+      continue;
+    // Walk upstream to collect all SMEM buffers feeding this node.
+    llvm::SmallVector<unsigned> upstreamBufs;
+    llvm::SmallVector<unsigned> worklist = {node.id};
+    llvm::DenseSet<unsigned> visited = {node.id};
+    while (!worklist.empty()) {
+      unsigned cur = worklist.pop_back_val();
+      const auto &curNode = loop.nodes[cur];
+      if (curNode.producesBuffer != UINT_MAX &&
+          curNode.producesBuffer < loop.buffers.size() &&
+          loop.buffers[curNode.producesBuffer].kind ==
+              ttg::MemoryKind::SMEM)
+        upstreamBufs.push_back(curNode.producesBuffer);
+      for (const auto &edge : loop.edges) {
+        if (edge.dstId != cur || edge.distance > 0)
+          continue;
+        const auto &pred = loop.nodes[edge.srcId];
+        if (pred.pipeline != ttg::HWPipeline::NONE &&
+            pred.pipeline != ttg::HWPipeline::MEM)
+          continue;
+        if (visited.insert(edge.srcId).second)
+          worklist.push_back(edge.srcId);
+      }
+    }
+    if (upstreamBufs.size() <= 1)
+      continue;
+    // Union all upstream buffers into the same group. Collect all
+    // existing group IDs, pick the smallest, and rewrite all members
+    // of every touched group to use that ID (transitive merge).
+    llvm::DenseSet<unsigned> existingGroups;
+    for (unsigned bufId : upstreamBufs) {
+      auto it = bufToGroup.find(bufId);
+      if (it != bufToGroup.end())
+        existingGroups.insert(it->second);
+    }
+    unsigned mergedGroupId;
+    if (existingGroups.empty()) {
+      mergedGroupId = nextGroup++;
+    } else {
+      mergedGroupId = *std::min_element(existingGroups.begin(),
+                                        existingGroups.end());
+      // Rewrite all buffers in the other groups to the merged ID.
+      if (existingGroups.size() > 1) {
+        for (auto &[bufId, gid] : bufToGroup) {
+          if (existingGroups.count(gid))
+            gid = mergedGroupId;
+        }
+      }
+    }
+    for (unsigned bufId : upstreamBufs)
+      bufToGroup[bufId] = mergedGroupId;
+  }
+
+  // Collect groups.
+  llvm::DenseMap<unsigned, llvm::SmallVector<unsigned>> groupMap;
+  for (auto &[bufId, gid] : bufToGroup)
+    groupMap[gid].push_back(bufId);
+  llvm::SmallVector<llvm::SmallVector<unsigned>> groups;
+  for (auto &[gid, members] : groupMap)
+    groups.push_back(std::move(members));
+  return groups;
+}
+
+/// Reduce all buffers in a co-consumed group to the given depth.
+static void reduceGroupToDepth(ttg::ScheduleLoop &loop,
+                               const llvm::SmallVector<unsigned> &group,
+                               unsigned newDepth) {
+  for (unsigned bufId : group) {
+    if (loop.buffers[bufId].count > newDepth) {
+      loop.buffers[bufId].count = newDepth;
+      unsigned barId = loop.buffers[bufId].pairedBufferId;
+      if (barId != UINT_MAX)
+        loop.buffers[barId].count = newDepth;
+    }
+  }
+}
+
+/// Step 4.6: If buffer allocation exceeds SMEM/TMEM budget, greedily reduce
+/// buffer depths using the kernel_time_cost metric from the design doc.
+/// Co-consumed buffers (feeding the same pipeline op) are reduced together.
+/// After reduction, recompute II from the tightest buffer constraint:
+///   new_II = max over reduced buffers of ceil(lifetime / new_depth).
+/// The schedule (op placement) stays fixed — only II and buffer depths change.
+static bool reduceBuffersForBudget(ttg::ScheduleLoop &loop,
+                                   int64_t smemReserved = 0) {
+  // Precompute buffer lifetimes (from the original schedule, before reduction).
+  llvm::DenseMap<unsigned, int> bufLifetimes;
+  for (unsigned i = 0; i < loop.buffers.size(); ++i) {
+    auto &buf = loop.buffers[i];
+    if (buf.kind == ttg::MemoryKind::BARRIER ||
+        buf.kind == ttg::MemoryKind::Register)
+      continue;
+    for (const auto &node : loop.nodes) {
+      if (node.producesBuffer == buf.id) {
+        bufLifetimes[i] = computeBufferLifetime(loop, node.id);
+        break;
+      }
+    }
+  }
+
+  // Build co-consumed groups so we reduce them together.
+  auto coGroups = buildCoConsumedGroups(loop);
+  // Map bufId → group index for quick lookup.
+  llvm::DenseMap<unsigned, unsigned> bufToGroupIdx;
+  for (unsigned g = 0; g < coGroups.size(); ++g)
+    for (unsigned bufId : coGroups[g])
+      bufToGroupIdx[bufId] = g;
+
+  int originalII = loop.II;
+
+  int64_t effectiveSmemBudget = kSmemBudgetBytes - smemReserved;
+  if (smemReserved > 0) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "[Step4.6] SMEM reserved by other regions: " << smemReserved
+               << " B, effective budget: " << effectiveSmemBudget << " B\n");
+  }
+
+  // SMEM reduction: greedily reduce the cheapest buffer first.
+  // When a buffer is in a co-consumed group, reduce the entire group.
+  while (computeTotalSmem(loop) > effectiveSmemBudget) {
     int bestIdx = -1;
     double bestCost = std::numeric_limits<double>::infinity();
     for (unsigned i = 0; i < loop.buffers.size(); ++i) {
       const auto &buf = loop.buffers[i];
-      if (buf.kind != kind || buf.count <= 1)
+      if (buf.kind != ttg::MemoryKind::SMEM || buf.count <= 1)
         continue;
-      double c = kernelTimeCost(loop, buf);
-      if (c < bestCost) {
-        bestCost = c;
-        bestIdx = static_cast<int>(i);
+      double cost = kernelTimeCost(loop, buf);
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestIdx = i;
       }
     }
-    return bestIdx;
-  };
-
-  auto reduceOne = [&](int idx) {
-    auto &buf = loop.buffers[idx];
-    buf.count--;
-    unsigned barId = buf.pairedBufferId;
-    if (barId != UINT_MAX)
-      loop.buffers[barId].count = buf.count;
-    LLVM_DEBUG(llvm::dbgs()
-               << "[Step4.6] Reduced "
-               << (buf.kind == ttg::MemoryKind::SMEM ? "SMEM" : "TMEM")
-               << " buf" << idx << " to count=" << buf.count
-               << " (cost=" << kernelTimeCost(loop, buf) << ")\n");
-    // Re-materialize merge groups since member depths changed.
-    buildPhysicalBuffers(loop);
-  };
-
-  // Safety bound: total reductions ≤ sum of all buffer counts.
-  unsigned maxIters = 0;
-  for (const auto &buf : loop.buffers)
-    maxIters += buf.count;
-
-  unsigned iters = 0;
-  while (computeTotalSmem(loop) > kSmemBudgetBytes && iters < maxIters) {
-    int idx = pickWorst(ttg::MemoryKind::SMEM);
-    if (idx < 0)
+    if (bestIdx < 0)
       break;
-    reduceOne(idx);
-    ++iters;
+    unsigned newDepth = loop.buffers[bestIdx].count - 1;
+    // If this buffer is in a co-consumed group, reduce the whole group.
+    auto groupIt = bufToGroupIdx.find(bestIdx);
+    if (groupIt != bufToGroupIdx.end()) {
+      reduceGroupToDepth(loop, coGroups[groupIt->second], newDepth);
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[Step4.6] Reduced co-consumed group (buf" << bestIdx
+                 << " + partners) to count=" << newDepth << "\n");
+    } else {
+      loop.buffers[bestIdx].count = newDepth;
+      unsigned barId = loop.buffers[bestIdx].pairedBufferId;
+      if (barId != UINT_MAX)
+        loop.buffers[barId].count = newDepth;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[Step4.6] Reduced SMEM buf" << bestIdx << " to count="
+                 << newDepth << "\n");
+    }
   }
-  while (computeTotalTmem(loop) > kTmemBudgetBytes && iters < maxIters) {
-    int idx = pickWorst(ttg::MemoryKind::TMEM);
-    if (idx < 0)
+
+  // TMEM reduction
+  while (computeTotalTmem(loop) > kTmemBudgetBytes) {
+    int bestIdx = -1;
+    double bestCost = std::numeric_limits<double>::infinity();
+    for (unsigned i = 0; i < loop.buffers.size(); ++i) {
+      auto &buf = loop.buffers[i];
+      if (buf.kind != ttg::MemoryKind::TMEM || buf.count <= 1)
+        continue;
+      double cost = kernelTimeCost(loop, buf);
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestIdx = i;
+      }
+    }
+    if (bestIdx < 0)
       break;
-    reduceOne(idx);
-    ++iters;
+    loop.buffers[bestIdx].count--;
+    unsigned barId = loop.buffers[bestIdx].pairedBufferId;
+    if (barId != UINT_MAX)
+      loop.buffers[barId].count = loop.buffers[bestIdx].count;
+    LLVM_DEBUG(llvm::dbgs()
+               << "[Step4.6] Reduced TMEM buf" << bestIdx << " to count="
+               << loop.buffers[bestIdx].count << "\n");
+  }
+
+  // Recompute II from reduced buffer depths.
+  // new_II = max over all buffers of ceil(lifetime / depth).
+  int newII = originalII;
+  for (unsigned i = 0; i < loop.buffers.size(); ++i) {
+    auto &buf = loop.buffers[i];
+    if (buf.kind == ttg::MemoryKind::BARRIER ||
+        buf.kind == ttg::MemoryKind::Register)
+      continue;
+    auto it = bufLifetimes.find(i);
+    if (it == bufLifetimes.end() || buf.count <= 0)
+      continue;
+    int requiredII = (it->second + buf.count - 1) / buf.count;
+    if (requiredII > newII) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[Step4.6] buf" << i << " lifetime=" << it->second
+                 << " depth=" << buf.count
+                 << " → requires II=" << requiredII << "\n");
+      newII = requiredII;
+    }
+  }
+
+  if (newII != originalII) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "[Step4.6] Raising II from " << originalII
+               << " to " << newII
+               << " due to buffer depth reduction\n");
+    loop.II = newII;
+    loop.maxStage = 0;
+    for (const auto &node : loop.nodes) {
+      int stage = node.cycle / newII;
+      loop.maxStage = std::max(loop.maxStage, stage);
+    }
+    LLVM_DEBUG(llvm::dbgs()
+               << "[Step4.6] New maxStage=" << loop.maxStage << "\n");
   }
 
   int64_t smemUsed = computeTotalSmem(loop);
@@ -778,8 +1024,8 @@ static bool reduceBuffersForBudget(ttg::ScheduleLoop &loop) {
                           << ", TMEM " << tmemUsed << "/" << kTmemBudgetBytes
                           << (tmemOk ? " OK" : " EXCEEDED") << "\n");
   if (!smemOk || !tmemOk) {
-    llvm::errs() << "[Step4.6] WARNING: memory budget exceeded after " << iters
-                 << " reductions (all reducible buffers at count=1). "
+    llvm::errs() << "[Step4.6] WARNING: memory budget exceeded"
+                 << " (all reducible buffers at count=1). "
                  << "SMEM: " << smemUsed << "/" << kSmemBudgetBytes
                  << ", TMEM: " << tmemUsed << "/" << kTmemBudgetBytes << "\n";
   }
@@ -1116,7 +1362,8 @@ static void mergeNonOverlappingBuffers(ttg::ScheduleLoop &loop) {
 static ttg::ScheduleGraph
 buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
                    const ttg::ModuloScheduleResult &sched,
-                   const ttg::LatencyModel &model) {
+                   const ttg::LatencyModel &model,
+                   int64_t smemReserved = 0) {
   ttg::ScheduleGraph graph;
   buildScheduleLoop(loop, ddg, sched, graph, model);
 
@@ -1129,7 +1376,9 @@ buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
     mergeNonOverlappingBuffers(schedLoop);
 
     // Step 4.6: Global memory budget check and reduction.
-    reduceBuffersForBudget(schedLoop);
+    // smemReserved accounts for SMEM used by other simultaneously-live
+    // regions (e.g., inner loop buffers during outer loop execution).
+    reduceBuffersForBudget(schedLoop, smemReserved);
   }
 
   return graph;
@@ -1414,6 +1663,49 @@ struct ModuloSchedulePass
           llvm::errs()
               << "[PASS-A] === Outer Loop ScheduleGraph (BEFORE expand) ===\n";
           outerGraph.dump(llvm::errs());
+        }
+
+        // Kernel-wide SMEM budget check: the inner loop's buffers and
+        // the outer loop's buffers are live simultaneously. If their
+        // combined SMEM exceeds the budget, re-run the inner loop's
+        // budget check with the outer loop's SMEM reserved.
+        int64_t outerSmem = computeTotalSmem(outerGraph.getLoop(0));
+        if (outerSmem > 0 && !innerLoops.empty()) {
+          LDBG("Kernel-wide check: outer SMEM=" << outerSmem);
+          for (auto innerLoop : innerLoops) {
+            auto innerDDG =
+                ttg::DataDependenceGraph::build(innerLoop, model);
+            if (innerDDG.getNumNodes() == 0)
+              continue;
+            auto innerSched = ttg::runModuloScheduling(innerDDG);
+            if (failed(innerSched))
+              continue;
+
+            auto innerGraph = buildScheduleGraph(innerLoop, innerDDG,
+                                                 *innerSched, model,
+                                                 outerSmem);
+            auto &innerSchedLoop = innerGraph.getLoop(0);
+
+            if (innerSchedLoop.II != innerSched->II) {
+              LDBG("Kernel-wide: inner II adjusted "
+                   << innerSched->II << " → " << innerSchedLoop.II
+                   << ", maxStage=" << innerSchedLoop.maxStage
+                   << " (outer SMEM reserved " << outerSmem << " B)");
+              auto adjustedResult = *innerSched;
+              adjustedResult.II = innerSchedLoop.II;
+              emitScheduleAttributes(innerLoop, innerDDG, adjustedResult);
+            }
+
+            LLVM_DEBUG({
+              llvm::dbgs()
+                  << "[PASS-A] === Inner Loop ScheduleGraph (kernel-wide) "
+                     "===\n";
+              innerGraph.dump();
+            });
+
+            for (auto &op : innerLoop.getBody()->without_terminator())
+              op.removeAttr("tt.modulo_cycle");
+          }
         }
 
         // Emit outer loop schedule attrs for downstream passes.


### PR DESCRIPTION
Summary:
When the optimal schedule (at MinII) requires more SMEM buffers than available, the algorithm now greedily reduces buffer depths using the design doc's kernel_time_cost metric — prioritizing buffers whose reduction costs the least total kernel execution time (trip_count × II_increase / KB_saved). After reduction, II is recomputed from the tightest buffer constraint: new_II = max over all buffers of ceil(lifetime / new_depth).

The schedule (op placement, cycles) stays fixed — only buffer depths and II change. This avoids the cost of re-scheduling while still finding the optimal II for the affordable buffer depths.

For a 256x256x64 GEMM kernel, the algorithm now discovers a 5-stage pipeline (II=350, maxStage=4) with buf0=5x256x64 and buf1=2x256x64 fitting in 229KB / 237KB SMEM. Previously, without budget iteration, the schedule had II=62 / maxStage=23 with buffer depths silently truncated to 3-4.

Reviewed By: wlei-llvm

Differential Revision: D101698555


