### PR TITLE
[AutoWS] Add warp budget enforcement to OptimizePartitionWarps

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -47,10 +47,6 @@ static OwningOpRef<ModuleOp> takeIntoFunction(ModuleAxisInfoAnalysis &axisInfo,
     op.erase();
   });
 
-  // This should make valid IR.
-  if (failed(mlir::verify(*container)))
-    llvm::report_fatal_error("expected partition region to make valid IR");
-
   // Attach axis info properties.
   auto wsOp = partition->getParentOfType<WarpSpecializeOp>();
   auto *funcInfo =
@@ -313,12 +309,11 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
     // "Guess" the register usage for each partition.
     estRegs = tensorRegs ? maxRegAutoWS : minRegAutoWS;
 
-    // Layouts need to be reassigned if the number of warps changed and there
-    // are tensor computations.
-    if (newNumWarps == prevNumWarps || !tensorRegs)
+    // Layouts were computed with the module-level num_warps (defaultNumWarps).
+    // Relayout if the partition's final warp count differs from that.
+    if (newNumWarps == (int32_t)defaultNumWarps || !tensorRegs)
       continue;
-    // We need to reassign layouts.
-    if (failed(relayoutWarps(axisInfo, partition, prevNumWarps, newNumWarps,
+    if (failed(relayoutWarps(axisInfo, partition, defaultNumWarps, newNumWarps,
                              runPipeline)))
       return failure();
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -255,6 +255,27 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
     }
   } while (changed);
 
+  // Compute the warp budget from maxnreg if specified by the user.
+  // When maxnreg is set, the total warps across all partitions (including
+  // default) must not exceed nTotalRegs / maxnreg / threadsPerWarp.
+  // When maxnreg is not set, AllocateWarpGroups auto-derives it from the
+  // total warp count, so there is no hard budget to enforce.
+  ModuleOp mod = axisInfo.getModuleOp();
+  int32_t maxWarps = 0;
+  if (auto maxnregAttr =
+          mod->getAttrOfType<IntegerAttr>(AttrMaxRegistersName)) {
+    maxWarps = nTotalRegs / maxnregAttr.getInt() / threadsPerWarp;
+  }
+
+  // Helper to compute actual total warps including warp group padding.
+  // Non-default partitions are packed into warp groups of 4 warps each.
+  auto computeTotalWarps = [&]() -> int32_t {
+    int32_t extraWarps =
+        std::accumulate(partitionNumWarps.begin(), partitionNumWarps.end(), 0);
+    int32_t extraWarpGroups = llvm::divideCeil(extraWarps, 4);
+    return defaultNumWarps + extraWarpGroups * 4;
+  };
+
   // Read partition types if available for type-aware warp assignment.
   SmallVector<StringRef> partitionTypes;
   if (auto typesAttr =
@@ -271,8 +292,12 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
   // This ensures layouts are computed with the correct warp counts.
   //
   // For bwd FA (has reduction): computation partition gets 8 warps.
-  // With reduction=4 (TMEM floor), gemm=1, load=1, computation=8,
+  // The warp budget is nTotalRegs / maxnreg / threadsPerWarp (e.g., 16 warps
+  // with maxnreg=128 on Blackwell).
+  // With num_warps=4: reduction=4 (TMEM floor), gemm=1, load=1, computation=8,
   // total = 14, within the 16 warp budget.
+  // With num_warps=8: total = 18 (4 extra warps in default partition),
+  // exceeds the budget - the override is skipped.
   //
   // Note: the types array comes from the scheduler and may be longer than
   // partitionNumWarps (the WarpSpecializeOp may have fewer regions). We scan
@@ -288,11 +313,40 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
   }
 
   if (hasReduction && hasComputation && !partitionNumWarps.empty()) {
+    int32_t saved = partitionNumWarps.back();
     partitionNumWarps.back() = 8;
+    if (maxWarps > 0 && computeTotalWarps() > maxWarps)
+      partitionNumWarps.back() = saved;
   }
 
-  // Read the attribute from the module
-  ModuleOp mod = axisInfo.getModuleOp();
+  // Budget enforcement: if maxnreg is specified and total warps exceed the
+  // budget, shrink the largest partitions (respecting minimums).
+  //
+  // TODO: if shrinking alone is insufficient (all partitions at minimums but
+  // still over budget), try merging same-type partitions (e.g., two
+  // "computation" partitions into one). If that also fails, fall back to
+  // non-warp-specialized compilation.
+  if (maxWarps > 0) {
+    bool shrunk;
+    do {
+      shrunk = false;
+      if (computeTotalWarps() <= maxWarps)
+        break;
+      int32_t bestIdx = -1;
+      int32_t bestWarps = 0;
+      for (int32_t i = 0; i < (int32_t)partitionNumWarps.size(); ++i) {
+        if (partitionNumWarps[i] > minWarpsForPartition[i] &&
+            partitionNumWarps[i] > bestWarps) {
+          bestWarps = partitionNumWarps[i];
+          bestIdx = i;
+        }
+      }
+      if (bestIdx >= 0) {
+        partitionNumWarps[bestIdx] /= 2;
+        shrunk = true;
+      }
+    } while (shrunk);
+  }
   int minRegAutoWS = 24; // default value
   if (auto attr = mod->getAttrOfType<IntegerAttr>(AttrMinRegAutoWSName)) {
     minRegAutoWS = attr.getInt();

--- a/test/TritonGPU/optimize-partition-warps-budget-gated-override.mlir
+++ b/test/TritonGPU/optimize-partition-warps-budget-gated-override.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-optimize-partition-warps | FileCheck %s
+
+// Test that the BWD FA type-aware override (computation=8 warps) is
+// budget-gated when maxnreg is set.
+//
+// With num_warps=8 and maxnreg=128:
+//   budget = 65536 / 128 / 32 = 16 warps
+//   BWD override would give: 8 (default) + 1 + 1 + 8 = 18, padded to 20
+//   That exceeds the budget, so the override should be skipped.
+//   Without override: 8 + 1 + 1 + 4 = 14, padded to 16 — fits.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: @bwd_override_budget_gated
+// computation partition stays at 4 (not overridden to 8) because budget is tight
+// CHECK: partition0({{.*}}) num_warps(1)
+// CHECK: partition1({{.*}}) num_warps(1)
+// CHECK: partition2({{.*}}) num_warps(4)
+module attributes {ttg.target = "cuda:100", "ttg.num-warps" = 8 : i32, "ttg.maxnreg" = 128 : i32} {
+
+tt.func @bwd_override_budget_gated(%arg0: i32) {
+  ttg.warp_specialize(%arg0)
+    attributes {"ttg.partition.types" = ["reduction", "gemm", "load", "computation"]}
+  default {
+    ttg.warp_yield
+  }
+  // gemm: scalar, shrinks to 1
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // load: scalar, shrinks to 1
+  partition1(%arg1: i32) num_warps(8) {
+    %0 = arith.muli %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // computation: has TMEM op (minimum 4 warps). Would be overridden to 8
+  // by BWD pattern, but budget enforcement keeps it at 4.
+  partition2(%arg1: i32) num_warps(4) {
+    %alloc, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+}

--- a/test/TritonGPU/optimize-partition-warps-num-warps8.mlir
+++ b/test/TritonGPU/optimize-partition-warps-num-warps8.mlir
@@ -1,0 +1,58 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-optimize-partition-warps | FileCheck %s
+
+// Test that non-default partitions are capped at the base warp group size (4)
+// when the module's num_warps is greater than 4. Only the default partition
+// should use the user's num_warps setting.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#shared_1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK: module attributes {{.*}}"ttg.num-warps" = 8
+module attributes {ttg.target = "cuda:100", "ttg.num-warps" = 8 : i32} {
+
+// CHECK-LABEL: @non_default_partitions_capped_to_base_warps
+tt.func @non_default_partitions_capped_to_base_warps(%arg0: i32) {
+  ttg.warp_specialize(%arg0)
+    attributes {"ttg.partition.types" = ["default", "gemm", "load", "computation"]}
+  default {
+    ttg.warp_yield
+  }
+  // Partitions initialized at 8 warps should be shrunk.
+  // gemm: scalar-only, shrinks to 1
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // load: scalar-only, shrinks to 1
+  // CHECK: partition1({{.*}}) num_warps(1)
+  partition1(%arg1: i32) num_warps(8) {
+    %0 = arith.muli %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // computation: scalar-only, shrinks to 1
+  // CHECK: partition2({{.*}}) num_warps(1)
+  partition2(%arg1: i32) num_warps(8) {
+    %0 = arith.subi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+// Verify that num_warps=4 behaves the same as before (no regression).
+// CHECK-LABEL: @num_warps_4_unchanged
+tt.func @num_warps_4_unchanged(%arg0: i32) {
+  ttg.warp_specialize(%arg0)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(4) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+}


### PR DESCRIPTION
Teach OptimizePartitionWarps to enforce a warp budget derived from `maxnreg`.

When the user specifies `maxnreg` (e.g., `maxnreg=128` for FA kernels), the maximum number of warps is `65536 / maxnreg / threadsPerWarp`. This PR adds two mechanisms to stay within that budget:

1. **Budget-gated BWD override**: The existing type-aware override that forces the computation partition to 8 warps (for BWD FA) is now conditional — it only applies if the resulting schedule fits within the warp budget. With `num_warps=4` (total=14, budget=16) the override still fires. With `num_warps=8` (total=18, budget=16) it is skipped.
2. **Shrink loop**: After all overrides, if the schedule still exceeds the budget, iteratively halve the largest partition that is above its minimum warp count (1 for scalar partitions, 2 for TMA gather/scatter, 4 for TMEM ops) until the budget is met.

When `maxnreg` is not set, the budget is not enforced — `AllocateWarpGroups` auto-derives `maxnreg` from the total warp count, so the system is self-balancing and this PR is a no-op.

This is a prerequisite for enabling `num_warps!=4` in a follow-up PR.

Stacked on https://github.com/facebookexperimental/triton/pull/1277.