### PR TITLE
[triton][beta] Fix pre-existing test failure: py_tlx_amd_test::test_default_task_rejects_registers (#1361)

### DIFF
--- a/third_party/tlx/language/tlx/async_task_utils.py
+++ b/third_party/tlx/language/tlx/async_task_utils.py
@@ -18,7 +18,7 @@ class async_task:
         self.warp_group_start_id = None
         if args:
             assert len(args) == 1
-            if isinstance(args[0], core.constexpr) and args[0] == "default":
+            if core._unwrap_if_constexpr(args[0]) == "default":
                 self.is_explict = True
                 self.is_default = True
                 assert "num_regs" not in kwargs and "registers" not in kwargs, \


### PR DESCRIPTION
Summary:

The `async_task.__init__` guard on line 21 checked `isinstance(args[0], core.constexpr)` before comparing to `"default"`. When called from Python test code (outside the JIT compiler), `"default"` is a plain `str`, not wrapped in `core.constexpr`, so the guard always failed and the assertion on line 24 was never reached. Fix: use `core._unwrap_if_constexpr(args[0])` which handles both `str` and `constexpr("default")`.

Reviewed By: sfzhu93

Differential Revision: D102413261
