### PR TITLE
[Triton JIT][2a/N] LLVM-compiled kernel launcher for JIT path (#1387)

### DIFF
--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -6,10 +6,19 @@ are consistent with the existing metadata bag.
 """
 
 import json
+import subprocess
+from types import SimpleNamespace
 
 import pytest
+import torch
 import triton
 import triton.language as tl
+from triton._C.libtriton import llvm
+from triton.backends.nvidia.compiler import CUDABackend
+from triton.backends.nvidia.launcher_llvm import (
+    make_launcher as make_llvm_launcher,
+    make_launcher_ir,
+)
 from triton.compiler.compiler import ASTSource, compile as triton_compile
 
 
@@ -310,3 +319,226 @@ def test_launcher_src_has_abi_version_comment():
     )
     src = compiled.asm["launcher_src"]
     assert "ABI version: 1" in src
+
+
+def test_tuple_args_excluded_from_schema():
+    """Tuple-typed args (implicitly constexpr) should not appear in schema args."""
+
+    # Build a minimal mock src with a tuple-typed arg in the signature.
+    mock_fn = SimpleNamespace(arg_names=["Y", "fn_args"])
+    mock_src = SimpleNamespace(
+        signature={"Y": "*i32", "fn_args": "()"},
+        constants={},
+        attrs={},
+        fn=mock_fn,
+    )
+
+    # Minimal metadata dict matching what make_launch_metadata expects.
+    metadata = {
+        "num_warps": 4,
+        "num_ctas": 1,
+        "shared": 0,
+        "cluster_dims": (1, 1, 1),
+        "preferred_ctas_per_cga": (0, 0, 0),
+        "launch_cooperative_grid": False,
+        "launch_cluster": False,
+        "launch_pdl": False,
+        "global_scratch_size": 0,
+        "profile_scratch_size": 0,
+        "target": ("cuda", 90),
+        "name": "test_kernel",
+    }
+
+    target = triton.runtime.driver.active.get_current_target()
+    backend = CUDABackend(target)
+    schema = backend.make_launch_metadata(metadata, mock_src)
+
+    arg_names = [a["name"] for a in schema["args"]]
+    assert "fn_args" not in arg_names, "tuple-typed arg should be excluded from schema args"
+    assert "Y" in arg_names
+
+
+# ---------------------------------------------------------------------------
+# Tests for LLVM-compiled launcher
+# ---------------------------------------------------------------------------
+
+
+def test_launcher_llvm_ir_generation():
+    """make_launcher_ir should produce valid LLVM IR with the launch function."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = json.loads(compiled.asm["launch_metadata"])
+    ir_text = make_launcher_ir(schema)
+
+    # Should be valid LLVM IR text
+    assert 'target triple = "x86_64-unknown-linux-gnu"' in ir_text
+    assert "define i32 @triton_launch_" in ir_text
+    assert "@cuLaunchKernelEx" in ir_text
+    # Constants should be baked in
+    block_dim_x = 32 * schema["num_warps"]
+    assert f"store i32 {block_dim_x}" in ir_text
+    assert f"store i32 {schema['shared_mem']}" in ir_text
+
+
+def test_launcher_llvm_ir_compiles():
+    """LLVM IR should compile to a host .o via translate_to_asm."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    schema = json.loads(compiled.asm["launch_metadata"])
+
+    ir_text = make_launcher_ir(schema)
+    obj_bytes = llvm.translate_to_asm(
+        ir_text,
+        "x86_64-unknown-linux-gnu",
+        "generic",
+        "",
+        [],
+        False,
+        True,
+    )
+    # Should produce a non-empty ELF object
+    assert isinstance(obj_bytes, bytes)
+    assert len(obj_bytes) > 0
+    # ELF magic number
+    assert obj_bytes[:4] == b'\x7fELF'
+
+
+@pytest.mark.parametrize("dtype", ["*fp32"])
+def test_launcher_llvm_e2e(dtype):
+    """End-to-end test: compile kernel, build LLVM launcher, launch on GPU."""
+
+    N = 1024
+    BLOCK = 256
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": dtype, "Y": dtype, "OUT": dtype, "N": "i32"},
+        constexprs={"BLOCK": BLOCK},
+    )
+    schema = json.loads(compiled.asm["launch_metadata"])
+
+    launch = make_llvm_launcher(schema)
+
+    # Get the CUfunction handle
+    compiled._init_handles()
+    function = compiled.function
+    stream = torch.cuda.current_stream().cuda_stream
+
+    grid_x = N // BLOCK
+    launch(
+        grid_x,
+        1,
+        1,
+        stream,
+        function,
+        False,
+        False,
+        False,  # cooperative, cluster, pdl
+        None,
+        None,  # global_scratch, profile_scratch
+        None,
+        None,  # kernel_metadata, launch_metadata
+        None,
+        None,  # enter_hook, exit_hook
+        x.data_ptr(),
+        y.data_ptr(),
+        out.data_ptr(),
+        N,
+    )
+    torch.cuda.synchronize()
+    assert torch.allclose(out, x + y), f"max diff: {(out - x - y).abs().max()}"
+
+
+@pytest.mark.parametrize("dtype_x,dtype_n", [("*fp32", "i32"), ("*fp32", "i64")])
+def test_launcher_llvm_mixed_types(dtype_x, dtype_n):
+    """Test with different scalar types."""
+
+    N = 512
+    BLOCK = 128
+
+    @triton.jit
+    def scale_kernel(X, OUT, N, SCALE, BLOCK: tl.constexpr):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < N
+        x = tl.load(X + offs, mask=mask)
+        tl.store(OUT + offs, x * SCALE, mask=mask)
+
+    x = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    scale = 2.0
+
+    compiled = _compile_kernel(
+        scale_kernel,
+        signature={"X": dtype_x, "OUT": dtype_x, "N": dtype_n, "SCALE": "fp32"},
+        constexprs={"BLOCK": BLOCK},
+    )
+    schema = json.loads(compiled.asm["launch_metadata"])
+
+    try:
+        launch = make_llvm_launcher(schema)
+    except subprocess.CalledProcessError:
+        pytest.skip("Cannot link launcher: libcuda not available in this environment")
+    compiled._init_handles()
+
+    stream = torch.cuda.current_stream().cuda_stream
+    grid_x = N // BLOCK
+    # Use a value exceeding 2^31 for i64 to exercise large integer handling
+    n_val = N if dtype_n == "i32" else (1 << 33) + N
+    launch(
+        grid_x,
+        1,
+        1,
+        stream,
+        compiled.function,
+        False,
+        False,
+        False,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        x.data_ptr(),
+        out.data_ptr(),
+        n_val,
+        scale,
+    )
+    torch.cuda.synchronize()
+    assert torch.allclose(out, x * scale, atol=1e-5), f"max diff: {(out - x * scale).abs().max()}"
+
+
+def test_launcher_llvm_via_jit_dispatch():
+    """End-to-end: LLVM launcher called through normal kernel[grid](*args) dispatch."""
+    import triton.knobs
+
+    # Skip if use_launcher_src is not supported
+    if not hasattr(triton.knobs, "nvidia") or not hasattr(triton.knobs.nvidia, "use_launcher_src"):
+        pytest.skip("use_launcher_src knob not available")
+
+    original = triton.knobs.nvidia.use_launcher_src
+    try:
+        triton.knobs.nvidia.use_launcher_src = True
+
+        N = 1024
+        BLOCK = 256
+        x = torch.randn(N, device="cuda")
+        y = torch.randn(N, device="cuda")
+        out = torch.empty(N, device="cuda")
+
+        # Call through normal JIT dispatch — exercises CudaLauncher.__call__
+        add_kernel[(N // BLOCK, )](x, y, out, N, BLOCK=BLOCK)
+        torch.cuda.synchronize()
+        assert torch.allclose(out, x + y), f"max diff: {(out - x - y).abs().max()}"
+    finally:
+        triton.knobs.nvidia.use_launcher_src = original

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -517,6 +517,7 @@ class nvidia_knobs(base_knobs):
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
+    use_launcher_src: env_bool = env_bool("TRITON_USE_LAUNCHER_SRC")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     enable_tileir: env_bool = env_bool("ENABLE_TILE")
 

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -65,6 +65,51 @@ static PyTypeObject PyTDMDescriptorType = {
     .tp_dealloc = (destructor)PyTDMDescriptor_dealloc,
 };
 
+typedef enum { ARG_CONSTEXPR = 0, ARG_KERNEL = 1, ARG_TUPLE = 2 } ArgType;
+
+// Annotation struct to know how the argument should be handled.
+typedef struct {
+  PyObject_HEAD;
+  PyObject *nested_tuple; // Can be a List of PyKernelArgObjects or None
+  ArgType type;
+} PyKernelArgObject;
+
+// Deallocator
+static void PyKernelArg_dealloc(PyKernelArgObject *self) {
+  Py_XDECREF(self->nested_tuple);
+  Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+// Constructor
+static int PyKernelArg_init(PyKernelArgObject *self, PyObject *args,
+                            PyObject *kwds) {
+  static char *kwlist[] = {"nested_tuple", "type", NULL};
+  PyObject *tup = NULL;
+  int type_val = 0;
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|i", kwlist, &tup,
+                                   &type_val)) {
+    return -1;
+  }
+  Py_XINCREF(tup);
+  self->nested_tuple = tup;
+  self->type = (ArgType)type_val;
+  return 0;
+}
+
+static void PyKernelArg_free(void *ptr) { free(ptr); }
+
+static PyTypeObject PyKernelArgType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name =
+        "triton.backends.nvidia.PyKernelArg",
+    .tp_basicsize = sizeof(PyKernelArgObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Kernel Argument Metadata",
+    .tp_new = PyType_GenericNew,
+    .tp_init = (initproc)PyKernelArg_init,
+    .tp_dealloc = (destructor)PyKernelArg_dealloc,
+};
+
 // Encodes a TDM descriptor. Supports 1D-5D tensors.
 // Uses the same encoding format as createTDMDescriptor in TDMUtility.cpp.
 static bool encodeTDMDescriptor(TDMDescriptor *desc, int elementBitWidth,
@@ -185,6 +230,7 @@ static const char *hipLibSearchPaths[] = {"/*py_libhip_search_path*/"};
 // |FOR_EACH_ERR_FN| is a macro to process APIs that return hipError_t;
 // |FOR_EACH_STR_FN| is a macro to process APIs that return const char *.
 #define HIP_SYMBOL_LIST(FOR_EACH_ERR_FN, FOR_EACH_STR_FN)                      \
+  FOR_EACH_STR_FN(hipGetLastError)                                             \
   FOR_EACH_STR_FN(hipGetErrorString, hipError_t hipError)                      \
   FOR_EACH_ERR_FN(hipGetDeviceProperties, hipDeviceProp_t *prop, int deviceId) \
   FOR_EACH_ERR_FN(hipModuleLoadDataEx, hipModule_t *module, const void *image, \
@@ -193,7 +239,23 @@ static const char *hipLibSearchPaths[] = {"/*py_libhip_search_path*/"};
   FOR_EACH_ERR_FN(hipModuleGetFunction, hipFunction_t *function,               \
                   hipModule_t module, const char *kname)                       \
   FOR_EACH_ERR_FN(hipFuncGetAttribute, int *, hipFunction_attribute attr,      \
-                  hipFunction_t function)
+                  hipFunction_t function)                                      \
+  FOR_EACH_ERR_FN(hipDrvLaunchKernelEx, const HIP_LAUNCH_CONFIG *config,       \
+                  hipFunction_t f, void **kernelParams, void **extra)          \
+  FOR_EACH_ERR_FN(hipModuleLaunchKernel, hipFunction_t f,                      \
+                  unsigned int gridDimX, unsigned int gridDimY,                \
+                  unsigned int gridDimZ, unsigned int blockDimX,               \
+                  unsigned int blockDimY, unsigned int blockDimZ,              \
+                  unsigned int sharedMemBytes, hipStream_t stream,             \
+                  void **kernelParams, void **extra)                           \
+  FOR_EACH_ERR_FN(hipModuleLaunchCooperativeKernel, hipFunction_t f,           \
+                  unsigned int gridDimX, unsigned int gridDimY,                \
+                  unsigned int gridDimZ, unsigned int blockDimX,               \
+                  unsigned int blockDimY, unsigned int blockDimZ,              \
+                  unsigned int sharedMemBytes, hipStream_t stream,             \
+                  void **kernelParams, void **extra)                           \
+  FOR_EACH_ERR_FN(hipPointerGetAttribute, void *data,                          \
+                  hipPointer_attribute attribute, hipDeviceptr_t ptr)
 
 // HIP driver version format: HIP_VERSION_MAJOR * 10000000 + HIP_VERSION_MINOR *
 // 100000 + HIP_VERSION_PATCH.
@@ -352,11 +414,16 @@ static inline void gpuAssert(hipError_t code, const char *file, int line) {
   }
 }
 
-#define HIP_CHECK(ans)                                                         \
+#define HIP_CHECK_AND_RETURN_NULL(ans)                                         \
   {                                                                            \
     gpuAssert((ans), __FILE__, __LINE__);                                      \
     if (PyErr_Occurred())                                                      \
       return NULL;                                                             \
+  }
+
+#define HIP_CHECK(ans)                                                         \
+  {{gpuAssert((ans), __FILE__, __LINE__);                                      \
+  }                                                                            \
   }
 
 static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
@@ -365,7 +432,8 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
     return NULL;
 
   hipDeviceProp_t props;
-  HIP_CHECK(hipSymbolTable.hipGetDeviceProperties(&props, device_id));
+  HIP_CHECK_AND_RETURN_NULL(
+      hipSymbolTable.hipGetDeviceProperties(&props, device_id));
 
   // create a struct to hold device properties
   return Py_BuildValue(
@@ -404,8 +472,10 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   // launch HIP Binary
   hipModule_t mod;
   hipFunction_t fun;
-  HIP_CHECK(hipSymbolTable.hipModuleLoadDataEx(&mod, data, 5, opt, optval))
-  HIP_CHECK(hipSymbolTable.hipModuleGetFunction(&fun, mod, name));
+  HIP_CHECK_AND_RETURN_NULL(
+      hipSymbolTable.hipModuleLoadDataEx(&mod, data, 5, opt, optval))
+  HIP_CHECK_AND_RETURN_NULL(
+      hipSymbolTable.hipModuleGetFunction(&fun, mod, name));
 
   // get allocated registers and spilled registers from the function
   int n_regs = 0;
@@ -533,6 +603,494 @@ cleanup:
   return NULL;
 }
 
+static void _launch(int gridX, int gridY, int gridZ, int num_warps,
+                    int num_ctas, int launch_cooperative_grid,
+                    int shared_memory, int warp_size, hipStream_t stream,
+                    hipFunction_t function, void **params) {
+  if (gridX * gridY * gridZ == 0)
+    return;
+  if (num_ctas > 1) {
+    if (!hipSymbolTable.hipDrvLaunchKernelEx) {
+      PyErr_SetString(
+          PyExc_RuntimeError,
+          "missing hipDrvLaunchKernelEx symbol; please update HIP runtime");
+      return;
+    }
+
+    hipLaunchAttribute attributes[2];
+    // Attribute0: Cluster dimensions
+    attributes[0].id = 4;
+    int *cluster_dims = (int *)attributes[0].val.pad;
+    cluster_dims[0] = num_ctas;
+    cluster_dims[1] = 1;
+    cluster_dims[2] = 1;
+    // Attribute1: Cooperative launch
+    attributes[1].id = hipLaunchAttributeCooperative;
+    attributes[1].val.cooperative = launch_cooperative_grid;
+
+    HIP_LAUNCH_CONFIG config = {
+        gridX * num_ctas,      gridY,  gridZ,        // Grid size
+        warp_size * num_warps, 1,      1,            // Block size
+        shared_memory,         stream, attributes, 2 // Number of attributes
+    };
+    HIP_CHECK(
+        hipSymbolTable.hipDrvLaunchKernelEx(&config, function, params, 0));
+    return;
+  } else if (launch_cooperative_grid) {
+    HIP_CHECK(hipSymbolTable.hipModuleLaunchCooperativeKernel(
+        function, gridX, gridY, gridZ, warp_size * num_warps, 1, 1,
+        shared_memory, stream, params, 0));
+    return;
+  } else {
+    HIP_CHECK(hipSymbolTable.hipModuleLaunchKernel(
+        function, gridX, gridY, gridZ, warp_size * num_warps, 1, 1,
+        shared_memory, stream, params, 0));
+  }
+}
+
+static PyObject *data_ptr_str = NULL;
+
+bool extractPointer(void *ptr, PyObject *obj) {
+  hipDeviceptr_t *dev_ptr = ptr;
+  if (obj == Py_None) {
+    *dev_ptr = (hipDeviceptr_t)0; // valid nullptr
+    return true;
+  }
+  if (PyLong_Check(obj)) {
+    *dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(obj);
+    return true;
+  }
+  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
+  if (!ret) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "Pointer argument must be either uint64 or have data_ptr method");
+    return false;
+  }
+  if (!PyLong_Check(ret)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "data_ptr method of Pointer object must return 64-bit int");
+    return false;
+  }
+  *dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(ret);
+  Py_DECREF(ret);
+  if (*dev_ptr == 0) {
+    return true; // valid nullptr
+  }
+  hipError_t status = hipSymbolTable.hipPointerGetAttribute(
+      dev_ptr, HIP_POINTER_ATTRIBUTE_DEVICE_POINTER, *dev_ptr);
+  if (status == hipErrorInvalidValue) {
+    PyErr_Format(PyExc_ValueError, "Pointer argument (at %d) cannot be "
+                                   "accessed from Triton (cpu tensor?)");
+    // Clear and ignore HIP error
+    (void)hipSymbolTable.hipGetLastError();
+    return false;
+  }
+  return true;
+}
+
+bool extractI8(void *ptr, PyObject *obj) {
+  *((int8_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI16(void *ptr, PyObject *obj) {
+  *((int16_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI32(void *ptr, PyObject *obj) {
+  *((int32_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI64(void *ptr, PyObject *obj) {
+  *((int64_t *)ptr) = PyLong_AsLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU8(void *ptr, PyObject *obj) {
+  *((uint8_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU16(void *ptr, PyObject *obj) {
+  *((uint16_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU32(void *ptr, PyObject *obj) {
+  *((uint32_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU64(void *ptr, PyObject *obj) {
+  *((uint64_t *)ptr) = PyLong_AsUnsignedLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  uint16_t result;
+  // from https://github.com/python/pythoncapi-compat
+#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 &&            \
+    !defined(PYPY_VERSION)
+  _PyFloat_Pack2(temp_double, (unsigned char *)&result, 1);
+#else
+  PyFloat_Pack2(temp_double, (char *)&result, 1);
+#endif
+  *((uint16_t *)ptr) = result;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractBF16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  uint32_t u32 = *(uint32_t *)&f32;
+  *((uint16_t *)ptr) = (u32 >> 16);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP32(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  *((uint32_t *)ptr) = *(uint32_t *)&f32;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP64(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  *((uint64_t *)ptr) = *(uint64_t *)&temp_double;
+  return PyErr_Occurred() == NULL;
+}
+
+// Extract a TDM descriptor from a python object, and store it to the
+// memory location pointed by ptr.
+bool extractTDMDescriptor(void *ptr, PyObject *obj) {
+  TDMDescriptor *desc = &((PyTDMDescriptorObject *)obj)->desc;
+  if (desc == NULL) {
+    PyErr_Format(PyExc_TypeError,
+                 "object must be of type PyTDMDescriptor, got %s",
+                 Py_TYPE(obj)->tp_name);
+    return false;
+  }
+  *((TDMDescriptor *)ptr) = *desc;
+  return true;
+}
+
+typedef bool (*ExtractorFunc)(void *ptr, PyObject *obj);
+
+#define MAX_NAMES_PER_EXTRACTOR 2
+
+typedef struct {
+  ExtractorFunc extract;
+  size_t size;
+  const char *name[MAX_NAMES_PER_EXTRACTOR];
+} Extractor;
+
+typedef enum {
+  EXTRACTOR_UNKOWN_INDEX = 0,
+  // pointers
+  EXTRACTOR_POINTER_INDEX = 1,
+  // ints
+  EXTRACTOR_INT8_INDEX = 2,
+  EXTRACTOR_INT16_INDEX = 3,
+  EXTRACTOR_INT32_INDEX = 4,
+  EXTRACTOR_INT64_INDEX = 5,
+  // uints
+  EXTRACTOR_UINT8_INDEX = 6,
+  EXTRACTOR_UINT16_INDEX = 7,
+  EXTRACTOR_UINT32_INDEX = 8,
+  EXTRACTOR_UINT64_INDEX = 9,
+  // floats
+  EXTRACTOR_FP16_INDEX = 10,
+  EXTRACTOR_BF16_INDEX = 11,
+  EXTRACTOR_FP32_INDEX = 12,
+  EXTRACTOR_FP64_INDEX = 13,
+  // custom
+  EXTRACTOR_TDMDESC_INDEX = 14,
+  // last entry to have a count
+  EXTRACTOR_TYPE_COUNT
+} ExtractorTypeIndex;
+
+Extractor extraction_map[EXTRACTOR_TYPE_COUNT] = {
+    [EXTRACTOR_UNKOWN_INDEX] =
+        (Extractor){.extract = NULL, .size = 0, .name = NULL},
+    [EXTRACTOR_POINTER_INDEX] = (Extractor){.extract = extractPointer,
+                                            .size = sizeof(hipDeviceptr_t),
+                                            .name = NULL},
+    [EXTRACTOR_INT8_INDEX] = (Extractor){.extract = extractI8,
+                                         .size = sizeof(int8_t),
+                                         .name = {"i8"}},
+    [EXTRACTOR_INT16_INDEX] = (Extractor){.extract = extractI16,
+                                          .size = sizeof(int16_t),
+                                          .name = {"i16"}},
+    [EXTRACTOR_INT32_INDEX] = (Extractor){.extract = extractI32,
+                                          .size = sizeof(int32_t),
+                                          .name = {"i1", "i32"}},
+    [EXTRACTOR_INT64_INDEX] = (Extractor){.extract = extractI64,
+                                          .size = sizeof(int64_t),
+                                          .name = {"i64"}},
+    [EXTRACTOR_UINT8_INDEX] = (Extractor){.extract = extractU8,
+                                          .size = sizeof(uint8_t),
+                                          .name = {"u8"}},
+    [EXTRACTOR_UINT16_INDEX] = (Extractor){.extract = extractU16,
+                                           .size = sizeof(uint16_t),
+                                           .name = {"u16"}},
+    [EXTRACTOR_UINT32_INDEX] = (Extractor){.extract = extractU32,
+                                           .size = sizeof(uint32_t),
+                                           .name = {"u1", "u32"}},
+    [EXTRACTOR_UINT64_INDEX] = (Extractor){.extract = extractU64,
+                                           .size = sizeof(uint64_t),
+                                           .name = {"u64"}},
+    [EXTRACTOR_FP16_INDEX] = (Extractor){.extract = extractFP16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"fp16"}},
+    [EXTRACTOR_BF16_INDEX] = (Extractor){.extract = extractBF16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"bf16"}},
+    [EXTRACTOR_FP32_INDEX] = (Extractor){.extract = extractFP32,
+                                         .size = sizeof(uint32_t),
+                                         .name = {"fp32", "f32"}},
+    [EXTRACTOR_FP64_INDEX] = (Extractor){.extract = extractFP64,
+                                         .size = sizeof(uint64_t),
+                                         .name = {"fp64"}},
+    [EXTRACTOR_TDMDESC_INDEX] = (Extractor){.extract = extractTDMDescriptor,
+                                            .size = sizeof(TDMDescriptor),
+                                            .name = {"tensordesc"}},
+};
+
+Extractor getExtractor(uint8_t index) {
+  if (index >= EXTRACTOR_TYPE_COUNT) {
+    return extraction_map[EXTRACTOR_UNKOWN_INDEX];
+  }
+  return extraction_map[index];
+}
+
+bool isMatch(const char *type_bytes, ExtractorTypeIndex idx) {
+  Extractor extractor = extraction_map[idx];
+  for (int j = 0; j < MAX_NAMES_PER_EXTRACTOR; j++) {
+    if (extractor.name[j] != NULL &&
+        strcmp(type_bytes, extractor.name[j]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ExtractorTypeIndex getExtractorIndex(PyObject *type) {
+  Py_ssize_t type_len = 0;
+  const char *type_bytes = PyUnicode_AsUTF8AndSize(type, &type_len);
+  if (!type_bytes) {
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  if (type_len < 2) {
+    PyErr_Format(PyExc_RuntimeError, "Unexpected data type: %R", type);
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  // Examples: '*fp32', 'fp32', 'i8', etc.
+  if (type_bytes[0] == '*') {
+    return EXTRACTOR_POINTER_INDEX;
+  }
+  for (ExtractorTypeIndex i = EXTRACTOR_INT8_INDEX; i < EXTRACTOR_TYPE_COUNT;
+       i++) {
+    if (isMatch(type_bytes, i)) {
+      return i;
+    }
+  }
+
+  PyErr_Format(PyExc_RuntimeError, "Unknown data type: %R", type);
+  return EXTRACTOR_UNKOWN_INDEX;
+}
+
+// Takes in a list of types (ex: ['*fp32', 'u8', 'tensordesc']) and returns
+// a bytes array that represent extractors for quick argument extraction
+// when launching.
+static PyObject *buildSignatureMetadata(PyObject *self, PyObject *args) {
+  PyObject *signature = NULL;
+  if (!PyArg_ParseTuple(args, "O", &signature)) {
+    return NULL;
+  }
+  PyObject *fast_signature = PySequence_Fast(
+      signature, "Expected kernel_arg_types to be a sequence or iterable");
+  if (!fast_signature) {
+    return NULL;
+  }
+  Py_ssize_t signature_size = PySequence_Fast_GET_SIZE(fast_signature);
+  PyObject **signature_items = PySequence_Fast_ITEMS(fast_signature);
+
+  // Create return bytes object.
+  PyObject *ret_bytes = PyBytes_FromStringAndSize(NULL, signature_size);
+  if (ret_bytes == NULL) {
+    Py_XDECREF(fast_signature);
+    return NULL;
+  }
+  char *buffer = PyBytes_AS_STRING(ret_bytes);
+  for (Py_ssize_t i = 0; i < signature_size; ++i) {
+    ExtractorTypeIndex extractor_idx = getExtractorIndex(signature_items[i]);
+    if (extractor_idx == EXTRACTOR_UNKOWN_INDEX) {
+      goto cleanup;
+    }
+    buffer[i] = (uint8_t)extractor_idx;
+  }
+
+  Py_XDECREF(fast_signature);
+  return ret_bytes;
+
+cleanup:
+  Py_XDECREF(fast_signature);
+  Py_XDECREF(ret_bytes);
+  return NULL;
+}
+
+bool extractArgs(PyObject **final_list, int *list_idx, PyObject *kernel_args,
+                 PyObject *arg_annotations) {
+  // Extract arg annotations
+  PyObject *fast_annotations = PySequence_Fast(
+      arg_annotations, "Expected arg_annotations to be a sequence or iterable");
+  if (!fast_annotations) {
+    goto cleanup;
+  }
+  Py_ssize_t num_annotations = PySequence_Fast_GET_SIZE(fast_annotations);
+  PyObject **annotations = PySequence_Fast_ITEMS(fast_annotations);
+
+  PyObject *fast_args = PySequence_Fast(
+      kernel_args, "Expected kernel_args to be a sequence or iterable");
+  if (!fast_args) {
+    goto cleanup;
+  }
+  PyObject **args = PySequence_Fast_ITEMS(fast_args);
+
+  int arg_idx = 0;
+  for (int i = 0; i < num_annotations; ++i) {
+    PyKernelArgObject *annotation = (PyKernelArgObject *)annotations[i];
+    switch (annotation->type) {
+    case ARG_KERNEL:
+      final_list[(*list_idx)++] = args[arg_idx++];
+      break;
+    case ARG_TUPLE:
+      if (!extractArgs(final_list, list_idx, args[arg_idx++],
+                       annotation->nested_tuple)) {
+        goto cleanup;
+      }
+      break;
+    case ARG_CONSTEXPR:
+      arg_idx++;
+      break;
+    }
+  }
+  Py_DECREF(fast_annotations);
+  Py_DECREF(fast_args);
+  return true;
+
+cleanup:
+  Py_XDECREF(fast_annotations);
+  Py_XDECREF(fast_args);
+  return false;
+}
+
+bool launchHook(PyObject *hook, PyObject *metadata) {
+  if (hook != Py_None) {
+    PyObject *ret = PyObject_CallOneArg(hook, metadata);
+    if (!ret) {
+      return false;
+    }
+    Py_DECREF(ret);
+  }
+  return true;
+}
+
+static PyObject *launchKernel(PyObject *self, PyObject *args) {
+  int gridX, gridY, gridZ;
+  uint64_t _stream;
+  uint64_t _function;
+  int launch_cooperative_grid;
+  PyObject *profile_scratch_obj = NULL;
+  PyObject *launch_enter_hook = NULL;
+  PyObject *launch_exit_hook = NULL;
+  int num_warps, num_ctas, shared_memory;
+  PyObject *launch_metadata = NULL;
+  int warp_size;
+  PyObject *arg_annotations = NULL;
+  Py_buffer signature;
+  PyObject *kernel_args = NULL;
+  if (!PyArg_ParseTuple(args, "piiiKKO(iii)OOOiOy*O", &launch_cooperative_grid,
+                        &gridX, &gridY, &gridZ, &_stream, &_function,
+                        &profile_scratch_obj, &num_warps, &num_ctas,
+                        &shared_memory, &launch_metadata, &launch_enter_hook,
+                        &launch_exit_hook, &warp_size, &arg_annotations,
+                        &signature, &kernel_args)) {
+    return NULL;
+  }
+
+  // launch entry hook.
+  if (!launchHook(launch_enter_hook, launch_metadata)) {
+    goto cleanup;
+  }
+
+  uint8_t *extractor_data = (uint8_t *)signature.buf;
+  Py_ssize_t num_args = signature.len;
+
+  // Extract kernel parameters - flatten tuples & remove constexpr.
+  PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
+  if (args_data == NULL) {
+    goto cleanup;
+  }
+  int list_idx = 0;
+  if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
+    goto cleanup;
+  }
+
+  // Number of parameters passed to kernel. + 2 for global & profile scratch.
+  int num_params = num_args + 2;
+  void **params = (void **)alloca(num_params * sizeof(void *));
+  int params_idx = 0;
+  // This loop has to stay in the same function that owns params, since we are
+  // using alloca to allocate pointers to it on the stack of the function.
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    // Get extractor that will send back a struct with
+    // * size for allocation
+    // * function to call to put the parameter in params buffer
+    Extractor extractor = getExtractor(extractor_data[i]);
+    if (extractor.extract == NULL) {
+      goto cleanup;
+    }
+    PyObject *current_arg = args_data[i];
+    params[params_idx] = alloca(extractor.size);
+    if (!extractor.extract(params[params_idx++], current_arg)) {
+      goto cleanup;
+    }
+  }
+  // Add global scratch object (nullptr).
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], Py_None)) {
+    goto cleanup;
+  }
+  // Add profile scratch object.
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], profile_scratch_obj)) {
+    goto cleanup;
+  }
+
+  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
+          shared_memory, warp_size, (hipStream_t)_stream,
+          (hipFunction_t)_function, params);
+
+  if (!launchHook(launch_exit_hook, launch_metadata)) {
+    goto cleanup;
+  }
+
+  if (PyErr_Occurred()) {
+    goto cleanup;
+  }
+  PyBuffer_Release(&signature);
+  Py_RETURN_NONE;
+
+cleanup:
+  PyBuffer_Release(&signature);
+  return NULL;
+}
+
 static PyMethodDef ModuleMethods[] = {
     {"load_binary", loadBinary, METH_VARARGS,
      "Load provided hsaco into HIP driver"},
@@ -540,6 +1098,12 @@ static PyMethodDef ModuleMethods[] = {
      "Get the properties for a given device"},
     {"create_tdm_descriptor", createTDMDescriptor, METH_VARARGS,
      "create a host-side TDM descriptor"},
+    {"build_signature_metadata", buildSignatureMetadata, METH_VARARGS,
+     "Calling it with a signature list (ex: ['*fp32', 'u8', 'tensordesc']), "
+     "will return metadata to be passed into 'launch' for quicker "
+     "argument parsing."},
+    {"launch", launchKernel, METH_VARARGS,
+     "Entry point for all kernels with this signature"},
     {NULL, NULL, 0, NULL} // sentinel
 };
 
@@ -559,10 +1123,23 @@ PyMODINIT_FUNC PyInit_hip_utils(void) {
   }
   PyModule_AddFunctions(m, ModuleMethods);
 
-  if (PyType_Ready(&PyTDMDescriptorType) < 0)
+  if (PyType_Ready(&PyTDMDescriptorType) < 0) {
     return NULL;
+  }
+  if (PyType_Ready(&PyKernelArgType) < 0) {
+    return NULL;
+  }
+  data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  if (data_ptr_str == NULL) {
+    return NULL;
+  }
   Py_INCREF(&PyTDMDescriptorType);
   PyModule_AddObject(m, "PyTDMDescriptor", (PyObject *)&PyTDMDescriptorType);
+  Py_INCREF(&PyKernelArgType);
+  PyModule_AddObject(m, "PyKernelArg", (PyObject *)&PyKernelArgType);
+  PyModule_AddIntConstant(m, "ARG_CONSTEXPR", ARG_CONSTEXPR);
+  PyModule_AddIntConstant(m, "ARG_KERNEL", ARG_KERNEL);
+  PyModule_AddIntConstant(m, "ARG_TUPLE", ARG_TUPLE);
 
   return m;
 }

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -13,6 +13,10 @@ from triton.runtime.build import compile_module_from_src
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dirs = [os.path.join(dirname, "include")]
 PyTDMDescriptor = None
+PyKernelArg = None
+ARG_CONSTEXPR = None
+ARG_KERNEL = None
+ARG_TUPLE = None
 
 
 def _find_already_mmapped_dylib_on_linux(lib_name):
@@ -177,8 +181,18 @@ class HIPUtils(object):
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
         self.create_tdm_descriptor = mod.create_tdm_descriptor
+        self.launch = mod.launch
+        self.build_signature_metadata = mod.build_signature_metadata
         global PyTDMDescriptor
+        global PyKernelArg
+        global ARG_CONSTEXPR
+        global ARG_KERNEL
+        global ARG_TUPLE
         PyTDMDescriptor = mod.PyTDMDescriptor
+        PyKernelArg = mod.PyKernelArg
+        ARG_CONSTEXPR = mod.ARG_CONSTEXPR
+        ARG_KERNEL = mod.ARG_KERNEL
+        ARG_TUPLE = mod.ARG_TUPLE
 
 
 # -------------------- Launcher ----------------------------
@@ -206,519 +220,74 @@ def ty_to_cpp(ty):
     }[ty]
 
 
-FLOAT_STORAGE_TYPE = {
-    "fp16": "uint16_t",
-    "bf16": "uint16_t",
-    "fp32": "uint32_t",
-    "f32": "uint32_t",
-    "fp64": "uint64_t",
-}
-FLOAT_PACK_FUNCTION = {
-    "fp16": "pack_fp16",
-    "bf16": "pack_bf16",
-    "fp32": "pack_fp32",
-    "f32": "pack_fp32",
-    "fp64": "pack_fp64",
-}
+def expand_signature(signature, tensordesc_meta):
+    output = []
+    tensordesc_idx = 0
+    for sig in signature:
+        if isinstance(sig, str) and sig.startswith("tensordesc"):
+            meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
+            tensordesc_idx += 1
 
-_BASE_ARGS_FORMAT = "piiiKKOOOOO"
+            match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
+            dtype = match.group(1)
+            shape = match.group(2)
+            ndim = shape.count(",") + 1
 
-
-def make_launcher(constants, signature, warp_size, tensordesc_meta):
-
-    def _expand_signature(signature):
-        output = []
-        tensordesc_idx = 0
-        for sig in signature:
-            if isinstance(sig, str) and sig.startswith("tensordesc"):
-                meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
-                tensordesc_idx += 1
-
-                match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
-                dtype = match.group(1)
-                shape = match.group(2)
-                ndim = shape.count(",") + 1
-
-                # If there is no descriptor's metadata, the descriptor has been decomposed to base pointer, shape and strides
-                if meta is None:
-                    output.append("*" + dtype)
-                    for _ in range(2 * ndim):
-                        output.append("i64")
-                    output.append("i1")
-                else:
-                    output.append("tensordesc")
-
-                for _ in range(ndim):
-                    output.append("i32")
-                for _ in range(ndim):
+            # If there is no descriptor's metadata, the descriptor has been decomposed to base pointer, shape and strides
+            if meta is None:
+                output.append("*" + dtype)
+                for _ in range(2 * ndim):
                     output.append("i64")
+                output.append("i1")
             else:
-                output.append(sig)
+                output.append("tensordesc")
 
-        return output
-
-    def _serialize_signature(sig):
-        if isinstance(sig, tuple):
-            return ','.join(map(_serialize_signature, sig))
-        return sig
-
-    def _extracted_type(ty):
-        if isinstance(ty, tuple):
-            val = ','.join(map(_extracted_type, ty))
-            return f"[{val}]"
-        if ty.startswith("*") or ty.startswith("tensordesc"):
-            return "PyObject*"
-        if ty == "constexpr":
-            return "PyObject*"
-        return ty_to_cpp(ty)
-
-    def format_of(ty):
-        if isinstance(ty, tuple):
-            val = ''.join(map(format_of, ty))
-            return f"({val})"
-        if ty.startswith("*") or ty.startswith("tensordesc"):
-            return "O"
-        if ty == "constexpr":
-            return "O"
-        return {
-            "double": "d",
-            "long": "l",
-            "int8_t": "b",
-            "int16_t": "h",
-            "int32_t": "i",
-            "int64_t": "L",
-            "uint8_t": "B",
-            "uint16_t": "H",
-            "uint32_t": "I",
-            "uint64_t": "K",
-        }[ty_to_cpp(ty)]
-
-    signature = {idx: s for idx, s in enumerate(_expand_signature(signature.values()))}
-
-    args_format = ''.join([format_of(ty) for ty in signature.values()])
-    format = _BASE_ARGS_FORMAT + args_format
-    signature = ','.join(map(_serialize_signature, signature.values()))
-    signature = list(filter(bool, signature.split(',')))
-    signature = {i: s for i, s in enumerate(signature)}
-    args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
-    # Record the end of regular arguments;
-    # subsequent arguments are architecture-specific descriptors, such as tensor descriptors for CUDA.
-    arg_decl_list = []
-    for i, ty in signature.items():
-        if ty == "constexpr":
-            continue
-        if ty in FLOAT_STORAGE_TYPE:
-            arg_decl_list.append(f"{FLOAT_STORAGE_TYPE[ty]} arg{i}")
+            for _ in range(ndim):
+                output.append("i32")
+            for _ in range(ndim):
+                output.append("i64")
         else:
-            arg_decl_list.append(f"{ty_to_cpp(ty)} arg{i}")
-    arg_decls = ', '.join(arg_decl_list)
-    internal_args_list = []
-    for i, ty in signature.items():
-        if ty.startswith("*"):
-            internal_args_list.append(f"ptr_info{i}.dev_ptr")
-        elif ty.startswith("tensordesc"):
-            internal_args_list.append(f"*desc{i}")
-        elif ty in FLOAT_STORAGE_TYPE:
-            internal_args_list.append(f"_arg{i}_storage")
-        elif ty != "constexpr":
-            internal_args_list.append(f"_arg{i}")
+            output.append(sig)
 
-    newline = '\n  '
-    ptr_decls = [
-        f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}); if (!ptr_info{i}.valid) return NULL;"
-        for i, ty in signature.items()
-        if ty.startswith("*")
-    ]
-    tensor_desc_decls = [
-        f"TDMDescriptor* desc{i} = getTDMDescriptor(_arg{i}, {i});" for i, ty in signature.items()
-        if ty.startswith("tensordesc")
-    ]
-    float_storage_decls = [
-        f"{FLOAT_STORAGE_TYPE[ty]} _arg{i}_storage = {FLOAT_PACK_FUNCTION[ty]}(_arg{i});"
-        for i, ty in signature.items()
-        if ty in FLOAT_STORAGE_TYPE
-    ]
+    return output
 
-    libhip_path = _get_path_to_hip_runtime_dylib()
 
-    # generate glue code
-    params = list(range(len(signature)))
-    params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
-    params.append("&global_scratch")
-    params.append("&profile_scratch")
-    src = f"""
-#define __HIP_PLATFORM_AMD__
-#include <hip/hip_runtime.h>
-#include <hip/hip_runtime_api.h>
-#include <Python.h>
-#include <dlfcn.h>
-#include <stdbool.h>
-#include <dlfcn.h>
+def make_kernel_signature(signature):
+    """
+    Creates a kernel signature in C to be able to efficiently extract
+    arguments in the launcher.
+    """
 
-typedef struct {{
-  uint32_t group0_0;
-  uint32_t group0_1;
-  uint32_t group0_2;
-  uint32_t group0_3;
-  uint32_t group1_0;
-  uint32_t group1_1;
-  uint32_t group1_2;
-  uint32_t group1_3;
-  uint32_t group1_4;
-  uint32_t group1_5;
-  uint32_t group1_6;
-  uint32_t group1_7;
-  uint32_t group2_0;
-  uint32_t group2_1;
-  uint32_t group2_2;
-  uint32_t group2_3;
-  uint32_t group3_0;
-  uint32_t group3_1;
-  uint32_t group3_2;
-  uint32_t group3_3;
-}} TDMDescriptor;
+    def _flatten_signature(sig, output):
+        # Flatten tuples
+        if isinstance(sig, tuple):
+            for x in sig:
+                _flatten_signature(x, output)
+        else:
+            output.append(sig)
 
-typedef struct {{
-  PyObject_HEAD;
-  TDMDescriptor desc;
-}} PyTDMDescriptorObject;
+    flat_signature = []
+    for sig in signature:
+        _flatten_signature(sig, flat_signature)
+    kernel_signature = [x for x in flat_signature if x != "constexpr"]
 
-// The list of paths to search for the HIP runtime library. The caller Python
-// code should substitute the search path placeholder.
-static const char *hipLibSearchPaths[] = {{"{libhip_path}"}};
+    return triton.runtime.driver.active.utils.build_signature_metadata(kernel_signature)
 
-// The list of HIP dynamic library symbols and their signature we are interested
-// in this file.
-#define HIP_SYMBOL_LIST(FOR_EACH_ERR_FN, FOR_EACH_STR_FN)                     \\
-  FOR_EACH_STR_FN(hipGetLastError, true)                                      \\
-  FOR_EACH_STR_FN(hipGetErrorString, true, hipError_t hipError)               \\
-  FOR_EACH_ERR_FN(hipDrvLaunchKernelEx, false,                                \\
-                  const HIP_LAUNCH_CONFIG *config,                            \\
-                  hipFunction_t f,                                            \\
-                  void **kernelParams,                                        \\
-                  void **extra)                                               \\
-  FOR_EACH_ERR_FN(hipModuleLaunchKernel, true, hipFunction_t f,               \\
-                  unsigned int gridDimX, unsigned int gridDimY,               \\
-                  unsigned int gridDimZ, unsigned int blockDimX,              \\
-                  unsigned int blockDimY, unsigned int blockDimZ,             \\
-                  unsigned int sharedMemBytes, hipStream_t stream,            \\
-                  void **kernelParams, void **extra)                          \\
-  FOR_EACH_ERR_FN(hipModuleLaunchCooperativeKernel, true, hipFunction_t f,    \\
-                  unsigned int gridDimX, unsigned int gridDimY,               \\
-                  unsigned int gridDimZ, unsigned int blockDimX,              \\
-                  unsigned int blockDimY, unsigned int blockDimZ,             \\
-                  unsigned int sharedMemBytes, hipStream_t stream,            \\
-                  void **kernelParams, void **extra)                          \\
-  FOR_EACH_ERR_FN(hipPointerGetAttribute, true, void *data,                   \\
-                  hipPointer_attribute attribute, hipDeviceptr_t ptr)
 
-// The HIP symbol table for holding resolved dynamic library symbols.
-struct HIPSymbolTable {{
-#define DEFINE_EACH_ERR_FIELD(hipSymbolName, required, ...)                   \\
-  hipError_t (*hipSymbolName)(__VA_ARGS__);
-#define DEFINE_EACH_STR_FIELD(hipSymbolName, required, ...)                   \\
-  const char *(*hipSymbolName)(__VA_ARGS__);
-
-  HIP_SYMBOL_LIST(DEFINE_EACH_ERR_FIELD, DEFINE_EACH_STR_FIELD)
-}};
-
-static struct HIPSymbolTable hipSymbolTable;
-
-bool initSymbolTable() {{
-  // Use the HIP runtime library loaded into the existing process if it exits.
-  void *lib = dlopen("libamdhip64.so", RTLD_NOLOAD);
-
-  // Otherwise, go through the list of search paths to dlopen the first HIP
-  // driver library.
-  if (!lib) {{
-    int n = sizeof(hipLibSearchPaths) / sizeof(hipLibSearchPaths[0]);
-    for (int i = 0; i < n; ++i) {{
-      void *handle = dlopen(hipLibSearchPaths[i], RTLD_LAZY | RTLD_LOCAL);
-      if (handle) {{
-        lib = handle;
-      }}
-    }}
-  }}
-  if (!lib) {{
-    PyErr_SetString(PyExc_RuntimeError, "cannot open libamdhip64.so");
-    return false;
-  }}
-
-  typedef hipError_t (*hipGetProcAddress_fn)(
-      const char *symbol, void **pfn, int hipVersion, uint64_t hipFlags,
-      hipDriverProcAddressQueryResult *symbolStatus);
-  hipGetProcAddress_fn hipGetProcAddress;
-  dlerror(); // Clear existing errors
-  const char *error = NULL;
-  *(void **)&hipGetProcAddress = dlsym(lib, "hipGetProcAddress");
-  error = dlerror();
-  if (error) {{
-    PyErr_SetString(PyExc_RuntimeError,
-                    "cannot query 'hipGetProcAddress' from libamdhip64.so");
-    dlclose(lib);
-    return false;
-  }}
-
-  // Resolve all symbols we are interested in.
-  int hipVersion = HIP_VERSION;
-  uint64_t hipFlags = 0;
-  hipDriverProcAddressQueryResult symbolStatus;
-  hipError_t status = hipSuccess;
-#define QUERY_EACH_FN(hipSymbolName, required, ...)                            \
-  status = hipGetProcAddress(#hipSymbolName,                                   \
-                             (void **)&hipSymbolTable.hipSymbolName,           \
-                             hipVersion, hipFlags, &symbolStatus);             \
-  if (required && status != hipSuccess) {{                                     \
-    PyErr_SetString(PyExc_RuntimeError,                                        \
-                    "cannot get address for '" #hipSymbolName                  \
-                    "' from libamdhip64.so");                                  \
-    dlclose(lib);                                                              \
-    return false;                                                              \
-  }}
-
-  HIP_SYMBOL_LIST(QUERY_EACH_FN, QUERY_EACH_FN)
-
-  return true;
-}}
-
-static inline void gpuAssert(hipError_t code, const char *file, int line)
-{{
-   if (code != hipSuccess)
-   {{
-      const char* prefix = "Triton Error [HIP]: ";
-      const char* str = hipSymbolTable.hipGetErrorString(code);
-      char err[1024] = {{0}};
-      snprintf(err, 1024, "%s Code: %d, Messsage: %s", prefix, code, str );
-      PyErr_SetString(PyExc_RuntimeError, err);
-   }}
-}}
-
-#define HIP_CHECK(ans) {{ gpuAssert((ans), __FILE__, __LINE__); }}
-
-static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas, int launch_cooperative_grid, int shared_memory, hipStream_t stream, hipFunction_t function, hipDeviceptr_t profile_scratch{', ' + arg_decls if len(arg_decls) > 0 else ''}) {{
-  if (gridX * gridY * gridZ == 0)
-    return;
-  hipDeviceptr_t global_scratch = 0;
-  void *params[] = {{ {', '.join(params)} }};
-  if(num_ctas > 1) {{
-    if (!hipSymbolTable.hipDrvLaunchKernelEx) {{
-        PyErr_SetString(PyExc_RuntimeError, "missing hipDrvLaunchKernelEx symbol; please update HIP runtime");
-        return;
-    }}
-
-    hipLaunchAttribute attributes[2];
-    // Attribute0: Cluster dimensions
-    attributes[0].id = (hipLaunchAttributeID)4;
-    int *cluster_dims = (int*)attributes[0].val.pad;
-    cluster_dims[0] = num_ctas;
-    cluster_dims[1] = 1;
-    cluster_dims[2] = 1;
-    // Attribute1: Cooperative launch
-    attributes[1].id = hipLaunchAttributeCooperative;
-    attributes[1].val.cooperative = launch_cooperative_grid;
-
-    HIP_LAUNCH_CONFIG config = {{
-        (unsigned int)(gridX * num_ctas), (unsigned int)gridY, (unsigned int)gridZ, // Grid size
-        (unsigned int)({warp_size} * num_warps), 1, 1, // Block size
-        (unsigned int)shared_memory, stream,
-        attributes, 2 // Number of attributes
-    }};
-    HIP_CHECK(hipSymbolTable.hipDrvLaunchKernelEx(&config, function, params, 0));
-    return;
-  }}
-  else if (launch_cooperative_grid) {{
-    HIP_CHECK(hipSymbolTable.hipModuleLaunchCooperativeKernel(function, gridX, gridY, gridZ, {warp_size}*num_warps, 1, 1, shared_memory, stream, params, 0));
-    return;
-  }}
-  else {{
-    HIP_CHECK(hipSymbolTable.hipModuleLaunchKernel(function, gridX, gridY, gridZ, {warp_size}*num_warps, 1, 1, shared_memory, stream, params, 0));
-  }}
-}}
-
-typedef struct _DevicePtrInfo {{
-    hipDeviceptr_t dev_ptr;
-    bool valid;
-}} DevicePtrInfo;
-
-static PyObject* data_ptr_str = NULL;
-static PyObject* py_tdm_descriptor_type = NULL;
-
-static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
-  DevicePtrInfo ptr_info;
-  hipError_t status = hipSuccess;
-  ptr_info.dev_ptr = 0;
-  ptr_info.valid = true;
-  if (PyLong_Check(obj)) {{
-    ptr_info.dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(obj);
-    return ptr_info;
-  }}
-  if (obj == Py_None) {{
-    // valid nullptr
-    return ptr_info;
-  }}
-  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
-  if (!ret) {{
-    PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  if (!PyLong_Check(ret)) {{
-    PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  ptr_info.dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(ret);
-  if (!ptr_info.dev_ptr)
-    goto cleanup;
-  uint64_t dev_ptr;
-  status = hipSymbolTable.hipPointerGetAttribute(&dev_ptr, HIP_POINTER_ATTRIBUTE_DEVICE_POINTER, ptr_info.dev_ptr);
-  if (status == hipErrorInvalidValue) {{
-      PyErr_Format(PyExc_ValueError,
-                   "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
-      ptr_info.valid = false;
-      // Clear and ignore HIP error
-      (void)hipSymbolTable.hipGetLastError();
-  }}
-  ptr_info.dev_ptr = (hipDeviceptr_t)dev_ptr;
-cleanup:
-  Py_DECREF(ret);
-  return ptr_info;
-}}
-
-static inline TDMDescriptor* getTDMDescriptor(PyObject* obj, int idx) {{
-  if (Py_TYPE(obj) != (PyTypeObject*)py_tdm_descriptor_type) {{
-    PyErr_Format(PyExc_TypeError, "object must be of type PyTDMDescriptor, got %s", Py_TYPE(obj)->tp_name);
-    return NULL;
-  }}
-
-  TDMDescriptor* desc = &((PyTDMDescriptorObject*)obj)->desc;
-  return desc;
-}}
-
-static uint16_t pack_fp16(double f) {{
-    uint16_t result;
-    // from https://github.com/python/pythoncapi-compat/blob/5e317108f872c904eb726cb8d560dcadbdf88a72/pythoncapi_compat.h#L482-L492
-#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && !defined(PYPY_VERSION)
-    _PyFloat_Pack2(f, (unsigned char*)&result, 1);
-#else
-    PyFloat_Pack2(f, (char*)&result, 1);
-#endif
-    return result;
-}}
-
-static uint16_t pack_bf16(double f) {{
-    float f32 = (float)f;
-    uint32_t u32 = *(uint32_t*)&f32;
-    return (uint16_t)(u32 >> 16);
-}}
-
-static uint32_t pack_fp32(double f) {{
-    float f32 = (float)f;
-    return *(uint32_t*)&f32;
-}}
-
-static uint64_t pack_fp64(double f) {{
-    return *(uint64_t*)&f;
-}}
-
-static PyObject* launch(PyObject* self, PyObject* args) {{
-  int gridX, gridY, gridZ;
-  uint64_t _stream;
-  uint64_t _function;
-  int launch_cooperative_grid;
-  PyObject *profile_scratch_obj = NULL;
-  PyObject *launch_enter_hook = NULL;
-  PyObject *launch_exit_hook = NULL;
-  PyObject *kernel_metadata = NULL;
-  PyObject *launch_metadata = NULL;
-  {' '.join([f"{_extracted_type(ty)} _arg{i}; " for i, ty in signature.items()])}
-  if(!PyArg_ParseTuple(args, \"{format}\", &launch_cooperative_grid,
-                                           &gridX, &gridY, &gridZ, &_stream, &_function, &profile_scratch_obj,
-                                           &kernel_metadata, &launch_metadata,
-                                           &launch_enter_hook, &launch_exit_hook {args_list})) {{
-    return NULL;
-  }}
-
-  // extract kernel metadata
-  int num_warps, num_ctas, shared_memory;
-  if (!PyArg_ParseTuple(kernel_metadata, \"iii\", &num_warps, &num_ctas, &shared_memory)) {{
-    return NULL;
-  }}
-  // extract launch metadata
-  if (launch_enter_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_enter_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  hipDeviceptr_t profile_scratch = 0;
-  if (profile_scratch_obj != Py_None) {{
-    DevicePtrInfo profile_scratch_info = getPointer(profile_scratch_obj, -1);
-    if (!profile_scratch_info.valid) {{
-      return NULL;
-    }}
-    profile_scratch = profile_scratch_info.dev_ptr;
-  }}
-
-  // raise exception asap
-  {newline.join(tensor_desc_decls)}
-  {newline.join(ptr_decls)}
-  {newline.join(float_storage_decls)}
-  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid, shared_memory, (hipStream_t)_stream, (hipFunction_t)_function, (hipDeviceptr_t)profile_scratch{', ' + ', '.join(internal_args_list) if len(internal_args_list) > 0 else ''});
-
-  if(launch_exit_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_exit_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  if(PyErr_Occurred()) {{
-    return NULL;
-  }}
-  Py_RETURN_NONE;
-}}
-
-static PyMethodDef ModuleMethods[] = {{
-  {{"launch", launch, METH_VARARGS, "Entry point for all kernels with this signature"}},
-  {{NULL, NULL, 0, NULL}} // sentinel
-}};
-
-static struct PyModuleDef ModuleDef = {{
-  PyModuleDef_HEAD_INIT,
-  \"__triton_launcher\",
-  NULL, //documentation
-  -1, //size
-  ModuleMethods
-}};
-
-PyMODINIT_FUNC PyInit___triton_launcher(void) {{
-  if (!initSymbolTable()) {{
-    return NULL;
-  }}
-  PyObject *m = PyModule_Create(&ModuleDef);
-  if(m == NULL) {{
-    return NULL;
-  }}
-  data_ptr_str = PyUnicode_InternFromString("data_ptr");
-  if(data_ptr_str == NULL) {{
-    return NULL;
-  }}
-  PyObject* driver_mod = PyImport_ImportModule("triton.backends.amd.driver");
-  if (driver_mod == NULL) {{
-    return NULL;
-  }}
-  py_tdm_descriptor_type = PyObject_GetAttrString(driver_mod, "PyTDMDescriptor");
-  if (py_tdm_descriptor_type == NULL) {{
-    return NULL;
-  }}
-
-  PyModule_AddFunctions(m, ModuleMethods);
-  return m;
-}}
-"""
-    return src
+def annotate_arguments(signature):
+    """
+    This recreates the signature with annotations as C objects which can then
+    be used to efficiently flatten tuples, and remove constexpr in the launcher.
+    """
+    annotated_arguments = []
+    for sig in signature:
+        if isinstance(sig, tuple):
+            annotated_arguments.append((PyKernelArg(nested_tuple=annotate_arguments(sig), type=ARG_TUPLE)))
+        elif sig != "constexpr":
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_KERNEL))
+        else:
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_CONSTEXPR))
+    return annotated_arguments
 
 
 def make_tensordesc_arg(arg, kernel_metadata, tensordesc_metadata):
@@ -788,19 +357,20 @@ def wrap_handle_tensordesc(launcher, signature, tensordesc_metadata):
         tensordesc_metadata = [None] * len(tensordesc_indices)
 
     def inner(*args):
-        meta_args = args[:len(_BASE_ARGS_FORMAT)]
-        raw_kernel_args = args[len(_BASE_ARGS_FORMAT):]
-        final_args = []
+        base_args = args[:-1]
+        kernel_metadata = base_args[7]
+        kernel_args = args[-1]
+
+        final_kernel_args = []
         tensordesc_idx = 0
-        for i, arg in enumerate(raw_kernel_args):
+        for i, arg in enumerate(kernel_args):
             if i in tensordesc_indices:
-                tensordesc_args = make_tensordesc_arg(arg, meta_args[7],  # kernel_metadata
-                                                      tensordesc_metadata[tensordesc_idx])
-                final_args.extend(tensordesc_args)
+                final_kernel_args.extend(make_tensordesc_arg(arg, kernel_metadata, tensordesc_metadata[tensordesc_idx]))
                 tensordesc_idx += 1
             else:
-                final_args.append(arg)
-        return launcher(*meta_args, *final_args)
+                final_kernel_args.append(arg)
+
+        return launcher(*base_args, final_kernel_args)
 
     return inner
 
@@ -813,10 +383,13 @@ class HIPLauncher(object):
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
-        src = make_launcher(constants, signature, metadata.warp_size, tensordesc_meta)
-        mod = compile_module_from_src(src=src, name="__triton_launcher", include_dirs=include_dirs)
-        self.launch = wrap_handle_tensordesc(mod.launch, signature, tensordesc_meta)
+        launcher = triton.runtime.driver.active.utils.launch
+        expanded_signature = expand_signature(signature.values(), tensordesc_meta)
+        self.arg_annotations = annotate_arguments(expanded_signature)
+        self.kernel_signature = make_kernel_signature(expanded_signature)
+        self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
         self.launch_cooperative_grid = metadata.launch_cooperative_grid
+        self.warp_size = metadata.warp_size
         # Check if cooperative groups are supported on the device.
         if self.launch_cooperative_grid:
             driver = triton.runtime.driver.active
@@ -828,7 +401,8 @@ class HIPLauncher(object):
         self.profile_scratch_size = metadata.profile_scratch_size
         self.profile_scratch_align = metadata.profile_scratch_align
 
-    def __call__(self, gridX, gridY, gridZ, stream, function, *args):
+    def __call__(self, gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
+                 launch_exit_hook, *args):
 
         def allocate_scratch(size, align, allocator):
             if size > 0:
@@ -841,7 +415,9 @@ class HIPLauncher(object):
         profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
                                            _allocation._profile_allocator)
 
-        self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, profile_scratch, *args)
+        self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, profile_scratch,
+                    kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, self.warp_size,
+                    self.arg_annotations, self.kernel_signature, args)
 
 
 class HIPDriver(GPUDriver):

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1,6 +1,8 @@
 #include "cuda.h"
 #include <dlfcn.h>
+#include <stdalign.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #define PY_SSIZE_T_CLEAN
@@ -10,6 +12,51 @@ typedef struct {
   PyObject_HEAD;
   _Alignas(128) CUtensorMap tensorMap;
 } PyCUtensorMapObject;
+
+typedef enum { ARG_CONSTEXPR = 0, ARG_KERNEL = 1, ARG_TUPLE = 2 } ArgType;
+
+// Annotation struct to know how the argument should be handled.
+typedef struct {
+  PyObject_HEAD;
+  PyObject *nested_tuple; // Can be a List of PyKernelArgObjects or None
+  ArgType type;
+} PyKernelArgObject;
+
+// Deallocator
+static void PyKernelArg_dealloc(PyKernelArgObject *self) {
+  Py_XDECREF(self->nested_tuple);
+  Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+// Constructor
+static int PyKernelArg_init(PyKernelArgObject *self, PyObject *args,
+                            PyObject *kwds) {
+  static char *kwlist[] = {"nested_tuple", "type", NULL};
+  PyObject *tup = NULL;
+  int type_val = 0;
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|i", kwlist, &tup,
+                                   &type_val)) {
+    return -1;
+  }
+  Py_XINCREF(tup);
+  self->nested_tuple = tup;
+  self->type = (ArgType)type_val;
+  return 0;
+}
+
+static void PyKernelArg_free(void *ptr) { free(ptr); }
+
+static PyTypeObject PyKernelArgType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name =
+        "triton.backends.nvidia.PyKernelArg",
+    .tp_basicsize = sizeof(PyKernelArgObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Kernel Argument Metadata",
+    .tp_new = PyType_GenericNew,
+    .tp_init = (initproc)PyKernelArg_init,
+    .tp_dealloc = (destructor)PyKernelArg_dealloc,
+};
 
 // Raises a Python exception and returns false if code is not CUDA_SUCCESS.
 static bool gpuAssert(CUresult code, const char *file, int line) {
@@ -28,6 +75,13 @@ static bool gpuAssert(CUresult code, const char *file, int line) {
   PyGILState_Release(gil_state);
   return false;
 }
+
+// To be used only *outside* a Py_{BEGIN,END}_ALLOW_THREADS block.
+#define CUDA_CHECK(ans)                                                        \
+  do {                                                                         \
+    if (!gpuAssert((ans), __FILE__, __LINE__))                                 \
+      return;                                                                  \
+  } while (0)
 
 // To be used only *outside* a Py_{BEGIN,END}_ALLOW_THREADS block.
 #define CUDA_CHECK_AND_RETURN_NULL(ans)                                        \
@@ -174,6 +228,10 @@ typedef CUresult (*cuTensorMapEncodeTiled_t)(
     CUtensorMapSwizzle swizzle, CUtensorMapL2promotion l2Promotion,
     CUtensorMapFloatOOBfill oobFill);
 
+typedef CUresult (*cuLaunchKernelEx_t)(const CUlaunchConfig *config,
+                                       CUfunction f, void **kernelParams,
+                                       void **extra);
+
 #define defineGetFunctionHandle(name, symbolName)                              \
   static symbolName##_t name() {                                               \
     /* Open the shared library */                                              \
@@ -201,6 +259,8 @@ defineGetFunctionHandle(getCuOccupancyMaxActiveClustersHandle,
 
 defineGetFunctionHandle(getCuTensorMapEncodeTiledHandle,
                         cuTensorMapEncodeTiled);
+
+defineGetFunctionHandle(getLaunchKernelExHandle, cuLaunchKernelEx);
 
 static PyObject *occupancyMaxActiveClusters(PyObject *self, PyObject *args) {
   int clusterDim = -1, maxActiveClusters = -1;
@@ -741,6 +801,589 @@ cleanup:
   return NULL;
 }
 
+static void ensureCudaContext() {
+  CUcontext pctx;
+  CUDA_CHECK(cuCtxGetCurrent(&pctx));
+  if (!pctx) {
+    // Ensure device context.
+    CUdevice device;
+    CUDA_CHECK(cuDeviceGet(&device, 0));
+    CUDA_CHECK(cuDevicePrimaryCtxRetain(&pctx, device));
+    CUDA_CHECK(cuCtxSetCurrent(pctx));
+  }
+}
+
+static void _launch(int gridX, int gridY, int gridZ, int num_warps,
+                    int num_ctas, int launch_cooperative_grid, int launch_pdl,
+                    int preferredClusterDimX, int preferredClusterDimY,
+                    int preferredClusterDimZ, int shared_memory, CUstream stream,
+                    CUfunction function, void **params) {
+  if (gridX * gridY * gridZ > 0) {
+    // 5 attributes that we can currently pass maximum
+    CUlaunchAttribute launchAttr[5];
+    static cuLaunchKernelEx_t cuLaunchKernelExHandle = NULL;
+    if (cuLaunchKernelExHandle == NULL) {
+      cuLaunchKernelExHandle = getLaunchKernelExHandle();
+    }
+    CUlaunchConfig config;
+    config.gridDimX = gridX * num_ctas;
+    config.gridDimY = gridY;
+    config.gridDimZ = gridZ;
+
+    config.blockDimX = 32 * num_warps;
+    config.blockDimY = 1;
+    config.blockDimZ = 1;
+    config.sharedMemBytes = shared_memory;
+    config.hStream = stream;
+    config.attrs = launchAttr;
+    int num_attrs = 0;
+
+    if (launch_pdl != 0) {
+      CUlaunchAttribute pdlAttr = {
+          .id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION,
+          .value = 1};
+      launchAttr[num_attrs] = pdlAttr;
+      ++num_attrs;
+    }
+
+    if (launch_cooperative_grid != 0) {
+      CUlaunchAttribute coopAttr = {.id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE,
+                                    .value = 1};
+      launchAttr[num_attrs] = coopAttr;
+      ++num_attrs;
+    }
+
+    if (num_ctas != 1 || preferredClusterDimX > 0) {
+      // Only set CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for Triton's num_ctas
+      // path. For ctas_per_cga path (num_ctas == 1), PTX's .reqnctapercluster
+      // handles it.
+      if (num_ctas > 1) {
+        CUlaunchAttribute clusterAttr = {};
+        clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+        clusterAttr.value.clusterDim.x = num_ctas;
+        clusterAttr.value.clusterDim.y = 1;
+        clusterAttr.value.clusterDim.z = 1;
+        launchAttr[num_attrs] = clusterAttr;
+        ++num_attrs;
+      }
+
+      CUlaunchAttribute clusterSchedulingAttr = {};
+      clusterSchedulingAttr.id =
+          CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+      clusterSchedulingAttr.value.clusterSchedulingPolicyPreference =
+          CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+      launchAttr[num_attrs] = clusterSchedulingAttr;
+      ++num_attrs;
+    }
+
+#if CUDA_VERSION >= 12080
+    if (preferredClusterDimX > 0) {
+      CUlaunchAttribute preferredClusterAttr = {};
+      preferredClusterAttr.id =
+          CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
+      preferredClusterAttr.value.preferredClusterDim.x = preferredClusterDimX;
+      preferredClusterAttr.value.preferredClusterDim.y = preferredClusterDimY;
+      preferredClusterAttr.value.preferredClusterDim.z = preferredClusterDimZ;
+      launchAttr[num_attrs] = preferredClusterAttr;
+      ++num_attrs;
+    }
+#endif
+
+    // num_ctas == 16 is non-portable. Does work for H100 and B200 tho
+    config.numAttrs = num_attrs;
+    if (num_ctas == 16) {
+      CUDA_CHECK(cuFuncSetAttribute(
+          function, CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED, 1));
+    }
+
+    CUDA_CHECK(cuLaunchKernelExHandle(&config, function, params, 0));
+  }
+}
+
+static PyObject *data_ptr_str = NULL;
+
+// Extract a CUDA device pointer from a pointer-like PyObject obj, and store
+// it to the memory location pointed by ptr.
+bool extractPointer(void *ptr, PyObject *obj) {
+  CUdeviceptr *dev_ptr = ptr;
+  if (obj == Py_None) {
+    *dev_ptr = (CUdeviceptr)0; // valid nullptr
+    return true;
+  }
+  if (PyLong_Check(obj)) {
+    *dev_ptr = PyLong_AsUnsignedLongLong(obj);
+    return true;
+  }
+  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
+  if (!ret) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "Pointer argument must be either uint64 or have data_ptr method");
+    return false;
+  }
+  if (!PyLong_Check(ret)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "data_ptr method of Pointer object must return 64-bit int");
+    return false;
+  }
+  *dev_ptr = PyLong_AsUnsignedLongLong(ret);
+  Py_DECREF(ret);
+  if (*dev_ptr == 0) {
+    return true; // valid nullptr
+  }
+  CUresult status = cuPointerGetAttribute(
+      dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, *dev_ptr);
+  if (status == CUDA_ERROR_INVALID_VALUE) {
+    PyErr_Format(PyExc_ValueError,
+                 "Pointer argument cannot be accessed from Triton "
+                 "(cpu tensor?)");
+    return false;
+  }
+  return gpuAssert(status, __FILE__, __LINE__);
+}
+
+bool extractI8(void *ptr, PyObject *obj) {
+  *((int8_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI16(void *ptr, PyObject *obj) {
+  *((int16_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI32(void *ptr, PyObject *obj) {
+  *((int32_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI64(void *ptr, PyObject *obj) {
+  *((int64_t *)ptr) = PyLong_AsLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU8(void *ptr, PyObject *obj) {
+  *((uint8_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU16(void *ptr, PyObject *obj) {
+  *((uint16_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU32(void *ptr, PyObject *obj) {
+  *((uint32_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU64(void *ptr, PyObject *obj) {
+  *((uint64_t *)ptr) = PyLong_AsUnsignedLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  uint16_t result;
+  // from https://github.com/python/pythoncapi-compat
+#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 &&            \
+    !defined(PYPY_VERSION)
+  _PyFloat_Pack2(temp_double, (unsigned char *)&result, 1);
+#else
+  PyFloat_Pack2(temp_double, (char *)&result, 1);
+#endif
+  *((uint16_t *)ptr) = result;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractBF16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  uint32_t u32 = *(uint32_t *)&f32;
+  *((uint16_t *)ptr) = (u32 >> 16);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP32(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  *((uint32_t *)ptr) = *(uint32_t *)&f32;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP64(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  *((uint64_t *)ptr) = *(uint64_t *)&temp_double;
+  return PyErr_Occurred() == NULL;
+}
+
+// Extract a CUtensorMap descriptor from a python object, and store it to the
+// memory location pointed by ptr.
+bool extractTmaDesc(void *ptr, PyObject *obj) {
+  if (sizeof(CUtensorMap *) != 8) {
+    PyErr_SetString(PyExc_SystemError,
+                    "getTmaDesc() requires 64-bit compilation");
+    return false;
+  }
+  if (Py_TYPE(obj) != &PyCUtensorMapType) {
+    PyErr_Format(PyExc_TypeError,
+                 "object must be of type PyCUtensorMap, got %s",
+                 Py_TYPE(obj)->tp_name);
+    return false;
+  }
+  *((CUtensorMap *)ptr) = ((PyCUtensorMapObject *)obj)->tensorMap;
+  uintptr_t align_128 = (uintptr_t)ptr & (128 - 1);
+  if (align_128 != 0) {
+    PyErr_Format(
+        PyExc_ValueError,
+        "CUtensorMap must be aligned to 128B, but got (&map) mod 128 = %ld",
+        align_128);
+    return false;
+  }
+  return true;
+}
+
+typedef bool (*ExtractorFunc)(void *ptr, PyObject *obj);
+
+#define MAX_NAMES_PER_EXTRACTOR 2
+
+typedef struct {
+  ExtractorFunc extract;
+  size_t size;
+  size_t alignment;
+  const char *name[MAX_NAMES_PER_EXTRACTOR];
+} Extractor;
+
+typedef enum {
+  EXTRACTOR_UNKOWN_INDEX = 0,
+  // pointers
+  EXTRACTOR_POINTER_INDEX = 1,
+  // ints
+  EXTRACTOR_INT8_INDEX = 2,
+  EXTRACTOR_INT16_INDEX = 3,
+  EXTRACTOR_INT32_INDEX = 4,
+  EXTRACTOR_INT64_INDEX = 5,
+  // uints
+  EXTRACTOR_UINT8_INDEX = 6,
+  EXTRACTOR_UINT16_INDEX = 7,
+  EXTRACTOR_UINT32_INDEX = 8,
+  EXTRACTOR_UINT64_INDEX = 9,
+  // floats
+  EXTRACTOR_FP16_INDEX = 10,
+  EXTRACTOR_BF16_INDEX = 11,
+  EXTRACTOR_FP32_INDEX = 12,
+  EXTRACTOR_FP64_INDEX = 13,
+  // custom
+  EXTRACTOR_NVTMADESC_INDEX = 14,
+  // last entry to have a count
+  EXTRACTOR_TYPE_COUNT
+} ExtractorTypeIndex;
+
+Extractor extraction_map[EXTRACTOR_TYPE_COUNT] = {
+    [EXTRACTOR_UNKOWN_INDEX] =
+        (Extractor){.extract = NULL, .size = 0, .name = NULL},
+    [EXTRACTOR_POINTER_INDEX] = (Extractor){.extract = extractPointer,
+                                            .size = sizeof(CUdeviceptr),
+                                            .name = NULL},
+    [EXTRACTOR_INT8_INDEX] = (Extractor){.extract = extractI8,
+                                         .size = sizeof(int8_t),
+                                         .name = {"i8"}},
+    [EXTRACTOR_INT16_INDEX] = (Extractor){.extract = extractI16,
+                                          .size = sizeof(int16_t),
+                                          .name = {"i16"}},
+    [EXTRACTOR_INT32_INDEX] = (Extractor){.extract = extractI32,
+                                          .size = sizeof(int32_t),
+                                          .name = {"i1", "i32"}},
+    [EXTRACTOR_INT64_INDEX] = (Extractor){.extract = extractI64,
+                                          .size = sizeof(int64_t),
+                                          .name = {"i64"}},
+    [EXTRACTOR_UINT8_INDEX] = (Extractor){.extract = extractU8,
+                                          .size = sizeof(uint8_t),
+                                          .name = {"u8"}},
+    [EXTRACTOR_UINT16_INDEX] = (Extractor){.extract = extractU16,
+                                           .size = sizeof(uint16_t),
+                                           .name = {"u16"}},
+    [EXTRACTOR_UINT32_INDEX] = (Extractor){.extract = extractU32,
+                                           .size = sizeof(uint32_t),
+                                           .name = {"u1", "u32"}},
+    [EXTRACTOR_UINT64_INDEX] = (Extractor){.extract = extractU64,
+                                           .size = sizeof(uint64_t),
+                                           .name = {"u64"}},
+    [EXTRACTOR_FP16_INDEX] = (Extractor){.extract = extractFP16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"fp16"}},
+    [EXTRACTOR_BF16_INDEX] = (Extractor){.extract = extractBF16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"bf16"}},
+    [EXTRACTOR_FP32_INDEX] = (Extractor){.extract = extractFP32,
+                                         .size = sizeof(uint32_t),
+                                         .name = {"fp32", "f32"}},
+    [EXTRACTOR_FP64_INDEX] = (Extractor){.extract = extractFP64,
+                                         .size = sizeof(uint64_t),
+                                         .name = {"fp64"}},
+    [EXTRACTOR_NVTMADESC_INDEX] = (Extractor){.extract = extractTmaDesc,
+                                              .size = sizeof(CUtensorMap),
+                                              .alignment = alignof(CUtensorMap),
+                                              .name = {"nvTmaDesc"}},
+};
+
+Extractor getExtractor(uint8_t index) {
+  if (index >= EXTRACTOR_TYPE_COUNT) {
+    return extraction_map[EXTRACTOR_UNKOWN_INDEX];
+  }
+  return extraction_map[index];
+}
+
+bool isMatch(const char *type_bytes, ExtractorTypeIndex idx) {
+  Extractor extractor = extraction_map[idx];
+  for (int j = 0; j < MAX_NAMES_PER_EXTRACTOR; j++) {
+    if (extractor.name[j] != NULL &&
+        strcmp(type_bytes, extractor.name[j]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ExtractorTypeIndex getExtractorIndex(PyObject *type) {
+  Py_ssize_t type_len = 0;
+  const char *type_bytes = PyUnicode_AsUTF8AndSize(type, &type_len);
+  if (!type_bytes) {
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  if (type_len < 2) {
+    PyErr_Format(PyExc_RuntimeError, "Unexpected data type: %R", type);
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  // Examples: '*fp32', 'fp32', 'i8', etc.
+  if (type_bytes[0] == '*') {
+    return EXTRACTOR_POINTER_INDEX;
+  }
+  for (ExtractorTypeIndex i = EXTRACTOR_INT8_INDEX; i < EXTRACTOR_TYPE_COUNT;
+       i++) {
+    if (isMatch(type_bytes, i)) {
+      return i;
+    }
+  }
+
+  PyErr_Format(PyExc_RuntimeError, "Unknown data type: %R", type);
+  return EXTRACTOR_UNKOWN_INDEX;
+}
+
+// Takes in a list of types (ex: ['*fp32', 'u8', 'nvTmaDesc']) and returns
+// a bytes array that represent extractors for quick argument extraction
+// when launching.
+static PyObject *buildSignatureMetadata(PyObject *self, PyObject *args) {
+  PyObject *signature = NULL;
+  if (!PyArg_ParseTuple(args, "O", &signature)) {
+    return NULL;
+  }
+  PyObject *fast_signature = PySequence_Fast(
+      signature, "Expected kernel_arg_types to be a sequence or iterable");
+  if (!fast_signature) {
+    return NULL;
+  }
+  Py_ssize_t signature_size = PySequence_Fast_GET_SIZE(fast_signature);
+  PyObject **signature_items = PySequence_Fast_ITEMS(fast_signature);
+
+  // Create return bytes object.
+  PyObject *ret_bytes = PyBytes_FromStringAndSize(NULL, signature_size);
+  if (ret_bytes == NULL) {
+    Py_XDECREF(fast_signature);
+    return NULL;
+  }
+  char *buffer = PyBytes_AS_STRING(ret_bytes);
+  for (Py_ssize_t i = 0; i < signature_size; ++i) {
+    ExtractorTypeIndex extractor_idx = getExtractorIndex(signature_items[i]);
+    if (extractor_idx == EXTRACTOR_UNKOWN_INDEX) {
+      goto cleanup;
+    }
+    buffer[i] = (uint8_t)extractor_idx;
+  }
+
+  Py_XDECREF(fast_signature);
+  return ret_bytes;
+
+cleanup:
+  Py_XDECREF(fast_signature);
+  Py_XDECREF(ret_bytes);
+  return NULL;
+}
+
+bool extractArgs(PyObject **final_list, int *list_idx, PyObject *kernel_args,
+                 PyObject *arg_annotations) {
+  // Extract arg annotations
+  PyObject *fast_annotations = PySequence_Fast(
+      arg_annotations, "Expected arg_annotations to be a sequence or iterable");
+  if (!fast_annotations) {
+    goto cleanup;
+  }
+  Py_ssize_t num_annotations = PySequence_Fast_GET_SIZE(fast_annotations);
+  PyObject **annotations = PySequence_Fast_ITEMS(fast_annotations);
+
+  PyObject *fast_args = PySequence_Fast(
+      kernel_args, "Expected kernel_args to be a sequence or iterable");
+  if (!fast_args) {
+    goto cleanup;
+  }
+  PyObject **args = PySequence_Fast_ITEMS(fast_args);
+
+  int arg_idx = 0;
+  for (int i = 0; i < num_annotations; ++i) {
+    PyKernelArgObject *annotation = (PyKernelArgObject *)annotations[i];
+    switch (annotation->type) {
+    case ARG_KERNEL:
+      final_list[(*list_idx)++] = args[arg_idx++];
+      break;
+    case ARG_TUPLE:
+      if (!extractArgs(final_list, list_idx, args[arg_idx++],
+                       annotation->nested_tuple)) {
+        goto cleanup;
+      }
+      break;
+    case ARG_CONSTEXPR:
+      arg_idx++;
+      break;
+    }
+  }
+  Py_DECREF(fast_annotations);
+  Py_DECREF(fast_args);
+  return true;
+
+cleanup:
+  Py_XDECREF(fast_annotations);
+  Py_XDECREF(fast_args);
+  return false;
+}
+
+bool launchHook(PyObject *hook, PyObject *metadata) {
+  if (hook != Py_None) {
+    PyObject *ret = PyObject_CallOneArg(hook, metadata);
+    if (!ret) {
+      return false;
+    }
+    Py_DECREF(ret);
+  }
+  return true;
+}
+
+static PyObject *launchKernel(PyObject *self, PyObject *args) {
+  // ensure cuda context is valid before calling any CUDA APIs, e.g. before
+  // calls to cuPointerGetAttributes
+  ensureCudaContext();
+
+  // Parse the arguments.
+  int gridX, gridY, gridZ;
+  uint64_t _stream;
+  uint64_t _function;
+  int launch_cooperative_grid;
+  int launch_pdl;
+  int num_warps, num_ctas, shared_memory, preferredClusterDimX,
+      preferredClusterDimY, preferredClusterDimZ;
+  PyObject *launch_metadata = NULL;
+  PyObject *launch_enter_hook = NULL;
+  PyObject *launch_exit_hook = NULL;
+  PyObject *global_scratch_obj = NULL;
+  PyObject *profile_scratch_obj = NULL;
+  PyObject *arg_annotations = NULL;
+  Py_buffer signature;
+  PyObject *kernel_args = NULL;
+  if (!PyArg_ParseTuple(args, "iiiKKpp(iiiiii)OOOOOOy*O", &gridX, &gridY, &gridZ,
+                        &_stream, &_function, &launch_cooperative_grid,
+                        &launch_pdl, &num_warps, &num_ctas, &shared_memory,
+                        &preferredClusterDimX, &preferredClusterDimY,
+                        &preferredClusterDimZ,
+                        &launch_metadata, &launch_enter_hook, &launch_exit_hook,
+                        &global_scratch_obj, &profile_scratch_obj,
+                        &arg_annotations, &signature, &kernel_args)) {
+    return NULL;
+  }
+
+  // launch entry hook.
+  if (!launchHook(launch_enter_hook, launch_metadata)) {
+    goto cleanup;
+  }
+
+  uint8_t *extractor_data = (uint8_t *)signature.buf;
+  Py_ssize_t num_args = signature.len;
+
+  // Extract kernel parameters - flatten tuples & remove constexpr.
+  PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
+  if (args_data == NULL) {
+    goto cleanup;
+  }
+  int list_idx = 0;
+  if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
+    goto cleanup;
+  }
+
+  // Number of parameters passed to kernel. + 2 for global & profile scratch.
+  int num_params = num_args + 2;
+  void **params = (void **)alloca(num_params * sizeof(void *));
+  int params_idx = 0;
+  // This loop has to stay in the same function that owns params, since we are
+  // using alloca to allocate pointers to it on the stack of the function.
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    // Get extractor that will send back a struct with
+    // * size for allocation
+    // * function to call to put the parameter in params buffer
+    Extractor extractor = getExtractor(extractor_data[i]);
+    if (extractor.extract == NULL) {
+      goto cleanup;
+    }
+
+    size_t alignment = extractor.alignment;
+    if (alignment != 0) {
+      // Allocate enough space on the stack to guarantee an aligned block.
+      size_t size_with_alignment = extractor.size + alignment - 1;
+      void *storage_ptr = alloca(size_with_alignment);
+      void *aligned_ptr = (void *)((((uintptr_t)storage_ptr) + alignment - 1) &
+                                   ~(alignment - 1));
+      if (aligned_ptr == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "Failed to align parameter storage");
+        goto cleanup;
+      }
+      params[params_idx] = aligned_ptr;
+    } else {
+      params[params_idx] = alloca(extractor.size);
+    }
+
+    PyObject *current_arg = args_data[i];
+    if (!extractor.extract(params[params_idx++], current_arg)) {
+      goto cleanup;
+    }
+  }
+  // Add scratch objects.
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], global_scratch_obj)) {
+    goto cleanup;
+  }
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], profile_scratch_obj)) {
+    goto cleanup;
+  }
+
+  Py_BEGIN_ALLOW_THREADS;
+  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
+          launch_pdl, preferredClusterDimX, preferredClusterDimY,
+          preferredClusterDimZ, shared_memory, (CUstream)_stream,
+          (CUfunction)_function, params);
+  Py_END_ALLOW_THREADS;
+  if (PyErr_Occurred()) {
+    goto cleanup;
+  }
+
+  if (!launchHook(launch_exit_hook, launch_metadata)) {
+    goto cleanup;
+  }
+  PyBuffer_Release(&signature);
+  Py_RETURN_NONE;
+
+cleanup:
+  PyBuffer_Release(&signature);
+  return NULL;
+}
+
 static PyMethodDef ModuleMethods[] = {
     {"load_binary", loadBinary, METH_VARARGS,
      "Load provided cubin into CUDA driver"},
@@ -755,6 +1398,11 @@ static PyMethodDef ModuleMethods[] = {
      "particular it's an error to change this value after launching any kernel "
      "that calls printf()."},
     {"fill_tma_descriptor", fillTMADescriptor, METH_VARARGS, "doc"},
+    {"build_signature_metadata", buildSignatureMetadata, METH_VARARGS,
+     "Calling it with a signature list (ex: ['*fp32', 'u8', 'nvTmaDesc']), "
+     "will return metadata to be passed into 'launch' for quicker "
+     "argument parsing."},
+    {"launch", launchKernel, METH_VARARGS, "launches cuda kernel"},
     {"fill_1d_tma_descriptor", fill1DTMADescriptor, METH_VARARGS, "doc"},
     {"fill_2d_tma_descriptor", fill2DTMADescriptor, METH_VARARGS, "doc"},
     {"fill_1d_tma_descriptor_type", fill1DTMADescriptorType, METH_VARARGS,
@@ -774,15 +1422,29 @@ PyMODINIT_FUNC PyInit_cuda_utils(void) {
   if (PyType_Ready(&PyCUtensorMapType) < 0) {
     return NULL;
   }
+  if (PyType_Ready(&PyKernelArgType) < 0) {
+    return NULL;
+  }
 
   PyObject *m = PyModule_Create(&ModuleDef);
   if (m == NULL) {
     return NULL;
   }
+  data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  if (data_ptr_str == NULL) {
+    return NULL;
+  }
 
   PyModule_AddFunctions(m, ModuleMethods);
+
   Py_INCREF(&PyCUtensorMapType);
   PyModule_AddObject(m, "PyCUtensorMap", (PyObject *)&PyCUtensorMapType);
+
+  Py_INCREF(&PyKernelArgType);
+  PyModule_AddObject(m, "PyKernelArg", (PyObject *)&PyKernelArgType);
+  PyModule_AddIntConstant(m, "ARG_CONSTEXPR", ARG_CONSTEXPR);
+  PyModule_AddIntConstant(m, "ARG_KERNEL", ARG_KERNEL);
+  PyModule_AddIntConstant(m, "ARG_TUPLE", ARG_TUPLE);
 
   return m;
 }

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -301,11 +301,31 @@ class CudaLauncher(object):
         signature = {idx: value for idx, value in src.signature.items()}
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
 
-        launcher = triton.runtime.driver.active.utils.launch
-        expanded_signature = expand_signature(signature.values(), tensordesc_meta)
-        self.arg_annotations = annotate_arguments(expanded_signature)
-        self.kernel_signature = make_kernel_signature(expanded_signature)
-        self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
+        if knobs.nvidia.use_launcher_src and tensordesc_meta is None:
+            try:
+                from triton.compiler.compiler import make_backend
+                from triton.backends.nvidia.launcher_llvm import make_launcher as make_llvm_launcher
+                backend = make_backend(metadata.target)
+                schema = backend.make_launch_metadata(metadata._asdict(), src)
+                launch_fn = make_llvm_launcher(schema)
+                self.launch = wrap_handle_tensordesc(launch_fn, signature, tensordesc_meta)
+                self.launch_cluster = metadata.launch_cluster
+                self._use_llvm_launcher = True
+            except Exception:
+                # Fall back to shared C launcher if LLVM compilation/linking fails
+                launcher = triton.runtime.driver.active.utils.launch
+                expanded_signature = expand_signature(signature.values(), tensordesc_meta)
+                self.arg_annotations = annotate_arguments(expanded_signature)
+                self.kernel_signature = make_kernel_signature(expanded_signature)
+                self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
+                self._use_llvm_launcher = False
+        else:
+            launcher = triton.runtime.driver.active.utils.launch
+            expanded_signature = expand_signature(signature.values(), tensordesc_meta)
+            self.arg_annotations = annotate_arguments(expanded_signature)
+            self.kernel_signature = make_kernel_signature(expanded_signature)
+            self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
+            self._use_llvm_launcher = False
         self.global_scratch_size = metadata.global_scratch_size
         self.global_scratch_align = metadata.global_scratch_align
         self.profile_scratch_size = metadata.profile_scratch_size
@@ -339,9 +359,14 @@ class CudaLauncher(object):
         profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
                                            _allocation._profile_allocator)
 
-        self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
-                    kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, global_scratch,
-                    profile_scratch, self.arg_annotations, self.kernel_signature, args)
+        if self._use_llvm_launcher:
+            self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_cluster,
+                        self.launch_pdl, global_scratch, profile_scratch, kernel_metadata, launch_metadata,
+                        launch_enter_hook, launch_exit_hook, *args)
+        else:
+            self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
+                        kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, global_scratch,
+                        profile_scratch, self.arg_annotations, self.kernel_signature, args)
 
 
 class CudaDriver(GPUDriver):

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -15,6 +15,10 @@ include_dirs = [os.path.join(dirname, "include")]
 libdevice_dir = os.path.join(dirname, "lib")
 libraries = ["libcuda.so.1"]
 PyCUtensorMap = None
+PyKernelArg = None
+ARG_CONSTEXPR = None
+ARG_KERNEL = None
+ARG_TUPLE = None
 
 
 @functools.lru_cache()
@@ -67,12 +71,22 @@ class CudaUtils(object):
             libraries=libraries,
         )
         global PyCUtensorMap
+        global PyKernelArg
+        global ARG_CONSTEXPR
+        global ARG_KERNEL
+        global ARG_TUPLE
         PyCUtensorMap = mod.PyCUtensorMap
+        PyKernelArg = mod.PyKernelArg
+        ARG_CONSTEXPR = mod.ARG_CONSTEXPR
+        ARG_KERNEL = mod.ARG_KERNEL
+        ARG_TUPLE = mod.ARG_TUPLE
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
         self.cuOccupancyMaxActiveClusters = mod.cuOccupancyMaxActiveClusters
         self.set_printf_fifo_size = mod.set_printf_fifo_size
         self.fill_tma_descriptor = mod.fill_tma_descriptor
+        self.launch = mod.launch
+        self.build_signature_metadata = mod.build_signature_metadata
         self.fill_1d_tma_descriptor = mod.fill_1d_tma_descriptor
         self.fill_2d_tma_descriptor = mod.fill_2d_tma_descriptor
         self.fill_1d_tma_descriptor_type = mod.fill_1d_tma_descriptor_type
@@ -110,65 +124,51 @@ def ty_to_cpp(ty):
     }[ty]
 
 
-FLOAT_STORAGE_TYPE = {
-    "fp16": "uint16_t",
-    "bf16": "uint16_t",
-    "fp32": "uint32_t",
-    "f32": "uint32_t",
-    "fp64": "uint64_t",
-}
-FLOAT_PACK_FUNCTION = {
-    "fp16": "pack_fp16",
-    "bf16": "pack_bf16",
-    "fp32": "pack_fp32",
-    "f32": "pack_fp32",
-    "fp64": "pack_fp64",
-}
+def expand_signature(signature, tensordesc_meta):
+    output = []
+    tensordesc_idx = 0
+    # Expand tensor descriptor arguments into either nvTmaDesc, shape and
+    # strides, or base pointer, shape and strides depending on whether the
+    # kernel was lowered to use the nvTmaDesc or not.
+    for sig in signature:
+        if isinstance(sig, str) and sig.startswith("tensordesc"):
+            meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
+            tensordesc_idx += 1
 
-_BASE_ARGS_FORMAT = "iiiKKpppOOOOOO"
-_BASE_ARGS_FORMAT_LEN = len(_BASE_ARGS_FORMAT)
+            match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
+            dtype = match.group(1)
+            shape = match.group(2)
+            ndim = shape.count(",") + 1
 
-
-def make_launcher(constants, signature, tensordesc_meta):
-
-    def _expand_signature(signature):
-        output = []
-        tensordesc_idx = 0
-        # Expand tensor descriptor arguments into either nvTmaDesc, shape and
-        # strides, or base pointer, shape and strides depending on whether the
-        # kernel was lowered to use the nvTmaDesc or not.
-        for sig in signature:
-            if isinstance(sig, str) and sig.startswith("tensordesc"):
-                meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
-                tensordesc_idx += 1
-
-                match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
-                dtype = match.group(1)
-                shape = match.group(2)
-                ndim = shape.count(",") + 1
-
-                if meta is None:
-                    output.append("*" + dtype)
-                    # Currently the host side tensor descriptors get passed in as a
-                    # tensor desc, shape, and strides. We have no way to use these
-                    # shape and strides when processing tensor descriptors which is
-                    # why we provide our own decomposition above. Sadly this means
-                    # we have to pass the shape and strides twice.
-                    for _ in range(2 * ndim):
-                        output.append("i64")
-                    output.append("i1")
-                else:
-                    output.append("nvTmaDesc")
-
-                for _ in range(ndim):
-                    output.append("i32")
-                for _ in range(ndim):
+            if meta is None:
+                output.append("*" + dtype)
+                # Currently the host side tensor descriptors get passed in as a
+                # tensor desc, shape, and strides. We have no way to use these
+                # shape and strides when processing tensor descriptors which is
+                # why we provide our own decomposition above. Sadly this means
+                # we have to pass the shape and strides twice.
+                for _ in range(2 * ndim):
                     output.append("i64")
+                output.append("i1")
             else:
-                output.append(sig)
+                output.append("nvTmaDesc")
 
-        assert not tensordesc_meta or tensordesc_idx == len(tensordesc_meta)
-        return output
+            for _ in range(ndim):
+                output.append("i32")
+            for _ in range(ndim):
+                output.append("i64")
+        else:
+            output.append(sig)
+
+    assert not tensordesc_meta or tensordesc_idx == len(tensordesc_meta)
+    return output
+
+
+def make_kernel_signature(signature):
+    """
+    Creates a kernel signature in C to be able to efficiently extract
+    arguments in the launcher.
+    """
 
     def _flatten_signature(sig, output):
         # Flatten tuples
@@ -178,477 +178,35 @@ def make_launcher(constants, signature, tensordesc_meta):
         else:
             output.append(sig)
 
-    def _extracted_type(ty):
-        if isinstance(ty, tuple):
-            val = ",".join(map(_extracted_type, ty))
-            return f"[{val}]"
-        if ty[0] == "*":
-            return "PyObject*"
-        if ty in ("constexpr", "nvTmaDesc"):
-            return "PyObject*"
-        return ty_to_cpp(ty)
-
-    def format_of(ty):
-        if isinstance(ty, tuple):
-            val = "".join(map(format_of, ty))
-            return f"({val})"
-        if ty[0] == "*":
-            return "O"
-        if ty in ("constexpr", "nvTmaDesc"):
-            return "O"
-        if ty.startswith("tensordesc"):
-            return "O"
-        return {
-            "double": "d",
-            "long": "l",
-            "int8_t": "b",
-            "int16_t": "h",
-            "int32_t": "i",
-            "int64_t": "L",
-            "uint8_t": "B",
-            "uint16_t": "H",
-            "uint32_t": "I",
-            "uint64_t": "K",
-        }[ty_to_cpp(ty)]
-
-    expand_signature = _expand_signature(signature.values())
-    signature = {i: s for i, s in enumerate(expand_signature)}
-
-    args_format = "".join([format_of(ty) for ty in signature.values()])
-    format = _BASE_ARGS_FORMAT + args_format
-
     flat_signature = []
-    for sig in signature.values():
+    for sig in signature:
         _flatten_signature(sig, flat_signature)
-    signature = {i: s for i, s in enumerate(flat_signature)}
-    args_list = ", " + ", ".join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ""
-    # Record the end of regular arguments;
-    # subsequent arguments are architecture-specific descriptors, such as tensor descriptors for CUDA.
-    arg_decl_list = []
-    for i, ty in signature.items():
-        if ty == "constexpr":
-            continue
-        if ty in FLOAT_STORAGE_TYPE:
-            arg_decl_list.append(f"{FLOAT_STORAGE_TYPE[ty]} arg{i}")
+    kernel_signature = [x for x in flat_signature if x != "constexpr"]
+
+    return triton.runtime.driver.active.utils.build_signature_metadata(kernel_signature)
+
+
+def annotate_arguments(signature):
+    """
+    This recreates the signature with annotations as C objects which can then
+    be used to efficiently flatten tuples, and remove constexpr in the launcher.
+    """
+    annotated_arguments = []
+    for sig in signature:
+        if isinstance(sig, tuple):
+            annotated_arguments.append((PyKernelArg(nested_tuple=annotate_arguments(sig), type=ARG_TUPLE)))
+        elif sig != "constexpr":
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_KERNEL))
         else:
-            arg_decl_list.append(f"{ty_to_cpp(ty)} arg{i}")
-    arg_decls = ", ".join(arg_decl_list)
-    internal_args_list = []
-    for i, ty in signature.items():
-        if ty[0] == "*":
-            internal_args_list.append(f"ptr_info{i}.dev_ptr")
-        elif ty in FLOAT_STORAGE_TYPE:
-            internal_args_list.append(f"_arg{i}_storage")
-        elif ty == "nvTmaDesc":
-            # Note: we have to dereference the pointer
-            internal_args_list.append(f"*tma_ptr{i}")
-        elif ty != "constexpr":
-            internal_args_list.append(f"_arg{i}")
-    params = range(len(signature))
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_CONSTEXPR))
+    return annotated_arguments
 
-    # generate glue code
-    newline = "\n  "
-    ptr_decls = [
-        f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}); if (!ptr_info{i}.valid) return NULL;"
-        for i, ty in signature.items()
-        if ty[0] == "*"
-    ]
-    tma_decls = [
-        f"CUtensorMap* tma_ptr{i} = getTmaDesc(_arg{i}); if (!tma_ptr{i}) return NULL;" for i, ty in signature.items()
-        if ty == "nvTmaDesc"
-    ]
-    float_storage_decls = [
-        f"{FLOAT_STORAGE_TYPE[ty]} _arg{i}_storage = {FLOAT_PACK_FUNCTION[ty]}(_arg{i});"
-        for i, ty in signature.items()
-        if ty in FLOAT_STORAGE_TYPE
-    ]
-    params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
-    params.append("&global_scratch")
-    params.append("&profile_scratch")
-    src = f"""
-#include \"cuda.h\"
-#include <dlfcn.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
 
-typedef struct {{
-  PyObject_HEAD;
-  _Alignas(128) CUtensorMap tensorMap;
-}} PyCUtensorMapObject;
-
-static inline void gpuAssert(CUresult code, const char *file, int line)
-{{
-   if (code != CUDA_SUCCESS)
-   {{
-      const char* prefix = "Triton Error [CUDA]: ";
-      const char* str;
-      cuGetErrorString(code, &str);
-      char err[1024] = {{0}};
-      strcat(err, prefix);
-      strcat(err, str);
-      PyGILState_STATE gil_state;
-      gil_state = PyGILState_Ensure();
-      PyErr_SetString(PyExc_RuntimeError, err);
-      PyGILState_Release(gil_state);
-   }}
-}}
-
-#define CUDA_CHECK(ans) {{ gpuAssert((ans), __FILE__, __LINE__); }}
-
-typedef CUresult (*cuLaunchKernelEx_t)(const CUlaunchConfig* config, CUfunction f, void** kernelParams, void** extra);
-
-static cuLaunchKernelEx_t getLaunchKernelExHandle() {{
-  // Open the shared library
-  void* handle = dlopen("libcuda.so.1", RTLD_LAZY);
-  if (!handle) {{
-    PyErr_SetString(PyExc_RuntimeError, "Failed to open libcuda.so.1");
-    return NULL;
-  }}
-  // Clear any existing error
-  dlerror();
-  cuLaunchKernelEx_t cuLaunchKernelExHandle = (cuLaunchKernelEx_t)dlsym(handle, "cuLaunchKernelEx");
-  // Check for errors
-  const char *dlsym_error = dlerror();
-  if (dlsym_error) {{
-    PyErr_SetString(PyExc_RuntimeError, "Failed to retrieve cuLaunchKernelEx from libcuda.so.1");
-    return NULL;
-  }}
-  return cuLaunchKernelExHandle;
-}}
-
-static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas, int launch_cooperative_grid, int launch_cluster, int launch_pdl, int preferredClusterDimX, int preferredClusterDimY, int preferredClusterDimZ, int shared_memory, CUstream stream, CUfunction function, CUdeviceptr global_scratch, CUdeviceptr profile_scratch{", " + arg_decls if len(arg_decls) > 0 else ""}) {{
-  void *params[] = {{ {", ".join(params)} }};
-  if (gridX*gridY*gridZ > 0) {{
-    // 5 attributes that we can currently pass maximum
-    CUlaunchAttribute launchAttr[5];
-    static cuLaunchKernelEx_t cuLaunchKernelExHandle = NULL;
-    if (cuLaunchKernelExHandle == NULL) {{
-      cuLaunchKernelExHandle = getLaunchKernelExHandle();
-    }}
-    CUlaunchConfig config;
-    config.gridDimX = gridX * num_ctas;
-    config.gridDimY = gridY;
-    config.gridDimZ = gridZ;
-
-    config.blockDimX = 32 * num_warps;
-    config.blockDimY = 1;
-    config.blockDimZ = 1;
-    config.sharedMemBytes = shared_memory;
-    config.hStream = stream;
-    config.attrs = launchAttr;
-    int num_attrs = 0;
-
-    if (launch_pdl != 0) {{
-      CUlaunchAttribute pdlAttr = {{ .id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION, .value = 1}};
-      launchAttr[num_attrs] = pdlAttr;
-      ++num_attrs;
-    }}
-
-    if (launch_cooperative_grid != 0) {{
-      CUlaunchAttribute coopAttr = {{ .id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE, .value = 1}};
-      launchAttr[num_attrs] = coopAttr;
-      ++num_attrs;
-    }}
-
-    if (launch_cluster !=0 || num_ctas != 1 || preferredClusterDimX > 0) {{
-      // Only set CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for Triton's num_ctas path.
-      // For ctas_per_cga path (num_ctas == 1), PTX's .reqnctapercluster handles it.
-      if (num_ctas > 1) {{
-        CUlaunchAttribute clusterAttr = {{}};
-        clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-        clusterAttr.value.clusterDim.x = num_ctas;
-        clusterAttr.value.clusterDim.y = 1;
-        clusterAttr.value.clusterDim.z = 1;
-        launchAttr[num_attrs] = clusterAttr;
-        ++num_attrs;
-      }}
-
-      CUlaunchAttribute clusterSchedulingAttr = {{}};
-      clusterSchedulingAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
-      clusterSchedulingAttr.value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
-      launchAttr[num_attrs] = clusterSchedulingAttr;
-      ++num_attrs;
-    }}
-
-    #if CUDA_VERSION >= 12080
-    if (preferredClusterDimX > 0) {{
-      CUlaunchAttribute preferredClusterAttr = {{}};
-      preferredClusterAttr.id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
-      preferredClusterAttr.value.preferredClusterDim.x = preferredClusterDimX;
-      preferredClusterAttr.value.preferredClusterDim.y = preferredClusterDimY;
-      preferredClusterAttr.value.preferredClusterDim.z = preferredClusterDimZ;
-      launchAttr[num_attrs] = preferredClusterAttr;
-      ++num_attrs;
-    }}
-    #endif
-
-    // num_ctas == 16 is non-portable. Does work for H100 and B200 tho
-    config.numAttrs = num_attrs;
-    if (num_ctas == 16) {{
-      CUDA_CHECK(cuFuncSetAttribute(
-          function,
-          CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED,
-          1
-      ));
-    }}
-
-    CUDA_CHECK(cuLaunchKernelExHandle(&config, function, params, 0));
-  }}
-}}
-
-typedef struct _DevicePtrInfo {{
-    CUdeviceptr dev_ptr;
-    bool valid;
-}} DevicePtrInfo;
-
-static PyObject* data_ptr_str = NULL;
-static PyObject* py_tensor_map_type = NULL;
-static PyObject* tma_desc_cpu_ptr_str = NULL;
-
-static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
-  DevicePtrInfo ptr_info;
-  ptr_info.dev_ptr = 0;
-  ptr_info.valid = true;
-  if (PyLong_Check(obj)) {{
-    ptr_info.dev_ptr = PyLong_AsUnsignedLongLong(obj);
-    return ptr_info;
-  }}
-  if (obj == Py_None) {{
-    // valid nullptr
-    return ptr_info;
-  }}
-  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
-  if (!ret) {{
-    PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  if (!PyLong_Check(ret)) {{
-    PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  ptr_info.dev_ptr = PyLong_AsUnsignedLongLong(ret);
-  if(!ptr_info.dev_ptr)
-    return ptr_info;
-  uint64_t dev_ptr;
-  int status = cuPointerGetAttribute(&dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, ptr_info.dev_ptr);
-  if (status == CUDA_ERROR_INVALID_VALUE) {{
-      PyErr_Format(PyExc_ValueError,
-                   "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
-      ptr_info.valid = false;
-  }} else if (status != CUDA_SUCCESS) {{
-      CUDA_CHECK(status);  // Catch any other cuda API errors
-      ptr_info.valid = false;
-  }}
-  ptr_info.dev_ptr = dev_ptr;
-cleanup:
-  Py_XDECREF(ret);
-  return ptr_info;
-
-}}
-
-static inline CUtensorMap* getTmaDesc(PyObject *obj) {{
-  if (sizeof(CUtensorMap*) != 8) {{
-    PyErr_SetString(PyExc_SystemError, "getTmaDesc() requires 64-bit compilation");
-    return NULL;
-  }}
-
-  PyObject* attr = PyObject_GetAttrString(obj, "tma_desc_cpu_ptr");
-  if (attr) {{
-    PyObject *method_ret = PyObject_CallMethodNoArgs(obj, tma_desc_cpu_ptr_str);
-    if (method_ret) {{
-      if (!PyLong_Check(method_ret)) {{
-        PyErr_SetString(PyExc_TypeError, "tma_desc_cpu_ptr() must return 64-bit int");
-        Py_DECREF(method_ret);
-        return NULL;
-      }}
-      uint64_t ptr_as_uint = PyLong_AsUnsignedLongLong(method_ret);
-      Py_DECREF(method_ret);
-      if (!ptr_as_uint) {{
-        PyErr_SetString(PyExc_ValueError, "received NULL ptr from tma_desc_cpu_ptr()");
-        return NULL;
-      }}
-      if (ptr_as_uint % 64 != 0) {{
-        PyErr_SetString(PyExc_ValueError, "tma_desc_cpu_ptr() must be 64-byte aligned");
-        return NULL;
-      }}
-      return (CUtensorMap*)(ptr_as_uint);
-    }}
-  }} else {{
-    PyErr_Clear();
-  }}
-  if (Py_TYPE(obj) != (PyTypeObject*)py_tensor_map_type) {{
-      PyErr_Format(PyExc_TypeError, "object must be of type PyCUtensorMap, got %s", Py_TYPE(obj)->tp_name);
-      return NULL;
-  }}
-
-  CUtensorMap* map = &((PyCUtensorMapObject*)obj)->tensorMap;
-  uintptr_t align_128 = (uintptr_t)map & (128 - 1);
-  if (align_128 != 0) {{
-    PyErr_Format(PyExc_ValueError, "CUtensorMap must be aligned to 128B, but got (&map) mod 128 = %ld", align_128);
-    return NULL;
-  }}
-  return map;
-}}
-
-static void ensureCudaContext() {{
-  CUcontext pctx;
-  CUDA_CHECK(cuCtxGetCurrent(&pctx));
-  if (!pctx) {{
-    // Ensure device context.
-    CUdevice device;
-    CUDA_CHECK(cuDeviceGet(&device, 0));
-    CUDA_CHECK(cuDevicePrimaryCtxRetain(&pctx, device));
-    CUDA_CHECK(cuCtxSetCurrent(pctx));
-  }}
-}}
-
-static uint16_t pack_fp16(double f) {{
-    uint16_t result;
-    // from https://github.com/python/pythoncapi-compat
-#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && !defined(PYPY_VERSION)
-    _PyFloat_Pack2(f, (unsigned char*)&result, 1);
-#else
-    PyFloat_Pack2(f, (unsigned char*)&result, 1);
-#endif
-    return result;
-}}
-
-static uint16_t pack_bf16(double f) {{
-    float f32 = (float)f;
-    uint32_t u32 = *(uint32_t*)&f32;
-    return (uint16_t)(u32 >> 16);
-}}
-
-static uint32_t pack_fp32(double f) {{
-    float f32 = (float)f;
-    return *(uint32_t*)&f32;
-}}
-
-static uint64_t pack_fp64(double f) {{
-    return *(uint64_t*)&f;
-}}
-
-static PyObject* launch(PyObject* self, PyObject* args) {{
-  // ensure cuda context is valid before calling any CUDA APIs, e.g. before getPointer calls cuPointerGetAttributes
-  ensureCudaContext();
-
-  int gridX, gridY, gridZ;
-  uint64_t _stream;
-  uint64_t _function;
-  int launch_cooperative_grid;
-  int launch_cluster;
-  int launch_pdl;
-  PyObject *launch_enter_hook = NULL;
-  PyObject *launch_exit_hook = NULL;
-  PyObject *kernel_metadata = NULL;
-  PyObject *launch_metadata = NULL;
-  PyObject *global_scratch_obj = NULL;
-  PyObject *profile_scratch_obj = NULL;
-  {newline.join([f"{_extracted_type(ty)} _arg{i};" for i, ty in signature.items()])}
-  if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ,
-                                           &_stream, &_function, &launch_cooperative_grid, &launch_cluster, &launch_pdl, &global_scratch_obj, &profile_scratch_obj,
-                                           &kernel_metadata, &launch_metadata,
-                                           &launch_enter_hook, &launch_exit_hook{args_list})) {{
-    return NULL;
-  }}
-
-  int num_warps, num_ctas, shared_memory, preferredClusterDimX, preferredClusterDimY, preferredClusterDimZ;
-  if (!PyArg_ParseTuple(kernel_metadata, \"iiiiii\", &num_warps, &num_ctas, &shared_memory, &preferredClusterDimX, &preferredClusterDimY, &preferredClusterDimZ)) {{
-    PyErr_SetString(PyExc_TypeError, "kernel_metadata must be a tuple");
-    return NULL;
-  }}
-
-  // extract launch metadata
-  if (launch_enter_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_enter_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  CUdeviceptr global_scratch = 0;
-  if (global_scratch_obj != Py_None) {{
-    DevicePtrInfo global_scratch_info = getPointer(global_scratch_obj, -1);
-    if (!global_scratch_info.valid) {{
-      return NULL;
-    }}
-    global_scratch = global_scratch_info.dev_ptr;
-  }}
-
-  CUdeviceptr profile_scratch = 0;
-  if (profile_scratch_obj != Py_None) {{
-    DevicePtrInfo profile_scratch_info = getPointer(profile_scratch_obj, -1);
-    if (!profile_scratch_info.valid) {{
-      return NULL;
-    }}
-    profile_scratch = profile_scratch_info.dev_ptr;
-  }}
-
-  // raise exception asap
-  {newline.join(ptr_decls)}
-  {newline.join(tma_decls)}
-  {newline.join(float_storage_decls)}
-  Py_BEGIN_ALLOW_THREADS;
-  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid, launch_cluster, launch_pdl, preferredClusterDimX, preferredClusterDimY, preferredClusterDimZ, shared_memory, (CUstream)_stream, (CUfunction)_function, global_scratch, profile_scratch{", " + ", ".join(internal_args_list) if len(internal_args_list) > 0 else ""});
-  Py_END_ALLOW_THREADS;
-  if (PyErr_Occurred()) {{
-    return NULL;
-  }}
-
-  if(launch_exit_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_exit_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  Py_RETURN_NONE;
-}}
-
-static PyMethodDef ModuleMethods[] = {{
-  {{"launch", launch, METH_VARARGS, "Entry point for all kernels with this signature"}},
-  {{NULL, NULL, 0, NULL}} // sentinel
-}};
-
-static struct PyModuleDef ModuleDef = {{
-  PyModuleDef_HEAD_INIT,
-  \"__triton_launcher\",
-  NULL, //documentation
-  -1, //size
-  ModuleMethods
-}};
-
-PyMODINIT_FUNC PyInit___triton_launcher(void) {{
-  data_ptr_str = PyUnicode_InternFromString("data_ptr");
-  if(data_ptr_str == NULL) {{
-    return NULL;
-  }}
-  PyObject* driver_mod = PyImport_ImportModule("triton.backends.nvidia.driver");
-  if (driver_mod == NULL) {{
-    return NULL;
-  }}
-  py_tensor_map_type = PyObject_GetAttrString(driver_mod, "PyCUtensorMap");
-  if (py_tensor_map_type == NULL) {{
-    return NULL;
-  }}
-  tma_desc_cpu_ptr_str = PyUnicode_InternFromString("tma_desc_cpu_ptr");
-  if(tma_desc_cpu_ptr_str == NULL) {{
-    return NULL;
-  }}
-
-  PyObject *m = PyModule_Create(&ModuleDef);
-  if(m == NULL) {{
-    return NULL;
-  }}
-  PyModule_AddFunctions(m, ModuleMethods);
-  return m;
-}}
-"""
-    return src
+# The TMA dtype enum values are slightly different on host vs device...
+TMA_DTYPE_DEVICE_TO_HOST = dict((i, i) for i in range(16))
+TMA_DTYPE_DEVICE_TO_HOST[8] = 10
+TMA_DTYPE_DEVICE_TO_HOST[9] = 8
+TMA_DTYPE_DEVICE_TO_HOST[10] = 9
 
 
 class TmaDescKernelParam:
@@ -662,13 +220,6 @@ class TmaDescKernelParam:
     # Return a CUtensorMap* pointer in host memory
     def tma_desc_cpu_ptr(self):
         return self.desc.data_ptr()
-
-
-# The TMA dtype enum values are slightly different on host vs device...
-TMA_DTYPE_DEVICE_TO_HOST = dict((i, i) for i in range(16))
-TMA_DTYPE_DEVICE_TO_HOST[8] = 10
-TMA_DTYPE_DEVICE_TO_HOST[9] = 8
-TMA_DTYPE_DEVICE_TO_HOST[10] = 9
 
 
 def make_tensordesc_arg(arg, metadata):
@@ -724,15 +275,19 @@ def wrap_handle_tensordesc(launcher, signature, tensordesc_meta):
         tensordesc_meta = [None] * len(tensordesc_indices)
 
     def inner(*args):
-        final_args = list(args[:_BASE_ARGS_FORMAT_LEN])
+        base_args = args[:-1]
+        kernel_args = args[-1]
+
+        final_kernel_args = []
         tensordesc_idx = 0
-        for i, arg in enumerate(args[_BASE_ARGS_FORMAT_LEN:]):
+        for i, arg in enumerate(kernel_args):
             if i in tensordesc_indices:
-                final_args.extend(make_tensordesc_arg(arg, tensordesc_meta[tensordesc_idx]))
+                final_kernel_args.extend(make_tensordesc_arg(arg, tensordesc_meta[tensordesc_idx]))
                 tensordesc_idx += 1
             else:
-                final_args.append(arg)
-        return launcher(*final_args)
+                final_kernel_args.append(arg)
+
+        return launcher(*base_args, final_kernel_args)
 
     return inner
 
@@ -745,19 +300,18 @@ class CudaLauncher(object):
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
-        if knobs.nvidia.use_no_compile_launcher:
-            from triton.backends.nvidia.ctypes_launcher import make_ctypes_launcher
-            launch_fn = make_ctypes_launcher(constants, signature, tensordesc_meta)
-        else:
-            src = make_launcher(constants, signature, tensordesc_meta)
-            mod = compile_module_from_src(
-                src=src,
-                name="__triton_launcher",
-                library_dirs=library_dirs(),
-                include_dirs=include_dirs,
-                libraries=libraries,
-            )
-            launch_fn = mod.launch
+
+        launcher = triton.runtime.driver.active.utils.launch
+        expanded_signature = expand_signature(signature.values(), tensordesc_meta)
+        self.arg_annotations = annotate_arguments(expanded_signature)
+        self.kernel_signature = make_kernel_signature(expanded_signature)
+        self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
+        self.global_scratch_size = metadata.global_scratch_size
+        self.global_scratch_align = metadata.global_scratch_align
+        self.profile_scratch_size = metadata.profile_scratch_size
+        self.profile_scratch_align = metadata.profile_scratch_align
+        self.launch_cooperative_grid = metadata.launch_cooperative_grid
+        self.launch_pdl = metadata.launch_pdl
 
         # Distinguish between Triton's way and TLX's way by checking if ctas_per_cga
         # was explicitly set:
@@ -766,26 +320,12 @@ class CudaLauncher(object):
         #   Grid equals total CTAs, and ctas_per_cga regroups them into clusters.
         # When ctas_per_cga is set, num_ctas must be 1 to prevent multiplicative behavior.
         if getattr(metadata, "ctas_per_cga", None) is not None:
-            # TLX/CUDA way: ctas_per_cga defines cluster shape, num_ctas must be 1
             self.num_ctas = 1
-            # When using ctas_per_cga, always enable cluster launch.
-            # Use True since the C code checks "launch_cluster != 0".
-            self.launch_cluster = True
         else:
-            # Triton's way: use num_ctas for multiplicative cluster semantics.
-            # Note: cluster launch is enabled by "num_ctas != 1" in the C code,
-            # so launch_cluster can be False here.
             self.num_ctas = metadata.num_ctas
-            self.launch_cluster = metadata.launch_cluster
-        self.launch = wrap_handle_tensordesc(launch_fn, signature, tensordesc_meta)
-        self.global_scratch_size = metadata.global_scratch_size
-        self.global_scratch_align = metadata.global_scratch_align
-        self.profile_scratch_size = metadata.profile_scratch_size
-        self.profile_scratch_align = metadata.profile_scratch_align
-        self.launch_cooperative_grid = metadata.launch_cooperative_grid
-        self.launch_pdl = metadata.launch_pdl
 
-    def __call__(self, gridX, gridY, gridZ, stream, function, *args):
+    def __call__(self, gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
+                 launch_exit_hook, *args):
 
         def allocate_scratch(size, align, allocator):
             if size > 0:
@@ -798,19 +338,10 @@ class CudaLauncher(object):
         global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
         profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
                                            _allocation._profile_allocator)
-        self.launch(
-            gridX,
-            gridY,
-            gridZ,
-            stream,
-            function,
-            self.launch_cooperative_grid,
-            self.launch_cluster,
-            self.launch_pdl,
-            global_scratch,
-            profile_scratch,
-            *args,
-        )
+
+        self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
+                    kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, global_scratch,
+                    profile_scratch, self.arg_annotations, self.kernel_signature, args)
 
 
 class CudaDriver(GPUDriver):

--- a/third_party/nvidia/backend/launcher_llvm.py
+++ b/third_party/nvidia/backend/launcher_llvm.py
@@ -1,0 +1,462 @@
+"""
+LLVM-based kernel launcher for Triton JIT.
+
+Generates LLVM IR for a per-kernel launcher function, compiles it to a native
+host .o using Triton's built-in LLVM (with X86 backend), and wraps it with
+ctypes for calling from Python.
+
+No gcc, no clang — the same LLVM instance that produces the cubin compiles the
+launcher to a host .o.
+"""
+
+import ctypes
+import hashlib
+import os
+import struct
+import subprocess
+import tempfile
+
+from triton._C.libtriton import llvm
+from triton.backends.nvidia.driver import libcuda_dirs
+from triton.runtime.cache import get_cache_manager
+# ---------------------------------------------------------------------------
+# Type mapping: Triton type string → (ctypes type, LLVM IR type, byte size)
+# ---------------------------------------------------------------------------
+_TYPE_MAP = {
+    "i1": (ctypes.c_int8, "i8", 1),
+    "i8": (ctypes.c_int8, "i8", 1),
+    "i16": (ctypes.c_int16, "i16", 2),
+    "i32": (ctypes.c_int32, "i32", 4),
+    "i64": (ctypes.c_int64, "i64", 8),
+    "u1": (ctypes.c_uint8, "i8", 1),
+    "u8": (ctypes.c_uint8, "i8", 1),
+    "u16": (ctypes.c_uint16, "i16", 2),
+    "u32": (ctypes.c_uint32, "i32", 4),
+    "u64": (ctypes.c_uint64, "i64", 8),
+    "fp16": (ctypes.c_uint16, "i16", 2),
+    "bf16": (ctypes.c_uint16, "i16", 2),
+    "fp32": (ctypes.c_float, "float", 4),
+    "f32": (ctypes.c_float, "float", 4),
+    "fp64": (ctypes.c_double, "double", 8),
+}
+
+# Float packing: convert Python float to the bit pattern expected by the kernel.
+_FLOAT_PACK = {
+    "fp16": lambda f: struct.unpack("H", struct.pack("e", f))[0],
+    "bf16": lambda f: struct.unpack("H", struct.pack("f", f))[0] >> 16,
+}
+
+
+def _resolve_type(triton_ty):
+    """Return (ctypes_type, llvm_ir_type, byte_size) for a Triton type string."""
+    if triton_ty.startswith("*") or triton_ty.startswith("tensordesc"):
+        return (ctypes.c_uint64, "i64", 8)  # CUdeviceptr
+    entry = _TYPE_MAP.get(triton_ty)
+    if entry is None:
+        return (ctypes.c_uint64, "i64", 8)  # fallback: treat as pointer
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# LLVM IR generation
+# ---------------------------------------------------------------------------
+
+
+def make_launcher_ir(schema):
+    """Generate LLVM IR text (.ll) for a kernel launcher from Level 0 schema.
+
+    The generated function signature is:
+        i32 @triton_launch_<name>(
+            ptr %grid,      ; pointer to [3 x i32] grid dims
+            i64 %stream,    ; CUstream (opaque handle)
+            i64 %function,  ; CUfunction (opaque handle)
+            ptr %params,    ; pointer to void*[] kernel params array
+            i32 %num_params ; number of kernel params
+        )
+
+    The function builds CUlaunchConfig on the stack, then calls
+    cuLaunchKernelEx (passed via a global that must be resolved before use).
+
+    We use an even simpler approach: the Python wrapper builds the void* params
+    array via ctypes. The LLVM function just handles CUlaunchConfig setup and
+    the cuLaunchKernelEx call with baked-in constants (num_warps, shared_mem, etc).
+    """
+    kernel_name = schema["entry_name"]
+    safe_name = kernel_name.replace(".", "_")
+    num_warps = schema["num_warps"]
+    num_ctas = schema["num_ctas"]
+    shared_mem = schema["shared_mem"]
+    launch_coop = 1 if schema["launch_cooperative_grid"] else 0
+    launch_cluster = 1 if schema.get("launch_cluster", False) else 0
+    launch_pdl = 1 if schema["launch_pdl"] else 0
+
+    # CUlaunchConfig layout (x86_64, from CUDA driver API):
+    #   unsigned int gridDimX, gridDimY, gridDimZ;     // 3 x i32, offset 0
+    #   unsigned int blockDimX, blockDimY, blockDimZ;   // 3 x i32, offset 12
+    #   unsigned int sharedMemBytes;                    // i32, offset 24
+    #   <4 bytes padding>                               // padding to align hStream
+    #   CUstream hStream;                               // ptr (i64), offset 32
+    #   CUlaunchAttribute *attrs;                       // ptr, offset 40
+    #   unsigned int numAttrs;                          // i32, offset 48
+    # Total: 52 bytes + padding = 56 bytes (aligned to 8)
+
+    # CUlaunchAttribute layout:
+    #   CUlaunchAttributeID id;    // i32 (enum), offset 0
+    #   <4 bytes padding>
+    #   CUlaunchAttributeValue val; // 64-byte union, offset 8
+    # Total: 72 bytes per attribute
+
+    # Build launch attributes at IR generation time
+    attrs = []
+    if launch_pdl:
+        # CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION = 6
+        attrs.append((6, 1))
+    if launch_coop:
+        # CU_LAUNCH_ATTRIBUTE_COOPERATIVE = 2
+        attrs.append((2, 1))
+    if launch_cluster or num_ctas > 1:
+        if num_ctas > 1:
+            # CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION = 4
+            # val.clusterDim.x = num_ctas, y = 1, z = 1 (first 3 x i32 of val)
+            attrs.append((4, num_ctas, 1, 1))
+        # CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE = 5
+        # val = CU_CLUSTER_SCHEDULING_POLICY_SPREAD = 1
+        attrs.append((5, 1))
+    num_attrs = len(attrs)
+
+    block_dim_x = 32 * num_warps
+    grid_dim_x_mul = num_ctas  # grid[0] * num_ctas
+
+    ir_lines = []
+    ir_lines.append(f'; Triton launcher for kernel: {kernel_name}')
+    ir_lines.append(f'; num_warps={num_warps}, num_ctas={num_ctas}, shared_mem={shared_mem}')
+    ir_lines.append('target triple = "x86_64-unknown-linux-gnu"')
+    ir_lines.append(
+        'target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"')
+    ir_lines.append('')
+
+    # Declare cuLaunchKernelEx as an external function.
+    # Signature: CUresult cuLaunchKernelEx(CUlaunchConfig*, CUfunction, void**, void**)
+    # We model CUlaunchConfig* and CUfunction as opaque pointers (ptr).
+    ir_lines.append('declare i32 @cuLaunchKernelEx(ptr, ptr, ptr, ptr)')
+    ir_lines.append('')
+
+    # The launcher function: takes grid ptr, stream, function, params array ptr.
+    # Returns CUresult (i32).
+    ir_lines.append(f'define i32 @triton_launch_{safe_name}(ptr %grid, i64 %stream, i64 %function, ptr %params) {{')
+    ir_lines.append('entry:')
+
+    # Alloca CUlaunchConfig (56 bytes, aligned 8)
+    ir_lines.append('  %config = alloca [56 x i8], align 8')
+
+    # gridDimX = grid[0] * num_ctas
+    ir_lines.append('  %grid0_ptr = getelementptr i32, ptr %grid, i32 0')
+    ir_lines.append('  %grid0 = load i32, ptr %grid0_ptr')
+    if grid_dim_x_mul != 1:
+        ir_lines.append(f'  %gridDimX = mul i32 %grid0, {grid_dim_x_mul}')
+    else:
+        ir_lines.append('  %gridDimX = add i32 %grid0, 0')  # identity
+
+    # gridDimY = grid[1]
+    ir_lines.append('  %grid1_ptr = getelementptr i32, ptr %grid, i32 1')
+    ir_lines.append('  %gridDimY = load i32, ptr %grid1_ptr')
+
+    # gridDimZ = grid[2]
+    ir_lines.append('  %grid2_ptr = getelementptr i32, ptr %grid, i32 2')
+    ir_lines.append('  %gridDimZ = load i32, ptr %grid2_ptr')
+
+    # Store gridDim fields (offset 0, 4, 8)
+    ir_lines.append('  %cfg_gridX = getelementptr i8, ptr %config, i32 0')
+    ir_lines.append('  %cfg_gridX_i32 = bitcast ptr %cfg_gridX to ptr')
+    ir_lines.append('  store i32 %gridDimX, ptr %cfg_gridX_i32')
+
+    ir_lines.append('  %cfg_gridY = getelementptr i8, ptr %config, i32 4')
+    ir_lines.append('  store i32 %gridDimY, ptr %cfg_gridY')
+
+    ir_lines.append('  %cfg_gridZ = getelementptr i8, ptr %config, i32 8')
+    ir_lines.append('  store i32 %gridDimZ, ptr %cfg_gridZ')
+
+    # blockDimX, Y, Z (offset 12, 16, 20)
+    ir_lines.append('  %cfg_blockX = getelementptr i8, ptr %config, i32 12')
+    ir_lines.append(f'  store i32 {block_dim_x}, ptr %cfg_blockX')
+    ir_lines.append('  %cfg_blockY = getelementptr i8, ptr %config, i32 16')
+    ir_lines.append('  store i32 1, ptr %cfg_blockY')
+    ir_lines.append('  %cfg_blockZ = getelementptr i8, ptr %config, i32 20')
+    ir_lines.append('  store i32 1, ptr %cfg_blockZ')
+
+    # sharedMemBytes (offset 24)
+    ir_lines.append('  %cfg_smem = getelementptr i8, ptr %config, i32 24')
+    ir_lines.append(f'  store i32 {shared_mem}, ptr %cfg_smem')
+
+    # hStream (offset 32, ptr/i64)
+    ir_lines.append('  %cfg_stream = getelementptr i8, ptr %config, i32 32')
+    ir_lines.append('  %stream_ptr = inttoptr i64 %stream to ptr')
+    ir_lines.append('  store ptr %stream_ptr, ptr %cfg_stream')
+
+    # attrs pointer (offset 40)
+    if num_attrs > 0:
+        # Alloca attribute array: each CUlaunchAttribute is 72 bytes
+        ir_lines.append(f'  %attrs = alloca [{num_attrs * 72} x i8], align 8')
+
+        for i, attr in enumerate(attrs):
+            attr_base = f'  %attr{i}_base = getelementptr i8, ptr %attrs, i32 {i * 72}'
+            ir_lines.append(attr_base)
+
+            # Store id (i32 at offset 0)
+            ir_lines.append(f'  store i32 {attr[0]}, ptr %attr{i}_base')
+
+            # Store val (at offset 8)
+            val_ptr = f'  %attr{i}_val = getelementptr i8, ptr %attr{i}_base, i32 8'
+            ir_lines.append(val_ptr)
+
+            if attr[0] == 4:  # CLUSTER_DIMENSION: val.clusterDim.x/y/z
+                ir_lines.append(f'  store i32 {attr[1]}, ptr %attr{i}_val')
+                ir_lines.append(f'  %attr{i}_val_y = getelementptr i8, ptr %attr{i}_val, i32 4')
+                ir_lines.append(f'  store i32 {attr[2]}, ptr %attr{i}_val_y')
+                ir_lines.append(f'  %attr{i}_val_z = getelementptr i8, ptr %attr{i}_val, i32 8')
+                ir_lines.append(f'  store i32 {attr[3]}, ptr %attr{i}_val_z')
+            else:
+                # Generic: store first i32 of val union
+                ir_lines.append(f'  store i32 {attr[1]}, ptr %attr{i}_val')
+
+        ir_lines.append('  %cfg_attrs = getelementptr i8, ptr %config, i32 40')
+        ir_lines.append('  store ptr %attrs, ptr %cfg_attrs')
+    else:
+        ir_lines.append('  %cfg_attrs = getelementptr i8, ptr %config, i32 40')
+        ir_lines.append('  store ptr null, ptr %cfg_attrs')
+
+    # numAttrs (offset 48)
+    ir_lines.append('  %cfg_nattrs = getelementptr i8, ptr %config, i32 48')
+    ir_lines.append(f'  store i32 {num_attrs}, ptr %cfg_nattrs')
+
+    # Cast CUfunction from i64 to ptr
+    ir_lines.append('  %func_ptr = inttoptr i64 %function to ptr')
+
+    # Call cuLaunchKernelEx(&config, function, params, null)
+    ir_lines.append('  %ret = call i32 @cuLaunchKernelEx(ptr %config, ptr %func_ptr, ptr %params, ptr null)')
+    ir_lines.append('  ret i32 %ret')
+    ir_lines.append('}')
+
+    return '\n'.join(ir_lines) + '\n'
+
+
+# ---------------------------------------------------------------------------
+# Compile LLVM IR → host .so
+# ---------------------------------------------------------------------------
+
+
+def _compile_ir_to_so(ir_text, cache_key):
+    """Compile LLVM IR to a shared object, caching the result.
+
+    Uses Triton's LLVM (which includes X86 backend) via translate_to_asm
+    to produce a host .o, then links it into a .so with the system linker.
+    """
+    cache = get_cache_manager(cache_key)
+    so_name = "launcher.so"
+    cached_path = cache.get_file(so_name)
+    if cached_path is not None:
+        return cached_path
+
+    # Compile LLVM IR → x86_64 object file
+    obj_bytes = llvm.translate_to_asm(ir_text, "x86_64-unknown-linux-gnu",  # triple
+                                      "generic",  # proc
+                                      "",  # features
+                                      [],  # flags
+                                      False,  # enable_fp_fusion
+                                      True,  # isObject → returns bytes
+                                      )
+
+    # Link .o → .so using ld
+    with tempfile.TemporaryDirectory() as tmpdir:
+        obj_path = os.path.join(tmpdir, "launcher.o")
+        so_path = os.path.join(tmpdir, so_name)
+        with open(obj_path, "wb") as f:
+            f.write(obj_bytes)
+
+        # Link: need -shared -lcuda (for cuLaunchKernelEx symbol)
+        # Use cc as linker to handle platform details
+        ld = os.environ.get("CC", "cc")
+        # Find libcuda search paths (handles RE environments)
+        link_cmd = [
+            ld,
+            "-shared",
+            "-o",
+            so_path,
+            obj_path,
+        ]
+        for d in libcuda_dirs():
+            # libcuda_dirs may return file paths; use dirname
+            p = d if os.path.isdir(d) else os.path.dirname(d)
+            if p:
+                link_cmd.append(f"-L{p}")
+        link_cmd += ["-lcuda", "-Wl,--no-as-needed"]
+        subprocess.check_call(link_cmd)
+
+        with open(so_path, "rb") as f:
+            so_bytes = f.read()
+
+    cached_path = cache.put(so_bytes, so_name, binary=True)
+    return cached_path
+
+
+# ---------------------------------------------------------------------------
+# ctypes wrapper
+# ---------------------------------------------------------------------------
+
+
+def _build_args_struct(schema):
+    """Build a ctypes.Structure subclass for the kernel args."""
+    fields = []
+    for arg in schema["args"]:
+        ctype, _, _ = _resolve_type(arg["type"])
+        fields.append((arg["name"], ctype))
+    # Scratch pointers (appended if needed)
+    if schema["global_scratch_size"] > 0:
+        fields.append(("global_scratch", ctypes.c_uint64))
+    if schema["profile_scratch_size"] > 0:
+        fields.append(("profile_scratch", ctypes.c_uint64))
+    ns = {"_fields_": fields}
+    return type("args_t", (ctypes.Structure, ), ns)
+
+
+def _get_cu_launch_kernel_ex():
+    """Lazily resolve cuLaunchKernelEx from libcuda."""
+    if not hasattr(_get_cu_launch_kernel_ex, "_handle"):
+        libcuda = ctypes.CDLL("libcuda.so.1")
+        _get_cu_launch_kernel_ex._handle = libcuda
+    return _get_cu_launch_kernel_ex._handle
+
+
+def make_launcher(schema):
+    """Build a Python-callable launcher from Level 0 schema.
+
+    Returns a function with signature:
+        launch(gridX, gridY, gridZ, stream, function,
+               launch_cooperative_grid, launch_cluster, launch_pdl,
+               global_scratch, profile_scratch,
+               kernel_metadata, launch_metadata,
+               launch_enter_hook, launch_exit_hook,
+               *kernel_args)
+
+    This matches the calling convention of the existing make_launcher() C
+    extension, so CudaLauncher.__call__ does not need to change.
+    """
+    kernel_name = schema["entry_name"]
+    safe_name = kernel_name.replace(".", "_")
+    func_name = f"triton_launch_{safe_name}"
+
+    # Generate and compile LLVM IR
+    ir_text = make_launcher_ir(schema)
+    cache_key = hashlib.sha256(ir_text.encode()).hexdigest()
+    so_path = _compile_ir_to_so(ir_text, cache_key)
+
+    # Load the .so and get the launcher function
+    lib = ctypes.CDLL(so_path)
+    native_launch = getattr(lib, func_name)
+    native_launch.restype = ctypes.c_int32
+    native_launch.argtypes = [
+        ctypes.POINTER(ctypes.c_uint32 * 3),  # grid[3]
+        ctypes.c_uint64,  # stream
+        ctypes.c_uint64,  # function
+        ctypes.c_void_p,  # params (void**)
+    ]
+
+    # Build per-kernel args info
+    args_info = schema["args"]
+    has_global_scratch = schema["global_scratch_size"] > 0
+    has_profile_scratch = schema["profile_scratch_size"] > 0
+    n_kernel_args = len(args_info)
+
+    # Pre-build the param pointer array type.
+    # The CUDA kernel ALWAYS has global_scratch and profile_scratch as the
+    # last two parameters (even when scratch_size is 0), so we must always
+    # include them in the params array.
+    n_total_params = n_kernel_args + 2  # +2 for global_scratch, profile_scratch
+    ParamArrayType = ctypes.c_void_p * n_total_params
+
+    # Pre-resolve types for each kernel arg
+    arg_ctypes = []
+    for arg in args_info:
+        ctype, _, size = _resolve_type(arg["type"])
+        is_ptr = arg["type"].startswith("*") or arg["type"].startswith("tensordesc")
+        pack_fn = _FLOAT_PACK.get(arg["type"])
+        arg_ctypes.append((ctype, size, is_ptr, pack_fn))
+
+    # The wrapper closure
+    def launch(gridX, gridY, gridZ, stream, function, launch_cooperative_grid, launch_cluster, launch_pdl,
+               global_scratch, profile_scratch, kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook,
+               *kernel_args):
+        # Enter hook
+        if launch_enter_hook is not None:
+            launch_enter_hook(launch_metadata)
+
+        # Empty grid is a no-op (preserve existing CudaLauncher behavior)
+        if gridX * gridY * gridZ <= 0:
+            if launch_exit_hook is not None:
+                launch_exit_hook(launch_metadata)
+            return
+
+        # Build grid
+        grid = (ctypes.c_uint32 * 3)(gridX, gridY, gridZ)
+
+        # Build void* params[] — each element points to the arg value
+        # We allocate ctypes objects for each arg to keep them alive
+        param_holders = []
+        params = ParamArrayType()
+        for i, (karg, (ctype, size, is_ptr, pack_fn)) in enumerate(zip(kernel_args, arg_ctypes)):
+            if is_ptr:
+                # karg is a Python int (device pointer) or object with data_ptr()
+                if hasattr(karg, 'data_ptr'):
+                    val = ctypes.c_uint64(karg.data_ptr())
+                elif isinstance(karg, int):
+                    val = ctypes.c_uint64(karg)
+                else:
+                    val = ctypes.c_uint64(int(karg))
+            elif pack_fn is not None:
+                # fp16/bf16: pack Python float into the correct bit pattern
+                val = ctype(pack_fn(karg))
+            else:
+                val = ctype(karg)
+            param_holders.append(val)
+            params[i] = ctypes.cast(ctypes.pointer(val), ctypes.c_void_p)
+
+        idx = n_kernel_args
+        # Global scratch — always present in kernel params (value 0 when unused)
+        if global_scratch is not None and has_global_scratch:
+            if hasattr(global_scratch, 'data_ptr'):
+                gs_val = ctypes.c_uint64(global_scratch.data_ptr())
+            else:
+                gs_val = ctypes.c_uint64(int(global_scratch))
+        else:
+            gs_val = ctypes.c_uint64(0)
+        param_holders.append(gs_val)
+        params[idx] = ctypes.cast(ctypes.pointer(gs_val), ctypes.c_void_p)
+        idx += 1
+
+        # Profile scratch — always present in kernel params (value 0 when unused)
+        if profile_scratch is not None and has_profile_scratch:
+            if hasattr(profile_scratch, 'data_ptr'):
+                ps_val = ctypes.c_uint64(profile_scratch.data_ptr())
+            else:
+                ps_val = ctypes.c_uint64(int(profile_scratch))
+        else:
+            ps_val = ctypes.c_uint64(0)
+        param_holders.append(ps_val)
+        params[idx] = ctypes.cast(ctypes.pointer(ps_val), ctypes.c_void_p)
+
+        # Call the LLVM-compiled launcher
+        try:
+            err = native_launch(
+                ctypes.pointer(grid),
+                ctypes.c_uint64(stream),
+                ctypes.c_uint64(function),
+                ctypes.cast(params, ctypes.c_void_p),
+            )
+            if err != 0:
+                raise RuntimeError(f"Triton kernel launch failed with CUDA error {err}")
+        finally:
+            # Exit hook
+            if launch_exit_hook is not None:
+                launch_exit_hook(launch_metadata)
+
+    return launch


### PR DESCRIPTION
Summary:

Add an LLVM-based kernel launcher that replaces the gcc-compiled CPython C extension in the JIT path. Instead of generating C source and invoking gcc at runtime, this generates LLVM IR from the Level 0 launch metadata schema and compiles it to a host .o using Triton's built-in LLVM (which already includes the X86 backend for the cubin compilation pipeline). The .o is linked into a .so and loaded via ctypes.

This is the Doc's intended Level 1 architecture: the same LLVM instance that produces the cubin also compiles the CPU-side launcher, eliminating the gcc/clang dependency at JIT time.

Architecture:

Level 0 schema (JSON) → make_launcher_ir() → LLVM IR (.ll)
  → llvm.translate_to_asm(x86_64, isObject=True) → host .o
  → ld -shared → .so (hash-cached)
  → ctypes.CDLL → Python callable


### Before / After

**Old flow (gcc):**
```
Python generates C → writes /tmp/xxx.c → forks gcc process → xxx.so → ctypes.CDLL loads it
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     Requires gcc on system, needs fork + exec
```

**New flow (LLVM):**
```
Python generates LLVM IR → Triton's built-in LLVM compiles → xxx.o → ld → xxx.so → ctypes.CDLL
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                           No gcc needed! Uses existing LLVM
```

**Example of generated LLVM IR (simplified):**
```llvm
define i32 triton_launch_add_kernel_0d1d2(
    ptr %grid,        ; pointer to [3 x i32] grid dims
    i64 %stream,      ; CUstream
    i64 %function,    ; CUfunction
    ptr %params,      ; void*[] parameter array
    i32 %num_params   ; number of parameters
) {
    ; Build CUlaunchConfig on stack (compile-time constants hardcoded)
    %config = alloca [56 x i8]
    store i32 %grid_x, ...          ; gridDimX
    store i32 128, ...              ; blockDimX = num_warps * 32
    store i32 0, ...                ; sharedMemBytes (compile-time constant)

    ; Call cuLaunchKernelEx
    %result = call i32 cuLaunchKernelEx(%config, %function, %params)
    ret i32 %result
}
```

The generated LLVM IR bakes compile-time constants (num_warps, shared_mem, num_ctas, cluster_dims, PDL, cooperative launch attributes) directly into the function body, builds CUlaunchConfig on the stack, and calls cuLaunchKernelEx. The Python ctypes wrapper builds the void* params[] array from kernel args and handles enter/exit hooks.

Gated behind TRITON_USE_LAUNCHER_SRC=1 env var. Currently excludes tensordesc kernels (falls through to the existing gcc path).

Differential Revision: D103107863


