### PR TITLE
[TLX] Support 2cta_m64 TMEM layouts

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -6,6 +6,21 @@ include "mlir/IR/EnumAttr.td"
 include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUDialect.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 
+//===----------------------------------------------------------------------===//
+// TensorMemoryCTAMode enum
+//===----------------------------------------------------------------------===//
+
+def TTNG_TensorMemoryCTAMode_Default    : I32EnumAttrCase<"DEFAULT",    0, "default">;
+def TTNG_TensorMemoryCTAMode_TwoCTA_LHS : I32EnumAttrCase<"TwoCTA_LHS", 1, "twocta_lhs">;
+def TTNG_TensorMemoryCTAMode_TwoCTA_RHS : I32EnumAttrCase<"TwoCTA_RHS", 2, "twocta_rhs">;
+
+def TTNG_TensorMemoryCTAMode : I32EnumAttr<"TensorMemoryCTAMode",
+    "Tensor memory CTA mode for LinearLayout conversion",
+    [TTNG_TensorMemoryCTAMode_Default, TTNG_TensorMemoryCTAMode_TwoCTA_LHS,
+     TTNG_TensorMemoryCTAMode_TwoCTA_RHS]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+}
+
 def TTG_SharedClusterMemorySpace : AttrDef<TritonNvidiaGPU_Dialect, "SharedClusterMemorySpace"> {
   let mnemonic = "shared_cluster_memory";
   let description = [{
@@ -59,7 +74,8 @@ def TTG_TensorMemoryEncodingAttr : AttrDef<TritonNvidiaGPU_Dialect, "TensorMemor
     "unsigned":$colStride,
     DefaultValuedParameter<"unsigned", "1">:$CTASplitM,
     DefaultValuedParameter<"unsigned", "1">:$CTASplitN,
-    DefaultValuedParameter<"bool", "false">:$twoCTAs
+    DefaultValuedParameter<"bool", "false">:$twoCTAs,
+    DefaultValuedParameter<"TensorMemoryCTAMode", "TensorMemoryCTAMode::DEFAULT">:$ctaMode
   );
   let genVerifyDecl = 1;
   let assemblyFormat = "`<` struct(params) `>`";

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1096,20 +1096,40 @@ LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,
   LinearLayout tile =
       LinearLayout::zeros1D(encoding.getColStride(), kCol, dims[1]);
   if (blockM == 64) {
-    tile *= LinearLayout::identity1D(16, kRow, dims[0]) *
-            LinearLayout::identity1D(blockN, kCol, dims[1]);
-    auto bases = tile.getBases();
-    if (shape[0] > blockM) {
-      bases[kRow].push_back({64, 0});
-    } else if (shape[1] > blockN) {
-      bases[kRow].push_back({0, blockN});
+    // BlockM=64(per CTA) in 2cta mode has special layouts for both LHS (A) and
+    // RHS (D)
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-data-path-layout-b
+    if (encoding.getCtaMode() ==
+        triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_LHS) {
+      // This applies to all TMEM encoding in 2cta_m64 except accumulator of MMA
+      tile *= LinearLayout::identity1D(blockM, kRow, dims[0]) *
+              LinearLayout::identity1D(blockN, kCol, dims[1]);
+      tile *= LinearLayout::zeros1D(2, kRow, dims[0]);
+
+    } else if (encoding.getCtaMode() ==
+               triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_RHS) {
+      // This applies to TMEM encoding in 2cta_m64 accumulator of MMA
+      tile = LinearLayout::identity1D(blockM, kRow, dims[0]) *
+             LinearLayout::identity1D(blockN / 2, kCol, dims[1]);
+      // row 64~127 stores the right half of the logical tensor (D[0:64, N/2:N])
+      tile *= LinearLayout::identity1D(2, kRow, dims[1]);
     } else {
-      // Empty, meaning the element is not defined
-      bases[kRow].push_back({0, 0});
+      // non 2cta_m64 cases
+      tile *= LinearLayout::identity1D(16, kRow, dims[0]) *
+              LinearLayout::identity1D(blockN, kCol, dims[1]);
+      auto bases = tile.getBases();
+      if (shape[0] > blockM) {
+        bases[kRow].push_back({64, 0});
+      } else if (shape[1] > blockN) {
+        bases[kRow].push_back({0, blockN});
+      } else {
+        // Empty, meaning the element is not defined
+        bases[kRow].push_back({0, 0});
+      }
+      bases[kRow].push_back({16, 0});
+      bases[kRow].push_back({32, 0});
+      tile = LinearLayout(std::move(bases), dims);
     }
-    bases[kRow].push_back({16, 0});
-    bases[kRow].push_back({32, 0});
-    tile = LinearLayout(std::move(bases), dims);
   } else {
     tile *= LinearLayout::identity1D(blockM, kRow, dims[0]) *
             LinearLayout::identity1D(blockN, kCol, dims[1]);

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1057,7 +1057,7 @@ LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,
     auto newEncoding = TensorMemoryEncodingAttr::get(
         ctx, encoding.getBlockM(), encoding.getBlockN(),
         encoding.getColStride(), encoding.getCTASplitM(), 1,
-        encoding.getTwoCTAs());
+        encoding.getTwoCTAs(), encoding.getCtaMode());
     return tensorMemoryToLinearLayout(
                {shape[0], shape[1] / encoding.getCTASplitN()}, newEncoding) *
            split;
@@ -1074,7 +1074,7 @@ LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,
     }
     auto newEncoding = TensorMemoryEncodingAttr::get(
         ctx, blockM, encoding.getBlockN(), encoding.getColStride(), 1,
-        encoding.getCTASplitN(), encoding.getTwoCTAs());
+        encoding.getCTASplitN(), encoding.getTwoCTAs(), encoding.getCtaMode());
     auto ret =
         tensorMemoryToLinearLayout({shape[0] / splitM, shape[1]}, newEncoding);
     // In this case, we swap the basis of the last row and last column

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -576,7 +576,8 @@ public:
     unsigned colStride = 32 / bitwidth;
     Attribute accEncoding = triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
         context, instrShape[0], instrShape[1], colStride, CTASplitNum[0],
-        CTASplitNum[1], useTwoCTAs);
+        CTASplitNum[1], useTwoCTAs,
+        triton::nvidia_gpu::TensorMemoryCTAMode::DEFAULT);
     Attribute tensorMemorySpace =
         triton::nvidia_gpu::TensorMemorySpaceAttr::get(context);
     MemDescType accMemDescType =
@@ -833,7 +834,8 @@ public:
     auto bitwidth = oldRetType.getElementType().getIntOrFloatBitWidth();
     unsigned colStride = 32 / bitwidth;
     Attribute accEncoding = triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
-        context, m, n, colStride, CTASplitNum[0], CTASplitNum[1], false);
+        context, m, n, colStride, CTASplitNum[0], CTASplitNum[1], false,
+        triton::nvidia_gpu::TensorMemoryCTAMode::DEFAULT);
     Attribute tensorMemorySpace =
         triton::nvidia_gpu::TensorMemorySpaceAttr::get(context);
     MemDescType accMemDescType =

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -413,11 +413,10 @@ bool isDistributedLayoutTMemCompatible(Operation *op,
   return succeeded(computeTMemLdStEncodingInfo(tensorType, memType, maxnreg));
 }
 
-LogicalResult
-TensorMemoryEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
-                                 unsigned blockM, unsigned blockN,
-                                 unsigned colStride, unsigned CTASplitM,
-                                 unsigned CTASplitN, bool) {
+LogicalResult TensorMemoryEncodingAttr::verify(
+    function_ref<InFlightDiagnostic()> emitError, unsigned blockM,
+    unsigned blockN, unsigned colStride, unsigned CTASplitM, unsigned CTASplitN,
+    bool, TensorMemoryCTAMode) {
   if (!(CTASplitM >= 1 && CTASplitN >= 1 && llvm::isPowerOf2_32(CTASplitM) &&
         llvm::isPowerOf2_32(CTASplitN))) {
     return emitError()

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -442,6 +442,12 @@ LogicalResult TensorMemoryEncodingAttr::verify(
 LogicalResult impl::verifyMMAv5Op(Operation *op) {
   auto isInterleaved = [](MemDescType memdesc) {
     auto enc = dyn_cast<TensorMemoryEncodingAttr>(memdesc.getEncoding());
+    if (!enc)
+      return false;
+    if (enc.getCtaMode() == TensorMemoryCTAMode::TwoCTA_LHS ||
+        enc.getCtaMode() == TensorMemoryCTAMode::TwoCTA_RHS) {
+      return false;
+    }
     return enc && getTmemAllocSizes(memdesc).numRows != 64 &&
            enc.getBlockM() == 64;
   };

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1144,7 +1144,7 @@ void TMEMSubSliceOp::build(OpBuilder &builder, OperationState &state,
   auto newEncoding = triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
       builder.getContext(), encoding.getBlockM(), newBlockN,
       encoding.getColStride(), encoding.getCTASplitM(), encoding.getCTASplitN(),
-      encoding.getTwoCTAs());
+      encoding.getTwoCTAs(), encoding.getCtaMode());
   auto subsliceType = gpu::MemDescType::get(
       shape, allocTy.getElementType(), newEncoding, allocTy.getMemorySpace(),
       allocTy.getMutableMemory(), allocTy.getAllocShape());

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -128,8 +128,10 @@ public:
     const unsigned colStride = 1;
     auto aTMemEncoding = TensorMemoryEncodingAttr::get(
         context, accTMemEncoding.getBlockM(), lhs.getType().getShape()[1],
-        colStride, CTASplitNum[0], CTASplitNum[1],
-        accTMemEncoding.getTwoCTAs());
+        colStride, CTASplitNum[0], CTASplitNum[1], accTMemEncoding.getTwoCTAs(),
+        accTMemEncoding.getCtaMode() == TensorMemoryCTAMode::TwoCTA_RHS
+            ? TensorMemoryCTAMode::TwoCTA_LHS
+            : accTMemEncoding.getCtaMode());
     Attribute tensorMemorySpace =
         triton::nvidia_gpu::TensorMemorySpaceAttr::get(context);
     ttg::MemDescType lhsMemDescType = ttg::MemDescType::get(

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -318,13 +318,21 @@ allocateTMem(Operation *parentOp,
         } else {
           // TODO: we need to handle cases where the format is blockM and we
           // have multiple blocks.
-          assert((cast<TensorMemoryEncodingAttr>(
-                      mmaOp.getA().getType().getEncoding())
-                          .getBlockM() != 64 &&
-                  cast<TensorMemoryEncodingAttr>(
-                      mmaOp.getAccumulator().getType().getEncoding())
-                          .getBlockM() != 64) &&
-                 "interleaved layout with TMEM operand is not supported yet.");
+
+          // Special case: 2cta_m64 has operand A (AKA LHS) where allocSize is
+          // 128 for rows but blockM is 64. We allow this case.
+          auto aTmemEnc = cast<TensorMemoryEncodingAttr>(
+              mmaOp.getA().getType().getEncoding());
+          if (aTmemEnc.getCtaMode() != TensorMemoryCTAMode::TwoCTA_LHS) {
+            assert(
+                (cast<TensorMemoryEncodingAttr>(
+                     mmaOp.getA().getType().getEncoding())
+                         .getBlockM() != 64 &&
+                 cast<TensorMemoryEncodingAttr>(
+                     mmaOp.getAccumulator().getType().getEncoding())
+                         .getBlockM() != 64) &&
+                "interleaved layout with TMEM operand is not supported yet.");
+          }
         }
       }
     }

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -537,7 +537,7 @@ void init_gluon_ir(py::module &&m) {
              check(ctaSplitNum.size() == 2, "expected 2D CTA dimensions");
              return self.getChecked<ttng::TensorMemoryEncodingAttr>(
                  ctx, block[0], block[1], colStride, ctaSplitNum[0],
-                 ctaSplitNum[1], twoCTAs);
+                 ctaSplitNum[1], twoCTAs, ttng::TensorMemoryCTAMode::DEFAULT);
            })
       .def("get_tensor_memory_scales_layout",
            [](GluonOpBuilder &self,

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -414,19 +414,9 @@ def test_async_dot_blackwell_not_use_d(device):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
-def test_async_dot_blackwell_2cta_tma(device):
-    run_async_dot_blackwell_2cta_tma(device, False, 256)  # A in SMEM
-    run_async_dot_blackwell_2cta_tma(device, True, 256)  # A in TMEM
-
-    # M=64 per CTA, explicitly unsupported for now
-    # should throw a compilation error for users, but not NE assertion error
-    with pytest.raises(Exception) as e:
-        run_async_dot_blackwell_2cta_tma(device, False, 128)
-    assert isinstance(e.value, triton.CompilationError), "expecting a compilation error"
-    assert "only supports M=128 per CTA for pair-CTA mma" in e.value.error_message
-
-
-def run_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
+@pytest.mark.parametrize("A_TMEM", [False, True])
+@pytest.mark.parametrize("SAMPLE_M", [256, 128])
+def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
     """
     Test 2cta collective D = A*B for 1 tile.
     """

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1713,7 +1713,6 @@ class TritonSemantic(Generic[TensorTy]):
 
         M = lhs.type.shape[-2]
         if tlx_paired_ctas:
-            assert M == 128, f"Currently only supports M=128 per CTA for pair-CTA mma, but got M={M}"
             N = 2 * rhs.type.shape[-1]  # rhs is actually [K, N/2] in two_ctas mode so we scale it back
         else:
             N = rhs.type.shape[-1]

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -320,7 +320,8 @@ ttg::MemDescType createTMEMDesc(OpBuilder &builder, Type inputType,
     assert(false && "Unsupported encoding");
   }
   auto outputEncoding = ttng::TensorMemoryEncodingAttr::get(
-      context, blockM, blockN, colStride, CTASplitM, CTASplitN, twoCTAs);
+      context, blockM, blockN, colStride, CTASplitM, CTASplitN, twoCTAs,
+      ttng::TensorMemoryCTAMode::DEFAULT);
   if (highShape > 0) {
     llvm::SmallVector<int64_t> shapeVec{highShape, blockM, blockN};
     llvm::ArrayRef<int64_t> shape(shapeVec);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1634,7 +1634,7 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
     unsigned colStride = 32 / elemBitWidth;
     auto encoding = ttng::TensorMemoryEncodingAttr::get(
         context, blockM, bufferShape[1], colStride, /*CTASplitM=*/1,
-        /*CTASplitN=*/1, /*twoCTAs=*/false);
+        /*CTASplitN=*/1, /*twoCTAs=*/false, ttng::TensorMemoryCTAMode::DEFAULT);
     Type memdescType =
         ttg::MemDescType::get(bufferShape, elemType, encoding,
                               tensorMemorySpace, /*mutableMemory*/ true);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -925,7 +925,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
                     builder.getContext(), tmem.getBlockM(),
                     dim == 1 ? tmem.getBlockN() / 2 : tmem.getBlockN(),
                     tmem.getColStride(), tmem.getCTASplitM(),
-                    tmem.getCTASplitN(), tmem.getTwoCTAs());
+                    tmem.getCTASplitN(), tmem.getTwoCTAs(), tmem.getCtaMode());
             auto newType = MemDescType::get(shape, type.getElementType(),
                                             accEncoding, type.getMemorySpace(),
                                             type.getMutableMemory());
@@ -1104,7 +1104,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
           builder.getContext(), tmem.getBlockM(),
           dim == 1 ? tmem.getBlockN() / 2 : tmem.getBlockN(),
           tmem.getColStride(), tmem.getCTASplitM(), tmem.getCTASplitN(),
-          tmem.getTwoCTAs());
+          tmem.getTwoCTAs(), tmem.getCtaMode());
       auto newType = MemDescType::get(shape, retType.getElementType(),
                                       accEncoding, retType.getMemorySpace(),
                                       retType.getMutableMemory());

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -156,7 +156,7 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
             tmemEncoding.getContext(), srcEncoding.getBlockM(),
             srcEncoding.getBlockN(), tmemEncoding.getColStride(),
             tmemEncoding.getCTASplitM(), tmemEncoding.getCTASplitN(),
-            tmemEncoding.getTwoCTAs());
+            tmemEncoding.getTwoCTAs(), tmemEncoding.getCtaMode());
         const auto updatedResultLayoutEncoding =
             LayoutEncoding(newTmemEncoding);
         auto operandLattice = operands[0];
@@ -285,7 +285,8 @@ LogicalResult LayoutForwardPropagation::visitOperation(
         auto newEncoding = ttng::TensorMemoryEncodingAttr::get(
             op->getContext(), dstEncoding.getBlockM(), dstEncoding.getBlockN(),
             encoding.getColStride(), encoding.getCTASplitM(),
-            encoding.getCTASplitN(), encoding.getTwoCTAs());
+            encoding.getCTASplitN(), encoding.getTwoCTAs(),
+            encoding.getCtaMode());
         operandLayoutEncoding = LayoutEncoding(newEncoding);
       }
     }

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
@@ -154,7 +154,8 @@ LogicalResult materializeStorageAliasAllocations(
       auto tmemEncoding = ttng::TensorMemoryEncodingAttr::get(
           m.getContext(), blockM, blockN,
           /*colStride=*/1, /*CTASplitM=*/1, /*CTASplitN=*/1,
-          /*twoCTAs=*/false);
+          /*twoCTAs=*/false,
+          ttng::TensorMemoryCTAMode::DEFAULT); // todo: use non-default CTAMode?
       auto memDescType =
           ttg::MemDescType::get(tmemShape, tmemElemType, tmemEncoding,
                                 memorySpace, /*mutableMemory=*/true);

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -174,7 +174,7 @@ void init_triton_tlx_ir(py::module &&m) {
              auto context = self.getBuilder().getContext();
              return mlir::cast<Attribute>(ttng::TensorMemoryEncodingAttr::get(
                  context, blockM, blockN, colStride, CTASplitM, CTASplitN,
-                 /*twoCTAs=*/false));
+                 /*twoCTAs=*/false, ttng::TensorMemoryCTAMode::DEFAULT));
            })
       .def("make_tensor_memory_scales_encoding_attr",
            [](TritonOpBuilder &self, unsigned CTASplitM, unsigned CTASplitN) {

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -170,11 +170,13 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("make_tensor_memory_encoding_attr",
            [](TritonOpBuilder &self, unsigned blockM, unsigned blockN,
-              unsigned colStride, unsigned CTASplitM, unsigned CTASplitN) {
+              unsigned colStride, unsigned CTASplitM, unsigned CTASplitN,
+              unsigned ctaMode) {
              auto context = self.getBuilder().getContext();
              return mlir::cast<Attribute>(ttng::TensorMemoryEncodingAttr::get(
                  context, blockM, blockN, colStride, CTASplitM, CTASplitN,
-                 /*twoCTAs=*/false, ttng::TensorMemoryCTAMode::DEFAULT));
+                 /*twoCTAs=*/false,
+                 static_cast<ttng::TensorMemoryCTAMode>(ctaMode)));
            })
       .def("make_tensor_memory_scales_encoding_attr",
            [](TritonOpBuilder &self, unsigned CTASplitM, unsigned CTASplitN) {

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -75,6 +75,7 @@ from .types import (
     tensor_descriptor_ptr,
     tensor_descriptor_ptr_type,
     tensor_memory_layout_encoding,
+    TMemCTAMode,
 )
 from .utility import (
     async_task_replica_id,
@@ -100,6 +101,7 @@ __all__ = [
     "shared_layout_encoding",
     "swizzled_shared_layout_encoding",
     "tensor_memory_layout_encoding",
+    "TMemCTAMode",
     "nv_mma_shared_layout_encoding",
     "storage_kind",
     "buffered_tensor",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -36,17 +36,19 @@ def require_dot_operand_layout(opnd: tl.tensor, opIdx, parent_layout, _builder=N
     return _builder.create_require_layout(opnd.handle, layout_handle)
 
 
-def require_tmem_layout_col_stride(src: tlx.buffered_tensor, col_stride: int, _builder=None):
+def require_tmem_layout(src: tlx.buffered_tensor, col_stride: int, cta_mode: int = tlx.TMemCTAMode.DEFAULT,
+                        _builder=None):
     assert (isinstance(src, tlx.buffered_tensor) and src.type.storage == tlx.storage_kind.tmem
             and isinstance(src.type.layout, tlx.tensor_memory_layout_encoding)), "input must be a TMEM tensor"
     old_layout = src.type.layout
-    if old_layout.colStride != col_stride:
+    if old_layout.colStride != col_stride or old_layout.ctaMode != cta_mode:
         layout_handle = _builder.make_tensor_memory_encoding_attr(
             old_layout.blockM,
             old_layout.blockN,
             col_stride,
             old_layout.CTASplitM,
             old_layout.CTASplitN,
+            cta_mode,
         )
         return _builder.create_require_layout(src.handle, layout_handle)
     # if the layout is already correct, return the original handle
@@ -114,21 +116,29 @@ def async_dot(
     version = 5 if cuda_compute_capability >= 100 else 3
 
     # TODO. batched dot is not supported yet
+    a_is_tmem = isinstance(A, tlx.buffered_tensor) and A.type.storage == tlx.storage_kind.tmem
+    a_cta_mode = tlx.TMemCTAMode.DEFAULT
+    acc_cta_mode = tlx.TMemCTAMode.DEFAULT
+    if two_ctas and isinstance(acc, tlx.buffered_tensor) and acc.type.layout.blockM == 64:
+        acc_cta_mode = tlx.TMemCTAMode.TwoCTA_RHS
+        if a_is_tmem:
+            a_cta_mode = tlx.TMemCTAMode.TwoCTA_LHS
+
     if isinstance(A, tlx.buffered_tensor) and A.type.storage == tlx.storage_kind.smem:
         A_handle = require_nv_mma_shared_layout(A, True, _semantic.builder)
     elif isinstance(A, tl.tensor):
         assert cuda_compute_capability < 100, "register operand is not supported on Blackwell"
         A_handle = A.handle
     else:
-        # set colStride to 1 (packed) for A
-        A_handle = require_tmem_layout_col_stride(A, 1, _semantic.builder)
+        # set colStride to 1 (packed) for A, and set cta_mode
+        A_handle = require_tmem_layout(A, 1, a_cta_mode, _semantic.builder)
 
     B_handle = require_nv_mma_shared_layout(B, True, _semantic.builder)
 
     if version == 5:
         assert isinstance(A, tlx.buffered_tensor), "input must be a buffered tensor"
         # D needs colStride = 32 / bitwidth, see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-packing-formats
-        acc_handle = require_tmem_layout_col_stride(acc, 1, _semantic.builder)
+        acc_handle = require_tmem_layout(acc, 1, acc_cta_mode, _semantic.builder)
         handles = [t.handle for t in mBarriers]
         is_async = force_async or len(handles) > 0
         use_acc_handle = None
@@ -256,6 +266,14 @@ def async_dot_scaled(
     A_type = _semantic._str_to_fp_type(A_format)
     B_type = _semantic._str_to_fp_type(B_format)
 
+    a_is_tmem = A.type.storage == tlx.storage_kind.tmem
+    a_cta_mode = tlx.TMemCTAMode.DEFAULT
+    acc_cta_mode = tlx.TMemCTAMode.DEFAULT
+    if two_ctas and acc.type.layout.blockM == 64:
+        acc_cta_mode = tlx.TMemCTAMode.TwoCTA_RHS
+        if a_is_tmem:
+            a_cta_mode = tlx.TMemCTAMode.TwoCTA_LHS
+
     # Require layout for A: SMEM or TMEM (mirroring async_dot's 3-way branch)
     is_A_fp4 = A_format == "e2m1"
     is_B_fp4 = B_format == "e2m1"
@@ -264,8 +282,8 @@ def async_dot_scaled(
         A_fp4Padded = is_A_fp4 and is_mixed_precision
         A_handle = require_nv_mma_shared_layout(A, True, _semantic.builder, fp4Padded=A_fp4Padded)
     else:
-        assert A.type.storage == tlx.storage_kind.tmem, "A must be in SMEM or TMEM"
-        A_handle = require_tmem_layout_col_stride(A, 1, _semantic.builder)
+        assert a_is_tmem, "A must be in SMEM or TMEM"
+        A_handle = require_tmem_layout(A, 1, a_cta_mode, _semantic.builder)
 
     # Require layout for B (always SMEM)
     B_fp4Padded = is_B_fp4 and is_mixed_precision
@@ -288,7 +306,7 @@ def async_dot_scaled(
         B_scale_handle = require_nv_mma_shared_layout(B_scale, False, _semantic.builder)
 
     # D needs colStride = 32 / bitwidth, see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-packing-formats
-    acc_handle = require_tmem_layout_col_stride(acc, 1, _semantic.builder)
+    acc_handle = require_tmem_layout(acc, 1, acc_cta_mode, _semantic.builder)
     bar_handles = [t.handle for t in mBarriers]
     is_async = force_async or len(bar_handles) > 0
     use_acc_handle = None

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -106,19 +106,23 @@ class swizzled_shared_layout_encoding(shared_layout_encoding):
         )
 
 
+class TMemCTAMode:
+    # The order of fields here must be in sync with TTNG_TensorMemoryCTAMode enum
+    DEFAULT = 0
+    TwoCTA_LHS = 1
+    TwoCTA_RHS = 2
+
+
 class tensor_memory_layout_encoding(shared_layout_encoding):
 
-    def __init__(self, blockM, blockN, colStride, CTASplitM, CTASplitN):
+    def __init__(self, blockM, blockN, colStride, CTASplitM, CTASplitN, ctaMode=TMemCTAMode.DEFAULT):
         super().__init__()
         self.blockM = blockM
         self.blockN = blockN
         self.colStride = colStride
         self.CTASplitM = CTASplitM
         self.CTASplitN = CTASplitN
-
-    """
-    Make a default tensor memory layout encoding.
-    """
+        self.ctaMode = ctaMode
 
     @classmethod
     def make_default(cls, shape):
@@ -137,6 +141,7 @@ class tensor_memory_layout_encoding(shared_layout_encoding):
             self.colStride,
             self.CTASplitM,
             self.CTASplitN,
+            self.ctaMode,
         )
 
 

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -137,7 +137,8 @@ public:
                                 unsigned colStride, unsigned ctaSplitM,
                                 unsigned ctaSplitN) {
     return TensorMemoryEncodingAttr::get(&ctx, blockM, blockN, colStride,
-                                         ctaSplitM, ctaSplitN, false);
+                                         ctaSplitM, ctaSplitN, false,
+                                         TensorMemoryCTAMode::DEFAULT);
   }
 
   TensorMemoryEncodingAttr tmem(unsigned blockM, unsigned blockN,


### PR DESCRIPTION
When M is 64 per CTA in 2cta mode, the TMEM layout is weird: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-data-path-layout-b

Suppose A is [64, K], B is [K, N] and D is [64, N]. The layout has these attributes:

For A's logical tensor view,

| | col 0 - K
| -------- | -------- 
|row 0-32|  HW row 0-32 and 64-96, col 0-K, corresponding to warp_rank % 4 == 0 and 2
|row 32-64| HW row 32-64 and 96-128, col 0-K, corresponding to warp_rank % 4 == 1 and 3

For D's logical tensor view,

| | col 0-N/2 | col N/2 - N
| -------- | -------- | -------- |
|row 0-32|  HW row 0-32, col 0-N/2, warp_rank % 4 == 0  | HW row 64-96, col 0-N/2 warp_rank % 4 == 2
|row 32-64| HW row 32-64, col 0-N/2, warp_rank % 4 == 1  | HW row 96-128, col 0-N/2, warp_rank % 4 == 3


Note due to HW limit, warp layout is basically locked in with HW row layout. The main focus of this PR is to model the TMEM row/col correctly. The existing utilities will then be able to deduce a proper register layout compatible with this TMEM layout.

For easier reviews, each single commit in this PR is a complete piece:
- Add an attribute to indicate whether it's A or D in 2cta m64 mode. These two are both unique and need to be handled differently than the rest of TMEM layouts.
- Model these two TMEM layouts with the right Linear Layout as shown visually above. The layout here will be a map from HW row/col to logical tensor row/col.
- (#1369 has fixed the dummy layout resolver to pass TMEM encoding over when calculating TMEM compatible reg layouts. Without that the reg layout might be wrong. )
- Add require_layout anchor for TMEM for A and D on front end. The tlx layout prop pass will propagate the TMEM layout before dummy layout resolver calculates TMEM compatible reg layouts.  Fix front end checking and add pytests. Now we have a combo of 4 tests [BM 64, BM 128] x [TS MMA, SS MMA].

TODO: validate and possibly ban tmem_subslice on 2cta RHS TMEM. It might not make sense to allow subslicing alone N dim according to the visual above.

Test plan: pytest: `pytest -vsx python/test/unit/language/test_tlx_dot.py::test_async_dot_blackwell_2cta_tma`