### PR TITLE
[lint-autofix] Fix pre-commit formatting issues (#1516)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -2134,9 +2134,8 @@ public:
           }
           if (safeToMutate) {
             // Safe: mutate the local_load and chain in place.
-            current.setType(
-                cast<RankedTensorType>(current.getType())
-                    .cloneWithEncoding(srcEnc));
+            current.setType(cast<RankedTensorType>(current.getType())
+                                .cloneWithEncoding(srcEnc));
             for (Operation *chainOp : backwardChain) {
               for (Value result : chainOp->getResults()) {
                 if (auto rty = dyn_cast<RankedTensorType>(result.getType()))
@@ -2147,8 +2146,8 @@ public:
             // Unsafe: fall back to inserting a convert on this operand.
             rewriter.setInsertionPoint(op);
             auto newTy = ty.cloneWithEncoding(srcEnc);
-            auto newCvt = ConvertLayoutOp::create(rewriter, op->getLoc(),
-                                                  newTy, operand.get());
+            auto newCvt = ConvertLayoutOp::create(rewriter, op->getLoc(), newTy,
+                                                  operand.get());
             operand.set(newCvt);
           }
         } else {

--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -678,8 +678,8 @@ struct ParamMeta {
   uint8_t do_not_specialize : 1;
   uint8_t do_not_specialize_on_alignment : 1;
   uint8_t has_annotation : 1;
-  uint8_t is_ptr
-      : 1; // Set if annotation starts with '*' (pointer/tensor param)
+  uint8_t
+      is_ptr : 1; // Set if annotation starts with '*' (pointer/tensor param)
   uint8_t is_tensordesc : 1; // Set if annotation starts with 'tensordesc'
   uint8_t annotation_type_code;
 };

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1091,7 +1091,8 @@ static void ensureCudaContext() {
   }
 }
 
-// File-level handle for cuLaunchKernelEx (shared by _launch and _TritonDispatcher)
+// File-level handle for cuLaunchKernelEx (shared by _launch and
+// _TritonDispatcher)
 static cuLaunchKernelEx_t g_cuLaunchKernelExHandle = NULL;
 static inline cuLaunchKernelEx_t ensureLaunchHandle(void) {
   if (g_cuLaunchKernelExHandle == NULL)
@@ -1183,7 +1184,7 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
 }
 
 static PyObject *data_ptr_str = NULL;
-static PyObject *td_get_str = NULL;  /* interned "get" for allocator.get() */
+static PyObject *td_get_str = NULL; /* interned "get" for allocator.get() */
 
 // Extract a CUDA device pointer from a pointer-like PyObject obj, and store
 // it to the memory location pointed by ptr.
@@ -1710,339 +1711,412 @@ cleanup:
  * ========================================================================= */
 
 #define TD_MAX_KERNEL_ARGS 64
-#define TD_FIXED_ARGS 4  /* grid_x, grid_y, grid_z, stream */
+#define TD_FIXED_ARGS 4 /* grid_x, grid_y, grid_z, stream */
 
 typedef union {
-    CUdeviceptr ptr;
-    int8_t   i8;
-    int16_t  i16;
-    int32_t  i32;
-    int64_t  i64;
-    uint8_t  u8;
-    uint16_t u16;
-    uint32_t u32;
-    uint64_t u64;
-    float    f32;
-    double   f64;
+  CUdeviceptr ptr;
+  int8_t i8;
+  int16_t i16;
+  int32_t i32;
+  int64_t i64;
+  uint8_t u8;
+  uint16_t u16;
+  uint32_t u32;
+  uint64_t u64;
+  float f32;
+  double f64;
 } TDArgSlot;
 
 typedef struct {
-    PyObject_HEAD
-    vectorcallfunc vectorcall;
-    CUfunction function;
-    unsigned grid_mult;     /* num_ctas — grid_x multiplied by this */
-    unsigned block_dim_x;   /* 32 * num_warps */
-    unsigned shared_mem;
-    CUlaunchAttribute launch_attrs[5];
-    unsigned num_launch_attrs;
-    int arg_types[TD_MAX_KERNEL_ARGS];  /* ExtractorTypeIndex values */
-    int num_args;
-    int total_params;
-    TDArgSlot arg_storage[TD_MAX_KERNEL_ARGS];
-    void *kernel_params[TD_MAX_KERNEL_ARGS];
-    int has_global_scratch;
-    int has_profile_scratch;
-    /* Scratch allocation support */
-    unsigned global_scratch_size;
-    unsigned global_scratch_align;
-    unsigned profile_scratch_size;
-    unsigned profile_scratch_align;
-    PyObject *allocator;          /* _allocation._allocator (ContextVar) */
-    PyObject *profile_allocator;  /* _allocation._profile_allocator (wrapper) */
+  PyObject_HEAD vectorcallfunc vectorcall;
+  CUfunction function;
+  unsigned grid_mult;   /* num_ctas — grid_x multiplied by this */
+  unsigned block_dim_x; /* 32 * num_warps */
+  unsigned shared_mem;
+  CUlaunchAttribute launch_attrs[5];
+  unsigned num_launch_attrs;
+  int arg_types[TD_MAX_KERNEL_ARGS]; /* ExtractorTypeIndex values */
+  int num_args;
+  int total_params;
+  TDArgSlot arg_storage[TD_MAX_KERNEL_ARGS];
+  void *kernel_params[TD_MAX_KERNEL_ARGS];
+  int has_global_scratch;
+  int has_profile_scratch;
+  /* Scratch allocation support */
+  unsigned global_scratch_size;
+  unsigned global_scratch_align;
+  unsigned profile_scratch_size;
+  unsigned profile_scratch_align;
+  PyObject *allocator;         /* _allocation._allocator (ContextVar) */
+  PyObject *profile_allocator; /* _allocation._profile_allocator (wrapper) */
 } TritonDispatcher;
 
 /* Forward declarations */
-static PyObject *TritonDispatcher_vectorcall(
-    PyObject *self, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static PyObject *TritonDispatcher_vectorcall(PyObject *self,
+                                             PyObject *const *args,
+                                             size_t nargsf, PyObject *kwnames);
 static void TritonDispatcher_dealloc(PyObject *self);
 
 /* Fast pointer extraction (no cuPointerGetAttribute validation — hot path) */
 static inline CUdeviceptr td_get_ptr(PyObject *obj) {
-    if (PyLong_Check(obj))
-        return (CUdeviceptr)PyLong_AsUnsignedLongLong(obj);
-    if (obj == Py_None)
-        return 0;
-    PyObject *r = PyObject_CallMethodNoArgs(obj, data_ptr_str);
-    if (!r) return 0;
-    CUdeviceptr p = (CUdeviceptr)PyLong_AsUnsignedLongLong(r);
-    Py_DECREF(r);
-    return p;
+  if (PyLong_Check(obj))
+    return (CUdeviceptr)PyLong_AsUnsignedLongLong(obj);
+  if (obj == Py_None)
+    return 0;
+  PyObject *r = PyObject_CallMethodNoArgs(obj, data_ptr_str);
+  if (!r)
+    return 0;
+  CUdeviceptr p = (CUdeviceptr)PyLong_AsUnsignedLongLong(r);
+  Py_DECREF(r);
+  return p;
 }
 
 /* Fast fp16/bf16 packing (equivalent to extractFP16/BF16 but returns value) */
 static inline uint16_t td_pack_fp16(double v) {
-    uint16_t result;
-#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && \
+  uint16_t result;
+#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 &&            \
     !defined(PYPY_VERSION)
-    _PyFloat_Pack2(v, (unsigned char *)&result, 1);
+  _PyFloat_Pack2(v, (unsigned char *)&result, 1);
 #else
-    PyFloat_Pack2(v, (char *)&result, 1);
+  PyFloat_Pack2(v, (char *)&result, 1);
 #endif
-    return result;
+  return result;
 }
 static inline uint16_t td_pack_bf16(double v) {
-    float f = (float)v;
-    uint32_t b; memcpy(&b, &f, 4);
-    return (uint16_t)(b >> 16);
+  float f = (float)v;
+  uint32_t b;
+  memcpy(&b, &f, 4);
+  return (uint16_t)(b >> 16);
 }
 
 /* Arg conversion using ExtractorTypeIndex codes */
-static inline int td_convert_args(TritonDispatcher *self, PyObject *const *kargs) {
-    for (int i = 0; i < self->num_args; i++) {
-        PyObject *a = kargs[i];
-        TDArgSlot *s = &self->arg_storage[i];
-        switch (self->arg_types[i]) {
-        case EXTRACTOR_POINTER_INDEX:
-            s->ptr = td_get_ptr(a);
-            break;
-        case EXTRACTOR_INT8_INDEX:  s->i8  = (int8_t)PyLong_AsLong(a); break;
-        case EXTRACTOR_INT16_INDEX: s->i16 = (int16_t)PyLong_AsLong(a); break;
-        case EXTRACTOR_INT32_INDEX: s->i32 = (int32_t)PyLong_AsLong(a); break;
-        case EXTRACTOR_INT64_INDEX: s->i64 = (int64_t)PyLong_AsLongLong(a); break;
-        case EXTRACTOR_UINT8_INDEX:  s->u8  = (uint8_t)PyLong_AsUnsignedLong(a); break;
-        case EXTRACTOR_UINT16_INDEX: s->u16 = (uint16_t)PyLong_AsUnsignedLong(a); break;
-        case EXTRACTOR_UINT32_INDEX: s->u32 = (uint32_t)PyLong_AsUnsignedLong(a); break;
-        case EXTRACTOR_UINT64_INDEX: s->u64 = (uint64_t)PyLong_AsUnsignedLongLong(a); break;
-        case EXTRACTOR_FP16_INDEX: s->u16 = td_pack_fp16(PyFloat_AsDouble(a)); break;
-        case EXTRACTOR_BF16_INDEX: s->u16 = td_pack_bf16(PyFloat_AsDouble(a)); break;
-        case EXTRACTOR_FP32_INDEX: { float f = (float)PyFloat_AsDouble(a); memcpy(&s->u32, &f, 4); break; }
-        case EXTRACTOR_FP64_INDEX: s->f64 = PyFloat_AsDouble(a); break;
-        default:
-            PyErr_Format(PyExc_TypeError, "Unknown type code %d for arg %d", self->arg_types[i], i);
-            return -1;
-        }
+static inline int td_convert_args(TritonDispatcher *self,
+                                  PyObject *const *kargs) {
+  for (int i = 0; i < self->num_args; i++) {
+    PyObject *a = kargs[i];
+    TDArgSlot *s = &self->arg_storage[i];
+    switch (self->arg_types[i]) {
+    case EXTRACTOR_POINTER_INDEX:
+      s->ptr = td_get_ptr(a);
+      break;
+    case EXTRACTOR_INT8_INDEX:
+      s->i8 = (int8_t)PyLong_AsLong(a);
+      break;
+    case EXTRACTOR_INT16_INDEX:
+      s->i16 = (int16_t)PyLong_AsLong(a);
+      break;
+    case EXTRACTOR_INT32_INDEX:
+      s->i32 = (int32_t)PyLong_AsLong(a);
+      break;
+    case EXTRACTOR_INT64_INDEX:
+      s->i64 = (int64_t)PyLong_AsLongLong(a);
+      break;
+    case EXTRACTOR_UINT8_INDEX:
+      s->u8 = (uint8_t)PyLong_AsUnsignedLong(a);
+      break;
+    case EXTRACTOR_UINT16_INDEX:
+      s->u16 = (uint16_t)PyLong_AsUnsignedLong(a);
+      break;
+    case EXTRACTOR_UINT32_INDEX:
+      s->u32 = (uint32_t)PyLong_AsUnsignedLong(a);
+      break;
+    case EXTRACTOR_UINT64_INDEX:
+      s->u64 = (uint64_t)PyLong_AsUnsignedLongLong(a);
+      break;
+    case EXTRACTOR_FP16_INDEX:
+      s->u16 = td_pack_fp16(PyFloat_AsDouble(a));
+      break;
+    case EXTRACTOR_BF16_INDEX:
+      s->u16 = td_pack_bf16(PyFloat_AsDouble(a));
+      break;
+    case EXTRACTOR_FP32_INDEX: {
+      float f = (float)PyFloat_AsDouble(a);
+      memcpy(&s->u32, &f, 4);
+      break;
     }
-    if (PyErr_Occurred()) return -1;
-    return 0;
+    case EXTRACTOR_FP64_INDEX:
+      s->f64 = PyFloat_AsDouble(a);
+      break;
+    default:
+      PyErr_Format(PyExc_TypeError, "Unknown type code %d for arg %d",
+                   self->arg_types[i], i);
+      return -1;
+    }
+  }
+  if (PyErr_Occurred())
+    return -1;
+  return 0;
 }
 
 /* Relaunch with pre-built attrs (cuLaunchKernelEx wrapper) */
-static inline CUresult td_relaunch(
-    TritonDispatcher *d, unsigned gx, unsigned gy, unsigned gz, CUstream stream)
-{
-    if (gx * gy * gz == 0) return CUDA_SUCCESS;
-    CUlaunchConfig cfg;
-    cfg.gridDimX = gx * d->grid_mult; cfg.gridDimY = gy; cfg.gridDimZ = gz;
-    cfg.blockDimX = d->block_dim_x; cfg.blockDimY = 1; cfg.blockDimZ = 1;
-    cfg.sharedMemBytes = d->shared_mem; cfg.hStream = stream;
-    cfg.attrs = d->num_launch_attrs > 0 ? d->launch_attrs : NULL;
-    cfg.numAttrs = d->num_launch_attrs;
-    return ensureLaunchHandle()(&cfg, d->function, d->kernel_params, NULL);
+static inline CUresult td_relaunch(TritonDispatcher *d, unsigned gx,
+                                   unsigned gy, unsigned gz, CUstream stream) {
+  if (gx * gy * gz == 0)
+    return CUDA_SUCCESS;
+  CUlaunchConfig cfg;
+  cfg.gridDimX = gx * d->grid_mult;
+  cfg.gridDimY = gy;
+  cfg.gridDimZ = gz;
+  cfg.blockDimX = d->block_dim_x;
+  cfg.blockDimY = 1;
+  cfg.blockDimZ = 1;
+  cfg.sharedMemBytes = d->shared_mem;
+  cfg.hStream = stream;
+  cfg.attrs = d->num_launch_attrs > 0 ? d->launch_attrs : NULL;
+  cfg.numAttrs = d->num_launch_attrs;
+  return ensureLaunchHandle()(&cfg, d->function, d->kernel_params, NULL);
 }
 
 /* ---- Constructor ---- */
-static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
-    unsigned long long func_ptr;
-    int num_warps, num_ctas, shared_mem;
-    int launch_pdl, launch_coop, launch_cluster;
-    PyObject *arg_type_codes;
-    int has_global_scratch, has_profile_scratch;
-    unsigned global_scratch_size = 0, global_scratch_align = 1;
-    unsigned profile_scratch_size = 0, profile_scratch_align = 1;
-    PyObject *allocator_obj = NULL, *profile_allocator_obj = NULL;
+static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
+                                      PyObject *kwargs) {
+  unsigned long long func_ptr;
+  int num_warps, num_ctas, shared_mem;
+  int launch_pdl, launch_coop, launch_cluster;
+  PyObject *arg_type_codes;
+  int has_global_scratch, has_profile_scratch;
+  unsigned global_scratch_size = 0, global_scratch_align = 1;
+  unsigned profile_scratch_size = 0, profile_scratch_align = 1;
+  PyObject *allocator_obj = NULL, *profile_allocator_obj = NULL;
 
-    static char *kwlist[] = {
-        "function", "num_warps", "num_ctas", "shared_mem",
-        "launch_pdl", "launch_cooperative_grid", "launch_cluster",
-        "arg_type_codes", "has_global_scratch", "has_profile_scratch",
-        "global_scratch_size", "global_scratch_align",
-        "profile_scratch_size", "profile_scratch_align",
-        "allocator", "profile_allocator", NULL
-    };
+  static char *kwlist[] = {"function",
+                           "num_warps",
+                           "num_ctas",
+                           "shared_mem",
+                           "launch_pdl",
+                           "launch_cooperative_grid",
+                           "launch_cluster",
+                           "arg_type_codes",
+                           "has_global_scratch",
+                           "has_profile_scratch",
+                           "global_scratch_size",
+                           "global_scratch_align",
+                           "profile_scratch_size",
+                           "profile_scratch_align",
+                           "allocator",
+                           "profile_allocator",
+                           NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "KiiiiiiOpp|IIIIOO", kwlist,
-            &func_ptr, &num_warps, &num_ctas, &shared_mem,
-            &launch_pdl, &launch_coop, &launch_cluster,
-            &arg_type_codes, &has_global_scratch, &has_profile_scratch,
-            &global_scratch_size, &global_scratch_align,
-            &profile_scratch_size, &profile_scratch_align,
-            &allocator_obj, &profile_allocator_obj))
-        return NULL;
+  if (!PyArg_ParseTupleAndKeywords(
+          args, kwargs, "KiiiiiiOpp|IIIIOO", kwlist, &func_ptr, &num_warps,
+          &num_ctas, &shared_mem, &launch_pdl, &launch_coop, &launch_cluster,
+          &arg_type_codes, &has_global_scratch, &has_profile_scratch,
+          &global_scratch_size, &global_scratch_align, &profile_scratch_size,
+          &profile_scratch_align, &allocator_obj, &profile_allocator_obj))
+    return NULL;
 
-    TritonDispatcher *self = (TritonDispatcher *)type->tp_alloc(type, 0);
-    if (!self) return NULL;
+  TritonDispatcher *self = (TritonDispatcher *)type->tp_alloc(type, 0);
+  if (!self)
+    return NULL;
 
-    self->vectorcall = TritonDispatcher_vectorcall;
-    self->function = (CUfunction)(uintptr_t)func_ptr;
-    self->grid_mult = (unsigned)num_ctas;
-    self->block_dim_x = 32 * (unsigned)num_warps;
-    self->shared_mem = (unsigned)shared_mem;
-    self->has_global_scratch = has_global_scratch;
-    self->has_profile_scratch = has_profile_scratch;
-    self->global_scratch_size = global_scratch_size;
-    self->global_scratch_align = global_scratch_align;
-    self->profile_scratch_size = profile_scratch_size;
-    self->profile_scratch_align = profile_scratch_align;
-    self->allocator = allocator_obj;
-    Py_XINCREF(self->allocator);
-    self->profile_allocator = profile_allocator_obj;
-    Py_XINCREF(self->profile_allocator);
+  self->vectorcall = TritonDispatcher_vectorcall;
+  self->function = (CUfunction)(uintptr_t)func_ptr;
+  self->grid_mult = (unsigned)num_ctas;
+  self->block_dim_x = 32 * (unsigned)num_warps;
+  self->shared_mem = (unsigned)shared_mem;
+  self->has_global_scratch = has_global_scratch;
+  self->has_profile_scratch = has_profile_scratch;
+  self->global_scratch_size = global_scratch_size;
+  self->global_scratch_align = global_scratch_align;
+  self->profile_scratch_size = profile_scratch_size;
+  self->profile_scratch_align = profile_scratch_align;
+  self->allocator = allocator_obj;
+  Py_XINCREF(self->allocator);
+  self->profile_allocator = profile_allocator_obj;
+  Py_XINCREF(self->profile_allocator);
 
-    memset(self->launch_attrs, 0, sizeof(self->launch_attrs));
-    memset(self->arg_storage, 0, sizeof(self->arg_storage));
-    memset(self->kernel_params, 0, sizeof(self->kernel_params));
+  memset(self->launch_attrs, 0, sizeof(self->launch_attrs));
+  memset(self->arg_storage, 0, sizeof(self->arg_storage));
+  memset(self->kernel_params, 0, sizeof(self->kernel_params));
 
-    /* Parse arg types (ExtractorTypeIndex values from buildSignatureMetadata) */
-    Py_ssize_t n = PyTuple_Size(arg_type_codes);
-    if (n > TD_MAX_KERNEL_ARGS - 2) {
-        PyErr_SetString(PyExc_ValueError, "Too many kernel args");
-        Py_DECREF(self);
-        return NULL;
+  /* Parse arg types (ExtractorTypeIndex values from buildSignatureMetadata) */
+  Py_ssize_t n = PyTuple_Size(arg_type_codes);
+  if (n > TD_MAX_KERNEL_ARGS - 2) {
+    PyErr_SetString(PyExc_ValueError, "Too many kernel args");
+    Py_DECREF(self);
+    return NULL;
+  }
+  self->num_args = (int)n;
+  for (Py_ssize_t i = 0; i < n; i++)
+    self->arg_types[i] =
+        (int)PyLong_AsLong(PyTuple_GET_ITEM(arg_type_codes, i));
+  if (PyErr_Occurred()) {
+    Py_DECREF(self);
+    return NULL;
+  }
+
+  /* Build kernel_params pointers */
+  int pidx = 0;
+  for (int i = 0; i < self->num_args; i++) {
+    self->kernel_params[pidx] = &self->arg_storage[pidx];
+    pidx++;
+  }
+  self->kernel_params[pidx] = &self->arg_storage[pidx];
+  pidx++; /* global_scratch */
+  self->kernel_params[pidx] = &self->arg_storage[pidx];
+  pidx++; /* profile_scratch */
+  self->total_params = pidx;
+
+  /* Pre-build launch attributes */
+  unsigned na = 0;
+  if (launch_pdl) {
+    self->launch_attrs[na].id =
+        CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+    self->launch_attrs[na].value.programmaticStreamSerializationAllowed = 1;
+    na++;
+  }
+  if (launch_coop) {
+    self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+    self->launch_attrs[na].value.cooperative = 1;
+    na++;
+  }
+  if (launch_cluster || num_ctas > 1) {
+    if (num_ctas > 1) {
+      self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+      self->launch_attrs[na].value.clusterDim.x = num_ctas;
+      self->launch_attrs[na].value.clusterDim.y = 1;
+      self->launch_attrs[na].value.clusterDim.z = 1;
+      na++;
     }
-    self->num_args = (int)n;
-    for (Py_ssize_t i = 0; i < n; i++)
-        self->arg_types[i] = (int)PyLong_AsLong(PyTuple_GET_ITEM(arg_type_codes, i));
-    if (PyErr_Occurred()) {
-        Py_DECREF(self);
-        return NULL;
-    }
+    self->launch_attrs[na].id =
+        CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+    self->launch_attrs[na].value.clusterSchedulingPolicyPreference =
+        CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+    na++;
+  }
+  self->num_launch_attrs = na;
 
-    /* Build kernel_params pointers */
-    int pidx = 0;
-    for (int i = 0; i < self->num_args; i++) {
-        self->kernel_params[pidx] = &self->arg_storage[pidx];
-        pidx++;
-    }
-    self->kernel_params[pidx] = &self->arg_storage[pidx]; pidx++;  /* global_scratch */
-    self->kernel_params[pidx] = &self->arg_storage[pidx]; pidx++;  /* profile_scratch */
-    self->total_params = pidx;
-
-    /* Pre-build launch attributes */
-    unsigned na = 0;
-    if (launch_pdl) {
-        self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
-        self->launch_attrs[na].value.programmaticStreamSerializationAllowed = 1;
-        na++;
-    }
-    if (launch_coop) {
-        self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
-        self->launch_attrs[na].value.cooperative = 1;
-        na++;
-    }
-    if (launch_cluster || num_ctas > 1) {
-        if (num_ctas > 1) {
-            self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-            self->launch_attrs[na].value.clusterDim.x = num_ctas;
-            self->launch_attrs[na].value.clusterDim.y = 1;
-            self->launch_attrs[na].value.clusterDim.z = 1;
-            na++;
-        }
-        self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
-        self->launch_attrs[na].value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
-        na++;
-    }
-    self->num_launch_attrs = na;
-
-    return (PyObject *)self;
+  return (PyObject *)self;
 }
 
 static void TritonDispatcher_dealloc(PyObject *o) {
-    TritonDispatcher *self = (TritonDispatcher *)o;
-    Py_XDECREF(self->allocator);
-    Py_XDECREF(self->profile_allocator);
-    Py_TYPE(o)->tp_free(o);
+  TritonDispatcher *self = (TritonDispatcher *)o;
+  Py_XDECREF(self->allocator);
+  Py_XDECREF(self->profile_allocator);
+  Py_TYPE(o)->tp_free(o);
 }
 
 /* ==== THE HOT PATH ==== */
-static PyObject *TritonDispatcher_vectorcall(
-    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
-{
-    TritonDispatcher *self = (TritonDispatcher *)callable;
-    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+static PyObject *TritonDispatcher_vectorcall(PyObject *callable,
+                                             PyObject *const *args,
+                                             size_t nargsf, PyObject *kwnames) {
+  TritonDispatcher *self = (TritonDispatcher *)callable;
+  Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
 
-    if (nargs < TD_FIXED_ARGS + self->num_args) {
-        PyErr_Format(PyExc_TypeError,
-            "_TritonDispatcher: expected %d args, got %zd",
-            TD_FIXED_ARGS + self->num_args, nargs);
-        return NULL;
-    }
+  if (nargs < TD_FIXED_ARGS + self->num_args) {
+    PyErr_Format(PyExc_TypeError,
+                 "_TritonDispatcher: expected %d args, got %zd",
+                 TD_FIXED_ARGS + self->num_args, nargs);
+    return NULL;
+  }
 
-    long gx_l = PyLong_AsLong(args[0]);
-    long gy_l = PyLong_AsLong(args[1]);
-    long gz_l = PyLong_AsLong(args[2]);
-    if (PyErr_Occurred()) return NULL;
+  long gx_l = PyLong_AsLong(args[0]);
+  long gy_l = PyLong_AsLong(args[1]);
+  long gz_l = PyLong_AsLong(args[2]);
+  if (PyErr_Occurred())
+    return NULL;
 
-    unsigned gx = (unsigned)gx_l;
-    unsigned gy = (unsigned)gy_l;
-    unsigned gz = (unsigned)gz_l;
+  unsigned gx = (unsigned)gx_l;
+  unsigned gy = (unsigned)gy_l;
+  unsigned gz = (unsigned)gz_l;
 
-    if (gx * gy * gz == 0)
-        Py_RETURN_NONE;
-
-    CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(args[3]);
-
-    /* Convert kernel args.
-     * No cleanup needed on failure: scratch/profile buffers are allocated below,
-     * and no other resources have been acquired at this point. */
-    if (td_convert_args(self, args + TD_FIXED_ARGS) < 0)
-        return NULL;
-
-    /* Scratch allocation: call Python allocator if scratch is needed.
-     * alloc_size = grid_x * grid_y * grid_z * num_ctas * scratch_size */
-    PyObject *scratch_buf = NULL, *profile_buf = NULL;
-    if (self->global_scratch_size > 0 && self->allocator) {
-        unsigned long long alloc_size =
-            (unsigned long long)gx * gy * gz * self->grid_mult * self->global_scratch_size;
-        PyObject *alloc_fn = PyObject_CallMethodNoArgs(self->allocator, td_get_str);
-        if (!alloc_fn) return NULL;
-        scratch_buf = PyObject_CallFunction(alloc_fn, "KIK",
-            alloc_size, (unsigned)self->global_scratch_align, (unsigned long long)(uintptr_t)stream);
-        Py_DECREF(alloc_fn);
-        if (!scratch_buf) return NULL;
-        PyObject *ptr_obj = PyObject_CallMethodNoArgs(scratch_buf, data_ptr_str);
-        if (!ptr_obj) { Py_DECREF(scratch_buf); return NULL; }
-        self->arg_storage[self->num_args].ptr = (CUdeviceptr)PyLong_AsUnsignedLongLong(ptr_obj);
-        Py_DECREF(ptr_obj);
-    } else {
-        self->arg_storage[self->num_args].ptr = 0;
-    }
-
-    if (self->profile_scratch_size > 0 && self->profile_allocator) {
-        unsigned long long alloc_size =
-            (unsigned long long)gx * gy * gz * self->grid_mult * self->profile_scratch_size;
-        PyObject *alloc_fn = PyObject_CallMethodNoArgs(self->profile_allocator, td_get_str);
-        if (!alloc_fn) { Py_XDECREF(scratch_buf); return NULL; }
-        profile_buf = PyObject_CallFunction(alloc_fn, "KIK",
-            alloc_size, (unsigned)self->profile_scratch_align, (unsigned long long)(uintptr_t)stream);
-        Py_DECREF(alloc_fn);
-        if (!profile_buf) { Py_XDECREF(scratch_buf); return NULL; }
-        PyObject *ptr_obj = PyObject_CallMethodNoArgs(profile_buf, data_ptr_str);
-        if (!ptr_obj) { Py_DECREF(profile_buf); Py_XDECREF(scratch_buf); return NULL; }
-        self->arg_storage[self->num_args + 1].ptr = (CUdeviceptr)PyLong_AsUnsignedLongLong(ptr_obj);
-        Py_DECREF(ptr_obj);
-    } else {
-        self->arg_storage[self->num_args + 1].ptr = 0;
-    }
-
-    /* Launch using pre-built attrs.
-     * Thread safety: arg_storage is per-instance and the GIL is held up to
-     * Py_BEGIN_ALLOW_THREADS. cuLaunchKernelEx copies kernel_params at call
-     * entry (documented CUDA driver behavior), so releasing the GIL after
-     * the call begins is safe — another thread cannot corrupt params mid-copy. */
-    CUresult err;
-    Py_BEGIN_ALLOW_THREADS
-    err = td_relaunch(self, gx, gy, gz, stream);
-    Py_END_ALLOW_THREADS
-
-    /* Release scratch buffers after launch (kernel params already copied) */
-    Py_XDECREF(scratch_buf);
-    Py_XDECREF(profile_buf);
-
-    if (err != CUDA_SUCCESS) {
-        const char *s = NULL;
-        cuGetErrorString(err, &s);
-        PyErr_Format(PyExc_RuntimeError,
-            "Triton Error [CUDA]: cuLaunchKernelEx failed: %s (%d)",
-            s ? s : "unknown", (int)err);
-        return NULL;
-    }
-
+  if (gx * gy * gz == 0)
     Py_RETURN_NONE;
+
+  CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(args[3]);
+
+  /* Convert kernel args.
+   * No cleanup needed on failure: scratch/profile buffers are allocated below,
+   * and no other resources have been acquired at this point. */
+  if (td_convert_args(self, args + TD_FIXED_ARGS) < 0)
+    return NULL;
+
+  /* Scratch allocation: call Python allocator if scratch is needed.
+   * alloc_size = grid_x * grid_y * grid_z * num_ctas * scratch_size */
+  PyObject *scratch_buf = NULL, *profile_buf = NULL;
+  if (self->global_scratch_size > 0 && self->allocator) {
+    unsigned long long alloc_size = (unsigned long long)gx * gy * gz *
+                                    self->grid_mult * self->global_scratch_size;
+    PyObject *alloc_fn = PyObject_CallMethodNoArgs(self->allocator, td_get_str);
+    if (!alloc_fn)
+      return NULL;
+    scratch_buf = PyObject_CallFunction(alloc_fn, "KIK", alloc_size,
+                                        (unsigned)self->global_scratch_align,
+                                        (unsigned long long)(uintptr_t)stream);
+    Py_DECREF(alloc_fn);
+    if (!scratch_buf)
+      return NULL;
+    PyObject *ptr_obj = PyObject_CallMethodNoArgs(scratch_buf, data_ptr_str);
+    if (!ptr_obj) {
+      Py_DECREF(scratch_buf);
+      return NULL;
+    }
+    self->arg_storage[self->num_args].ptr =
+        (CUdeviceptr)PyLong_AsUnsignedLongLong(ptr_obj);
+    Py_DECREF(ptr_obj);
+  } else {
+    self->arg_storage[self->num_args].ptr = 0;
+  }
+
+  if (self->profile_scratch_size > 0 && self->profile_allocator) {
+    unsigned long long alloc_size = (unsigned long long)gx * gy * gz *
+                                    self->grid_mult *
+                                    self->profile_scratch_size;
+    PyObject *alloc_fn =
+        PyObject_CallMethodNoArgs(self->profile_allocator, td_get_str);
+    if (!alloc_fn) {
+      Py_XDECREF(scratch_buf);
+      return NULL;
+    }
+    profile_buf = PyObject_CallFunction(alloc_fn, "KIK", alloc_size,
+                                        (unsigned)self->profile_scratch_align,
+                                        (unsigned long long)(uintptr_t)stream);
+    Py_DECREF(alloc_fn);
+    if (!profile_buf) {
+      Py_XDECREF(scratch_buf);
+      return NULL;
+    }
+    PyObject *ptr_obj = PyObject_CallMethodNoArgs(profile_buf, data_ptr_str);
+    if (!ptr_obj) {
+      Py_DECREF(profile_buf);
+      Py_XDECREF(scratch_buf);
+      return NULL;
+    }
+    self->arg_storage[self->num_args + 1].ptr =
+        (CUdeviceptr)PyLong_AsUnsignedLongLong(ptr_obj);
+    Py_DECREF(ptr_obj);
+  } else {
+    self->arg_storage[self->num_args + 1].ptr = 0;
+  }
+
+  /* Launch using pre-built attrs.
+   * Thread safety: arg_storage is per-instance and the GIL is held up to
+   * Py_BEGIN_ALLOW_THREADS. cuLaunchKernelEx copies kernel_params at call
+   * entry (documented CUDA driver behavior), so releasing the GIL after
+   * the call begins is safe — another thread cannot corrupt params mid-copy. */
+  CUresult err;
+  Py_BEGIN_ALLOW_THREADS err = td_relaunch(self, gx, gy, gz, stream);
+  Py_END_ALLOW_THREADS
+
+      /* Release scratch buffers after launch (kernel params already copied) */
+      Py_XDECREF(scratch_buf);
+  Py_XDECREF(profile_buf);
+
+  if (err != CUDA_SUCCESS) {
+    const char *s = NULL;
+    cuGetErrorString(err, &s);
+    PyErr_Format(PyExc_RuntimeError,
+                 "Triton Error [CUDA]: cuLaunchKernelEx failed: %s (%d)",
+                 s ? s : "unknown", (int)err);
+    return NULL;
+  }
+
+  Py_RETURN_NONE;
 }
 
 static PyTypeObject TritonDispatcherType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "triton.backends.nvidia._TritonDispatcher",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name =
+        "triton.backends.nvidia._TritonDispatcher",
     .tp_basicsize = sizeof(TritonDispatcher),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
     .tp_vectorcall_offset = offsetof(TritonDispatcher, vectorcall),
@@ -2053,109 +2127,133 @@ static PyTypeObject TritonDispatcherType = {
 };
 
 typedef struct {
-    PyObject_HEAD
-    vectorcallfunc vectorcall;
-    TritonDispatcher *dispatcher;
-    unsigned grid[3];
-    PyObject *get_stream_fn;
-    PyObject *get_device_fn;
-    int num_args;
-    PyObject *slow_path_fn;
+  PyObject_HEAD vectorcallfunc vectorcall;
+  TritonDispatcher *dispatcher;
+  unsigned grid[3];
+  PyObject *get_stream_fn;
+  PyObject *get_device_fn;
+  int num_args;
+  PyObject *slow_path_fn;
 } TritonJITRunner;
 
-static PyObject *JITRunner_vectorcall(
-    PyObject *self, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static PyObject *JITRunner_vectorcall(PyObject *self, PyObject *const *args,
+                                      size_t nargsf, PyObject *kwnames);
 static void JITRunner_dealloc(PyObject *self);
 
-static PyObject *JITRunner_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
-    PyObject *dispatcher_obj, *grid_tuple, *get_stream_fn, *get_device_fn, *slow_path_fn;
-    int num_kernel_args;
+static PyObject *JITRunner_new(PyTypeObject *type, PyObject *args,
+                               PyObject *kwargs) {
+  PyObject *dispatcher_obj, *grid_tuple, *get_stream_fn, *get_device_fn,
+      *slow_path_fn;
+  int num_kernel_args;
 
-    static char *kwlist[] = {
-        "dispatcher", "grid", "get_stream_fn", "get_device_fn", "slow_path_fn", "num_kernel_args", NULL
-    };
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOOOi", kwlist,
-            &dispatcher_obj, &grid_tuple, &get_stream_fn, &get_device_fn, &slow_path_fn, &num_kernel_args))
-        return NULL;
+  static char *kwlist[] = {"dispatcher",
+                           "grid",
+                           "get_stream_fn",
+                           "get_device_fn",
+                           "slow_path_fn",
+                           "num_kernel_args",
+                           NULL};
+  if (!PyArg_ParseTupleAndKeywords(
+          args, kwargs, "OOOOOi", kwlist, &dispatcher_obj, &grid_tuple,
+          &get_stream_fn, &get_device_fn, &slow_path_fn, &num_kernel_args))
+    return NULL;
 
-    TritonJITRunner *self = (TritonJITRunner *)type->tp_alloc(type, 0);
-    if (!self) return NULL;
+  TritonJITRunner *self = (TritonJITRunner *)type->tp_alloc(type, 0);
+  if (!self)
+    return NULL;
 
-    self->vectorcall = JITRunner_vectorcall;
-    self->dispatcher = (TritonDispatcher *)dispatcher_obj;
-    Py_INCREF(dispatcher_obj);
+  self->vectorcall = JITRunner_vectorcall;
+  self->dispatcher = (TritonDispatcher *)dispatcher_obj;
+  Py_INCREF(dispatcher_obj);
 
-    Py_ssize_t gs = PyTuple_Size(grid_tuple);
-    self->grid[0] = (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
-    self->grid[1] = (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
-    self->grid[2] = (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
+  Py_ssize_t gs = PyTuple_Size(grid_tuple);
+  self->grid[0] =
+      (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
+  self->grid[1] =
+      (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
+  self->grid[2] =
+      (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
 
-    self->get_stream_fn = get_stream_fn; Py_INCREF(get_stream_fn);
-    self->get_device_fn = get_device_fn; Py_INCREF(get_device_fn);
-    self->slow_path_fn = slow_path_fn; Py_INCREF(slow_path_fn);
-    self->num_args = num_kernel_args;
+  self->get_stream_fn = get_stream_fn;
+  Py_INCREF(get_stream_fn);
+  self->get_device_fn = get_device_fn;
+  Py_INCREF(get_device_fn);
+  self->slow_path_fn = slow_path_fn;
+  Py_INCREF(slow_path_fn);
+  self->num_args = num_kernel_args;
 
-    return (PyObject *)self;
+  return (PyObject *)self;
 }
 
 static void JITRunner_dealloc(PyObject *o) {
-    TritonJITRunner *self = (TritonJITRunner *)o;
-    Py_XDECREF((PyObject *)self->dispatcher);
-    Py_XDECREF(self->get_stream_fn);
-    Py_XDECREF(self->get_device_fn);
-    Py_XDECREF(self->slow_path_fn);
-    Py_TYPE(o)->tp_free(o);
+  TritonJITRunner *self = (TritonJITRunner *)o;
+  Py_XDECREF((PyObject *)self->dispatcher);
+  Py_XDECREF(self->get_stream_fn);
+  Py_XDECREF(self->get_device_fn);
+  Py_XDECREF(self->slow_path_fn);
+  Py_TYPE(o)->tp_free(o);
 }
 
-static PyObject *JITRunner_vectorcall(
-    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
-{
-    TritonJITRunner *self = (TritonJITRunner *)callable;
-    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+static PyObject *JITRunner_vectorcall(PyObject *callable, PyObject *const *args,
+                                      size_t nargsf, PyObject *kwnames) {
+  TritonJITRunner *self = (TritonJITRunner *)callable;
+  Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
 
-    if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
-        return PyObject_Vectorcall(self->slow_path_fn, args, nargsf, kwnames);
-    }
-    if (nargs < self->num_args) {
-        PyErr_Format(PyExc_TypeError,
-            "_TritonJITRunner: expected %d args, got %zd", self->num_args, nargs);
-        return NULL;
-    }
+  if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
+    return PyObject_Vectorcall(self->slow_path_fn, args, nargsf, kwnames);
+  }
+  if (nargs < self->num_args) {
+    PyErr_Format(PyExc_TypeError, "_TritonJITRunner: expected %d args, got %zd",
+                 self->num_args, nargs);
+    return NULL;
+  }
 
-    /* The caller (activate_fast_dispatch) ensures the kernel is already
-     * compiled for these arg types. We just extract + launch. */
-    PyObject *device = PyObject_CallNoArgs(self->get_device_fn);
-    if (!device) return NULL;
-    PyObject *stream_obj = PyObject_CallOneArg(self->get_stream_fn, device);
-    Py_DECREF(device);
-    if (!stream_obj) return NULL;
-    uint64_t stream = PyLong_AsUnsignedLongLong(stream_obj);
-    Py_DECREF(stream_obj);
+  /* The caller (activate_fast_dispatch) ensures the kernel is already
+   * compiled for these arg types. We just extract + launch. */
+  PyObject *device = PyObject_CallNoArgs(self->get_device_fn);
+  if (!device)
+    return NULL;
+  PyObject *stream_obj = PyObject_CallOneArg(self->get_stream_fn, device);
+  Py_DECREF(device);
+  if (!stream_obj)
+    return NULL;
+  uint64_t stream = PyLong_AsUnsignedLongLong(stream_obj);
+  Py_DECREF(stream_obj);
 
-    /* Build dispatcher args: [grid_x, grid_y, grid_z, stream, *kernel_args] */
-    Py_ssize_t disp_nargs = TD_FIXED_ARGS + self->num_args;
-    PyObject **disp_args = (PyObject **)alloca(disp_nargs * sizeof(PyObject *));
-    PyObject *gx = PyLong_FromUnsignedLong(self->grid[0]);
-    PyObject *gy = PyLong_FromUnsignedLong(self->grid[1]);
-    PyObject *gz = PyLong_FromUnsignedLong(self->grid[2]);
-    PyObject *st = PyLong_FromUnsignedLongLong(stream);
-    if (!gx || !gy || !gz || !st) {
-        Py_XDECREF(gx); Py_XDECREF(gy); Py_XDECREF(gz); Py_XDECREF(st);
-        return NULL;
-    }
-    disp_args[0] = gx; disp_args[1] = gy; disp_args[2] = gz; disp_args[3] = st;
-    for (int i = 0; i < self->num_args; i++)
-        disp_args[TD_FIXED_ARGS + i] = (PyObject *)args[i];
+  /* Build dispatcher args: [grid_x, grid_y, grid_z, stream, *kernel_args] */
+  Py_ssize_t disp_nargs = TD_FIXED_ARGS + self->num_args;
+  PyObject **disp_args = (PyObject **)alloca(disp_nargs * sizeof(PyObject *));
+  PyObject *gx = PyLong_FromUnsignedLong(self->grid[0]);
+  PyObject *gy = PyLong_FromUnsignedLong(self->grid[1]);
+  PyObject *gz = PyLong_FromUnsignedLong(self->grid[2]);
+  PyObject *st = PyLong_FromUnsignedLongLong(stream);
+  if (!gx || !gy || !gz || !st) {
+    Py_XDECREF(gx);
+    Py_XDECREF(gy);
+    Py_XDECREF(gz);
+    Py_XDECREF(st);
+    return NULL;
+  }
+  disp_args[0] = gx;
+  disp_args[1] = gy;
+  disp_args[2] = gz;
+  disp_args[3] = st;
+  for (int i = 0; i < self->num_args; i++)
+    disp_args[TD_FIXED_ARGS + i] = (PyObject *)args[i];
 
-    PyObject *result = TritonDispatcher_vectorcall(
-        (PyObject *)self->dispatcher, (PyObject *const *)disp_args, disp_nargs, NULL);
-    Py_DECREF(gx); Py_DECREF(gy); Py_DECREF(gz); Py_DECREF(st);
-    return result;
+  PyObject *result = TritonDispatcher_vectorcall((PyObject *)self->dispatcher,
+                                                 (PyObject *const *)disp_args,
+                                                 disp_nargs, NULL);
+  Py_DECREF(gx);
+  Py_DECREF(gy);
+  Py_DECREF(gz);
+  Py_DECREF(st);
+  return result;
 }
 
 static PyTypeObject TritonJITRunnerType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "triton.backends.nvidia._TritonJITRunner",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name =
+        "triton.backends.nvidia._TritonJITRunner",
     .tp_basicsize = sizeof(TritonJITRunner),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
     .tp_vectorcall_offset = offsetof(TritonJITRunner, vectorcall),
@@ -2169,76 +2267,80 @@ static PyTypeObject TritonJITRunnerType = {
  * Pre-binds grid + stream getter + dispatcher. Always extracts args fresh
  * ========================================================================= */
 typedef struct {
-    PyObject_HEAD
-    vectorcallfunc vectorcall;
-    TritonDispatcher *dispatcher;
-    unsigned grid[3];
-    PyObject *get_stream_fn;
-    PyObject *get_device_fn;
-    PyObject *kernel;
-    int num_args;
+  PyObject_HEAD vectorcallfunc vectorcall;
+  TritonDispatcher *dispatcher;
+  unsigned grid[3];
+  PyObject *get_stream_fn;
+  PyObject *get_device_fn;
+  PyObject *kernel;
+  int num_args;
 } ProxyRunner;
 
-static PyObject *ProxyRunner_vectorcall(
-    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static PyObject *ProxyRunner_vectorcall(PyObject *callable,
+                                        PyObject *const *args, size_t nargsf,
+                                        PyObject *kwnames);
 static void ProxyRunner_dealloc(PyObject *o);
 
-static PyObject *ProxyRunner_vectorcall(
-    PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
-{
-    ProxyRunner *self = (ProxyRunner *)callable;
-    TritonDispatcher *d = self->dispatcher;
-    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+static PyObject *ProxyRunner_vectorcall(PyObject *callable,
+                                        PyObject *const *args, size_t nargsf,
+                                        PyObject *kwnames) {
+  ProxyRunner *self = (ProxyRunner *)callable;
+  TritonDispatcher *d = self->dispatcher;
+  Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
 
-    if (nargs < self->num_args) {
-        PyErr_Format(PyExc_TypeError,
-            "_ProxyRunner: expected >= %d args, got %zd", self->num_args, nargs);
-        return NULL;
-    }
+  if (nargs < self->num_args) {
+    PyErr_Format(PyExc_TypeError, "_ProxyRunner: expected >= %d args, got %zd",
+                 self->num_args, nargs);
+    return NULL;
+  }
 
-    /* Always extract args fresh */
-    if (td_convert_args(d, args) < 0) return NULL;
+  /* Always extract args fresh */
+  if (td_convert_args(d, args) < 0)
+    return NULL;
 
-    /* Get current stream */
-    PyObject *dev = PyObject_CallNoArgs(self->get_device_fn);
-    if (!dev) return NULL;
-    PyObject *st = PyObject_CallOneArg(self->get_stream_fn, dev);
-    Py_DECREF(dev);
-    if (!st) return NULL;
-    CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(st);
-    Py_DECREF(st);
+  /* Get current stream */
+  PyObject *dev = PyObject_CallNoArgs(self->get_device_fn);
+  if (!dev)
+    return NULL;
+  PyObject *st = PyObject_CallOneArg(self->get_stream_fn, dev);
+  Py_DECREF(dev);
+  if (!st)
+    return NULL;
+  CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(st);
+  Py_DECREF(st);
 
-    /* Launch.
-     * Thread safety: arg_storage is per-dispatcher-instance and td_convert_args
-     * runs while holding the GIL. cuLaunchKernelEx copies kernel_params at call
-     * entry (documented CUDA driver behavior), so releasing the GIL after the
-     * call begins is safe. Sharing the same dispatcher across Python threads is
-     * NOT supported — each ProxyRunner holds a dedicated dispatcher reference. */
-    CUresult err;
-    Py_BEGIN_ALLOW_THREADS
-    err = td_relaunch(d, self->grid[0], self->grid[1], self->grid[2], stream);
-    Py_END_ALLOW_THREADS
-    if (err != CUDA_SUCCESS) {
-        const char *s = NULL; cuGetErrorString(err, &s);
-        PyErr_Format(PyExc_RuntimeError, "cuLaunchKernelEx: %s (%d)", s?s:"?", (int)err);
-        return NULL;
-    }
-    Py_INCREF(self->kernel);
-    return self->kernel;
+  /* Launch.
+   * Thread safety: arg_storage is per-dispatcher-instance and td_convert_args
+   * runs while holding the GIL. cuLaunchKernelEx copies kernel_params at call
+   * entry (documented CUDA driver behavior), so releasing the GIL after the
+   * call begins is safe. Sharing the same dispatcher across Python threads is
+   * NOT supported — each ProxyRunner holds a dedicated dispatcher reference. */
+  CUresult err;
+  Py_BEGIN_ALLOW_THREADS err =
+      td_relaunch(d, self->grid[0], self->grid[1], self->grid[2], stream);
+  Py_END_ALLOW_THREADS if (err != CUDA_SUCCESS) {
+    const char *s = NULL;
+    cuGetErrorString(err, &s);
+    PyErr_Format(PyExc_RuntimeError, "cuLaunchKernelEx: %s (%d)", s ? s : "?",
+                 (int)err);
+    return NULL;
+  }
+  Py_INCREF(self->kernel);
+  return self->kernel;
 }
 
 static void ProxyRunner_dealloc(PyObject *o) {
-    ProxyRunner *self = (ProxyRunner *)o;
-    Py_XDECREF((PyObject *)self->dispatcher);
-    Py_XDECREF(self->get_stream_fn);
-    Py_XDECREF(self->get_device_fn);
-    Py_XDECREF(self->kernel);
-    Py_TYPE(o)->tp_free(o);
+  ProxyRunner *self = (ProxyRunner *)o;
+  Py_XDECREF((PyObject *)self->dispatcher);
+  Py_XDECREF(self->get_stream_fn);
+  Py_XDECREF(self->get_device_fn);
+  Py_XDECREF(self->kernel);
+  Py_TYPE(o)->tp_free(o);
 }
 
 static PyTypeObject ProxyRunnerType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "triton.backends.nvidia._ProxyRunner",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name =
+        "triton.backends.nvidia._ProxyRunner",
     .tp_basicsize = sizeof(ProxyRunner),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
     .tp_vectorcall_offset = offsetof(ProxyRunner, vectorcall),
@@ -2251,128 +2353,182 @@ static PyTypeObject ProxyRunnerType = {
  * Creates _ProxyRunner per grid, caching in _runner_cache dict.
  * ========================================================================= */
 static PyObject *fast_subscript(PyObject *self, PyObject *grid) {
-    static PyObject *_rc_key = NULL;
-    if (!_rc_key) _rc_key = PyUnicode_InternFromString("_runner_cache");
+  static PyObject *_rc_key = NULL;
+  if (!_rc_key)
+    _rc_key = PyUnicode_InternFromString("_runner_cache");
 
-    /* Normalize grid to tuple for consistent cache key */
-    PyObject *grid_tuple;
-    if (!PyTuple_Check(grid)) {
-        grid_tuple = PyTuple_Pack(1, grid);
-        if (!grid_tuple) return NULL;
-    } else {
-        grid_tuple = grid;
-        Py_INCREF(grid_tuple);
+  /* Normalize grid to tuple for consistent cache key */
+  PyObject *grid_tuple;
+  if (!PyTuple_Check(grid)) {
+    grid_tuple = PyTuple_Pack(1, grid);
+    if (!grid_tuple)
+      return NULL;
+  } else {
+    grid_tuple = grid;
+    Py_INCREF(grid_tuple);
+  }
+
+  PyObject **dictptr = _PyObject_GetDictPtr(self);
+  if (!dictptr || !*dictptr) {
+    Py_DECREF(grid_tuple);
+    goto fallback;
+  }
+  PyObject *dict = *dictptr;
+
+  PyObject *cache = PyDict_GetItem(dict, _rc_key);
+  if (!cache) {
+    Py_DECREF(grid_tuple);
+    goto fallback;
+  }
+
+  PyObject *runner = PyDict_GetItem(cache, grid_tuple);
+  if (runner) {
+    Py_DECREF(grid_tuple);
+    Py_INCREF(runner);
+    return runner;
+  }
+
+  /* Create new ProxyRunner */
+  {
+    static PyObject *_disp_key = NULL, *_nka_key = NULL, *_gsf_key = NULL,
+                    *_gdf_key = NULL, *_kern_key = NULL;
+    if (!_disp_key) {
+      _disp_key = PyUnicode_InternFromString("_fast_dispatcher");
+      _nka_key = PyUnicode_InternFromString("_fast_num_args");
+      _gsf_key = PyUnicode_InternFromString("_fast_get_stream");
+      _gdf_key = PyUnicode_InternFromString("_fast_get_device");
+      _kern_key = PyUnicode_InternFromString("_fast_kernel");
     }
 
-    PyObject **dictptr = _PyObject_GetDictPtr(self);
-    if (!dictptr || !*dictptr) { Py_DECREF(grid_tuple); goto fallback; }
-    PyObject *dict = *dictptr;
-
-    PyObject *cache = PyDict_GetItem(dict, _rc_key);
-    if (!cache) { Py_DECREF(grid_tuple); goto fallback; }
-
-    PyObject *runner = PyDict_GetItem(cache, grid_tuple);
-    if (runner) { Py_DECREF(grid_tuple); Py_INCREF(runner); return runner; }
-
-    /* Create new ProxyRunner */
-    {
-        static PyObject *_disp_key = NULL, *_nka_key = NULL, *_gsf_key = NULL, *_gdf_key = NULL, *_kern_key = NULL;
-        if (!_disp_key) {
-            _disp_key = PyUnicode_InternFromString("_fast_dispatcher");
-            _nka_key = PyUnicode_InternFromString("_fast_num_args");
-            _gsf_key = PyUnicode_InternFromString("_fast_get_stream");
-            _gdf_key = PyUnicode_InternFromString("_fast_get_device");
-            _kern_key = PyUnicode_InternFromString("_fast_kernel");
-        }
-
-        PyObject *disp = PyDict_GetItem(dict, _disp_key);
-        if (!disp) { Py_DECREF(grid_tuple); goto fallback; }
-        PyObject *kern = PyDict_GetItem(dict, _kern_key);
-        if (!kern) kern = Py_None;
-
-        PyObject *nka_obj = PyDict_GetItem(dict, _nka_key);
-        int nka = nka_obj ? (int)PyLong_AsLong(nka_obj) : 0;
-        PyObject *gsf = PyDict_GetItem(dict, _gsf_key);
-        PyObject *gdf = PyDict_GetItem(dict, _gdf_key);
-        if (!gsf || !gdf) { Py_DECREF(grid_tuple); goto fallback; }
-
-        ProxyRunner *pr = PyObject_New(ProxyRunner, &ProxyRunnerType);
-        if (!pr) { Py_DECREF(grid_tuple); return NULL; }
-        pr->vectorcall = ProxyRunner_vectorcall;
-        /* Multiple ProxyRunner instances may reference the same TritonDispatcher.
-         * This is safe because: (1) td_convert_args + cuLaunchKernelEx both run
-         * while holding the GIL, and cuLaunchKernelEx copies kernel_params at
-         * call entry before we release the GIL via Py_BEGIN_ALLOW_THREADS.
-         * (2) Each ProxyRunner_vectorcall completes the full sequence
-         * (convert → launch → GIL release) atomically from Python's perspective.
-         * Direct multi-threaded use of kernel._dispatcher without the GIL is
-         * unsupported (same restriction as all CPython C extension objects). */
-        pr->dispatcher = (TritonDispatcher *)disp; Py_INCREF(disp);
-        Py_ssize_t gs = PyTuple_Size(grid_tuple);
-        pr->grid[0] = (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
-        pr->grid[1] = (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
-        pr->grid[2] = (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
-
-        pr->get_stream_fn = gsf; Py_INCREF(gsf);
-        pr->get_device_fn = gdf; Py_INCREF(gdf);
-        pr->kernel = kern; Py_INCREF(kern);
-        pr->num_args = nka;
-
-        if (PyDict_SetItem(cache, grid_tuple, (PyObject *)pr) < 0) {
-            Py_DECREF(grid_tuple);
-            Py_DECREF(pr);
-            return NULL;
-        }
-        Py_DECREF(grid_tuple);
-        return (PyObject *)pr;
+    PyObject *disp = PyDict_GetItem(dict, _disp_key);
+    if (!disp) {
+      Py_DECREF(grid_tuple);
+      goto fallback;
     }
+    PyObject *kern = PyDict_GetItem(dict, _kern_key);
+    if (!kern)
+      kern = Py_None;
+
+    PyObject *nka_obj = PyDict_GetItem(dict, _nka_key);
+    int nka = nka_obj ? (int)PyLong_AsLong(nka_obj) : 0;
+    PyObject *gsf = PyDict_GetItem(dict, _gsf_key);
+    PyObject *gdf = PyDict_GetItem(dict, _gdf_key);
+    if (!gsf || !gdf) {
+      Py_DECREF(grid_tuple);
+      goto fallback;
+    }
+
+    ProxyRunner *pr = PyObject_New(ProxyRunner, &ProxyRunnerType);
+    if (!pr) {
+      Py_DECREF(grid_tuple);
+      return NULL;
+    }
+    pr->vectorcall = ProxyRunner_vectorcall;
+    /* Multiple ProxyRunner instances may reference the same TritonDispatcher.
+     * This is safe because: (1) td_convert_args + cuLaunchKernelEx both run
+     * while holding the GIL, and cuLaunchKernelEx copies kernel_params at
+     * call entry before we release the GIL via Py_BEGIN_ALLOW_THREADS.
+     * (2) Each ProxyRunner_vectorcall completes the full sequence
+     * (convert → launch → GIL release) atomically from Python's perspective.
+     * Direct multi-threaded use of kernel._dispatcher without the GIL is
+     * unsupported (same restriction as all CPython C extension objects). */
+    pr->dispatcher = (TritonDispatcher *)disp;
+    Py_INCREF(disp);
+    Py_ssize_t gs = PyTuple_Size(grid_tuple);
+    pr->grid[0] =
+        (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
+    pr->grid[1] =
+        (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
+    pr->grid[2] =
+        (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
+
+    pr->get_stream_fn = gsf;
+    Py_INCREF(gsf);
+    pr->get_device_fn = gdf;
+    Py_INCREF(gdf);
+    pr->kernel = kern;
+    Py_INCREF(kern);
+    pr->num_args = nka;
+
+    if (PyDict_SetItem(cache, grid_tuple, (PyObject *)pr) < 0) {
+      Py_DECREF(grid_tuple);
+      Py_DECREF(pr);
+      return NULL;
+    }
+    Py_DECREF(grid_tuple);
+    return (PyObject *)pr;
+  }
 
 fallback:;
-    /* Build functools.partial(self.run, grid=grid, warmup=False) */
-    static PyObject *_run_str = NULL, *_grid_str = NULL, *_warmup_str = NULL;
-    if (!_run_str) _run_str = PyUnicode_InternFromString("run");
-    if (!_grid_str) _grid_str = PyUnicode_InternFromString("grid");
-    if (!_warmup_str) _warmup_str = PyUnicode_InternFromString("warmup");
-    PyObject *run = PyObject_GetAttr(self, _run_str);
-    if (!run) return NULL;
-    PyObject *kw = PyDict_New();
-    if (!kw) { Py_DECREF(run); return NULL; }
-    if (PyDict_SetItem(kw, _grid_str, grid) < 0 ||
-        PyDict_SetItem(kw, _warmup_str, Py_False) < 0) {
-        Py_DECREF(run); Py_DECREF(kw); return NULL;
-    }
-    PyObject *partial_mod = PyImport_ImportModule("functools");
-    if (!partial_mod) { Py_DECREF(run); Py_DECREF(kw); return NULL; }
-    PyObject *partial_fn = PyObject_GetAttrString(partial_mod, "partial");
-    Py_DECREF(partial_mod);
-    PyObject *pack = PyTuple_Pack(1, run);
-    if (!pack) { Py_DECREF(partial_fn); Py_DECREF(run); Py_DECREF(kw); return NULL; }
-    PyObject *result = PyObject_Call(partial_fn, pack, kw);
-    Py_DECREF(pack); Py_DECREF(partial_fn); Py_DECREF(run); Py_DECREF(kw);
-    return result;
+  /* Build functools.partial(self.run, grid=grid, warmup=False) */
+  static PyObject *_run_str = NULL, *_grid_str = NULL, *_warmup_str = NULL;
+  if (!_run_str)
+    _run_str = PyUnicode_InternFromString("run");
+  if (!_grid_str)
+    _grid_str = PyUnicode_InternFromString("grid");
+  if (!_warmup_str)
+    _warmup_str = PyUnicode_InternFromString("warmup");
+  PyObject *run = PyObject_GetAttr(self, _run_str);
+  if (!run)
+    return NULL;
+  PyObject *kw = PyDict_New();
+  if (!kw) {
+    Py_DECREF(run);
+    return NULL;
+  }
+  if (PyDict_SetItem(kw, _grid_str, grid) < 0 ||
+      PyDict_SetItem(kw, _warmup_str, Py_False) < 0) {
+    Py_DECREF(run);
+    Py_DECREF(kw);
+    return NULL;
+  }
+  PyObject *partial_mod = PyImport_ImportModule("functools");
+  if (!partial_mod) {
+    Py_DECREF(run);
+    Py_DECREF(kw);
+    return NULL;
+  }
+  PyObject *partial_fn = PyObject_GetAttrString(partial_mod, "partial");
+  Py_DECREF(partial_mod);
+  PyObject *pack = PyTuple_Pack(1, run);
+  if (!pack) {
+    Py_DECREF(partial_fn);
+    Py_DECREF(run);
+    Py_DECREF(kw);
+    return NULL;
+  }
+  PyObject *result = PyObject_Call(partial_fn, pack, kw);
+  Py_DECREF(pack);
+  Py_DECREF(partial_fn);
+  Py_DECREF(run);
+  Py_DECREF(kw);
+  return result;
 }
 
-/* create_fast_jit_type(base_type) — create heap type with mp_subscript = fast_subscript */
-static PyObject *py_create_fast_jit_type(PyObject *module, PyObject *base_type) {
-    if (!PyType_Check(base_type)) {
-        PyErr_SetString(PyExc_TypeError, "Expected a type");
-        return NULL;
-    }
-    static PyType_Slot slots[] = {
-        {Py_mp_subscript, fast_subscript},
-        {0, NULL},
-    };
-    PyType_Spec spec = {
-        .name = "triton.backends.nvidia._FastJITFunction",
-        .basicsize = 0,
-        .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
-        .slots = slots,
-    };
-    PyObject *bases = PyTuple_Pack(1, base_type);
-    if (!bases) return NULL;
-    PyObject *new_type = PyType_FromSpecWithBases(&spec, bases);
-    Py_DECREF(bases);
-    return new_type;
+/* create_fast_jit_type(base_type) — create heap type with mp_subscript =
+ * fast_subscript */
+static PyObject *py_create_fast_jit_type(PyObject *module,
+                                         PyObject *base_type) {
+  if (!PyType_Check(base_type)) {
+    PyErr_SetString(PyExc_TypeError, "Expected a type");
+    return NULL;
+  }
+  static PyType_Slot slots[] = {
+      {Py_mp_subscript, fast_subscript},
+      {0, NULL},
+  };
+  PyType_Spec spec = {
+      .name = "triton.backends.nvidia._FastJITFunction",
+      .basicsize = 0,
+      .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
+      .slots = slots,
+  };
+  PyObject *bases = PyTuple_Pack(1, base_type);
+  if (!bases)
+    return NULL;
+  PyObject *new_type = PyType_FromSpecWithBases(&spec, bases);
+  Py_DECREF(bases);
+  return new_type;
 }
 
 /* ========================================================================= */

--- a/third_party/tlx/language/tlx/mxfp8_utils.py
+++ b/third_party/tlx/language/tlx/mxfp8_utils.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import triton
 import triton.language as tl
-import triton.language.extra.tlx as tlx
 
 
 @triton.jit

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -1177,9 +1177,7 @@ def _attn_bwd_preprocess(
     off_h = off_hz % H
     off_z = off_hz // H
     base = (off_z * H + off_h) * N_CTX
-    o_offsets = (
-        (base + off_m[:, None]) * HEAD_DIM + off_d[None, :]
-    )
+    o_offsets = ((base + off_m[:, None]) * HEAD_DIM + off_d[None, :])
     o_mask = off_m[:, None] < N_CTX
     o = tl.load(O + o_offsets, mask=o_mask, other=0.0)
     do = tl.load(DO + o_offsets, mask=o_mask, other=0.0).to(tl.float32)
@@ -1328,7 +1326,7 @@ def _attn_bwd_mxf8_ws(
     #   tile_idx -> (off_z, off_h, pid)
     #   pid = N-block index within (z, h)
     n_tile_num = N_CTX // BLOCK_N1
-    num_steps = N_CTX // BLOCK_M1   # full M sweep per N-tile
+    num_steps = N_CTX // BLOCK_M1  # full M sweep per N-tile
     prog_id = tl.program_id(0)
     num_progs = tl.num_programs(0)
     total_tiles = n_tile_num * Z * H
@@ -1357,7 +1355,11 @@ def _attn_bwd_mxf8_ws(
         reuse=tmem_storage_alias,
     )
     dv_tiles = tlx.local_alloc(
-        (BLOCK_N1, HEAD_DIM), tl.float32, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, HEAD_DIM),
+        tl.float32,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     dp_tiles = tlx.local_alloc(
         (BLOCK_N1, BLOCK_M1),
@@ -1374,10 +1376,18 @@ def _attn_bwd_mxf8_ws(
         reuse=tmem_storage_alias,
     )
     dk_tiles = tlx.local_alloc(
-        (BLOCK_N1, HEAD_DIM), tl.float32, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, HEAD_DIM),
+        tl.float32,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     ds_tiles_tmem = tlx.local_alloc(
-        (BLOCK_N1, HEAD_DIM), p_dtype, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, HEAD_DIM),
+        p_dtype,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
 
     ###### Scales #######
@@ -1386,19 +1396,39 @@ def _attn_bwd_mxf8_ws(
     # Allocate separate prologue tiles because dq is unused at this stage.
     # This simplifies the scale check
     k_scale_tmem_prologue = tlx.local_alloc(
-        (BLOCK_N1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     q_scale_tmem_prologue = tlx.local_alloc(
-        (BLOCK_M1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_M1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     v_scale_tmem_prologue = tlx.local_alloc(
-        (BLOCK_N1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     do_scale_dp_tmem_prologue = tlx.local_alloc(
-        (BLOCK_N1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     do_scale_dv_tmem_prologue = tlx.local_alloc(
-        (HEAD_DIM, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (HEAD_DIM, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     p_scale_tmem_prologue = tlx.local_alloc(
         (BLOCK_N1, BLOCK_M1 // VEC_SIZE),
@@ -1446,25 +1476,53 @@ def _attn_bwd_mxf8_ws(
         reuse=tmem_storage_alias,
     )
     k_scale_qk_tmem = tlx.local_alloc(
-        (BLOCK_N1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     k_scale_dq_tmem = tlx.local_alloc(
-        (BLOCK_N1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     v_scale_tmem = tlx.local_alloc(
-        (BLOCK_N1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_N1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     do_scale_dp_tmem = tlx.local_alloc(
-        (BLOCK_M1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_M1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     do_scale_dv_tmem = tlx.local_alloc(
-        (BLOCK_M1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_M1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     q_scale_qk_tmem = tlx.local_alloc(
-        (BLOCK_M1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_M1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     q_scale_dk_tmem = tlx.local_alloc(
-        (BLOCK_M1, SCALE_TMEM_COLS), tl.uint8, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem, reuse=tmem_storage_alias,
+        (BLOCK_M1, SCALE_TMEM_COLS),
+        tl.uint8,
+        NUM_BUFFERS_TMEM,
+        tlx.storage_kind.tmem,
+        reuse=tmem_storage_alias,
     )
     # Define the reuse strategy.
     #
@@ -1556,8 +1614,7 @@ def _attn_bwd_mxf8_ws(
                 group_type=tlx.reuse_group_type.shared,
             ),
             group_type=tlx.reuse_group_type.distinct,
-        )
-    )
+        ))
 
     # ===== TMEM barriers =====
     qk_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
@@ -1573,57 +1630,33 @@ def _attn_bwd_mxf8_ws(
 
     # ===== SMEM allocations =====
     k_smem = tlx.local_alloc((BLOCK_N1, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
-    k_dq_smem = tlx.local_alloc(
-        (BLOCK_N1, HEAD_DIM), tlx.dtype_of(desc_k_dq), NUM_BUFFERS_KV
-    )
+    k_dq_smem = tlx.local_alloc((BLOCK_N1, HEAD_DIM), tlx.dtype_of(desc_k_dq), NUM_BUFFERS_KV)
     v_smem = tlx.local_alloc((BLOCK_N1, HEAD_DIM), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
     q_smem = tlx.local_alloc((BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_q), NUM_BUFFERS_Q)
     q_dk_smem = tlx.local_alloc((BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_q), NUM_BUFFERS_Q)
-    do_smem = tlx.local_alloc(
-        (BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_do), NUM_BUFFERS_DO
-    )
-    do_dv_smem = tlx.local_alloc(
-        (BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_do_dv), NUM_BUFFERS_DO
-    )
+    do_smem = tlx.local_alloc((BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_do), NUM_BUFFERS_DO)
+    do_dv_smem = tlx.local_alloc((BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_do_dv), NUM_BUFFERS_DO)
     # dK consumes dS^T while dQ consumes dS. MXFP8 quantization depends on the
     # reduction axis, so we keep separate internal encodings for the two GEMMs.
     ds_tiles_smem = tlx.local_alloc((BLOCK_N1, BLOCK_M1), p_dtype, NUM_BUFFERS_DS)
     ds_dq_tiles_smem = tlx.local_alloc((BLOCK_M1, BLOCK_N1), p_dtype, NUM_BUFFERS_DS)
 
-    k_scale_smem = tlx.local_alloc(
-        (1, REP_N, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_KV
-    )
-    k_scale_dq_smem = tlx.local_alloc(
-        (1, REP_HEAD, REP_N, 2, 256), tl.uint8, NUM_BUFFERS_KV
-    )
-    v_scale_smem = tlx.local_alloc(
-        (1, REP_N, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_KV
-    )
-    q_scale_smem = tlx.local_alloc(
-        (1, REP_M, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_Q
-    )
-    q_dk_scale_smem = tlx.local_alloc(
-        (1, REP_M, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_Q
-    )
-    do_scale_smem = tlx.local_alloc(
-        (1, REP_M, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_DO
-    )
-    do_scale_dv_smem = tlx.local_alloc(
-        (1, REP_HEAD, REP_M, 2, 256), tl.uint8, NUM_BUFFERS_DO
-    )
+    k_scale_smem = tlx.local_alloc((1, REP_N, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_KV)
+    k_scale_dq_smem = tlx.local_alloc((1, REP_HEAD, REP_N, 2, 256), tl.uint8, NUM_BUFFERS_KV)
+    v_scale_smem = tlx.local_alloc((1, REP_N, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_KV)
+    q_scale_smem = tlx.local_alloc((1, REP_M, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_Q)
+    q_dk_scale_smem = tlx.local_alloc((1, REP_M, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_Q)
+    do_scale_smem = tlx.local_alloc((1, REP_M, REP_HEAD, 2, 256), tl.uint8, NUM_BUFFERS_DO)
+    do_scale_dv_smem = tlx.local_alloc((1, REP_HEAD, REP_M, 2, 256), tl.uint8, NUM_BUFFERS_DO)
 
     slice_size_alloc: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     # TODO: Actually expose.
     NUM_DKV_STORE_BUFFERS: tl.constexpr = 1
-    dkv_store_buf = tlx.local_alloc(
-        (BLOCK_N1, slice_size_alloc), tl.bfloat16, NUM_DKV_STORE_BUFFERS
-    )
+    dkv_store_buf = tlx.local_alloc((BLOCK_N1, slice_size_alloc), tl.bfloat16, NUM_DKV_STORE_BUFFERS)
     DQ_REDUCE_NCOL: tl.constexpr = HEAD_DIM // (EPILOGUE_SUBTILE * 2)
     DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
     DQ_REDUCE_STAGES: tl.constexpr = 2
-    dq_store_buf = tlx.local_alloc(
-        (BLOCK_M1, DQ_REDUCE_NCOL), tlx.dtype_of(desc_dq), DQ_REDUCE_STAGES
-    )
+    dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_REDUCE_NCOL), tlx.dtype_of(desc_dq), DQ_REDUCE_STAGES)
 
     # ===== SMEM barriers =====
     k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
@@ -1667,9 +1700,7 @@ def _attn_bwd_mxf8_ws(
                 BWD_NUM_BLOCKS: tl.constexpr = BLOCK_M1 // VEC_SIZE
 
                 # Prologue: produce P for the first M-block.
-                _, tmem_phase = _get_bufidx_phase(
-                    blk_idx, NUM_BUFFERS_TMEM
-                )
+                _, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
                 offs_m = curr_m + tl.arange(0, BLOCK_M1)
                 m = tl.load(M_off + offs_m)
 
@@ -1690,9 +1721,7 @@ def _attn_bwd_mxf8_ws(
                 pT = tl.math.exp2(qkT_scaled)
 
                 # Block amax for P via monotonicity of exp2
-                qkT_reshaped = tl.reshape(
-                    qkT_scaled, [BLOCK_N1, BWD_NUM_BLOCKS, VEC_SIZE]
-                )
+                qkT_reshaped = tl.reshape(qkT_scaled, [BLOCK_N1, BWD_NUM_BLOCKS, VEC_SIZE])
                 block_maxes_p = tl.max(qkT_reshaped, 2)
                 block_amax_p = tl.math.exp2(block_maxes_p)
 
@@ -1729,12 +1758,8 @@ def _attn_bwd_mxf8_ws(
                         p_dtype,
                     )
                     tlx.local_store(tlx.local_view(ds_tiles_smem, ds_buf_id), ds_fp8)
-                    ds_scale_packed = (
-                        ds_scale
-                        .reshape([REP_N, 4, 32, REP_M, 4])
-                        .permute(0, 3, 2, 1, 4)
-                        .reshape([1, REP_N, REP_M, 2, 256])
-                    )
+                    ds_scale_packed = (ds_scale.reshape([REP_N, 4, 32, REP_M,
+                                                         4]).permute(0, 3, 2, 1, 4).reshape([1, REP_N, REP_M, 2, 256]))
                     tlx.local_store(tlx.local_view(ds_scale_smem, 0), ds_scale_packed)
                     ds_dq_fp8, ds_scale_dq = _to_mxfp8_block(
                         tl.trans(dsT),
@@ -1742,12 +1767,9 @@ def _attn_bwd_mxf8_ws(
                         p_dtype,
                     )
                     tlx.local_store(tlx.local_view(ds_dq_tiles_smem, ds_buf_id), ds_dq_fp8)
-                    ds_scale_dq_packed = (
-                        ds_scale_dq
-                        .reshape([REP_M, 4, 32, REP_N, 4])
-                        .permute(0, 3, 2, 1, 4)
-                        .reshape([1, REP_M, REP_N, 2, 256])
-                    )
+                    ds_scale_dq_packed = (ds_scale_dq.reshape([REP_M, 4, 32, REP_N,
+                                                               4]).permute(0, 3, 2, 1,
+                                                                           4).reshape([1, REP_M, REP_N, 2, 256]))
                     tlx.local_store(tlx.local_view(ds_scale_dq_smem, 0), ds_scale_dq_packed)
                     tlx.barrier_arrive(ds_fulls[ds_buf_id])
 
@@ -1755,9 +1777,7 @@ def _attn_bwd_mxf8_ws(
                     blk_idx += 1
 
                     # Start P for the current M-block.
-                    _, tmem_phase = _get_bufidx_phase(
-                        blk_idx, NUM_BUFFERS_TMEM
-                    )
+                    _, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
                     offs_m = curr_m + tl.arange(0, BLOCK_M1)
                     m = tl.load(M_off + offs_m)
 
@@ -1772,9 +1792,7 @@ def _attn_bwd_mxf8_ws(
                     pT = tl.math.exp2(qkT_scaled)
 
                     # Block amax for P via monotonicity of exp2
-                    qkT_reshaped = tl.reshape(
-                        qkT_scaled, [BLOCK_N1, BWD_NUM_BLOCKS, VEC_SIZE]
-                    )
+                    qkT_reshaped = tl.reshape(qkT_scaled, [BLOCK_N1, BWD_NUM_BLOCKS, VEC_SIZE])
                     block_maxes_p = tl.max(qkT_reshaped, 2)
                     block_amax_p = tl.math.exp2(block_maxes_p)
 
@@ -1811,12 +1829,8 @@ def _attn_bwd_mxf8_ws(
                     p_dtype,
                 )
                 tlx.local_store(tlx.local_view(ds_tiles_smem, ds_buf_id), ds_fp8)
-                ds_scale_packed = (
-                    ds_scale
-                    .reshape([REP_N, 4, 32, REP_M, 4])
-                    .permute(0, 3, 2, 1, 4)
-                    .reshape([1, REP_N, REP_M, 2, 256])
-                )
+                ds_scale_packed = (ds_scale.reshape([REP_N, 4, 32, REP_M,
+                                                     4]).permute(0, 3, 2, 1, 4).reshape([1, REP_N, REP_M, 2, 256]))
                 tlx.local_store(tlx.local_view(ds_scale_smem, 0), ds_scale_packed)
                 ds_dq_fp8, ds_scale_dq = _to_mxfp8_block(
                     tl.trans(dsT),
@@ -1824,12 +1838,9 @@ def _attn_bwd_mxf8_ws(
                     p_dtype,
                 )
                 tlx.local_store(tlx.local_view(ds_dq_tiles_smem, ds_buf_id), ds_dq_fp8)
-                ds_scale_dq_packed = (
-                    ds_scale_dq
-                    .reshape([REP_M, 4, 32, REP_N, 4])
-                    .permute(0, 3, 2, 1, 4)
-                    .reshape([1, REP_M, REP_N, 2, 256])
-                )
+                ds_scale_dq_packed = (ds_scale_dq.reshape([REP_M, 4, 32, REP_N,
+                                                           4]).permute(0, 3, 2, 1, 4).reshape([1, REP_M, REP_N, 2,
+                                                                                               256]))
                 tlx.local_store(tlx.local_view(ds_scale_dq_smem, 0), ds_scale_dq_packed)
                 tlx.barrier_arrive(ds_fulls[ds_buf_id])
 
@@ -1900,9 +1911,7 @@ def _attn_bwd_mxf8_ws(
 
                 curr_m = 0
                 for _ in range(num_steps):
-                    _, tmem_phase = _get_bufidx_phase(
-                        blk_idx, NUM_BUFFERS_TMEM
-                    )
+                    _, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
                     tlx.barrier_wait(dq_fulls[0], tmem_phase)
                     for slice_id in tl.static_range(DQ_REDUCE_ITERS):
                         dq_smem_idx = slice_id % DQ_REDUCE_STAGES
@@ -1944,12 +1953,8 @@ def _attn_bwd_mxf8_ws(
                 # --- Prolog: first M-block ---
                 q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
                 do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
-                _, tmem_phase = _get_bufidx_phase(
-                    blk_idx, NUM_BUFFERS_TMEM
-                )
-                _, tmem_phase_prev = _get_bufidx_phase(
-                    blk_idx - 1, NUM_BUFFERS_TMEM
-                )
+                _, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+                _, tmem_phase_prev = _get_bufidx_phase(blk_idx - 1, NUM_BUFFERS_TMEM)
                 _, persistent_tmem_phase = _get_bufidx_phase(_i, NUM_BUFFERS_TMEM)
 
                 # MMA 1: qkT = K @ Q^T
@@ -2036,19 +2041,11 @@ def _attn_bwd_mxf8_ws(
                 # --- Main loop: iters 1 .. num_steps-1 ---
                 for j in range(1, num_steps):
                     q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
-                    _, tmem_phase = _get_bufidx_phase(
-                        blk_idx, NUM_BUFFERS_TMEM
-                    )
+                    _, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
                     prev_blk_idx = blk_idx - 1
-                    q_buf_id_prev, q_phase_prev = _get_bufidx_phase(
-                        prev_blk_idx, NUM_BUFFERS_Q
-                    )
-                    _, tmem_phase_prev = _get_bufidx_phase(
-                        prev_blk_idx, NUM_BUFFERS_TMEM
-                    )
-                    ds_buf_id_prev, ds_phase_prev = _get_bufidx_phase(
-                        prev_blk_idx, NUM_BUFFERS_DS
-                    )
+                    q_buf_id_prev, q_phase_prev = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
+                    _, tmem_phase_prev = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_TMEM)
+                    ds_buf_id_prev, ds_phase_prev = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_DS)
 
                     # MMA 1: qkT = K @ Q^T (current)
                     tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
@@ -2061,14 +2058,10 @@ def _attn_bwd_mxf8_ws(
                     # Not needed for prologue.
                     # with buffers: v_scale_tmem, do_scale_dp_tmem
                     tlx.barrier_wait(p_empties[0], tmem_phase ^ 1)
-                    tlx.barrier_wait(
-                        dq_empties[0], tmem_phase_prev ^ 1
-                    )
+                    tlx.barrier_wait(dq_empties[0], tmem_phase_prev ^ 1)
                     # REUSE_GROUP_3: wait for Compute to finish reading dp_tiles
                     # before overwriting with scale tmem_copies.
-                    tlx.barrier_wait(
-                        dp_empties[0], tmem_phase_prev
-                    )
+                    tlx.barrier_wait(dp_empties[0], tmem_phase_prev)
                     tlx.tmem_copy(k_scale_smem[kv_buf_id], k_scale_qk_tmem[0])
                     tlx.tmem_copy(q_scale_smem[q_buf_id], q_scale_qk_tmem[0])
                     qT = tlx.local_trans(q_smem[q_buf_id])
@@ -2203,12 +2196,8 @@ def _attn_bwd_mxf8_ws(
                 # --- Epilog: last dK / dQ ---
                 prev_blk_idx = blk_idx - 1
                 q_buf_id, q_phase = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
-                _, tmem_phase = _get_bufidx_phase(
-                    prev_blk_idx, NUM_BUFFERS_TMEM
-                )
-                ds_buf_id, ds_phase = _get_bufidx_phase(
-                    prev_blk_idx, NUM_BUFFERS_DS
-                )
+                _, tmem_phase = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_TMEM)
+                ds_buf_id, ds_phase = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_DS)
 
                 # MMA 4: dK += dS^T @ Q (last)
                 # REUSE_GROUP_3 SYNCHRONIZATION:
@@ -2258,10 +2247,10 @@ def _attn_bwd_mxf8_ws(
                     ds_scale_dq_tmem[0],
                     DS_FP8_FORMAT,
                     k_scale_dq_tmem[0],
-                        K_FP8_FORMAT,
-                        use_acc=False,
-                        mBarriers=[dq_fulls[0], ds_empties[ds_buf_id], k_dq_empties[kv_buf_id]],
-                    )
+                    K_FP8_FORMAT,
+                    use_acc=False,
+                    mBarriers=[dq_fulls[0], ds_empties[ds_buf_id], k_dq_empties[kv_buf_id]],
+                )
                 kv_tile_idx += 1
                 tile_idx += num_progs
 
@@ -2286,9 +2275,7 @@ def _attn_bwd_mxf8_ws(
                 # Load K data + scale
                 kv_buf_id, kv_phase = _get_bufidx_phase(kv_tile_idx, NUM_BUFFERS_KV)
                 tlx.barrier_wait(k_empties[kv_buf_id], kv_phase ^ 1)
-                tlx.barrier_expect_bytes(
-                    k_fulls[kv_buf_id], (K_BYTES * BLOCK_N1 * HEAD_DIM) + SCALE_BYTES
-                )
+                tlx.barrier_expect_bytes(k_fulls[kv_buf_id], (K_BYTES * BLOCK_N1 * HEAD_DIM) + SCALE_BYTES)
                 tlx.async_descriptor_load(
                     desc_k,
                     k_smem[kv_buf_id],
@@ -2321,9 +2308,7 @@ def _attn_bwd_mxf8_ws(
 
                 # Load V data + scale
                 # Share 1 barrier
-                tlx.barrier_expect_bytes(
-                    v_fulls[kv_buf_id], K_BYTES * BLOCK_N1 * HEAD_DIM + SCALE_BYTES
-                )
+                tlx.barrier_expect_bytes(v_fulls[kv_buf_id], K_BYTES * BLOCK_N1 * HEAD_DIM + SCALE_BYTES)
                 tlx.async_descriptor_load(
                     desc_v,
                     v_smem[kv_buf_id],
@@ -2342,9 +2327,7 @@ def _attn_bwd_mxf8_ws(
                 q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
                 q_scale_m = (curr_m // 128) * REP_M
                 tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
-                tlx.barrier_expect_bytes(
-                    q_fulls[q_buf_id], (Q_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES
-                )
+                tlx.barrier_expect_bytes(q_fulls[q_buf_id], (Q_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES)
                 tlx.async_descriptor_load(
                     desc_q,
                     q_smem[q_buf_id],
@@ -2402,18 +2385,14 @@ def _attn_bwd_mxf8_ws(
                 for _j in range(1, num_steps):
                     prev_blk_idx = blk_idx - 1
                     prev_m = curr_m - BLOCK_M1
-                    prev_q_buf_id, prev_q_phase = _get_bufidx_phase(
-                        prev_blk_idx, NUM_BUFFERS_Q
-                    )
+                    prev_q_buf_id, prev_q_phase = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
                     q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
                     do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
                     q_scale_m = (curr_m // 128) * REP_M
                     do_scale_m = (curr_m // 128) * REP_M
 
                     tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
-                    tlx.barrier_expect_bytes(
-                        q_fulls[q_buf_id], (Q_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES
-                    )
+                    tlx.barrier_expect_bytes(q_fulls[q_buf_id], (Q_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES)
                     tlx.async_descriptor_load(
                         desc_q,
                         q_smem[q_buf_id],
@@ -2484,9 +2463,7 @@ def _attn_bwd_mxf8_ws(
                     blk_idx += 1
                 last_blk_idx = blk_idx - 1
                 last_m = curr_m - BLOCK_M1
-                last_q_buf_id, last_q_phase = _get_bufidx_phase(
-                    last_blk_idx, NUM_BUFFERS_Q
-                )
+                last_q_buf_id, last_q_phase = _get_bufidx_phase(last_blk_idx, NUM_BUFFERS_Q)
                 tlx.barrier_wait(q_dk_empties[last_q_buf_id], last_q_phase ^ 1)
                 tlx.barrier_expect_bytes(
                     q_dk_fulls[last_q_buf_id],
@@ -2514,8 +2491,22 @@ def _attn_bwd_mxf8_ws(
 
 
 def attention_bwd(
-    do, do_dv, q, q_dk, k, k_dq, v, o, M,
-    q_scale, q_dk_scale, k_scale, k_dq_scale, v_scale, do_scale, do_dv_scale,
+    do,
+    do_dv,
+    q,
+    q_dk,
+    k,
+    k_dq,
+    v,
+    o,
+    M,
+    q_scale,
+    q_dk_scale,
+    k_scale,
+    k_dq_scale,
+    v_scale,
+    do_scale,
+    do_dv_scale,
     sm_scale,
     do_bf16=None,
 ):
@@ -2540,8 +2531,7 @@ def attention_bwd(
     Non-causal only. Assumes N_CTX is a multiple of 128.
     """
     assert q.shape == q_dk.shape == k.shape == k_dq.shape == v.shape == do.shape, (
-        "Q, Q_dK, K, K_dQ, V, dO must have the same shape"
-    )
+        "Q, Q_dK, K, K_dQ, V, dO must have the same shape")
     Z, H, N_CTX, HEAD_DIM = q.shape
     assert HEAD_DIM == 128, "this kernel only supports HEAD_DIM = 128"
     assert N_CTX % 128 == 0, "N_CTX must be a multiple of 128 (BLOCK_M1)"
@@ -2555,8 +2545,12 @@ def attention_bwd(
     preproc_grid = (triton.cdiv(N_CTX, PRE_BLOCK_M), Z * H)
     do_preproc = do_bf16 if do_bf16 is not None else do
     _attn_bwd_preprocess[preproc_grid](
-        o, do_preproc, delta,
-        Z, H, N_CTX,
+        o,
+        do_preproc,
+        delta,
+        Z,
+        H,
+        N_CTX,
         HEAD_DIM=HEAD_DIM,
         BLOCK_M=PRE_BLOCK_M,
     )
@@ -2569,36 +2563,16 @@ def attention_bwd(
     dummy_block = [1, 1]
     dummy_5d = [1, 1, 1, 1, 1]
 
-    desc_q = TensorDescriptor(
-        q, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_q_dk = TensorDescriptor(
-        q_dk, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_k = TensorDescriptor(
-        k, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_k_dq = TensorDescriptor(
-        k_dq, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_v = TensorDescriptor(
-        v, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_do = TensorDescriptor(
-        do, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_do_dv = TensorDescriptor(
-        do_dv, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_dq = TensorDescriptor(
-        dq, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_dk = TensorDescriptor(
-        dk, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_dv = TensorDescriptor(
-        dv, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
+    desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_q_dk = TensorDescriptor(q_dk, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_k_dq = TensorDescriptor(k_dq, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_do = TensorDescriptor(do, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_do_dv = TensorDescriptor(do_dv, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_dq = TensorDescriptor(dq, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_dk = TensorDescriptor(dk, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_dv = TensorDescriptor(dv, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
 
     desc_q_scale = TensorDescriptor.from_tensor(q_scale, block_shape=dummy_5d)
     desc_q_dk_scale = TensorDescriptor.from_tensor(q_dk_scale, block_shape=dummy_5d)
@@ -2606,9 +2580,7 @@ def attention_bwd(
     desc_k_dq_scale = TensorDescriptor.from_tensor(k_dq_scale, block_shape=dummy_5d)
     desc_v_scale = TensorDescriptor.from_tensor(v_scale, block_shape=dummy_5d)
     desc_do_scale = TensorDescriptor.from_tensor(do_scale, block_shape=dummy_5d)
-    desc_do_dv_scale = TensorDescriptor.from_tensor(
-        do_dv_scale, block_shape=dummy_5d
-    )
+    desc_do_dv_scale = TensorDescriptor.from_tensor(do_dv_scale, block_shape=dummy_5d)
 
     def alloc_fn(size: int, align: int, _):
         return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -2640,7 +2612,9 @@ def attention_bwd(
         sm_scale,
         M,
         delta,
-        Z, H, N_CTX,
+        Z,
+        H,
+        N_CTX,
         desc_q_scale,
         desc_q_dk_scale,
         desc_k_scale,

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -947,8 +947,8 @@ configs_bwd_subtile_opt = [
 ]
 
 configs_bwd_persist = [
-     triton.Config(
-         {
+    triton.Config(
+        {
             "BLOCK_M1": 128,
             "BLOCK_N1": 128,
             "BLOCK_M2": 128,
@@ -1007,7 +1007,7 @@ configs_bwd_persist = [
         num_warps=4,
         num_stages=2,
         pre_hook=_bwd_host_descriptor_pre_hook,
-     ),
+    ),
 ]
 
 

--- a/third_party/tlx/tutorials/testing/test_blackwell_fa_mxfp8_perf.py
+++ b/third_party/tlx/tutorials/testing/test_blackwell_fa_mxfp8_perf.py
@@ -20,7 +20,6 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 from triton._internal_testing import is_blackwell
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
-
 """
 Benchmarks for the TLX MXFP8 flash attention forward and backward kernels.
 Run with: third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_blackwell_fa_mxfp8_perf.py --mode fwd
@@ -32,22 +31,14 @@ Facebook: If you are developing in fbsource, use tritonbench instead to collect 
 
 def _setup_bwd_inputs(shape, sm_scale, dtype):
     Z, H, N_CTX, HEAD_DIM = shape
-    (q, q_scale, q_ref), (k, k_scale, k_ref), (v, v_scale, v_ref) = (
-        generate_attention_inputs(shape, DEVICE, dtype)
-    )
+    (q, q_scale, q_ref), (k, k_scale, k_ref), (v, v_scale, v_ref) = (generate_attention_inputs(shape, DEVICE, dtype))
 
-    q_dk, q_scale_dk = _quantize_mxfp8_bwd_operand(
-        q_ref, dtype, transpose_for_reduction=True
-    )
-    k_dq, k_scale_dq = _quantize_mxfp8_bwd_operand(
-        k_ref, dtype, transpose_for_reduction=True
-    )
+    q_dk, q_scale_dk = _quantize_mxfp8_bwd_operand(q_ref, dtype, transpose_for_reduction=True)
+    k_dq, k_scale_dq = _quantize_mxfp8_bwd_operand(k_ref, dtype, transpose_for_reduction=True)
     v_bwd, v_scale_bwd = _quantize_mxfp8_bwd_operand(v_ref, dtype)
     do_bf16 = torch.randn(shape, device=DEVICE, dtype=torch.bfloat16)
     do_fp8, do_scale = _quantize_mxfp8_bwd_operand(do_bf16, dtype)
-    do_fp8_dv, do_scale_dv = _quantize_mxfp8_bwd_operand(
-        do_bf16, dtype, transpose_for_reduction=True
-    )
+    do_fp8_dv, do_scale_dv = _quantize_mxfp8_bwd_operand(do_bf16, dtype, transpose_for_reduction=True)
 
     fwd_config = FlashAttention.CONFIGS["blackwell_fa_ws_pipelined_persistent_mxfp8"]
     y_dim = Z * H * N_CTX
@@ -56,18 +47,10 @@ def _setup_bwd_inputs(shape, sm_scale, dtype):
     dummy_block = [1, 1]
     dummy_5d = [1, 1, 1, 1, 1]
 
-    desc_q = TensorDescriptor(
-        q, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_k = TensorDescriptor(
-        k, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_v = TensorDescriptor(
-        v, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
-    desc_o = TensorDescriptor(
-        o, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block
-    )
+    desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
     desc_q_scale = TensorDescriptor.from_tensor(q_scale, block_shape=dummy_5d)
     desc_k_scale = TensorDescriptor.from_tensor(k_scale, block_shape=dummy_5d)
     desc_v_scale = TensorDescriptor.from_tensor(v_scale, block_shape=dummy_5d)
@@ -112,13 +95,23 @@ def _setup_bwd_inputs(shape, sm_scale, dtype):
     )
 
     return {
-        "do_fp8": do_fp8, "do_fp8_dv": do_fp8_dv, "do_bf16": do_bf16,
-        "q": q, "q_dk": q_dk, "k": k, "k_dq": k_dq,
-        "v_bwd": v_bwd, "o": o, "M": M,
-        "q_scale": q_scale, "q_scale_dk": q_scale_dk,
-        "k_scale": k_scale, "k_scale_dq": k_scale_dq,
+        "do_fp8": do_fp8,
+        "do_fp8_dv": do_fp8_dv,
+        "do_bf16": do_bf16,
+        "q": q,
+        "q_dk": q_dk,
+        "k": k,
+        "k_dq": k_dq,
+        "v_bwd": v_bwd,
+        "o": o,
+        "M": M,
+        "q_scale": q_scale,
+        "q_scale_dk": q_scale_dk,
+        "k_scale": k_scale,
+        "k_scale_dq": k_scale_dq,
         "v_scale_bwd": v_scale_bwd,
-        "do_scale": do_scale, "do_scale_dv": do_scale_dv,
+        "do_scale": do_scale,
+        "do_scale_dv": do_scale_dv,
     }
 
 
@@ -144,26 +137,34 @@ def create_benchmark(mode="fwd"):
         if mode == "bwd":
             bwd = _setup_bwd_inputs(shape, sm_scale, dtype)
             fn = lambda: _attention_bwd_mxfp8(
-                bwd["do_fp8"], bwd["do_fp8_dv"],
-                bwd["q"], bwd["q_dk"], bwd["k"], bwd["k_dq"],
-                bwd["v_bwd"], bwd["o"], bwd["M"],
-                bwd["q_scale"], bwd["q_scale_dk"],
-                bwd["k_scale"], bwd["k_scale_dq"],
+                bwd["do_fp8"],
+                bwd["do_fp8_dv"],
+                bwd["q"],
+                bwd["q_dk"],
+                bwd["k"],
+                bwd["k_dq"],
+                bwd["v_bwd"],
+                bwd["o"],
+                bwd["M"],
+                bwd["q_scale"],
+                bwd["q_scale_dk"],
+                bwd["k_scale"],
+                bwd["k_scale_dq"],
                 bwd["v_scale_bwd"],
-                bwd["do_scale"], bwd["do_scale_dv"],
+                bwd["do_scale"],
+                bwd["do_scale_dv"],
                 sm_scale,
                 do_bf16=bwd["do_bf16"],
             )
         else:
-            (q, q_scale, _), (k, k_scale, _), (v, v_scale, _) = (
-                generate_attention_inputs(shape, DEVICE, dtype)
-            )
-            fn = lambda: _attention_ws_pipelined_persistent_mxfp8(
-                q, k, v, q_scale, k_scale, v_scale, sm_scale, causal
-            )
+            (q, q_scale, _), (k, k_scale, _), (v, v_scale, _) = (generate_attention_inputs(shape, DEVICE, dtype))
+            fn = lambda: _attention_ws_pipelined_persistent_mxfp8(q, k, v, q_scale, k_scale, v_scale, sm_scale, causal)
 
         ms, min_ms, max_ms = triton.testing.do_bench(
-            fn, quantiles=quantiles, warmup=500, rep=500,
+            fn,
+            quantiles=quantiles,
+            warmup=500,
+            rep=500,
         )
 
         flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * HEAD_DIM
@@ -176,9 +177,7 @@ def create_benchmark(mode="fwd"):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Benchmark TLX Blackwell MXFP8 Flash Attention"
-    )
+    parser = argparse.ArgumentParser(description="Benchmark TLX Blackwell MXFP8 Flash Attention")
     parser.add_argument(
         "--mode",
         type=str,

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -609,6 +609,7 @@ def _quantize_mxfp8_bwd_operand(ref, dtype, transpose_for_reduction=False):
         scale = swizzled_to_tma_preshuffled(mx.scale, N_CTX, HEAD_DIM, 32, Z * H)
     return data, scale
 
+
 def _cosine_similarity(actual: torch.Tensor, expected: torch.Tensor) -> float:
     actual_flat = actual.float().reshape(-1)
     expected_flat = expected.float().reshape(-1)
@@ -631,10 +632,8 @@ def _assert_close_with_cosine(
     cosine = _cosine_similarity(actual, expected)
     # TODO: Enable testing?
     # torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
-    assert cosine >= min_cosine, (
-        f"{label} cosine_similarity={cosine:.6f} fell below "
-        f"min_cosine={min_cosine:.6f}"
-    )
+    assert cosine >= min_cosine, (f"{label} cosine_similarity={cosine:.6f} fell below "
+                                  f"min_cosine={min_cosine:.6f}")
 
 @pytest.mark.parametrize(
     "Z,H,N_CTX",
@@ -661,29 +660,20 @@ def test_blackwell_fa_ws_pipelined_persistent_mxfp8_bwd(Z, H, N_CTX):
     bwd_min_cosine: float = 0.98
     torch.manual_seed(20)
 
-    (q, q_scale, q_ref), (k, k_scale, k_ref), (v, v_scale, v_ref) = (
-        _generate_mxfp8_attention_inputs(shape, DEVICE, dtype)
-    )
+    (q, q_scale, q_ref), (k, k_scale, k_ref), (v, v_scale,
+                                               v_ref) = (_generate_mxfp8_attention_inputs(shape, DEVICE, dtype))
     q_ref = q_ref.detach().requires_grad_(True)
     k_ref = k_ref.detach().requires_grad_(True)
     v_ref = v_ref.detach().requires_grad_(True)
-    ref_out = torch.nn.functional.scaled_dot_product_attention(
-        q_ref, k_ref, v_ref, scale=sm_scale, is_causal=False
-    )
+    ref_out = torch.nn.functional.scaled_dot_product_attention(q_ref, k_ref, v_ref, scale=sm_scale, is_causal=False)
     do_bf16 = torch.randn_like(ref_out)
     ref_out.backward(do_bf16)
 
-    q_dk, q_scale_dk = _quantize_mxfp8_bwd_operand(
-        q_ref.detach(), dtype, transpose_for_reduction=True
-    )
-    k_dq, k_scale_dq = _quantize_mxfp8_bwd_operand(
-        k_ref.detach(), dtype, transpose_for_reduction=True
-    )
+    q_dk, q_scale_dk = _quantize_mxfp8_bwd_operand(q_ref.detach(), dtype, transpose_for_reduction=True)
+    k_dq, k_scale_dq = _quantize_mxfp8_bwd_operand(k_ref.detach(), dtype, transpose_for_reduction=True)
     v_bwd, v_scale_bwd = _quantize_mxfp8_bwd_operand(v_ref.detach(), dtype)
     do_fp8, do_scale = _quantize_mxfp8_bwd_operand(do_bf16, dtype)
-    do_fp8_dv, do_scale_dv = _quantize_mxfp8_bwd_operand(
-        do_bf16, dtype, transpose_for_reduction=True
-    )
+    do_fp8_dv, do_scale_dv = _quantize_mxfp8_bwd_operand(do_bf16, dtype, transpose_for_reduction=True)
 
     fwd_config = FlashAttention.CONFIGS["blackwell_fa_ws_pipelined_persistent_mxfp8"]
     y_dim = Z * H * N_CTX
@@ -691,18 +681,10 @@ def test_blackwell_fa_ws_pipelined_persistent_mxfp8_bwd(Z, H, N_CTX):
     M = torch.empty((Z, H, N_CTX), device=DEVICE, dtype=torch.float32)
     dummy_block = [1, 1]
     dummy_5d = [1, 1, 1, 1, 1]
-    desc_q = TensorDescriptor(
-        q, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block
-    )
-    desc_k = TensorDescriptor(
-        k, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block
-    )
-    desc_v = TensorDescriptor(
-        v, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block
-    )
-    desc_o = TensorDescriptor(
-        o, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block
-    )
+    desc_q = TensorDescriptor(q, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block)
+    desc_k = TensorDescriptor(k, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block)
+    desc_v = TensorDescriptor(v, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block)
+    desc_o = TensorDescriptor(o, shape=[y_dim, head_dim], strides=[head_dim, 1], block_shape=dummy_block)
     desc_q_scale = TensorDescriptor.from_tensor(q_scale, block_shape=dummy_5d)
     desc_k_scale = TensorDescriptor.from_tensor(k_scale, block_shape=dummy_5d)
     desc_v_scale = TensorDescriptor.from_tensor(v_scale, block_shape=dummy_5d)


### PR DESCRIPTION
Summary:

Automated formatting fix generated by running `pre-commit run --all-files`
and `pre-commit run clang-format --all-files` on the GitHub mirror
(facebookexperimental/triton). 8 file(s) fixed.

Reviewed By: dshi7

Differential Revision: D105197389


