### PR TITLE
[Triton] Add ModularArithmetic library for non-pow2 layout support (#1507)

### DIFF
--- a/include/triton/Tools/ModularArithmetic.h
+++ b/include/triton/Tools/ModularArithmetic.h
@@ -1,0 +1,86 @@
+#ifndef TRITON_TOOLS_MODULARARITHMETIC_H
+#define TRITON_TOOLS_MODULARARITHMETIC_H
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace mlir::triton {
+
+// Result of Extended Euclidean Algorithm: (gcd, x, y) where ax + by = gcd
+struct ExtGCDResult {
+  int64_t gcd;
+  int64_t x;
+  int64_t y;
+};
+
+// Extended Euclidean Algorithm: returns gcd(a,b) and Bezout coefficients
+ExtGCDResult extendedGCD(int64_t a, int64_t b);
+
+// Modular inverse: returns x such that (a*x) % m == 1, or nullopt if gcd(a,m)
+// != 1
+std::optional<int64_t> modInverse(int64_t a, int64_t m);
+
+// Chinese Remainder Theorem result: solution x where x ≡ r_i (mod m_i)
+struct CRTResult {
+  int64_t solution;
+  int64_t modulus;
+};
+
+// Solve system x ≡ r_i (mod m_i). Requires pairwise coprime moduli.
+std::optional<CRTResult> solveCRT(const std::vector<int64_t> &remainders,
+                                  const std::vector<int64_t> &moduli);
+
+// Integer exponentiation: a^b
+int64_t intPow(int64_t a, int b);
+
+// Matrix over Z/nZ in row-major order
+struct ModMatrix {
+  std::vector<int64_t> data;
+  int rows;
+  int cols;
+  int64_t modulus; // Modulus for matrix arithmetic
+
+  ModMatrix(int r, int c, int64_t mod) : rows(r), cols(c), modulus(mod) {
+    data.resize(r * c, 0);
+  }
+
+  int64_t &at(int r, int c) { return data[r * cols + c]; }
+  const int64_t &at(int r, int c) const { return data[r * cols + c]; }
+
+  void normalize();
+};
+
+// Gaussian elimination to RREF in Z/nZ. Modifies matrix in-place, returns rank.
+int modRREF(ModMatrix &mat);
+
+// Solve Ax = b (mod modulus) using Gaussian elimination.
+// The modulus parameter overrides A.modulus for the solve operation.
+std::vector<int64_t> modSolveLinear(const ModMatrix &A,
+                                    const std::vector<int64_t> &b,
+                                    int64_t modulus);
+
+// Solve Ax = b (mod p^e) using Hensel lifting
+std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
+                                          const std::vector<int64_t> &b,
+                                          int64_t prime, int exponent);
+
+// Solve Ax = b (mod N) using CRT: factor N, solve subsystems, combine
+// solutions. Precondition: modulus > 0. Returns {} on precondition violation.
+std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
+                                       const std::vector<int64_t> &b,
+                                       int64_t modulus);
+
+// Prime factorization: N = p1^e1 * p2^e2 * ... * pk^ek
+struct PrimeFactorization {
+  std::vector<std::pair<int64_t, int>> factors;
+
+  int64_t product() const;
+};
+
+// Compute prime factorization of n
+PrimeFactorization factorize(int64_t n);
+
+} // namespace mlir::triton
+
+#endif // TRITON_TOOLS_MODULARARITHMETIC_H

--- a/lib/Tools/CMakeLists.txt
+++ b/lib/Tools/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonTools
   GenericSwizzling.cpp
   LayoutUtils.cpp
   LinearLayout.cpp
+  ModularArithmetic.cpp
   PluginUtils.cpp
 
   DEPENDS

--- a/lib/Tools/ModularArithmetic.cpp
+++ b/lib/Tools/ModularArithmetic.cpp
@@ -1,0 +1,532 @@
+#include "triton/Tools/ModularArithmetic.h"
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <limits>
+#include <numeric>
+
+namespace mlir::triton {
+
+int64_t intPow(int64_t a, int b) {
+  assert(b >= 0 && "intPow requires non-negative exponent");
+  if (b == 0)
+    return 1;
+
+  int64_t result = 1;
+  int64_t base = a;
+
+  while (b > 0) {
+    if (b & 1) {
+      result *= base;
+    }
+    base *= base;
+    b >>= 1;
+  }
+
+  return result;
+}
+
+// gcd(0,0) returns {0, 0, 0} by convention. INT64_MIN inputs are rejected
+// (also returning {0, 0, 0}) because |INT64_MIN| does not fit in int64_t,
+// so std::abs(INT64_MIN) would be undefined behavior. Callers expecting to
+// operate at the bit-width limit should pre-check.
+ExtGCDResult extendedGCD(int64_t a, int64_t b) {
+  if (a == std::numeric_limits<int64_t>::min() ||
+      b == std::numeric_limits<int64_t>::min()) {
+    return {0, 0, 0};
+  }
+  bool a_neg = a < 0;
+  bool b_neg = b < 0;
+  a = std::abs(a);
+  b = std::abs(b);
+
+  if (a == 0) {
+    return {b, 0, b_neg ? -1 : 1};
+  }
+  if (b == 0) {
+    return {a, a_neg ? -1 : 1, 0};
+  }
+
+  // Iterative extended GCD maintaining r_i = s_i * a + t_i * b
+  int64_t r0 = a, r1 = b;
+  int64_t s0 = 1, s1 = 0;
+  int64_t t0 = 0, t1 = 1;
+
+  while (r1 != 0) {
+    int64_t q = r0 / r1;
+
+    int64_t r_new = r0 - q * r1;
+    r0 = r1;
+    r1 = r_new;
+
+    int64_t s_new = s0 - q * s1;
+    s0 = s1;
+    s1 = s_new;
+
+    int64_t t_new = t0 - q * t1;
+    t0 = t1;
+    t1 = t_new;
+  }
+
+  int64_t x = a_neg ? -s0 : s0;
+  int64_t y = b_neg ? -t0 : t0;
+
+  return {r0, x, y};
+}
+
+std::optional<int64_t> modInverse(int64_t a, int64_t m) {
+  if (m <= 0)
+    return std::nullopt;
+
+  a = ((a % m) + m) % m;
+  if (a == 0)
+    return std::nullopt;
+
+  auto result = extendedGCD(a, m);
+  if (result.gcd != 1) {
+    return std::nullopt;
+  }
+
+  int64_t inv = ((result.x % m) + m) % m;
+  return inv;
+}
+
+namespace {
+// Returns true iff the moduli are pairwise coprime (gcd == 1 for every pair).
+// Used only to validate the solveCRT precondition under assert().
+bool arePairwiseCoprime(const std::vector<int64_t> &moduli) {
+  for (size_t i = 0; i < moduli.size(); ++i)
+    for (size_t j = i + 1; j < moduli.size(); ++j)
+      if (std::gcd(moduli[i], moduli[j]) != 1)
+        return false;
+  return true;
+}
+} // namespace
+
+std::optional<CRTResult> solveCRT(const std::vector<int64_t> &remainders,
+                                  const std::vector<int64_t> &moduli) {
+  if (remainders.size() != moduli.size() || remainders.empty()) {
+    return std::nullopt;
+  }
+
+  size_t n = moduli.size();
+
+  for (auto m : moduli) {
+    if (m <= 0) {
+      return std::nullopt;
+    }
+  }
+
+  // Pairwise coprimality is a precondition; callers ensure via factorization.
+  assert(arePairwiseCoprime(moduli) &&
+         "solveCRT requires pairwise coprime moduli");
+
+  // NB: M can overflow int64 when the product of moduli exceeds ~3e9 (squared
+  // fits in int64). Callers must ensure moduli come from layout dimensions
+  // which are bounded well below this in practice.
+  int64_t M = 1;
+  for (auto m : moduli) {
+    M *= m;
+  }
+
+  // CRT: x = Σ(r_i * M_i * y_i) mod M, where M_i = M/m_i, y_i = M_i^{-1} mod
+  // m_i
+  int64_t solution = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    int64_t m_i = moduli[i];
+    int64_t r_i = ((remainders[i] % m_i) + m_i) % m_i;
+    int64_t M_i = M / m_i;
+
+    auto y_i_opt = modInverse(M_i, m_i);
+    if (!y_i_opt.has_value()) {
+      return std::nullopt;
+    }
+    int64_t y_i = y_i_opt.value();
+
+    int64_t term = ((r_i % M) * (M_i % M)) % M;
+    term = (term * y_i) % M;
+    solution = (solution + term) % M;
+  }
+
+  solution = ((solution % M) + M) % M;
+  return CRTResult{solution, M};
+}
+
+void ModMatrix::normalize() {
+  // Z/N arithmetic requires modulus > 0 (see ModMatrix invariant); assert here
+  // so misuse fails loudly before the % operations below.
+  assert(modulus > 0 && "ModMatrix modulus must be positive");
+  for (auto &val : data) {
+    val = ((val % modulus) + modulus) % modulus;
+  }
+}
+
+int modRREF(ModMatrix &mat) {
+  int64_t mod = mat.modulus;
+  int rows = mat.rows;
+  int cols = mat.cols;
+
+  // Normalize all entries first
+  mat.normalize();
+
+  int pivotRow = 0;
+
+  for (int col = 0; col < cols && pivotRow < rows; ++col) {
+    // Find pivot: row with non-zero entry in this column
+    int bestPivot = -1;
+    for (int r = pivotRow; r < rows; ++r) {
+      if (mat.at(r, col) % mod != 0) {
+        // Prefer entries coprime to mod (invertible)
+        if (std::gcd(mat.at(r, col), mod) == 1) {
+          bestPivot = r;
+          break;
+        }
+        if (bestPivot == -1) {
+          bestPivot = r;
+        }
+      }
+    }
+
+    if (bestPivot == -1) {
+      // No pivot in this column, move to next column
+      continue;
+    }
+
+    // Swap rows to bring pivot to pivotRow
+    if (bestPivot != pivotRow) {
+      for (int c = 0; c < cols; ++c) {
+        std::swap(mat.at(pivotRow, c), mat.at(bestPivot, c));
+      }
+    }
+
+    // Get the pivot value
+    int64_t pivotVal = mat.at(pivotRow, col);
+
+    // Try to get modular inverse
+    auto invOpt = modInverse(pivotVal, mod);
+
+    if (!invOpt.has_value()) {
+      // Pivot is not invertible — can't reduce this column.
+      // Swap the row back and skip without advancing pivotRow.
+      if (bestPivot != pivotRow) {
+        for (int c = 0; c < cols; ++c) {
+          std::swap(mat.at(pivotRow, c), mat.at(bestPivot, c));
+        }
+      }
+      continue;
+    }
+
+    int64_t pivotInv = invOpt.value();
+
+    // Scale pivot row to make pivot = 1
+    for (int c = 0; c < cols; ++c) {
+      mat.at(pivotRow, c) = (mat.at(pivotRow, c) * pivotInv) % mod;
+    }
+
+    // Eliminate all other rows in this column
+    for (int r = 0; r < rows; ++r) {
+      if (r == pivotRow)
+        continue;
+
+      int64_t factor = mat.at(r, col);
+      if (factor == 0)
+        continue;
+
+      // Subtract factor * pivotRow from row r
+      for (int c = 0; c < cols; ++c) {
+        int64_t val = mat.at(r, c) - factor * mat.at(pivotRow, c);
+        mat.at(r, c) = ((val % mod) + mod) % mod;
+      }
+    }
+
+    pivotRow++;
+  }
+
+  return pivotRow;
+}
+
+// NB: The `modulus` parameter is the modulus used for the solve, which may
+// differ from A.modulus (the modulus A was originally constructed with).
+// Callers (e.g. modSolveLinearCRT) re-reduce A's entries mod the new modulus.
+std::vector<int64_t> modSolveLinear(const ModMatrix &A,
+                                    const std::vector<int64_t> &b,
+                                    int64_t modulus) {
+  int n = A.rows;
+  int m = A.cols;
+
+  if (static_cast<int>(b.size()) != n) {
+    return {}; // Size mismatch
+  }
+
+  // Z/N arithmetic is only defined for N > 0. The downstream % modulus
+  // operations would otherwise crash (modulus == 0) or produce ill-defined
+  // results (modulus < 0).
+  if (modulus <= 0) {
+    return {};
+  }
+
+  // Create augmented matrix [A | b]
+  ModMatrix aug(n, m + 1, modulus);
+
+  // Copy A, reducing mod the target modulus
+  for (int r = 0; r < n; ++r) {
+    for (int c = 0; c < m; ++c) {
+      aug.at(r, c) = ((A.at(r, c) % modulus) + modulus) % modulus;
+    }
+  }
+
+  // Copy b
+  for (int r = 0; r < n; ++r) {
+    aug.at(r, m) = ((b[r] % modulus) + modulus) % modulus;
+  }
+
+  // Perform RREF
+  modRREF(aug);
+
+  // Check for inconsistent system (0 = c where c != 0)
+  for (int r = 0; r < n; ++r) {
+    bool rowIsZero = true;
+    for (int c = 0; c < m; ++c) {
+      if (aug.at(r, c) != 0) {
+        rowIsZero = false;
+        break;
+      }
+    }
+    if (rowIsZero && aug.at(r, m) != 0) {
+      // Inconsistent: 0 = aug.at(r, m) where aug.at(r, m) != 0
+      return {};
+    }
+  }
+
+  // Extract solution
+  std::vector<int64_t> x(m, 0);
+
+  for (int r = 0; r < n; ++r) {
+    // Find leading 1 in this row
+    int leadCol = -1;
+    for (int c = 0; c < m; ++c) {
+      if (aug.at(r, c) != 0) {
+        leadCol = c;
+        break;
+      }
+    }
+
+    if (leadCol >= 0) {
+      // Should be 1 after RREF, but normalize anyway
+      x[leadCol] = aug.at(r, m);
+    }
+  }
+
+  return x;
+}
+
+// Solve Ax = b (mod p^e) by solving mod p then lifting each power via
+// residual correction: r = (b - Ax) / p^k, delta = A^{-1} r (mod p).
+// NB: intermediate products can overflow int64 for large matrices or high
+// prime powers; layout dimensions keep values small enough in practice.
+std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
+                                          const std::vector<int64_t> &b,
+                                          int64_t prime, int exponent) {
+  int n = A.rows;
+  int m = A.cols;
+
+  if (static_cast<int>(b.size()) != n) {
+    return {};
+  }
+
+  if (exponent < 1) {
+    return {};
+  }
+
+  // Hensel lifting requires a genuine prime modulus base (prime >= 2). A base
+  // of 0 or 1 is not a valid prime: prime == 1 makes every modulus prime^k == 1
+  // (Z/1 is trivial), so modSolveLinear mod 1 yields the all-zero "solution"
+  // and the per-power lift never makes progress -- and `p_k *= prime` stays
+  // stuck at 1, so callers that loop until p_k reaches the modulus would spin
+  // forever. Reject prime < 2 up front rather than return a meaningless result
+  // or risk a non-terminating lift.
+  if (prime < 2) {
+    return {};
+  }
+
+  // modulus = prime^exponent. We accumulate sums of products A[r,c] * x[c]
+  // in int64; both factors are < modulus after reduction. To stay safe we
+  // require modulus <= 2^31 so that products fit in int64 and the per-row
+  // accumulation across m columns can't wrap (m bounded by tensor rank,
+  // well under 1000 in practice). Triton's layout-derived moduli stay
+  // below 2^20, so this leaves ~11 bits of headroom.
+  int64_t modulus = intPow(prime, exponent);
+  assert(modulus <= (int64_t{1} << 31) &&
+         "modSolveLinearHensel: modulus too large; "
+         "accumulation may overflow int64");
+  (void)modulus;
+
+  std::vector<int64_t> x_k = modSolveLinear(A, b, prime);
+  if (x_k.empty()) {
+    return {};
+  }
+
+  if (exponent == 1) {
+    return x_k;
+  }
+
+  int64_t p_k = prime;
+
+  for (int k = 2; k <= exponent; ++k) {
+    std::vector<int64_t> residual(n);
+
+    for (int r = 0; r < n; ++r) {
+      int64_t ax_r = 0;
+      for (int c = 0; c < m; ++c) {
+        ax_r += A.at(r, c) * x_k[c];
+      }
+
+      int64_t diff = b[r] - ax_r;
+      if (diff % p_k != 0) {
+        return {};
+      }
+      residual[r] = diff / p_k;
+    }
+
+    std::vector<int64_t> delta = modSolveLinear(A, residual, prime);
+    if (delta.empty()) {
+      return {};
+    }
+
+    for (int i = 0; i < m; ++i) {
+      x_k[i] += p_k * delta[i];
+    }
+
+    p_k *= prime;
+  }
+
+  int64_t p_e = intPow(prime, exponent);
+  for (auto &val : x_k) {
+    val = ((val % p_e) + p_e) % p_e;
+  }
+
+  return x_k;
+}
+
+std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
+                                       const std::vector<int64_t> &b,
+                                       int64_t modulus) {
+  int n = A.rows;
+  int m = A.cols;
+
+  if (static_cast<int>(b.size()) != n) {
+    return {};
+  }
+
+  // modulus must be a positive integer for Z/N arithmetic to be defined.
+  // factorize(0) returns no factors, which would leave moduli/subsolutions
+  // empty and silently fail at the per-variable solveCRT step. Negative
+  // moduli are similarly ill-defined.
+  if (modulus <= 0) {
+    return {};
+  }
+
+  if (modulus == 1) {
+    return std::vector<int64_t>(m, 0);
+  }
+
+  PrimeFactorization factors = factorize(modulus);
+
+  std::vector<std::vector<int64_t>> subsolutions;
+  std::vector<int64_t> moduli;
+
+  for (const auto &[p, e] : factors.factors) {
+    int64_t mod_i = intPow(p, e);
+    moduli.push_back(mod_i);
+
+    ModMatrix A_i(n, m, mod_i);
+    std::vector<int64_t> b_i(n);
+
+    for (int r = 0; r < n; ++r) {
+      for (int c = 0; c < m; ++c) {
+        A_i.at(r, c) = ((A.at(r, c) % mod_i) + mod_i) % mod_i;
+      }
+      b_i[r] = ((b[r] % mod_i) + mod_i) % mod_i;
+    }
+
+    std::vector<int64_t> x_i;
+    if (e == 1) {
+      x_i = modSolveLinear(A_i, b_i, p);
+    } else {
+      x_i = modSolveLinearHensel(A_i, b_i, p, e);
+    }
+
+    if (x_i.empty()) {
+      return {};
+    }
+
+    subsolutions.push_back(x_i);
+  }
+
+  std::vector<int64_t> x(m);
+
+  for (int var = 0; var < m; ++var) {
+    std::vector<int64_t> remainders;
+    for (const auto &sol : subsolutions) {
+      remainders.push_back(sol[var]);
+    }
+
+    auto crt_result = solveCRT(remainders, moduli);
+    if (!crt_result.has_value()) {
+      return {};
+    }
+
+    x[var] = crt_result->solution;
+  }
+
+  return x;
+}
+
+int64_t PrimeFactorization::product() const {
+  int64_t result = 1;
+  for (const auto &[prime, exp] : factors)
+    result *= intPow(prime, exp);
+  return result;
+}
+
+PrimeFactorization factorize(int64_t n) {
+  // Trial division O(sqrt(n)); for Triton's bounded moduli (typically < 2^20)
+  // this completes in microseconds.
+  PrimeFactorization result;
+
+  if (n <= 1) {
+    return result;
+  }
+
+  // Handle factor of 2
+  int exp2 = 0;
+  while (n % 2 == 0) {
+    exp2++;
+    n /= 2;
+  }
+  if (exp2 > 0) {
+    result.factors.push_back({2, exp2});
+  }
+
+  // Handle odd factors
+  for (int64_t i = 3; i * i <= n; i += 2) {
+    int exp = 0;
+    while (n % i == 0) {
+      exp++;
+      n /= i;
+    }
+    if (exp > 0) {
+      result.factors.push_back({i, exp});
+    }
+  }
+
+  // If n > 1, then it's a prime factor
+  if (n > 1) {
+    result.factors.push_back({n, 1});
+  }
+
+  return result;
+}
+
+} // namespace mlir::triton

--- a/unittest/Tools/CMakeLists.txt
+++ b/unittest/Tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_triton_ut(
 	NAME LinearLayout
-	SRCS LayoutUtilsTest.cpp LinearLayoutTest.cpp
+	SRCS LayoutUtilsTest.cpp LinearLayoutTest.cpp ModularArithmeticTest.cpp
 	LIBS TritonTools
 )

--- a/unittest/Tools/ModularArithmeticTest.cpp
+++ b/unittest/Tools/ModularArithmeticTest.cpp
@@ -1,0 +1,486 @@
+#include "triton/Tools/ModularArithmetic.h"
+
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+namespace mlir::triton {
+namespace {
+
+class ModularArithmeticTest : public ::testing::Test {};
+
+TEST_F(ModularArithmeticTest, ExtGCD_Basic) {
+  auto result = extendedGCD(240, 46);
+  EXPECT_EQ(result.gcd, 2);
+  EXPECT_EQ(240 * result.x + 46 * result.y, result.gcd);
+
+  result = extendedGCD(0, 5);
+  EXPECT_EQ(result.gcd, 5);
+  EXPECT_EQ(0 * result.x + 5 * result.y, result.gcd);
+
+  result = extendedGCD(7, 0);
+  EXPECT_EQ(result.gcd, 7);
+  EXPECT_EQ(7 * result.x + 0 * result.y, result.gcd);
+
+  result = extendedGCD(0, 0);
+  EXPECT_EQ(result.gcd, 0);
+
+  result = extendedGCD(0, -5);
+  EXPECT_EQ(result.gcd, 5);
+  EXPECT_EQ(0 * result.x + (-5) * result.y, result.gcd);
+
+  result = extendedGCD(-7, 0);
+  EXPECT_EQ(result.gcd, 7);
+  EXPECT_EQ((-7) * result.x + 0 * result.y, result.gcd);
+}
+
+TEST_F(ModularArithmeticTest, ExtGCD_NegativeInputs) {
+  // Both negative
+  auto result = extendedGCD(-12, -8);
+  EXPECT_EQ(result.gcd, 4);
+  EXPECT_EQ((-12) * result.x + (-8) * result.y, result.gcd);
+
+  // One negative
+  result = extendedGCD(-15, 10);
+  EXPECT_EQ(result.gcd, 5);
+  EXPECT_EQ((-15) * result.x + 10 * result.y, result.gcd);
+}
+
+TEST_F(ModularArithmeticTest, ModInverse_Basic) {
+  auto inv = modInverse(3, 11);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ((3 * (*inv)) % 11, 1);
+
+  inv = modInverse(2, 4);
+  EXPECT_FALSE(inv.has_value());
+
+  inv = modInverse(6, 9);
+  EXPECT_FALSE(inv.has_value());
+
+  // modInverse(1, N) always returns 1
+  inv = modInverse(1, 7);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ(*inv, 1);
+
+  inv = modInverse(1, 100);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ(*inv, 1);
+}
+
+TEST_F(ModularArithmeticTest, ModInverse_NegativeA) {
+  // -3 mod 11 = 8, inverse of 8 mod 11 = 7
+  auto inv = modInverse(-3, 11);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ(((-3 % 11 + 11) % 11 * (*inv)) % 11, 1);
+}
+
+TEST_F(ModularArithmeticTest, IntPow_Basic) {
+  EXPECT_EQ(intPow(2, 10), 1024);
+  EXPECT_EQ(intPow(0, 0), 1);
+  EXPECT_EQ(intPow(5, 0), 1);
+  EXPECT_EQ(intPow(1, 100), 1);
+  EXPECT_EQ(intPow(3, 5), 243);
+  EXPECT_EQ(intPow(-2, 3), -8);
+}
+
+TEST_F(ModularArithmeticTest, CRT_Basic) {
+  // Single congruence: x ≡ 5 (mod 7)
+  auto result = solveCRT({5}, {7});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->solution, 5);
+  EXPECT_EQ(result->modulus, 7);
+
+  // x ≡ 2 (mod 3), x ≡ 3 (mod 5), x ≡ 2 (mod 7)
+  result = solveCRT({2, 3, 2}, {3, 5, 7});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->modulus, 105);
+  EXPECT_GE(result->solution, 0);
+  EXPECT_LT(result->solution, 105);
+  EXPECT_EQ(result->solution % 3, 2);
+  EXPECT_EQ(result->solution % 5, 3);
+  EXPECT_EQ(result->solution % 7, 2);
+}
+
+TEST_F(ModularArithmeticTest, CRT_RejectsInvalidInput) {
+  // Pairwise coprime moduli are required (documented precondition). In
+  // release builds the assertion compiles out and the implementation falls
+  // through to a per-modulus modInverse step that returns nullopt when
+  // M_i and m_i share a factor — verify the API surfaces nullopt rather
+  // than silently producing a wrong answer. (In debug builds the assertion
+  // fires before reaching this path; this test guards the release path.)
+#ifdef NDEBUG
+  // moduli 4 and 6 share factor 2 — not pairwise coprime.
+  auto noncoprime = solveCRT({1, 1}, {4, 6});
+  EXPECT_FALSE(noncoprime.has_value());
+#endif
+
+  // Empty inputs.
+  EXPECT_FALSE(solveCRT({}, {}).has_value());
+
+  // Size mismatch.
+  EXPECT_FALSE(solveCRT({1}, {2, 3}).has_value());
+
+  // Non-positive modulus.
+  EXPECT_FALSE(solveCRT({1, 1}, {3, 0}).has_value());
+  EXPECT_FALSE(solveCRT({1, 1}, {3, -5}).has_value());
+}
+
+TEST_F(ModularArithmeticTest, ExtendedGCD_RejectsInt64Min) {
+  // |INT64_MIN| does not fit in int64_t, so std::abs(INT64_MIN) is UB.
+  // The implementation rejects INT64_MIN inputs by returning {0, 0, 0}
+  // (matching the gcd(0, 0) convention).
+  auto r1 = extendedGCD(std::numeric_limits<int64_t>::min(), 7);
+  EXPECT_EQ(r1.gcd, 0);
+  auto r2 = extendedGCD(7, std::numeric_limits<int64_t>::min());
+  EXPECT_EQ(r2.gcd, 0);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_Mod5) {
+  ModMatrix mat(2, 2, 5);
+  mat.at(0, 0) = 1;
+  mat.at(0, 1) = 2;
+  mat.at(1, 0) = 3;
+  mat.at(1, 1) = 4;
+
+  int rank = modRREF(mat);
+  EXPECT_EQ(rank, 2);
+
+  EXPECT_EQ(mat.at(0, 0), 1);
+  EXPECT_EQ(mat.at(0, 1), 0);
+  EXPECT_EQ(mat.at(1, 0), 0);
+  EXPECT_EQ(mat.at(1, 1), 1);
+
+  // Singular matrix (mod 3): [[1, 2], [1, 2]] has rank 1
+  ModMatrix singularMat(2, 2, 3);
+  singularMat.at(0, 0) = 1;
+  singularMat.at(0, 1) = 2;
+  singularMat.at(1, 0) = 1;
+  singularMat.at(1, 1) = 2;
+  rank = modRREF(singularMat);
+  EXPECT_EQ(rank, 1);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_RectangularMatrix) {
+  // 3x2 over Z/7Z: [[1,2],[3,4],[5,6]] has rank 2
+  ModMatrix mat(3, 2, 7);
+  mat.at(0, 0) = 1;
+  mat.at(0, 1) = 2;
+  mat.at(1, 0) = 3;
+  mat.at(1, 1) = 4;
+  mat.at(2, 0) = 5;
+  mat.at(2, 1) = 6;
+
+  int rank = modRREF(mat);
+  ASSERT_EQ(rank, 2);
+
+  EXPECT_EQ(mat.at(0, 0), 1);
+  EXPECT_EQ(mat.at(0, 1), 0);
+  EXPECT_EQ(mat.at(1, 0), 0);
+  EXPECT_EQ(mat.at(1, 1), 1);
+  EXPECT_EQ(mat.at(2, 0), 0);
+  EXPECT_EQ(mat.at(2, 1), 0);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_CompositeModulus) {
+  // [[2, 0], [0, 3]] mod 6: neither pivot is invertible, rank should be 0
+  ModMatrix mat(2, 2, 6);
+  mat.at(0, 0) = 2;
+  mat.at(0, 1) = 0;
+  mat.at(1, 0) = 0;
+  mat.at(1, 1) = 3;
+  int rank = modRREF(mat);
+  EXPECT_EQ(rank, 0);
+
+  // [[1, 2], [3, 4]] mod 6: det=-2, gcd(2,6)!=1, so rank 1 not 2
+  ModMatrix mat2(2, 2, 6);
+  mat2.at(0, 0) = 1;
+  mat2.at(0, 1) = 2;
+  mat2.at(1, 0) = 3;
+  mat2.at(1, 1) = 4;
+  rank = modRREF(mat2);
+  EXPECT_EQ(rank, 1);
+
+  // [[1, 0], [0, 5]] mod 6: both pivots invertible, rank 2
+  ModMatrix mat3(2, 2, 6);
+  mat3.at(0, 0) = 1;
+  mat3.at(0, 1) = 0;
+  mat3.at(1, 0) = 0;
+  mat3.at(1, 1) = 5;
+  rank = modRREF(mat3);
+  EXPECT_EQ(rank, 2);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_CompositeModulus_PivotSwap) {
+  // Row swap needed: row 0 col 0 is 4 (gcd(4,6)=2), row 1 col 0 is 1
+  ModMatrix mat(2, 2, 6);
+  mat.at(0, 0) = 4;
+  mat.at(0, 1) = 2;
+  mat.at(1, 0) = 1;
+  mat.at(1, 1) = 3;
+  int rank = modRREF(mat);
+  EXPECT_EQ(rank, 1);
+
+  // Full-rank: det=-1, gcd(1,6)=1 → identity
+  ModMatrix mat2(2, 2, 6);
+  mat2.at(0, 0) = 5;
+  mat2.at(0, 1) = 2;
+  mat2.at(1, 0) = 3;
+  mat2.at(1, 1) = 1;
+  rank = modRREF(mat2);
+  EXPECT_EQ(rank, 2);
+  EXPECT_EQ(mat2.at(0, 0), 1);
+  EXPECT_EQ(mat2.at(0, 1), 0);
+  EXPECT_EQ(mat2.at(1, 0), 0);
+  EXPECT_EQ(mat2.at(1, 1), 1);
+
+  // 3x3 mod 10: row 1 is 2×row 0, rank=2
+  ModMatrix mat3(3, 3, 10);
+  mat3.at(0, 0) = 1;
+  mat3.at(0, 1) = 2;
+  mat3.at(0, 2) = 3;
+  mat3.at(1, 0) = 2;
+  mat3.at(1, 1) = 4;
+  mat3.at(1, 2) = 6;
+  mat3.at(2, 0) = 0;
+  mat3.at(2, 1) = 0;
+  mat3.at(2, 2) = 3;
+  rank = modRREF(mat3);
+  EXPECT_EQ(rank, 2);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinear_Basic) {
+  // Consistent 2x2 mod 7
+  ModMatrix A(2, 2, 7);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 3;
+  A.at(1, 1) = 1;
+  std::vector<int64_t> b = {5, 4};
+  auto x = modSolveLinear(A, b, 7);
+  ASSERT_EQ(x.size(), 2u);
+  EXPECT_EQ((A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 7, b[0] % 7);
+  EXPECT_EQ((A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 7, b[1] % 7);
+
+  // Inconsistent system mod 5
+  ModMatrix A2(2, 2, 5);
+  A2.at(0, 0) = 1;
+  A2.at(0, 1) = 0;
+  A2.at(1, 0) = 1;
+  A2.at(1, 1) = 0;
+  std::vector<int64_t> b2 = {1, 2};
+  auto x2 = modSolveLinear(A2, b2, 5);
+  EXPECT_TRUE(x2.empty());
+
+  // Underdetermined 1x2 mod 7
+  ModMatrix A3(1, 2, 7);
+  A3.at(0, 0) = 1;
+  A3.at(0, 1) = 3;
+  std::vector<int64_t> b3 = {4};
+  auto x3 = modSolveLinear(A3, b3, 7);
+  ASSERT_EQ(x3.size(), 2u);
+  EXPECT_EQ((A3.at(0, 0) * x3[0] + A3.at(0, 1) * x3[1]) % 7, b3[0] % 7);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Mod9) {
+  // modulus = 9 = 3^2
+  ModMatrix A(2, 2, 9);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 1;
+  A.at(1, 1) = 1;
+
+  std::vector<int64_t> b = {5, 4};
+  auto x = modSolveLinearHensel(A, b, 3, 2);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 2u);
+
+  int64_t res0 = (A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 9;
+  int64_t res1 = (A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 9;
+  EXPECT_EQ(res0, b[0] % 9);
+  EXPECT_EQ(res1, b[1] % 9);
+
+  // modulus = 27 = 3^3
+  ModMatrix A27(2, 2, 27);
+  A27.at(0, 0) = 1;
+  A27.at(0, 1) = 2;
+  A27.at(1, 0) = 1;
+  A27.at(1, 1) = 1;
+
+  std::vector<int64_t> b27 = {8, 7};
+  auto x27 = modSolveLinearHensel(A27, b27, 3, 3);
+
+  ASSERT_FALSE(x27.empty());
+  ASSERT_EQ(x27.size(), 2u);
+
+  int64_t res0_27 = (A27.at(0, 0) * x27[0] + A27.at(0, 1) * x27[1]) % 27;
+  int64_t res1_27 = (A27.at(1, 0) * x27[0] + A27.at(1, 1) * x27[1]) % 27;
+  EXPECT_EQ(res0_27, b27[0] % 27);
+  EXPECT_EQ(res1_27, b27[1] % 27);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Pow2_Mod16) {
+  // 2x2 system over Z/16 = 2^4. Tests Hensel lifting with exponent=4
+  // (the typical case for pow2 layout dims like 16, 32, 64).
+  ModMatrix A(2, 2, 16);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 3;
+  A.at(1, 1) = 5;
+  std::vector<int64_t> b = {7, 11};
+
+  auto x = modSolveLinearHensel(A, b, 2, 4);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 2u);
+
+  int64_t res0 = (A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 16;
+  int64_t res1 = (A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 16;
+  EXPECT_EQ(res0, b[0] % 16);
+  EXPECT_EQ(res1, b[1] % 16);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_NoSolution) {
+  // Inconsistent: 1x = 1 and 1x = 2 (mod 3)
+  ModMatrix A(2, 2, 9);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 0;
+  A.at(1, 0) = 1;
+  A.at(1, 1) = 0;
+
+  std::vector<int64_t> b = {1, 2};
+  auto x = modSolveLinearHensel(A, b, 3, 2);
+  EXPECT_TRUE(x.empty());
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Underdetermined) {
+  // 1x + 2y + 3z = 7 (mod 9)
+  ModMatrix A(1, 3, 9);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(0, 2) = 3;
+
+  std::vector<int64_t> b = {7};
+  auto x = modSolveLinearHensel(A, b, 3, 2);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 3u);
+
+  int64_t res0 =
+      (A.at(0, 0) * x[0] + A.at(0, 1) * x[1] + A.at(0, 2) * x[2]) % 9;
+  EXPECT_EQ(res0, b[0] % 9);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_InvalidPrimeRejected) {
+  // prime < 2 is not a valid prime base for Hensel lifting. prime == 1 in
+  // particular makes every modulus prime^k == 1 (trivial ring) and the lift
+  // cannot make progress, so the solver must reject it cleanly (empty result)
+  // rather than return a meaningless answer or fail to terminate.
+  ModMatrix A(1, 1, 9);
+  A.at(0, 0) = 1;
+  std::vector<int64_t> b = {1};
+
+  EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/1, /*exponent=*/2).empty());
+  EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/0, /*exponent=*/2).empty());
+  EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/-3, /*exponent=*/2).empty());
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearCRT_Composite_Mod15) {
+  // modulus = 15 = 3 × 5
+  ModMatrix A(2, 2, 15);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 1;
+  A.at(1, 1) = 1;
+
+  std::vector<int64_t> b = {7, 5};
+  auto x = modSolveLinearCRT(A, b, 15);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 2u);
+
+  int64_t res0 = (A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 15;
+  int64_t res1 = (A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 15;
+  EXPECT_EQ(res0, b[0] % 15);
+  EXPECT_EQ(res1, b[1] % 15);
+
+  // modulus = 48 = 2^4 × 3
+  ModMatrix A48(2, 2, 48);
+  A48.at(0, 0) = 1;
+  A48.at(0, 1) = 2;
+  A48.at(1, 0) = 1;
+  A48.at(1, 1) = 1;
+
+  std::vector<int64_t> b48 = {11, 7};
+  auto x48 = modSolveLinearCRT(A48, b48, 48);
+
+  ASSERT_FALSE(x48.empty());
+  ASSERT_EQ(x48.size(), 2u);
+
+  int64_t res0_48 = (A48.at(0, 0) * x48[0] + A48.at(0, 1) * x48[1]) % 48;
+  int64_t res1_48 = (A48.at(1, 0) * x48[0] + A48.at(1, 1) * x48[1]) % 48;
+  EXPECT_EQ(res0_48, b48[0] % 48);
+  EXPECT_EQ(res1_48, b48[1] % 48);
+
+  // No solution: inconsistent system
+  ModMatrix A_nosol(2, 2, 15);
+  A_nosol.at(0, 0) = 1;
+  A_nosol.at(0, 1) = 0;
+  A_nosol.at(1, 0) = 1;
+  A_nosol.at(1, 1) = 0;
+
+  std::vector<int64_t> b_nosol = {1, 2};
+  auto x_nosol = modSolveLinearCRT(A_nosol, b_nosol, 15);
+  EXPECT_TRUE(x_nosol.empty());
+
+  // Precondition: modulus must be > 0. Zero and negative moduli return {}
+  // explicitly rather than silently failing inside the per-variable CRT
+  // step (factorize(0) returns no factors, leaving the moduli vector empty).
+  ModMatrix A_ok(2, 2, 15);
+  A_ok.at(0, 0) = 1;
+  A_ok.at(0, 1) = 0;
+  A_ok.at(1, 0) = 0;
+  A_ok.at(1, 1) = 1;
+  std::vector<int64_t> b_ok = {0, 0};
+  EXPECT_TRUE(modSolveLinearCRT(A_ok, b_ok, 0).empty());
+  EXPECT_TRUE(modSolveLinearCRT(A_ok, b_ok, -1).empty());
+}
+
+TEST_F(ModularArithmeticTest, Factorize) {
+  // Negative and zero inputs return empty factorization
+  auto f0 = factorize(0);
+  EXPECT_TRUE(f0.factors.empty());
+
+  auto fn = factorize(-10);
+  EXPECT_TRUE(fn.factors.empty());
+
+  auto f1 = factorize(1);
+  EXPECT_TRUE(f1.factors.empty());
+
+  auto f2 = factorize(2);
+  ASSERT_EQ(f2.factors.size(), 1u);
+  EXPECT_EQ(f2.factors[0].first, 2);
+  EXPECT_EQ(f2.factors[0].second, 1);
+  EXPECT_EQ(f2.product(), 2);
+
+  auto f12 = factorize(12);
+  ASSERT_EQ(f12.factors.size(), 2u);
+  EXPECT_EQ(f12.factors[0].first, 2);
+  EXPECT_EQ(f12.factors[0].second, 2);
+  EXPECT_EQ(f12.factors[1].first, 3);
+  EXPECT_EQ(f12.factors[1].second, 1);
+  EXPECT_EQ(f12.product(), 12);
+
+  auto f60 = factorize(60);
+  ASSERT_EQ(f60.factors.size(), 3u);
+  EXPECT_EQ(f60.factors[0].first, 2);
+  EXPECT_EQ(f60.factors[0].second, 2);
+  EXPECT_EQ(f60.factors[1].first, 3);
+  EXPECT_EQ(f60.factors[1].second, 1);
+  EXPECT_EQ(f60.factors[2].first, 5);
+  EXPECT_EQ(f60.factors[2].second, 1);
+  EXPECT_EQ(f60.product(), 60);
+}
+
+} // namespace
+} // namespace mlir::triton


### PR DESCRIPTION
Summary:

Standalone modular arithmetic library for non-power-of-2 dimension support
in Triton's LinearLayout system (beta source tree, namespace mlir::triton).
Provides:

- Extended GCD and modular inverse (with Bezout coefficient verification)
- Chinese Remainder Theorem (CRT) solver
- GF(p) Gaussian elimination (RREF)
- Hensel lifting for prime power moduli
- CRT-based linear system solver (modSolveLinearCRT)
- Prime factorization

Used by the mod-affine LinearLayout extension (D98768027) for CRT-based
invertAndCompose and modular surjectivity checking.

6 files, 850 lines (502 library + 258 tests + header/build).

Reviewed By: yliuy, htyu

Differential Revision: D99121733


