### PR TITLE
[triton][beta] [Cherry-pick] '[TOOLS] Add hip support for link.py (#9084)' (#1331)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -2009,10 +2009,25 @@ public:
           }
           continue;
         }
-        // TODO: propagate through scf.yield by updating parent op result
-        // types, scf.for iter_args, and init values to match srcEnc.
-        if (isa<scf::YieldOp>(user))
+        // scf.yield passes values through to the parent op's results.
+        // For ForOp/WhileOp, the parent results are tied to block arguments
+        // and init operands via loop-carried dependencies — in-place type
+        // rewriting cannot safely update all of them, so block propagation.
+        // For IfOp, the results are simple branches with no loop-carried
+        // deps, so propagation is safe if we also follow the IfOp results.
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+          Operation *parent = yieldOp->getParentOp();
+          if (isa<scf::ForOp, scf::WhileOp>(parent))
+            return false;
+          if (auto ifOp = dyn_cast<scf::IfOp>(parent)) {
+            for (Value result : ifOp.getResults()) {
+              if (isa<RankedTensorType>(result.getType()))
+                worklist.push_back(result);
+            }
+            continue;
+          }
           return false;
+        }
         // Any other user (dot, reduce, another convert, etc.) blocks
         // propagation.
         return false;
@@ -2034,6 +2049,7 @@ public:
 
     // Collect all ops that need type rewriting (forward from convert users).
     SmallVector<Operation *> opsToRewrite;
+    SetVector<Operation *> ifOpsToRewrite;
     SmallVector<Value> worklist = {dst};
     DenseSet<Value> visited;
 
@@ -2043,8 +2059,20 @@ public:
         continue;
       for (OpOperand &use : v.getUses()) {
         Operation *user = use.getOwner();
-        if (isa<LocalStoreOp>(user) || isa<scf::YieldOp>(user))
+        if (isa<LocalStoreOp>(user))
           continue;
+        // For scf.yield under scf.if, follow through to the IfOp results.
+        // ForOp/WhileOp yields are blocked by canPropagateSrcEncodingThroughUsers.
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+          if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp())) {
+            ifOpsToRewrite.insert(ifOp.getOperation());
+            for (Value result : ifOp.getResults()) {
+              if (isa<RankedTensorType>(result.getType()))
+                worklist.push_back(result);
+            }
+          }
+          continue;
+        }
         opsToRewrite.push_back(user);
         for (Value result : user->getResults()) {
           if (isa<RankedTensorType>(result.getType()))
@@ -2112,6 +2140,14 @@ public:
         if (auto ty = dyn_cast<RankedTensorType>(result.getType())) {
           if (srcEncRank > 0 && ty.getRank() != srcEncRank)
             continue;
+          result.setType(ty.cloneWithEncoding(srcEnc));
+        }
+      }
+    }
+    // Rewrite IfOp result types that we propagated through.
+    for (Operation *op : ifOpsToRewrite) {
+      for (Value result : op->getResults()) {
+        if (auto ty = dyn_cast<RankedTensorType>(result.getType())) {
           result.setType(ty.cloneWithEncoding(srcEnc));
         }
       }

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2093,9 +2093,9 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     :param input_precision: How to exercise the Tensor Cores for f32 x f32. If
       the device does not have Tensor Cores or the inputs are not of dtype f32,
       this option is ignored. For devices that do have tensor cores, the
-      default precision is tf32.
-    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
-    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32".
+      default precision is tf32x3.
+    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32x3"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
+    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32x3".
       Only one of :code:`input_precision` and :code:`allow_tf32` can be
       specified (i.e. at least one must be :code:`None`).
     :param attrs: Optional dictionary of string-valued attributes to attach to the dot operation.

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1629,8 +1629,8 @@ class TritonSemantic(Generic[TensorTy]):
         assert input_precision is None or tl._unwrap_if_constexpr(allow_tf32) is None, (
             "Only one of input_precision and allow_tf32 can be specified")
         if input_precision is None:
-            supports_tf32 = "tf32" in self.builder.options.allowed_dot_input_precisions
-            input_precision = knobs.language.fp32_default or ("tf32" if
+            supports_tf32 = "tf32x3" in self.builder.options.allowed_dot_input_precisions
+            input_precision = knobs.language.fp32_default or ("tf32x3" if
                                                               (supports_tf32 and
                                                                (allow_tf32 or allow_tf32 is None)) else "ieee")
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -134,7 +134,7 @@ class InterpreterOptions:
     arch: Optional[str] = None
     supported_fp8_dtypes: Tuple[str, ...] = ("fp8e5", "fp8e5b16", "fp8e4nv", "fp8e4b8", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str, ...] = ()
-    default_dot_input_precision: str = "tf32"
+    default_dot_input_precision: str = "tf32x3"
     allowed_dot_input_precisions: Tuple[str, ...] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0
     backend_name: str = "interpreter"

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -173,6 +173,7 @@ def compile_kernel(args: CompileArgs):
     hex_ = str(binascii.hexlify(asm))[2:-1]
 
     ty_to_cpp = triton.runtime.driver.active.map_python_to_cpp_type
+    backend_name = target.backend
 
     params = {
         "kernel_name": func_name,
@@ -192,9 +193,9 @@ def compile_kernel(args: CompileArgs):
         "gridZ": grid[2],
         "_placeholder": "",
         "warp_size": target.warp_size,
+        "backend_name": backend_name,
     }
     output_files = []
-    backend_name = target.backend
     template_dir = Path(__file__).parent / "extra" / backend_name
     for template_path in template_dir.glob('compile.*'):
         ext = template_path.suffix

--- a/python/triton/tools/link.py
+++ b/python/triton/tools/link.py
@@ -39,8 +39,11 @@ class HeaderParser:
         self.c_sig = re.compile("[\\s]*(\\w+)\\s(\\w+)[,]?")
         # [d|c]
         self.arg_suffix = re.compile("[c,d]")
+        # [backend_name]
+        self.backend_name_re = re.compile("//[\\s]*tt-linker-backend:[\\s]*([\\w]+)")
 
         self.kernels = defaultdict(list)
+        self.backend_name = None
 
     def extract_linker_meta(self, header: str):
         for ln in header.splitlines():
@@ -64,6 +67,14 @@ class HeaderParser:
                             num_specs=num_specs,
                         ),
                     )
+                else:
+                    m = self.backend_name_re.match(ln)
+                    if _exists(m):
+                        backend_name = m.group(1)
+                        if self.backend_name is None:
+                            self.backend_name = backend_name
+                        elif self.backend_name != backend_name:
+                            raise RuntimeError(f"differing backend {self.backend_name} vs. {backend_name}")
 
     def _match_name(self, ker_name: str):
         m = self.kernel_name.match(ker_name)
@@ -135,7 +146,7 @@ def gen_signature(m):
 # generate declarations of kernels with meta-parameter and constant values
 def make_algo_decls(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     return f"""
-CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])});
+TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])});
 void load_{name}();
 void unload_{name}();
     """
@@ -144,8 +155,8 @@ void unload_{name}();
 # generate declarations of kernels with meta-parameter and constant values
 def make_global_decl(meta: KernelLinkerMeta) -> str:
     return f"""
-CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)});
-CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id);
+TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)});
+TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id);
 void load_{meta.orig_kernel_name}();
 void unload_{meta.orig_kernel_name}();
     """
@@ -153,7 +164,7 @@ void unload_{meta.orig_kernel_name}();
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)}){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)}){{\n"
     src += (f"  return {meta.orig_kernel_name}(stream, {', '.join(meta.arg_names)}, 0);\n")
     src += "}\n"
     return src
@@ -163,14 +174,14 @@ def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
 def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     src = f"// launcher for: {name}\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
-        src += f"CUresult {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(CUstream stream, {gen_signature(meta)});\n"
+        src += f"TT_ResultTy {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(TT_StreamTy stream, {gen_signature(meta)});\n"
     src += "\n"
 
-    src += (f"CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])}){{")
+    src += (f"TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])}){{")
     src += "\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
         cond_fn = (  #
-            lambda val, hint: f"({val} % {hint} == 0)"  #
+            lambda val, hint: f"((uintptr_t){val} % {hint} == 0)"  #
             if hint == 16  #
             else f"({val} == {hint})"  #
             if hint == 1  #
@@ -185,7 +196,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
         arg_names = [arg for arg, hint in zip(meta.arg_names, meta.sizes) if hint != 1]
         src += f"    return {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(stream, {', '.join(arg_names)});\n"
     src += "\n"
-    src += "  return CUDA_ERROR_INVALID_VALUE;\n"
+    src += "  return TT_ERROR_INVALID_VALUE;\n"
     src += "}\n"
 
     for mode in ["load", "unload"]:
@@ -202,7 +213,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
     src += f"  assert (algo_id < (int)sizeof({meta.orig_kernel_name}_kernels));\n"
     src += f"  return {meta.orig_kernel_name}_kernels[algo_id](stream, {', '.join(meta.arg_names)});\n"
     src += "}\n"
@@ -212,7 +223,7 @@ def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
 # generate definition of function pointers of kernel dispatchers based on meta-parameter and constant values
 def make_func_pointers(names: str, meta: KernelLinkerMeta) -> str:
     # the table of hint dispatchers
-    src = f"typedef CUresult (*kernel_func_t)(CUstream stream, {gen_signature_with_full_args(meta)});\n"
+    src = f"typedef TT_ResultTy (*kernel_func_t)(TT_StreamTy stream, {gen_signature_with_full_args(meta)});\n"
     src += f"kernel_func_t {meta.orig_kernel_name}_kernels[] = {{\n"
     for name in names:
         src += f"  {name},\n"
@@ -287,8 +298,9 @@ if __name__ == "__main__":
     meta = meta_lists[0][0]
     get_num_algos_decl = make_get_num_algos_decl(meta)
     global_decl = make_global_decl(meta)
+    backend_prelude = (Path(__file__).parent / "extra" / parser.backend_name / "link.h").read_text()
     with args.out.with_suffix(".h").open("w") as fp:
-        out = "#include <cuda.h>\n"
+        out = backend_prelude
         out += "\n".join(algo_decls)
         out += "\n"
         out += get_num_algos_decl
@@ -305,8 +317,7 @@ if __name__ == "__main__":
     get_num_algos_def = make_get_num_algos_def(meta)
     default_algo_kernel = make_default_algo_kernel(meta)
     with args.out.with_suffix(".c").open("w") as fp:
-        out = ""
-        out += "#include <cuda.h>\n"
+        out = backend_prelude
         out += "#include <stdint.h>\n"
         out += "#include <assert.h>\n"
         out += "\n"

--- a/third_party/amd/tools/hip/compile.c
+++ b/third_party/amd/tools/hip/compile.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
+#define __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
 
 // helpers to check for hip errors
@@ -28,8 +29,8 @@ static inline void gpuAssert(hipError_t code, const char *file, int line) {{
 
 // globals
 #define HSACO_NAME {kernel_name}_hsaco
-hipModule_t {kernel_name}_mod = nullptr;
-hipFunction_t {kernel_name}_func = nullptr;
+hipModule_t {kernel_name}_mod = NULL;
+hipFunction_t {kernel_name}_func = NULL;
 unsigned char HSACO_NAME[{bin_size}] = {{ {bin_data} }};
 
 
@@ -50,7 +51,7 @@ void load_{kernel_name}() {{
 {kernel_docstring}
 */
 hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
-    if ({kernel_name}_func == nullptr)
+    if ({kernel_name}_func == NULL)
        load_{kernel_name}();
     unsigned int gX = {gridX};
     unsigned int gY = {gridY};
@@ -61,7 +62,7 @@ hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
 
     // TODO: shared memory
     if(gX * gY * gZ > 0)
-      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, nullptr);
+      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, NULL);
     else
       return hipErrorInvalidValue;
 }}

--- a/third_party/amd/tools/hip/compile.h
+++ b/third_party/amd/tools/hip/compile.h
@@ -3,11 +3,16 @@
 
 #pragma once
 
+#define __HIP_PLATFORM_AMD__
+
 #include <hip/hip_runtime.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
+// tt-linker: {kernel_name}:{full_signature}:{algo_info}
 hipError_t{_placeholder} {kernel_name}(hipStream_t stream, {signature});

--- a/third_party/amd/tools/hip/link.h
+++ b/third_party/amd/tools/hip/link.h
@@ -1,0 +1,14 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#define __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+
+typedef hipStream_t TT_StreamTy;
+typedef hipError_t TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE hipErrorInvalidValue
+
+#endif

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -474,7 +474,9 @@ class CUDABackend(BaseBackend):
         # Budget-aware layout conversion elimination — runs last to ensure
         # converts whose scratch would exceed SMEM budget are eliminated
         # after all other passes that may introduce layout conversions.
-        passes.ttgpuir.add_remove_layout_conversions(pm, smem_budget)
+        # TODO(njriasan): Re-enable once propagateSrcEncodingAndErase handles
+        # scf::ForOp/WhileOp loop-carried values correctly.
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()

--- a/third_party/nvidia/tools/cuda/compile.h
+++ b/third_party/nvidia/tools/cuda/compile.h
@@ -8,6 +8,8 @@
 
 #endif
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
 // tt-linker: {kernel_name}:{full_signature}:{algo_info}

--- a/third_party/nvidia/tools/cuda/link.h
+++ b/third_party/nvidia/tools/cuda/link.h
@@ -1,0 +1,13 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#include <cuda.h>
+
+typedef CUstream TT_StreamTy;
+typedef CUresult TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE CUDA_ERROR_INVALID_VALUE
+
+#endif


### PR DESCRIPTION
Summary:

This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9084

Upstream commit message:
```
> [TOOLS] Add hip support for link.py (#9084)

> * Use the same link cpp scr except hipStrean/CUstream etc.
> * Add a link.h prelude for AMD/Nvidia to adapt for the difference.
> * Enable test_aot.py for AMD.
> * Also rename AMD's compile.cpp to compile.c.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: a0e769fc26e4adefca6522598ab3969b089be45c

Diff Comparison: https://www.internalfb.com/intern/paste/P2283337631/
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1 --no-submit
```

Reviewed By: sfzhu93

Differential Revision: D101982807
