### PR TITLE
[AutoWS] Hoist convert_layout before broadcast to reduce SMEM usage

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -407,31 +407,6 @@ struct CanonicalizeConvertFromConvert
       return success();
     }
 
-    // cvt(broadcast(x)) -> broadcast(cvt(x))
-    // Hoists the convert before the broadcast so it operates on the smaller
-    // pre-broadcast tensor. This can dramatically reduce SMEM scratch for
-    // the convert (e.g., [1,256] * 4 bytes = 1KB vs [128,256] * 4 bytes =
-    // 128KB).
-    if (auto broadcast = dyn_cast<triton::BroadcastOp>(arg)) {
-      auto srcType = cast<RankedTensorType>(broadcast.getSrc().getType());
-      auto cvtDstEnc = op.getType().getEncoding();
-      // Skip if source and dest encodings are the same
-      if (srcType.getEncoding() == cvtDstEnc)
-        return failure();
-      auto newSrcType = srcType.cloneWithEncoding(cvtDstEnc);
-      auto cvtSrc = ConvertLayoutOp::create(rewriter, op.getLoc(), newSrcType,
-                                            broadcast.getSrc());
-      auto newBroadcast = rewriter.replaceOpWithNewOp<triton::BroadcastOp>(
-          op, op.getType(), cvtSrc.getResult());
-      // Propagate all attributes from original ops to new ones to preserve
-      // WS partition info (async_task_id, ttg.partition, etc.)
-      for (auto attr : op->getDialectAttrs())
-        cvtSrc->setAttr(attr.getName(), attr.getValue());
-      for (auto attr : broadcast->getDialectAttrs())
-        newBroadcast->setAttr(attr.getName(), attr.getValue());
-      return success();
-    }
-
     // cvt(type, constant) -> constant
     if (auto cst = llvm::dyn_cast<arith::ConstantOp>(arg))
       if (auto ret = dyn_cast<SplatElementsAttr>(cst.getValue())) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -407,6 +407,31 @@ struct CanonicalizeConvertFromConvert
       return success();
     }
 
+    // cvt(broadcast(x)) -> broadcast(cvt(x))
+    // Hoists the convert before the broadcast so it operates on the smaller
+    // pre-broadcast tensor. This can dramatically reduce SMEM scratch for
+    // the convert (e.g., [1,256] * 4 bytes = 1KB vs [128,256] * 4 bytes =
+    // 128KB).
+    if (auto broadcast = dyn_cast<triton::BroadcastOp>(arg)) {
+      auto srcType = cast<RankedTensorType>(broadcast.getSrc().getType());
+      auto cvtDstEnc = op.getType().getEncoding();
+      // Skip if source and dest encodings are the same
+      if (srcType.getEncoding() == cvtDstEnc)
+        return failure();
+      auto newSrcType = srcType.cloneWithEncoding(cvtDstEnc);
+      auto cvtSrc = ConvertLayoutOp::create(rewriter, op.getLoc(), newSrcType,
+                                            broadcast.getSrc());
+      auto newBroadcast = rewriter.replaceOpWithNewOp<triton::BroadcastOp>(
+          op, op.getType(), cvtSrc.getResult());
+      // Propagate all attributes from original ops to new ones to preserve
+      // WS partition info (async_task_id, ttg.partition, etc.)
+      for (auto attr : op->getDialectAttrs())
+        cvtSrc->setAttr(attr.getName(), attr.getValue());
+      for (auto attr : broadcast->getDialectAttrs())
+        newBroadcast->setAttr(attr.getName(), attr.getValue());
+      return success();
+    }
+
     // cvt(type, constant) -> constant
     if (auto cst = llvm::dyn_cast<arith::ConstantOp>(arg))
       if (auto ret = dyn_cast<SplatElementsAttr>(cst.getValue())) {

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -110,8 +110,12 @@ public:
   void dump();
 
 private:
+  unsigned estimateAnchorConvertCost(Value value, Attribute encoding);
+
   // map from value to layout information.
   llvm::MapVector<Value, LayoutInfo> layouts;
+  // Values that are layout anchors (encoding fixed by hardware/op semantics).
+  DenseSet<Value> anchorValues;
   // map of the values rewrite based on their encoding.
   DenseMap<std::pair<Value, Attribute>, Value> rewriteMapping;
   SetVector<Operation *> opToDelete;
@@ -309,6 +313,7 @@ void LayoutPropagation::initAnchorLayout() {
       }
       // Facebook end
       layouts.insert({v, LayoutInfo(tensorType.getEncoding())});
+      anchorValues.insert(v);
     }
   };
 
@@ -513,6 +518,66 @@ static int64_t getLayoutScore(Attribute encoding) {
   return score;
 }
 
+// Walk backward from `value` through the layouts map to find anchor boundaries
+// where a convert would be needed if `encoding` is chosen. Returns the total
+// SMEM scratch cost in bytes. This accounts for shape differences (e.g., a
+// convert on a 1x256 tensor pre-broadcast is much cheaper than on 128x256).
+unsigned LayoutPropagation::estimateAnchorConvertCost(Value value,
+                                                      Attribute encoding) {
+  unsigned totalCost = 0;
+  DenseSet<Value> visited;
+  SmallVector<Value> worklist = {value};
+  auto encTrait = dyn_cast<LayoutEncodingTrait>(encoding);
+
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    if (!visited.insert(v).second)
+      continue;
+
+    // If this value is an anchor, check if it needs a convert.
+    if (anchorValues.contains(v)) {
+      auto srcTy = dyn_cast<RankedTensorType>(v.getType());
+      if (!srcTy)
+        continue;
+      Attribute srcEnc = srcTy.getEncoding();
+      if (srcEnc == encoding)
+        continue;
+      if (encTrait && srcTy.getRank() != encTrait.getRank())
+        continue;
+      auto dstTy = srcTy.cloneWithEncoding(encoding);
+      if (cvtNeedsSharedMemory(srcTy, dstTy)) {
+        unsigned elems = getNumScratchElemsSwizzledCvt(srcTy, dstTy);
+        totalCost += elems * getElementBitWidth(srcTy) / 8;
+      }
+      continue;
+    }
+
+    // Not an anchor — walk through its defining op's operands.
+    Operation *defOp = v.getDefiningOp();
+    if (!defOp)
+      continue;
+
+    // For scf.for results, also trace through the corresponding yield operand
+    // inside the loop body, since that's where the actual value comes from.
+    if (auto forOp = dyn_cast<scf::ForOp>(defOp)) {
+      unsigned idx = cast<OpResult>(v).getResultNumber();
+      auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      Value yieldOperand = yield.getOperand(idx);
+      if (isa<RankedTensorType>(yieldOperand.getType()) &&
+          layouts.find(yieldOperand) != layouts.end())
+        worklist.push_back(yieldOperand);
+    }
+
+    for (Value operand : defOp->getOperands()) {
+      if (!isa<RankedTensorType>(operand.getType()))
+        continue;
+      if (layouts.find(operand) != layouts.end())
+        worklist.push_back(operand);
+    }
+  }
+  return totalCost;
+}
+
 void LayoutPropagation::resolveConflicts() {
   for (auto &it : layouts) {
     Operation *op = it.first.getDefiningOp();
@@ -545,6 +610,27 @@ void LayoutPropagation::resolveConflicts() {
             (!isLoadOrStore && isa<MmaEncodingTrait>(e))) {
           encoding = e;
           break;
+        }
+      }
+    }
+    // When layout scores are close (within 2x), use SMEM scratch cost at
+    // anchor boundaries as a tiebreaker. This walks backward through the
+    // dataflow to find where converts would actually be inserted (at anchors
+    // like tmem_load, local_load) and uses the anchor tensor shape for cost
+    // estimation. This naturally prefers converting smaller tensors (e.g.,
+    // a 1x256 bias before broadcast rather than a 128x256 accumulator).
+    {
+      unsigned chosenCost = estimateAnchorConvertCost(it.first, encoding);
+      for (Attribute e : info.encodings) {
+        if (e == encoding)
+          continue;
+        int64_t score = getLayoutScore(e);
+        if (score > 0 && bestScore <= 2 * score) {
+          unsigned cost = estimateAnchorConvertCost(it.first, e);
+          if (cost < chosenCost) {
+            encoding = e;
+            chosenCost = cost;
+          }
         }
       }
     }

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -108,10 +108,11 @@ public:
   Value getRewrittenValue(Value value);
   // Dump the current stage of layout information.
   void dump();
-
-private:
+  // Walk backward to anchor boundaries and estimate the SMEM scratch cost
+  // (in bytes) of converts needed if `encoding` is chosen for `value`.
   unsigned estimateAnchorConvertCost(Value value, Attribute encoding);
 
+private:
   // map from value to layout information.
   llvm::MapVector<Value, LayoutInfo> layouts;
   // Values that are layout anchors (encoding fixed by hardware/op semantics).
@@ -578,33 +579,55 @@ unsigned LayoutPropagation::estimateAnchorConvertCost(Value value,
   return totalCost;
 }
 
+// Estimate the total cost of choosing `encoding` for `value`. Combines:
+// 1. Convert scratch cost at anchor boundaries (SMEM bytes for converts that
+//    would be inserted where the chosen encoding meets a fixed anchor encoding).
+// 2. Transaction cost penalty for lower vectorization (more SMEM bank
+//    transactions when sizePerThread is smaller).
+// Both are in bytes so they're directly comparable.
+static unsigned estimateTotalCost(Value value, Attribute encoding,
+                                  LayoutPropagation &propagation) {
+  unsigned convertCost = propagation.estimateAnchorConvertCost(value, encoding);
+
+  // Transaction cost: totalBytes / sizePerThread gives the number of bytes
+  // each thread must individually load/store from SMEM. Lower sizePerThread
+  // means more transactions for the same data volume.
+  unsigned transactionCost = 0;
+  if (auto tensorTy = dyn_cast<RankedTensorType>(value.getType())) {
+    int64_t numElems = tensorTy.getNumElements();
+    unsigned elemBytes = tensorTy.getElementTypeBitWidth() / 8;
+    int64_t totalBytes = numElems * elemBytes;
+    int64_t score = getLayoutScore(encoding);
+    if (score > 0)
+      transactionCost = totalBytes / score;
+  }
+
+  return convertCost + transactionCost;
+}
+
 void LayoutPropagation::resolveConflicts() {
   for (auto &it : layouts) {
     Operation *op = it.first.getDefiningOp();
     LayoutInfo &info = it.second;
     if (info.encodings.size() <= 1)
       continue;
-    // Hacky resolve, prefer block encoding.
-    // TODO: add a proper heuristic.
     Attribute encoding = *info.encodings.begin();
     bool isLoadOrStore =
         op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
-    // Pick the layout with maximum score.
-    // This prefers layouts with larger sizePerThread values for better
-    // vectorized memory access. Both blocked and linear encodings are scored,
-    // so e.g. a linear layout from TMEMLoadOp (sizePerThread=[1,32]) beats
-    // a blocked layout from local_load (sizePerThread=[1,8]).
-    int64_t bestScore = getLayoutScore(encoding);
+
+    // Pick the encoding with the lowest total cost, combining convert scratch
+    // cost at anchor boundaries and SMEM transaction cost from vectorization.
+    unsigned bestCost = estimateTotalCost(it.first, encoding, *this);
     for (Attribute e : info.encodings) {
-      int64_t score = getLayoutScore(e);
-      if (score > bestScore) {
-        bestScore = score;
+      unsigned cost = estimateTotalCost(it.first, e, *this);
+      if (cost < bestCost) {
+        bestCost = cost;
         encoding = e;
       }
     }
-    // If no layout with vectorization found, fall back to the original
-    // heuristic (prefer blocked for load/store, MMA for compute).
-    if (bestScore == 0) {
+    // If costs are tied (e.g., all zero), fall back to heuristics:
+    // prefer blocked for load/store, MMA for compute.
+    if (bestCost == 0) {
       for (Attribute e : info.encodings) {
         if ((isLoadOrStore && isa<BlockedEncodingAttr>(e)) ||
             (!isLoadOrStore && isa<MmaEncodingTrait>(e))) {
@@ -613,42 +636,20 @@ void LayoutPropagation::resolveConflicts() {
         }
       }
     }
-    // When layout scores are close (within 2x), use SMEM scratch cost at
-    // anchor boundaries as a tiebreaker. This walks backward through the
-    // dataflow to find where converts would actually be inserted (at anchors
-    // like tmem_load, local_load) and uses the anchor tensor shape for cost
-    // estimation. This naturally prefers converting smaller tensors (e.g.,
-    // a 1x256 bias before broadcast rather than a 128x256 accumulator).
-    {
-      unsigned chosenCost = estimateAnchorConvertCost(it.first, encoding);
-      for (Attribute e : info.encodings) {
-        if (e == encoding)
-          continue;
-        int64_t score = getLayoutScore(e);
-        if (score > 0 && bestScore <= 2 * score) {
-          unsigned cost = estimateAnchorConvertCost(it.first, e);
-          if (cost < chosenCost) {
-            encoding = e;
-            chosenCost = cost;
-          }
-        }
-      }
-    }
     // Budget-aware override: if the chosen encoding would introduce a
     // convert_layout whose scratch buffer pushes SMEM over budget, pick the
     // candidate with the lowest scratch cost instead.
     if (smemBudget > 0) {
       unsigned baseCost = computeBaseSmem(funcOp);
-      unsigned scratchCost = estimateConvertScratchCost(it.first, encoding);
+      unsigned scratchCost = estimateAnchorConvertCost(it.first, encoding);
       if (baseCost + scratchCost > smemBudget) {
         LDBG("Budget override: base=" << baseCost << " scratch=" << scratchCost
                                       << " total=" << (baseCost + scratchCost)
                                       << " budget=" << smemBudget);
-        // Try each candidate and pick the one with lowest scratch cost.
         Attribute bestEncoding = encoding;
         unsigned bestScratchCost = scratchCost;
         for (Attribute e : info.encodings) {
-          unsigned cost = estimateConvertScratchCost(it.first, e);
+          unsigned cost = estimateAnchorConvertCost(it.first, e);
           if (cost < bestScratchCost) {
             bestScratchCost = cost;
             bestEncoding = e;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -504,6 +504,23 @@ static Attribute inferSrcEncoding(triton::ReshapeOp op, Attribute encoding) {
                                    op.getAllowReorder());
 }
 
+static Attribute inferSrcEncoding(triton::BroadcastOp op, Attribute encoding) {
+  auto srcShape = op.getSrc().getType().getShape();
+  auto dstShape = op.getResult().getType().getShape();
+  auto linearEnc = dyn_cast<ttg::LinearEncodingAttr>(encoding);
+  if (!linearEnc)
+    return encoding;
+  auto ll = linearEnc.getLinearLayout();
+  auto *ctx = op->getContext();
+  for (int i = 0, rank = srcShape.size(); i < rank; i++) {
+    if (srcShape[i] == 1 && dstShape[i] > 1) {
+      auto dimName = StringAttr::get(ctx, "dim" + llvm::Twine(i));
+      ll = ll.resizeOutDim(dimName, 1);
+    }
+  }
+  return ttg::LinearEncodingAttr::get(ctx, std::move(ll));
+}
+
 static bool isSingleValue(Value value) {
   // Don't consider load as expensive if it is loading a scalar.
   if (auto tensorTy = dyn_cast<RankedTensorType>(value.getType()))
@@ -551,6 +568,8 @@ Attribute inferSrcEncoding(Operation *op, Attribute encoding) {
     return inferSrcEncoding(gather, encoding);
   if (auto fp4ToFp = dyn_cast<triton::gpu::Fp4ToFpOp>(op))
     return inferSrcEncoding(fp4ToFp, encoding);
+  if (auto broadcast = dyn_cast<triton::BroadcastOp>(op))
+    return inferSrcEncoding(broadcast, encoding);
 
   return {};
 }

--- a/test/TritonGPU/hoist-convert-before-broadcast.mlir
+++ b/test/TritonGPU/hoist-convert-before-broadcast.mlir
@@ -1,0 +1,138 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-remove-layout-conversions -cse | FileCheck %s
+
+// Test: hoistConvertOnTopOfExtOrBroadcast hoists convert before broadcast
+// to reduce SMEM scratch (convert operates on smaller pre-broadcast tensor).
+// e.g., convert on [1,256] = 1KB SMEM vs convert on [128,256] = 128KB SMEM.
+
+// -----
+
+// Blocked -> blocked: basic case.
+// CHECK-LABEL: @test_blocked_to_blocked
+// CHECK-SAME: (%[[ARG:.+]]: tensor<1x256xf32
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[ARG]] : tensor<1x256xf32, #{{.+}}> -> tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<1x256xf32, #{{.+}}> -> tensor<128x256xf32, #{{.+}}>
+//       CHECK:   tt.return %[[BC]]
+#blocked_src = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_dst = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:90"} {
+tt.func @test_blocked_to_blocked(%arg0: tensor<1x256xf32, #blocked_src>) -> tensor<128x256xf32, #blocked_dst> {
+    %bc = tt.broadcast %arg0 : tensor<1x256xf32, #blocked_src> -> tensor<128x256xf32, #blocked_src>
+    %cvt = ttg.convert_layout %bc : tensor<128x256xf32, #blocked_src> -> tensor<128x256xf32, #blocked_dst>
+    tt.return %cvt : tensor<128x256xf32, #blocked_dst>
+}
+}  // end module
+
+// -----
+
+// Blocked -> linear: the real-world addmm bias broadcast case from B200 persistent
+// TMA matmul. The bias is loaded as [1,256] #blocked, broadcast to [128,256],
+// then converted to #linear for the tmem accumulator add.
+// CHECK-LABEL: @test_blocked_to_linear
+// CHECK-SAME: (%[[ARG:.+]]: tensor<1x256xf32
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[ARG]] : tensor<1x256xf32, #{{.+}}> -> tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<1x256xf32, #{{.+}}> -> tensor<128x256xf32, #{{.+}}>
+//       CHECK:   tt.return %[[BC]]
+#blocked_bias = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear_acc = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:100"} {
+tt.func @test_blocked_to_linear(%arg0: tensor<1x256xf32, #blocked_bias>) -> tensor<128x256xf32, #linear_acc> {
+    %bc = tt.broadcast %arg0 : tensor<1x256xf32, #blocked_bias> -> tensor<128x256xf32, #blocked_bias>
+    %cvt = ttg.convert_layout %bc : tensor<128x256xf32, #blocked_bias> -> tensor<128x256xf32, #linear_acc>
+    tt.return %cvt : tensor<128x256xf32, #linear_acc>
+}
+}  // end module
+
+// -----
+
+// Ext + broadcast chain: extf(bf16->f32) then broadcast, matching the actual
+// addmm epilogue pattern where bias is loaded as bf16, extended, then broadcast.
+// CHECK-LABEL: @test_ext_then_broadcast_to_linear
+// CHECK-SAME: (%[[ARG:.+]]: tensor<1x256xbf16
+//       CHECK:   %[[EXT:.+]] = arith.extf %[[ARG]] : tensor<1x256xbf16, #{{.+}}> to tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[EXT]] : tensor<1x256xf32, #{{.+}}> -> tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<1x256xf32, #{{.+}}> -> tensor<128x256xf32, #{{.+}}>
+//       CHECK:   tt.return %[[BC]]
+#blocked_bf16 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear_f32 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:100"} {
+tt.func @test_ext_then_broadcast_to_linear(%arg0: tensor<1x256xbf16, #blocked_bf16>) -> tensor<128x256xf32, #linear_f32> {
+    %ext = arith.extf %arg0 : tensor<1x256xbf16, #blocked_bf16> to tensor<1x256xf32, #blocked_bf16>
+    %bc = tt.broadcast %ext : tensor<1x256xf32, #blocked_bf16> -> tensor<128x256xf32, #blocked_bf16>
+    %cvt = ttg.convert_layout %bc : tensor<128x256xf32, #blocked_bf16> -> tensor<128x256xf32, #linear_f32>
+    tt.return %cvt : tensor<128x256xf32, #linear_f32>
+}
+}  // end module
+
+// -----
+
+// Column broadcast: broadcast along dim1 instead of dim0.
+// CHECK-LABEL: @test_col_broadcast_blocked
+// CHECK-SAME: (%[[ARG:.+]]: tensor<128x1xf32
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[ARG]] : tensor<128x1xf32, #{{.+}}> -> tensor<128x1xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<128x1xf32, #{{.+}}> -> tensor<128x256xf32, #{{.+}}>
+//       CHECK:   tt.return %[[BC]]
+#blocked_col_src = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked_col_dst = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:90"} {
+tt.func @test_col_broadcast_blocked(%arg0: tensor<128x1xf32, #blocked_col_src>) -> tensor<128x256xf32, #blocked_col_dst> {
+    %bc = tt.broadcast %arg0 : tensor<128x1xf32, #blocked_col_src> -> tensor<128x256xf32, #blocked_col_src>
+    %cvt = ttg.convert_layout %bc : tensor<128x256xf32, #blocked_col_src> -> tensor<128x256xf32, #blocked_col_dst>
+    tt.return %cvt : tensor<128x256xf32, #blocked_col_dst>
+}
+}  // end module
+
+// -----
+
+// End-to-end addmm epilogue: local_load -> extf -> broadcast -> convert_layout.
+// Mirrors the real B200 persistent TMA matmul bias path where bias is loaded
+// from SMEM via local_load as bf16, extended to f32, broadcast, then converted
+// to #linear for the tmem accumulator add.
+// CHECK-LABEL: @test_local_load_ext_broadcast_to_linear
+//       CHECK:   %[[LD:.+]] = ttg.local_load
+//       CHECK:   %[[EXT:.+]] = arith.extf %[[LD]] : tensor<1x256xbf16, #{{.+}}> to tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[EXT]] : tensor<1x256xf32, #{{.+}}> -> tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<1x256xf32, #{{.+}}> -> tensor<128x256xf32, #{{.+}}>
+//       CHECK:   tt.return %[[BC]]
+#blocked_ld = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear_tmem = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared_ld = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#smem_ld = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:100"} {
+tt.func @test_local_load_ext_broadcast_to_linear(%alloc: !ttg.memdesc<1x256xbf16, #shared_ld, #smem_ld, mutable>) -> tensor<128x256xf32, #linear_tmem> {
+    %ld = ttg.local_load %alloc : !ttg.memdesc<1x256xbf16, #shared_ld, #smem_ld, mutable> -> tensor<1x256xbf16, #blocked_ld>
+    %ext = arith.extf %ld : tensor<1x256xbf16, #blocked_ld> to tensor<1x256xf32, #blocked_ld>
+    %bc = tt.broadcast %ext : tensor<1x256xf32, #blocked_ld> -> tensor<128x256xf32, #blocked_ld>
+    %cvt = ttg.convert_layout %bc : tensor<128x256xf32, #blocked_ld> -> tensor<128x256xf32, #linear_tmem>
+    tt.return %cvt : tensor<128x256xf32, #linear_tmem>
+}
+}  // end module
+
+// -----
+
+// BLOCK_M=64, BLOCK_N=256, BLOCK_K=64, num_warps=4, num_stages=4. This config was
+// verified to successfully hoist the convert before broadcast in end-to-end runs.
+// CHECK-LABEL: @test_config3_block_m64_n256
+//       CHECK:   %[[LD:.+]] = ttg.local_load
+//       CHECK:   %[[EXT:.+]] = arith.extf %[[LD]] : tensor<1x256xbf16, #{{.+}}> to tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[EXT]] : tensor<1x256xf32, #{{.+}}> -> tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<1x256xf32, #{{.+}}> -> tensor<64x256xf32, #{{.+}}>
+//       CHECK:   tt.return %[[BC]]
+#blocked_c3 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear_c3 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 128]], warp = [[16, 0], [32, 0]], block = []}>
+#shared_c3 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#smem_c3 = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:100"} {
+tt.func @test_config3_block_m64_n256(%alloc: !ttg.memdesc<1x256xbf16, #shared_c3, #smem_c3, mutable>) -> tensor<64x256xf32, #linear_c3> {
+    %ld = ttg.local_load %alloc : !ttg.memdesc<1x256xbf16, #shared_c3, #smem_c3, mutable> -> tensor<1x256xbf16, #blocked_c3>
+    %ext = arith.extf %ld : tensor<1x256xbf16, #blocked_c3> to tensor<1x256xf32, #blocked_c3>
+    %bc = tt.broadcast %ext : tensor<1x256xf32, #blocked_c3> -> tensor<64x256xf32, #blocked_c3>
+    %cvt = ttg.convert_layout %bc : tensor<64x256xf32, #blocked_c3> -> tensor<64x256xf32, #linear_c3>
+    tt.return %cvt : tensor<64x256xf32, #linear_c3>
+}
+}  // end module

--- a/test/TritonGPU/hoist-convert-before-broadcast.mlir
+++ b/test/TritonGPU/hoist-convert-before-broadcast.mlir
@@ -136,3 +136,68 @@ tt.func @test_config3_block_m64_n256(%alloc: !ttg.memdesc<1x256xbf16, #shared_c3
     tt.return %cvt : tensor<64x256xf32, #linear_c3>
 }
 }  // end module
+
+// -----
+
+// BLOCK_M=128, BLOCK_N=256, BLOCK_K=64,
+// num_warps=4, num_stages=3. Uses the exact #linear encoding from the real TTGIR
+// dump. This config previously failed to hoist because resolveConflicts picked
+// #blocked over #linear based on sizePerThread score alone, without considering
+// that the tmem_load anchor (128x256) would need an expensive 64KB convert.
+// CHECK-LABEL: @test_config1_block_m128_n256
+//       CHECK:   %[[LD:.+]] = ttg.local_load
+//       CHECK:   %[[EXT:.+]] = arith.extf %[[LD]] : tensor<1x256xbf16, #{{.+}}> to tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[EXT]] : tensor<1x256xf32, #{{.+}}> -> tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<1x256xf32, #{{.+}}> -> tensor<128x256xf32, #{{.+}}>
+//       CHECK:   tt.return %[[BC]]
+#blocked_c1 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear_c1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared_c1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#smem_c1 = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:100"} {
+tt.func @test_config1_block_m128_n256(%alloc: !ttg.memdesc<1x256xbf16, #shared_c1, #smem_c1, mutable>) -> tensor<128x256xf32, #linear_c1> {
+    %ld = ttg.local_load %alloc : !ttg.memdesc<1x256xbf16, #shared_c1, #smem_c1, mutable> -> tensor<1x256xbf16, #blocked_c1>
+    %ext = arith.extf %ld : tensor<1x256xbf16, #blocked_c1> to tensor<1x256xf32, #blocked_c1>
+    %bc = tt.broadcast %ext : tensor<1x256xf32, #blocked_c1> -> tensor<128x256xf32, #blocked_c1>
+    %cvt = ttg.convert_layout %bc : tensor<128x256xf32, #blocked_c1> -> tensor<128x256xf32, #linear_c1>
+    tt.return %cvt : tensor<128x256xf32, #linear_c1>
+}
+}  // end module
+
+// -----
+
+// Conflict resolution test: tmem_load anchor (#linear, 128x256) vs descriptor_load
+// anchor (#blocked, 1x256 bias). After AccelerateMatmul, both meet at an addf with
+// an explicit #linear->#blocked convert on the accumulator. resolveConflicts must
+// pick #linear (512B bias convert) over #blocked (128KB accumulator convert).
+// This reproduces Config 1 (BLOCK_M=128, BLOCK_N=256) where the tiebreaker must
+// walk backward through the layouts map to anchor boundaries to see the cost
+// difference.
+// CHECK-LABEL: @test_resolve_conflict_tmem_vs_broadcast
+//       CHECK:   %[[ACC:.+]] = ttng.tmem_load
+//       CHECK:   %[[BIAS_BF16:.+]] = tt.descriptor_load
+//       CHECK:   %[[BIAS_F32:.+]] = arith.extf %[[BIAS_BF16]]
+//  Convert must be on the small 1x256 bias, not the 128x256 accumulator:
+//       CHECK:   %[[CVT:.+]] = ttg.convert_layout %[[BIAS_F32]] : tensor<1x256xf32, #{{.+}}> -> tensor<1x256xf32, #{{.+}}>
+//       CHECK:   %[[BC:.+]] = tt.broadcast %[[CVT]] : tensor<1x256xf32, #{{.+}}> -> tensor<128x256xf32, #{{.+}}>
+//       CHECK:   %[[ADD:.+]] = arith.addf %[[ACC]], %[[BC]]
+#blocked_cr = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear_cr = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#tmem_cr = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:100"} {
+tt.func @test_resolve_conflict_tmem_vs_broadcast(
+    %tmem_desc: !ttg.memdesc<128x256xf32, #tmem_cr, #ttng.tensor_memory, mutable>,
+    %bias_desc: !tt.tensordesc<tensor<1x256xbf16>>) -> tensor<128x256xbf16, #blocked_cr> {
+    %acc_linear = ttng.tmem_load %tmem_desc : !ttg.memdesc<128x256xf32, #tmem_cr, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #linear_cr>
+    %acc_blocked = ttg.convert_layout %acc_linear : tensor<128x256xf32, #linear_cr> -> tensor<128x256xf32, #blocked_cr>
+    %c0 = arith.constant 0 : i32
+    %bias_bf16 = tt.descriptor_load %bias_desc[%c0, %c0] : !tt.tensordesc<tensor<1x256xbf16>> -> tensor<1x256xbf16, #blocked_cr>
+    %bias_f32 = arith.extf %bias_bf16 : tensor<1x256xbf16, #blocked_cr> to tensor<1x256xf32, #blocked_cr>
+    %bias_bc = tt.broadcast %bias_f32 : tensor<1x256xf32, #blocked_cr> -> tensor<128x256xf32, #blocked_cr>
+    %result = arith.addf %acc_blocked, %bias_bc : tensor<128x256xf32, #blocked_cr>
+    %out = arith.truncf %result : tensor<128x256xf32, #blocked_cr> to tensor<128x256xbf16, #blocked_cr>
+    tt.return %out : tensor<128x256xbf16, #blocked_cr>
+}
+}  // end module


### PR DESCRIPTION
In cases in which the IR matches a `broadcast --> convert_layout` pattern, hoist the `convert_layout` to before the `broadcast` op by enabling the `hoistConvertOnTopOfExtOrBroadcast` pass for the `broadcast` + `cvt` path.

e.g.
`broadcast` --> `convert_layout`: broadcast `1x256` to `128x256` in registers, then perform layout conversion in SMEM on `128x256` block. We incur `128 * 256 * 4 bytes (FP32) = 128 KB` of SMEM usage.

`convert_layout` --> `broadcast`: perform layout conversion for `1x256` block in SMEM, then broadcast `1x256` to `128x256` in registers. We incur `1 * 256 * 4 bytes (FP32) = 1 KB` of SMEM usage.

### Performance: e.g. (M, N, K) = (1152, 12800, 1024)
Best config after reducing SMEM usage:
- Before: `BLOCK_M: 128, BLOCK_N: 128, BLOCK_K: 128, EPILOGUE_SUBTILE: 2, TMA_LOAD_EPILOGUE: True, TMA_STORE_EPILOGUE: True, num_warps: 4, num_ctas: 1, num_stages: 6 --> 0.0491 ms
- After: `BLOCK_M: 128, BLOCK_N: 128, BLOCK_K: 128, EPILOGUE_SUBTILE: 4, TMA_LOAD_EPILOGUE: True, TMA_STORE_EPILOGUE: True, num_warps: 4, num_ctas: 1, num_stages: 6` --> 0.0471 ms
--> 4% perf gain

With config `BLOCK_M=128, BLOCK_N=256, BLOCK_K=64, EPILOGUE_SUBTILE=1, num_warps=4, num_stages=3`:
- Triton runtime before: 0.1073 ms
- Triton runtime after: 0.1007 ms
--> 6% perf gain

TTGIR before: [P2342237775](https://www.internalfb.com/phabricator/paste/view/P2342237775)
```
...
%bias_tile_49 = tt.broadcast %bias_tile_48 {async_task_id = array<i32: 0>} : tensor<1x256xf32, #blocked> -> tensor<128x256xf32, #blocked> loc(#loc85)
%result = ttg.convert_layout %accumulator_45 : tensor<128x256xf32, #linear> -> tensor<128x256xf32, #linear> loc(#loc86)
%result_50 = ttg.convert_layout %bias_tile_49 : tensor<128x256xf32, #blocked> -> tensor<128x256xf32, #linear> loc(#loc86)
%result_51 = arith.addf %result, %result_50 {async_task_id = array<i32: 0>} : tensor<128x256xf32, #linear> loc(#loc86)
%0 = ttg.convert_layout %result_51 : tensor<128x256xf32, #linear> -> tensor<128x256xf32, #linear> loc(#loc33)
...
```
TTGIR after: [P2342237328](https://www.internalfb.com/phabricator/paste/view/P2342237328)
```
...
%bias_tile_44 = ttg.convert_layout %bias_tile_43 : tensor<1x256xf32, #blocked> -> tensor<1x256xf32, #linear> loc(#loc85)
%bias_tile_45 = tt.broadcast %bias_tile_44 {async_task_id = array<i32: 0>} : tensor<1x256xf32, #linear> -> tensor<128x256xf32, #linear> loc(#loc85)
...
```