### PR TITLE
 [TLX] Restrict TMEM_COPY accept SMEM formats (#1508)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -1127,14 +1127,14 @@ def TTNG_TMEMCopyOp : TTNG_Op<"tmem_copy"> {
     Each 32x128b block in SMEM is duplicated over 4 warps and stored into 128 rows
     and 4 columns of TMEM. The primary use case of this op is to copy blocked scales from SMEM to TMEM.
 
-    The shape of the input SMEM can be flexibily chosen depending on use cases. In the simplest case (e.g. unit test),
-    the source SMEM can be of shape (32 x num_blocks, 16), and the destination TMEM should be of shape (128, 16 x num_blocks),
-    for copying 8 bit values. For scaled GEMM, rep_m x rep_k copies of a 32x128b block need to be stored in SMEM, where
+    The shape of the input SMEM must explicitly encode the packed 32x128b blocks consumed by the instruction.
+    For scaled GEMM, rep_m x rep_k copies of a 32x128b block need to be stored in SMEM, where
     rep_m = BLOCK_M / 128, rep_k = BLOCK_K / scale_vec_size / 4, and scale_vec_size = 32 for MXFP.
     Conceptually, the SMEM is organized in a high-dimensional layout, (rep_m, rep_k, 32, 4, 4B).
     Some of axes can be flattened into one, to reduce the rank of the load. For example, the following patterns are supported:
-     * (rep_m, rep_k * 32 x 4 x 4B), 2D scale load with cp.async
+     * (rep_m, rep_k * 32 x 4 x 4B), flattened packed scale load
      * (rep_m, rep_k, 32, 16B), 4D scale load with TMA
+     * (1, rep_m, rep_k, 2, 256B), 5D scale load with TMA
      * (rep_m, rep_k, 32, 4, 4B), 5D scale load with cp.async
     Since rep_m blocks are not contiguous in SMEM, this axis cannot be flattened into inner ones.
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1184,6 +1184,48 @@ void TMEMAllocOp::getEffects(
 }
 
 // -- TMEMCopyOp --
+static bool hasShape(MemDescType type, ArrayRef<int64_t> shape) {
+  return type.getRank() == static_cast<int64_t>(shape.size()) &&
+         llvm::equal(type.getShape(), shape);
+}
+
+static LogicalResult verifyScaleTMEMCopyShape(TMEMCopyOp op, MemDescType srcTy,
+                                              MemDescType dstTy) {
+  auto isI8MemDesc = [](MemDescType type) {
+    return type.getElementType().isIntOrFloat() &&
+           type.getElementType().getIntOrFloatBitWidth() == 8;
+  };
+  auto emitScaleShapeError = [&]() -> LogicalResult {
+    return op.emitOpError()
+           << "scale tmem_copy requires an explicit packed i8 SMEM shape "
+              "matching the rank-2 TMEM scale shape; accepted source shapes "
+              "are [rows / 128, cols / 4, 32, 16], [rows / 128, cols / 4, "
+              "32, 4, 4], [1, rows / 128, cols / 4, 2, 256], or "
+              "[rows / 128, (cols / 4) * 512]";
+  };
+
+  if (!isI8MemDesc(srcTy) || !isI8MemDesc(dstTy))
+    return emitScaleShapeError();
+
+  if (dstTy.getRank() != 2)
+    return emitScaleShapeError();
+
+  int64_t rows = dstTy.getDimSize(0);
+  int64_t cols = dstTy.getDimSize(1);
+  if (rows % 128 != 0 || cols % 4 != 0)
+    return emitScaleShapeError();
+
+  int64_t repRows = rows / 128;
+  int64_t repCols = cols / 4;
+  if (hasShape(srcTy, {repRows, repCols, 32, 16}) ||
+      hasShape(srcTy, {repRows, repCols, 32, 4, 4}) ||
+      hasShape(srcTy, {1, repRows, repCols, 2, 256}) ||
+      hasShape(srcTy, {repRows, repCols * 512}))
+    return success();
+
+  return emitScaleShapeError();
+}
+
 LogicalResult TMEMCopyOp::verify() {
   if (!isa<triton::gpu::SharedMemorySpaceAttr>(
           getSrc().getType().getMemorySpace()))
@@ -1224,6 +1266,8 @@ LogicalResult TMEMCopyOp::verify() {
     if (nvmmaEnc && nvmmaEnc.getSwizzlingByteWidth() != 0) {
       return emitOpError("The source should not be swizzled for now");
     }
+    if (failed(verifyScaleTMEMCopyShape(*this, srcTy, dstTy)))
+      return failure();
   } else {
     if (getSrc().getType().getShape() != getDst().getType().getShape()) {
       return emitOpError(

--- a/python/test/unit/language/test_tlx_memory_ops.py
+++ b/python/test/unit/language/test_tlx_memory_ops.py
@@ -569,6 +569,22 @@ def test_tmem_alloc_index(BLOCK_SIZE, device):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_tmem_copy_rejects_logical_rank2_scale_smem(device):
+
+    @triton.jit
+    def kernel(dummy):
+        smem = tlx.local_alloc((128, 4), tl.uint8, tl.constexpr(1))
+        tmem = tlx.local_alloc((128, 4), tl.uint8, tl.constexpr(1), tlx.storage_kind.tmem)
+        tlx.tmem_copy(smem[0], tmem[0])
+        tl.store(dummy, tl.full((), 0, tl.int32))
+
+    dummy = torch.empty((), dtype=torch.int32, device=device)
+    with pytest.raises(triton.CompilationError) as exc_info:
+        kernel[(1, )](dummy)
+    assert "scale tmem_copy requires an explicit packed i8 SMEM shape" in str(exc_info.value)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
 @pytest.mark.parametrize("BLOCK_SIZE_M, BLOCK_SIZE_N", [(64, 64), (64, 8), (128, 16)])
 def test_tmem_load_store(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
 
@@ -772,7 +788,7 @@ def local_gather_kernel(
 
 
 @pytest.mark.parametrize("N,M", [(32, 32), (64, 64), (128, 128)])
-def test_local_gather(N, M):
+def test_local_gather_1d_native(N, M):
     """Test gathering from 1D reshaped shared memory (diagonal of 2D matrix)."""
     device = torch.device("cuda")
 

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -188,14 +188,14 @@ tt.func @no_barrier_between_same_index_init_inval() {
 #smem = #ttg.shared_memory
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @tmem_copy_after_alloc(%arg0: tensor<128x16xf8E4M3FN, #blocked>) {
+  tt.func @tmem_copy_after_alloc(%arg0: tensor<1x2048xi8, #blocked>) {
     // CHECK: local_alloc
-    %0 = ttg.local_alloc %arg0 {allocation.offset = 53248 : i32} : (tensor<128x16xf8E4M3FN, #blocked>) -> !ttg.memdesc<128x16xf8E4M3FN, #shared, #smem>
+    %0 = ttg.local_alloc %arg0 {allocation.offset = 53248 : i32} : (tensor<1x2048xi8, #blocked>) -> !ttg.memdesc<1x2048xi8, #shared, #smem>
     // CHECK: tmem_alloc
-    %1 = ttng.tmem_alloc  {tensor_memory_col_offset = 256 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_alloc  {tensor_memory_col_offset = 256 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // ttg.barrier local
     // CHECK: tmem_copy
-    ttng.tmem_copy %0, %1 : !ttg.memdesc<128x16xf8E4M3FN, #shared, #smem>, !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %0, %1 : !ttg.memdesc<1x2048xi8, #shared, #smem>, !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -349,26 +349,26 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, "ttng.tw
 
 
 #blocked = #ttg.blocked<{sizePerThread=[1, 4], threadsPerWarp=[32, 1], warpsPerCTA=[4, 1], order=[0, 1]}>
-#shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#shared2 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16], [128, 0], [256, 0]]}, alignment = 16>
-#shared3 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [128, 0]]}, alignment = 128>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
 // CHECK-LABEL: @tmem_copy_2d
-tt.func public @tmem_copy_2d(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
+tt.func public @tmem_copy_2d(%src: !ttg.memdesc<1x1x8x2x256xi8, #shared, #ttg.shared_memory>,
                              %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
 		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
   // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
   // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
-  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<1x1x8x2x256xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
   tt.return
 }
 
 // CHECK-LABEL: @tmem_copy_2d_256
-tt.func public @tmem_copy_2d_256(%src: !ttg.memdesc<256x4xi8, #shared3, #ttg.shared_memory>,
+tt.func public @tmem_copy_2d_256(%src: !ttg.memdesc<1x2x1x2x256xi8, #shared3, #ttg.shared_memory>,
                                  %dst: !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
   // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
   // CHECK: [[BASE:%.*]] = llvm.ptrtoint %arg1
@@ -378,17 +378,17 @@ tt.func public @tmem_copy_2d_256(%src: !ttg.memdesc<256x4xi8, #shared3, #ttg.sha
   // CHECK: [[OFFS1:%.*]] = llvm.add [[BASE]], [[C4]]
   // CHECK: tcgen05.cp.cta_group::1.warpx4.32x128b {{.*}} "r,l,b" [[OFFS1]]
   // CHECK-NOT: tcgen05.cp
-  ttng.tmem_copy %src, %dst : !ttg.memdesc<256x4xi8, #shared3, #ttg.shared_memory>, !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+  ttng.tmem_copy %src, %dst : !ttg.memdesc<1x2x1x2x256xi8, #shared3, #ttg.shared_memory>, !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
   tt.return
 }
 
 // CHECK-LABEL: @tmem_copy_2d_slice
-tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<128x32xi8, #shared2, #ttg.shared_memory, 512x32>,
+tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<1x1x8x2x256xi8, #shared2, #ttg.shared_memory, 4x1x8x2x256>,
                                    %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
   // CHECK: [[OFF0:%.*]] = llvm.extractvalue %arg0[1]
   // CHECK: [[OFF1:%.*]] = llvm.extractvalue %arg0[2]
   // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
-  ttng.tmem_copy %src, %dst : !ttg.memdesc<128x32xi8, #shared2, #ttg.shared_memory, 512x32>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+  ttng.tmem_copy %src, %dst : !ttg.memdesc<1x1x8x2x256xi8, #shared2, #ttg.shared_memory, 4x1x8x2x256>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
   tt.return
 }
 
@@ -397,13 +397,13 @@ tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<128x32xi8, #shared2, #ttg.
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread=[1, 4], threadsPerWarp=[32, 1], warpsPerCTA=[4, 1], order=[0, 1]}>
-#shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttng.two-ctas" = true} {
 
-tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
+tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<1x1x8x2x256xi8, #shared, #ttg.shared_memory>,
                              %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
   %c0_i32 = arith.constant 0 : i32
   %bar_alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
@@ -414,7 +414,7 @@ tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.sh
   // CHECK: llvm.urem %[[CTAID]], %[[TWO]]
   // CHECK-COUNT-8: tcgen05.cp.cta_group::2.warpx4.32x128b
   // CHECK: tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64
-  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<1x1x8x2x256xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
   tt.return
 }
 

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -358,12 +358,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // Test that tmem_copy with barrier in paired CTA MMA mode triggers cluster sync.
 // The barrier on tmem_copy will generate a tcgen05.commit with multicast in 2cta mode.
 #shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#shared_scales = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
+#shared_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttng.two-ctas" = true} {
   // CHECK-LABEL: @tmem_copy_barrier_paired_cta
   tt.func public @tmem_copy_barrier_paired_cta(
-      %src: !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>,
+      %src: !ttg.memdesc<1x1x8x2x256xi8, #shared_scales, #ttg.shared_memory>,
       %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) attributes {noinline = false} {
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
@@ -373,7 +373,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: tcgen05.cp
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
-    ttng.tmem_copy %src, %dst, %1 : !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tmem_copy %src, %dst, %1 : !ttg.memdesc<1x1x8x2x256xi8, #shared_scales, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     tt.return
   }
 }
@@ -383,12 +383,12 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
 // Test that tmem_copy with barrier but WITHOUT paired CTA MMA does NOT trigger
 // cluster sync. The commit stays local without multicast.
 #shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#shared_scales = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]]}, alignment = 16>
+#shared_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
   // CHECK-LABEL: @tmem_copy_barrier_no_paired_cta_no_sync
   tt.func public @tmem_copy_barrier_no_paired_cta_no_sync(
-      %src: !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>,
+      %src: !ttg.memdesc<1x1x8x2x256xi8, #shared_scales, #ttg.shared_memory>,
       %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) attributes {noinline = false} {
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
@@ -396,7 +396,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-NOT: nvvm.cluster.arrive
     // CHECK-NOT: nvvm.cluster.wait
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
-    ttng.tmem_copy %src, %dst, %1 : !ttg.memdesc<128x32xi8, #shared_scales, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    ttng.tmem_copy %src, %dst, %1 : !ttg.memdesc<1x1x8x2x256xi8, #shared_scales, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     tt.return
   }
 }

--- a/test/TLX/propagate-layout-invalid.mlir
+++ b/test/TLX/propagate-layout-invalid.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt -split-input-file --verify-diagnostics --tlx-propagate-layout %s
+
+#shared_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 2}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory
+#dummy_tmem_layout = #tlx.dummy_tmem_layout<>
+#scales_encoding = #ttng.tensor_memory_scales_encoding<>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @logical_rank2_scale_tmem_copy_after_propagate(
+      %scale_smem: !ttg.memdesc<128x4xi8, #shared_scales, #smem, mutable>) {
+    %scale_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<128x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // expected-error @+1 {{scale tmem_copy requires an explicit packed i8 SMEM shape}}
+    ttng.tmem_copy %scale_smem, %scale_tmem : !ttg.memdesc<128x4xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<128x4xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    %scale_req = tlx.require_layout %scale_tmem : !ttg.memdesc<128x4xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x4xi8, #scales_encoding, #tmem, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/propagate-layout.mlir
+++ b/test/TLX/propagate-layout.mlir
@@ -256,7 +256,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %a_smem: !ttg.memdesc<128x256xf8E4M3FN, #shared, #smem, mutable>,
       %b_smem: !ttg.memdesc<256x128xf8E4M3FN, #shared, #smem, mutable>,
       %a_scale_smem: !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>,
-      %b_scale_smem: !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>) {
+      %b_scale_smem: !ttg.memdesc<1x2x1x2x256xi8, #shared_scales, #smem, mutable>) {
     %c0_i32 = arith.constant 0 : i32
     %false = arith.constant false
     %true = arith.constant true
@@ -276,7 +276,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     // Copy scales from SMEM to TMEM
     ttng.tmem_copy %a_scale_smem, %a_scale_indexed : !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable>
-    ttng.tmem_copy %b_scale_smem, %b_scale_indexed : !ttg.memdesc<1x1x2x2x256xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable>
+    ttng.tmem_copy %b_scale_smem, %b_scale_indexed : !ttg.memdesc<1x2x1x2x256xi8, #shared_scales, #smem, mutable>, !ttg.memdesc<256x4xi8, #dummy_tmem_layout, #tmem, mutable>
 
     // Require scales layout for the MMA op
     %a_scale_req = tlx.require_layout %a_scale_indexed : !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x8xi8, #scales_encoding, #tmem, mutable>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -55,6 +55,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#tmem = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @logical_rank2_scale_tmem_copy(%arg: !ttg.memdesc<128x4xi8, #shared, #ttg.shared_memory, mutable>,
+                                                %dst: !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>) {
+    // expected-error @+1 {{scale tmem_copy requires an explicit packed i8 SMEM shape}}
+    ttng.tmem_copy %arg, %dst : !ttg.memdesc<128x4xi8, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 

--- a/test/TritonNvidiaGPU/mma_lowering.mlir
+++ b/test/TritonNvidiaGPU/mma_lowering.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --triton-nvidia-mma-lowering | FileCheck %s
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
 #smem = #ttg.shared_memory
@@ -10,20 +10,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-LABEL: gen5_mma_scaled_shmem_to_tmem
   tt.func public @gen5_mma_scaled_shmem_to_tmem(
     %A_sh: !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>,
-    %B_sh: !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
-    %C_tmem: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
-    %A_scale_sh: !ttg.memdesc<128x8xi8, #shared1, #smem>,
-    %B_scale_sh: !ttg.memdesc<64x8xi8, #shared1, #smem>,
+    %B_sh: !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>,
+    %C_tmem: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %A_scale_sh: !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>,
+    %B_scale_sh: !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>,
     %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
 
     %true = arith.constant true
     // Verify that the scale in tmem has the shape of (LHS) BlockM x BlockK / 32, (RHS) BlockN x BlockK / 32
     // CHECK: %[[A_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[A_SC_TMEM]]
-    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<64x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[B_SC_TMEM]]
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_SC_TMEM]], %[[B_SC_TMEM]]
-    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e5m2 rhs = e5m2, %barrier[%true] {is_async} : !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #shared1, #smem>, !ttg.memdesc<64x8xi8, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e5m2 rhs = e5m2, %barrier[%true] {is_async} : !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
     tt.return
   }
 }
@@ -32,7 +32,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
 #sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
 #smem = #ttg.shared_memory
@@ -41,20 +41,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-LABEL: gen5_mma_scaled_shmem_to_tmem
   tt.func public @gen5_mma_scaled_shmem_to_tmem(
     %A_sh: !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>,
-    %B_sh: !ttg.memdesc<256x64xi8, #sharedT, #ttg.shared_memory>,
-    %C_tmem: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
-    %A_scale_sh: !ttg.memdesc<128x8xf8E4M3FN, #shared1, #smem>,
-    %B_scale_sh: !ttg.memdesc<64x8xf8E4M3FN, #shared1, #smem>,
+    %B_sh: !ttg.memdesc<256x128xi8, #sharedT, #ttg.shared_memory>,
+    %C_tmem: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %A_scale_sh: !ttg.memdesc<1x2x32x4x4xf8E4M3FN, #shared1, #smem>,
+    %B_scale_sh: !ttg.memdesc<1x2x32x4x4xf8E4M3FN, #shared1, #smem>,
     %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
 
     %true = arith.constant true
     // Verify that the scale in tmem has the shape of (LHS) BlockM x BlockK / 32, (RHS) BlockN x BlockK / 32
     // CHECK: %[[A_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[A_SC_TMEM]]
-    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<64x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
+    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[B_SC_TMEM]]
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_SC_TMEM]], %[[B_SC_TMEM]]
-    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e2m1 rhs = e2m1, %barrier[%true] {is_async} : !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<256x64xi8, #sharedT, #ttg.shared_memory>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<64x8xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e2m1 rhs = e2m1, %barrier[%true] {is_async} : !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<256x128xi8, #sharedT, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xf8E4M3FN, #shared1, #smem>, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -3,6 +3,9 @@
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared_scales2d = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 2}>
+#shared_scales4d = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 4}>
+#shared_scales5d = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #tmem_f16 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 2>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
@@ -32,6 +35,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
        !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
        !ttg.memdesc<128x256xf8E5M2, #shared1, #ttg.shared_memory>,
        !ttg.memdesc<128x256xf16, #tmem_f16, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @valid_scale_tmem_copy_shapes
+  // CHECK-COUNT-4: ttng.tmem_copy
+  tt.func @valid_scale_tmem_copy_shapes(
+      %src4d: !ttg.memdesc<1x1x32x16xi8, #shared_scales4d, #ttg.shared_memory>,
+      %src5d_cp: !ttg.memdesc<1x1x32x4x4xi8, #shared_scales5d, #ttg.shared_memory>,
+      %src5d_tma: !ttg.memdesc<1x1x1x2x256xi8, #shared_scales5d, #ttg.shared_memory>,
+      %src2d_flat: !ttg.memdesc<1x512xi8, #shared_scales2d, #ttg.shared_memory>,
+      %dst: !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
+    ttng.tmem_copy %src4d, %dst : !ttg.memdesc<1x1x32x16xi8, #shared_scales4d, #ttg.shared_memory>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src5d_cp, %dst : !ttg.memdesc<1x1x32x4x4xi8, #shared_scales5d, #ttg.shared_memory>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src5d_tma, %dst : !ttg.memdesc<1x1x1x2x256xi8, #shared_scales5d, #ttg.shared_memory>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src2d_flat, %dst : !ttg.memdesc<1x512xi8, #shared_scales2d, #ttg.shared_memory>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     tt.return
   }
 

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -425,7 +425,7 @@ def async_remote_shmem_copy(
         remote_cta_rank: The rank of the remote CTA within the cluster
         barrier: mbarrier in local shared memory whose address will be mapa'd to the remote CTA
     """
-    assert src.type.storage == tlx.storage_kind.smem, ("async_remote_shmem_copy requires local smem src")
+    assert src.type.storage == tlx.storage_kind.smem, "async_remote_shmem_copy requires local smem src"
     assert dst.type.storage == tlx.storage_kind.smem, (
         "async_remote_shmem_copy requires local smem dst (will be mapa'd to remote CTA)")
     assert remote_cta_rank is not None, "remote_cta_rank is required for async_remote_shmem_copy"
@@ -723,7 +723,6 @@ def local_scatter(
     """
     Scatter elements to shared memory along a specified axis using an indices tensor.
     """
-    block_type = tl.block_type(src.type.element_ty, indices.type.shape)
     storage = dst.type.storage
     assert storage == tlx.storage_kind.smem, "local_scatter only supports shared memory!"
     return tl.tensor(_semantic.builder.create_local_scatter(dst.handle, src.handle, indices.handle, axis), tl.void)
@@ -746,6 +745,43 @@ def local_store(
         return tl.tensor(_semantic.builder.create_tmem_store(dst.handle, src_handle), tl.void)
 
     return tl.tensor(_semantic.builder.create_local_store(dst.handle, src.handle), tl.void)
+
+
+def _shape_as_ints(shape):
+    return [int(tl._unwrap_if_constexpr(dim)) for dim in shape]
+
+
+def _is_scale_tmem_copy_candidate(dst: tlx.buffered_tensor) -> bool:
+    if dst.type.storage != tlx.storage_kind.tmem:
+        return False
+    if dst.type.scalar not in (tl.int8, tl.uint8):
+        return False
+    return isinstance(dst.type.layout, (tlx.DummyTMEMLayoutEncoding, tlx.tensor_memory_scales_layout_encoding))
+
+
+def _verify_scale_tmem_copy_shape(src: tlx.buffered_tensor, dst: tlx.buffered_tensor) -> None:
+    src_shape = _shape_as_ints(src.type.shape)
+    dst_shape = _shape_as_ints(dst.type.shape)
+    error_msg = ("scale tmem_copy requires an explicit packed i8 SMEM shape matching the rank-2 TMEM scale shape; "
+                 "accepted source shapes are [rows / 128, cols / 4, 32, 16], "
+                 "[rows / 128, cols / 4, 32, 4, 4], [1, rows / 128, cols / 4, 2, 256], "
+                 "or [rows / 128, (cols / 4) * 512]")
+
+    assert src.type.scalar in (tl.int8, tl.uint8) and dst.type.scalar in (tl.int8, tl.uint8), error_msg
+    assert len(dst_shape) == 2, error_msg
+
+    rows, cols = dst_shape
+    assert rows % 128 == 0 and cols % 4 == 0, error_msg
+
+    rep_rows = rows // 128
+    rep_cols = cols // 4
+    accepted_shapes = [
+        [rep_rows, rep_cols, 32, 16],
+        [rep_rows, rep_cols, 32, 4, 4],
+        [1, rep_rows, rep_cols, 2, 256],
+        [rep_rows, rep_cols * 512],
+    ]
+    assert src_shape in accepted_shapes, error_msg
 
 
 @tl.builtin
@@ -774,6 +810,8 @@ def tmem_copy(
     assert src.type.storage == tlx.storage_kind.smem, "source must be in shared memory"
     assert dst.type.storage == tlx.storage_kind.tmem, "destination must be in tensor memory"
     _assert_blackwell_for_tmem(_semantic.builder.options.arch)
+    if _is_scale_tmem_copy_candidate(dst):
+        _verify_scale_tmem_copy_shape(src, dst)
     _semantic.builder.create_tmem_copy(src.handle, dst.handle)
 
 
@@ -860,8 +898,8 @@ def async_descriptor_load(
                  TMA loads signal the leader's barrier.
     """
     assert isinstance(desc, tl.tensor_descriptor_base)
-    assert eviction_policy in ("", "evict_first", "evict_last"), \
-        f"eviction_policy must be '', 'evict_first', or 'evict_last', got '{eviction_policy}'"
+    assert eviction_policy in ("", "evict_first", "evict_last"), (
+        f"eviction_policy must be '', 'evict_first', or 'evict_last', got '{eviction_policy}'")
     ndim = len(desc.block_shape)
     assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
     # 1D TMA doesn't use swizzling, so request unswizzled NVMMASharedEncoding.
@@ -907,8 +945,8 @@ def async_descriptor_prefetch_tensor(
     Hint the hardware to prefetch a tensor tile from global memory into L2 cache using TMA.
     """
     assert isinstance(desc, tl.tensor_descriptor_base)
-    assert eviction_policy in ("", "evict_first", "evict_last"), \
-        f"eviction_policy must be '', 'evict_first', or 'evict_last', got '{eviction_policy}'"
+    assert eviction_policy in ("", "evict_first", "evict_last"), (
+        f"eviction_policy must be '', 'evict_first', or 'evict_last', got '{eviction_policy}'")
     ndim = len(desc.block_shape)
     assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
     offsets = _semantic._convert_to_ir_values(offsets, require_i64=False)


### PR DESCRIPTION
Summary:
TMEM_COPY assumes data is laid out in certain fashion for underlying tcgen05.cp instruction can move the data. Particularly for scales this can lead to silent failures due to a lack of shape checking.

This makes the shape checking explicit and rejects 2D shapes that would require the user to have previously moved data. In particular, this is done to avoid ambiguities regarding if the data is already permuted.

Here is the new error:

```
E       triton.compiler.errors.CompilationError: at 837:20:
E                           # REUSE_GROUP_3 SYNCHRONIZATION:
E                           # Linear order for all deps. For body MMA 2 -> MMA 5.
E                           # MMA 2 handled by ds_fulls[ds_buf_id_prev].
E                           tlx.barrier_wait(ds_fulls[ds_buf_id_prev], ds_phase_prev)
E                           tlx.barrier_wait(k_dq_fulls[kv_buf_id], kv_phase)
E                           # REUSE_GROUP_1: wait for Compute to finish reading qk_tiles
E                           # before overwriting with scale tmem_copies.
E                           tlx.barrier_wait(qk_empties[0], tmem_phase)
E                           # Copy the dQ-specific dS scales from SMEM to TMEM.
E                           # Fence for scale copies to be visible.
E                           tlx.fence("async_shared")
E                           tlx.tmem_copy(ds_scale_dq_smem[0], ds_scale_dq_tmem[0])
E                           ^
E       scale tmem_copy requires an explicit packed i8 SMEM shape matching the rank-2 TMEM scale shape; accepted source shapes are [rows / 128, cols / 4, 32, 16], [rows / 128, cols / 4, 32, 4, 4], [1, rows / 128, cols / 4, 2, 256], or [rows / 128, (cols / 4) * 512]
```


Reviewed By: htyu

Differential Revision: D105188118

Pulled By: njriasan


