### PR TITLE
Add fbtriton PyPI publish workflow (fork-only)

### DIFF
--- a/.github/workflows/publish_fbtriton.yml
+++ b/.github/workflows/publish_fbtriton.yml
@@ -1,0 +1,64 @@
+name: Publish fbtriton to PyPI
+# Builds fbtriton wheels (by reusing wheels_fb.yml) and publishes them to
+# PyPI via Trusted Publishing (OIDC) — no API token in repo secrets.
+#
+# Trigger (formal, gated):
+# - push of a tag matching:
+#     v<MAJOR>.<MINOR>.<PATCH>             → release   (e.g. v3.6.0)
+#     v<MAJOR>.<MINOR>.<PATCH>-rc<N>       → release candidate (e.g. v3.6.0-rc1)
+#     v<MAJOR>.<MINOR>.<PATCH>.dev<N>      → dev/nightly (e.g. v3.6.0.dev20260515)
+#
+# No manual workflow_dispatch — publishing is intentionally tag-only so the
+# released artifact is always tied to a specific git tag.
+#
+# PyPI side requires a configured Trusted Publisher for this repo:
+#   project:     fbtriton
+#   owner:       facebookexperimental
+#   repo:        triton
+#   workflow:    publish_fbtriton.yml
+#   environment: pypi
+# See: https://docs.pypi.org/trusted-publishers/
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+.dev[0-9]+
+
+permissions: read-all
+
+jobs:
+  build:
+    name: Build wheels
+    uses: ./.github/workflows/wheels_fb.yml
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-22.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fbtriton
+    permissions:
+      # Required for Trusted Publishing (OIDC).
+      id-token: write
+
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: dist
+          pattern: wheels-*
+          merge-multiple: true
+
+      - name: List wheels
+        run: ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: false
+          print-hash: true

--- a/.github/workflows/wheels_fb.yml
+++ b/.github/workflows/wheels_fb.yml
@@ -1,0 +1,105 @@
+name: Wheels (fbtriton)
+# Builds fbtriton manylinux wheels (x86_64 + aarch64) for each supported
+# CPython ABI on GitHub-hosted runners. Smoke-tests each wheel by importing it
+# inside the per-ABI venv that cibuildwheel creates. No publish step — wheel
+# artifacts are uploaded for download via 'gh run download'. Reused by
+# publish_fbtriton.yml via `workflow_call`.
+#
+# This is the Meta-fork-only build. The upstream `wheels.yml` is left
+# untouched so it stays trivially mergeable from triton-lang/triton.
+#
+# Trigger via:
+#   gh workflow run wheels_fb.yml -R facebookexperimental/triton
+# Or by editing this file in a PR.
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    paths:
+      - .github/workflows/wheels_fb.yml
+
+permissions: read-all
+
+jobs:
+  build:
+    name: Build wheel ${{ matrix.python }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
+    timeout-minutes: 90
+
+    strategy:
+      # Don't cancel sibling builds when one fails — we want to see which
+      # ABIs/arches work and which break.
+      fail-fast: false
+      matrix:
+        python: [cp313]
+        arch: [x86_64]
+        # python: [cp310, cp311, cp312, cp313, cp314]
+        # arch: [x86_64, aarch64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Tag-triggered builds (via publish.yml) need a clean PEP 440 version
+      # (no +gitHASH suffix) for PyPI. Bypass setup.py's dynamic version
+      # logic (get_git_version_suffix + TRITON_WHEEL_VERSION_SUFFIX) by
+      # hardcoding TRITON_VERSION from the tag — same approach as upstream
+      # triton-lang/triton's create_release.yml.
+      #   v3.6.0          → 3.6.0
+      #   v3.6.0-rc1      → 3.6.0rc1     (PEP 440 drops the dash)
+      #   v3.6.0.dev123   → 3.6.0.dev123
+      - name: Pin TRITON_VERSION from tag for PyPI (tag builds only)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          base="${GITHUB_REF_NAME#v}"
+          base="${base/-rc/rc}"
+          sed -i "s:^TRITON_VERSION = .*:TRITON_VERSION = '${base}':" setup.py
+          grep '^TRITON_VERSION' setup.py
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Build wheel via cibuildwheel
+        run: |
+          python3 -m pip install --upgrade cibuildwheel
+
+          # This fork always publishes as 'fbtriton' — hard-code it so PR
+          # and cron CI exercise the exact wheel layout the publish flow ships.
+          # LDFLAGS strips debug symbols from libtriton.so at link time, cutting
+          # the wheel size roughly in half (the static LLVM/MLIR blob is the
+          # bulk of it).
+          export CIBW_ENVIRONMENT="\
+            MAX_JOBS=4 \
+            TRITON_BUILD_WITH_CLANG_LLD=1 \
+            TRITON_WHEEL_NAME=fbtriton \
+            LDFLAGS=-Wl,--strip-all"
+          export CIBW_BEFORE_ALL="dnf install clang lld -y"
+
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux_2_28_x86_64:latest"
+          else
+            export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_aarch64:latest"
+          fi
+          export CIBW_BUILD="${{ matrix.python }}-manylinux_${{ matrix.arch }}"
+
+          # Defensive: tell auditwheel not to follow libtriton.so's deps into
+          # triton.libs/. Currently a no-op because TRITON_BUILD_WITH_CLANG_LLD=1
+          # links LLVM/MLIR statically into libtriton.so, so it has no exotic
+          # shared deps to bundle. Kept so a future switch to dynamic LLVM
+          # linking doesn't silently bloat the wheel by 100+ MB.
+          export CIBW_REPAIR_WHEEL_COMMAND_LINUX="auditwheel repair --exclude libtriton.so -w {dest_dir} {wheel}"
+
+          # Smoke-test: import the freshly-built wheel inside the per-ABI venv
+          # cibuildwheel creates. CPU-only — GPU correctness is covered by
+          # h100.yml / mi350.yml, which build from source on real hardware.
+          export CIBW_TEST_COMMAND='python -c "import triton; print(\"OK\", triton.__version__)"'
+
+          python3 -m cibuildwheel . --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: wheels-${{ matrix.python }}-manylinux_2_28_${{ matrix.arch }}
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Adds two new fork-only workflow files so we can publish `fbtriton` to PyPI on tag pushes, without touching upstream's `wheels.yml`. The upstream file is left untouched so it stays trivially mergeable from `triton-lang/triton`.

## What's added

| File | Purpose |
|---|---|
| `.github/workflows/wheels_fb.yml` | cibuildwheel build matrix for the `fbtriton` package. Reusable via `workflow_call`. |
| `.github/workflows/publish_fbtriton.yml` | PyPI publish via Trusted Publishing (OIDC). Tag-triggered only. |

## How it works

`publish_fbtriton.yml` is triggered by tag pushes matching:

| Tag | Resulting wheel version |
|---|---|
| `vX.Y.Z` | `X.Y.Z` |
| `vX.Y.Z-rcN` | `X.Y.ZrcN` |
| `vX.Y.Z.devN` | `X.Y.Z.devN` |

The version is hardcoded into `setup.py` at CI time via `sed` — same pattern as upstream's `create_release.yml`. This avoids the `+gitHASH` PEP 440 local version that PyPI rejects, **without modifying `setup.py` in the repo**.

The workflow then calls `wheels_fb.yml` (via `workflow_call`), which builds the wheels with cibuildwheel inside `manylinux_2_28` containers. Wheel artifacts are uploaded to GHA, then `publish_fbtriton.yml` downloads them and uploads to PyPI via `pypa/gh-action-pypi-publish`.

## Wheel size

Each wheel is ~295 MB (x86_64) / ~283 MB (aarch64), larger than upstream `triton`'s ~190–202 MB due to the additional TLX dialect and warp-specialization passes carried in the fork. PyPI's default 100 MB per-file limit is well below this; a separate file-size-limit increase request has been filed for project `fbtriton`.

Build-side size-reduction measures already applied:
- `LDFLAGS=-Wl,--strip-all` strips debug symbols (~½ size)
- `TRITON_BUILD_WITH_CLANG_LLD=1` links LLVM/MLIR statically into one `libtriton.so` (avoids ~100 MB of `triton.libs/` bloat)
- `auditwheel repair --exclude libtriton.so` defensive against future dynamic deps

## PyPI Trusted Publisher

PyPI must have a Trusted Publisher configured matching this workflow:

```
project:     fbtriton
owner:       facebookexperimental   (or wychi initially, see "rollout")
repo:        triton
workflow:    publish_fbtriton.yml
environment: pypi
```

## Rollout plan

1. Bootstrap the `fbtriton` PyPI project from a tiny placeholder uploaded out of band (separate one-shot workflow not in this PR).
2. Request a per-file size-limit increase on PyPI to ~400 MB.
3. Push the first real tag (`v3.6.0`) — `publish_fbtriton.yml` takes over and ships the actual wheels.
4. Once stable, transfer Owner role on PyPI to a Meta-controlled account and add the production `facebookexperimental/triton` Trusted Publisher binding.

## Notes

- Upstream `wheels.yml` is **not** modified. It still runs on its existing schedule. (Disable the upstream nightly cron via the GitHub Actions UI rather than editing the file, so the file stays in sync with upstream.)
- No changes to `setup.py`, source code, or any test.
- This is fork-only by design — these workflows would not be appropriate to upstream.
- Pypi: triton - https://pypi.org/project/triton/#files
- Pypi: fbtriton - https://pypi.org/project/fbtriton/#files