### PR TITLE
[triton][beta] [Cherry-pick] '[AMD] skip test_gather[src_shape2-indices_shape2-0] for RDNA (#9210)' (#1413)

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7019,7 +7019,8 @@ def gather_test_kernel_1d(
     ],
 )
 def test_gather(src_shape, indices_shape, axis, device):
-    if (is_hip_cdna2() or is_hip_cdna3()) and src_shape == [128, 64] and indices_shape == [256, 64]:
+    if (is_hip_cdna2() or is_hip_cdna3() or is_hip_rdna3()
+            or is_hip_rdna4()) and src_shape == [128, 64] and indices_shape == [256, 64]:
         # This could be solved by reducing vectorization in general swizzling algorithm.
         # We will do this if any relevant workload suffers from large LDS consumption of the algorithm.
         pytest.skip('Not enough LDS.')


### PR DESCRIPTION
Summary:

This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9210

Upstream commit message:
```
> [AMD] skip test_gather[src_shape2-indices_shape2-0] for RDNA (#9210)

> The test_gather[src_shape2-indices_shape2-0] test fails on RDNA3 and
> RDNA4 GPUs with:
> triton.runtime.errors.OutOfResources: out of resource: shared memory,
> Required: 131072, Hardware limit: 65536.

> Extend the existing skip condition (which already covers CDNA2 and
> CDNA3) to also include RDNA3 and RDNA4 GPUs.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 7eac37d40a3be4829f97d048755ec26a7479d330
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1 --no-submit
```

Reviewed By: sfzhu93

Differential Revision: D103489797


