### PR TITLE
[triton][beta] Remove stale XFAIL from reduce_inner_tree_to_llvm.mlir

### DIFF
--- a/test/Conversion/reduce_inner_tree_to_llvm.mlir
+++ b/test/Conversion/reduce_inner_tree_to_llvm.mlir
@@ -1,5 +1,4 @@
 // RUN: triton-opt %s --allocate-shared-memory --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
-// XFAIL: *
 
 // Test that the inner_tree reduction ordering produces count-up shuffle order
 // (stride 2, 4, 8, 16) instead of the default count-down order (16, 8, 4, 2).


### PR DESCRIPTION
Summary:
The test was marked `XFAIL: *` when the `inner_tree` reduction ordering was not yet implemented. The LinearLayout-based rewrite of ReduceOpToLLVM now naturally produces the correct count-up shuffle strides (2, 4, 8, 16), so the test passes and the XFAIL marker causes an XPASS failure.

Authored with Claude.

Reviewed By: shawnxu26

Differential Revision: D103450528


