### PR TITLE
[Tritonbench] [Bugfix] Disabling budget aware layout conversion for breaking modules

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -523,6 +523,7 @@ class nvidia_knobs(base_knobs):
     use_triton_dispatcher: env_bool = env_bool("TRITON_USE_TRITON_DISPATCHER")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     enable_tileir: env_bool = env_bool("ENABLE_TILE")
+    disable_budget_aware_layout_conversion: env_bool = env_bool("TRITON_DISABLE_BUDGET_AWARE_LAYOUT_CONVERSION")
 
 
 class amd_knobs(base_knobs):

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -728,7 +728,8 @@ class CUDABackend(BaseBackend):
         # Budget-aware layout conversion elimination — runs last to ensure
         # converts whose scratch would exceed SMEM budget are eliminated
         # after all other passes that may introduce layout conversions.
-        passes.ttgpuir.add_remove_layout_conversions(pm, smem_budget)
+        terminal_smem_budget = 0 if knobs.nvidia.disable_budget_aware_layout_conversion else smem_budget
+        passes.ttgpuir.add_remove_layout_conversions(pm, terminal_smem_budget)
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()


### PR DESCRIPTION
Summary: Introduces the `TRITON_DISABLE_BUDGET_AWARE_LAYOUT_CONVERSION` environment variable to provide an escape hatch for disabling budget-aware layout conversions during Triton compilation. This allows bypassing shared memory budget constraints for layout conversions, and is specifically enabled for the `ragged_hstu_attn_fwd` operator to resolve potential compilation or execution issues related to SMEM limits.

Differential Revision: D105017489


