### PR TITLE
[Triton] [BE] Fix type check issue in Triton build

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -312,7 +312,7 @@ class base_knobs:
 class BuildImpl(Protocol):
 
     def __call__(self, name: str, src: str, srcdir: str, library_dirs: list[str], include_dirs: list[str],
-                 libraries: list[str], /) -> str:
+                 libraries: list[str], ccflags: list[str], /) -> str:
         ...
 
 


### PR DESCRIPTION
Fixes this pre-commit issue:

```
python/triton/runtime/build.py:23: error: Too many arguments for "__call__" of "BuildImpl"  [call-arg]
Found 1 error in 1 file (checked 7 source files)
```