### PR TITLE
[TLX] Delay dummy layout resolver pass to after layout prop pass

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -307,8 +307,7 @@ class CUDABackend(BaseBackend):
         # Handle storage lowering. In the future this may need
         # dummy layouts
         tlx.tlx_passes.add_tlx_storage_alias_lowering(pm)
-        # Only determine layouts after inlining is finished.
-        tlx.tlx_passes.add_tlx_resolve_placeholder_layouts(pm)
+
         passes.ttir.add_rewrite_tensor_pointer(pm)
         if capability // 10 < 9:
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
@@ -360,6 +359,8 @@ class CUDABackend(BaseBackend):
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         tlx.tlx_passes.add_tlx_propagate_layout(pm)
+        # Only determine reg layouts after TMEM layout is finalized
+        tlx.tlx_passes.add_tlx_resolve_placeholder_layouts(pm)
         tlx.tlx_passes.add_tlx_rewrite_local_alias(pm)
         passes.ttgpuir.add_f32_dot_tc(pm, emuTF32)
         # TODO(Qingyi): Move PlanCTAPass to the front of CoalescePass

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -140,31 +140,6 @@ public:
       return WalkResult::advance();
     });
 
-    // Fix up RequireLayoutOps feeding into TMEMStoreOps with scales encoding.
-    // ResolvePlaceholderLayouts assigned a generic TMEM-compatible register
-    // layout, but for scales the register layout must use a scales-compatible
-    // layout from getScaleTMEMStoreLinearLayout.
-    funcOp.walk([&](ttng::TMEMStoreOp storeOp) {
-      auto memTy = storeOp.getDst().getType();
-      if (!isa<ttng::TensorMemoryScalesEncodingAttr>(memTy.getEncoding()))
-        return WalkResult::advance();
-
-      auto requireOp = storeOp.getSrc().getDefiningOp<RequireLayoutOp>();
-      if (!requireOp)
-        return WalkResult::advance();
-
-      auto srcTy = cast<RankedTensorType>(requireOp.getResult().getType());
-      auto compatibleLayouts =
-          ttng::getTmemCompatibleLayouts(storeOp, srcTy, memTy);
-      assert(!compatibleLayouts.empty() &&
-             "No TMEM-compatible layout found for scales");
-      auto newEncoding = compatibleLayouts.front();
-      auto newType = RankedTensorType::get(srcTy.getShape(),
-                                           srcTy.getElementType(), newEncoding);
-      requireOp->getResult(0).setType(newType);
-      return WalkResult::advance();
-    });
-
     // Verify that no DummyTMEMLayoutAttr remains after layout propagation
     bool hasDummyLayout = false;
     funcOp.walk([&](ttng::TMEMAllocOp allocOp) {

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -48,8 +48,8 @@ static Attribute getDummyLayoutFromType(Type type) {
 /// BlockedEncodingAttr.
 ///
 static Attribute resolveRegisterLayout(DummyRegisterLayoutAttr dummyLayout,
-                                       Operation *contextOp,
-                                       ModuleOp moduleOp) {
+                                       Operation *contextOp, ModuleOp moduleOp,
+                                       Attribute tmemEncoding) {
   auto shape = dummyLayout.getShape();
   auto elementType = dummyLayout.getElementType();
   auto rank = shape.size();
@@ -61,22 +61,17 @@ static Attribute resolveRegisterLayout(DummyRegisterLayoutAttr dummyLayout,
 
   if (dummyLayout.getTmemCompatible()) {
     // Create a TMEM-compatible register layout
+    assert(tmemEncoding != nullptr &&
+           "missing TMEM layout when finding compatible reg layouts");
     assert(rank == 2 &&
            "Only supporting 2D tensors for TMEM compatible layout.");
     assert((numWarps == 4 || numWarps == 8) &&
            "Currently only support numWarps 4 or 8 for TMEM load and store.");
 
     auto *ctx = moduleOp.getContext();
-    unsigned bitwidth = elementType.getIntOrFloatBitWidth();
-    unsigned colStride = 32 / bitwidth;
-    auto tmemEncoding = ttng::TensorMemoryEncodingAttr::get(
-        ctx, shape[0], shape[1], colStride, /*CTASplitM=*/1,
-        /*CTASplitN=*/1, /*twoCTAs=*/false);
     auto memSpace = ttng::TensorMemorySpaceAttr::get(ctx);
     auto memDescType = ttg::MemDescType::get(shape, elementType, tmemEncoding,
                                              memSpace, /*mutableMemory=*/true);
-    auto ctaLayout =
-        ttg::CGAEncodingAttr::fromSplitParams(ctx, {1, 1}, {1, 1}, {1, 0});
 
     // Create a temporary RankedTensorType with a blocked encoding for
     // getTmemCompatibleLayout to use as a reference type.
@@ -109,9 +104,10 @@ static Attribute resolveRegisterLayout(DummyRegisterLayoutAttr dummyLayout,
 /// to determine the block dimensions.
 /// For register layouts from TMEMLoadOp, definingOp is used to get the source
 /// memdesc's allocation shape.
-static Attribute resolveDummyLayout(Attribute dummyLayout,
-                                    ArrayRef<int64_t> allocShape, Value value,
-                                    ModuleOp moduleOp) {
+static Attribute
+resolveDummyLayout(Attribute dummyLayout, ArrayRef<int64_t> allocShape,
+                   Value value, ModuleOp moduleOp,
+                   const DenseMap<Value, Attribute> &valuesToRefTMEMLayoutMap) {
   // Get the context operation for lookupNumWarps - this allows finding
   // partition-specific num_warps for warp specialized regions
   Operation *contextOp = nullptr;
@@ -124,8 +120,10 @@ static Attribute resolveDummyLayout(Attribute dummyLayout,
     contextOp = moduleOp;
   }
 
+  auto tmemLayout = valuesToRefTMEMLayoutMap.lookup_or(value, nullptr);
+
   if (auto regLayout = dyn_cast<DummyRegisterLayoutAttr>(dummyLayout))
-    return resolveRegisterLayout(regLayout, contextOp, moduleOp);
+    return resolveRegisterLayout(regLayout, contextOp, moduleOp, tmemLayout);
 
   llvm_unreachable("Unknown dummy layout type");
 }
@@ -153,13 +151,14 @@ static void replaceTypeWithNewEncoding(Value value, Attribute newEncoding) {
 
 LogicalResult resolvePlaceholderLayouts(ModuleOp moduleOp) {
   // Collect all values that have dummy layouts
-  SmallVector<std::pair<Value, Attribute>> valuesToResolve;
+  DenseMap<Value, Attribute> valuesToResolve;
+  DenseMap<Value, Attribute> valuesToRefTMEMLayoutMap;
 
   moduleOp.walk([&](Operation *op) {
     // Check all result types for dummy layouts
     for (Value result : op->getResults()) {
       if (Attribute dummyLayout = getDummyLayoutFromType(result.getType())) {
-        valuesToResolve.emplace_back(result, dummyLayout);
+        valuesToResolve.try_emplace(result, dummyLayout);
       }
     }
 
@@ -168,9 +167,25 @@ LogicalResult resolvePlaceholderLayouts(ModuleOp moduleOp) {
       for (Block &block : region) {
         for (BlockArgument arg : block.getArguments()) {
           if (Attribute dummyLayout = getDummyLayoutFromType(arg.getType())) {
-            valuesToResolve.emplace_back(arg, dummyLayout);
+            valuesToResolve.try_emplace(arg, dummyLayout);
           }
         }
+      }
+    }
+  });
+
+  moduleOp.walk([&](Operation *op) {
+    if (auto tmemLdOp = dyn_cast<ttng::TMEMLoadOp>(op)) {
+      auto v = tmemLdOp.getResult();
+      if (valuesToResolve.contains(v)) {
+        valuesToRefTMEMLayoutMap.try_emplace(
+            v, tmemLdOp.getSrc().getType().getEncoding());
+      }
+    } else if (auto tmemStOp = dyn_cast<ttng::TMEMStoreOp>(op)) {
+      auto v = tmemStOp.getSrc();
+      if (valuesToResolve.contains(v)) {
+        valuesToRefTMEMLayoutMap.try_emplace(
+            v, tmemStOp.getDst().getType().getEncoding());
       }
     }
   });
@@ -182,8 +197,8 @@ LogicalResult resolvePlaceholderLayouts(ModuleOp moduleOp) {
     if (auto memDescType = dyn_cast<ttg::MemDescType>(value.getType())) {
       allocShape = memDescType.getAllocShape();
     }
-    Attribute resolvedLayout =
-        resolveDummyLayout(dummyLayout, allocShape, value, moduleOp);
+    Attribute resolvedLayout = resolveDummyLayout(
+        dummyLayout, allocShape, value, moduleOp, valuesToRefTMEMLayoutMap);
     LLVM_DEBUG({
       DBGS() << "Resolving dummy layout: ";
       dummyLayout.dump();


### PR DESCRIPTION
The reg layout has to be compatible with TMEM when doing tmem load/store. TMEM layouts are true and final only when the tlx layout prop pass finishes.

Then in the dummy layout resolver we could just pass in the correct tmem layout to construct correct reg layouts, without hacky fixing up in the layout prop pass.

Test plan: `pytest -vsx python/test/unit/language/test_tlx_dot.py::test_tmem_buffer_scales_two_entries`
