### PR TITLE
[TLX][AMD] Improve layout propagation

### DIFF
--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -219,6 +219,69 @@ def test_async_token_loop_compiles_gfx950(device):
     assert "async_wait" in ttgir
 
 
+# ---------------------------------------------------------------------------
+# Test: loop-carried dot operands do not fall back through tensor local_alloc.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _loop_carried_dot_layout_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    K_ITERS: tl.constexpr,
+):
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = a_ptr + offs_m[:, None] * (BLOCK_K * K_ITERS) + offs_k[None, :]
+    b_ptrs = b_ptr + offs_k[:, None] * BLOCK_N + offs_n[None, :]
+
+    a_buffers = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, 2)
+    b_buffers = tlx.local_alloc((BLOCK_K, BLOCK_N), tl.float16, 2)
+
+    a_buf = tlx.local_view(a_buffers, 0)
+    b_buf = tlx.local_view(b_buffers, 0)
+    tlx.local_store(a_buf, tl.load(a_ptrs))
+    tlx.local_store(b_buf, tl.load(b_ptrs))
+
+    a_reg = tlx.local_load(a_buf)
+    b_reg = tlx.local_load(b_buf)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k in tl.range(0, K_ITERS - 1, num_stages=0):
+        acc = tl.dot(a_reg, b_reg, acc)
+        next_slot = (k + 1) % 2
+        next_a = tlx.local_view(a_buffers, next_slot)
+        next_b = tlx.local_view(b_buffers, next_slot)
+        tlx.local_store(next_a, tl.load(a_ptrs + (k + 1) * BLOCK_K))
+        tlx.local_store(next_b, tl.load(b_ptrs + (k + 1) * BLOCK_K * BLOCK_N))
+        a_reg = tlx.local_load(next_a)
+        b_reg = tlx.local_load(next_b)
+
+    acc = tl.dot(a_reg, b_reg, acc)
+    c_ptrs = c_ptr + offs_m[:, None] * BLOCK_N + offs_n[None, :]
+    tl.store(c_ptrs, acc)
+
+
+def test_loop_carried_dot_layout_cleanup_compiles_gfx950(device):
+    """Full AMD pipeline should remove late dot operand local_alloc fallbacks."""
+    compiled = compile_for_gfx950(
+        _loop_carried_dot_layout_kernel,
+        signature={"a_ptr": "*fp16", "b_ptr": "*fp16", "c_ptr": "*fp32"},
+        constexprs={"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 32, "K_ITERS": 3},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "ttg.local_alloc %" not in ttgir
+    assert "tt.dot" in ttgir
+    assert "amdgcn" in compiled.asm
+    assert len(compiled.asm["amdgcn"]) > 0
+
+
 # 1D gather test
 @triton.jit
 def local_gather_kernel(

--- a/test/TLX/insert-require-layout-propagate.mlir
+++ b/test/TLX/insert-require-layout-propagate.mlir
@@ -260,3 +260,78 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     tt.return %sum : tensor<64x64xf32, #mma_5>
   }
 }
+
+// -----
+// Test 7: AMD TDM full-tile load with LDS subtile slicing.
+// The TDM op writes a 32x128 tile, then local_load consumes a 32x32
+// memdesc_subslice as a dot operand. The insert+propagate pipeline should:
+//   * propagate the WMMA-tuned padded encoding to the full local_alloc,
+//   * preserve the subslice alloc shape (`32x128`) while retagging its result,
+//   * remove explicit tlx.require_layout ops.
+
+#mma_6 = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
+#shared_6 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #[[$PADDED_A:.*]] = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [32, 128]}>
+#smem_6 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tdm_full_tile_subslice_dot
+  tt.func public @tdm_full_tile_subslice_dot(%desc: !tt.tensordesc<32x128xf16>, %m: i32, %k: i32, %p: i32)
+      -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_6, kWidth = 8}>> {
+    %c0 = arith.constant 0 : i32
+    // CHECK: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #[[$PADDED_A]], #smem, mutable>
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared_6, #smem_6, mutable>
+    // CHECK: %[[BUF:.*]] = ttg.memdesc_index %[[ALLOC]][%{{.*}}] : !ttg.memdesc<2x32x128xf16, #[[$PADDED_A]], #smem, mutable> -> !ttg.memdesc<32x128xf16, #[[$PADDED_A]], #smem, mutable>
+    %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x32x128xf16, #shared_6, #smem_6, mutable> -> !ttg.memdesc<32x128xf16, #shared_6, #smem_6, mutable>
+    // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF]]
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_6, #smem_6, mutable>
+    // CHECK: %[[SUB:.*]] = ttg.memdesc_subslice %[[BUF]][0, 0] : !ttg.memdesc<32x128xf16, #[[$PADDED_A]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_A]], #smem, mutable, 32x128>
+    %sub = ttg.memdesc_subslice %buf[0, 0] : !ttg.memdesc<32x128xf16, #shared_6, #smem_6, mutable> -> !ttg.memdesc<32x32xf16, #shared_6, #smem_6, mutable, 32x128>
+    // CHECK: ttg.local_load %[[SUB]] : !ttg.memdesc<32x32xf16, #[[$PADDED_A]], #smem, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %t_dot = ttg.local_load %sub : !ttg.memdesc<32x32xf16, #shared_6, #smem_6, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_6, kWidth = 8}>>
+    // CHECK-NOT: tlx.require_layout
+    tt.return %t_dot : tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_6, kWidth = 8}>>
+  }
+}
+
+// -----
+// Test 8: full GEMM-shaped TDM load + LDS subtile slices feeding an actual dot.
+// This covers both dot operands, non-zero subtile offsets, and verifies that
+// the propagated memdesc_subslice encodings are used directly by tt.dot.
+
+#mma_7 = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
+#shared_7 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #[[$PADDED_A_SUB:.*]] = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [32, 128]}>
+// CHECK-DAG: #[[$PADDED_B_SUB:.*]] = #ttg.padded_shared<[128:+16] {order = [1, 0], shape = [128, 32]}>
+#smem_7 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tdm_full_tile_subslices_feed_dot
+  tt.func public @tdm_full_tile_subslices_feed_dot(%desc_a: !tt.tensordesc<32x128xf16>, %desc_b: !tt.tensordesc<128x32xf16>, %m: i32, %n: i32, %k: i32, %p: i32)
+      -> tensor<32x32xf32, #mma_7> {
+    %c0 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma_7>
+    // CHECK: %[[ALLOC_A:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #[[$PADDED_A_SUB]], #smem, mutable>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared_7, #smem_7, mutable>
+    // CHECK: %[[ALLOC_B:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #[[$PADDED_B_SUB]], #smem, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared_7, #smem_7, mutable>
+    // CHECK: %[[BUF_A:.*]] = ttg.memdesc_index %[[ALLOC_A]][%{{.*}}] : !ttg.memdesc<2x32x128xf16, #[[$PADDED_A_SUB]], #smem, mutable> -> !ttg.memdesc<32x128xf16, #[[$PADDED_A_SUB]], #smem, mutable>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0] : !ttg.memdesc<2x32x128xf16, #shared_7, #smem_7, mutable> -> !ttg.memdesc<32x128xf16, #shared_7, #smem_7, mutable>
+    // CHECK: %[[BUF_B:.*]] = ttg.memdesc_index %[[ALLOC_B]][%{{.*}}] : !ttg.memdesc<2x128x32xf16, #[[$PADDED_B_SUB]], #smem, mutable> -> !ttg.memdesc<128x32xf16, #[[$PADDED_B_SUB]], #smem, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0] : !ttg.memdesc<2x128x32xf16, #shared_7, #smem_7, mutable> -> !ttg.memdesc<128x32xf16, #shared_7, #smem_7, mutable>
+    // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF_A]]
+    %tok_a = amdg.async_tdm_copy_global_to_local %desc_a[%m, %k] into %buf_a, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_7, #smem_7, mutable>
+    // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF_B]]
+    %tok_b = amdg.async_tdm_copy_global_to_local %desc_b[%k, %n] into %buf_b, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared_7, #smem_7, mutable>
+    // CHECK: %[[SUB_A:.*]] = ttg.memdesc_subslice %[[BUF_A]][0, 32] : !ttg.memdesc<32x128xf16, #[[$PADDED_A_SUB]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_A_SUB]], #smem, mutable, 32x128>
+    %sub_a = ttg.memdesc_subslice %buf_a[0, 32] : !ttg.memdesc<32x128xf16, #shared_7, #smem_7, mutable> -> !ttg.memdesc<32x32xf16, #shared_7, #smem_7, mutable, 32x128>
+    // CHECK: %[[SUB_B:.*]] = ttg.memdesc_subslice %[[BUF_B]][32, 0] : !ttg.memdesc<128x32xf16, #[[$PADDED_B_SUB]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_B_SUB]], #smem, mutable, 128x32>
+    %sub_b = ttg.memdesc_subslice %buf_b[32, 0] : !ttg.memdesc<128x32xf16, #shared_7, #smem_7, mutable> -> !ttg.memdesc<32x32xf16, #shared_7, #smem_7, mutable, 128x32>
+    // CHECK: %[[A:.*]] = ttg.local_load %[[SUB_A]] : !ttg.memdesc<32x32xf16, #[[$PADDED_A_SUB]], #smem, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %a = ttg.local_load %sub_a : !ttg.memdesc<32x32xf16, #shared_7, #smem_7, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_7, kWidth = 8}>>
+    // CHECK: %[[B:.*]] = ttg.local_load %[[SUB_B]] : !ttg.memdesc<32x32xf16, #[[$PADDED_B_SUB]], #smem, mutable, 128x32> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    %b = ttg.local_load %sub_b : !ttg.memdesc<32x32xf16, #shared_7, #smem_7, mutable, 128x32> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_7, kWidth = 8}>>
+    // CHECK: tt.dot %[[A]], %[[B]], %{{.*}}
+    // CHECK-NOT: tlx.require_layout
+    %dot = tt.dot %a, %b, %cst : tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_7, kWidth = 8}>> * tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_7, kWidth = 8}>> -> tensor<32x32xf32, #mma_7>
+    tt.return %dot : tensor<32x32xf32, #mma_7>
+  }
+}

--- a/test/TLX/insert-require-layout-propagate.mlir
+++ b/test/TLX/insert-require-layout-propagate.mlir
@@ -335,3 +335,48 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     tt.return %dot : tensor<32x32xf32, #mma_7>
   }
 }
+
+// -----
+// Test 9: transposed-B GEMM-shaped TDM load + LDS subtile slices feeding dot.
+// The B subtile is represented as memdesc_subslice followed by memdesc_trans,
+// mirroring `tlx.local_load(tlx.local_trans(b_view))`.
+
+#mma_8 = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
+#shared_8 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_8_trans = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+// CHECK-DAG: #[[$PADDED_A_TRANS:.*]] = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [32, 128]}>
+// CHECK-DAG: #[[$PADDED_B_TRANS:.*]] = #ttg.padded_shared<[128:+16] {order = [1, 0], shape = [32, 128]}>
+#smem_8 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tdm_transposed_b_subslice_trans_feed_dot
+  tt.func public @tdm_transposed_b_subslice_trans_feed_dot(%desc_a: !tt.tensordesc<32x128xf16>, %desc_b: !tt.tensordesc<32x128xf16>, %m: i32, %n: i32, %k: i32, %p: i32)
+      -> tensor<32x32xf32, #mma_8> {
+    %c0 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma_8>
+    // CHECK: %[[ALLOC_A:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #[[$PADDED_A_TRANS]], #smem, mutable>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared_8, #smem_8, mutable>
+    // CHECK: %[[ALLOC_B:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #[[$PADDED_B_TRANS]], #smem, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared_8, #smem_8, mutable>
+    // CHECK: %[[BUF_A:.*]] = ttg.memdesc_index %[[ALLOC_A]][%{{.*}}] : !ttg.memdesc<2x32x128xf16, #[[$PADDED_A_TRANS]], #smem, mutable> -> !ttg.memdesc<32x128xf16, #[[$PADDED_A_TRANS]], #smem, mutable>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0] : !ttg.memdesc<2x32x128xf16, #shared_8, #smem_8, mutable> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
+    // CHECK: %[[BUF_B:.*]] = ttg.memdesc_index %[[ALLOC_B]][%{{.*}}] : !ttg.memdesc<2x32x128xf16, #[[$PADDED_B_TRANS]], #smem, mutable> -> !ttg.memdesc<32x128xf16, #[[$PADDED_B_TRANS]], #smem, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0] : !ttg.memdesc<2x32x128xf16, #shared_8, #smem_8, mutable> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
+    %tok_a = amdg.async_tdm_copy_global_to_local %desc_a[%m, %k] into %buf_a, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
+    // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF_B]]
+    %tok_b = amdg.async_tdm_copy_global_to_local %desc_b[%n, %k] into %buf_b, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
+    // CHECK: %[[SUB_A:.*]] = ttg.memdesc_subslice %[[BUF_A]][0, 64] : !ttg.memdesc<32x128xf16, #[[$PADDED_A_TRANS]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_A_TRANS]], #smem, mutable, 32x128>
+    %sub_a = ttg.memdesc_subslice %buf_a[0, 64] : !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable> -> !ttg.memdesc<32x32xf16, #shared_8, #smem_8, mutable, 32x128>
+    // CHECK: %[[SUB_B:.*]] = ttg.memdesc_subslice %[[BUF_B]][0, 64] : !ttg.memdesc<32x128xf16, #[[$PADDED_B_TRANS]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_B_TRANS]], #smem, mutable, 32x128>
+    %sub_b = ttg.memdesc_subslice %buf_b[0, 64] : !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable> -> !ttg.memdesc<32x32xf16, #shared_8, #smem_8, mutable, 32x128>
+    // CHECK: %[[TRANS_B:.*]] = ttg.memdesc_trans %[[SUB_B]] {order = array<i32: 1, 0>} : !ttg.memdesc<32x32xf16, #[[$PADDED_B_TRANS]], #smem, mutable, 32x128> -> !ttg.memdesc<32x32xf16, #{{.*}}, #smem, mutable, 128x32>
+    %trans_b = ttg.memdesc_trans %sub_b {order = array<i32: 1, 0>} : !ttg.memdesc<32x32xf16, #shared_8, #smem_8, mutable, 32x128> -> !ttg.memdesc<32x32xf16, #shared_8_trans, #smem_8, mutable, 128x32>
+    // CHECK: %[[A:.*]] = ttg.local_load %[[SUB_A]] : !ttg.memdesc<32x32xf16, #[[$PADDED_A_TRANS]], #smem, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %a = ttg.local_load %sub_a : !ttg.memdesc<32x32xf16, #shared_8, #smem_8, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_8, kWidth = 8}>>
+    // CHECK: %[[B:.*]] = ttg.local_load %[[TRANS_B]] : !ttg.memdesc<32x32xf16, #{{.*}}, #smem, mutable, 128x32> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    %b = ttg.local_load %trans_b : !ttg.memdesc<32x32xf16, #shared_8_trans, #smem_8, mutable, 128x32> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_8, kWidth = 8}>>
+    // CHECK: tt.dot %[[A]], %[[B]], %{{.*}}
+    // CHECK-NOT: tlx.require_layout
+    %dot = tt.dot %a, %b, %cst : tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_8, kWidth = 8}>> * tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_8, kWidth = 8}>> -> tensor<32x32xf32, #mma_8>
+    tt.return %dot : tensor<32x32xf32, #mma_8>
+  }
+}

--- a/test/TLX/insert-require-layout-tdm.mlir
+++ b/test/TLX/insert-require-layout-tdm.mlir
@@ -582,3 +582,37 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     tt.return
   }
 }
+
+// -----
+// =============================================================================
+// 21. Dot consumer reached through memdesc_subslice.
+// This is the single-warp-per-SIMD GEMM shape: TDM loads the full
+// BLOCK_K=128 tile, while local_load consumes 32-wide LDS subtiles.
+// The TDM anchor must still discover the dot consumer through
+// memdesc_subslice and choose the WMMA-tuned full-tile encoding `[128:+8]`.
+// The dot-path walk should also recognize that the subslice is TDM-fed and
+// avoid inserting a sibling swizzled anchor on the local_load operand.
+// =============================================================================
+
+// CHECK-DAG: #{{.*}} = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [32, 128]}>
+
+#mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tdm_dot_consumer_through_subslice
+  // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<32x128xf16, #{{.*}}, #smem, mutable>
+  // CHECK-NEXT: amdg.async_tdm_copy_global_to_local
+  // CHECK-NOT: tlx.require_layout
+  tt.func public @tdm_dot_consumer_through_subslice(%desc: !tt.tensordesc<32x128xf16>, %m: i32, %k: i32, %p: i32)
+      -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> {
+    %c0 = arith.constant 0 : i32
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared, #smem, mutable>
+    %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x32x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<32x128xf16, #shared, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared, #smem, mutable>
+    %sub = ttg.memdesc_subslice %buf[0, 0] : !ttg.memdesc<32x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x128>
+    %t = ttg.local_load %sub : !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    tt.return %t : tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+  }
+}

--- a/test/TLX/insert-require-layout-tdm.mlir
+++ b/test/TLX/insert-require-layout-tdm.mlir
@@ -616,3 +616,36 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     tt.return %t : tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
   }
 }
+
+// -----
+// =============================================================================
+// 22. Dot consumer reached through memdesc_subslice + memdesc_trans.
+// This is the transposed-B single-warp-per-SIMD GEMM shape: TDM loads a
+// full 32x128 tile, slices a 32-wide K subtile, transposes the memdesc view,
+// and only then performs the dot-operand local_load.
+// =============================================================================
+
+// CHECK-DAG: #{{.*}} = #ttg.padded_shared<[128:+16] {order = [1, 0], shape = [32, 128]}>
+
+#mma_t = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
+#shared_t = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_t_trans = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem_t = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tdm_dot_consumer_through_subslice_trans
+  // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<32x128xf16, #{{.*}}, #smem, mutable>
+  // CHECK-NEXT: amdg.async_tdm_copy_global_to_local
+  // CHECK-NOT: tlx.require_layout
+  tt.func public @tdm_dot_consumer_through_subslice_trans(%desc: !tt.tensordesc<32x128xf16>, %m: i32, %k: i32, %p: i32)
+      -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_t, kWidth = 8}>> {
+    %c0 = arith.constant 0 : i32
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared_t, #smem_t, mutable>
+    %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x32x128xf16, #shared_t, #smem_t, mutable> -> !ttg.memdesc<32x128xf16, #shared_t, #smem_t, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_t, #smem_t, mutable>
+    %sub = ttg.memdesc_subslice %buf[0, 32] : !ttg.memdesc<32x128xf16, #shared_t, #smem_t, mutable> -> !ttg.memdesc<32x32xf16, #shared_t, #smem_t, mutable, 32x128>
+    %trans = ttg.memdesc_trans %sub {order = array<i32: 1, 0>} : !ttg.memdesc<32x32xf16, #shared_t, #smem_t, mutable, 32x128> -> !ttg.memdesc<32x32xf16, #shared_t_trans, #smem_t, mutable, 128x32>
+    %t = ttg.local_load %trans : !ttg.memdesc<32x32xf16, #shared_t_trans, #smem_t, mutable, 128x32> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_t, kWidth = 8}>>
+    tt.return %t : tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_t, kWidth = 8}>>
+  }
+}

--- a/test/TLX/propagate-layout-tensor-residual.mlir
+++ b/test/TLX/propagate-layout-tensor-residual.mlir
@@ -49,3 +49,81 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return %rel : tensor<8x8xf16, #blocked_id>
   }
 }
+
+// -----
+// Test that a late dot-operand fallback through local_alloc/local_load is folded
+// after the loop-carried tensor is retagged through RegionBranchOpInterface.
+
+#blocked_loop = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_loop = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_loop = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_loop = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @fold_loop_carried_dot_local_alloc
+  tt.func public @fold_loop_carried_dot_local_alloc() -> tensor<64x64xf32, #mma_loop> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_loop>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x64x32xf16, #shared_loop, #smem_loop, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x32x64xf16, #shared_loop, #smem_loop, mutable>
+    %buf_a0 = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<2x64x32xf16, #shared_loop, #smem_loop, mutable> -> !ttg.memdesc<64x32xf16, #shared_loop, #smem_loop, mutable>
+    %buf_b0 = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<2x32x64xf16, #shared_loop, #smem_loop, mutable> -> !ttg.memdesc<32x64xf16, #shared_loop, #smem_loop, mutable>
+    // CHECK: %[[A_INIT:.*]] = ttg.local_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #{{.*}}, kWidth = 4}>>
+    %a_init = ttg.local_load %buf_a0 : !ttg.memdesc<64x32xf16, #shared_loop, #smem_loop, mutable> -> tensor<64x32xf16, #blocked_loop>
+    // CHECK: %[[B_INIT:.*]] = ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #{{.*}}, kWidth = 4}>>
+    %b_init = ttg.local_load %buf_b0 : !ttg.memdesc<32x64xf16, #shared_loop, #smem_loop, mutable> -> tensor<32x64xf16, #blocked_loop>
+    // CHECK: scf.for {{.*}} iter_args(%[[ACC_ARG:.*]] = {{.*}}, %[[A_ARG:.*]] = %[[A_INIT]], %[[B_ARG:.*]] = %[[B_INIT]]) -> (tensor<64x64xf32, #{{.*}}>, tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #{{.*}}, kWidth = 4}>>, tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #{{.*}}, kWidth = 4}>>)
+    %result:3 = scf.for %i = %c0_i32 to %c2_i32 step %c1_i32
+        iter_args(%acc = %cst, %a_reg = %a_init, %b_reg = %b_init)
+        -> (tensor<64x64xf32, #mma_loop>, tensor<64x32xf16, #blocked_loop>, tensor<32x64xf16, #blocked_loop>) : i32 {
+      %a_tmp = ttg.local_alloc %a_reg : (tensor<64x32xf16, #blocked_loop>) -> !ttg.memdesc<64x32xf16, #shared_loop, #smem_loop>
+      %a_dot = ttg.local_load %a_tmp : !ttg.memdesc<64x32xf16, #shared_loop, #smem_loop> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_loop, kWidth = 4}>>
+      %b_tmp = ttg.local_alloc %b_reg : (tensor<32x64xf16, #blocked_loop>) -> !ttg.memdesc<32x64xf16, #shared_loop, #smem_loop>
+      %b_dot = ttg.local_load %b_tmp : !ttg.memdesc<32x64xf16, #shared_loop, #smem_loop> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_loop, kWidth = 4}>>
+      // CHECK-NOT: ttg.local_alloc %
+      // CHECK: tt.dot %[[A_ARG]], %[[B_ARG]], %[[ACC_ARG]]
+      %dot = tt.dot %a_dot, %b_dot, %acc : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_loop, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_loop, kWidth = 4}>> -> tensor<64x64xf32, #mma_loop>
+      %buf_a1 = ttg.memdesc_index %alloc_a[%c1_i32] : !ttg.memdesc<2x64x32xf16, #shared_loop, #smem_loop, mutable> -> !ttg.memdesc<64x32xf16, #shared_loop, #smem_loop, mutable>
+      %buf_b1 = ttg.memdesc_index %alloc_b[%c1_i32] : !ttg.memdesc<2x32x64xf16, #shared_loop, #smem_loop, mutable> -> !ttg.memdesc<32x64xf16, #shared_loop, #smem_loop, mutable>
+      %a_next = ttg.local_load %buf_a1 : !ttg.memdesc<64x32xf16, #shared_loop, #smem_loop, mutable> -> tensor<64x32xf16, #blocked_loop>
+      %b_next = ttg.local_load %buf_b1 : !ttg.memdesc<32x64xf16, #shared_loop, #smem_loop, mutable> -> tensor<32x64xf16, #blocked_loop>
+      scf.yield %dot, %a_next, %b_next : tensor<64x64xf32, #mma_loop>, tensor<64x32xf16, #blocked_loop>, tensor<32x64xf16, #blocked_loop>
+    }
+    tt.return %result#0 : tensor<64x64xf32, #mma_loop>
+  }
+}
+
+// -----
+// Test that a single fallback local_alloc feeding multiple compatible dot
+// local_load users is folded one load at a time. Dead alloc cleanup is left to
+// canonicalization/DCE.
+
+#blocked_multi = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_multi = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_multi = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_multi = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @fold_multi_use_dot_local_alloc
+  tt.func public @fold_multi_use_dot_local_alloc() -> tensor<64x64xf32, #mma_multi> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_multi>
+    %b_arg = arith.constant dense<0.000000e+00> : tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_multi, kWidth = 4}>>
+    %src_alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_multi, #smem_multi, mutable>
+    %src_buf = ttg.memdesc_index %src_alloc[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_multi, #smem_multi, mutable> -> !ttg.memdesc<64x32xf16, #shared_multi, #smem_multi, mutable>
+    %src = ttg.local_load %src_buf : !ttg.memdesc<64x32xf16, #shared_multi, #smem_multi, mutable> -> tensor<64x32xf16, #blocked_multi>
+    %fallback = ttg.local_alloc %src : (tensor<64x32xf16, #blocked_multi>) -> !ttg.memdesc<64x32xf16, #shared_multi, #smem_multi>
+    %a0 = ttg.local_load %fallback : !ttg.memdesc<64x32xf16, #shared_multi, #smem_multi> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_multi, kWidth = 4}>>
+    %a1 = ttg.local_load %fallback : !ttg.memdesc<64x32xf16, #shared_multi, #smem_multi> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_multi, kWidth = 4}>>
+    // CHECK: %[[SRC:.*]] = ttg.local_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #{{.*}}, kWidth = 4}>>
+    // CHECK-NOT: ttg.local_alloc %
+    // CHECK-NOT: ttg.local_load %{{.*}} : !ttg.memdesc<64x32xf16
+    // CHECK: %[[DOT0:.*]] = tt.dot %[[SRC]], %{{.*}}, %{{.*}} : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #{{.*}}, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #{{.*}}, kWidth = 4}>>
+    %dot0 = tt.dot %a0, %b_arg, %cst : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_multi, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_multi, kWidth = 4}>> -> tensor<64x64xf32, #mma_multi>
+    // CHECK: %[[DOT1:.*]] = tt.dot %[[SRC]], %{{.*}}, %[[DOT0]] : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #{{.*}}, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #{{.*}}, kWidth = 4}>>
+    %dot1 = tt.dot %a1, %b_arg, %dot0 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_multi, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_multi, kWidth = 4}>> -> tensor<64x64xf32, #mma_multi>
+    tt.return %dot1 : tensor<64x64xf32, #mma_multi>
+  }
+}

--- a/test/TLX/propagate-layout-tensor-residual.mlir
+++ b/test/TLX/propagate-layout-tensor-residual.mlir
@@ -127,3 +127,49 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     tt.return %dot1 : tensor<64x64xf32, #mma_multi>
   }
 }
+
+// -----
+// Same late fallback as above, but with the gfx1250 WMMA layout and 32x32
+// operands used by the single-warp-per-SIMD TDM GEMM. This guards the exact
+// shape that previously survived as LDS spill/reload traffic.
+
+#blocked_wmma = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_wmma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
+#shared_wmma = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_wmma = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @fold_wmma_loop_carried_dot_local_alloc
+  tt.func public @fold_wmma_loop_carried_dot_local_alloc() -> tensor<32x32xf32, #mma_wmma> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma_wmma>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x32x32xf16, #shared_wmma, #smem_wmma, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x32x32xf16, #shared_wmma, #smem_wmma, mutable>
+    %buf_a0 = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<2x32x32xf16, #shared_wmma, #smem_wmma, mutable> -> !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable>
+    %buf_b0 = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<2x32x32xf16, #shared_wmma, #smem_wmma, mutable> -> !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable>
+    // CHECK: %[[A_INIT:.*]] = ttg.local_load {{.*}} -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #{{.*}}, kWidth = 8}>>
+    %a_init = ttg.local_load %buf_a0 : !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable> -> tensor<32x32xf16, #blocked_wmma>
+    // CHECK: %[[B_INIT:.*]] = ttg.local_load {{.*}} -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #{{.*}}, kWidth = 8}>>
+    %b_init = ttg.local_load %buf_b0 : !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable> -> tensor<32x32xf16, #blocked_wmma>
+    // CHECK: scf.for {{.*}} iter_args(%[[A_ARG:.*]] = %[[A_INIT]], %[[B_ARG:.*]] = %[[B_INIT]], %[[ACC_ARG:.*]] = {{.*}}) -> (tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #{{.*}}, kWidth = 8}>>, tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #{{.*}}, kWidth = 8}>>, tensor<32x32xf32, #{{.*}}>)
+    %result:3 = scf.for %i = %c0_i32 to %c2_i32 step %c1_i32
+        iter_args(%a_reg = %a_init, %b_reg = %b_init, %acc = %cst)
+        -> (tensor<32x32xf16, #blocked_wmma>, tensor<32x32xf16, #blocked_wmma>, tensor<32x32xf32, #mma_wmma>) : i32 {
+      %a_tmp = ttg.local_alloc %a_reg : (tensor<32x32xf16, #blocked_wmma>) -> !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma>
+      %a_dot = ttg.local_load %a_tmp : !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_wmma, kWidth = 8}>>
+      %b_tmp = ttg.local_alloc %b_reg : (tensor<32x32xf16, #blocked_wmma>) -> !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma>
+      %b_dot = ttg.local_load %b_tmp : !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_wmma, kWidth = 8}>>
+      // CHECK-NOT: ttg.local_alloc %
+      // CHECK: tt.dot %[[A_ARG]], %[[B_ARG]], %[[ACC_ARG]]
+      %dot = tt.dot %a_dot, %b_dot, %acc : tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_wmma, kWidth = 8}>> * tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_wmma, kWidth = 8}>> -> tensor<32x32xf32, #mma_wmma>
+      %buf_a1 = ttg.memdesc_index %alloc_a[%c1_i32] : !ttg.memdesc<2x32x32xf16, #shared_wmma, #smem_wmma, mutable> -> !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable>
+      %buf_b1 = ttg.memdesc_index %alloc_b[%c1_i32] : !ttg.memdesc<2x32x32xf16, #shared_wmma, #smem_wmma, mutable> -> !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable>
+      %a_next = ttg.local_load %buf_a1 : !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable> -> tensor<32x32xf16, #blocked_wmma>
+      %b_next = ttg.local_load %buf_b1 : !ttg.memdesc<32x32xf16, #shared_wmma, #smem_wmma, mutable> -> tensor<32x32xf16, #blocked_wmma>
+      scf.yield %a_next, %b_next, %dot : tensor<32x32xf16, #blocked_wmma>, tensor<32x32xf16, #blocked_wmma>, tensor<32x32xf32, #mma_wmma>
+    }
+    tt.return %result#2 : tensor<32x32xf32, #mma_wmma>
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -305,11 +305,11 @@ class HIPBackend(BaseBackend):
 
         amd.passes.ttgpuir.add_fold_true_cmpi(pm)
         amd.passes.ttgpuir.add_prepare_if_combining(pm)
-        # Late AMD passes can reintroduce dot-operand layout conversions as
-        # tensor local_alloc/local_load pairs. Run TLX propagation after them so
-        # the final cleanup sees and folds those fallbacks.
-        tlx.tlx_passes.add_tlx_propagate_layout(pm)
         passes.common.add_canonicalizer(pm)
+        # Late AMD passes can reintroduce dot-operand layout conversions as
+        # tensor local_alloc/local_load pairs. Run TLX propagation after
+        # canonicalization so the final cleanup sees and folds those fallbacks.
+        tlx.tlx_passes.add_tlx_propagate_layout(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
         if options.instrumentation_mode == "fpsan" and is_fpsan_supported(options.arch):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -305,6 +305,10 @@ class HIPBackend(BaseBackend):
 
         amd.passes.ttgpuir.add_fold_true_cmpi(pm)
         amd.passes.ttgpuir.add_prepare_if_combining(pm)
+        # Late AMD passes can reintroduce dot-operand layout conversions as
+        # tensor local_alloc/local_load pairs. Run TLX propagation after them so
+        # the final cleanup sees and folds those fallbacks.
+        tlx.tlx_passes.add_tlx_propagate_layout(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -217,11 +217,10 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
             swizzledEncoding.getContext(), swizzledEncoding.getVec(),
             swizzledEncoding.getPerPhase(), swizzledEncoding.getMaxPhase(),
             permutedOrder, swizzledEncoding.getCGALayout());
-      }
-      if (!srcEncoding) {
-        // Generic shared encodings, especially padded TDM layouts, need the
-        // inverse transpose to push a result-side requirement back to the
-        // source memdesc.
+      } else {
+        // Other shared encodings (e.g. PaddedSharedEncodingAttr for TDM tiles)
+        // fall back on the dialect's transpose inference to push a result-side
+        // requirement back to the source memdesc via the inverse permutation.
         auto resultType = cast<ttg::MemDescType>(memDescTransOp.getType());
         auto inverseOrder = invertPermutation(memDescTransOp.getOrder());
         FailureOr<Attribute> inferred = inferTransEncoding(

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -23,6 +23,29 @@ namespace ttng = ::mlir::triton::nvidia_gpu;
 
 namespace mlir::triton::tlx {
 
+// Reuse the dialect's transpose inference so TLX propagation stays in sync
+// with verifier/type inference for padded, swizzled, and MMA shared layouts.
+static FailureOr<Attribute> inferTransEncoding(Attribute encoding,
+                                               ArrayRef<int64_t> shape,
+                                               ArrayRef<int32_t> order,
+                                               Location loc) {
+  Dialect &dialect = encoding.getDialect();
+  auto inferLayoutInterface =
+      cast<::mlir::triton::DialectInferLayoutInterface>(&dialect);
+  Attribute resultEncoding;
+  if (failed(inferLayoutInterface->inferTransOpEncoding(encoding, shape, order,
+                                                        resultEncoding, loc)))
+    return failure();
+  return resultEncoding;
+}
+
+static SmallVector<int32_t> invertPermutation(ArrayRef<int32_t> order) {
+  SmallVector<int32_t> inverse(order.size());
+  for (auto [i, dim] : llvm::enumerate(order))
+    inverse[dim] = i;
+  return inverse;
+}
+
 //===----------------------------------------------------------------------===//
 // LayoutEncoding
 //===----------------------------------------------------------------------===//
@@ -194,6 +217,18 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
             swizzledEncoding.getContext(), swizzledEncoding.getVec(),
             swizzledEncoding.getPerPhase(), swizzledEncoding.getMaxPhase(),
             permutedOrder, swizzledEncoding.getCGALayout());
+      }
+      if (!srcEncoding) {
+        // Generic shared encodings, especially padded TDM layouts, need the
+        // inverse transpose to push a result-side requirement back to the
+        // source memdesc.
+        auto resultType = cast<ttg::MemDescType>(memDescTransOp.getType());
+        auto inverseOrder = invertPermutation(memDescTransOp.getOrder());
+        FailureOr<Attribute> inferred = inferTransEncoding(
+            resultEnc, resultType.getShape(), inverseOrder, op->getLoc());
+        if (failed(inferred))
+          return failure();
+        srcEncoding = *inferred;
       }
       if (srcEncoding) {
         const auto updatedResultLayoutEncoding = LayoutEncoding(srcEncoding);
@@ -566,14 +601,30 @@ LogicalResult LayoutForwardPropagation::visitOperation(
     return visitRegion(op);
 
   if (!isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
-           ttg::MemDescSubsliceOp, ttng::TMEMSubSliceOp, ttg::LocalAllocOp,
-           ttng::TMEMAllocOp>(op))
+           ttg::MemDescSubsliceOp, ttg::MemDescTransOp, ttng::TMEMSubSliceOp,
+           ttg::LocalAllocOp, ttng::TMEMAllocOp>(op))
     return success();
 
   for (const auto [operandIdx, operandLattice] : llvm::enumerate(operands)) {
     if (!isa<ttg::MemDescType>(op->getOperand(operandIdx).getType()))
       continue;
     LayoutEncoding operandLayoutEncoding = operandLattice->getValue();
+
+    if (auto transOp = dyn_cast<ttg::MemDescTransOp>(op)) {
+      if (!operandLayoutEncoding.isUninitialized() &&
+          !operandLayoutEncoding.isUnknown()) {
+        // Forward propagation must transpose the concrete source layout before
+        // meeting it into the transposed view; copying the attribute verbatim
+        // leaves verifier-incompatible memdesc_trans result types.
+        auto srcTy = cast<ttg::MemDescType>(transOp.getSrc().getType());
+        FailureOr<Attribute> inferred = inferTransEncoding(
+            operandLayoutEncoding.getLayoutEncoding(), srcTy.getShape(),
+            transOp.getOrder(), op->getLoc());
+        if (failed(inferred))
+          return failure();
+        operandLayoutEncoding = LayoutEncoding(*inferred);
+      }
+    }
 
     // Unknown layouts do not provide enough information to refine a TMEM slice
     // result, so only splice concrete tensor-memory encodings through.

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -565,8 +565,9 @@ LogicalResult LayoutForwardPropagation::visitOperation(
   if (isa<RegionBranchOpInterface, ttg::WarpSpecializePartitionsOp>(op))
     return visitRegion(op);
 
-  if (!isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp, ttng::TMEMSubSliceOp,
-           ttg::LocalAllocOp, ttng::TMEMAllocOp>(op))
+  if (!isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
+           ttg::MemDescSubsliceOp, ttng::TMEMSubSliceOp, ttg::LocalAllocOp,
+           ttng::TMEMAllocOp>(op))
     return success();
 
   for (const auto [operandIdx, operandLattice] : llvm::enumerate(operands)) {

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -2,7 +2,6 @@
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -384,6 +383,29 @@ static bool isAllowedTensorLayoutUser(Operation *op, unsigned operandIndex) {
   return isa<ttg::ConvertLayoutOp>(op) || isTransparentLayoutCarrierOp(op);
 }
 
+// Later layout cleanup may express a dot-operand conversion as
+// tensor -> local_alloc -> local_load(dot). Treat that fallback as another dot
+// layout constraint on the source tensor so propagation can retag the original
+// value instead of preserving the redundant LDS round trip.
+static bool isDotLocalAllocFallback(Operation *op, unsigned operandIndex) {
+  auto allocOp = dyn_cast<ttg::LocalAllocOp>(op);
+  if (!allocOp || operandIndex != 0 || !allocOp.getSrc())
+    return false;
+  if (allocOp->use_empty())
+    return false;
+
+  for (Operation *user : allocOp->getUsers()) {
+    auto localLoadOp = dyn_cast<ttg::LocalLoadOp>(user);
+    if (!localLoadOp)
+      return false;
+    auto resultType = dyn_cast<RankedTensorType>(localLoadOp.getType());
+    if (!resultType ||
+        !isSupportedDotConstraintEncoding(resultType.getEncoding()))
+      return false;
+  }
+  return true;
+}
+
 static bool canRewriteTensorResult(Operation *op) {
   return isa<ttg::LocalLoadOp, RegionBranchOpInterface>(op);
 }
@@ -434,6 +456,29 @@ LogicalResult TensorBackwardPropagation::visitOperation(
     }
     // Don't return early — fall through to let the poison check handle
     // mixed-use cases where the operand has other non-allowed users.
+  }
+
+  if (auto allocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
+    if (!allocOp.getSrc() || !isTrackedTensorValue(allocOp.getSrc()) ||
+        !isDotLocalAllocFallback(op, /*operandIndex=*/0))
+      return success();
+
+    // Meet all fallback users so mixed or conflicting dot requirements still
+    // widen to unknown and keep the explicit conversion path.
+    TensorLayout state;
+    for (Operation *user : allocOp->getUsers()) {
+      auto localLoadOp = cast<ttg::LocalLoadOp>(user);
+      auto resultType = cast<RankedTensorType>(localLoadOp.getType());
+      state = TensorLayout::meet(state, TensorLayout(resultType.getEncoding()));
+      state = TensorLayout::meet(
+          state, getLatticeElement(localLoadOp.getResult())->getValue());
+    }
+
+    if (!state.isUninitialized()) {
+      ChangeResult changed = operands[0]->meet(state);
+      propagateIfChanged(operands[0], changed);
+    }
+    return success();
   }
 
   // If a tracked tensor value is used by an unsupported operation, rewriting

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -270,8 +270,11 @@ static Value findMemDescRoot(Value memdesc) {
     Operation *def = root.getDefiningOp();
     if (!def)
       break;
+    // Treat memdesc views as aliases of the same allocation. This lets TDM
+    // anchors and dot-consumer discovery meet on the full buffer even when
+    // WMMA consumes a sliced or transposed view.
     if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
-            ttg::MemDescSubsliceOp>(def)) {
+            ttg::MemDescSubsliceOp, ttg::MemDescTransOp>(def)) {
       root = def->getOperand(0);
       continue;
     }
@@ -296,8 +299,10 @@ static bool isFedByTDM(Value memdesc) {
       if (isa<amdgpu::AsyncTDMCopyGlobalToLocalOp,
               amdgpu::AsyncTDMCopyLocalToGlobalOp>(u))
         return true;
+      // Follow sibling views from the root allocation so local_load(subslice)
+      // and local_load(transpose(subslice)) are recognized as TDM-fed too.
       if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
-              ttg::MemDescSubsliceOp>(u))
+              ttg::MemDescSubsliceOp, ttg::MemDescTransOp>(u))
         worklist.insert(u->getResult(0));
     }
   }
@@ -517,7 +522,8 @@ public:
     // source memdesc, which lets the alloc converge to the meet of
     // every sibling subview's dot-consumer state.
     if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
-            ttg::MemDescSubsliceOp, tlx::RequireLayoutOp>(op)) {
+            ttg::MemDescSubsliceOp, ttg::MemDescTransOp, tlx::RequireLayoutOp>(
+            op)) {
       for (const auto resultLattice : results) {
         for (auto [i, operandLattice] : llvm::enumerate(operands)) {
           if (!isa<ttg::MemDescType>(op->getOpOperand(i).get().getType()))

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -270,7 +270,8 @@ static Value findMemDescRoot(Value memdesc) {
     Operation *def = root.getDefiningOp();
     if (!def)
       break;
-    if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp>(def)) {
+    if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
+            ttg::MemDescSubsliceOp>(def)) {
       root = def->getOperand(0);
       continue;
     }
@@ -295,7 +296,8 @@ static bool isFedByTDM(Value memdesc) {
       if (isa<amdgpu::AsyncTDMCopyGlobalToLocalOp,
               amdgpu::AsyncTDMCopyLocalToGlobalOp>(u))
         return true;
-      if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp>(u))
+      if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
+              ttg::MemDescSubsliceOp>(u))
         worklist.insert(u->getResult(0));
     }
   }
@@ -336,7 +338,7 @@ static void applyRequireLayout(ttg::SwizzledSharedEncodingAttr encoding,
   if (auto type = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
     auto newType = ttg::MemDescType::get(
         type.getShape(), type.getElementType(), mlir::cast<Attribute>(encoding),
-        type.getMemorySpace(), type.getMutableMemory());
+        type.getMemorySpace(), type.getMutableMemory(), type.getAllocShape());
     auto requireOp = tlx::RequireLayoutOp::create(
         builder, localLoadOp->getLoc(), newType, loadMemDesc);
     localLoadOp->setOperand(0, requireOp.getResult());
@@ -515,7 +517,7 @@ public:
     // source memdesc, which lets the alloc converge to the meet of
     // every sibling subview's dot-consumer state.
     if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
-            tlx::RequireLayoutOp>(op)) {
+            ttg::MemDescSubsliceOp, tlx::RequireLayoutOp>(op)) {
       for (const auto resultLattice : results) {
         for (auto [i, operandLattice] : llvm::enumerate(operands)) {
           if (!isa<ttg::MemDescType>(op->getOpOperand(i).get().getType()))
@@ -629,7 +631,8 @@ static void anchorTDMRequireLayout(TDMOp tdmOp, Value buf,
   builder.setInsertionPoint(tdmOp);
   auto newType = ttg::MemDescType::get(
       bufType.getShape(), bufType.getElementType(), encoding,
-      bufType.getMemorySpace(), bufType.getMutableMemory());
+      bufType.getMemorySpace(), bufType.getMutableMemory(),
+      bufType.getAllocShape());
   auto requireOp =
       tlx::RequireLayoutOp::create(builder, tdmOp.getLoc(), newType, buf);
   operandToRewire.assign(requireOp.getResult());

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -6,7 +6,6 @@
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "tlx/dialect/include/Analysis/LayoutPropagation.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -69,8 +69,11 @@ public:
   }
 };
 
-// Once tensor propagation has retagged the source value to the local_load's dot
-// type, this late layout-conversion fallback becomes an identity.
+// Late AMD passes can express a tensor layout conversion as a spill through
+// immutable local memory:
+//   tensor -> ttg.local_alloc -> ttg.local_load(dot)
+// Fold it back to either an identity or an explicit convert_layout so the
+// fallback does not survive to LLVM as LDS traffic.
 class FoldRetaggedLocalAllocLoad
     : public mlir::OpRewritePattern<ttg::LocalLoadOp> {
 public:
@@ -82,12 +85,59 @@ public:
     auto allocOp = localLoadOp.getSrc().getDefiningOp<ttg::LocalAllocOp>();
     if (!allocOp || !allocOp.getSrc())
       return failure();
-    if (allocOp.getType().getMutableMemory())
+    if (localLoadOp.getToken())
       return failure();
-    if (allocOp.getSrc().getType() != localLoadOp.getType())
+    auto resultType = dyn_cast<RankedTensorType>(localLoadOp.getType());
+    if (!resultType ||
+        !isSupportedDotConstraintEncoding(resultType.getEncoding()))
       return failure();
 
-    rewriter.replaceOp(localLoadOp, allocOp.getSrc());
+    if (allocOp.getSrc().getType() == localLoadOp.getType()) {
+      rewriter.replaceOp(localLoadOp, allocOp.getSrc());
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
+        localLoadOp, localLoadOp.getType(), allocOp.getSrc());
+    return success();
+  }
+};
+
+class FoldLocalAllocLoadFallback
+    : public mlir::OpRewritePattern<ttg::LocalAllocOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ttg::LocalAllocOp allocOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Value src = allocOp.getSrc();
+    if (!src || !isa<RankedTensorType>(src.getType()))
+      return failure();
+    SmallVector<ttg::LocalLoadOp> loads;
+    for (Operation *user : allocOp->getUsers()) {
+      auto localLoadOp = dyn_cast<ttg::LocalLoadOp>(user);
+      if (!localLoadOp || localLoadOp.getToken())
+        return failure();
+      auto resultType = dyn_cast<RankedTensorType>(localLoadOp.getType());
+      if (!resultType ||
+          !isSupportedDotConstraintEncoding(resultType.getEncoding()))
+        return failure();
+      loads.push_back(localLoadOp);
+    }
+    if (loads.empty())
+      return failure();
+
+    for (ttg::LocalLoadOp localLoadOp : loads) {
+      rewriter.setInsertionPoint(localLoadOp);
+      Value replacement = src;
+      if (src.getType() != localLoadOp.getType())
+        replacement = ttg::ConvertLayoutOp::create(
+            rewriter, localLoadOp.getLoc(), localLoadOp.getType(), src);
+      rewriter.replaceOp(localLoadOp, replacement);
+    }
+    if (allocOp->use_empty())
+      rewriter.eraseOp(allocOp);
     return success();
   }
 };
@@ -450,6 +500,7 @@ public:
     patterns.add<RequireLayoutPattern>(context);
     patterns.add<ReleaseLayoutPattern>(context);
     patterns.add<FoldRetaggedLocalAllocLoad>(context);
+    patterns.add<FoldLocalAllocLoadFallback>(context);
 
     if (applyPatternsGreedily(getOperation(), std::move(patterns)).failed())
       signalPassFailure();

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -159,7 +159,8 @@ static ttg::MemDescType getNewMemDescType(ttg::MemDescType origType,
                                           Attribute encoding) {
   return ttg::MemDescType::get(origType.getShape(), origType.getElementType(),
                                encoding, origType.getMemorySpace(),
-                               origType.getMutableMemory());
+                               origType.getMutableMemory(),
+                               origType.getAllocShape());
 }
 
 static FailureOr<const LayoutEncodingLattice *>

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -69,6 +69,29 @@ public:
   }
 };
 
+// Once tensor propagation has retagged the source value to the local_load's dot
+// type, this late layout-conversion fallback becomes an identity.
+class FoldRetaggedLocalAllocLoad
+    : public mlir::OpRewritePattern<ttg::LocalLoadOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ttg::LocalLoadOp localLoadOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto allocOp = localLoadOp.getSrc().getDefiningOp<ttg::LocalAllocOp>();
+    if (!allocOp || !allocOp.getSrc())
+      return failure();
+    if (allocOp.getType().getMutableMemory())
+      return failure();
+    if (allocOp.getSrc().getType() != localLoadOp.getType())
+      return failure();
+
+    rewriter.replaceOp(localLoadOp, allocOp.getSrc());
+    return success();
+  }
+};
+
 static RankedTensorType getNewTensorType(RankedTensorType origType,
                                          Attribute encoding) {
   return RankedTensorType::get(origType.getShape(), origType.getElementType(),
@@ -80,7 +103,9 @@ static bool isRetaggableTensorProducerValue(Value value) {
     return false;
 
   Operation *definingOp = value.getDefiningOp();
-  return isa_and_nonnull<ttg::LocalLoadOp>(definingOp);
+  // Sparse dataflow handles the RegionBranchOpInterface edge consistency; if
+  // all incoming values agree, retagging the region result is safe.
+  return isa_and_nonnull<ttg::LocalLoadOp, RegionBranchOpInterface>(definingOp);
 }
 
 static Type getTensorCandidateType(Value value, DataFlowSolver &solver,
@@ -95,6 +120,24 @@ static Type getTensorCandidateType(Value value, DataFlowSolver &solver,
     return tensorType;
 
   return getNewTensorType(tensorType, lattice->getValue().getLayoutEncoding());
+}
+
+static bool isRetaggableLocalAllocLoadFallback(ttg::LocalAllocOp allocOp) {
+  if (!allocOp.getSrc() || !isa<RankedTensorType>(allocOp.getSrc().getType()))
+    return false;
+  if (allocOp->use_empty())
+    return false;
+
+  for (Operation *user : allocOp->getUsers()) {
+    auto localLoadOp = dyn_cast<ttg::LocalLoadOp>(user);
+    if (!localLoadOp)
+      return false;
+    auto resultType = dyn_cast<RankedTensorType>(localLoadOp.getType());
+    if (!resultType ||
+        !isSupportedDotConstraintEncoding(resultType.getEncoding()))
+      return false;
+  }
+  return true;
 }
 
 static void
@@ -299,6 +342,10 @@ public:
     WalkResult walkResult = funcOp.walk([&](mlir::Operation *op) {
       if (isa<tlx::RequireLayoutOp, tlx::ReleaseLayoutOp>(op))
         return WalkResult::interrupt();
+      if (auto allocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
+        if (isRetaggableLocalAllocLoadFallback(allocOp))
+          return WalkResult::interrupt();
+      }
       return WalkResult::advance();
     });
     if (!walkResult.wasInterrupted())
@@ -401,6 +448,7 @@ public:
     RewritePatternSet patterns(context);
     patterns.add<RequireLayoutPattern>(context);
     patterns.add<ReleaseLayoutPattern>(context);
+    patterns.add<FoldRetaggedLocalAllocLoad>(context);
 
     if (applyPatternsGreedily(getOperation(), std::move(patterns)).failed())
       signalPassFailure();

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -97,6 +97,10 @@ public:
       return success();
     }
 
+    // The matched local_alloc -> local_load pair is always an LDS round-trip.
+    // Replace it with a layout conversion: it lowers to register shuffles for
+    // the common encoding pairs and is no worse than the spill in the few
+    // cases where the conversion itself still goes through LDS.
     rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
         localLoadOp, localLoadOp.getType(), allocOp.getSrc());
     return success();


### PR DESCRIPTION
This PR tightens TLX layout propagation for AMD GEMM-style pipelines where TDM-loaded LDS tiles are consumed through views before `tt.dot`.

- Propagates TDM/dot layout requirements through `ttg.memdesc_subslice` and `ttg.memdesc_trans`, preserving backing alloc shapes for sliced views.
- Folds late tensor-backed dot operand fallbacks (`tensor -> ttg.local_alloc -> ttg.local_load(dot)`) back to identity or direct `ttg.convert_layout`.
- Runs TLX layout cleanup after AMD canonicalization, where the fallback can be introduced.