### PR TITLE
 [AutoWS] Extend AutoWS Barrier region definitions to handle channel aware graph regions. (#1486)

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_code_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition.mlir
@@ -5,14 +5,34 @@
 // CHECK: default
 // CHECK: scf.for
 // CHECK: nvws.producer_acquire
+// CHECK-SAME: channelGraph = array<i32: 1>
+// CHECK-SAME: dstTask = 1 : i32
+// CHECK-SAME: maxRegionId = 2 : i32
+// CHECK-SAME: minRegionId = 2 : i32
+// CHECK-SAME: parentId = [[WS_PARENT:[0-9]+]] : i32
 // CHECK: ttg.async_copy_global_to_local
 // CHECK: ttg.async_copy_global_to_local
 // CHECK: nvws.producer_commit
+// CHECK-SAME: channelGraph = array<i32: 1>
+// CHECK-SAME: dstTask = 1 : i32
+// CHECK-SAME: maxRegionId = 1 : i32
+// CHECK-SAME: minRegionId = 1 : i32
+// CHECK-SAME: parentId = [[WS_PARENT]] : i32
 // CHECK: partition0
 // CHECK: nvws.consumer_wait
+// CHECK-SAME: channelGraph = array<i32: 0>
+// CHECK-SAME: dstTask = 0 : i32
+// CHECK-SAME: maxRegionId = 1 : i32
+// CHECK-SAME: minRegionId = 1 : i32
+// CHECK-SAME: parentId = [[WS_PARENT]] : i32
 // CHECK: ttg.local_load
 // CHECK: ttg.local_load
 // CHECK: nvws.consumer_release
+// CHECK-SAME: channelGraph = array<i32: 0>
+// CHECK-SAME: dstTask = 0 : i32
+// CHECK-SAME: maxRegionId = 2 : i32
+// CHECK-SAME: minRegionId = 2 : i32
+// CHECK-SAME: parentId = [[WS_PARENT]] : i32
 // CHECK: tt.dot
 
 

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -351,6 +351,49 @@ tt.func @tmem_load_sinks_after_barrier_reorder(
   tt.return
 }
 
+// Ordered WSBarrier metadata lets a tmem_load inherit constraints and sink past
+// an overlapping wait when the wait's region is earlier than the arrive's
+// region in the same parent.
+// CHECK-LABEL: @tmem_load_sinks_with_ordered_regions
+tt.func @tmem_load_sinks_with_ordered_regions(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: tmem_load
+  // CHECK-NEXT: ttng.arrive_barrier
+  // CHECK-SAME: minRegionId = 3 : i32
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: minRegionId = 1 : i32
+  // CHECK-NEXT: "user"
+  %0 = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1>, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  "user"(%0) : (tensor<128x128xf32, #linear128>) -> ()
+  tt.return
+}
+
+// Ordered WSBarrier metadata does not let a tmem_load sink past an overlapping
+// wait when the wait's region is not before the arrive's region.
+// CHECK-LABEL: @tmem_load_does_not_sink_with_later_wait_region
+tt.func @tmem_load_does_not_sink_with_later_wait_region(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.arrive_barrier
+  // CHECK-SAME: minRegionId = 1 : i32
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: minRegionId = 3 : i32
+  %0 = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1>, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  "user"(%0) : (tensor<128x128xf32, #linear128>) -> ()
+  tt.return
+}
+
 // All split tmem_loads should inherit the channelGraph from their arrive
 // barrier and sink past store-channel barriers independently.
 // CHECK-LABEL: @split_tmem_loads_all_sink

--- a/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
+++ b/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
@@ -23,15 +23,8 @@ inline bool hasWSBarrierConstraints(std::optional<DictionaryAttr> constraints) {
   return static_cast<bool>(getWSBarrierConstraints(constraints));
 }
 
-// Check if two WS barriers can be safely swapped by verifying their
-// channelGraph sets are disjoint. Returns false if either barrier lacks
-// a WSBarrier constraint or channelGraph constraint (conservative).
-inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraintsA,
-                                std::optional<DictionaryAttr> constraintsB) {
-  auto wsBarrierA = getWSBarrierConstraints(constraintsA);
-  auto wsBarrierB = getWSBarrierConstraints(constraintsB);
-  if (!wsBarrierA || !wsBarrierB)
-    return false;
+inline bool areChannelGraphsDisjoint(DictionaryAttr wsBarrierA,
+                                     DictionaryAttr wsBarrierB) {
   auto graphA = wsBarrierA.getAs<DenseI32ArrayAttr>("channelGraph");
   auto graphB = wsBarrierB.getAs<DenseI32ArrayAttr>("channelGraph");
   if (!graphA || !graphB)
@@ -41,6 +34,48 @@ inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraintsA,
     if (setA.contains(id))
       return false;
   return true;
+}
+
+inline bool hasOrderedWSBarrierInfo(DictionaryAttr wsBarrier) {
+  auto parentId = wsBarrier.getAs<IntegerAttr>("parentId");
+  auto minRegionId = wsBarrier.getAs<IntegerAttr>("minRegionId");
+  auto maxRegionId = wsBarrier.getAs<IntegerAttr>("maxRegionId");
+  return parentId && parentId.getInt() >= 0 && minRegionId &&
+         minRegionId.getInt() >= 0 && maxRegionId && maxRegionId.getInt() >= 0;
+}
+
+// Check if two WS barriers can be safely swapped by verifying their
+// channelGraph sets are disjoint. Returns false if either barrier lacks
+// a WSBarrier constraint or channelGraph constraint (conservative).
+inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraintsA,
+                                std::optional<DictionaryAttr> constraintsB) {
+  auto wsBarrierA = getWSBarrierConstraints(constraintsA);
+  auto wsBarrierB = getWSBarrierConstraints(constraintsB);
+  if (!wsBarrierA || !wsBarrierB)
+    return false;
+  return areChannelGraphsDisjoint(wsBarrierA, wsBarrierB);
+}
+
+// Check whether an arrive can be delayed past a wait. V1 allows this when the
+// channel graphs are disjoint. V2 also allows overlapping channel graphs when
+// both barriers are in the same parent and the wait's ordered region is before
+// the arrive's ordered region.
+inline bool
+canAdvanceWSBarrierArrivePastWait(std::optional<DictionaryAttr> arrive,
+                                  std::optional<DictionaryAttr> wait) {
+  auto arriveWS = getWSBarrierConstraints(arrive);
+  auto waitWS = getWSBarrierConstraints(wait);
+  if (!arriveWS || !waitWS)
+    return false;
+  if (areChannelGraphsDisjoint(arriveWS, waitWS))
+    return true;
+  if (!hasOrderedWSBarrierInfo(arriveWS) || !hasOrderedWSBarrierInfo(waitWS))
+    return false;
+  if (arriveWS.getAs<IntegerAttr>("parentId").getInt() !=
+      waitWS.getAs<IntegerAttr>("parentId").getInt())
+    return false;
+  return waitWS.getAs<IntegerAttr>("maxRegionId").getInt() <
+         arriveWS.getAs<IntegerAttr>("minRegionId").getInt();
 }
 
 inline bool hasArriveLikeSemantics(Operation *op) {
@@ -57,7 +92,8 @@ inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraints,
   if (auto arrive = dyn_cast<ArriveBarrierOp>(op))
     return canAdvanceWSBarrier(constraints, arrive.getConstraints());
   if (auto wait = dyn_cast<WaitBarrierOp>(op))
-    return canAdvanceWSBarrier(constraints, wait.getConstraints());
+    return canAdvanceWSBarrierArrivePastWait(constraints,
+                                             wait.getConstraints());
   return !hasArriveLikeSemantics(op);
 }
 
@@ -112,6 +148,10 @@ inline bool sinkWSArrives(Block &block) {
       if (auto otherArrive = dyn_cast<ArriveBarrierOp>(cur)) {
         if (!hasWSBarrierConstraints(otherArrive.getConstraints()))
           break;
+      } else if (auto wait = dyn_cast<WaitBarrierOp>(cur)) {
+        if (!canAdvanceWSBarrierArrivePastWait(constraints,
+                                               wait.getConstraints()))
+          break;
       } else if (!canAdvanceWSBarrier(constraints, cur)) {
         break;
       }
@@ -155,6 +195,10 @@ inline bool raiseWSWaits(Block &block) {
         break;
       if (auto otherWait = dyn_cast<WaitBarrierOp>(cur)) {
         if (!hasWSBarrierConstraints(otherWait.getConstraints()))
+          break;
+      } else if (auto arrive = dyn_cast<ArriveBarrierOp>(cur)) {
+        if (!canAdvanceWSBarrierArrivePastWait(arrive.getConstraints(),
+                                               constraints))
           break;
       } else if (!canAdvanceWSBarrier(constraints, cur)) {
         break;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBarrierAnalysis.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBarrierAnalysis.h
@@ -2,11 +2,17 @@
 #define NV_DIALECT_HOPPER_TRANSFORMS_WSBARRIERANALYSIS_H_
 
 #include "CodePartitionUtility.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include <algorithm>
+#include <functional>
+#include <optional>
 
 namespace mlir {
 
@@ -33,6 +39,16 @@ struct WSBarrierAttr {
   // buildChannelGraph() + injectChannelGraph().
   DenseI32ArrayAttr channelGraph;
 
+  // V2 ordered-region metadata. These fields are optional and only used to
+  // relax overlapping channelGraph checks when both barriers came from the same
+  // parent region and the wait is known to be earlier than the arrive.
+  // TODO: Refine parent/region construction to match the region-based design
+  // doc exactly; the initial implementation only provides the metadata shape
+  // and a conservative same-parent ordering hook.
+  IntegerAttr parentId;
+  IntegerAttr minRegionId;
+  IntegerAttr maxRegionId;
+
   // Build a constraints DictionaryAttr from the populated fields. Null fields
   // are omitted from the nested WSBarrier dictionary.
   DictionaryAttr build(MLIRContext *ctx) const {
@@ -41,6 +57,12 @@ struct WSBarrierAttr {
       entries.emplace_back(StringAttr::get(ctx, "channelGraph"), channelGraph);
     if (dstTask)
       entries.emplace_back(StringAttr::get(ctx, "dstTask"), dstTask);
+    if (parentId)
+      entries.emplace_back(StringAttr::get(ctx, "parentId"), parentId);
+    if (minRegionId)
+      entries.emplace_back(StringAttr::get(ctx, "minRegionId"), minRegionId);
+    if (maxRegionId)
+      entries.emplace_back(StringAttr::get(ctx, "maxRegionId"), maxRegionId);
     if (entries.empty())
       return {};
     auto wsBarrier = DictionaryAttr::get(ctx, entries);
@@ -59,6 +81,9 @@ struct WSBarrierAttr {
       return attr;
     attr.dstTask = wsBarrier.getAs<IntegerAttr>("dstTask");
     attr.channelGraph = wsBarrier.getAs<DenseI32ArrayAttr>("channelGraph");
+    attr.parentId = wsBarrier.getAs<IntegerAttr>("parentId");
+    attr.minRegionId = wsBarrier.getAs<IntegerAttr>("minRegionId");
+    attr.maxRegionId = wsBarrier.getAs<IntegerAttr>("maxRegionId");
     return attr;
   }
 
@@ -67,6 +92,23 @@ struct WSBarrierAttr {
     WSBarrierAttr attr;
     attr.dstTask = IntegerAttr::get(IntegerType::get(ctx, 32), taskId);
     return attr;
+  }
+};
+
+struct WSBarrierRegionInfo {
+  int parentId = -1;
+  int minRegionId = -1;
+  int maxRegionId = -1;
+};
+
+struct WSBarrierOpRegionInfo {
+  Operation *parent = nullptr;
+  int parentId = -1;
+  int regionId = -1;
+  int numRegions = -1;
+
+  bool isValid() const {
+    return parent && parentId >= 0 && regionId >= 0 && numRegions > 0;
   }
 };
 
@@ -124,11 +166,22 @@ buildChannelGraph(ArrayRef<Channel *> channels) {
 }
 
 // Inject the channelGraph into a WSBarrierAttr stored in a constraints dict.
-static inline DictionaryAttr injectChannelGraph(MLIRContext *ctx,
-                                                DictionaryAttr existing,
-                                                ArrayRef<int> graphTaskIds) {
+static inline DictionaryAttr
+injectChannelGraph(MLIRContext *ctx, DictionaryAttr existing,
+                   ArrayRef<int> graphTaskIds,
+                   std::optional<int> parentId = std::nullopt,
+                   std::optional<int> minRegionId = std::nullopt,
+                   std::optional<int> maxRegionId = std::nullopt) {
   auto attr = WSBarrierAttr::parse(existing);
   attr.channelGraph = DenseI32ArrayAttr::get(ctx, graphTaskIds);
+  if (parentId)
+    attr.parentId = IntegerAttr::get(IntegerType::get(ctx, 32), *parentId);
+  if (minRegionId)
+    attr.minRegionId =
+        IntegerAttr::get(IntegerType::get(ctx, 32), *minRegionId);
+  if (maxRegionId)
+    attr.maxRegionId =
+        IntegerAttr::get(IntegerType::get(ctx, 32), *maxRegionId);
   auto updated = attr.build(ctx);
   if (!existing)
     return updated;
@@ -148,6 +201,249 @@ static inline DictionaryAttr injectChannelGraph(MLIRContext *ctx,
     merged.emplace_back(StringAttr::get(ctx, WSBarrierAttr::kKey),
                         updated.getAs<DictionaryAttr>(WSBarrierAttr::kKey));
   return DictionaryAttr::get(ctx, merged);
+}
+
+static inline bool isWSBarrierBackwardToken(Operation *op) {
+  return isa<triton::nvws::ProducerAcquireOp, triton::nvws::ConsumerReleaseOp>(
+      op);
+}
+
+static inline bool isWSBarrierForwardToken(Operation *op) {
+  return isa<triton::nvws::ProducerCommitOp, triton::nvws::ConsumerWaitOp>(op);
+}
+
+static inline Operation *getNearestWSBarrierParent(Operation *op) {
+  for (Operation *cur = op->getParentOp(); cur; cur = cur->getParentOp()) {
+    if (isa<scf::IfOp>(cur))
+      return nullptr;
+    if (isa<scf::ForOp, scf::WhileOp>(cur))
+      return cur;
+    if (isa<triton::FuncOp>(cur))
+      return cur;
+  }
+  return nullptr;
+}
+
+static inline Operation *getDirectChildInParent(Operation *op,
+                                                Operation *parent) {
+  Operation *child = op;
+  while (child && child->getParentOp() != parent)
+    child = child->getParentOp();
+  return child;
+}
+
+static inline int getNumOrderedRegions(Block &block) {
+  int count = 1;
+  for (Operation &op : block.without_terminator())
+    if (op.getNumRegions() != 0)
+      ++count;
+  return count;
+}
+
+static inline DenseMap<Block *, int>
+getOrderedRegionBlockOffsets(Operation *parent, int &numRegions) {
+  DenseMap<Block *, int> blockOffsets;
+  numRegions = 0;
+  for (Region &region : parent->getRegions()) {
+    for (Block &block : region) {
+      blockOffsets[&block] = numRegions;
+      numRegions += getNumOrderedRegions(block);
+    }
+  }
+  return blockOffsets;
+}
+
+static inline std::optional<int>
+getBaseRegionInParent(Operation *parent, Operation *op,
+                      const DenseMap<Block *, int> &blockOffsets) {
+  Operation *child = getDirectChildInParent(op, parent);
+  if (!child || child->getBlock()->getParentOp() != parent)
+    return std::nullopt;
+
+  auto offsetIt = blockOffsets.find(child->getBlock());
+  if (offsetIt == blockOffsets.end())
+    return std::nullopt;
+  int baseRegion = offsetIt->second;
+  for (Operation &cur : child->getBlock()->without_terminator()) {
+    if (&cur == child)
+      return baseRegion;
+    if (cur.getNumRegions() != 0)
+      ++baseRegion;
+  }
+  return std::nullopt;
+}
+
+// Build deterministic ordered-region metadata for every operation under
+// `scope`. Parent IDs are assigned in DFS order. Region IDs are one-based and
+// split each ordered parent into basic-block regions separated by direct child
+// region-bearing ops. Ops nested under scf.if get invalid metadata so V2 falls
+// back to the V1 channelGraph rule for conditional channels.
+static inline DenseMap<Operation *, WSBarrierOpRegionInfo>
+buildWSBarrierOpRegionInfo(Operation *scope) {
+  struct ParentInfo {
+    int parentId = -1;
+    int numRegions = -1;
+    DenseMap<Block *, int> blockOffsets;
+  };
+
+  DenseMap<Operation *, WSBarrierOpRegionInfo> result;
+  DenseMap<Operation *, int> parentIds;
+  DenseMap<Operation *, ParentInfo> parentInfo;
+
+  auto getParentInfo = [&](Operation *parent) -> ParentInfo & {
+    auto [idIt, insertedId] = parentIds.try_emplace(parent, parentIds.size());
+    auto [infoIt, insertedInfo] = parentInfo.try_emplace(parent);
+    if (insertedInfo) {
+      infoIt->second.parentId = idIt->second;
+      infoIt->second.blockOffsets =
+          getOrderedRegionBlockOffsets(parent, infoIt->second.numRegions);
+    }
+    return infoIt->second;
+  };
+
+  std::function<void(Block &)> assignBlock = [&](Block &block) {
+    for (Operation &op : block.without_terminator()) {
+      Operation *parent = getNearestWSBarrierParent(&op);
+      if (parent) {
+        ParentInfo &info = getParentInfo(parent);
+        auto baseRegionInfo =
+            getBaseRegionInParent(parent, &op, info.blockOffsets);
+        if (baseRegionInfo) {
+          result[&op] = {parent, info.parentId, *baseRegionInfo + 1,
+                         info.numRegions};
+        } else {
+          result[&op] = {};
+        }
+      } else {
+        result[&op] = {};
+      }
+      for (Region &region : op.getRegions())
+        for (Block &childBlock : region)
+          assignBlock(childBlock);
+    }
+  };
+
+  for (Region &region : scope->getRegions())
+    for (Block &block : region)
+      assignBlock(block);
+
+  return result;
+}
+
+// Initial ordered-region ID assignment for token ops. The parent is the nearest
+// valid ordered parent op: scf.for, scf.while, or the containing tt.func.
+// Backward resource-reuse tokens are shifted into the second half of the
+// parent's region ID space so forward and backward edges are never confused.
+static inline DenseMap<Operation *, WSBarrierRegionInfo>
+buildWSBarrierRegionInfo(Operation *scope) {
+  auto opRegionInfo = buildWSBarrierOpRegionInfo(scope);
+  DenseMap<Operation *, WSBarrierRegionInfo> result;
+  for (auto &it : opRegionInfo) {
+    Operation *op = it.first;
+    const WSBarrierOpRegionInfo &info = it.second;
+    if (!isWSBarrierForwardToken(op) && !isWSBarrierBackwardToken(op))
+      continue;
+    if (!info.isValid()) {
+      result[op] = {-1, -1};
+      continue;
+    }
+    int regionId = info.regionId;
+    if (isWSBarrierBackwardToken(op))
+      regionId += info.numRegions;
+    result[op] = {info.parentId, regionId, regionId};
+  }
+  return result;
+}
+
+// Complete the V2 ordered-region summary for each WS token. The V1
+// channelGraph remains a partition reachability set. V2 only adds ordered
+// parent/range information used when two overlapping V1 graphs are compared.
+//
+// The range is intentionally same-iteration only:
+//   1. Start from the token's own ordered region.
+//   2. Group sibling channels in the same parent, direction, and region. This
+//      makes equivalent same-region channel relationships visible from either
+//      participating partition.
+//   3. For waits, also union later regions in the waiting partition for the
+//      same direction. This evaluates an arrive-past-wait move from the delayed
+//      arrive's perspective and prevents proving a move that would cross later
+//      logical work in the waiting partition.
+// Channels under scf.if keep invalid metadata and therefore use the V1
+// disjoint-channelGraph fallback.
+static inline DenseMap<Operation *, WSBarrierRegionInfo>
+buildWSBarrierOrderedRegionRanges(
+    Operation *scope,
+    const DenseMap<std::pair<int, int>, SmallVector<int>> &channelGraph) {
+  struct TokenNode {
+    Operation *op = nullptr;
+    int srcTask = -1;
+    int dstTask = -1;
+    int parentId = -1;
+    int regionId = -1;
+    bool isBackward = false;
+    bool isWait = false;
+  };
+
+  auto tokenRegionInfo = buildWSBarrierRegionInfo(scope);
+  SmallVector<TokenNode> nodes;
+  scope->walk([&](Operation *op) {
+    if (!isWSBarrierForwardToken(op) && !isWSBarrierBackwardToken(op))
+      return;
+    auto constraints = op->getAttrOfType<DictionaryAttr>("constraints");
+    auto attr = WSBarrierAttr::parse(constraints);
+    if (!attr.dstTask)
+      return;
+    auto taskIds = getAsyncTaskIds(op);
+    if (taskIds.size() != 1)
+      return;
+    auto regionIt = tokenRegionInfo.find(op);
+    if (regionIt == tokenRegionInfo.end())
+      return;
+    nodes.push_back(
+        {op, taskIds[0], static_cast<int>(attr.dstTask.getInt()),
+         regionIt->second.parentId, regionIt->second.minRegionId,
+         isWSBarrierBackwardToken(op),
+         isa<triton::nvws::ProducerAcquireOp, triton::nvws::ConsumerWaitOp>(
+             op)});
+  });
+
+  DenseMap<Operation *, WSBarrierRegionInfo> result;
+  for (const TokenNode &node : nodes) {
+    if (node.parentId < 0 || node.regionId < 0) {
+      result[node.op] = {-1, -1, -1};
+      continue;
+    }
+
+    int minRegionId = node.regionId;
+    int maxRegionId = node.regionId;
+    DenseSet<int> reachableTasks;
+    if (auto it = channelGraph.find({node.srcTask, node.dstTask});
+        it != channelGraph.end()) {
+      reachableTasks.insert(it->second.begin(), it->second.end());
+    }
+
+    for (const TokenNode &other : nodes) {
+      if (other.parentId != node.parentId ||
+          other.isBackward != node.isBackward || other.regionId < 0)
+        continue;
+
+      bool sameRegionPeer = other.regionId == node.regionId &&
+                            (other.srcTask == node.srcTask ||
+                             reachableTasks.contains(other.srcTask) ||
+                             reachableTasks.contains(other.dstTask));
+      bool laterWaitInSamePartition = node.isWait &&
+                                      other.srcTask == node.srcTask &&
+                                      other.regionId >= node.regionId;
+      if (!sameRegionPeer && !laterWaitInSamePartition)
+        continue;
+
+      minRegionId = std::min(minRegionId, other.regionId);
+      maxRegionId = std::max(maxRegionId, other.regionId);
+    }
+
+    result[node.op] = {node.parentId, minRegionId, maxRegionId};
+  }
+  return result;
 }
 
 // canAdvanceWSBarrier, sinkWSArrives, raiseWSWaits are defined in

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -44,6 +44,7 @@ namespace mlir {
 static void injectChannelGraphOnTokenOps(triton::FuncOp &funcOp,
                                          ArrayRef<Channel *> channels) {
   auto graph = buildChannelGraph(channels);
+  auto regionInfo = buildWSBarrierOrderedRegionRanges(funcOp, graph);
   if (graph.empty())
     return;
   funcOp.walk([&](Operation *op) {
@@ -62,9 +63,21 @@ static void injectChannelGraphOnTokenOps(triton::FuncOp &funcOp,
     int srcTask = taskIds[0];
     int dstTask = wsAttr.dstTask.getInt();
     auto it = graph.find({srcTask, dstTask});
-    if (it != graph.end())
-      op->setAttr("constraints", injectChannelGraph(funcOp.getContext(),
-                                                    constraints, it->second));
+    if (it != graph.end()) {
+      auto regionIt = regionInfo.find(op);
+      std::optional<int> parentId;
+      std::optional<int> minRegionId;
+      std::optional<int> maxRegionId;
+      if (regionIt != regionInfo.end()) {
+        parentId = regionIt->second.parentId;
+        minRegionId = regionIt->second.minRegionId;
+        maxRegionId = regionIt->second.maxRegionId;
+      }
+      op->setAttr("constraints",
+                  injectChannelGraph(funcOp.getContext(), constraints,
+                                     it->second, parentId, minRegionId,
+                                     maxRegionId));
+    }
   });
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierConstraints.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierConstraints.md
@@ -80,30 +80,48 @@ intervening waits).
 |-----|------|-------------|
 | `dstTask` | `I32Attr` | Destination task ID — the foreign partition this barrier communicates with. The source task is the partition where the barrier lives (available via `async_task_id`). |
 | `channelGraph` | `DenseI32ArrayAttr` | Set of task IDs reachable from the destination through the channel adjacency graph (excluding the source). Used by `canAdvanceWSBarrier` to check if two barriers can be safely reordered. |
+| `parentId` | `I32Attr` | Local ID for the nearest ordered parent scope (`scf.for`, `scf.while`, or containing `tt.func`). Used only inside the current function for V2 ordered-region checks. |
+| `minRegionId` | `I32Attr` | Earliest ordered region reached by this channel summary. |
+| `maxRegionId` | `I32Attr` | Latest ordered region reached by this channel summary. |
 
 **Lifecycle:**
 1. `dstTask` is set when token ops are created in `insertAsyncComm`
    (before code partitioning).
-2. `channelGraph` is injected after code partitioning via
-   `buildChannelGraph()` + `injectChannelGraph()`.
-3. Both propagate through `doTokenLowering` to the resulting barrier ops.
+2. `channelGraph`, `parentId`, `minRegionId`, and `maxRegionId` are injected
+   after code partitioning via `buildChannelGraph()`,
+   `buildWSBarrierOrderedRegionRanges()`, and `injectChannelGraph()`.
+3. These fields propagate through `doTokenLowering` to the resulting barrier
+   ops.
 
-**Reordering rule:** Two WS barriers can be safely swapped if their
-`channelGraph` sets are disjoint. This is checked by
-`canAdvanceWSBarrier()` (see [Barrier Reordering](#barrier-reordering) below).
+**Reordering rule:** Same-direction WS barriers can be swapped directly. An
+arrive can be delayed past a wait if the graphs are disjoint, or if both
+barriers have valid ordered-region metadata in the same parent and the wait's
+reached regions are strictly earlier than the arrive's reached regions. This is
+checked by `canAdvanceWSBarrier()` and
+`canAdvanceWSBarrierArrivePastWait()` (see
+[Barrier Reordering](#barrier-reordering) below).
 
 Example:
 ```mlir
 // Producer commit to consumer task 2
 nvws.producer_commit %tok, %idx {
-  constraints = {dstTask = 2 : i32}
+  constraints = {WSBarrier = {dstTask = 2 : i32}}
 } : tensor<1x!nvws.token>, i32
 
-// After channelGraph injection
+// After channelGraph and ordered-region injection
 ttng.arrive_barrier %bar, 1 {
-  constraints = {dstTask = 2 : i32, channelGraph = array<i32: 1, 2>}
+  constraints = {WSBarrier = {
+    dstTask = 2 : i32,
+    channelGraph = array<i32: 1, 2>,
+    parentId = 0 : i32,
+    minRegionId = 3 : i32,
+    maxRegionId = 3 : i32
+  }}
 } : !ttg.memdesc<1xi64, #shared, #smem, mutable>
 ```
+
+See [WS Barrier Ordered Region Tracking](WSBarrierOrderedRegionTracking.md)
+for the V2 construction details.
 
 ### Pipeline Scheduling (future)
 
@@ -122,11 +140,11 @@ barrier ops, so any key set on a token op will appear on the lowered
 ```mlir
 // dstTask is set during insertAsyncComm
 nvws.producer_acquire %tok, %idx, %phase {
-  constraints = {dstTask = 2 : i32}
+  constraints = {WSBarrier = {dstTask = 2 : i32}}
 } : tensor<1x!nvws.token>, i32, i1
 
 nvws.consumer_wait %tok, %idx, %phase {
-  constraints = {dstTask = 0 : i32}
+  constraints = {WSBarrier = {dstTask = 0 : i32}}
 } : tensor<1x!nvws.token>, i32, i1
 ```
 
@@ -210,7 +228,7 @@ attribute directly (as currently defined). The two approaches can coexist:
 ## Barrier Reordering
 
 **Files:**
-- `nvidia/hopper/include/Transforms/WSBarrierReorder.h` — `canAdvanceWSBarrier`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations`
+- `nvidia/hopper/include/Transforms/WSBarrierReorder.h` — `canAdvanceWSBarrier`, `canAdvanceWSBarrierArrivePastWait`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations`
 - `lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp` — consumer of the above
 
 ### Motivation
@@ -234,17 +252,18 @@ before the existing tmem_load sinking. Four steps:
 2. **`sinkWSArrives` / `raiseWSWaits`** — Push arrive barriers down and
    pull wait barriers up within each basic block. An arrive can move past
    any non-barrier op (delaying the signal is always safe) and past another
-   arrive. It can move past a wait only if `canAdvanceWSBarrier` confirms
-   their `channelGraph` sets are disjoint. Waits follow the mirror rule,
-   with an additional check to not move past definitions of their operands.
+   WS arrive. It can move past a wait only if
+   `canAdvanceWSBarrierArrivePastWait` accepts either the V1 disjoint-graph
+   rule or the V2 ordered-region rule. Waits follow the mirror rule, with an
+   additional check to not move past definitions of their operands.
 
-3. **tmem_load sinking (channelGraph-aware)** — Each `tmem_load` inherits
-   the `channelGraph` from its associated arrive barrier. When the sinking
-   loop encounters a barrier, it calls `canAdvanceWSBarrier` with the
-   tmem_load's channelGraph to decide whether to pass it. All tmem_loads
-   in the same channel region (between the arrive and the preceding
-   same-channel barrier) get the same constraints, so split tmem_loads
-   are treated uniformly.
+3. **tmem_load sinking (WSBarrier-aware)** — Each `tmem_load` inherits the
+   full `WSBarrier` dictionary from its associated arrive barrier, including
+   `channelGraph` and ordered-region metadata. When the sinking loop
+   encounters a barrier, it calls `canAdvanceWSBarrier` with the `tmem_load`'s
+   constraints to decide whether to pass it. All tmem_loads in the same channel
+   region (between the arrive and the preceding same-channel barrier) get the
+   same constraints, so split tmem_loads are treated uniformly.
 
 4. **`optimizeWSBarrierLocations`** — After sinking, relocate each barrier
    back to an optimal position right next to its associated memory op
@@ -257,9 +276,27 @@ bool canAdvanceWSBarrier(optional<DictionaryAttr> constraintsA,
                          optional<DictionaryAttr> constraintsB);
 ```
 
-Returns true when both barriers have a `channelGraph` attribute and the
-two sets are disjoint (no shared task ID). Returns false conservatively
-if either barrier lacks `channelGraph`.
+Returns true when both barriers have `WSBarrier.channelGraph` and the two sets
+are disjoint (no shared task ID). Returns false conservatively if either
+barrier lacks `WSBarrier` or `channelGraph`.
+
+```cpp
+bool canAdvanceWSBarrierArrivePastWait(optional<DictionaryAttr> arrive,
+                                       optional<DictionaryAttr> wait);
+```
+
+This is the stricter opposite-direction check. It first accepts the same V1
+disjoint-graph case. If the graphs overlap, it accepts only when both barriers
+have valid `parentId`, `minRegionId`, and `maxRegionId`, both `parentId`
+values match, and:
+
+```text
+wait.maxRegionId < arrive.minRegionId
+```
+
+Invalid ordered-region metadata, including `parentId = -1` or region IDs of
+`-1`, preserves the conservative V1 behavior. Channels nested under `scf.if`
+currently receive invalid ordered-region metadata for this reason.
 
 ### Barrier Movement Rules
 
@@ -267,7 +304,7 @@ if either barrier lacks `channelGraph`.
 |------|--------|
 | Arrive, Arrive | Always safe |
 | Wait, Wait | Always safe |
-| Arrive, Wait | Safe only if `canAdvanceWSBarrier` returns true |
+| Arrive, Wait | Safe only if `canAdvanceWSBarrierArrivePastWait` returns true |
 | Wait, Arrive | Same check (mirror direction) |
 
 ### IR Example
@@ -277,25 +314,35 @@ Before (barriers block tmem_load sinking):
 ttng.wait_barrier %bar0, %phase : ...                           // tmem_load wait
 ttng.tmem_load %s0 → %v0                                        // stuck here
 ttng.tmem_load %s1 → %v1
-ttng.arrive_barrier %bar0, 1 {channelGraph = [1, 3]} : ...      // ← blocks sinking
-ttng.wait_barrier %bar1, %phase {channelGraph = [2]} : ...      // store wait
+ttng.arrive_barrier %bar0, 1 {constraints = {WSBarrier = {
+  channelGraph = array<i32: 1, 3>}}} : ...
+ttng.wait_barrier %bar1, %phase {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
 ttg.local_store %v0, %smem
-ttng.arrive_barrier %bar1, 1 {channelGraph = [2]} : ...
-ttng.wait_barrier %bar2, %phase {channelGraph = [2]} : ...
+ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
+ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
 ttg.local_store %v1, %smem
-ttng.arrive_barrier %bar2, 1 {channelGraph = [2]} : ...
+ttng.arrive_barrier %bar2, 1 {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
 ```
 
 After (tmem_loads interleaved with store pipeline):
 ```mlir
 ttng.wait_barrier %bar0, %phase : ...                           // tmem_load wait
-ttng.wait_barrier %bar1, %phase {channelGraph = [2]} : ...      // store wait
+ttng.wait_barrier %bar1, %phase {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
 ttng.tmem_load %s0 → %v0                                        // sunk past store wait
 ttg.local_store %v0, %smem
-ttng.arrive_barrier %bar1, 1 {channelGraph = [2]} : ...
-ttng.wait_barrier %bar2, %phase {channelGraph = [2]} : ...
+ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
+ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
 ttng.tmem_load %s1 → %v1                                        // sunk past store wait
 ttg.local_store %v1, %smem
-ttng.arrive_barrier %bar0, 1 {channelGraph = [1, 3]} : ...      // sunk to end
-ttng.arrive_barrier %bar2, 1 {channelGraph = [2]} : ...
+ttng.arrive_barrier %bar0, 1 {constraints = {WSBarrier = {
+  channelGraph = array<i32: 1, 3>}}} : ...
+ttng.arrive_barrier %bar2, 1 {constraints = {WSBarrier = {
+  channelGraph = array<i32: 2>}}} : ...
 ```

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -63,8 +63,8 @@ an earlier partition scheduling pass (`PartitionSchedulingMeta`).
 | `TaskIdPropagation.h` | `TaskId` lattice, `TaskIdLattice`, `TaskIdBackwardPropagation` analysis |
 | `CodePartitionUtility.h` | `Channel`, `ChannelPost`, `TmemDataChannel`, `TmemDataChannelPost`, `ReuseGroup`, `ReuseConfig`, `CommChannel` |
 | `TMEMUtils.h` | `TMEM1DAllocator`, `sliceAndReinterpretMDTMEM`, `createTMEMDesc` |
-| `WSBarrierAnalysis.h` | `WSBarrierAttr`, `buildChannelGraph`, `injectChannelGraph` — channel graph construction for barrier constraints |
-| `nvidia/hopper/include/Transforms/WSBarrierReorder.h` | `canAdvanceWSBarrier`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations` — barrier reordering utilities consumed by `InterleaveTMem` |
+| `WSBarrierAnalysis.h` | `WSBarrierAttr`, `buildChannelGraph`, `buildWSBarrierOrderedRegionRanges`, `injectChannelGraph` — channel graph and ordered-region construction for barrier constraints |
+| `nvidia/hopper/include/Transforms/WSBarrierReorder.h` | `canAdvanceWSBarrier`, `canAdvanceWSBarrierArrivePastWait`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations` — barrier reordering utilities consumed by `InterleaveTMem` |
 
 ## Glossary
 
@@ -95,6 +95,8 @@ an earlier partition scheduling pass (`PartitionSchedulingMeta`).
 - [TMEM Allocation Heuristics](TMEMAllocationHeuristics.md) — TMEM memory planning algorithms
 - [SMEM Allocation Design](SmemAllocationDesign.md) — SMEM budget-aware allocation
 - [Barrier Fusion](BarrierFusion.md) — TMA fusion, tcgen05_commit combining
+- [Barrier Constraints](BarrierConstraints.md) — generic barrier constraints and WSBarrier reordering metadata
+- [WS Barrier Ordered Region Tracking](WSBarrierOrderedRegionTracking.md) — V2 ordered-region metadata for overlapping channel graphs
 - [Reuse Groups](ReuseGroups.md) — buffer sharing mechanics
 - [Ping-Pong Scheduling](PingPongScheduling.md) — named barrier insertion for expensive ops
 - [Utilities](Utilities.md) — `OpBuilderWithAsyncTaskIds`, task ID helpers, location utilities

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WSBarrierOrderedRegionTracking.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WSBarrierOrderedRegionTracking.md
@@ -1,0 +1,203 @@
+# WS Barrier Ordered Region Tracking
+
+This document describes the V2 ordered-region metadata used by WSBarrier
+reordering. It complements [Barrier Constraints](BarrierConstraints.md), which
+documents the `constraints.WSBarrier` attribute contract and the lowering-time
+consumers.
+
+The design is based on the region-based WSBarrier design doc and the
+implementation in:
+
+- `WSBarrierAnalysis.h`
+- `WSCodePartition.cpp::injectChannelGraphOnTokenOps`
+- `nvidia/hopper/include/Transforms/WSBarrierReorder.h`
+- `lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp`
+
+## Motivation
+
+V1 WSBarrier analysis represents each channel by a `channelGraph`: the set of
+foreign task IDs reachable from the destination partition through the channel
+graph. This proves simple cases by allowing an arrive to move past a wait only
+when their reachable task sets are disjoint.
+
+That is enough for isolated GEMM epilogues, but too conservative for addmm with
+TMA bias loads. In addmm, the epilogue partition needs to delay the TMEM load
+arrive past waits for later logical work, while the TMA load partition contains
+both loop-body A/B loads and loop-epilogue bias loads. V1 sees overlapping
+partitions and rejects the move, even when the relevant wait is in an earlier
+same-iteration region than the arrive being delayed.
+
+V2 keeps the V1 fallback and adds ordered parent/region metadata. The extra
+metadata allows some overlapping `channelGraph` cases when both barriers belong
+to the same ordered parent and the wait is known to be earlier than the arrive.
+
+## Metadata
+
+The nested `constraints.WSBarrier` dictionary can contain:
+
+| Field | Meaning |
+|-------|---------|
+| `dstTask` | Destination partition for the channel. The source partition is the op's `async_task_id`. |
+| `channelGraph` | V1 reachable foreign task set, excluding the source task. |
+| `parentId` | Function-local ID for the nearest ordered parent scope. |
+| `minRegionId` | Earliest ordered region reached by the channel summary. |
+| `maxRegionId` | Latest ordered region reached by the channel summary. |
+
+`parentId` is local compiler metadata, not an ABI. It only needs to be unique
+within the current function. The implementation assigns IDs deterministically as
+ordered parents are first encountered during an IR walk, which keeps lit checks
+readable.
+
+Invalid ordered metadata uses `-1`. Any barrier with missing metadata or a
+negative `parentId`, `minRegionId`, or `maxRegionId` falls back to the V1
+disjoint-graph rule.
+
+## Ordered Parents
+
+`getNearestWSBarrierParent()` walks from a token op to its enclosing ordered
+parent. The valid parents are:
+
+- nearest `scf.for`
+- nearest `scf.while`
+- containing `tt.func`
+
+If the walk crosses `scf.if`, the token receives invalid ordered metadata.
+Conditional channels therefore keep the V1 behavior for now.
+
+Barrier movement also stops at region-bearing operations. `canAdvanceWSBarrier`
+returns false for any operation with regions, so WSBarrier sinking and raising
+stay within one basic-block region and do not move barriers into or out of
+control flow.
+
+## Region Numbering
+
+Each ordered parent is split into ordered regions by its direct child
+region-bearing operations. For each block owned by the parent, the first
+segment starts as one region, and every direct child op with regions starts the
+next segment.
+
+For a parent with `N` ordered regions:
+
+- Forward tokens use region IDs `1..N`.
+- Backward tokens use region IDs `N+1..2N`.
+
+Forward tokens are:
+
+- `nvws.producer_commit`
+- `nvws.consumer_wait`
+
+Backward resource-reuse tokens are:
+
+- `nvws.producer_acquire`
+- `nvws.consumer_release`
+
+Splitting forward and backward ranges prevents a data-availability edge from
+being confused with a resource-reuse edge in the same program region.
+
+## Channel Range Construction
+
+`buildWSBarrierOrderedRegionRanges()` runs after `insertAsyncComm()` has
+created token ops with `WSBarrier.dstTask`. It starts from the V1
+`buildChannelGraph()` result and computes a region summary for every WS token.
+
+For each token node, the initial range is its own ordered region:
+
+```text
+minRegionId = regionId
+maxRegionId = regionId
+```
+
+The range is then extended in two conservative same-iteration cases:
+
+1. Same-region peer channels are grouped when they share the same parent,
+   direction, and ordered region, and are visible through the starting token's
+   V1 graph. This makes the same relationship visible from both participating
+   partitions.
+2. For wait tokens, later regions in the same source partition, parent, and
+   direction are unioned into the range. This evaluates an arrive-past-wait
+   move from the delayed arrive's perspective.
+
+The range does not try to prove moves across multiple loop iterations. It only
+summarizes same-iteration ordered regions.
+
+## Injection
+
+`WSCodePartition.cpp::injectChannelGraphOnTokenOps()` writes the V1 and V2
+metadata back to token constraints:
+
+1. Build the V1 partition reachability graph with `buildChannelGraph()`.
+2. Build ordered-region ranges with `buildWSBarrierOrderedRegionRanges()`.
+3. For each WS token with one `async_task_id` and a valid `dstTask`, inject:
+   - `channelGraph`
+   - `parentId`
+   - `minRegionId`
+   - `maxRegionId`
+
+`doTokenLowering()` then propagates the token constraints to the lowered
+`ttng.wait_barrier` and `ttng.arrive_barrier` ops.
+
+## Reordering Rule
+
+For an arrive delayed past a wait, the implementation checks:
+
+```text
+if channelGraph sets are disjoint:
+  allow
+else if parentId matches and wait.maxRegionId < arrive.minRegionId:
+  allow
+else:
+  reject
+```
+
+The first branch is V1. The second branch is the V2 same-parent,
+same-iteration ordered-region relaxation. Missing or invalid region metadata
+rejects the second branch.
+
+Same-direction moves are simpler:
+
+- Arrive past arrive is safe when both are WSBarrier arrives.
+- Wait before wait is safe when both are WSBarrier waits.
+
+Opposite-direction movement always goes through
+`canAdvanceWSBarrierArrivePastWait()`, including the mirror case where a wait
+is raised before an arrive.
+
+## TMEM Load Sinking
+
+`InterleaveTMem` uses the same WSBarrier constraints for `tmem_load` sinking.
+For each WS arrive in a block with TMEM loads, it walks backward through the
+same channel region and assigns the arrive's `WSBarrier` dictionary to every
+`tmem_load` it finds. The sinking pass then calls `canAdvanceWSBarrier()` when
+the load encounters another barrier.
+
+This is necessary because the `tmem_load` represents work protected by the same
+wait/arrive pair as the channel. Split TMEM loads must all carry the same
+constraints, otherwise one split could move past a barrier that another split
+cannot.
+
+## Conservative Cases
+
+The implementation intentionally keeps these cases conservative:
+
+- Channels nested under `scf.if` get invalid ordered metadata and use V1 only.
+- Barriers are not moved across region-bearing operations.
+- V2 proves only same-iteration ordering.
+- Resource-aware reasoning, such as proving additional safety from buffer
+  independence or aliasing information, is not modeled yet.
+- If either compared barrier lacks `WSBarrier` or `channelGraph`, reordering is
+  rejected.
+
+## Debugging
+
+Useful checks:
+
+- Before token lowering, inspect `nvws.*` token ops for
+  `constraints = {WSBarrier = {...}}`.
+- After token lowering, inspect `ttng.wait_barrier` and
+  `ttng.arrive_barrier` for the same nested dictionary.
+- For V1 behavior, check `channelGraph`.
+- For V2 behavior, check that both barriers have the same `parentId` and that
+  the wait's `maxRegionId` is less than the arrive's `minRegionId`.
+
+Lit coverage should prefer checking the nested `WSBarrier` dictionary rather
+than relying on comments around a specific barrier placement.


### PR DESCRIPTION
Summary:
See V2 in this doc: https://docs.google.com/document/d/1tRGWRpQXZodUqs06Jm3Tn2YLKixhgO2ERkpr57Eq5Ng/edit?tab=t.0.

This implementation extends the AutoWS barrier handling to modify the underlying structure of ADDMM. In particular this leverages the idea that the "forward" and "backward" channels fundamentally relate to separate iterations (backwards is the start of iteration i + 1 and fwd is in iteration i) to determine that these channels do not conflict. This allows us to restructure a partition group into additional "subregions". The subregions can be then be ordered which will be used to determine if such reordering is legal.

This introduces the following new details:
- parentID: We only reorder with the same relative iteration (e.g. parentOp)
- regionID: Split into min/max. Divides the regions of each partition based on the order in which it executes.

The other parts remain unchanged/are additive.


Reviewed By: Sibylau, manman-ren

Differential Revision: D104699342

Pulled By: njriasan


