### PR TITLE
[Triton JIT][2a/N] Derive kernel_signature from Level 0 metadata schema in CudaLauncher (#1430)

### DIFF
--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -10,7 +10,12 @@ import json
 import pytest
 import triton
 import triton.language as tl
-from triton.compiler.compiler import ASTSource, compile as triton_compile
+from triton.backends.nvidia.driver import (
+    build_kernel_signature_from_schema,
+    expand_signature,
+    make_kernel_signature,
+)
+from triton.compiler.compiler import ASTSource, compile as triton_compile, make_backend
 
 
 @triton.jit
@@ -310,3 +315,94 @@ def test_launcher_src_has_abi_version_comment():
     )
     src = compiled.asm["launcher_src"]
     assert "ABI version: 1" in src
+
+
+# =============================================================================
+# Tests for schema-driven kernel_signature derivation
+# =============================================================================
+
+
+@triton.jit
+def multi_type_kernel(ptr_fp32, ptr_fp16, scalar_i32, scalar_i64, scalar_fp32, N, BLOCK: tl.constexpr):
+    """Kernel with diverse arg types to test schema-driven signature derivation."""
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    tl.store(ptr_fp32 + offs, tl.load(ptr_fp32 + offs, mask=offs < N), mask=offs < N)
+
+
+@pytest.mark.parametrize("kernel,signature,constexprs", [
+    (add_kernel, {"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"}, {"BLOCK": 1024}),
+    (kernel_with_constant, {"X": "*fp16", "N": "i64"}, {"BLOCK": 512}),
+    (multi_type_kernel, {
+        "ptr_fp32": "*fp32", "ptr_fp16": "*fp16", "scalar_i32": "i32", "scalar_i64": "i64", "scalar_fp32": "fp32", "N":
+        "i32"
+    }, {"BLOCK": 256}),
+])
+def test_schema_derived_signature_matches_legacy(kernel, signature, constexprs):
+    """kernel_signature from Level 0 schema must match legacy expand_signature path.
+
+    This validates that build_kernel_signature_from_schema() produces the exact
+    same byte sequence as the old make_kernel_signature(expand_signature(...)) path.
+    """
+    compiled = _compile_kernel(kernel, signature=signature, constexprs=constexprs)
+    src = compiled.src
+    md = compiled.metadata
+
+    # Legacy path: expand_signature → make_kernel_signature
+    sig = {idx: value for idx, value in src.signature.items()}
+    tensordesc_meta = getattr(md, "tensordesc_meta", None)
+    expanded = expand_signature(sig.values(), tensordesc_meta)
+    legacy_signature = make_kernel_signature(expanded)
+
+    # Schema path: make_launch_metadata → build_kernel_signature_from_schema
+    backend = make_backend(md.target)
+    schema = backend.make_launch_metadata(md._asdict(), src)
+    schema_signature = build_kernel_signature_from_schema(schema)
+
+    assert schema_signature == legacy_signature, (f"Schema-derived signature differs from legacy!\n"
+                                                  f"  schema args: {[a['type'] for a in schema['args']]}\n"
+                                                  f"  expanded sig: {expanded}\n"
+                                                  f"  schema bytes: {list(schema_signature)}\n"
+                                                  f"  legacy bytes: {list(legacy_signature)}")
+
+
+@pytest.mark.parametrize("tensordesc_type,tensordesc_meta,other_args", [
+    # Host TMA path (meta is None): 2D tensor descriptor
+    ("tensordesc<fp32[128, 64]>", [], [{"name": "N", "type": "i32", "index": 1}]),
+    # Device TMA path: 2D tensor descriptor with device TMA metadata
+    ("tensordesc<fp16[64, 64]>", [{"use_device_tma": True}], [{"name": "N", "type": "i32", "index": 1}]),
+    # Host TMA path: 1D tensor descriptor
+    ("tensordesc<fp32[256]>", [], []),
+    # Device TMA path: 1D tensor descriptor
+    ("tensordesc<bf16[128]>", [{"use_device_tma": True}], []),
+    # Mixed: tensordesc + regular pointer args
+    ("tensordesc<fp16[32, 32]>", [], [
+        {"name": "out_ptr", "type": "*fp16", "index": 1},
+        {"name": "N", "type": "i32", "index": 2},
+    ]),
+])
+def test_schema_derived_signature_tensordesc(tensordesc_type, tensordesc_meta, other_args):
+    """build_kernel_signature_from_schema handles tensordesc args (host and device TMA paths).
+
+    This directly constructs a schema dict to test tensordesc expansion logic
+    without requiring GPU compilation of a TMA kernel.
+    """
+    schema = {
+        "args": [{"name": "desc", "type": tensordesc_type, "index": 0}] + other_args,
+        "tensordesc_meta": tensordesc_meta,
+    }
+
+    # Schema path
+    schema_signature = build_kernel_signature_from_schema(schema)
+
+    # Legacy path: build equivalent flat signature list
+    sig_values = [tensordesc_type] + [a["type"] for a in other_args]
+    expanded = expand_signature(sig_values, tensordesc_meta or None)
+    legacy_signature = make_kernel_signature(expanded)
+
+    assert schema_signature == legacy_signature, (f"Schema-derived signature differs from legacy for tensordesc!\n"
+                                                  f"  tensordesc_type: {tensordesc_type}\n"
+                                                  f"  tensordesc_meta: {tensordesc_meta}\n"
+                                                  f"  expanded sig: {expanded}\n"
+                                                  f"  schema bytes: {list(schema_signature)}\n"
+                                                  f"  legacy bytes: {list(legacy_signature)}")

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -20,7 +20,7 @@ from .. import knobs
 def _build(name: str, src: str, srcdir: str, library_dirs: list[str], include_dirs: list[str], libraries: list[str],
            ccflags: list[str]) -> str:
     if impl := knobs.build.impl:
-        return impl(name, src, srcdir, library_dirs, include_dirs, libraries)
+        return impl(name, src, srcdir, library_dirs, include_dirs, libraries, ccflags)
     suffix = sysconfig.get_config_var('EXT_SUFFIX')
     so = os.path.join(srcdir, '{name}{suffix}'.format(name=name, suffix=suffix))
     cc = os.environ.get("CC")

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -65,6 +65,51 @@ static PyTypeObject PyTDMDescriptorType = {
     .tp_dealloc = (destructor)PyTDMDescriptor_dealloc,
 };
 
+typedef enum { ARG_CONSTEXPR = 0, ARG_KERNEL = 1, ARG_TUPLE = 2 } ArgType;
+
+// Annotation struct to know how the argument should be handled.
+typedef struct {
+  PyObject_HEAD;
+  PyObject *nested_tuple; // Can be a List of PyKernelArgObjects or None
+  ArgType type;
+} PyKernelArgObject;
+
+// Deallocator
+static void PyKernelArg_dealloc(PyKernelArgObject *self) {
+  Py_XDECREF(self->nested_tuple);
+  Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+// Constructor
+static int PyKernelArg_init(PyKernelArgObject *self, PyObject *args,
+                            PyObject *kwds) {
+  static char *kwlist[] = {"nested_tuple", "type", NULL};
+  PyObject *tup = NULL;
+  int type_val = 0;
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|i", kwlist, &tup,
+                                   &type_val)) {
+    return -1;
+  }
+  Py_XINCREF(tup);
+  self->nested_tuple = tup;
+  self->type = (ArgType)type_val;
+  return 0;
+}
+
+static void PyKernelArg_free(void *ptr) { free(ptr); }
+
+static PyTypeObject PyKernelArgType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name =
+        "triton.backends.nvidia.PyKernelArg",
+    .tp_basicsize = sizeof(PyKernelArgObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Kernel Argument Metadata",
+    .tp_new = PyType_GenericNew,
+    .tp_init = (initproc)PyKernelArg_init,
+    .tp_dealloc = (destructor)PyKernelArg_dealloc,
+};
+
 // Encodes a TDM descriptor. Supports 1D-5D tensors.
 // Uses the same encoding format as createTDMDescriptor in TDMUtility.cpp.
 static bool encodeTDMDescriptor(TDMDescriptor *desc, int elementBitWidth,
@@ -185,6 +230,7 @@ static const char *hipLibSearchPaths[] = {"/*py_libhip_search_path*/"};
 // |FOR_EACH_ERR_FN| is a macro to process APIs that return hipError_t;
 // |FOR_EACH_STR_FN| is a macro to process APIs that return const char *.
 #define HIP_SYMBOL_LIST(FOR_EACH_ERR_FN, FOR_EACH_STR_FN)                      \
+  FOR_EACH_STR_FN(hipGetLastError)                                             \
   FOR_EACH_STR_FN(hipGetErrorString, hipError_t hipError)                      \
   FOR_EACH_ERR_FN(hipGetDeviceProperties, hipDeviceProp_t *prop, int deviceId) \
   FOR_EACH_ERR_FN(hipModuleLoadDataEx, hipModule_t *module, const void *image, \
@@ -193,7 +239,23 @@ static const char *hipLibSearchPaths[] = {"/*py_libhip_search_path*/"};
   FOR_EACH_ERR_FN(hipModuleGetFunction, hipFunction_t *function,               \
                   hipModule_t module, const char *kname)                       \
   FOR_EACH_ERR_FN(hipFuncGetAttribute, int *, hipFunction_attribute attr,      \
-                  hipFunction_t function)
+                  hipFunction_t function)                                      \
+  FOR_EACH_ERR_FN(hipDrvLaunchKernelEx, const HIP_LAUNCH_CONFIG *config,       \
+                  hipFunction_t f, void **kernelParams, void **extra)          \
+  FOR_EACH_ERR_FN(hipModuleLaunchKernel, hipFunction_t f,                      \
+                  unsigned int gridDimX, unsigned int gridDimY,                \
+                  unsigned int gridDimZ, unsigned int blockDimX,               \
+                  unsigned int blockDimY, unsigned int blockDimZ,              \
+                  unsigned int sharedMemBytes, hipStream_t stream,             \
+                  void **kernelParams, void **extra)                           \
+  FOR_EACH_ERR_FN(hipModuleLaunchCooperativeKernel, hipFunction_t f,           \
+                  unsigned int gridDimX, unsigned int gridDimY,                \
+                  unsigned int gridDimZ, unsigned int blockDimX,               \
+                  unsigned int blockDimY, unsigned int blockDimZ,              \
+                  unsigned int sharedMemBytes, hipStream_t stream,             \
+                  void **kernelParams, void **extra)                           \
+  FOR_EACH_ERR_FN(hipPointerGetAttribute, void *data,                          \
+                  hipPointer_attribute attribute, hipDeviceptr_t ptr)
 
 // HIP driver version format: HIP_VERSION_MAJOR * 10000000 + HIP_VERSION_MINOR *
 // 100000 + HIP_VERSION_PATCH.
@@ -352,11 +414,16 @@ static inline void gpuAssert(hipError_t code, const char *file, int line) {
   }
 }
 
-#define HIP_CHECK(ans)                                                         \
+#define HIP_CHECK_AND_RETURN_NULL(ans)                                         \
   {                                                                            \
     gpuAssert((ans), __FILE__, __LINE__);                                      \
     if (PyErr_Occurred())                                                      \
       return NULL;                                                             \
+  }
+
+#define HIP_CHECK(ans)                                                         \
+  {{gpuAssert((ans), __FILE__, __LINE__);                                      \
+  }                                                                            \
   }
 
 static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
@@ -365,7 +432,8 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
     return NULL;
 
   hipDeviceProp_t props;
-  HIP_CHECK(hipSymbolTable.hipGetDeviceProperties(&props, device_id));
+  HIP_CHECK_AND_RETURN_NULL(
+      hipSymbolTable.hipGetDeviceProperties(&props, device_id));
 
   // create a struct to hold device properties
   return Py_BuildValue(
@@ -404,8 +472,10 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   // launch HIP Binary
   hipModule_t mod;
   hipFunction_t fun;
-  HIP_CHECK(hipSymbolTable.hipModuleLoadDataEx(&mod, data, 5, opt, optval))
-  HIP_CHECK(hipSymbolTable.hipModuleGetFunction(&fun, mod, name));
+  HIP_CHECK_AND_RETURN_NULL(
+      hipSymbolTable.hipModuleLoadDataEx(&mod, data, 5, opt, optval))
+  HIP_CHECK_AND_RETURN_NULL(
+      hipSymbolTable.hipModuleGetFunction(&fun, mod, name));
 
   // get allocated registers and spilled registers from the function
   int n_regs = 0;
@@ -533,6 +603,494 @@ cleanup:
   return NULL;
 }
 
+static void _launch(int gridX, int gridY, int gridZ, int num_warps,
+                    int num_ctas, int launch_cooperative_grid,
+                    int shared_memory, int warp_size, hipStream_t stream,
+                    hipFunction_t function, void **params) {
+  if (gridX * gridY * gridZ == 0)
+    return;
+  if (num_ctas > 1) {
+    if (!hipSymbolTable.hipDrvLaunchKernelEx) {
+      PyErr_SetString(
+          PyExc_RuntimeError,
+          "missing hipDrvLaunchKernelEx symbol; please update HIP runtime");
+      return;
+    }
+
+    hipLaunchAttribute attributes[2];
+    // Attribute0: Cluster dimensions
+    attributes[0].id = 4;
+    int *cluster_dims = (int *)attributes[0].val.pad;
+    cluster_dims[0] = num_ctas;
+    cluster_dims[1] = 1;
+    cluster_dims[2] = 1;
+    // Attribute1: Cooperative launch
+    attributes[1].id = hipLaunchAttributeCooperative;
+    attributes[1].val.cooperative = launch_cooperative_grid;
+
+    HIP_LAUNCH_CONFIG config = {
+        gridX * num_ctas,      gridY,  gridZ,        // Grid size
+        warp_size * num_warps, 1,      1,            // Block size
+        shared_memory,         stream, attributes, 2 // Number of attributes
+    };
+    HIP_CHECK(
+        hipSymbolTable.hipDrvLaunchKernelEx(&config, function, params, 0));
+    return;
+  } else if (launch_cooperative_grid) {
+    HIP_CHECK(hipSymbolTable.hipModuleLaunchCooperativeKernel(
+        function, gridX, gridY, gridZ, warp_size * num_warps, 1, 1,
+        shared_memory, stream, params, 0));
+    return;
+  } else {
+    HIP_CHECK(hipSymbolTable.hipModuleLaunchKernel(
+        function, gridX, gridY, gridZ, warp_size * num_warps, 1, 1,
+        shared_memory, stream, params, 0));
+  }
+}
+
+static PyObject *data_ptr_str = NULL;
+
+bool extractPointer(void *ptr, PyObject *obj) {
+  hipDeviceptr_t *dev_ptr = ptr;
+  if (obj == Py_None) {
+    *dev_ptr = (hipDeviceptr_t)0; // valid nullptr
+    return true;
+  }
+  if (PyLong_Check(obj)) {
+    *dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(obj);
+    return true;
+  }
+  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
+  if (!ret) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "Pointer argument must be either uint64 or have data_ptr method");
+    return false;
+  }
+  if (!PyLong_Check(ret)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "data_ptr method of Pointer object must return 64-bit int");
+    return false;
+  }
+  *dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(ret);
+  Py_DECREF(ret);
+  if (*dev_ptr == 0) {
+    return true; // valid nullptr
+  }
+  hipError_t status = hipSymbolTable.hipPointerGetAttribute(
+      dev_ptr, HIP_POINTER_ATTRIBUTE_DEVICE_POINTER, *dev_ptr);
+  if (status == hipErrorInvalidValue) {
+    PyErr_Format(PyExc_ValueError, "Pointer argument (at %d) cannot be "
+                                   "accessed from Triton (cpu tensor?)");
+    // Clear and ignore HIP error
+    (void)hipSymbolTable.hipGetLastError();
+    return false;
+  }
+  return true;
+}
+
+bool extractI8(void *ptr, PyObject *obj) {
+  *((int8_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI16(void *ptr, PyObject *obj) {
+  *((int16_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI32(void *ptr, PyObject *obj) {
+  *((int32_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI64(void *ptr, PyObject *obj) {
+  *((int64_t *)ptr) = PyLong_AsLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU8(void *ptr, PyObject *obj) {
+  *((uint8_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU16(void *ptr, PyObject *obj) {
+  *((uint16_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU32(void *ptr, PyObject *obj) {
+  *((uint32_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU64(void *ptr, PyObject *obj) {
+  *((uint64_t *)ptr) = PyLong_AsUnsignedLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  uint16_t result;
+  // from https://github.com/python/pythoncapi-compat
+#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 &&            \
+    !defined(PYPY_VERSION)
+  _PyFloat_Pack2(temp_double, (unsigned char *)&result, 1);
+#else
+  PyFloat_Pack2(temp_double, (char *)&result, 1);
+#endif
+  *((uint16_t *)ptr) = result;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractBF16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  uint32_t u32 = *(uint32_t *)&f32;
+  *((uint16_t *)ptr) = (u32 >> 16);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP32(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  *((uint32_t *)ptr) = *(uint32_t *)&f32;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP64(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  *((uint64_t *)ptr) = *(uint64_t *)&temp_double;
+  return PyErr_Occurred() == NULL;
+}
+
+// Extract a TDM descriptor from a python object, and store it to the
+// memory location pointed by ptr.
+bool extractTDMDescriptor(void *ptr, PyObject *obj) {
+  TDMDescriptor *desc = &((PyTDMDescriptorObject *)obj)->desc;
+  if (desc == NULL) {
+    PyErr_Format(PyExc_TypeError,
+                 "object must be of type PyTDMDescriptor, got %s",
+                 Py_TYPE(obj)->tp_name);
+    return false;
+  }
+  *((TDMDescriptor *)ptr) = *desc;
+  return true;
+}
+
+typedef bool (*ExtractorFunc)(void *ptr, PyObject *obj);
+
+#define MAX_NAMES_PER_EXTRACTOR 2
+
+typedef struct {
+  ExtractorFunc extract;
+  size_t size;
+  const char *name[MAX_NAMES_PER_EXTRACTOR];
+} Extractor;
+
+typedef enum {
+  EXTRACTOR_UNKOWN_INDEX = 0,
+  // pointers
+  EXTRACTOR_POINTER_INDEX = 1,
+  // ints
+  EXTRACTOR_INT8_INDEX = 2,
+  EXTRACTOR_INT16_INDEX = 3,
+  EXTRACTOR_INT32_INDEX = 4,
+  EXTRACTOR_INT64_INDEX = 5,
+  // uints
+  EXTRACTOR_UINT8_INDEX = 6,
+  EXTRACTOR_UINT16_INDEX = 7,
+  EXTRACTOR_UINT32_INDEX = 8,
+  EXTRACTOR_UINT64_INDEX = 9,
+  // floats
+  EXTRACTOR_FP16_INDEX = 10,
+  EXTRACTOR_BF16_INDEX = 11,
+  EXTRACTOR_FP32_INDEX = 12,
+  EXTRACTOR_FP64_INDEX = 13,
+  // custom
+  EXTRACTOR_TDMDESC_INDEX = 14,
+  // last entry to have a count
+  EXTRACTOR_TYPE_COUNT
+} ExtractorTypeIndex;
+
+Extractor extraction_map[EXTRACTOR_TYPE_COUNT] = {
+    [EXTRACTOR_UNKOWN_INDEX] =
+        (Extractor){.extract = NULL, .size = 0, .name = NULL},
+    [EXTRACTOR_POINTER_INDEX] = (Extractor){.extract = extractPointer,
+                                            .size = sizeof(hipDeviceptr_t),
+                                            .name = NULL},
+    [EXTRACTOR_INT8_INDEX] = (Extractor){.extract = extractI8,
+                                         .size = sizeof(int8_t),
+                                         .name = {"i8"}},
+    [EXTRACTOR_INT16_INDEX] = (Extractor){.extract = extractI16,
+                                          .size = sizeof(int16_t),
+                                          .name = {"i16"}},
+    [EXTRACTOR_INT32_INDEX] = (Extractor){.extract = extractI32,
+                                          .size = sizeof(int32_t),
+                                          .name = {"i1", "i32"}},
+    [EXTRACTOR_INT64_INDEX] = (Extractor){.extract = extractI64,
+                                          .size = sizeof(int64_t),
+                                          .name = {"i64"}},
+    [EXTRACTOR_UINT8_INDEX] = (Extractor){.extract = extractU8,
+                                          .size = sizeof(uint8_t),
+                                          .name = {"u8"}},
+    [EXTRACTOR_UINT16_INDEX] = (Extractor){.extract = extractU16,
+                                           .size = sizeof(uint16_t),
+                                           .name = {"u16"}},
+    [EXTRACTOR_UINT32_INDEX] = (Extractor){.extract = extractU32,
+                                           .size = sizeof(uint32_t),
+                                           .name = {"u1", "u32"}},
+    [EXTRACTOR_UINT64_INDEX] = (Extractor){.extract = extractU64,
+                                           .size = sizeof(uint64_t),
+                                           .name = {"u64"}},
+    [EXTRACTOR_FP16_INDEX] = (Extractor){.extract = extractFP16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"fp16"}},
+    [EXTRACTOR_BF16_INDEX] = (Extractor){.extract = extractBF16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"bf16"}},
+    [EXTRACTOR_FP32_INDEX] = (Extractor){.extract = extractFP32,
+                                         .size = sizeof(uint32_t),
+                                         .name = {"fp32", "f32"}},
+    [EXTRACTOR_FP64_INDEX] = (Extractor){.extract = extractFP64,
+                                         .size = sizeof(uint64_t),
+                                         .name = {"fp64"}},
+    [EXTRACTOR_TDMDESC_INDEX] = (Extractor){.extract = extractTDMDescriptor,
+                                            .size = sizeof(TDMDescriptor),
+                                            .name = {"tensordesc"}},
+};
+
+Extractor getExtractor(uint8_t index) {
+  if (index >= EXTRACTOR_TYPE_COUNT) {
+    return extraction_map[EXTRACTOR_UNKOWN_INDEX];
+  }
+  return extraction_map[index];
+}
+
+bool isMatch(const char *type_bytes, ExtractorTypeIndex idx) {
+  Extractor extractor = extraction_map[idx];
+  for (int j = 0; j < MAX_NAMES_PER_EXTRACTOR; j++) {
+    if (extractor.name[j] != NULL &&
+        strcmp(type_bytes, extractor.name[j]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ExtractorTypeIndex getExtractorIndex(PyObject *type) {
+  Py_ssize_t type_len = 0;
+  const char *type_bytes = PyUnicode_AsUTF8AndSize(type, &type_len);
+  if (!type_bytes) {
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  if (type_len < 2) {
+    PyErr_Format(PyExc_RuntimeError, "Unexpected data type: %R", type);
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  // Examples: '*fp32', 'fp32', 'i8', etc.
+  if (type_bytes[0] == '*') {
+    return EXTRACTOR_POINTER_INDEX;
+  }
+  for (ExtractorTypeIndex i = EXTRACTOR_INT8_INDEX; i < EXTRACTOR_TYPE_COUNT;
+       i++) {
+    if (isMatch(type_bytes, i)) {
+      return i;
+    }
+  }
+
+  PyErr_Format(PyExc_RuntimeError, "Unknown data type: %R", type);
+  return EXTRACTOR_UNKOWN_INDEX;
+}
+
+// Takes in a list of types (ex: ['*fp32', 'u8', 'tensordesc']) and returns
+// a bytes array that represent extractors for quick argument extraction
+// when launching.
+static PyObject *buildSignatureMetadata(PyObject *self, PyObject *args) {
+  PyObject *signature = NULL;
+  if (!PyArg_ParseTuple(args, "O", &signature)) {
+    return NULL;
+  }
+  PyObject *fast_signature = PySequence_Fast(
+      signature, "Expected kernel_arg_types to be a sequence or iterable");
+  if (!fast_signature) {
+    return NULL;
+  }
+  Py_ssize_t signature_size = PySequence_Fast_GET_SIZE(fast_signature);
+  PyObject **signature_items = PySequence_Fast_ITEMS(fast_signature);
+
+  // Create return bytes object.
+  PyObject *ret_bytes = PyBytes_FromStringAndSize(NULL, signature_size);
+  if (ret_bytes == NULL) {
+    Py_XDECREF(fast_signature);
+    return NULL;
+  }
+  char *buffer = PyBytes_AS_STRING(ret_bytes);
+  for (Py_ssize_t i = 0; i < signature_size; ++i) {
+    ExtractorTypeIndex extractor_idx = getExtractorIndex(signature_items[i]);
+    if (extractor_idx == EXTRACTOR_UNKOWN_INDEX) {
+      goto cleanup;
+    }
+    buffer[i] = (uint8_t)extractor_idx;
+  }
+
+  Py_XDECREF(fast_signature);
+  return ret_bytes;
+
+cleanup:
+  Py_XDECREF(fast_signature);
+  Py_XDECREF(ret_bytes);
+  return NULL;
+}
+
+bool extractArgs(PyObject **final_list, int *list_idx, PyObject *kernel_args,
+                 PyObject *arg_annotations) {
+  // Extract arg annotations
+  PyObject *fast_annotations = PySequence_Fast(
+      arg_annotations, "Expected arg_annotations to be a sequence or iterable");
+  if (!fast_annotations) {
+    goto cleanup;
+  }
+  Py_ssize_t num_annotations = PySequence_Fast_GET_SIZE(fast_annotations);
+  PyObject **annotations = PySequence_Fast_ITEMS(fast_annotations);
+
+  PyObject *fast_args = PySequence_Fast(
+      kernel_args, "Expected kernel_args to be a sequence or iterable");
+  if (!fast_args) {
+    goto cleanup;
+  }
+  PyObject **args = PySequence_Fast_ITEMS(fast_args);
+
+  int arg_idx = 0;
+  for (int i = 0; i < num_annotations; ++i) {
+    PyKernelArgObject *annotation = (PyKernelArgObject *)annotations[i];
+    switch (annotation->type) {
+    case ARG_KERNEL:
+      final_list[(*list_idx)++] = args[arg_idx++];
+      break;
+    case ARG_TUPLE:
+      if (!extractArgs(final_list, list_idx, args[arg_idx++],
+                       annotation->nested_tuple)) {
+        goto cleanup;
+      }
+      break;
+    case ARG_CONSTEXPR:
+      arg_idx++;
+      break;
+    }
+  }
+  Py_DECREF(fast_annotations);
+  Py_DECREF(fast_args);
+  return true;
+
+cleanup:
+  Py_XDECREF(fast_annotations);
+  Py_XDECREF(fast_args);
+  return false;
+}
+
+bool launchHook(PyObject *hook, PyObject *metadata) {
+  if (hook != Py_None) {
+    PyObject *ret = PyObject_CallOneArg(hook, metadata);
+    if (!ret) {
+      return false;
+    }
+    Py_DECREF(ret);
+  }
+  return true;
+}
+
+static PyObject *launchKernel(PyObject *self, PyObject *args) {
+  int gridX, gridY, gridZ;
+  uint64_t _stream;
+  uint64_t _function;
+  int launch_cooperative_grid;
+  PyObject *profile_scratch_obj = NULL;
+  PyObject *launch_enter_hook = NULL;
+  PyObject *launch_exit_hook = NULL;
+  int num_warps, num_ctas, shared_memory;
+  PyObject *launch_metadata = NULL;
+  int warp_size;
+  PyObject *arg_annotations = NULL;
+  Py_buffer signature;
+  PyObject *kernel_args = NULL;
+  if (!PyArg_ParseTuple(args, "piiiKKO(iii)OOOiOy*O", &launch_cooperative_grid,
+                        &gridX, &gridY, &gridZ, &_stream, &_function,
+                        &profile_scratch_obj, &num_warps, &num_ctas,
+                        &shared_memory, &launch_metadata, &launch_enter_hook,
+                        &launch_exit_hook, &warp_size, &arg_annotations,
+                        &signature, &kernel_args)) {
+    return NULL;
+  }
+
+  // launch entry hook.
+  if (!launchHook(launch_enter_hook, launch_metadata)) {
+    goto cleanup;
+  }
+
+  uint8_t *extractor_data = (uint8_t *)signature.buf;
+  Py_ssize_t num_args = signature.len;
+
+  // Extract kernel parameters - flatten tuples & remove constexpr.
+  PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
+  if (args_data == NULL) {
+    goto cleanup;
+  }
+  int list_idx = 0;
+  if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
+    goto cleanup;
+  }
+
+  // Number of parameters passed to kernel. + 2 for global & profile scratch.
+  int num_params = num_args + 2;
+  void **params = (void **)alloca(num_params * sizeof(void *));
+  int params_idx = 0;
+  // This loop has to stay in the same function that owns params, since we are
+  // using alloca to allocate pointers to it on the stack of the function.
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    // Get extractor that will send back a struct with
+    // * size for allocation
+    // * function to call to put the parameter in params buffer
+    Extractor extractor = getExtractor(extractor_data[i]);
+    if (extractor.extract == NULL) {
+      goto cleanup;
+    }
+    PyObject *current_arg = args_data[i];
+    params[params_idx] = alloca(extractor.size);
+    if (!extractor.extract(params[params_idx++], current_arg)) {
+      goto cleanup;
+    }
+  }
+  // Add global scratch object (nullptr).
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], Py_None)) {
+    goto cleanup;
+  }
+  // Add profile scratch object.
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], profile_scratch_obj)) {
+    goto cleanup;
+  }
+
+  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
+          shared_memory, warp_size, (hipStream_t)_stream,
+          (hipFunction_t)_function, params);
+
+  if (!launchHook(launch_exit_hook, launch_metadata)) {
+    goto cleanup;
+  }
+
+  if (PyErr_Occurred()) {
+    goto cleanup;
+  }
+  PyBuffer_Release(&signature);
+  Py_RETURN_NONE;
+
+cleanup:
+  PyBuffer_Release(&signature);
+  return NULL;
+}
+
 static PyMethodDef ModuleMethods[] = {
     {"load_binary", loadBinary, METH_VARARGS,
      "Load provided hsaco into HIP driver"},
@@ -540,6 +1098,12 @@ static PyMethodDef ModuleMethods[] = {
      "Get the properties for a given device"},
     {"create_tdm_descriptor", createTDMDescriptor, METH_VARARGS,
      "create a host-side TDM descriptor"},
+    {"build_signature_metadata", buildSignatureMetadata, METH_VARARGS,
+     "Calling it with a signature list (ex: ['*fp32', 'u8', 'tensordesc']), "
+     "will return metadata to be passed into 'launch' for quicker "
+     "argument parsing."},
+    {"launch", launchKernel, METH_VARARGS,
+     "Entry point for all kernels with this signature"},
     {NULL, NULL, 0, NULL} // sentinel
 };
 
@@ -559,10 +1123,23 @@ PyMODINIT_FUNC PyInit_hip_utils(void) {
   }
   PyModule_AddFunctions(m, ModuleMethods);
 
-  if (PyType_Ready(&PyTDMDescriptorType) < 0)
+  if (PyType_Ready(&PyTDMDescriptorType) < 0) {
     return NULL;
+  }
+  if (PyType_Ready(&PyKernelArgType) < 0) {
+    return NULL;
+  }
+  data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  if (data_ptr_str == NULL) {
+    return NULL;
+  }
   Py_INCREF(&PyTDMDescriptorType);
   PyModule_AddObject(m, "PyTDMDescriptor", (PyObject *)&PyTDMDescriptorType);
+  Py_INCREF(&PyKernelArgType);
+  PyModule_AddObject(m, "PyKernelArg", (PyObject *)&PyKernelArgType);
+  PyModule_AddIntConstant(m, "ARG_CONSTEXPR", ARG_CONSTEXPR);
+  PyModule_AddIntConstant(m, "ARG_KERNEL", ARG_KERNEL);
+  PyModule_AddIntConstant(m, "ARG_TUPLE", ARG_TUPLE);
 
   return m;
 }

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -13,6 +13,10 @@ from triton.runtime.build import compile_module_from_src
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dirs = [os.path.join(dirname, "include")]
 PyTDMDescriptor = None
+PyKernelArg = None
+ARG_CONSTEXPR = None
+ARG_KERNEL = None
+ARG_TUPLE = None
 
 
 def _find_already_mmapped_dylib_on_linux(lib_name):
@@ -173,12 +177,23 @@ class HIPUtils(object):
         # This way we don't need to escape-quote C code curly brackets and we can replace
         # exactly once.
         src = src.replace('/*py_libhip_search_path*/', libhip_path, 1)
-        mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)
+        mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs,
+                                      ccflags=["-xc", "-std=gnu11"])
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
         self.create_tdm_descriptor = mod.create_tdm_descriptor
+        self.launch = mod.launch
+        self.build_signature_metadata = mod.build_signature_metadata
         global PyTDMDescriptor
+        global PyKernelArg
+        global ARG_CONSTEXPR
+        global ARG_KERNEL
+        global ARG_TUPLE
         PyTDMDescriptor = mod.PyTDMDescriptor
+        PyKernelArg = mod.PyKernelArg
+        ARG_CONSTEXPR = mod.ARG_CONSTEXPR
+        ARG_KERNEL = mod.ARG_KERNEL
+        ARG_TUPLE = mod.ARG_TUPLE
 
 
 # -------------------- Launcher ----------------------------
@@ -206,519 +221,74 @@ def ty_to_cpp(ty):
     }[ty]
 
 
-FLOAT_STORAGE_TYPE = {
-    "fp16": "uint16_t",
-    "bf16": "uint16_t",
-    "fp32": "uint32_t",
-    "f32": "uint32_t",
-    "fp64": "uint64_t",
-}
-FLOAT_PACK_FUNCTION = {
-    "fp16": "pack_fp16",
-    "bf16": "pack_bf16",
-    "fp32": "pack_fp32",
-    "f32": "pack_fp32",
-    "fp64": "pack_fp64",
-}
+def expand_signature(signature, tensordesc_meta):
+    output = []
+    tensordesc_idx = 0
+    for sig in signature:
+        if isinstance(sig, str) and sig.startswith("tensordesc"):
+            meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
+            tensordesc_idx += 1
 
-_BASE_ARGS_FORMAT = "piiiKKOOOOO"
+            match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
+            dtype = match.group(1)
+            shape = match.group(2)
+            ndim = shape.count(",") + 1
 
-
-def make_launcher(constants, signature, warp_size, tensordesc_meta):
-
-    def _expand_signature(signature):
-        output = []
-        tensordesc_idx = 0
-        for sig in signature:
-            if isinstance(sig, str) and sig.startswith("tensordesc"):
-                meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
-                tensordesc_idx += 1
-
-                match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
-                dtype = match.group(1)
-                shape = match.group(2)
-                ndim = shape.count(",") + 1
-
-                # If there is no descriptor's metadata, the descriptor has been decomposed to base pointer, shape and strides
-                if meta is None:
-                    output.append("*" + dtype)
-                    for _ in range(2 * ndim):
-                        output.append("i64")
-                    output.append("i1")
-                else:
-                    output.append("tensordesc")
-
-                for _ in range(ndim):
-                    output.append("i32")
-                for _ in range(ndim):
+            # If there is no descriptor's metadata, the descriptor has been decomposed to base pointer, shape and strides
+            if meta is None:
+                output.append("*" + dtype)
+                for _ in range(2 * ndim):
                     output.append("i64")
+                output.append("i1")
             else:
-                output.append(sig)
+                output.append("tensordesc")
 
-        return output
-
-    def _serialize_signature(sig):
-        if isinstance(sig, tuple):
-            return ','.join(map(_serialize_signature, sig))
-        return sig
-
-    def _extracted_type(ty):
-        if isinstance(ty, tuple):
-            val = ','.join(map(_extracted_type, ty))
-            return f"[{val}]"
-        if ty.startswith("*") or ty.startswith("tensordesc"):
-            return "PyObject*"
-        if ty == "constexpr":
-            return "PyObject*"
-        return ty_to_cpp(ty)
-
-    def format_of(ty):
-        if isinstance(ty, tuple):
-            val = ''.join(map(format_of, ty))
-            return f"({val})"
-        if ty.startswith("*") or ty.startswith("tensordesc"):
-            return "O"
-        if ty == "constexpr":
-            return "O"
-        return {
-            "double": "d",
-            "long": "l",
-            "int8_t": "b",
-            "int16_t": "h",
-            "int32_t": "i",
-            "int64_t": "L",
-            "uint8_t": "B",
-            "uint16_t": "H",
-            "uint32_t": "I",
-            "uint64_t": "K",
-        }[ty_to_cpp(ty)]
-
-    signature = {idx: s for idx, s in enumerate(_expand_signature(signature.values()))}
-
-    args_format = ''.join([format_of(ty) for ty in signature.values()])
-    format = _BASE_ARGS_FORMAT + args_format
-    signature = ','.join(map(_serialize_signature, signature.values()))
-    signature = list(filter(bool, signature.split(',')))
-    signature = {i: s for i, s in enumerate(signature)}
-    args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
-    # Record the end of regular arguments;
-    # subsequent arguments are architecture-specific descriptors, such as tensor descriptors for CUDA.
-    arg_decl_list = []
-    for i, ty in signature.items():
-        if ty == "constexpr":
-            continue
-        if ty in FLOAT_STORAGE_TYPE:
-            arg_decl_list.append(f"{FLOAT_STORAGE_TYPE[ty]} arg{i}")
+            for _ in range(ndim):
+                output.append("i32")
+            for _ in range(ndim):
+                output.append("i64")
         else:
-            arg_decl_list.append(f"{ty_to_cpp(ty)} arg{i}")
-    arg_decls = ', '.join(arg_decl_list)
-    internal_args_list = []
-    for i, ty in signature.items():
-        if ty.startswith("*"):
-            internal_args_list.append(f"ptr_info{i}.dev_ptr")
-        elif ty.startswith("tensordesc"):
-            internal_args_list.append(f"*desc{i}")
-        elif ty in FLOAT_STORAGE_TYPE:
-            internal_args_list.append(f"_arg{i}_storage")
-        elif ty != "constexpr":
-            internal_args_list.append(f"_arg{i}")
+            output.append(sig)
 
-    newline = '\n  '
-    ptr_decls = [
-        f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}); if (!ptr_info{i}.valid) return NULL;"
-        for i, ty in signature.items()
-        if ty.startswith("*")
-    ]
-    tensor_desc_decls = [
-        f"TDMDescriptor* desc{i} = getTDMDescriptor(_arg{i}, {i});" for i, ty in signature.items()
-        if ty.startswith("tensordesc")
-    ]
-    float_storage_decls = [
-        f"{FLOAT_STORAGE_TYPE[ty]} _arg{i}_storage = {FLOAT_PACK_FUNCTION[ty]}(_arg{i});"
-        for i, ty in signature.items()
-        if ty in FLOAT_STORAGE_TYPE
-    ]
+    return output
 
-    libhip_path = _get_path_to_hip_runtime_dylib()
 
-    # generate glue code
-    params = list(range(len(signature)))
-    params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
-    params.append("&global_scratch")
-    params.append("&profile_scratch")
-    src = f"""
-#define __HIP_PLATFORM_AMD__
-#include <hip/hip_runtime.h>
-#include <hip/hip_runtime_api.h>
-#include <Python.h>
-#include <dlfcn.h>
-#include <stdbool.h>
-#include <dlfcn.h>
+def make_kernel_signature(signature):
+    """
+    Creates a kernel signature in C to be able to efficiently extract
+    arguments in the launcher.
+    """
 
-typedef struct {{
-  uint32_t group0_0;
-  uint32_t group0_1;
-  uint32_t group0_2;
-  uint32_t group0_3;
-  uint32_t group1_0;
-  uint32_t group1_1;
-  uint32_t group1_2;
-  uint32_t group1_3;
-  uint32_t group1_4;
-  uint32_t group1_5;
-  uint32_t group1_6;
-  uint32_t group1_7;
-  uint32_t group2_0;
-  uint32_t group2_1;
-  uint32_t group2_2;
-  uint32_t group2_3;
-  uint32_t group3_0;
-  uint32_t group3_1;
-  uint32_t group3_2;
-  uint32_t group3_3;
-}} TDMDescriptor;
+    def _flatten_signature(sig, output):
+        # Flatten tuples
+        if isinstance(sig, tuple):
+            for x in sig:
+                _flatten_signature(x, output)
+        else:
+            output.append(sig)
 
-typedef struct {{
-  PyObject_HEAD;
-  TDMDescriptor desc;
-}} PyTDMDescriptorObject;
+    flat_signature = []
+    for sig in signature:
+        _flatten_signature(sig, flat_signature)
+    kernel_signature = [x for x in flat_signature if x != "constexpr"]
 
-// The list of paths to search for the HIP runtime library. The caller Python
-// code should substitute the search path placeholder.
-static const char *hipLibSearchPaths[] = {{"{libhip_path}"}};
+    return triton.runtime.driver.active.utils.build_signature_metadata(kernel_signature)
 
-// The list of HIP dynamic library symbols and their signature we are interested
-// in this file.
-#define HIP_SYMBOL_LIST(FOR_EACH_ERR_FN, FOR_EACH_STR_FN)                     \\
-  FOR_EACH_STR_FN(hipGetLastError, true)                                      \\
-  FOR_EACH_STR_FN(hipGetErrorString, true, hipError_t hipError)               \\
-  FOR_EACH_ERR_FN(hipDrvLaunchKernelEx, false,                                \\
-                  const HIP_LAUNCH_CONFIG *config,                            \\
-                  hipFunction_t f,                                            \\
-                  void **kernelParams,                                        \\
-                  void **extra)                                               \\
-  FOR_EACH_ERR_FN(hipModuleLaunchKernel, true, hipFunction_t f,               \\
-                  unsigned int gridDimX, unsigned int gridDimY,               \\
-                  unsigned int gridDimZ, unsigned int blockDimX,              \\
-                  unsigned int blockDimY, unsigned int blockDimZ,             \\
-                  unsigned int sharedMemBytes, hipStream_t stream,            \\
-                  void **kernelParams, void **extra)                          \\
-  FOR_EACH_ERR_FN(hipModuleLaunchCooperativeKernel, true, hipFunction_t f,    \\
-                  unsigned int gridDimX, unsigned int gridDimY,               \\
-                  unsigned int gridDimZ, unsigned int blockDimX,              \\
-                  unsigned int blockDimY, unsigned int blockDimZ,             \\
-                  unsigned int sharedMemBytes, hipStream_t stream,            \\
-                  void **kernelParams, void **extra)                          \\
-  FOR_EACH_ERR_FN(hipPointerGetAttribute, true, void *data,                   \\
-                  hipPointer_attribute attribute, hipDeviceptr_t ptr)
 
-// The HIP symbol table for holding resolved dynamic library symbols.
-struct HIPSymbolTable {{
-#define DEFINE_EACH_ERR_FIELD(hipSymbolName, required, ...)                   \\
-  hipError_t (*hipSymbolName)(__VA_ARGS__);
-#define DEFINE_EACH_STR_FIELD(hipSymbolName, required, ...)                   \\
-  const char *(*hipSymbolName)(__VA_ARGS__);
-
-  HIP_SYMBOL_LIST(DEFINE_EACH_ERR_FIELD, DEFINE_EACH_STR_FIELD)
-}};
-
-static struct HIPSymbolTable hipSymbolTable;
-
-bool initSymbolTable() {{
-  // Use the HIP runtime library loaded into the existing process if it exits.
-  void *lib = dlopen("libamdhip64.so", RTLD_NOLOAD);
-
-  // Otherwise, go through the list of search paths to dlopen the first HIP
-  // driver library.
-  if (!lib) {{
-    int n = sizeof(hipLibSearchPaths) / sizeof(hipLibSearchPaths[0]);
-    for (int i = 0; i < n; ++i) {{
-      void *handle = dlopen(hipLibSearchPaths[i], RTLD_LAZY | RTLD_LOCAL);
-      if (handle) {{
-        lib = handle;
-      }}
-    }}
-  }}
-  if (!lib) {{
-    PyErr_SetString(PyExc_RuntimeError, "cannot open libamdhip64.so");
-    return false;
-  }}
-
-  typedef hipError_t (*hipGetProcAddress_fn)(
-      const char *symbol, void **pfn, int hipVersion, uint64_t hipFlags,
-      hipDriverProcAddressQueryResult *symbolStatus);
-  hipGetProcAddress_fn hipGetProcAddress;
-  dlerror(); // Clear existing errors
-  const char *error = NULL;
-  *(void **)&hipGetProcAddress = dlsym(lib, "hipGetProcAddress");
-  error = dlerror();
-  if (error) {{
-    PyErr_SetString(PyExc_RuntimeError,
-                    "cannot query 'hipGetProcAddress' from libamdhip64.so");
-    dlclose(lib);
-    return false;
-  }}
-
-  // Resolve all symbols we are interested in.
-  int hipVersion = HIP_VERSION;
-  uint64_t hipFlags = 0;
-  hipDriverProcAddressQueryResult symbolStatus;
-  hipError_t status = hipSuccess;
-#define QUERY_EACH_FN(hipSymbolName, required, ...)                            \
-  status = hipGetProcAddress(#hipSymbolName,                                   \
-                             (void **)&hipSymbolTable.hipSymbolName,           \
-                             hipVersion, hipFlags, &symbolStatus);             \
-  if (required && status != hipSuccess) {{                                     \
-    PyErr_SetString(PyExc_RuntimeError,                                        \
-                    "cannot get address for '" #hipSymbolName                  \
-                    "' from libamdhip64.so");                                  \
-    dlclose(lib);                                                              \
-    return false;                                                              \
-  }}
-
-  HIP_SYMBOL_LIST(QUERY_EACH_FN, QUERY_EACH_FN)
-
-  return true;
-}}
-
-static inline void gpuAssert(hipError_t code, const char *file, int line)
-{{
-   if (code != hipSuccess)
-   {{
-      const char* prefix = "Triton Error [HIP]: ";
-      const char* str = hipSymbolTable.hipGetErrorString(code);
-      char err[1024] = {{0}};
-      snprintf(err, 1024, "%s Code: %d, Messsage: %s", prefix, code, str );
-      PyErr_SetString(PyExc_RuntimeError, err);
-   }}
-}}
-
-#define HIP_CHECK(ans) {{ gpuAssert((ans), __FILE__, __LINE__); }}
-
-static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas, int launch_cooperative_grid, int shared_memory, hipStream_t stream, hipFunction_t function, hipDeviceptr_t profile_scratch{', ' + arg_decls if len(arg_decls) > 0 else ''}) {{
-  if (gridX * gridY * gridZ == 0)
-    return;
-  hipDeviceptr_t global_scratch = 0;
-  void *params[] = {{ {', '.join(params)} }};
-  if(num_ctas > 1) {{
-    if (!hipSymbolTable.hipDrvLaunchKernelEx) {{
-        PyErr_SetString(PyExc_RuntimeError, "missing hipDrvLaunchKernelEx symbol; please update HIP runtime");
-        return;
-    }}
-
-    hipLaunchAttribute attributes[2];
-    // Attribute0: Cluster dimensions
-    attributes[0].id = (hipLaunchAttributeID)4;
-    int *cluster_dims = (int*)attributes[0].val.pad;
-    cluster_dims[0] = num_ctas;
-    cluster_dims[1] = 1;
-    cluster_dims[2] = 1;
-    // Attribute1: Cooperative launch
-    attributes[1].id = hipLaunchAttributeCooperative;
-    attributes[1].val.cooperative = launch_cooperative_grid;
-
-    HIP_LAUNCH_CONFIG config = {{
-        (unsigned int)(gridX * num_ctas), (unsigned int)gridY, (unsigned int)gridZ, // Grid size
-        (unsigned int)({warp_size} * num_warps), 1, 1, // Block size
-        (unsigned int)shared_memory, stream,
-        attributes, 2 // Number of attributes
-    }};
-    HIP_CHECK(hipSymbolTable.hipDrvLaunchKernelEx(&config, function, params, 0));
-    return;
-  }}
-  else if (launch_cooperative_grid) {{
-    HIP_CHECK(hipSymbolTable.hipModuleLaunchCooperativeKernel(function, gridX, gridY, gridZ, {warp_size}*num_warps, 1, 1, shared_memory, stream, params, 0));
-    return;
-  }}
-  else {{
-    HIP_CHECK(hipSymbolTable.hipModuleLaunchKernel(function, gridX, gridY, gridZ, {warp_size}*num_warps, 1, 1, shared_memory, stream, params, 0));
-  }}
-}}
-
-typedef struct _DevicePtrInfo {{
-    hipDeviceptr_t dev_ptr;
-    bool valid;
-}} DevicePtrInfo;
-
-static PyObject* data_ptr_str = NULL;
-static PyObject* py_tdm_descriptor_type = NULL;
-
-static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
-  DevicePtrInfo ptr_info;
-  hipError_t status = hipSuccess;
-  ptr_info.dev_ptr = 0;
-  ptr_info.valid = true;
-  if (PyLong_Check(obj)) {{
-    ptr_info.dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(obj);
-    return ptr_info;
-  }}
-  if (obj == Py_None) {{
-    // valid nullptr
-    return ptr_info;
-  }}
-  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
-  if (!ret) {{
-    PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  if (!PyLong_Check(ret)) {{
-    PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  ptr_info.dev_ptr = (hipDeviceptr_t)PyLong_AsUnsignedLongLong(ret);
-  if (!ptr_info.dev_ptr)
-    goto cleanup;
-  uint64_t dev_ptr;
-  status = hipSymbolTable.hipPointerGetAttribute(&dev_ptr, HIP_POINTER_ATTRIBUTE_DEVICE_POINTER, ptr_info.dev_ptr);
-  if (status == hipErrorInvalidValue) {{
-      PyErr_Format(PyExc_ValueError,
-                   "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
-      ptr_info.valid = false;
-      // Clear and ignore HIP error
-      (void)hipSymbolTable.hipGetLastError();
-  }}
-  ptr_info.dev_ptr = (hipDeviceptr_t)dev_ptr;
-cleanup:
-  Py_DECREF(ret);
-  return ptr_info;
-}}
-
-static inline TDMDescriptor* getTDMDescriptor(PyObject* obj, int idx) {{
-  if (Py_TYPE(obj) != (PyTypeObject*)py_tdm_descriptor_type) {{
-    PyErr_Format(PyExc_TypeError, "object must be of type PyTDMDescriptor, got %s", Py_TYPE(obj)->tp_name);
-    return NULL;
-  }}
-
-  TDMDescriptor* desc = &((PyTDMDescriptorObject*)obj)->desc;
-  return desc;
-}}
-
-static uint16_t pack_fp16(double f) {{
-    uint16_t result;
-    // from https://github.com/python/pythoncapi-compat/blob/5e317108f872c904eb726cb8d560dcadbdf88a72/pythoncapi_compat.h#L482-L492
-#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && !defined(PYPY_VERSION)
-    _PyFloat_Pack2(f, (unsigned char*)&result, 1);
-#else
-    PyFloat_Pack2(f, (char*)&result, 1);
-#endif
-    return result;
-}}
-
-static uint16_t pack_bf16(double f) {{
-    float f32 = (float)f;
-    uint32_t u32 = *(uint32_t*)&f32;
-    return (uint16_t)(u32 >> 16);
-}}
-
-static uint32_t pack_fp32(double f) {{
-    float f32 = (float)f;
-    return *(uint32_t*)&f32;
-}}
-
-static uint64_t pack_fp64(double f) {{
-    return *(uint64_t*)&f;
-}}
-
-static PyObject* launch(PyObject* self, PyObject* args) {{
-  int gridX, gridY, gridZ;
-  uint64_t _stream;
-  uint64_t _function;
-  int launch_cooperative_grid;
-  PyObject *profile_scratch_obj = NULL;
-  PyObject *launch_enter_hook = NULL;
-  PyObject *launch_exit_hook = NULL;
-  PyObject *kernel_metadata = NULL;
-  PyObject *launch_metadata = NULL;
-  {' '.join([f"{_extracted_type(ty)} _arg{i}; " for i, ty in signature.items()])}
-  if(!PyArg_ParseTuple(args, \"{format}\", &launch_cooperative_grid,
-                                           &gridX, &gridY, &gridZ, &_stream, &_function, &profile_scratch_obj,
-                                           &kernel_metadata, &launch_metadata,
-                                           &launch_enter_hook, &launch_exit_hook {args_list})) {{
-    return NULL;
-  }}
-
-  // extract kernel metadata
-  int num_warps, num_ctas, shared_memory;
-  if (!PyArg_ParseTuple(kernel_metadata, \"iii\", &num_warps, &num_ctas, &shared_memory)) {{
-    return NULL;
-  }}
-  // extract launch metadata
-  if (launch_enter_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_enter_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  hipDeviceptr_t profile_scratch = 0;
-  if (profile_scratch_obj != Py_None) {{
-    DevicePtrInfo profile_scratch_info = getPointer(profile_scratch_obj, -1);
-    if (!profile_scratch_info.valid) {{
-      return NULL;
-    }}
-    profile_scratch = profile_scratch_info.dev_ptr;
-  }}
-
-  // raise exception asap
-  {newline.join(tensor_desc_decls)}
-  {newline.join(ptr_decls)}
-  {newline.join(float_storage_decls)}
-  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid, shared_memory, (hipStream_t)_stream, (hipFunction_t)_function, (hipDeviceptr_t)profile_scratch{', ' + ', '.join(internal_args_list) if len(internal_args_list) > 0 else ''});
-
-  if(launch_exit_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_exit_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  if(PyErr_Occurred()) {{
-    return NULL;
-  }}
-  Py_RETURN_NONE;
-}}
-
-static PyMethodDef ModuleMethods[] = {{
-  {{"launch", launch, METH_VARARGS, "Entry point for all kernels with this signature"}},
-  {{NULL, NULL, 0, NULL}} // sentinel
-}};
-
-static struct PyModuleDef ModuleDef = {{
-  PyModuleDef_HEAD_INIT,
-  \"__triton_launcher\",
-  NULL, //documentation
-  -1, //size
-  ModuleMethods
-}};
-
-PyMODINIT_FUNC PyInit___triton_launcher(void) {{
-  if (!initSymbolTable()) {{
-    return NULL;
-  }}
-  PyObject *m = PyModule_Create(&ModuleDef);
-  if(m == NULL) {{
-    return NULL;
-  }}
-  data_ptr_str = PyUnicode_InternFromString("data_ptr");
-  if(data_ptr_str == NULL) {{
-    return NULL;
-  }}
-  PyObject* driver_mod = PyImport_ImportModule("triton.backends.amd.driver");
-  if (driver_mod == NULL) {{
-    return NULL;
-  }}
-  py_tdm_descriptor_type = PyObject_GetAttrString(driver_mod, "PyTDMDescriptor");
-  if (py_tdm_descriptor_type == NULL) {{
-    return NULL;
-  }}
-
-  PyModule_AddFunctions(m, ModuleMethods);
-  return m;
-}}
-"""
-    return src
+def annotate_arguments(signature):
+    """
+    This recreates the signature with annotations as C objects which can then
+    be used to efficiently flatten tuples, and remove constexpr in the launcher.
+    """
+    annotated_arguments = []
+    for sig in signature:
+        if isinstance(sig, tuple):
+            annotated_arguments.append((PyKernelArg(nested_tuple=annotate_arguments(sig), type=ARG_TUPLE)))
+        elif sig != "constexpr":
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_KERNEL))
+        else:
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_CONSTEXPR))
+    return annotated_arguments
 
 
 def make_tensordesc_arg(arg, kernel_metadata, tensordesc_metadata):
@@ -788,19 +358,20 @@ def wrap_handle_tensordesc(launcher, signature, tensordesc_metadata):
         tensordesc_metadata = [None] * len(tensordesc_indices)
 
     def inner(*args):
-        meta_args = args[:len(_BASE_ARGS_FORMAT)]
-        raw_kernel_args = args[len(_BASE_ARGS_FORMAT):]
-        final_args = []
+        base_args = args[:-1]
+        kernel_metadata = base_args[7]
+        kernel_args = args[-1]
+
+        final_kernel_args = []
         tensordesc_idx = 0
-        for i, arg in enumerate(raw_kernel_args):
+        for i, arg in enumerate(kernel_args):
             if i in tensordesc_indices:
-                tensordesc_args = make_tensordesc_arg(arg, meta_args[7],  # kernel_metadata
-                                                      tensordesc_metadata[tensordesc_idx])
-                final_args.extend(tensordesc_args)
+                final_kernel_args.extend(make_tensordesc_arg(arg, kernel_metadata, tensordesc_metadata[tensordesc_idx]))
                 tensordesc_idx += 1
             else:
-                final_args.append(arg)
-        return launcher(*meta_args, *final_args)
+                final_kernel_args.append(arg)
+
+        return launcher(*base_args, final_kernel_args)
 
     return inner
 
@@ -813,10 +384,13 @@ class HIPLauncher(object):
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
-        src = make_launcher(constants, signature, metadata.warp_size, tensordesc_meta)
-        mod = compile_module_from_src(src=src, name="__triton_launcher", include_dirs=include_dirs)
-        self.launch = wrap_handle_tensordesc(mod.launch, signature, tensordesc_meta)
+        launcher = triton.runtime.driver.active.utils.launch
+        expanded_signature = expand_signature(signature.values(), tensordesc_meta)
+        self.arg_annotations = annotate_arguments(expanded_signature)
+        self.kernel_signature = make_kernel_signature(expanded_signature)
+        self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
         self.launch_cooperative_grid = metadata.launch_cooperative_grid
+        self.warp_size = metadata.warp_size
         # Check if cooperative groups are supported on the device.
         if self.launch_cooperative_grid:
             driver = triton.runtime.driver.active
@@ -828,7 +402,8 @@ class HIPLauncher(object):
         self.profile_scratch_size = metadata.profile_scratch_size
         self.profile_scratch_align = metadata.profile_scratch_align
 
-    def __call__(self, gridX, gridY, gridZ, stream, function, *args):
+    def __call__(self, gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
+                 launch_exit_hook, *args):
 
         def allocate_scratch(size, align, allocator):
             if size > 0:
@@ -841,7 +416,9 @@ class HIPLauncher(object):
         profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
                                            _allocation._profile_allocator)
 
-        self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, profile_scratch, *args)
+        self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, profile_scratch,
+                    kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, self.warp_size,
+                    self.arg_annotations, self.kernel_signature, args)
 
 
 class HIPDriver(GPUDriver):

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1,6 +1,8 @@
 #include "cuda.h"
 #include <dlfcn.h>
+#include <stdalign.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #define PY_SSIZE_T_CLEAN
@@ -10,6 +12,51 @@ typedef struct {
   PyObject_HEAD;
   _Alignas(128) CUtensorMap tensorMap;
 } PyCUtensorMapObject;
+
+typedef enum { ARG_CONSTEXPR = 0, ARG_KERNEL = 1, ARG_TUPLE = 2 } ArgType;
+
+// Annotation struct to know how the argument should be handled.
+typedef struct {
+  PyObject_HEAD;
+  PyObject *nested_tuple; // Can be a List of PyKernelArgObjects or None
+  ArgType type;
+} PyKernelArgObject;
+
+// Deallocator
+static void PyKernelArg_dealloc(PyKernelArgObject *self) {
+  Py_XDECREF(self->nested_tuple);
+  Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+// Constructor
+static int PyKernelArg_init(PyKernelArgObject *self, PyObject *args,
+                            PyObject *kwds) {
+  static char *kwlist[] = {"nested_tuple", "type", NULL};
+  PyObject *tup = NULL;
+  int type_val = 0;
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|i", kwlist, &tup,
+                                   &type_val)) {
+    return -1;
+  }
+  Py_XINCREF(tup);
+  self->nested_tuple = tup;
+  self->type = (ArgType)type_val;
+  return 0;
+}
+
+static void PyKernelArg_free(void *ptr) { free(ptr); }
+
+static PyTypeObject PyKernelArgType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name =
+        "triton.backends.nvidia.PyKernelArg",
+    .tp_basicsize = sizeof(PyKernelArgObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Kernel Argument Metadata",
+    .tp_new = PyType_GenericNew,
+    .tp_init = (initproc)PyKernelArg_init,
+    .tp_dealloc = (destructor)PyKernelArg_dealloc,
+};
 
 // Raises a Python exception and returns false if code is not CUDA_SUCCESS.
 static bool gpuAssert(CUresult code, const char *file, int line) {
@@ -28,6 +75,13 @@ static bool gpuAssert(CUresult code, const char *file, int line) {
   PyGILState_Release(gil_state);
   return false;
 }
+
+// To be used only *outside* a Py_{BEGIN,END}_ALLOW_THREADS block.
+#define CUDA_CHECK(ans)                                                        \
+  do {                                                                         \
+    if (!gpuAssert((ans), __FILE__, __LINE__))                                 \
+      return;                                                                  \
+  } while (0)
 
 // To be used only *outside* a Py_{BEGIN,END}_ALLOW_THREADS block.
 #define CUDA_CHECK_AND_RETURN_NULL(ans)                                        \
@@ -1024,6 +1078,589 @@ cleanup:
   return NULL;
 }
 
+static void ensureCudaContext() {
+  CUcontext pctx;
+  CUDA_CHECK(cuCtxGetCurrent(&pctx));
+  if (!pctx) {
+    // Ensure device context.
+    CUdevice device;
+    CUDA_CHECK(cuDeviceGet(&device, 0));
+    CUDA_CHECK(cuDevicePrimaryCtxRetain(&pctx, device));
+    CUDA_CHECK(cuCtxSetCurrent(pctx));
+  }
+}
+
+static void _launch(int gridX, int gridY, int gridZ, int num_warps,
+                    int num_ctas, int launch_cooperative_grid, int launch_pdl,
+                    int preferredClusterDimX, int preferredClusterDimY,
+                    int preferredClusterDimZ, int shared_memory, CUstream stream,
+                    CUfunction function, void **params) {
+  if (gridX * gridY * gridZ > 0) {
+    // 5 attributes that we can currently pass maximum
+    CUlaunchAttribute launchAttr[5];
+    static cuLaunchKernelEx_t cuLaunchKernelExHandle = NULL;
+    if (cuLaunchKernelExHandle == NULL) {
+      cuLaunchKernelExHandle = getLaunchKernelExHandle();
+    }
+    CUlaunchConfig config;
+    config.gridDimX = gridX * num_ctas;
+    config.gridDimY = gridY;
+    config.gridDimZ = gridZ;
+
+    config.blockDimX = 32 * num_warps;
+    config.blockDimY = 1;
+    config.blockDimZ = 1;
+    config.sharedMemBytes = shared_memory;
+    config.hStream = stream;
+    config.attrs = launchAttr;
+    int num_attrs = 0;
+
+    if (launch_pdl != 0) {
+      CUlaunchAttribute pdlAttr = {
+          .id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION,
+          .value = 1};
+      launchAttr[num_attrs] = pdlAttr;
+      ++num_attrs;
+    }
+
+    if (launch_cooperative_grid != 0) {
+      CUlaunchAttribute coopAttr = {.id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE,
+                                    .value = 1};
+      launchAttr[num_attrs] = coopAttr;
+      ++num_attrs;
+    }
+
+    if (num_ctas != 1 || preferredClusterDimX > 0) {
+      // Only set CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for Triton's num_ctas
+      // path. For ctas_per_cga path (num_ctas == 1), PTX's .reqnctapercluster
+      // handles it.
+      if (num_ctas > 1) {
+        CUlaunchAttribute clusterAttr = {};
+        clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+        clusterAttr.value.clusterDim.x = num_ctas;
+        clusterAttr.value.clusterDim.y = 1;
+        clusterAttr.value.clusterDim.z = 1;
+        launchAttr[num_attrs] = clusterAttr;
+        ++num_attrs;
+      }
+
+      CUlaunchAttribute clusterSchedulingAttr = {};
+      clusterSchedulingAttr.id =
+          CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+      clusterSchedulingAttr.value.clusterSchedulingPolicyPreference =
+          CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+      launchAttr[num_attrs] = clusterSchedulingAttr;
+      ++num_attrs;
+    }
+
+#if CUDA_VERSION >= 12080
+    if (preferredClusterDimX > 0) {
+      CUlaunchAttribute preferredClusterAttr = {};
+      preferredClusterAttr.id =
+          CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
+      preferredClusterAttr.value.preferredClusterDim.x = preferredClusterDimX;
+      preferredClusterAttr.value.preferredClusterDim.y = preferredClusterDimY;
+      preferredClusterAttr.value.preferredClusterDim.z = preferredClusterDimZ;
+      launchAttr[num_attrs] = preferredClusterAttr;
+      ++num_attrs;
+    }
+#endif
+
+    // num_ctas == 16 is non-portable. Does work for H100 and B200 tho
+    config.numAttrs = num_attrs;
+    if (num_ctas == 16) {
+      CUDA_CHECK(cuFuncSetAttribute(
+          function, CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED, 1));
+    }
+
+    CUDA_CHECK(cuLaunchKernelExHandle(&config, function, params, 0));
+  }
+}
+
+static PyObject *data_ptr_str = NULL;
+
+// Extract a CUDA device pointer from a pointer-like PyObject obj, and store
+// it to the memory location pointed by ptr.
+bool extractPointer(void *ptr, PyObject *obj) {
+  CUdeviceptr *dev_ptr = ptr;
+  if (obj == Py_None) {
+    *dev_ptr = (CUdeviceptr)0; // valid nullptr
+    return true;
+  }
+  if (PyLong_Check(obj)) {
+    *dev_ptr = PyLong_AsUnsignedLongLong(obj);
+    return true;
+  }
+  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
+  if (!ret) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "Pointer argument must be either uint64 or have data_ptr method");
+    return false;
+  }
+  if (!PyLong_Check(ret)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "data_ptr method of Pointer object must return 64-bit int");
+    return false;
+  }
+  *dev_ptr = PyLong_AsUnsignedLongLong(ret);
+  Py_DECREF(ret);
+  if (*dev_ptr == 0) {
+    return true; // valid nullptr
+  }
+  CUresult status = cuPointerGetAttribute(
+      dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, *dev_ptr);
+  if (status == CUDA_ERROR_INVALID_VALUE) {
+    PyErr_Format(PyExc_ValueError,
+                 "Pointer argument cannot be accessed from Triton "
+                 "(cpu tensor?)");
+    return false;
+  }
+  return gpuAssert(status, __FILE__, __LINE__);
+}
+
+bool extractI8(void *ptr, PyObject *obj) {
+  *((int8_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI16(void *ptr, PyObject *obj) {
+  *((int16_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI32(void *ptr, PyObject *obj) {
+  *((int32_t *)ptr) = PyLong_AsLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractI64(void *ptr, PyObject *obj) {
+  *((int64_t *)ptr) = PyLong_AsLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU8(void *ptr, PyObject *obj) {
+  *((uint8_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU16(void *ptr, PyObject *obj) {
+  *((uint16_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU32(void *ptr, PyObject *obj) {
+  *((uint32_t *)ptr) = PyLong_AsUnsignedLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractU64(void *ptr, PyObject *obj) {
+  *((uint64_t *)ptr) = PyLong_AsUnsignedLongLong(obj);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  uint16_t result;
+  // from https://github.com/python/pythoncapi-compat
+#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 &&            \
+    !defined(PYPY_VERSION)
+  _PyFloat_Pack2(temp_double, (unsigned char *)&result, 1);
+#else
+  PyFloat_Pack2(temp_double, (char *)&result, 1);
+#endif
+  *((uint16_t *)ptr) = result;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractBF16(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  uint32_t u32 = *(uint32_t *)&f32;
+  *((uint16_t *)ptr) = (u32 >> 16);
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP32(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  float f32 = (float)temp_double;
+  *((uint32_t *)ptr) = *(uint32_t *)&f32;
+  return PyErr_Occurred() == NULL;
+}
+
+bool extractFP64(void *ptr, PyObject *obj) {
+  double temp_double = PyFloat_AsDouble(obj);
+  *((uint64_t *)ptr) = *(uint64_t *)&temp_double;
+  return PyErr_Occurred() == NULL;
+}
+
+// Extract a CUtensorMap descriptor from a python object, and store it to the
+// memory location pointed by ptr.
+bool extractTmaDesc(void *ptr, PyObject *obj) {
+  if (sizeof(CUtensorMap *) != 8) {
+    PyErr_SetString(PyExc_SystemError,
+                    "getTmaDesc() requires 64-bit compilation");
+    return false;
+  }
+  if (Py_TYPE(obj) != &PyCUtensorMapType) {
+    PyErr_Format(PyExc_TypeError,
+                 "object must be of type PyCUtensorMap, got %s",
+                 Py_TYPE(obj)->tp_name);
+    return false;
+  }
+  *((CUtensorMap *)ptr) = ((PyCUtensorMapObject *)obj)->tensorMap;
+  uintptr_t align_128 = (uintptr_t)ptr & (128 - 1);
+  if (align_128 != 0) {
+    PyErr_Format(
+        PyExc_ValueError,
+        "CUtensorMap must be aligned to 128B, but got (&map) mod 128 = %ld",
+        align_128);
+    return false;
+  }
+  return true;
+}
+
+typedef bool (*ExtractorFunc)(void *ptr, PyObject *obj);
+
+#define MAX_NAMES_PER_EXTRACTOR 2
+
+typedef struct {
+  ExtractorFunc extract;
+  size_t size;
+  size_t alignment;
+  const char *name[MAX_NAMES_PER_EXTRACTOR];
+} Extractor;
+
+typedef enum {
+  EXTRACTOR_UNKOWN_INDEX = 0,
+  // pointers
+  EXTRACTOR_POINTER_INDEX = 1,
+  // ints
+  EXTRACTOR_INT8_INDEX = 2,
+  EXTRACTOR_INT16_INDEX = 3,
+  EXTRACTOR_INT32_INDEX = 4,
+  EXTRACTOR_INT64_INDEX = 5,
+  // uints
+  EXTRACTOR_UINT8_INDEX = 6,
+  EXTRACTOR_UINT16_INDEX = 7,
+  EXTRACTOR_UINT32_INDEX = 8,
+  EXTRACTOR_UINT64_INDEX = 9,
+  // floats
+  EXTRACTOR_FP16_INDEX = 10,
+  EXTRACTOR_BF16_INDEX = 11,
+  EXTRACTOR_FP32_INDEX = 12,
+  EXTRACTOR_FP64_INDEX = 13,
+  // custom
+  EXTRACTOR_NVTMADESC_INDEX = 14,
+  // last entry to have a count
+  EXTRACTOR_TYPE_COUNT
+} ExtractorTypeIndex;
+
+Extractor extraction_map[EXTRACTOR_TYPE_COUNT] = {
+    [EXTRACTOR_UNKOWN_INDEX] =
+        (Extractor){.extract = NULL, .size = 0, .name = NULL},
+    [EXTRACTOR_POINTER_INDEX] = (Extractor){.extract = extractPointer,
+                                            .size = sizeof(CUdeviceptr),
+                                            .name = NULL},
+    [EXTRACTOR_INT8_INDEX] = (Extractor){.extract = extractI8,
+                                         .size = sizeof(int8_t),
+                                         .name = {"i8"}},
+    [EXTRACTOR_INT16_INDEX] = (Extractor){.extract = extractI16,
+                                          .size = sizeof(int16_t),
+                                          .name = {"i16"}},
+    [EXTRACTOR_INT32_INDEX] = (Extractor){.extract = extractI32,
+                                          .size = sizeof(int32_t),
+                                          .name = {"i1", "i32"}},
+    [EXTRACTOR_INT64_INDEX] = (Extractor){.extract = extractI64,
+                                          .size = sizeof(int64_t),
+                                          .name = {"i64"}},
+    [EXTRACTOR_UINT8_INDEX] = (Extractor){.extract = extractU8,
+                                          .size = sizeof(uint8_t),
+                                          .name = {"u8"}},
+    [EXTRACTOR_UINT16_INDEX] = (Extractor){.extract = extractU16,
+                                           .size = sizeof(uint16_t),
+                                           .name = {"u16"}},
+    [EXTRACTOR_UINT32_INDEX] = (Extractor){.extract = extractU32,
+                                           .size = sizeof(uint32_t),
+                                           .name = {"u1", "u32"}},
+    [EXTRACTOR_UINT64_INDEX] = (Extractor){.extract = extractU64,
+                                           .size = sizeof(uint64_t),
+                                           .name = {"u64"}},
+    [EXTRACTOR_FP16_INDEX] = (Extractor){.extract = extractFP16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"fp16"}},
+    [EXTRACTOR_BF16_INDEX] = (Extractor){.extract = extractBF16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"bf16"}},
+    [EXTRACTOR_FP32_INDEX] = (Extractor){.extract = extractFP32,
+                                         .size = sizeof(uint32_t),
+                                         .name = {"fp32", "f32"}},
+    [EXTRACTOR_FP64_INDEX] = (Extractor){.extract = extractFP64,
+                                         .size = sizeof(uint64_t),
+                                         .name = {"fp64"}},
+    [EXTRACTOR_NVTMADESC_INDEX] = (Extractor){.extract = extractTmaDesc,
+                                              .size = sizeof(CUtensorMap),
+                                              .alignment = alignof(CUtensorMap),
+                                              .name = {"nvTmaDesc"}},
+};
+
+Extractor getExtractor(uint8_t index) {
+  if (index >= EXTRACTOR_TYPE_COUNT) {
+    return extraction_map[EXTRACTOR_UNKOWN_INDEX];
+  }
+  return extraction_map[index];
+}
+
+bool isMatch(const char *type_bytes, ExtractorTypeIndex idx) {
+  Extractor extractor = extraction_map[idx];
+  for (int j = 0; j < MAX_NAMES_PER_EXTRACTOR; j++) {
+    if (extractor.name[j] != NULL &&
+        strcmp(type_bytes, extractor.name[j]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ExtractorTypeIndex getExtractorIndex(PyObject *type) {
+  Py_ssize_t type_len = 0;
+  const char *type_bytes = PyUnicode_AsUTF8AndSize(type, &type_len);
+  if (!type_bytes) {
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  if (type_len < 2) {
+    PyErr_Format(PyExc_RuntimeError, "Unexpected data type: %R", type);
+    return EXTRACTOR_UNKOWN_INDEX;
+  }
+  // Examples: '*fp32', 'fp32', 'i8', etc.
+  if (type_bytes[0] == '*') {
+    return EXTRACTOR_POINTER_INDEX;
+  }
+  for (ExtractorTypeIndex i = EXTRACTOR_INT8_INDEX; i < EXTRACTOR_TYPE_COUNT;
+       i++) {
+    if (isMatch(type_bytes, i)) {
+      return i;
+    }
+  }
+
+  PyErr_Format(PyExc_RuntimeError, "Unknown data type: %R", type);
+  return EXTRACTOR_UNKOWN_INDEX;
+}
+
+// Takes in a list of types (ex: ['*fp32', 'u8', 'nvTmaDesc']) and returns
+// a bytes array that represent extractors for quick argument extraction
+// when launching.
+static PyObject *buildSignatureMetadata(PyObject *self, PyObject *args) {
+  PyObject *signature = NULL;
+  if (!PyArg_ParseTuple(args, "O", &signature)) {
+    return NULL;
+  }
+  PyObject *fast_signature = PySequence_Fast(
+      signature, "Expected kernel_arg_types to be a sequence or iterable");
+  if (!fast_signature) {
+    return NULL;
+  }
+  Py_ssize_t signature_size = PySequence_Fast_GET_SIZE(fast_signature);
+  PyObject **signature_items = PySequence_Fast_ITEMS(fast_signature);
+
+  // Create return bytes object.
+  PyObject *ret_bytes = PyBytes_FromStringAndSize(NULL, signature_size);
+  if (ret_bytes == NULL) {
+    Py_XDECREF(fast_signature);
+    return NULL;
+  }
+  char *buffer = PyBytes_AS_STRING(ret_bytes);
+  for (Py_ssize_t i = 0; i < signature_size; ++i) {
+    ExtractorTypeIndex extractor_idx = getExtractorIndex(signature_items[i]);
+    if (extractor_idx == EXTRACTOR_UNKOWN_INDEX) {
+      goto cleanup;
+    }
+    buffer[i] = (uint8_t)extractor_idx;
+  }
+
+  Py_XDECREF(fast_signature);
+  return ret_bytes;
+
+cleanup:
+  Py_XDECREF(fast_signature);
+  Py_XDECREF(ret_bytes);
+  return NULL;
+}
+
+bool extractArgs(PyObject **final_list, int *list_idx, PyObject *kernel_args,
+                 PyObject *arg_annotations) {
+  // Extract arg annotations
+  PyObject *fast_annotations = PySequence_Fast(
+      arg_annotations, "Expected arg_annotations to be a sequence or iterable");
+  if (!fast_annotations) {
+    goto cleanup;
+  }
+  Py_ssize_t num_annotations = PySequence_Fast_GET_SIZE(fast_annotations);
+  PyObject **annotations = PySequence_Fast_ITEMS(fast_annotations);
+
+  PyObject *fast_args = PySequence_Fast(
+      kernel_args, "Expected kernel_args to be a sequence or iterable");
+  if (!fast_args) {
+    goto cleanup;
+  }
+  PyObject **args = PySequence_Fast_ITEMS(fast_args);
+
+  int arg_idx = 0;
+  for (int i = 0; i < num_annotations; ++i) {
+    PyKernelArgObject *annotation = (PyKernelArgObject *)annotations[i];
+    switch (annotation->type) {
+    case ARG_KERNEL:
+      final_list[(*list_idx)++] = args[arg_idx++];
+      break;
+    case ARG_TUPLE:
+      if (!extractArgs(final_list, list_idx, args[arg_idx++],
+                       annotation->nested_tuple)) {
+        goto cleanup;
+      }
+      break;
+    case ARG_CONSTEXPR:
+      arg_idx++;
+      break;
+    }
+  }
+  Py_DECREF(fast_annotations);
+  Py_DECREF(fast_args);
+  return true;
+
+cleanup:
+  Py_XDECREF(fast_annotations);
+  Py_XDECREF(fast_args);
+  return false;
+}
+
+bool launchHook(PyObject *hook, PyObject *metadata) {
+  if (hook != Py_None) {
+    PyObject *ret = PyObject_CallOneArg(hook, metadata);
+    if (!ret) {
+      return false;
+    }
+    Py_DECREF(ret);
+  }
+  return true;
+}
+
+static PyObject *launchKernel(PyObject *self, PyObject *args) {
+  // ensure cuda context is valid before calling any CUDA APIs, e.g. before
+  // calls to cuPointerGetAttributes
+  ensureCudaContext();
+
+  // Parse the arguments.
+  int gridX, gridY, gridZ;
+  uint64_t _stream;
+  uint64_t _function;
+  int launch_cooperative_grid;
+  int launch_pdl;
+  int num_warps, num_ctas, shared_memory, preferredClusterDimX,
+      preferredClusterDimY, preferredClusterDimZ;
+  PyObject *launch_metadata = NULL;
+  PyObject *launch_enter_hook = NULL;
+  PyObject *launch_exit_hook = NULL;
+  PyObject *global_scratch_obj = NULL;
+  PyObject *profile_scratch_obj = NULL;
+  PyObject *arg_annotations = NULL;
+  Py_buffer signature;
+  PyObject *kernel_args = NULL;
+  if (!PyArg_ParseTuple(args, "iiiKKpp(iiiiii)OOOOOOy*O", &gridX, &gridY, &gridZ,
+                        &_stream, &_function, &launch_cooperative_grid,
+                        &launch_pdl, &num_warps, &num_ctas, &shared_memory,
+                        &preferredClusterDimX, &preferredClusterDimY,
+                        &preferredClusterDimZ,
+                        &launch_metadata, &launch_enter_hook, &launch_exit_hook,
+                        &global_scratch_obj, &profile_scratch_obj,
+                        &arg_annotations, &signature, &kernel_args)) {
+    return NULL;
+  }
+
+  // launch entry hook.
+  if (!launchHook(launch_enter_hook, launch_metadata)) {
+    goto cleanup;
+  }
+
+  uint8_t *extractor_data = (uint8_t *)signature.buf;
+  Py_ssize_t num_args = signature.len;
+
+  // Extract kernel parameters - flatten tuples & remove constexpr.
+  PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
+  if (args_data == NULL) {
+    goto cleanup;
+  }
+  int list_idx = 0;
+  if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
+    goto cleanup;
+  }
+
+  // Number of parameters passed to kernel. + 2 for global & profile scratch.
+  int num_params = num_args + 2;
+  void **params = (void **)alloca(num_params * sizeof(void *));
+  int params_idx = 0;
+  // This loop has to stay in the same function that owns params, since we are
+  // using alloca to allocate pointers to it on the stack of the function.
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    // Get extractor that will send back a struct with
+    // * size for allocation
+    // * function to call to put the parameter in params buffer
+    Extractor extractor = getExtractor(extractor_data[i]);
+    if (extractor.extract == NULL) {
+      goto cleanup;
+    }
+
+    size_t alignment = extractor.alignment;
+    if (alignment != 0) {
+      // Allocate enough space on the stack to guarantee an aligned block.
+      size_t size_with_alignment = extractor.size + alignment - 1;
+      void *storage_ptr = alloca(size_with_alignment);
+      void *aligned_ptr = (void *)((((uintptr_t)storage_ptr) + alignment - 1) &
+                                   ~(alignment - 1));
+      if (aligned_ptr == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "Failed to align parameter storage");
+        goto cleanup;
+      }
+      params[params_idx] = aligned_ptr;
+    } else {
+      params[params_idx] = alloca(extractor.size);
+    }
+
+    PyObject *current_arg = args_data[i];
+    if (!extractor.extract(params[params_idx++], current_arg)) {
+      goto cleanup;
+    }
+  }
+  // Add scratch objects.
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], global_scratch_obj)) {
+    goto cleanup;
+  }
+  params[params_idx] = alloca(sizeof(void *));
+  if (!extractPointer(params[params_idx++], profile_scratch_obj)) {
+    goto cleanup;
+  }
+
+  Py_BEGIN_ALLOW_THREADS;
+  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
+          launch_pdl, preferredClusterDimX, preferredClusterDimY,
+          preferredClusterDimZ, shared_memory, (CUstream)_stream,
+          (CUfunction)_function, params);
+  Py_END_ALLOW_THREADS;
+  if (PyErr_Occurred()) {
+    goto cleanup;
+  }
+
+  if (!launchHook(launch_exit_hook, launch_metadata)) {
+    goto cleanup;
+  }
+  PyBuffer_Release(&signature);
+  Py_RETURN_NONE;
+
+cleanup:
+  PyBuffer_Release(&signature);
+  return NULL;
+}
+
 static PyMethodDef ModuleMethods[] = {
     {"load_binary", loadBinary, METH_VARARGS,
      "Load provided cubin into CUDA driver"},
@@ -1041,6 +1678,11 @@ static PyMethodDef ModuleMethods[] = {
      "Create TMA descriptor for tiled mode"},
     {"fill_tma_descriptor_im2col", fillTMADescriptorIm2col, METH_VARARGS,
      "Create TMA descriptor for im2col mode"},
+    {"build_signature_metadata", buildSignatureMetadata, METH_VARARGS,
+     "Calling it with a signature list (ex: ['*fp32', 'u8', 'nvTmaDesc']), "
+     "will return metadata to be passed into 'launch' for quicker "
+     "argument parsing."},
+    {"launch", launchKernel, METH_VARARGS, "launches cuda kernel"},
     {"fill_1d_tma_descriptor", fill1DTMADescriptor, METH_VARARGS, "doc"},
     {"fill_2d_tma_descriptor", fill2DTMADescriptor, METH_VARARGS, "doc"},
     {"fill_1d_tma_descriptor_type", fill1DTMADescriptorType, METH_VARARGS,
@@ -1060,15 +1702,29 @@ PyMODINIT_FUNC PyInit_cuda_utils(void) {
   if (PyType_Ready(&PyCUtensorMapType) < 0) {
     return NULL;
   }
+  if (PyType_Ready(&PyKernelArgType) < 0) {
+    return NULL;
+  }
 
   PyObject *m = PyModule_Create(&ModuleDef);
   if (m == NULL) {
     return NULL;
   }
+  data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  if (data_ptr_str == NULL) {
+    return NULL;
+  }
 
   PyModule_AddFunctions(m, ModuleMethods);
+
   Py_INCREF(&PyCUtensorMapType);
   PyModule_AddObject(m, "PyCUtensorMap", (PyObject *)&PyCUtensorMapType);
+
+  Py_INCREF(&PyKernelArgType);
+  PyModule_AddObject(m, "PyKernelArg", (PyObject *)&PyKernelArgType);
+  PyModule_AddIntConstant(m, "ARG_CONSTEXPR", ARG_CONSTEXPR);
+  PyModule_AddIntConstant(m, "ARG_KERNEL", ARG_KERNEL);
+  PyModule_AddIntConstant(m, "ARG_TUPLE", ARG_TUPLE);
 
   return m;
 }

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -125,6 +125,48 @@ def ty_to_cpp(ty):
     }[ty]
 
 
+def build_kernel_signature_from_schema(schema):
+    """Derive kernel_signature bytes from Level 0 schema args array.
+
+    This makes the Level 0 schema the source of truth for type dispatch in the
+    shared variadic launcher (driver.c).  The schema's ``args`` list contains
+    only non-constant kernel parameters with their types already resolved.
+    """
+    flat_types = []
+    tensordesc_meta = schema.get("tensordesc_meta") or []
+    tensordesc_idx = 0
+
+    for arg in schema["args"]:
+        ty = arg["type"]
+        if ty.startswith("tensordesc"):
+            meta = tensordesc_meta[tensordesc_idx] if tensordesc_idx < len(tensordesc_meta) else None
+            tensordesc_idx += 1
+
+            match = re.match(r"tensordesc<([^[>]*)\[([^]]*)\]", ty)
+            dtype = match.group(1)
+            shape = match.group(2)
+            ndim = shape.count(",") + 1
+
+            if meta is None:
+                # Host TMA path: base pointer + shape + strides + padding flag
+                flat_types.append("*" + dtype)
+                for _ in range(2 * ndim):
+                    flat_types.append("i64")
+                flat_types.append("i1")
+            else:
+                # Device TMA path: nvTmaDesc
+                flat_types.append("nvTmaDesc")
+
+            for _ in range(ndim):
+                flat_types.append("i32")
+            for _ in range(ndim):
+                flat_types.append("i64")
+        else:
+            flat_types.append(ty)
+
+    return triton.runtime.driver.active.utils.build_signature_metadata(flat_types)
+
+
 def expand_signature(signature, tensordesc_meta):
     output = []
     tensordesc_idx = 0
@@ -322,10 +364,21 @@ class CudaLauncher(object):
         signature = {idx: value for idx, value in src.signature.items()}
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
 
+        # Compute Level 0 schema — the canonical ABI description for this kernel.
+        from triton.compiler.compiler import make_backend
+        backend = make_backend(metadata.target)
+        schema = backend.make_launch_metadata(metadata._asdict(), src)
+
         launcher = triton.runtime.driver.active.utils.launch
+
+        # kernel_signature: derived from Level 0 schema (single source of truth).
+        self.kernel_signature = build_kernel_signature_from_schema(schema)
+
+        # arg_annotations: still needs structural info from src.signature
+        # (tuple grouping is a Python calling convention, not kernel ABI).
         expanded_signature = expand_signature(signature.values(), tensordesc_meta)
         self.arg_annotations = annotate_arguments(expanded_signature)
-        self.kernel_signature = make_kernel_signature(expanded_signature)
+
         self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
         self.global_scratch_size = metadata.global_scratch_size
         self.global_scratch_align = metadata.global_scratch_align

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -15,6 +15,10 @@ include_dirs = [os.path.join(dirname, "include")]
 libdevice_dir = os.path.join(dirname, "lib")
 libraries = ["libcuda.so.1"]
 PyCUtensorMap = None
+PyKernelArg = None
+ARG_CONSTEXPR = None
+ARG_KERNEL = None
+ARG_TUPLE = None
 
 
 @functools.lru_cache()
@@ -67,13 +71,23 @@ class CudaUtils(object):
             libraries=libraries,
         )
         global PyCUtensorMap
+        global PyKernelArg
+        global ARG_CONSTEXPR
+        global ARG_KERNEL
+        global ARG_TUPLE
         PyCUtensorMap = mod.PyCUtensorMap
+        PyKernelArg = mod.PyKernelArg
+        ARG_CONSTEXPR = mod.ARG_CONSTEXPR
+        ARG_KERNEL = mod.ARG_KERNEL
+        ARG_TUPLE = mod.ARG_TUPLE
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
         self.cuOccupancyMaxActiveClusters = mod.cuOccupancyMaxActiveClusters
         self.set_printf_fifo_size = mod.set_printf_fifo_size
         self.fill_tma_descriptor_tiled = mod.fill_tma_descriptor_tiled
         self.fill_tma_descriptor_im2col = mod.fill_tma_descriptor_im2col
+        self.launch = mod.launch
+        self.build_signature_metadata = mod.build_signature_metadata
         self.fill_1d_tma_descriptor = mod.fill_1d_tma_descriptor
         self.fill_2d_tma_descriptor = mod.fill_2d_tma_descriptor
         self.fill_1d_tma_descriptor_type = mod.fill_1d_tma_descriptor_type
@@ -111,78 +125,51 @@ def ty_to_cpp(ty):
     }[ty]
 
 
-FLOAT_STORAGE_TYPE = {
-    "fp16": "uint16_t",
-    "bf16": "uint16_t",
-    "fp32": "uint32_t",
-    "f32": "uint32_t",
-    "fp64": "uint64_t",
-}
-FLOAT_PACK_FUNCTION = {
-    "fp16": "pack_fp16",
-    "bf16": "pack_bf16",
-    "fp32": "pack_fp32",
-    "f32": "pack_fp32",
-    "fp64": "pack_fp64",
-}
+def expand_signature(signature, tensordesc_meta):
+    output = []
+    tensordesc_idx = 0
+    # Expand tensor descriptor arguments into either nvTmaDesc, shape and
+    # strides, or base pointer, shape and strides depending on whether the
+    # kernel was lowered to use the nvTmaDesc or not.
+    for sig in signature:
+        if isinstance(sig, str) and sig.startswith("tensordesc"):
+            meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
+            tensordesc_idx += 1
 
-_BASE_ARGS_FORMAT = "iiiKKpppOOOOOO"
-_BASE_ARGS_FORMAT_LEN = len(_BASE_ARGS_FORMAT)
+            match = re.match("tensordesc<([^[>]*)\\[([^]]*)\\]", sig)
+            dtype = match.group(1)
+            shape = match.group(2)
+            ndim = shape.count(",") + 1
 
-
-def make_launcher(constants, signature, tensordesc_meta):
-
-    def _expand_signature(signature):
-        output = []
-        tensordesc_idx = 0
-        # Expand tensor descriptor arguments into either nvTmaDesc, shape and
-        # strides, or base pointer, shape and strides depending on whether the
-        # kernel was lowered to use the nvTmaDesc or not.
-        for sig in signature:
-            if isinstance(sig, str) and sig.startswith("tensordesc"):
-                meta = tensordesc_meta[tensordesc_idx] if tensordesc_meta else None
-                tensordesc_idx += 1
-
-                # Parse tensordesc signature with optional input_rank for im2col mode
-                # Format: tensordesc<dtype[block_shape],...> or tensordesc_im2col<dtype[block_shape],input_rank=N,...>
-                is_im2col = sig.startswith("tensordesc_im2col")
-                match = re.match(r"tensordesc(?:_im2col)?<([^[>]*)\[([^\]]*)\]", sig)
-                dtype = match.group(1)
-                block_shape = match.group(2)
-                block_ndim = block_shape.count(",") + 1
-
-                # For im2col, look for input_rank=N in the type string
-                tensor_rank = None
-                if is_im2col:
-                    rank_match = re.search(r",input_rank=(\d+)", sig)
-                    assert rank_match, "Expected tensordesc_im2col to have input_rank"
-                    tensor_rank = int(rank_match.group(1))
-
-                # For im2col with input_rank, use tensor's rank; otherwise use block_shape ndim
-                ndim = tensor_rank if tensor_rank else block_ndim
-
-                if meta is None:
-                    output.append("*" + dtype)
-                    # Currently the host side tensor descriptors get passed in as a
-                    # tensor desc, shape, and strides. We have no way to use these
-                    # shape and strides when processing tensor descriptors which is
-                    # why we provide our own decomposition above. Sadly this means
-                    # we have to pass the shape and strides twice.
-                    for _ in range(2 * ndim):
-                        output.append("i64")
-                    output.append("i1")
-                else:
-                    output.append("nvTmaDesc")
-
-                for _ in range(ndim):
-                    output.append("i32")
-                for _ in range(ndim):
+            if meta is None:
+                output.append("*" + dtype)
+                # Currently the host side tensor descriptors get passed in as a
+                # tensor desc, shape, and strides. We have no way to use these
+                # shape and strides when processing tensor descriptors which is
+                # why we provide our own decomposition above. Sadly this means
+                # we have to pass the shape and strides twice.
+                for _ in range(2 * ndim):
                     output.append("i64")
+                output.append("i1")
             else:
-                output.append(sig)
+                output.append("nvTmaDesc")
 
-        assert not tensordesc_meta or tensordesc_idx == len(tensordesc_meta)
-        return output
+            for _ in range(ndim):
+                output.append("i32")
+            for _ in range(ndim):
+                output.append("i64")
+        else:
+            output.append(sig)
+
+    assert not tensordesc_meta or tensordesc_idx == len(tensordesc_meta)
+    return output
+
+
+def make_kernel_signature(signature):
+    """
+    Creates a kernel signature in C to be able to efficiently extract
+    arguments in the launcher.
+    """
 
     def _flatten_signature(sig, output):
         # Flatten tuples
@@ -192,477 +179,35 @@ def make_launcher(constants, signature, tensordesc_meta):
         else:
             output.append(sig)
 
-    def _extracted_type(ty):
-        if isinstance(ty, tuple):
-            val = ",".join(map(_extracted_type, ty))
-            return f"[{val}]"
-        if ty[0] == "*":
-            return "PyObject*"
-        if ty in ("constexpr", "nvTmaDesc"):
-            return "PyObject*"
-        return ty_to_cpp(ty)
-
-    def format_of(ty):
-        if isinstance(ty, tuple):
-            val = "".join(map(format_of, ty))
-            return f"({val})"
-        if ty[0] == "*":
-            return "O"
-        if ty in ("constexpr", "nvTmaDesc"):
-            return "O"
-        if ty.startswith("tensordesc"):
-            return "O"
-        return {
-            "double": "d",
-            "long": "l",
-            "int8_t": "b",
-            "int16_t": "h",
-            "int32_t": "i",
-            "int64_t": "L",
-            "uint8_t": "B",
-            "uint16_t": "H",
-            "uint32_t": "I",
-            "uint64_t": "K",
-        }[ty_to_cpp(ty)]
-
-    expand_signature = _expand_signature(signature.values())
-    signature = {i: s for i, s in enumerate(expand_signature)}
-
-    args_format = "".join([format_of(ty) for ty in signature.values()])
-    format = _BASE_ARGS_FORMAT + args_format
-
     flat_signature = []
-    for sig in signature.values():
+    for sig in signature:
         _flatten_signature(sig, flat_signature)
-    signature = {i: s for i, s in enumerate(flat_signature)}
-    args_list = ", " + ", ".join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ""
-    # Record the end of regular arguments;
-    # subsequent arguments are architecture-specific descriptors, such as tensor descriptors for CUDA.
-    arg_decl_list = []
-    for i, ty in signature.items():
-        if ty == "constexpr":
-            continue
-        if ty in FLOAT_STORAGE_TYPE:
-            arg_decl_list.append(f"{FLOAT_STORAGE_TYPE[ty]} arg{i}")
+    kernel_signature = [x for x in flat_signature if x != "constexpr"]
+
+    return triton.runtime.driver.active.utils.build_signature_metadata(kernel_signature)
+
+
+def annotate_arguments(signature):
+    """
+    This recreates the signature with annotations as C objects which can then
+    be used to efficiently flatten tuples, and remove constexpr in the launcher.
+    """
+    annotated_arguments = []
+    for sig in signature:
+        if isinstance(sig, tuple):
+            annotated_arguments.append((PyKernelArg(nested_tuple=annotate_arguments(sig), type=ARG_TUPLE)))
+        elif sig != "constexpr":
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_KERNEL))
         else:
-            arg_decl_list.append(f"{ty_to_cpp(ty)} arg{i}")
-    arg_decls = ", ".join(arg_decl_list)
-    internal_args_list = []
-    for i, ty in signature.items():
-        if ty[0] == "*":
-            internal_args_list.append(f"ptr_info{i}.dev_ptr")
-        elif ty in FLOAT_STORAGE_TYPE:
-            internal_args_list.append(f"_arg{i}_storage")
-        elif ty == "nvTmaDesc":
-            # Note: we have to dereference the pointer
-            internal_args_list.append(f"*tma_ptr{i}")
-        elif ty != "constexpr":
-            internal_args_list.append(f"_arg{i}")
-    params = range(len(signature))
+            annotated_arguments.append(PyKernelArg(nested_tuple=None, type=ARG_CONSTEXPR))
+    return annotated_arguments
 
-    # generate glue code
-    newline = "\n  "
-    ptr_decls = [
-        f"DevicePtrInfo ptr_info{i} = getPointer(_arg{i}, {i}); if (!ptr_info{i}.valid) return NULL;"
-        for i, ty in signature.items()
-        if ty[0] == "*"
-    ]
-    tma_decls = [
-        f"CUtensorMap* tma_ptr{i} = getTmaDesc(_arg{i}); if (!tma_ptr{i}) return NULL;" for i, ty in signature.items()
-        if ty == "nvTmaDesc"
-    ]
-    float_storage_decls = [
-        f"{FLOAT_STORAGE_TYPE[ty]} _arg{i}_storage = {FLOAT_PACK_FUNCTION[ty]}(_arg{i});"
-        for i, ty in signature.items()
-        if ty in FLOAT_STORAGE_TYPE
-    ]
-    params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
-    params.append("&global_scratch")
-    params.append("&profile_scratch")
-    src = f"""
-#include \"cuda.h\"
-#include <dlfcn.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
 
-typedef struct {{
-  PyObject_HEAD;
-  _Alignas(128) CUtensorMap tensorMap;
-}} PyCUtensorMapObject;
-
-static inline void gpuAssert(CUresult code, const char *file, int line)
-{{
-   if (code != CUDA_SUCCESS)
-   {{
-      const char* prefix = "Triton Error [CUDA]: ";
-      const char* str;
-      cuGetErrorString(code, &str);
-      char err[1024] = {{0}};
-      strcat(err, prefix);
-      strcat(err, str);
-      PyGILState_STATE gil_state;
-      gil_state = PyGILState_Ensure();
-      PyErr_SetString(PyExc_RuntimeError, err);
-      PyGILState_Release(gil_state);
-   }}
-}}
-
-#define CUDA_CHECK(ans) {{ gpuAssert((ans), __FILE__, __LINE__); }}
-
-typedef CUresult (*cuLaunchKernelEx_t)(const CUlaunchConfig* config, CUfunction f, void** kernelParams, void** extra);
-
-static cuLaunchKernelEx_t getLaunchKernelExHandle() {{
-  // Open the shared library
-  void* handle = dlopen("libcuda.so.1", RTLD_LAZY);
-  if (!handle) {{
-    PyErr_SetString(PyExc_RuntimeError, "Failed to open libcuda.so.1");
-    return NULL;
-  }}
-  // Clear any existing error
-  dlerror();
-  cuLaunchKernelEx_t cuLaunchKernelExHandle = (cuLaunchKernelEx_t)dlsym(handle, "cuLaunchKernelEx");
-  // Check for errors
-  const char *dlsym_error = dlerror();
-  if (dlsym_error) {{
-    PyErr_SetString(PyExc_RuntimeError, "Failed to retrieve cuLaunchKernelEx from libcuda.so.1");
-    return NULL;
-  }}
-  return cuLaunchKernelExHandle;
-}}
-
-static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas, int launch_cooperative_grid, int launch_cluster, int launch_pdl, int preferredClusterDimX, int preferredClusterDimY, int preferredClusterDimZ, int shared_memory, CUstream stream, CUfunction function, CUdeviceptr global_scratch, CUdeviceptr profile_scratch{", " + arg_decls if len(arg_decls) > 0 else ""}) {{
-  void *params[] = {{ {", ".join(params)} }};
-  if (gridX*gridY*gridZ > 0) {{
-    // 5 attributes that we can currently pass maximum
-    CUlaunchAttribute launchAttr[5];
-    static cuLaunchKernelEx_t cuLaunchKernelExHandle = NULL;
-    if (cuLaunchKernelExHandle == NULL) {{
-      cuLaunchKernelExHandle = getLaunchKernelExHandle();
-    }}
-    CUlaunchConfig config;
-    config.gridDimX = gridX * num_ctas;
-    config.gridDimY = gridY;
-    config.gridDimZ = gridZ;
-
-    config.blockDimX = 32 * num_warps;
-    config.blockDimY = 1;
-    config.blockDimZ = 1;
-    config.sharedMemBytes = shared_memory;
-    config.hStream = stream;
-    config.attrs = launchAttr;
-    int num_attrs = 0;
-
-    if (launch_pdl != 0) {{
-      CUlaunchAttribute pdlAttr = {{ .id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION, .value = 1}};
-      launchAttr[num_attrs] = pdlAttr;
-      ++num_attrs;
-    }}
-
-    if (launch_cooperative_grid != 0) {{
-      CUlaunchAttribute coopAttr = {{ .id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE, .value = 1}};
-      launchAttr[num_attrs] = coopAttr;
-      ++num_attrs;
-    }}
-
-    if (launch_cluster !=0 || num_ctas != 1 || preferredClusterDimX > 0) {{
-      // Only set CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for Triton's num_ctas path.
-      // For ctas_per_cga path (num_ctas == 1), PTX's .reqnctapercluster handles it.
-      if (num_ctas > 1) {{
-        CUlaunchAttribute clusterAttr = {{}};
-        clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-        clusterAttr.value.clusterDim.x = num_ctas;
-        clusterAttr.value.clusterDim.y = 1;
-        clusterAttr.value.clusterDim.z = 1;
-        launchAttr[num_attrs] = clusterAttr;
-        ++num_attrs;
-      }}
-
-      CUlaunchAttribute clusterSchedulingAttr = {{}};
-      clusterSchedulingAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
-      clusterSchedulingAttr.value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
-      launchAttr[num_attrs] = clusterSchedulingAttr;
-      ++num_attrs;
-    }}
-
-    #if CUDA_VERSION >= 12080
-    if (preferredClusterDimX > 0) {{
-      CUlaunchAttribute preferredClusterAttr = {{}};
-      preferredClusterAttr.id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
-      preferredClusterAttr.value.preferredClusterDim.x = preferredClusterDimX;
-      preferredClusterAttr.value.preferredClusterDim.y = preferredClusterDimY;
-      preferredClusterAttr.value.preferredClusterDim.z = preferredClusterDimZ;
-      launchAttr[num_attrs] = preferredClusterAttr;
-      ++num_attrs;
-    }}
-    #endif
-
-    // num_ctas == 16 is non-portable. Does work for H100 and B200 tho
-    config.numAttrs = num_attrs;
-    if (num_ctas == 16) {{
-      CUDA_CHECK(cuFuncSetAttribute(
-          function,
-          CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED,
-          1
-      ));
-    }}
-
-    CUDA_CHECK(cuLaunchKernelExHandle(&config, function, params, 0));
-  }}
-}}
-
-typedef struct _DevicePtrInfo {{
-    CUdeviceptr dev_ptr;
-    bool valid;
-}} DevicePtrInfo;
-
-static PyObject* data_ptr_str = NULL;
-static PyObject* py_tensor_map_type = NULL;
-static PyObject* tma_desc_cpu_ptr_str = NULL;
-
-static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
-  DevicePtrInfo ptr_info;
-  ptr_info.dev_ptr = 0;
-  ptr_info.valid = true;
-  if (PyLong_Check(obj)) {{
-    ptr_info.dev_ptr = PyLong_AsUnsignedLongLong(obj);
-    return ptr_info;
-  }}
-  if (obj == Py_None) {{
-    // valid nullptr
-    return ptr_info;
-  }}
-  PyObject *ret = PyObject_CallMethodNoArgs(obj, data_ptr_str);
-  if (!ret) {{
-    PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  if (!PyLong_Check(ret)) {{
-    PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
-    ptr_info.valid = false;
-    goto cleanup;
-  }}
-  ptr_info.dev_ptr = PyLong_AsUnsignedLongLong(ret);
-  if(!ptr_info.dev_ptr)
-    return ptr_info;
-  uint64_t dev_ptr;
-  int status = cuPointerGetAttribute(&dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, ptr_info.dev_ptr);
-  if (status == CUDA_ERROR_INVALID_VALUE) {{
-      PyErr_Format(PyExc_ValueError,
-                   "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
-      ptr_info.valid = false;
-  }} else if (status != CUDA_SUCCESS) {{
-      CUDA_CHECK(status);  // Catch any other cuda API errors
-      ptr_info.valid = false;
-  }}
-  ptr_info.dev_ptr = dev_ptr;
-cleanup:
-  Py_XDECREF(ret);
-  return ptr_info;
-
-}}
-
-static inline CUtensorMap* getTmaDesc(PyObject *obj) {{
-  if (sizeof(CUtensorMap*) != 8) {{
-    PyErr_SetString(PyExc_SystemError, "getTmaDesc() requires 64-bit compilation");
-    return NULL;
-  }}
-
-  PyObject* attr = PyObject_GetAttrString(obj, "tma_desc_cpu_ptr");
-  if (attr) {{
-    PyObject *method_ret = PyObject_CallMethodNoArgs(obj, tma_desc_cpu_ptr_str);
-    if (method_ret) {{
-      if (!PyLong_Check(method_ret)) {{
-        PyErr_SetString(PyExc_TypeError, "tma_desc_cpu_ptr() must return 64-bit int");
-        Py_DECREF(method_ret);
-        return NULL;
-      }}
-      uint64_t ptr_as_uint = PyLong_AsUnsignedLongLong(method_ret);
-      Py_DECREF(method_ret);
-      if (!ptr_as_uint) {{
-        PyErr_SetString(PyExc_ValueError, "received NULL ptr from tma_desc_cpu_ptr()");
-        return NULL;
-      }}
-      if (ptr_as_uint % 64 != 0) {{
-        PyErr_SetString(PyExc_ValueError, "tma_desc_cpu_ptr() must be 64-byte aligned");
-        return NULL;
-      }}
-      return (CUtensorMap*)(ptr_as_uint);
-    }}
-  }} else {{
-    PyErr_Clear();
-  }}
-  if (Py_TYPE(obj) != (PyTypeObject*)py_tensor_map_type) {{
-      PyErr_Format(PyExc_TypeError, "object must be of type PyCUtensorMap, got %s", Py_TYPE(obj)->tp_name);
-      return NULL;
-  }}
-
-  CUtensorMap* map = &((PyCUtensorMapObject*)obj)->tensorMap;
-  uintptr_t align_128 = (uintptr_t)map & (128 - 1);
-  if (align_128 != 0) {{
-    PyErr_Format(PyExc_ValueError, "CUtensorMap must be aligned to 128B, but got (&map) mod 128 = %ld", align_128);
-    return NULL;
-  }}
-  return map;
-}}
-
-static void ensureCudaContext() {{
-  CUcontext pctx;
-  CUDA_CHECK(cuCtxGetCurrent(&pctx));
-  if (!pctx) {{
-    // Ensure device context.
-    CUdevice device;
-    CUDA_CHECK(cuDeviceGet(&device, 0));
-    CUDA_CHECK(cuDevicePrimaryCtxRetain(&pctx, device));
-    CUDA_CHECK(cuCtxSetCurrent(pctx));
-  }}
-}}
-
-static uint16_t pack_fp16(double f) {{
-    uint16_t result;
-    // from https://github.com/python/pythoncapi-compat
-#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && !defined(PYPY_VERSION)
-    _PyFloat_Pack2(f, (unsigned char*)&result, 1);
-#else
-    PyFloat_Pack2(f, (unsigned char*)&result, 1);
-#endif
-    return result;
-}}
-
-static uint16_t pack_bf16(double f) {{
-    float f32 = (float)f;
-    uint32_t u32 = *(uint32_t*)&f32;
-    return (uint16_t)(u32 >> 16);
-}}
-
-static uint32_t pack_fp32(double f) {{
-    float f32 = (float)f;
-    return *(uint32_t*)&f32;
-}}
-
-static uint64_t pack_fp64(double f) {{
-    return *(uint64_t*)&f;
-}}
-
-static PyObject* launch(PyObject* self, PyObject* args) {{
-  // ensure cuda context is valid before calling any CUDA APIs, e.g. before getPointer calls cuPointerGetAttributes
-  ensureCudaContext();
-
-  int gridX, gridY, gridZ;
-  uint64_t _stream;
-  uint64_t _function;
-  int launch_cooperative_grid;
-  int launch_cluster;
-  int launch_pdl;
-  PyObject *launch_enter_hook = NULL;
-  PyObject *launch_exit_hook = NULL;
-  PyObject *kernel_metadata = NULL;
-  PyObject *launch_metadata = NULL;
-  PyObject *global_scratch_obj = NULL;
-  PyObject *profile_scratch_obj = NULL;
-  {newline.join([f"{_extracted_type(ty)} _arg{i};" for i, ty in signature.items()])}
-  if(!PyArg_ParseTuple(args, \"{format}\", &gridX, &gridY, &gridZ,
-                                           &_stream, &_function, &launch_cooperative_grid, &launch_cluster, &launch_pdl, &global_scratch_obj, &profile_scratch_obj,
-                                           &kernel_metadata, &launch_metadata,
-                                           &launch_enter_hook, &launch_exit_hook{args_list})) {{
-    return NULL;
-  }}
-
-  int num_warps, num_ctas, shared_memory, preferredClusterDimX, preferredClusterDimY, preferredClusterDimZ;
-  if (!PyArg_ParseTuple(kernel_metadata, \"iiiiii\", &num_warps, &num_ctas, &shared_memory, &preferredClusterDimX, &preferredClusterDimY, &preferredClusterDimZ)) {{
-    PyErr_SetString(PyExc_TypeError, "kernel_metadata must be a tuple");
-    return NULL;
-  }}
-
-  // extract launch metadata
-  if (launch_enter_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_enter_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  CUdeviceptr global_scratch = 0;
-  if (global_scratch_obj != Py_None) {{
-    DevicePtrInfo global_scratch_info = getPointer(global_scratch_obj, -1);
-    if (!global_scratch_info.valid) {{
-      return NULL;
-    }}
-    global_scratch = global_scratch_info.dev_ptr;
-  }}
-
-  CUdeviceptr profile_scratch = 0;
-  if (profile_scratch_obj != Py_None) {{
-    DevicePtrInfo profile_scratch_info = getPointer(profile_scratch_obj, -1);
-    if (!profile_scratch_info.valid) {{
-      return NULL;
-    }}
-    profile_scratch = profile_scratch_info.dev_ptr;
-  }}
-
-  // raise exception asap
-  {newline.join(ptr_decls)}
-  {newline.join(tma_decls)}
-  {newline.join(float_storage_decls)}
-  Py_BEGIN_ALLOW_THREADS;
-  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid, launch_cluster, launch_pdl, preferredClusterDimX, preferredClusterDimY, preferredClusterDimZ, shared_memory, (CUstream)_stream, (CUfunction)_function, global_scratch, profile_scratch{", " + ", ".join(internal_args_list) if len(internal_args_list) > 0 else ""});
-  Py_END_ALLOW_THREADS;
-  if (PyErr_Occurred()) {{
-    return NULL;
-  }}
-
-  if(launch_exit_hook != Py_None){{
-    PyObject* ret = PyObject_CallOneArg(launch_exit_hook, launch_metadata);
-    if (!ret)
-      return NULL;
-    Py_DECREF(ret);
-  }}
-
-  Py_RETURN_NONE;
-}}
-
-static PyMethodDef ModuleMethods[] = {{
-  {{"launch", launch, METH_VARARGS, "Entry point for all kernels with this signature"}},
-  {{NULL, NULL, 0, NULL}} // sentinel
-}};
-
-static struct PyModuleDef ModuleDef = {{
-  PyModuleDef_HEAD_INIT,
-  \"__triton_launcher\",
-  NULL, //documentation
-  -1, //size
-  ModuleMethods
-}};
-
-PyMODINIT_FUNC PyInit___triton_launcher(void) {{
-  data_ptr_str = PyUnicode_InternFromString("data_ptr");
-  if(data_ptr_str == NULL) {{
-    return NULL;
-  }}
-  PyObject* driver_mod = PyImport_ImportModule("triton.backends.nvidia.driver");
-  if (driver_mod == NULL) {{
-    return NULL;
-  }}
-  py_tensor_map_type = PyObject_GetAttrString(driver_mod, "PyCUtensorMap");
-  if (py_tensor_map_type == NULL) {{
-    return NULL;
-  }}
-  tma_desc_cpu_ptr_str = PyUnicode_InternFromString("tma_desc_cpu_ptr");
-  if(tma_desc_cpu_ptr_str == NULL) {{
-    return NULL;
-  }}
-
-  PyObject *m = PyModule_Create(&ModuleDef);
-  if(m == NULL) {{
-    return NULL;
-  }}
-  PyModule_AddFunctions(m, ModuleMethods);
-  return m;
-}}
-"""
-    return src
+# The TMA dtype enum values are slightly different on host vs device...
+TMA_DTYPE_DEVICE_TO_HOST = dict((i, i) for i in range(16))
+TMA_DTYPE_DEVICE_TO_HOST[8] = 10
+TMA_DTYPE_DEVICE_TO_HOST[9] = 8
+TMA_DTYPE_DEVICE_TO_HOST[10] = 9
 
 
 class TmaDescKernelParam:
@@ -676,13 +221,6 @@ class TmaDescKernelParam:
     # Return a CUtensorMap* pointer in host memory
     def tma_desc_cpu_ptr(self):
         return self.desc.data_ptr()
-
-
-# The TMA dtype enum values are slightly different on host vs device...
-TMA_DTYPE_DEVICE_TO_HOST = dict((i, i) for i in range(16))
-TMA_DTYPE_DEVICE_TO_HOST[8] = 10
-TMA_DTYPE_DEVICE_TO_HOST[9] = 8
-TMA_DTYPE_DEVICE_TO_HOST[10] = 9
 
 
 def make_tensordesc_arg(arg, metadata):
@@ -758,15 +296,19 @@ def wrap_handle_tensordesc(launcher, signature, tensordesc_meta):
         tensordesc_meta = [None] * len(tensordesc_indices)
 
     def inner(*args):
-        final_args = list(args[:_BASE_ARGS_FORMAT_LEN])
+        base_args = args[:-1]
+        kernel_args = args[-1]
+
+        final_kernel_args = []
         tensordesc_idx = 0
-        for i, arg in enumerate(args[_BASE_ARGS_FORMAT_LEN:]):
+        for i, arg in enumerate(kernel_args):
             if i in tensordesc_indices:
-                final_args.extend(make_tensordesc_arg(arg, tensordesc_meta[tensordesc_idx]))
+                final_kernel_args.extend(make_tensordesc_arg(arg, tensordesc_meta[tensordesc_idx]))
                 tensordesc_idx += 1
             else:
-                final_args.append(arg)
-        return launcher(*final_args)
+                final_kernel_args.append(arg)
+
+        return launcher(*base_args, final_kernel_args)
 
     return inner
 
@@ -779,19 +321,18 @@ class CudaLauncher(object):
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
-        if knobs.nvidia.use_no_compile_launcher:
-            from triton.backends.nvidia.ctypes_launcher import make_ctypes_launcher
-            launch_fn = make_ctypes_launcher(constants, signature, tensordesc_meta)
-        else:
-            src = make_launcher(constants, signature, tensordesc_meta)
-            mod = compile_module_from_src(
-                src=src,
-                name="__triton_launcher",
-                library_dirs=library_dirs(),
-                include_dirs=include_dirs,
-                libraries=libraries,
-            )
-            launch_fn = mod.launch
+
+        launcher = triton.runtime.driver.active.utils.launch
+        expanded_signature = expand_signature(signature.values(), tensordesc_meta)
+        self.arg_annotations = annotate_arguments(expanded_signature)
+        self.kernel_signature = make_kernel_signature(expanded_signature)
+        self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
+        self.global_scratch_size = metadata.global_scratch_size
+        self.global_scratch_align = metadata.global_scratch_align
+        self.profile_scratch_size = metadata.profile_scratch_size
+        self.profile_scratch_align = metadata.profile_scratch_align
+        self.launch_cooperative_grid = metadata.launch_cooperative_grid
+        self.launch_pdl = metadata.launch_pdl
 
         # Distinguish between Triton's way and TLX's way by checking if ctas_per_cga
         # was explicitly set:
@@ -800,26 +341,12 @@ class CudaLauncher(object):
         #   Grid equals total CTAs, and ctas_per_cga regroups them into clusters.
         # When ctas_per_cga is set, num_ctas must be 1 to prevent multiplicative behavior.
         if getattr(metadata, "ctas_per_cga", None) is not None:
-            # TLX/CUDA way: ctas_per_cga defines cluster shape, num_ctas must be 1
             self.num_ctas = 1
-            # When using ctas_per_cga, always enable cluster launch.
-            # Use True since the C code checks "launch_cluster != 0".
-            self.launch_cluster = True
         else:
-            # Triton's way: use num_ctas for multiplicative cluster semantics.
-            # Note: cluster launch is enabled by "num_ctas != 1" in the C code,
-            # so launch_cluster can be False here.
             self.num_ctas = metadata.num_ctas
-            self.launch_cluster = metadata.launch_cluster
-        self.launch = wrap_handle_tensordesc(launch_fn, signature, tensordesc_meta)
-        self.global_scratch_size = metadata.global_scratch_size
-        self.global_scratch_align = metadata.global_scratch_align
-        self.profile_scratch_size = metadata.profile_scratch_size
-        self.profile_scratch_align = metadata.profile_scratch_align
-        self.launch_cooperative_grid = metadata.launch_cooperative_grid
-        self.launch_pdl = metadata.launch_pdl
 
-    def __call__(self, gridX, gridY, gridZ, stream, function, *args):
+    def __call__(self, gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
+                 launch_exit_hook, *args):
 
         def allocate_scratch(size, align, allocator):
             if size > 0:
@@ -832,19 +359,10 @@ class CudaLauncher(object):
         global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
         profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
                                            _allocation._profile_allocator)
-        self.launch(
-            gridX,
-            gridY,
-            gridZ,
-            stream,
-            function,
-            self.launch_cooperative_grid,
-            self.launch_cluster,
-            self.launch_pdl,
-            global_scratch,
-            profile_scratch,
-            *args,
-        )
+
+        self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
+                    kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, global_scratch,
+                    profile_scratch, self.arg_annotations, self.kernel_signature, args)
 
 
 class CudaDriver(GPUDriver):


### PR DESCRIPTION
Summary:

Refactors `CudaLauncher.__init__` to derive kernel_signature (the byte-array used by the shared variadic launcher's per-arg type dispatch) from the Level 0 metadata schema (make_launch_metadata() output), instead of independently reconstructing it from src.signature.

This makes the Level 0 schema the single source of truth for the kernel's type dispatch in the shared launcher — the same schema that will drive AOT launcher generation. Both JIT and AOT paths now derive their type information from the same canonical description.

### Background
Today, the Triton NVIDIA backend has two independent paths for extracting kernel argument type information:

Shared variadic launcher (D103454938): CudaLauncher.__init__ calls expand_signature(src.signature) → make_kernel_signature() to produce kernel_signature bytes for runtime type dispatch.
Level 0 schema: make_launch_metadata(metadata, src) computes a versioned JSON dict with an args[] array containing each kernel parameter's type — intended as the canonical ABI description.
These two paths compute equivalent results from the same inputs, but independently. This means schema evolution requires updating both paths, and there's no guarantee they stay in sync.

Reviewed By: htyu

Differential Revision: D103954493


