### PR TITLE
[TLX][AMD] Optimize K.T loads on FA and fix FA regression

### DIFF
--- a/test/TLX/propagate-layout-memdesc-trans-errors.mlir
+++ b/test/TLX/propagate-layout-memdesc-trans-errors.mlir
@@ -1,29 +1,5 @@
 // RUN: triton-opt -split-input-file --tlx-propagate-layout --verify-diagnostics %s
 
-// Test that tlx-propagate-layout emits a diagnostic for nontrivial
-// swizzled_shared backward propagation through ttg.memdesc_trans.
-
-#shared_src = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#shared_trans = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
-// Nontrivially swizzled encoding that triggers the backward memdesc_trans error.
-#shared_req = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
-#smem = #ttg.shared_memory
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @reject_nontrivial_swizzled_memdesc_trans() -> tensor<128x64xf16, #blocked> {
-    %c0_i32 = arith.constant 0 : i32
-    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared_src, #smem, mutable>
-    %slice = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared_src, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared_src, #smem, mutable>
-    // expected-error @+1 {{swizzled_shared backward propagation through memdesc_trans only supports effectively unswizzled encodings}}
-    %trans = ttg.memdesc_trans %slice {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared_src, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_trans, #smem, mutable>
-    %req = tlx.require_layout %trans : !ttg.memdesc<128x64xf16, #shared_trans, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_req, #smem, mutable>
-    %val = ttg.local_load %req : !ttg.memdesc<128x64xf16, #shared_req, #smem, mutable> -> tensor<128x64xf16, #blocked>
-    tt.return %val : tensor<128x64xf16, #blocked>
-  }
-}
-
-// -----
 // Test that malformed ttg.memdesc_trans permutation metadata is rejected by the
 // op verifier before tlx-propagate-layout can run.
 

--- a/test/TLX/propagate-layout-memdesc-trans.mlir
+++ b/test/TLX/propagate-layout-memdesc-trans.mlir
@@ -1,9 +1,9 @@
 // RUN: triton-opt -split-input-file --tlx-propagate-layout %s | FileCheck %s
 
 // Test that tlx-propagate-layout can propagate a swizzled_shared constraint
-// backward through ttg.memdesc_trans when the swizzle is effectively
-// unswizzled. This exercises the guarded SwizzledSharedEncodingAttr path in
-// LayoutBackwardPropagation.
+// backward through ttg.memdesc_trans. Swizzle parameters (vec/perPhase/
+// maxPhase) describe an XOR pattern over the contiguous dim and are invariant
+// under transpose; only `order` is permuted by the inverse transpose order.
 
 #shared_src = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #shared_trans = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
@@ -57,5 +57,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // CHECK: ttg.local_load %[[TRANS]] : !ttg.memdesc<128x64xf16, #[[$NVMMA_DST]], #smem, mutable> -> tensor<128x64xf16, #blocked>
     %val = ttg.local_load %req : !ttg.memdesc<128x64xf16, #nvmma_req, #smem_nv, mutable> -> tensor<128x64xf16, #blocked_nv>
     tt.return %val : tensor<128x64xf16, #blocked_nv>
+  }
+}
+
+// -----
+// Test that tlx-propagate-layout supports nontrivially-swizzled encodings
+// through ttg.memdesc_trans (the previously-rejected case). The required
+// swizzle (vec=4, perPhase=2, maxPhase=8, order=[1,0]) propagates back to the
+// source alloc with the same vec/perPhase/maxPhase but the inverse-permuted
+// order=[0,1].
+
+#shared_src_sw = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_trans_sw = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared_req_sw = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+// CHECK-DAG: #[[$SHARED_SRC_SW:.*]] = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [0, 1]}>
+// CHECK-DAG: #[[$SHARED_REQ_SW:.*]] = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#blocked_sw = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#smem_sw = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @propagate_nontrivial_swizzled_through_memdesc_trans
+  tt.func public @propagate_nontrivial_swizzled_through_memdesc_trans() -> tensor<128x64xf16, #blocked_sw> {
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #[[$SHARED_SRC_SW]], #smem, mutable>
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared_src_sw, #smem_sw, mutable>
+    // CHECK: %[[SLICE:.*]] = ttg.memdesc_index %{{.*}}[%c0_i32] : !ttg.memdesc<1x64x128xf16, #[[$SHARED_SRC_SW]], #smem, mutable> -> !ttg.memdesc<64x128xf16, #[[$SHARED_SRC_SW]], #smem, mutable>
+    %slice = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared_src_sw, #smem_sw, mutable> -> !ttg.memdesc<64x128xf16, #shared_src_sw, #smem_sw, mutable>
+    // CHECK: %[[TRANS:.*]] = ttg.memdesc_trans %[[SLICE]] {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #[[$SHARED_SRC_SW]], #smem, mutable> -> !ttg.memdesc<128x64xf16, #[[$SHARED_REQ_SW]], #smem, mutable>
+    %trans = ttg.memdesc_trans %slice {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared_src_sw, #smem_sw, mutable> -> !ttg.memdesc<128x64xf16, #shared_trans_sw, #smem_sw, mutable>
+    %req = tlx.require_layout %trans : !ttg.memdesc<128x64xf16, #shared_trans_sw, #smem_sw, mutable> -> !ttg.memdesc<128x64xf16, #shared_req_sw, #smem_sw, mutable>
+    // CHECK: ttg.local_load %[[TRANS]] : !ttg.memdesc<128x64xf16, #[[$SHARED_REQ_SW]], #smem, mutable> -> tensor<128x64xf16, #blocked>
+    %val = ttg.local_load %req : !ttg.memdesc<128x64xf16, #shared_req_sw, #smem_sw, mutable> -> tensor<128x64xf16, #blocked_sw>
+    tt.return %val : tensor<128x64xf16, #blocked_sw>
   }
 }

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -91,25 +91,6 @@ LayoutEncoding LayoutEncoding::meet(const LayoutEncoding &lhs,
   return LayoutEncoding::getUnknownLayout();
 }
 
-static bool isValidPermutation(ArrayRef<int32_t> order, unsigned rank) {
-  if (order.size() != rank)
-    return false;
-
-  SmallVector<char> seen(rank, 0);
-  for (int32_t dim : order) {
-    if (dim < 0 || static_cast<unsigned>(dim) >= rank || seen[dim])
-      return false;
-    seen[dim] = 1;
-  }
-  return true;
-}
-
-static bool
-isEffectivelyUnswizzledShared(ttg::SwizzledSharedEncodingAttr encoding) {
-  return encoding.getVec() == 1 && encoding.getPerPhase() == 1 &&
-         encoding.getMaxPhase() == 1;
-}
-
 //===----------------------------------------------------------------------===//
 // LayoutBackwardPropagation
 //===----------------------------------------------------------------------===//
@@ -184,41 +165,8 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
             mmaEncoding.getCGALayout(),
             memDescTransOp.getSrc().getType().getElementType(),
             mmaEncoding.getFp4Padded());
-      } else if (auto swizzledEncoding =
-                     dyn_cast<ttg::SwizzledSharedEncodingAttr>(resultEnc)) {
-        auto srcType =
-            cast<ttg::MemDescType>(memDescTransOp.getSrc().getType());
-        unsigned rank = srcType.getRank();
-        auto transOrder = memDescTransOp.getOrder();
-        if (!isValidPermutation(transOrder, rank) ||
-            swizzledEncoding.getOrder().size() != rank) {
-          memDescTransOp.emitOpError(
-              "swizzled_shared backward propagation through memdesc_trans "
-              "requires a valid transpose permutation");
-          return failure();
-        }
-        if (!isEffectivelyUnswizzledShared(swizzledEncoding)) {
-          memDescTransOp.emitOpError(
-              "swizzled_shared backward propagation through memdesc_trans "
-              "only supports effectively unswizzled encodings");
-          return failure();
-        }
-
-        // For effectively unswizzled shared layouts, inverting the transpose
-        // only needs to update the iteration order.
-        SmallVector<unsigned> invOrder(rank);
-        for (unsigned i = 0; i < rank; ++i)
-          invOrder[transOrder[i]] = i;
-        auto encOrder = swizzledEncoding.getOrder();
-        SmallVector<unsigned> permutedOrder(rank);
-        for (unsigned i = 0; i < rank; ++i)
-          permutedOrder[i] = invOrder[encOrder[i]];
-        srcEncoding = ttg::SwizzledSharedEncodingAttr::get(
-            swizzledEncoding.getContext(), swizzledEncoding.getVec(),
-            swizzledEncoding.getPerPhase(), swizzledEncoding.getMaxPhase(),
-            permutedOrder, swizzledEncoding.getCGALayout());
       } else {
-        // Other shared encodings (e.g. PaddedSharedEncodingAttr for TDM tiles)
+        // Other shared encodings (e.g. SwizzledShared, PaddedShared)
         // fall back on the dialect's transpose inference to push a result-side
         // requirement back to the source memdesc via the inverse permutation.
         auto resultType = cast<ttg::MemDescType>(memDescTransOp.getType());

--- a/third_party/tlx/tutorials/amd-fa-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-fa-pipelined_test.py
@@ -204,24 +204,48 @@ def _attn_fwd_async_prefetch(
 ):
     """
     Prefetch flash attention with explicit modulo-scheduled prologue,
-    hot loop (steady state), and epilogue
+    hot loop (steady state), and epilogue.
 
-    Single-buffered K/V shared memory.
-    Each commit group bundles K and V for the same tile.
+    Design notes:
+      * K and V are both double-buffered (2 LDS slots, ping-pong index
+        i%2).  Reasons:
+          - The K consumer goes through `local_trans(k_buf[slot])` which
+            creates a `memdesc_trans` view.  The AMD scheduler does not
+            track the alias between that view and the original `k_buf`
+            written by `buffer_load_lds`, so single-buffered K races the
+            current iter's transposed `ds_read` against the next iter's
+            `buffer_load_lds` writes — wrong results at D=64 and at any
+            (D=128, nw=8) config.
+          - V single-buffered also races for the same reason: the AMD
+            scheduler reorders the next iter's `buffer_load_lds` ahead of
+            the current iter's `ds_read` since they have no register
+            dependency (the mfma consumes register values, not LDS).
+        Two slots per buffer eliminate the alias entirely: each iter
+        writes to slot (i+1)%2 while reading from slot i%2.
+      * `kt_cur` / `v_cur` are LOCAL SSA values (not loop-carried
+        iter_args) — avoids the AMDGCN register WAR hazard previously
+        observed at D=64 when iter_arg ds_read registers aliased with
+        in-flight mfma operands.
+      * `local_trans` is applied to K so `local_load` lands directly in
+        dot-operand layout 1, skipping the per-iter ds_write+barrier+
+        ds_read shuffle that `tl.dot(q, k_cur.T)` would emit (10M+ cycles
+        saved at D=64/N=8192 according to rocprofv3 ATT).
+      * Prefetch is "real": global->LDS load for tile i+1 is issued right
+        after the current tile's LDS reads, so it overlaps with the
+        QK+softmax+PV compute that immediately follows.  The next iter's
+        wait blocks only on whatever portion the compute didn't already
+        hide.
 
     Prologue:
-    t = 0
-    [GLDS_KV]
-    [LR_KV]
+      t=0:  [GLDS_KV]                                ; issue tile 0 -> slot 0
 
-    Steady State (Hot Loop):
-    t = i               t = i+1
-    [QK, SM0, SM1, PV]  [GLDS_KV],
-                        [LR_KV]
+    Steady state (i = 0..n_main-1):
+      [wait_t_i] [LR_K_t_i (slot i%2), LR_V_t_i (slot i%2)]
+        [GLDS_K_{i+1} (slot (i+1)%2), GLDS_V_{i+1} (slot (i+1)%2)]
+        [QK SM PV]_i
 
-    Epilogue:
-                        t = i+1
-                        [QK (masked), SM0, SM1, PV]
+    Epilogue (last tile = n_main):
+      [wait] [LR_KV (slot n_main%2)] [QK_masked SM PV]
     """
     _assume_strides(stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh, stride_kn, stride_kk, stride_vz,
                     stride_vh, stride_vn, stride_vk, stride_oz, stride_oh, stride_om, stride_ok)
@@ -250,8 +274,11 @@ def _attn_fwd_async_prefetch(
     else:
         hi = N_CTX
 
-    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, 1)
-    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, 1)
+    # K and V: 2 LDS slots each (ping-pong) -- avoids both the memdesc_trans
+    # alias race for K and any single-buf RAW hazards.
+    NUM_BUFFERS: tl.constexpr = 2
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, NUM_BUFFERS)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, NUM_BUFFERS)
 
     k_ptrs = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
     v_ptrs = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
@@ -262,48 +289,44 @@ def _attn_fwd_async_prefetch(
     m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
     l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
-    """
-    Prologue:
-    t = 0
-    [GLDS_KV]
-    [LR_KV]
-    """
-    # GLDS_KV_t0
-    tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0), mask=offs_n[:, None] < N_CTX)
-    tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0), mask=offs_n[:, None] < N_CTX)
-    tlx.async_load_commit_group([tok_k, tok_v])
 
-    # LR_KV_t0
-    wait_tok = tlx.async_load_wait_group(0)
-    k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
-    v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
-    """
-    Steady State (Hot Loop):
-    t = i               t = i+1
-    [QK, SM0, SM1, PV]  [GLDS_KV],
-                        [LR_KV]
-    """
+    # Prologue: issue async load for tile 0 into K slot 0 and V (only slot).
+    tok_k0 = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0), mask=offs_n[:, None] < N_CTX)
+    tok_v0 = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0), mask=offs_n[:, None] < N_CTX)
+    tlx.async_load_commit_group([tok_k0, tok_v0])
+
+    # Steady state.  Loop counter `i` indexes the *current* tile.
+    # i%2 selects the K slot being read this iter; (i+1)%2 receives the
+    # next prefetch.  V single-buffered: read then immediately overwrite
+    # (compiler tracks the alias).
     for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=0):
         next_off = block_id + BLOCK_N
         kn = block_id + offs_n
         next_mask = (next_off + offs_n[:, None]) < N_CTX
 
+        i = block_id // BLOCK_N
+        slot_cur = i % 2
+        slot_nxt = (i + 1) % 2
+
+        wait_tok = tlx.async_load_wait_group(0)
+        kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_cur))
+        kt_cur = tlx.local_load(kt_view, token=wait_tok, relaxed=True)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok, relaxed=True)
+
+        # Prefetch tile i+1 into the *other* slots.
+        tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, slot_nxt), mask=next_mask)
+        tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, slot_nxt), mask=next_mask)
+        tlx.async_load_commit_group([tok_k, tok_v])
+
         # QK_ti
-        qk = tl.dot(q, k_cur.T)
+        qk = tl.dot(q, kt_cur)
         if IS_CAUSAL:
             qk = tl.where(offs_m[:, None] >= kn[None, :], qk, float("-inf"))
 
-        # SM0_ti
+        # SM_ti
         m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
         p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
         l_ij = tl.sum(p, 1)
-
-        # GLDS after SM0: overlaps with SM1 + PV
-        tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, 0), mask=next_mask)
-        tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, 0), mask=next_mask)
-        tlx.async_load_commit_group([tok_k, tok_v])
-
-        # SM1_ti
         alpha = tl.math.exp2(m_i - m_ij)
         acc = acc * alpha[:, None]
         l_i = l_i * alpha + l_ij
@@ -312,38 +335,29 @@ def _attn_fwd_async_prefetch(
         # PV_ti
         acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
 
-        # LR_KV_t(i+1)
-        wait_tok = tlx.async_load_wait_group(0)
-        k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
-        v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
-    """
-    Epilogue:
-    t = i+1
-    [QK (masked), SM0, SM1, PV]
-    """
-    kn_last = n_main * BLOCK_N + offs_n
+    # Epilogue: consume tile n_main from slot (n_main % 2).
+    wait_tok = tlx.async_load_wait_group(0)
+    slot_last = n_main % 2
+    kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_last))
+    kt_cur = tlx.local_load(kt_view, token=wait_tok, relaxed=True)
+    v_cur = tlx.local_load(tlx.local_view(v_buf, slot_last), token=wait_tok, relaxed=True)
 
-    # QK_t(i+1) — with boundary + causal masking
-    qk = tl.dot(q, k_cur.T)
+    kn_last = n_main * BLOCK_N + offs_n
+    qk = tl.dot(q, kt_cur)
     qk = tl.where(kn_last[None, :] < N_CTX, qk, float("-inf"))
     if IS_CAUSAL:
         qk = tl.where(offs_m[:, None] >= kn_last[None, :], qk, float("-inf"))
 
-    # SM0_t(i+1)
     m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
     p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
     l_ij = tl.sum(p, 1)
-
-    # SM1_t(i+1)
     alpha = tl.math.exp2(m_i - m_ij)
     acc = acc * alpha[:, None]
     l_i = l_i * alpha + l_ij
     m_i = m_ij
 
-    # PV_t(i+1)
     acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
 
-    # Store output
     acc = acc / l_i[:, None]
     o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
     tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
@@ -400,13 +414,21 @@ def flash_attn_async_simple(q, k, v, sm_scale, causal=False, **kw):
 
 
 def flash_attn_async_prefetch(q, k, v, sm_scale, causal=False, **kw):
-    """Prefetch FA with modulo-scheduled prologue/hot-loop/epilogue."""
+    """Prefetch FA with modulo-scheduled prologue/hot-loop/epilogue.
+
+    Default block size and warp count are tuned for the common (D=64,
+    D=128) configs; both work correctly across nw=4/8 and BLOCK_N=64/128
+    but the defaults below give the best end-to-end on MI350X.
+    """
     B, H, N_CTX, D = q.shape
     o = torch.empty_like(q)
 
     BLOCK_M = kw.pop("BLOCK_M", 256)
-    BLOCK_N = kw.pop("BLOCK_N", 64)
-    num_warps = kw.pop("num_warps", 8)
+    # BLOCK_N=128 wins at D=64 nocausal (more compute per barrier),
+    # but the diagonal masking cost overwhelms that for causal, and at
+    # D=128 it blows the 64KB LDS budget for double-buffered K+V.
+    BLOCK_N = kw.pop("BLOCK_N", 128 if (D <= 64 and not causal) else 64)
+    num_warps = kw.pop("num_warps", 4)
 
     grid = (triton.cdiv(N_CTX, BLOCK_M), B * H)
     _attn_fwd_async_prefetch[grid](

--- a/third_party/tlx/tutorials/amd-fa-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-fa-pipelined_test.py
@@ -153,8 +153,7 @@ def _attn_fwd_async_simple(
         qk = tl.dot(q, kt_cur)
         if IS_CAUSAL:
             qk = tl.where(offs_m[:, None] >= kn[None, :], qk, float("-inf"))
-        if start_n + BLOCK_N > N_CTX:
-            qk = tl.where(kn[None, :] < N_CTX, qk, float("-inf"))
+        qk = tl.where(kn[None, :] < N_CTX, qk, float("-inf"))
 
         m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
         qk = qk * QK_SCALE - m_ij[:, None]

--- a/third_party/tlx/tutorials/amd-fa-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-fa-pipelined_test.py
@@ -143,10 +143,14 @@ def _attn_fwd_async_simple(
         tlx.async_load_commit_group([tok_k, tok_v])
 
         wait_tok = tlx.async_load_wait_group(0)
-        k_cur = tlx.local_load(tlx.local_view(k_buf, 0), token=wait_tok, relaxed=True)
+        # Transpose K at the memdesc level (metadata-only) so local_load lands
+        # directly in dot_op(opIdx=1) layout — skips the register-shuffle + LDS
+        # round-trip that `tl.dot(q, k_cur.T)` would otherwise emit.
+        kt_view = tlx.local_trans(tlx.local_view(k_buf, 0))
+        kt_cur = tlx.local_load(kt_view, token=wait_tok, relaxed=True)
         v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok, relaxed=True)
 
-        qk = tl.dot(q, k_cur.T)
+        qk = tl.dot(q, kt_cur)
         if IS_CAUSAL:
             qk = tl.where(offs_m[:, None] >= kn[None, :], qk, float("-inf"))
         if start_n + BLOCK_N > N_CTX:

--- a/third_party/tlx/tutorials/amd-fa-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-fa-pipelined_test.py
@@ -207,44 +207,22 @@ def _attn_fwd_async_prefetch(
 
     Design notes:
       * K and V are both double-buffered (2 LDS slots, ping-pong index
-        i%2).  Reasons:
-          - The K consumer goes through `local_trans(k_buf[slot])` which
-            creates a `memdesc_trans` view.  The AMD scheduler does not
-            track the alias between that view and the original `k_buf`
-            written by `buffer_load_lds`, so single-buffered K races the
-            current iter's transposed `ds_read` against the next iter's
-            `buffer_load_lds` writes — wrong results at D=64 and at any
-            (D=128, nw=8) config.
-          - V single-buffered also races for the same reason: the AMD
-            scheduler reorders the next iter's `buffer_load_lds` ahead of
-            the current iter's `ds_read` since they have no register
-            dependency (the mfma consumes register values, not LDS).
-        Two slots per buffer eliminate the alias entirely: each iter
-        writes to slot (i+1)%2 while reading from slot i%2.
-      * `kt_cur` / `v_cur` are LOCAL SSA values (not loop-carried
-        iter_args) — avoids the AMDGCN register WAR hazard previously
-        observed at D=64 when iter_arg ds_read registers aliased with
-        in-flight mfma operands.
+        i%2).
       * `local_trans` is applied to K so `local_load` lands directly in
         dot-operand layout 1, skipping the per-iter ds_write+barrier+
-        ds_read shuffle that `tl.dot(q, k_cur.T)` would emit (10M+ cycles
-        saved at D=64/N=8192 according to rocprofv3 ATT).
-      * Prefetch is "real": global->LDS load for tile i+1 is issued right
-        after the current tile's LDS reads, so it overlaps with the
-        QK+softmax+PV compute that immediately follows.  The next iter's
-        wait blocks only on whatever portion the compute didn't already
-        hide.
-
+        ds_read shuffle that `tl.dot(q, k_cur.T)` would emit.
     Prologue:
-      t=0:  [GLDS_KV]                                ; issue tile 0 -> slot 0
+    t = 0
+    [GLDS_KV]
 
-    Steady state (i = 0..n_main-1):
-      [wait_t_i] [LR_K_t_i (slot i%2), LR_V_t_i (slot i%2)]
-        [GLDS_K_{i+1} (slot (i+1)%2), GLDS_V_{i+1} (slot (i+1)%2)]
-        [QK SM PV]_i
-
-    Epilogue (last tile = n_main):
-      [wait] [LR_KV (slot n_main%2)] [QK_masked SM PV]
+    Steady State (Hot Loop):
+    t = i               t = i+1
+    [LR_KV]
+    [QK, SM0, SM1, PV]  [GLDS_KV],
+    Epilogue:
+                        t = i+1
+                        [LR_KV]
+                        [QK (masked), SM0, SM1, PV]
     """
     _assume_strides(stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh, stride_kn, stride_kk, stride_vz,
                     stride_vh, stride_vn, stride_vk, stride_oz, stride_oh, stride_om, stride_ok)
@@ -288,16 +266,20 @@ def _attn_fwd_async_prefetch(
     m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
     l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
-
-    # Prologue: issue async load for tile 0 into K slot 0 and V (only slot).
+    """
+    Prologue:
+    t = 0
+    [GLDS_KV]
+    """
     tok_k0 = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0), mask=offs_n[:, None] < N_CTX)
     tok_v0 = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0), mask=offs_n[:, None] < N_CTX)
     tlx.async_load_commit_group([tok_k0, tok_v0])
-
-    # Steady state.  Loop counter `i` indexes the *current* tile.
-    # i%2 selects the K slot being read this iter; (i+1)%2 receives the
-    # next prefetch.  V single-buffered: read then immediately overwrite
-    # (compiler tracks the alias).
+    """
+    Steady State (Hot Loop):
+    t = i               t = i+1
+    [LR_KV]
+    [QK, SM0, SM1, PV]  [GLDS_KV],
+    """
     for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=0):
         next_off = block_id + BLOCK_N
         kn = block_id + offs_n
@@ -307,12 +289,13 @@ def _attn_fwd_async_prefetch(
         slot_cur = i % 2
         slot_nxt = (i + 1) % 2
 
+        # LR_KV_ti
         wait_tok = tlx.async_load_wait_group(0)
         kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_cur))
         kt_cur = tlx.local_load(kt_view, token=wait_tok, relaxed=True)
         v_cur = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok, relaxed=True)
 
-        # Prefetch tile i+1 into the *other* slots.
+        # GLDS_KV_t(i+1), prefetch tile i+1 into the *other* slots.
         tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, slot_nxt), mask=next_mask)
         tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, slot_nxt), mask=next_mask)
         tlx.async_load_commit_group([tok_k, tok_v])
@@ -333,30 +316,41 @@ def _attn_fwd_async_prefetch(
 
         # PV_ti
         acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
-
-    # Epilogue: consume tile n_main from slot (n_main % 2).
+    """
+    Epilogue:
+    t = i+1
+    [LR_KV]
+    [QK (masked), SM0, SM1, PV]
+    """
+    # Consume tile n_main from slot (n_main % 2).
     wait_tok = tlx.async_load_wait_group(0)
     slot_last = n_main % 2
     kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_last))
     kt_cur = tlx.local_load(kt_view, token=wait_tok, relaxed=True)
     v_cur = tlx.local_load(tlx.local_view(v_buf, slot_last), token=wait_tok, relaxed=True)
 
+    # QK_t(i+1) — with boundary + causal masking
     kn_last = n_main * BLOCK_N + offs_n
     qk = tl.dot(q, kt_cur)
     qk = tl.where(kn_last[None, :] < N_CTX, qk, float("-inf"))
     if IS_CAUSAL:
         qk = tl.where(offs_m[:, None] >= kn_last[None, :], qk, float("-inf"))
 
+    # SM0_t(i+1)
     m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
     p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
     l_ij = tl.sum(p, 1)
+
+    # SM1_t(i+1)
     alpha = tl.math.exp2(m_i - m_ij)
     acc = acc * alpha[:, None]
     l_i = l_i * alpha + l_ij
     m_i = m_ij
 
+    # PV_t(i+1)
     acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
 
+    # Store output
     acc = acc / l_i[:, None]
     o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
     tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
@@ -413,12 +407,7 @@ def flash_attn_async_simple(q, k, v, sm_scale, causal=False, **kw):
 
 
 def flash_attn_async_prefetch(q, k, v, sm_scale, causal=False, **kw):
-    """Prefetch FA with modulo-scheduled prologue/hot-loop/epilogue.
-
-    Default block size and warp count are tuned for the common (D=64,
-    D=128) configs; both work correctly across nw=4/8 and BLOCK_N=64/128
-    but the defaults below give the best end-to-end on MI350X.
-    """
+    """Prefetch FA with modulo-scheduled prologue/hot-loop/epilogue."""
     B, H, N_CTX, D = q.shape
     o = torch.empty_like(q)
 


### PR DESCRIPTION
The main motivation for this change is there is massive performance regression AND numeric issue after couple layout PRs landed. Upon further investigation issue has always been there but these new layouts/optimzations expose a big underlying bug which is K.T needed to do roundtrip to shared memory due to having a pattern of (load K to shared memory + load K from shared memory + K.T), where K.T ended up costing us a lot of time.

This PR bring in 3 main changes:

1. Implementing `tkt = lx.local_trans(K_buf) + local_load(kt_buf)` instead of the previous ` kt = local_load(k_buf) + K.T`. This enables compiler to detect that K.T can just be loaded  instead of loading into register and doing round trip to transpose manually.

2. To enable one, we need to modify compiler side as well. We needed to let `inferTransEncoding` handle transOp encoding for swizzle, as opposed to special branch/code that we introduce. the branch/code we introduce was added before the `inferTransEncoding` was added. That special branch/code was failing on  `isEffectivelyUnswizzledShared` for K.T 

3. Some minor tweaks to kernel schedule and kernel itself for be optimized for new actual buffer_load_to_lds and ds_Load_tr structure.

Performace numbers before or without update:
```
  ==============================================================================================
  Summary (TFLOPS)
  ==============================================================================================
  | Config                                  |     Torch SDPA |   async_simple | async_prefetch |
  |-----------------------------------------|----------------|----------------|----------------|
  | B=1, H=64, D=64, N=1024, causal=False   |          286.4 |          363.1 |          376.2 |
  | B=1, H=64, D=64, N=8192, causal=False   |          557.6 |          451.8 |          467.2 |
  | B=1, H=64, D=64, N=16384, causal=False  |          599.6 |          460.4 |          476.2 |
  | B=1, H=64, D=128, N=1024, causal=False  |          344.3 |   Numeric issue|          175.0 |
  | B=1, H=64, D=128, N=8192, causal=False  |          596.4 |   Numeric issue|          218.2 |
  | B=1, H=64, D=128, N=16384, causal=False |          654.8 |   Numeric issue|          219.0 |
  ==============================================================================================
  ```

Performance numbers w/ update:
```
==============================================================================================
Summary (TFLOPS)
==============================================================================================
| Config                                  |     Torch SDPA |   async_simple | async_prefetch |
|-----------------------------------------|----------------|----------------|----------------|
| B=1, H=64, D=64, N=1024, causal=False   |          284.7 |          379.4 |          483.6 |
| B=1, H=64, D=64, N=8192, causal=False   |          517.1 |          476.7 |          641.4 |
| B=1, H=64, D=64, N=16384, causal=False  |          601.1 |          487.0 |          662.3 |
| B=1, H=64, D=128, N=1024, causal=False  |          345.7 |          440.3 |          483.5 |
| B=1, H=64, D=128, N=8192, causal=False  |          595.8 |          587.0 |          629.5 |
| B=1, H=64, D=128, N=16384, causal=False |          654.2 |          602.2 |          644.1 |
==============================================================================================
```