### PR TITLE
[Triton JIT] Handle kwargs in JITCacheProxy C fast path (#1519)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -1445,8 +1445,9 @@ typedef struct {
   PyObject *params_list; // self.params
   PyObject *run_partial; // functools.partial(self.run, grid=grid, warmup=False)
   PyObject *grid_py[3];  // pre-extracted grid PyLong objects
-  PyObject *stream_getter; // driver.active.get_current_stream
-  PyObject *device_getter; // driver.active.get_current_device
+  PyObject *stream_getter;     // driver.active.get_current_stream
+  PyObject *device_getter;     // driver.active.get_current_device
+  PyObject *param_name_to_idx; // dict: param_name → positional index
   uint64_t options_hash;
   int n_params;
 } JITCacheProxy;
@@ -1461,12 +1462,42 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
                                           PyObject *kwnames) {
   JITCacheProxy *self = (JITCacheProxy *)callable;
   Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+  PyObject **merged_args = nullptr;
+  PyObject *const *effective_args = args;
+  int effective_nargs = (int)nargs;
 
-  // Fast path: no kwargs, arg count matches
-  if (kwnames && PyTuple_GET_SIZE(kwnames) > 0)
+  // When kwargs are present, merge them into positional args in C.
+  // This mirrors the Python-side logic in jit.py run() c_cache path.
+  if (kwnames && PyTuple_GET_SIZE(kwnames) > 0) {
+    if (!self->param_name_to_idx)
+      goto fallback;
+    Py_ssize_t nkw = PyTuple_GET_SIZE(kwnames);
+    int total = self->n_params;
+    // Allocate merged array on stack (max ~64 params for typical kernels)
+    merged_args = (PyObject **)alloca(total * sizeof(PyObject *));
+    // Copy positional args
+    for (int i = 0; i < total; i++)
+      merged_args[i] = (i < (int)nargs) ? (PyObject *)args[i] : Py_None;
+    // Merge kwargs by name lookup
+    for (Py_ssize_t ki = 0; ki < nkw; ki++) {
+      PyObject *name = PyTuple_GET_ITEM(kwnames, ki);
+      PyObject *idx_obj = PyDict_GetItem(self->param_name_to_idx, name);
+      if (idx_obj) {
+        int idx = (int)PyLong_AsLong(idx_obj);
+        if (idx >= 0 && idx < total)
+          merged_args[idx] = (PyObject *)args[nargs + ki];
+      }
+      // kwargs not in param_name_to_idx are "options" — affect hash only.
+      // For now, treat them as cache-miss (different options_hash) and
+      // fallback.
+      else
+        goto fallback;
+    }
+    effective_args = merged_args;
+    effective_nargs = total;
+  } else if (nargs != self->n_params) {
     goto fallback;
-  if (nargs != self->n_params)
-    goto fallback;
+  }
 
   {
     FastCache *cache =
@@ -1475,10 +1506,11 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
       goto fallback;
 
     FCCacheKey key;
-    if (!fc_build_key(key, cache, args, (int)nargs, self->options_hash))
+    if (!fc_build_key(key, cache, effective_args, effective_nargs,
+                      self->options_hash))
       goto fallback;
 
-    FCEntry *entry = cache->lookup(key, args);
+    FCEntry *entry = cache->lookup(key, effective_args);
     if (!entry)
       goto fallback;
 
@@ -1504,7 +1536,7 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     // Build dispatcher vectorcall args: grid0, grid1, grid2, stream,
     // *kernel_args
     int n_kernel_args = 0;
-    for (int i = 0; i < (int)nargs && i < cache->n_params; i++) {
+    for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
       if (!cache->param_meta[i].is_constexpr)
         n_kernel_args++;
     }
@@ -1515,9 +1547,9 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     vc_args[2] = self->grid_py[2];
     vc_args[3] = stream_obj;
     int ki = 0;
-    for (int i = 0; i < (int)nargs && i < cache->n_params; i++) {
+    for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
       if (!cache->param_meta[i].is_constexpr)
-        vc_args[4 + ki++] = args[i];
+        vc_args[4 + ki++] = effective_args[i];
     }
     PyObject *result =
         PyObject_Vectorcall(dispatcher, vc_args, vc_nargs, nullptr);
@@ -1549,6 +1581,7 @@ static void JITCacheProxy_dealloc(PyObject *o) {
   Py_XDECREF(self->grid_py[2]);
   Py_XDECREF(self->stream_getter);
   Py_XDECREF(self->device_getter);
+  Py_XDECREF(self->param_name_to_idx);
   Py_TYPE(o)->tp_free(o);
 }
 
@@ -1562,6 +1595,7 @@ static int JITCacheProxy_traverse(PyObject *o, visitproc visit, void *arg) {
   Py_VISIT(self->grid_py[2]);
   Py_VISIT(self->stream_getter);
   Py_VISIT(self->device_getter);
+  Py_VISIT(self->param_name_to_idx);
   return 0;
 }
 
@@ -1570,6 +1604,7 @@ static int JITCacheProxy_clear(PyObject *o) {
   Py_CLEAR(self->jit_fn);
   Py_CLEAR(self->params_list);
   Py_CLEAR(self->run_partial);
+  Py_CLEAR(self->param_name_to_idx);
   Py_CLEAR(self->grid_py[0]);
   Py_CLEAR(self->grid_py[1]);
   Py_CLEAR(self->grid_py[2]);
@@ -1692,6 +1727,14 @@ PyObject *native_create_jit_proxy(PyObject *self_unused, PyObject *const *args,
   Py_INCREF(stream_getter);
   proxy->device_getter = device_getter;
   Py_INCREF(device_getter);
+  // Get _param_name_to_idx from jit_fn for kwargs→positional merging
+  static PyObject *pnti_str = nullptr;
+  if (!pnti_str)
+    pnti_str = PyUnicode_InternFromString("_param_name_to_idx");
+  PyObject *pnti = PyObject_GetAttr(jit_fn, pnti_str);
+  proxy->param_name_to_idx = pnti; // may be NULL if attr missing
+  if (!pnti)
+    PyErr_Clear();
   proxy->options_hash = opts_hash;
   proxy->n_params = n_params;
   PyObject_GC_Track((PyObject *)proxy);

--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -1087,10 +1087,15 @@ static FastCache *fc_get_or_create(PyObject *jit_fn, PyObject *params_list,
     val = PyObject_GetAttrString(param, "annotation");
     if (val && val != Py_None) {
       const char *s = PyUnicode_AsUTF8(val);
-      if (s && s[0] == '*')
+      if (s && s[0] == '*') {
         cache->param_meta[i].is_ptr = 1;
-      else if (s && strncmp(s, "tensordesc", 10) == 0)
-        cache->param_meta[i].is_tensordesc = 1;
+      } else if (s) {
+        char lower[11] = {};
+        for (int j = 0; j < 10 && s[j]; j++)
+          lower[j] = (s[j] >= 'A' && s[j] <= 'Z') ? s[j] + 32 : s[j];
+        if (strncmp(lower, "tensordesc", 10) == 0)
+          cache->param_meta[i].is_tensordesc = 1;
+      }
     }
     if (val)
       Py_DECREF(val);
@@ -1258,9 +1263,27 @@ static bool fc_build_key(FCCacheKey &key, FastCache *cache,
         } else {
           key.slots[i].align_bit = 255;
         }
+      } else {
+        // fc_get_tensor_type_code failed — try detecting TensorDescriptor.
+        // TensorDescriptor has .base.dtype (not .dtype directly), so the
+        // tensor probe above fails. Detect by checking for .base + .block_shape
+        // and handle like meta.is_tensordesc to avoid false cache hits from
+        // zeroed slots that can't distinguish different TensorDescriptor types.
+        Py_hash_t h = fc_hash_tensordesc(arg);
+        if (h != -1) {
+          // It's a TensorDescriptor — cache this for future calls
+          meta.is_tensordesc = 1;
+          key.slots[i].type_code = TC_TENSORDESC;
+          key.slots[i].constexpr_hash = h;
+        } else {
+          // Not a TensorDescriptor either — truly unknown type.
+          // Return false to force cache miss (falling back to Python slow
+          // path) rather than leaving a zeroed slot that would produce
+          // false cache hits for different arg types at this position.
+          PyErr_Clear();
+          return false;
+        }
       }
-      // else: truly unknown type — slot stays zeroed (safe for fixed
-      // signatures where the same position always receives the same type).
     }
   }
   return true;

--- a/python/test/unit/cuda/test_tensordesc_tma_dispatcher.py
+++ b/python/test/unit/cuda/test_tensordesc_tma_dispatcher.py
@@ -1,0 +1,243 @@
+"""Correctness tests for TMA TensorDescriptor with C fast cache + _TritonDispatcher.
+
+Verifies that kernels using TMA-path TensorDescriptors (nvTmaDesc) produce
+correct results when launched via:
+  1. C fast cache (c_cache=True) — cache key correctly built
+  2. _TritonDispatcher (TRITON_USE_TRITON_DISPATCHER=1) — nvTmaDesc dispatched
+  3. Repeated calls hit cache and still produce correct results
+"""
+
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+def _get_device():
+    """Get the active torch device (deferred to avoid module-scope side effects)."""
+    return triton.runtime.driver.active.get_active_torch_device()
+
+
+@triton.jit(c_cache=True)
+def _tma_load_kernel(out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    """Load a block from TensorDescriptor (TMA) and store to output."""
+    block = desc.load([0, 0])
+    idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+    tl.store(out_ptr + idx, block)
+
+
+@triton.jit(c_cache=False)
+def _tma_load_kernel_nocache(out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    """Same kernel without c_cache — used as correctness reference."""
+    block = desc.load([0, 0])
+    idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+    tl.store(out_ptr + idx, block)
+
+
+@triton.jit(c_cache=True)
+def _tma_load_offset_kernel(out_ptr, desc, row_off, col_off, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    """Load a block at a given offset."""
+    block = desc.load([row_off, col_off])
+    idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+    tl.store(out_ptr + idx, block)
+
+
+class TestTmaTensorDescCorrectness(TestCase):
+    """Verify TMA TensorDescriptor produces correct results via fast cache + dispatcher."""
+
+    def setUp(self):
+        patcher = patch.dict(os.environ, {"TRITON_USE_TRITON_DISPATCHER": "1"})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_basic_load_correctness(self):
+        """TMA load through fast cache + dispatcher produces correct output."""
+        device = _get_device()
+        M_BLOCK, N_BLOCK = 8, 32
+        M, N = M_BLOCK * 3, N_BLOCK * 4
+
+        # Input tensor with known values
+        src = torch.arange(M * N, device=device, dtype=torch.float16).reshape(M, N)
+        out = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+        desc = TensorDescriptor(src, shape=src.shape, strides=src.stride(), block_shape=[M_BLOCK, N_BLOCK])
+
+        _tma_load_kernel[(1, )](out, desc, M, N, M_BLOCK, N_BLOCK)
+
+        # The kernel loads block at [0,0] — should be top-left M_BLOCK x N_BLOCK
+        expected = src[:M_BLOCK, :N_BLOCK]
+        torch.testing.assert_close(out, expected)
+
+    def test_matches_nocache_reference(self):
+        """Fast cache + dispatcher result matches no-cache Python path exactly."""
+        device = _get_device()
+        M_BLOCK, N_BLOCK = 8, 32
+        M, N = M_BLOCK * 2, N_BLOCK * 2
+
+        src = torch.randn(M, N, device=device, dtype=torch.float16)
+        desc = TensorDescriptor(src, shape=src.shape, strides=src.stride(), block_shape=[M_BLOCK, N_BLOCK])
+
+        out_cached = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+        out_nocache = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+
+        _tma_load_kernel[(1, )](out_cached, desc, M, N, M_BLOCK, N_BLOCK)
+        _tma_load_kernel_nocache[(1, )](out_nocache, desc, M, N, M_BLOCK, N_BLOCK)
+
+        torch.testing.assert_close(out_cached, out_nocache)
+
+    def test_repeated_calls_still_correct(self):
+        """Multiple cached calls with different data produce correct (not stale) results."""
+        device = _get_device()
+        M_BLOCK, N_BLOCK = 8, 32
+        M, N = M_BLOCK * 2, N_BLOCK * 2
+
+        for i in range(5):
+            src = torch.full((M, N), fill_value=float(i + 1), device=device, dtype=torch.float16)
+            out = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+            desc = TensorDescriptor(
+                src,
+                shape=src.shape,
+                strides=src.stride(),
+                block_shape=[M_BLOCK, N_BLOCK],
+            )
+
+            _tma_load_kernel[(1, )](out, desc, M, N, M_BLOCK, N_BLOCK)
+
+            expected = torch.full(
+                (M_BLOCK, N_BLOCK),
+                fill_value=float(i + 1),
+                device=device,
+                dtype=torch.float16,
+            )
+            torch.testing.assert_close(out, expected, msg=f"Failed on iteration {i}")
+
+    def test_different_tensors_same_desc_shape(self):
+        """Different backing tensors with same desc shape use cache but read correct data."""
+        device = _get_device()
+        M_BLOCK, N_BLOCK = 8, 32
+        M, N = M_BLOCK * 2, N_BLOCK * 2
+
+        src_a = torch.ones(M, N, device=device, dtype=torch.float16) * 42.0
+        src_b = torch.ones(M, N, device=device, dtype=torch.float16) * 7.0
+
+        desc_a = TensorDescriptor(
+            src_a,
+            shape=src_a.shape,
+            strides=src_a.stride(),
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+        desc_b = TensorDescriptor(
+            src_b,
+            shape=src_b.shape,
+            strides=src_b.stride(),
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+
+        # First call — populates cache
+        @triton.jit(c_cache=True)
+        def _load_kernel(out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+            block = desc.load([0, 0])
+            idx = (tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :])
+            tl.store(out_ptr + idx, block)
+
+        out_a = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+        out_b = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+
+        _load_kernel[(1, )](out_a, desc_a, M, N, M_BLOCK, N_BLOCK)
+        _load_kernel[(1, )](out_b, desc_b, M, N, M_BLOCK, N_BLOCK)
+
+        # Both should read their own data, NOT stale cached values
+        torch.testing.assert_close(out_a, torch.full_like(out_a, 42.0))
+        torch.testing.assert_close(out_b, torch.full_like(out_b, 7.0))
+
+    def test_offset_load_correctness(self):
+        """TMA load at non-zero offset produces correct block."""
+        device = _get_device()
+        M_BLOCK, N_BLOCK = 8, 32
+        M, N = M_BLOCK * 4, N_BLOCK * 4
+
+        src = torch.arange(M * N, device=device, dtype=torch.float16).reshape(M, N)
+        desc = TensorDescriptor(src, shape=src.shape, strides=src.stride(), block_shape=[M_BLOCK, N_BLOCK])
+
+        out = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+        row_off = M_BLOCK  # load second block row
+        col_off = N_BLOCK  # load second block col
+
+        _tma_load_offset_kernel[(1, )](out, desc, row_off, col_off, M, N, M_BLOCK, N_BLOCK)
+
+        expected = src[row_off:row_off + M_BLOCK, col_off:col_off + N_BLOCK]
+        torch.testing.assert_close(out, expected)
+
+
+class TestTmaCacheKeyDiscrimination(TestCase):
+    """Verify the C fast cache correctly distinguishes TMA TensorDescriptor specializations."""
+
+    def setUp(self):
+        patcher = patch.dict(os.environ, {"TRITON_USE_TRITON_DISPATCHER": "1"})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_different_dtype_different_compilation(self):
+        """fp16 vs fp32 TMA TensorDescriptors must compile different kernels."""
+        device = _get_device()
+        M_BLOCK, N_BLOCK = 8, 32
+        M, N = M_BLOCK * 2, N_BLOCK * 2
+
+        @triton.jit(c_cache=True)
+        def _dtype_kernel(out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+            block = desc.load([0, 0])
+            idx = (tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :])
+            tl.store(out_ptr + idx, block)
+
+        src_fp16 = torch.ones(M, N, device=device, dtype=torch.float16) * 3.0
+        src_fp32 = torch.ones(M, N, device=device, dtype=torch.float32) * 5.0
+
+        desc_fp16 = TensorDescriptor(
+            src_fp16,
+            shape=src_fp16.shape,
+            strides=src_fp16.stride(),
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+        desc_fp32 = TensorDescriptor(
+            src_fp32,
+            shape=src_fp32.shape,
+            strides=src_fp32.stride(),
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+
+        out_fp16 = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float16)
+        out_fp32 = torch.zeros(M_BLOCK, N_BLOCK, device=device, dtype=torch.float32)
+
+        _dtype_kernel[(1, )](out_fp16, desc_fp16, M, N, M_BLOCK, N_BLOCK)
+        _dtype_kernel[(1, )](out_fp32, desc_fp32, M, N, M_BLOCK, N_BLOCK)
+
+        # Each should produce correct output for its dtype
+        torch.testing.assert_close(out_fp16, torch.full_like(out_fp16, 3.0))
+        torch.testing.assert_close(out_fp32, torch.full_like(out_fp32, 5.0))
+
+    def test_different_block_shape_different_compilation(self):
+        """Different block_shapes must compile different kernels (different constexpr)."""
+        device = _get_device()
+
+        src = torch.arange(64 * 128, device=device, dtype=torch.float16).reshape(64, 128)
+
+        @triton.jit(c_cache=True)
+        def _block_kernel(out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+            block = desc.load([0, 0])
+            idx = (tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :])
+            tl.store(out_ptr + idx, block)
+
+        # Block shape 8x32
+        desc_8x32 = TensorDescriptor(src, shape=src.shape, strides=src.stride(), block_shape=[8, 32])
+        out_8x32 = torch.zeros(8, 32, device=device, dtype=torch.float16)
+        _block_kernel[(1, )](out_8x32, desc_8x32, 64, 128, 8, 32)
+        torch.testing.assert_close(out_8x32, src[:8, :32])
+
+        # Block shape 16x64
+        desc_16x64 = TensorDescriptor(src, shape=src.shape, strides=src.stride(), block_shape=[16, 64])
+        out_16x64 = torch.zeros(16, 64, device=device, dtype=torch.float16)
+        _block_kernel[(1, )](out_16x64, desc_16x64, 64, 128, 16, 64)
+        torch.testing.assert_close(out_16x64, src[:16, :64])

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -808,11 +808,10 @@ class JITFunction(JITCallable, KernelInterface[T]):
             if kwargs:
                 _fc_args = list(args)
                 _fc_opts = {}
-                _param_names = self.arg_names
-                _param_set = set(_param_names)
+                _name_to_idx = self._param_name_to_idx
                 for k, v in kwargs.items():
-                    if k in _param_set:
-                        idx = _param_names.index(k)
+                    idx = _name_to_idx.get(k)
+                    if idx is not None:
                         while len(_fc_args) <= idx:
                             _fc_args.append(None)
                         _fc_args[idx] = v
@@ -949,11 +948,10 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 if _user_kwargs:
                     _ins_args = list(args)
                     _ins_opts = {}
-                    _param_names = self.arg_names
-                    _param_set = set(_param_names)
+                    _name_to_idx = self._param_name_to_idx
                     for k, v in _user_kwargs.items():
-                        if k in _param_set:
-                            idx = _param_names.index(k)
+                        idx = _name_to_idx.get(k)
+                        if idx is not None:
                             while len(_ins_args) <= idx:
                                 _ins_args.append(None)
                             _ins_args[idx] = v
@@ -1016,6 +1014,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # TODO(jlebar): Remove uses of these fields outside this file, then
         # remove the fields here.
         self.arg_names = [p.name for p in self.params]
+        self._param_name_to_idx = {name: i for i, name in enumerate(self.arg_names)}
         self.constexprs = [p.num for p in self.params if p.is_constexpr]
 
         # Hooks that will be called prior to executing "run"

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -411,6 +411,12 @@ class KernelInterface(Generic[T]):
                 if proxy is not None:
                     cache[grid_key] = proxy
             if proxy is not None:
+                # For pure positional calls, return proxy directly — avoids
+                # the overhead of an intermediate Python *args/**kwargs closure
+                # (~5-10us per dispatch due to tuple reallocation).
+                # Kernels called with kwargs (e.g., mm.py) will hit the proxy
+                # and get TypeError, so those callers should use the autotuner
+                # path which merges kwargs→positional before calling the proxy.
                 return proxy
         return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
         # return cast(T, functools.partial(cast(Callable, self.run), grid=grid))
@@ -790,7 +796,6 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # (callable grid, first call, or C extension unavailable).
         # Static-grid repeat calls go through JITCacheProxy directly.
         if not _skip_fc and self.c_cache and not warmup and not self.pre_run_hooks and not knobs.compilation.always_compile \
-                and not self.used_global_vals \
                 and knobs.runtime.add_stages_inspection_hook is None \
                 and not knobs.runtime.launch_enter_hook and not knobs.runtime.launch_exit_hook \
                 and not self.launch_metadata:
@@ -819,6 +824,11 @@ class JITFunction(JITCallable, KernelInterface[T]):
             else:
                 _fc_args = args
                 _fc_hash = self._fc_options_hash
+            # Pad missing trailing args (default-valued constexpr params not
+            # explicitly passed) with None so the arg count matches n_params.
+            # None slots are hashed as TC_CONSTEXPR(hash(None)) which is stable.
+            if len(_fc_args) < len(self.params):
+                _fc_args = tuple(list(_fc_args) + [None] * (len(self.params) - len(_fc_args)))
             if len(_fc_args) == len(self.params):
                 if callable(grid):
                     _fc_grid = grid(dict(zip(self.arg_names, _fc_args)))
@@ -826,15 +836,29 @@ class JITFunction(JITCallable, KernelInterface[T]):
                     _fc_grid = grid
                 result = native_fast_dispatch(self, _fc_args, self.params, _fc_hash, _fc_grid, stream)
                 if result is not None:
-                    kernel = result
-                    if not getattr(kernel, '_dispatcher', None):
-                        grid_size = len(_fc_grid) if isinstance(_fc_grid, (tuple, list)) else 1
-                        grid_0 = _fc_grid[0] if grid_size > 0 else 1
-                        grid_1 = _fc_grid[1] if grid_size > 1 else 1
-                        grid_2 = _fc_grid[2] if grid_size > 2 else 1
-                        kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, None, None,
-                                   None, *_fc_args)
-                    return kernel
+                    # Verify globals haven't changed (cheap dict lookups).
+                    # used_global_vals tracks Python globals referenced in the kernel
+                    # body (e.g., module-level constants used as tl.constexpr). Their
+                    # values are baked into the compiled kernel at specialization time,
+                    # so if they change, the cached kernel is stale — fall through to
+                    # slow path which detects the mismatch and triggers recompilation.
+                    _globals_ok = True
+                    if self.used_global_vals:
+                        _not_present = object()
+                        for (name, _), (val, globals_dict) in self.used_global_vals.items():
+                            if globals_dict.get(name, _not_present) != val:
+                                _globals_ok = False
+                                break
+                    if _globals_ok:
+                        kernel = result
+                        if not getattr(kernel, '_dispatcher', None):
+                            grid_size = len(_fc_grid) if isinstance(_fc_grid, (tuple, list)) else 1
+                            grid_0 = _fc_grid[0] if grid_size > 0 else 1
+                            grid_1 = _fc_grid[1] if grid_size > 1 else 1
+                            grid_2 = _fc_grid[2] if grid_size > 2 else 1
+                            kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, None,
+                                       None, None, *_fc_args)
+                        return kernel
         _user_kwargs = dict(kwargs) if kwargs else {}
         kwargs["debug"] = kwargs.get("debug", self.debug) or knobs.runtime.debug
         # Enable sanitize_overflow if explicitly set via kwarg, env var (TRITON_SANITIZE_OVERFLOW), or if debug is enabled
@@ -876,6 +900,9 @@ class JITFunction(JITCallable, KernelInterface[T]):
             kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup)
             if kernel is None:
                 return None
+            _fc_needs_insert = self.c_cache
+        else:
+            _fc_needs_insert = False
 
         # Check that used global values have not changed.
         not_present = object()
@@ -916,8 +943,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
                            knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook, *bound_args.values())
 
-            # Populate C specialization cache for future calls.
-            if self.c_cache:
+            # Populate C specialization cache for future calls (only on first compile).
+            if _fc_needs_insert:
                 _disp = getattr(kernel, '_dispatcher', None)
                 if _user_kwargs:
                     _ins_args = list(args)
@@ -938,6 +965,9 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 else:
                     _ins_args = args
                     _ins_hash = self._fc_options_hash
+                # Pad missing trailing args (same as lookup path)
+                if len(_ins_args) < len(self.params):
+                    _ins_args = tuple(list(_ins_args) + [None] * (len(self.params) - len(_ins_args)))
                 native_fast_dispatch_insert(self, _ins_args, self.params, _ins_hash, kernel, _disp)
         return kernel
 
@@ -956,8 +986,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
         self.do_not_specialize_on_alignment = do_not_specialize_on_alignment
         self._repr = repr
         self.launch_metadata = launch_metadata
-        self.c_cache = c_cache
-        if c_cache:
+        self.c_cache = c_cache or (os.environ.get("TRITON_ENABLE_C_CACHE", "0") == "1")
+        if self.c_cache:
             _ensure_torch_bridge()
         # Register for simple deserialization of JITFunction constants
         _triton_jit_function_registry[f"{self.module}:{self.fn.__qualname__}"] = self

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -542,9 +542,11 @@ static PyObject *fillTMADescriptorTiled(PyObject *self, PyObject *args) {
 
   // Follow the CUTLASS change for the driver version check
   // https://github.com/NVIDIA/cutlass/commit/b7ecaa605dd70326900433695e11ebfec407edd2#diff-1dfcaf77b33258ff3175540718d9caff1cd471215f741ba42943ef00770e6d04
-  int driver_version = 0;
-  CUresult driver_version_result = cuDriverGetVersion(&driver_version);
-  assert(driver_version_result == CUDA_SUCCESS);
+  static int driver_version = -1;
+  if (driver_version < 0) {
+    CUresult driver_version_result = cuDriverGetVersion(&driver_version);
+    assert(driver_version_result == CUDA_SUCCESS);
+  }
 
   if (driver_version <= 13010) {
     int max_byte_index = 0;
@@ -1184,7 +1186,9 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
 }
 
 static PyObject *data_ptr_str = NULL;
-static PyObject *td_get_str = NULL; /* interned "get" for allocator.get() */
+static PyObject *td_get_str = NULL;  /* interned "get" for allocator.get() */
+static PyObject *padding_str = NULL; /* interned "padding" for TMA fill mode */
+static PyObject *nan_str = NULL; /* interned "nan" for NaN fill comparison */
 
 // Extract a CUDA device pointer from a pointer-like PyObject obj, and store
 // it to the memory location pointed by ptr.
@@ -1393,7 +1397,15 @@ typedef enum {
   EXTRACTOR_FP32_INDEX = 12,
   EXTRACTOR_FP64_INDEX = 13,
   // custom
-  EXTRACTOR_NVTMADESC_INDEX = 14,
+  EXTRACTOR_NVTMADESC_INDEX =
+      14, /* pre-built TMA desc (PyCUtensorMap or tma_desc_cpu_ptr());
+              used by _experimental_descriptor API and as fallback
+              when Python wrap_handle_tensordesc() pre-encodes */
+  EXTRACTOR_TENSORDESC_INDEX =
+      15, /* raw TensorDescriptor → build TMA desc in C (cached);
+              replaces Python-side make_tensordesc_arg() for the
+              new TensorDescriptor API */
+  EXTRACTOR_SKIP_INDEX = 16, /* shadow arg filled by TMA expansion */
   // last entry to have a count
   EXTRACTOR_TYPE_COUNT
 } ExtractorTypeIndex;
@@ -1710,8 +1722,56 @@ cleanup:
  * Calling convention: dispatcher(grid_x, grid_y, grid_z, stream, *kernel_args)
  * ========================================================================= */
 
+/* ============================================================
+ * Torch bridge API — fast TensorDescriptor field extraction
+ * ============================================================ */
+typedef struct {
+  int8_t (*get_scalar_type)(PyObject *);
+  uint64_t (*get_data_ptr)(PyObject *);
+  int (*extract_tensordesc)(PyObject *td_obj, uint64_t *out_data_ptr,
+                            int64_t *out_shape, int64_t *out_strides,
+                            int max_ndim);
+} TritonTensorAccessAPI;
+
+static TritonTensorAccessAPI *g_td_bridge = NULL;
+
+static PyObject *register_tensor_bridge(PyObject *self, PyObject *arg) {
+  (void)self;
+  if (!PyCapsule_IsValid(arg, "triton_tensor_access_api")) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "Expected a PyCapsule with name 'triton_tensor_access_api'");
+    return NULL;
+  }
+  g_td_bridge = (TritonTensorAccessAPI *)PyCapsule_GetPointer(
+      arg, "triton_tensor_access_api");
+  Py_RETURN_NONE;
+}
+
 #define TD_MAX_KERNEL_ARGS 64
-#define TD_FIXED_ARGS 4 /* grid_x, grid_y, grid_z, stream */
+#define TD_FIXED_ARGS 4          /* grid_x, grid_y, grid_z, stream */
+#define TD_MAX_TMA_DESCS 8       /* max nvTmaDesc args per kernel */
+#define TD_MAX_TENSORDESC_NDIM 5 /* max dimensionality for TensorDescriptor */
+
+/* Per-TMA-slot metadata for inline expansion of TensorDescriptor objects */
+typedef struct {
+  int swizzle;
+  int elem_size;
+  int elem_type; /* host-remapped CUtensorMapDataType */
+  int ndim;
+  int fp4_padded;
+  uint32_t block_size[TD_MAX_TENSORDESC_NDIM];
+  /* Shadow arg indices: where to write shape[j] and strides[j] in kernel_params
+   */
+  int shape_param_indices[TD_MAX_TENSORDESC_NDIM];
+  int stride_param_indices[TD_MAX_TENSORDESC_NDIM];
+  /* Cache: skip cuTensorMapEncodeTiled if unchanged */
+  uint64_t cached_data_ptr;
+  int64_t cached_shape[TD_MAX_TENSORDESC_NDIM];
+  int64_t cached_strides[TD_MAX_TENSORDESC_NDIM];
+  int cached_fill; /* CUtensorMapFloatOOBfill value (padding mode) */
+  int cache_valid;
+} TMASlotMeta;
 
 typedef union {
   CUdeviceptr ptr;
@@ -1736,7 +1796,8 @@ typedef struct {
   CUlaunchAttribute launch_attrs[5];
   unsigned num_launch_attrs;
   int arg_types[TD_MAX_KERNEL_ARGS]; /* ExtractorTypeIndex values */
-  int num_args;
+  int num_args;      /* total kernel param slots (excluding scratch) */
+  int num_user_args; /* number of Python-visible args passed by caller */
   int total_params;
   TDArgSlot arg_storage[TD_MAX_KERNEL_ARGS];
   void *kernel_params[TD_MAX_KERNEL_ARGS];
@@ -1749,6 +1810,12 @@ typedef struct {
   unsigned profile_scratch_align;
   PyObject *allocator;         /* _allocation._allocator (ContextVar) */
   PyObject *profile_allocator; /* _allocation._profile_allocator (wrapper) */
+  /* TMA descriptor storage (128-byte aligned) */
+  int num_tma_descs;
+  int tma_slot_for_arg[TD_MAX_KERNEL_ARGS]; /* -1 if not TMA, else tma_descs
+                                               index */
+  TMASlotMeta tma_meta[TD_MAX_TMA_DESCS];
+  CUtensorMap tma_descs[TD_MAX_TMA_DESCS] __attribute__((aligned(128)));
 } TritonDispatcher;
 
 /* Forward declarations */
@@ -1790,10 +1857,192 @@ static inline uint16_t td_pack_bf16(double v) {
 }
 
 /* Arg conversion using ExtractorTypeIndex codes */
+
+/* Extract and expand a raw TensorDescriptor into a TMA descriptor.
+ * Handles: field extraction (via bridge or Python fallback), per-slot caching,
+ * cuTensorMapEncodeTiled on cache miss, and filling shadow shape/stride slots.
+ */
+static int td_extract_tensordesc(TritonDispatcher *self, int i, PyObject *a) {
+  int slot = self->tma_slot_for_arg[i];
+  if (slot < 0 || slot >= TD_MAX_TMA_DESCS) {
+    PyErr_Format(PyExc_RuntimeError, "Invalid TMA slot %d for arg %d", slot, i);
+    return -1;
+  }
+  TMASlotMeta *meta = &self->tma_meta[slot];
+  int ndim = meta->ndim;
+
+  uint64_t data_ptr;
+  int64_t cur_shape[TD_MAX_TENSORDESC_NDIM];
+  int64_t cur_strides[TD_MAX_TENSORDESC_NDIM];
+
+  if (g_td_bridge && g_td_bridge->extract_tensordesc) {
+    /* Fast path: use bridge to extract fields directly */
+    int got_ndim = g_td_bridge->extract_tensordesc(
+        a, &data_ptr, cur_shape, cur_strides, TD_MAX_TENSORDESC_NDIM);
+    if (got_ndim < 0) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "Failed to extract TensorDescriptor via bridge");
+      return -1;
+    }
+  } else {
+    /* Slow fallback: Python attribute lookups */
+    PyObject *base_obj = PyObject_GetAttrString(a, "base");
+    if (!base_obj)
+      return -1;
+    PyObject *dptr_obj = PyObject_CallMethodNoArgs(base_obj, data_ptr_str);
+    Py_DECREF(base_obj);
+    if (!dptr_obj)
+      return -1;
+    data_ptr = PyLong_AsUnsignedLongLong(dptr_obj);
+    Py_DECREF(dptr_obj);
+
+    PyObject *shape_obj = PyObject_GetAttrString(a, "shape");
+    if (!shape_obj)
+      return -1;
+    PyObject *shape_fast = PySequence_Fast(shape_obj, "shape");
+    Py_DECREF(shape_obj);
+    if (!shape_fast)
+      return -1;
+    for (int j = 0; j < ndim; j++)
+      cur_shape[j] = PyLong_AsLongLong(PySequence_Fast_GET_ITEM(shape_fast, j));
+    Py_DECREF(shape_fast);
+
+    PyObject *strides_obj = PyObject_GetAttrString(a, "strides");
+    if (!strides_obj)
+      return -1;
+    PyObject *strides_fast = PySequence_Fast(strides_obj, "strides");
+    Py_DECREF(strides_obj);
+    if (!strides_fast)
+      return -1;
+    for (int j = 0; j < ndim; j++)
+      cur_strides[j] =
+          PyLong_AsLongLong(PySequence_Fast_GET_ITEM(strides_fast, j));
+    Py_DECREF(strides_fast);
+
+    if (PyErr_Occurred())
+      return -1;
+  }
+
+  /* Resolve padding/fill mode upfront (needed for cache key) */
+  CUtensorMapFloatOOBfill fill = CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE;
+  PyObject *pad_obj = PyObject_GetAttr(a, padding_str);
+  if (pad_obj) {
+    if (PyObject_RichCompareBool(pad_obj, nan_str, Py_EQ) == 1)
+      fill = CU_TENSOR_MAP_FLOAT_OOB_FILL_NAN_REQUEST_ZERO_FMA;
+    Py_DECREF(pad_obj);
+  } else {
+    PyErr_Clear();
+  }
+
+  /* Check cache (data_ptr + shape + strides + padding) */
+  int cache_hit = meta->cache_valid && (meta->cached_data_ptr == data_ptr) &&
+                  (meta->cached_fill == (int)fill);
+  if (cache_hit) {
+    for (int j = 0; j < ndim; j++) {
+      if (meta->cached_shape[j] != cur_shape[j] ||
+          meta->cached_strides[j] != cur_strides[j]) {
+        cache_hit = 0;
+        break;
+      }
+    }
+  }
+
+  if (!cache_hit) {
+    /* Rebuild TMA descriptor in-place */
+    int elem_size = meta->elem_size;
+    int rank = ndim;
+    uint32_t blockSizeInt[TD_MAX_TENSORDESC_NDIM];
+    uint64_t shapeInt[TD_MAX_TENSORDESC_NDIM];
+    uint64_t stridesLL[TD_MAX_TENSORDESC_NDIM];
+
+    int64_t *eshape = cur_shape;
+    int64_t expanded_shape_buf[TD_MAX_TENSORDESC_NDIM];
+    if (meta->fp4_padded) {
+      for (int j = 0; j < rank; j++)
+        expanded_shape_buf[j] = cur_shape[j];
+      expanded_shape_buf[rank - 1] *= 2;
+      eshape = expanded_shape_buf;
+    }
+
+    /* Reverse order for cuTensorMapEncodeTiled (row-major → col-major) */
+    for (int j = 0; j < rank; j++) {
+      blockSizeInt[rank - j - 1] = meta->block_size[j];
+      shapeInt[rank - j - 1] = (uint64_t)eshape[j];
+    }
+    for (int j = 0; j + 1 < rank; j++)
+      stridesLL[rank - j - 2] = (uint64_t)(elem_size * cur_strides[j]);
+    stridesLL[rank - 1] =
+        shapeInt[rank - 1] *
+        (rank == 1 ? (uint64_t)elem_size : stridesLL[rank - 2]);
+
+    uint32_t elementStrides[TD_MAX_TENSORDESC_NDIM] = {1, 1, 1, 1, 1};
+    static cuTensorMapEncodeTiled_t cuTensorMapEncodeTiled_fn = NULL;
+    if (!cuTensorMapEncodeTiled_fn)
+      cuTensorMapEncodeTiled_fn = getCuTensorMapEncodeTiledHandle();
+    if (!cuTensorMapEncodeTiled_fn)
+      return -1;
+
+    CUresult res = cuTensorMapEncodeTiled_fn(
+        &self->tma_descs[slot], meta->elem_type, rank,
+        (void *)(uintptr_t)data_ptr, shapeInt, stridesLL, blockSizeInt,
+        elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE, meta->swizzle,
+        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, fill);
+    if (res != CUDA_SUCCESS) {
+      const char *str;
+      cuGetErrorString(res, &str);
+      PyErr_Format(PyExc_RuntimeError,
+                   "cuTensorMapEncodeTiled failed in TMA expansion: %s",
+                   str ? str : "?");
+      return -1;
+    }
+
+    /* CUTLASS driver workaround */
+    static int driver_version = -1;
+    if (driver_version < 0)
+      cuDriverGetVersion(&driver_version);
+    if (driver_version <= 13010) {
+      int max_byte_index = 0;
+      for (int j = 0; j < rank; j++) {
+        int bytes_stride = j == 0 ? elem_size : (int)stridesLL[j - 1];
+        max_byte_index += ((int)shapeInt[j] - 1) * bytes_stride;
+      }
+      if (max_byte_index + 1 < 128 * 1024) {
+        uint64_t *desc_u64 = (uint64_t *)&self->tma_descs[slot];
+        desc_u64[1] &= ~(1llu << 21);
+      }
+    }
+
+    /* Update cache */
+    meta->cached_data_ptr = data_ptr;
+    meta->cached_fill = (int)fill;
+    for (int j = 0; j < ndim; j++) {
+      meta->cached_shape[j] = cur_shape[j];
+      meta->cached_strides[j] = cur_strides[j];
+    }
+    meta->cache_valid = 1;
+  }
+
+  /* Fill shadow shape/stride kernel_params slots */
+  for (int j = 0; j < ndim; j++) {
+    int si = meta->shape_param_indices[j];
+    if (si >= 0)
+      self->arg_storage[si].i32 = (int32_t)cur_shape[j];
+    int sti = meta->stride_param_indices[j];
+    if (sti >= 0)
+      self->arg_storage[sti].i64 = cur_strides[j];
+  }
+  return 0;
+}
+
 static inline int td_convert_args(TritonDispatcher *self,
                                   PyObject *const *kargs) {
+  int user_idx = 0; /* index into kargs[] (Python-visible args) */
   for (int i = 0; i < self->num_args; i++) {
-    PyObject *a = kargs[i];
+    if (self->arg_types[i] == EXTRACTOR_SKIP_INDEX) {
+      /* Shadow arg: filled by EXTRACTOR_TENSORDESC_INDEX, skip Python arg */
+      continue;
+    }
+    PyObject *a = kargs[user_idx++];
     TDArgSlot *s = &self->arg_storage[i];
     switch (self->arg_types[i]) {
     case EXTRACTOR_POINTER_INDEX:
@@ -1836,6 +2085,25 @@ static inline int td_convert_args(TritonDispatcher *self,
     }
     case EXTRACTOR_FP64_INDEX:
       s->f64 = PyFloat_AsDouble(a);
+      break;
+    case EXTRACTOR_NVTMADESC_INDEX: {
+      int slot = self->tma_slot_for_arg[i];
+      if (slot < 0 || slot >= TD_MAX_TMA_DESCS) {
+        PyErr_Format(PyExc_RuntimeError, "Invalid TMA slot %d for arg %d", slot,
+                     i);
+        return -1;
+      }
+      if (!extractTmaDesc(&self->tma_descs[slot], a))
+        return -1;
+      break;
+    }
+    case EXTRACTOR_TENSORDESC_INDEX: {
+      if (td_extract_tensordesc(self, i, a) < 0)
+        return -1;
+      break;
+    }
+    case EXTRACTOR_SKIP_INDEX:
+      /* Shadow arg: already filled by EXTRACTOR_TENSORDESC_INDEX above */
       break;
     default:
       PyErr_Format(PyExc_TypeError, "Unknown type code %d for arg %d",
@@ -1895,14 +2163,17 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
                            "profile_scratch_align",
                            "allocator",
                            "profile_allocator",
+                           "tma_meta",
                            NULL};
+  PyObject *tma_meta_list = NULL;
 
   if (!PyArg_ParseTupleAndKeywords(
-          args, kwargs, "KiiiiiiOpp|IIIIOO", kwlist, &func_ptr, &num_warps,
+          args, kwargs, "KiiiiiiOpp|IIIIOOO", kwlist, &func_ptr, &num_warps,
           &num_ctas, &shared_mem, &launch_pdl, &launch_coop, &launch_cluster,
           &arg_type_codes, &has_global_scratch, &has_profile_scratch,
           &global_scratch_size, &global_scratch_align, &profile_scratch_size,
-          &profile_scratch_align, &allocator_obj, &profile_allocator_obj))
+          &profile_scratch_align, &allocator_obj, &profile_allocator_obj,
+          &tma_meta_list))
     return NULL;
 
   TritonDispatcher *self = (TritonDispatcher *)type->tp_alloc(type, 0);
@@ -1937,6 +2208,8 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
     return NULL;
   }
   self->num_args = (int)n;
+  self->num_user_args =
+      (int)n; /* default: same as num_args; updated below for SKIP */
   for (Py_ssize_t i = 0; i < n; i++)
     self->arg_types[i] =
         (int)PyLong_AsLong(PyTuple_GET_ITEM(arg_type_codes, i));
@@ -1944,18 +2217,103 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
     Py_DECREF(self);
     return NULL;
   }
+  /* Count user-visible args (exclude SKIP slots) */
+  {
+    int user_count = 0;
+    for (int i = 0; i < self->num_args; i++) {
+      if (self->arg_types[i] != EXTRACTOR_SKIP_INDEX)
+        user_count++;
+    }
+    self->num_user_args = user_count;
+  }
 
   /* Build kernel_params pointers */
   int pidx = 0;
+  int tma_idx = 0;
+  memset(self->tma_slot_for_arg, -1, sizeof(self->tma_slot_for_arg));
+  memset(self->tma_meta, 0, sizeof(self->tma_meta));
   for (int i = 0; i < self->num_args; i++) {
-    self->kernel_params[pidx] = &self->arg_storage[pidx];
+    if (self->arg_types[i] == EXTRACTOR_NVTMADESC_INDEX ||
+        self->arg_types[i] == EXTRACTOR_TENSORDESC_INDEX) {
+      if (tma_idx >= TD_MAX_TMA_DESCS) {
+        PyErr_SetString(PyExc_ValueError, "Too many nvTmaDesc/TensorDesc args");
+        Py_DECREF(self);
+        return NULL;
+      }
+      self->tma_slot_for_arg[i] = tma_idx;
+      self->kernel_params[pidx] = &self->tma_descs[tma_idx];
+      tma_idx++;
+    } else {
+      self->kernel_params[pidx] = &self->arg_storage[pidx];
+    }
     pidx++;
   }
+  self->num_tma_descs = tma_idx;
   self->kernel_params[pidx] = &self->arg_storage[pidx];
   pidx++; /* global_scratch */
   self->kernel_params[pidx] = &self->arg_storage[pidx];
   pidx++; /* profile_scratch */
   self->total_params = pidx;
+
+  /* Parse tma_meta list if provided (for EXTRACTOR_TENSORDESC_INDEX slots) */
+  if (tma_meta_list && tma_meta_list != Py_None &&
+      PyList_Check(tma_meta_list)) {
+    Py_ssize_t nmeta = PyList_Size(tma_meta_list);
+    for (Py_ssize_t mi = 0; mi < nmeta && mi < TD_MAX_TMA_DESCS; mi++) {
+      PyObject *d = PyList_GET_ITEM(tma_meta_list, mi);
+      if (!PyDict_Check(d))
+        continue;
+      TMASlotMeta *m = &self->tma_meta[mi];
+      PyObject *v;
+      v = PyDict_GetItemString(d, "swizzle");
+      if (v)
+        m->swizzle = (int)PyLong_AsLong(v);
+      v = PyDict_GetItemString(d, "elem_size");
+      if (v)
+        m->elem_size = (int)PyLong_AsLong(v);
+      v = PyDict_GetItemString(d, "elem_type");
+      if (v)
+        m->elem_type = (int)PyLong_AsLong(v);
+      v = PyDict_GetItemString(d, "ndim");
+      if (v)
+        m->ndim = (int)PyLong_AsLong(v);
+      v = PyDict_GetItemString(d, "fp4_padded");
+      if (v)
+        m->fp4_padded = PyObject_IsTrue(v);
+      v = PyDict_GetItemString(d, "block_size");
+      if (v && PySequence_Check(v)) {
+        Py_ssize_t blen = PySequence_Size(v);
+        for (Py_ssize_t j = 0; j < blen && j < TD_MAX_TENSORDESC_NDIM; j++) {
+          PyObject *item = PySequence_GetItem(v, j);
+          m->block_size[j] = (uint32_t)PyLong_AsUnsignedLong(item);
+          Py_DECREF(item);
+        }
+      }
+      v = PyDict_GetItemString(d, "shape_param_indices");
+      if (v && PySequence_Check(v)) {
+        Py_ssize_t slen = PySequence_Size(v);
+        for (Py_ssize_t j = 0; j < slen && j < TD_MAX_TENSORDESC_NDIM; j++) {
+          PyObject *item = PySequence_GetItem(v, j);
+          m->shape_param_indices[j] = (int)PyLong_AsLong(item);
+          Py_DECREF(item);
+        }
+      }
+      v = PyDict_GetItemString(d, "stride_param_indices");
+      if (v && PySequence_Check(v)) {
+        Py_ssize_t slen = PySequence_Size(v);
+        for (Py_ssize_t j = 0; j < slen && j < TD_MAX_TENSORDESC_NDIM; j++) {
+          PyObject *item = PySequence_GetItem(v, j);
+          m->stride_param_indices[j] = (int)PyLong_AsLong(item);
+          Py_DECREF(item);
+        }
+      }
+      m->cache_valid = 0;
+    }
+    if (PyErr_Occurred()) {
+      Py_DECREF(self);
+      return NULL;
+    }
+  }
 
   /* Pre-build launch attributes */
   unsigned na = 0;
@@ -2003,10 +2361,10 @@ static PyObject *TritonDispatcher_vectorcall(PyObject *callable,
   TritonDispatcher *self = (TritonDispatcher *)callable;
   Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
 
-  if (nargs < TD_FIXED_ARGS + self->num_args) {
+  if (nargs < TD_FIXED_ARGS + self->num_user_args) {
     PyErr_Format(PyExc_TypeError,
                  "_TritonDispatcher: expected %d args, got %zd",
-                 TD_FIXED_ARGS + self->num_args, nargs);
+                 TD_FIXED_ARGS + self->num_user_args, nargs);
     return NULL;
   }
 
@@ -2563,6 +2921,8 @@ static PyMethodDef ModuleMethods[] = {
      "doc"},
     {"create_fast_jit_type", py_create_fast_jit_type, METH_O,
      "Create a heap type inheriting from JITFunction with C mp_subscript"},
+    {"register_tensor_bridge", register_tensor_bridge, METH_O,
+     "Register PyCapsule from _torch_bridge for fast TensorDescriptor access"},
 
     {NULL, NULL, 0, NULL} // sentinel
 };
@@ -2599,6 +2959,14 @@ PyMODINIT_FUNC PyInit_cuda_utils(void) {
   }
   td_get_str = PyUnicode_InternFromString("get");
   if (td_get_str == NULL) {
+    return NULL;
+  }
+  padding_str = PyUnicode_InternFromString("padding");
+  if (padding_str == NULL) {
+    return NULL;
+  }
+  nan_str = PyUnicode_InternFromString("nan");
+  if (nan_str == NULL) {
     return NULL;
   }
 

--- a/third_party/nvidia/backend/triton_dispatcher_factory.py
+++ b/third_party/nvidia/backend/triton_dispatcher_factory.py
@@ -17,10 +17,21 @@ import re
 from triton.runtime import _allocation
 from triton.runtime.driver import driver
 
+_bridge_registered = False
+
 
 def _load_module():
     """Return the cuda_utils module (contains _TritonDispatcher type)."""
-    return driver.active.utils
+    global _bridge_registered
+    mod = driver.active.utils
+    if not _bridge_registered:
+        _bridge_registered = True
+        try:
+            from triton._C._torch_bridge import get_tensor_access_capsule
+            mod.register_tensor_bridge(get_tensor_access_capsule())
+        except (ImportError, AttributeError):
+            pass  # Bridge not available, fallback to slow path
+    return mod
 
 
 def _expand_schema_arg_types(schema):
@@ -60,8 +71,12 @@ def _expand_schema_arg_types(schema):
                 for _ in range(ndim):
                     flat_types.append("i64")
             else:
-                # TMA path uses nvTmaDesc which the C dispatcher doesn't handle.
-                return None, None
+                # TMA path: nvTmaDesc + shapes (i32) + strides (i64)
+                flat_types.append("nvTmaDesc")
+                for _ in range(ndim):
+                    flat_types.append("i32")
+                for _ in range(ndim):
+                    flat_types.append("i64")
         else:
             flat_types.append(ty)
 
@@ -69,19 +84,26 @@ def _expand_schema_arg_types(schema):
 
 
 class _TensorDescDispatcherWrapper:
-    """Wrapper that expands tensordesc args before calling the C dispatcher."""
+    """Wrapper that expands host-side tensordesc args before calling the C dispatcher.
 
-    __slots__ = ("_c_dispatcher", "_tensordesc_positions")
+    Only used for host-side tensordescs (meta=None). TMA tensordescs are
+    expanded directly in C via EXTRACTOR_TENSORDESC_INDEX (type code 15).
+    """
+
+    __slots__ = ("_c_dispatcher", "_tensordesc_info_map")
 
     def __init__(self, c_dispatcher, tensordesc_info):
         self._c_dispatcher = c_dispatcher
-        # Only non-TMA tensordesc (meta=None) reaches here.
-        self._tensordesc_positions = set(pos for pos, _, _ in tensordesc_info)
+        # Map from position in schema args → (ndim, meta)
+        self._tensordesc_info_map = {pos: (ndim, meta) for pos, ndim, meta in tensordesc_info}
 
     def __call__(self, grid_x, grid_y, grid_z, stream, *kernel_args):
         expanded = []
         for i, arg in enumerate(kernel_args):
-            if i in self._tensordesc_positions:
+            info = self._tensordesc_info_map.get(i)
+            if info is not None:
+                _, meta = info
+                assert meta is None, "TMA tensordesc should be handled in C, not Python wrapper"
                 # Host-side tensordesc: base ptr, shape, strides, padding, shape, strides
                 expanded.append(arg.base)
                 expanded.extend(arg.shape)
@@ -102,18 +124,75 @@ def make_triton_dispatcher(schema, cu_function: int):
         cu_function: CUfunction handle as uint64
 
     Returns:
-        A callable _TritonDispatcher instance (or wrapper for tensordesc kernels).
+        A callable _TritonDispatcher instance.
         Call as: dispatcher(grid_x, grid_y, grid_z, stream, *kernel_args)
     """
     mod = _load_module()
 
     # Expand tensordesc types into flat component types for build_signature_metadata.
-    # Returns None for tensordesc_info if TMA path is detected (unsupported by C dispatcher).
     flat_types, tensordesc_info = _expand_schema_arg_types(schema)
     if flat_types is None:
         return None
     sig_metadata = mod.build_signature_metadata(flat_types)
-    arg_type_codes = tuple(sig_metadata)
+    arg_type_codes = list(sig_metadata)
+
+    # Build tma_meta for C-level TMA expansion
+    tma_meta_list = None
+    if tensordesc_info is not None:
+        tma_meta_list = []
+
+        # Compute flat_pos for each tensordesc entry
+        flat_pos_for_td = []
+        current_flat_pos = 0
+        td_iter = 0
+        for arg_pos, arg in enumerate(schema["args"]):
+            ty = arg["type"]
+            if ty.startswith("tensordesc"):
+                _, ndim_td, meta_td = tensordesc_info[td_iter]
+                flat_pos_for_td.append(current_flat_pos)
+                if meta_td is None:
+                    current_flat_pos += 1 + 2 * ndim_td + 1 + ndim_td + ndim_td
+                else:
+                    current_flat_pos += 1 + ndim_td + ndim_td
+                td_iter += 1
+            else:
+                current_flat_pos += 1
+
+        from triton.backends.nvidia.driver import TMA_DTYPE_DEVICE_TO_HOST
+        for td_idx, (arg_pos, ndim, meta) in enumerate(tensordesc_info):
+            if meta is None:
+                # Host-side tensordesc: keep Python wrapper path
+                continue
+
+            flat_pos = flat_pos_for_td[td_idx]
+            # Replace type codes: 15 for desc, 16 for shadow shape/stride slots
+            arg_type_codes[flat_pos] = 15  # EXTRACTOR_TENSORDESC_INDEX
+
+            shape_indices = []
+            stride_indices = []
+            for j in range(ndim):
+                shape_idx = flat_pos + 1 + j
+                arg_type_codes[shape_idx] = 16  # EXTRACTOR_SKIP_INDEX
+                shape_indices.append(shape_idx)
+            for j in range(ndim):
+                stride_idx = flat_pos + 1 + ndim + j
+                arg_type_codes[stride_idx] = 16  # EXTRACTOR_SKIP_INDEX
+                stride_indices.append(stride_idx)
+
+            tma_meta_list.append({
+                "swizzle": meta["swizzle"],
+                "elem_size": meta["elem_size"],
+                "elem_type": TMA_DTYPE_DEVICE_TO_HOST[meta["elem_type"]],
+                "ndim": ndim,
+                "fp4_padded": meta["fp4_padded"],
+                "block_size": meta["block_size"],
+                "shape_param_indices": shape_indices,
+                "stride_param_indices": stride_indices,
+            })
+
+        # If all tensordescs are host-side (no TMA), fall back to Python wrapper
+        if not tma_meta_list:
+            tma_meta_list = None
 
     c_dispatcher = mod._TritonDispatcher(
         function=cu_function,
@@ -123,7 +202,7 @@ def make_triton_dispatcher(schema, cu_function: int):
         launch_pdl=1 if schema.get("launch_pdl", False) else 0,
         launch_cooperative_grid=1 if schema.get("launch_cooperative_grid", False) else 0,
         launch_cluster=1 if schema.get("launch_cluster", False) else 0,
-        arg_type_codes=arg_type_codes,
+        arg_type_codes=tuple(arg_type_codes),
         has_global_scratch=schema.get("global_scratch_size", 0) > 0,
         has_profile_scratch=schema.get("profile_scratch_size", 0) > 0,
         global_scratch_size=schema.get("global_scratch_size", 0),
@@ -132,10 +211,16 @@ def make_triton_dispatcher(schema, cu_function: int):
         profile_scratch_align=schema.get("profile_scratch_align", 1),
         allocator=_allocation._allocator,
         profile_allocator=_allocation._profile_allocator,
+        tma_meta=tma_meta_list,
     )
 
-    if tensordesc_info is not None:
-        return _TensorDescDispatcherWrapper(c_dispatcher, tensordesc_info)
+    # If there are host-side tensordescs (no TMA meta) that still need Python expansion,
+    # use the wrapper. If all tensordescs are TMA (handled in C), return raw dispatcher.
+    has_host_side_td = tensordesc_info and any(meta is None for _, _, meta in tensordesc_info)
+    if has_host_side_td:
+        # Filter to only host-side tensordesc entries for the wrapper
+        host_td_info = [(pos, ndim, meta) for pos, ndim, meta in tensordesc_info if meta is None]
+        return _TensorDescDispatcherWrapper(c_dispatcher, host_td_info)
     return c_dispatcher
 
 


### PR DESCRIPTION
Summary:

## Problem

When a Triton kernel is called with keyword arguments (kwargs), `JITCacheProxy.__vectorcall__` in specialize.cc immediately falls back to the Python slow path:

```c
// BEFORE: any kwargs → immediate fallback to Python
if (kwnames && PyTuple_GET_SIZE(kwnames) > 0)
    goto fallback;
```

This is a **silent performance regression** — the call still produces correct results via `run()`, but completely bypasses the C fast cache. Worse, the fallback adds overhead compared to not using c_cache at all (extra vectorcall dispatch layer).

## Solution

Merge kwargs into positional args in C before proceeding through the fast cache. The proxy stores a `param_name_to_idx` dict (built from the JIT function signature at proxy construction time) and uses it to place kwargs into the correct positional slots:

```c
// AFTER: merge kwargs into positional array in C
if (kwnames && PyTuple_GET_SIZE(kwnames) > 0) {
    if (!self->param_name_to_idx)
        goto fallback;
    merged_args = alloca(total * sizeof(PyObject *));
    // copy positional, then merge kwargs by name→index lookup
    for (ki = 0; ki < nkw; ki++) {
        PyObject *name = PyTuple_GET_ITEM(kwnames, ki);
        PyObject *idx_obj = PyDict_GetItem(self->param_name_to_idx, name);
        merged_args[idx] = args[nargs + ki];
    }
    effective_args = merged_args;
    effective_nargs = total;
}
```

All downstream usage of `args`/`nargs` in the vectorcall function is replaced with `effective_args`/`effective_nargs`.

## Performance

Benchmark: `nop_triton_kernel_kwargs` (19 args: 14 positional + 5 constexpr kwargs)

| Configuration | Without this fix | With this fix | Speedup |
|---|---|---|---|
| `C_CACHE=0 DISPATCHER=0` (Python baseline) | ~10.9 ms | ~10.9 ms | — |
| `C_CACHE=1 DISPATCHER=1` | ~14.4 ms | ~7.5 ms | **1.9x** |

Key observations:
- Without the fix, c_cache=1 with kwargs is **worse** than c_cache=0 (fallback adds overhead)
- With the fix, c_cache=1 with kwargs is **31% faster** than the Python baseline

Differential Revision: D105262254


