### PR TITLE
[triton][beta] Backport 'Check for correct alignment in CUtensorMap (#9499)' (#1452)

### DIFF
--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -10,7 +10,7 @@
 
 typedef struct {
   PyObject_HEAD;
-  _Alignas(128) CUtensorMap tensorMap;
+  _Alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
 } PyCUtensorMapObject;
 
 typedef enum { ARG_CONSTEXPR = 0, ARG_KERNEL = 1, ARG_TUPLE = 2 } ArgType;
@@ -1309,12 +1309,14 @@ bool extractTmaDesc(void *ptr, PyObject *obj) {
     return false;
   }
   *((CUtensorMap *)ptr) = ((PyCUtensorMapObject *)obj)->tensorMap;
-  uintptr_t align_128 = (uintptr_t)ptr & (128 - 1);
-  if (align_128 != 0) {
+  // Depending on the cuda version, alignof(CUtensorMap) may be 64 or 128.
+  size_t alignment = alignof(CUtensorMap);
+  uintptr_t remainder = (uintptr_t)ptr & (alignment - 1);
+  if (remainder != 0) {
     PyErr_Format(
         PyExc_ValueError,
-        "CUtensorMap must be aligned to 128B, but got (&map) mod 128 = %ld",
-        align_128);
+        "CUtensorMap must be aligned to %ld, but got (&map) mod %ld = %ld",
+        alignment, alignment, remainder);
     return false;
   }
   return true;


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9499

Upstream commit message:
```
> Check for correct alignment in CUtensorMap (#9499)

> Previously, we were checking that CUtensorMap's alignment was 128.
> However, before CUDA 13.0, alignof(CUtensorMap) is actually 64, so we
> were aligning it to 64 and checking for 128. This PR makes the check
> aligned with the value returned by `alignof`.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 5893664b2751f3bd4fd766f96d64838edc4ec26e
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 9499
```

Reviewed By: xunzhang

Differential Revision: D104335131


