### PR TITLE
[TLX] Insert cluster sync for 2-CTA tmem alloc

### DIFF
--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -553,11 +553,12 @@ def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
     assert ttgir.count("ttng.map_to_remote_buffer") == 1
 
     ptx = kernel.asm["ptx"]
-    assert ptx.count("fence.mbarrier_init.release.cluster") == 1
-    assert ptx.count("barrier.cluster.arrive.aligned") == 1  # one for remote bar init
-    assert ptx.count("barrier.cluster.wait.aligned") == 1  # one for remote bar init
-    assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
-    assert ptx.count("tcgen05.mma.cta_group::2") == 8  # BK=128 divided into steps of 16
+    # Verify ordering: alloc → alloc cluster sync → fences → barrier init cluster sync
+    tmem_alloc_pos = ptx.index("tcgen05.alloc.cta_group::2")
+    fence_mbar_pos = ptx.index("fence.mbarrier_init.release.cluster")
+    assert tmem_alloc_pos < fence_mbar_pos
+    assert ptx.count("mapa.shared::cluster") == 1
+    assert ptx.count("tcgen05.mma.cta_group::2") == 8
 
     ref_out = torch.matmul(x, y)
     torch.testing.assert_close(z, ref_out)
@@ -695,13 +696,14 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
 
     ptx = kernel.asm["ptx"]
     assert ptx.count("fence.mbarrier_init.release.cluster") == 1
-    # two for trunk remote bar init: one for default wg, one for non default
-    assert ptx.count("barrier.cluster.arrive.aligned") == 2
-    # one for trunk remote bar init: non default WGs just arrive anyway, then it's equivalent to a sync between
-    #   default WGs in all CTAs
-    assert ptx.count("barrier.cluster.wait.aligned") == 1
-    assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
-    assert ptx.count("tcgen05.mma.cta_group::2") == 8  # BK=128 divided into steps of 16
+    assert ptx.count("tcgen05.alloc.cta_group::2") == 1
+    # Barrier init cluster sync after fences
+    fence_mbar_pos = ptx.index("fence.mbarrier_init.release.cluster")
+    cluster_arrive_pos = ptx.index("barrier.cluster.arrive.aligned", fence_mbar_pos)
+    cluster_wait_pos = ptx.index("barrier.cluster.wait.aligned", cluster_arrive_pos)
+    assert fence_mbar_pos < cluster_arrive_pos < cluster_wait_pos
+    assert ptx.count("mapa.shared::cluster") == 1
+    assert ptx.count("tcgen05.mma.cta_group::2") == 8
 
     ref_out = torch.matmul(x, y)
     torch.testing.assert_close(z, ref_out)

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -565,7 +565,7 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     auto ctx = ret->getContext();
     auto loc = ret.getLoc();
     auto voidTy = void_ty(ctx);
-    if (twoCTAs && !tlxPairedMMA) {
+    if (twoCTAs) {
       NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
       NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));
     } else {
@@ -619,6 +619,39 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func) {
   return alloc;
 }
 
+// For TLX paired MMA, insert a cluster sync before tcgen05.alloc (at function
+// start) to ensure both CTAs are synchronized before the allocation.
+// This is separate from the barrier init cluster sync in maybeInsertClusterSync.
+// lowerWarpSpecialize emits a matching arrive on the non-default warp side.
+static void maybeInsertAllocClusterSync(LLVM::LLVMFuncOp kernel) {
+  auto mod = kernel->getParentOfType<ModuleOp>();
+  if (!tlx::tlxEnablePairedMMA(mod))
+    return;
+  if (!tlx::tlxIsClustered(mod) || tlx::tlxExplicitClusterSync(mod))
+    return;
+
+  // Find the tcgen05.alloc inline asm — the cluster sync goes right before it.
+  Operation *insertBefore = nullptr;
+  for (auto &op : kernel.front()) {
+    if (auto asmOp = dyn_cast<LLVM::InlineAsmOp>(&op)) {
+      if (asmOp.getAsmString().contains("tcgen05.alloc")) {
+        insertBefore = &op;
+        break;
+      }
+    }
+  }
+  if (!insertBefore)
+    return;
+
+  auto ctx = kernel->getContext();
+  IRRewriter rewriter(ctx);
+  rewriter.setInsertionPoint(insertBefore);
+  NVVM::ClusterArriveOp::create(rewriter, insertBefore->getLoc(),
+                                UnitAttr::get(ctx));
+  NVVM::ClusterWaitOp::create(rewriter, insertBefore->getLoc(),
+                              UnitAttr::get(ctx));
+}
+
 static void lowerTensorMemoryAlloc(ModuleOp mod) {
   SmallVector<Operation *> baseOps;
   LLVM::LLVMFuncOp kernel = nullptr;
@@ -640,6 +673,9 @@ static void lowerTensorMemoryAlloc(ModuleOp mod) {
     baseOp->getResult(0).replaceAllUsesWith(newBase);
     baseOp->erase();
   }
+
+  // Insert cluster sync after tcgen05.alloc for 2-CTA tmem alloc.
+  maybeInsertAllocClusterSync(kernel);
 }
 
 } // anonymous namespace

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -191,14 +191,15 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
   wid = targetInfo.shuffleIdx(b, b.getLoc(), wid, 0);
   Value isDefault = b.icmp_ult(wid, b.i32_val(defaultNumWarps));
   if (tlx::tlxIsClustered(func) && !tlx::tlxExplicitClusterSync(func)) {
-    // All these have to be true before we can insert an arrive here:
+    // All these have to be true before we can insert arrives here:
     // - The kernel is in clustered mode
     // - There's no user controlled explicit cluster sync
-    // - There's an ClusterWaitOp (then it had to be inserted by compiler)
-    bool hasClusterBarWait =
-        func.walk([&](NVVM::ClusterWaitOp) { return WalkResult::interrupt(); })
-            .wasInterrupted();
-    if (hasClusterBarWait) {
+    // - There are ClusterWaitOps (inserted by compiler for barrier init,
+    //   tmem alloc, and tmem dealloc). Non-default warps need a matching
+    //   arrive for each.
+    unsigned numClusterWaits = 0;
+    func.walk([&](NVVM::ClusterWaitOp) { ++numClusterWaits; });
+    for (unsigned i = 0; i < numClusterWaits; ++i) {
       // Non default warps should just do a cluster arrive unconditionally.
       // Note this instruction is at kernel beginning shared by all warps, and
       // we use `isDefault` as predicate here to select only non default warps

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -413,6 +413,8 @@ private:
     // need to insert fence to make mbar init visible to cluster
     ttng::FenceMBarrierInitReleaseClusterOp::create(builder,
                                                     lastBarInitOp.getLoc());
+    ttng::FenceAsyncSharedOp::create(builder, lastBarInitOp.getLoc(),
+                                        /*bCluster=*/true);
     // need to insert cluster arrive and wait to prevent CTA_X from arriving
     // CTA_Y's bar before CTA_Y inits it, as shown in ptx doc examples:
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-try-wait


### PR DESCRIPTION
For TLX paired MMA kernels, insert a cluster sync before tcgen05.alloc to ensure both CTAs are synchronized before TMEM allocation. The alloc stays at function start; the cluster sync is deferred to NVGPUToLLVM where the alloc is visible. Similarly a cluster sync is is added before tcgen05.dealloc.

Key changes:
- maybeInsertClusterSync: keeps barrier init cluster sync, adds fence.proxy.async.shared::cluster for paired MMA
- maybeInsertAllocClusterSync (new, in NVGPUToLLVM): inserts cluster sync before tcgen05.alloc for paired MMA
- lowerWarpSpecialize: counts ClusterWaitOps and emits matching arrives on non-default warp side
