### PR TITLE
[triton][beta] [Cherry-pick] 'Fix handling conflicting layouts when hoisting convert into conditionals (#9083)' (#1352)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -642,6 +642,7 @@ void filterFuncAttributes(triton::FuncOp op, bool filterArgAttrs,
 triton::FuncOp amendFuncOp(triton::FuncOp funcOp,
                            ConversionPatternRewriter &rewriter,
                            const TargetInfoBase &targetInfo);
+void handleArgPtrDatatype(triton::FuncOp funcOp, LLVM::LLVMFuncOp &llvmFuncOp);
 } // namespace mlir
 
 #endif

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -65,6 +65,23 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     }
   }
 
+  static void handleArgPtrDatatype(triton::FuncOp funcOp,
+                                   LLVM::LLVMFuncOp &llvmFuncOp) {
+
+    // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
+    // the pointee datatype. This function add the pointee datatype to arg
+    // attribute.
+    FunctionType fty = funcOp.getFunctionType();
+    for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
+      auto argType = fty.getInput(i);
+      if (auto argPtrType = dyn_cast<triton::PointerType>(argType)) {
+        auto argDType = argPtrType.getPointeeType();
+        llvmFuncOp.setArgAttr(i, "tt.pointee_type",
+                              mlir::TypeAttr::get(argDType));
+      }
+    }
+  }
+
   LogicalResult
   matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -79,6 +96,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     }
 
     LLVM::LLVMFuncOp newFuncOp = *maybeNewFuncOp;
+    handleArgPtrDatatype(funcOp, newFuncOp);
 
     auto ctx = funcOp->getContext();
 

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -65,23 +65,6 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     }
   }
 
-  static void handleArgPtrDatatype(triton::FuncOp funcOp,
-                                   LLVM::LLVMFuncOp &llvmFuncOp) {
-
-    // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
-    // the pointee datatype. This function add the pointee datatype to arg
-    // attribute.
-    FunctionType fty = funcOp.getFunctionType();
-    for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
-      auto argType = fty.getInput(i);
-      if (auto argPtrType = dyn_cast<triton::PointerType>(argType)) {
-        auto argDType = argPtrType.getPointeeType();
-        llvmFuncOp.setArgAttr(i, "tt.pointee_type",
-                              mlir::TypeAttr::get(argDType));
-      }
-    }
-  }
-
   LogicalResult
   matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1687,4 +1687,19 @@ triton::FuncOp amendFuncOp(triton::FuncOp funcOp,
   return amendedFuncOp;
 }
 
+void handleArgPtrDatatype(triton::FuncOp funcOp, LLVM::LLVMFuncOp &llvmFuncOp) {
+  // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
+  // the pointee datatype information.
+  // This function add back the pointee datatype information to arg attribute.
+  FunctionType fty = funcOp.getFunctionType();
+  for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
+    auto argType = fty.getInput(i);
+    if (auto argPtrType = dyn_cast<triton::PointerType>(argType)) {
+      auto argDType = argPtrType.getPointeeType();
+      llvmFuncOp.setArgAttr(i, "tt.pointee_type",
+                            mlir::TypeAttr::get(argDType));
+    }
+  }
+}
+
 } // namespace mlir

--- a/lib/Dialect/Triton/Transforms/Combine.td
+++ b/lib/Dialect/Triton/Transforms/Combine.td
@@ -12,7 +12,7 @@ defvar DefOverflow = ConstantEnumCase<Arith_IntegerOverflowAttr, "none">;
 
 def CopyDiscardableAttrs: NativeCodeCallVoid<
         "$1.getOwner()->setDiscardableAttrs(triton::filterDiscardableAttrs($0.getOwner(), "
-        "{\"tt.divisibility\", \"tt.contiguity\", \"tt.constancy\"}))">;
+        "{\"tt.divisibility\", \"tt.contiguity\", \"tt.constancy\", \"tt.pointee_type\"}))">;
 
 def CombineAddPtrPattern : Pat<
         (TT_AddPtrOp:$src (TT_AddPtrOp $ptr, $idx0), $idx1),

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1736,21 +1736,19 @@ void LayoutRematerialization::hoistConvertIntoConditionals(
     OpOperand &thenRes = thenYield.getResultsMutable()[resIdx];
     OpOperand &elseRes = elseYield.getResultsMutable()[resIdx];
 
-    SetVector<Value> thenSlice, elseSlice;
-    DenseMap<Value, Attribute> thenLayout, elseLayout;
+    auto newSlice = slice;
+    auto newLayout = layout;
 
     LogicalResult thenResult = getRematerializableSlice(
-        thenRes, rootLayout, thenSlice, thenLayout, isIfOp);
+        thenRes, rootLayout, newSlice, newLayout, isIfOp);
     LogicalResult elseResult = getRematerializableSlice(
-        elseRes, rootLayout, elseSlice, elseLayout, isIfOp);
+        elseRes, rootLayout, newSlice, newLayout, isIfOp);
 
     // If propagation across both edges of this conditional succeeded, then we
     // don't need to hoist across it. Merge into the current slice.
     if (succeeded(thenResult) && succeeded(elseResult)) {
-      slice.insert(thenSlice.begin(), thenSlice.end());
-      slice.insert(elseSlice.begin(), elseSlice.end());
-      layout.insert(thenLayout.begin(), thenLayout.end());
-      layout.insert(elseLayout.begin(), elseLayout.end());
+      slice = std::move(newSlice);
+      layout = std::move(newLayout);
       continue;
     }
 
@@ -1769,17 +1767,15 @@ void LayoutRematerialization::hoistConvertIntoConditionals(
       continue;
     }
 
+    slice = std::move(newSlice);
+    layout = std::move(newLayout);
     // The layout conversion can be rematerialized along one edge but not the
     // other. We can hoist the conversion into the other branch. Push this
     // into the subslice list for analysis.
     if (succeeded(thenResult)) {
       hoistAbove.emplace_back(v, &elseRes);
-      slice.insert(thenSlice.begin(), thenSlice.end());
-      layout.insert(thenLayout.begin(), thenLayout.end());
     } else {
       hoistAbove.emplace_back(v, &thenRes);
-      slice.insert(elseSlice.begin(), elseSlice.end());
-      layout.insert(elseLayout.begin(), elseLayout.end());
     }
   }
 

--- a/lib/Target/LLVMIR/CMakeLists.txt
+++ b/lib/Target/LLVMIR/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonLLVMIR
         LLVMDIScope.cpp
         LLVMDILocalVariable.cpp
         LLVMIRBreakPhiStruct.cpp
+        LLVMDIUtils.cpp
 
         DEPENDS
         LLVMIRIncGen

--- a/lib/Target/LLVMIR/LLVMDIUtils.cpp
+++ b/lib/Target/LLVMIR/LLVMDIUtils.cpp
@@ -1,0 +1,122 @@
+#include "lib/Target/LLVMIR/LLVMDIUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Types.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+
+namespace mlir {
+
+// Note: mlir does not provided any built-in conversion from mlir::Type to
+// mlir::LLVM::DITypeAttr
+LLVM::DITypeAttr LLVMDIUtils::convertType(MLIRContext *context,
+                                          mlir::Type type) {
+  if (type.isInteger(1)) {
+    return LLVM::DIBasicTypeAttr::get(context, llvm::dwarf::DW_TAG_base_type,
+                                      mlir::StringAttr::get(context, "bool"),
+                                      type.getIntOrFloatBitWidth(),
+                                      llvm::dwarf::DW_ATE_boolean);
+  }
+  if (type.isInteger()) {
+    return LLVM::DIBasicTypeAttr::get(context, llvm::dwarf::DW_TAG_base_type,
+                                      mlir::StringAttr::get(context, "int"),
+                                      type.getIntOrFloatBitWidth(),
+                                      llvm::dwarf::DW_ATE_signed);
+  } else if (type.isF16()) {
+    return LLVM::DIBasicTypeAttr::get(context, llvm::dwarf::DW_TAG_base_type,
+                                      mlir::StringAttr::get(context, "half"),
+                                      type.getIntOrFloatBitWidth(),
+                                      llvm::dwarf::DW_ATE_float);
+  } else if (type.isF32()) {
+    return LLVM::DIBasicTypeAttr::get(context, llvm::dwarf::DW_TAG_base_type,
+                                      mlir::StringAttr::get(context, "float"),
+                                      type.getIntOrFloatBitWidth(),
+                                      llvm::dwarf::DW_ATE_float);
+  } else if (type.isF64()) {
+    return LLVM::DIBasicTypeAttr::get(context, llvm::dwarf::DW_TAG_base_type,
+                                      mlir::StringAttr::get(context, "double"),
+                                      type.getIntOrFloatBitWidth(),
+                                      llvm::dwarf::DW_ATE_float);
+  } else if (mlir::isa<mlir::VectorType>(type)) {
+    if (auto vectorTypeSize = calcBitWidth(type); vectorTypeSize.has_value()) {
+      return LLVM::DIBasicTypeAttr::get(
+          context, llvm::dwarf::DW_TAG_base_type,
+          mlir::StringAttr::get(context, "vector"), vectorTypeSize.value(),
+          llvm::dwarf::DW_ATE_float);
+    } else {
+      // TODO: falling back to unknown_type, perhaps theres a better way to
+      // handle when element type size is not determined
+    }
+  }
+  return LLVM::DIBasicTypeAttr::get(
+      context, llvm::dwarf::DW_TAG_base_type,
+      mlir::StringAttr::get(context, "unknown_type"), 0,
+      llvm::dwarf::DW_ATE_signed);
+}
+
+LLVM::DITypeAttr LLVMDIUtils::convertPtrType(MLIRContext *context,
+                                             mlir::Type pointerType,
+                                             mlir::Type pointeeType,
+                                             unsigned sizeInBits) {
+  // LLVMPointerType does not include pointee info, need to pass from external
+  // source
+  if (auto ptrType = dyn_cast<LLVM::LLVMPointerType>(pointerType)) {
+    unsigned addrSpace = ptrType.getAddressSpace();
+
+    LLVM::DITypeAttr diElTypeAttr = convertType(context, pointeeType);
+    LLVM::DITypeAttr diTypeAttr = mlir::LLVM::DIDerivedTypeAttr::get(
+        context, llvm::dwarf::DW_TAG_pointer_type,
+        mlir::StringAttr::get(context, "pointer"), diElTypeAttr, sizeInBits,
+        /*alignInBits=*/0, /*offset=*/0, addrSpace, /*extra data=*/nullptr);
+    return diTypeAttr;
+  }
+  // Return unknown_type if fail to construct DIDerivedTypeAttr with
+  // WD_TAG_pointer_type.
+  return LLVM::DIBasicTypeAttr::get(
+      context, llvm::dwarf::DW_TAG_base_type,
+      mlir::StringAttr::get(context, "unknown_type"), 0,
+      llvm::dwarf::DW_ATE_signed);
+}
+
+std::optional<unsigned> LLVMDIUtils::calcBitWidth(mlir::Type type) {
+  if (type.isIntOrFloat()) {
+    return type.getIntOrFloatBitWidth();
+  } else if (mlir::isa<mlir::VectorType>(type)) {
+    auto vectorType = dyn_cast<mlir::VectorType>(type);
+    llvm::ArrayRef<int64_t> shape = vectorType.getShape();
+    mlir::Type elementType = vectorType.getElementType();
+    llvm::ArrayRef<bool> scalableDims = vectorType.getScalableDims();
+    unsigned size = 1;
+    for (auto i : shape) {
+      size *= i;
+    }
+
+    if (auto elementTypeSize = calcBitWidth(elementType);
+        elementTypeSize.has_value()) {
+      return size * elementTypeSize.value();
+    }
+  }
+
+  return std::nullopt;
+}
+
+/// Attempt to extract a filename for the given loc.
+FileLineColLoc LLVMDIUtils::extractFileLoc(Location loc, bool getCaller) {
+  if (auto fileLoc = dyn_cast<FileLineColLoc>(loc))
+    return fileLoc;
+  if (auto nameLoc = dyn_cast<NameLoc>(loc))
+    return extractFileLoc(nameLoc.getChildLoc());
+  if (auto opaqueLoc = dyn_cast<OpaqueLoc>(loc))
+    return extractFileLoc(opaqueLoc.getFallbackLocation());
+  if (auto fusedLoc = dyn_cast<FusedLoc>(loc))
+    return extractFileLoc(fusedLoc.getLocations().front());
+  if (auto callerLoc = dyn_cast<CallSiteLoc>(loc))
+    return getCaller ? extractFileLoc(callerLoc.getCaller())
+                     : extractFileLoc(callerLoc.getCallee());
+  StringAttr unknownFile = mlir::StringAttr::get(loc.getContext(), "<unknown>");
+  return mlir::FileLineColLoc::get(unknownFile, 0, 0);
+}
+
+} // namespace mlir

--- a/lib/Target/LLVMIR/LLVMDIUtils.h
+++ b/lib/Target/LLVMIR/LLVMDIUtils.h
@@ -1,0 +1,17 @@
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Types.h"
+
+namespace mlir {
+namespace LLVMDIUtils {
+LLVM::DITypeAttr convertType(MLIRContext *context, mlir::Type type);
+LLVM::DITypeAttr convertPtrType(MLIRContext *context, mlir::Type pointerType,
+                                mlir::Type pointeeType, unsigned sizeInBits);
+
+FileLineColLoc extractFileLoc(Location loc, bool getCaller = true);
+std::optional<unsigned> calcBitWidth(mlir::Type type);
+} // namespace LLVMDIUtils
+} // namespace mlir

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1763,8 +1763,8 @@ def test_atomic_cas(sem, num_ctas, dtype_str, device):
 @pytest.mark.parametrize("dtype_str", ["bfloat16", "float16", "float32", "uint64", "int64", "float64"])
 def test_tensor_atomic_cas(sem, size, dtype_str, num_ctas, device):
     check_type_supported(dtype_str, device)
-    if "float" in dtype_str and is_hip():
-        pytest.skip("HIP does not support atomic cas with float types")
+    if is_hip_cdna2():
+        pytest.skip("Disabled due to being flaky on CDNA2")
 
     @triton.jit
     def change_value(X, BLOCK_SIZE: tl.constexpr, sem: tl.constexpr, dtype: tl.constexpr):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -35,6 +35,7 @@ from triton._internal_testing import (
     is_hip_cdna4,
     is_hip_rdna3,
     is_hip_rdna4,
+    is_hip_gfx1250,
     is_xpu,
     get_arch,
     torch_float8_dtypes,
@@ -75,7 +76,7 @@ elif is_hip():
     # for CDNA multiple variants of mma instructions are supported:
     # mfma 16x16/mfma 32x32
     # 0 is a special value for automatic heuristic
-    if is_hip_cdna():
+    if is_hip_cdna() or is_hip_gfx1250():
         mma_nonk_sizes = [0, 16, 32]
     elif is_hip_rdna3() or is_hip_rdna4():
         mma_nonk_sizes = [16]
@@ -1926,11 +1927,12 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
         check_type_supported(dtype_z, device)
 
     if is_hip():
-        if not is_hip_cdna3() and not is_hip_cdna4() and (dtype_x == "float8_e4m3fn" or dtype_z == "float8_e4m3fn"):
-            pytest.skip(f"test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3/CDNA4.")
-        if (not is_hip_cdna4()) and ((dtype_x == "bfloat16" and dtype_z == "float8_e4m3fn") or
-                                     (dtype_x == "float8_e4m3fn" and dtype_z == "bfloat16")):
-            pytest.skip(f"test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4.")
+        if not is_hip_cdna3() and not is_hip_cdna4() and not is_hip_gfx1250() and (dtype_x == 'float8_e4m3fn'
+                                                                                   or dtype_z == 'float8_e4m3fn'):
+            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3/CDNA4 and above.')
+        if (not (is_hip_cdna4() or is_hip_gfx1250())) and ((dtype_x == 'bfloat16' and dtype_z == "float8_e4m3fn") or
+                                                           (dtype_x == "float8_e4m3fn" and dtype_z == 'bfloat16')):
+            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4 and above.')
 
     torch.manual_seed(0)
     # This is tricky because numpy doesn't have bfloat, and torch doesn't have uints.
@@ -3519,7 +3521,7 @@ def get_test_dot_h100_shortcut_cases():
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #3908
 def get_test_dot_mfma_edge_cases():
-    if not is_hip_cdna():
+    if not (is_hip_cdna() or is_hip_gfx1250()):
         return []
     return [
         (16, 16, 8, 4, False, False, "None", "ieee", "float32", "float32", 1, None),
@@ -3537,7 +3539,7 @@ def get_test_dot_fp8_output_cases():
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #5406
 def get_test_dot_small_k_mfma_cases():
-    if not is_hip_cdna():
+    if not (is_hip_cdna() or is_hip_gfx1250()):
         return []
     return [(32, 32, k_size, 4, False, False, "None", "ieee", in_dtype, out_dtype, 1, mma_nonk_size)
             for k_size in [1, 2, 4, 8]
@@ -3548,7 +3550,7 @@ def get_test_dot_small_k_mfma_cases():
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #4516
 def get_test_dot_small_mn_mfma_cases():
-    if not is_hip_cdna():
+    if not (is_hip_cdna() or is_hip_gfx1250()):
         return []
     return [(*shape_nw, False, False, epilogue, "ieee", in_dtype, out_dtype, 1, None)
             for shape_nw in [(4, 64, 64, 1), (64, 4, 64, 1)]
@@ -3557,7 +3559,7 @@ def get_test_dot_small_mn_mfma_cases():
 
 
 def get_test_dot_double_rate_cases():
-    if not is_hip_cdna():
+    if not (is_hip_cdna() or is_hip_gfx1250()):
         return []
     return [
         (32, 32, 16, 4, False, False, "None", "ieee", "float16", "float32", 1, None),
@@ -3568,7 +3570,7 @@ def get_test_dot_double_rate_cases():
 
 
 def get_test_dot_vdot2_cases():
-    if not is_hip_cdna():
+    if not (is_hip_cdna() or is_hip_gfx1250()):
         return []
     return [
         (4, 32, 32, 4, False, False, "None", "ieee", "float16", "float32", 1, None),
@@ -3640,8 +3642,8 @@ def test_dot(
                 pytest.skip("Only IEEE precision is supported for float64 dot")
 
         if is_hip():
-            if in_dtype in ("float8e5", "float8e4nv") and not (is_hip_cdna4() or is_hip_rdna4()):
-                pytest.skip(f"{in_dtype} only supported on CDNA4 and RDNA4")
+            if in_dtype in ("float8e5", "float8e4nv") and not (is_hip_gfx1250() or is_hip_cdna4() or is_hip_rdna4()):
+                pytest.skip(f"{in_dtype} only supported on CDNA4, RDNA4 and above")
             if in_dtype in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
                 pytest.skip(f"{in_dtype} only supported on CDNA3")
             if not ((input_precision in ("bf16x3", "bf16x6")) or (input_precision == "ieee") or
@@ -3844,19 +3846,19 @@ def test_dot(
         # added atol, to loose precision for float16xfloat16->float32 case
         np.testing.assert_allclose(z_ref, to_numpy(z_tri), rtol=0.01, atol=1e-3)
 
-    if not (is_cuda() or is_hip_cdna()):
+    if not (is_cuda() or is_hip_cdna() or is_hip_gfx1250()):
         return
 
-    if is_hip_cdna():
-        amdgcn = pgm.asm["amdgcn"]
+    if is_hip_cdna() or is_hip_gfx1250():
+        amdgcn = pgm.asm['amdgcn']
 
         if (M, N) == (4, 64) or (M, N) == (64, 4):
             assert "v_mfma_f32_4x4" in amdgcn
         elif (M, N) == (4, 32):
-            if in_dtype == "float16":
-                assert "v_dot2c_f32_f16" in amdgcn
-            elif (in_dtype == "bfloat16") and is_hip_cdna4():
-                assert "v_dot2c_f32_bf16" in amdgcn
+            if in_dtype == 'float16':
+                assert 'v_dot2c_f32_f16' in amdgcn
+            elif (in_dtype == 'bfloat16') and (is_hip_cdna4() or is_hip_gfx1250()):
+                assert 'v_dot2c_f32_bf16' in amdgcn
         return
 
     # make sure ld/st are vectorized
@@ -3932,7 +3934,7 @@ def test_dot(
      for mxfp_type in ["e2m1", "e4m3", "e5m2"]
      for normal_type in ["e4m3", "e5m2", "bf16", "fp16"]
      for mma in (mma_nonk_sizes if is_hip() else [16])
-     for kpack in ([1, 2] if (is_hip() and not is_hip_cdna4()) else [1])],
+     for kpack in ([1, 2] if (is_hip() and not (is_hip_cdna4() or is_hip_gfx1250())) else [1])],
 )
 def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack, device):
     is_SM120 = False
@@ -3942,12 +3944,14 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
             pytest.skip("float8e4nv not supported on CUDA < 8.9")
         is_SM120 = cc >= (12, 0)
     if is_hip():
-        if not (is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4()):
-            pytest.skip("scaled_dot only implemented for HIP CDNA, RDNA3, RDNA4")
+        if not (is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()):
+            pytest.skip("scaled_dot only implemented for HIP CDNA, RDNA3, RDNA4 and above")
         if "e4m3" in (mxfp_type, normal_type):
-            if not (is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4()):
-                pytest.skip(f"scaled_dot({mxfp_type}, {normal_type}) only implemented for CDNA3, CDNA4, RDNA3, RDNA4")
-        if mma == 16 and K == 64 and not (is_hip_rdna4() or is_hip_rdna3()):
+            if not (is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()):
+                pytest.skip(
+                    f"scaled_dot({mxfp_type}, {normal_type}) only implemented for CDNA3, CDNA4, RDNA3, RDNA4, and above"
+                )
+        if mma == 16 and K == 64 and not (is_hip_rdna4() or is_hip_rdna3() or is_hip_gfx1250()):
             pytest.skip(f"K == {K} too small for mfma {mma} in scaled_dot")
 
     @triton.jit
@@ -4132,7 +4136,7 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
             # Clamp to avoid relative error issues
             ret.clamp_(-(2**comp_dtype_max_exp), 2**comp_dtype_max_exp - 1)
         else:
-            if is_hip_cdna4():
+            if is_hip_cdna4() or is_hip_gfx1250():
                 # On other chips, the A/B operands are upcasted to fp16/bf16
                 # before matmul, which has larger range to avoid overflow.
                 # On CDNA4, we use the V_MFMA_*_F8F6F4 instructions to
@@ -6235,8 +6239,8 @@ def test_dot_max_num_imprecise_acc(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_s
         num_stages = 2
         if in_type_str in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
             pytest.skip(f"{in_type_str} only supported on CDNA3")
-        if in_type_str in ("float8e5", "float8e4nv") and not (is_hip_cdna4() or is_hip_rdna4()):
-            pytest.skip(f"{in_type_str} only supported on CDNA4 or RDNA4")
+        if in_type_str in ("float8e5", "float8e4nv") and not (is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()):
+            pytest.skip(f"{in_type_str} only supported on CDNA4, RDNA4 and above")
 
     check_type_supported(in_type_str, device)
     A = numpy_random((M, K), dtype_str=in_type_str)

--- a/python/test/unit/language/test_libdevice.py
+++ b/python/test/unit/language/test_libdevice.py
@@ -56,3 +56,30 @@ def test_libdevice_rename(device):
     out = torch.empty_like(inp)
 
     triton_copy[(1, )](inp, out, BLOCK_SIZE)
+
+
+@pytest.mark.parametrize("dtype_str", ["float32", "float64"])
+def test_isinf(device, dtype_str):
+
+    @triton.jit
+    def triton_isinf(in_ptr, out_ptr, numel, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < numel
+        in_tile = tl.load(in_ptr + offsets, mask=mask)
+        if in_ptr.dtype.element_ty == tl.float32:
+            out_tile = libdevice.finitef(in_tile)
+        else:
+            out_tile = libdevice.isfinited(in_tile)
+        tl.store(out_ptr + offsets, out_tile, mask=mask)
+
+    x = torch.tensor(
+        [float(1), -float(1),
+         float(0), -float(0),
+         float("inf"), -float("inf"),
+         float("nan"), -float("nan")], device=device, dtype=getattr(torch, dtype_str))
+    res = torch.tensor([True, True, True, True, False, False, False, False])
+    numel = x.numel()
+    y = torch.empty_like(x, dtype=torch.bool)
+    BLOCK_SIZE = 256
+    triton_isinf[(triton.cdiv(numel, BLOCK_SIZE), )](x, y, numel, BLOCK_SIZE)
+    assert torch.equal(y.cpu(), res)

--- a/python/test/unit/test_stages_inspection.py
+++ b/python/test/unit/test_stages_inspection.py
@@ -1,5 +1,4 @@
 import triton
-from triton import knobs
 
 import os
 import pathlib
@@ -9,7 +8,7 @@ from triton._internal_testing import is_cuda
 
 
 @pytest.mark.skipif(not is_cuda(), reason="only currently tested on CUDA")
-def test_inspection(monkeypatch, tmp_path: pathlib.Path):
+def test_inspection(monkeypatch, fresh_knobs, tmp_path: pathlib.Path):
     stage_name = 'make_ttgir'
     curr_repro_path = tmp_path / ("repro_prefix." + stage_name + ".repro.mlir")
     repro_path = tmp_path / "repro_prefix"
@@ -55,7 +54,7 @@ def test_inspection(monkeypatch, tmp_path: pathlib.Path):
     curr_repro_path.unlink()
 
     # Setup hook and call again, check if hooks got called
-    knobs.runtime.add_stages_inspection_hook = inspect_stages_hook
+    fresh_knobs.runtime.add_stages_inspection_hook = inspect_stages_hook
     k2[(1, )]()
     assert inspect_stages_hook_called and make_ttgir_wrapper_called
     assert os.path.exists(curr_repro_path)

--- a/python/triton_kernels/tests/test_distributed.py
+++ b/python/triton_kernels/tests/test_distributed.py
@@ -10,7 +10,6 @@ from triton_kernels.distributed import convert_dp_to_ep, convert_ep_to_dp, make_
 from triton_kernels.reduce import reduce
 from triton_kernels.topk import topk
 from triton_kernels.matmul import matmul
-from triton_kernels.target_info import is_hip
 from triton_kernels.tensor import make_ragged_tensor_metadata, remap_ragged_tensor_metadata
 import pytest
 
@@ -248,8 +247,6 @@ def _run_expert_sharding(rank, world_size, *, n_tokens, d_model, n_expts_tot, n_
 @pytest.mark.parametrize("d_model, n_expts_tot, n_expts_act", [(16, 4, 4), (5760, 128, 4)])
 @pytest.mark.parametrize("affinity_mode", ["uniform", "random"])
 def test_expert_sharding(distributed_launcher, n_tokens, d_model, n_expts_tot, n_expts_act, affinity_mode):
-    if is_hip():
-        pytest.skip("Distributed test is not supported on AMD GPU")
     if n_tokens < distributed_launcher.world_size:
         raise ValueError("n_tokens must be >= number of gpus")
     if n_tokens % distributed_launcher.world_size != 0:

--- a/test/Conversion/amd/atomic_cas.mlir
+++ b/test/Conversion/amd/atomic_cas.mlir
@@ -57,3 +57,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @atomic_cas_f32(%arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    // CHECK-LABEL: @atomic_cas_f32
+    %c64_f32 = arith.constant 64. : f32
+    %c32_f32 = arith.constant 32. : f32
+    // CHECK-DAG: %[[C64:.*]] = llvm.mlir.constant(6.400000e+01 : f32) : f32
+    // CHECK-DAG: %[[C32:.*]] = llvm.mlir.constant(3.200000e+01 : f32) : f32
+    // CHECK-DAG: %[[C64I:.*]] = llvm.bitcast %[[C64]] : f32 to i32
+    // CHECK-DAG: %[[C32I:.*]] = llvm.bitcast %[[C32]] : f32 to i32
+    // CHECK: %[[CMPXCHG:.*]] = llvm.cmpxchg %{{.*}}, %[[C32I]], %[[C64I]] acquire monotonic
+    // CHECK: %[[RESI:.*]] = llvm.extractvalue %[[CMPXCHG]][0] : !llvm.struct<(i32, i1)>
+    // CHECK: %[[RES:.*]] = llvm.bitcast %[[RESI]] : i32 to f32
+    // CHECK: llvm.store %[[RES]], %{{.*}} : f32, !llvm.ptr<3>
+    %0 = tt.atomic_cas acquire, sys, %arg3, %c32_f32, %c64_f32 { allocation.offset = 0 : i32 }: (!tt.ptr<f32>, f32, f32) -> f32
+    tt.print "some print" {hex = false, isSigned = array<i32: 0>} : %0: f32
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts 2>/dev/null | FileCheck %s --dump-input-context 20
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK: llvm.func @test_empty_kernel(%arg0: i32, %arg1: !llvm.ptr<1>, %arg2: !llvm.ptr<1>, %arg3: !llvm.ptr<1>)
+  // CHECK: llvm.func @test_empty_kernel(%arg0: i32, %arg1: !llvm.ptr<1> {tt.pointee_type = f16}, %arg2: !llvm.ptr<1>, %arg3: !llvm.ptr<1>)
   // Here the 128 comes from the 4 in module attribute multiples 32
   // CHECK: nvvm.kernel = 1 : ui1, nvvm.reqntid = array<i32: 128>
   tt.func @test_empty_kernel(%lb : index, %A : !tt.ptr<f16>) {

--- a/test/LLVMIR/convert-to-llvmir-with-dbg-info.mlir
+++ b/test/LLVMIR/convert-to-llvmir-with-dbg-info.mlir
@@ -5,83 +5,70 @@
 // to get DILocation and DILocalVariable when converting LLVMIR otherwise they
 // will be dropped
 
-#di_file = #llvm.di_file<"01-vector-add.py" in "">
-#di_null_type = #llvm.di_null_type
-#di_subroutine_type = #llvm.di_subroutine_type<callingConvention = DW_CC_normal>
-
-#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file,
-                                         producer = "triton", isOptimized = true, emissionKind = LineTablesOnly>
-#di_subprogram = #llvm.di_subprogram<id = distinct[0]<>, compileUnit = #di_compile_unit,
-                                     scope = #di_file, name = "add_kernel", linkageName = "add_kernel",
-                                     file = #di_file, line = 30, scopeLine = 30,
-                                     subprogramFlags = "Definition|Optimized", type = #di_subroutine_type>
-
-#di_local_variable0 = #llvm.di_local_variable<scope = #di_subprogram, name = "pid", file = #di_file, type = #di_null_type>
-#di_local_variable1 = #llvm.di_local_variable<scope = #di_subprogram, name = "block_start", file = #di_file, type = #di_null_type>
-#di_local_variable2 = #llvm.di_local_variable<scope = #di_subprogram, name = "offsets", file = #di_file, type = #di_null_type>
-#di_local_variable3 = #llvm.di_local_variable<scope = #di_subprogram, name = "mask", file = #di_file, type = #di_null_type>
-#di_local_variable4 = #llvm.di_local_variable<scope = #di_subprogram, name = "x", file = #di_file, type = #di_null_type>
-#di_local_variable5 = #llvm.di_local_variable<scope = #di_subprogram, name = "y", file = #di_file, type = #di_null_type>
-#di_local_variable6 = #llvm.di_local_variable<scope = #di_subprogram, name = "output", file = #di_file, type = #di_null_type>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  llvm.func @add_kernel(%arg0: !llvm.ptr<1>, %arg1: !llvm.ptr<1>,
-                        %arg2: !llvm.ptr<1>, %arg3: i32, %arg4: !llvm.ptr<1>) {
+  llvm.func @add_kernel(%arg0: !llvm.ptr<1> loc(#loc10), %arg1: !llvm.ptr<1> loc(#loc11), %arg2: !llvm.ptr<1> loc(#loc12), %arg3: i32 loc(#loc13), %arg4: !llvm.ptr<1>) {
+    // CHECK-DAG: distinct !DISubprogram({{.*}}, retainedNodes:
+    // CHECK-DAG: !DISubroutineType(cc: DW_CC_normal, types:
+    // CHECK-DAG: !DIDerivedType(tag: DW_TAG_pointer_type, name: "pointer",
+    // CHECK-DAG: !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+
+    // CHECK: !DILocalVariable(name: "x_ptr", arg: 1, scope:
+    // CHECK: !DILocalVariable(name: "y_ptr", arg: 2, scope:
+    // CHECK: !DILocalVariable(name: "out_ptr", arg: 3, scope:
+    // CHECK: !DILocalVariable(name: "n_elements", arg: 4, scope:
+
     %constant_i32 = llvm.mlir.constant(9 : i32) : i32
     %constant_i16 = llvm.mlir.constant(0 : i16) : i16
     %constant_i64 = llvm.mlir.constant(9 : i64) : i64
 
     // CHECK: !DILocalVariable(name: "pid", scope:
     %pid = rocdl.workgroup.id.x : i32 loc(#loc14)
-    llvm.intr.dbg.value #di_local_variable0 = %pid : i32 loc(#loc2)
 
     // CHECK: !DILocalVariable(name: "block_start", scope:
     %block_start = llvm.mul %pid, %constant_i32 : i32 loc(#loc15)
-    llvm.intr.dbg.value #di_local_variable1 = %block_start : i32 loc(#loc3)
 
     // CHECK: !DILocalVariable(name: "offsets", scope:
     %offsets = llvm.add %block_start, %constant_i32 : i32 loc(#loc16)
-    llvm.intr.dbg.value #di_local_variable2 = %offsets : i32 loc(#loc5)
 
     // CHECK: !DILocalVariable(name: "mask", scope:
     %mask = llvm.icmp "slt" %offsets, %arg3 : i32 loc(#loc17)
     %mask_i1 = llvm.select %mask, %constant_i32, %constant_i32 : i1, i32 loc(#loc18)
-    llvm.intr.dbg.value #di_local_variable3 = %mask : i1 loc(#loc6)
 
     // CHECK: !DILocalVariable(name: "x", scope:
     %x_ptr = llvm.getelementptr %arg0[%block_start] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
     %x_buffer_ptr = rocdl.make.buffer.rsrc %x_ptr, %constant_i16, %constant_i64, %constant_i32 : <1> to <8> loc(#loc18)
-    llvm.intr.dbg.value #di_local_variable4 = %x_buffer_ptr : !llvm.ptr<8> loc(#loc8)
     %x_val = rocdl.raw.ptr.buffer.load %x_buffer_ptr, %mask_i1, %constant_i32, %constant_i32 : vector<4xf32> loc(#loc18)
     %x_scalar = llvm.extractelement %x_val[%constant_i32 : i32] : vector<4xf32> loc(#loc18)
 
     // CHECK: !DILocalVariable(name: "y", scope:
     %y_ptr = llvm.getelementptr %arg1[%block_start] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, f32
     %y_buffer_ptr = rocdl.make.buffer.rsrc %y_ptr, %constant_i16, %constant_i64, %constant_i32 : <1> to <8> loc(#loc19)
-    llvm.intr.dbg.value #di_local_variable5 = %y_buffer_ptr : !llvm.ptr<8> loc(#loc10)
     %y_val = rocdl.raw.ptr.buffer.load %y_buffer_ptr, %mask_i1, %constant_i32, %constant_i32 : vector<4xf32> loc(#loc19)
     %y_scalar = llvm.extractelement %y_val[%constant_i32 : i32] : vector<4xf32> loc(#loc19)
 
     // CHECK: !DILocalVariable(name: "output", scope:
     %output = llvm.fadd %x_scalar, %y_scalar : f32 loc(#loc20)
-    llvm.intr.dbg.value #di_local_variable6 = %output : f32 loc(#loc11)
 
     llvm.return
-  } loc(#loc21)
+  }
 }
 #loc = loc("01-vector-add.py":30:0)
 #loc2 = loc("01-vector-add.py":39:10)
 #loc3 = loc("01-vector-add.py":44:18)
 #loc5 = loc("01-vector-add.py":45:14)
 #loc6 = loc("01-vector-add.py":47:11)
-#loc8 = loc("01-vector-add.py":50:8)
-#loc10 = loc("01-vector-add.py":51:8)
-#loc11 = loc("01-vector-add.py":52:13)
+#loc7 = loc("01-vector-add.py":50:8)
+#loc8 = loc("01-vector-add.py":51:8)
+#loc9 = loc("01-vector-add.py":52:13)
+#loc10 = loc("x_ptr"(#loc))
+#loc11 = loc("y_ptr"(#loc))
+#loc12 = loc("out_ptr"(#loc))
+#loc13 = loc("n_elements"(#loc))
 #loc14 = loc("pid"(#loc2))
 #loc15 = loc("block_start"(#loc3))
 #loc16 = loc("offsets"(#loc5))
 #loc17 = loc("mask"(#loc6))
-#loc18 = loc("x"(#loc8))
-#loc19 = loc("y"(#loc10))
-#loc20 = loc("output"(#loc11))
-#loc21 = loc(fused<#di_subprogram>[#loc])
+#loc18 = loc("x"(#loc7))
+#loc19 = loc("y"(#loc8))
+#loc20 = loc("output"(#loc9))

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -4010,3 +4010,61 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     tt.return %1 : tensor<128x64xf32, #mma>
   }
 }
+
+// -----
+
+// Test that when we attempt to hoist layout conversions into one branch of an
+// if/else, we validate that the layouts required by different conditionals or
+// different branches do not conflict.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @hoist_into_cond_layout_conflict(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg2: i1) -> tensor<4x1xi64, #blocked> {
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %1 = arith.extsi %0 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> to tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %3 = tt.expand_dims %1 {axis = 1 : i32} : tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi64, #blocked1>
+    %4 = tt.addptr %2, %1 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>, tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %5 = tt.load %4 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %6 = tt.reshape %5 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi32, #blocked1>
+    %7 = arith.extsi %6 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
+    %cst = arith.constant dense<0> : tensor<4x1xi64, #blocked>
+    %8 = scf.if %arg2 -> (tensor<4x1xi64, #blocked1>) {
+      // The backward slice from this extsi will produce a non-sliced layout for
+      // %1.
+      scf.yield %7 : tensor<4x1xi64, #blocked1>
+    } else {
+      // The backward slice from this add will produce a sliced layout for %1.
+      scf.yield %3 : tensor<4x1xi64, #blocked1>
+    }
+    // CHECK: scf.for
+    // CHECK-NEXT: scf.if
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: } else {
+    // CHECK: ttg.convert_layout
+    // CHECK-NOT: ttg.convert-layout
+    %9 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<4x1xi64, #blocked>)  : i32 {
+      %10 = scf.if %arg2 -> (tensor<4x1xi64, #blocked1>) {
+        // The backward slice from this extsi will produce a non-sliced layout
+        // for %1 when it is rematerialized conflicting with the sliced layout
+        // produced by %3 in the else arm of the other if.
+        %14 = arith.extsi %6 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
+        scf.yield %14 : tensor<4x1xi64, #blocked1>
+      } else {
+        // The backward slice from this add will produce conflicting layouts for
+        // %1, so we try to hoist the convert into this arm.
+        %14 = arith.addi %7, %3 : tensor<4x1xi64, #blocked1>
+        scf.yield %14 : tensor<4x1xi64, #blocked1>
+      }
+      %11 = arith.addi %8, %10 : tensor<4x1xi64, #blocked1>
+      %12 = ttg.convert_layout %11 : tensor<4x1xi64, #blocked1> -> tensor<4x1xi64, #blocked>
+      %13 = arith.addi %arg4, %12 : tensor<4x1xi64, #blocked>
+      scf.yield %13 : tensor<4x1xi64, #blocked>
+    }
+    tt.return %9 : tensor<4x1xi64, #blocked>
+  }
+}

--- a/third_party/amd/language/hip/libdevice.py
+++ b/third_party/amd/language/hip/libdevice.py
@@ -489,3 +489,17 @@ def round(arg0, _semantic=None):
             (core.dtype("fp32"), ): ("__ocml_round_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_round_f64", core.dtype("fp64")),
         }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def finitef(arg0, _semantic=None):
+    return core.extern_elementwise("", "", [arg0], {
+        (core.dtype("fp32"), ): ("__ocml_isfinite_f32", core.dtype("int32")),
+    }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)
+
+
+@core.extern
+def isfinited(arg0, _semantic=None):
+    return core.extern_elementwise("", "", [arg0], {
+        (core.dtype("fp64"), ): ("__ocml_isfinite_f64", core.dtype("int32")),
+    }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
@@ -10,23 +10,6 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
                    const TargetInfoBase &targetInfo, PatternBenefit benefit)
       : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
 
-  static void handleArgPtrDatatype(triton::FuncOp funcOp,
-                                   LLVM::LLVMFuncOp &llvmFuncOp) {
-
-    // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
-    // the pointee datatype information.
-    // This function add back the pointee datatype information to arg attribute.
-    FunctionType fty = funcOp.getFunctionType();
-    for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
-      auto argType = fty.getInput(i);
-      if (auto argPtrType = dyn_cast<triton::PointerType>(argType)) {
-        auto argDType = argPtrType.getPointeeType();
-        llvmFuncOp.setArgAttr(i, "tt.pointee_type",
-                              mlir::TypeAttr::get(argDType));
-      }
-    }
-  }
-
   LogicalResult
   matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1782,6 +1782,10 @@ struct AtomicCASOpConversion
         tensorTy ? getTypeConverter()->convertType(tensorTy.getElementType())
                  : valueTy;
     auto valueElemNBits = valueElemTy.getIntOrFloatBitWidth();
+    Type valueElemIntTy{};
+    if (!valueElemTy.isSignlessInteger()) {
+      valueElemIntTy = rewriter.getIntegerType(valueElemNBits);
+    }
     auto elemsPerThread = getTotalElemsPerThread(op.getVal().getType());
     SmallVector<Value> resultVals(elemsPerThread);
 
@@ -1794,6 +1798,10 @@ struct AtomicCASOpConversion
       Value casVal = valElements[i];
       Value casCmp = cmpElements[i];
       Value casPtr = ptrElements[i];
+      if (valueElemIntTy) {
+        casVal = LLVM::BitcastOp::create(rewriter, loc, valueElemIntTy, casVal);
+        casCmp = LLVM::BitcastOp::create(rewriter, loc, valueElemIntTy, casCmp);
+      }
       // use op
       if (tensorTy) { // for tensor
         auto retType = valueElemTy;
@@ -1804,7 +1812,13 @@ struct AtomicCASOpConversion
             failureOrdering, scopeStr);
 
         // Extract the new_loaded value from the pair.
-        Value ret = b.extract_val(valueElemTy, cmpxchg, 0);
+        Value ret;
+        if (valueElemIntTy) {
+          ret = b.extract_val(valueElemIntTy, cmpxchg, 0);
+          ret = LLVM::BitcastOp::create(rewriter, loc, valueElemTy, ret);
+        } else {
+          ret = b.extract_val(valueElemTy, cmpxchg, 0);
+        }
         resultVals[i] = ret;
       } else { // for scalar
         // Build blocks to bypass the atomic instruction for ~rmwMask.
@@ -1828,7 +1842,14 @@ struct AtomicCASOpConversion
 
         if (!op.getResult().use_empty()) {
           // Extract the new_loaded value from the pair.
-          Value newLoaded = b.extract_val(valueElemTy, cmpxchg, 0);
+          Value newLoaded;
+          if (valueElemIntTy) {
+            newLoaded = b.extract_val(valueElemIntTy, cmpxchg, 0);
+            newLoaded =
+                LLVM::BitcastOp::create(rewriter, loc, valueElemTy, newLoaded);
+          } else {
+            newLoaded = b.extract_val(valueElemTy, cmpxchg, 0);
+          }
           Value atomPtr =
               getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
           b.store(newLoaded, atomPtr);


### PR DESCRIPTION
Summary:

This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9083

Upstream commit message:
```
> Fix handling conflicting layouts when hoisting convert into conditionals (#9083)

> I noticed that hoisting into conditionals is prone to the same layout
> conflict issue that we have previously fixed in hoisting above
> ext/broadcast ops (#7058). Fix this by attempting to extend the existing
> slice and layout map when considering rematerialisation.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: d3a7dc30b8fda6f2d1d6a2fdee65adae4ed1b234
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1 --no-submit
```

Diff Comparison: https://www.internalfb.com/intern/paste/P2287255260/

Reviewed By: sfzhu93

Differential Revision: D102340029


