### PR TITLE
[triton][AutoWS] Promote partition requiring 4 warps to default warp group (#1365)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -66,6 +66,7 @@ public:
       function_ref<void(OpResult, OpOperand &, unsigned)> callback) const;
 
 private:
+  friend class PartitionSet;
   void setIndex(int idx) { this->idx = idx; }
 
   // The partition number.
@@ -112,6 +113,9 @@ public:
 
   // Utility to be used when the op is known to belong to one partition
   Partition *getPartition(Operation *op);
+
+  // Swap two partitions' indices and update all op annotations in the loop.
+  void swapPartitions(unsigned idxA, unsigned idxB, scf::ForOp loop);
 
 private:
   // WarpSpecialization tag

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -1,5 +1,6 @@
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -146,6 +147,40 @@ Partition *PartitionSet::getPartition(Operation *op) {
   auto id = getPartitionIds(op);
   assert(id.size() == 1);
   return getPartition(id[0]);
+}
+
+void PartitionSet::swapPartitions(unsigned idxA, unsigned idxB,
+                                  scf::ForOp loop) {
+  if (idxA == idxB)
+    return;
+
+  // Swap the partition objects in the vector.
+  std::swap(partitions[idxA], partitions[idxB]);
+
+  // Update the internal indices to match their new positions.
+  partitions[idxA]->setIndex(idxA);
+  partitions[idxB]->setIndex(idxB);
+
+  // Walk all ops in the loop and update their partition annotations.
+  Builder b(loop->getContext());
+  auto remapIds = [&](DenseI32ArrayAttr attr) -> DenseI32ArrayAttr {
+    SmallVector<int32_t> ids(attr.asArrayRef());
+    for (int32_t &id : ids) {
+      if (id == static_cast<int32_t>(idxA))
+        id = static_cast<int32_t>(idxB);
+      else if (id == static_cast<int32_t>(idxB))
+        id = static_cast<int32_t>(idxA);
+    }
+    llvm::sort(ids);
+    return b.getDenseI32ArrayAttr(ids);
+  };
+
+  // Walk the containing function to update annotations both inside and
+  // outside the loop (post-loop ops also carry partition annotations).
+  loop->getParentOfType<FuncOp>().walk([&](Operation *op) {
+    if (auto attr = op->getAttrOfType<DenseI32ArrayAttr>(kPartitionAttrName))
+      op->setAttr(kPartitionAttrName, remapIds(attr));
+  });
 }
 
 FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-data-partition.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-data-partition.mlir
@@ -48,7 +48,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["gemm", "epilogue", "epilogue_store", "load", "computation"]
+// CHECK-SAME: ttg.partition.types = ["epilogue", "gemm", "epilogue_store", "load", "computation"]
 tt.func public @data_partitioned_gemm_uses_gemm_template(
   %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
   %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
@@ -51,7 +51,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["gemm", "epilogue", "epilogue_store", "load", "computation"]
+// CHECK-SAME: ttg.partition.types = ["epilogue", "gemm", "epilogue_store", "load", "computation"]
 tt.func public @persistent_gemm_no_computation_partition(
   %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
   %b_desc: !tt.tensordesc<tensor<256x64xf16, #shared>>,

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-splitk-default-promotion.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-splitk-default-promotion.mlir
@@ -1,0 +1,108 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+
+// Tests that partition scheduling promotes the epilogue partition (which
+// contains tmem_load, requiring 4 warps) to index 0 so it becomes the
+// default warp group in the final warp_specialize lowering.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @persistent_splitk_gemm_default_promotion
+//
+// Epilogue partition (tmem_load + truncf + descriptor_store) should be
+// promoted to index 0 because tmem_load requires 4 warps.
+//
+// --- In-loop: loads → load partition ---
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
+// --- In-loop: memdesc_trans and MMA → gemm partition ---
+// CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
+//
+// --- Epilogue: tmem_load, truncf, descriptor_store → epilogue partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[EPIL:[0-9]+]]>
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: [[EPIL]]>
+//
+// --- Partition types: epilogue is first (index 0 = default warp group) ---
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["epilogue", "gemm", "load"
+tt.func public @persistent_splitk_gemm_default_promotion(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+  %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+  %ws_desc: !tt.tensordesc<tensor<128x128xf16, #shared>>,
+  %M: i32 {tt.divisibility = 16 : i32},
+  %N: i32 {tt.divisibility = 16 : i32},
+  %K: i32 {tt.divisibility = 16 : i32}
+) {
+  %false = arith.constant false
+  %true = arith.constant true
+  %c148_i32 = arith.constant 148 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
+
+  %start_pid = tt.get_program_id x : i32
+  %num_pid_m = arith.addi %M, %c128_i32 : i32
+  %num_pid_m_div = arith.divsi %num_pid_m, %c128_i32 : i32
+  %num_pid_n = arith.addi %N, %c128_i32 : i32
+  %num_pid_n_div = arith.divsi %num_pid_n, %c128_i32 : i32
+  %k_tiles = arith.addi %K, %c64_i32 : i32
+  %k_tiles_div = arith.divsi %k_tiles, %c64_i32 : i32
+  %num_mn_tiles = arith.muli %num_pid_m_div, %num_pid_n_div : i32
+  %num_tiles = arith.muli %num_mn_tiles, %c2_i32 : i32
+  %k_per_split = arith.addi %k_tiles_div, %c1_i32 : i32
+  %k_per_split_div = arith.divsi %k_per_split, %c2_i32 : i32
+
+  %tile_id_c_out = scf.for %tile_id = %start_pid to %num_tiles step %c148_i32
+      iter_args(%tile_id_c = %c0_i32) -> (i32) : i32 {
+    %split_id = arith.divsi %tile_id, %num_mn_tiles : i32
+    %k_start = arith.muli %split_id, %k_per_split_div : i32
+    %k_end = arith.addi %k_start, %k_per_split_div : i32
+    %k_end_clamped = arith.minsi %k_end, %k_tiles_div : i32
+    %pid_m = arith.remsi %tile_id, %num_pid_m_div : i32
+    %pid_n = arith.divsi %tile_id, %num_pid_m_div : i32
+    %offs_am = arith.muli %pid_m, %c128_i32 : i32
+    %offs_bn = arith.muli %pid_n, %c128_i32 : i32
+
+    // Accumulator init
+    %acc_mem, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+
+    // Inner k-loop
+    %loop_out:2 = scf.for %ki = %k_start to %k_end_clamped step %c1_i32
+        iter_args(%use_acc = %false, %loop_tok = %acc_tok) -> (i1, !ttg.async.token) : i32 {
+      %offs_k = arith.muli %ki, %c64_i32 : i32
+      %a = tt.descriptor_load %a_desc[%offs_am, %offs_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %a_smem = ttg.local_alloc %a : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %b = tt.descriptor_load %b_desc[%offs_bn, %offs_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %b_smem = ttg.local_alloc %b : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %b_trans = ttg.memdesc_trans %b_smem {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+      %mma_tok = ttng.tc_gen5_mma %a_smem, %b_trans, %acc_mem[%loop_tok], %use_acc, %true {tt.self_latency = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %true, %mma_tok : i1, !ttg.async.token
+    } {tt.scheduled_max_stage = 3 : i32}
+
+    // Epilogue: tmem_load + truncf + TMA store to workspace
+    %result, %result_tok = ttng.tmem_load %acc_mem[%loop_out#1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %c = arith.truncf %result : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+    %row_base = arith.muli %split_id, %M : i32
+    %ws_row = arith.addi %row_base, %offs_am : i32
+    tt.descriptor_store %ws_desc[%ws_row, %offs_bn], %c : !tt.tensordesc<tensor<128x128xf16, #shared>>, tensor<128x128xf16, #blocked>
+
+    %tile_id_c_next = arith.addi %tile_id_c, %c1_i32 : i32
+    scf.yield %tile_id_c_next : i32
+  } {tt.disallow_acc_multi_buffer, tt.flatten, tt.warp_specialize}
+
+  tt.return
+}
+
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-fa.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-fa.mlir
@@ -20,23 +20,23 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @hopper_fa_forward_3_partitions
 //
 // --- memdesc_trans must be cloned: one copy per computation partition ---
-// CHECK: ttg.memdesc_trans {{.*}} ttg.partition = array<i32: 1>
+// CHECK: ttg.memdesc_trans {{.*}} ttg.partition = array<i32: 0>
 // CHECK: ttg.memdesc_trans {{.*}} ttg.partition = array<i32: 2>
 //
-// --- Partition types: load + two computation partitions ---
+// --- Partition types: computation (promoted to default) + load + computation ---
 // CHECK: tt.warp_specialize
 // CHECK-SAME: ttg.partition.types =
-// CHECK-SAME: "load"
 // CHECK-SAME: "computation"
+// CHECK-SAME: "load"
 // CHECK-SAME: "computation"
 //
 // --- Post-loop epilogue: each data partition's ops must stay in its own
-//     computation partition (dp0 → partition 2, dp1 → partition 1).
+//     computation partition (dp0 → partition 2, dp1 → partition 0).
 //     Verifies the dpId backward walk assigns the correct partition to
 //     post-loop consumers of yield values not in MMA backward slices
 //     (e.g. l_i sum accumulation).
 // CHECK: tt.expand_dims {{.*}}#1 {{.*}} ttg.partition = array<i32: 2>
-// CHECK: tt.expand_dims {{.*}}#4 {{.*}} ttg.partition = array<i32: 1>
+// CHECK: tt.expand_dims {{.*}}#4 {{.*}} ttg.partition = array<i32: 0>
 
 tt.func public @hopper_fa_forward_3_partitions(
   %Q: !tt.ptr<f16> {tt.divisibility = 16 : i32},

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-post-loop-epilogue.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-post-loop-epilogue.mlir
@@ -41,7 +41,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["gemm", "epilogue", "load", "computation"]
+// CHECK-SAME: ttg.partition.types = ["epilogue", "gemm", "load", "computation"]
 //
 // --- Post-loop: tmem_load → epilogue ---
 // CHECK: ttng.tmem_load

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-types.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-types.mlir
@@ -29,7 +29,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["gemm", "load", "computation"]
+// CHECK-SAME: ttg.partition.types = ["computation", "load", "gemm"]
 //
 // --- Post-loop: use → no partition annotation (unregistered dialect op) ---
 tt.func public @simple_gemm_partition_types(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -286,6 +286,17 @@ struct PartitionLayout {
       defaultPartition = part;
     return part;
   }
+
+  /// Promote an existing partition to index 0 (default warp group) by
+  /// swapping it with whatever is currently at index 0. Call after ops
+  /// have been assigned so that op annotations are updated correctly.
+  void makeDefaultPartition(PartitionSet &schedule, Partition *part,
+                            scf::ForOp loop) {
+    if (!part || part->getIndex() == 0)
+      return;
+    schedule.swapPartitions(0, part->getIndex(), loop);
+    defaultPartition = part;
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -1872,6 +1883,33 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   // Update defaultPartition after computation partitions are created.
   layout.defaultPartition = layout.getDefaultPartition();
+
+  // Scan partitions for one that requires 4 warps (TMEM or WarpGroupDot
+  // ops) and promote it to index 0 so it becomes the default warp group.
+  // Skip if partition 0 already contains 4-warp ops.
+  auto needs4Warps = [](Partition &p) {
+    return llvm::any_of(p.getOps(), [](Operation *op) {
+      return isa<ttng::TMEMLoadOp, ttng::TMEMStoreOp, ttng::TMEMAllocOp,
+                 ttng::WarpGroupDotOp>(op);
+    });
+  };
+  bool defaultNeeds4Warps = false;
+  for (Partition &p : schedule.getPartitions()) {
+    if (p.getIndex() == 0) {
+      defaultNeeds4Warps = needs4Warps(p);
+      break;
+    }
+  }
+  if (!defaultNeeds4Warps) {
+    for (Partition &p : schedule.getPartitions()) {
+      if (p.getIndex() == 0)
+        continue;
+      if (needs4Warps(p)) {
+        layout.makeDefaultPartition(schedule, &p, mainLoop);
+        break;
+      }
+    }
+  }
 
   bool createComputePartitions =
       (layout.correctionPartition != nullptr ||


### PR DESCRIPTION
Summary:

After partition scheduling assigns ops to partitions, scan for a non-default partition that contains ops requiring 4 warps (TMEMLoadOp, TMEMStoreOp, TMEMAllocOp, or WarpGroupDotOp) and promote it to index 0 so it becomes the default warp group in the final warp_specialize lowering.

Previously the gemm partition always landed at index 0 for simple Blackwell GEMMs (no correction/reduction). This meant the epilogue partition — which contains `tmem_load` and needs TMEM ownership (4 warps) — was a named partition. Now the epilogue is promoted to default, ensuring it owns TMEM.

The promotion uses a new `swapPartitions` method on `PartitionSet` that swaps two partitions' positions in the vector, updates their internal indices, and remaps all `ttg.partition` op annotations in the loop.

Authored with Claude.

Differential Revision: D102497045


