### PR TITLE
[triton][beta] Fix TMA descriptor handling in C launcher: duck-typing support (#1447)

### DIFF
--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1295,20 +1295,50 @@ bool extractFP64(void *ptr, PyObject *obj) {
 }
 
 // Extract a CUtensorMap descriptor from a python object, and store it to the
-// memory location pointed by ptr.
+// memory location pointed by ptr. Supports both PyCUtensorMap objects (from
+// fill_tma_descriptor_tiled) and duck-typed wrappers with tma_desc_cpu_ptr()
+// (e.g., KernelParamWrapper from fast_moe/fbgemm).
+static PyObject *tma_desc_cpu_ptr_str = NULL;
+
 bool extractTmaDesc(void *ptr, PyObject *obj) {
   if (sizeof(CUtensorMap *) != 8) {
     PyErr_SetString(PyExc_SystemError,
                     "getTmaDesc() requires 64-bit compilation");
     return false;
   }
-  if (Py_TYPE(obj) != &PyCUtensorMapType) {
-    PyErr_Format(PyExc_TypeError,
-                 "object must be of type PyCUtensorMap, got %s",
-                 Py_TYPE(obj)->tp_name);
-    return false;
+
+  if (Py_TYPE(obj) == &PyCUtensorMapType) {
+    // Fast path: native PyCUtensorMap object
+    *((CUtensorMap *)ptr) = ((PyCUtensorMapObject *)obj)->tensorMap;
+  } else {
+    // Duck-typing fallback: try tma_desc_cpu_ptr() method
+    if (!tma_desc_cpu_ptr_str) {
+      tma_desc_cpu_ptr_str = PyUnicode_InternFromString("tma_desc_cpu_ptr");
+      if (!tma_desc_cpu_ptr_str)
+        return false;
+    }
+    PyObject *host_ptr_obj = PyObject_CallMethodNoArgs(obj, tma_desc_cpu_ptr_str);
+    if (!host_ptr_obj) {
+      // Only replace the error if the method doesn't exist (AttributeError).
+      // If the method exists but raised, propagate the real exception.
+      if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        PyErr_Clear();
+        PyErr_Format(PyExc_TypeError,
+                     "object must be of type PyCUtensorMap or have tma_desc_cpu_ptr() method, got %s",
+                     Py_TYPE(obj)->tp_name);
+      }
+      return false;
+    }
+    uintptr_t host_ptr = (uintptr_t)PyLong_AsUnsignedLongLong(host_ptr_obj);
+    Py_DECREF(host_ptr_obj);
+    if (PyErr_Occurred()) return false;
+    if (host_ptr == 0) {
+      PyErr_SetString(PyExc_ValueError, "tma_desc_cpu_ptr() returned NULL");
+      return false;
+    }
+    memcpy(ptr, (const void *)host_ptr, sizeof(CUtensorMap));
   }
-  *((CUtensorMap *)ptr) = ((PyCUtensorMapObject *)obj)->tensorMap;
+
   // Depending on the cuda version, alignof(CUtensorMap) may be 64 or 128.
   size_t alignment = alignof(CUtensorMap);
   uintptr_t remainder = (uintptr_t)ptr & (alignment - 1);

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -10,7 +10,7 @@
 
 typedef struct {
   PyObject_HEAD;
-  _Alignas(128) CUtensorMap tensorMap;
+  _Alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
 } PyCUtensorMapObject;
 
 typedef enum { ARG_CONSTEXPR = 0, ARG_KERNEL = 1, ARG_TUPLE = 2 } ArgType;
@@ -1309,12 +1309,14 @@ bool extractTmaDesc(void *ptr, PyObject *obj) {
     return false;
   }
   *((CUtensorMap *)ptr) = ((PyCUtensorMapObject *)obj)->tensorMap;
-  uintptr_t align_128 = (uintptr_t)ptr & (128 - 1);
-  if (align_128 != 0) {
+  // Depending on the cuda version, alignof(CUtensorMap) may be 64 or 128.
+  size_t alignment = alignof(CUtensorMap);
+  uintptr_t remainder = (uintptr_t)ptr & (alignment - 1);
+  if (remainder != 0) {
     PyErr_Format(
         PyExc_ValueError,
-        "CUtensorMap must be aligned to 128B, but got (&map) mod 128 = %ld",
-        align_128);
+        "CUtensorMap must be aligned to %ld, but got (&map) mod %ld = %ld",
+        alignment, alignment, remainder);
     return false;
   }
   return true;


### PR DESCRIPTION
Summary:

Fix TypeError in the variadic C launcher introduced by D103454938 (backport of upstream PR #6788).

**Root cause: Meta/upstream divergence in TMA descriptor passing.**

Upstream's `extractTmaDesc` only accepts native `PyCUtensorMap` objects, which works fine upstream because all callers pass `PyCUtensorMap` directly. However, Meta-internal code (fast_moe, fbgemm grouped_gemm) uses `KernelParamWrapper` — a duck-typed TMA descriptor wrapper that exposes a `tma_desc_cpu_ptr()` method instead of being a `PyCUtensorMap` instance. The old ctypes-based launcher (pre-#6788) handled this via Python-level duck typing, but the new C variadic launcher only checks the C struct type directly, breaking compatibility with these Meta-internal wrappers.

**Fix:** Add a fallback path in `extractTmaDesc`: if the object is not a native `PyCUtensorMap`, try calling `tma_desc_cpu_ptr()` and memcpy the 128-byte descriptor — matching the behavior the ctypes launcher already supported.

Reviewed By: jma2333

Differential Revision: D104290596


