### PR TITLE
Port changes from main branch to call var._flattten_ir for using buffer_tensor as function argument

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -435,7 +435,10 @@ class CodeGenerator(ast.NodeVisitor):
         if isinstance(val, (ir.value, ir.block_argument)):
             val.set_loc(self.builder.create_name_loc(name, val.get_loc()))
         elif _is_triton_value(val):
-            val._set_name(self.builder, name)
+            handles = []
+            val._flatten_ir(handles)
+            for handle in handles:
+                handle.set_loc(self.builder.create_name_loc(name, handle.get_loc()))
 
     def set_value(self, name: str, value: Union[base_value, constexpr]) -> None:
         ''' This function:

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -435,10 +435,7 @@ class CodeGenerator(ast.NodeVisitor):
         if isinstance(val, (ir.value, ir.block_argument)):
             val.set_loc(self.builder.create_name_loc(name, val.get_loc()))
         elif _is_triton_value(val):
-            handles = []
-            val._flatten_ir(handles)
-            for handle in handles:
-                handle.set_loc(self.builder.create_name_loc(name, handle.get_loc()))
+            val._set_name(self.builder, name)
 
     def set_value(self, name: str, value: Union[base_value, constexpr]) -> None:
         ''' This function:

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -776,6 +776,9 @@ class buffered_tensor(tl.base_value):
         # Following the practice in pytorch, dtype is scalar type
         self.dtype = element_ty
 
+    def _set_name(self, builder: ir.builder, name: str) -> None:
+        self.handle.set_loc(builder.create_name_loc(name, self.handle.get_loc()))
+
     def _flatten_ir(self, handles) -> None:
         handles.append(self.handle)
 


### PR DESCRIPTION
This PR port a change from the main branch to resolve an error `NotImplementedError()`.

The root cause: `_maybe_set_loc_to_name` was changed in the branch `tlx-amd-meta` to call `val._set_name(self.builder, name)`, but buffered_tensor never implements `_set_name` (inheriting the abstract base_value._set_name → raise NotImplementedError). In main, the same function instead calls `val._flatten_ir(handles)` to extract the underlying IR handles and sets the location on each handle directly — no `_set_name` needed. buffered_tensor does implement `_flatten_ir`. The fix restores the main branch's approach.