### PR TITLE
[TLX] Fix stale test assertions after cluster sync unification (#1491)

### DIFF
--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -691,9 +691,6 @@ def test_explicit_cluster_sync_ws(device):
     )
 
     ttgir = kernel.asm["ttgir"]
-    # The Fixup pass should have detected the user cluster_barrier and set this
-    assert "tlx.explicit_cluster_sync = true" in ttgir, (
-        f"Expected tlx.explicit_cluster_sync module attr in TTGIR:\n{ttgir}")
     # User placed exactly one cluster arrive+wait pair for each task (from cluster_barrier)
     assert ttgir.count("ttng.fence_mbarrier_init_release_cluster") == 1, (
         f"Expected exactly 1 fence_mbarrier_init_release_cluster in TTGIR:\n{ttgir}")
@@ -701,15 +698,15 @@ def test_explicit_cluster_sync_ws(device):
     assert ttgir.count("ttng.cluster_wait") == 3, (f"Expected exactly 3 cluster_wait in TTGIR:\n{ttgir}")
 
     ptx = kernel.asm["ptx"]
-    assert ptx.count("fence.mbarrier_init.release.cluster") == 1, (
-        f"Expected exactly 1 fence.mbarrier_init.release.cluster in PTX:\n{ptx}")
-    # The user's cluster_barrier should produce exactly one
-    # barrier.cluster.arrive.aligned and one barrier.cluster.wait.aligned
-    # No extra heuristic ones should be inserted
-    assert ptx.count("barrier.cluster.arrive.aligned") == 3, (
-        f"Expected exactly 3 barrier.cluster.arrive.aligned in PTX:\n{ptx}")
-    assert ptx.count("barrier.cluster.wait.aligned") == 3, (
-        f"Expected exactly 3 barrier.cluster.wait.aligned in PTX:\n{ptx}")
+    # 1 user fence + 1 compiler-inserted fence from maybeInsertClusterSync
+    assert ptx.count("fence.mbarrier_init.release.cluster") == 2, (
+        f"Expected exactly 2 fence.mbarrier_init.release.cluster in PTX:\n{ptx}")
+    # 3 user cluster_barrier + 1 compiler-inserted + 1 WS non-default warp arrive
+    assert ptx.count("barrier.cluster.arrive.aligned") == 5, (
+        f"Expected exactly 5 barrier.cluster.arrive.aligned in PTX:\n{ptx}")
+    # 3 user cluster_barrier + 1 compiler-inserted
+    assert ptx.count("barrier.cluster.wait.aligned") == 4, (
+        f"Expected exactly 4 barrier.cluster.wait.aligned in PTX:\n{ptx}")
 
     # --- Check correctness ---
     torch.testing.assert_close(y, x)

--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -637,11 +637,12 @@ def test_cluster_launch_control_multi_cta_delayed_exit(device):
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer for cluster sync")
 def test_explicit_cluster_sync_ws(device):
-    """Test that explicit cluster_barrier() in WS mode sets the
-    tlx.explicit_cluster_sync module attribute and suppresses heuristic
-    cluster sync insertion.  The kernel uses two CTAs in a cluster with
-    warp specialization: the default task does a remote barrier arrive
-    to signal CTA 1, and a partition task waits on the barrier.
+    """Test explicit cluster_barrier() behavior in WS mode.
+
+    The kernel uses two CTAs in a cluster with warp specialization: the
+    default task does a remote barrier arrive to signal CTA 1, and a
+    partition task waits on the barrier. PTX may still contain additional
+    compiler-inserted cluster sync from maybeInsertClusterSync.
     """
 
     @triton.jit
@@ -655,7 +656,7 @@ def test_explicit_cluster_sync_ws(device):
         tlx.fence_mbarrier_init_cluster()
         cta_rank = tlx.cluster_cta_rank()
 
-        # Explicit cluster sync placed by user – compiler must not auto-insert
+        # User places explicit cluster sync via cluster_barrier().
         with tlx.async_tasks():
             with tlx.async_task("default"):
                 # This has to be inside default task, because at WS entry there'd be task syncs


### PR DESCRIPTION
  #1491 intentionally removed the explicit/implicit cluster sync
  differentiation but left test_explicit_cluster_sync_ws assertions
  unchanged, causing the test to fail on main.

  - Remove the `tlx.explicit_cluster_sync = true` module attr check
    (attribute no longer exists)
  - Update PTX count expectations to account for compiler-inserted
    cluster sync from `maybeInsertClusterSync` coexisting with
    user-placed `cluster_barrier()` calls

## Test plan

`pytest python/test/unit/language/test_tlx_cluster.py::test_explicit_cluster_sync_ws`