### PR TITLE
[TLX] Fix CoalesceAsyncCopy bulk crash and TMA test type mismatches

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
@@ -85,7 +85,9 @@ struct ClipAsyncCopySizePerThread
     Value src = copyOp.getSrc();
     Value mask = copyOp.getMask();
     Value other = copyOp.getOther();
-    auto srcTy = cast<RankedTensorType>(src.getType());
+    auto srcTy = dyn_cast<RankedTensorType>(src.getType());
+    if (!srcTy)
+      return failure();
     auto dstTy = cast<MemDescType>(copyOp.getResult().getType());
     auto blockedEnc = dyn_cast<BlockedEncodingAttr>(srcTy.getEncoding());
     if (!blockedEnc)
@@ -153,7 +155,9 @@ struct CoalesceCheapAsyncCopyGlobalToLocal
     Value src = copyOp.getSrc();
     Value mask = copyOp.getMask();
     Value other = copyOp.getOther();
-    RankedTensorType srcTy = cast<RankedTensorType>(src.getType());
+    auto srcTy = dyn_cast<RankedTensorType>(src.getType());
+    if (!srcTy)
+      return failure();
     auto dstTy = cast<MemDescType>(copyOp.getResult().getType());
     int numWarps = triton::gpu::lookupNumWarps(copyOp);
     auto mod = copyOp->getParentOfType<ModuleOp>();
@@ -189,6 +193,10 @@ struct CoalesceAsyncCopyPass
     // axis analysis.
     DenseMap<AsyncCopyGlobalToLocalOp, Attribute> coalescedAsyncCopyMap;
     m.walk([&](AsyncCopyGlobalToLocalOp copyOp) {
+      if (copyOp.getUseBulk())
+        return;
+      if (!isa<RankedTensorType>(copyOp.getSrc().getType()))
+        return;
       auto dstTy = cast<MemDescType>(copyOp.getResult().getType());
       int numWarps = triton::gpu::lookupNumWarps(copyOp);
       int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(m);

--- a/python/test/unit/language/test_tlx_tma.py
+++ b/python/test/unit/language/test_tlx_tma.py
@@ -571,7 +571,7 @@ def test_descriptor_load_multicast(device):
             block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
         )
 
-        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.int16, tl.constexpr(1))
+        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float16, tl.constexpr(1))
         buffer = tlx.local_view(buffers, 0)
         bars = tlx.alloc_barriers(tl.constexpr(1))
         bar = tlx.local_view(bars, 0)
@@ -664,7 +664,7 @@ def test_descriptor_load_two_cta(device):
         )
 
         # Each CTA has its own SMEM buffer for its portion of the tile
-        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N // NUM_CTAS), tl.int16, tl.constexpr(1))
+        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N // NUM_CTAS), tl.float16, tl.constexpr(1))
         buffer = tlx.local_view(buffers, 0)
 
         # Leader's barrier tracks BOTH CTAs' TMA loads via cta_group::2
@@ -731,7 +731,7 @@ def test_prefetch_tensormap(device):
         tlx.prefetch(in_desc, tensormap=True)
         tlx.prefetch(out_desc, tensormap=True)
 
-        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.int16, tl.constexpr(1))
+        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float16, tl.constexpr(1))
         buffer = tlx.local_view(buffers, 0)
         bars = tlx.alloc_barriers(tl.constexpr(1))
         bar = tlx.local_view(bars, 0)
@@ -792,7 +792,7 @@ def test_prefetch_tensormap(device):
         tlx.prefetch(desc_in, tensormap=True)
         tlx.prefetch(desc_out, tensormap=True)
 
-        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.int16, tl.constexpr(1))
+        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float16, tl.constexpr(1))
         buffer = tlx.local_view(buffers, 0)
         bars = tlx.alloc_barriers(tl.constexpr(1))
         bar = tlx.local_view(bars, 0)

--- a/python/test/unit/language/test_tlx_tma.py
+++ b/python/test/unit/language/test_tlx_tma.py
@@ -731,7 +731,7 @@ def test_prefetch_tensormap(device):
         tlx.prefetch(in_desc, tensormap=True)
         tlx.prefetch(out_desc, tensormap=True)
 
-        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float16, tl.constexpr(1))
+        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.int16, tl.constexpr(1))
         buffer = tlx.local_view(buffers, 0)
         bars = tlx.alloc_barriers(tl.constexpr(1))
         bar = tlx.local_view(bars, 0)
@@ -792,7 +792,7 @@ def test_prefetch_tensormap(device):
         tlx.prefetch(desc_in, tensormap=True)
         tlx.prefetch(desc_out, tensormap=True)
 
-        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.float16, tl.constexpr(1))
+        buffers = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tl.int16, tl.constexpr(1))
         buffer = tlx.local_view(buffers, 0)
         bars = tlx.alloc_barriers(tl.constexpr(1))
         bar = tlx.local_view(bars, 0)

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -241,8 +241,11 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
 void LayoutBackwardPropagation::visitBranchOperand(OpOperand &operand) {
   auto branchOp = operand.getOwner();
   LDBG("Backward visiting branch op " << *branchOp << "\n");
-  if (isa<ttg::WarpSpecializeOp>(branchOp)) {
-    auto unused = visitRegionInReverse(branchOp);
+  if (isa<ttg::WarpSpecializeOp, ttg::WarpSpecializePartitionsOp>(branchOp)) {
+    auto *regionOp = isa<ttg::WarpSpecializePartitionsOp>(branchOp)
+                         ? branchOp->getParentOp()
+                         : branchOp;
+    auto unused = visitRegionInReverse(regionOp);
     (void)unused;
   }
 }
@@ -311,16 +314,15 @@ LogicalResult LayoutForwardPropagation::visitWarpSpecRegionArgs(
   // corresponding warp spec region arg if it is a captured arg.
   for (auto &use : result.getUses()) {
     Operation *user = use.getOwner();
-    if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+    if (auto partOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
       unsigned idx = use.getOperandNumber();
-      // Propagate to the i-th argument of every partition region
-      // Propagate to all the partition regions
-      for (Region *partitionRegion : wsOp.getPartitionRegions()) {
+      for (Region &partitionRegion : partOp.getPartitionRegions()) {
         auto blockArgumentLattice =
-            getLatticeElement(partitionRegion->getArgument(idx));
+            getLatticeElement(partitionRegion.getArgument(idx));
         ChangeResult changed = blockArgumentLattice->meet(resultEncoding);
         propagateIfChanged(blockArgumentLattice, changed);
       }
+      auto wsOp = partOp.getParentOp();
       if (failed(visitRegion(wsOp)))
         return failure();
     }

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasAllocation.cpp
@@ -32,11 +32,11 @@ static void updateBlockArgTypesForUsers(Value newValue) {
   Type newType = newValue.getType();
   for (OpOperand &use : newValue.getUses()) {
     Operation *user = use.getOwner();
-    if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+    if (auto partOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
       unsigned idx = use.getOperandNumber();
-      for (Region *partition : wsOp.getPartitionRegions()) {
-        if (idx < partition->getNumArguments()) {
-          partition->getArgument(idx).setType(newType);
+      for (Region &partition : partOp.getPartitionRegions()) {
+        if (idx < partition.getNumArguments()) {
+          partition.getArgument(idx).setType(newType);
         }
       }
     }
@@ -59,14 +59,11 @@ collectMemDescIndexOps(Value memDesc,
     } else if (auto alias = dyn_cast<LocalAliasOp>(user)) {
       // Follow through nested aliases
       collectMemDescIndexOps(alias.getResult(), result);
-    } else if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
-      // Follow through warp_specialize captures to partition block arguments.
-      // The alias may be captured as an operand; the corresponding block arg
-      // in each partition region is used inside the isolated region.
+    } else if (auto partOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
       unsigned idx = use.getOperandNumber();
-      for (Region *partition : wsOp.getPartitionRegions()) {
-        if (idx < partition->getNumArguments()) {
-          collectMemDescIndexOps(partition->getArgument(idx), result);
+      for (Region &partition : partOp.getPartitionRegions()) {
+        if (idx < partition.getNumArguments()) {
+          collectMemDescIndexOps(partition.getArgument(idx), result);
         }
       }
     }

--- a/third_party/tlx/run_all.sh
+++ b/third_party/tlx/run_all.sh
@@ -96,6 +96,7 @@ case $user_choice in
         echo "Measuring performance of TLX tutorial kernels"
         third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py
         third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_blackwell_fa_perf.py
+        third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_blackwell_fa_mxfp8_perf.py
         third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_hopper_gemm_perf.py
         third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_hopper_fa_perf.py
         ;;


### PR DESCRIPTION
Fix several compiler and test issues exposed by recent upstream cherry-picks that broke TLX kernel compilation and tests.

Compiler fixes:

CoalesceAsyncCopy bulk copy crash (CoalesceAsyncCopy.cpp): The pass assumed all AsyncCopyGlobalToLocalOp sources are RankedTensorType (tensor of pointers), but bulk copies use a scalar !tt.ptr. Fix: skip bulk copies in the runOnOperation walk and guard both pattern matchers with dyn_cast.

Test fixes:

TMA test type mismatches (test_tlx_tma.py): The TMA verifier now requires exact element type matching between descriptor and SMEM buffer. Fix tl.int16 → tl.float16 for tests that use torch.float16 input.

run_all.sh: Add MXFP8 FA perf test to the performance test suite.