### PR TITLE
[autoWS] FA tutorial: use triton.knobs instead of env vars (#1344)

### DIFF
--- a/.claude/skills/autows-testing/SKILL.md
+++ b/.claude/skills/autows-testing/SKILL.md
@@ -27,9 +27,12 @@ pytest python/test/unit/language/test_tutorial09_warp_specialization.py
 # Addmm autoWS Python test
 pytest python/test/unit/language/test_autows_addmm.py
 
-# FA autoWS tutorial kernels (with Meta WS/partition)
-TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 pytest python/tutorials/fused-attention-ws-device-tma.py
-TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 python python/tutorials/test_tlx_bwd_from_fused_attention.py
+# FA autoWS tutorial kernels
+TRITON_ALWAYS_COMPILE=1 pytest python/tutorials/fused-attention-ws-device-tma.py
+TRITON_ALWAYS_COMPILE=1 python python/tutorials/test_tlx_bwd_from_fused_attention.py
+
+# FA autoWS Hopper tutorial kernel
+TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 pytest python/tutorials/fused-attention-ws-device-tma-hopper.py
 ```
 
 ## LIT tests

--- a/python/tutorials/fused-attention-ws-device-tma-hopper.py
+++ b/python/tutorials/fused-attention-ws-device-tma-hopper.py
@@ -1328,10 +1328,7 @@ class _attention_opt(torch.autograd.Function):
         ctx.grid = grid
         persistent = baseVariant == "persistent" or baseVariant == "ws_persistent"
         if is_blackwell() and warp_specialize:
-            if HEAD_DIM_K == 128 and (q.dtype == torch.float16 or q.dtype == torch.bfloat16):
-                extra_kern_args["maxnreg"] = 128
-            else:
-                extra_kern_args["maxnreg"] = 128
+            extra_kern_args["maxnreg"] = 128
         if persistent:
             _attn_fwd_persist[grid_persist](
                 sm_scale,

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -923,6 +923,28 @@ configs_bwd = [
 configs_bwd_persist = [
     triton.Config(
         {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _DEFAULT_BWD_DOT_ATTRS,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128, "EPILOGUE_SUBTILE": 4, "BWD_DOT_ATTRS":
+            _BWD_DOT_ATTRS_SCHED,  # use memory planner heuristics
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
             "BLOCK_M1": 64,
             "BLOCK_N1": 128,
             "BLOCK_M2": 128,
@@ -1248,7 +1270,8 @@ def _attn_bwd_persist(
 class _attention_opt(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE):
+    def forward(ctx, q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE,
+                early_tma_store_lowering=False):
         # shape constraints
         HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
         # when v is in float8_e5m2 it is transposed.
@@ -1299,53 +1322,53 @@ class _attention_opt(torch.autograd.Function):
         ctx.grid = grid
         persistent = baseVariant == "persistent" or baseVariant == "ws_persistent"
         if is_blackwell() and warp_specialize:
-            if HEAD_DIM_K == 128 and (q.dtype == torch.float16 or q.dtype == torch.bfloat16):
-                extra_kern_args["maxnreg"] = 128
+            extra_kern_args["maxnreg"] = 128
+        with triton.knobs.nvidia.scope():
+            triton.knobs.nvidia.use_meta_ws = True
+            triton.knobs.nvidia.use_meta_partition = True
+            if persistent:
+                _attn_fwd_persist[grid_persist](
+                    sm_scale,
+                    M,  #
+                    q.shape[0],
+                    q.shape[1],  #
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    desc_o,  #
+                    N_CTX=q.shape[2],  #
+                    HEAD_DIM=HEAD_DIM_K,  #
+                    FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                    STAGE=stage,  #
+                    warp_specialize=warp_specialize,
+                    OUTER_LOOP=True,
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    SUBTILING=SUBTILING,
+                    VECT_MUL=VECT_MUL,
+                    FADD2_REDUCE=FADD2_REDUCE,
+                    **extra_kern_args,
+                )
             else:
-                extra_kern_args["maxnreg"] = 128
-        if persistent:
-            _attn_fwd_persist[grid_persist](
-                sm_scale,
-                M,  #
-                q.shape[0],
-                q.shape[1],  #
-                desc_q,
-                desc_k,
-                desc_v,
-                desc_o,  #
-                N_CTX=q.shape[2],  #
-                HEAD_DIM=HEAD_DIM_K,  #
-                FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-                STAGE=stage,  #
-                warp_specialize=warp_specialize,
-                OUTER_LOOP=True,
-                dtype=torch_dtype_to_triton(q.dtype),
-                SUBTILING=SUBTILING,
-                VECT_MUL=VECT_MUL,
-                FADD2_REDUCE=FADD2_REDUCE,
-                **extra_kern_args,
-            )
-        else:
-            _attn_fwd[grid](
-                sm_scale,
-                M,  #
-                q.shape[0],
-                q.shape[1],  #
-                desc_q,
-                desc_k,
-                desc_v,
-                desc_o,  #
-                N_CTX=q.shape[2],  #
-                HEAD_DIM=HEAD_DIM_K,  #
-                FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-                STAGE=stage,  #
-                warp_specialize=warp_specialize,
-                dtype=torch_dtype_to_triton(q.dtype),
-                SUBTILING=SUBTILING,
-                VECT_MUL=VECT_MUL,
-                FADD2_REDUCE=FADD2_REDUCE,
-                **extra_kern_args,
-            )
+                _attn_fwd[grid](
+                    sm_scale,
+                    M,  #
+                    q.shape[0],
+                    q.shape[1],  #
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    desc_o,  #
+                    N_CTX=q.shape[2],  #
+                    HEAD_DIM=HEAD_DIM_K,  #
+                    FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                    STAGE=stage,  #
+                    warp_specialize=warp_specialize,
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    SUBTILING=SUBTILING,
+                    VECT_MUL=VECT_MUL,
+                    FADD2_REDUCE=FADD2_REDUCE,
+                    **extra_kern_args,
+                )
 
         ctx.save_for_backward(q, k, v, o, M)
 
@@ -1353,6 +1376,7 @@ class _attention_opt(torch.autograd.Function):
         ctx.HEAD_DIM = HEAD_DIM_K
         ctx.causal = causal
         ctx.persistent = persistent
+        ctx.early_tma_store_lowering = early_tma_store_lowering
         return o
 
     @staticmethod
@@ -1469,57 +1493,63 @@ class _attention_opt(torch.autograd.Function):
                     1,
                 )
 
-            _attn_bwd_persist[grid_persist_bwd](
-                desc_q,
-                desc_k,
-                desc_v,
-                ctx.sm_scale,
-                desc_do,
-                desc_dq,
-                desc_dk,
-                desc_dv,  #
-                desc_m,
-                desc_delta,  #
-                q.stride(0),
-                q.stride(1),
-                q.stride(2),
-                q.stride(3),  #
-                BATCH,
-                N_HEAD,
-                N_CTX,  #
-                BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
-                HEAD_DIM=ctx.HEAD_DIM,  #
-                dtype=torch_dtype_to_triton(q.dtype),
-                warp_specialize=warp_specialize,
-                maxRegAutoWS=192,
-            )
-        else:
-            _attn_bwd[grid](
-                desc_q,
-                desc_k,
-                desc_v,
-                ctx.sm_scale,
-                desc_do,
-                desc_dq,
-                desc_dk,
-                desc_dv,  #
-                desc_m,
-                desc_delta,  #
-                q.stride(0),
-                q.stride(1),
-                q.stride(2),
-                q.stride(3),  #
-                BATCH,
-                N_HEAD,
-                N_CTX,  #
-                BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
-                HEAD_DIM=ctx.HEAD_DIM,  #
-                dtype=torch_dtype_to_triton(q.dtype),
-                warp_specialize=warp_specialize,
-                maxRegAutoWS=192,
-            )
+        with triton.knobs.nvidia.scope():
+            triton.knobs.nvidia.use_meta_ws = True
+            triton.knobs.nvidia.use_meta_partition = True
+            if ctx.persistent:
+                _attn_bwd_persist[grid_persist_bwd](
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    ctx.sm_scale,
+                    desc_do,
+                    desc_dq,
+                    desc_dk,
+                    desc_dv,  #
+                    desc_m,
+                    desc_delta,  #
+                    q.stride(0),
+                    q.stride(1),
+                    q.stride(2),
+                    q.stride(3),  #
+                    BATCH,
+                    N_HEAD,
+                    N_CTX,  #
+                    BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+                    HEAD_DIM=ctx.HEAD_DIM,  #
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    warp_specialize=warp_specialize,
+                    maxRegAutoWS=192,
+                    early_tma_store_lowering=ctx.early_tma_store_lowering,
+                )
+            else:
+                _attn_bwd[grid](
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    ctx.sm_scale,
+                    desc_do,
+                    desc_dq,
+                    desc_dk,
+                    desc_dv,  #
+                    desc_m,
+                    desc_delta,  #
+                    q.stride(0),
+                    q.stride(1),
+                    q.stride(2),
+                    q.stride(3),  #
+                    BATCH,
+                    N_HEAD,
+                    N_CTX,  #
+                    BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+                    HEAD_DIM=ctx.HEAD_DIM,  #
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    warp_specialize=warp_specialize,
+                    maxRegAutoWS=192,
+                    early_tma_store_lowering=ctx.early_tma_store_lowering,
+                )
 
-        return dq, dk, dv, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None
 
 
 attention = _attention_opt.apply
@@ -1541,6 +1571,7 @@ attention = _attention_opt.apply
 @pytest.mark.parametrize("VECT_MUL", [0])  # , 1, 2, 3])
 @pytest.mark.parametrize("FADD2_REDUCE", [False])
 @pytest.mark.parametrize("bwd_config_idx", range(len(configs_bwd_persist)))
+@pytest.mark.parametrize("early_tma_store_lowering", [False])
 def test_op(
     Z,
     H,
@@ -1554,6 +1585,7 @@ def test_op(
     VECT_MUL,
     FADD2_REDUCE,
     bwd_config_idx,
+    early_tma_store_lowering,
     dtype=torch.float16,
 ):
     # For fwd mode, only run once (bwd_config_idx=0) to avoid redundant tests
@@ -1602,7 +1634,10 @@ def test_op(
         v = v.permute(0, 1, 3, 2).contiguous()
         v = v.permute(0, 1, 3, 2)
         v = v.to(torch.float8_e5m2)
-    tri_out = attention(q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE).half()
+    if mode == "fwd" and early_tma_store_lowering:
+        pytest.skip("early_tma_store_lowering only applies to bwd mode")
+    tri_out = attention(q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE,
+                        early_tma_store_lowering).half()
     if mode == "fwd":
         atol = 3 if "fp8" in provider else 1e-2
         torch.testing.assert_close(tri_out, ref_out, atol=atol, rtol=0)
@@ -1675,7 +1710,7 @@ def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, baseVariant, provider
         SUBTILING = True
         VECT_MUL = 1
         FADD2_REDUCE = False
-        fn = lambda: attention(q, k, v, False, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE)
+        fn = lambda: attention(q, k, v, False, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE, True)
         if mode == "bwd":
             o = fn()
             do = torch.randn_like(o)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -30,18 +30,15 @@ static OpPrintingFlags getOpPrintingFlagsWithLoc() {
   return flags;
 }
 
-void doTaskPartition(triton::FuncOp &funcOp, unsigned numWarpGroups);
 int doTaskIdPropagate(triton::FuncOp &funcOp);
 LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
                               StringRef readDecisionFile = "",
                               StringRef writeDecisionFile = "",
                               int smemAllocAlgo = 0, unsigned smemBudget = 0,
                               bool smemCircularReuse = false);
-bool doDataPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups);
 void doBufferAllocation(triton::FuncOp &funcOp);
 void doHoistLoopInvariantTMEMStore(triton::FuncOp &funcOp);
 void removeRedundantTmemZeroStores(triton::FuncOp &funcOp);
-void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
 void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
 void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
@@ -135,8 +132,10 @@ public:
     unsigned numWarpGroups = ForBlackWell ? 2 : 3;
 
     int retCode = doTaskIdPropagate(funcOp);
-    if (retCode == -1)
+    if (retCode == -1) {
       signalPassFailure();
+      return;
+    }
     if (dumpIntermediateSteps) {
       llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
                       "doTaskIdPropagate\n";

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -263,7 +263,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Value phase, Operation *headProducer,
                             Operation *headConsumer,
                             Operation *headConsumerSameLevel,
-                            SmallVector<int> additionalConsumerTaskIds = {},
+                            ArrayRef<int> additionalConsumerTaskIds = {},
                             bool isPost = false);
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
 Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3664,8 +3664,10 @@ void insertAsyncComm(
         // headConsumer for this token's task ID. Each consumer partition
         // needs its own wait point.
         int tokenTaskId = token.first;
-        LDBG("ConsumerWaitOp: tokenTaskId=" << tokenTaskId
-                                            << " headConsumer task=");
+        auto headConsumerTaskIds = getAsyncTaskIds(headConsumer);
+        LDBG("ConsumerWaitOp: tokenTaskId="
+             << tokenTaskId << " headConsumer task="
+             << (headConsumerTaskIds.empty() ? -1 : headConsumerTaskIds[0]));
         Operation *tokenHeadConsumer = headConsumer;
         for (auto &op : headConsumer->getBlock()->getOperations()) {
           if (consumerOps.count(&op)) {
@@ -3698,7 +3700,7 @@ void insertAsyncComm(
           builder.setLoopScheduleInfoFromOp(actualCons);
           LDBG("  inserting ConsumerWaitOp for task " << tokenTaskId);
           auto waitOp = builder.createWithAsyncTaskIds<ttnvws::ConsumerWaitOp>(
-              headConsumer->getLoc(), token.second, bufferIdx, phase);
+              tokenHeadConsumer->getLoc(), token.second, bufferIdx, phase);
           // Propagate the actual consumer's loop schedule to the
           // phase/bufferIdx value ops. These were computed earlier (by
           // getBufferIdxAndPhase) with no loop.stage/loop.cluster, but they

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -329,7 +329,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Value phase, Operation *headProducer,
                             Operation *headConsumer,
                             Operation *headConsumerSameLevel,
-                            SmallVector<int> additionalConsumerTaskIds,
+                            ArrayRef<int> additionalConsumerTaskIds,
                             bool isPost) {
   auto loc = barrierAlloc.getLoc();
 
@@ -388,7 +388,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
   auto wait = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
       loc, consBarrier, phase, waitPred);
   for (int extraTaskId : additionalConsumerTaskIds) {
-    builder.setAsynTaskIdsFromArray(extraTaskId);
+    builder.setAsynTaskIdsFromArray({extraTaskId});
     builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(loc, consBarrier, phase,
                                                         waitPred);
   }

--- a/third_party/nvidia/hopper/run_all.sh
+++ b/third_party/nvidia/hopper/run_all.sh
@@ -30,8 +30,8 @@ pytest python/test/unit/language/test_autows_addmm.py
 
 echo "Run autoWS tutorial kernels"
 echo "Verifying correctness of FA tutorial kernels"
-TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 pytest python/tutorials/fused-attention-ws-device-tma.py
-TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 python python/tutorials/test_tlx_bwd_from_fused_attention.py
+TRITON_ALWAYS_COMPILE=1 pytest python/tutorials/fused-attention-ws-device-tma.py
+TRITON_ALWAYS_COMPILE=1 python python/tutorials/test_tlx_bwd_from_fused_attention.py
 
 echo "run for Hopper"
 TRITON_USE_META_PARTITION=1 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 pytest python/tutorials/fused-attention-ws-device-tma-hopper.py


### PR DESCRIPTION
Summary:

- Switch fused-attention-ws-device-tma.py from env variables to
  triton.knobs.nvidia.scope()
- Add early_tma_store_lowering as a parametrized option

Address D101418092 review comments for Hopper FA support:
- Add missing return after signalPassFailure() in WarpSpecialization.cpp
- Remove dead forward declarations not called from this file
- Fix headConsumer->getLoc() to tokenHeadConsumer->getLoc() for accurate
  source location on per-task ConsumerWaitOp
- Complete debug log to print actual task IDs
- Change SmallVector<int> by-value to ArrayRef<int> in optimizeTMALoads

Reviewed By: htyu

Differential Revision: D102392643


