### PR TITLE
[triton][beta] Add missing USE_WARP_BARRIER to test config

### DIFF
--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -208,6 +208,7 @@ class FlashAttention:
             "NUM_MMA_GROUPS": 2,
             "NUM_MMA_SLICES": 2,
             "GROUP_SIZE_N": 1,
+            "USE_WARP_BARRIER": False,
         },
         "blackwell_fa_clc": {
             "BLOCK_M": 256,


### PR DESCRIPTION
Summary:
The `_attn_fwd_ws` kernel in `blackwell_fa_ws_pipelined_persistent.py` requires `USE_WARP_BARRIER` as a mandatory `tl.constexpr` parameter with no default value. The test config dict `"blackwell_fa_ws_pipelined_persistent"` in `test_correctness.py` was missing this key. When the launcher unpacks the config via `**config`, the missing key causes `TypeError: dynamic_func() missing 1 required positional argument: 'USE_WARP_BARRIER'`, failing all 12 parametrized cases in `test_blackwell_fa_ws_pipelined_persistent` (2 causal x 3 RESCALE_OPT/USE_WHERE combos x 2 BLOCK_M values).

Fix: add `"USE_WARP_BARRIER": False` to the base test config. `False` is the correct default — the `True` case is already covered by the separate `test_blackwell_fa_ws_pipelined_persistent_warp_barrier` test, and other kernels like `blackwell_fa_clc` also default to `False`.

Authored with Claude.

Reviewed By: dshi7

Differential Revision: D105029735


