### PR TITLE
 [autoWS] Fix compilation error for causal FA with compiler generated data partition (#1506) (#1506)

### DIFF
--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
@@ -39,6 +39,34 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: [[COMP_A:[0-9]+]]>
 // CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: [[COMP_B:[0-9]+]]>
 //
+// --- Split scf.if: the condition and else-yield operands defined outside the
+//     scf.if must NOT have a ttg.partition attribute. If they keep partition 0
+//     (from the original shared scf.if), doTaskIdPropagate expands the split
+//     scf.if's task set to include partition 0, creating a cross-partition
+//     SMEM channel that overflows shared memory. ---
+// CHECK: arith.mulf
+// CHECK-NOT: ttg.partition
+// CHECK: arith.mulf
+// CHECK-NOT: ttg.partition
+// CHECK: arith.cmpi
+// CHECK-NOT: ttg.partition
+//
+// --- Split scf.if: ops inside then-block get the parent's computation partition.
+//     The scf.if itself inherits loop scheduling attributes from the original so
+//     the downstream pipeliner can schedule channel ops derived from it. ---
+// CHECK: scf.if
+// CHECK: tt.splat {{.*}} ttg.partition = array<i32: [[COMP_A]]>
+// CHECK: } {
+// CHECK-SAME: loop.cluster
+// CHECK-SAME: loop.stage
+// CHECK-SAME: ttg.partition = array<i32: [[COMP_A]]>
+// CHECK: scf.if
+// CHECK: tt.splat {{.*}} ttg.partition = array<i32: [[COMP_B]]>
+// CHECK: } {
+// CHECK-SAME: loop.cluster
+// CHECK-SAME: loop.stage
+// CHECK-SAME: ttg.partition = array<i32: [[COMP_B]]>
+//
 // --- Correction/rescale ops (acc tmem_load, tmem_store) go to correction (partition 0) ---
 // CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: 0>
 // CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: 0>
@@ -156,14 +184,20 @@ tt.func public @flex_attention_data_partition_split(
     %scores_1 = arith.mulf %qk_val_1, %cst_scale {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
 
     // scf.if for masking — this is the merge point that causes both data
-    // partitions to collapse into one computation partition without the fix
+    // partitions to collapse into one computation partition without the fix.
+    // The then-block has transitive dependencies (splat → mulf) to test that
+    // splitDataPartitionedIfOps clones the entire backward slice, not just
+    // the immediate defining ops of the yield operands.
     %is_full = arith.cmpi sge, %i, %c1_i32 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : i32
     %masked:2 = scf.if %is_full -> (tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>) {
-      scf.yield %scores_0, %scores_1 : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
+      %full_scale = tt.splat %SM_SCALE {loop.cluster = 1 : i32, loop.stage = 1 : i32} : f32 -> tensor<128x128xf32, #blocked>
+      %full_0 = arith.mulf %scores_0, %full_scale {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+      %full_1 = arith.mulf %scores_1, %full_scale {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+      scf.yield %full_0, %full_1 : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
     } else {
-      %mask_0 = arith.select %false, %scores_0, %cst_neg_inf_2d {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
-      %mask_1 = arith.select %false, %scores_1, %cst_neg_inf_2d {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
-      scf.yield %mask_0, %mask_1 : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
+      // Yield values defined OUTSIDE the scf.if — this exercises the fix that
+      // removes stale partition assignments from such ops.
+      scf.yield %scores_0, %scores_1 : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
     } {loop.cluster = 1 : i32, loop.stage = 1 : i32}
 
     // Online softmax: m_ij, alpha, p, l_i — per data partition

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -244,3 +244,49 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Test that tt.map_elementwise and its non-dot operands are correctly
+// backward-sliced during data partitioning. Without the fix, the splat
+// feeding the mask operand would not be added to the partition scheme,
+// leaving it at 128x256 while the dot operand is halved to 64x256.
+// CHECK-LABEL: @test_map_elementwise_partition
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_map_elementwise_partition(%arg0: !tt.ptr<f16>, %arg1: tensor<64x256xf16, #blocked1>, %arg2: !tt.ptr<f16>) {
+    %cst = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %c0_i32 = arith.constant {async_task_id = array<i32: 1, 2>} 0 : i32
+    %cst_neg_inf = arith.constant {async_task_id = array<i32: 1, 2>} 0xFF800000 : f32
+    %mask_val = arith.constant {async_task_id = array<i32: 1, 2>} 42 : i32
+    %ptr = tt.splat %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ld = tt.load %ptr {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    %a = ttg.local_alloc %ld {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b = ttg.local_alloc %arg1 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+    // CHECK: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32, #mma>
+    // CHECK: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32, #mma>
+    %dot = ttng.warp_group_dot %a, %b, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    %mask = tt.splat %mask_val {async_task_id = array<i32: 1, 2>} : i32 -> tensor<128x256xi32, #mma>
+    // CHECK: "tt.map_elementwise"
+    // CHECK: : (tensor<64x256xf32, #mma>, tensor<64x256xi32, #mma>) -> tensor<64x256xf32, #mma>
+    // CHECK: "tt.map_elementwise"
+    // CHECK: : (tensor<64x256xf32, #mma>, tensor<64x256xi32, #mma>) -> tensor<64x256xf32, #mma>
+    %result = "tt.map_elementwise"(%dot, %mask) <{pack = 1 : i32}> ({
+    ^bb0(%d: f32, %m: i32):
+      %cmp = arith.cmpi sgt, %m, %c0_i32 : i32
+      %sel = arith.select %cmp, %d, %cst_neg_inf : f32
+      tt.map_elementwise.return %sel : f32
+    }) {async_task_id = array<i32: 1, 2>} : (tensor<128x256xf32, #mma>, tensor<128x256xi32, #mma>) -> tensor<128x256xf32, #mma>
+    %trunc = arith.truncf %result {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+    %cvt = ttg.convert_layout %trunc {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+    %st_ptr = tt.splat %arg2 {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
+    // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>,
+    // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>,
+    tt.store %st_ptr, %cvt {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2445,25 +2445,34 @@ void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
       auto *origElseYield =
           origElseBlock ? origElseBlock->getTerminator() : nullptr;
 
-      // Collect needed ops for the else block via backward reachability.
-      DenseSet<Operation *> neededElseOps;
-      if (origElseBlock) {
-        for (unsigned idx : resultIndices) {
+      // Collect needed ops via backward reachability from yield operands.
+      auto collectNeededOps = [](Block *block, Operation *yieldOp,
+                                 ArrayRef<unsigned> indices) {
+        DenseSet<Operation *> needed;
+        for (unsigned idx : indices) {
           SmallVector<Operation *> worklist;
-          if (auto *def = origElseYield->getOperand(idx).getDefiningOp())
+          if (auto *def = yieldOp->getOperand(idx).getDefiningOp())
             worklist.push_back(def);
           while (!worklist.empty()) {
             Operation *curr = worklist.pop_back_val();
-            if (!curr || curr->getBlock() != origElseBlock)
+            if (!curr || curr->getBlock() != block)
               continue;
-            if (!neededElseOps.insert(curr).second)
+            if (!needed.insert(curr).second)
               continue;
             for (Value operand : curr->getOperands())
               if (auto *def = operand.getDefiningOp())
                 worklist.push_back(def);
           }
         }
-      }
+        return needed;
+      };
+
+      DenseSet<Operation *> neededThenOps =
+          collectNeededOps(origThenBlock, origThenYield, resultIndices);
+      DenseSet<Operation *> neededElseOps;
+      if (origElseBlock)
+        neededElseOps =
+            collectNeededOps(origElseBlock, origElseYield, resultIndices);
 
       // Build result types for this split.
       SmallVector<Type> splitResultTypes;
@@ -2474,12 +2483,7 @@ void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
       auto thenBuilder = [&](OpBuilder &b, Location loc) {
         IRMapping mapping;
         for (Operation &op : origThenBlock->without_terminator()) {
-          bool needed = false;
-          for (unsigned idx : resultIndices) {
-            if (origThenYield->getOperand(idx).getDefiningOp() == &op)
-              needed = true;
-          }
-          if (needed)
+          if (neededThenOps.contains(&op))
             b.clone(op, mapping);
         }
         SmallVector<Value> yieldVals;
@@ -2509,13 +2513,47 @@ void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
               : static_cast<function_ref<void(OpBuilder &, Location)>>(
                     nullptr));
 
-      // Assign the new scf.if to this computation partition.
-      setPartition(newIf, schedule.getPartition(partId));
+      // Assign the new scf.if and all ops inside it to this computation
+      // partition. Without this, cloned ops inside the then/else blocks
+      // keep stale partition assignments from the originals, causing the
+      // downstream code partition pass to miss them when building this
+      // partition's code.
+      auto *targetPartition = schedule.getPartition(partId);
+      newIf->walk([&](Operation *op) { setPartition(op, targetPartition); });
+
+      // Copy loop scheduling attributes (loop.stage, loop.cluster) from
+      // the original scf.if to the new one. Without these, the downstream
+      // pipeliner can't schedule ops derived from the split scf.if (e.g.
+      // local_store channel ops created by code partition).
+      if (auto attr = ifOp->getAttr("loop.stage"))
+        newIf->setAttr("loop.stage", attr);
+      if (auto attr = ifOp->getAttr("loop.cluster"))
+        newIf->setAttr("loop.cluster", attr);
 
       // Replace uses of the original results with the new scf.if results.
       for (unsigned i = 0; i < resultIndices.size(); i++) {
         ifOp.getResult(resultIndices[i]).replaceAllUsesWith(newIf.getResult(i));
       }
+    }
+
+    // Remove stale partition assignments from ops outside the scf.if that
+    // were pulled into partition 0 because the original scf.if was shared.
+    // This includes the condition and yield operands defined outside the
+    // scf.if (e.g. convert_layout ops cloned by optimizeSchedule). Leaving
+    // them in partition 0 causes doTaskIdPropagate to expand the split
+    // scf.if's task set, creating cross-partition SMEM channels that
+    // overflow shared memory.
+    auto removeStalePartition = [&](Value v) {
+      if (auto *op = v.getDefiningOp())
+        if (op->getParentOp() == ifOp->getParentOp())
+          op->removeAttr(kPartitionAttrName);
+    };
+    removeStalePartition(ifOp.getCondition());
+    for (auto *block : {ifOp.thenBlock(), ifOp.elseBlock()}) {
+      if (!block)
+        continue;
+      for (Value operand : block->getTerminator()->getOperands())
+        removeStalePartition(operand);
     }
 
     // Erase the original scf.if (all uses should be replaced).

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -348,7 +348,7 @@ static bool getBackwardSliceToPartition(Value v,
                    TransOp, MemDescTransOp, AtomicRMWOp, triton::AddPtrOp,
                    nvidia_gpu::TMEMAllocOp, nvidia_gpu::TMEMLoadOp,
                    nvidia_gpu::TMEMStoreOp, FpToFpOp, SplitOp, JoinOp,
-                   ReshapeOp>(op)) {
+                   ReshapeOp, MapElementwiseOp>(op)) {
       for (Value operand : op->getOperands())
         if (!getBackwardSliceToPartition(operand, partitionScheme,
                                          currentDim)) {
@@ -608,7 +608,7 @@ static bool getSliceToPartition(Value root,
                                        currentDim))
         return false;
     } else if (op->hasTrait<OpTrait::Elementwise>() ||
-               isa<StoreOp, AtomicRMWOp>(op)) {
+               isa<StoreOp, AtomicRMWOp, MapElementwiseOp>(op)) {
       for (OpOperand &operand : op->getOpOperands()) {
         if (!getBackwardSliceToPartition(operand.get(), partitionScheme,
                                          currentDim))

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -33,11 +33,38 @@ def is_hopper():
 
 
 @triton.jit
+def _mask_scalar(qk, col_limit_right, s, i):
+    col_lim_right_s = col_limit_right - s
+    col_lim_right_cur = max(col_lim_right_s, 0)
+    mask = -1 << col_lim_right_cur
+    mask_i_bit = (mask & (1 << i)) == 0
+    return tl.where(mask_i_bit, qk, -float("inf"))
+
+
+@triton.jit
+def _apply_causal_mask(qk, col_limit_right, BLOCK_N: tl.constexpr):
+    # Apply causal mask via a bitmask calculated for each block of 16 elements.
+    # This allows the efficient R2P (register to predicate) instruction to be used at the SASS level.
+    # Credit to Tri Dao,
+    # https://github.com/Dao-AILab/flash-attention/commit/bac1001e4f6caa09d70537495d6746a685a2fa78
+    #
+    # NOTE: We use map_elementiwse here in order to generate an interleaved sequence of instructions
+    # that processes one element of qk at a time. This improves ptxas's resulting SASS.
+    offs_n = tl.arange(0, BLOCK_N)[None, :]
+    s = offs_n & ~0xF
+    i = offs_n & 0xF
+    return tl.map_elementwise(_mask_scalar, qk, col_limit_right, s, i)
+
+
+@triton.jit
 def _attn_fwd_subtile(
     q,
     k,
     offs_m,
     start_n,
+    start_m,
+    BLOCK_N,
+    BLOCK_M,
     offs_n,
     qk_scale,
     l_i0,
@@ -52,17 +79,18 @@ def _attn_fwd_subtile(
     FADD2_REDUCE: tl.constexpr,
 ):
     qk = tl.dot(q, k)
-    if STAGE == 2:
-        mask = offs_m[:, None] >= (start_n + offs_n[None, :])
-        qk = qk * qk_scale + tl.where(mask, 0, -1.0e6)
-        m_ij = tl.maximum(m_i, tl.max(qk, 1))
-        qk -= m_ij[:, None]
+
+    if STAGE == 3 and start_n >= start_m * BLOCK_M:
+        col_limit_right = (offs_m - start_n + 1)[:, None]
+        qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
+
+    m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+
+    if VECT_MUL == 2 or VECT_MUL == 3:
+        qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
     else:
-        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
-        if VECT_MUL == 2 or VECT_MUL == 3:
-            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
-        else:
-            qk = qk * qk_scale - m_ij[:, None]
+        qk = qk * qk_scale - m_ij[:, None]
+
     p = tl.math.exp2(qk)
     # -- compute correction factor
     alpha = tl.math.exp2(m_i - m_ij)
@@ -133,14 +161,10 @@ def _attn_fwd_inner_oss_dp(
     DP_FACTOR: tl.constexpr,
 ):
     # range of values handled by this stage
-    if STAGE == 1:
-        lo, hi = 0, start_m * BLOCK_M
-    elif STAGE == 2:
-        lo, hi = start_m * BLOCK_M, (start_m + 1) * BLOCK_M
-        lo = tl.multiple_of(lo, BLOCK_M)
-    # causal = False
-    else:
+    if STAGE == 1:  # causal = False
         lo, hi = 0, N_CTX
+    else:  # causal = True
+        lo, hi = 0, (start_m + 1) * BLOCK_M
     offsetkv_y = offset_y + lo
 
     # loop over k, v and update accumulator
@@ -164,6 +188,9 @@ def _attn_fwd_inner_oss_dp(
             k,
             offs_m0,
             start_n,
+            start_m,
+            BLOCK_N,
+            BLOCK_M,
             offs_n,
             qk_scale,
             l_i0,
@@ -215,7 +242,6 @@ configs = [
         num_stages=s,
         num_warps=w,
         pre_hook=_host_descriptor_pre_hook,
-        # ir_override=f"/home/mren/OpenSource/tritonbench/override/_attn_fwd_persist.ttgir"
     ) for BM in [256] for BN in [128] for s in NUM_STAGES_OPTIONS for w in [4]
 ]
 
@@ -292,58 +318,31 @@ def _attn_fwd_tma_dp(
     else:
         l_i0_1 = 0
 
-    if STAGE & 1:
-        acc0, l_i0_0, l_i0_1, m_i0 = _attn_fwd_inner_oss_dp(
-            acc0,
-            l_i0_0,
-            l_i0_1,
-            m_i0,
-            q0,
-            desc_k,
-            desc_v,  #
-            offset_y,
-            dtype,
-            start_m,
-            qk_scale,  #
-            BLOCK_M,
-            HEAD_DIM,
-            BLOCK_N,  #
-            4 - STAGE,
-            offs_m0,
-            offs_n,
-            N_CTX,  #
-            warp_specialize,
-            SUBTILING,
-            VECT_MUL,
-            FADD2_REDUCE,
-            DP_FACTOR,
-        )
-    if STAGE & 2:
-        acc0, l_i0_0, l_i0_1, m_i0 = _attn_fwd_inner_oss_dp(
-            acc0,
-            l_i0_0,
-            l_i0_1,
-            m_i0,
-            q0,
-            desc_k,
-            desc_v,  #
-            offset_y,
-            dtype,
-            start_m,
-            qk_scale,  #
-            BLOCK_M,
-            HEAD_DIM,
-            BLOCK_N,  #
-            2,
-            offs_m0,
-            offs_n,
-            N_CTX,  #
-            warp_specialize,
-            SUBTILING,
-            VECT_MUL,
-            FADD2_REDUCE,
-            DP_FACTOR,
-        )
+    acc0, l_i0_0, l_i0_1, m_i0 = _attn_fwd_inner_oss_dp(
+        acc0,
+        l_i0_0,
+        l_i0_1,
+        m_i0,
+        q0,
+        desc_k,
+        desc_v,
+        offset_y,
+        dtype,
+        start_m,
+        qk_scale,
+        BLOCK_M,
+        HEAD_DIM,
+        BLOCK_N,
+        STAGE,
+        offs_m0,
+        offs_n,
+        N_CTX,
+        warp_specialize,
+        SUBTILING,
+        VECT_MUL,
+        FADD2_REDUCE,
+        DP_FACTOR,
+    )
 
     if FADD2_REDUCE:
         l_i0 = l_i0_0 + l_i0_1


### PR DESCRIPTION
Summary:
Enables causal FA kernel to compile and run through the AutoWS pipeline with data_partition_factor=2.
Previously, MapElementwiseOp (used for causal masking) was unhandled by several WS passes, causing compilation failures at every stage from data partitioning through pipelining.

The fixes span three passes, all related to MapElementwiseOp and the scf.if it lives inside:

- `WSDataPartition` —  added MapElementwiseOp to slice traversal lists.

- `PartitionSchedulingMeta` / `splitDataPartitionedIfOps` — fixes for splitting shared 2-result scf.if ops into per-partition single-result ops:
  1. Clone the full backward slice in then-blocks, not just immediate yield defs (else-blocks already did this)
  2. Assign the split scf.if regions to the target computation partition
  3. Copy loop.stage/loop.cluster from the original scf.if to the split ops
  4. Remove stale ttg.partition from the condition and yield operands defined outside the scf.if, preventing
  doTaskIdPropagate from expanding task sets and creating 262KB cross-partition SMEM channels


Test Plan:
1. Lit tests added/updated:
    - ws_data_partition.mlir — MapElementwiseOp partitioning
    - partition-scheduling-meta-flex-attention.mlir — split scf.if partition, scheduling, and stale partition cleanup
2. tritonbench test
```
CUDA_VISIBLE_DEVICES=6 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 bash ~/fbsource/fbcode/ads_mkl/benchmarks/denoise.sh python run.py --op blackwell_attentions --seq-len 8192 --batch 4 --n-heads 32 --d-head 128 --mode fwd --causal --metrics tflops --rep 3000 --sleep 1.0 --simple-output --only triton_autows_flash_persistent_blackwell --force
```
shows
```
Processing GPU 6...
→ Locking power cap to 750 W and SM clock to 1965 MHz on GPU 6
  (Batch, Heads, Heads_KV, SeqLen, SeqLen_KV, Dhead)    triton_autows_flash_persistent_blackwell-tflops
----------------------------------------------------  -------------------------------------------------
             (4, 32, 32, 8192, 8192, 128) Causal fwd                                            241.758
                                   241.7580180546291
```

### TODO
Track using task T271478579.
Accuracy and performance debugging for this kernel with causal mode.

Pulled By:
Sibylau

Sibylau

Differential Revision: D105121695


