### PR TITLE
[triton][beta] [Cherry-pick] '[ci] Pin pandas < 3.0 (#9273)' (#1454)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ sphinx
 matplotlib
 myst_parser
 sphinx-rtd-theme
-pandas
+pandas<3.0
 pytest
 sphinx-gallery
 sphinx-multiversion

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -6,5 +6,6 @@ pytest-forked
 pytest-xdist
 scipy>=1.7.1
 llnl-hatchet
+pandas<3.0
 expecttest
 msgpack


### PR DESCRIPTION
Summary:

This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9273

Upstream commit message:
```
> [ci] Pin pandas < 3.0 (#9273)

> We're seeing test failures in proton, and it looks like pandas updating
> is the cause. Lets pin the version for now.
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 4760187e6f3439377b20fb38bf8ee041c6b918d5
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1 --no-submit
```

Reviewed By: shawnxu26

Differential Revision: D104123392


