### PR TITLE
[TLX] Fix WarpSpecializeOp captures after upstream refactor (#9133)

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1120,8 +1120,12 @@ void init_gluon_ir(py::module &&m) {
             return *self.getPartitionRegions()[idx];
           },
           ret::reference)
-      .def("set_requested_registers", [](ttg::WarpSpecializeOp &self,
-                                         std::vector<int> &requestedRegisters) {
-        self.setRequestedRegisters(requestedRegisters);
+      .def("set_requested_registers",
+           [](ttg::WarpSpecializeOp &self,
+              std::vector<int> &requestedRegisters) {
+             self.setRequestedRegisters(requestedRegisters);
+           })
+      .def("get_partition_op", [](ttg::WarpSpecializeOp &self) -> OpState {
+        return self.getPartitionOp();
       });
 }

--- a/third_party/tlx/language/tlx/compiler/code_generator.py
+++ b/third_party/tlx/language/tlx/compiler/code_generator.py
@@ -289,7 +289,9 @@ def visit_withAsyncTasks(self, node):
                 index += task_replicate
                 block.erase()
 
-        # Add captures
+        # Add captures to the partitions op (which owns explicitCaptures
+        # after the upstream refactor in PR #9133).
+        partition_op = ws_op.get_partition_op()
         captures = sorted(v for v in (liveins.keys() & self.used_vars) if not _is_constexpr(liveins[v]))
         for name in captures:
             val = liveins[name]
@@ -297,10 +299,10 @@ def visit_withAsyncTasks(self, node):
                 for field in val.type.fields:
                     v = getattr(val, field[0])
                     for h in _flatten_value_handles(v):
-                        ws_op.append_operand(h)
+                        partition_op.append_operand(h)
             else:
                 for h in _flatten_value_handles(val):
-                    ws_op.append_operand(h)
+                    partition_op.append_operand(h)
 
         # real codegen
         index = 0


### PR DESCRIPTION
Upstream PR #9133 (cherry-picked as 750145bc6) moved explicitCaptures from WarpSpecializeOp to WarpSpecializePartitionsOp. The TLX code generator was still calling ws_op.append_operand() on the parent op which no longer has operand storage, causing an MLIR assertion:
  "inserting operands without an operand storage"

Fix: add get_partition_op() binding to expose WarpSpecializePartitionsOp, then call partition_op.append_operand() instead of ws_op.append_operand() in visit_withAsyncTasks.