### PR TITLE
[Triton] [AutoWS] Strip orphan partition metadata in WS early-exit

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -69,12 +69,24 @@ public:
   using impl::NVGPUWarpSpecializationBase<
       NVGPUWarpSpecializationPass>::NVGPUWarpSpecializationBase;
 
-  // Remove the warp_specialize attribute from all loops in the function so
-  // downstream passes (pipelining, latency assignment) don't mistakenly
-  // treat the loop as warp-specialized.
+  // Remove the warp_specialize attribute from all loops in the function, plus
+  // any partition metadata that the earlier `tritongpu-partition-scheduling`
+  // pass may have written. The two passes form a pair: when this pass takes
+  // an early-exit and skips warp specialization (e.g. else-block fallback),
+  // leaving `ttg.partition` / `ttg.partition.stages` / `ttg.warp_specialize.tag`
+  // behind on ops + loops produces a half-tagged state — the downstream
+  // `tritongpu-pipeline` pass treats partition-tagged regions as WS regions
+  // and crashes when sibling ops in an scf.if/else aren't tagged. Stripping
+  // everything ensures downstream sees a plain (non-WS) loop.
   void removeWarpSpecializeAttr(triton::FuncOp funcOp) {
     funcOp->walk([&](scf::ForOp forOp) {
       forOp->removeAttr(mlir::triton::kWarpSpecializeAttrName);
+      forOp->removeAttr(mlir::triton::gpu::kPartitionStagesAttrName);
+      forOp->removeAttr(mlir::triton::gpu::kWarpSpecializeTagAttrName);
+    });
+    funcOp->walk([&](Operation *op) {
+      op->removeAttr(mlir::triton::gpu::kPartitionAttrName);
+      op->removeAttr(mlir::triton::gpu::kPartitionOutputsAttrName);
     });
   }
 


### PR DESCRIPTION
Summary:
`NVGPUWarpSpecializationPass::removeWarpSpecializeAttr` is called on
every early-exit path in this pass (num_warps != 4, has-else fallback,
etc.). It only stripped `tt.warp_specialize` from `scf.for` ops, but
the earlier `tritongpu-partition-scheduling` pass had already written
`ttg.partition` / `ttg.partition.outputs` / `ttg.partition.stages` and
`ttg.warp_specialize.tag` on the loop and its body. Removing only the
WS marker leaves the IR in a half-tagged state — the downstream
`tritongpu-pipeline` pass treats partition-tagged regions as WS regions
and verifies that every op under a partitioned parent carries
`ttg.partition`. When the WS loop sits inside an `scf.if`/`else`
(which triggers the has-else fallback in the first place), the
sibling prologue ops in the surrounding region are untagged and the
verifier fails:

  error: 'arith.subi' op does not have expected attribute ttg.partition
         which is expected for ops whose parent has partitions

Extend `removeWarpSpecializeAttr` to also strip `ttg.partition`,
`ttg.partition.outputs`, `ttg.partition.stages`, and
`ttg.warp_specialize.tag` so the IR is left in a fully-clean non-WS
state for downstream passes.

Reproducer: AOT-compile `scaled_mm_autows_kernel` (D101259482) for
`GPUTarget("cuda", 100, 32)` with `TRITON_USE_META_WS=1` and the
default `TRITON_USE_META_PARTITION` (off). Before this patch, compile
crashes in `tritongpu-pipeline` with the verifier error above. After,
TTGIR is generated cleanly with a non-WS lowering (correct fallback
behavior given the has-else early-exit).

Differential Revision: D102856779


