### PR TITLE
[AutoWS] [WSBarrier] Add safety checks for WSBarrier + fix arrival placement

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -349,8 +349,8 @@ static void lowerTMACopy(PartitionBuilder &b, Partition &loadPartition,
   Value truePred = b.boolCst(true);
   if (auto load = dyn_cast<DescriptorLoadOp>(op)) {
     b.createInto<ttng::AsyncTMACopyGlobalToLocalOp>(
-        loadPartition, stageCluster, load.getDesc(), load.getIndices(),
-        barrier, view, truePred);
+        loadPartition, stageCluster, load.getDesc(), load.getIndices(), barrier,
+        view, truePred);
   } else {
     auto gather = cast<DescriptorGatherOp>(op);
     b.createInto<ttng::AsyncTMAGatherOp>(

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -1431,7 +1431,8 @@ void assignPartitionsForOpsWithNoUse(Graph *graph) {
 
 namespace {
 struct PartitionScheduling
-    : public mlir::triton::gpu::impl::TritonGPUPartitionSchedulingBase<PartitionScheduling> {
+    : public mlir::triton::gpu::impl::TritonGPUPartitionSchedulingBase<
+          PartitionScheduling> {
   using TritonGPUPartitionSchedulingBase::TritonGPUPartitionSchedulingBase;
 
   void runOnOperation() override {

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -457,8 +457,8 @@ LogicalResult AsyncTMACopyGlobalToLocalOp::verify() {
                                   getResult().getType())))
     return failure();
   if (failed(verifyTMAMode(*this,
-                          isIm2Col ? TensorMode::IM2COL : TensorMode::TILED,
-                          getCoord(), getOffsets())))
+                           isIm2Col ? TensorMode::IM2COL : TensorMode::TILED,
+                           getCoord(), getOffsets())))
     return failure();
   return success();
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -213,13 +213,8 @@ bool sinkOps(Value buffer, ArrayRef<Operation *> useChain,
         break;
       }
     }
-    if (auto arrive = dyn_cast<ArriveBarrierOp>(next)) {
-      if (!canAdvanceWSBarrier(opConstraints, arrive.getConstraints()))
-        break;
-    } else if (auto wait = dyn_cast<WaitBarrierOp>(next)) {
-      if (!canAdvanceWSBarrier(opConstraints, wait.getConstraints()))
-        break;
-    }
+    if (!canAdvanceWSBarrier(opConstraints, next))
+      break;
     if (!isMemoryEffectFree(next)) {
       SmallVector<MemoryEffects::EffectInstance> effects;
       collectEffects(next, effects);
@@ -262,6 +257,11 @@ bool trySinkOp(Operation *op, Value buffer,
   return sinkOps(buffer, useChain, opConstraints);
 }
 
+bool hasTMEMLoad(Block *block) {
+  return llvm::any_of(*block,
+                      [](Operation &op) { return isa<TMEMLoadOp>(op); });
+}
+
 } // anonymous namespace
 
 struct TritonNvidiaGPUInterleaveTMemPass
@@ -274,9 +274,19 @@ struct TritonNvidiaGPUInterleaveTMemPass
     MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
 
+    bool hasAnyTMEMLoad = false;
+    m.walk([&](TMEMLoadOp) {
+      hasAnyTMEMLoad = true;
+      return WalkResult::interrupt();
+    });
+    if (!hasAnyTMEMLoad)
+      return;
+
     // Step 1: Record which memory op each WS barrier guards.
     SmallVector<DenseMap<Operation *, Operation *>> barrierMaps;
     m.walk([&](Block *block) {
+      if (!hasTMEMLoad(block))
+        return;
       auto map = buildBarrierToMemoryOpMap(*block);
       if (!map.empty())
         barrierMaps.push_back(std::move(map));
@@ -285,6 +295,8 @@ struct TritonNvidiaGPUInterleaveTMemPass
     // Step 2: Reorder WS barriers. Pushes arrives down and pulls waits up
     // past barriers from independent channels, unblocking tmem_load sinking.
     m.walk([&](Block *block) {
+      if (!hasTMEMLoad(block))
+        return;
       sinkWSArrives(*block);
       raiseWSWaits(*block);
     });
@@ -296,18 +308,14 @@ struct TritonNvidiaGPUInterleaveTMemPass
     // channelGraph, not just the one nearest to the arrive.
     DenseMap<Operation *, DictionaryAttr> memOpConstraints;
     m.walk([&](ArriveBarrierOp arrive) {
+      if (!hasTMEMLoad(arrive->getBlock()))
+        return;
       auto constraints = arrive.getConstraints();
-      if (!constraints)
+      if (!hasWSBarrierConstraints(constraints))
         return;
       DictionaryAttr dict = *constraints;
       for (auto *cur = arrive->getPrevNode(); cur; cur = cur->getPrevNode()) {
-        if (isa<WaitBarrierOp>(cur) &&
-            !canAdvanceWSBarrier(constraints,
-                                 cast<WaitBarrierOp>(cur).getConstraints()))
-          break;
-        if (isa<ArriveBarrierOp>(cur) &&
-            !canAdvanceWSBarrier(constraints,
-                                 cast<ArriveBarrierOp>(cur).getConstraints()))
+        if (!canAdvanceWSBarrier(constraints, cur))
           break;
         if (isa<TMEMLoadOp>(cur))
           memOpConstraints[cur] = dict;

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -1,7 +1,6 @@
 import expecttest
 import importlib.util
 import itertools
-import os
 import re
 import shutil
 import pathlib

--- a/python/tutorials/fused-attention-ws-device-tma.py
+++ b/python/tutorials/fused-attention-ws-device-tma.py
@@ -823,15 +823,9 @@ def _attn_bwd_dkdv(
     curr_m = start_m
     step_m = BLOCK_M1
     if warp_specialize:
-        for blk_idx in tl.range(
-                0,
-                num_steps,
-                warp_specialize=True,
-                merge_epilogue_to_computation=True,
-                tmem_alloc_algo=2,
-                smem_alloc_algo=1,
-                smem_budget=200000, #231000,
-        ):
+        for blk_idx in tl.range(0, num_steps, warp_specialize=True, merge_epilogue_to_computation=True,
+                                tmem_alloc_algo=2, smem_alloc_algo=1, smem_budget=200000,  #231000,
+                                ):
             dk, dv, curr_m = _attn_bwd_dkdv_inner(
                 dk,
                 dv,
@@ -1246,15 +1240,9 @@ def _attn_bwd_persist(
         block_shape=[BLOCK_M1],
     )
 
-    for _ in tl.range(
-            0,
-            tiles_per_sm,
-            warp_specialize=True,
-            merge_epilogue_to_computation=True,
-            tmem_alloc_algo=2,
-            smem_alloc_algo=1,
-            smem_budget=200000, #231000,
-    ):
+    for _ in tl.range(0, tiles_per_sm, warp_specialize=True, merge_epilogue_to_computation=True, tmem_alloc_algo=2,
+                      smem_alloc_algo=1, smem_budget=200000,  #231000,
+                      ):
         pid = tile_idx % n_tile_num
         bhid = tile_idx // n_tile_num
         _attn_bwd_core(
@@ -1690,7 +1678,7 @@ BATCH, N_HEADS = 4, 32
 configs = []
 for HEAD_DIM in [128]:  # 64, 128]:
     for baseVariant in ["ws_persistent"]:
-        for mode in ["bwd"]:#"fwd", "bwd"]:
+        for mode in ["bwd"]:  #"fwd", "bwd"]:
             configs.append(
                 triton.testing.Benchmark(
                     x_names=["N_CTX"],

--- a/test/NVWS/ops.mlir
+++ b/test/NVWS/ops.mlir
@@ -113,22 +113,22 @@ tt.func @token_producer_consumer() {
 tt.func @token_with_ws_constraints() {
 
   // CHECK: nvws.producer_acquire
-  // CHECK-SAME: constraints = {dstTask = 1 : i32}
+  // CHECK-SAME: constraints = {WSBarrier = {dstTask = 1 : i32}}
   // CHECK: nvws.producer_commit
-  // CHECK-SAME: constraints = {dstTask = 1 : i32}
+  // CHECK-SAME: constraints = {WSBarrier = {dstTask = 1 : i32}}
   // CHECK: nvws.consumer_wait
-  // CHECK-SAME: constraints = {dstTask = 0 : i32}
+  // CHECK-SAME: constraints = {WSBarrier = {dstTask = 0 : i32}}
   // CHECK: nvws.consumer_release
-  // CHECK-SAME: constraints = {dstTask = 0 : i32}
+  // CHECK-SAME: constraints = {WSBarrier = {dstTask = 0 : i32}}
 
   %0 = nvws.create_token {loadType = 1 : i32, numBuffers = 3 : i32} : tensor<3x!nvws.token>
 
   %c0_i32 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 0 : i32
   %false = arith.constant {async_task_id = dense<0> : vector<1xi32>} false
 
-  nvws.producer_acquire %0, %c0_i32, %false {async_task_id = dense<0> : vector<1xi32>, constraints = {dstTask = 1 : i32}} : tensor<3x!nvws.token>, i32, i1
-  nvws.producer_commit %0, %c0_i32 {async_task_id = dense<0> : vector<1xi32>, constraints = {dstTask = 1 : i32}} : tensor<3x!nvws.token>, i32
-  nvws.consumer_wait %0, %c0_i32, %false {async_task_id = dense<1> : vector<1xi32>, constraints = {dstTask = 0 : i32}} : tensor<3x!nvws.token>, i32, i1
-  nvws.consumer_release %0, %c0_i32 {async_task_id = dense<1> : vector<1xi32>, constraints = {dstTask = 0 : i32}} : tensor<3x!nvws.token>, i32
+  nvws.producer_acquire %0, %c0_i32, %false {async_task_id = dense<0> : vector<1xi32>, constraints = {WSBarrier = {dstTask = 1 : i32}}} : tensor<3x!nvws.token>, i32, i1
+  nvws.producer_commit %0, %c0_i32 {async_task_id = dense<0> : vector<1xi32>, constraints = {WSBarrier = {dstTask = 1 : i32}}} : tensor<3x!nvws.token>, i32
+  nvws.consumer_wait %0, %c0_i32, %false {async_task_id = dense<1> : vector<1xi32>, constraints = {WSBarrier = {dstTask = 0 : i32}}} : tensor<3x!nvws.token>, i32, i1
+  nvws.consumer_release %0, %c0_i32 {async_task_id = dense<1> : vector<1xi32>, constraints = {WSBarrier = {dstTask = 0 : i32}}} : tensor<3x!nvws.token>, i32
   tt.return
 }

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -116,6 +116,27 @@ tt.func @arrive_barrier(%arg0: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutab
   tt.return
 }
 
+// CHECK-LABEL: @arrive_restore_after_operand_defs
+tt.func @arrive_restore_after_operand_defs(
+    %arg0: !ttg.memdesc<1x1xi64, #barrier_shared, #smem, mutable>) {
+  %true = arith.constant true
+  %c0 = arith.constant 0 : i32
+  %cst = arith.constant dense<0.0> : tensor<128x128xf32, #linear128>
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.tmem_store
+  ttng.tmem_store %cst, %alloc, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  // CHECK-NEXT: [[BAR:%.+]] = ttg.memdesc_index
+  %bar = ttg.memdesc_index %arg0[%c0] : !ttg.memdesc<1x1xi64, #barrier_shared, #smem, mutable> -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %use0 = arith.addi %c0, %c0 : i32
+  // CHECK-NEXT: ttng.arrive_barrier [[BAR]], 1
+  ttng.arrive_barrier %bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // CHECK-NEXT: arith.addi
+  %use1 = arith.addi %use0, %c0 : i32
+  "user"(%unused, %use1) : (tensor<128x128xf32, #linear128>, i32) -> ()
+  tt.return
+}
+
 // CHECK-LABEL: @sink_alloc_op
 tt.func @sink_alloc_op(%arg0: tensor<128x128xf32, #linear128>) {
   %c0 = arith.constant 0 : i32
@@ -143,18 +164,16 @@ tt.func @sink_arrive_past_wait_disjoint(
     %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %phase: i32) {
-  // CHECK: ttng.wait_barrier
-  // CHECK-SAME: channelGraph = array<i32: 2>
-  // CHECK-NEXT: ttng.wait_barrier
-  // CHECK-SAME: channelGraph = array<i32: 1>
-  // CHECK-NEXT: ttng.arrive_barrier
-  // CHECK-SAME: channelGraph = array<i32: 2>
-  // CHECK-NEXT: ttng.arrive_barrier
-  // CHECK-SAME: channelGraph = array<i32: 1>
-  ttng.wait_barrier %bar1, %phase {constraints = {channelGraph = array<i32: 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-  ttng.arrive_barrier %bar1, 1 {constraints = {channelGraph = array<i32: 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-  ttng.wait_barrier %bar2, %phase {constraints = {channelGraph = array<i32: 1>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-  ttng.arrive_barrier %bar2, 1 {constraints = {channelGraph = array<i32: 1>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
+  // CHECK: ttng.wait_barrier {{.*}}channelGraph = array<i32: 1>
+  // CHECK: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1>
+  // CHECK: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
+  ttng.wait_barrier %bar1, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %bar2, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   tt.return
 }
 
@@ -165,12 +184,14 @@ tt.func @no_reorder_overlapping_graph(
     %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
   // CHECK: ttng.arrive_barrier
   // CHECK-SAME: channelGraph = array<i32: 1, 2>
   // CHECK-NEXT: ttng.wait_barrier
   // CHECK-SAME: channelGraph = array<i32: 2, 3>
-  ttng.arrive_barrier %bar1, 1 {constraints = {channelGraph = array<i32: 1, 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-  ttng.wait_barrier %bar2, %phase {constraints = {channelGraph = array<i32: 2, 3>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2, 3>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   tt.return
 }
 
@@ -180,10 +201,108 @@ tt.func @no_reorder_without_constraints(
     %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
   // CHECK: ttng.arrive_barrier
   // CHECK-NEXT: ttng.wait_barrier
   ttng.arrive_barrier %bar1, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.wait_barrier %bar2, %phase : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
+// WS barriers are not reordered in a parent block without a direct tmem_load,
+// even if a nested region contains one.
+// CHECK-LABEL: @no_reorder_without_tmem_load_in_parent_block
+tt.func @no_reorder_without_tmem_load_in_parent_block(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  // CHECK: ttng.arrive_barrier
+  // CHECK-SAME: channelGraph = array<i32: 2>
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: channelGraph = array<i32: 1>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  scf.for %i = %c0 to %c1 step %c1 : i32 {
+    %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  }
+  tt.return
+}
+
+// WS arrives cannot sink past a non-WS arrive barrier.
+// CHECK-LABEL: @sink_arrive_stops_at_non_ws_arrive
+tt.func @sink_arrive_stops_at_non_ws_arrive(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.arrive_barrier
+  // CHECK-SAME: WSBarrier
+  // CHECK-NEXT: ttng.arrive_barrier
+  // CHECK-SAME: loweringMask
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %bar2, 1 {constraints = {loweringMask = array<i32: 0, 1>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
+// WS waits cannot rise past a non-WS wait barrier.
+// CHECK-LABEL: @raise_wait_stops_at_non_ws_wait
+tt.func @raise_wait_stops_at_non_ws_wait(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.wait_barrier
+  // CHECK-SAME: loweringMask
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: WSBarrier
+  ttng.wait_barrier %bar1, %phase {constraints = {loweringMask = array<i32: 1, 0>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
+// WS barriers cannot move past non-barrier ops with arrive-like semantics.
+// CHECK-LABEL: @no_reorder_across_arrive_like_op
+tt.func @no_reorder_across_arrive_like_op(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.arrive_barrier
+  // CHECK-SAME: channelGraph = array<i32: 2>
+  // CHECK-NEXT: ttng.async_tma_store_wait
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: channelGraph = array<i32: 1>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.async_tma_store_wait {pendings = 0 : i32}
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
+// WS barriers cannot move past control-flow ops.
+// CHECK-LABEL: @no_reorder_across_control_flow
+tt.func @no_reorder_across_control_flow(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.arrive_barrier
+  // CHECK-SAME: channelGraph = array<i32: 2>
+  // CHECK-NEXT: scf.for
+  // CHECK: ttng.wait_barrier
+  // CHECK-SAME: channelGraph = array<i32: 1>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  scf.for %i = %c0 to %c1 step %c1 : i32 {
+  }
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   tt.return
 }
 
@@ -207,8 +326,8 @@ tt.func @tmem_load_sinks_after_barrier_reorder(
   // CHECK-SAME: channelGraph = array<i32: 1>
   // CHECK-NEXT: "user"
   %0 = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
-  ttng.arrive_barrier %bar1, 1 {constraints = {channelGraph = array<i32: 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-  ttng.wait_barrier %bar2, %phase {constraints = {channelGraph = array<i32: 1>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   "user"(%0) : (tensor<128x128xf32, #linear128>) -> ()
   tt.return
 }
@@ -234,18 +353,18 @@ tt.func @split_tmem_loads_all_sink(
   %v1 = ttng.tmem_load %s1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear64>
 
   // tmem_load arrive (channelGraph disjoint from store channel)
-  ttng.arrive_barrier %tmem_wait_bar, 1 {constraints = {channelGraph = array<i32: 1, 3>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %tmem_wait_bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
 
   // Store channel: wait → local_store → arrive, repeated for each subtile
-  ttng.wait_barrier %store_bar0, %phase {constraints = {channelGraph = array<i32: 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %store_bar0, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   %t0 = arith.truncf %v0 : tensor<128x64xf32, #linear64> to tensor<128x64xf16, #linear64>
   ttg.local_store %t0, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
-  ttng.arrive_barrier %store_bar0, 1 {constraints = {channelGraph = array<i32: 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %store_bar0, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
 
-  ttng.wait_barrier %store_bar1, %phase {constraints = {channelGraph = array<i32: 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %store_bar1, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   %t1 = arith.truncf %v1 : tensor<128x64xf32, #linear64> to tensor<128x64xf16, #linear64>
   ttg.local_store %t1, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
-  ttng.arrive_barrier %store_bar1, 1 {constraints = {channelGraph = array<i32: 2>}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %store_bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
 
   // Expected: both tmem_loads sink past the store waits, interleaved with
   // the store pipeline.

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -168,8 +168,8 @@ tt.func @sink_arrive_past_wait_disjoint(
   %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
   // CHECK: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
   // CHECK: ttng.wait_barrier {{.*}}channelGraph = array<i32: 1>
-  // CHECK: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1>
   // CHECK: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
+  // CHECK: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1>
   ttng.wait_barrier %bar1, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
@@ -280,6 +280,25 @@ tt.func @no_reorder_across_arrive_like_op(
   // CHECK-SAME: channelGraph = array<i32: 1>
   ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.async_tma_store_wait {pendings = 0 : i32}
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
+// WS barriers cannot move past tcgen05 commits.
+// CHECK-LABEL: @no_reorder_across_tcgen5_commit
+tt.func @no_reorder_across_tcgen5_commit(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.arrive_barrier
+  // CHECK-SAME: channelGraph = array<i32: 2>
+  // CHECK-NEXT: ttng.tc_gen5_commit
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: channelGraph = array<i32: 1>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.tc_gen5_commit %bar1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   tt.return
 }

--- a/test/TritonNvidiaGPU/ws_barrier_ops.mlir
+++ b/test/TritonNvidiaGPU/ws_barrier_ops.mlir
@@ -30,14 +30,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
   // CHECK-LABEL: @barrier_with_ws_constraints
   // CHECK: ttng.wait_barrier
-  // CHECK-SAME: constraints = {dstTask = 1 : i32}
+  // CHECK-SAME: constraints = {WSBarrier = {dstTask = 1 : i32}}
   // CHECK: ttng.arrive_barrier
-  // CHECK-SAME: constraints = {channelGraph = array<i32: 0, 3>, dstTask = 0 : i32}
+  // CHECK-SAME: constraints = {WSBarrier = {channelGraph = array<i32: 0, 3>, dstTask = 0 : i32}}
   tt.func @barrier_with_ws_constraints(
       %bar: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
       %phase: i32) {
-    ttng.wait_barrier %bar, %phase {constraints = {dstTask = 1 : i32}} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    ttng.arrive_barrier %bar, 1 {constraints = {channelGraph = array<i32: 0, 3>, dstTask = 0 : i32}} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase {constraints = {WSBarrier = {dstTask = 1 : i32}}} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 0, 3>, dstTask = 0 : i32}}} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
+++ b/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
@@ -47,7 +47,7 @@ inline bool hasArriveLikeSemantics(Operation *op) {
   // TODO: Refine this using WSBarrier metadata so independent arrive-like ops
   // can be reordered when their channel constraints prove it is safe.
   return isa<AsyncTMACopyGlobalToLocalOp, AsyncTMAGatherOp, TMAStoreWaitOp,
-             TMAStoreTokenWaitOp, MMAv5OpInterface>(op);
+             TMAStoreTokenWaitOp, TCGen5CommitOp, MMAv5OpInterface>(op);
 }
 
 inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraints,

--- a/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
+++ b/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
@@ -12,15 +12,28 @@ namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
 
+inline DictionaryAttr
+getWSBarrierConstraints(std::optional<DictionaryAttr> constraints) {
+  if (!constraints)
+    return {};
+  return constraints->getAs<DictionaryAttr>("WSBarrier");
+}
+
+inline bool hasWSBarrierConstraints(std::optional<DictionaryAttr> constraints) {
+  return static_cast<bool>(getWSBarrierConstraints(constraints));
+}
+
 // Check if two WS barriers can be safely swapped by verifying their
 // channelGraph sets are disjoint. Returns false if either barrier lacks
-// a channelGraph constraint (conservative).
+// a WSBarrier constraint or channelGraph constraint (conservative).
 inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraintsA,
                                 std::optional<DictionaryAttr> constraintsB) {
-  if (!constraintsA || !constraintsB)
+  auto wsBarrierA = getWSBarrierConstraints(constraintsA);
+  auto wsBarrierB = getWSBarrierConstraints(constraintsB);
+  if (!wsBarrierA || !wsBarrierB)
     return false;
-  auto graphA = constraintsA->getAs<DenseI32ArrayAttr>("channelGraph");
-  auto graphB = constraintsB->getAs<DenseI32ArrayAttr>("channelGraph");
+  auto graphA = wsBarrierA.getAs<DenseI32ArrayAttr>("channelGraph");
+  auto graphB = wsBarrierB.getAs<DenseI32ArrayAttr>("channelGraph");
   if (!graphA || !graphB)
     return false;
   DenseSet<int> setA(graphA.asArrayRef().begin(), graphA.asArrayRef().end());
@@ -28,6 +41,24 @@ inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraintsA,
     if (setA.contains(id))
       return false;
   return true;
+}
+
+inline bool hasArriveLikeSemantics(Operation *op) {
+  // TODO: Refine this using WSBarrier metadata so independent arrive-like ops
+  // can be reordered when their channel constraints prove it is safe.
+  return isa<AsyncTMACopyGlobalToLocalOp, AsyncTMAGatherOp, TMAStoreWaitOp,
+             TMAStoreTokenWaitOp, MMAv5OpInterface>(op);
+}
+
+inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraints,
+                                Operation *op) {
+  if (op->getNumRegions() != 0)
+    return false;
+  if (auto arrive = dyn_cast<ArriveBarrierOp>(op))
+    return canAdvanceWSBarrier(constraints, arrive.getConstraints());
+  if (auto wait = dyn_cast<WaitBarrierOp>(op))
+    return canAdvanceWSBarrier(constraints, wait.getConstraints());
+  return !hasArriveLikeSemantics(op);
 }
 
 // Check whether moving `op` to just before `insertPt` would break SSA
@@ -45,28 +76,44 @@ inline bool wouldBreakOperandDominance(Operation *op, Operation *insertPt) {
   return false;
 }
 
+// Return the latest same-block operation that an arrive must follow when it is
+// restored near its associated memory op.
+inline Operation *getArriveAnchorAfterOperands(ArriveBarrierOp arrive,
+                                               Operation *memOp) {
+  Operation *anchor = memOp;
+  for (auto operand : arrive->getOperands()) {
+    auto *defOp = operand.getDefiningOp();
+    if (!defOp || defOp->getBlock() != arrive->getBlock())
+      continue;
+    if (anchor->isBeforeInBlock(defOp))
+      anchor = defOp;
+  }
+  return anchor;
+}
+
 // Push WS arrive barriers as far down as possible within a block.
 // An arrive can freely move past non-barrier ops (it just delays the signal).
-// An arrive can move past another arrive (always safe).
+// An arrive can move past another WSBarrier arrive (always safe).
 // An arrive can move past a wait only if canAdvanceWSBarrier says their
 // channel graphs are disjoint.
 inline bool sinkWSArrives(Block &block) {
   bool changed = false;
   SmallVector<ArriveBarrierOp> arrives;
   for (auto &op : block)
-    if (auto arrive = dyn_cast<ArriveBarrierOp>(&op))
+    if (auto arrive = dyn_cast<ArriveBarrierOp>(&op);
+        arrive && hasWSBarrierConstraints(arrive.getConstraints()))
       arrives.push_back(arrive);
 
   for (auto arrive : arrives) {
     auto constraints = arrive.getConstraints();
-    if (!constraints)
-      continue;
     Operation *insertPt = arrive->getNextNode();
     for (auto *cur = insertPt; cur && !cur->hasTrait<OpTrait::IsTerminator>();
          cur = cur->getNextNode()) {
-      if (auto wait = dyn_cast<WaitBarrierOp>(cur)) {
-        if (!canAdvanceWSBarrier(constraints, wait.getConstraints()))
+      if (auto otherArrive = dyn_cast<ArriveBarrierOp>(cur)) {
+        if (!hasWSBarrierConstraints(otherArrive.getConstraints()))
           break;
+      } else if (!canAdvanceWSBarrier(constraints, cur)) {
+        break;
       }
       insertPt = cur->getNextNode();
     }
@@ -80,7 +127,7 @@ inline bool sinkWSArrives(Block &block) {
 
 // Pull WS wait barriers as far up as possible within a block.
 // A wait can freely move past non-barrier ops (it just starts waiting sooner).
-// A wait can move past another wait (always safe).
+// A wait can move past another WSBarrier wait (always safe).
 // A wait can move past an arrive only if canAdvanceWSBarrier says their
 // channel graphs are disjoint.
 // Stops before moving past any op that defines an operand of the wait.
@@ -88,13 +135,12 @@ inline bool raiseWSWaits(Block &block) {
   bool changed = false;
   SmallVector<WaitBarrierOp> waits;
   for (auto &op : block)
-    if (auto wait = dyn_cast<WaitBarrierOp>(&op))
+    if (auto wait = dyn_cast<WaitBarrierOp>(&op);
+        wait && hasWSBarrierConstraints(wait.getConstraints()))
       waits.push_back(wait);
 
   for (auto wait : llvm::reverse(waits)) {
     auto constraints = wait.getConstraints();
-    if (!constraints)
-      continue;
     Operation *insertPt = wait.getOperation();
     for (auto *cur = wait->getPrevNode(); cur; cur = cur->getPrevNode()) {
       // Don't raise past the definition of any of our operands.
@@ -107,9 +153,11 @@ inline bool raiseWSWaits(Block &block) {
       }
       if (definesOperand)
         break;
-      if (auto arrive = dyn_cast<ArriveBarrierOp>(cur)) {
-        if (!canAdvanceWSBarrier(arrive.getConstraints(), constraints))
+      if (auto otherWait = dyn_cast<WaitBarrierOp>(cur)) {
+        if (!hasWSBarrierConstraints(otherWait.getConstraints()))
           break;
+      } else if (!canAdvanceWSBarrier(constraints, cur)) {
+        break;
       }
       insertPt = cur;
     }
@@ -135,7 +183,7 @@ buildBarrierToMemoryOpMap(Block &block) {
 
   for (auto &op : block) {
     if (auto arrive = dyn_cast<ArriveBarrierOp>(&op)) {
-      if (!arrive.getConstraints())
+      if (!hasWSBarrierConstraints(arrive.getConstraints()))
         continue;
       for (auto *cur = arrive->getPrevNode(); cur; cur = cur->getPrevNode()) {
         if (isMemoryOp(cur)) {
@@ -144,7 +192,7 @@ buildBarrierToMemoryOpMap(Block &block) {
         }
       }
     } else if (auto wait = dyn_cast<WaitBarrierOp>(&op)) {
-      if (!wait.getConstraints())
+      if (!hasWSBarrierConstraints(wait.getConstraints()))
         continue;
       for (auto *cur = wait->getNextNode(); cur; cur = cur->getNextNode()) {
         if (isMemoryOp(cur)) {
@@ -158,19 +206,20 @@ buildBarrierToMemoryOpMap(Block &block) {
 }
 
 // After tmem_load sinking, relocate WS barriers back to optimal positions
-// relative to their associated memory ops. Arrives go right after their
-// memory op; waits go right before. Skips moves that would break SSA
-// dominance.
+// relative to their associated memory ops. Arrives go right after their memory
+// op, or after later same-block operand definitions required by SSA. Waits go
+// right before their memory op. Skips moves that would break SSA dominance.
 inline void optimizeWSBarrierLocations(
     const DenseMap<Operation *, Operation *> &barrierToMemOp) {
   for (auto [barrier, memOp] : barrierToMemOp) {
     if (barrier->getBlock() != memOp->getBlock())
       continue;
-    if (isa<ArriveBarrierOp>(barrier)) {
-      if (barrier->getPrevNode() != memOp) {
-        Operation *target = memOp->getNextNode();
+    if (auto arrive = dyn_cast<ArriveBarrierOp>(barrier)) {
+      Operation *anchor = getArriveAnchorAfterOperands(arrive, memOp);
+      if (barrier->getPrevNode() != anchor) {
+        Operation *target = anchor->getNextNode();
         if (!wouldBreakOperandDominance(barrier, target))
-          barrier->moveAfter(memOp);
+          barrier->moveAfter(anchor);
       }
     } else {
       if (barrier->getNextNode() != memOp) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBarrierAnalysis.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBarrierAnalysis.h
@@ -6,6 +6,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir {
 
@@ -15,9 +16,14 @@ namespace mlir {
 // from async_task_id). The destination is the partition on the other side of
 // the channel that this barrier communicates with.
 //
+// WS barrier metadata is stored under a top-level constraints.WSBarrier key so
+// generic barrier constraints can coexist without being treated as WS barriers.
+//
 // All fields are optional — unknown information is left null and filled in
 // by later passes.
 struct WSBarrierAttr {
+  static constexpr llvm::StringLiteral kKey = "WSBarrier";
+
   // Destination task ID — the foreign partition this barrier communicates with.
   // Set during insertAsyncComm.
   IntegerAttr dstTask;
@@ -27,7 +33,8 @@ struct WSBarrierAttr {
   // buildChannelGraph() + injectChannelGraph().
   DenseI32ArrayAttr channelGraph;
 
-  // Build a DictionaryAttr from the populated fields. Null fields are omitted.
+  // Build a constraints DictionaryAttr from the populated fields. Null fields
+  // are omitted from the nested WSBarrier dictionary.
   DictionaryAttr build(MLIRContext *ctx) const {
     SmallVector<NamedAttribute> entries;
     if (channelGraph)
@@ -36,7 +43,10 @@ struct WSBarrierAttr {
       entries.emplace_back(StringAttr::get(ctx, "dstTask"), dstTask);
     if (entries.empty())
       return {};
-    return DictionaryAttr::get(ctx, entries);
+    auto wsBarrier = DictionaryAttr::get(ctx, entries);
+    SmallVector<NamedAttribute> topLevel;
+    topLevel.emplace_back(StringAttr::get(ctx, kKey), wsBarrier);
+    return DictionaryAttr::get(ctx, topLevel);
   }
 
   // Parse from an existing constraints DictionaryAttr.
@@ -44,8 +54,11 @@ struct WSBarrierAttr {
     WSBarrierAttr attr;
     if (!dict)
       return attr;
-    attr.dstTask = dict.getAs<IntegerAttr>("dstTask");
-    attr.channelGraph = dict.getAs<DenseI32ArrayAttr>("channelGraph");
+    auto wsBarrier = dict.getAs<DictionaryAttr>(kKey);
+    if (!wsBarrier)
+      return attr;
+    attr.dstTask = wsBarrier.getAs<IntegerAttr>("dstTask");
+    attr.channelGraph = wsBarrier.getAs<DenseI32ArrayAttr>("channelGraph");
     return attr;
   }
 
@@ -116,7 +129,25 @@ static inline DictionaryAttr injectChannelGraph(MLIRContext *ctx,
                                                 ArrayRef<int> graphTaskIds) {
   auto attr = WSBarrierAttr::parse(existing);
   attr.channelGraph = DenseI32ArrayAttr::get(ctx, graphTaskIds);
-  return attr.build(ctx);
+  auto updated = attr.build(ctx);
+  if (!existing)
+    return updated;
+
+  SmallVector<NamedAttribute> merged;
+  bool replaced = false;
+  for (NamedAttribute namedAttr : existing) {
+    if (namedAttr.getName().getValue() == WSBarrierAttr::kKey) {
+      merged.emplace_back(StringAttr::get(ctx, WSBarrierAttr::kKey),
+                          updated.getAs<DictionaryAttr>(WSBarrierAttr::kKey));
+      replaced = true;
+    } else {
+      merged.push_back(namedAttr);
+    }
+  }
+  if (!replaced)
+    merged.emplace_back(StringAttr::get(ctx, WSBarrierAttr::kKey),
+                        updated.getAs<DictionaryAttr>(WSBarrierAttr::kKey));
+  return DictionaryAttr::get(ctx, merged);
 }
 
 // canAdvanceWSBarrier, sinkWSArrives, raiseWSWaits are defined in

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -2362,9 +2362,10 @@ public:
           LDBG("TMEM pre-assign: reuser buffer.id="
                << bid << " colOffset=" << nextColOffset
                << " size=" << reuserBuf->rowSize << "x" << reuserBuf->colSize);
-          // When we have 3 buffers sharing one space, we don't move the colOffset.
-          // As moving the colOffset can make it exceed the size of the owner buffer.
-          nextColOffset += 0; //reuserBuf->colSize;
+          // When we have 3 buffers sharing one space, we don't move the
+          // colOffset. As moving the colOffset can make it exceed the size of
+          // the owner buffer.
+          nextColOffset += 0; // reuserBuf->colSize;
         }
       }
 


### PR DESCRIPTION
Adds the following constraints for correctness:
1. WSBarrier will not move past a non WSBarrier even if its the same barrier type (e.g. Arrive past Arrive). This is to respect that barriers may have different roles, although I don't expect correctness issues.
2. WSBarriers may not move past the alternative arriveOPs (e.g. TMA load). In the future these need to be extended to add WSBarrier constraints when used in channels. This is probably not an issue, but this is to be extra safe.
3. Block barriers from moving past control flow. Previously barriers would try move relative to a for loop, which is clearly wrong and was causing a hang.

In addition we add the following optimizations to limit code change:
1. Only apply WSBarrier movement in the regions that contain a TMEM_LOAD. This should reduce unnecessary changes.
2. Fix the memoryOp mapping to ensure arrives are pulled back up. Previously because the arguments were after the memory op they would not be moved. Now this pulls them to the first location after the memory ops where all args are defined.

Finally for code clarity we add a top-level WSBarrier key.

Together with some scheduler changes @Sibylau is working on, this fixes the issues in causal fwd.