### PR TITLE
[TLX] Unify cluster sync attempt 2

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
@@ -1,10 +1,12 @@
 #include "triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/OperationSupport.h"
+#include "tlx/dialect/include/IR/Dialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
@@ -196,6 +198,8 @@ static void rewritePartitionRegions(WarpSpecializeOp ws, Block *switchLoop,
     // another barrier here.
     callbacks.createAllBarrier(b, switchLoopBarrierIdx);
 
+    bool hasClusterSyncKernelCleanup = tlx::hasClusterSyncKernelCleanup(ws);
+
     // Rewrite all warp returns.
     partition->walk([&](WarpReturnOp op) {
       TritonLLVMIRRewriter b(op.getLoc(), op);
@@ -203,6 +207,14 @@ static void rewritePartitionRegions(WarpSpecializeOp ws, Block *switchLoop,
       callbacks.reallocRegisters(b, ws,
                                  RegisterReallocPhase::WorkerPartitionEnd,
                                  partition->getRegionNumber());
+      if (hasClusterSyncKernelCleanup) {
+        // If there was a cluster sync point before tmem de-alloc, it would
+        // block default warps. Non default warps should arrive at the end of
+        // its region to unblock.
+        b.setInsertionPoint(op);
+        NVVM::ClusterArriveOp::create(b, b.getLoc(),
+                                      UnitAttr::get(b.getContext()));
+      }
       b.replaceOpWithNewOp<LLVM::BrOp>(op, switchLoop);
     });
   }

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -562,6 +562,10 @@ def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
     cluster_wait_pos = ptx.index("barrier.cluster.wait.aligned")
     tmem_alloc_pos = ptx.index("tcgen05.alloc.cta_group::2")
     assert fence_mbar_pos < fence_proxy_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
+    # 2 cluster syncs: 1 for init (before tmem alloc, after bar init), 1 for cleanup (before tmem dealloc)
+    assert ptx.count("barrier.cluster.arrive.aligned") == 2
+    assert ptx.count("barrier.cluster.wait.aligned") == 2
+    assert ptx.count("tcgen05.dealloc.cta_group::2") == 1
     assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
     assert ptx.count("tcgen05.mma.cta_group::2") == 8  # BK=128 divided into steps of 16
 
@@ -712,8 +716,12 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
     cluster_wait_pos = ptx.index("barrier.cluster.wait.aligned")
     tmem_alloc_pos = ptx.index("tcgen05.alloc.cta_group::2")
     assert fence_mbar_pos < fence_proxy_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
-    assert ptx.count("barrier.cluster.arrive.aligned") == 2
-    assert ptx.count("barrier.cluster.wait.aligned") == 1
+    # 6 cluster arrives: 1 init (default) + 1 init (non-default) +
+    #   1 cleanup (default, before tmem dealloc) + 3 cleanup (non-default warps MMA/producer/idle, per partition end)
+    # 2 cluster waits: 1 init (default) + 1 cleanup (default, before tmem dealloc)
+    assert ptx.count("barrier.cluster.arrive.aligned") == 6
+    assert ptx.count("barrier.cluster.wait.aligned") == 2
+    assert ptx.count("tcgen05.dealloc.cta_group::2") == 1
     assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
     assert ptx.count("tcgen05.mma.cta_group::2") == 8  # BK=128 divided into steps of 16
 

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -978,7 +978,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
-module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
   // CHECK-LABEL: @not_fold_cta_id_2cta
   // CHECK: nvg.cluster_id
   tt.func public @not_fold_cta_id_2cta(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -1189,3 +1189,48 @@ llvm.func @explicit_cluster_sync_no_ws_arrive(%a: !llvm.ptr<3>, %b: i1) attribut
   llvm.return
 }
 }
+
+// -----
+
+// Test cluster sync insertion for both init and cleanup phases.
+// Init: non-default warps arrive before entering the switch loop so default
+//       warps can complete cluster-wide bar init.
+// Cleanup: non-default warps arrive at partition end so default warps can
+//          proceed with cluster-wide TMEM dealloc.
+module attributes {"tlx.cluster_sync_kernel_init" = true, "tlx.cluster_sync_kernel_cleanup" = true, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 6 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+
+llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
+// CHECK-LABEL: @cluster_sync_init_and_cleanup
+
+// Init: non-default warps arrive before the default/partition branch
+// CHECK: llvm.inline_asm
+// CHECK-SAME: @!$0 barrier.cluster.arrive.aligned
+// CHECK-NEXT: llvm.cond_br
+
+// Cleanup: non-default warps arrive at partition end before looping back
+// CHECK: "use"
+// CHECK: nvvm.cluster.arrive {aligned}
+// CHECK-NEXT: llvm.br
+
+// Default warps: arrive/wait after bar init
+// CHECK: mbarrier.init.shared::cta.b64
+// CHECK-NEXT: nvvm.cluster.arrive {aligned}
+// CHECK-NEXT: nvvm.cluster.wait {aligned}
+
+llvm.func @cluster_sync_init_and_cleanup(%a: !llvm.ptr<3>, %b: i1) attributes {allocation.offset = 0 : i32} {
+  %c = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 mbarrier.init.shared::cta.b64 [$1], 2;", "b,r" %b, %a : (i1, !llvm.ptr<3>) -> !llvm.void
+  nvvm.cluster.arrive {aligned}
+  nvvm.cluster.wait {aligned}
+  ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 4>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(1) {
+    %1 = llvm.mlir.constant(42 : i32) : i32
+    "use"(%1) : (i32) -> ()
+    ttg.warp_return
+  } : () -> ()
+  llvm.return
+}
+}

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -1127,7 +1127,7 @@ llvm.func @dynamic_register_reallocation_overalloc() attributes {allocation.offs
 
 // -----
 
-module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 6 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+module attributes {tlx.enable_paired_cta_mma = true, "tlx.cluster_sync_kernel_init" = true, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.total-num-warps" = 6 : i32, "ttg.cluster-dim-x" = 2 : i32} {
 
 llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 

--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -195,35 +195,3 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttng.tw
     tt.return
   }
 }
-
-// -----
-
-// Test that Fixup sets tlx.explicit_cluster_sync when ClusterArriveOp is present.
-// At Fixup time, cluster arrive/wait ops can only come from user frontend code.
-// CHECK: module attributes {
-// CHECK-SAME: tlx.explicit_cluster_sync = true
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
-  tt.func public @explicit_cluster_sync_arrive() attributes {noinline = false} {
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
-    tt.return
-  }
-}
-
-// -----
-
-// Test that Fixup does NOT set tlx.explicit_cluster_sync when no cluster
-// arrive/wait ops are present.
-// CHECK: module attributes {
-// CHECK-NOT: tlx.explicit_cluster_sync
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
-  tt.func public @no_explicit_cluster_sync() attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    tt.return
-  }
-}

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -563,29 +563,3 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
-
-// -----
-
-// Test that explicit_cluster_sync suppresses heuristic cluster sync insertion.
-// Even though there is a remote barrier (map_to_remote_buffer + arrive_barrier),
-// the compiler must not auto-insert cluster arrive/wait because the user is
-// responsible for placing them manually.
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {tlx.enable_paired_cta_mma = true, tlx.explicit_cluster_sync = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
-  // CHECK-LABEL: @explicit_cluster_sync_no_auto_insert
-  tt.func public @explicit_cluster_sync_no_auto_insert() attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK-NOT: nvvm.cluster.arrive
-    // CHECK-NOT: nvvm.cluster.wait
-    // CHECK: nvvm.mapa
-    ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
-
-    %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    ttng.arrive_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    tt.return
-  }
-}

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -3,6 +3,8 @@
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
+// CHECK: module attributes {
+// CHECK-SAME: tlx.cluster_sync_kernel_init = true
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
   // CHECK-LABEL: @tlx_bar_init
   tt.func public @tlx_bar_init() attributes {noinline = false} {

--- a/test/TLX/tcgen5_global_alloc_lowering.mlir
+++ b/test/TLX/tcgen5_global_alloc_lowering.mlir
@@ -8,6 +8,9 @@
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
+// CHECK: module attributes {
+// CHECK-SAME: tlx.cluster_sync_kernel_cleanup = true
+// CHECK-SAME: tlx.cluster_sync_kernel_init = true
 // ALLOC: ttg.shared = 132 : i32
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.tensor_memory_size" = 128 : i32} {
   // CHECK-LABEL: @tcgen5_global_alloc_lowering
@@ -17,6 +20,9 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
   // CHECK: tcgen05.alloc.cta_group::2
   // CHECK: nvvm.barrier0
   // CHECK: tcgen05.relinquish_alloc_permit.cta_group::2
+  // CHECK: nvvm.cluster.arrive {aligned}
+  // CHECK: nvvm.cluster.wait {aligned}
+  // CHECK: tcgen05.dealloc.cta_group::2
   // ALLOC-LABEL: @tcgen5_global_alloc_lowering
   tt.func public @tcgen5_global_alloc_lowering() attributes {noinline = false} {
     %c0_i32 = arith.constant 0 : i32
@@ -45,6 +51,10 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
   // must assign a non-zero offset for the scratch buffer (via GEP).
   // CHECK: llvm.getelementptr
   // CHECK: tcgen05.alloc.cta_group::2
+  // CHECK: tcgen05.relinquish_alloc_permit.cta_group::2
+  // CHECK: nvvm.cluster.arrive {aligned}
+  // CHECK: nvvm.cluster.wait {aligned}
+  // CHECK: tcgen05.dealloc.cta_group::2
   // ALLOC-LABEL: @tcgen5_global_alloc_no_smem_overlap
   tt.func public @tcgen5_global_alloc_no_smem_overlap(%bar: !ttg.memdesc<1xi64, #shared, #smem, mutable>) attributes {noinline = false} {
     %buf = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>

--- a/test/TLX/tcgen5_global_alloc_lowering.mlir
+++ b/test/TLX/tcgen5_global_alloc_lowering.mlir
@@ -6,16 +6,25 @@
 // alloc result.
 
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
-// ALLOC: ttg.shared = 4 : i32
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+// ALLOC: ttg.shared = 132 : i32
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.tensor_memory_size" = 128 : i32} {
   // CHECK-LABEL: @tcgen5_global_alloc_lowering
+  // CHECK: mbarrier.init.shared::cta.b64
+  // CHECK: nvvm.cluster.arrive {aligned}
+  // CHECK: nvvm.cluster.wait {aligned}
   // CHECK: tcgen05.alloc.cta_group::2
   // CHECK: nvvm.barrier0
   // CHECK: tcgen05.relinquish_alloc_permit.cta_group::2
   // ALLOC-LABEL: @tcgen5_global_alloc_lowering
   tt.func public @tcgen5_global_alloc_lowering() attributes {noinline = false} {
-    // ALLOC-NEXT: ttng.tcgen5_global_alloc
-    // ALLOC-SAME: allocation.offset = 0 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %bar_idx = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.init_barrier %bar_idx, 1 : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    // ALLOC: ttng.tcgen5_global_alloc
+    // ALLOC-SAME: allocation.offset = 128 : i32
     ttng.tcgen5_global_alloc {tensor_memory_size = 128 : i32, two_ctas = true}
     %alloc = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -579,9 +579,13 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     auto ctx = ret->getContext();
     auto loc = ret.getLoc();
     auto voidTy = void_ty(ctx);
-    if (twoCTAs && !tlxPairedMMA) {
+    if (twoCTAs || tlxPairedMMA) {
       NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
       NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));
+      if (tlxPairedMMA) {
+        // mark mod attr so that WS lowering is aware of this cluster sync point
+        tlx::setClusterSyncKernelCleanupOnMod(func, true);
+      }
     } else {
       NVVM::Barrier0Op::create(b, loc);
     }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -190,30 +190,19 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
   // Tell PTXAS this value is warp-uniform.
   wid = targetInfo.shuffleIdx(b, b.getLoc(), wid, 0);
   Value isDefault = b.icmp_ult(wid, b.i32_val(defaultNumWarps));
-  if (tlx::tlxIsClustered(func) && !tlx::tlxExplicitClusterSync(func)) {
-    // All these have to be true before we can insert an arrive here:
-    // - The kernel is in clustered mode
-    // - There's no user controlled explicit cluster sync
-    // - There's an ClusterWaitOp (then it had to be inserted by compiler)
-    // Count the number of compiler-inserted cluster syncs (one for barrier
-    // init, possibly one more for tmem alloc in TLX paired MMA). Non-default
-    // warps need a matching arrive for each.
-    int numClusterWaits = 0;
-    func.walk([&](NVVM::ClusterWaitOp) { numClusterWaits++; });
-    assert(numClusterWaits <= 1 &&
-           "compiler should only insert one cluster barrier");
-    if (numClusterWaits == 1) {
-      // Non default warps should just do a cluster arrive unconditionally.
-      // Note this instruction is at kernel beginning shared by all warps, and
-      // we use `isDefault` as predicate here to select only non default warps
-      PTXBuilder ptxBuilder;
-      auto clusterArriveOp =
-          *ptxBuilder.create("@!$0 barrier.cluster.arrive.aligned;");
-      clusterArriveOp({ptxBuilder.newOperand(isDefault, "b")},
-                      /*onlyAttachMLIRArgs=*/true);
-      auto voidTy = void_ty(ctx);
-      ptxBuilder.launch(b, func.getLoc(), voidTy);
-    }
+  if (tlx::hasClusterSyncKernelInit(func)) {
+    // There was a cluster sync inserted by compiler for kernel init, and it
+    // would only be executed by default warps. We now need to insert an arrive
+    // for non default warps to unblock default warps. Note this instruction is
+    // at kernel beginning shared by all warps, and we use `isDefault` as
+    // predicate here to select only non default warps
+    PTXBuilder ptxBuilder;
+    auto clusterArriveOp =
+        *ptxBuilder.create("@!$0 barrier.cluster.arrive.aligned;");
+    clusterArriveOp({ptxBuilder.newOperand(isDefault, "b")},
+                    /*onlyAttachMLIRArgs=*/true);
+    auto voidTy = void_ty(ctx);
+    ptxBuilder.launch(b, func.getLoc(), voidTy);
   }
   LLVM::CondBrOp::create(b, b.getLoc(), isDefault, entry, switchLoop);
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -352,15 +352,9 @@ private:
   }
 
   // If the kernel is clustered, insert cluster sync properly to
-  // bootstrap remote bars
+  // bootstrap remote bars or tmem
   LogicalResult maybeInsertClusterSync(ModuleOp &mod) {
     if (!tlx::tlxIsClustered(mod)) {
-      return success();
-    }
-
-    // If the kernel is in explicit(manual) cluster sync mode, users will be
-    // responsible for inserting cluster sync correctly from front end.
-    if (tlx::tlxExplicitClusterSync(mod)) {
       return success();
     }
 
@@ -375,8 +369,11 @@ private:
       }
       return WalkResult::advance();
     });
-    // If there's no remote barrier, skipping
-    if (!hasRemoteBar) {
+
+    // If we have remote mbar/SMEM access, or if we have 2cta TMEM allocation,
+    // we need a cluster sync after mbar init and before TMEM alloc
+    bool shouldInsert = hasRemoteBar || tlx::tlxEnablePairedMMA(mod);
+    if (!shouldInsert) {
       return success();
     }
 
@@ -386,8 +383,12 @@ private:
       remoteOrLocalBarInitOps.insert(barInitOp);
     });
 
+    // It's almost impossible for a clustered kernel to not have any mbar but
+    // have 2cta TMEM allocation. We enforce that such that we know it's safe
+    // to insert a cluster sync after the last bar init op, as long as we can
+    // enforce tmem alloc happens after all such mbar init.
     assert(!remoteOrLocalBarInitOps.empty() &&
-           "Failed to find bar init op when we know there's remote bar");
+           "Failed to find bar init op in a clustered kernel");
 
     // Enforcing front end for 2cta kernels:
     // All remote barrier init ops need to happen at the first block of
@@ -426,7 +427,8 @@ private:
     ttng::ClusterArriveOp::create(builder, lastBarInitOp.getLoc(),
                                   /*relaxed*/ false);
     ttng::ClusterWaitOp::create(builder, lastBarInitOp.getLoc());
-
+    // mark mod attr so that WS lowering is aware of this cluster sync point
+    tlx::setClusterSyncKernelInitOnMod(mod, true);
     return success();
   }
 };

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -29,10 +29,20 @@ constexpr static char AttrTLXEnablePairedCTAMMAName[] =
     "tlx.enable_paired_cta_mma";
 constexpr static char AttrTLXExplicitClusterSyncName[] =
     "tlx.explicit_cluster_sync";
+constexpr static char AttrClusterSyncKernelInitName[] =
+    "tlx.cluster_sync_kernel_init";
+constexpr static char AttrClusterSyncKernelCleanupName[] =
+    "tlx.cluster_sync_kernel_cleanup";
 
 bool tlxEnablePairedMMA(Operation *op);
 
 bool tlxExplicitClusterSync(Operation *op);
+
+bool hasClusterSyncKernelInit(Operation *op);
+void setClusterSyncKernelInitOnMod(Operation *op, bool value);
+
+bool hasClusterSyncKernelCleanup(Operation *op);
+void setClusterSyncKernelCleanupOnMod(Operation *op, bool value);
 
 // Returns true if the kernel uses clusters (clusterDims product > 1).
 // Subsumes tlxEnablePairedMMA: paired CTA MMA always implies clustering.

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -27,16 +27,12 @@ constexpr static char AttrHasTLXOpsName[] = "tlx.has_tlx_ops";
 constexpr static char AttrHasWarpSpecOpsName[] = "tlx.has_warp_spec_ops";
 constexpr static char AttrTLXEnablePairedCTAMMAName[] =
     "tlx.enable_paired_cta_mma";
-constexpr static char AttrTLXExplicitClusterSyncName[] =
-    "tlx.explicit_cluster_sync";
 constexpr static char AttrClusterSyncKernelInitName[] =
     "tlx.cluster_sync_kernel_init";
 constexpr static char AttrClusterSyncKernelCleanupName[] =
     "tlx.cluster_sync_kernel_cleanup";
 
 bool tlxEnablePairedMMA(Operation *op);
-
-bool tlxExplicitClusterSync(Operation *op);
 
 bool hasClusterSyncKernelInit(Operation *op);
 void setClusterSyncKernelInitOnMod(Operation *op, bool value);

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -55,6 +55,60 @@ bool mlir::triton::tlx::tlxExplicitClusterSync(Operation *op) {
   return attr != nullptr && attr.getValue() == true;
 }
 
+bool mlir::triton::tlx::hasClusterSyncKernelInit(Operation *op) {
+  assert(op != nullptr &&
+         "expecting nonnull op for checking cluster sync kernel init");
+  auto module = op;
+  if (!isa<ModuleOp>(module)) {
+    module = op->getParentOfType<ModuleOp>();
+  }
+  assert(module != nullptr && "expecting op nested in a module for checking "
+                              "cluster sync kernel init marker");
+  auto attr = module->getAttrOfType<BoolAttr>(AttrClusterSyncKernelInitName);
+  return attr != nullptr && attr.getValue() == true;
+}
+
+void mlir::triton::tlx::setClusterSyncKernelInitOnMod(Operation *op,
+                                                      bool value) {
+  assert(op != nullptr &&
+         "expecting nonnull op for setting cluster sync kernel init");
+  auto module = op;
+  if (!isa<ModuleOp>(module)) {
+    module = op->getParentOfType<ModuleOp>();
+  }
+  assert(module != nullptr && "expecting op nested in a module for setting "
+                              "cluster sync kernel init marker");
+  module->setAttr(AttrClusterSyncKernelInitName,
+                  BoolAttr::get(module->getContext(), value));
+}
+
+bool mlir::triton::tlx::hasClusterSyncKernelCleanup(Operation *op) {
+  assert(op != nullptr &&
+         "expecting nonnull op for checking cluster sync kernel cleanup");
+  auto module = op;
+  if (!isa<ModuleOp>(module)) {
+    module = op->getParentOfType<ModuleOp>();
+  }
+  assert(module != nullptr && "expecting op nested in a module for checking "
+                              "cluster sync kernel cleanup marker");
+  auto attr = module->getAttrOfType<BoolAttr>(AttrClusterSyncKernelCleanupName);
+  return attr != nullptr && attr.getValue() == true;
+}
+
+void mlir::triton::tlx::setClusterSyncKernelCleanupOnMod(Operation *op,
+                                                         bool value) {
+  assert(op != nullptr &&
+         "expecting nonnull op for setting cluster sync kernel cleanup");
+  auto module = op;
+  if (!isa<ModuleOp>(module)) {
+    module = op->getParentOfType<ModuleOp>();
+  }
+  assert(module != nullptr && "expecting op nested in a module for setting "
+                              "cluster sync kernel cleanup marker");
+  module->setAttr(AttrClusterSyncKernelCleanupName,
+                  BoolAttr::get(module->getContext(), value));
+}
+
 bool mlir::triton::tlx::tlxIsClustered(Operation *op) {
   assert(op != nullptr && "expecting nonnull op for checking cluster dims");
   auto moduleOp = op;

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -42,19 +42,6 @@ bool mlir::triton::tlx::tlxEnablePairedMMA(Operation *op) {
   return attr != nullptr && attr.getValue() == true;
 }
 
-bool mlir::triton::tlx::tlxExplicitClusterSync(Operation *op) {
-  assert(op != nullptr &&
-         "expecting nonnull op for checking explicit cluster sync");
-  auto module = op;
-  if (!isa<ModuleOp>(module)) {
-    module = op->getParentOfType<ModuleOp>();
-  }
-  assert(module != nullptr &&
-         "expecting op nested in a module for checking explicit cluster sync");
-  auto attr = module->getAttrOfType<BoolAttr>(AttrTLXExplicitClusterSyncName);
-  return attr != nullptr && attr.getValue() == true;
-}
-
 bool mlir::triton::tlx::hasClusterSyncKernelInit(Operation *op) {
   assert(op != nullptr &&
          "expecting nonnull op for checking cluster sync kernel init");

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -197,17 +197,9 @@ public:
                                return WalkResult::advance();
                              })
                               .wasInterrupted();
-    auto hasExplicitClusterSync =
-        mod.walk([&](Operation *op) {
-             if (isa<ttng::ClusterArriveOp, ttng::ClusterWaitOp>(op)) {
-               return WalkResult::interrupt();
-             }
-             return WalkResult::advance();
-           })
-            .wasInterrupted();
 
     if (!hasTLXOps && !hasExplicitLocalMemAccess && !hasWarpSpecOps &&
-        !hasTLXTwoCTAs && !hasExplicitClusterSync) {
+        !hasTLXTwoCTAs) {
       return;
     }
 
@@ -226,9 +218,6 @@ public:
       mod->setAttr(AttrHasWarpSpecOpsName, b.getBoolAttr(true));
     if (hasTLXTwoCTAs) {
       mod->setAttr(AttrTLXEnablePairedCTAMMAName, b.getBoolAttr(true));
-    }
-    if (hasExplicitClusterSync) {
-      mod->setAttr(AttrTLXExplicitClusterSyncName, b.getBoolAttr(true));
     }
   }
 };


### PR DESCRIPTION
https://github.com/facebookexperimental/triton/pull/1198 was attempt 1 to unify cluster sync in TLX. It assumed users took full responsibility if they chose to insert cluster sync manually. Since then we've learned it's required to have a cluster sync before tmem alloc and recommended to have one before tmem de-alloc. Having users deal with all these is too much and counter intuitive. This PR resets the programming model with this contract:

- Compiler enforces (in a separate PR) the sequence of mbar init -> tmem alloc -> WS regions. 
- Compiler inserts cluster sync into the kernel init phase (more precisely, after the final mbar init), if it's cluster kernel AND (the kernel has a remote mbar OR tmem alloc is 2cta mode). This cluster sync will be executed before any code in WS regions.
- Compiler inserts cluster sync into the kernel cleanup phase (i.e. before tmem de-alloc), if it's cluster kernel AND tmem de-alloc is 2cta mode. This cluster sync will be executed after any code in WS regions.
- Whenever compiler inserts a cluster sync, we record a corresponding module attribute, to generate cluster arrive for non default warps in WS lowering. For init phase, the non default warps just insert an arrive at kernel beginning; for cleanup phase, the arrive will be right before warp_return.

- Users can still choose to use explicit cluster sync in non WS kernel or in WS regions, but the compiler will do its insertions anyway to guard mbar/tmem. Those happen before or "after" WS regions so should not have issues co-existing with user inserted ones inside WS regions.

Also note the compiler inserted two cluster arrives before and after WS won't interfere with each other even if a WS region is empty. The WS lowering made sure non default warps will have to wait to default warps signal to be able to enter WS body, by which time the first cluster wait is done.

For easier review, each commit in this PR is a standalone and complete piece:
- Set up the mod attr to record compiler inserted 
- Fix insertion for kernel init phase
- Fix kernel cleanup phase
- Remove code that was used to differentiate "explicit/implicit" mode of cluster sync insertion
- Add test cases