### PR TITLE
[triton][beta] Fix NUM_CTAS=2 crash from WarpSpecializePartitionsOp captures refactoring

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1169,18 +1169,7 @@ void WarpSpecializePartitionsOp::getSuccessorRegions(
 
 OperandRange
 WarpSpecializePartitionsOp::getEntrySuccessorOperands(RegionSuccessor) {
-  // Propagate capture types to block argument types. Passes may temporarily
-  // create type mismatches between captures and partition region arguments.
-  auto captures = getExplicitCaptures();
-  for (Region &region : getPartitionRegions()) {
-    for (auto [i, cap] : llvm::enumerate(captures)) {
-      if (i < region.getNumArguments() &&
-          region.getArgument(i).getType() != cap.getType()) {
-        region.getArgument(i).setType(cap.getType());
-      }
-    }
-  }
-  return captures;
+  return getExplicitCaptures();
 }
 
 LogicalResult WarpSpecializeOp::verify() {
@@ -1373,18 +1362,6 @@ LogicalResult WarpSpecializePartitionsOp::verify() {
 LogicalResult
 WarpSpecializePartitionsOp::canonicalize(WarpSpecializePartitionsOp op,
                                          PatternRewriter &b) {
-  // Propagate capture types to block argument types.
-  bool typesUpdated = false;
-  for (auto [i, capture] : llvm::enumerate(op.getExplicitCaptures())) {
-    for (Region &region : op.getPartitionRegions()) {
-      auto arg = region.getArgument(i);
-      if (arg.getType() != capture.getType()) {
-        arg.setType(capture.getType());
-        typesUpdated = true;
-      }
-    }
-  }
-
   llvm::BitVector unusedArgs(op.getNumOperands());
 
   // Remove duplicate captures.
@@ -1412,7 +1389,7 @@ WarpSpecializePartitionsOp::canonicalize(WarpSpecializePartitionsOp op,
   }
 
   if (unusedArgs.none())
-    return typesUpdated ? success() : failure();
+    return failure();
 
   b.modifyOpInPlace(op, [&] {
     for (Region &region : op.getPartitionRegions())

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -488,9 +488,6 @@ LogicalResult assignMemoryLayouts(FuncOp &func) {
       } else if (isa<scf::YieldOp>(op)) {
         auto vals = getTiedArgs(op->getParentOp(), use.getOperandNumber());
         updateEncoding(vals, EncodingInfo{});
-      } else if (isa<ttg::WarpSpecializeOp>(op)) {
-        auto vals = getTiedArgs(op, use.getOperandNumber());
-        updateEncoding(vals, EncodingInfo{});
       } else if (isa<ttg::WarpSpecializePartitionsOp>(op)) {
         auto vals = getTiedArgs(op, use.getOperandNumber());
         updateEncoding(vals, EncodingInfo{});

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PruneUnusedBarriers.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PruneUnusedBarriers.cpp
@@ -56,10 +56,10 @@ void traceBarrierUses(Value barrierVal,
     }
 
     // Follow through warp_specialize captures.
-    if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+    if (auto partOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
       unsigned operandIdx = use.getOperandNumber();
-      for (Region *region : wsOp.getPartitionRegions()) {
-        Value blockArg = region->getArgument(operandIdx);
+      for (Region &region : partOp.getPartitionRegions()) {
+        Value blockArg = region.getArgument(operandIdx);
         traceBarrierUses(blockArg, terminalUses);
       }
       continue;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -315,7 +315,9 @@ static void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
       }
     }
   } else if (twoCTAs) {
-    mask = LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, 0x1);
+    auto clusterCTARank = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+    Value ctaPairBase = b.and_(clusterCTARank, b.i32_val(~1));
+    mask = b.shl(b.i32_val(3), ctaPairBase);
   }
 
   SmallVector<PTXBuilder::Operand *> ptxOperands;


### PR DESCRIPTION
Summary:
D102557807 (upstream PR #9133) moved explicitCaptures from WarpSpecializeOp to WarpSpecializePartitionsOp but left several stale references and introduced a side-effecting query method that breaks 2CTA ws kernels

The Canonicalizer hang was caused by WarpSpecializePartitionsOp::canonicalize         unconditionally calling modifyOpInPlace then returning failure(), creating an infinite loop — fixed by removing the no-op type-propagation block.


The GPU kernel deadlock was caused by D103289139's createMMACommit computing the multicast mask via createTMAMulticastMask which uses ttg.num-ctas=1 (TLX Convention) instead of the cluster size, producing mask=1 (CTA0 only) so CTA1's barriers never get arrived — fixed by computing the 2-CTA pair mask directly as 3 << (clusterCTARank & ~1).

Differential Revision: D103792519


