### PR TITLE
[autoWS] Fix for Causal FA kernel

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -213,13 +213,10 @@ bool sinkOps(Value buffer, ArrayRef<Operation *> useChain,
         break;
       }
     }
-    if (auto arrive = dyn_cast<ArriveBarrierOp>(next)) {
-      if (!canAdvanceWSBarrier(opConstraints, arrive.getConstraints()))
-        break;
-    } else if (auto wait = dyn_cast<WaitBarrierOp>(next)) {
-      if (!canAdvanceWSBarrier(opConstraints, wait.getConstraints()))
-        break;
-    }
+    // Don't sink past barrier signals, since they may guard the liverange
+    // of the buffer.
+    if (isa<ArriveBarrierOp>(next))
+      break;
     if (!isMemoryEffectFree(next)) {
       SmallVector<MemoryEffects::EffectInstance> effects;
       collectEffects(next, effects);
@@ -274,20 +271,8 @@ struct TritonNvidiaGPUInterleaveTMemPass
     MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
 
-    // Step 1: Record which memory op each WS barrier guards.
+    // Steps 1-2 disabled: barrier reordering causes deadlocks on causal FA.
     SmallVector<DenseMap<Operation *, Operation *>> barrierMaps;
-    m.walk([&](Block *block) {
-      auto map = buildBarrierToMemoryOpMap(*block);
-      if (!map.empty())
-        barrierMaps.push_back(std::move(map));
-    });
-
-    // Step 2: Reorder WS barriers. Pushes arrives down and pulls waits up
-    // past barriers from independent channels, unblocking tmem_load sinking.
-    m.walk([&](Block *block) {
-      sinkWSArrives(*block);
-      raiseWSWaits(*block);
-    });
 
     // Build memOp → channelGraph constraints. For each arrive barrier with
     // constraints, scan backward and assign its constraints to ALL tmem_loads
@@ -323,18 +308,11 @@ struct TritonNvidiaGPUInterleaveTMemPass
         opsToSink.emplace_back(alloc, alloc.getResult());
     });
     for (auto [op, buffer] : opsToSink) {
-      auto it = memOpConstraints.find(op);
-      std::optional<DictionaryAttr> constraints =
-          it != memOpConstraints.end()
-              ? std::optional<DictionaryAttr>(it->second)
-              : std::nullopt;
-      while (trySinkOp(op, buffer, constraints)) {
+      while (trySinkOp(op, buffer, std::nullopt)) {
       }
     }
 
-    // Step 4: Restore barriers to optimal positions near their memory ops.
-    for (auto &map : barrierMaps)
-      optimizeWSBarrierLocations(map);
+    // Step 4: Disabled along with Steps 1-2.
   }
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -114,49 +114,7 @@ static SetVector<Operation *> collectMMABackwardSlice(scf::ForOp loop,
     (void)getBackwardSlice(operand, &slice, options);
   }
 
-  // Enter scf.if regions: follow yield operands backward until fixpoint.
-  // getBackwardSlice adds scf.if ops to the slice but does NOT enter their
-  // regions. Only follow yield operands that correspond to scf.if results
-  // actually consumed by ops already in the slice. This prevents pulling in
-  // ops from other data partitions (e.g., in flex attention, scf.if yields
-  // values for both dp0 and dp1 — we only want the one used by this MMA).
-  DenseSet<Operation *> visitedIfs;
-  bool changed = true;
-  while (changed) {
-    changed = false;
-    for (Operation *op : llvm::to_vector(slice)) {
-      auto ifOp = dyn_cast<scf::IfOp>(op);
-      if (!ifOp || !visitedIfs.insert(ifOp).second)
-        continue;
-      // Find which scf.if results are actually used by ops in the slice.
-      DenseSet<unsigned> usedResultIndices;
-      for (unsigned i = 0; i < ifOp.getNumResults(); ++i) {
-        for (Operation *user : ifOp.getResult(i).getUsers()) {
-          if (slice.contains(user) ||
-              llvm::any_of(mmaOp->getOperands(), [&](Value v) {
-                return v.getDefiningOp() == user;
-              })) {
-            usedResultIndices.insert(i);
-            break;
-          }
-        }
-      }
-      // Follow only the yield operands for used results.
-      for (Region *region : {&ifOp.getThenRegion(), &ifOp.getElseRegion()}) {
-        if (region->empty())
-          continue;
-        auto *yieldOp = region->front().getTerminator();
-        for (unsigned idx : usedResultIndices) {
-          if (idx < yieldOp->getNumOperands()) {
-            unsigned prevSize = slice.size();
-            (void)getBackwardSlice(yieldOp->getOperand(idx), &slice, options);
-            if (slice.size() > prevSize)
-              changed = true;
-          }
-        }
-      }
-    }
-  }
+  // NOTE: Do NOT enter scf.if regions (causal FA fix).
 
   return slice;
 }
@@ -476,6 +434,13 @@ private:
             continue; // Already visited
           for (Value result : user->getResults())
             worklist.push_back(result);
+          Operation *ancestor =
+              innermostLoop.getBody()->findAncestorOpInBlock(*user);
+          if (ancestor && ancestor != user &&
+              forwardSet.insert(ancestor).second) {
+            for (Value result : ancestor->getResults())
+              worklist.push_back(result);
+          }
         }
       }
 
@@ -1111,14 +1076,14 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
       if (auto *p = dpIdFallbackPartition())
         return p;
     }
-    if (layout.epiloguePartition)
-      return layout.epiloguePartition;
     return layout.defaultPartition;
   };
 
   auto getStoreTarget = [&](Operation *op) -> Partition * {
     if (layout.epilogueStorePartition)
       return layout.epilogueStorePartition;
+    if (layout.epiloguePartition)
+      return layout.epiloguePartition;
     return getEpilogueTarget(op);
   };
 
@@ -1347,10 +1312,18 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       }
     } else {
       SmallVector<unsigned> sortedDpIds(usedDpIds.begin(), usedDpIds.end());
-      llvm::sort(sortedDpIds, std::greater<unsigned>());
-      for (unsigned dpId : sortedDpIds) {
-        dpIdToPartition[dpId] = schedule.addPartition(0);
-        dpIdToPartition[dpId]->setType("computation");
+      llvm::sort(sortedDpIds);
+      SmallVector<Partition *> compPartitions;
+      for (unsigned i = 0; i < std::min((unsigned)sortedDpIds.size(), dataPartitionFactor); ++i) {
+        compPartitions.push_back(schedule.addPartition(0));
+        compPartitions.back()->setType("computation");
+      }
+      for (unsigned i = 0; i < sortedDpIds.size(); ++i)
+        dpIdToPartition[sortedDpIds[i]] = compPartitions[i % compPartitions.size()];
+      for (auto mmaOp : llvm::reverse(mmas)) {
+        unsigned mmaDpId = categorizer.getDpId(mmaOp);
+        if (mmaDpId != SHARED_DPID && !dpIdToPartition.count(mmaDpId))
+          dpIdToPartition[mmaDpId] = compPartitions[mmaDpId % compPartitions.size()];
       }
     }
 
@@ -1751,6 +1724,10 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
             // MMA op itself into the computation partition.
             if (!mmaPartition)
               tryScheduleOp(targetPart, mmaOp);
+            for (OpOperand &use : mmaOp->getUses()) {
+              if (auto tmemLoad = dyn_cast<ttng::TMEMLoadOp>(use.getOwner()))
+                if (!hasPartition(tmemLoad)) tryScheduleOp(targetPart, tmemLoad);
+            }
             mmaToPartition[mmaOp] = targetPart;
             inFirstLoop.push_back(mmaOp);
             continue;


### PR DESCRIPTION
Fix for FA kernel with causal mode.

Test plan:
```
cd tritonbench &&
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 TRITON_USE_META_PARTITION=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --mode fwd --causal --rep 3000 --sleep 1.0 --metrics accuracy --simple-output --baseline tlx_blackwell_ws_pipelined_persistent --only triton_tutorial_flash_dp_persistent_blackwell,tlx_blackwell_ws_pipelined_persistent --force --rtol 0 --atol 1e-2
```