### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[PROTON][TEST] Test proton on tensor descriptor and two-cta mode (#9070)' (#1333)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test-distributed: all
 test-gluon: all
 	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/gluon
 	$(PYTEST) --tb=short -vs python/examples/gluon/01-attention-forward.py
+	$(PYTEST) --tb=short -n $(NUM_PROCS) -vs python/tutorials/gluon
 
 .PHONY: test-regression
 test-regression: all

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -47,8 +47,7 @@ public:
 private:
   std::tuple<Interval<size_t>, const void *, llvm::ArrayRef<int64_t>>
   asTuple() const {
-    return std::make_tuple(allocationInterval, accessTy.getAsOpaquePointer(),
-                           subsliceOffsets);
+    return {allocationInterval, accessTy.getAsOpaquePointer(), subsliceOffsets};
   }
   // Offsets from subslice. Empty when offsets are unknown
   SmallVector<int64_t> subsliceOffsets;

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
@@ -16,10 +16,6 @@ inline bool isFp4Padded(Attribute encoding) {
   return mmaEnc && mmaEnc.getFp4Padded();
 }
 
-SmallVector<Value> translateTMAIndices(OpBuilder &builder, Location loc,
-                                       Attribute encoding,
-                                       SmallVector<Value> indices);
-
 gpu::CGAEncodingAttr updateCGALayoutForShape(gpu::CGAEncodingAttr cgaLayout,
                                              ArrayRef<int64_t> shape);
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -244,15 +244,11 @@ void createTMAAsyncLoad(scf::ForOp forOp, tt::DescriptorLoadOp loadOp,
   return createTMAAsyncCopy(
       forOp, loadOp, loadOp.getDesc(), alloc, insertIdx, extractIdx, barrier,
       waitOp, schedule,
-      [&](OpBuilderForStage &builder, Value tmaPtr, Value barrier, Value view,
+      [&](OpBuilderForStage &builder, Value desc, Value barrier, Value view,
           Value pred) {
-        auto indices = ttng::translateTMAIndices(
-            builder, loadOp.getLoc(),
-            loadOp.getDesc().getType().getBlockType().getEncoding(),
-            loadOp.getIndices());
         ttng::AsyncTMACopyGlobalToLocalOp::create(
-            builder, loadOp.getLoc(), /*multicastTargets*/ Value(), tmaPtr,
-            indices, barrier, view, pred);
+            builder, loadOp.getLoc(), /*multicastTargets*/ Value(), desc,
+            loadOp.getIndices(), barrier, view, pred);
       });
 }
 
@@ -262,10 +258,10 @@ void createTMAAsyncGather(scf::ForOp forOp, tt::DescriptorGatherOp gatherOp,
                           CoarseSchedule &schedule) {
   return createTMAAsyncCopy(forOp, gatherOp, gatherOp.getDesc(), alloc,
                             insertIdx, extractIdx, barrier, waitOp, schedule,
-                            [&](OpBuilderForStage &builder, Value tmaPtr,
+                            [&](OpBuilderForStage &builder, Value desc,
                                 Value barrier, Value view, Value pred) {
                               ttng::AsyncTMAGatherOp::create(
-                                  builder, gatherOp.getLoc(), tmaPtr,
+                                  builder, gatherOp.getLoc(), desc,
                                   gatherOp.getXOffsets(), gatherOp.getYOffset(),
                                   barrier, view, pred);
                             });

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -60,17 +60,9 @@ static void createTMAAsyncCopy(scf::ForOp forOp, const TMAStore &store,
   ttng::FenceAsyncSharedOp::create(builder, loc, false);
   auto desc = store.desc;
   if (auto storeOp = dyn_cast<tt::DescriptorStoreOp>(store.op)) {
-    auto indices = ttng::translateTMAIndices(
-        builder, storeOp.getLoc(),
-        storeOp.getDesc().getType().getBlockType().getEncoding(),
-        storeOp.getIndices());
     ttng::AsyncTMACopyLocalToGlobalOp::create(builder, loc, desc,
                                               storeOp.getIndices(), alloc);
   } else if (auto reduceOp = dyn_cast<tt::DescriptorReduceOp>(store.op)) {
-    auto indices = ttng::translateTMAIndices(
-        builder, reduceOp.getLoc(),
-        reduceOp.getDesc().getType().getBlockType().getEncoding(),
-        reduceOp.getIndices());
     ttng::AsyncTMAReduceOp::create(builder, loc, reduceOp.getKind(), desc,
                                    reduceOp.getIndices(), alloc,
                                    triton::EvictionPolicy::NORMAL);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -2009,10 +2009,25 @@ public:
           }
           continue;
         }
-        // TODO: propagate through scf.yield by updating parent op result
-        // types, scf.for iter_args, and init values to match srcEnc.
-        if (isa<scf::YieldOp>(user))
+        // scf.yield passes values through to the parent op's results.
+        // For ForOp/WhileOp, the parent results are tied to block arguments
+        // and init operands via loop-carried dependencies — in-place type
+        // rewriting cannot safely update all of them, so block propagation.
+        // For IfOp, the results are simple branches with no loop-carried
+        // deps, so propagation is safe if we also follow the IfOp results.
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+          Operation *parent = yieldOp->getParentOp();
+          if (isa<scf::ForOp, scf::WhileOp>(parent))
+            return false;
+          if (auto ifOp = dyn_cast<scf::IfOp>(parent)) {
+            for (Value result : ifOp.getResults()) {
+              if (isa<RankedTensorType>(result.getType()))
+                worklist.push_back(result);
+            }
+            continue;
+          }
           return false;
+        }
         // Any other user (dot, reduce, another convert, etc.) blocks
         // propagation.
         return false;
@@ -2034,6 +2049,7 @@ public:
 
     // Collect all ops that need type rewriting (forward from convert users).
     SmallVector<Operation *> opsToRewrite;
+    SetVector<Operation *> ifOpsToRewrite;
     SmallVector<Value> worklist = {dst};
     DenseSet<Value> visited;
 
@@ -2043,8 +2059,20 @@ public:
         continue;
       for (OpOperand &use : v.getUses()) {
         Operation *user = use.getOwner();
-        if (isa<LocalStoreOp>(user) || isa<scf::YieldOp>(user))
+        if (isa<LocalStoreOp>(user))
           continue;
+        // For scf.yield under scf.if, follow through to the IfOp results.
+        // ForOp/WhileOp yields are blocked by canPropagateSrcEncodingThroughUsers.
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+          if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp())) {
+            ifOpsToRewrite.insert(ifOp.getOperation());
+            for (Value result : ifOp.getResults()) {
+              if (isa<RankedTensorType>(result.getType()))
+                worklist.push_back(result);
+            }
+          }
+          continue;
+        }
         opsToRewrite.push_back(user);
         for (Value result : user->getResults()) {
           if (isa<RankedTensorType>(result.getType()))
@@ -2112,6 +2140,14 @@ public:
         if (auto ty = dyn_cast<RankedTensorType>(result.getType())) {
           if (srcEncRank > 0 && ty.getRank() != srcEncRank)
             continue;
+          result.setType(ty.cloneWithEncoding(srcEnc));
+        }
+      }
+    }
+    // Rewrite IfOp result types that we propagated through.
+    for (Operation *op : ifOpsToRewrite) {
+      for (Value result : op->getResults()) {
+        if (auto ty = dyn_cast<RankedTensorType>(result.getType())) {
           result.setType(ty.cloneWithEncoding(srcEnc));
         }
       }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -348,13 +348,10 @@ static void lowerTMACopy(PartitionBuilder &b, Partition &loadPartition,
                          Value barrier, Value view) {
   Value truePred = b.boolCst(true);
   if (auto load = dyn_cast<DescriptorLoadOp>(op)) {
-    auto indices = ttng::translateTMAIndices(
-        b, load.getLoc(), load.getDesc().getType().getBlockType().getEncoding(),
-        load.getIndices());
     b.createInto<ttng::AsyncTMACopyGlobalToLocalOp>(
         loadPartition, stageCluster,
-        /*multicastTargets*/ Value(), load.getDesc(), indices, barrier, view,
-        truePred);
+        /*multicastTargets*/ Value(), load.getDesc(), load.getIndices(),
+        barrier, view, truePred);
   } else {
     auto gather = cast<DescriptorGatherOp>(op);
     b.createInto<ttng::AsyncTMAGatherOp>(

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -68,14 +68,11 @@ public:
   LogicalResult matchAndRewrite(DescriptorLoadOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto createLoad = [&](Value tmaPtr, Value barrierAlloc, Value alloc,
+    auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred) {
-      auto indices = translateTMAIndices(
-          rewriter, op.getLoc(),
-          op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
       triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
-          rewriter, op.getLoc(), /*multicastTargets*/ Value(), tmaPtr, indices,
-          barrierAlloc, alloc, pred);
+          rewriter, op.getLoc(), /*multicastTargets*/ Value(), desc,
+          op.getIndices(), barrierAlloc, alloc, pred);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
     return success();
@@ -87,10 +84,10 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
 
   LogicalResult matchAndRewrite(DescriptorGatherOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createLoad = [&](Value tmaPtr, Value barrierAlloc, Value alloc,
+    auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred) {
       triton::nvidia_gpu::AsyncTMAGatherOp::create(
-          rewriter, op.getLoc(), tmaPtr, op.getXOffsets(), op.getYOffset(),
+          rewriter, op.getLoc(), desc, op.getXOffsets(), op.getYOffset(),
           barrierAlloc, alloc, pred);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
@@ -148,13 +145,9 @@ struct TMAStoreLowering : public OpRewritePattern<DescriptorStoreOp> {
 
   LogicalResult matchAndRewrite(DescriptorStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createStore = [&](Value tmaPtr, Value alloc) {
-      auto indices = translateTMAIndices(
-          rewriter, op.getLoc(),
-          op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
+    auto createStore = [&](Value desc, Value alloc) {
       triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp::create(
-          rewriter, op.getLoc(), tmaPtr, indices, alloc,
-          triton::EvictionPolicy::NORMAL);
+          rewriter, op.getLoc(), desc, op.getIndices(), alloc);
     };
     lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);
     return success();
@@ -166,13 +159,9 @@ struct TMAReduceLowering : public OpRewritePattern<DescriptorReduceOp> {
 
   LogicalResult matchAndRewrite(DescriptorReduceOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createStore = [&](Value tmaPtr, Value alloc) {
-      auto indices = translateTMAIndices(
-          rewriter, op.getLoc(),
-          op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
+    auto createStore = [&](Value desc, Value alloc) {
       triton::nvidia_gpu::AsyncTMAReduceOp::create(
-          rewriter, op.getLoc(), op.getKind(), tmaPtr, indices, alloc,
-          triton::EvictionPolicy::NORMAL);
+          rewriter, op.getLoc(), op.getKind(), desc, op.getIndices(), alloc);
     };
     lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);
     return success();
@@ -184,9 +173,9 @@ struct TMAScatterLowering : public OpRewritePattern<DescriptorScatterOp> {
 
   LogicalResult matchAndRewrite(DescriptorScatterOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createStore = [&](Value tmaPtr, Value alloc) {
-      triton::nvidia_gpu::AsyncTMAScatterOp::create(rewriter, op.getLoc(),
-                                                    tmaPtr, op.getXOffsets(),
+    auto createStore = [&](Value desc, Value alloc) {
+      triton::nvidia_gpu::AsyncTMAScatterOp::create(rewriter, op.getLoc(), desc,
+                                                    op.getXOffsets(),
                                                     op.getYOffset(), alloc);
     };
     lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -7,16 +7,6 @@ namespace ttg = mlir::triton::gpu;
 
 namespace mlir::triton::nvidia_gpu {
 
-SmallVector<Value> translateTMAIndices(OpBuilder &builder, Location loc,
-                                       Attribute encoding,
-                                       SmallVector<Value> indices) {
-  if (isFp4Padded(encoding)) {
-    auto two = arith::ConstantIntOp::create(builder, loc, 2, 32);
-    indices.back() = arith::MulIOp::create(builder, loc, indices.back(), two);
-  }
-  return indices;
-}
-
 ttg::CGAEncodingAttr updateCGALayoutForShape(ttg::CGAEncodingAttr cgaLayout,
                                              ArrayRef<int64_t> shape) {
   auto rank = shape.size();

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -459,6 +459,8 @@ def test_mxfp(BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device)
             pytest.skip("Scaled mxfp8 matmul is only natively supported on CDNA4 or above")
         if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
+        if (BLOCK_M == 256 or BLOCK_N == 256) and BLOCK_K == 256:
+            pytest.skip("Config requires too much shared memory")
 
     if BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = min(NUM_STAGES, 2)
@@ -1443,6 +1445,8 @@ def test_mxfp8_mxfp4_matmul(
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
         if (A_DATA_TYPE == "float4" and not WITH_A_SCALE) or (B_DATA_TYPE == "float4" and not WITH_B_SCALE):
             pytest.skip("Float4 without scale is tested in test_block_scale_fp4")
+        if (BLOCK_M == 256 or BLOCK_N == 256) and BLOCK_K == 256:
+            pytest.skip("Config requires too much shared memory")
     if not PACK_B_ALONG_K and B_DATA_TYPE != "float4":
         pytest.skip("Pack along K can only be False for float4")
     if BLOCK_N == 256 and BLOCK_K == 256:
@@ -1603,7 +1607,7 @@ def batched_mxfp_matmul(  #
 
 
 @pytest.mark.parametrize("BATCH_SIZE, BLOCK_BATCH_SIZE", [(1, 1), (16, 1), (16, 4)])
-@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 64), (128, 64, 128)])
+@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 64), (128, 64, 128), (64, 64, 128)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 2 if is_hip() else 3])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
 @pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))
@@ -1619,6 +1623,8 @@ def test_batched_mxfp(BATCH_SIZE, BLOCK_BATCH_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, N
             pytest.skip("Scaled mxfp8 matmul is only natively supported on CDNA4 and above")
         if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
+        if is_hip_cdna4() and NUM_STAGES > 1 and max(BLOCK_M, BLOCK_N) > 64:
+            pytest.skip("Config requires too much shared memory")
 
     torch.manual_seed(42)
     dtype_src_str = "float8e5"

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -533,8 +533,8 @@ class amd_knobs(base_knobs):
     # We use strs so that we can have a default value based on other runtime info
     use_block_pingpong: env_opt_bool = env_opt_bool("TRITON_HIP_USE_BLOCK_PINGPONG")
     use_in_thread_transpose: env_opt_bool = env_opt_bool("TRITON_HIP_USE_IN_THREAD_TRANSPOSE")
+    use_async_copy: env_opt_bool = env_opt_bool("TRITON_HIP_USE_ASYNC_COPY")
 
-    use_async_copy: env_bool = env_bool("TRITON_HIP_USE_ASYNC_COPY")
     scalarize_packed_fops: env_bool = env_bool("AMDGCN_SCALARIZE_PACKED_FOPS")
 
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2093,9 +2093,9 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     :param input_precision: How to exercise the Tensor Cores for f32 x f32. If
       the device does not have Tensor Cores or the inputs are not of dtype f32,
       this option is ignored. For devices that do have tensor cores, the
-      default precision is tf32x3.
-    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32x3"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
-    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32x3".
+      default precision is tf32.
+    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
+    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32".
       Only one of :code:`input_precision` and :code:`allow_tf32` can be
       specified (i.e. at least one must be :code:`None`).
     :param attrs: Optional dictionary of string-valued attributes to attach to the dot operation.

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2093,9 +2093,9 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     :param input_precision: How to exercise the Tensor Cores for f32 x f32. If
       the device does not have Tensor Cores or the inputs are not of dtype f32,
       this option is ignored. For devices that do have tensor cores, the
-      default precision is tf32.
-    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
-    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32".
+      default precision is tf32x3.
+    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32x3"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
+    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32x3".
       Only one of :code:`input_precision` and :code:`allow_tf32` can be
       specified (i.e. at least one must be :code:`None`).
     :param attrs: Optional dictionary of string-valued attributes to attach to the dot operation.

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1629,8 +1629,8 @@ class TritonSemantic(Generic[TensorTy]):
         assert input_precision is None or tl._unwrap_if_constexpr(allow_tf32) is None, (
             "Only one of input_precision and allow_tf32 can be specified")
         if input_precision is None:
-            supports_tf32 = "tf32" in self.builder.options.allowed_dot_input_precisions
-            input_precision = knobs.language.fp32_default or ("tf32" if
+            supports_tf32 = "tf32x3" in self.builder.options.allowed_dot_input_precisions
+            input_precision = knobs.language.fp32_default or ("tf32x3" if
                                                               (supports_tf32 and
                                                                (allow_tf32 or allow_tf32 is None)) else "ieee")
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1629,8 +1629,8 @@ class TritonSemantic(Generic[TensorTy]):
         assert input_precision is None or tl._unwrap_if_constexpr(allow_tf32) is None, (
             "Only one of input_precision and allow_tf32 can be specified")
         if input_precision is None:
-            supports_tf32 = "tf32x3" in self.builder.options.allowed_dot_input_precisions
-            input_precision = knobs.language.fp32_default or ("tf32x3" if
+            supports_tf32 = "tf32" in self.builder.options.allowed_dot_input_precisions
+            input_precision = knobs.language.fp32_default or ("tf32" if
                                                               (supports_tf32 and
                                                                (allow_tf32 or allow_tf32 is None)) else "ieee")
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -134,7 +134,7 @@ class InterpreterOptions:
     arch: Optional[str] = None
     supported_fp8_dtypes: Tuple[str, ...] = ("fp8e5", "fp8e5b16", "fp8e4nv", "fp8e4b8", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str, ...] = ()
-    default_dot_input_precision: str = "tf32x3"
+    default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str, ...] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0
     backend_name: str = "interpreter"

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -134,7 +134,7 @@ class InterpreterOptions:
     arch: Optional[str] = None
     supported_fp8_dtypes: Tuple[str, ...] = ("fp8e5", "fp8e5b16", "fp8e4nv", "fp8e4b8", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str, ...] = ()
-    default_dot_input_precision: str = "tf32"
+    default_dot_input_precision: str = "tf32x3"
     allowed_dot_input_precisions: Tuple[str, ...] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0
     backend_name: str = "interpreter"

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -173,6 +173,7 @@ def compile_kernel(args: CompileArgs):
     hex_ = str(binascii.hexlify(asm))[2:-1]
 
     ty_to_cpp = triton.runtime.driver.active.map_python_to_cpp_type
+    backend_name = target.backend
 
     params = {
         "kernel_name": func_name,
@@ -192,9 +193,9 @@ def compile_kernel(args: CompileArgs):
         "gridZ": grid[2],
         "_placeholder": "",
         "warp_size": target.warp_size,
+        "backend_name": backend_name,
     }
     output_files = []
-    backend_name = target.backend
     template_dir = Path(__file__).parent / "extra" / backend_name
     for template_path in template_dir.glob('compile.*'):
         ext = template_path.suffix

--- a/python/triton/tools/link.py
+++ b/python/triton/tools/link.py
@@ -39,8 +39,11 @@ class HeaderParser:
         self.c_sig = re.compile("[\\s]*(\\w+)\\s(\\w+)[,]?")
         # [d|c]
         self.arg_suffix = re.compile("[c,d]")
+        # [backend_name]
+        self.backend_name_re = re.compile("//[\\s]*tt-linker-backend:[\\s]*([\\w]+)")
 
         self.kernels = defaultdict(list)
+        self.backend_name = None
 
     def extract_linker_meta(self, header: str):
         for ln in header.splitlines():
@@ -64,6 +67,14 @@ class HeaderParser:
                             num_specs=num_specs,
                         ),
                     )
+                else:
+                    m = self.backend_name_re.match(ln)
+                    if _exists(m):
+                        backend_name = m.group(1)
+                        if self.backend_name is None:
+                            self.backend_name = backend_name
+                        elif self.backend_name != backend_name:
+                            raise RuntimeError(f"differing backend {self.backend_name} vs. {backend_name}")
 
     def _match_name(self, ker_name: str):
         m = self.kernel_name.match(ker_name)
@@ -135,7 +146,7 @@ def gen_signature(m):
 # generate declarations of kernels with meta-parameter and constant values
 def make_algo_decls(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     return f"""
-CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])});
+TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])});
 void load_{name}();
 void unload_{name}();
     """
@@ -144,8 +155,8 @@ void unload_{name}();
 # generate declarations of kernels with meta-parameter and constant values
 def make_global_decl(meta: KernelLinkerMeta) -> str:
     return f"""
-CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)});
-CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id);
+TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)});
+TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id);
 void load_{meta.orig_kernel_name}();
 void unload_{meta.orig_kernel_name}();
     """
@@ -153,7 +164,7 @@ void unload_{meta.orig_kernel_name}();
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)}){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)}){{\n"
     src += (f"  return {meta.orig_kernel_name}(stream, {', '.join(meta.arg_names)}, 0);\n")
     src += "}\n"
     return src
@@ -163,14 +174,14 @@ def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
 def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     src = f"// launcher for: {name}\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
-        src += f"CUresult {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(CUstream stream, {gen_signature(meta)});\n"
+        src += f"TT_ResultTy {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(TT_StreamTy stream, {gen_signature(meta)});\n"
     src += "\n"
 
-    src += (f"CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])}){{")
+    src += (f"TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])}){{")
     src += "\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
         cond_fn = (  #
-            lambda val, hint: f"({val} % {hint} == 0)"  #
+            lambda val, hint: f"((uintptr_t){val} % {hint} == 0)"  #
             if hint == 16  #
             else f"({val} == {hint})"  #
             if hint == 1  #
@@ -185,7 +196,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
         arg_names = [arg for arg, hint in zip(meta.arg_names, meta.sizes) if hint != 1]
         src += f"    return {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(stream, {', '.join(arg_names)});\n"
     src += "\n"
-    src += "  return CUDA_ERROR_INVALID_VALUE;\n"
+    src += "  return TT_ERROR_INVALID_VALUE;\n"
     src += "}\n"
 
     for mode in ["load", "unload"]:
@@ -202,7 +213,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
     src += f"  assert (algo_id < (int)sizeof({meta.orig_kernel_name}_kernels));\n"
     src += f"  return {meta.orig_kernel_name}_kernels[algo_id](stream, {', '.join(meta.arg_names)});\n"
     src += "}\n"
@@ -212,7 +223,7 @@ def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
 # generate definition of function pointers of kernel dispatchers based on meta-parameter and constant values
 def make_func_pointers(names: str, meta: KernelLinkerMeta) -> str:
     # the table of hint dispatchers
-    src = f"typedef CUresult (*kernel_func_t)(CUstream stream, {gen_signature_with_full_args(meta)});\n"
+    src = f"typedef TT_ResultTy (*kernel_func_t)(TT_StreamTy stream, {gen_signature_with_full_args(meta)});\n"
     src += f"kernel_func_t {meta.orig_kernel_name}_kernels[] = {{\n"
     for name in names:
         src += f"  {name},\n"
@@ -287,8 +298,9 @@ if __name__ == "__main__":
     meta = meta_lists[0][0]
     get_num_algos_decl = make_get_num_algos_decl(meta)
     global_decl = make_global_decl(meta)
+    backend_prelude = (Path(__file__).parent / "extra" / parser.backend_name / "link.h").read_text()
     with args.out.with_suffix(".h").open("w") as fp:
-        out = "#include <cuda.h>\n"
+        out = backend_prelude
         out += "\n".join(algo_decls)
         out += "\n"
         out += get_num_algos_decl
@@ -305,8 +317,7 @@ if __name__ == "__main__":
     get_num_algos_def = make_get_num_algos_def(meta)
     default_algo_kernel = make_default_algo_kernel(meta)
     with args.out.with_suffix(".c").open("w") as fp:
-        out = ""
-        out += "#include <cuda.h>\n"
+        out = backend_prelude
         out += "#include <stdint.h>\n"
         out += "#include <assert.h>\n"
         out += "\n"

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -129,13 +129,12 @@ def make_default_opt_flags_amd(
         num_stages = 1
 
     # specific configs for F16 x MXFP4 on CDNA4
-    # Note that these configs will exceed LDS usage with async copy enabled
     if is_cdna4 and bitwidth(lhs_dtype) == 16 and bitwidth(rhs_dtype) == 4 and precision_config.b_mx_scale is not None:
         split_k = 1
         if m <= 1024:
             target_kernel_kwargs["waves_per_eu"] = 3
             block_n = 128
-            block_k = 256
+            block_k = 128
             num_warps = 4
         else:
             target_kernel_kwargs["waves_per_eu"] = 0

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_amd.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_amd.py
@@ -14,14 +14,12 @@ def compute_block_nk(n, block_m, grid_m, num_xcds, lhs_dtype, rhs_dtype, precisi
         if n <= 128 and (n & (n - 1)) == 0:
             block_n = n
         else:
-            block_n = max(32, min(256, triton.next_power_of_2(grid_m * n * num_xcds // n_cu)))
+            max_n = 64 if get_cdna_version() == 4 else 256
+            block_n = max(32, min(max_n, triton.next_power_of_2(grid_m * n * num_xcds // n_cu)))
     elif block_m > 64:
         block_n = 256
     else:
         block_n = 128
-
-    if get_cdna_version() == 4 and block_m == 128:
-        block_n = 512
 
     if get_rdna_version() in (3, 4) and block_m == 64:
         block_n = 256

--- a/test/Proton/allocate_shared_memory.mlir
+++ b/test/Proton/allocate_shared_memory.mlir
@@ -20,6 +20,26 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 
 // -----
 
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0], CGALayout = [[1, 0]]}>
+// CHECK: ttg.shared = 832 : i32
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 2 : i32} {
+  // CHECK-LABEL: allocate_aligned
+  tt.func @allocate_aligned(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record start "name0"
+  %cst1 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst2 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst1 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record end "name0"
+  ttg.local_dealloc %cst2 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // CHECK: ttg.local_alloc  {allocation.offset = 768 : i32}
+  tt.return
+  }
+}
+
+// -----
+
 #A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
 // CHECK: ttg.shared = 64 : i32
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -19,12 +19,16 @@ def get_min_dot_size(target: GPUTarget):
 
 
 def is_pingpong_schedule_enabled(arch, use_async_copy):
-    return (arch == "gfx942" or (arch == "gfx950" and use_async_copy is True)
-            ) if knobs.amd.use_block_pingpong is None else knobs.amd.use_block_pingpong
+    return (arch == "gfx942" or (arch == "gfx950" and use_async_copy is True)) \
+        if knobs.amd.use_block_pingpong is None else knobs.amd.use_block_pingpong
 
 
 def is_in_thread_transpose_enabled(arch):
     return (arch == "gfx942") if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
+
+
+def is_async_copy_enabled(arch):
+    return (arch in ["gfx950", "gfx1250"]) if knobs.amd.use_async_copy is None else knobs.amd.use_async_copy
 
 
 @dataclass(frozen=True)
@@ -241,7 +245,7 @@ class HIPBackend(BaseBackend):
         passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)
 
-        use_async_copy = knobs.amd.use_async_copy
+        use_async_copy = is_async_copy_enabled(options.arch)
         use_block_pingpong = is_pingpong_schedule_enabled(options.arch, use_async_copy)
 
         amd.passes.ttgpuir.add_schedule_loops(pm, options.num_stages)

--- a/third_party/amd/tools/hip/compile.c
+++ b/third_party/amd/tools/hip/compile.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
+#define __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
 
 // helpers to check for hip errors
@@ -28,8 +29,8 @@ static inline void gpuAssert(hipError_t code, const char *file, int line) {{
 
 // globals
 #define HSACO_NAME {kernel_name}_hsaco
-hipModule_t {kernel_name}_mod = nullptr;
-hipFunction_t {kernel_name}_func = nullptr;
+hipModule_t {kernel_name}_mod = NULL;
+hipFunction_t {kernel_name}_func = NULL;
 unsigned char HSACO_NAME[{bin_size}] = {{ {bin_data} }};
 
 
@@ -50,7 +51,7 @@ void load_{kernel_name}() {{
 {kernel_docstring}
 */
 hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
-    if ({kernel_name}_func == nullptr)
+    if ({kernel_name}_func == NULL)
        load_{kernel_name}();
     unsigned int gX = {gridX};
     unsigned int gY = {gridY};
@@ -61,7 +62,7 @@ hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
 
     // TODO: shared memory
     if(gX * gY * gZ > 0)
-      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, nullptr);
+      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, NULL);
     else
       return hipErrorInvalidValue;
 }}

--- a/third_party/amd/tools/hip/compile.h
+++ b/third_party/amd/tools/hip/compile.h
@@ -3,11 +3,16 @@
 
 #pragma once
 
+#define __HIP_PLATFORM_AMD__
+
 #include <hip/hip_runtime.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
+// tt-linker: {kernel_name}:{full_signature}:{algo_info}
 hipError_t{_placeholder} {kernel_name}(hipStream_t stream, {signature});

--- a/third_party/amd/tools/hip/link.h
+++ b/third_party/amd/tools/hip/link.h
@@ -1,0 +1,14 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#define __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+
+typedef hipStream_t TT_StreamTy;
+typedef hipError_t TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE hipErrorInvalidValue
+
+#endif

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -474,7 +474,9 @@ class CUDABackend(BaseBackend):
         # Budget-aware layout conversion elimination — runs last to ensure
         # converts whose scratch would exceed SMEM budget are eliminated
         # after all other passes that may introduce layout conversions.
-        passes.ttgpuir.add_remove_layout_conversions(pm, smem_budget)
+        # TODO(njriasan): Re-enable once propagateSrcEncodingAndErase handles
+        # scf::ForOp/WhileOp loop-carried values correctly.
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -360,7 +360,6 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     builder.setLoopScheduleInfoFromOp(tmaLoad);
     auto pipelineBuffer = getBufferForPipelineStage(builder, tmaLoad.getType(),
                                                     buffer, bufferIdx, true);
-    // FIXME: translateTMAIndices
     copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(
         loc, /*multicastTargets*/ Value(), tmaLoad.getDesc(),
         tmaLoad.getIndices(), prodBarrier, pipelineBuffer, pred);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -61,15 +61,11 @@ void doTMAStoreLowering(triton::FuncOp &funcOp) {
 
     auto alloc = builder.create<ttg::LocalAllocOp>(loc, memDescType, src);
 
-    // Translate indices for TMA.
-    auto indices = ttng::translateTMAIndices(
-        builder, loc, desc.getType().getBlockType().getEncoding(),
-        storeOp.getIndices());
-
     // Async TMA copy from local (SMEM) to global, producing a token.
     auto tokenType = ttg::AsyncTokenType::get(ctx);
     auto tmaStore = builder.create<ttng::AsyncTMACopyLocalToGlobalOp>(
-        loc, tokenType, desc, indices, alloc, tt::EvictionPolicy::NORMAL);
+        loc, tokenType, desc, storeOp.getIndices(), alloc,
+        tt::EvictionPolicy::NORMAL);
     copyLoopScheduleAttrs(storeOp, tmaStore);
 
     // Wait for this specific TMA store to finish reading from SMEM.

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -286,28 +286,9 @@ getSubViews(ArefValue arefVal, Value stage, Location loc, OpBuilder &rewriter,
 
 void createTMALoad(triton::nvws::DescriptorLoadOp op, PatternRewriter &rewriter,
                    Value barrierAlloc, Value pred) {
-  auto indices = translateTMAIndices(
-      rewriter, op.getLoc(),
-      op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
-  for (auto [newIdx, oldIdx] : llvm::zip(indices, op.getIndices())) {
-    // translateTMAIndices may create ops, we need to annotated them
-    if (newIdx != oldIdx) {
-      auto partitionIds = getPartitionWsTagIds(op);
-      auto stageCluster = getStageCluster(op);
-      assignStageCluster(newIdx.getDefiningOp(), partitionIds, stageCluster,
-                         rewriter);
-      for (auto val : newIdx.getDefiningOp()->getOperands()) {
-        if (auto op = val.getDefiningOp()) {
-          if (!hasPartition(op)) {
-            assignStageCluster(op, partitionIds, stageCluster, rewriter);
-          }
-        }
-      }
-    }
-  }
   auto newLoadOp = triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
       rewriter, op.getLoc(), /*multicastTargets*/ Value(), op.getDesc(),
-      indices, barrierAlloc, op.getResult(), pred);
+      op.getIndices(), barrierAlloc, op.getResult(), pred);
   assignStageCluster(newLoadOp, getPartitionWsTagIds(op), getStageCluster(op),
                      rewriter);
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1508,10 +1508,16 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       auto offsets = applyLinearLayout(loc, rewriter, msgToOffset,
                                        {{kMsg, copyIdxVal}, {kBlock, ctaId}});
       int operandIdx = 3;
+      auto encoding = op.getDesc().getType().getBlockType().getEncoding();
+      bool fp4Padded = nvidia_gpu::isFp4Padded(encoding);
       for (int i = 0; i < rank; i++) {
         Value coord = adaptor.getCoord()[rank - i - 1];
+        if (fp4Padded && i == 0) {
+          coord = b.mul(coord, b.i32_val(2));
+        }
         if (i < offsets.size())
           coord = b.add(coord, offsets[offsets.size() - i - 1].second);
+
         operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
         tmaInst += "$" + std::to_string(operandIdx++);
         if (i != rank - 1)
@@ -1711,8 +1717,12 @@ convertTMAStoreLikeOp(Operation *op, const TypeConverter *typeConverter,
 
     auto offsets = applyLinearLayout(loc, rewriter, msgToOffset,
                                      {{kMsg, copyIdxVal}, {kBlock, ctaId}});
+    bool fp4Padded = nvidia_gpu::isFp4Padded(srcTy.getEncoding());
     for (int i = 0; i < rank; i++) {
       Value coord = coords[rank - i - 1];
+      if (fp4Padded && i == 0) {
+        coord = b.mul(coord, b.i32_val(2));
+      }
       if (i < offsets.size())
         coord = b.add(coord, offsets[offsets.size() - i - 1].second);
       operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
@@ -1890,8 +1900,11 @@ static LogicalResult iterateGatherScatterIndices(
     return op->emitError("memdesc shape must match alloc shape");
   // `NVMMASharedEncodingAttr` means the core matrix tiles are placed next to
   // each other in shared memory, which lines up with how `gather4` loads data.
-  if (!isa<NVMMASharedEncodingAttr>(smemType.getEncoding()))
+  auto enc = dyn_cast<NVMMASharedEncodingAttr>(smemType.getEncoding());
+  if (!enc)
     return op->emitError("requires dst encoding NVMMASharedEncodingAttr");
+  if (enc.getFp4Padded())
+    yOffsetValue = b.mul(yOffsetValue, b.i32_val(2));
   Type llvmElemTy = typeConverter.convertType(smemType.getElementType());
   Type elemPtrTy = ptr_ty(ctx, /*addrspace=*/3);
   auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, smemObjValue,

--- a/third_party/nvidia/tools/cuda/compile.h
+++ b/third_party/nvidia/tools/cuda/compile.h
@@ -8,6 +8,8 @@
 
 #endif
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
 // tt-linker: {kernel_name}:{full_signature}:{algo_info}

--- a/third_party/nvidia/tools/cuda/link.h
+++ b/third_party/nvidia/tools/cuda/link.h
@@ -1,0 +1,13 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#include <cuda.h>
+
+typedef CUstream TT_StreamTy;
+typedef CUresult TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE CUDA_ERROR_INVALID_VALUE
+
+#endif

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -1,7 +1,7 @@
 import json
 import pathlib
 
-from typing import NamedTuple, Tuple
+from typing import NamedTuple, Tuple, Optional
 
 import triton.profiler as proton
 
@@ -10,7 +10,6 @@ import torch
 
 import triton
 import triton.language as tl
-import triton.language.semantic
 import triton.profiler.language as pl
 from triton._internal_testing import (
     is_cuda,
@@ -973,3 +972,66 @@ def test_threaded_kernel_call(tmp_path: pathlib.Path):
         assert len(events) > 0
         kernel_events = [e for e in events if e["name"] == "kernel"]
         assert len(kernel_events) > 0
+
+
+@pytest.mark.parametrize("num_ctas", [1, 2])
+def test_tensor_descriptor(num_ctas, tmp_path: pathlib.Path):
+    if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
+        pytest.skip("CTAs is unsupported for these cards")
+
+    @triton.jit
+    def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[M, N],
+            strides=[N, 1],
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+
+        assert desc.shape[0] == M
+        assert desc.shape[1] == N
+        assert desc.strides[0] == N
+        assert desc.strides[1] == 1
+        assert desc.block_shape == [M_BLOCK, N_BLOCK]
+        pl.enter_scope("load_block")
+        block = desc.load([M_BLOCK, 2 * N_BLOCK])
+        pl.exit_scope("load_block")
+        idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+        tl.store(out_ptr + idx, block)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        assert size == 128 * num_ctas
+        assert align == 128
+        assert stream == 0
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+
+    M_BLOCK = 4
+    N_BLOCK = 4
+    M, N = M_BLOCK * 3, N_BLOCK * 4
+    inp = torch.randn((M, N), device="cuda", dtype=torch.float32)
+    out = inp.new_empty((M_BLOCK, N_BLOCK))
+
+    temp_file = tmp_path / "test_tensor_descriptor.chrome_trace"
+    proton.start(str(temp_file.with_suffix("")), backend="instrumentation", data="trace")
+
+    kernel[(1, )](out, inp, M, N, M_BLOCK, N_BLOCK, num_ctas=num_ctas)
+    expect = inp[1 * M_BLOCK:2 * M_BLOCK, 2 * N_BLOCK:3 * N_BLOCK]
+    torch.testing.assert_close(expect, out)
+
+    proton.finalize()
+
+    with temp_file.open() as f:
+        data = json.load(f)
+        trace_events = data["traceEvents"]
+        if num_ctas == 1:
+            assert len(trace_events) == 4
+            num_cta0_events = sum(1 for e in trace_events if "CTA0" in e["pid"])
+            assert num_cta0_events == 4
+        else:
+            assert len(trace_events) == 8
+            num_cta0_events = sum(1 for e in trace_events if "CTA0" in e["pid"])
+            num_cta1_events = sum(1 for e in trace_events if "CTA1" in e["pid"])
+            assert num_cta0_events == 4
+            assert num_cta1_events == 4


### PR DESCRIPTION
Summary:

This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9070

Upstream commit message:
```
> [PROTON][TEST] Test proton on tensor descriptor and two-cta mode (#9070)
```

Conflict Resolution:
- File: third_party/proton/test/test_instrumentation.py
  Action: Removed conflict markers; deleted the local "import triton.language.semantic" line and dropped the duplicate "import triton.profiler as proton" line that the upstream patch tried to insert.
  Reason: Locally "import triton.profiler as proton" was moved earlier in the file (before pytest/torch). Upstream removes "import triton.language.semantic" at the original position; we apply that intent and avoid duplicating the proton import.

Raw Conflicts: https://www.internalfb.com/intern/paste/P2283344021/
Resolution Diff: https://www.internalfb.com/intern/paste/P2283344580/
Diff Comparison: https://www.internalfb.com/intern/paste/P2283345055/

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: f40d53eef39fc6c2c23dbaef4b498fd22034acdd

Reviewed By: sfzhu93

Differential Revision: D101982802
