### PR TITLE
[AutoWS] Enable warp specialization with num_warps != 4

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3313,14 +3313,19 @@ struct TritonGPUVerifyTensorLayoutInterface
     }
 
     // Number of warps per CTA.
+    // Skip this check inside WarpSpecializeOp partition regions: partitions
+    // may temporarily have layouts with the module-level warp count while
+    // the partition's num_warps is smaller. OptimizePartitionWarps fixes this.
     std::optional<int> moduleWarpsPerCTA = maybeLookupNumWarps(op);
     if (!moduleWarpsPerCTA) {
       return makeErr()
              << "Could not determine the number of warps per CTA. Operation "
                 "is not in a context with `ttg.num-warps`.";
     }
+    bool inPartitionRegion =
+        op->getParentOfType<WarpSpecializePartitionsOp>() != nullptr;
     auto kWarp = StringAttr::get(module.getContext(), "warp");
-    if (ll.getInDimSize(kWarp) != *moduleWarpsPerCTA) {
+    if (!inPartitionRegion && ll.getInDimSize(kWarp) != *moduleWarpsPerCTA) {
       return makeErr() << layout << ".\nLayout has " << ll.getInDimSize(kWarp)
                        << " warps per CTA, but the context requires "
                        << *moduleWarpsPerCTA << " warps per CTA.";

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -582,7 +582,7 @@ def test_tutorial09_matmul_tma_warp_specialize(
 @pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
 @pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
 @pytest.mark.parametrize("num_stages", [2, 3])
-@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("FLATTEN", [True, False])
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
 @pytest.mark.parametrize("A_col_major", [False, True])
@@ -617,6 +617,9 @@ def test_tutorial09_matmul_tma_persistent_warp_specialize(
     # DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 256:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256")
+
+    if num_warps != 4 and DATA_PARTITION_FACTOR > 1:
+        pytest.skip("DATA_PARTITION_FACTOR > 1 with num_warps != 4 not yet supported")
 
     if (DATA_PARTITION_FACTOR == 1 and BLOCK_SIZE_M == 256
             and (BLOCK_SIZE_N == 256 or (BLOCK_SIZE_K == 128 and not FLATTEN))):
@@ -745,7 +748,7 @@ def test_tutorial09_matmul_tma_persistent_warp_specialize(
 @pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
 @pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
 @pytest.mark.parametrize("num_stages", [2, 3])
-@pytest.mark.parametrize("num_warps", [4])
+@pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("FLATTEN", [True, False])
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
 @pytest.mark.parametrize("A_col_major", [False, True])
@@ -780,6 +783,9 @@ def test_tutorial09_matmul_descriptor_persistent_warp_specialize(
     # DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 256:
         pytest.skip("DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256")
+
+    if num_warps != 4 and DATA_PARTITION_FACTOR > 1:
+        pytest.skip("DATA_PARTITION_FACTOR > 1 with num_warps != 4 not yet supported")
 
     if DATA_PARTITION_FACTOR == 1 and BLOCK_SIZE_M == 256 and num_stages == 3 and FLATTEN:
         pytest.skip("Out of resources: shared memory and/or tensor memory exceeded")

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -936,6 +936,19 @@ configs_bwd_persist = [
     ),
     triton.Config(
         {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _DEFAULT_BWD_DOT_ATTRS,
+        },
+        num_warps=8,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
             "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128, "EPILOGUE_SUBTILE": 4, "BWD_DOT_ATTRS":
             _BWD_DOT_ATTRS_SCHED,  # use memory planner heuristics
         },

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -99,13 +99,15 @@ public:
     if (!enabled)
       return;
 
+    // num_warps != 4 is allowed. OptimizePartitionWarps enforces the warp
+    // budget and falls back to non-WS if the schedule can't fit.
+    //
+    // Known limitation: kernels with data_partition_factor > 1 (e.g., FA fwd
+    // dual-pass) create multiple computation partitions that exceed the warp
+    // budget with num_warps > 4. The budget fallback will remove WS for these.
+    // TODO: implement computation partition merging to support dp > 1 with
+    // num_warps > 4.
     int numWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
-    if (numWarps != 4) {
-      LDBG("Warp specialization requires num_warps=4, but got "
-           << numWarps << ". Skipping.");
-      removeWarpSpecializeAttr(funcOp);
-      return;
-    }
 
     // FIXME: skip warpspec if there is else block. Need to improve
     // CodePartitioning to correctly handle channels in else block.


### PR DESCRIPTION
Enable `num_warps != 4` cases by removing the existing warning. We also remove the existing warp count verifier check for ops within warp-specialized partitions, since the partition layouts are bound to temporarily mismatch until the `OptimizePartitionWarps` pass fixes them.

Tests:
- GEMM, FA bwd: parametrized tests with `num_warps=8`
- All existing lit tests pass

Known limitations:
- `data_partition_factor > 1` with `num_warps > 4` exceeds the warp budget. The budget fallback removes WS for these cases. In a future PR, we may explore merging similar partitions (e.g. in the FA fwd case, we can merge the 2 computation/softmax partitions).
- FA fwd: fails with a pre-existing compilation error on main (with both `num_warps=4` and `num_warps=8`

Stacked on #1372.