### PR TITLE
[TLX][AMD] Add simple and prefetch async FA kernels

### DIFF
--- a/third_party/tlx/tutorials/amd-fa-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-fa-pipelined_test.py
@@ -28,44 +28,82 @@ import triton.language.extra.tlx as tlx
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
+
 @triton.jit
 def _assume_strides(
-    stride_qz, stride_qh, stride_qm, stride_qk,
-    stride_kz, stride_kh, stride_kn, stride_kk,
-    stride_vz, stride_vh, stride_vn, stride_vk,
-    stride_oz, stride_oh, stride_om, stride_ok,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
 ):
-    tl.assume(stride_qz >= 0); tl.assume(stride_qh >= 0)
-    tl.assume(stride_qm > 0);  tl.assume(stride_qk >= 0)
-    tl.assume(stride_kz >= 0); tl.assume(stride_kh >= 0)
-    tl.assume(stride_kn > 0);  tl.assume(stride_kk >= 0)
-    tl.assume(stride_vz >= 0); tl.assume(stride_vh >= 0)
-    tl.assume(stride_vn > 0);  tl.assume(stride_vk >= 0)
-    tl.assume(stride_oz >= 0); tl.assume(stride_oh >= 0)
-    tl.assume(stride_om > 0);  tl.assume(stride_ok >= 0)
+    tl.assume(stride_qz >= 0)
+    tl.assume(stride_qh >= 0)
+    tl.assume(stride_qm > 0)
+    tl.assume(stride_qk >= 0)
+    tl.assume(stride_kz >= 0)
+    tl.assume(stride_kh >= 0)
+    tl.assume(stride_kn > 0)
+    tl.assume(stride_kk >= 0)
+    tl.assume(stride_vz >= 0)
+    tl.assume(stride_vh >= 0)
+    tl.assume(stride_vn > 0)
+    tl.assume(stride_vk >= 0)
+    tl.assume(stride_oz >= 0)
+    tl.assume(stride_oh >= 0)
+    tl.assume(stride_om > 0)
+    tl.assume(stride_ok >= 0)
 
 
 @triton.jit
 def _attn_fwd_async_simple(
-    Q, K, V, Out,
-    stride_qz, stride_qh, stride_qm, stride_qk,
-    stride_kz, stride_kh, stride_kn, stride_kk,
-    stride_vz, stride_vh, stride_vn, stride_vk,
-    stride_oz, stride_oh, stride_om, stride_ok,
-    Z, H, N_CTX, sm_scale: tl.constexpr,
-    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr, IS_CAUSAL: tl.constexpr,
+    Q,
+    K,
+    V,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    Z,
+    H,
+    N_CTX,
+    sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
 ):
-    _assume_strides(
-        stride_qz, stride_qh, stride_qm, stride_qk,
-        stride_kz, stride_kh, stride_kn, stride_kk,
-        stride_vz, stride_vh, stride_vn, stride_vk,
-        stride_oz, stride_oh, stride_om, stride_ok)
+    _assume_strides(stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh, stride_kn, stride_kk, stride_vz,
+                    stride_vh, stride_vn, stride_vk, stride_oz, stride_oh, stride_om, stride_ok)
 
-    pid_m  = tl.program_id(0)
+    pid_m = tl.program_id(0)
     pid_hz = tl.program_id(1)
-    off_z  = pid_hz // H
-    off_h  = pid_hz %  H
+    off_z = pid_hz // H
+    off_h = pid_hz % H
 
     q_off = off_z * stride_qz + off_h * stride_qh
     k_off = off_z * stride_kz + off_h * stride_kh
@@ -76,8 +114,8 @@ def _attn_fwd_async_simple(
     offs_n = tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, HEAD_DIM)
 
-    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk,
-                mask=offs_m[:, None] < N_CTX, other=0.0)
+    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk, mask=offs_m[:, None] < N_CTX,
+                other=0.0)
 
     m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
     l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
@@ -100,17 +138,13 @@ def _attn_fwd_async_simple(
         k_mask = kn[:, None] < N_CTX
         v_mask = kn[:, None] < N_CTX
 
-        tok_k = tlx.async_load(k_base + start_n * stride_kn,
-                               tlx.local_view(k_buf, 0), mask=k_mask)
-        tok_v = tlx.async_load(v_base + start_n * stride_vn,
-                               tlx.local_view(v_buf, 0), mask=v_mask)
+        tok_k = tlx.async_load(k_base + start_n * stride_kn, tlx.local_view(k_buf, 0), mask=k_mask)
+        tok_v = tlx.async_load(v_base + start_n * stride_vn, tlx.local_view(v_buf, 0), mask=v_mask)
         tlx.async_load_commit_group([tok_k, tok_v])
 
         wait_tok = tlx.async_load_wait_group(0)
-        k_cur = tlx.local_load(tlx.local_view(k_buf, 0),
-                               token=wait_tok, relaxed=True)
-        v_cur = tlx.local_load(tlx.local_view(v_buf, 0),
-                               token=wait_tok, relaxed=True)
+        k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
 
         qk = tl.dot(q, k_cur.T)
         if IS_CAUSAL:
@@ -118,30 +152,51 @@ def _attn_fwd_async_simple(
         if start_n + BLOCK_N > N_CTX:
             qk = tl.where(kn[None, :] < N_CTX, qk, float("-inf"))
 
-        m_ij  = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
-        qk    = qk * QK_SCALE - m_ij[:, None]
-        p     = tl.math.exp2(qk)
-        l_ij  = tl.sum(p, 1)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+        qk = qk * QK_SCALE - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        l_ij = tl.sum(p, 1)
         alpha = tl.math.exp2(m_i - m_ij)
-        acc = acc * alpha[:, None]; l_i = l_i * alpha + l_ij; m_i = m_ij
+        acc = acc * alpha[:, None]
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
         acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
 
     acc = acc / l_i[:, None]
     o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
-    tl.store(o_ptrs, acc.to(Out.dtype.element_ty),
-             mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
 
 
 @triton.jit
 def _attn_fwd_async_prefetch(
-    Q, K, V, Out,
-    stride_qz, stride_qh, stride_qm, stride_qk,
-    stride_kz, stride_kh, stride_kn, stride_kk,
-    stride_vz, stride_vh, stride_vn, stride_vk,
-    stride_oz, stride_oh, stride_om, stride_ok,
-    Z, H, N_CTX, sm_scale: tl.constexpr,
-    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr, IS_CAUSAL: tl.constexpr,
+    Q,
+    K,
+    V,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    Z,
+    H,
+    N_CTX,
+    sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
 ):
     """
     Prefetch flash attention with explicit modulo-scheduled prologue,
@@ -157,23 +212,20 @@ def _attn_fwd_async_prefetch(
 
     Steady State (Hot Loop):
     t = i               t = i+1
-    [QK, SM0, SM1, PV]  [GLDS_KV],          
+    [QK, SM0, SM1, PV]  [GLDS_KV],
                         [LR_KV]
 
     Epilogue:
                         t = i+1
                         [QK (masked), SM0, SM1, PV]
     """
-    _assume_strides(
-        stride_qz, stride_qh, stride_qm, stride_qk,
-        stride_kz, stride_kh, stride_kn, stride_kk,
-        stride_vz, stride_vh, stride_vn, stride_vk,
-        stride_oz, stride_oh, stride_om, stride_ok)
+    _assume_strides(stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh, stride_kn, stride_kk, stride_vz,
+                    stride_vh, stride_vn, stride_vk, stride_oz, stride_oh, stride_om, stride_ok)
 
-    pid_m  = tl.program_id(0)
+    pid_m = tl.program_id(0)
     pid_hz = tl.program_id(1)
-    off_z  = pid_hz // H
-    off_h  = pid_hz %  H
+    off_z = pid_hz // H
+    off_h = pid_hz % H
 
     q_off = off_z * stride_qz + off_h * stride_qh
     k_off = off_z * stride_kz + off_h * stride_kh
@@ -184,8 +236,8 @@ def _attn_fwd_async_prefetch(
     offs_n = tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, HEAD_DIM)
 
-    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk,
-                mask=offs_m[:, None] < N_CTX, other=0.0)
+    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk, mask=offs_m[:, None] < N_CTX,
+                other=0.0)
 
     QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
 
@@ -206,7 +258,6 @@ def _attn_fwd_async_prefetch(
     m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
     l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
-
     """
     Prologue:
     t = 0
@@ -214,21 +265,18 @@ def _attn_fwd_async_prefetch(
     [LR_KV]
     """
     # GLDS_KV_t0
-    tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0),
-                           mask=offs_n[:, None] < N_CTX)
-    tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0),
-                           mask=offs_n[:, None] < N_CTX)
+    tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0), mask=offs_n[:, None] < N_CTX)
+    tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0), mask=offs_n[:, None] < N_CTX)
     tlx.async_load_commit_group([tok_k, tok_v])
 
     # LR_KV_t0
     wait_tok = tlx.async_load_wait_group(0)
     k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
     v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
-
     """
     Steady State (Hot Loop):
     t = i               t = i+1
-    [QK, SM0, SM1, PV]  [GLDS_KV],         
+    [QK, SM0, SM1, PV]  [GLDS_KV],
                         [LR_KV]
     """
     for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=0):
@@ -247,10 +295,8 @@ def _attn_fwd_async_prefetch(
         l_ij = tl.sum(p, 1)
 
         # GLDS after SM0: overlaps with SM1 + PV
-        tok_k = tlx.async_load(k_ptrs + next_off * stride_kn,
-                               tlx.local_view(k_buf, 0), mask=next_mask)
-        tok_v = tlx.async_load(v_ptrs + next_off * stride_vn,
-                               tlx.local_view(v_buf, 0), mask=next_mask)
+        tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, 0), mask=next_mask)
+        tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, 0), mask=next_mask)
         tlx.async_load_commit_group([tok_k, tok_v])
 
         # SM1_ti
@@ -266,7 +312,6 @@ def _attn_fwd_async_prefetch(
         wait_tok = tlx.async_load_wait_group(0)
         k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
         v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
-
     """
     Epilogue:
     t = i+1
@@ -297,13 +342,13 @@ def _attn_fwd_async_prefetch(
     # Store output
     acc = acc / l_i[:, None]
     o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
-    tl.store(o_ptrs, acc.to(Out.dtype.element_ty),
-             mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Host wrapper
 # ═══════════════════════════════════════════════════════════════════════════
+
 
 def flash_attn_async_simple(q, k, v, sm_scale, causal=False, **kw):
     """Launch with K in original BHND layout — stride_kk=1 avoids alignment issues."""
@@ -316,14 +361,36 @@ def flash_attn_async_simple(q, k, v, sm_scale, causal=False, **kw):
 
     grid = (triton.cdiv(N_CTX, BLOCK_M), B * H)
     _attn_fwd_async_simple[grid](
-        q, k, v, o,
-        q.stride(0), q.stride(1), q.stride(2), q.stride(3),
-        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
-        v.stride(0), v.stride(1), v.stride(2), v.stride(3),
-        o.stride(0), o.stride(1), o.stride(2), o.stride(3),
-        B, H, N_CTX, sm_scale,
-        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, HEAD_DIM=D,
-        IS_CAUSAL=causal, num_warps=num_warps, **kw,
+        q,
+        k,
+        v,
+        o,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        o.stride(3),
+        B,
+        H,
+        N_CTX,
+        sm_scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        HEAD_DIM=D,
+        IS_CAUSAL=causal,
+        num_warps=num_warps,
+        **kw,
     )
     return o
 
@@ -339,14 +406,36 @@ def flash_attn_async_prefetch(q, k, v, sm_scale, causal=False, **kw):
 
     grid = (triton.cdiv(N_CTX, BLOCK_M), B * H)
     _attn_fwd_async_prefetch[grid](
-        q, k, v, o,
-        q.stride(0), q.stride(1), q.stride(2), q.stride(3),
-        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
-        v.stride(0), v.stride(1), v.stride(2), v.stride(3),
-        o.stride(0), o.stride(1), o.stride(2), o.stride(3),
-        B, H, N_CTX, sm_scale,
-        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, HEAD_DIM=D,
-        IS_CAUSAL=causal, num_warps=num_warps, **kw,
+        q,
+        k,
+        v,
+        o,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        o.stride(3),
+        B,
+        H,
+        N_CTX,
+        sm_scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        HEAD_DIM=D,
+        IS_CAUSAL=causal,
+        num_warps=num_warps,
+        **kw,
     )
     return o
 
@@ -363,16 +452,15 @@ KERNEL_REGISTRY = {
 
 def get_kernel(name):
     if name not in KERNEL_REGISTRY:
-        raise ValueError(
-            f"Unknown kernel: {name!r}. "
-            f"Available: {list(KERNEL_REGISTRY.keys())}"
-        )
+        raise ValueError(f"Unknown kernel: {name!r}. "
+                         f"Available: {list(KERNEL_REGISTRY.keys())}")
     return KERNEL_REGISTRY[name]
 
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Reference, verification, and Misc Utils
 # ═══════════════════════════════════════════════════════════════════════════
+
 
 def print_summary_table(results, kernel_names):
     """Print a markdown-style summary table of benchmark results."""
@@ -396,11 +484,11 @@ def print_summary_table(results, kernel_names):
     print(sep)
 
     for label, prov in rows:
-        vals = (f"{prov[p]['tflops']:>{col_w}.1f}" if p in prov else f"{'—':>{col_w}}"
-                for p in providers)
+        vals = (f"{prov[p]['tflops']:>{col_w}.1f}" if p in prov else f"{'—':>{col_w}}" for p in providers)
         print(f"| {label:<{cfg_w}} |" + "".join(f" {v} |" for v in vals))
 
     print(f"{'=' * len(sep)}\n")
+
 
 def ref_sdpa(q, k, v, sm_scale, causal=False):
     return F.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=sm_scale)
@@ -409,7 +497,7 @@ def ref_sdpa(q, k, v, sm_scale, causal=False):
 def verify(name, got, ref, atol=2e-2, rtol=2e-2, log=True):
     diff = (got.float() - ref.float()).abs()
     ok = torch.allclose(ref, got, atol=atol, rtol=rtol)
-    max_err  = diff.max().item()
+    max_err = diff.max().item()
     mean_err = diff.mean().item()
     status = "PASS" if ok else "FAIL"
     if log:
@@ -442,6 +530,7 @@ def test_fa_correctness(kernel_name, causal, n_test, dtype=torch.bfloat16, D=128
 # Benchmark
 # ═══════════════════════════════════════════════════════════════════════════
 
+
 def run_benchmark(args):
     causal_modes = [s.lower() in ("true", "1", "yes") for s in args.causal]
     dtype = {"bf16": torch.bfloat16, "fp16": torch.float16}[args.dtype]
@@ -449,48 +538,49 @@ def run_benchmark(args):
     results = {}
 
     for kernel_name in args.kernel:
-      kernel_fn = get_kernel(kernel_name)
-      for B in args.b:
-        for H in args.hq:
-          for D in args.d:
-            for N in args.sq:
-              for causal in causal_modes:
-                torch.manual_seed(42)
-                q = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
-                k = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
-                v = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
-                sm = 1.0 / math.sqrt(D)
+        kernel_fn = get_kernel(kernel_name)
+        for B in args.b:
+            for H in args.hq:
+                for D in args.d:
+                    for N in args.sq:
+                        for causal in causal_modes:
+                            torch.manual_seed(42)
+                            q = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                            k = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                            v = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                            sm = 1.0 / math.sqrt(D)
 
-                if causal:
-                    valid_el = N * (N + 1) // 2
-                else:
-                    valid_el = N * N
-                total_flops = 2 * 2.0 * B * H * valid_el * D
+                            if causal:
+                                valid_el = N * (N + 1) // 2
+                            else:
+                                valid_el = N * N
+                            total_flops = 2 * 2.0 * B * H * valid_el * D
 
-                causal_str = "causal" if causal else "nc"
-                ref_sdpa_lambda = lambda: F.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=sm)
+                            causal_str = "causal" if causal else "nc"
+                            ref_sdpa_lambda = lambda: F.scaled_dot_product_attention(
+                                q, k, v, is_causal=causal, scale=sm)
 
-                try:
-                    tlx_sdpa_lambda = lambda: kernel_fn(q, k, v, sm, causal)
-                    ref_out = ref_sdpa_lambda()
-                    tlx_out = tlx_sdpa_lambda()
-                    assert verify("", tlx_out, ref_out, log=False)
-                except Exception as e:
-                    print(f"  {kernel_name:20s} D={D} N={N:5d} {causal_str:6s} -> SKIPPED ({e})")
-                    continue
+                            try:
+                                tlx_sdpa_lambda = lambda: kernel_fn(q, k, v, sm, causal)
+                                ref_out = ref_sdpa_lambda()
+                                tlx_out = tlx_sdpa_lambda()
+                                assert verify("", tlx_out, ref_out, log=False)
+                            except Exception as e:
+                                print(f"  {kernel_name:20s} D={D} N={N:5d} {causal_str:6s} -> SKIPPED ({e})")
+                                continue
 
-                key = (B, H, D, N, causal)
-                if key not in results:
-                    results[key] = {}
+                            key = (B, H, D, N, causal)
+                            if key not in results:
+                                results[key] = {}
 
-                if "Torch SDPA" not in results[key]:
-                    ms = triton.testing.do_bench(ref_sdpa_lambda, warmup=25, rep=100)
-                    tflops = total_flops / ms * 1e-9
-                    results[key]["Torch SDPA"] = {"ms": ms, "tflops": tflops}
+                            if "Torch SDPA" not in results[key]:
+                                ms = triton.testing.do_bench(ref_sdpa_lambda, warmup=25, rep=100)
+                                tflops = total_flops / ms * 1e-9
+                                results[key]["Torch SDPA"] = {"ms": ms, "tflops": tflops}
 
-                ms = triton.testing.do_bench(tlx_sdpa_lambda, warmup=25, rep=100)
-                tflops = total_flops / ms * 1e-9
-                results[key][kernel_name] = {"ms": ms, "tflops": tflops}
+                            ms = triton.testing.do_bench(tlx_sdpa_lambda, warmup=25, rep=100)
+                            tflops = total_flops / ms * 1e-9
+                            results[key][kernel_name] = {"ms": ms, "tflops": tflops}
 
     print_summary_table(results, args.kernel)
 
@@ -499,12 +589,13 @@ def run_benchmark(args):
 # CLI
 # ═══════════════════════════════════════════════════════════════════════════
 
+
 def parse_args():
     p = argparse.ArgumentParser(prog="AMD TLX FA Pipelined")
-    p.add_argument("-b",  type=int, nargs="+", default=[1])
+    p.add_argument("-b", type=int, nargs="+", default=[1])
     p.add_argument("-hq", type=int, nargs="+", default=[64])
     p.add_argument("-sq", type=int, nargs="+", default=[1024, 8192, 16384])
-    p.add_argument("-d",  type=int, nargs="+", default=[64, 128])
+    p.add_argument("-d", type=int, nargs="+", default=[64, 128])
     p.add_argument("-causal", type=str, nargs="+", default=["false"],
                    help="Causal modes to benchmark (e.g. -causal true false)")
     p.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16"])

--- a/third_party/tlx/tutorials/amd-fa-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-fa-pipelined_test.py
@@ -1,0 +1,517 @@
+"""
+AMD Flash Attention Forward — Async DMA Kernel (CDNA4)
+============================================================
+
+Usage:
+    # Defaults: -b 1 -hq 64 -sq 1024 8192 16384 -d 64 128 -causal false --kernel async_simple
+    python amd-fa-pipelined_test.py
+
+    # Sweep sequence lengths and head dims
+    python amd-fa-pipelined_test.py -sq 512 1024 4096 -d 64 128
+
+    # Both causal modes, multiple batch sizes
+    python amd-fa-pipelined_test.py -b 1 2 -causal true false
+
+    # Multiple kernels
+    python amd-fa-pipelined_test.py --kernel async_simple --dtype fp16
+"""
+
+import argparse
+import math
+import pytest
+import torch
+import torch.nn.functional as F
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+@triton.jit
+def _assume_strides(
+    stride_qz, stride_qh, stride_qm, stride_qk,
+    stride_kz, stride_kh, stride_kn, stride_kk,
+    stride_vz, stride_vh, stride_vn, stride_vk,
+    stride_oz, stride_oh, stride_om, stride_ok,
+):
+    tl.assume(stride_qz >= 0); tl.assume(stride_qh >= 0)
+    tl.assume(stride_qm > 0);  tl.assume(stride_qk >= 0)
+    tl.assume(stride_kz >= 0); tl.assume(stride_kh >= 0)
+    tl.assume(stride_kn > 0);  tl.assume(stride_kk >= 0)
+    tl.assume(stride_vz >= 0); tl.assume(stride_vh >= 0)
+    tl.assume(stride_vn > 0);  tl.assume(stride_vk >= 0)
+    tl.assume(stride_oz >= 0); tl.assume(stride_oh >= 0)
+    tl.assume(stride_om > 0);  tl.assume(stride_ok >= 0)
+
+
+@triton.jit
+def _attn_fwd_async_simple(
+    Q, K, V, Out,
+    stride_qz, stride_qh, stride_qm, stride_qk,
+    stride_kz, stride_kh, stride_kn, stride_kk,
+    stride_vz, stride_vh, stride_vn, stride_vk,
+    stride_oz, stride_oh, stride_om, stride_ok,
+    Z, H, N_CTX, sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr, IS_CAUSAL: tl.constexpr,
+):
+    _assume_strides(
+        stride_qz, stride_qh, stride_qm, stride_qk,
+        stride_kz, stride_kh, stride_kn, stride_kk,
+        stride_vz, stride_vh, stride_vn, stride_vk,
+        stride_oz, stride_oh, stride_om, stride_ok)
+
+    pid_m  = tl.program_id(0)
+    pid_hz = tl.program_id(1)
+    off_z  = pid_hz // H
+    off_h  = pid_hz %  H
+
+    q_off = off_z * stride_qz + off_h * stride_qh
+    k_off = off_z * stride_kz + off_h * stride_kh
+    v_off = off_z * stride_vz + off_h * stride_vh
+    o_off = off_z * stride_oz + off_h * stride_oh
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk,
+                mask=offs_m[:, None] < N_CTX, other=0.0)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    QK_SCALE = sm_scale * 1.44269504089
+
+    if IS_CAUSAL:
+        hi = min(N_CTX, (pid_m + 1) * BLOCK_M)
+    else:
+        hi = N_CTX
+
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, 1)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, 1)
+
+    k_base = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+    v_base = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
+
+    for start_n in tl.range(0, hi, BLOCK_N, num_stages=0):
+        kn = start_n + offs_n
+        k_mask = kn[:, None] < N_CTX
+        v_mask = kn[:, None] < N_CTX
+
+        tok_k = tlx.async_load(k_base + start_n * stride_kn,
+                               tlx.local_view(k_buf, 0), mask=k_mask)
+        tok_v = tlx.async_load(v_base + start_n * stride_vn,
+                               tlx.local_view(v_buf, 0), mask=v_mask)
+        tlx.async_load_commit_group([tok_k, tok_v])
+
+        wait_tok = tlx.async_load_wait_group(0)
+        k_cur = tlx.local_load(tlx.local_view(k_buf, 0),
+                               token=wait_tok, relaxed=True)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, 0),
+                               token=wait_tok, relaxed=True)
+
+        qk = tl.dot(q, k_cur.T)
+        if IS_CAUSAL:
+            qk = tl.where(offs_m[:, None] >= kn[None, :], qk, float("-inf"))
+        if start_n + BLOCK_N > N_CTX:
+            qk = tl.where(kn[None, :] < N_CTX, qk, float("-inf"))
+
+        m_ij  = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+        qk    = qk * QK_SCALE - m_ij[:, None]
+        p     = tl.math.exp2(qk)
+        l_ij  = tl.sum(p, 1)
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]; l_i = l_i * alpha + l_ij; m_i = m_ij
+        acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+
+    acc = acc / l_i[:, None]
+    o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty),
+             mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+
+
+@triton.jit
+def _attn_fwd_async_prefetch(
+    Q, K, V, Out,
+    stride_qz, stride_qh, stride_qm, stride_qk,
+    stride_kz, stride_kh, stride_kn, stride_kk,
+    stride_vz, stride_vh, stride_vn, stride_vk,
+    stride_oz, stride_oh, stride_om, stride_ok,
+    Z, H, N_CTX, sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr, IS_CAUSAL: tl.constexpr,
+):
+    """
+    Prefetch flash attention with explicit modulo-scheduled prologue,
+    hot loop (steady state), and epilogue
+
+    Single-buffered K/V shared memory.
+    Each commit group bundles K and V for the same tile.
+
+    Prologue:
+    t = 0
+    [GLDS_KV]
+    [LR_KV]
+
+    Steady State (Hot Loop):
+    t = i               t = i+1
+    [QK, SM0, SM1, PV]  [GLDS_KV],          
+                        [LR_KV]
+
+    Epilogue:
+                        t = i+1
+                        [QK (masked), SM0, SM1, PV]
+    """
+    _assume_strides(
+        stride_qz, stride_qh, stride_qm, stride_qk,
+        stride_kz, stride_kh, stride_kn, stride_kk,
+        stride_vz, stride_vh, stride_vn, stride_vk,
+        stride_oz, stride_oh, stride_om, stride_ok)
+
+    pid_m  = tl.program_id(0)
+    pid_hz = tl.program_id(1)
+    off_z  = pid_hz // H
+    off_h  = pid_hz %  H
+
+    q_off = off_z * stride_qz + off_h * stride_qh
+    k_off = off_z * stride_kz + off_h * stride_kh
+    v_off = off_z * stride_vz + off_h * stride_vh
+    o_off = off_z * stride_oz + off_h * stride_oh
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk,
+                mask=offs_m[:, None] < N_CTX, other=0.0)
+
+    QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
+
+    if IS_CAUSAL:
+        hi = min(N_CTX, (pid_m + 1) * BLOCK_M)
+    else:
+        hi = N_CTX
+
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, 1)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, 1)
+
+    k_ptrs = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+    v_ptrs = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
+
+    n_blocks = (hi + BLOCK_N - 1) // BLOCK_N
+    n_main = tl.maximum(n_blocks - 1, 0)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    """
+    Prologue:
+    t = 0
+    [GLDS_KV]
+    [LR_KV]
+    """
+    # GLDS_KV_t0
+    tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0),
+                           mask=offs_n[:, None] < N_CTX)
+    tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0),
+                           mask=offs_n[:, None] < N_CTX)
+    tlx.async_load_commit_group([tok_k, tok_v])
+
+    # LR_KV_t0
+    wait_tok = tlx.async_load_wait_group(0)
+    k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
+    v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
+
+    """
+    Steady State (Hot Loop):
+    t = i               t = i+1
+    [QK, SM0, SM1, PV]  [GLDS_KV],         
+                        [LR_KV]
+    """
+    for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=0):
+        next_off = block_id + BLOCK_N
+        kn = block_id + offs_n
+        next_mask = (next_off + offs_n[:, None]) < N_CTX
+
+        # QK_ti
+        qk = tl.dot(q, k_cur.T)
+        if IS_CAUSAL:
+            qk = tl.where(offs_m[:, None] >= kn[None, :], qk, float("-inf"))
+
+        # SM0_ti
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+        p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
+        l_ij = tl.sum(p, 1)
+
+        # GLDS after SM0: overlaps with SM1 + PV
+        tok_k = tlx.async_load(k_ptrs + next_off * stride_kn,
+                               tlx.local_view(k_buf, 0), mask=next_mask)
+        tok_v = tlx.async_load(v_ptrs + next_off * stride_vn,
+                               tlx.local_view(v_buf, 0), mask=next_mask)
+        tlx.async_load_commit_group([tok_k, tok_v])
+
+        # SM1_ti
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+
+        # PV_ti
+        acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+
+        # LR_KV_t(i+1)
+        wait_tok = tlx.async_load_wait_group(0)
+        k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
+
+    """
+    Epilogue:
+    t = i+1
+    [QK (masked), SM0, SM1, PV]
+    """
+    kn_last = n_main * BLOCK_N + offs_n
+
+    # QK_t(i+1) — with boundary + causal masking
+    qk = tl.dot(q, k_cur.T)
+    qk = tl.where(kn_last[None, :] < N_CTX, qk, float("-inf"))
+    if IS_CAUSAL:
+        qk = tl.where(offs_m[:, None] >= kn_last[None, :], qk, float("-inf"))
+
+    # SM0_t(i+1)
+    m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+    p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
+    l_ij = tl.sum(p, 1)
+
+    # SM1_t(i+1)
+    alpha = tl.math.exp2(m_i - m_ij)
+    acc = acc * alpha[:, None]
+    l_i = l_i * alpha + l_ij
+    m_i = m_ij
+
+    # PV_t(i+1)
+    acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+
+    # Store output
+    acc = acc / l_i[:, None]
+    o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty),
+             mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Host wrapper
+# ═══════════════════════════════════════════════════════════════════════════
+
+def flash_attn_async_simple(q, k, v, sm_scale, causal=False, **kw):
+    """Launch with K in original BHND layout — stride_kk=1 avoids alignment issues."""
+    B, H, N_CTX, D = q.shape
+    o = torch.empty_like(q)
+
+    BLOCK_M = kw.pop("BLOCK_M", 256)
+    BLOCK_N = kw.pop("BLOCK_N", 64)
+    num_warps = kw.pop("num_warps", 4)
+
+    grid = (triton.cdiv(N_CTX, BLOCK_M), B * H)
+    _attn_fwd_async_simple[grid](
+        q, k, v, o,
+        q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+        o.stride(0), o.stride(1), o.stride(2), o.stride(3),
+        B, H, N_CTX, sm_scale,
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, HEAD_DIM=D,
+        IS_CAUSAL=causal, num_warps=num_warps, **kw,
+    )
+    return o
+
+
+def flash_attn_async_prefetch(q, k, v, sm_scale, causal=False, **kw):
+    """Prefetch FA with modulo-scheduled prologue/hot-loop/epilogue."""
+    B, H, N_CTX, D = q.shape
+    o = torch.empty_like(q)
+
+    BLOCK_M = kw.pop("BLOCK_M", 256)
+    BLOCK_N = kw.pop("BLOCK_N", 64)
+    num_warps = kw.pop("num_warps", 8)
+
+    grid = (triton.cdiv(N_CTX, BLOCK_M), B * H)
+    _attn_fwd_async_prefetch[grid](
+        q, k, v, o,
+        q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+        o.stride(0), o.stride(1), o.stride(2), o.stride(3),
+        B, H, N_CTX, sm_scale,
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, HEAD_DIM=D,
+        IS_CAUSAL=causal, num_warps=num_warps, **kw,
+    )
+    return o
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Kernel registry — add new kernel wrappers here
+# ═══════════════════════════════════════════════════════════════════════════
+
+KERNEL_REGISTRY = {
+    "async_simple": flash_attn_async_simple,
+    "async_prefetch": flash_attn_async_prefetch,
+}
+
+
+def get_kernel(name):
+    if name not in KERNEL_REGISTRY:
+        raise ValueError(
+            f"Unknown kernel: {name!r}. "
+            f"Available: {list(KERNEL_REGISTRY.keys())}"
+        )
+    return KERNEL_REGISTRY[name]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Reference, verification, and Misc Utils
+# ═══════════════════════════════════════════════════════════════════════════
+
+def print_summary_table(results, kernel_names):
+    """Print a markdown-style summary table of benchmark results."""
+    providers = ["Torch SDPA"] + list(kernel_names)
+
+    rows = []
+    for key in sorted(results.keys()):
+        B, H, D, N, causal = key
+        rows.append((f"B={B}, H={H}, D={D}, N={N}, causal={causal}", results[key]))
+
+    cfg_w = max(len("Config"), *(len(lbl) for lbl, _ in rows)) if rows else len("Config")
+    col_w = max(14, *(len(p) for p in providers))
+
+    hdr = f"| {'Config':<{cfg_w}} |" + "".join(f" {p:>{col_w}} |" for p in providers)
+    sep = f"|{'-' * (cfg_w + 2)}|" + "".join(f"{'-' * (col_w + 2)}|" for _ in providers)
+
+    print(f"\n{'=' * len(sep)}")
+    print("Summary (TFLOPS)")
+    print(f"{'=' * len(sep)}")
+    print(hdr)
+    print(sep)
+
+    for label, prov in rows:
+        vals = (f"{prov[p]['tflops']:>{col_w}.1f}" if p in prov else f"{'—':>{col_w}}"
+                for p in providers)
+        print(f"| {label:<{cfg_w}} |" + "".join(f" {v} |" for v in vals))
+
+    print(f"{'=' * len(sep)}\n")
+
+def ref_sdpa(q, k, v, sm_scale, causal=False):
+    return F.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=sm_scale)
+
+
+def verify(name, got, ref, atol=2e-2, rtol=2e-2, log=True):
+    diff = (got.float() - ref.float()).abs()
+    ok = torch.allclose(ref, got, atol=atol, rtol=rtol)
+    max_err  = diff.max().item()
+    mean_err = diff.mean().item()
+    status = "PASS" if ok else "FAIL"
+    if log:
+        print(f"  {name:<28} {status}  max={max_err:.6f}  mean={mean_err:.6f}")
+    return ok
+
+
+def run_correctness_check(kernel_fn, dtype, causal, B=2, H=4, N=512, D=128):
+    torch.manual_seed(42)
+    q = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    k = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    v = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    sm = 1.0 / math.sqrt(D)
+    ref = ref_sdpa(q, k, v, sm, causal)
+    tag = f"causal={causal} N={N}"
+    out = kernel_fn(q, k, v, sm, causal)
+    return verify(f"{kernel_fn.__name__} [{tag}]", out, ref)
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["nocausal", "causal"])
+@pytest.mark.parametrize("n_test", [128, 192, 256, 500, 512, 1024])
+@pytest.mark.parametrize("kernel_name", list(KERNEL_REGISTRY.keys()))
+def test_fa_correctness(kernel_name, causal, n_test, dtype=torch.bfloat16, D=128):
+    kernel_fn = get_kernel(kernel_name)
+    ok = run_correctness_check(kernel_fn, dtype, causal, B=1, H=4, N=n_test, D=D)
+    assert ok, f"Correctness failed: kernel={kernel_name} causal={causal} N={n_test}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Benchmark
+# ═══════════════════════════════════════════════════════════════════════════
+
+def run_benchmark(args):
+    causal_modes = [s.lower() in ("true", "1", "yes") for s in args.causal]
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16}[args.dtype]
+
+    results = {}
+
+    for kernel_name in args.kernel:
+      kernel_fn = get_kernel(kernel_name)
+      for B in args.b:
+        for H in args.hq:
+          for D in args.d:
+            for N in args.sq:
+              for causal in causal_modes:
+                torch.manual_seed(42)
+                q = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                k = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                v = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                sm = 1.0 / math.sqrt(D)
+
+                if causal:
+                    valid_el = N * (N + 1) // 2
+                else:
+                    valid_el = N * N
+                total_flops = 2 * 2.0 * B * H * valid_el * D
+
+                causal_str = "causal" if causal else "nc"
+                ref_sdpa_lambda = lambda: F.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=sm)
+
+                try:
+                    tlx_sdpa_lambda = lambda: kernel_fn(q, k, v, sm, causal)
+                    ref_out = ref_sdpa_lambda()
+                    tlx_out = tlx_sdpa_lambda()
+                    assert verify("", tlx_out, ref_out, log=False)
+                except Exception as e:
+                    print(f"  {kernel_name:20s} D={D} N={N:5d} {causal_str:6s} -> SKIPPED ({e})")
+                    continue
+
+                key = (B, H, D, N, causal)
+                if key not in results:
+                    results[key] = {}
+
+                if "Torch SDPA" not in results[key]:
+                    ms = triton.testing.do_bench(ref_sdpa_lambda, warmup=25, rep=100)
+                    tflops = total_flops / ms * 1e-9
+                    results[key]["Torch SDPA"] = {"ms": ms, "tflops": tflops}
+
+                ms = triton.testing.do_bench(tlx_sdpa_lambda, warmup=25, rep=100)
+                tflops = total_flops / ms * 1e-9
+                results[key][kernel_name] = {"ms": ms, "tflops": tflops}
+
+    print_summary_table(results, args.kernel)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════════════════════════
+
+def parse_args():
+    p = argparse.ArgumentParser(prog="AMD TLX FA Pipelined")
+    p.add_argument("-b",  type=int, nargs="+", default=[1])
+    p.add_argument("-hq", type=int, nargs="+", default=[64])
+    p.add_argument("-sq", type=int, nargs="+", default=[1024, 8192, 16384])
+    p.add_argument("-d",  type=int, nargs="+", default=[64, 128])
+    p.add_argument("-causal", type=str, nargs="+", default=["false"],
+                   help="Causal modes to benchmark (e.g. -causal true false)")
+    p.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16"])
+    p.add_argument("--kernel", type=str, nargs="+", default=["async_simple", "async_prefetch"],
+                   help="Kernel variants to benchmark")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    run_benchmark(parse_args())


### PR DESCRIPTION
Introduce two flash attention forward kernels using the TLX async DMA API for CDNA4: a straightforward single-buffered variant (async_simple) and a manually modulo-scheduled prefetch variant with prologue/hot-loop/ epilogue structure.

Example usage:
```sh
python third_party/tlx/tutorials/amd-fa-pipelined_test.py -sq 1024 4096 8192 --
kernel async_simple async_prefetch -d 64

=============================================================================================
Summary (TFLOPS)
=============================================================================================
| Config                                 |     Torch SDPA |   async_simple | async_prefetch |
|----------------------------------------|----------------|----------------|----------------|
| B=1, H=64, D=64, N=1024, causal=False  |          284.5 |          389.9 |          413.3 |
| B=1, H=64, D=64, N=4096, causal=False  |          525.4 |          619.1 |          500.8 |
| B=1, H=64, D=64, N=8192, causal=False  |          558.2 |          635.9 |          523.6 |
| B=1, H=64, D=128, N=1024, causal=False |          347.1 |          414.9 |          455.3 |
| B=1, H=64, D=128, N=4096, causal=False |          502.3 |          532.5 |          547.3 |
| B=1, H=64, D=128, N=8192, causal=False |          598.9 |          562.7 |          569.2 |
=============================================================================================

```