### PR TITLE
[Triton JIT][2b/N] Add _TritonDispatcher: full C dispatch path for Triton JIT (#1391)

### DIFF
--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -8,14 +8,17 @@ are consistent with the existing metadata bag.
 import json
 
 import pytest
+import torch
 import triton
 import triton.language as tl
+from triton import knobs
 from triton.backends.nvidia.driver import (
     build_kernel_signature_from_schema,
     expand_signature,
     make_kernel_signature,
 )
 from triton.compiler.compiler import ASTSource, compile as triton_compile, make_backend
+from triton.knobs import HookChain
 
 
 @triton.jit
@@ -406,3 +409,126 @@ def test_schema_derived_signature_tensordesc(tensordesc_type, tensordesc_meta, o
                                                   f"  expanded sig: {expanded}\n"
                                                   f"  schema bytes: {list(schema_signature)}\n"
                                                   f"  legacy bytes: {list(legacy_signature)}")
+
+
+# =========================================================================
+# HookChain.__bool__, _TritonDispatcher, _TritonJITRunner
+# =========================================================================
+
+
+def test_hookchain_bool_empty():
+    """Empty HookChain should evaluate as False."""
+    chain = HookChain()
+    assert not chain
+    assert bool(chain) is False
+
+
+def test_hookchain_bool_nonempty():
+    """HookChain with hooks should evaluate as True."""
+    chain = HookChain()
+    chain.add(lambda: None)
+    assert chain
+    assert bool(chain) is True
+
+
+def test_hookchain_bool_after_remove():
+    """HookChain should become False again after removing all hooks."""
+    chain = HookChain()
+    fn = lambda: None
+    chain.add(fn)
+    assert bool(chain) is True
+    chain.remove(fn)
+    assert bool(chain) is False
+
+
+def test_dispatcher_created_with_flag(monkeypatch):
+    """CompiledKernel._dispatcher should be set when use_triton_dispatcher is enabled."""
+    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    compiled._init_handles()
+    assert compiled._dispatcher is not None
+
+
+def test_dispatcher_not_created_without_flag(monkeypatch):
+    """CompiledKernel._dispatcher should be None without the flag."""
+    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "0")
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    compiled._init_handles()
+    assert compiled._dispatcher is None
+
+
+def test_dispatcher_is_callable(monkeypatch):
+    """_TritonDispatcher should be callable when created."""
+    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    compiled._init_handles()
+    assert compiled._dispatcher is not None, "_dispatcher was not created"
+    assert callable(compiled._dispatcher)
+
+
+def test_launch_metadata_returns_none_without_hooks():
+    """launch_metadata should return None when no enter hooks are registered."""
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    if knobs.runtime.launch_enter_hook:
+        pytest.skip("launch_enter_hook is registered, precondition not met")
+    result = compiled.launch_metadata((1, 1, 1), 0)
+    assert result is None
+
+
+def test_dispatcher_e2e(monkeypatch):
+    """End-to-end: _TritonDispatcher dispatches correctly on GPU."""
+    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+    compiled._init_handles()
+    if compiled._dispatcher is None:
+        pytest.skip("Dispatcher not available")
+
+    N = 1024
+    x = torch.randn(N, device="cuda", dtype=torch.float32)
+    y = torch.randn(N, device="cuda", dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    stream = torch.cuda.current_stream().cuda_stream
+    compiled._dispatcher(1, 1, 1, stream, x.data_ptr(), y.data_ptr(), out.data_ptr(), N)
+    torch.cuda.synchronize()
+    assert torch.allclose(out, x + y, atol=1e-5), f"max diff: {(out - x - y).abs().max()}"
+
+
+def test_dispatcher_getitem_jit_runner(monkeypatch):
+    """CompiledKernel.__getitem__ should return a _TritonJITRunner when dispatcher is available."""
+    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    compiled = _compile_kernel(
+        add_kernel,
+        signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+        constexprs={"BLOCK": 1024},
+    )
+
+    N = 1024
+    x = torch.randn(N, device="cuda", dtype=torch.float32)
+    y = torch.randn(N, device="cuda", dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    runner = compiled[(1, 1, 1)]
+    runner(x.data_ptr(), y.data_ptr(), out.data_ptr(), N)
+    torch.cuda.synchronize()
+    assert torch.allclose(out, x + y, atol=1e-5), f"max diff: {(out - x - y).abs().max()}"

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -1,22 +1,30 @@
 from __future__ import annotations
+
+import functools
 import hashlib
 import json
-from .._C.libtriton import get_cache_invalidating_env_vars, ir
-from ..backends import backends
-from ..backends.compiler import Language
-from ..backends.compiler import BaseBackend, GPUTarget
-from .. import __version__, knobs
-from ..runtime.autotuner import OutOfResources
-from ..runtime.cache import get_cache_manager, get_dump_manager, get_override_manager, get_cache_key
-from ..runtime.driver import driver
-from ..tools.disasm import get_sass
-from pathlib import Path
-import re
-import functools
+import logging
 import os
+import re
 import time
 import weakref
+from pathlib import Path
 
+from .. import __version__, knobs
+from .._C.libtriton import get_cache_invalidating_env_vars, ir
+from ..backends import backends
+from ..backends.compiler import BaseBackend, GPUTarget, Language
+from ..runtime.autotuner import OutOfResources
+from ..runtime.cache import (
+    get_cache_key,
+    get_cache_manager,
+    get_dump_manager,
+    get_override_manager,
+)
+from ..runtime.driver import driver
+from ..tools.disasm import get_sass
+
+logger: logging.Logger = logging.getLogger(__name__)
 # - ^\s*tt\.func\s+ : match the start of the string, any leading whitespace, the keyword func,
 #    and any following whitespace
 # - (public\s+)? : optionally match the keyword public and any following whitespace
@@ -567,14 +575,33 @@ class CompiledKernel:
         if knobs.runtime.kernel_load_end_hook is not None:
             knobs.runtime.kernel_load_end_hook(self.module, self.function, self.name, self.metadata_group, self.hash)
 
+        # Create C dispatcher if enabled and schema is available.
+        self._dispatcher = None
+        self._dispatch_arg_indices = None
+        self._num_kernel_args = None
+        if knobs.nvidia.use_triton_dispatcher and "launch_metadata" in self.asm:
+            try:
+                from triton.backends.nvidia.triton_dispatcher_factory import make_triton_dispatcher
+                schema = json.loads(self.asm["launch_metadata"])
+                # Build both values before assigning to self so that a failure
+                # in either step leaves both attributes as None (atomic assignment).
+                dispatcher = make_triton_dispatcher(schema, self.function)
+                if dispatcher is not None:
+                    indices = tuple(a["index"] for a in schema["args"])
+                    self._dispatcher = dispatcher
+                    self._dispatch_arg_indices = indices
+                    self._num_kernel_args = len(schema["args"])
+            except (KeyError, TypeError, ValueError, RuntimeError, json.JSONDecodeError) as e:
+                logger.warning("Triton dispatcher creation failed for %s: %s", self.name, e)
+
     @property
     def run(self):
-        if self._run is None:
+        if self._run is None or self.module is None:
             self._init_handles()
         return self._run
 
     def launch_metadata(self, grid, stream, *args):
-        if knobs.runtime.launch_enter_hook is None:
+        if not knobs.runtime.launch_enter_hook:
             return None
         self._init_handles()
         ret = LazyDict({"name": self.name, "function": self.function, "stream": stream})
@@ -586,6 +613,49 @@ class CompiledKernel:
 
     def __getitem__(self, grid):
         self._init_handles()
+
+        dispatcher = getattr(self, '_dispatcher', None)
+        if dispatcher is not None and not callable(grid):
+            # Try to create a _TritonJITRunner for maximum speed
+            try:
+                from triton.backends.nvidia.triton_dispatcher_factory import _load_module
+                mod = _load_module()
+                grid_tuple = grid if isinstance(grid, tuple) else (grid, )
+                while len(grid_tuple) < 3:
+                    grid_tuple = grid_tuple + (1, )
+
+                num_kernel_args = self._num_kernel_args
+
+                def slow_path(*args, stream=None):
+                    """Fallback: full Python dispatch on cache miss."""
+                    if stream is None:
+                        stream = driver.active.get_current_stream(driver.active.get_current_device())
+                    gx, gy, gz = grid_tuple
+                    dispatcher(gx, gy, gz, stream, *args)
+
+                jit_runner = mod._TritonJITRunner(
+                    dispatcher=dispatcher,
+                    grid=grid_tuple,
+                    get_stream_fn=driver.active.get_current_stream,
+                    get_device_fn=driver.active.get_current_device,
+                    slow_path_fn=slow_path,
+                    num_kernel_args=num_kernel_args,
+                )
+                return jit_runner
+            except (KeyError, TypeError, ValueError, RuntimeError, AttributeError) as e:
+                logging.warning("_TritonJITRunner creation failed for %s, using fallback: %s", self.name, e)
+
+            # Fallback: Python wrapper around dispatcher
+            def runner(*args, stream=None):
+                if stream is None:
+                    device = driver.active.get_current_device()
+                    stream = driver.active.get_current_stream(device)
+                gx = grid[0]
+                gy = grid[1] if len(grid) > 1 else 1
+                gz = grid[2] if len(grid) > 2 else 1
+                dispatcher(gx, gy, gz, stream, *args)
+
+            return runner
 
         def runner(*args, stream=None):
             if stream is None:

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -423,6 +423,9 @@ class HookChain(Generic[F]):
         if func in self.calls:
             self.calls.remove(func)
 
+    def __bool__(self):
+        return len(self.calls) > 0
+
     def __call__(self, *args, **kwargs):
         for call in self.calls if not self.reversed else reversed(self.calls):
             call(*args, **kwargs)
@@ -516,6 +519,8 @@ class nvidia_knobs(base_knobs):
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
+    use_llvm_launcher: env_bool = env_bool("TRITON_USE_LLVM_LAUNCHER")
+    use_triton_dispatcher: env_bool = env_bool("TRITON_USE_TRITON_DISPATCHER")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     enable_tileir: env_bool = env_bool("ENABLE_TILE")
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -802,10 +802,17 @@ class JITFunction(JITCallable, KernelInterface[T]):
 
             if hasattr(kernel, "result"):
                 kernel = kernel.result()
-            # launch kernel
-            launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
-            kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
-                       knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook, *bound_args.values())
+            # launch kernel — prefer _TritonDispatcher (C direct cuLaunchKernelEx)
+            # when available and hooks are not needed.
+            _disp = getattr(kernel, '_dispatcher', None)
+            if _disp is not None and not knobs.runtime.launch_enter_hook and not knobs.runtime.launch_exit_hook:
+                _vals = tuple(bound_args.values())
+                _indices = kernel._dispatch_arg_indices
+                _disp(grid_0, grid_1, grid_2, stream, *[_vals[i] for i in _indices])
+            else:
+                launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
+                kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
+                           knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook, *bound_args.values())
 
         return kernel
 

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
@@ -1090,6 +1091,14 @@ static void ensureCudaContext() {
   }
 }
 
+// File-level handle for cuLaunchKernelEx (shared by _launch and _TritonDispatcher)
+static cuLaunchKernelEx_t g_cuLaunchKernelExHandle = NULL;
+static inline cuLaunchKernelEx_t ensureLaunchHandle(void) {
+  if (g_cuLaunchKernelExHandle == NULL)
+    g_cuLaunchKernelExHandle = getLaunchKernelExHandle();
+  return g_cuLaunchKernelExHandle;
+}
+
 static void _launch(int gridX, int gridY, int gridZ, int num_warps,
                     int num_ctas, int launch_cooperative_grid, int launch_pdl,
                     int preferredClusterDimX, int preferredClusterDimY,
@@ -1098,10 +1107,7 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
   if (gridX * gridY * gridZ > 0) {
     // 5 attributes that we can currently pass maximum
     CUlaunchAttribute launchAttr[5];
-    static cuLaunchKernelEx_t cuLaunchKernelExHandle = NULL;
-    if (cuLaunchKernelExHandle == NULL) {
-      cuLaunchKernelExHandle = getLaunchKernelExHandle();
-    }
+    cuLaunchKernelEx_t cuLaunchKernelExHandle = ensureLaunchHandle();
     CUlaunchConfig config;
     config.gridDimX = gridX * num_ctas;
     config.gridDimY = gridY;
@@ -1178,6 +1184,7 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
 }
 
 static PyObject *data_ptr_str = NULL;
+static PyObject *td_get_str = NULL;  /* interned "get" for allocator.get() */
 
 // Extract a CUDA device pointer from a pointer-like PyObject obj, and store
 // it to the memory location pointed by ptr.
@@ -1693,6 +1700,682 @@ cleanup:
   return NULL;
 }
 
+/* =========================================================================
+ * _TritonDispatcher: Meta-specific vectorcall-based kernel dispatcher.
+ *
+ * Replaces the Python dispatch path with a single C vectorcall.
+ * Pre-binds CUfunction, launch attributes, and arg type layout.
+ * Calling convention: dispatcher(grid_x, grid_y, grid_z, stream, *kernel_args)
+ * ========================================================================= */
+
+#define TD_MAX_KERNEL_ARGS 64
+#define TD_FIXED_ARGS 4  /* grid_x, grid_y, grid_z, stream */
+
+typedef union {
+    CUdeviceptr ptr;
+    int8_t   i8;
+    int16_t  i16;
+    int32_t  i32;
+    int64_t  i64;
+    uint8_t  u8;
+    uint16_t u16;
+    uint32_t u32;
+    uint64_t u64;
+    float    f32;
+    double   f64;
+} TDArgSlot;
+
+typedef struct {
+    PyObject_HEAD
+    vectorcallfunc vectorcall;
+    CUfunction function;
+    unsigned grid_mult;     /* num_ctas — grid_x multiplied by this */
+    unsigned block_dim_x;   /* 32 * num_warps */
+    unsigned shared_mem;
+    CUlaunchAttribute launch_attrs[5];
+    unsigned num_launch_attrs;
+    int arg_types[TD_MAX_KERNEL_ARGS];  /* ExtractorTypeIndex values */
+    int num_args;
+    int total_params;
+    TDArgSlot arg_storage[TD_MAX_KERNEL_ARGS];
+    void *kernel_params[TD_MAX_KERNEL_ARGS];
+    int has_global_scratch;
+    int has_profile_scratch;
+    /* Scratch allocation support */
+    unsigned global_scratch_size;
+    unsigned global_scratch_align;
+    unsigned profile_scratch_size;
+    unsigned profile_scratch_align;
+    PyObject *allocator;          /* _allocation._allocator (ContextVar) */
+    PyObject *profile_allocator;  /* _allocation._profile_allocator (wrapper) */
+} TritonDispatcher;
+
+/* Forward declarations */
+static PyObject *TritonDispatcher_vectorcall(
+    PyObject *self, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static void TritonDispatcher_dealloc(PyObject *self);
+
+/* Fast pointer extraction (no cuPointerGetAttribute validation — hot path) */
+static inline CUdeviceptr td_get_ptr(PyObject *obj) {
+    if (PyLong_Check(obj))
+        return (CUdeviceptr)PyLong_AsUnsignedLongLong(obj);
+    if (obj == Py_None)
+        return 0;
+    PyObject *r = PyObject_CallMethodNoArgs(obj, data_ptr_str);
+    if (!r) return 0;
+    CUdeviceptr p = (CUdeviceptr)PyLong_AsUnsignedLongLong(r);
+    Py_DECREF(r);
+    return p;
+}
+
+/* Fast fp16/bf16 packing (equivalent to extractFP16/BF16 but returns value) */
+static inline uint16_t td_pack_fp16(double v) {
+    uint16_t result;
+#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && \
+    !defined(PYPY_VERSION)
+    _PyFloat_Pack2(v, (unsigned char *)&result, 1);
+#else
+    PyFloat_Pack2(v, (char *)&result, 1);
+#endif
+    return result;
+}
+static inline uint16_t td_pack_bf16(double v) {
+    float f = (float)v;
+    uint32_t b; memcpy(&b, &f, 4);
+    return (uint16_t)(b >> 16);
+}
+
+/* Arg conversion using ExtractorTypeIndex codes */
+static inline int td_convert_args(TritonDispatcher *self, PyObject *const *kargs) {
+    for (int i = 0; i < self->num_args; i++) {
+        PyObject *a = kargs[i];
+        TDArgSlot *s = &self->arg_storage[i];
+        switch (self->arg_types[i]) {
+        case EXTRACTOR_POINTER_INDEX:
+            s->ptr = td_get_ptr(a);
+            break;
+        case EXTRACTOR_INT8_INDEX:  s->i8  = (int8_t)PyLong_AsLong(a); break;
+        case EXTRACTOR_INT16_INDEX: s->i16 = (int16_t)PyLong_AsLong(a); break;
+        case EXTRACTOR_INT32_INDEX: s->i32 = (int32_t)PyLong_AsLong(a); break;
+        case EXTRACTOR_INT64_INDEX: s->i64 = (int64_t)PyLong_AsLongLong(a); break;
+        case EXTRACTOR_UINT8_INDEX:  s->u8  = (uint8_t)PyLong_AsUnsignedLong(a); break;
+        case EXTRACTOR_UINT16_INDEX: s->u16 = (uint16_t)PyLong_AsUnsignedLong(a); break;
+        case EXTRACTOR_UINT32_INDEX: s->u32 = (uint32_t)PyLong_AsUnsignedLong(a); break;
+        case EXTRACTOR_UINT64_INDEX: s->u64 = (uint64_t)PyLong_AsUnsignedLongLong(a); break;
+        case EXTRACTOR_FP16_INDEX: s->u16 = td_pack_fp16(PyFloat_AsDouble(a)); break;
+        case EXTRACTOR_BF16_INDEX: s->u16 = td_pack_bf16(PyFloat_AsDouble(a)); break;
+        case EXTRACTOR_FP32_INDEX: { float f = (float)PyFloat_AsDouble(a); memcpy(&s->u32, &f, 4); break; }
+        case EXTRACTOR_FP64_INDEX: s->f64 = PyFloat_AsDouble(a); break;
+        default:
+            PyErr_Format(PyExc_TypeError, "Unknown type code %d for arg %d", self->arg_types[i], i);
+            return -1;
+        }
+    }
+    if (PyErr_Occurred()) return -1;
+    return 0;
+}
+
+/* Relaunch with pre-built attrs (cuLaunchKernelEx wrapper) */
+static inline CUresult td_relaunch(
+    TritonDispatcher *d, unsigned gx, unsigned gy, unsigned gz, CUstream stream)
+{
+    if (gx * gy * gz == 0) return CUDA_SUCCESS;
+    CUlaunchConfig cfg;
+    cfg.gridDimX = gx * d->grid_mult; cfg.gridDimY = gy; cfg.gridDimZ = gz;
+    cfg.blockDimX = d->block_dim_x; cfg.blockDimY = 1; cfg.blockDimZ = 1;
+    cfg.sharedMemBytes = d->shared_mem; cfg.hStream = stream;
+    cfg.attrs = d->num_launch_attrs > 0 ? d->launch_attrs : NULL;
+    cfg.numAttrs = d->num_launch_attrs;
+    return ensureLaunchHandle()(&cfg, d->function, d->kernel_params, NULL);
+}
+
+/* ---- Constructor ---- */
+static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
+    unsigned long long func_ptr;
+    int num_warps, num_ctas, shared_mem;
+    int launch_pdl, launch_coop, launch_cluster;
+    PyObject *arg_type_codes;
+    int has_global_scratch, has_profile_scratch;
+    unsigned global_scratch_size = 0, global_scratch_align = 1;
+    unsigned profile_scratch_size = 0, profile_scratch_align = 1;
+    PyObject *allocator_obj = NULL, *profile_allocator_obj = NULL;
+
+    static char *kwlist[] = {
+        "function", "num_warps", "num_ctas", "shared_mem",
+        "launch_pdl", "launch_cooperative_grid", "launch_cluster",
+        "arg_type_codes", "has_global_scratch", "has_profile_scratch",
+        "global_scratch_size", "global_scratch_align",
+        "profile_scratch_size", "profile_scratch_align",
+        "allocator", "profile_allocator", NULL
+    };
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "KiiiiiiOpp|IIIIOO", kwlist,
+            &func_ptr, &num_warps, &num_ctas, &shared_mem,
+            &launch_pdl, &launch_coop, &launch_cluster,
+            &arg_type_codes, &has_global_scratch, &has_profile_scratch,
+            &global_scratch_size, &global_scratch_align,
+            &profile_scratch_size, &profile_scratch_align,
+            &allocator_obj, &profile_allocator_obj))
+        return NULL;
+
+    TritonDispatcher *self = (TritonDispatcher *)type->tp_alloc(type, 0);
+    if (!self) return NULL;
+
+    self->vectorcall = TritonDispatcher_vectorcall;
+    self->function = (CUfunction)(uintptr_t)func_ptr;
+    self->grid_mult = (unsigned)num_ctas;
+    self->block_dim_x = 32 * (unsigned)num_warps;
+    self->shared_mem = (unsigned)shared_mem;
+    self->has_global_scratch = has_global_scratch;
+    self->has_profile_scratch = has_profile_scratch;
+    self->global_scratch_size = global_scratch_size;
+    self->global_scratch_align = global_scratch_align;
+    self->profile_scratch_size = profile_scratch_size;
+    self->profile_scratch_align = profile_scratch_align;
+    self->allocator = allocator_obj;
+    Py_XINCREF(self->allocator);
+    self->profile_allocator = profile_allocator_obj;
+    Py_XINCREF(self->profile_allocator);
+
+    memset(self->launch_attrs, 0, sizeof(self->launch_attrs));
+    memset(self->arg_storage, 0, sizeof(self->arg_storage));
+    memset(self->kernel_params, 0, sizeof(self->kernel_params));
+
+    /* Parse arg types (ExtractorTypeIndex values from buildSignatureMetadata) */
+    Py_ssize_t n = PyTuple_Size(arg_type_codes);
+    if (n > TD_MAX_KERNEL_ARGS - 2) {
+        PyErr_SetString(PyExc_ValueError, "Too many kernel args");
+        Py_DECREF(self);
+        return NULL;
+    }
+    self->num_args = (int)n;
+    for (Py_ssize_t i = 0; i < n; i++)
+        self->arg_types[i] = (int)PyLong_AsLong(PyTuple_GET_ITEM(arg_type_codes, i));
+    if (PyErr_Occurred()) {
+        Py_DECREF(self);
+        return NULL;
+    }
+
+    /* Build kernel_params pointers */
+    int pidx = 0;
+    for (int i = 0; i < self->num_args; i++) {
+        self->kernel_params[pidx] = &self->arg_storage[pidx];
+        pidx++;
+    }
+    self->kernel_params[pidx] = &self->arg_storage[pidx]; pidx++;  /* global_scratch */
+    self->kernel_params[pidx] = &self->arg_storage[pidx]; pidx++;  /* profile_scratch */
+    self->total_params = pidx;
+
+    /* Pre-build launch attributes */
+    unsigned na = 0;
+    if (launch_pdl) {
+        self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+        self->launch_attrs[na].value.programmaticStreamSerializationAllowed = 1;
+        na++;
+    }
+    if (launch_coop) {
+        self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+        self->launch_attrs[na].value.cooperative = 1;
+        na++;
+    }
+    if (launch_cluster || num_ctas > 1) {
+        if (num_ctas > 1) {
+            self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+            self->launch_attrs[na].value.clusterDim.x = num_ctas;
+            self->launch_attrs[na].value.clusterDim.y = 1;
+            self->launch_attrs[na].value.clusterDim.z = 1;
+            na++;
+        }
+        self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+        self->launch_attrs[na].value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+        na++;
+    }
+    self->num_launch_attrs = na;
+
+    return (PyObject *)self;
+}
+
+static void TritonDispatcher_dealloc(PyObject *o) {
+    TritonDispatcher *self = (TritonDispatcher *)o;
+    Py_XDECREF(self->allocator);
+    Py_XDECREF(self->profile_allocator);
+    Py_TYPE(o)->tp_free(o);
+}
+
+/* ==== THE HOT PATH ==== */
+static PyObject *TritonDispatcher_vectorcall(
+    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
+{
+    TritonDispatcher *self = (TritonDispatcher *)callable;
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+
+    if (nargs < TD_FIXED_ARGS + self->num_args) {
+        PyErr_Format(PyExc_TypeError,
+            "_TritonDispatcher: expected %d args, got %zd",
+            TD_FIXED_ARGS + self->num_args, nargs);
+        return NULL;
+    }
+
+    long gx_l = PyLong_AsLong(args[0]);
+    long gy_l = PyLong_AsLong(args[1]);
+    long gz_l = PyLong_AsLong(args[2]);
+    if (PyErr_Occurred()) return NULL;
+
+    unsigned gx = (unsigned)gx_l;
+    unsigned gy = (unsigned)gy_l;
+    unsigned gz = (unsigned)gz_l;
+
+    if (gx * gy * gz == 0)
+        Py_RETURN_NONE;
+
+    CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(args[3]);
+
+    /* Convert kernel args.
+     * No cleanup needed on failure: scratch/profile buffers are allocated below,
+     * and no other resources have been acquired at this point. */
+    if (td_convert_args(self, args + TD_FIXED_ARGS) < 0)
+        return NULL;
+
+    /* Scratch allocation: call Python allocator if scratch is needed.
+     * alloc_size = grid_x * grid_y * grid_z * num_ctas * scratch_size */
+    PyObject *scratch_buf = NULL, *profile_buf = NULL;
+    if (self->global_scratch_size > 0 && self->allocator) {
+        unsigned long long alloc_size =
+            (unsigned long long)gx * gy * gz * self->grid_mult * self->global_scratch_size;
+        PyObject *alloc_fn = PyObject_CallMethodNoArgs(self->allocator, td_get_str);
+        if (!alloc_fn) return NULL;
+        scratch_buf = PyObject_CallFunction(alloc_fn, "KIK",
+            alloc_size, (unsigned)self->global_scratch_align, (unsigned long long)(uintptr_t)stream);
+        Py_DECREF(alloc_fn);
+        if (!scratch_buf) return NULL;
+        PyObject *ptr_obj = PyObject_CallMethodNoArgs(scratch_buf, data_ptr_str);
+        if (!ptr_obj) { Py_DECREF(scratch_buf); return NULL; }
+        self->arg_storage[self->num_args].ptr = (CUdeviceptr)PyLong_AsUnsignedLongLong(ptr_obj);
+        Py_DECREF(ptr_obj);
+    } else {
+        self->arg_storage[self->num_args].ptr = 0;
+    }
+
+    if (self->profile_scratch_size > 0 && self->profile_allocator) {
+        unsigned long long alloc_size =
+            (unsigned long long)gx * gy * gz * self->grid_mult * self->profile_scratch_size;
+        PyObject *alloc_fn = PyObject_CallMethodNoArgs(self->profile_allocator, td_get_str);
+        if (!alloc_fn) { Py_XDECREF(scratch_buf); return NULL; }
+        profile_buf = PyObject_CallFunction(alloc_fn, "KIK",
+            alloc_size, (unsigned)self->profile_scratch_align, (unsigned long long)(uintptr_t)stream);
+        Py_DECREF(alloc_fn);
+        if (!profile_buf) { Py_XDECREF(scratch_buf); return NULL; }
+        PyObject *ptr_obj = PyObject_CallMethodNoArgs(profile_buf, data_ptr_str);
+        if (!ptr_obj) { Py_DECREF(profile_buf); Py_XDECREF(scratch_buf); return NULL; }
+        self->arg_storage[self->num_args + 1].ptr = (CUdeviceptr)PyLong_AsUnsignedLongLong(ptr_obj);
+        Py_DECREF(ptr_obj);
+    } else {
+        self->arg_storage[self->num_args + 1].ptr = 0;
+    }
+
+    /* Launch using pre-built attrs.
+     * Thread safety: arg_storage is per-instance and the GIL is held up to
+     * Py_BEGIN_ALLOW_THREADS. cuLaunchKernelEx copies kernel_params at call
+     * entry (documented CUDA driver behavior), so releasing the GIL after
+     * the call begins is safe — another thread cannot corrupt params mid-copy. */
+    CUresult err;
+    Py_BEGIN_ALLOW_THREADS
+    err = td_relaunch(self, gx, gy, gz, stream);
+    Py_END_ALLOW_THREADS
+
+    /* Release scratch buffers after launch (kernel params already copied) */
+    Py_XDECREF(scratch_buf);
+    Py_XDECREF(profile_buf);
+
+    if (err != CUDA_SUCCESS) {
+        const char *s = NULL;
+        cuGetErrorString(err, &s);
+        PyErr_Format(PyExc_RuntimeError,
+            "Triton Error [CUDA]: cuLaunchKernelEx failed: %s (%d)",
+            s ? s : "unknown", (int)err);
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyTypeObject TritonDispatcherType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "triton.backends.nvidia._TritonDispatcher",
+    .tp_basicsize = sizeof(TritonDispatcher),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
+    .tp_vectorcall_offset = offsetof(TritonDispatcher, vectorcall),
+    .tp_call = PyVectorcall_Call,
+    .tp_new = TritonDispatcher_new,
+    .tp_dealloc = TritonDispatcher_dealloc,
+    .tp_doc = "Full C dispatcher for Triton JIT kernel launch (vectorcall).",
+};
+
+typedef struct {
+    PyObject_HEAD
+    vectorcallfunc vectorcall;
+    TritonDispatcher *dispatcher;
+    unsigned grid[3];
+    PyObject *get_stream_fn;
+    PyObject *get_device_fn;
+    int num_args;
+    PyObject *slow_path_fn;
+} TritonJITRunner;
+
+static PyObject *JITRunner_vectorcall(
+    PyObject *self, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static void JITRunner_dealloc(PyObject *self);
+
+static PyObject *JITRunner_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
+    PyObject *dispatcher_obj, *grid_tuple, *get_stream_fn, *get_device_fn, *slow_path_fn;
+    int num_kernel_args;
+
+    static char *kwlist[] = {
+        "dispatcher", "grid", "get_stream_fn", "get_device_fn", "slow_path_fn", "num_kernel_args", NULL
+    };
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOOOi", kwlist,
+            &dispatcher_obj, &grid_tuple, &get_stream_fn, &get_device_fn, &slow_path_fn, &num_kernel_args))
+        return NULL;
+
+    TritonJITRunner *self = (TritonJITRunner *)type->tp_alloc(type, 0);
+    if (!self) return NULL;
+
+    self->vectorcall = JITRunner_vectorcall;
+    self->dispatcher = (TritonDispatcher *)dispatcher_obj;
+    Py_INCREF(dispatcher_obj);
+
+    Py_ssize_t gs = PyTuple_Size(grid_tuple);
+    self->grid[0] = (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
+    self->grid[1] = (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
+    self->grid[2] = (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
+
+    self->get_stream_fn = get_stream_fn; Py_INCREF(get_stream_fn);
+    self->get_device_fn = get_device_fn; Py_INCREF(get_device_fn);
+    self->slow_path_fn = slow_path_fn; Py_INCREF(slow_path_fn);
+    self->num_args = num_kernel_args;
+
+    return (PyObject *)self;
+}
+
+static void JITRunner_dealloc(PyObject *o) {
+    TritonJITRunner *self = (TritonJITRunner *)o;
+    Py_XDECREF((PyObject *)self->dispatcher);
+    Py_XDECREF(self->get_stream_fn);
+    Py_XDECREF(self->get_device_fn);
+    Py_XDECREF(self->slow_path_fn);
+    Py_TYPE(o)->tp_free(o);
+}
+
+static PyObject *JITRunner_vectorcall(
+    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
+{
+    TritonJITRunner *self = (TritonJITRunner *)callable;
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+
+    if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
+        return PyObject_Vectorcall(self->slow_path_fn, args, nargsf, kwnames);
+    }
+    if (nargs < self->num_args) {
+        PyErr_Format(PyExc_TypeError,
+            "_TritonJITRunner: expected %d args, got %zd", self->num_args, nargs);
+        return NULL;
+    }
+
+    /* The caller (activate_fast_dispatch) ensures the kernel is already
+     * compiled for these arg types. We just extract + launch. */
+    PyObject *device = PyObject_CallNoArgs(self->get_device_fn);
+    if (!device) return NULL;
+    PyObject *stream_obj = PyObject_CallOneArg(self->get_stream_fn, device);
+    Py_DECREF(device);
+    if (!stream_obj) return NULL;
+    uint64_t stream = PyLong_AsUnsignedLongLong(stream_obj);
+    Py_DECREF(stream_obj);
+
+    /* Build dispatcher args: [grid_x, grid_y, grid_z, stream, *kernel_args] */
+    Py_ssize_t disp_nargs = TD_FIXED_ARGS + self->num_args;
+    PyObject **disp_args = (PyObject **)alloca(disp_nargs * sizeof(PyObject *));
+    PyObject *gx = PyLong_FromUnsignedLong(self->grid[0]);
+    PyObject *gy = PyLong_FromUnsignedLong(self->grid[1]);
+    PyObject *gz = PyLong_FromUnsignedLong(self->grid[2]);
+    PyObject *st = PyLong_FromUnsignedLongLong(stream);
+    if (!gx || !gy || !gz || !st) {
+        Py_XDECREF(gx); Py_XDECREF(gy); Py_XDECREF(gz); Py_XDECREF(st);
+        return NULL;
+    }
+    disp_args[0] = gx; disp_args[1] = gy; disp_args[2] = gz; disp_args[3] = st;
+    for (int i = 0; i < self->num_args; i++)
+        disp_args[TD_FIXED_ARGS + i] = (PyObject *)args[i];
+
+    PyObject *result = TritonDispatcher_vectorcall(
+        (PyObject *)self->dispatcher, (PyObject *const *)disp_args, disp_nargs, NULL);
+    Py_DECREF(gx); Py_DECREF(gy); Py_DECREF(gz); Py_DECREF(st);
+    return result;
+}
+
+static PyTypeObject TritonJITRunnerType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "triton.backends.nvidia._TritonJITRunner",
+    .tp_basicsize = sizeof(TritonJITRunner),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
+    .tp_vectorcall_offset = offsetof(TritonJITRunner, vectorcall),
+    .tp_call = PyVectorcall_Call,
+    .tp_new = JITRunner_new,
+    .tp_dealloc = JITRunner_dealloc,
+};
+
+/* =========================================================================
+ * _ProxyRunner: returned by fast_subscript (__getitem__ in C).
+ * Pre-binds grid + stream getter + dispatcher. Always extracts args fresh
+ * ========================================================================= */
+typedef struct {
+    PyObject_HEAD
+    vectorcallfunc vectorcall;
+    TritonDispatcher *dispatcher;
+    unsigned grid[3];
+    PyObject *get_stream_fn;
+    PyObject *get_device_fn;
+    PyObject *kernel;
+    int num_args;
+} ProxyRunner;
+
+static PyObject *ProxyRunner_vectorcall(
+    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static void ProxyRunner_dealloc(PyObject *o);
+
+static PyObject *ProxyRunner_vectorcall(
+    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
+{
+    ProxyRunner *self = (ProxyRunner *)callable;
+    TritonDispatcher *d = self->dispatcher;
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+
+    if (nargs < self->num_args) {
+        PyErr_Format(PyExc_TypeError,
+            "_ProxyRunner: expected >= %d args, got %zd", self->num_args, nargs);
+        return NULL;
+    }
+
+    /* Always extract args fresh */
+    if (td_convert_args(d, args) < 0) return NULL;
+
+    /* Get current stream */
+    PyObject *dev = PyObject_CallNoArgs(self->get_device_fn);
+    if (!dev) return NULL;
+    PyObject *st = PyObject_CallOneArg(self->get_stream_fn, dev);
+    Py_DECREF(dev);
+    if (!st) return NULL;
+    CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(st);
+    Py_DECREF(st);
+
+    /* Launch.
+     * Thread safety: arg_storage is per-dispatcher-instance and td_convert_args
+     * runs while holding the GIL. cuLaunchKernelEx copies kernel_params at call
+     * entry (documented CUDA driver behavior), so releasing the GIL after the
+     * call begins is safe. Sharing the same dispatcher across Python threads is
+     * NOT supported — each ProxyRunner holds a dedicated dispatcher reference. */
+    CUresult err;
+    Py_BEGIN_ALLOW_THREADS
+    err = td_relaunch(d, self->grid[0], self->grid[1], self->grid[2], stream);
+    Py_END_ALLOW_THREADS
+    if (err != CUDA_SUCCESS) {
+        const char *s = NULL; cuGetErrorString(err, &s);
+        PyErr_Format(PyExc_RuntimeError, "cuLaunchKernelEx: %s (%d)", s?s:"?", (int)err);
+        return NULL;
+    }
+    Py_INCREF(self->kernel);
+    return self->kernel;
+}
+
+static void ProxyRunner_dealloc(PyObject *o) {
+    ProxyRunner *self = (ProxyRunner *)o;
+    Py_XDECREF((PyObject *)self->dispatcher);
+    Py_XDECREF(self->get_stream_fn);
+    Py_XDECREF(self->get_device_fn);
+    Py_XDECREF(self->kernel);
+    Py_TYPE(o)->tp_free(o);
+}
+
+static PyTypeObject ProxyRunnerType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "triton.backends.nvidia._ProxyRunner",
+    .tp_basicsize = sizeof(ProxyRunner),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
+    .tp_vectorcall_offset = offsetof(ProxyRunner, vectorcall),
+    .tp_call = PyVectorcall_Call,
+    .tp_dealloc = ProxyRunner_dealloc,
+};
+
+/* =========================================================================
+ * fast_subscript: C __getitem__ slot for the dynamic heap type.
+ * Creates _ProxyRunner per grid, caching in _runner_cache dict.
+ * ========================================================================= */
+static PyObject *fast_subscript(PyObject *self, PyObject *grid) {
+    static PyObject *_rc_key = NULL;
+    if (!_rc_key) _rc_key = PyUnicode_InternFromString("_runner_cache");
+
+    /* Normalize grid to tuple for consistent cache key */
+    PyObject *grid_tuple;
+    if (!PyTuple_Check(grid)) {
+        grid_tuple = PyTuple_Pack(1, grid);
+        if (!grid_tuple) return NULL;
+    } else {
+        grid_tuple = grid;
+        Py_INCREF(grid_tuple);
+    }
+
+    PyObject **dictptr = _PyObject_GetDictPtr(self);
+    if (!dictptr || !*dictptr) { Py_DECREF(grid_tuple); goto fallback; }
+    PyObject *dict = *dictptr;
+
+    PyObject *cache = PyDict_GetItem(dict, _rc_key);
+    if (!cache) { Py_DECREF(grid_tuple); goto fallback; }
+
+    PyObject *runner = PyDict_GetItem(cache, grid_tuple);
+    if (runner) { Py_DECREF(grid_tuple); Py_INCREF(runner); return runner; }
+
+    /* Create new ProxyRunner */
+    {
+        static PyObject *_disp_key = NULL, *_nka_key = NULL, *_gsf_key = NULL, *_gdf_key = NULL, *_kern_key = NULL;
+        if (!_disp_key) {
+            _disp_key = PyUnicode_InternFromString("_fast_dispatcher");
+            _nka_key = PyUnicode_InternFromString("_fast_num_args");
+            _gsf_key = PyUnicode_InternFromString("_fast_get_stream");
+            _gdf_key = PyUnicode_InternFromString("_fast_get_device");
+            _kern_key = PyUnicode_InternFromString("_fast_kernel");
+        }
+
+        PyObject *disp = PyDict_GetItem(dict, _disp_key);
+        if (!disp) { Py_DECREF(grid_tuple); goto fallback; }
+        PyObject *kern = PyDict_GetItem(dict, _kern_key);
+        if (!kern) kern = Py_None;
+
+        PyObject *nka_obj = PyDict_GetItem(dict, _nka_key);
+        int nka = nka_obj ? (int)PyLong_AsLong(nka_obj) : 0;
+        PyObject *gsf = PyDict_GetItem(dict, _gsf_key);
+        PyObject *gdf = PyDict_GetItem(dict, _gdf_key);
+        if (!gsf || !gdf) { Py_DECREF(grid_tuple); goto fallback; }
+
+        ProxyRunner *pr = PyObject_New(ProxyRunner, &ProxyRunnerType);
+        if (!pr) { Py_DECREF(grid_tuple); return NULL; }
+        pr->vectorcall = ProxyRunner_vectorcall;
+        /* Multiple ProxyRunner instances may reference the same TritonDispatcher.
+         * This is safe because: (1) td_convert_args + cuLaunchKernelEx both run
+         * while holding the GIL, and cuLaunchKernelEx copies kernel_params at
+         * call entry before we release the GIL via Py_BEGIN_ALLOW_THREADS.
+         * (2) Each ProxyRunner_vectorcall completes the full sequence
+         * (convert → launch → GIL release) atomically from Python's perspective.
+         * Direct multi-threaded use of kernel._dispatcher without the GIL is
+         * unsupported (same restriction as all CPython C extension objects). */
+        pr->dispatcher = (TritonDispatcher *)disp; Py_INCREF(disp);
+        Py_ssize_t gs = PyTuple_Size(grid_tuple);
+        pr->grid[0] = (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
+        pr->grid[1] = (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
+        pr->grid[2] = (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
+
+        pr->get_stream_fn = gsf; Py_INCREF(gsf);
+        pr->get_device_fn = gdf; Py_INCREF(gdf);
+        pr->kernel = kern; Py_INCREF(kern);
+        pr->num_args = nka;
+
+        if (PyDict_SetItem(cache, grid_tuple, (PyObject *)pr) < 0) {
+            Py_DECREF(grid_tuple);
+            Py_DECREF(pr);
+            return NULL;
+        }
+        Py_DECREF(grid_tuple);
+        return (PyObject *)pr;
+    }
+
+fallback:;
+    /* Build functools.partial(self.run, grid=grid, warmup=False) */
+    static PyObject *_run_str = NULL, *_grid_str = NULL, *_warmup_str = NULL;
+    if (!_run_str) _run_str = PyUnicode_InternFromString("run");
+    if (!_grid_str) _grid_str = PyUnicode_InternFromString("grid");
+    if (!_warmup_str) _warmup_str = PyUnicode_InternFromString("warmup");
+    PyObject *run = PyObject_GetAttr(self, _run_str);
+    if (!run) return NULL;
+    PyObject *kw = PyDict_New();
+    if (!kw) { Py_DECREF(run); return NULL; }
+    if (PyDict_SetItem(kw, _grid_str, grid) < 0 ||
+        PyDict_SetItem(kw, _warmup_str, Py_False) < 0) {
+        Py_DECREF(run); Py_DECREF(kw); return NULL;
+    }
+    PyObject *partial_mod = PyImport_ImportModule("functools");
+    if (!partial_mod) { Py_DECREF(run); Py_DECREF(kw); return NULL; }
+    PyObject *partial_fn = PyObject_GetAttrString(partial_mod, "partial");
+    Py_DECREF(partial_mod);
+    PyObject *pack = PyTuple_Pack(1, run);
+    if (!pack) { Py_DECREF(partial_fn); Py_DECREF(run); Py_DECREF(kw); return NULL; }
+    PyObject *result = PyObject_Call(partial_fn, pack, kw);
+    Py_DECREF(pack); Py_DECREF(partial_fn); Py_DECREF(run); Py_DECREF(kw);
+    return result;
+}
+
+/* create_fast_jit_type(base_type) — create heap type with mp_subscript = fast_subscript */
+static PyObject *py_create_fast_jit_type(PyObject *module, PyObject *base_type) {
+    if (!PyType_Check(base_type)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a type");
+        return NULL;
+    }
+    static PyType_Slot slots[] = {
+        {Py_mp_subscript, fast_subscript},
+        {0, NULL},
+    };
+    PyType_Spec spec = {
+        .name = "triton.backends.nvidia._FastJITFunction",
+        .basicsize = 0,
+        .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
+        .slots = slots,
+    };
+    PyObject *bases = PyTuple_Pack(1, base_type);
+    if (!bases) return NULL;
+    PyObject *new_type = PyType_FromSpecWithBases(&spec, bases);
+    Py_DECREF(bases);
+    return new_type;
+}
+
+/* ========================================================================= */
+
 static PyMethodDef ModuleMethods[] = {
     {"load_binary", loadBinary, METH_VARARGS,
      "Load provided cubin into CUDA driver"},
@@ -1721,6 +2404,8 @@ static PyMethodDef ModuleMethods[] = {
      "doc"},
     {"fill_2d_tma_descriptor_type", fill2DTMADescriptorType, METH_VARARGS,
      "doc"},
+    {"create_fast_jit_type", py_create_fast_jit_type, METH_O,
+     "Create a heap type inheriting from JITFunction with C mp_subscript"},
 
     {NULL, NULL, 0, NULL} // sentinel
 };
@@ -1737,6 +2422,15 @@ PyMODINIT_FUNC PyInit_cuda_utils(void) {
   if (PyType_Ready(&PyKernelArgType) < 0) {
     return NULL;
   }
+  if (PyType_Ready(&TritonDispatcherType) < 0) {
+    return NULL;
+  }
+  if (PyType_Ready(&TritonJITRunnerType) < 0) {
+    return NULL;
+  }
+  if (PyType_Ready(&ProxyRunnerType) < 0) {
+    return NULL;
+  }
 
   PyObject *m = PyModule_Create(&ModuleDef);
   if (m == NULL) {
@@ -1744,6 +2438,10 @@ PyMODINIT_FUNC PyInit_cuda_utils(void) {
   }
   data_ptr_str = PyUnicode_InternFromString("data_ptr");
   if (data_ptr_str == NULL) {
+    return NULL;
+  }
+  td_get_str = PyUnicode_InternFromString("get");
+  if (td_get_str == NULL) {
     return NULL;
   }
 
@@ -1757,6 +2455,13 @@ PyMODINIT_FUNC PyInit_cuda_utils(void) {
   PyModule_AddIntConstant(m, "ARG_CONSTEXPR", ARG_CONSTEXPR);
   PyModule_AddIntConstant(m, "ARG_KERNEL", ARG_KERNEL);
   PyModule_AddIntConstant(m, "ARG_TUPLE", ARG_TUPLE);
+
+  Py_INCREF(&TritonDispatcherType);
+  PyModule_AddObject(m, "_TritonDispatcher", (PyObject *)&TritonDispatcherType);
+  Py_INCREF(&TritonJITRunnerType);
+  PyModule_AddObject(m, "_TritonJITRunner", (PyObject *)&TritonJITRunnerType);
+  Py_INCREF(&ProxyRunnerType);
+  PyModule_AddObject(m, "_ProxyRunner", (PyObject *)&ProxyRunnerType);
 
   return m;
 }

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -93,6 +93,10 @@ class CudaUtils(object):
         self.fill_1d_tma_descriptor_type = mod.fill_1d_tma_descriptor_type
         self.fill_2d_tma_descriptor_type = mod.fill_2d_tma_descriptor_type
         self.TmaDescKernelParam = TmaDescKernelParam
+        self._TritonDispatcher = mod._TritonDispatcher
+        self._TritonJITRunner = mod._TritonJITRunner
+        self._ProxyRunner = mod._ProxyRunner
+        self.create_fast_jit_type = mod.create_fast_jit_type
 
 
 # ------------------------

--- a/third_party/nvidia/backend/triton_dispatcher_factory.py
+++ b/third_party/nvidia/backend/triton_dispatcher_factory.py
@@ -1,0 +1,168 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""Factory for _TritonDispatcher — full C dispatcher for Triton JIT.
+
+Creates a _TritonDispatcher instance from a Level 0 metadata schema +
+CUfunction handle.  The dispatcher pre-binds everything and uses vectorcall
+for the entire dispatch: (grid_x, grid_y, grid_z, stream, *kernel_args).
+
+The _TritonDispatcher type lives in driver.c (cuda_utils module) alongside
+upstream's launchKernel — sharing extractors, type codes, and the
+cuLaunchKernelEx handle.
+"""
+
+from __future__ import annotations
+
+import re
+
+from triton.runtime import _allocation
+from triton.runtime.driver import driver
+
+
+def _load_module():
+    """Return the cuda_utils module (contains _TritonDispatcher type)."""
+    return driver.active.utils
+
+
+def _expand_schema_arg_types(schema):
+    """Expand tensordesc types in the schema into flat component types.
+
+    Returns (flat_types, tensordesc_info) where tensordesc_info is a list of
+    (position_in_schema_args, ndim, meta) for each tensordesc arg, or None
+    if there are no tensordesc args.
+    """
+    flat_types = []
+    tensordesc_info = []
+    tensordesc_meta = schema.get("tensordesc_meta") or []
+    tensordesc_idx = 0
+
+    for arg_pos, arg in enumerate(schema["args"]):
+        ty = arg["type"]
+        if ty.startswith("tensordesc"):
+            meta = tensordesc_meta[tensordesc_idx] if tensordesc_idx < len(tensordesc_meta) else None
+            match = re.match(r"tensordesc<([^[>]*)\[([^]]*)\]", ty)
+            if match is None:
+                raise ValueError(f"Cannot parse tensordesc type: {ty}")
+            dtype = match.group(1)
+            shape = match.group(2)
+            ndim = shape.count(",") + 1
+            tensordesc_info.append((arg_pos, ndim, meta))
+            tensordesc_idx += 1
+
+            if meta is None:
+                # Host-side path: base pointer + shape + strides + padding flag
+                flat_types.append("*" + dtype)
+                for _ in range(2 * ndim):
+                    flat_types.append("i64")
+                flat_types.append("i1")
+                # Host-side also appends shapes (i32) + strides (i64) as explicit kernel args
+                for _ in range(ndim):
+                    flat_types.append("i32")
+                for _ in range(ndim):
+                    flat_types.append("i64")
+            else:
+                # TMA path uses nvTmaDesc which the C dispatcher doesn't handle.
+                return None, None
+        else:
+            flat_types.append(ty)
+
+    return flat_types, tensordesc_info if tensordesc_info else None
+
+
+class _TensorDescDispatcherWrapper:
+    """Wrapper that expands tensordesc args before calling the C dispatcher."""
+
+    __slots__ = ("_c_dispatcher", "_tensordesc_positions")
+
+    def __init__(self, c_dispatcher, tensordesc_info):
+        self._c_dispatcher = c_dispatcher
+        # Only non-TMA tensordesc (meta=None) reaches here.
+        self._tensordesc_positions = set(pos for pos, _, _ in tensordesc_info)
+
+    def __call__(self, grid_x, grid_y, grid_z, stream, *kernel_args):
+        expanded = []
+        for i, arg in enumerate(kernel_args):
+            if i in self._tensordesc_positions:
+                # Host-side tensordesc: base ptr, shape, strides, padding, shape, strides
+                expanded.append(arg.base)
+                expanded.extend(arg.shape)
+                expanded.extend(arg.strides)
+                expanded.append(arg.padding == "nan")
+                expanded.extend(arg.shape)
+                expanded.extend(arg.strides)
+            else:
+                expanded.append(arg)
+        return self._c_dispatcher(grid_x, grid_y, grid_z, stream, *expanded)
+
+
+def make_triton_dispatcher(schema, cu_function: int):
+    """Create a _TritonDispatcher from Level 0 schema + CUfunction handle.
+
+    Args:
+        schema: Level 0 launch metadata dict (from CompiledKernel.launch_metadata_schema)
+        cu_function: CUfunction handle as uint64
+
+    Returns:
+        A callable _TritonDispatcher instance (or wrapper for tensordesc kernels).
+        Call as: dispatcher(grid_x, grid_y, grid_z, stream, *kernel_args)
+    """
+    mod = _load_module()
+
+    # Expand tensordesc types into flat component types for build_signature_metadata.
+    # Returns None for tensordesc_info if TMA path is detected (unsupported by C dispatcher).
+    flat_types, tensordesc_info = _expand_schema_arg_types(schema)
+    if flat_types is None:
+        return None
+    sig_metadata = mod.build_signature_metadata(flat_types)
+    arg_type_codes = tuple(sig_metadata)
+
+    c_dispatcher = mod._TritonDispatcher(
+        function=cu_function,
+        num_warps=schema["num_warps"],
+        num_ctas=schema["num_ctas"],
+        shared_mem=schema["shared_mem"],
+        launch_pdl=1 if schema.get("launch_pdl", False) else 0,
+        launch_cooperative_grid=1 if schema.get("launch_cooperative_grid", False) else 0,
+        launch_cluster=1 if schema.get("launch_cluster", False) else 0,
+        arg_type_codes=arg_type_codes,
+        has_global_scratch=schema.get("global_scratch_size", 0) > 0,
+        has_profile_scratch=schema.get("profile_scratch_size", 0) > 0,
+        global_scratch_size=schema.get("global_scratch_size", 0),
+        global_scratch_align=schema.get("global_scratch_align", 1),
+        profile_scratch_size=schema.get("profile_scratch_size", 0),
+        profile_scratch_align=schema.get("profile_scratch_align", 1),
+        allocator=_allocation._allocator,
+        profile_allocator=_allocation._profile_allocator,
+    )
+
+    if tensordesc_info is not None:
+        return _TensorDescDispatcherWrapper(c_dispatcher, tensordesc_info)
+    return c_dispatcher
+
+
+_fast_jit_type_cache = {}
+
+
+def activate_fast_dispatch(jit_function, kernel):
+    """Swap jit_function.__class__ to a C heap type with mp_subscript."""
+
+    disp = getattr(kernel, '_dispatcher', None)
+    if disp is None:
+        return
+
+    base_type = type(jit_function)
+    if base_type not in _fast_jit_type_cache:
+        mod = _load_module()
+        fast_type = mod.create_fast_jit_type(base_type)
+        _fast_jit_type_cache[base_type] = fast_type
+
+    schema = getattr(kernel, 'launch_metadata_schema', None)
+    num_args = len(schema["args"]) if schema else 0
+
+    jit_function._runner_cache = {}
+    jit_function._fast_dispatcher = disp
+    jit_function._fast_num_args = num_args
+    jit_function._fast_kernel = kernel
+    jit_function._fast_get_stream = driver.active.get_current_stream
+    jit_function._fast_get_device = driver.active.get_current_device
+
+    jit_function.__class__ = _fast_jit_type_cache[base_type]


### PR DESCRIPTION
Summary:

Gated by `TRITON_USE_TRITON_DISPATCHER=1`. Default off. Orthogonal to the LLVM launcher (2a/N).

### Architecture
```
Normal path (upstream, D103454938):
  JITFunction.run() → CudaLauncher.__call__() → driver.c::launchKernel()
                                                  ↑ PyArg_ParseTuple
                                                  ↑ per-launch alloca
                                                  ↑ full arg conversion every call

Fast path (this diff):
  JITFunction[grid](*args) → C: _ProxyRunner.__vectorcall__()
    → td_convert_args() + td_relaunch() with pre-built CUlaunchConfig
```

### Before / After
Before (upstream C launcher, D103454938):
```
// driver.c::launchKernel — called from Python via PyArg_ParseTuple
static PyObject *launchKernel(PyObject *self, PyObject *args) {
    PyArg_ParseTuple(args, "iiiKKpp(iiiiii)OOOOOOy*O", ...);
    void *params[num_args];
    for (i = 0; i < num_args; i++) {
        Extractor ext = extraction_map[type_code];
        ext.extract(aligned_ptr, current_arg);
    }
    _launch(gridX, gridY, gridZ, ...);
}
```
After (this diff — vectorcall + pre-allocated storage):
```
// TritonDispatcher_vectorcall — args arrive as C array, no parsing
static PyObject *TritonDispatcher_vectorcall(
    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
{
    // Pre-computed type codes, pre-allocated ArgSlot — no alloca, no isinstance
    for (int i = 0; i < self->num_args; i++) {
        switch (self->arg_types[i]) {
        case EXTRACTOR_POINTER_INDEX:
            self->arg_storage[i].ptr = td_get_ptr(kargs[i]);
            break;
        case EXTRACTOR_INT32_INDEX:
            self->arg_storage[i].i32 = (int32_t)PyLong_AsLong(kargs[i]);
            break;
        ...
        }
    }
    // Launch with pre-built attrs (constructed once, reused every call)
    td_relaunch(self, gx, gy, gz, stream);
}
```

### Performance (B200, 19 args)
| Benchmark (0 args) | Without dispatcher | With dispatcher | Delta |
|---|---|---|---|
| `nop_triton_kernel` | 19.2 us | 8.72 us | -55% |
| `nop_triton_kernel_kwargs` | 11.4 us | 9.00 us | -21% |
| `nop_compiled_kernel_run` | 3.81 us | 3.71 us | ~neutral |

| Benchmark (19 args) | Without dispatcher | With dispatcher | Delta |
|---|---|---|---|
| `nop_triton_kernel` | 17.7 us | 14.4 us | -19% |
| `nop_triton_kernel_kwargs` | 18.0 us | 15.7 us | -13% |
| `nop_compiled_kernel_run` | 5.05 us | 5.16 us | ~neutral |

| Benchmark (58 args) | Without dispatcher | With dispatcher | Delta |
|---|---|---|---|
| `nop_triton_kernel` | 27.8 us | 25.2 us | -9% |
| `nop_triton_kernel_kwargs` | 11.1 us | 9.11 us | -18% |
| `nop_compiled_kernel_run` | 6.40 us | 6.25 us | ~neutral |

### Why faster?

- **vectorcall**: args arrive as `PyObject *const *` C array — no PyArg_ParseTuple (~200-300ns saved)
- **Pre-allocated storage**: ArgSlot[] bound at construction — no per-launch alloca (~50ns saved)
- **No pointer validation**: skips cuPointerGetAttribute in hot path (vs upstream's extractPointer)
- **Pre-built CUlaunchConfig**: launch attributes computed once at construction
- **No identity cache**: intentionally omitted to avoid lifetime extension of tensor args and soundness issues with `tensor._set()`. Fresh arg extraction every call is fast enough that the vectorcall + pre-allocated storage savings dominate.

### What's shared with upstream (driver.c)

| Infrastructure | Used by |
|---|---|
| `ExtractorTypeIndex` enum | type codes from `buildSignatureMetadata()` |
| `data_ptr_str` global | pointer extraction for both paths |
| `ensureLaunchHandle()` | lazy-loaded `cuLaunchKernelEx` function pointer |
| `_launch()` fallback | available for non-optimized codepaths |

Differential Revision: D103107874


