### PR TITLE
 [BE] [TLX] Refactor subtile ops file to a single location (#1530)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ python/triton/backends/*
 python/triton/language/extra/*
 !python/triton/language/extra/__init__.py
 !python/triton/language/extra/libdevice.py
+!python/triton/language/extra/subtile_ops.py
 
 # Tools extras
 python/triton/tools/extra

--- a/python/triton/language/extra/subtile_ops.py
+++ b/python/triton/language/extra/subtile_ops.py
@@ -1,0 +1,22 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _split_n_2D(x, SPLIT_FACTOR: tl.constexpr):
+    if SPLIT_FACTOR == 1:
+        return (x, )
+    else:
+        x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
+        return _split_n_2D(x0, SPLIT_FACTOR // 2) + _split_n_2D(x1, SPLIT_FACTOR // 2)
+
+
+@triton.jit
+def _join_n_2D(xs):
+    if len(xs) == 1:
+        return xs[0]
+    else:
+        x0 = _join_n_2D(xs[:len(xs) // 2])
+        x1 = _join_n_2D(xs[len(xs) // 2:])
+        x = tl.join(x0, x1).permute(0, 2, 1).reshape([x0.shape[0], x0.shape[1] * 2])
+        return x

--- a/third_party/tlx/tutorials/blackwell_fa_clc.py
+++ b/third_party/tlx/tutorials/blackwell_fa_clc.py
@@ -9,6 +9,7 @@ import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2
+from triton.language.extra.subtile_ops import _join_n_2D, _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -124,26 +125,6 @@ def _compute_offsets(
 
 
 @triton.jit
-def _split_n(x, SPLIT_FACTOR: tl.constexpr):
-    if SPLIT_FACTOR == 1:
-        return (x, )
-    else:
-        x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
-        return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
-
-
-@triton.jit
-def _join_n(xs):
-    if len(xs) == 1:
-        return xs[0]
-    else:
-        x0 = _join_n(xs[:len(xs) // 2])
-        x1 = _join_n(xs[len(xs) // 2:])
-        x = tl.join(x0, x1).permute(0, 2, 1).reshape([x0.shape[0], x0.shape[1] * 2])
-        return x
-
-
-@triton.jit
 def _mask_scalar(qk, col_limit_right, s, i):
     col_lim_right_s = col_limit_right - s
     col_lim_right_cur = max(col_lim_right_s, 0)
@@ -217,7 +198,7 @@ def _softmax_inner_loop(
             qk = _fma_f32x2(qk, qk_scale, -m_scaled[:, None])
         else:
             qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
-        qks = _split_n(qk, NUM_MMA_SLICES)
+        qks = _split_n_2D(qk, NUM_MMA_SLICES)
         ps = ()
         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
             p_bufIdx = cid * NUM_MMA_SLICES + slice_id
@@ -226,7 +207,7 @@ def _softmax_inner_loop(
             tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
             ps = ps + (p_i, )
 
-        p = _join_n(ps)
+        p = _join_n_2D(ps)
         l_ij = tl.sum(p, 1)
         l_i = l_i * alpha + l_ij
         m_i = m_ij

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -3,6 +3,7 @@ import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _sub_f32x2
+from triton.language.extra.subtile_ops import _join_n_2D, _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -144,26 +145,6 @@ def _compute_offsets(
 
 
 @triton.jit
-def _split_n(x, SPLIT_FACTOR: tl.constexpr):
-    if SPLIT_FACTOR == 1:
-        return (x, )
-    else:
-        x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
-        return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
-
-
-@triton.jit
-def _join_n(xs):
-    if len(xs) == 1:
-        return xs[0]
-    else:
-        x0 = _join_n(xs[:len(xs) // 2])
-        x1 = _join_n(xs[len(xs) // 2:])
-        x = tl.join(x0, x1).permute(0, 2, 1).reshape([x0.shape[0], x0.shape[1] * 2])
-        return x
-
-
-@triton.jit
 def _mask_scalar(qk, col_limit_right, s, i):
     col_lim_right_s = col_limit_right - s
     col_lim_right_cur = max(col_lim_right_s, 0)
@@ -264,7 +245,7 @@ def _softmax_inner_loop(
         # for last fragment, always use SFU, for first 3 fragments, elements 0 to 11 use SFU,
         # elements 12 to 15 use emulation, elements 16 to 27 use SFU, elements 28 to 31 use emulation
         # the loop is unrolled twice likely for vectorization
-        qks = _split_n(qk, NUM_MMA_SLICES)
+        qks = _split_n_2D(qk, NUM_MMA_SLICES)
         ps = ()
         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
             # prepare p for the v dot
@@ -274,7 +255,7 @@ def _softmax_inner_loop(
             tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
             ps = ps + (p_i, )
 
-        p = _join_n(ps)
+        p = _join_n_2D(ps)
         l_ij = tl.sum(p, 1)
         l_i = l_i * alpha + l_ij
         m_i = m_ij

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -5,6 +5,7 @@ import torch
 import triton
 import triton.language as tl
 from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _reduce_fadd2
+from triton.language.extra.subtile_ops import _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -548,15 +549,6 @@ def torch_dtype_to_triton(dtype):
 
 
 @triton.jit
-def _split_n(x, SPLIT_FACTOR: tl.constexpr):
-    if SPLIT_FACTOR == 1:
-        return (x, )
-    else:
-        x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
-        return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
-
-
-@triton.jit
 def _attn_bwd_preprocess(O, DO,  #
                          Delta,  #
                          Z, H, N_CTX,  #
@@ -715,7 +707,7 @@ def _attn_bwd_dkdv_inner(
     else:
         dk += tl.dot(dsT, tl.trans(qT))
         dq = tl.dot(tl.trans(dsT), k)
-    dqs = _split_n(dq, EPILOGUE_SUBTILE)
+    dqs = _split_n_2D(dq, EPILOGUE_SUBTILE)
     slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
         dqN = dqs[slice_id] * LN2
@@ -1022,7 +1014,7 @@ def _attn_bwd_core(
         BWD_DOT_ATTRS=BWD_DOT_ATTRS,
     )
 
-    dvs = _split_n(dv, EPILOGUE_SUBTILE)
+    dvs = _split_n_2D(dv, EPILOGUE_SUBTILE)
     slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
         dvN = dvs[slice_id]
@@ -1031,7 +1023,7 @@ def _attn_bwd_core(
             dvN.to(dtype),
         )
 
-    dks = _split_n(dk, EPILOGUE_SUBTILE)
+    dks = _split_n_2D(dk, EPILOGUE_SUBTILE)
     for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
         dkN = dks[slice_id] * sm_scale
         desc_dk.store(


### PR DESCRIPTION
Summary:
Moves the subtile operations to a new locations for standardized usage. Should reduce code duplication between Triton/TLX.

General motivation is the need to copy code across attention implementations.


Reviewed By: nmacchioni

Differential Revision: D105497474

Pulled By: njriasan


