### PR TITLE
[AutoWS] [ADDMM] Restore layout removal pass based on SMEM budget

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -729,9 +729,7 @@ class CUDABackend(BaseBackend):
         # Budget-aware layout conversion elimination — runs last to ensure
         # converts whose scratch would exceed SMEM budget are eliminated
         # after all other passes that may introduce layout conversions.
-        # TODO(njriasan): Re-enable once propagateSrcEncodingAndErase handles
-        # scf::ForOp/WhileOp loop-carried values correctly.
-        passes.ttgpuir.add_remove_layout_conversions(pm, 0)
+        passes.ttgpuir.add_remove_layout_conversions(pm, smem_budget)
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()


### PR DESCRIPTION
Restores the logic that disabled ADDMM based on the SMEM budget. The tests mentioned in the prior diff: [D101982801](https://www.internalfb.com/diff/D101982801) are not failing at all based on this change (most likely the convert layout change in the diff fully works).