### PR TITLE
[triton][beta] [Cherry-pick] '[Backend][NFC] Change getClusterCTAId to return 0 for 1 CTA (#9125)' (#1356)

### DIFF
--- a/include/triton/Dialect/Gluon/Transforms/Passes.td
+++ b/include/triton/Dialect/Gluon/Transforms/Passes.td
@@ -45,8 +45,8 @@ def GluonSimplifyControlFlow: Pass<"gluon-slimplify-control-flow"> {
   let summary = "simplications for control flow ops";
 
   let description = [{
-    The `gluon-inline` pass applies a reduced set of simplification
-    and canonicalization patterns to the module.
+    The `gluon-simplify-control-flow` pass applies a reduced set of
+    simplification and canonicalization patterns for control flow ops.
   }];
   let dependentDialects = [];
 }

--- a/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
@@ -25,8 +25,7 @@ struct MakeRangeOpConversion
     auto elemTy = ty.getElementType();
     assert(elemTy.isInteger(32));
     Value start = createIndexAttrConstant(rewriter, loc, elemTy, op.getStart());
-    auto numCTAs = triton::gpu::getNumCTAs(layout);
-    auto idxs = emitIndices(loc, rewriter, targetInfo, layout, ty, numCTAs > 1);
+    auto idxs = emitIndices(loc, rewriter, targetInfo, layout, ty, true);
     unsigned elems = idxs.size();
     SmallVector<Value> retVals(elems);
     // TODO: slice layout has more elements than expected.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -434,14 +434,12 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
   //   vals: Values to process (packed pointers/masks)
   //   llShared: LLVM value for shared memory struct
   //   isLoad: true for global→shared, false for shared→global
-  //   numCTAs: Number of CTAs (only used for load multicast)
   //   isaFamily: ISA family (only used for load multicast)
   //   lowerInst: Callback to emit the actual load/store instruction
   LogicalResult lowerDirectLDSAsyncCopy(
       RewriterBase &rewriter, Location loc, RankedTensorType globalTy,
       MemDescType sharedTy, SmallVector<Value> vals, Value llShared,
-      Type resElemTy, unsigned vec, bool isLoad, int numCTAs,
-      triton::AMD::ISAFamily isaFamily,
+      Type resElemTy, unsigned vec, bool isLoad,
       std::function<SmallVector<Value>(RewriterBase &, Location,
                                        ArrayRef<Value>, Value, int, VectorType,
                                        Value)>
@@ -475,7 +473,7 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
 
     // Multicast is only supported for loads
     Value ctaMulticastMask;
-    if (isLoad && numCTAs > 1 && isaFamily == ISAFamily::GFX1250) {
+    if (isLoad && targetInfo.supportsMultiCTALaunch()) {
       ctaMulticastMask = LLVM::AMD::emitCtaMulticastMask(
           rewriter, loc, targetInfo.getClusterCTAId(rewriter, loc),
           globalLayout);
@@ -590,9 +588,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       otherElems = unpackLLElements(loc, llOther, rewriter);
 
     Value multicastMask;
-    auto mod = op->getParentOfType<ModuleOp>();
-    int numCTAs = TritonGPUDialect::getNumCTAs(mod);
-    if (numCTAs > 1) {
+    if (targetInfo.supportsMultiCTALaunch()) {
       Value clusterCTAId = targetInfo.getClusterCTAId(rewriter, loc);
       auto regLayout =
           triton::gpu::toLinearLayout(cast<RankedTensorType>(ptr.getType()));
@@ -872,10 +868,9 @@ struct BufferLoadToLocalOpConversion
       return {};
     };
 
-    int numCTAs = TritonGPUDialect::getNumCTAs(op->getParentOfType<ModuleOp>());
-    auto res = lowerDirectLDSAsyncCopy(
-        rewriter, loc, ptrType, flatDstTy, loadVals, llDst, resElemTy, vec,
-        /*isLoad=*/true, numCTAs, targetInfo.getISAFamily(), emitBufferLoadLds);
+    auto res = lowerDirectLDSAsyncCopy(rewriter, loc, ptrType, flatDstTy,
+                                       loadVals, llDst, resElemTy, vec,
+                                       /*isLoad=*/true, emitBufferLoadLds);
     if (failed(res)) {
       return failure();
     }
@@ -1005,10 +1000,9 @@ struct AsyncCopyGlobalToLocalOpConversion
       return {};
     };
 
-    int numCTAs = TritonGPUDialect::getNumCTAs(op->getParentOfType<ModuleOp>());
-    auto res = lowerDirectLDSAsyncCopy(
-        rewriter, loc, srcTy, flatDstTy, loadVals, llDst, resElemTy, vec,
-        /*isLoad=*/true, numCTAs, targetInfo.getISAFamily(), emitGlobalLoadLds);
+    auto res = lowerDirectLDSAsyncCopy(rewriter, loc, srcTy, flatDstTy,
+                                       loadVals, llDst, resElemTy, vec,
+                                       /*isLoad=*/true, emitGlobalLoadLds);
     if (failed(res)) {
       return failure();
     }
@@ -1138,11 +1132,9 @@ struct AsyncCopyLocalToGlobalOpConversion
       return {};
     };
 
-    int numCTAs = TritonGPUDialect::getNumCTAs(op->getParentOfType<ModuleOp>());
-    auto res = lowerDirectLDSAsyncCopy(
-        rewriter, loc, dstTy, srcTy, storeVals, llSrc, resElemTy, vec,
-        /*isLoad=*/false, numCTAs, targetInfo.getISAFamily(),
-        emitGlobalStoreLds);
+    auto res = lowerDirectLDSAsyncCopy(rewriter, loc, dstTy, srcTy, storeVals,
+                                       llSrc, resElemTy, vec,
+                                       /*isLoad=*/false, emitGlobalStoreLds);
     if (failed(res)) {
       return failure();
     }
@@ -1198,7 +1190,6 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
     auto paddedEnc =
         llvm::dyn_cast<PaddedSharedEncodingAttr>(smemTy.getEncoding());
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
-    int numCTAs = TritonGPUDialect::getNumCTAs(op->getParentOfType<ModuleOp>());
 
     triton::LinearLayout sharedLayout;
     unsigned padInterval = 0;
@@ -1213,7 +1204,7 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
       sharedLayout = triton::gpu::toLinearLayout(smemTy);
     }
     Value multicastMask;
-    if (numCTAs > 1) {
+    if (targetInfo.supportsMultiCTALaunch()) {
       multicastMask = LLVM::AMD::emitCtaMulticastMask(
           rewriter, loc, targetInfo.getClusterCTAId(rewriter, loc),
           sharedLayout);
@@ -1249,8 +1240,7 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
     auto kBlock = rewriter.getStringAttr("block");
     auto cgaLayout = sharedLayout.sublayout(
         {kBlock}, to_vector(sharedLayout.getOutDimNames()));
-    auto ctaId =
-        numCTAs > 1 ? targetInfo.getClusterCTAId(rewriter, loc) : b.i32_val(0);
+    auto ctaId = targetInfo.getClusterCTAId(rewriter, loc);
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
     mlir::LLVM::AMD::emitTDMOperation(
@@ -1284,7 +1274,6 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
     auto tensorDescTy = op.getDesc().getType();
     auto smemTy = op.getSrc().getType();
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
-    int numCTAs = TritonGPUDialect::getNumCTAs(op->getParentOfType<ModuleOp>());
 
     SmallVector<Value> desc =
         unpackLLElements(loc, adaptor.getDesc(), rewriter);
@@ -1318,8 +1307,7 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
     auto kBlock = rewriter.getStringAttr("block");
     auto cgaLayout = sharedLayout.sublayout(
         {kBlock}, to_vector(sharedLayout.getOutDimNames()));
-    auto ctaId =
-        numCTAs > 1 ? targetInfo.getClusterCTAId(rewriter, loc) : b.i32_val(0);
+    auto ctaId = targetInfo.getClusterCTAId(rewriter, loc);
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
     mlir::LLVM::AMD::emitTDMOperation(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -101,14 +101,14 @@ bool TargetInfo::supportMaximumMinimum() const {
 }
 
 Value TargetInfo::getClusterCTAId(RewriterBase &rewriter, Location loc) const {
-  if (supportsMultiCTALaunch()) {
-    // We dispatch only along x; return the workgroup id x
-    return LLVM::createLLVMIntrinsicCallOp(rewriter, loc,
-                                           "llvm.amdgcn.cluster.workgroup.id.x",
-                                           {rewriter.getI32Type()}, {})
-        .getResult(0);
-  }
-  return arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+  if (triton::gpu::lookupNumCTAs(&rewriter.getInsertionBlock()->front()) == 1)
+    return arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+
+  // We dispatch only along x; return the workgroup id x
+  return LLVM::createLLVMIntrinsicCallOp(rewriter, loc,
+                                         "llvm.amdgcn.cluster.workgroup.id.x",
+                                         {rewriter.getI32Type()}, {})
+      .getResult(0);
 }
 
 Value TargetInfo::ballot(RewriterBase &rewriter, Location loc, Type type,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -131,6 +131,9 @@ bool TargetInfo::supportMaximumMinimum() const {
 }
 
 Value TargetInfo::getClusterCTAId(RewriterBase &rewriter, Location loc) const {
+  if (triton::gpu::lookupNumCTAs(&rewriter.getInsertionBlock()->front()) == 1)
+    return arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+
   return triton::nvgpu::ClusterCTAIdOp::create(rewriter, loc,
                                                rewriter.getI32Type());
 }


### PR DESCRIPTION
Summary:

This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9125

Upstream commit message:
```
> [Backend][NFC] Change getClusterCTAId to return 0 for 1 CTA (#9125)

> Follow up based on [this comment on a previous
> PR](https://github.com/triton-lang/triton/pull/8790#discussion_r2549358694)
> to return `0` if we compile for a single CTA.
> This also removes some guard when lowering load ops in the AMD backend
> which are no longer required.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 04af4e3bed63453cb893729e0e67e576fbbe8826
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1 --no-submit
```

Diff Comparison: https://www.internalfb.com/intern/paste/P2287259982/

Reviewed By: sfzhu93

Differential Revision: D102340030
