### PR TITLE
 [TLX] Support tlx.local_slice with scales (#1520)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1298,26 +1298,66 @@ LogicalResult TMEMCopyOp::verify() {
 // -- TMEMSubSliceOp --
 LogicalResult TMEMSubSliceOp::verify() {
   auto srcTy = cast<triton::gpu::MemDescType>(getSrc().getType());
-  auto encoding = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
-      srcTy.getEncoding());
-  if (!encoding)
-    return emitOpError("The source must be a tensor memory buffer.");
-  if (!llvm::is_contained({64, 128}, encoding.getBlockM())) {
-    return emitOpError("The source tensor memory descriptor must have a 128xN "
-                       "or 64xN layout, got block_m=")
-           << encoding.getBlockM();
-  }
   auto dstTy = cast<triton::gpu::MemDescType>(getResult().getType());
-  auto dstEncoding = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
-      dstTy.getEncoding());
-  if (!dstEncoding)
+
+  if (!isa<triton::nvidia_gpu::TensorMemorySpaceAttr>(srcTy.getMemorySpace()))
+    return emitOpError("The source must be a tensor memory buffer.");
+  if (srcTy.getRank() != dstTy.getRank())
+    return emitOpError(
+        "The destination must have the same rank as the source.");
+  if (getN() < 0 || getN() + dstTy.getShape().back() > srcTy.getShape().back())
+    return emitOpError("Subslice range exceeds source shape.");
+  for (auto [srcDim, dstDim] :
+       llvm::zip(srcTy.getShape().drop_back(), dstTy.getShape().drop_back())) {
+    if (srcDim != dstDim)
+      return emitOpError(
+          "Only slicing along the innermost dimension is supported.");
+  }
+
+  Attribute srcEncoding = srcTy.getEncoding();
+  Attribute dstEncoding = dstTy.getEncoding();
+  if (!isa<triton::nvidia_gpu::TensorMemoryEncodingAttr,
+           TensorMemoryScalesEncodingAttr, triton::tlx::DummyTMEMLayoutAttr>(
+          srcEncoding))
+    return emitOpError("The source must be a tensor memory buffer.");
+  if (!isa<triton::nvidia_gpu::TensorMemoryEncodingAttr,
+           TensorMemoryScalesEncodingAttr, triton::tlx::DummyTMEMLayoutAttr>(
+          dstEncoding))
     return emitOpError("The destination must be a tensor memory buffer.");
-  if (dstEncoding.getBlockM() != encoding.getBlockM() ||
-      dstEncoding.getCTASplitM() != encoding.getCTASplitM() ||
-      dstEncoding.getCTASplitN() != encoding.getCTASplitN() ||
-      dstEncoding.getColStride() != encoding.getColStride())
-    return emitOpError("The destination must have the same block size and "
-                       "CTASplit size as the source.");
+
+  if (auto encoding =
+          dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcEncoding)) {
+    if (!llvm::is_contained({64, 128}, encoding.getBlockM())) {
+      return emitOpError("The source tensor memory descriptor must have a "
+                         "128xN or 64xN layout, got block_m=")
+             << encoding.getBlockM();
+    }
+    auto dstTmemEncoding =
+        dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(dstEncoding);
+    if (!dstTmemEncoding)
+      return emitOpError("The destination must use the same TMEM encoding kind "
+                         "as the source.");
+    if (dstTmemEncoding.getBlockM() != encoding.getBlockM() ||
+        dstTmemEncoding.getCTASplitM() != encoding.getCTASplitM() ||
+        dstTmemEncoding.getCTASplitN() != encoding.getCTASplitN() ||
+        dstTmemEncoding.getColStride() != encoding.getColStride())
+      return emitOpError("The destination must have the same block size and "
+                         "CTASplit size as the source.");
+  } else if (auto scaleEncoding =
+                 dyn_cast<TensorMemoryScalesEncodingAttr>(srcEncoding)) {
+    auto dstScaleEncoding =
+        dyn_cast<TensorMemoryScalesEncodingAttr>(dstEncoding);
+    if (!dstScaleEncoding)
+      return emitOpError("The destination must use the same TMEM encoding kind "
+                         "as the source.");
+    if (dstScaleEncoding.getCTASplitM() != scaleEncoding.getCTASplitM() ||
+        dstScaleEncoding.getCTASplitN() != scaleEncoding.getCTASplitN())
+      return emitOpError(
+          "The destination must have the same CTASplit size as the source.");
+  } else if (!isa<triton::tlx::DummyTMEMLayoutAttr>(dstEncoding)) {
+    return emitOpError(
+        "The destination must use the same TMEM encoding kind as the source.");
+  }
   return mlir::success();
 }
 
@@ -1326,13 +1366,15 @@ void TMEMSubSliceOp::build(OpBuilder &builder, OperationState &state,
   auto allocTy = cast<triton::gpu::MemDescType>(alloc.getType());
   SmallVector<int64_t> shape(allocTy.getShape());
   shape.back() = size;
-  auto encoding =
-      cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(allocTy.getEncoding());
-  unsigned newBlockN = std::min<unsigned>(encoding.getBlockN(), size);
-  auto newEncoding = triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
-      builder.getContext(), encoding.getBlockM(), newBlockN,
-      encoding.getColStride(), encoding.getCTASplitM(), encoding.getCTASplitN(),
-      encoding.getTwoCTAs(), encoding.getCtaMode());
+  Attribute newEncoding = allocTy.getEncoding();
+  if (auto encoding = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
+          allocTy.getEncoding())) {
+    unsigned newBlockN = std::min<unsigned>(encoding.getBlockN(), size);
+    newEncoding = triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
+        builder.getContext(), encoding.getBlockM(), newBlockN,
+        encoding.getColStride(), encoding.getCTASplitM(),
+        encoding.getCTASplitN(), encoding.getTwoCTAs(), encoding.getCtaMode());
+  }
   auto subsliceType = gpu::MemDescType::get(
       shape, allocTy.getElementType(), newEncoding, allocTy.getMemorySpace(),
       allocTy.getMutableMemory(), allocTy.getAllocShape());

--- a/python/test/unit/language/test_tlx_memory_ops.py
+++ b/python/test/unit/language/test_tlx_memory_ops.py
@@ -626,6 +626,34 @@ def test_tmem_load_store(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+@pytest.mark.parametrize("SCALE_OFFSET", [0, 8])
+def test_tmem_scale_subslice_compile(SCALE_OFFSET):
+    SCALE_BLOCK_N = 16
+    SCALE_SLICE_N = 8
+
+    @triton.jit
+    def tmem_scale_subslice_compile_kernel(SCALE_OFFSET: tl.constexpr):
+        scale_smem = tlx.local_alloc((1, 1, 2, 2, 256), tl.uint8, tl.constexpr(1))
+        scale_tmem = tlx.local_alloc((128, SCALE_BLOCK_N), tl.uint8, tl.constexpr(1), tlx.storage_kind.tmem)
+        scale_slice = tlx.subslice(scale_tmem[0], SCALE_OFFSET, SCALE_SLICE_N)
+        tlx.tmem_copy(scale_smem[0], scale_slice)
+
+    kernel = tmem_scale_subslice_compile_kernel.warmup(SCALE_OFFSET, grid=(1, ))
+    ttgir = kernel.asm["ttgir"]
+    subslice_ops = [line.strip() for line in ttgir.splitlines() if "ttng.tmem_subslice" in line]
+    copy_ops = [line.strip() for line in ttgir.splitlines() if "ttng.tmem_copy" in line]
+
+    assert "tensor_memory_scales_encoding" in ttgir
+    assert len(subslice_ops) == 1
+    assert len(copy_ops) == 1
+    assert f"N = {SCALE_OFFSET} : i32" in subslice_ops[0]
+    assert f"!ttg.memdesc<128x{SCALE_BLOCK_N}xi8" in subslice_ops[0]
+    assert f"!ttg.memdesc<128x{SCALE_SLICE_N}xi8" in subslice_ops[0]
+    assert f"!ttg.memdesc<128x{SCALE_SLICE_N}xi8" in copy_ops[0]
+    assert "tcgen05.cp" in kernel.asm["ptx"]
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
 @pytest.mark.parametrize("BLOCK_SIZE_M, BLOCK_SIZE_N", [(128, 64)])
 def test_tmem_subslice(BLOCK_SIZE_M, BLOCK_SIZE_N, device):
 

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -932,12 +932,12 @@ tt.func private @subslice_16x32bx2_interleaved_block0_offset(%arg0: !ttg.memdesc
 }
 
 // CHECK-LABEL: @subslice_16x32bx2_interleaved_block4_offset
-tt.func private @subslice_16x32bx2_interleaved_block4_offset(%arg0: !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem>) -> !ttg.memdesc<64x16xf32, #bm64_bn16, #tmem, 64x128> {
+tt.func private @subslice_16x32bx2_interleaved_block4_offset(%arg0: !ttg.memdesc<64x256xf32, #bm64_bn32, #tmem>) -> !ttg.memdesc<64x16xf32, #bm64_bn16, #tmem, 64x256> {
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(80 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]]
-  %0 = ttng.tmem_subslice %arg0 {N = 144 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn16, #tmem, 64x128>
-  tt.return %0 : !ttg.memdesc<64x16xf32, #bm64_bn16, #tmem, 64x128>
+  %0 = ttng.tmem_subslice %arg0 {N = 144 : i32} : !ttg.memdesc<64x256xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn16, #tmem, 64x256>
+  tt.return %0 : !ttg.memdesc<64x16xf32, #bm64_bn16, #tmem, 64x256>
 }
 
 }

--- a/test/TLX/propagate-layout.mlir
+++ b/test/TLX/propagate-layout.mlir
@@ -39,6 +39,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// Test that scale layout requirements propagate through TMEM subslices.
+
+#tmem = #ttng.tensor_memory
+#shared_unswizzled = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
+#smem = #ttg.shared_memory
+#dummy_tmem_layout = #tlx.dummy_tmem_layout<>
+#scales_encoding = #ttng.tensor_memory_scales_encoding<>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_subslice_propagates_scales_layout
+  tt.func public @tmem_subslice_propagates_scales_layout() {
+    %c0_i32 = arith.constant 0 : i32
+
+    %scale_smem = ttg.local_alloc : () -> !ttg.memdesc<1x1x2x2x256xi8, #shared_unswizzled, #smem, mutable>
+    // CHECK: ttng.tmem_alloc : () -> !ttg.memdesc<1x128x16xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    %scale_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x16xi8, #dummy_tmem_layout, #tmem, mutable>
+    %scale_tmem_indexed = ttg.memdesc_index %scale_tmem[%c0_i32] : !ttg.memdesc<1x128x16xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x16xi8, #dummy_tmem_layout, #tmem, mutable>
+
+    // CHECK: ttng.tmem_subslice {{.*}} : !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable{{.*}}>
+    %scale_slice = ttng.tmem_subslice %scale_tmem_indexed {N = 8 : i32} : !ttg.memdesc<128x16xi8, #dummy_tmem_layout, #tmem, mutable> -> !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable, 128x16>
+
+    %scale_req = tlx.require_layout %scale_slice : !ttg.memdesc<128x8xi8, #dummy_tmem_layout, #tmem, mutable, 128x16> -> !ttg.memdesc<128x8xi8, #scales_encoding, #tmem, mutable, 128x16>
+    ttng.tmem_copy %scale_smem, %scale_req : !ttg.memdesc<1x1x2x2x256xi8, #shared_unswizzled, #smem, mutable>, !ttg.memdesc<128x8xi8, #scales_encoding, #tmem, mutable, 128x16>
+
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -1005,38 +1005,46 @@ struct TMEMSubSliceOpConversion
     auto dstTy = op.getResult().getType();
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
 
-    auto encoding = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
-        srcTy.getEncoding());
-    auto shapePerCTA = getShapePerCTA(srcTy);
-    int blockN = encoding.getBlockN();
-    int blockM = encoding.getBlockM();
     int offsetCol = 0;
     int offsetRow = 0;
-    assert(llvm::is_contained({64, 128}, blockM) && "checked by the verifier");
-    offsetCol = op.getN();
 
-    if (blockM == 64) {
-      // The layout interleaves blocks along the N dimension with the rows, such
-      // that the odd numbered blocks are in lanes [16, 32), below the previous
-      // even-numbered block.
-      int blockOffset = op.getN() / blockN;
-      if (blockOffset % 2) {
-        // Offset into rows [16, 32).
-        offsetRow = 16;
-        // Normalize column offset to the even block.
-        offsetCol -= blockN;
-      }
-      offsetCol -= blockN * (blockOffset / 2);
-    }
+    if (auto encoding = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
+            srcTy.getEncoding())) {
+      int blockN = encoding.getBlockN();
+      int blockM = encoding.getBlockM();
+      assert(llvm::is_contained({64, 128}, blockM) &&
+             "checked by the verifier");
+      offsetCol = op.getN();
 
-    unsigned elementBitWidth = srcTy.getElementTypeBitWidth();
-    if (encoding.getColStride() * elementBitWidth != 32) {
-      // Adjust the column offset based on the element size.
-      int numElementsPer32B = 32 / (encoding.getColStride() * elementBitWidth);
-      if (offsetCol % numElementsPer32B != 0) {
-        return failure();
+      if (blockM == 64) {
+        // The layout interleaves blocks along the N dimension with the rows,
+        // such that the odd numbered blocks are in lanes [16, 32), below the
+        // previous even-numbered block.
+        int blockOffset = op.getN() / blockN;
+        if (blockOffset % 2) {
+          // Offset into rows [16, 32).
+          offsetRow = 16;
+          // Normalize column offset to the even block.
+          offsetCol -= blockN;
+        }
+        offsetCol -= blockN * (blockOffset / 2);
       }
-      offsetCol /= numElementsPer32B;
+
+      unsigned elementBitWidth = srcTy.getElementTypeBitWidth();
+      if (encoding.getColStride() * elementBitWidth != 32) {
+        // Adjust the column offset based on the element size.
+        int numElementsPer32B =
+            32 / (encoding.getColStride() * elementBitWidth);
+        if (offsetCol % numElementsPer32B != 0) {
+          return failure();
+        }
+        offsetCol /= numElementsPer32B;
+      }
+    } else if (isa<triton::nvidia_gpu::TensorMemoryScalesEncodingAttr>(
+                   srcTy.getEncoding())) {
+      offsetCol = op.getN();
+    } else {
+      return failure();
     }
 
     Value tmemBase = adaptor.getSrc();

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -151,16 +151,24 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     auto resultLattice = results[0];
     LayoutEncoding resultLayoutEncoding = resultLattice->getValue();
     if (!resultLayoutEncoding.isUninitialized()) {
-      if (auto tmemEncoding = dyn_cast<ttng::TensorMemoryEncodingAttr>(
-              resultLattice->getValue().getLayoutEncoding())) {
+      Attribute resultEncoding = resultLayoutEncoding.getLayoutEncoding();
+      if (auto tmemEncoding =
+              dyn_cast<ttng::TensorMemoryEncodingAttr>(resultEncoding)) {
         auto srcTy = cast<ttg::MemDescType>(tmemSliceOp.getSrc().getType());
         auto srcEncoding =
             dyn_cast<ttng::TensorMemoryEncodingAttr>(srcTy.getEncoding());
+        unsigned blockM =
+            srcEncoding ? srcEncoding.getBlockM() : tmemEncoding.getBlockM();
+        unsigned blockN =
+            srcEncoding ? srcEncoding.getBlockN()
+                        : std::min<unsigned>(
+                              tmemEncoding.getBlockN(),
+                              static_cast<unsigned>(srcTy.getShape().back()));
         auto newTmemEncoding = ttng::TensorMemoryEncodingAttr::get(
-            tmemEncoding.getContext(), srcEncoding.getBlockM(),
-            srcEncoding.getBlockN(), tmemEncoding.getColStride(),
-            tmemEncoding.getCTASplitM(), tmemEncoding.getCTASplitN(),
-            tmemEncoding.getTwoCTAs(), tmemEncoding.getCtaMode());
+            tmemEncoding.getContext(), blockM, blockN,
+            tmemEncoding.getColStride(), tmemEncoding.getCTASplitM(),
+            tmemEncoding.getCTASplitN(), tmemEncoding.getTwoCTAs(),
+            tmemEncoding.getCtaMode());
         const auto updatedResultLayoutEncoding =
             LayoutEncoding(newTmemEncoding);
         auto operandLattice = operands[0];
@@ -169,6 +177,12 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
         propagateIfChanged(operandLattice, changed);
         visitWarpSpecRegionArgs(op, tmemSliceOp.getSrc(),
                                 updatedResultLayoutEncoding);
+      } else if (isa<ttng::TensorMemoryScalesEncodingAttr,
+                     triton::tlx::DummyTMEMLayoutAttr>(resultEncoding)) {
+        auto operandLattice = operands[0];
+        ChangeResult changed = operandLattice->meet(resultLayoutEncoding);
+        propagateIfChanged(operandLattice, changed);
+        visitWarpSpecRegionArgs(op, tmemSliceOp.getSrc(), resultLayoutEncoding);
       }
     }
     return success();
@@ -284,17 +298,28 @@ LogicalResult LayoutForwardPropagation::visitOperation(
     // Slice operandLayoutEncoding
     if (auto sliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
       if (!operandLayoutEncoding.isUninitialized()) {
-        auto dstTy = cast<ttg::MemDescType>(sliceOp.getType());
-        auto dstEncoding =
-            dyn_cast<ttng::TensorMemoryEncodingAttr>(dstTy.getEncoding());
-        auto encoding = dyn_cast<ttng::TensorMemoryEncodingAttr>(
-            operandLayoutEncoding.getLayoutEncoding());
-        auto newEncoding = ttng::TensorMemoryEncodingAttr::get(
-            op->getContext(), dstEncoding.getBlockM(), dstEncoding.getBlockN(),
-            encoding.getColStride(), encoding.getCTASplitM(),
-            encoding.getCTASplitN(), encoding.getTwoCTAs(),
-            encoding.getCtaMode());
-        operandLayoutEncoding = LayoutEncoding(newEncoding);
+        Attribute operandEncoding = operandLayoutEncoding.getLayoutEncoding();
+        if (auto encoding =
+                dyn_cast<ttng::TensorMemoryEncodingAttr>(operandEncoding)) {
+          auto dstTy = cast<ttg::MemDescType>(sliceOp.getType());
+          auto dstEncoding =
+              dyn_cast<ttng::TensorMemoryEncodingAttr>(dstTy.getEncoding());
+          unsigned blockM =
+              dstEncoding ? dstEncoding.getBlockM() : encoding.getBlockM();
+          unsigned blockN =
+              dstEncoding ? dstEncoding.getBlockN()
+                          : std::min<unsigned>(
+                                encoding.getBlockN(),
+                                static_cast<unsigned>(dstTy.getShape().back()));
+          auto newEncoding = ttng::TensorMemoryEncodingAttr::get(
+              op->getContext(), blockM, blockN, encoding.getColStride(),
+              encoding.getCTASplitM(), encoding.getCTASplitN(),
+              encoding.getTwoCTAs(), encoding.getCtaMode());
+          operandLayoutEncoding = LayoutEncoding(newEncoding);
+        } else if (isa<ttng::TensorMemoryScalesEncodingAttr,
+                       triton::tlx::DummyTMEMLayoutAttr>(operandEncoding)) {
+          operandLayoutEncoding = LayoutEncoding(operandEncoding);
+        }
       }
     }
 

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -70,10 +70,13 @@ void init_triton_tlx_ir(py::module &&m) {
              Type newType;
              if (auto type = dyn_cast<ttg::MemDescType>(v.getType())) {
                // consider allocation type for subslice
+               SmallVector<int64_t> allocShape(type.getAllocShape());
+               if (isa<ttng::TensorMemoryScalesEncodingAttr>(encoding))
+                 allocShape.assign(type.getShape().begin(),
+                                   type.getShape().end());
                newType = ttg::MemDescType::get(
                    type.getShape(), type.getElementType(), encoding,
-                   type.getMemorySpace(), type.getMutableMemory(),
-                   type.getAllocShape());
+                   type.getMemorySpace(), type.getMutableMemory(), allocShape);
                return self.create<tlx::RequireLayoutOp>(newType, v);
              } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
                newType = RankedTensorType::get(type.getShape(),
@@ -439,11 +442,11 @@ void init_triton_tlx_ir(py::module &&m) {
              // only passes valid inputs to the op
              auto srcTy = dyn_cast<triton::gpu::MemDescType>(src.getType());
              assert(srcTy != nullptr && "Expect MemDescType for src");
-             auto encoding =
-                 dyn_cast<ttng::TensorMemoryEncodingAttr>(srcTy.getEncoding());
-             auto blockN = encoding.getBlockN();
-             assert(offset >= 0 && offset < blockN && "Invalid offset");
-             assert(size > 0 && size <= blockN - offset && "Invalid size");
+             auto shape = srcTy.getShape();
+             assert(!shape.empty() && "Expect non-empty shape for src");
+             auto dimN = shape.back();
+             assert(offset >= 0 && offset < dimN && "Invalid offset");
+             assert(size > 0 && size <= dimN - offset && "Invalid size");
              return self.create<ttng::TMEMSubSliceOp>(src, offset, size);
            })
       .def("create_tcgen5_dot",


### PR DESCRIPTION
Summary:
Supports using tlx.local_slice with scale encodings. This is needed to ensure we can slice the fp8 quantization step.


Reviewed By: htyu

Differential Revision: D105272498

Pulled By: njriasan


