### PR TITLE
[autoWS][CI] Add B200 Buck target for test_autows_flash_attention.py

### DIFF
--- a/third_party/nvidia/hopper/run_all.sh
+++ b/third_party/nvidia/hopper/run_all.sh
@@ -27,6 +27,7 @@ fi
 echo "Running core Triton python unit tests"
 pytest python/test/unit/language/test_tutorial09_warp_specialization.py
 pytest python/test/unit/language/test_autows_addmm.py
+pytest python/test/unit/language/test_autows_flash_attention.py
 
 echo "Run autoWS tutorial kernels"
 echo "Verifying correctness of FA tutorial kernels"


### PR DESCRIPTION
Summary:
The CI skipped `pytest python/test/unit/language/test_autows_flash_attention.py`, and this is probably because test_autows_flash_attention.py requires Blackwell GPU hardware (pytest.mark.skipif(not is_blackwell())) while it was included in the triton_pytest_directory("unit/language") target which defaults to A100.

This diff adds a dedicated py_autows_flash_attention_blackwell_test target with cuda_generation="B200" and CUDA 12.8, matching the existing pattern for py_autows_addmm_blackwell_test.

Differential Revision: D103963531


