### PR TITLE
[triton][beta] Fix null pointer crash in PartitionScheduling and fix stale lit tests

### DIFF
--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -429,7 +429,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_local_to_global_with_token_wait
@@ -447,17 +447,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#bar_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_store_token_wait_with_barriers
   // CHECK: nvvm.cp.async.bulk.wait_group 0 {read}
   // CHECK: nvvm.barrier0
   // CHECK: mbarrier.arrive.shared::cta.b64
-  tt.func @tma_store_token_wait_with_barriers(%tma: !tt.tensordesc<tensor<128x128xf32, #shared1>>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) {
+  tt.func @tma_store_token_wait_with_barriers(%tma: !tt.tensordesc<tensor<128x128xf32, #shared1>>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem>, %x: i32, %barrier: !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>) {
     %true = arith.constant true
     %token = ttng.async_tma_copy_local_to_global %tma[%x, %x] %alloc : !tt.tensordesc<tensor<128x128xf32, #shared1>>, !ttg.memdesc<128x128xf32, #shared1, #smem> -> !ttg.async.token
-    ttng.async_tma_store_token_wait %token, %barrier[%true] : !ttg.async.token, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.async_tma_store_token_wait %token, %barrier[%true] : !ttg.async.token, !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>
     tt.return
   }
 }

--- a/test/NVWS/insert_aref.mlir
+++ b/test/NVWS/insert_aref.mlir
@@ -745,7 +745,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         scf.yield {ttg.partition = array<i32: 1, 2>} %true, %26 : i1, !ttg.async.token
       } {tt.scheduled_max_stage = 2 : i32, ttg.partition = array<i32: 1, 2>, ttg.partition.outputs = [array<i32: 1, 2>, array<i32: 1>]}
       %result_0, %token_1 = ttng.tmem_load %result[%19#1] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
-      %20 = tt.fp_to_fp %result_0 {ttg.partition = array<i32: 0>}, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
+      %20 = tt.fp_to_fp %result_0, rounding = rtne {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
       %21 = ttg.convert_layout %20 {ttg.partition = array<i32: 0>} : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #blocked1>
       tt.descriptor_store %arg2[%15, %16], %21 {ttg.partition = array<i32: 0>} : !tt.tensordesc<tensor<128x128xf8E4M3FN, #shared>>, tensor<128x128xf8E4M3FN, #blocked1>
       scf.yield {ttg.partition = array<i32: 0, 1, 2>} %token_1 : !ttg.async.token

--- a/test/Proton/proton_to_protongpu.mlir
+++ b/test/Proton/proton_to_protongpu.mlir
@@ -188,7 +188,7 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 
 module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-GMEM-LABEL: global_mem_buffer
-  // CHECK-GMEM: %[[SCRATCH:.*]] = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+  // CHECK-GMEM: %[[SCRATCH:.*]] = ttg.global_scratch_alloc {alignment = 128 : i32, backend = "proton", nbytes = 1152 : i32} : !tt.ptr<i32>
   // CHECK-GMEM: proton_gpu.initialize %[[SCRATCH]] : !tt.ptr<i32>
   // CHECK-GMEM: %[[PTR:.*]] = tt.addptr %[[SCRATCH]]
   // CHECK-GMEM: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[PTR]] : !tt.ptr<i32> -> <1024, #proton_gpu.global_memory, warp>


### PR DESCRIPTION
Summary:
Fix a SEGV in `propagatePartitions` when processing nested `scf.for` loops. The recently added recursion into inner loops exposed a bug where `Partition::iterateUses` produces uses from the outer loop, causing `findAncestorOpInBlock` to return null. The null pointer propagated into the worklist and crashed in `visitNestedOperands`. Added null guards in `iterateUsers` and the `useCallback` lambda.

Also fix three stale lit tests:
- `tritonnvidiagpu_to_llvm.mlir`: removed deprecated `CTAsPerCGA`/`CTASplitNum`/`CTAOrder` keys from `nvmma_shared`, and used `swizzled_shared` for the 1D barrier memdesc
- `proton_to_protongpu.mlir`: updated CHECK-GMEM expectation from `proton_gpu.global_scratch_alloc` to `ttg.global_scratch_alloc` with `backend = "proton"`
- `insert_aref.mlir`: fixed `tt.fp_to_fp` attribute ordering (`rounding` must precede the attr-dict per the custom parser)

Authored with Claude.

Reviewed By: htyu

Differential Revision: D103070990


