### PR TITLE
[triton][beta] [Cherry-pick] '[Kernels] Fix hopper mxfp4 swizzled kernels for num_warps=4 (#9029)'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test-distributed: all
 test-gluon: all
 	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/gluon
 	$(PYTEST) --tb=short -vs python/examples/gluon/01-attention-forward.py
+	$(PYTEST) --tb=short -n $(NUM_PROCS) -vs python/tutorials/gluon
 
 .PHONY: test-regression
 test-regression: all

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -47,8 +47,7 @@ public:
 private:
   std::tuple<Interval<size_t>, const void *, llvm::ArrayRef<int64_t>>
   asTuple() const {
-    return std::make_tuple(allocationInterval, accessTy.getAsOpaquePointer(),
-                           subsliceOffsets);
+    return {allocationInterval, accessTy.getAsOpaquePointer(), subsliceOffsets};
   }
   // Offsets from subslice. Empty when offsets are unknown
   SmallVector<int64_t> subsliceOffsets;

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
@@ -16,10 +16,6 @@ inline bool isFp4Padded(Attribute encoding) {
   return mmaEnc && mmaEnc.getFp4Padded();
 }
 
-SmallVector<Value> translateTMAIndices(OpBuilder &builder, Location loc,
-                                       Attribute encoding,
-                                       SmallVector<Value> indices);
-
 gpu::CGAEncodingAttr updateCGALayoutForShape(gpu::CGAEncodingAttr cgaLayout,
                                              ArrayRef<int64_t> shape);
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -244,15 +244,11 @@ void createTMAAsyncLoad(scf::ForOp forOp, tt::DescriptorLoadOp loadOp,
   return createTMAAsyncCopy(
       forOp, loadOp, loadOp.getDesc(), alloc, insertIdx, extractIdx, barrier,
       waitOp, schedule,
-      [&](OpBuilderForStage &builder, Value tmaPtr, Value barrier, Value view,
+      [&](OpBuilderForStage &builder, Value desc, Value barrier, Value view,
           Value pred) {
-        auto indices = ttng::translateTMAIndices(
-            builder, loadOp.getLoc(),
-            loadOp.getDesc().getType().getBlockType().getEncoding(),
-            loadOp.getIndices());
         ttng::AsyncTMACopyGlobalToLocalOp::create(
-            builder, loadOp.getLoc(), /*multicastTargets*/ Value(), tmaPtr,
-            indices, barrier, view, pred);
+            builder, loadOp.getLoc(), /*multicastTargets*/ Value(), desc,
+            loadOp.getIndices(), barrier, view, pred);
       });
 }
 
@@ -262,10 +258,10 @@ void createTMAAsyncGather(scf::ForOp forOp, tt::DescriptorGatherOp gatherOp,
                           CoarseSchedule &schedule) {
   return createTMAAsyncCopy(forOp, gatherOp, gatherOp.getDesc(), alloc,
                             insertIdx, extractIdx, barrier, waitOp, schedule,
-                            [&](OpBuilderForStage &builder, Value tmaPtr,
+                            [&](OpBuilderForStage &builder, Value desc,
                                 Value barrier, Value view, Value pred) {
                               ttng::AsyncTMAGatherOp::create(
-                                  builder, gatherOp.getLoc(), tmaPtr,
+                                  builder, gatherOp.getLoc(), desc,
                                   gatherOp.getXOffsets(), gatherOp.getYOffset(),
                                   barrier, view, pred);
                             });

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -60,17 +60,9 @@ static void createTMAAsyncCopy(scf::ForOp forOp, const TMAStore &store,
   ttng::FenceAsyncSharedOp::create(builder, loc, false);
   auto desc = store.desc;
   if (auto storeOp = dyn_cast<tt::DescriptorStoreOp>(store.op)) {
-    auto indices = ttng::translateTMAIndices(
-        builder, storeOp.getLoc(),
-        storeOp.getDesc().getType().getBlockType().getEncoding(),
-        storeOp.getIndices());
     ttng::AsyncTMACopyLocalToGlobalOp::create(builder, loc, desc,
                                               storeOp.getIndices(), alloc);
   } else if (auto reduceOp = dyn_cast<tt::DescriptorReduceOp>(store.op)) {
-    auto indices = ttng::translateTMAIndices(
-        builder, reduceOp.getLoc(),
-        reduceOp.getDesc().getType().getBlockType().getEncoding(),
-        reduceOp.getIndices());
     ttng::AsyncTMAReduceOp::create(builder, loc, reduceOp.getKind(), desc,
                                    reduceOp.getIndices(), alloc,
                                    triton::EvictionPolicy::NORMAL);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -2009,10 +2009,25 @@ public:
           }
           continue;
         }
-        // TODO: propagate through scf.yield by updating parent op result
-        // types, scf.for iter_args, and init values to match srcEnc.
-        if (isa<scf::YieldOp>(user))
+        // scf.yield passes values through to the parent op's results.
+        // For ForOp/WhileOp, the parent results are tied to block arguments
+        // and init operands via loop-carried dependencies — in-place type
+        // rewriting cannot safely update all of them, so block propagation.
+        // For IfOp, the results are simple branches with no loop-carried
+        // deps, so propagation is safe if we also follow the IfOp results.
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+          Operation *parent = yieldOp->getParentOp();
+          if (isa<scf::ForOp, scf::WhileOp>(parent))
+            return false;
+          if (auto ifOp = dyn_cast<scf::IfOp>(parent)) {
+            for (Value result : ifOp.getResults()) {
+              if (isa<RankedTensorType>(result.getType()))
+                worklist.push_back(result);
+            }
+            continue;
+          }
           return false;
+        }
         // Any other user (dot, reduce, another convert, etc.) blocks
         // propagation.
         return false;
@@ -2034,6 +2049,7 @@ public:
 
     // Collect all ops that need type rewriting (forward from convert users).
     SmallVector<Operation *> opsToRewrite;
+    SetVector<Operation *> ifOpsToRewrite;
     SmallVector<Value> worklist = {dst};
     DenseSet<Value> visited;
 
@@ -2043,8 +2059,20 @@ public:
         continue;
       for (OpOperand &use : v.getUses()) {
         Operation *user = use.getOwner();
-        if (isa<LocalStoreOp>(user) || isa<scf::YieldOp>(user))
+        if (isa<LocalStoreOp>(user))
           continue;
+        // For scf.yield under scf.if, follow through to the IfOp results.
+        // ForOp/WhileOp yields are blocked by canPropagateSrcEncodingThroughUsers.
+        if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+          if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp())) {
+            ifOpsToRewrite.insert(ifOp.getOperation());
+            for (Value result : ifOp.getResults()) {
+              if (isa<RankedTensorType>(result.getType()))
+                worklist.push_back(result);
+            }
+          }
+          continue;
+        }
         opsToRewrite.push_back(user);
         for (Value result : user->getResults()) {
           if (isa<RankedTensorType>(result.getType()))
@@ -2112,6 +2140,14 @@ public:
         if (auto ty = dyn_cast<RankedTensorType>(result.getType())) {
           if (srcEncRank > 0 && ty.getRank() != srcEncRank)
             continue;
+          result.setType(ty.cloneWithEncoding(srcEnc));
+        }
+      }
+    }
+    // Rewrite IfOp result types that we propagated through.
+    for (Operation *op : ifOpsToRewrite) {
+      for (Value result : op->getResults()) {
+        if (auto ty = dyn_cast<RankedTensorType>(result.getType())) {
           result.setType(ty.cloneWithEncoding(srcEnc));
         }
       }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -348,13 +348,10 @@ static void lowerTMACopy(PartitionBuilder &b, Partition &loadPartition,
                          Value barrier, Value view) {
   Value truePred = b.boolCst(true);
   if (auto load = dyn_cast<DescriptorLoadOp>(op)) {
-    auto indices = ttng::translateTMAIndices(
-        b, load.getLoc(), load.getDesc().getType().getBlockType().getEncoding(),
-        load.getIndices());
     b.createInto<ttng::AsyncTMACopyGlobalToLocalOp>(
         loadPartition, stageCluster,
-        /*multicastTargets*/ Value(), load.getDesc(), indices, barrier, view,
-        truePred);
+        /*multicastTargets*/ Value(), load.getDesc(), load.getIndices(),
+        barrier, view, truePred);
   } else {
     auto gather = cast<DescriptorGatherOp>(op);
     b.createInto<ttng::AsyncTMAGatherOp>(

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -68,14 +68,11 @@ public:
   LogicalResult matchAndRewrite(DescriptorLoadOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto createLoad = [&](Value tmaPtr, Value barrierAlloc, Value alloc,
+    auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred) {
-      auto indices = translateTMAIndices(
-          rewriter, op.getLoc(),
-          op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
       triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
-          rewriter, op.getLoc(), /*multicastTargets*/ Value(), tmaPtr, indices,
-          barrierAlloc, alloc, pred);
+          rewriter, op.getLoc(), /*multicastTargets*/ Value(), desc,
+          op.getIndices(), barrierAlloc, alloc, pred);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
     return success();
@@ -87,10 +84,10 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
 
   LogicalResult matchAndRewrite(DescriptorGatherOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createLoad = [&](Value tmaPtr, Value barrierAlloc, Value alloc,
+    auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred) {
       triton::nvidia_gpu::AsyncTMAGatherOp::create(
-          rewriter, op.getLoc(), tmaPtr, op.getXOffsets(), op.getYOffset(),
+          rewriter, op.getLoc(), desc, op.getXOffsets(), op.getYOffset(),
           barrierAlloc, alloc, pred);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
@@ -148,13 +145,9 @@ struct TMAStoreLowering : public OpRewritePattern<DescriptorStoreOp> {
 
   LogicalResult matchAndRewrite(DescriptorStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createStore = [&](Value tmaPtr, Value alloc) {
-      auto indices = translateTMAIndices(
-          rewriter, op.getLoc(),
-          op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
+    auto createStore = [&](Value desc, Value alloc) {
       triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp::create(
-          rewriter, op.getLoc(), tmaPtr, indices, alloc,
-          triton::EvictionPolicy::NORMAL);
+          rewriter, op.getLoc(), desc, op.getIndices(), alloc);
     };
     lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);
     return success();
@@ -166,13 +159,9 @@ struct TMAReduceLowering : public OpRewritePattern<DescriptorReduceOp> {
 
   LogicalResult matchAndRewrite(DescriptorReduceOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createStore = [&](Value tmaPtr, Value alloc) {
-      auto indices = translateTMAIndices(
-          rewriter, op.getLoc(),
-          op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
+    auto createStore = [&](Value desc, Value alloc) {
       triton::nvidia_gpu::AsyncTMAReduceOp::create(
-          rewriter, op.getLoc(), op.getKind(), tmaPtr, indices, alloc,
-          triton::EvictionPolicy::NORMAL);
+          rewriter, op.getLoc(), op.getKind(), desc, op.getIndices(), alloc);
     };
     lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);
     return success();
@@ -184,9 +173,9 @@ struct TMAScatterLowering : public OpRewritePattern<DescriptorScatterOp> {
 
   LogicalResult matchAndRewrite(DescriptorScatterOp op,
                                 PatternRewriter &rewriter) const override {
-    auto createStore = [&](Value tmaPtr, Value alloc) {
-      triton::nvidia_gpu::AsyncTMAScatterOp::create(rewriter, op.getLoc(),
-                                                    tmaPtr, op.getXOffsets(),
+    auto createStore = [&](Value desc, Value alloc) {
+      triton::nvidia_gpu::AsyncTMAScatterOp::create(rewriter, op.getLoc(), desc,
+                                                    op.getXOffsets(),
                                                     op.getYOffset(), alloc);
     };
     lowerTMAStore(op, op.getSrc(), op.getDesc(), createStore, rewriter);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -7,16 +7,6 @@ namespace ttg = mlir::triton::gpu;
 
 namespace mlir::triton::nvidia_gpu {
 
-SmallVector<Value> translateTMAIndices(OpBuilder &builder, Location loc,
-                                       Attribute encoding,
-                                       SmallVector<Value> indices) {
-  if (isFp4Padded(encoding)) {
-    auto two = arith::ConstantIntOp::create(builder, loc, 2, 32);
-    indices.back() = arith::MulIOp::create(builder, loc, indices.back(), two);
-  }
-  return indices;
-}
-
 ttg::CGAEncodingAttr updateCGALayoutForShape(ttg::CGAEncodingAttr cgaLayout,
                                              ArrayRef<int64_t> shape) {
   auto rank = shape.size();

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -459,6 +459,8 @@ def test_mxfp(BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device)
             pytest.skip("Scaled mxfp8 matmul is only natively supported on CDNA4 or above")
         if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
+        if (BLOCK_M == 256 or BLOCK_N == 256) and BLOCK_K == 256:
+            pytest.skip("Config requires too much shared memory")
 
     if BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = min(NUM_STAGES, 2)
@@ -1443,6 +1445,8 @@ def test_mxfp8_mxfp4_matmul(
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
         if (A_DATA_TYPE == "float4" and not WITH_A_SCALE) or (B_DATA_TYPE == "float4" and not WITH_B_SCALE):
             pytest.skip("Float4 without scale is tested in test_block_scale_fp4")
+        if (BLOCK_M == 256 or BLOCK_N == 256) and BLOCK_K == 256:
+            pytest.skip("Config requires too much shared memory")
     if not PACK_B_ALONG_K and B_DATA_TYPE != "float4":
         pytest.skip("Pack along K can only be False for float4")
     if BLOCK_N == 256 and BLOCK_K == 256:
@@ -1603,7 +1607,7 @@ def batched_mxfp_matmul(  #
 
 
 @pytest.mark.parametrize("BATCH_SIZE, BLOCK_BATCH_SIZE", [(1, 1), (16, 1), (16, 4)])
-@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 64), (128, 64, 128)])
+@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 64), (128, 64, 128), (64, 64, 128)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 2 if is_hip() else 3])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
 @pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))
@@ -1619,6 +1623,8 @@ def test_batched_mxfp(BATCH_SIZE, BLOCK_BATCH_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, N
             pytest.skip("Scaled mxfp8 matmul is only natively supported on CDNA4 and above")
         if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
+        if is_hip_cdna4() and NUM_STAGES > 1 and max(BLOCK_M, BLOCK_N) > 64:
+            pytest.skip("Config requires too much shared memory")
 
     torch.manual_seed(42)
     dtype_src_str = "float8e5"

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -533,8 +533,8 @@ class amd_knobs(base_knobs):
     # We use strs so that we can have a default value based on other runtime info
     use_block_pingpong: env_opt_bool = env_opt_bool("TRITON_HIP_USE_BLOCK_PINGPONG")
     use_in_thread_transpose: env_opt_bool = env_opt_bool("TRITON_HIP_USE_IN_THREAD_TRANSPOSE")
+    use_async_copy: env_opt_bool = env_opt_bool("TRITON_HIP_USE_ASYNC_COPY")
 
-    use_async_copy: env_bool = env_bool("TRITON_HIP_USE_ASYNC_COPY")
     scalarize_packed_fops: env_bool = env_bool("AMDGCN_SCALARIZE_PACKED_FOPS")
 
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2093,9 +2093,9 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     :param input_precision: How to exercise the Tensor Cores for f32 x f32. If
       the device does not have Tensor Cores or the inputs are not of dtype f32,
       this option is ignored. For devices that do have tensor cores, the
-      default precision is tf32x3.
-    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32x3"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
-    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32x3".
+      default precision is tf32.
+    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
+    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32".
       Only one of :code:`input_precision` and :code:`allow_tf32` can be
       specified (i.e. at least one must be :code:`None`).
     :param attrs: Optional dictionary of string-valued attributes to attach to the dot operation.

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2093,9 +2093,9 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     :param input_precision: How to exercise the Tensor Cores for f32 x f32. If
       the device does not have Tensor Cores or the inputs are not of dtype f32,
       this option is ignored. For devices that do have tensor cores, the
-      default precision is tf32.
-    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
-    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32".
+      default precision is tf32x3.
+    :type input_precision: string. Available options for nvidia: :code:`"tf32"`, :code:`"tf32x3"`, :code:`"ieee"`. Default: :code:`"tf32x3"`. Available options for amd: :code:`"ieee"`, (CDNA3 only) :code:`"tf32"`.
+    :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32x3".
       Only one of :code:`input_precision` and :code:`allow_tf32` can be
       specified (i.e. at least one must be :code:`None`).
     :param attrs: Optional dictionary of string-valued attributes to attach to the dot operation.

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1629,8 +1629,8 @@ class TritonSemantic(Generic[TensorTy]):
         assert input_precision is None or tl._unwrap_if_constexpr(allow_tf32) is None, (
             "Only one of input_precision and allow_tf32 can be specified")
         if input_precision is None:
-            supports_tf32 = "tf32" in self.builder.options.allowed_dot_input_precisions
-            input_precision = knobs.language.fp32_default or ("tf32" if
+            supports_tf32 = "tf32x3" in self.builder.options.allowed_dot_input_precisions
+            input_precision = knobs.language.fp32_default or ("tf32x3" if
                                                               (supports_tf32 and
                                                                (allow_tf32 or allow_tf32 is None)) else "ieee")
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1629,8 +1629,8 @@ class TritonSemantic(Generic[TensorTy]):
         assert input_precision is None or tl._unwrap_if_constexpr(allow_tf32) is None, (
             "Only one of input_precision and allow_tf32 can be specified")
         if input_precision is None:
-            supports_tf32 = "tf32x3" in self.builder.options.allowed_dot_input_precisions
-            input_precision = knobs.language.fp32_default or ("tf32x3" if
+            supports_tf32 = "tf32" in self.builder.options.allowed_dot_input_precisions
+            input_precision = knobs.language.fp32_default or ("tf32" if
                                                               (supports_tf32 and
                                                                (allow_tf32 or allow_tf32 is None)) else "ieee")
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -134,7 +134,7 @@ class InterpreterOptions:
     arch: Optional[str] = None
     supported_fp8_dtypes: Tuple[str, ...] = ("fp8e5", "fp8e5b16", "fp8e4nv", "fp8e4b8", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str, ...] = ()
-    default_dot_input_precision: str = "tf32x3"
+    default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str, ...] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0
     backend_name: str = "interpreter"

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -134,7 +134,7 @@ class InterpreterOptions:
     arch: Optional[str] = None
     supported_fp8_dtypes: Tuple[str, ...] = ("fp8e5", "fp8e5b16", "fp8e4nv", "fp8e4b8", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str, ...] = ()
-    default_dot_input_precision: str = "tf32"
+    default_dot_input_precision: str = "tf32x3"
     allowed_dot_input_precisions: Tuple[str, ...] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0
     backend_name: str = "interpreter"

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -173,6 +173,7 @@ def compile_kernel(args: CompileArgs):
     hex_ = str(binascii.hexlify(asm))[2:-1]
 
     ty_to_cpp = triton.runtime.driver.active.map_python_to_cpp_type
+    backend_name = target.backend
 
     params = {
         "kernel_name": func_name,
@@ -192,9 +193,9 @@ def compile_kernel(args: CompileArgs):
         "gridZ": grid[2],
         "_placeholder": "",
         "warp_size": target.warp_size,
+        "backend_name": backend_name,
     }
     output_files = []
-    backend_name = target.backend
     template_dir = Path(__file__).parent / "extra" / backend_name
     for template_path in template_dir.glob('compile.*'):
         ext = template_path.suffix

--- a/python/triton/tools/link.py
+++ b/python/triton/tools/link.py
@@ -39,8 +39,11 @@ class HeaderParser:
         self.c_sig = re.compile("[\\s]*(\\w+)\\s(\\w+)[,]?")
         # [d|c]
         self.arg_suffix = re.compile("[c,d]")
+        # [backend_name]
+        self.backend_name_re = re.compile("//[\\s]*tt-linker-backend:[\\s]*([\\w]+)")
 
         self.kernels = defaultdict(list)
+        self.backend_name = None
 
     def extract_linker_meta(self, header: str):
         for ln in header.splitlines():
@@ -64,6 +67,14 @@ class HeaderParser:
                             num_specs=num_specs,
                         ),
                     )
+                else:
+                    m = self.backend_name_re.match(ln)
+                    if _exists(m):
+                        backend_name = m.group(1)
+                        if self.backend_name is None:
+                            self.backend_name = backend_name
+                        elif self.backend_name != backend_name:
+                            raise RuntimeError(f"differing backend {self.backend_name} vs. {backend_name}")
 
     def _match_name(self, ker_name: str):
         m = self.kernel_name.match(ker_name)
@@ -135,7 +146,7 @@ def gen_signature(m):
 # generate declarations of kernels with meta-parameter and constant values
 def make_algo_decls(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     return f"""
-CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])});
+TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])});
 void load_{name}();
 void unload_{name}();
     """
@@ -144,8 +155,8 @@ void unload_{name}();
 # generate declarations of kernels with meta-parameter and constant values
 def make_global_decl(meta: KernelLinkerMeta) -> str:
     return f"""
-CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)});
-CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id);
+TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)});
+TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id);
 void load_{meta.orig_kernel_name}();
 void unload_{meta.orig_kernel_name}();
     """
@@ -153,7 +164,7 @@ void unload_{meta.orig_kernel_name}();
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)}){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)}){{\n"
     src += (f"  return {meta.orig_kernel_name}(stream, {', '.join(meta.arg_names)}, 0);\n")
     src += "}\n"
     return src
@@ -163,14 +174,14 @@ def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
 def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     src = f"// launcher for: {name}\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
-        src += f"CUresult {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(CUstream stream, {gen_signature(meta)});\n"
+        src += f"TT_ResultTy {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(TT_StreamTy stream, {gen_signature(meta)});\n"
     src += "\n"
 
-    src += (f"CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])}){{")
+    src += (f"TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])}){{")
     src += "\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
         cond_fn = (  #
-            lambda val, hint: f"({val} % {hint} == 0)"  #
+            lambda val, hint: f"((uintptr_t){val} % {hint} == 0)"  #
             if hint == 16  #
             else f"({val} == {hint})"  #
             if hint == 1  #
@@ -185,7 +196,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
         arg_names = [arg for arg, hint in zip(meta.arg_names, meta.sizes) if hint != 1]
         src += f"    return {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(stream, {', '.join(arg_names)});\n"
     src += "\n"
-    src += "  return CUDA_ERROR_INVALID_VALUE;\n"
+    src += "  return TT_ERROR_INVALID_VALUE;\n"
     src += "}\n"
 
     for mode in ["load", "unload"]:
@@ -202,7 +213,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
     src += f"  assert (algo_id < (int)sizeof({meta.orig_kernel_name}_kernels));\n"
     src += f"  return {meta.orig_kernel_name}_kernels[algo_id](stream, {', '.join(meta.arg_names)});\n"
     src += "}\n"
@@ -212,7 +223,7 @@ def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
 # generate definition of function pointers of kernel dispatchers based on meta-parameter and constant values
 def make_func_pointers(names: str, meta: KernelLinkerMeta) -> str:
     # the table of hint dispatchers
-    src = f"typedef CUresult (*kernel_func_t)(CUstream stream, {gen_signature_with_full_args(meta)});\n"
+    src = f"typedef TT_ResultTy (*kernel_func_t)(TT_StreamTy stream, {gen_signature_with_full_args(meta)});\n"
     src += f"kernel_func_t {meta.orig_kernel_name}_kernels[] = {{\n"
     for name in names:
         src += f"  {name},\n"
@@ -287,8 +298,9 @@ if __name__ == "__main__":
     meta = meta_lists[0][0]
     get_num_algos_decl = make_get_num_algos_decl(meta)
     global_decl = make_global_decl(meta)
+    backend_prelude = (Path(__file__).parent / "extra" / parser.backend_name / "link.h").read_text()
     with args.out.with_suffix(".h").open("w") as fp:
-        out = "#include <cuda.h>\n"
+        out = backend_prelude
         out += "\n".join(algo_decls)
         out += "\n"
         out += get_num_algos_decl
@@ -305,8 +317,7 @@ if __name__ == "__main__":
     get_num_algos_def = make_get_num_algos_def(meta)
     default_algo_kernel = make_default_algo_kernel(meta)
     with args.out.with_suffix(".c").open("w") as fp:
-        out = ""
-        out += "#include <cuda.h>\n"
+        out = backend_prelude
         out += "#include <stdint.h>\n"
         out += "#include <assert.h>\n"
         out += "\n"

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 from typing import Union
 import triton
+from triton._internal_testing import is_hopper
 # matmul utilities
 import triton_kernels.matmul_details.opt_flags as opt_flags
 from triton_kernels.matmul import FlexCtx, PrecisionConfig, FusedActivation, FnSpecs, FnName, Epilogue
@@ -42,12 +43,13 @@ def opt_flags_scope(request):
     opt_flags.reset_opt_flags_constraints()
 
 
-def make_constraints(block_m, split_k, is_persistent, epilogue_subtile, hbm_swizzling, weight_dtype_str):
+def make_constraints(block_m, split_k, is_persistent, epilogue_subtile, hbm_swizzling, weight_dtype_str, num_warps):
     constraints = {
         "block_m": block_m,
         "split_k": split_k,
         "is_persistent": is_persistent,
         "epilogue_subtile": epilogue_subtile,
+        "num_warps": num_warps,
     }
     if is_hip() and hbm_swizzling and "float4" in weight_dtype_str:
         # Minimum block size to satisfy scale preshuffling
@@ -204,7 +206,8 @@ def _build_test_op_cases():
 ])
 @pytest.mark.parametrize("do_gamma", [False,True])
 @pytest.mark.parametrize("is_persistent", [False,True])
-def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, n_slices,
+@pytest.mark.parametrize("num_warps", [4, 8] if is_hopper() else [None])
+def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
             mode, act_dtype_str, weight_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
             a_transpose, b_transpose, c_transpose,
             swiglu_opts, device, opt_flags_scope):
@@ -212,7 +215,7 @@ def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, i
     # the frame that called pytest.skip, including all the tensors, leading to OOM.
     skip_message = None
     try:
-        _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, n_slices,
+        _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
                  mode, act_dtype_str, weight_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
                  a_transpose, b_transpose, c_transpose,
                  swiglu_opts, device, opt_flags_scope)
@@ -222,7 +225,7 @@ def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, i
     if skip_message is not None:
         pytest.skip(skip_message)
 
-def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, n_slices,
+def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
             mode, act_dtype_str, weight_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
             a_transpose, b_transpose, c_transpose,
             swiglu_opts, device, opt_flags_scope):
@@ -237,6 +240,8 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
                 pytest.skip("float8 x mx not supported with cuda capability < 10")
         if swiglu_opts is not None and do_gamma:
             pytest.skip("NYI: swiglu and gamma not supported together")
+        if weight_dtype_str.startswith("mxfloat4") and b_hbm_swizzling and num_warps == 4:
+            pytest.skip("Disabled due to ptxas bug")
 
     elif is_hip():
         if "float8" in act_dtype_str and "mx" in weight_dtype_str and not is_hip_cdna4():
@@ -313,7 +318,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     torch.manual_seed(0)
 
     # set opt flags constraints
-    constraints = make_constraints(block_m, split_k, is_persistent, epilogue_subtile, b_hbm_swizzling, weight_dtype_str)
+    constraints = make_constraints(block_m, split_k, is_persistent, epilogue_subtile, b_hbm_swizzling, weight_dtype_str, num_warps)
     opt_flags.update_opt_flags_constraints(constraints)
 
     a_dtype = DType(act_dtype_str)
@@ -354,7 +359,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         value_hbm_swizzling = layout.make_default_matmul_mxfp4_w_layout if b_hbm_swizzling and colmajor_mxfp_weight and b_dtype.is_mxfloat4 else None,
         value_hbm_swizzling_args = {"mx_axis":-2},
         scale_hbm_swizzling = layout.make_default_matmul_mxfp4_w_scale_layout if b_hbm_swizzling and colmajor_mxfp_weight and b_dtype.is_mxfloat4 else None,
-        scale_hbm_swizzling_args = {"mx_axis":-2, "num_warps":8},
+        scale_hbm_swizzling_args = dict(mx_axis=-2, num_warps=num_warps),
     )
     gather_indx  = None if not do_gather  else torch.randint(0, max(m, 1), (m, ), dtype=torch.int32, device=device)
     scatter_indx = None if not do_scatter else torch.randperm(m, dtype=torch.int32, device=device)

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
@@ -69,7 +69,7 @@ def setup_nvidia(monkeypatch):
     monkeypatch.setattr(
         opt_flags.opt_flags_nvidia,
         "compute_num_warps",
-        lambda block_m, block_n, is_persistent, precision_config: 4,
+        lambda block_m, block_n, is_persistent, precision_config, constraints: 4,
     )
 
     fake_target = types.SimpleNamespace(backend="cuda")

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -1,6 +1,6 @@
 import pytest
 from triton._internal_testing import is_cuda
-from triton_kernels.tensor import wrap_torch_tensor, convert_layout, FP4
+from triton_kernels.tensor import wrap_torch_tensor, convert_layout, FP4, get_layout
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout
 from triton_kernels.numerics_details.mxfp import downcast_to_mxfp, upcast_from_mxfp
 from triton_kernels.tensor_details.layout_details.hopper_value import mxfp4_to_bf16_triton
@@ -73,12 +73,13 @@ def _upcast_mxfp4_to_bf16(Y, X, XScale, x_stride_m, x_stride_n, x_scale_stride_m
 
 @pytest.mark.skipif(not is_cuda(), reason="Only supported on cuda")
 @pytest.mark.skipif(not cuda_capability_geq(9), reason="Only supported for capability >= 9")
-def test_upcast_mxfp4_to_bf16():
-    mx_axis = 0
-    num_warps = 4
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("mx_axis", [0, 1])
+def test_upcast_mxfp4_to_bf16(num_warps, mx_axis):
     torch.manual_seed(0)
     torch.cuda.manual_seed(0)
-    shape = (256, 128)
+    shape = [64, 64]
+    shape[1 - mx_axis] = 32 * num_warps
     x = torch.randn(shape, dtype=torch.bfloat16, device="cuda")
     x_fp4_val, x_fp4_scale = downcast_to_mxfp(x, torch.uint8, axis=mx_axis)
     x_bf16 = upcast_from_mxfp(x_fp4_val, x_fp4_scale, x.dtype, axis=mx_axis)
@@ -87,13 +88,15 @@ def test_upcast_mxfp4_to_bf16():
     x_fp4_val = convert_layout(x_fp4_val, HopperMXValueLayout, mx_axis=mx_axis)
     x_fp4_scale = convert_layout(x_fp4_scale, HopperMXScaleLayout, mx_axis=mx_axis, num_warps=num_warps)
     y = torch.empty_like(x_bf16)
+    scale_block = [s // 32 if i == mx_axis else s for i, s in enumerate(shape)]
+    scale_block = get_layout(x_fp4_scale).swizzle_block_shape(scale_block)
+    value_block = [s // 2 if i == mx_axis else s for i, s in enumerate(shape)]
+    value_block = get_layout(x_fp4_val).swizzle_block_shape(value_block)
     _upcast_mxfp4_to_bf16[(1, )](
         y, x_fp4_val.storage.data, x_fp4_scale.storage.data,  #
         x_fp4_val.storage.data.stride(0), x_fp4_val.storage.data.stride(1),  #
         x_fp4_scale.storage.data.stride(0), x_fp4_scale.storage.data.stride(1),  #
         y.stride(0), y.stride(1),  #
-        x_fp4_val.storage.data.shape[0], x_fp4_val.storage.data.shape[1],  #
-        shape[0], shape[1],  #
-        x_fp4_scale.storage.data.shape[0], x_fp4_scale.storage.data.shape[1],  #
-        mx_axis=mx_axis, num_warps=num_warps)
+        *value_block, *shape,  #
+        *scale_block, mx_axis=mx_axis, num_warps=num_warps)
     assert (y == x_bf16).all()

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -264,7 +264,7 @@ def _matmul(
             # TODO: support non W_TRANSPOSE with Hopper swizzling
             tl.static_assert(W_TRANSPOSE)
             n_warps: tl.constexpr = tl.extra.cuda.num_warps()
-            tl.static_assert(n_warps == 8)
+            tl.static_assert(n_warps == 8 or n_warps == 4)
             tl.static_assert(BLOCK_N % (2 * n_warps * 2 * 8) == 0)
             tl.static_assert(MX_SCALE_BLOCK_K % 2 == 0)
             PACKED_MX_BLOCK: tl.constexpr = MX_SCALE_BLOCK_K * 32
@@ -356,7 +356,7 @@ def _matmul(
             elif SWIZZLE_MX_SCALE == "HOPPER_SCALE":
                 # Handshake with the swizzling code
                 num_warps: tl.constexpr = tl.extra.cuda.num_warps()
-                tl.static_assert(num_warps == 8)
+                tl.static_assert(num_warps == 8 or num_warps == 4)
                 w_scales = unswizzle_mxfp4_scale_hopper(tl.load(WMxScalePtrs), mx_axis=1, num_warps=num_warps)
             elif SWIZZLE_MX_SCALE == "CDNA4_SCALE":
                 w_scales = unswizzle_mx_scale_cdna4(tl.load(WMxScalePtrs), BLOCK_N, MX_SCALE_BLOCK_K)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -63,8 +63,9 @@ def make_default_opt_flags_amd(
     has_y_acc_in,
     constraints,
 ):
-    constraints_supported = ["block_m", "block_n", "block_k", "split_k", "is_persistent", "epilogue_subtile", "max_allowable_mn"]
-    assert not any([c not in constraints_supported for c in constraints]), constraints.keys()
+    constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "epilogue_subtile", "max_allowable_mn", "num_warps"}
+    unsupported = set(constraints.keys()) - constraints_supported
+    assert not unsupported, f"Given unsupported constraint: {unsupported}"
     # tokens per slice
     if ragged_metadata is None:
         slice_size = m
@@ -153,7 +154,7 @@ def make_default_opt_flags_amd(
         block_m=replace_with_valid_constraint('block_m', block_m),
         block_n=replace_with_valid_constraint('block_n', block_n),
         block_k=replace_with_valid_constraint('block_k', block_k),
-        num_warps=num_warps,
+        num_warps=replace_with_valid_constraint('num_warps', num_warps),
         num_stages=num_stages,
         group_m=group_m,
         xcd_swizzle=xcd_swizzle,
@@ -187,8 +188,9 @@ def make_default_opt_flags_nvidia(
     has_y_acc_in,
     constraints,
 ):
-    constraints_supported = ["block_m", "block_k", "split_k", "is_persistent", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn"]
-    assert not any([c not in constraints_supported for c in constraints]), constraints.keys()
+    constraints_supported = {"block_m", "block_k", "split_k", "is_persistent", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps"}
+    unsupported = set(constraints.keys()) - constraints_supported
+    assert not unsupported, f"Given unsupported constraint: {unsupported}"
     # tokens per expert
     if routing_data is None or batch_size > 1:
         slice_size = m
@@ -229,12 +231,16 @@ def make_default_opt_flags_nvidia(
     n_sms = torch.cuda.get_device_properties(0).multi_processor_count
     tiles_per_sm = grid_size_tma / n_sms
     supports_persistent = can_use_persistent_tma and (arch is None or int(arch[2:-1]) >= 9)
+    a_mx_scale_layout = get_layout(precision_config.a_mx_scale)
+    b_mx_scale_layout = get_layout(precision_config.b_mx_scale)
+    if isinstance(b_mx_scale_layout, HopperMXScaleLayout) and b_mx_scale_layout.num_warps == 4:
+        # TODO: persistent kernel is broken due with 4 warps due to a ptxas bug
+        supports_persistent = False
 
-    def _layout_name(tensor):
-        layout = get_layout(tensor)
-        return layout.name if layout is not None else None
+    def _layout_name(layout):
+        return None if layout is None else layout.name
 
-    requires_persistent = (_layout_name(precision_config.a_mx_scale) is not None or _layout_name(precision_config.b_mx_scale) is not None) and target_info.has_native_mxfp()
+    requires_persistent = (_layout_name(a_mx_scale_layout) is not None or _layout_name((b_mx_scale_layout)) is not None) and target_info.has_native_mxfp()
     if constraints.get("is_persistent", None) is not None:
         is_persistent = constraints["is_persistent"]
     elif requires_persistent:
@@ -246,12 +252,10 @@ def make_default_opt_flags_nvidia(
         # TMA is slower for batched matmuls with small m/n/k.
         if m * n * k < 131072:
             is_persistent = False
-        if (
-            (b_scale_layout := get_layout(precision_config.b_mx_scale)) is not None and
-            isinstance(b_scale_layout, HopperMXScaleLayout)
-        ):
+        if isinstance(b_mx_scale_layout, HopperMXScaleLayout):
             # TODO: persistent kernel is currently slower than non-persistent
             is_persistent = False
+
     # adjust block_n based on is_persistent signal
     block_n = block_n_tma if is_persistent else block_n
     # adjust block_m based on is_persistent signal
@@ -302,8 +306,7 @@ def make_default_opt_flags_nvidia(
     if constraints.get("num_stages", None):
         num_stages = constraints["num_stages"]
     assert num_stages >= 1
-    # Handshake with the HBM swizzling
-    num_warps = opt_flags_nvidia.compute_num_warps(block_m, block_n, is_persistent, precision_config)
+    num_warps = opt_flags_nvidia.compute_num_warps(block_m, block_n, is_persistent, precision_config, constraints)
     ret = OptFlags(
         block_m=block_m,
         block_n=block_n,

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -129,13 +129,12 @@ def make_default_opt_flags_amd(
         num_stages = 1
 
     # specific configs for F16 x MXFP4 on CDNA4
-    # Note that these configs will exceed LDS usage with async copy enabled
     if is_cdna4 and bitwidth(lhs_dtype) == 16 and bitwidth(rhs_dtype) == 4 and precision_config.b_mx_scale is not None:
         split_k = 1
         if m <= 1024:
             target_kernel_kwargs["waves_per_eu"] = 3
             block_n = 128
-            block_k = 256
+            block_k = 128
             num_warps = 4
         else:
             target_kernel_kwargs["waves_per_eu"] = 0

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_amd.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_amd.py
@@ -14,14 +14,12 @@ def compute_block_nk(n, block_m, grid_m, num_xcds, lhs_dtype, rhs_dtype, precisi
         if n <= 128 and (n & (n - 1)) == 0:
             block_n = n
         else:
-            block_n = max(32, min(256, triton.next_power_of_2(grid_m * n * num_xcds // n_cu)))
+            max_n = 64 if get_cdna_version() == 4 else 256
+            block_n = max(32, min(max_n, triton.next_power_of_2(grid_m * n * num_xcds // n_cu)))
     elif block_m > 64:
         block_n = 256
     else:
         block_n = 128
-
-    if get_cdna_version() == 4 and block_m == 128:
-        block_n = 512
 
     if get_rdna_version() in (3, 4) and block_m == 64:
         block_n = 256

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -74,10 +74,13 @@ def compute_split_k(block_k: int, k: int | None, grid_size: int) -> int:
     return split_k
 
 
-def compute_num_warps(block_m, block_n, is_persistent: bool, precision_config):
+def compute_num_warps(block_m, block_n, is_persistent: bool, precision_config, constraints):
     layout = get_layout(precision_config.b_mx_scale)
     if isinstance(layout, HopperMXScaleLayout):
         return layout.num_warps
+    num_warps = constraints.get("num_warps", None)
+    if num_warps is not None:
+        return num_warps
     return max(block_m * block_n // 4096, 4 if is_persistent else 1)
 
 

--- a/python/triton_kernels/triton_kernels/tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor.py
@@ -50,6 +50,7 @@ class Storage:
     def make_dense_tma(self, block_shape, is_scale):
         strides = list(self.data.stride())
         shape = list(self.data.shape)
+        block_shape = self.layout.swizzle_block_shape(block_shape)
         transpose = strides[-1] != 1
         if transpose:
             # Need to transpose since tensor descriptor expects strides except for the last dimension 16-byte aligned
@@ -63,7 +64,6 @@ class Storage:
             if isinstance(self.layout, BlackwellMXValueLayout) and shape[-1] % 128 != 0:
                 raise ValueError(
                     "inner shape need to be multiple of 128 for mxfp4 (CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B) TMAs.")
-        block_shape = self.layout.swizzle_block_shape(block_shape)
         return TensorDescriptor(self.data, shape, strides, block_shape)
 
     def make_tma(self, block_shape, mode, is_scale=False):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -213,9 +213,14 @@ class HopperMXValueLayout(Layout):
         return data[..., :self.K, :self.N]
 
     def swizzle_block_shape(self, block_shape):
-        N, K = block_shape[-2:]
-        assert N % 4 == 0
-        return [*block_shape[:-2], N // 4, K * 4]
+        if self.mx_axis == len(self.leading_shape) + 1:
+            *head, N, K = block_shape
+            assert N % 4 == 0
+            return [*head, N // 4, K * 4]
+        else:
+            *head, K, N = block_shape
+            assert N % 4 == 0
+            return [*head, K * 4, N // 4]
 
 
 @triton.jit

--- a/test/Proton/allocate_shared_memory.mlir
+++ b/test/Proton/allocate_shared_memory.mlir
@@ -20,6 +20,26 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 
 // -----
 
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0], CGALayout = [[1, 0]]}>
+// CHECK: ttg.shared = 832 : i32
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 2 : i32} {
+  // CHECK-LABEL: allocate_aligned
+  tt.func @allocate_aligned(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record start "name0"
+  %cst1 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst2 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst1 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record end "name0"
+  ttg.local_dealloc %cst2 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // CHECK: ttg.local_alloc  {allocation.offset = 768 : i32}
+  tt.return
+  }
+}
+
+// -----
+
 #A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
 // CHECK: ttg.shared = 64 : i32
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {

--- a/test/TritonGPU/amd/amd-convert-buffer-ops-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-range-analysis.mlir
@@ -2,500 +2,522 @@
 
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx942" | FileCheck %s
 
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
 // CHECK-LABEL:   tt.func @conversion1(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_2:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_3:.*]] = arith.muli %[[VAL_2]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_4:.*]] = tt.addptr %[[VAL_0]], %[[VAL_3]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_4]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_6:.*]] = tt.load %[[VAL_5]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_6]] : tensor<1024xf32>
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_4]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_6:.*]] = tt.load %[[VAL_5]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_6]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @conversion1(%arg0: !tt.ptr<f32>) -> tensor<1024xf32> {
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @conversion1(%arg0: !tt.ptr<f32>) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
     %2 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %4 = tt.load %3 : tensor<1024x!tt.ptr<f32>>
-    tt.return %4 : tensor<1024xf32>
+    %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %4 = tt.load %3 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %4 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @conversion2(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_3:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_5:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_0]], %[[VAL_4]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_7:.*]] = amdg.buffer_load %[[VAL_6]]{{\[}}%[[VAL_5]]] : tensor<1024xf32>
-// CHECK:           tt.return %[[VAL_7]] : tensor<1024xf32>
+// CHECK:           %[[VAL_7:.*]] = amdg.buffer_load %[[VAL_6]]{{\[}}%[[VAL_5]]] : tensor<1024xf32, #blocked>
+// CHECK:           tt.return %[[VAL_7]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @conversion2(%arg0: !tt.ptr<f32>) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @conversion2(%arg0: !tt.ptr<f32>) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = tt.splat %3 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %5 = tt.addptr %4, %2 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-    %6 = tt.load %5 : tensor<1024x!tt.ptr<f32>>
-    tt.return %6 : tensor<1024xf32>
+    %4 = tt.splat %3 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %5 = tt.addptr %4, %2 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+    %6 = tt.load %5 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %6 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @conversion3(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_2:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_3:.*]] = arith.muli %[[VAL_2]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_4:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_4:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_5:.*]] = tt.addptr %[[VAL_0]], %[[VAL_3]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_4]] : tensor<1024xi32> to tensor<1024xi64>
+// CHECK:           %[[VAL_6:.*]] = arith.extsi %[[VAL_4]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_5]], %[[VAL_3]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_8:.*]] = arith.extsi %[[VAL_4]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_6]] : tensor<1024xi64>
-// CHECK:           %[[VAL_10:.*]] = tt.splat %[[VAL_7]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_11:.*]] = tt.addptr %[[VAL_10]], %[[VAL_9]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_12:.*]] = tt.load %[[VAL_11]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_12]] : tensor<1024xf32>
+// CHECK:           %[[VAL_8:.*]] = arith.extsi %[[VAL_4]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_6]] : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_10:.*]] = tt.splat %[[VAL_7]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_11:.*]] = tt.addptr %[[VAL_10]], %[[VAL_9]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_12:.*]] = tt.load %[[VAL_11]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_12]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @conversion3(%arg0: !tt.ptr<f32>) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @conversion3(%arg0: !tt.ptr<f32>) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
+    %4 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
     %5 = tt.addptr %3, %1 : !tt.ptr<f32>, i32
-    %6 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %7 = arith.addi %6, %4 : tensor<1024xi64>
-    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>>
-    tt.return %10 : tensor<1024xf32>
+    %6 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %7 = arith.addi %6, %4 : tensor<1024xi64, #blocked0>
+    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %10 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @conversion4(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_3:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_3]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_5:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_0]], %[[VAL_4]] : !tt.ptr<f32>, i32
 // CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_6]], %[[VAL_4]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_5]], %[[VAL_5]] : tensor<1024xi32>
-// CHECK:           %[[VAL_9:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_8]]] : tensor<1024xf32>
-// CHECK:           tt.return %[[VAL_9]] : tensor<1024xf32>
+// CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_5]], %[[VAL_5]] : tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_9:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_8]]] : tensor<1024xf32, #blocked>
+// CHECK:           tt.return %[[VAL_9]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @conversion4(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @conversion4(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
     %4 = tt.addptr %3, %1 : !tt.ptr<f32>, i32
-    %5 = arith.addi %2, %2 : tensor<1024xi32>
-    %6 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %7 = tt.addptr %6, %5 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-    %8 = tt.load %7 : tensor<1024x!tt.ptr<f32>>
-    tt.return %8 : tensor<1024xf32>
+    %5 = arith.addi %2, %2 : tensor<1024xi32, #blocked0>
+    %6 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %7 = tt.addptr %6, %5 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+    %8 = tt.load %7 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %8 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @forOp(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_4:.*]] = arith.constant 128 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_6:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_9:.*]] = tt.addptr %[[VAL_0]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_11:.*]]:3 = scf.for %[[VAL_12:.*]] = %[[VAL_3]] to %[[VAL_4]] step %[[VAL_5]] iter_args(%[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_10]], %[[VAL_15:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+// CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_11:.*]]:3 = scf.for %[[VAL_12:.*]] = %[[VAL_3]] to %[[VAL_4]] step %[[VAL_5]] iter_args(%[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_10]], %[[VAL_15:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:             %[[VAL_16:.*]] = tt.addptr %[[VAL_13]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_17:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_14]] : tensor<1024xi64>
-// CHECK:             %[[VAL_19:.*]] = tt.splat %[[VAL_16]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_20:.*]] = tt.addptr %[[VAL_19]], %[[VAL_18]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:             %[[VAL_21:.*]] = tt.load %[[VAL_20]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_22:.*]] = arith.addf %[[VAL_21]], %[[VAL_15]] : tensor<1024xf32>
-// CHECK:             scf.yield %[[VAL_16]], %[[VAL_18]], %[[VAL_22]] : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:             %[[VAL_17:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_14]] : tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_19:.*]] = tt.splat %[[VAL_16]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_20:.*]] = tt.addptr %[[VAL_19]], %[[VAL_18]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_21:.*]] = tt.load %[[VAL_20]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_22:.*]] = arith.addf %[[VAL_21]], %[[VAL_15]] : tensor<1024xf32, #blocked>
+// CHECK:             scf.yield %[[VAL_16]], %[[VAL_18]], %[[VAL_22]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_23:.*]] = tt.addptr %[[VAL_24:.*]]#0, %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_25:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_24]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_27:.*]] = tt.splat %[[VAL_23]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_28:.*]] = tt.addptr %[[VAL_27]], %[[VAL_26]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_29:.*]] = tt.load %[[VAL_28]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_29]] : tensor<1024xf32>
+// CHECK:           %[[VAL_25:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_24]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_27:.*]] = tt.splat %[[VAL_23]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_28:.*]] = tt.addptr %[[VAL_27]], %[[VAL_26]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_29:.*]] = tt.load %[[VAL_28]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_29]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @forOp(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @forOp(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c1 = arith.constant 1 : index
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %5:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %3, %arg4 = %4, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+    %4 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %5:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %3, %arg4 = %4, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
       %12 = tt.addptr %arg3, %1 : !tt.ptr<f32>, i32
-      %13 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-      %14 = arith.addi %13, %arg4 : tensor<1024xi64>
-      %15 = tt.splat %12 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      %16 = tt.addptr %15, %14 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-      %17 = tt.load %16 : tensor<1024x!tt.ptr<f32>>
-      %18 = arith.addf %17, %arg5 : tensor<1024xf32>
-      scf.yield %12, %14, %18 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+      %13 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      %14 = arith.addi %13, %arg4 : tensor<1024xi64, #blocked0>
+      %15 = tt.splat %12 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+      %16 = tt.addptr %15, %14 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+      %17 = tt.load %16 : tensor<1024x!tt.ptr<f32>, #blocked0>
+      %18 = arith.addf %17, %arg5 : tensor<1024xf32, #blocked0>
+      scf.yield %12, %14, %18 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
     }
     %6 = tt.addptr %5#0, %1 : !tt.ptr<f32>, i32
-    %7 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %8 = arith.addi %7, %5#1 : tensor<1024xi64>
-    %9 = tt.splat %6 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %10 = tt.addptr %9, %8 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %11 = tt.load %10 : tensor<1024x!tt.ptr<f32>>
-    tt.return %11 : tensor<1024xf32>
+    %7 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %8 = arith.addi %7, %5#1 : tensor<1024xi64, #blocked0>
+    %9 = tt.splat %6 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %10 = tt.addptr %9, %8 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %11 = tt.load %10 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %11 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @forOp2(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>) -> tensor<1024xf32> {
-// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64>
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>) -> tensor<1024xf32, #blocked> {
+// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 128 : index
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_7:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_12:.*]] = %[[VAL_0]], %[[VAL_13:.*]] = %[[VAL_2]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_12:.*]] = %[[VAL_0]], %[[VAL_13:.*]] = %[[VAL_2]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:             %[[VAL_15:.*]] = tt.addptr %[[VAL_12]], %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_16:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : tensor<1024xi64>
-// CHECK:             %[[VAL_18:.*]] = tt.splat %[[VAL_15]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_19:.*]] = tt.addptr %[[VAL_18]], %[[VAL_17]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:             %[[VAL_20:.*]] = tt.load %[[VAL_19]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_21:.*]] = arith.addf %[[VAL_20]], %[[VAL_14]] : tensor<1024xf32>
-// CHECK:             scf.yield %[[VAL_15]], %[[VAL_17]], %[[VAL_21]] : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:             %[[VAL_16:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_18:.*]] = tt.splat %[[VAL_15]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_19:.*]] = tt.addptr %[[VAL_18]], %[[VAL_17]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_20:.*]] = tt.load %[[VAL_19]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_21:.*]] = arith.addf %[[VAL_20]], %[[VAL_14]] : tensor<1024xf32, #blocked>
+// CHECK:             scf.yield %[[VAL_15]], %[[VAL_17]], %[[VAL_21]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_22:.*]] = tt.addptr %[[VAL_23:.*]]#0, %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_26:.*]] = tt.splat %[[VAL_22]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_27:.*]] = tt.addptr %[[VAL_26]], %[[VAL_25]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_28:.*]] = tt.load %[[VAL_27]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_28]] : tensor<1024xf32>
+// CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_26:.*]] = tt.splat %[[VAL_22]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_27:.*]] = tt.addptr %[[VAL_26]], %[[VAL_25]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_28:.*]] = tt.load %[[VAL_27]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_28]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @forOp2(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
-    %cst = arith.constant dense<0> : tensor<1024xi64>
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @forOp2(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>) -> tensor<1024xf32, #blocked0> {
+    %cst = arith.constant dense<0> : tensor<1024xi64, #blocked0>
     %c1024_i32 = arith.constant 1024 : i32
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c1 = arith.constant 1 : index
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    %3:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %arg0, %arg4 = %cst, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
+    %3:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %arg0, %arg4 = %cst, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
       %10 = tt.addptr %arg3, %1 : !tt.ptr<f32>, i32
-      %11 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-      %12 = arith.addi %11, %arg4 : tensor<1024xi64>
-      %13 = tt.splat %10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      %14 = tt.addptr %13, %12 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-      %15 = tt.load %14 : tensor<1024x!tt.ptr<f32>>
-      %16 = arith.addf %15, %arg5 : tensor<1024xf32>
-      scf.yield %10, %12, %16 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+      %11 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      %12 = arith.addi %11, %arg4 : tensor<1024xi64, #blocked0>
+      %13 = tt.splat %10 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+      %14 = tt.addptr %13, %12 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+      %15 = tt.load %14 : tensor<1024x!tt.ptr<f32>, #blocked0>
+      %16 = arith.addf %15, %arg5 : tensor<1024xf32, #blocked0>
+      scf.yield %10, %12, %16 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
     }
     %4 = tt.addptr %3#0, %1 : !tt.ptr<f32>, i32
-    %5 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %6 = arith.addi %5, %3#1 : tensor<1024xi64>
-    %7 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %8 = tt.addptr %7, %6 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %9 = tt.load %8 : tensor<1024x!tt.ptr<f32>>
-    tt.return %9 : tensor<1024xf32>
+    %5 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %6 = arith.addi %5, %3#1 : tensor<1024xi64, #blocked0>
+    %7 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %8 = tt.addptr %7, %6 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %9 = tt.load %8 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %9 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @forNested(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>) -> tensor<1024xf32> {
-// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64>
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>) -> tensor<1024xf32, #blocked> {
+// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 16 : index
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_7:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_12:.*]] = %[[VAL_0]], %[[VAL_13:.*]] = %[[VAL_2]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
-// CHECK:             %[[VAL_15:.*]]:3 = scf.for %[[VAL_16:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_17:.*]] = %[[VAL_12]], %[[VAL_18:.*]] = %[[VAL_13]], %[[VAL_19:.*]] = %[[VAL_14]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_12:.*]] = %[[VAL_0]], %[[VAL_13:.*]] = %[[VAL_2]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
+// CHECK:             %[[VAL_15:.*]]:3 = scf.for %[[VAL_16:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_17:.*]] = %[[VAL_12]], %[[VAL_18:.*]] = %[[VAL_13]], %[[VAL_19:.*]] = %[[VAL_14]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:               %[[VAL_20:.*]] = tt.addptr %[[VAL_17]], %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:               %[[VAL_21:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64>
-// CHECK:               %[[VAL_23:.*]] = tt.splat %[[VAL_20]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:               %[[VAL_24:.*]] = tt.addptr %[[VAL_23]], %[[VAL_22]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:               %[[VAL_25:.*]] = tt.load %[[VAL_24]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:               %[[VAL_26:.*]] = arith.addf %[[VAL_25]], %[[VAL_19]] : tensor<1024xf32>
-// CHECK:               scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_26]] : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:               %[[VAL_21:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64, #blocked>
+// CHECK:               %[[VAL_23:.*]] = tt.splat %[[VAL_20]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:               %[[VAL_24:.*]] = tt.addptr %[[VAL_23]], %[[VAL_22]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:               %[[VAL_25:.*]] = tt.load %[[VAL_24]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:               %[[VAL_26:.*]] = arith.addf %[[VAL_25]], %[[VAL_19]] : tensor<1024xf32, #blocked>
+// CHECK:               scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_26]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_27:.*]]#0, %[[VAL_27]]#1, %[[VAL_27]]#2 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:             scf.yield %[[VAL_27:.*]]#0, %[[VAL_27]]#1, %[[VAL_27]]#2 : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_28:.*]] = tt.addptr %[[VAL_29:.*]]#0, %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_30:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_31:.*]] = arith.addi %[[VAL_30]], %[[VAL_29]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_32:.*]] = tt.splat %[[VAL_28]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_33:.*]] = tt.addptr %[[VAL_32]], %[[VAL_31]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_34:.*]] = tt.load %[[VAL_33]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_34]] : tensor<1024xf32>
+// CHECK:           %[[VAL_30:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_31:.*]] = arith.addi %[[VAL_30]], %[[VAL_29]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_32:.*]] = tt.splat %[[VAL_28]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_33:.*]] = tt.addptr %[[VAL_32]], %[[VAL_31]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_34:.*]] = tt.load %[[VAL_33]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_34]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @forNested(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
-    %cst = arith.constant dense<0> : tensor<1024xi64>
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @forNested(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>) -> tensor<1024xf32, #blocked0> {
+    %cst = arith.constant dense<0> : tensor<1024xi64, #blocked0>
     %c1024_i32 = arith.constant 1024 : i32
     %c0 = arith.constant 0 : index
     %c16 = arith.constant 16 : index
     %c1 = arith.constant 1 : index
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    %3:3 = scf.for %arg2 = %c0 to %c16 step %c1 iter_args(%arg3 = %arg0, %arg4 = %cst, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
-      %10:3 = scf.for %arg6 = %c0 to %c16 step %c1 iter_args(%arg7 = %arg3, %arg8 = %arg4, %arg9 = %arg5) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
+    %3:3 = scf.for %arg2 = %c0 to %c16 step %c1 iter_args(%arg3 = %arg0, %arg4 = %cst, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
+      %10:3 = scf.for %arg6 = %c0 to %c16 step %c1 iter_args(%arg7 = %arg3, %arg8 = %arg4, %arg9 = %arg5) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
         %11 = tt.addptr %arg7, %1 : !tt.ptr<f32>, i32
-        %12 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-        %13 = arith.addi %12, %arg8 : tensor<1024xi64>
-        %14 = tt.splat %11 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-        %15 = tt.addptr %14, %13 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-        %16 = tt.load %15 : tensor<1024x!tt.ptr<f32>>
-        %17 = arith.addf %16, %arg9 : tensor<1024xf32>
-        scf.yield %11, %13, %17 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+        %12 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+        %13 = arith.addi %12, %arg8 : tensor<1024xi64, #blocked0>
+        %14 = tt.splat %11 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+        %15 = tt.addptr %14, %13 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+        %16 = tt.load %15 : tensor<1024x!tt.ptr<f32>, #blocked0>
+        %17 = arith.addf %16, %arg9 : tensor<1024xf32, #blocked0>
+        scf.yield %11, %13, %17 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
       }
-      scf.yield %10#0, %10#1, %10#2 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+      scf.yield %10#0, %10#1, %10#2 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
     }
     %4 = tt.addptr %3#0, %1 : !tt.ptr<f32>, i32
-    %5 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %6 = arith.addi %5, %3#1 : tensor<1024xi64>
-    %7 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %8 = tt.addptr %7, %6 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %9 = tt.load %8 : tensor<1024x!tt.ptr<f32>>
-    tt.return %9 : tensor<1024xf32>
+    %5 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %6 = arith.addi %5, %3#1 : tensor<1024xi64, #blocked0>
+    %7 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %8 = tt.addptr %7, %6 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %9 = tt.load %8 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %9 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @forNestedOverMaxTripCount(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>) -> tensor<1024xf32> {
-// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64>
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>) -> tensor<1024xf32, #blocked> {
+// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 128 : index
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_7:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_12:.*]] = %[[VAL_0]], %[[VAL_13:.*]] = %[[VAL_2]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
-// CHECK:             %[[VAL_15:.*]]:3 = scf.for %[[VAL_16:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_17:.*]] = %[[VAL_12]], %[[VAL_18:.*]] = %[[VAL_13]], %[[VAL_19:.*]] = %[[VAL_14]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_12:.*]] = %[[VAL_0]], %[[VAL_13:.*]] = %[[VAL_2]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
+// CHECK:             %[[VAL_15:.*]]:3 = scf.for %[[VAL_16:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_17:.*]] = %[[VAL_12]], %[[VAL_18:.*]] = %[[VAL_13]], %[[VAL_19:.*]] = %[[VAL_14]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:               %[[VAL_20:.*]] = tt.addptr %[[VAL_17]], %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:               %[[VAL_21:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64>
-// CHECK:               %[[VAL_23:.*]] = tt.splat %[[VAL_20]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:               %[[VAL_24:.*]] = tt.addptr %[[VAL_23]], %[[VAL_22]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:               %[[VAL_25:.*]] = tt.load %[[VAL_24]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:               %[[VAL_26:.*]] = arith.addf %[[VAL_25]], %[[VAL_19]] : tensor<1024xf32>
-// CHECK:               scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_26]] : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:               %[[VAL_21:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64, #blocked>
+// CHECK:               %[[VAL_23:.*]] = tt.splat %[[VAL_20]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:               %[[VAL_24:.*]] = tt.addptr %[[VAL_23]], %[[VAL_22]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:               %[[VAL_25:.*]] = tt.load %[[VAL_24]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:               %[[VAL_26:.*]] = arith.addf %[[VAL_25]], %[[VAL_19]] : tensor<1024xf32, #blocked>
+// CHECK:               scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_26]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_27:.*]]#0, %[[VAL_27]]#1, %[[VAL_27]]#2 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:             scf.yield %[[VAL_27:.*]]#0, %[[VAL_27]]#1, %[[VAL_27]]#2 : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_28:.*]] = tt.addptr %[[VAL_29:.*]]#0, %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_30:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_31:.*]] = arith.addi %[[VAL_30]], %[[VAL_29]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_32:.*]] = tt.splat %[[VAL_28]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_33:.*]] = tt.addptr %[[VAL_32]], %[[VAL_31]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_34:.*]] = tt.load %[[VAL_33]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_34]] : tensor<1024xf32>
+// CHECK:           %[[VAL_30:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_31:.*]] = arith.addi %[[VAL_30]], %[[VAL_29]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_32:.*]] = tt.splat %[[VAL_28]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_33:.*]] = tt.addptr %[[VAL_32]], %[[VAL_31]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_34:.*]] = tt.load %[[VAL_33]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_34]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @forNestedOverMaxTripCount(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
-    %cst = arith.constant dense<0> : tensor<1024xi64>
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @forNestedOverMaxTripCount(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>) -> tensor<1024xf32, #blocked0> {
+    %cst = arith.constant dense<0> : tensor<1024xi64, #blocked0>
     %c1024_i32 = arith.constant 1024 : i32
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c1 = arith.constant 1 : index
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    %3:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %arg0, %arg4 = %cst, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
-      %10:3 = scf.for %arg6 = %c0 to %c128 step %c1 iter_args(%arg7 = %arg3, %arg8 = %arg4, %arg9 = %arg5) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
+    %3:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %arg0, %arg4 = %cst, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
+      %10:3 = scf.for %arg6 = %c0 to %c128 step %c1 iter_args(%arg7 = %arg3, %arg8 = %arg4, %arg9 = %arg5) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
         %11 = tt.addptr %arg7, %1 : !tt.ptr<f32>, i32
-        %12 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-        %13 = arith.addi %12, %arg8 : tensor<1024xi64>
-        %14 = tt.splat %11 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-        %15 = tt.addptr %14, %13 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-        %16 = tt.load %15 : tensor<1024x!tt.ptr<f32>>
-        %17 = arith.addf %16, %arg9 : tensor<1024xf32>
-        scf.yield %11, %13, %17 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+        %12 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+        %13 = arith.addi %12, %arg8 : tensor<1024xi64, #blocked0>
+        %14 = tt.splat %11 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+        %15 = tt.addptr %14, %13 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+        %16 = tt.load %15 : tensor<1024x!tt.ptr<f32>, #blocked0>
+        %17 = arith.addf %16, %arg9 : tensor<1024xf32, #blocked0>
+        scf.yield %11, %13, %17 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
       }
-      scf.yield %10#0, %10#1, %10#2 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+      scf.yield %10#0, %10#1, %10#2 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
     }
     %4 = tt.addptr %3#0, %1 : !tt.ptr<f32>, i32
-    %5 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %6 = arith.addi %5, %3#1 : tensor<1024xi64>
-    %7 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %8 = tt.addptr %7, %6 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %9 = tt.load %8 : tensor<1024x!tt.ptr<f32>>
-    tt.return %9 : tensor<1024xf32>
+    %5 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %6 = arith.addi %5, %3#1 : tensor<1024xi64, #blocked0>
+    %7 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %8 = tt.addptr %7, %6 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %9 = tt.load %8 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %9 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @ifOp(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>, %[[VAL_2:.*]]: i1) -> tensor<1024xf32> {
-// CHECK:           %[[VAL_4:.*]] = arith.constant dense<0> : tensor<1024xi64>
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>, %[[VAL_2:.*]]: i1) -> tensor<1024xf32, #blocked> {
+// CHECK:           %[[VAL_4:.*]] = arith.constant dense<0> : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_6:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[VAL_5]] : i32
-// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-// CHECK:           %[[VAL_9:.*]]:2 = scf.if %[[VAL_2]] -> (!tt.ptr<f32>, tensor<1024xi64>) {
+// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_9:.*]]:2 = scf.if %[[VAL_2]] -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>) {
 // CHECK:             %[[VAL_10:.*]] = tt.addptr %[[VAL_0]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_11:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             scf.yield %[[VAL_10]], %[[VAL_11]] : !tt.ptr<f32>, tensor<1024xi64>
+// CHECK:             %[[VAL_11:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             scf.yield %[[VAL_10]], %[[VAL_11]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>
 // CHECK:           } else {
 // CHECK:             %[[VAL_12:.*]] = tt.addptr %[[VAL_0]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:             scf.yield %[[VAL_12]], %[[VAL_4]] : !tt.ptr<f32>, tensor<1024xi64>
+// CHECK:             scf.yield %[[VAL_12]], %[[VAL_4]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>
 // CHECK:           }
-// CHECK:           %[[VAL_13:.*]] = arith.trunci %[[VAL_14:.*]]#1 : tensor<1024xi64> to tensor<1024xi32>
-// CHECK:           %[[VAL_15:.*]] = amdg.buffer_load %[[VAL_14]]#0{{\[}}%[[VAL_13]]] : tensor<1024xf32>
-// CHECK:           tt.return %[[VAL_15]] : tensor<1024xf32>
+// CHECK:           %[[VAL_13:.*]] = arith.trunci %[[VAL_14:.*]]#1 : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_15:.*]] = amdg.buffer_load %[[VAL_14]]#0{{\[}}%[[VAL_13]]] : tensor<1024xf32, #blocked>
+// CHECK:           tt.return %[[VAL_15]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @ifOp(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>, %arg2: i1) -> tensor<1024xf32> {
-    %cst = arith.constant dense<0> : tensor<1024xi64>
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @ifOp(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>, %arg2: i1) -> tensor<1024xf32, #blocked0> {
+    %cst = arith.constant dense<0> : tensor<1024xi64, #blocked0>
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    %3:2 = scf.if %arg2 -> (!tt.ptr<f32>, tensor<1024xi64>) {
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
+    %3:2 = scf.if %arg2 -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>) {
       %8 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-      %9 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-      scf.yield %8, %9 : !tt.ptr<f32>, tensor<1024xi64>
+      %9 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      scf.yield %8, %9 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>
     } else {
       %8 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-      scf.yield %8, %cst : !tt.ptr<f32>, tensor<1024xi64>
+      scf.yield %8, %cst : !tt.ptr<f32>, tensor<1024xi64, #blocked0>
     }
-    %4 = arith.trunci %3#1 : tensor<1024xi64> to tensor<1024xi32>
-    %5 = tt.splat %3#0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %6 = tt.addptr %5, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-    %7 = tt.load %6 : tensor<1024x!tt.ptr<f32>>
-    tt.return %7 : tensor<1024xf32>
+    %4 = arith.trunci %3#1 : tensor<1024xi64, #blocked0> to tensor<1024xi32, #blocked0>
+    %5 = tt.splat %3#0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %6 = tt.addptr %5, %4 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+    %7 = tt.load %6 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %7 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @condBranch(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: i1) -> tensor<1024xf32> {
-// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64>
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: i1) -> tensor<1024xf32, #blocked> {
+// CHECK:           %[[VAL_2:.*]] = arith.constant dense<0> : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_5:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_4]] : i32
-// CHECK:           %[[VAL_7:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_8:.*]] = tt.addptr %[[VAL_0]], %[[VAL_6]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_9:.*]] = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           cf.cond_br %[[VAL_1]], ^bb1(%[[VAL_0]], %[[VAL_2]] : !tt.ptr<f32>, tensor<1024xi64>), ^bb1(%[[VAL_8]], %[[VAL_9]] : !tt.ptr<f32>, tensor<1024xi64>)
-// CHECK:         ^bb1(%[[VAL_9:.*]]: !tt.ptr<f32>, %[[VAL_11:.*]]: tensor<1024xi64>):
-// CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64> to tensor<1024xi32>
-// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_9]]{{\[}}%[[VAL_12]]] : tensor<1024xf32>
-// CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32>
+// CHECK:           %[[VAL_9:.*]] = arith.extsi %2 : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           cf.cond_br %[[VAL_1]], ^bb1(%[[VAL_0]], %[[VAL_2]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>), ^bb1(%[[VAL_8]], %[[VAL_9]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>)
+// CHECK:         ^bb1(%[[VAL_9:.*]]: !tt.ptr<f32>, %[[VAL_11:.*]]: tensor<1024xi64, #blocked>):
+// CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_9]]{{\[}}%[[VAL_12]]] : tensor<1024xf32, #blocked>
+// CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @condBranch(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<1024xf32> {
-    %cst = arith.constant dense<0> : tensor<1024xi64>
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @condBranch(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<1024xf32, #blocked0> {
+    %cst = arith.constant dense<0> : tensor<1024xi64, #blocked0>
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    cf.cond_br %arg1, ^bb1(%arg0, %cst : !tt.ptr<f32>, tensor<1024xi64>), ^bb2(%3, %4 : !tt.ptr<f32>, tensor<1024xi64>)
-  ^bb1(%5: !tt.ptr<f32>, %6: tensor<1024xi64>):  // pred: ^bb0
-    %7 = arith.trunci %6 : tensor<1024xi64> to tensor<1024xi32>
-    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>>
-    tt.return %10 : tensor<1024xf32>
-  ^bb2(%11: !tt.ptr<f32>, %12: tensor<1024xi64>):  // pred: ^bb0
-    %13 = arith.trunci %12 : tensor<1024xi64> to tensor<1024xi32>
-    %14 = tt.splat %11 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %15 = tt.addptr %14, %13 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-    %16 = tt.load %15 : tensor<1024x!tt.ptr<f32>>
-    tt.return %16 : tensor<1024xf32>
+    %4 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    cf.cond_br %arg1, ^bb1(%arg0, %cst : !tt.ptr<f32>, tensor<1024xi64, #blocked0>), ^bb2(%3, %4 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>)
+  ^bb1(%5: !tt.ptr<f32>, %6: tensor<1024xi64, #blocked0>):  // pred: ^bb0
+    %7 = arith.trunci %6 : tensor<1024xi64, #blocked0> to tensor<1024xi32, #blocked0>
+    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %10 : tensor<1024xf32, #blocked0>
+  ^bb2(%11: !tt.ptr<f32>, %12: tensor<1024xi64, #blocked0>):  // pred: ^bb0
+    %13 = arith.trunci %12 : tensor<1024xi64, #blocked0> to tensor<1024xi32, #blocked0>
+    %14 = tt.splat %11 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %15 = tt.addptr %14, %13 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+    %16 = tt.load %15 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %16 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @branch(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: i1) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: i1) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_4:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_5:.*]] = arith.muli %[[VAL_4]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_6:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_6:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_0]], %[[VAL_5]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_8:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_6]]] : tensor<1024xf32>
-// CHECK:           tt.return %[[VAL_8]] : tensor<1024xf32>
+// CHECK:           %[[VAL_8:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_6]]] : tensor<1024xf32, #blocked>
+// CHECK:           tt.return %[[VAL_8]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @branch(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @branch(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = tt.splat %3 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %5 = tt.addptr %4, %2 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-    %6 = tt.load %5 : tensor<1024x!tt.ptr<f32>>
-    tt.return %6 : tensor<1024xf32>
+    %4 = tt.splat %3 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %5 = tt.addptr %4, %2 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+    %6 = tt.load %5 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %6 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
-// CHECK: #[[$ATTR_0:.+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK: #[[$ATTR_0:.+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL:   tt.func @tile_offset(
 // CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f16>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> tensor<16x256xf16, #[[$ATTR_0]]> {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 256 : i32
@@ -517,8 +539,8 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           tt.return %[[VAL_18]] : tensor<16x256xf16, #[[$ATTR_0]]>
 // CHECK:         }
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"ttg.num-warps" = 4 : i32} {
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @tile_offset(%arg0: !tt.ptr<f16>, %arg1: i32, %arg2: i32) -> tensor<16x256xf16, #blocked> {
     %c256_i32 = arith.constant 256 : i32
     %0 = tt.get_program_id x : i32
@@ -542,7 +564,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 // -----
 
-// CHECK: #[[$ATTR_1:.+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK: #[[$ATTR_1:.+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL:   tt.func public @matmul_kernel(
 // CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %[[VAL_1:.*]]: i32 {tt.divisibility = 16 : i32}) -> tensor<128x16xf16, #[[$ATTR_1]]> {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 128 : i32
@@ -565,8 +587,8 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           tt.return %[[VAL_18]] : tensor<128x16xf16, #[[$ATTR_1]]>
 // CHECK:         }
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"ttg.num-warps" = 4 : i32} {
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @matmul_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}) -> tensor<128x16xf16, #blocked> {
     %c128_i32 = arith.constant 128 : i32
     %0 = tt.get_program_id x : i32
@@ -592,131 +614,137 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // -----
 
 // CHECK-LABEL:   tt.func @select(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: i1) -> tensor<1024xf32> {
-// CHECK:           %[[VAL_3:.*]] = arith.constant dense<0> : tensor<1024xi64>
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: i1) -> tensor<1024xf32, #blocked> {
+// CHECK:           %[[VAL_3:.*]] = arith.constant dense<0> : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_5:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_4]] : i32
-// CHECK:           %[[VAL_7:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_8:.*]] = tt.addptr %[[VAL_0]], %[[VAL_6]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32> to tensor<1024xi64>
+// CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_10:.*]] = arith.select %[[VAL_1]], %[[VAL_0]], %[[VAL_8]] : !tt.ptr<f32>
-// CHECK:           %[[VAL_11:.*]] = arith.select %[[VAL_1]], %[[VAL_3]], %[[VAL_9]] : tensor<1024xi64>
-// CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64> to tensor<1024xi32>
-// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_10]]{{\[}}%[[VAL_12]]] : tensor<1024xf32>
-// CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32>
+// CHECK:           %[[VAL_11:.*]] = arith.select %[[VAL_1]], %[[VAL_3]], %[[VAL_9]] : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
+// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_10]]{{\[}}%[[VAL_12]]] : tensor<1024xf32, #blocked>
+// CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @select(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<1024xf32> {
-    %cst = arith.constant dense<0> : tensor<1024xi64>
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @select(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<1024xf32, #blocked0> {
+    %cst = arith.constant dense<0> : tensor<1024xi64, #blocked0>
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
+    %4 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
     %5 = arith.select %arg1, %arg0, %3 : !tt.ptr<f32>
-    %6 = arith.select %arg1, %cst, %4 : tensor<1024xi64>
-    %7 = arith.trunci %6 : tensor<1024xi64> to tensor<1024xi32>
-    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>>
-    tt.return %10 : tensor<1024xf32>
+    %6 = arith.select %arg1, %cst, %4 : tensor<1024xi64, #blocked0>
+    %7 = arith.trunci %6 : tensor<1024xi64, #blocked0> to tensor<1024xi32, #blocked0>
+    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %10 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @where_kernel(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<i64>, %[[VAL_1:.*]]: !tt.ptr<i64>, %[[VAL_2:.*]]: i8) -> tensor<1024xi64> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<i64>, %[[VAL_1:.*]]: !tt.ptr<i64>, %[[VAL_2:.*]]: i8) -> tensor<1024xi64, #blocked> {
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i8
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_6:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[VAL_5]] : i32
-// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_2]], %[[VAL_4]] : i8
 // CHECK:           %[[VAL_10:.*]] = arith.select %[[VAL_9]], %[[VAL_0]], %[[VAL_1]] : !tt.ptr<i64>
 // CHECK:           %[[VAL_11:.*]] = tt.addptr %[[VAL_10]], %[[VAL_7]] : !tt.ptr<i64>, i32
-// CHECK:           %[[VAL_12:.*]] = amdg.buffer_load %[[VAL_11]]{{\[}}%[[VAL_8]]] : tensor<1024xi64>
-// CHECK:           tt.return %[[VAL_12]] : tensor<1024xi64>
+// CHECK:           %[[VAL_12:.*]] = amdg.buffer_load %[[VAL_11]]{{\[}}%[[VAL_8]]] : tensor<1024xi64, #blocked>
+// CHECK:           tt.return %[[VAL_12]] : tensor<1024xi64, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-ctas" = 1 : i32} {
-  tt.func @where_kernel(%arg0: !tt.ptr<i64>, %arg1: !tt.ptr<i64>, %arg2: i8) -> tensor<1024xi64> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @where_kernel(%arg0: !tt.ptr<i64>, %arg1: !tt.ptr<i64>, %arg2: i8) -> tensor<1024xi64, #blocked0> {
     %c0_i8 = arith.constant 0 : i8
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = arith.cmpi ne, %arg2, %c0_i8 : i8
     %4 = arith.select %3, %arg0, %arg1 : !tt.ptr<i64>
     %5 = tt.addptr %4, %1 : !tt.ptr<i64>, i32
-    %6 = tt.splat %5 : !tt.ptr<i64> -> tensor<1024x!tt.ptr<i64>>
-    %7 = tt.addptr %6, %2 : tensor<1024x!tt.ptr<i64>>, tensor<1024xi32>
-    %8 = tt.load %7 : tensor<1024x!tt.ptr<i64>>
-    tt.return %8 : tensor<1024xi64>
+    %6 = tt.splat %5 : !tt.ptr<i64> -> tensor<1024x!tt.ptr<i64>, #blocked0>
+    %7 = tt.addptr %6, %2 : tensor<1024x!tt.ptr<i64>, #blocked0>, tensor<1024xi32, #blocked0>
+    %8 = tt.load %7 : tensor<1024x!tt.ptr<i64>, #blocked0>
+    tt.return %8 : tensor<1024xi64, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @forOpWithHints(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_4:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 128 : index
 // CHECK:           %[[VAL_6:.*]] = tt.get_program_id x : i32
-// CHECK:           %[[VAL_7:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_8:.*]] = tt.addptr %[[VAL_0]], %[[VAL_6]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_3]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_12:.*]] = %[[VAL_8]], %[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
-// CHECK:             %[[VAL_15:.*]] = arith.trunci %[[VAL_13]] : tensor<1024xi64> to tensor<1024xi32>
-// CHECK:             %[[VAL_16:.*]] = amdg.buffer_load %[[VAL_12]]{{\[}}%[[VAL_15]]] : tensor<1024xf32>
+// CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_3]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_12:.*]] = %[[VAL_8]], %[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
+// CHECK:             %[[VAL_15:.*]] = arith.trunci %[[VAL_13]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
+// CHECK:             %[[VAL_16:.*]] = amdg.buffer_load %[[VAL_12]]{{\[}}%[[VAL_15]]] : tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_17:.*]] = tt.addptr %[[VAL_12]], %[[VAL_6]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_18:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_13]] : tensor<1024xi64>
+// CHECK:             %[[VAL_18:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_13]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_20:.*]] = tt.addptr %[[VAL_17]], %[[VAL_6]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_21:.*]] = arith.addf %[[VAL_16]], %[[VAL_14]] : tensor<1024xf32>
-// CHECK:             scf.yield %[[VAL_20]], %[[VAL_19]], %[[VAL_21]] : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
-// CHECK:           } {tt.divisibility_arg1 = dense<16> : tensor<1xi32>, tt.divisibility_arg2 = dense<16> : tensor<1xi32>}
+// CHECK:             %[[VAL_21:.*]] = arith.addf %[[VAL_16]], %[[VAL_14]] : tensor<1024xf32, #blocked>
+// CHECK:             scf.yield %[[VAL_20]], %[[VAL_19]], %[[VAL_21]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
+// CHECK:           } {tt.divisibility_arg1 = dense<16> : tensor<1xi32, #blocked>, tt.divisibility_arg2 = dense<16> : tensor<1xi32, #blocked>}
 // CHECK:           %[[VAL_22:.*]] = tt.addptr %[[VAL_23:.*]]#0, %[[VAL_6]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_26:.*]] = tt.splat %[[VAL_22]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_27:.*]] = tt.addptr %[[VAL_26]], %[[VAL_25]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_28:.*]] = tt.load %[[VAL_27]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_28]] : tensor<1024xf32>
+// CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_26:.*]] = tt.splat %[[VAL_22]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_27:.*]] = tt.addptr %[[VAL_26]], %[[VAL_25]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_28:.*]] = tt.load %[[VAL_27]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_28]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @forOpWithHints(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @forOpWithHints(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>) -> tensor<1024xf32, #blocked0> {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c128 = arith.constant 128 : index
     %0 = tt.get_program_id x : i32
-    %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %2 = tt.addptr %arg0, %0 : !tt.ptr<f32>, i32
-    %3 = arith.extsi %1 : tensor<1024xi32> to tensor<1024xi64>
-    %4:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %2, %arg4 = %3, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
-      %11 = arith.trunci %arg4 : tensor<1024xi64> to tensor<1024xi32>
-      %12 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      %13 = tt.addptr %12, %11 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-      %14 = tt.load %13 : tensor<1024x!tt.ptr<f32>>
+    %3 = arith.extsi %1 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %4:3 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %2, %arg4 = %3, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
+      %11 = arith.trunci %arg4 : tensor<1024xi64, #blocked0> to tensor<1024xi32, #blocked0>
+      %12 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+      %13 = tt.addptr %12, %11 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+      %14 = tt.load %13 : tensor<1024x!tt.ptr<f32>, #blocked0>
       %15 = tt.addptr %arg3, %0 : !tt.ptr<f32>, i32
-      %16 = arith.extsi %1 : tensor<1024xi32> to tensor<1024xi64>
-      %17 = arith.addi %16, %arg4 : tensor<1024xi64>
+      %16 = arith.extsi %1 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      %17 = arith.addi %16, %arg4 : tensor<1024xi64, #blocked0>
       %18 = tt.addptr %15, %0 : !tt.ptr<f32>, i32
-      %19 = arith.addf %14, %arg5 : tensor<1024xf32>
-      scf.yield %18, %17, %19 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
-    } {tt.divisibility_arg1 = dense<16> : tensor<1xi32>, tt.divisibility_arg2 = dense<16> : tensor<1xi32>}
+      %19 = arith.addf %14, %arg5 : tensor<1024xf32, #blocked0>
+      scf.yield %18, %17, %19 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
+    } {tt.divisibility_arg1 = dense<16> : tensor<1xi32, #blocked0>, tt.divisibility_arg2 = dense<16> : tensor<1xi32, #blocked0>}
     %5 = tt.addptr %4#0, %0 : !tt.ptr<f32>, i32
-    %6 = arith.extsi %1 : tensor<1024xi32> to tensor<1024xi64>
-    %7 = arith.addi %6, %4#1 : tensor<1024xi64>
-    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>>
-    tt.return %10 : tensor<1024xf32>
+    %6 = arith.extsi %1 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %7 = arith.addi %6, %4#1 : tensor<1024xi64, #blocked0>
+    %8 = tt.splat %5 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %10 : tensor<1024xf32, #blocked0>
   }
 }
 
@@ -736,7 +764,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           tt.return
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @scalar_pointers(%arg0: !tt.ptr<i64> {tt.divisibility = 16 : i32}) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i32 = arith.constant 1 : i32
@@ -754,7 +784,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // -----
 
 // CHECK-LABEL:   tt.func @scalar_if(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>, %[[VAL_2:.*]]: i1) -> f32 {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>, %[[VAL_2:.*]]: i1) -> f32 {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 100 : i32
 // CHECK:           %[[VAL_5:.*]] = tt.addptr %[[VAL_0]], %[[VAL_3]] : !tt.ptr<f32>, i32
@@ -769,8 +799,10 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           tt.return %[[VAL_9]] : f32
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @scalar_if(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>, %arg2: i1) -> f32 {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @scalar_if(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>, %arg2: i1) -> f32 {
     %c1_i32 = arith.constant 1 : i32
     %c100_i32 = arith.constant 100 : i32
     %0 = tt.addptr %arg0, %c1_i32 : !tt.ptr<f32>, i32
@@ -796,7 +828,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           tt.return %[[VAL_4]] : f32
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @scalar_cond_branch(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i1) -> f32 {
     cf.cond_br %arg2, ^bb1(%arg0 : !tt.ptr<f32>), ^bb2(%arg1 : !tt.ptr<f32>)
   ^bb1(%0: !tt.ptr<f32>):  // pred: ^bb0
@@ -811,241 +845,249 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // -----
 
 // CHECK-LABEL:   tt.func @flipFlopForOpSimple(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_4:.*]] = arith.constant 128 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_6:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_9:.*]] = tt.addptr %[[VAL_0]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
+// CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_11:.*]] = tt.addptr %[[VAL_0]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_12:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_13:.*]]:5 = scf.for %[[VAL_14:.*]] = %[[VAL_3]] to %[[VAL_4]] step %[[VAL_5]] iter_args(%[[VAL_15:.*]] = %[[VAL_11]], %[[VAL_16:.*]] = %[[VAL_12]], %[[VAL_17:.*]] = %[[VAL_9]], %[[VAL_18:.*]] = %[[VAL_10]], %[[VAL_19:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+// CHECK:           %[[VAL_12:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_13:.*]]:5 = scf.for %[[VAL_14:.*]] = %[[VAL_3]] to %[[VAL_4]] step %[[VAL_5]] iter_args(%[[VAL_15:.*]] = %[[VAL_11]], %[[VAL_16:.*]] = %[[VAL_12]], %[[VAL_17:.*]] = %[[VAL_9]], %[[VAL_18:.*]] = %[[VAL_10]], %[[VAL_19:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:             %[[VAL_20:.*]] = tt.addptr %[[VAL_17]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_21:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64>
-// CHECK:             %[[VAL_23:.*]] = tt.splat %[[VAL_20]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_24:.*]] = tt.addptr %[[VAL_23]], %[[VAL_22]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:             %[[VAL_25:.*]] = tt.load %[[VAL_24]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_26:.*]] = arith.addf %[[VAL_25]], %[[VAL_19]] : tensor<1024xf32>
-// CHECK:             scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_15]], %[[VAL_16]], %[[VAL_26]] : !tt.ptr<f32>, tensor<1024xi64>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:             %[[VAL_21:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_23:.*]] = tt.splat %[[VAL_20]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_24:.*]] = tt.addptr %[[VAL_23]], %[[VAL_22]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_25:.*]] = tt.load %[[VAL_24]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_26:.*]] = arith.addf %[[VAL_25]], %[[VAL_19]] : tensor<1024xf32, #blocked>
+// CHECK:             scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_15]], %[[VAL_16]], %[[VAL_26]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_27:.*]] = tt.addptr %[[VAL_28:.*]]#0, %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_29:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_28]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_31:.*]] = tt.splat %[[VAL_27]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_32:.*]] = tt.addptr %[[VAL_31]], %[[VAL_30]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_33:.*]] = tt.load %[[VAL_32]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_33]] : tensor<1024xf32>
+// CHECK:           %[[VAL_29:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_28]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_31:.*]] = tt.splat %[[VAL_27]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_32:.*]] = tt.addptr %[[VAL_31]], %[[VAL_30]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_33:.*]] = tt.load %[[VAL_32]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_33]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @flipFlopForOpSimple(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @flipFlopForOpSimple(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c1 = arith.constant 1 : index
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
+    %4 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
     %5 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %6 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %7:5 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %5, %arg4 = %6, %arg5 = %3, %arg6 = %4, %arg7 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+    %6 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %7:5 = scf.for %arg2 = %c0 to %c128 step %c1 iter_args(%arg3 = %5, %arg4 = %6, %arg5 = %3, %arg6 = %4, %arg7 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
       %14 = tt.addptr %arg5, %1 : !tt.ptr<f32>, i32
-      %15 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-      %16 = arith.addi %15, %arg6 : tensor<1024xi64>
-      %17 = tt.splat %14 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      %18 = tt.addptr %17, %16 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-      %19 = tt.load %18 : tensor<1024x!tt.ptr<f32>>
-      %20 = arith.addf %19, %arg7 : tensor<1024xf32>
-      scf.yield %14, %16, %arg3, %arg4, %20 : !tt.ptr<f32>, tensor<1024xi64>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+      %15 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      %16 = arith.addi %15, %arg6 : tensor<1024xi64, #blocked0>
+      %17 = tt.splat %14 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+      %18 = tt.addptr %17, %16 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+      %19 = tt.load %18 : tensor<1024x!tt.ptr<f32>, #blocked0>
+      %20 = arith.addf %19, %arg7 : tensor<1024xf32, #blocked0>
+      scf.yield %14, %16, %arg3, %arg4, %20 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
     }
     %8 = tt.addptr %7#0, %1 : !tt.ptr<f32>, i32
-    %9 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %10 = arith.addi %9, %7#1 : tensor<1024xi64>
-    %11 = tt.splat %8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %12 = tt.addptr %11, %10 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %13 = tt.load %12 : tensor<1024x!tt.ptr<f32>>
-    tt.return %13 : tensor<1024xf32>
+    %9 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %10 = arith.addi %9, %7#1 : tensor<1024xi64, #blocked0>
+    %11 = tt.splat %8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %12 = tt.addptr %11, %10 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %13 = tt.load %12 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %13 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @flipFlopForOpComplex(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: !tt.ptr<f32>, %[[VAL_2:.*]]: tensor<1024xf32>) -> (tensor<1024xf32>, tensor<1024xf32>) {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: !tt.ptr<f32>, %[[VAL_2:.*]]: tensor<1024xf32, #blocked>) -> (tensor<1024xf32, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 128 : index
 // CHECK:           %[[VAL_6:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_7:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_7]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_9:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_10:.*]] = tt.addptr %[[VAL_0]], %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_11:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
+// CHECK:           %[[VAL_11:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_12:.*]] = tt.addptr %[[VAL_1]], %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_13:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_14:.*]]:6 = scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_16:.*]] = %[[VAL_10]], %[[VAL_17:.*]] = %[[VAL_11]], %[[VAL_18:.*]] = %[[VAL_2]], %[[VAL_19:.*]] = %[[VAL_12]], %[[VAL_20:.*]] = %[[VAL_13]], %[[VAL_21:.*]] = %[[VAL_2]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+// CHECK:           %[[VAL_13:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_14:.*]]:6 = scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_6]] iter_args(%[[VAL_16:.*]] = %[[VAL_10]], %[[VAL_17:.*]] = %[[VAL_11]], %[[VAL_18:.*]] = %[[VAL_2]], %[[VAL_19:.*]] = %[[VAL_12]], %[[VAL_20:.*]] = %[[VAL_13]], %[[VAL_21:.*]] = %[[VAL_2]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:             %[[VAL_22:.*]] = tt.addptr %[[VAL_16]], %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_23:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_17]] : tensor<1024xi64>
-// CHECK:             %[[VAL_25:.*]] = tt.splat %[[VAL_22]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_26:.*]] = tt.addptr %[[VAL_25]], %[[VAL_24]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:             %[[VAL_27:.*]] = tt.load %[[VAL_26]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_28:.*]] = arith.addf %[[VAL_27]], %[[VAL_18]] : tensor<1024xf32>
+// CHECK:             %[[VAL_23:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_17]] : tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_25:.*]] = tt.splat %[[VAL_22]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_26:.*]] = tt.addptr %[[VAL_25]], %[[VAL_24]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_27:.*]] = tt.load %[[VAL_26]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_28:.*]] = arith.addf %[[VAL_27]], %[[VAL_18]] : tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_29:.*]] = tt.addptr %[[VAL_19]], %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_30:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             %[[VAL_31:.*]] = arith.addi %[[VAL_30]], %[[VAL_20]] : tensor<1024xi64>
-// CHECK:             %[[VAL_32:.*]] = tt.splat %[[VAL_29]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_33:.*]] = tt.addptr %[[VAL_32]], %[[VAL_31]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:             %[[VAL_34:.*]] = tt.load %[[VAL_33]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_35:.*]] = arith.addf %[[VAL_34]], %[[VAL_21]] : tensor<1024xf32>
-// CHECK:             scf.yield %[[VAL_29]], %[[VAL_31]], %[[VAL_35]], %[[VAL_22]], %[[VAL_24]], %[[VAL_28]] : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:             %[[VAL_30:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_31:.*]] = arith.addi %[[VAL_30]], %[[VAL_20]] : tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_32:.*]] = tt.splat %[[VAL_29]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_33:.*]] = tt.addptr %[[VAL_32]], %[[VAL_31]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_34:.*]] = tt.load %[[VAL_33]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_35:.*]] = arith.addf %[[VAL_34]], %[[VAL_21]] : tensor<1024xf32, #blocked>
+// CHECK:             scf.yield %[[VAL_29]], %[[VAL_31]], %[[VAL_35]], %[[VAL_22]], %[[VAL_24]], %[[VAL_28]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_36:.*]] = tt.addptr %[[VAL_37:.*]]#0, %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_38:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_37]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_40:.*]] = tt.splat %[[VAL_36]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_41:.*]] = tt.addptr %[[VAL_40]], %[[VAL_39]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_42:.*]] = tt.load %[[VAL_41]] : tensor<1024x!tt.ptr<f32>>
+// CHECK:           %[[VAL_38:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_37]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_40:.*]] = tt.splat %[[VAL_36]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_41:.*]] = tt.addptr %[[VAL_40]], %[[VAL_39]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_42:.*]] = tt.load %[[VAL_41]] : tensor<1024x!tt.ptr<f32>, #blocked>
 // CHECK:           %[[VAL_43:.*]] = tt.addptr %[[VAL_37]]#3, %[[VAL_8]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_44:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_45:.*]] = arith.addi %[[VAL_44]], %[[VAL_37]]#4 : tensor<1024xi64>
-// CHECK:           %[[VAL_46:.*]] = tt.splat %[[VAL_43]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_47:.*]] = tt.addptr %[[VAL_46]], %[[VAL_45]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_48:.*]] = tt.load %[[VAL_47]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_42]], %[[VAL_48]] : tensor<1024xf32>, tensor<1024xf32>
+// CHECK:           %[[VAL_44:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_45:.*]] = arith.addi %[[VAL_44]], %[[VAL_37]]#4 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_46:.*]] = tt.splat %[[VAL_43]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_47:.*]] = tt.addptr %[[VAL_46]], %[[VAL_45]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_48:.*]] = tt.load %[[VAL_47]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_42]], %[[VAL_48]] : tensor<1024xf32, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @flipFlopForOpComplex(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: tensor<1024xf32>) -> (tensor<1024xf32>, tensor<1024xf32>) {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @flipFlopForOpComplex(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: tensor<1024xf32, #blocked0>) -> (tensor<1024xf32, #blocked0>, tensor<1024xf32, #blocked0>) {
     %c1024_i32 = arith.constant 1024 : i32
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c1 = arith.constant 1 : index
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
+    %4 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
     %5 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
-    %6 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %7:6 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %3, %arg5 = %4, %arg6 = %arg2, %arg7 = %5, %arg8 = %6, %arg9 = %arg2) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+    %6 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %7:6 = scf.for %arg3 = %c0 to %c128 step %c1 iter_args(%arg4 = %3, %arg5 = %4, %arg6 = %arg2, %arg7 = %5, %arg8 = %6, %arg9 = %arg2) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>, !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
       %20 = tt.addptr %arg4, %1 : !tt.ptr<f32>, i32
-      %21 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-      %22 = arith.addi %21, %arg5 : tensor<1024xi64>
-      %23 = tt.splat %20 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      %24 = tt.addptr %23, %22 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-      %25 = tt.load %24 : tensor<1024x!tt.ptr<f32>>
-      %26 = arith.addf %25, %arg6 : tensor<1024xf32>
+      %21 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      %22 = arith.addi %21, %arg5 : tensor<1024xi64, #blocked0>
+      %23 = tt.splat %20 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+      %24 = tt.addptr %23, %22 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+      %25 = tt.load %24 : tensor<1024x!tt.ptr<f32>, #blocked0>
+      %26 = arith.addf %25, %arg6 : tensor<1024xf32, #blocked0>
       %27 = tt.addptr %arg7, %1 : !tt.ptr<f32>, i32
-      %28 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-      %29 = arith.addi %28, %arg8 : tensor<1024xi64>
-      %30 = tt.splat %27 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      %31 = tt.addptr %30, %29 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-      %32 = tt.load %31 : tensor<1024x!tt.ptr<f32>>
-      %33 = arith.addf %32, %arg9 : tensor<1024xf32>
-      scf.yield %27, %29, %33, %20, %22, %26 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>, !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+      %28 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      %29 = arith.addi %28, %arg8 : tensor<1024xi64, #blocked0>
+      %30 = tt.splat %27 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+      %31 = tt.addptr %30, %29 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+      %32 = tt.load %31 : tensor<1024x!tt.ptr<f32>, #blocked0>
+      %33 = arith.addf %32, %arg9 : tensor<1024xf32, #blocked0>
+      scf.yield %27, %29, %33, %20, %22, %26 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>, !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
     }
     %8 = tt.addptr %7#0, %1 : !tt.ptr<f32>, i32
-    %9 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %10 = arith.addi %9, %7#1 : tensor<1024xi64>
-    %11 = tt.splat %8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %12 = tt.addptr %11, %10 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %13 = tt.load %12 : tensor<1024x!tt.ptr<f32>>
+    %9 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %10 = arith.addi %9, %7#1 : tensor<1024xi64, #blocked0>
+    %11 = tt.splat %8 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %12 = tt.addptr %11, %10 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %13 = tt.load %12 : tensor<1024x!tt.ptr<f32>, #blocked0>
     %14 = tt.addptr %7#3, %1 : !tt.ptr<f32>, i32
-    %15 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %16 = arith.addi %15, %7#4 : tensor<1024xi64>
-    %17 = tt.splat %14 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %18 = tt.addptr %17, %16 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %19 = tt.load %18 : tensor<1024x!tt.ptr<f32>>
-    tt.return %13, %19 : tensor<1024xf32>, tensor<1024xf32>
+    %15 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %16 = arith.addi %15, %7#4 : tensor<1024xi64, #blocked0>
+    %17 = tt.splat %14 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %18 = tt.addptr %17, %16 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %19 = tt.load %18 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %13, %19 : tensor<1024xf32, #blocked0>, tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @forOpDynamicKBound(
-// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32>, %[[VAL_2:.*]]: index) -> tensor<1024xf32> {
+// CHECK-SAME:  %[[VAL_0:.*]]: !tt.ptr<f32>, %[[VAL_1:.*]]: tensor<1024xf32, #blocked>, %[[VAL_2:.*]]: index) -> tensor<1024xf32, #blocked> {
 // CHECK:           %[[VAL_3:.*]] = arith.constant 1024 : i32
 // CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = arith.constant 128 : index
 // CHECK:           %[[VAL_6:.*]] = tt.get_program_id x : i32
 // CHECK:           %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+// CHECK:           %[[VAL_8:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_9:.*]] = tt.addptr %[[VAL_0]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_11:.*]]:3 = scf.for %[[VAL_12:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_2]] iter_args(%[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_10]], %[[VAL_15:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+// CHECK:           %[[VAL_10:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_11:.*]]:3 = scf.for %[[VAL_12:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_2]] iter_args(%[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_10]], %[[VAL_15:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:             %[[VAL_16:.*]] = tt.addptr %[[VAL_13]], %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:             %[[VAL_17:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_14]] : tensor<1024xi64>
-// CHECK:             %[[VAL_19:.*]] = tt.splat %[[VAL_16]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_20:.*]] = tt.addptr %[[VAL_19]], %[[VAL_18]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:             %[[VAL_21:.*]] = tt.load %[[VAL_20]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:             %[[VAL_22:.*]] = arith.addf %[[VAL_21]], %[[VAL_15]] : tensor<1024xf32>
-// CHECK:             scf.yield %[[VAL_16]], %[[VAL_18]], %[[VAL_22]] : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+// CHECK:             %[[VAL_17:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_14]] : tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_19:.*]] = tt.splat %[[VAL_16]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_20:.*]] = tt.addptr %[[VAL_19]], %[[VAL_18]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:             %[[VAL_21:.*]] = tt.load %[[VAL_20]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:             %[[VAL_22:.*]] = arith.addf %[[VAL_21]], %[[VAL_15]] : tensor<1024xf32, #blocked>
+// CHECK:             scf.yield %[[VAL_16]], %[[VAL_18]], %[[VAL_22]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_23:.*]] = tt.addptr %[[VAL_24:.*]]#0, %[[VAL_7]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_25:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32> to tensor<1024xi64>
-// CHECK:           %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_24]]#1 : tensor<1024xi64>
-// CHECK:           %[[VAL_27:.*]] = tt.splat %[[VAL_23]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-// CHECK:           %[[VAL_28:.*]] = tt.addptr %[[VAL_27]], %[[VAL_26]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-// CHECK:           %[[VAL_29:.*]] = tt.load %[[VAL_28]] : tensor<1024x!tt.ptr<f32>>
-// CHECK:           tt.return %[[VAL_29]] : tensor<1024xf32>
+// CHECK:           %[[VAL_25:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_24]]#1 : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_27:.*]] = tt.splat %[[VAL_23]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           %[[VAL_28:.*]] = tt.addptr %[[VAL_27]], %[[VAL_26]] : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_29:.*]] = tt.load %[[VAL_28]] : tensor<1024x!tt.ptr<f32>, #blocked>
+// CHECK:           tt.return %[[VAL_29]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @forOpDynamicKBound(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>, %K: index) -> tensor<1024xf32> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @forOpDynamicKBound(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>, %K: index) -> tensor<1024xf32, #blocked0> {
     %c1024_i32 = arith.constant 1024 : i32
     %c0 = arith.constant 0 : index
     %c128 = arith.constant 128 : index
     %c1 = arith.constant 1 : index
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %c1024_i32 : i32
-    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
     %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
-    %4 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %5:3 = scf.for %arg2 = %c0 to %c128 step %K iter_args(%arg3 = %3, %arg4 = %4, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
+    %4 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %5:3 = scf.for %arg2 = %c0 to %c128 step %K iter_args(%arg3 = %3, %arg4 = %4, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>) {
       %12 = tt.addptr %arg3, %1 : !tt.ptr<f32>, i32
-      %13 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-      %14 = arith.addi %13, %arg4 : tensor<1024xi64>
-      %15 = tt.splat %12 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-      %16 = tt.addptr %15, %14 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-      %17 = tt.load %16 : tensor<1024x!tt.ptr<f32>>
-      %18 = arith.addf %17, %arg5 : tensor<1024xf32>
-      scf.yield %12, %14, %18 : !tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>
+      %13 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+      %14 = arith.addi %13, %arg4 : tensor<1024xi64, #blocked0>
+      %15 = tt.splat %12 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+      %16 = tt.addptr %15, %14 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+      %17 = tt.load %16 : tensor<1024x!tt.ptr<f32>, #blocked0>
+      %18 = arith.addf %17, %arg5 : tensor<1024xf32, #blocked0>
+      scf.yield %12, %14, %18 : !tt.ptr<f32>, tensor<1024xi64, #blocked0>, tensor<1024xf32, #blocked0>
     }
     %6 = tt.addptr %5#0, %1 : !tt.ptr<f32>, i32
-    %7 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    %8 = arith.addi %7, %5#1 : tensor<1024xi64>
-    %9 = tt.splat %6 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %10 = tt.addptr %9, %8 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi64>
-    %11 = tt.load %10 : tensor<1024x!tt.ptr<f32>>
-    tt.return %11 : tensor<1024xf32>
+    %7 = arith.extsi %2 : tensor<1024xi32, #blocked0> to tensor<1024xi64, #blocked0>
+    %8 = arith.addi %7, %5#1 : tensor<1024xi64, #blocked0>
+    %9 = tt.splat %6 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %10 = tt.addptr %9, %8 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi64, #blocked0>
+    %11 = tt.load %10 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %11 : tensor<1024xf32, #blocked0>
   }
 }
 
 // -----
 
 // CHECK-LABEL:   tt.func @whileOp
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @whileOp(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
-    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
-    %2 = scf.while (%arg2 = %1) : (tensor<1024x!tt.ptr<f32>>) -> tensor<1024x!tt.ptr<f32>> {
+#blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @whileOp(%arg0: !tt.ptr<f32>, %arg1: tensor<1024xf32, #blocked0>) -> tensor<1024xf32, #blocked0> {
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked0>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked0>
+    %2 = scf.while (%arg2 = %1) : (tensor<1024x!tt.ptr<f32>, #blocked0>) -> tensor<1024x!tt.ptr<f32>, #blocked0> {
       %4 = "dummy.evaluate_condition"() : () -> i1
-      scf.condition(%4) %arg2 : tensor<1024x!tt.ptr<f32>>
+      scf.condition(%4) %arg2 : tensor<1024x!tt.ptr<f32>, #blocked0>
     } do {
-    ^bb0(%arg2: tensor<1024x!tt.ptr<f32>>):
-      %4 = tt.addptr %arg2, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
-      scf.yield %4 : tensor<1024x!tt.ptr<f32>>
+    ^bb0(%arg2: tensor<1024x!tt.ptr<f32>, #blocked0>):
+      %4 = tt.addptr %arg2, %0 : tensor<1024x!tt.ptr<f32>, #blocked0>, tensor<1024xi32, #blocked0>
+      scf.yield %4 : tensor<1024x!tt.ptr<f32>, #blocked0>
     }
-    %3 = tt.load %2 : tensor<1024x!tt.ptr<f32>>
-    tt.return %3 : tensor<1024xf32>
+    %3 = tt.load %2 : tensor<1024x!tt.ptr<f32>, #blocked0>
+    tt.return %3 : tensor<1024xf32, #blocked0>
   }
 }

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -19,12 +19,16 @@ def get_min_dot_size(target: GPUTarget):
 
 
 def is_pingpong_schedule_enabled(arch, use_async_copy):
-    return (arch == "gfx942" or (arch == "gfx950" and use_async_copy is True)
-            ) if knobs.amd.use_block_pingpong is None else knobs.amd.use_block_pingpong
+    return (arch == "gfx942" or (arch == "gfx950" and use_async_copy is True)) \
+        if knobs.amd.use_block_pingpong is None else knobs.amd.use_block_pingpong
 
 
 def is_in_thread_transpose_enabled(arch):
     return (arch == "gfx942") if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
+
+
+def is_async_copy_enabled(arch):
+    return (arch in ["gfx950", "gfx1250"]) if knobs.amd.use_async_copy is None else knobs.amd.use_async_copy
 
 
 @dataclass(frozen=True)
@@ -241,7 +245,7 @@ class HIPBackend(BaseBackend):
         passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)
 
-        use_async_copy = knobs.amd.use_async_copy
+        use_async_copy = is_async_copy_enabled(options.arch)
         use_block_pingpong = is_pingpong_schedule_enabled(options.arch, use_async_copy)
 
         amd.passes.ttgpuir.add_schedule_loops(pm, options.num_stages)

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -305,6 +305,9 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
       the first elements of each row in bytes. Compiler tries to obtain the `stride`
       when it converts to the buffer ops because it is important for optimizing
       the cache memory access.
+      Contiguity is the maximum number of elements that can be loaded in a single vector
+      with the given layout and mask.
+      This allows to use buffer_load even if the alignment cannot be proven based on IR.
     }];
     let arguments = (ins
       Arg<TT_Ptr, "Global memory scalar base pointer to load from", [MemRead<GlobalMemory>]>:$ptr,
@@ -312,7 +315,8 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
       Optional<I32>:$stride,
       DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
       Optional<TT_BoolTensor>:$mask,
-      Optional<TT_Tensor>:$other
+      Optional<TT_Tensor>:$other,
+      DefaultValuedAttr<I32Attr, "1">:$contiguity
     );
     let results = (outs TT_Tensor:$result);
 
@@ -480,6 +484,9 @@ def BufferStoreOp : TT_AMDGPU_Op<"buffer_store", [
       the first elements of each row in bytes. Compiler tries to obtain the `stride`
       when it converts to the buffer ops because it is important for optimizing
       the cache memory access.
+      Contiguity is the maximum number of elements that can be loaded in a single vector
+      with the given layout and mask.
+      This allows to use buffer_store even if the alignment cannot be proven based on IR.
     }];
     let arguments = (ins
       TT_Tensor:$value,
@@ -487,7 +494,8 @@ def BufferStoreOp : TT_AMDGPU_Op<"buffer_store", [
       I32Tensor:$offsets,
       Optional<I32>:$stride,
       DefaultValuedAttr<TT_CacheModifierAttr, "mlir::triton::CacheModifier::NONE">:$cache,
-      Optional<TT_BoolTensor>:$mask
+      Optional<TT_BoolTensor>:$mask,
+      DefaultValuedAttr<I32Attr, "1">:$contiguity
     );
 
     let assemblyFormat = [{

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -685,6 +685,8 @@ struct BufferLoadOpConversion
     Type ptrType = getPointerTypeWithShape(ptr, offset);
     unsigned numElems = getTotalElemsPerThread(ptrType);
     unsigned vec = getVectorSize(ptr, offset, axisAnalysisPass);
+    // If the op has a contiguity hint use it to increase the vector size.
+    vec = std::max(vec, op.getContiguity());
 
     // Get the offset
     SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
@@ -1696,6 +1698,8 @@ struct BufferStoreOpConversion
 
     unsigned numElems = getTotalElemsPerThread(ptrType);
     unsigned vec = getVectorSize(ptr, offset, axisAnalysisPass);
+    // If the op has a contiguity hint use it to increase the vector size.
+    vec = std::max(vec, op.getContiguity());
 
     // Get the offsets and value
     SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);

--- a/third_party/amd/tools/hip/compile.c
+++ b/third_party/amd/tools/hip/compile.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
+#define __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
 
 // helpers to check for hip errors
@@ -28,8 +29,8 @@ static inline void gpuAssert(hipError_t code, const char *file, int line) {{
 
 // globals
 #define HSACO_NAME {kernel_name}_hsaco
-hipModule_t {kernel_name}_mod = nullptr;
-hipFunction_t {kernel_name}_func = nullptr;
+hipModule_t {kernel_name}_mod = NULL;
+hipFunction_t {kernel_name}_func = NULL;
 unsigned char HSACO_NAME[{bin_size}] = {{ {bin_data} }};
 
 
@@ -50,7 +51,7 @@ void load_{kernel_name}() {{
 {kernel_docstring}
 */
 hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
-    if ({kernel_name}_func == nullptr)
+    if ({kernel_name}_func == NULL)
        load_{kernel_name}();
     unsigned int gX = {gridX};
     unsigned int gY = {gridY};
@@ -61,7 +62,7 @@ hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
 
     // TODO: shared memory
     if(gX * gY * gZ > 0)
-      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, nullptr);
+      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, NULL);
     else
       return hipErrorInvalidValue;
 }}

--- a/third_party/amd/tools/hip/compile.h
+++ b/third_party/amd/tools/hip/compile.h
@@ -3,11 +3,16 @@
 
 #pragma once
 
+#define __HIP_PLATFORM_AMD__
+
 #include <hip/hip_runtime.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
+// tt-linker: {kernel_name}:{full_signature}:{algo_info}
 hipError_t{_placeholder} {kernel_name}(hipStream_t stream, {signature});

--- a/third_party/amd/tools/hip/link.h
+++ b/third_party/amd/tools/hip/link.h
@@ -1,0 +1,14 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#define __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+
+typedef hipStream_t TT_StreamTy;
+typedef hipError_t TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE hipErrorInvalidValue
+
+#endif

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -474,7 +474,9 @@ class CUDABackend(BaseBackend):
         # Budget-aware layout conversion elimination — runs last to ensure
         # converts whose scratch would exceed SMEM budget are eliminated
         # after all other passes that may introduce layout conversions.
-        passes.ttgpuir.add_remove_layout_conversions(pm, smem_budget)
+        # TODO(njriasan): Re-enable once propagateSrcEncodingAndErase handles
+        # scf::ForOp/WhileOp loop-carried values correctly.
+        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -360,7 +360,6 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     builder.setLoopScheduleInfoFromOp(tmaLoad);
     auto pipelineBuffer = getBufferForPipelineStage(builder, tmaLoad.getType(),
                                                     buffer, bufferIdx, true);
-    // FIXME: translateTMAIndices
     copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(
         loc, /*multicastTargets*/ Value(), tmaLoad.getDesc(),
         tmaLoad.getIndices(), prodBarrier, pipelineBuffer, pred);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -61,15 +61,11 @@ void doTMAStoreLowering(triton::FuncOp &funcOp) {
 
     auto alloc = builder.create<ttg::LocalAllocOp>(loc, memDescType, src);
 
-    // Translate indices for TMA.
-    auto indices = ttng::translateTMAIndices(
-        builder, loc, desc.getType().getBlockType().getEncoding(),
-        storeOp.getIndices());
-
     // Async TMA copy from local (SMEM) to global, producing a token.
     auto tokenType = ttg::AsyncTokenType::get(ctx);
     auto tmaStore = builder.create<ttng::AsyncTMACopyLocalToGlobalOp>(
-        loc, tokenType, desc, indices, alloc, tt::EvictionPolicy::NORMAL);
+        loc, tokenType, desc, storeOp.getIndices(), alloc,
+        tt::EvictionPolicy::NORMAL);
     copyLoopScheduleAttrs(storeOp, tmaStore);
 
     // Wait for this specific TMA store to finish reading from SMEM.

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -286,28 +286,9 @@ getSubViews(ArefValue arefVal, Value stage, Location loc, OpBuilder &rewriter,
 
 void createTMALoad(triton::nvws::DescriptorLoadOp op, PatternRewriter &rewriter,
                    Value barrierAlloc, Value pred) {
-  auto indices = translateTMAIndices(
-      rewriter, op.getLoc(),
-      op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
-  for (auto [newIdx, oldIdx] : llvm::zip(indices, op.getIndices())) {
-    // translateTMAIndices may create ops, we need to annotated them
-    if (newIdx != oldIdx) {
-      auto partitionIds = getPartitionWsTagIds(op);
-      auto stageCluster = getStageCluster(op);
-      assignStageCluster(newIdx.getDefiningOp(), partitionIds, stageCluster,
-                         rewriter);
-      for (auto val : newIdx.getDefiningOp()->getOperands()) {
-        if (auto op = val.getDefiningOp()) {
-          if (!hasPartition(op)) {
-            assignStageCluster(op, partitionIds, stageCluster, rewriter);
-          }
-        }
-      }
-    }
-  }
   auto newLoadOp = triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
       rewriter, op.getLoc(), /*multicastTargets*/ Value(), op.getDesc(),
-      indices, barrierAlloc, op.getResult(), pred);
+      op.getIndices(), barrierAlloc, op.getResult(), pred);
   assignStageCluster(newLoadOp, getPartitionWsTagIds(op), getStageCluster(op),
                      rewriter);
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1508,10 +1508,16 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       auto offsets = applyLinearLayout(loc, rewriter, msgToOffset,
                                        {{kMsg, copyIdxVal}, {kBlock, ctaId}});
       int operandIdx = 3;
+      auto encoding = op.getDesc().getType().getBlockType().getEncoding();
+      bool fp4Padded = nvidia_gpu::isFp4Padded(encoding);
       for (int i = 0; i < rank; i++) {
         Value coord = adaptor.getCoord()[rank - i - 1];
+        if (fp4Padded && i == 0) {
+          coord = b.mul(coord, b.i32_val(2));
+        }
         if (i < offsets.size())
           coord = b.add(coord, offsets[offsets.size() - i - 1].second);
+
         operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
         tmaInst += "$" + std::to_string(operandIdx++);
         if (i != rank - 1)
@@ -1711,8 +1717,12 @@ convertTMAStoreLikeOp(Operation *op, const TypeConverter *typeConverter,
 
     auto offsets = applyLinearLayout(loc, rewriter, msgToOffset,
                                      {{kMsg, copyIdxVal}, {kBlock, ctaId}});
+    bool fp4Padded = nvidia_gpu::isFp4Padded(srcTy.getEncoding());
     for (int i = 0; i < rank; i++) {
       Value coord = coords[rank - i - 1];
+      if (fp4Padded && i == 0) {
+        coord = b.mul(coord, b.i32_val(2));
+      }
       if (i < offsets.size())
         coord = b.add(coord, offsets[offsets.size() - i - 1].second);
       operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
@@ -1890,8 +1900,11 @@ static LogicalResult iterateGatherScatterIndices(
     return op->emitError("memdesc shape must match alloc shape");
   // `NVMMASharedEncodingAttr` means the core matrix tiles are placed next to
   // each other in shared memory, which lines up with how `gather4` loads data.
-  if (!isa<NVMMASharedEncodingAttr>(smemType.getEncoding()))
+  auto enc = dyn_cast<NVMMASharedEncodingAttr>(smemType.getEncoding());
+  if (!enc)
     return op->emitError("requires dst encoding NVMMASharedEncodingAttr");
+  if (enc.getFp4Padded())
+    yOffsetValue = b.mul(yOffsetValue, b.i32_val(2));
   Type llvmElemTy = typeConverter.convertType(smemType.getElementType());
   Type elemPtrTy = ptr_ty(ctx, /*addrspace=*/3);
   auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, smemObjValue,

--- a/third_party/nvidia/tools/cuda/compile.h
+++ b/third_party/nvidia/tools/cuda/compile.h
@@ -8,6 +8,8 @@
 
 #endif
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
 // tt-linker: {kernel_name}:{full_signature}:{algo_info}

--- a/third_party/nvidia/tools/cuda/link.h
+++ b/third_party/nvidia/tools/cuda/link.h
@@ -1,0 +1,13 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#include <cuda.h>
+
+typedef CUstream TT_StreamTy;
+typedef CUresult TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE CUDA_ERROR_INVALID_VALUE
+
+#endif

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -1,7 +1,7 @@
 import json
 import pathlib
 
-from typing import NamedTuple, Tuple
+from typing import NamedTuple, Tuple, Optional
 
 import triton.profiler as proton
 
@@ -10,7 +10,6 @@ import torch
 
 import triton
 import triton.language as tl
-import triton.language.semantic
 import triton.profiler.language as pl
 from triton._internal_testing import (
     is_cuda,
@@ -973,3 +972,66 @@ def test_threaded_kernel_call(tmp_path: pathlib.Path):
         assert len(events) > 0
         kernel_events = [e for e in events if e["name"] == "kernel"]
         assert len(kernel_events) > 0
+
+
+@pytest.mark.parametrize("num_ctas", [1, 2])
+def test_tensor_descriptor(num_ctas, tmp_path: pathlib.Path):
+    if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
+        pytest.skip("CTAs is unsupported for these cards")
+
+    @triton.jit
+    def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[M, N],
+            strides=[N, 1],
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+
+        assert desc.shape[0] == M
+        assert desc.shape[1] == N
+        assert desc.strides[0] == N
+        assert desc.strides[1] == 1
+        assert desc.block_shape == [M_BLOCK, N_BLOCK]
+        pl.enter_scope("load_block")
+        block = desc.load([M_BLOCK, 2 * N_BLOCK])
+        pl.exit_scope("load_block")
+        idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+        tl.store(out_ptr + idx, block)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        assert size == 128 * num_ctas
+        assert align == 128
+        assert stream == 0
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+
+    M_BLOCK = 4
+    N_BLOCK = 4
+    M, N = M_BLOCK * 3, N_BLOCK * 4
+    inp = torch.randn((M, N), device="cuda", dtype=torch.float32)
+    out = inp.new_empty((M_BLOCK, N_BLOCK))
+
+    temp_file = tmp_path / "test_tensor_descriptor.chrome_trace"
+    proton.start(str(temp_file.with_suffix("")), backend="instrumentation", data="trace")
+
+    kernel[(1, )](out, inp, M, N, M_BLOCK, N_BLOCK, num_ctas=num_ctas)
+    expect = inp[1 * M_BLOCK:2 * M_BLOCK, 2 * N_BLOCK:3 * N_BLOCK]
+    torch.testing.assert_close(expect, out)
+
+    proton.finalize()
+
+    with temp_file.open() as f:
+        data = json.load(f)
+        trace_events = data["traceEvents"]
+        if num_ctas == 1:
+            assert len(trace_events) == 4
+            num_cta0_events = sum(1 for e in trace_events if "CTA0" in e["pid"])
+            assert num_cta0_events == 4
+        else:
+            assert len(trace_events) == 8
+            num_cta0_events = sum(1 for e in trace_events if "CTA0" in e["pid"])
+            num_cta1_events = sum(1 for e in trace_events if "CTA1" in e["pid"])
+            assert num_cta0_events == 4
+            assert num_cta1_events == 4


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9029

Upstream commit message:
```
> [Kernels] Fix hopper mxfp4 swizzled kernels for num_warps=4 (#9029)

> Currently the tests always use `num_warps=8` for hopper scale swizzling,
> makes the required changes to get it working for 4 warps. I also update the layout tests to
> test 4 and 8 warps as well.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 043a854e6a38d6ed0a3194639e2f1f4a75bdbd66

Diff Comparison: https://www.internalfb.com/intern/paste/P2283346100/
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1 --no-submit
```

Differential Revision: D101982811
