### PR TITLE
[TritonCC/AOTT][1/N] Emit standalone Level 1 launcher C source alongside cubin (#1385)

### DIFF
--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -1,0 +1,312 @@
+"""Tests for Level 0 launch metadata schema generation.
+
+Validates that the Triton compiler emits a versioned, machine-readable
+launch metadata JSON alongside the cubin, and that the schema fields
+are consistent with the existing metadata bag.
+"""
+
+import json
+
+import pytest
+import triton
+import triton.language as tl
+from triton.compiler.compiler import ASTSource, compile as triton_compile
+
+
+@triton.jit
+def add_kernel(X, Y, OUT, N, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(X + offs, mask=mask)
+    y = tl.load(Y + offs, mask=mask)
+    tl.store(OUT + offs, x + y, mask=mask)
+
+
+@triton.jit
+def kernel_with_constant(X, N, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(X + offs, mask=mask)
+    tl.store(X + offs, x + 1, mask=mask)
+
+
+def _compile_kernel(fn, signature, constexprs=None, attrs=None):
+    """Helper to compile a kernel and return the CompiledKernel."""
+    target = triton.runtime.driver.active.get_current_target()
+    src = ASTSource(fn=fn, signature=signature, constexprs=constexprs, attrs=attrs)
+    return triton_compile(src, target=target)
+
+
+@pytest.mark.parametrize("dtype", ["*fp32"])
+def test_launch_metadata_exists(dtype):
+    """asm['launch_metadata'] should exist and be valid JSON."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": dtype, "Y": dtype, "OUT": dtype, "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    assert "launch_metadata" in compiled.asm, "launch_metadata not found in asm dict"
+    schema = json.loads(compiled.asm["launch_metadata"])
+    assert isinstance(schema, dict)
+
+
+def test_abi_version():
+    """abi_version should be 1."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+    assert schema is not None
+    assert schema["abi_version"] == 1
+
+
+def test_entry_name_matches():
+    """entry_name in schema should match the kernel name from ptx."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+    assert schema["entry_name"] == compiled.metadata.name
+
+
+def test_launch_fields_match_metadata():
+    """Launch-critical fields should match the existing metadata."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+    md = compiled.metadata
+
+    assert schema["num_warps"] == md.num_warps
+    assert schema["num_ctas"] == md.num_ctas
+    assert schema["shared_mem"] == md.shared
+    assert schema["launch_cooperative_grid"] == md.launch_cooperative_grid
+    assert schema["launch_pdl"] == md.launch_pdl
+    assert schema["global_scratch_size"] == md.global_scratch_size
+    assert schema["global_scratch_align"] == md.global_scratch_align
+    assert schema["profile_scratch_size"] == md.profile_scratch_size
+    assert schema["profile_scratch_align"] == md.profile_scratch_align
+
+
+def test_constants_excluded_from_args():
+    """Compile-time constants (constexprs) should appear in 'constants', not 'args'."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+
+    arg_names = [a["name"] for a in schema["args"]]
+    assert "BLOCK" not in arg_names, "constexpr BLOCK should not be in args"
+    assert len(schema["constants"]) > 0, "constants dict should not be empty"
+
+    # The runtime args should be X, Y, OUT, N
+    assert "X" in arg_names
+    assert "Y" in arg_names
+    assert "OUT" in arg_names
+    assert "N" in arg_names
+
+
+def test_args_types():
+    """Each arg should have correct type information."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+    args_by_name = {a["name"]: a for a in schema["args"]}
+
+    assert args_by_name["X"]["type"] == "*fp32"
+    assert args_by_name["Y"]["type"] == "*fp32"
+    assert args_by_name["OUT"]["type"] == "*fp32"
+    assert args_by_name["N"]["type"] == "i32"
+
+
+def test_args_have_index():
+    """Each arg should have a positional index."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+    for arg in schema["args"]:
+        assert "index" in arg, f"arg {arg['name']} missing index"
+        assert isinstance(arg["index"], int)
+
+
+def test_pointer_divisibility():
+    """Pointer args with divisibility hints should have divisible_by in schema."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+        attrs={(0, ): [("tt.divisibility", 16)], (1, ): [("tt.divisibility", 16)], (2, ): [("tt.divisibility", 16)]},
+    )
+    schema = compiled.launch_metadata_schema
+    args_by_name = {a["name"]: a for a in schema["args"]}
+
+    assert args_by_name["X"].get("divisible_by") == 16
+    assert args_by_name["Y"].get("divisible_by") == 16
+    assert args_by_name["OUT"].get("divisible_by") == 16
+    # N is a scalar, should not have divisible_by
+    assert "divisible_by" not in args_by_name["N"]
+
+
+def test_schema_required_fields():
+    """All required fields should be present in the schema."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+    required_fields = [
+        "abi_version",
+        "entry_name",
+        "num_warps",
+        "num_ctas",
+        "shared_mem",
+        "cluster_dims",
+        "preferred_cluster_dims",
+        "launch_cooperative_grid",
+        "launch_pdl",
+        "global_scratch_size",
+        "global_scratch_align",
+        "profile_scratch_size",
+        "profile_scratch_align",
+        "tmem_size",
+        "args",
+        "constants",
+        "tensordesc_meta",
+    ]
+    for field in required_fields:
+        assert field in schema, f"Missing required field: {field}"
+
+
+def test_cluster_dims_is_list():
+    """cluster_dims and preferred_cluster_dims should be JSON-serializable lists."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = compiled.launch_metadata_schema
+    assert isinstance(schema["cluster_dims"], list)
+    assert isinstance(schema["preferred_cluster_dims"], list)
+    assert len(schema["cluster_dims"]) == 3
+    assert len(schema["preferred_cluster_dims"]) == 3
+
+
+def test_launch_metadata_schema_property():
+    """CompiledKernel.launch_metadata_schema should return parsed dict."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    assert compiled.launch_metadata_schema is not None
+    assert isinstance(compiled.launch_metadata_schema, dict)
+    assert compiled.launch_metadata_schema["abi_version"] == 1
+
+
+# =========================================================================
+# Level 1: Standalone launcher source (asm["launcher_src"])
+# =========================================================================
+
+
+def test_launcher_src_exists():
+    """asm['launcher_src'] should exist and be a non-empty string."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    assert "launcher_src" in compiled.asm, "launcher_src not found in asm dict"
+    src = compiled.asm["launcher_src"]
+    assert isinstance(src, str)
+    assert len(src) > 0
+
+
+def test_launcher_src_includes_launch_h():
+    """Generated C source should include triton/runtime/launch.h."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    src = compiled.asm["launcher_src"]
+    assert '#include "triton/runtime/launch.h"' in src
+
+
+def test_launcher_src_no_python_h():
+    """Generated C source must NOT depend on Python.h."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    src = compiled.asm["launcher_src"]
+    assert "Python.h" not in src
+    assert "PyObject" not in src
+    assert "PyArg_ParseTuple" not in src
+
+
+def test_launcher_src_has_launch_function():
+    """Generated C source should contain a triton_launch_<kernel> function."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    src = compiled.asm["launcher_src"]
+    assert "CUresult triton_launch_" in src
+
+
+def test_launcher_src_has_args_struct():
+    """Generated C source should define a typed args struct."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    src = compiled.asm["launcher_src"]
+    assert "_args_t;" in src
+    assert "CUdeviceptr X;" in src
+    assert "CUdeviceptr Y;" in src
+    assert "CUdeviceptr OUT;" in src
+    assert "int32_t N;" in src
+
+
+def test_launcher_src_bakes_constants():
+    """Compile-time constants (num_warps, shared_mem) should be baked in."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    src = compiled.asm["launcher_src"]
+    md = compiled.metadata
+    assert f"/*num_warps=*/{md.num_warps}" in src
+    assert f"/*shared_mem=*/{md.shared}u" in src
+
+
+def test_launcher_src_has_abi_version_comment():
+    """Generated source should contain the ABI version as a comment."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    src = compiled.asm["launcher_src"]
+    assert "ABI version: 1" in src

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -423,6 +423,17 @@ def compile(src, target=None, options=None, _env_vars=None):
     # facebook end T207797237
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,
                                                              binary=False)
+    # Generate Level 0 launch metadata schema if the backend supports it.
+    if hasattr(backend, "make_launch_metadata"):
+        launch_metadata = backend.make_launch_metadata(metadata, src)
+        launch_metadata_filename = f"{file_name}.launch_metadata"
+        metadata_group[launch_metadata_filename] = fn_cache_manager.put(json.dumps(launch_metadata),
+                                                                        launch_metadata_filename, binary=False)
+    # Generate Level 1 standalone launcher C source if the backend supports it.
+    if hasattr(backend, "make_launcher_src"):
+        launcher_src = backend.make_launcher_src(metadata, src)
+        launcher_src_filename = f"{file_name}.launcher_src"
+        metadata_group[launcher_src_filename] = fn_cache_manager.put(launcher_src, launcher_src_filename, binary=False)
     fn_cache_manager.put_group(metadata_filename, metadata_group)
 
     # notify any listener
@@ -512,6 +523,14 @@ class CompiledKernel:
         self.module = None
         self.function = None
         self._run = None
+
+    @property
+    def launch_metadata_schema(self):
+        """Return the Level 0 launch metadata schema as a parsed dict, or None."""
+        raw = self.asm.get("launch_metadata")
+        if raw is None:
+            return None
+        return json.loads(raw) if isinstance(raw, str) else raw
 
     def _init_handles(self):
         if self.module is not None:

--- a/python/triton/runtime/launch.h
+++ b/python/triton/runtime/launch.h
@@ -1,0 +1,234 @@
+/*
+ * triton/runtime/launch.h — Minimal runtime header for Triton standalone
+ * launchers.
+ *
+ * This header provides everything a compiler-generated launcher needs to call
+ * cuLaunchKernelEx.  It has NO dependency on Python.h — the generated launcher
+ * is a plain C function callable from C, C++, or via ctypes/cffi.
+ *
+ * Consumers: compiler-generated launcher sources (asm["launcher_src"]),
+ *            TritonCC, AOT-T, custom integrations.
+ */
+
+#ifndef TRITON_RUNTIME_LAUNCH_H
+#define TRITON_RUNTIME_LAUNCH_H
+
+#include <cuda.h>
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -------------------------------------------------------------------------
+ * Error handling
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Check a CUresult and return it if non-zero.
+ * Use inside functions that return CUresult.
+ */
+#define TRITON_CUDA_CHECK(expr)                                                \
+  do {                                                                         \
+    CUresult _triton_err = (expr);                                             \
+    if (_triton_err != CUDA_SUCCESS) {                                         \
+      return _triton_err;                                                      \
+    }                                                                          \
+  } while (0)
+
+/**
+ * Check a CUresult, print an error message and return it if non-zero.
+ * Use for debugging / verbose error reporting.
+ */
+#define TRITON_CUDA_CHECK_LOG(expr)                                            \
+  do {                                                                         \
+    CUresult _triton_err = (expr);                                             \
+    if (_triton_err != CUDA_SUCCESS) {                                         \
+      const char *_triton_err_str = NULL;                                      \
+      cuGetErrorString(_triton_err, &_triton_err_str);                         \
+      fprintf(stderr, "Triton Error [CUDA] at %s:%d: %s\n", __FILE__,          \
+              __LINE__, _triton_err_str ? _triton_err_str : "unknown");        \
+      return _triton_err;                                                      \
+    }                                                                          \
+  } while (0)
+
+/* -------------------------------------------------------------------------
+ * Lazy-loaded cuLaunchKernelEx
+ * ------------------------------------------------------------------------- */
+
+typedef CUresult (*triton_cuLaunchKernelEx_fn)(const CUlaunchConfig *config,
+                                               CUfunction f,
+                                               void **kernelParams,
+                                               void **extra);
+
+static triton_cuLaunchKernelEx_fn g_triton_launch_fn = NULL;
+
+/**
+ * Initialize cuLaunchKernelEx at program startup.
+ * Runs automatically before main() via __attribute__((constructor)).
+ * Thread-safe by virtue of running before any threads are created.
+ *
+ * Note: dlopen handle is intentionally not closed — libcuda.so.1 must remain
+ * loaded for the process lifetime since cuLaunchKernelEx is called on every
+ * kernel launch.
+ */
+__attribute__((constructor)) static void triton_init_launch_kernel_ex(void) {
+  void *lib = dlopen("libcuda.so.1", RTLD_LAZY);
+  if (!lib)
+    return; /* g_triton_launch_fn remains NULL */
+
+  g_triton_launch_fn =
+      (triton_cuLaunchKernelEx_fn)dlsym(lib, "cuLaunchKernelEx");
+}
+
+/**
+ * Get cuLaunchKernelEx function pointer (loaded at startup).
+ * Thread-safe — initialization happens before main().
+ * Returns NULL if libcuda.so.1 is not available.
+ */
+static inline triton_cuLaunchKernelEx_fn triton_get_launch_kernel_ex(void) {
+  return g_triton_launch_fn;
+}
+
+/* -------------------------------------------------------------------------
+ * Launch attribute helpers
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Maximum number of launch attributes a Triton launcher may set.
+ * Currently: PDL, cooperative, cluster dim, cluster scheduling, preferred
+ * cluster dim.
+ */
+#define TRITON_MAX_LAUNCH_ATTRS 5
+
+/**
+ * Build the CUlaunchAttribute array and return the number of attributes set.
+ *
+ * All parameters are compile-time constants baked into the generated launcher.
+ * This function is meant to be called from generated code.
+ */
+static inline unsigned triton_build_launch_attrs(
+    CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS], int launch_pdl,
+    int launch_cooperative_grid, int num_ctas, int launch_cluster,
+    int preferred_cluster_dim_x, int preferred_cluster_dim_y,
+    int preferred_cluster_dim_z) {
+  unsigned n = 0;
+
+  if (launch_pdl) {
+    attrs[n].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+    attrs[n].value.programmaticStreamSerializationAllowed = 1;
+    n++;
+  }
+
+  if (launch_cooperative_grid) {
+    attrs[n].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+    attrs[n].value.cooperative = 1;
+    n++;
+  }
+
+  if (launch_cluster || num_ctas > 1) {
+    /* Triton clusters are always 1-D (num_ctas along x); multi-dimensional
+     * clusters use the ctas_per_cga / PTX .reqnctapercluster path where
+     * num_ctas == 1 and no runtime CLUSTER_DIMENSION attr is needed. */
+    if (num_ctas > 1) {
+      attrs[n].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+      attrs[n].value.clusterDim.x = (unsigned)num_ctas;
+      attrs[n].value.clusterDim.y = 1;
+      attrs[n].value.clusterDim.z = 1;
+      n++;
+    }
+    attrs[n].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+    attrs[n].value.clusterSchedulingPolicyPreference =
+        CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+    n++;
+  }
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+  if (preferred_cluster_dim_x > 0) {
+    attrs[n].id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
+    attrs[n].value.clusterDim.x = (unsigned)preferred_cluster_dim_x;
+    attrs[n].value.clusterDim.y = (unsigned)preferred_cluster_dim_y;
+    attrs[n].value.clusterDim.z = (unsigned)preferred_cluster_dim_z;
+    n++;
+  }
+#else
+  (void)preferred_cluster_dim_x;
+  (void)preferred_cluster_dim_y;
+  (void)preferred_cluster_dim_z;
+#endif
+
+  return n;
+}
+
+/**
+ * Build and execute a CUlaunchConfig.  Consolidates the common launch pattern.
+ *
+ * @param grid          Grid dimensions [x, y, z]
+ * @param num_warps     Warps per block (compile-time constant)
+ * @param num_ctas      CTAs per cluster (compile-time constant)
+ * @param shared_mem    Dynamic shared memory in bytes (compile-time constant)
+ * @param stream        CUDA stream
+ * @param function      CUDA function handle
+ * @param params        Kernel parameter array (void*[])
+ * @param attrs         Pre-built launch attributes
+ * @param num_attrs     Number of launch attributes
+ * @return              CUDA_SUCCESS or error code
+ */
+static inline CUresult
+triton_launch_kernel(const uint32_t grid[3], int num_warps, int num_ctas,
+                     unsigned shared_mem, CUstream stream, CUfunction function,
+                     void **params, CUlaunchAttribute *attrs,
+                     unsigned num_attrs) {
+
+  triton_cuLaunchKernelEx_fn launch_fn = triton_get_launch_kernel_ex();
+  if (!launch_fn)
+    return CUDA_ERROR_NOT_FOUND;
+
+  CUlaunchConfig config;
+  config.gridDimX = grid[0] * (uint32_t)num_ctas;
+  config.gridDimY = grid[1];
+  config.gridDimZ = grid[2];
+  config.blockDimX = 32 * (uint32_t)num_warps;
+  config.blockDimY = 1;
+  config.blockDimZ = 1;
+  config.sharedMemBytes = shared_mem;
+  config.hStream = stream;
+  config.attrs = attrs;
+  config.numAttrs = num_attrs;
+
+  return launch_fn(&config, function, params, NULL);
+}
+
+/* -------------------------------------------------------------------------
+ * Hook support (optional)
+ * ------------------------------------------------------------------------- */
+
+typedef void (*triton_launch_hook_fn)(void *metadata);
+
+/**
+ * Per-translation-unit hook function pointers.  Set by the runtime before
+ * first launch.  If NULL (default), hooks are skipped.
+ *
+ * These are intentionally `static` (per-TU) because each generated launcher
+ * is compiled into its own .so and loaded independently.  For multi-TU
+ * scenarios, the runtime should call triton_set_launch_hooks() on each
+ * loaded launcher .so individually.
+ */
+static triton_launch_hook_fn triton_launch_enter_hook = NULL;
+static triton_launch_hook_fn triton_launch_exit_hook = NULL;
+
+static inline void triton_set_launch_hooks(triton_launch_hook_fn enter,
+                                           triton_launch_hook_fn exit_hook) {
+  triton_launch_enter_hook = enter;
+  triton_launch_exit_hook = exit_hook;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TRITON_RUNTIME_LAUNCH_H */

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -275,6 +275,252 @@ class CUDABackend(BaseBackend):
             preferred[2],
         )
 
+    def make_launch_metadata(self, metadata, src):
+        """Produce a versioned, machine-readable JSON dict describing the kernel launch contract.
+
+        This is the Level 0 metadata schema: a self-contained description of everything
+        a launcher needs to know to call cuLaunchKernelEx for this kernel.  It is stored
+        alongside the cubin as ``asm["launch_metadata"]`` and is intended to replace the
+        implicit metadata bag that downstream consumers currently probe with hasattr guards.
+
+        The schema is purely additive — existing ``pack_metadata()`` / ``make_launcher()``
+        paths are not affected.
+        """
+
+        def _get(key, default=None):
+            """Retrieve a field from metadata, which may be a dict or a namedtuple."""
+            if isinstance(metadata, dict):
+                return metadata.get(key, default)
+            return getattr(metadata, key, default)
+
+        cluster_dims = _get("cluster_dims") or (1, 1, 1)
+        preferred = _get("preferred_ctas_per_cga") or (0, 0, 0)
+
+        # Build the args array from src.signature, excluding compile-time constants.
+        constants = getattr(src, "constants", {})
+        # Normalize constant keys to tuple form for lookup.
+        constant_keys = set()
+        for k in constants:
+            if isinstance(k, str):
+                if hasattr(src, "fn"):
+                    constant_keys.add((src.fn.arg_names.index(k), ))
+                else:
+                    constant_keys.add((k, ))
+            elif isinstance(k, tuple):
+                constant_keys.add(k)
+            else:
+                constant_keys.add((k, ))
+
+        attrs = getattr(src, "attrs", {})
+        arg_names = src.fn.arg_names if hasattr(src, "fn") else None
+
+        args = []
+        for idx, (key, ty) in enumerate(src.signature.items()):
+            # Skip compile-time constants — they go in the "constants" dict.
+            if (idx, ) in constant_keys:
+                continue
+
+            name = key if isinstance(key, str) else (arg_names[idx] if arg_names and idx < len(arg_names) else str(idx))
+            arg_entry = {"name": name, "type": str(ty), "index": idx}
+
+            # Check for tt.divisibility attribute.
+            attr_specs = attrs.get((idx, ), [])
+            for attr_name, attr_val in attr_specs:
+                if attr_name == "tt.divisibility":
+                    arg_entry["divisible_by"] = attr_val
+            args.append(arg_entry)
+
+        # Serialize constants: keys are stringified indices, values are the constant values.
+        constants_dict = {}
+        for k, v in constants.items():
+            if isinstance(k, tuple):
+                str_key = str(k[0]) if len(k) == 1 else str(k)
+            elif isinstance(k, str):
+                if arg_names:
+                    str_key = str(arg_names.index(k))
+                else:
+                    str_key = k
+            else:
+                str_key = str(k)
+            # Convert to JSON-serializable value
+            if isinstance(v, (int, float, bool, str)) or v is None:
+                constants_dict[str_key] = v
+            else:
+                constants_dict[str_key] = str(v)
+
+        tensordesc_meta = _get("tensordesc_meta")
+
+        schema = {
+            "abi_version": 1,
+            "entry_name": _get("name", ""),
+            "num_warps": _get("num_warps"),
+            "num_ctas": _get("num_ctas"),
+            "shared_mem": _get("shared", 0),
+            "cluster_dims": list(cluster_dims),
+            "preferred_cluster_dims": list(preferred),
+            "launch_cooperative_grid": _get("launch_cooperative_grid", False),
+            "launch_cluster": _get("launch_cluster", False),
+            "launch_pdl": _get("launch_pdl", False),
+            "global_scratch_size": _get("global_scratch_size", 0),
+            "global_scratch_align": _get("global_scratch_align", 128),
+            "profile_scratch_size": _get("profile_scratch_size", 0),
+            "profile_scratch_align": _get("profile_scratch_align", 1),
+            "tmem_size": _get("tmem_size", 0),
+            "args": args,
+            "constants": constants_dict,
+            "tensordesc_meta": tensordesc_meta or [],
+        }
+        return schema
+
+    def make_launcher_src(self, metadata, src):
+        """Generate a standalone C launcher source from Level 0 metadata.
+
+        The generated C file includes ``triton/runtime/launch.h`` and implements
+        a single entry point ``triton_launch_<kernel>()`` that sets up
+        CUlaunchConfig with compile-time-known parameters baked in as constants,
+        builds the kernel parameter array, and calls ``cuLaunchKernelEx``.
+
+        The C source has NO dependency on Python.h — it is callable from C, C++,
+        or via ctypes/cffi.  It is stored as ``asm["launcher_src"]`` for
+        inspection and can be compiled by gcc/clang for use in TritonCC, AOT-T,
+        or other C/C++ consumers.
+        """
+        launch_meta = self.make_launch_metadata(metadata, src)
+        kernel_name = launch_meta["entry_name"]
+        safe_name = kernel_name.replace(".", "_")
+
+        # Type mapping: Triton type → C type for the args struct.
+        # WARNING: This map must be kept in sync with Triton's type system.
+        # If a new Triton type is added (e.g., fp8e4m3) and not present here,
+        # we raise an error rather than silently generating incorrect code.
+        _TYPE_TO_C = {
+            "i1": "int8_t",
+            "i8": "int8_t",
+            "i16": "int16_t",
+            "i32": "int32_t",
+            "i64": "int64_t",
+            "u1": "uint8_t",
+            "u8": "uint8_t",
+            "u16": "uint16_t",
+            "u32": "uint32_t",
+            "u64": "uint64_t",
+            "fp16": "uint16_t",
+            "bf16": "uint16_t",
+            "fp32": "float",
+            "f32": "float",
+            "fp64": "double",
+        }
+
+        def _c_type(triton_ty):
+            if triton_ty.startswith("*"):
+                return "CUdeviceptr"
+            if triton_ty.startswith("tensordesc"):
+                return "CUdeviceptr"  # host-side: passed as base pointer
+            c_ty = _TYPE_TO_C.get(triton_ty)
+            if c_ty is None:
+                raise ValueError(f"Unsupported Triton type '{triton_ty}' in launcher codegen. "
+                                 f"Add it to the _TYPE_TO_C map in make_launcher_src().")
+            return c_ty
+
+        args = launch_meta["args"]
+        num_warps = launch_meta["num_warps"]
+        num_ctas = launch_meta["num_ctas"]
+        shared_mem = launch_meta["shared_mem"]
+        cluster_dims = launch_meta["cluster_dims"]
+        preferred = launch_meta["preferred_cluster_dims"]
+        launch_coop = 1 if launch_meta["launch_cooperative_grid"] else 0
+        launch_cluster_flag = 1 if launch_meta.get("launch_cluster", False) else 0
+        launch_pdl = 1 if launch_meta["launch_pdl"] else 0
+        global_scratch_size = launch_meta["global_scratch_size"]
+        profile_scratch_size = launch_meta["profile_scratch_size"]
+
+        lines = []
+        lines.append("/* Generated by Triton compiler — do not edit. */")
+        lines.append(f"/* Kernel: {kernel_name} */")
+        lines.append(f"/* ABI version: {launch_meta['abi_version']} */")
+        lines.append("")
+        lines.append('#include "triton/runtime/launch.h"')
+        lines.append("")
+
+        # ---- Args struct ----
+        lines.append("typedef struct {")
+        for arg in args:
+            c_ty = _c_type(arg["type"])
+            lines.append(f"    {c_ty} {arg['name']};")
+        lines.append(f"}} {safe_name}_args_t;")
+        lines.append("")
+
+        # ---- Launch function ----
+        lines.append("/**")
+        lines.append(f" * Launch {kernel_name}.")
+        lines.append(" *")
+        lines.append(" * Compile-time constants baked in:")
+        lines.append(f" *   num_warps={num_warps}, num_ctas={num_ctas}, "
+                     f"shared_mem={shared_mem}")
+        lines.append(f" *   cluster_dims=[{cluster_dims[0]},{cluster_dims[1]},{cluster_dims[2]}]")
+        lines.append(f" *   launch_pdl={launch_pdl}, cooperative={launch_coop}")
+        if global_scratch_size > 0:
+            lines.append(f" *   global_scratch_size={global_scratch_size}")
+        if profile_scratch_size > 0:
+            lines.append(f" *   profile_scratch_size={profile_scratch_size}")
+        lines.append(" */")
+
+        lines.append(f"CUresult triton_launch_{safe_name}(")
+        lines.append("    const uint32_t grid[3],")
+        lines.append("    CUstream stream,")
+        lines.append("    CUfunction function,")
+        lines.append(f"    {safe_name}_args_t *args,")
+        # Always include scratch params for stable ABI across all kernels.
+        # Callers pass 0/NULL when the kernel doesn't use scratch buffers.
+        lines.append("    CUdeviceptr global_scratch,")
+        lines.append("    CUdeviceptr profile_scratch")
+        lines.append(") {")
+
+        # Null checks
+        lines.append("    if (!args) return CUDA_ERROR_INVALID_VALUE;")
+        lines.append("    if (!function) return CUDA_ERROR_INVALID_HANDLE;")
+        lines.append("")
+
+        # Build params array
+        param_names = [f"args->{arg['name']}" for arg in args]
+        param_names.append("global_scratch")
+        param_names.append("profile_scratch")
+
+        lines.append("    /* Kernel parameter pointers */")
+        for i, pname in enumerate(param_names):
+            lines.append(f"    void *_param{i} = (void *)&{pname};")
+        lines.append("    void *params[] = {")
+        for i in range(len(param_names)):
+            comma = "," if i < len(param_names) - 1 else ""
+            lines.append(f"        _param{i}{comma}")
+        lines.append("    };")
+        lines.append("")
+
+        # Build launch attributes (compile-time constants)
+        lines.append("    /* Launch attributes (compile-time constants) */")
+        lines.append("    CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS];")
+        lines.append("    unsigned num_attrs = triton_build_launch_attrs(")
+        lines.append("        attrs,")
+        lines.append(f"        /*launch_pdl=*/{launch_pdl},")
+        lines.append(f"        /*launch_cooperative_grid=*/{launch_coop},")
+        lines.append(f"        /*num_ctas=*/{num_ctas},")
+        lines.append(f"        /*launch_cluster=*/{launch_cluster_flag},")
+        lines.append(f"        /*preferred_cluster_dim_x=*/{preferred[0]},")
+        lines.append(f"        /*preferred_cluster_dim_y=*/{preferred[1]},")
+        lines.append(f"        /*preferred_cluster_dim_z=*/{preferred[2]}")
+        lines.append("    );")
+        lines.append("")
+
+        # Call triton_launch_kernel
+        lines.append("    return triton_launch_kernel(")
+        lines.append(f"        grid, /*num_warps=*/{num_warps}, /*num_ctas=*/{num_ctas},")
+        lines.append(f"        /*shared_mem=*/{shared_mem}u, stream, function,")
+        lines.append("        params, attrs, num_attrs")
+        lines.append("    );")
+        lines.append("}")
+
+        return "\n".join(lines) + "\n"
+
     def get_codegen_implementation(self, options):
         import triton.language.extra.cuda as cuda
         capability = int(self._parse_arch(options.arch))


### PR DESCRIPTION
Summary:

### What does this diff do?

Adds two new capabilities to the Triton compiler:
1. **Generate Level 0 metadata** (`launch_metadata`): A JSON "spec sheet" describing everything needed to launch this kernel.
2. **Generate Level 1 launcher C source** (`launcher_src`): A complete C source file that can be compiled directly into a `.so` to launch the kernel.

Also introduces a new header file `launch.h` that encapsulates the `cuLaunchKernelEx` calling logic.

### Files changed

| File | Change |
|------|--------|
| `nvidia/backend/compiler.py` | Added `make_launch_metadata()` and `make_launcher_src()` methods |
| `triton/compiler/compiler.py` | Compilation pipeline calls above methods, stores result in `asm["launcher_src"]` |
| `triton/runtime/launch.h` | **New file**: ~215 line C header providing `triton_launch_kernel()` and helpers |
| `test_launch_metadata.py` | Added 302 lines of tests |

### Before / After

**Before (only generates cubin):**
```
triton.compile(kernel)
  → asm["cubin"]     = <GPU binary>
  → asm["metadata"]  = {num_warps: 4, shared: 0, ...}
  # That's it! Downstream must write its own launcher.
```

**After (additionally generates launcher source):**
```
triton.compile(kernel)
  → asm["cubin"]           = <GPU binary>
  → asm["metadata"]        = {num_warps: 4, shared: 0, ...}
  → asm["launch_metadata"] = {abi_version: 1, args: [...], cluster_dims: [1,1,1], ...}   ← NEW!
  → asm["launcher_src"]    = "/* Generated by Triton */\n#include ...\n..."               ← NEW!
```

**Example of generated launcher_src:**
```c
/* Generated by Triton compiler — do not edit. */
/* Kernel: add_kernel_0d1d2 */
#include "triton/runtime/launch.h"

// Args struct (no more void*[] array!)
typedef struct {
    CUdeviceptr x_ptr;
    CUdeviceptr y_ptr;
    CUdeviceptr output_ptr;
    int32_t n_elements;
} add_kernel_0d1d2_args_t;

// Launch function (compile-time constants baked in)
CUresult triton_launch_add_kernel_0d1d2(
    const uint32_t grid[3], CUstream stream, CUfunction function,
    add_kernel_0d1d2_args_t *args
) {
    // Build parameter pointer array
    void *_param0 = (void *)&args->x_ptr;
    void *_param1 = (void *)&args->y_ptr;
    void *_param2 = (void *)&args->output_ptr;
    void *_param3 = (void *)&args->n_elements;
    void *params[] = { _param0, _param1, _param2, _param3 };

    // Build launch attributes from compile-time constants (num_warps=4, shared=0, etc.)
    CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS];
    unsigned num_attrs = triton_build_launch_attrs(attrs, /*pdl=*/0, /*coop=*/0, ...);

    // Launch kernel via new API
    return triton_launch_kernel(grid, /*num_warps=*/4, /*num_ctas=*/1,
                                 /*shared_mem=*/0, stream, function,
                                 params, attrs, num_attrs);
}
```

### Why is this valuable?

1. **Unified**: One launcher source, usable by all downstream consumers
2. **More capable**: Automatically supports cluster dims, PDL, cooperative launch, etc.
3. **Safer**: Compile-time constants baked in directly — no runtime parameter passing errors

Differential Revision: D101075266


