### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[BACKEND] Add tcgen05.mma + multicast support (#9071)'

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -708,7 +708,8 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [
     Variadic<TTG_MemDescType>:$barriers,
     Variadic<I1>:$barrier_preds,
     UnitAttr:$is_async,
-    UnitAttr:$two_ctas
+    UnitAttr:$two_ctas,
+    UnitAttr:$multicast
   );
   let results = (outs Optional<TTG_AsyncToken>:$token);
 
@@ -716,6 +717,7 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [
     OpBuilder<(ins "Type":$token,
       "Value":$a, "Value":$b, "Value":$d, "Value":$acc_dep, "Value":$useD,
       "Value":$pred, CArg<"bool", "false">:$two_ctas,
+      CArg<"bool", "false">:$multicast,
       CArg<"ValueRange", "{}">:$barriers,
       CArg<"ValueRange", "{}">:$barrier_preds,
       CArg<"bool", "false">:$is_async)>
@@ -801,7 +803,7 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
   let hasVerifier = 1;
 }
 
-def TTNG_TCGen5CommitOp : TTNG_Op<"tc_gen5_commit"> {
+def TTNG_TCGen5CommitOp : TTNG_Op<"tc_gen5_commit", [AttrSizedOperandSegments]> {
   let summary = "make an mbarrier track completion of all prior async tcgen5 ops";
 
   let description = [{
@@ -810,9 +812,9 @@ def TTNG_TCGen5CommitOp : TTNG_Op<"tc_gen5_commit"> {
     operations. Upon completion of all asynchronous operations, the mbarrier
     arrive operation is performed on the mbarrier with a count of 1.
 
-    If `two_ctas` is set, then the mbarrier tracks all prior operations
-    initiated with `two_ctas` set as well. Otherwise, it tracks all prior
-    operations initiated without `two_ctas`.
+    If `descs` are provided, the commit will be multicast across the CTA cluster
+    based on the shared layouts of those descriptors. This should be used when
+    the inputs to the tcgen5 MMA come from TMA descriptors using multicast.
 
     Note that the completion mechanisms are guaranteed to occur sequentially in
     the order the commit operations were issued. This means, for example:
@@ -833,18 +835,15 @@ def TTNG_TCGen5CommitOp : TTNG_Op<"tc_gen5_commit"> {
   let arguments = (ins
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier,
     Optional<I1>:$pred,
-    UnitAttr:$two_ctas
+    Variadic<TTG_MemDescType>:$descs
   );
 
   let assemblyFormat = [{
-    $barrier (`,` $pred^)? attr-dict `:` qualified(type($barrier))
+    $barrier (`,` $pred^)? (`descs` $descs^)? attr-dict `:`
+    qualified(type($barrier)) (`,` qualified(type($descs))^)?
   }];
 
-  let builders = [
-    OpBuilder<(ins "Value":$barrier, CArg<"bool", "false">:$two_ctas), [{
-      build($_builder, $_state, barrier, /*pred=*/Value(), two_ctas);
-    }]>,
-  ];
+  let hasVerifier = 1;
 }
 
 def TTNG_TMEMLoadOp : TTNG_Op<"tmem_load"> {

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -736,17 +736,27 @@ void TCGen5MMAOp::setPredicate(Value pred) { getPredMutable().assign(pred); }
 
 void TCGen5MMAOp::build(OpBuilder &builder, OperationState &state, Type token,
                         Value a, Value b, Value d, Value accDep, Value useD,
-                        Value pred, bool useTwoCTAs, ValueRange barriers,
-                        ValueRange barrierPreds, bool isAsync) {
+                        Value pred, bool twoCtas, bool multicast,
+                        ValueRange barriers, ValueRange barrierPreds,
+                        bool isAsync) {
   if (!barriers.empty()) {
     isAsync = true;
   }
   build(builder, state, token, a, b, d, accDep, useD, pred, barriers,
         barrierPreds, isAsync ? builder.getUnitAttr() : UnitAttr(),
-        useTwoCTAs ? builder.getUnitAttr() : UnitAttr());
+        twoCtas ? builder.getUnitAttr() : UnitAttr(),
+        multicast ? builder.getUnitAttr() : UnitAttr());
 }
 
 bool TCGen5MMAOp::isAsync() { return getIsAsync(); }
+
+// -- TCGen5CommitOp --
+LogicalResult TCGen5CommitOp::verify() {
+  auto numDescs = getDescs().size();
+  if (numDescs > 2)
+    return emitOpError("expected 0, 1, or 2 descriptors, got ") << numDescs;
+  return success();
+}
 
 // -- TCGen5MMAScaledOp --
 LogicalResult TCGen5MMAScaledOp::verify() {

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -816,12 +816,13 @@ void init_gluon_ir(py::module &&m) {
       .def("create_tcgen05_mma",
            [](GluonOpBuilder &self, Value a, Value b, Value acc, Value useAcc,
               Value pred, std::vector<Value> &mbarriers,
-              std::vector<Value> &mbarrier_preds, bool two_ctas) {
+              std::vector<Value> &mbarrier_preds, bool two_ctas,
+              bool multicast) {
              Value accDep;
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
              self.create<ttng::TCGen5MMAOp>(tokType, a, b, acc, accDep, useAcc,
-                                            pred, two_ctas, mbarriers,
-                                            mbarrier_preds);
+                                            pred, two_ctas, multicast,
+                                            mbarriers, mbarrier_preds);
            })
       .def("create_tcgen05_mma_scaled",
            [](GluonOpBuilder &self, Value a, Value b, Value acc, Value aScale,
@@ -836,8 +837,9 @@ void init_gluon_ir(py::module &&m) {
                  useAcc, pred, mbarriers, mbarrier_preds);
            })
       .def("create_tcgen05_commit",
-           [](GluonOpBuilder &self, Value &barrier, Value &pred, bool twoCTAs) {
-             self.create<ttng::TCGen5CommitOp>(barrier, pred, twoCTAs);
+           [](GluonOpBuilder &self, Value &barrier, Value &pred,
+              std::vector<Value> &descs) {
+             self.create<ttng::TCGen5CommitOp>(barrier, pred, descs);
            })
 
       .def("create_async_tma_copy_global_to_local",

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -30,6 +30,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
     get_tmem_reg_layout,
+    tcgen05_mma_barrier_count,
     tcgen05_mma,
     tcgen05_mma_scaled,
     tcgen05_commit,
@@ -163,6 +164,128 @@ def test_tma_multicast_copy(ctas_per_cga):
 
 
 @gluon.jit
+def tcgen05_mma_multicast_commit_kernel(a_desc, b_desc, out_ptrs, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,
+                                        acc_tmem_layout: ttgl.constexpr, blocked_c: ttgl.constexpr):
+    smem_a = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_shape, a_desc.layout)
+    smem_b = ttgl.allocate_shared_memory(b_desc.dtype, b_desc.block_shape, b_desc.layout)
+
+    tma_bar = mbarrier.allocate_mbarrier(two_ctas=acc_tmem_layout.two_ctas)
+    mbarrier.init(tma_bar, count=1)
+    mma_bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(mma_bar, count=tcgen05_mma_barrier_count([smem_a, smem_b], True))
+
+    # Need to synchronise all the CTAs after the mbarrier initialisation
+    # so that they all see it before tma.async_copy_global_to_shared(multicast=True)
+    mbarrier.sync_cluster_init()
+
+    mbarrier.expect(tma_bar, a_desc.nbytes_per_cta + b_desc.nbytes_per_cta)
+    tma.async_copy_global_to_shared(a_desc, [0, 0], tma_bar, smem_a, multicast=True)
+    tma.async_copy_global_to_shared(b_desc, [0, 0], tma_bar, smem_b, multicast=True)
+    mbarrier.wait(tma_bar, phase=0, deps=[smem_a, smem_b])
+    mbarrier.invalidate(tma_bar)
+
+    acc_tmem = allocate_tensor_memory(ttgl.float32, [BLOCK_M, BLOCK_N], acc_tmem_layout)
+    # If it's not in a loop we don't striclty need multicast=True, but we add it to exercise the path in the test
+    tcgen05_mma(smem_a, smem_b, acc_tmem, use_acc=False, multicast=True, mbarriers=[mma_bar])
+    mbarrier.wait(mma_bar, phase=0, deps=[smem_a, smem_b])
+    mbarrier.invalidate(mma_bar)
+
+    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
+        ttgl.float32,
+        (BLOCK_M, BLOCK_N),
+        acc_tmem_layout,
+        num_warps=ttgl.num_warps(),
+        cga_layout=blocked_c.cga_layout,
+    )
+    out = acc_tmem.load(tmem_reg_layout)
+    out = ttgl.convert_layout(out, blocked_c)
+
+    out_offs_m = ttgl.arange(0, BLOCK_M)[:, None]
+    out_offs_n = ttgl.arange(0, BLOCK_N)[None, :]
+    out_ptrs = out_ptrs + out_offs_m * BLOCK_N + out_offs_n
+    ttgl.store(out_ptrs, out)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("ctas_per_cga", [[2, 1], [2, 4], [4, 4]])
+@pytest.mark.parametrize("two_ctas", [True, False] if is_blackwell() else [False])
+def test_tcgen05_mma_multicast_commit(ctas_per_cga, two_ctas):
+
+    if two_ctas:
+        ctas_per_cga_b = [ctas_per_cga[0] // 2, 2 * ctas_per_cga[1]]
+    else:
+        ctas_per_cga_b = ctas_per_cga
+    BLOCK_M = 128 * ctas_per_cga[0]
+    BLOCK_N = 64 * ctas_per_cga_b[1]
+    BLOCK_K = 32
+
+    # multicast into tcgen05_mma
+    cta_split_a = [ctas_per_cga[0], 1]
+    cta_split_b = [1, ctas_per_cga_b[1]]
+    cta_order = [1, 0]
+
+    from triton._C.libtriton.gluon_ir import make_cga_layout
+    if two_ctas:
+
+        def make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, two_cta_dim):
+            ctas_per_cga = list(ctas_per_cga)
+            cta_split = list(cta_split)
+            assert cta_split[two_cta_dim] > 1
+            cta_split[two_cta_dim] //= 2
+            ctas_per_cga[two_cta_dim] //= 2
+            aux_cga_layout = make_cga_layout(ctas_per_cga, cta_split, cta_order)
+            assert two_cta_dim in (0, 1)
+            basis = [0, 0]
+            basis[two_cta_dim] = 1
+            for b in aux_cga_layout:
+                b[two_cta_dim] *= 2
+            cga_layout = [basis] + aux_cga_layout
+            return cga_layout
+
+        cga_layout_a = make_2cta_cga_layout(ctas_per_cga, cta_split_a, cta_order, 0)
+        cga_layout_b = make_2cta_cga_layout(ctas_per_cga_b, cta_split_b, cta_order, 1)
+        cga_layout_c = make_2cta_cga_layout(ctas_per_cga, ctas_per_cga, cta_order, 0)
+    else:
+        cga_layout_a = make_cga_layout(ctas_per_cga, cta_split_a, cta_order)
+        cga_layout_b = make_cga_layout(ctas_per_cga_b, cta_split_b, cta_order)
+        cga_layout_c = make_cga_layout(ctas_per_cga, ctas_per_cga, cta_order)
+
+    shared_layout_a = ttgl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_K], ttgl.float16, cga_layout=cga_layout_a)
+    shared_layout_b = ttgl.NVMMASharedLayout.get_default_for([BLOCK_K, BLOCK_N], ttgl.float16, cga_layout=cga_layout_b)
+
+    a = torch.randn((BLOCK_M, BLOCK_K), dtype=torch.float16, device="cuda")
+    b = torch.randn((BLOCK_K, BLOCK_N), dtype=torch.float16, device="cuda")
+    out = torch.empty((BLOCK_M, BLOCK_N), dtype=torch.float32, device="cuda")
+
+    a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(a, [BLOCK_M, BLOCK_K], shared_layout_a)
+    b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(b, [BLOCK_K, BLOCK_N], shared_layout_b)
+
+    tmem_shape = (128, BLOCK_N // ctas_per_cga[1])
+    acc_tmem_layout = TensorMemoryLayout(block=tmem_shape, col_stride=1, two_ctas=two_ctas,
+                                         cta_split_num=tuple(ctas_per_cga))
+    blocked_c = ttgl.BlockedLayout([1, 2], [ctas_per_cga[1], 32 // ctas_per_cga[1]], [4, 1], [1, 0],
+                                   cga_layout=cga_layout_c)
+
+    compiled = tcgen05_mma_multicast_commit_kernel[(1, )](
+        a_desc,
+        b_desc,
+        out,
+        BLOCK_M,
+        BLOCK_N,
+        acc_tmem_layout,
+        blocked_c,
+        num_warps=4,
+        num_ctas=ctas_per_cga[0] * ctas_per_cga[1],
+    )
+
+    assert "tcgen05.commit.cta_group::" + ("2" if two_ctas else "1") in compiled.asm["ptx"]
+    # For [2, 1] and two_ctas we don't multicast as there are not enough tiles
+    # but we do a commit.multicast::cluster so let's grep that one instead
+    assert ("multicast::cluster" in compiled.asm["ptx"])
+    torch.testing.assert_close(out, torch.matmul(a.to(out.dtype), b.to(out.dtype)))
+
+
+@gluon.jit
 def async_copy_mbarrier_kernel(out, inp, xnumel, XBLOCK: ttgl.constexpr, YBLOCK: ttgl.constexpr):
     smem = ttgl.allocate_shared_memory(inp.dtype.element_ty, [XBLOCK, YBLOCK],
                                        ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0]))
@@ -285,7 +408,7 @@ def test_device_tma_store():
 def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexpr, block_layout_a: ttgl.constexpr,
                block_layout_b: ttgl.constexpr, block_layout_c: ttgl.constexpr, acc_layout: ttgl.constexpr,
                shared_layout_a: ttgl.constexpr, shared_layout_b: ttgl.constexpr, acc_dtype: ttgl.constexpr,
-               ASYNC: ttgl.constexpr, USE_TCGEN05: ttgl.constexpr, mma_barrier_layout: ttgl.constexpr = None):
+               ASYNC: ttgl.constexpr, USE_TCGEN05: ttgl.constexpr):
     a_offs_m = ttgl.arange(0, M)[:, None]
     a_offs_k = ttgl.arange(0, K)[None, :]
     b_offs_k = ttgl.arange(0, K)[:, None]
@@ -300,13 +423,10 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
     smem_a = ttgl.allocate_shared_memory(operand_dtype, [M, K], shared_layout_a, a_tile)
     smem_b = ttgl.allocate_shared_memory(operand_dtype, [K, N], shared_layout_b, b_tile)
 
-    two_ctas: ttgl.constexpr = isinstance(acc_layout, TensorMemoryLayout) and acc_layout.two_ctas
-    fence_async_shared(cluster=two_ctas)
-
     if USE_TCGEN05:
-        assert mma_barrier_layout is not None, "Expected an mbarrier layout for TCGen05 MMA execution"
-        nbarriers: ttgl.constexpr = ttgl.num_ctas() // (2 if two_ctas else 1)
-        mma_barrier = ttgl.allocate_shared_memory(ttgl.int64, [nbarriers], mma_barrier_layout)
+        two_ctas: ttgl.constexpr = acc_layout.two_ctas
+        fence_async_shared(cluster=two_ctas)
+        mma_barrier = mbarrier.allocate_mbarrier()
         mbarrier.init(mma_barrier, count=1)
         # Need to synchronise all the CTAs after the mbarrier initialisation
         # so that they all see it
@@ -328,6 +448,7 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
         )
         acc = acc_tmem.load(tmem_reg_layout)
     else:
+        fence_async_shared()
         acc = ttgl.zeros([M, N], dtype=acc_dtype, layout=acc_layout)
         acc = hopper.warpgroup_mma(smem_a, smem_b, acc, is_async=ASYNC)
 
@@ -378,47 +499,61 @@ def test_warpgroup_mma(ASYNC):
 
 
 @gluon.jit
-def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, M: ttgl.constexpr, N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
-                                 NUM_K_TILES: ttgl.constexpr, block_layout_c: ttgl.constexpr,
+def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,
+                                 BLOCK_K: ttgl.constexpr, NUM_K_TILES: ttgl.constexpr, block_layout_c: ttgl.constexpr,
                                  acc_layout: ttgl.constexpr, acc_tmem_layout: ttgl.constexpr,
-                                 use_tcgen05: ttgl.constexpr):
+                                 use_tcgen05: ttgl.constexpr, multicast: ttgl.constexpr):
     smem_a = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_shape, a_desc.layout)
     smem_b = ttgl.allocate_shared_memory(b_desc.dtype, b_desc.block_shape, b_desc.layout)
 
-    tma_bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ttgl.constexpr(mbarrier.MBarrierLayout()))
+    two_ctas: ttgl.constexpr = isinstance(acc_tmem_layout, TensorMemoryLayout) and acc_tmem_layout.two_ctas
+
+    tma_bar = mbarrier.allocate_mbarrier(two_ctas=two_ctas)
+    mbarrier.init(tma_bar, count=1)
+    phase_tma = 0
 
     if use_tcgen05:
-        mma_bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ttgl.constexpr(mbarrier.MBarrierLayout()))
+        mma_bar = mbarrier.allocate_mbarrier()
+        phase_mma = 0
+        mbarrier.init(mma_bar, count=tcgen05_mma_barrier_count([smem_a, smem_b], multicast))
         acc_tmem = allocate_tensor_memory(
             element_ty=ttgl.float32,
-            shape=[M, N],
+            shape=[BLOCK_M, BLOCK_N],
             layout=acc_tmem_layout,
         )
     else:
-        acc = ttgl.zeros([M, N], dtype=ttgl.float32, layout=acc_layout)
+        acc = ttgl.zeros([BLOCK_M, BLOCK_N], dtype=ttgl.float32, layout=acc_layout)
+
+    # Need to synchronise all the CTAs after the mbarrier initialisation before we do
+    # cross-CTA ops
+    if (multicast and ttgl.num_ctas() > 1) or two_ctas:
+        mbarrier.sync_cluster_init()
 
     for k in range(NUM_K_TILES):
-        mbarrier.init(tma_bar, count=1)
         mbarrier.expect(tma_bar, a_desc.nbytes_per_cta + b_desc.nbytes_per_cta)
-        tma.async_copy_global_to_shared(a_desc, [0, k * BLOCK_K], tma_bar, smem_a)
-        tma.async_copy_global_to_shared(b_desc, [0, k * BLOCK_K], tma_bar, smem_b)
-        mbarrier.wait(tma_bar, phase=0, deps=[smem_a, smem_b])
-        smem_b_T = smem_b.permute((1, 0))
+        tma.async_copy_global_to_shared(a_desc, [0, k * BLOCK_K], tma_bar, smem_a, multicast=multicast)
+        tma.async_copy_global_to_shared(b_desc, [k * BLOCK_K, 0], tma_bar, smem_b, multicast=multicast)
+        mbarrier.wait(tma_bar, phase=phase_tma, deps=[smem_a, smem_b])
+        phase_tma ^= 1
 
         if use_tcgen05:
-            mbarrier.init(mma_bar, count=1)
-            tcgen05_mma(smem_a, smem_b_T, acc_tmem, use_acc=(k != 0), mbarriers=[mma_bar])
-            mbarrier.wait(mma_bar, phase=0, deps=[smem_a, smem_b_T])
-            mbarrier.invalidate(mma_bar)
+            tcgen05_mma(smem_a, smem_b, acc_tmem, use_acc=(k != 0), multicast=multicast, mbarriers=[mma_bar])
+            mbarrier.wait(mma_bar, phase=phase_mma, deps=[smem_a, smem_b])
+            phase_mma ^= 1
         else:
-            acc = hopper.warpgroup_mma(smem_a, smem_b_T, acc, use_acc=True, is_async=False)
+            acc = hopper.warpgroup_mma(smem_a, smem_b, acc, is_async=False)
+            if multicast:
+                # multicast into wgmma doesn't make much sense as you need to synchronise all
+                # CTAs after the wgmma, as it doesn't provide a finer synchronization mechanism.
+                ttgl.barrier(cluster=True)
 
-        mbarrier.invalidate(tma_bar)
+    mbarrier.invalidate(tma_bar)
 
     if use_tcgen05:
+        mbarrier.invalidate(mma_bar)
         reg_layout: ttgl.constexpr = get_tmem_reg_layout(
             ttgl.float32,
-            (M, N),
+            (BLOCK_M, BLOCK_N),
             acc_tmem_layout,
             num_warps=ttgl.num_warps(),
             cga_layout=block_layout_c.cga_layout,
@@ -426,93 +561,84 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, M: ttgl.constexpr, N: 
         acc = acc_tmem.load(reg_layout)
 
     acc = ttgl.convert_layout(acc, block_layout_c)
-    offs_m = ttgl.arange(0, M)[:, None]
-    offs_n = ttgl.arange(0, N)[None, :]
-    ttgl.store(out_ptr + offs_m * N + offs_n, acc)
+    offs_m = ttgl.arange(0, BLOCK_M)[:, None]
+    offs_n = ttgl.arange(0, BLOCK_N)[None, :]
+    ttgl.store(out_ptr + offs_m * BLOCK_N + offs_n, acc)
 
 
 @pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
-@pytest.mark.parametrize("bitwidth", [8, 16, 32])
 @pytest.mark.parametrize("warps", ([8, 1], [4, 2], [4, 1]))
-@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 16), (64, 128, 32), (32, 32, 32), (256, 128, 32),
-                                                       (64, 16, 64)])
+@pytest.mark.parametrize("reps", ([1, 1, 1], [2, 2, 2], [1, 4, 2]))
 @pytest.mark.parametrize("ctas_per_cga", [[1, 1], [2, 1], [4, 4]])
 @pytest.mark.parametrize("two_ctas", [False, True] if is_blackwell() else [False])
-def test_tma_mma_shared_inputs(bitwidth, warps, BLOCK_M, BLOCK_N, BLOCK_K, ctas_per_cga, two_ctas):
+@pytest.mark.parametrize("multicast", [False, True])
+def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast):
+    bitwidth = 16
     acc_dtype = torch.float32
 
-    if ctas_per_cga != [1, 1]:
-        pytest.skip("Only ctas_per_cga=[1, 1] supported for now")
     if ctas_per_cga[0] == 1 and two_ctas:
         pytest.skip("Need at least 2 CTAs along M for 2CTA mode")
 
-    def compute_swizzling(bitwidth, K):
-        return min(128, K * bitwidth // 8)
-
-    swizzling_a = compute_swizzling(bitwidth, BLOCK_K)
-    swizzling_b = compute_swizzling(bitwidth, BLOCK_K)
-
-    instr_k = 256 // bitwidth
-    if BLOCK_K % instr_k != 0:
-        pytest.skip(f"BLOCK_K must be a multiple of {instr_k} for bitwidth={bitwidth}")
-
-    torch_dtype = {
-        8: torch.float8_e4m3fn,
-        16: torch.float16,
-        32: torch.float32,
-    }[bitwidth]
-
     cta_order = [1, 0]
 
+    if two_ctas:
+        assert ctas_per_cga[0] >= 2, "Need at least 2 CTAs along M for 2CTA mode"
+        ctas_per_cga_b = [ctas_per_cga[0] // 2, 2 * ctas_per_cga[1]]
+    else:
+        ctas_per_cga_b = ctas_per_cga
     cta_split_a = [ctas_per_cga[0], 1]
-    cta_split_b = [1, ctas_per_cga[1]]
+    cta_split_b = [1, ctas_per_cga_b[1]]
+
+    # M = 128 for blackkwell
+    instr_shape = [32 if is_blackwell() else 16, 32, 256 // bitwidth]
+    NUM_K_TILES = 4
+    BLOCK_M = instr_shape[0] * warps[0] * ctas_per_cga[0] * reps[0]
+    BLOCK_N = instr_shape[1] * warps[1] * ctas_per_cga_b[1] * reps[1]
+    if is_blackwell() and BLOCK_N >= 256 * ctas_per_cga[1]:
+        # tcgen05 doesn't support reps along N
+        BLOCK_N = 256 * ctas_per_cga[1]
+    BLOCK_K = instr_shape[2] * reps[2]
+    K = (256 // bitwidth) * NUM_K_TILES
 
     from triton._C.libtriton.gluon_ir import make_cga_layout
-    cga_layout_a = make_cga_layout(ctas_per_cga, cta_split_a, cta_order)
-    cga_layout_b = make_cga_layout(ctas_per_cga, cta_split_b, cta_order)
-    cga_layout_c = make_cga_layout(ctas_per_cga, ctas_per_cga, cta_order)
+    if two_ctas:
 
-    shared_layout_a = ttgl.NVMMASharedLayout(
-        swizzle_byte_width=swizzling_a,
-        element_bitwidth=bitwidth,
-        rank=2,
-        transposed=False,
-        fp4_padded=False,
-        cga_layout=cga_layout_a,
-    )
-    shared_layout_b = ttgl.NVMMASharedLayout(
-        swizzle_byte_width=swizzling_b,
-        element_bitwidth=bitwidth,
-        rank=2,
-        transposed=False,
-        fp4_padded=False,
-        cga_layout=cga_layout_b,
-    )
+        def make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, two_cta_dim):
+            ctas_per_cga = list(ctas_per_cga)
+            cta_split = list(cta_split)
+            assert cta_split[two_cta_dim] > 1
+            cta_split[two_cta_dim] //= 2
+            ctas_per_cga[two_cta_dim] //= 2
+            aux_cga_layout = make_cga_layout(ctas_per_cga, cta_split, cta_order)
+            assert two_cta_dim in (0, 1)
+            basis = [0, 0]
+            basis[two_cta_dim] = 1
+            for b in aux_cga_layout:
+                b[two_cta_dim] *= 2
+            cga_layout = [basis] + aux_cga_layout
+            return cga_layout
+
+        cga_layout_a = make_2cta_cga_layout(ctas_per_cga, cta_split_a, cta_order, 0)
+        cga_layout_b = make_2cta_cga_layout(ctas_per_cga_b, cta_split_b, cta_order, 1)
+        cga_layout_c = make_2cta_cga_layout(ctas_per_cga, ctas_per_cga, cta_order, 0)
+    else:
+        cga_layout_a = make_cga_layout(ctas_per_cga, cta_split_a, cta_order)
+        cga_layout_b = make_cga_layout(ctas_per_cga_b, cta_split_b, cta_order)
+        cga_layout_c = make_cga_layout(ctas_per_cga, ctas_per_cga, cta_order)
 
     block_layout_c = ttgl.BlockedLayout([1, 8], [1, THREADS_PER_WARP], warps_per_cta=warps, order=[1, 0],
                                         cga_layout=cga_layout_c)
 
-    NUM_K_TILES = 4
-    M = BLOCK_M * ctas_per_cga[0]
-    N = BLOCK_N * ctas_per_cga[1]
-    K = BLOCK_K * NUM_K_TILES
-
-    use_tcgen05 = is_blackwell()
-
-    instr_shape = [16, min(16, BLOCK_N), instr_k]
-    if BLOCK_M % (instr_shape[0] * warps[0]) != 0 or BLOCK_N % (instr_shape[1] * warps[1]) != 0:
-        pytest.skip("Incompatible BLOCK_M/BLOCK_N and warps for selected instr_shape")
     acc_layout = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=warps, instr_shape=instr_shape,
                                              cga_layout=cga_layout_c)
 
+    tmem_shape = (min(BLOCK_M // ctas_per_cga[0], 128), BLOCK_N // ctas_per_cga[1])
     acc_tmem_layout = TensorMemoryLayout(
-        block=(min(BLOCK_M, 128), BLOCK_N),
+        block=tmem_shape,
         col_stride=1,
         cta_split_num=tuple(ctas_per_cga),
         two_ctas=two_ctas,
     )
-
-    torch.manual_seed(0)
 
     def cast(x, dtype):
         if dtype != torch.float32:
@@ -525,38 +651,48 @@ def test_tma_mma_shared_inputs(bitwidth, warps, BLOCK_M, BLOCK_N, BLOCK_K, ctas_
         x = x & ~((1 << 13) - 1)
         return x.view(dtype)
 
+    torch_dtype = torch.float16
     device = triton.runtime.driver.active.get_current_device()
-    a = cast(torch.randn((M, K), device=device, dtype=torch.float32), torch_dtype)
+    a = cast(torch.randn((BLOCK_M, K), device=device, dtype=torch.float32), torch_dtype)
     # We transpose b in the kernel
-    b = cast(torch.randn((N, K), device=device, dtype=torch.float32), torch_dtype)
-    out = torch.empty((M, N), device=device, dtype=acc_dtype)
+    b = cast(torch.randn((K, BLOCK_N), device=device, dtype=torch.float32), torch_dtype)
+    out = torch.empty((BLOCK_M, BLOCK_N), device=device, dtype=acc_dtype)
 
+    gluon_dtype = ttgl.float16
+    shared_layout_a = ttgl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_K], gluon_dtype, cga_layout=cga_layout_a)
+    shared_layout_b = ttgl.NVMMASharedLayout.get_default_for([BLOCK_K, BLOCK_N], gluon_dtype, cga_layout=cga_layout_b)
+    assert shared_layout_a.swizzle_byte_width != 0
+    assert shared_layout_b.swizzle_byte_width != 0
     a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(a, [BLOCK_M, BLOCK_K], shared_layout_a)
-    b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(b, [BLOCK_N, BLOCK_K], shared_layout_b)
+    b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(b, [BLOCK_K, BLOCK_N], shared_layout_b)
 
     num_warps = warps[0] * warps[1]
     num_ctas = ctas_per_cga[0] * ctas_per_cga[1]
 
-    tma_mma_shared_inputs_kernel[(1, )](
-        a_desc,
-        b_desc,
-        out,
-        M,
-        N,
-        BLOCK_K,
-        NUM_K_TILES,
-        block_layout_c,
-        acc_layout,
-        acc_tmem_layout,
-        use_tcgen05,
-        num_warps=num_warps,
-        num_ctas=num_ctas,
-    )
+    try:
+        tma_mma_shared_inputs_kernel[(1, )](
+            a_desc,
+            b_desc,
+            out,
+            BLOCK_M,
+            BLOCK_N,
+            BLOCK_K,
+            NUM_K_TILES,
+            block_layout_c,
+            acc_layout,
+            acc_tmem_layout,
+            is_blackwell(),
+            multicast=multicast,
+            num_warps=num_warps,
+            num_ctas=num_ctas,
+        )
+    except triton.runtime.errors.OutOfResources:
+        pytest.skip("Too much shared memory required")
 
     try:
         allow_tf32 = torch.backends.cuda.matmul.allow_tf32
         torch.backends.cuda.matmul.allow_tf32 = True
-        ref = torch.matmul(a.to(torch.float32), b.to(torch.float32).mT)
+        ref = torch.matmul(a.to(torch.float32), b.to(torch.float32))
     finally:
         torch.backends.cuda.matmul.allow_tf32 = allow_tf32
 
@@ -742,15 +878,6 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
 
     block_layout_c = ttgl.BlockedLayout([1, 8], [1, THREADS_PER_WARP], warps_per_cta=warps, order=[1, 0],
                                         cga_layout=cga_layout_c)
-    mma_barrier_layout = None
-    if use_tcgen05:
-        # The layout of this mbarrier seems to be irrelevant right now
-        # We might want to change the API here
-        barrier_cga_layout = []
-        if two_ctas:
-            barrier_cga_layout.append([0])
-        barrier_cga_layout.extend([2**i] for i in range(log2_int(num_ctas // (2 if two_ctas else 1))))
-        mma_barrier_layout = mbarrier.MBarrierLayout(cga_layout=barrier_cga_layout)
     torch.manual_seed(0)
 
     def cast(x, dtype):
@@ -786,7 +913,6 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
         gl_acc_dtype,
         False,
         use_tcgen05,
-        mma_barrier_layout,
         num_warps=num_warps,
         num_ctas=num_ctas,
     )

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -65,7 +65,7 @@ def test_compile_only_dot() -> None:
                r"(.|\n)*"
                r"tcgen05\.mma\.cta_group::1.kind::f16"
                r"(.|\n)*"
-               r"tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64"
+               r"tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
                r"(.|\n)*"
                r"mbarrier.try_wait.parity.shared::cta.b64"
                r"(.|\n)*"

--- a/python/triton/experimental/gluon/__init__.py
+++ b/python/triton/experimental/gluon/__init__.py
@@ -1,6 +1,6 @@
-from . import nvidia
-from . import amd
 from ._runtime import constexpr_function, jit
 from triton.language.core import must_use_result
+from . import nvidia
+from . import amd
 
 __all__ = ["constexpr_function", "jit", "must_use_result", "nvidia", "amd"]

--- a/python/triton/experimental/gluon/language/_layouts.py
+++ b/python/triton/experimental/gluon/language/_layouts.py
@@ -323,14 +323,17 @@ def _get_shape_per_cta(shape, cga_layout):
         return shape
     shape_per_cta = list(shape)
     rank = len(cga_layout[0])
-    cga_shape = [1] * rank
+    cga_shape = [0] * rank
     for basis in cga_layout:
         assert len(basis) == rank
         for i in range(rank):
             cga_shape[i] = max(cga_shape[i], basis[i])
-    # The shape is the largest stride * 2
+    # The shape is the largest stride * 2, or 1 if the stride was always zero
     for i in range(rank):
-        cga_shape[i] *= 2
+        if cga_shape[i] == 0:
+            cga_shape[i] = 1
+        else:
+            cga_shape[i] *= 2
     for dim in range(rank):
         assert shape_per_cta[dim] % cga_shape[dim] == 0, f"Shape {shape} is not divisible by CGA layout {cga_layout}"
         shape_per_cta[dim] //= cga_shape[dim]

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -15,7 +15,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK: %[[E:.+]] = nvvm.elect.sync -> i1
   // CHECK-COUNT-8: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %[[E]]
   // CHECK: %[[PRED:.+]] = llvm.and %arg6, %[[E]]
-  // CHECK: @$0 tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64 [$1];", "b,r" %[[PRED]]
+  // CHECK: @$0 tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [$1];", "b,r" %[[PRED]]
   tt.func @tc_gen5_mma(%a: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<128x128xf16, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -362,7 +362,7 @@ tt.func public @tmem_copy_2d(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_
                              %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
 		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
   // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
-  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64
+  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
   ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
   tt.return
 }
@@ -714,7 +714,7 @@ tt.func @tc_gen5_commit(%arg0: !ttg.memdesc<1xi64, #shared, #smem, mutable>, %pr
   // CHECK: [[ELECT:%.*]] = nvvm.elect.sync
   // CHECK: [[WARP_PRED:%.*]] = llvm.and [[IS_WARP_0]], [[ELECT]]
   // CHECK: [[PRED:%.*]] = llvm.and %arg1, [[WARP_PRED]]
-  // CHECK: @$0 tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64 [$1];", "b,r" [[PRED]]
+  // CHECK: @$0 tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [$1];", "b,r" [[PRED]]
   ttng.tc_gen5_commit %arg0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
   tt.return
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -188,7 +188,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local
   // CHECK: elect.sync
-  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
   // CHECK-NOT: cp.async.bulk.tensor.2d.shared
   // CHECK: return
   tt.func @tma_copy_global_to_local(%tma: !tt.tensordesc<tensor<128x128xf32, #shared1>>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3300,7 +3300,8 @@ void insertAsyncComm(
             auto indexedBarrier = getBarrierForPipelineStage(
                 builder, *commChannel.producerBarrier, bufferIdx);
             builder.createWithAsyncTaskIds<ttng::TCGen5CommitOp>(
-                mmaOp->getLoc(), indexedBarrier);
+                mmaOp->getLoc(), indexedBarrier, /*pred=*/Value(),
+                /*descs=*/ValueRange{});
           }
           builder.clearLoopScheduleInfo();
         }
@@ -3383,7 +3384,8 @@ void insertAsyncComm(
           auto indexedConsumerBarrier =
               getBarrierForPipelineStage(builder, consumerBarrier, bufferIdx);
           builder.createWithAsyncTaskIds<ttng::TCGen5CommitOp>(
-              mmaOp->getLoc(), indexedConsumerBarrier);
+              mmaOp->getLoc(), indexedConsumerBarrier, /*pred=*/Value(),
+              /*descs=*/ValueRange{});
           builder.clearLoopScheduleInfo();
         }
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -479,7 +479,8 @@ void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
       break;
     case AsyncOp::TC5MMA:
     case AsyncOp::TMEMCopy:
-      arriveOp = nvidia_gpu::TCGen5CommitOp::create(rewriter, loc, mbar);
+      arriveOp = nvidia_gpu::TCGen5CommitOp::create(rewriter, loc, mbar,
+                                                    Value(), ValueRange{});
       break;
     case AsyncOp::TMALoad:
       // nothing to do, the arrive is done by HW

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -223,13 +223,29 @@ struct WaitBarrierOpConversion
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::WaitBarrierOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto barrierTy = op.getAlloc().getType();
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
         op.getLoc(), adaptor.getAlloc(),
-        typeConverter->convertType(op.getAlloc().getType().getElementType()),
-        rewriter);
+        typeConverter->convertType(barrierTy.getElementType()), rewriter);
+    auto ctx = op.getContext();
     auto loc = op.getLoc();
-    bool predicated =
-        adaptor.getPred() && !matchPattern(op.getPred(), m_NonZero());
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto pred = adaptor.getPred();
+
+    auto kBlock = StringAttr::get(ctx, "block");
+    auto maskCGABroadcast =
+        toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
+    if (maskCGABroadcast) {
+      // If several CTAs cast to the same barrier, as when we do a TMA into a
+      // tcgen05.mma 2CTA, we send all the signals to the lead CTA, so even if
+      // this barrier is waiting for zero bytes, no one will arrive on it. As
+      // such, we predicate it out
+      auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+      auto ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
+      pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
+    }
+
+    bool predicated = pred && !matchPattern(pred, m_NonZero());
     std::string ptx;
     if (targetInfo->getComputeCapability() < 90) {
       if (!predicated) {
@@ -284,11 +300,10 @@ struct WaitBarrierOpConversion
         ptxBuilder.newOperand(smemObj.getBase(), "r"),
         ptxBuilder.newOperand(adaptor.getPhase(), "r")};
     if (predicated)
-      operands.push_back(ptxBuilder.newOperand(adaptor.getPred(), "b"));
+      operands.push_back(ptxBuilder.newOperand(pred, "b"));
 
     waitLoop(operands, /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(op->getContext());
-    ptxBuilder.launch(rewriter, op->getLoc(), voidTy);
+    ptxBuilder.launch(rewriter, loc, void_ty(ctx));
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -295,29 +295,47 @@ static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
 }
 
 static void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
-                            Value barrier, Value pred, bool twoCTAs = false) {
+                            Value barrier, Value pred, bool twoCTAs,
+                            ValueRange descs) {
   PTXBuilder ptxBuilder;
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value mask;
+  if (!descs.empty()) {
+    auto kBlock = StringAttr::get(rewriter.getContext(), "block");
+    for (Value desc : descs) {
+      auto descTy = cast<MemDescType>(desc.getType());
+      uint16_t broadcastBits =
+          toLinearLayout(descTy).getFreeVariableMasks().lookup(kBlock);
+      if (twoCTAs)
+        broadcastBits |= 1;
+      if (broadcastBits) {
+        Value descMask =
+            LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, broadcastBits);
+        mask = mask ? b.or_(descMask, mask) : descMask;
+      }
+    }
+  } else if (twoCTAs) {
+    mask = LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, 0x1);
+  }
+
   SmallVector<PTXBuilder::Operand *> ptxOperands;
   auto *predOperand = ptxBuilder.newOperand(pred, "b");
   ptxOperands.push_back(predOperand);
   barrier = b.ptrtoint(i32_ty, barrier);
   auto *barrierOperand = ptxBuilder.newOperand(barrier, "r");
   ptxOperands.push_back(barrierOperand);
-  std::string opcode;
-  if (twoCTAs) {
-    auto ctaId = b.trunc(i16_ty, nvgpu::ClusterCTAIdOp::create(rewriter, loc));
-    auto totalCTAs = lookupNumCTAs(rewriter);
-    auto ctaIdLead = b.and_(ctaId, b.i16_val(totalCTAs - 2));
-    Value mask = b.shl(b.i16_val(3), ctaIdLead);
-    auto *ctaMask = ptxBuilder.newOperand(mask, "h");
-    ptxOperands.push_back(ctaMask);
-    opcode = "@$0 "
-             "tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::"
-             "cluster.multicast::cluster.b64 [$1], $2;";
-  } else {
-    opcode = "@$0 tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64 [$1];";
+  std::string opcode =
+      "@$0 tcgen05.commit.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
+      ".mbarrier::arrive::one.shared::cluster";
+  if (mask)
+    opcode += ".multicast::cluster";
+  opcode += ".b64 [$1]";
+  if (mask) {
+    opcode += ", $2";
+    auto *maskOperand = ptxBuilder.newOperand(mask, "h");
+    ptxOperands.push_back(maskOperand);
   }
+  opcode += ";";
   auto &barrierOp = *ptxBuilder.create(opcode);
   barrierOp(ptxOperands, /*onlyAttachMLIRArgs=*/true);
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
@@ -368,7 +386,8 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
                              Value a, Value b, Value loadedA, Value loadedB,
                              MemDescType dTensorTy, Value useDFlag, Value pred,
                              ValueRange barriers, ValueRange barrierPreds,
-                             bool twoCTAs, bool tlxPairedMMA,
+                             bool twoCTAs, ValueRange commitDescs,
+                             bool tlxPairedMMA,
                              bool opKindIsMXFP4, const DotConversion &op) {
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -499,7 +518,8 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
     Value commitPred = tb.and_(barrierPred, elect);
     auto smemObj =
         LLVM::getSharedMemoryObjectFromStruct(loc, barrier, i64_ty, rewriter);
-    createMMACommit(rewriter, loc, smemObj.getBase(), commitPred, twoCTAs);
+    createMMACommit(rewriter, loc, smemObj.getBase(), commitPred, twoCTAs,
+                    commitDescs);
   }
   LLVM::BrOp::create(rewriter, loc, endBlock);
   return success();
@@ -514,6 +534,13 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
   MemDescType dTensorTy = op.getD().getType();
   auto dLayout = cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
   bool twoCTAs = ttng::getModuleTwoCTAs(op) || tlx::tlxEnablePairedMMA(op);
+  SmallVector<Value> commitDescs;
+  if (op.getMulticast()) {
+    if (isa<SharedEncodingTrait>(aTensorTy.getEncoding())) {
+      commitDescs.push_back(op.getA());
+    }
+    commitDescs.push_back(op.getB());
+  }
 
   DotConversion dot;
 
@@ -550,12 +577,11 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                   useInitAcc, desc.aInTmem, twoCTAs);
   };
 
-  return convertDotImpl(typeConverter, rewriter, loc, op.getA(), op.getB(),
-                        adaptor.getA(), adaptor.getB(), dTensorTy,
-                        adaptor.getUseD(), adaptor.getPred(),
-                        adaptor.getBarriers(), adaptor.getBarrierPreds(),
-                        twoCTAs, tlx::tlxEnablePairedMMA(op),
-                        /*opKindIsMXFP4=*/false, dot);
+  return convertDotImpl(
+      typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
+      adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
+      adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs, commitDescs,
+      tlx::tlxEnablePairedMMA(op), /*opKindIsMXFP4=*/false, dot);
 }
 
 int64_t getFormatBitSize(ScaleDotElemType type) {
@@ -671,7 +697,7 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
       typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
       adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
       adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs,
-      tlx::tlxEnablePairedMMA(op), opKindIsMXFP4, dot);
+      ValueRange{}, tlx::tlxEnablePairedMMA(op), opKindIsMXFP4, dot);
 }
 
 //===----------------------------------------------------------------------===//
@@ -727,8 +753,16 @@ struct TCGen5CommitOpConversion
     if (adaptor.getPred())
       pred = b.and_(adaptor.getPred(), pred);
 
-    createMMACommit(rewriter, op.getLoc(), smemObj.getBase(), pred,
-                    ttng::getModuleTwoCTAs(op) || tlx::tlxEnablePairedMMA(op));
+    bool twoCTAs = ttng::getModuleTwoCTAs(op) || tlx::tlxEnablePairedMMA(op);
+    if (twoCTAs) {
+      Value leftClusterId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+      leftClusterId = b.and_(leftClusterId, b.i32_val(1));
+      Value cluster0 = b.icmp_eq(leftClusterId, b.i32_val(0));
+      pred = b.and_(pred, cluster0);
+    }
+
+    createMMACommit(rewriter, op.getLoc(), smemObj.getBase(), pred, twoCTAs,
+                    op.getDescs());
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1442,31 +1442,41 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto zero = b.i32_val(0);
     auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
-    auto maskCGABroadcast = smemLayout.getFreeVariableMasks().lookup(kBlock);
+    uint32_t maskCGABroadcast =
+        smemLayout.getFreeVariableMasks().lookup(kBlock);
     bool multicast = op.getMulticast() && maskCGABroadcast != 0;
     Value multicastMask;
     Value barrierPtr = barrierMemObj.getBase();
     if (multicast) {
-      auto numCTAs = ttg::lookupNumCTAs(op);
-      multicastMask = LLVM::NVIDIA::createTMAMulticastMask(
-          loc, rewriter, maskCGABroadcast, numCTAs);
+      multicastMask =
+          LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, maskCGABroadcast);
       // If we multicast, we emit the full message from the representative CTA
       // meaning the CTA with the lowest CTA id in a multicast group.
       auto ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
       pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
     }
 
-    auto barrierMask =
+    uint32_t barrierMask =
         toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
-    if (barrierMask) {
+    // We emit a cluster-level barrier if we change the barrier and we don't
+    // multicast over that dimension (in which case that CTA would be predicated
+    // out)
+    bool clusterBarrier = barrierMask & ~maskCGABroadcast;
+    if (clusterBarrier) {
       // This part is to support TMA into tcgen05.mma 2CTA mostly, i.e.,
       // barrierMask == 1
       // Mask with ones on the bits where the CTA broadcasts.
       // This is a trick from cutlass to implement a faster `mapa`.
-      auto fullMask = ~(barrierMask << 24);
+      uint32_t fullMask = ~(barrierMask << 24);
       Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
       barrierInt = b.and_(barrierInt, b.i32_val(fullMask));
       barrierPtr = b.inttoptr(barrierPtr.getType(), barrierInt);
+    }
+
+    // Don't set cta_group::1 as it doesn't exist pre-Blackwell
+    std::string ctaGroup;
+    if (getModuleTwoCTAs(op)) {
+      ctaGroup = "cta_group::2.";
     }
 
     // The bounding box inner dimension must be less than or equal to the
@@ -1474,6 +1484,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html#group__CUDA__TENSOR__MEMORY_1ga7c7d2aaac9e49294304e755e6f341d7
     // We clamp the block size and the codegen will emit multiple copy
     // operations.
+
     for (int copyIdx = 0; copyIdx < numCopies; copyIdx += numWarps) {
       int numWarpsToCopy = std::min(numCopies - copyIdx, numWarps);
       if (numWarpsToCopy == 1)
@@ -1493,14 +1504,14 @@ struct AsyncTMACopyGlobalToLocalOpConversion
           ptxBuilderTMA.newOperand(shMemPtr, "r"),
           ptxBuilderTMA.newOperand(adaptor.getDesc(), "l")};
       std::string tmaInst =
-          "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
-          "d.shared::cluster.global.mbarrier::complete_tx::bytes";
+          "@$0 cp.async.bulk.tensor." + std::to_string(rank) + "d." + ctaGroup +
+          "shared::" + ((clusterBarrier || multicast) ? "cluster" : "cta") +
+          ".global.mbarrier::complete_tx::bytes";
       if (op.getTwoCta())
         tmaInst += ".cta_group::2";
-      auto multicastMask = op.getMulticastTargets();
-      if (multicastMask != nullptr)
+      auto tlxMulticastMask = op.getMulticastTargets();
+      if (multicast || tlxMulticastMask != nullptr)
         tmaInst += ".multicast::cluster";
-      // Add L2 cache hint modifier if eviction policy is specified
       if (l2PolicyReg)
         tmaInst += ".L2::cache_hint";
       tmaInst += " [$1], [$2, {";
@@ -1526,8 +1537,9 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       operands.push_back(
           ptxBuilderTMA.newOperand(barrierMemObj.getBase(), "r"));
       tmaInst += "}], [$" + std::to_string(operandIdx++) + "]";
-      if (multicastMask != nullptr) {
-        operands.push_back(ptxBuilderTMA.newOperand(multicastMask, "h"));
+      Value effectiveMulticastMask = multicast ? multicastMask : tlxMulticastMask;
+      if (effectiveMulticastMask != nullptr) {
+        operands.push_back(ptxBuilderTMA.newOperand(effectiveMulticastMask, "h"));
         tmaInst += ", $" + std::to_string(operandIdx++);
       }
       // Add L2 cache policy operand if specified

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -552,7 +552,9 @@ static void createCommit(ConversionPatternRewriter &rewriter, Location loc,
              "tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::"
              "cluster.multicast::cluster.b64 [$1], $2;";
   } else {
-    opcode = "@$0 tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64 [$1];";
+    opcode =
+        "@$0 tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster"
+        ".b64 [$1];";
   }
   auto &barrierOp = *ptxBuilder.create(opcode);
   barrierOp(ptxOperands, /*onlyAttachMLIRArgs=*/true);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -304,7 +304,7 @@ private:
       // all tcgen05 ops have to be consistent with module attr on this.
 
       // Case 1: explicit TCGen5CommitOp from front end or earlier passes
-      if (tcgen5CommitOp.getTwoCtas()) {
+      if (ttng::getModuleTwoCTAs(op) || tlx::tlxEnablePairedMMA(op)) {
         llvm::SetVector<Value> bars;
         bars.insert(tcgen5CommitOp.getBarrier());
         return bars;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -150,7 +150,8 @@ Value createLeaderCTAPredicate(Location loc, RewriterBase &rewriter) {
 }
 
 Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
-                             uint16_t broadcastBits, int numCTAs) {
+                             uint16_t broadcastBits) {
+  int numCTAs = triton::gpu::lookupNumCTAs(rewriter);
   int blockBits = llvm::Log2_32(numCTAs);
   uint32_t fixedBits = (~broadcastBits) & (numCTAs - 1);
   uint32_t pattern = 1;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -63,7 +63,7 @@ LogicalResult lowerLdStMatrix(
 // where for ctaId, it sets as 1's the positions that are in the same broadcast
 // group
 Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
-                             uint16_t broadcastBits, int numCTAs);
+                             uint16_t broadcastBits);
 } // namespace NVIDIA
 } // namespace LLVM
 

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -451,7 +451,8 @@ void init_triton_tlx_ir(py::module &&m) {
                  tokType, a, b, d, Value(),
                  useD.has_value() ? useD.value() : predTrue /*useD*/,
                  pred.has_value() ? pred.value() : predTrue /*pred */, twoCTAs,
-                 ValueRange(mBarriers), ValueRange(barrierPreds), isAsync);
+                 /*multicast=*/false, ValueRange(mBarriers),
+                 ValueRange(barrierPreds), isAsync);
            })
       .def("create_tcgen5_dot_scaled",
            [](TritonOpBuilder &self, Value a, Value b, Value d, Value aScale,
@@ -475,7 +476,8 @@ void init_triton_tlx_ir(py::module &&m) {
            })
       .def("create_tcgen05_commit",
            [](TritonOpBuilder &self, Value &barrier, Value &pred) -> void {
-             self.create<ttng::TCGen5CommitOp>(barrier, pred);
+             self.create<ttng::TCGen5CommitOp>(barrier, pred,
+                                                /*descs=*/ValueRange{});
            })
       .def("create_async_commit_group",
            [](TritonOpBuilder &self,


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9071

Upstream commit message:
```
> [BACKEND] Add tcgen05.mma + multicast support (#9071)
```

Conflict Resolution:
- File: third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
  Action: Merged additive parameters (commitDescs from upstream, tlxPairedMMA from local) into convertDotImpl signature and all call sites. Preserved local TLX paired MMA logic alongside upstream multicast commit desc support. Added upstream's cluster0 pred filtering in TCGen5CommitOpConversion while keeping local tlxEnablePairedMMA in twoCTAs calculation.
  Reason: Both sides add independent features to the same functions — upstream adds multicast descriptor support, local adds TLX paired MMA support. Both must coexist.
- File: third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
  Action: Adopted upstream's dynamic TMA instruction builder (ctaGroup, conditional shared::cluster/cta) while preserving local TLX-specific op.getTwoCta() and op.getMulticastTargets() code paths. Used effectiveMulticastMask to handle both upstream and TLX multicast operands.
  Reason: Upstream refactored TMA instruction construction to be dynamic; local had TLX-specific extensions on the same code. Merged both approaches.
- File: third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
  Action: Added .shared::cluster qualifier to the non-twoCTAs opcode path, matching upstream's change.
  Reason: Upstream added .shared::cluster to the commit opcode; local had a different code structure (if/else with multicast) but the same qualifier was missing from the non-twoCTAs branch.

Raw Conflicts: https://www.internalfb.com/intern/paste/P2293022971/
Resolution Diff: https://www.internalfb.com/intern/paste/P2293025741/

Diff Comparison: https://www.internalfb.com/intern/paste/P2293027216/

Test Fix:
- triton_tlx.cc: Added `multicast=false` param to TCGen5MMAOp::create() and `descs=ValueRange{}` to TCGen5CommitOp::create() to match new upstream op signatures
- WSCodePartition.cpp: Added `pred=Value()` and `descs=ValueRange{}` to two TCGen5CommitOp::createWithAsyncTaskIds() calls
- TritonGPUToLLVM.cpp: Replaced removed `tcgen5CommitOp.getTwoCtas()` with `ttng::getModuleTwoCTAs(op) || tlx::tlxEnablePairedMMA(op)` to match upstream's removal of two_ctas from TCGen5CommitOp

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: f1d668bfc2f57eb00e4454da9b41e8872b1e2314

Differential Revision: D102790730


