### PR TITLE
[AutoWS] Fix addmm scheduling bug

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1593,7 +1593,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // the use chain. Without this guard, load-user scheduling from
   // descriptor_load (m/Di metadata) transitively pulls the entire softmax
   // chain into the reduction partition.
-  if (defaultPartition && defaultPartition != reductionPartition) {
+  if (defaultPartition &&
+      (!layout.reductionPartition || defaultPartition != reductionPartition)) {
     for (Operation *loadOrAlloc : loadsAndAllocs) {
       scf::ForOp parentLoop = loadOrAlloc->getParentOfType<scf::ForOp>();
       if (!parentLoop) {


### PR DESCRIPTION
Fixes a scheduling bug where with the pattern:

```
      %bias = tt.descriptor_load %bias_desc[%offs_cm, %offs_cn] {ttg.partition = array<i32: 3>} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked> loc(#loc75)
      %bias_39 = arith.extf %bias : tensor<128x128xf16, #blocked> to tensor<128x128xf32, #blocked> loc(#loc76)
```

The `arith.extf` was being assigned to the load partition because step 4 incorrectly detecting the backwards pattern.
