### PR TITLE
[Triton JIT][2d/N] Fast tensor access bridge for C fast cache (#1498)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -47,6 +47,24 @@ static PyObject *canonicalize_dtype_fn = nullptr;
 static PyObject *canonicalize_ptr_dtype_fn = nullptr;
 static PyObject *torch_tensor_cls = nullptr;
 
+// Fast tensor access API — registered at runtime by _torch_bridge extension.
+// When available, provides ~10x faster dtype/data_ptr extraction by bypassing
+// Python attribute lookups and accessing THPVariable struct fields directly.
+struct TritonTensorAccessAPI {
+  int8_t (*get_scalar_type)(PyObject *);
+  uint64_t (*get_data_ptr)(PyObject *);
+  // Extract TensorDescriptor fields (base.data_ptr, shape, strides) in one
+  // shot. Returns ndim on success, -1 on failure.
+  int (*extract_tensordesc)(PyObject *td_obj, uint64_t *out_data_ptr,
+                            int64_t *out_shape, int64_t *out_strides,
+                            int max_ndim);
+};
+static TritonTensorAccessAPI *g_tensor_api = nullptr;
+
+// ScalarType → fc type_code mapping (indexed by c10::ScalarType int8_t value)
+static uint8_t scalar_type_to_fc_code[64];
+static bool scalar_type_map_initialized[64] = {};
+
 static PyObject *i32_str = nullptr;
 static PyObject *i64_str = nullptr;
 static PyObject *u64_str = nullptr;
@@ -895,9 +913,55 @@ static std::unordered_map<Py_hash_t, uint8_t> fc_dtype_to_code;
 static uint8_t fc_next_dtype_code = 0;
 
 static uint8_t fc_get_tensor_type_code(PyObject *arg, bool is_const) {
+  // Fast path: use torch_bridge direct struct access (no Python calls)
+  if (g_tensor_api) {
+    int8_t st = g_tensor_api->get_scalar_type(arg);
+    if (st < 0 || st >= 64)
+      goto slow_path;
+    uint8_t code;
+    if (scalar_type_map_initialized[st]) {
+      code = scalar_type_to_fc_code[st];
+    } else {
+      // Check if slow path already assigned a code for this dtype hash.
+      // This can happen when a Tensor subclass (fails THPVariable_CheckExact)
+      // was seen first via the slow path, and now a regular tensor with the
+      // same dtype arrives via the fast path. Reuse the existing code to
+      // avoid orphaning cache entries keyed by the slow-path code.
+      PyObject *dtype_obj = PyObject_GetAttr(arg, dtype_attr);
+      if (!dtype_obj) {
+        PyErr_Clear();
+        return TC_UNSUPPORTED;
+      }
+      Py_hash_t h = PyObject_Hash(dtype_obj);
+      Py_DECREF(dtype_obj);
+      if (h == -1) {
+        PyErr_Clear();
+        return TC_UNSUPPORTED;
+      }
+      auto it = fc_dtype_to_code.find(h);
+      if (it != fc_dtype_to_code.end()) {
+        // Reuse existing code from slow path
+        code = it->second;
+        scalar_type_to_fc_code[st] = code;
+        scalar_type_map_initialized[st] = true;
+        return is_const ? (TC_PTR_CONST_BASE + code) : (TC_PTR_BASE + code);
+      }
+      // No existing mapping — allocate a fresh code
+      code = fc_next_dtype_code++;
+      if (code > 30)
+        return TC_UNSUPPORTED;
+      scalar_type_to_fc_code[st] = code;
+      scalar_type_map_initialized[st] = true;
+      fc_dtype_to_code[h] = code;
+    }
+    return is_const ? (TC_PTR_CONST_BASE + code) : (TC_PTR_BASE + code);
+  }
+slow_path:
   PyObject *dtype_obj = PyObject_GetAttr(arg, dtype_attr);
-  if (!dtype_obj)
+  if (!dtype_obj) {
+    PyErr_Clear();
     return TC_UNSUPPORTED;
+  }
   Py_hash_t h = PyObject_Hash(dtype_obj);
   Py_DECREF(dtype_obj);
   if (h == -1) {
@@ -921,6 +985,13 @@ static uint8_t fc_get_tensor_type_code(PyObject *arg, bool is_const) {
 }
 
 static int fc_get_tensor_alignment(PyObject *arg) {
+  // Fast path: direct struct access via torch_bridge
+  if (g_tensor_api) {
+    uint64_t ptr = g_tensor_api->get_data_ptr(arg);
+    if (ptr != 0)
+      return (ptr & 15) == 0 ? 1 : 0;
+    // ptr==0: either not a torch tensor or zero-size tensor — fall through
+  }
   PyObject *ptr_obj = PyObject_CallMethodNoArgs(arg, data_ptr_attr);
   if (!ptr_obj)
     return -1;
@@ -1164,24 +1235,33 @@ static bool fc_build_key(FCCacheKey &key, FastCache *cache,
         return false;
       }
       key.slots[i].constexpr_hash = h;
+    } else {
+      // No metadata match — try detecting tensor-like objects.
+      // With _torch_bridge loaded, this is ~10x cheaper than Python attr
+      // lookups (direct THPVariable struct access). Without the bridge,
+      // falls back to PyObject_GetAttr which is ~80-150ns per call.
+      uint8_t tc = fc_get_tensor_type_code(arg, false);
+      if (tc != TC_UNSUPPORTED) {
+        meta.is_ptr = 1; // Cache for future calls → direct is_ptr branch
+        key.slots[i].type_code = tc;
+        bool spec = !meta.do_not_specialize;
+        bool align_flag = !meta.do_not_specialize_on_alignment;
+        if (spec && align_flag) {
+          int a = fc_get_tensor_alignment(arg);
+          if (a < 0) {
+            PyErr_Clear();
+            return false;
+          }
+          key.slots[i].align_bit = (uint8_t)a;
+        } else if (spec) {
+          key.slots[i].align_bit = 0;
+        } else {
+          key.slots[i].align_bit = 255;
+        }
+      }
+      // else: truly unknown type — slot stays zeroed (safe for fixed
+      // signatures where the same position always receives the same type).
     }
-    // NOTE: Unrecognized types (e.g. torch.Tensor params without annotation)
-    // leave the slot zeroed (from memset).  This is intentional for
-    // performance: proper detection via fc_get_tensor_type_code requires
-    // Python attr lookups (arg.dtype, arg.data_ptr()) adding ~0.1us per
-    // tensor on the hot path — a ~10-24% regression for typical kernels.
-    //
-    // Assumptions that make zeroed slots safe:
-    //  1. Triton JIT kernels have fixed signatures — the Python type at each
-    //     position never changes across invocations.
-    //  2. PyTorch allocates tensors 16-byte aligned (via cudaMalloc / caching
-    //     allocator), so alignment specialization is stable across calls.
-    //
-    // If assumption (2) is violated (e.g. user passes a tensor sliced into
-    // unaligned storage), the C fast cache may return a kernel specialized
-    // for aligned access.  The Python slow path handles this correctly; add
-    // proper detection here only if this becomes a real-world correctness
-    // issue (see fc_get_tensor_type_code / fc_get_tensor_alignment).
   }
   return true;
 }
@@ -1604,6 +1684,20 @@ static PyMethodDef module_methods[] = {
      METH_FASTCALL, nullptr},
     {"native_create_jit_proxy", (PyCFunction)native_create_jit_proxy,
      METH_FASTCALL, nullptr},
+    {"register_tensor_access_api",
+     (PyCFunction) + [](PyObject *self, PyObject *arg) -> PyObject * {
+       (void)self;
+       if (!PyCapsule_IsValid(arg, "triton_tensor_access_api")) {
+         PyErr_SetString(
+             PyExc_TypeError,
+             "Expected a PyCapsule with name 'triton_tensor_access_api'");
+         return nullptr;
+       }
+       g_tensor_api = (TritonTensorAccessAPI *)PyCapsule_GetPointer(
+           arg, "triton_tensor_access_api");
+       Py_RETURN_NONE;
+     },
+     METH_O, nullptr},
     {nullptr, nullptr, 0, nullptr} // sentinel
 };
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -26,6 +26,26 @@ try:
 except ImportError:
     native_create_jit_proxy = None
 
+# Fast tensor access API — lazily registered on first use.
+# Provides ~10x faster dtype/data_ptr extraction via direct C struct access.
+_torch_bridge_loaded = False
+_torch_bridge_init_done = False
+
+
+def _ensure_torch_bridge():
+    global _torch_bridge_loaded, _torch_bridge_init_done
+    if _torch_bridge_init_done:
+        return
+    _torch_bridge_init_done = True
+    try:
+        from triton._C.libtriton import register_tensor_access_api
+        from triton._C._torch_bridge import get_tensor_access_capsule
+        register_tensor_access_api(get_tensor_access_capsule())
+        _torch_bridge_loaded = True
+    except (ImportError, AttributeError):
+        pass
+
+
 TRITON_MODULE = "triton.language"
 GLUON_MODULE = "triton.experimental.gluon.language"
 
@@ -937,6 +957,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
         self._repr = repr
         self.launch_metadata = launch_metadata
         self.c_cache = c_cache
+        if c_cache:
+            _ensure_torch_bridge()
         # Register for simple deserialization of JITFunction constants
         _triton_jit_function_registry[f"{self.module}:{self.fn.__qualname__}"] = self
 

--- a/third_party/nvidia/backend/_torch_bridge.cpp
+++ b/third_party/nvidia/backend/_torch_bridge.cpp
@@ -1,0 +1,160 @@
+// _torch_bridge.cpp — Fast tensor accessor bridge for Triton's C fast cache.
+//
+// This extension links against torch_python to access THPVariable internals
+// directly, avoiding Python C-API overhead (PyObject_GetAttr,
+// CallMethodNoArgs). It exports a PyCapsule containing function pointers that
+// specialize.cc and driver.c consume.
+
+#include <Python.h>
+#include <c10/core/ScalarType.h>
+#include <stdint.h>
+#include <torch/csrc/autograd/python_variable.h>
+
+// ============================================================================
+// API struct — shared between this bridge and specialize.cc / driver.c
+// ============================================================================
+
+struct TritonTensorAccessAPI {
+  // Returns c10::ScalarType as int8_t. Returns -1 if not a valid torch tensor.
+  int8_t (*get_scalar_type)(PyObject *obj);
+  // Returns data_ptr as uint64_t. Returns 0 if not a valid torch tensor.
+  uint64_t (*get_data_ptr)(PyObject *obj);
+  // Extract TensorDescriptor fields in one shot (avoids
+  // PyObject_GetAttrString). td_obj: a Python dataclass TensorDescriptor
+  // instance. out_data_ptr: receives base tensor's data_ptr. out_shape:
+  // receives shape values (up to max_ndim). out_strides: receives stride values
+  // (up to max_ndim). Returns ndim on success, -1 on failure (not a valid
+  // TensorDescriptor).
+  int (*extract_tensordesc)(PyObject *td_obj, uint64_t *out_data_ptr,
+                            int64_t *out_shape, int64_t *out_strides,
+                            int max_ndim);
+};
+
+// ============================================================================
+// Fast accessor implementations
+// ============================================================================
+
+static int8_t fast_get_scalar_type(PyObject *obj) {
+  // Use Check (not CheckExact) to support tensor subclasses like
+  // nn.Parameter and DTensor. THPVariable_Unpack is safe for all
+  // subclasses — they share the same at::Tensor memory layout.
+  if (!THPVariable_Check(obj))
+    return -1;
+  const auto &tensor = THPVariable_Unpack(obj);
+  return static_cast<int8_t>(tensor.scalar_type());
+}
+
+static uint64_t fast_get_data_ptr(PyObject *obj) {
+  if (!THPVariable_CheckExact(obj))
+    return 0;
+  const auto &tensor = THPVariable_Unpack(obj);
+  return reinterpret_cast<uint64_t>(tensor.data_ptr());
+}
+
+// Interned attribute name strings for fast dict lookup
+static PyObject *s_base = nullptr;
+static PyObject *s_shape = nullptr;
+static PyObject *s_strides = nullptr;
+
+static int fast_extract_tensordesc(PyObject *td_obj, uint64_t *out_data_ptr,
+                                   int64_t *out_shape, int64_t *out_strides,
+                                   int max_ndim) {
+  // TensorDescriptor is a @dataclass — fields live in __dict__
+  PyObject *dict = PyObject_GenericGetDict(td_obj, nullptr);
+  if (!dict)
+    return -1;
+
+  // Get .base (the PyTorch tensor)
+  PyObject *base = PyDict_GetItem(dict, s_base); // borrowed ref
+  if (!base || !THPVariable_CheckExact(base)) {
+    Py_DECREF(dict);
+    return -1;
+  }
+  const auto &tensor = THPVariable_Unpack(base);
+  *out_data_ptr = reinterpret_cast<uint64_t>(tensor.data_ptr());
+
+  // Get .shape (Python list of ints)
+  PyObject *shape_list = PyDict_GetItem(dict, s_shape); // borrowed ref
+  if (!shape_list || !PyList_Check(shape_list)) {
+    Py_DECREF(dict);
+    return -1;
+  }
+  Py_ssize_t ndim = PyList_GET_SIZE(shape_list);
+  if (ndim > max_ndim) {
+    Py_DECREF(dict);
+    return -1;
+  }
+  for (Py_ssize_t i = 0; i < ndim; i++) {
+    out_shape[i] = PyLong_AsLongLong(PyList_GET_ITEM(shape_list, i));
+  }
+  if (PyErr_Occurred()) {
+    Py_DECREF(dict);
+    return -1;
+  }
+
+  // Get .strides (Python list of ints)
+  PyObject *strides_list = PyDict_GetItem(dict, s_strides); // borrowed ref
+  if (!strides_list || !PyList_Check(strides_list)) {
+    Py_DECREF(dict);
+    return -1;
+  }
+  for (Py_ssize_t i = 0; i < ndim; i++) {
+    out_strides[i] = PyLong_AsLongLong(PyList_GET_ITEM(strides_list, i));
+  }
+  if (PyErr_Occurred()) {
+    Py_DECREF(dict);
+    return -1;
+  }
+
+  Py_DECREF(dict);
+  return static_cast<int>(ndim);
+}
+
+// Singleton API instance
+static TritonTensorAccessAPI g_api = {
+    fast_get_scalar_type,
+    fast_get_data_ptr,
+    fast_extract_tensordesc,
+};
+
+// ============================================================================
+// Python-callable: returns PyCapsule wrapping the API struct
+// ============================================================================
+
+static PyObject *get_tensor_access_capsule(PyObject *self, PyObject *args) {
+  (void)self;
+  (void)args;
+  return PyCapsule_New(&g_api, "triton_tensor_access_api", nullptr);
+}
+
+// ============================================================================
+// Module definition
+// ============================================================================
+
+static PyMethodDef methods[] = {
+    {"get_tensor_access_capsule", get_tensor_access_capsule, METH_NOARGS,
+     "Returns a PyCapsule containing fast tensor accessor function pointers."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+static struct PyModuleDef module_def = {
+    PyModuleDef_HEAD_INIT,
+    "_torch_bridge",
+    "Fast tensor access bridge for Triton (links torch_python)",
+    -1,
+    methods,
+};
+
+PyMODINIT_FUNC PyInit__torch_bridge(void) {
+  // Intern attribute name strings
+  s_base = PyUnicode_InternFromString("base");
+  s_shape = PyUnicode_InternFromString("shape");
+  s_strides = PyUnicode_InternFromString("strides");
+  if (!s_base || !s_shape || !s_strides) {
+    Py_XDECREF(s_base);
+    Py_XDECREF(s_shape);
+    Py_XDECREF(s_strides);
+    return nullptr;
+  }
+  return PyModule_Create(&module_def);
+}


### PR DESCRIPTION
Summary:

### Background

The C fast cache (`fc_build_key` in specialize.cc) needs to read tensor
dtype and data_ptr on every cache lookup. Previously this used Python
C-API calls (~80-150ns per tensor arg). The C dispatcher (driver.c) also
needs to extract `.base.data_ptr()`, `.shape`, `.strides` from
TensorDescriptor dataclass objects on every TMA kernel launch — using
`PyObject_GetAttrString` for each field adds ~600ns per TensorDescriptor.

### Solution

Introduce `_torch_bridge` — a C++ extension linking `torch_python` that
exposes fast accessors via a PyCapsule:

- `get_scalar_type(obj)`: Direct `THPVariable_Unpack` → ~2-5ns (vs ~80ns)
- `get_data_ptr(obj)`: Direct `THPVariable_Unpack` → ~2-5ns (vs ~150ns)
- `extract_tensordesc(td_obj, &data_ptr, shape, strides, max_ndim)`:
  Extracts all TensorDescriptor fields in one shot:
  `PyObject_GenericGetDict` → `PyDict_GetItem` with interned keys →
  `THPVariable_Unpack(base).data_ptr()` + `PyList_GET_ITEM` loops.
  Eliminates 4× `PyObject_GetAttrString` + 1× `CallMethodNoArgs`.

Registered at import time via `register_tensor_access_api()` (specialize.cc)
and `register_tensor_bridge()` (driver.c). Falls back to slow Python
C-API when unavailable.

### Code path changes

**Before:**
```
td_convert_args (TensorDescriptor):
  → PyObject_GetAttrString(a, "base")           [~100ns]
  → PyObject_CallMethodNoArgs(base, "data_ptr") [~150ns]
  → PyObject_GetAttrString(a, "shape")          [~100ns]
  → PySequence_Fast + iterate
  → PyObject_GetAttrString(a, "strides")        [~100ns]
  → PySequence_Fast + iterate
  Total: ~600ns per descriptor
```

**After:**
```
td_convert_args (TensorDescriptor):
  → g_td_bridge->extract_tensordesc(a, &data_ptr, shape, strides, 5)
      → PyObject_GenericGetDict(a)            [~10ns]
      → PyDict_GetItem(dict, interned_base)   [~5ns]
      → THPVariable_Unpack(base).data_ptr()   [~5ns]
      → PyDict_GetItem(dict, interned_shape)  [~5ns]
      → PyList_GET_ITEM loop                  [~2ns/item]
      → PyDict_GetItem(dict, interned_strides)[~5ns]
      → PyList_GET_ITEM loop                  [~2ns/item]
  Total: ~50ns per descriptor
```

## Performance

With bridge, the hot path for tensor args is essentially zero overhead
compared to the "zeroed slot" approach, while also providing correct
dtype/alignment specialization in the cache key:

| x_val (args) | nop_triton_kernel | nocache | fc_miss |
|-------|------|------|------|
| 0  | 3.2-3.5us | 8.4-8.7us | 0.05us |
| 19 | 4.5-5.1us | 13.2-14.2us | 0.63-0.65us |
| 58 | 6.2-6.6us | 23.5-24.5us | 1.7us |

Reviewed By: htyu

Differential Revision: D104436377


