### PR TITLE
[triton] Enable C fast cache for autotuned kernels (#1512)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -1445,8 +1445,9 @@ typedef struct {
   PyObject *params_list; // self.params
   PyObject *run_partial; // functools.partial(self.run, grid=grid, warmup=False)
   PyObject *grid_py[3];  // pre-extracted grid PyLong objects
-  PyObject *stream_getter; // driver.active.get_current_stream
-  PyObject *device_getter; // driver.active.get_current_device
+  PyObject *stream_getter;     // driver.active.get_current_stream
+  PyObject *device_getter;     // driver.active.get_current_device
+  PyObject *param_name_to_idx; // dict: param_name → positional index
   uint64_t options_hash;
   int n_params;
 } JITCacheProxy;
@@ -1461,12 +1462,42 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
                                           PyObject *kwnames) {
   JITCacheProxy *self = (JITCacheProxy *)callable;
   Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+  PyObject **merged_args = nullptr;
+  PyObject *const *effective_args = args;
+  int effective_nargs = (int)nargs;
 
-  // Fast path: no kwargs, arg count matches
-  if (kwnames && PyTuple_GET_SIZE(kwnames) > 0)
+  // When kwargs are present, merge them into positional args in C.
+  // This mirrors the Python-side logic in jit.py run() c_cache path.
+  if (kwnames && PyTuple_GET_SIZE(kwnames) > 0) {
+    if (!self->param_name_to_idx)
+      goto fallback;
+    Py_ssize_t nkw = PyTuple_GET_SIZE(kwnames);
+    int total = self->n_params;
+    // Allocate merged array on stack (max ~64 params for typical kernels)
+    merged_args = (PyObject **)alloca(total * sizeof(PyObject *));
+    // Copy positional args
+    for (int i = 0; i < total; i++)
+      merged_args[i] = (i < (int)nargs) ? (PyObject *)args[i] : Py_None;
+    // Merge kwargs by name lookup
+    for (Py_ssize_t ki = 0; ki < nkw; ki++) {
+      PyObject *name = PyTuple_GET_ITEM(kwnames, ki);
+      PyObject *idx_obj = PyDict_GetItem(self->param_name_to_idx, name);
+      if (idx_obj) {
+        int idx = (int)PyLong_AsLong(idx_obj);
+        if (idx >= 0 && idx < total)
+          merged_args[idx] = (PyObject *)args[nargs + ki];
+      }
+      // kwargs not in param_name_to_idx are "options" — affect hash only.
+      // For now, treat them as cache-miss (different options_hash) and
+      // fallback.
+      else
+        goto fallback;
+    }
+    effective_args = merged_args;
+    effective_nargs = total;
+  } else if (nargs != self->n_params) {
     goto fallback;
-  if (nargs != self->n_params)
-    goto fallback;
+  }
 
   {
     FastCache *cache =
@@ -1475,10 +1506,11 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
       goto fallback;
 
     FCCacheKey key;
-    if (!fc_build_key(key, cache, args, (int)nargs, self->options_hash))
+    if (!fc_build_key(key, cache, effective_args, effective_nargs,
+                      self->options_hash))
       goto fallback;
 
-    FCEntry *entry = cache->lookup(key, args);
+    FCEntry *entry = cache->lookup(key, effective_args);
     if (!entry)
       goto fallback;
 
@@ -1504,7 +1536,7 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     // Build dispatcher vectorcall args: grid0, grid1, grid2, stream,
     // *kernel_args
     int n_kernel_args = 0;
-    for (int i = 0; i < (int)nargs && i < cache->n_params; i++) {
+    for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
       if (!cache->param_meta[i].is_constexpr)
         n_kernel_args++;
     }
@@ -1515,9 +1547,9 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     vc_args[2] = self->grid_py[2];
     vc_args[3] = stream_obj;
     int ki = 0;
-    for (int i = 0; i < (int)nargs && i < cache->n_params; i++) {
+    for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
       if (!cache->param_meta[i].is_constexpr)
-        vc_args[4 + ki++] = args[i];
+        vc_args[4 + ki++] = effective_args[i];
     }
     PyObject *result =
         PyObject_Vectorcall(dispatcher, vc_args, vc_nargs, nullptr);
@@ -1549,6 +1581,7 @@ static void JITCacheProxy_dealloc(PyObject *o) {
   Py_XDECREF(self->grid_py[2]);
   Py_XDECREF(self->stream_getter);
   Py_XDECREF(self->device_getter);
+  Py_XDECREF(self->param_name_to_idx);
   Py_TYPE(o)->tp_free(o);
 }
 
@@ -1562,6 +1595,7 @@ static int JITCacheProxy_traverse(PyObject *o, visitproc visit, void *arg) {
   Py_VISIT(self->grid_py[2]);
   Py_VISIT(self->stream_getter);
   Py_VISIT(self->device_getter);
+  Py_VISIT(self->param_name_to_idx);
   return 0;
 }
 
@@ -1570,6 +1604,7 @@ static int JITCacheProxy_clear(PyObject *o) {
   Py_CLEAR(self->jit_fn);
   Py_CLEAR(self->params_list);
   Py_CLEAR(self->run_partial);
+  Py_CLEAR(self->param_name_to_idx);
   Py_CLEAR(self->grid_py[0]);
   Py_CLEAR(self->grid_py[1]);
   Py_CLEAR(self->grid_py[2]);
@@ -1692,6 +1727,14 @@ PyObject *native_create_jit_proxy(PyObject *self_unused, PyObject *const *args,
   Py_INCREF(stream_getter);
   proxy->device_getter = device_getter;
   Py_INCREF(device_getter);
+  // Get _param_name_to_idx from jit_fn for kwargs→positional merging
+  static PyObject *pnti_str = nullptr;
+  if (!pnti_str)
+    pnti_str = PyUnicode_InternFromString("_param_name_to_idx");
+  PyObject *pnti = PyObject_GetAttr(jit_fn, pnti_str);
+  proxy->param_name_to_idx = pnti; // may be NULL if attr missing
+  if (!pnti)
+    PyErr_Clear();
   proxy->options_hash = opts_hash;
   proxy->n_params = n_params;
   PyObject_GC_Track((PyObject *)proxy);

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -219,6 +219,75 @@ class Autotuner(KernelInterface):
             }), file_name, binary=False)
         return False
 
+    def _try_fast_path(self, args, kwargs, config):
+        """Attempt C fast cache dispatch; return kernel or None to fall back.
+
+        Uses JITCacheProxy (hash=0) for subsequent calls after seeding.
+        On the first call per autotuner key, seeds the C cache by calling
+        run() with correct meta-params (kernel_cache HIT, no recompile)
+        and inserting the result under hash=0.
+
+        Returns None when preconditions aren't met (no c_cache, callable
+        grid that can't be evaluated, extra kwargs, etc.).
+        """
+        input_grid = kwargs.get('grid')
+        if input_grid is None or not getattr(self.fn, 'c_cache', False):
+            return None
+
+        # Build full positional args: user positional + config constexprs.
+        config_kwargs = config.all_kwargs()
+        fn_arg_names = self.fn.arg_names
+        _arg_name_set = set(fn_arg_names)
+        # Fall back if kwargs has extra keys (beyond 'grid'/'warmup') not in arg_names,
+        # since those would be silently dropped in the fast path.
+        if any(k not in _arg_name_set for k in kwargs if k not in {'grid', 'warmup'}):
+            return None
+
+        full_args = list(args)
+        for name in fn_arg_names[len(args):]:
+            if name in config_kwargs:
+                full_args.append(config_kwargs[name])
+            elif name in kwargs:
+                full_args.append(kwargs[name])
+            else:
+                return None  # Can't resolve all args.
+
+        # Evaluate callable grid using resolved args.
+        if callable(input_grid):
+            _meta_dict = dict(zip(fn_arg_names, full_args))
+            evaluated_grid = input_grid(_meta_dict)
+        else:
+            evaluated_grid = input_grid
+
+        # Separate meta-params (num_warps, etc.) from kernel args.
+        _meta = {k: v for k, v in config_kwargs.items() if k not in _arg_name_set}
+
+        # Seed C cache with hash=0 for JITCacheProxy.
+        # During autotuning, run() stored the kernel with a non-zero hash.
+        # JITCacheProxy always uses hash=0, so without seeding it would miss
+        # and recompile with wrong default options.
+        if not hasattr(self, '_fc_seeded'):
+            self._fc_seeded = set()
+        # Use autotuner key to distinguish specializations that may select
+        # different winning configs (different meta-params).
+        _seed_key = getattr(self, '_last_key', None)
+        if _seed_key not in self._fc_seeded:
+            try:
+                from triton._C.libtriton import native_fast_dispatch_insert
+            except (ImportError, AttributeError):
+                native_fast_dispatch_insert = None
+            kernel = self.fn.run(*full_args, grid=evaluated_grid, warmup=False, **_meta)
+            if native_fast_dispatch_insert is not None:
+                _disp = getattr(kernel, '_dispatcher', None)
+                if _disp is not None:
+                    _padded = tuple(full_args)
+                    if len(_padded) < len(self.fn.params):
+                        _padded = _padded + (None, ) * (len(self.fn.params) - len(_padded))
+                    native_fast_dispatch_insert(self.fn, _padded, self.fn.params, 0, kernel, _disp)
+            self._fc_seeded.add(_seed_key)
+            return kernel
+        return self.fn[evaluated_grid](*full_args)
+
     def run(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
         used_cached_result = True
@@ -270,6 +339,7 @@ class Autotuner(KernelInterface):
                     benchmark()
 
             config = self.cache[key]
+            self._last_key = key
         else:
             config = self.configs[0]
         self.best_config = config
@@ -293,11 +363,9 @@ class Autotuner(KernelInterface):
                     if isinstance(device_cache, tuple) and len(device_cache) >= 1:
                         device_cache[0].clear()
         try:
-            ret = self.fn.run(
-                *args,
-                **kwargs,
-                **config.all_kwargs(),
-            )
+            ret = None if dump_best else self._try_fast_path(args, kwargs, config)
+            if ret is None:
+                ret = self.fn.run(*args, **kwargs, **config.all_kwargs())
         finally:
             if dump_best:
                 knobs.compilation.dump_ir = original_dump_ir

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -808,11 +808,10 @@ class JITFunction(JITCallable, KernelInterface[T]):
             if kwargs:
                 _fc_args = list(args)
                 _fc_opts = {}
-                _param_names = self.arg_names
-                _param_set = set(_param_names)
+                _name_to_idx = self._param_name_to_idx
                 for k, v in kwargs.items():
-                    if k in _param_set:
-                        idx = _param_names.index(k)
+                    idx = _name_to_idx.get(k)
+                    if idx is not None:
                         while len(_fc_args) <= idx:
                             _fc_args.append(None)
                         _fc_args[idx] = v
@@ -949,11 +948,10 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 if _user_kwargs:
                     _ins_args = list(args)
                     _ins_opts = {}
-                    _param_names = self.arg_names
-                    _param_set = set(_param_names)
+                    _name_to_idx = self._param_name_to_idx
                     for k, v in _user_kwargs.items():
-                        if k in _param_set:
-                            idx = _param_names.index(k)
+                        idx = _name_to_idx.get(k)
+                        if idx is not None:
                             while len(_ins_args) <= idx:
                                 _ins_args.append(None)
                             _ins_args[idx] = v
@@ -1016,6 +1014,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # TODO(jlebar): Remove uses of these fields outside this file, then
         # remove the fields here.
         self.arg_names = [p.name for p in self.params]
+        self._param_name_to_idx = {name: i for i, name in enumerate(self.arg_names)}
         self.constexprs = [p.num for p in self.params if p.is_constexpr]
 
         # Hooks that will be called prior to executing "run"


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/1074


Autotuned kernels (`triton.autotune` + `triton.jit(c_cache=True)`) previously never used the C fast cache because `Autotuner.run()` called `self.fn.run()` directly, bypassing `JITFunction.__getitem__()` → `JITCacheProxy`. This diff fixes the `Autotuner` to redirect through the C fast path on steady-state calls.


## Background

The Triton C fast cache (`JITCacheProxy` in `specialize.cc`) intercepts kernel launches at `JITFunction.__getitem__(grid)`, returning a C proxy that does:
1. `fc_build_key()` — O(1) cache key from raw arg pointers
2. `cache->lookup()` — hash table hit
3. `dispatcher(grid, stream, *args)` — direct `cuLaunchKernelEx`

This bypasses ~15 us of Python overhead (binder, specialization, dict lookup, grid eval).

### Before (broken)

```
kernel[(grid,)](*args)
  → KernelInterface.__getitem__(grid)
    → getattr(self, 'c_cache', False)  # self = Autotuner → False!
    → returns lambda → Autotuner.run()
      → self.cache[key] → config
      → self.fn.run(*args, **kwargs, **config.all_kwargs())  ← full Python path
```

`c_cache` is set on the inner `JITFunction`, but `__getitem__` is called on the `Autotuner` wrapper which doesn't have it. Result: **c_cache=True on autotuned kernels was dead code.**

### After (fixed)

```
kernel[(grid,)](*args)
  → KernelInterface.__getitem__(grid)
    → returns lambda → Autotuner.run()
      → self.cache[key] → config
      → self.fn[grid](*full_positional_args)  ← NEW: goes through JITCacheProxy
        → C fast cache HIT → dispatcher → cuLaunchKernelEx
```

On steady-state (config already selected), `Autotuner.run()` now builds the full positional arg list (user args + config constexprs) and calls `self.fn[grid](...)`, which returns a `JITCacheProxy` and dispatches entirely in C.


## Results

x_val=19 (5 tensors + 9 scalars + 5 constexprs):

| Benchmark | Before | After | Improvement |
|---|---|---|---|
| `nop_triton_kernel` (no autotune, c_cache) | 4.9 us | 4.9 us | baseline |
| `nop_triton_kernel_autotuned` (autotune + c_cache) | **21.2 us** | **16.7 us** | **1.27x faster** |
| `nop_triton_kernel_autotuned_nocache` | 27.1 us | 27.3 us | unchanged |

Remaining ~12 us gap vs non-autotuned (4.9 us) is `Autotuner.run()` Python overhead (dict zip, key build, config lookup, arg list construction). Eliminating that requires a C-level autotune proxy (future work).

Reviewed By: htyu

Differential Revision: D104917209


