### PR TITLE
[TLX][AMD] Use padded layouts for TLX async dot loads

### DIFF
--- a/test/TLX/insert-require-layout.mlir
+++ b/test/TLX/insert-require-layout.mlir
@@ -44,6 +44,38 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
 }
 
 // -----
+// Test 1b: async direct-to-LDS producer feeding local_load -> dot on CDNA4.
+// InsertRequireLayout should prefer AMD's async-copy padded shared layout
+// instead of the dot-derived swizzled fallback.
+
+#blocked_6 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_6 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+#shared_6 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_6 = #ttg.shared_memory
+// CHECK-DAG: #{{.*}} = #ttg.padded_shared<[512:+32] {{.*}}>
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @async_copy_local_load_dot_uses_padded
+  tt.func public @async_copy_local_load_dot_uses_padded(
+      %ptrs: tensor<64x64x!tt.ptr<bf16>, #blocked_6>,
+      %lhs: tensor<256x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma_6, kWidth = 4}>>,
+      %acc: tensor<256x64xf32, #mma_6>) -> tensor<256x64xf32, #mma_6> {
+    %c0_i32 = arith.constant 0 : i32
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x64xbf16, #shared_6, #smem_6, mutable>
+    // CHECK: %[[BUF:.*]] = ttg.memdesc_index
+    %buf = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<1x64x64xbf16, #shared_6, #smem_6, mutable> -> !ttg.memdesc<64x64xbf16, #shared_6, #smem_6, mutable>
+    %tok = ttg.async_copy_global_to_local %ptrs, %buf {contiguity = 8 : i32} : tensor<64x64x!tt.ptr<bf16>, #blocked_6> -> <64x64xbf16, #shared_6, #smem_6, mutable>
+    // CHECK: %[[REQ:.*]] = tlx.require_layout %[[BUF]] {{.*}} -> !ttg.memdesc<64x64xbf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[RHS_LOAD:.*]] = ttg.local_load %[[REQ]] : !ttg.memdesc<64x64xbf16, #{{.*}}, #smem, mutable> -> tensor<64x64xbf16, #{{.*}}>
+    %rhs = ttg.local_load %buf : !ttg.memdesc<64x64xbf16, #shared_6, #smem_6, mutable> -> tensor<64x64xbf16, #blocked_6>
+    // CHECK: %[[RHS_REQ:.*]] = tlx.require_layout %[[RHS_LOAD]] : tensor<64x64xbf16, #{{.*}}> -> tensor<64x64xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %rhs_dot = ttg.convert_layout %rhs : tensor<64x64xbf16, #blocked_6> -> tensor<64x64xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma_6, kWidth = 4}>>
+    // CHECK: tt.dot %{{.*}}, %[[RHS_REQ]], %{{.*}}
+    %dot = tt.dot %lhs, %rhs_dot, %acc : tensor<256x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma_6, kWidth = 4}>> * tensor<64x64xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma_6, kWidth = 4}>> -> tensor<256x64xf32, #mma_6>
+    tt.return %dot : tensor<256x64xf32, #mma_6>
+  }
+}
+
+// -----
 // Test 2: local_load feeds scf.for iter_args that eventually reach a dot.
 // InsertRequireLayout keeps the loop-carried values in their original type and
 // materializes tensor constraints at the dot use.

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -12,6 +12,7 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "tlx-amd-insert-require-layout"
@@ -249,17 +250,59 @@ private:
 // Rewrite helpers
 // ============================================================================
 
-static ttg::SwizzledSharedEncodingAttr
-computeSharedEncFromDotEnc(ttg::DotOperandEncodingAttr dotEnc,
-                           ttg::LocalLoadOp localLoadOp) {
+static std::optional<SmallVector<unsigned>>
+getUserSharedOrder(ttg::LocalLoadOp localLoadOp) {
+  auto loadMemDesc = localLoadOp->getOperand(0);
+  if (auto srcType = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
+    if (auto srcEnc =
+            dyn_cast_or_null<ttg::SharedEncodingTrait>(srcType.getEncoding())) {
+      return ttg::getOrder(srcEnc, srcType.getShape());
+    }
+  }
+
+  return std::nullopt;
+}
+
+static Attribute computeSharedEncFromDotEnc(ttg::DotOperandEncodingAttr dotEnc,
+                                            ttg::LocalLoadOp localLoadOp,
+                                            bool useAsyncCopy) {
   auto resultType = cast<RankedTensorType>(localLoadOp.getType());
   auto order = ttg::getOrderForMemory(resultType);
+  auto userOrder = getUserSharedOrder(localLoadOp);
+  auto paddedOrder = userOrder.value_or(order);
   auto ctaLayout = ttg::getCGALayout(resultType.getEncoding());
   unsigned bitWidth = resultType.getElementType().getIntOrFloatBitWidth();
-  return ttg::SwizzledSharedEncodingAttr::get(localLoadOp->getContext(), dotEnc,
-                                              resultType.getShape(), order,
-                                              ctaLayout, bitWidth,
-                                              /*needTrans=*/false);
+
+  if (useAsyncCopy) {
+    auto loadMemDesc = localLoadOp->getOperand(0);
+    if (auto type = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
+      auto archStr = getAMDArch(localLoadOp->getParentOfType<ModuleOp>());
+      auto targetInfo = tt::AMD::TargetInfo(archStr.value_or("").str());
+      using tt::AMD::ISAFamily;
+      if (llvm::is_contained({ISAFamily::CDNA4, ISAFamily::GFX1250},
+                             targetInfo.getISAFamily())) {
+        if (auto padded = composePaddedLayout(
+                targetInfo, dotEnc.getOpIdx(), dotEnc.getKWidth(),
+                cast<ttg::TensorOrMemDesc>(type), paddedOrder, dotEnc,
+                /*useAsyncCopy=*/true)) {
+          LDBG("Deduced async-copy padded shared encoding from dot layout: "
+               << padded);
+          return padded;
+        }
+      }
+    }
+  }
+
+  auto swizzled = ttg::SwizzledSharedEncodingAttr::get(
+      localLoadOp->getContext(), dotEnc, resultType.getShape(), order,
+      ctaLayout, bitWidth, /*needTrans=*/false);
+  if (userOrder && *userOrder != order) {
+    LDBG("Respecting user-specified order instead of derived " << swizzled);
+    swizzled = ttg::SwizzledSharedEncodingAttr::get(
+        swizzled.getContext(), swizzled.getVec(), swizzled.getPerPhase(),
+        swizzled.getMaxPhase(), *userOrder, swizzled.getCGALayout());
+  }
+  return swizzled;
 }
 
 // Walk up the memdesc def-chain through subview / reinterpret ops to
@@ -274,8 +317,8 @@ static Value findMemDescRoot(Value memdesc) {
     // anchors and dot-consumer discovery meet on the full buffer even when
     // WMMA consumes a sliced or transposed view.
     if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
-            ttg::MemDescSubsliceOp, ttg::MemDescTransOp, ttg::MemDescReshapeOp>(
-            def)) {
+            ttg::MemDescSubsliceOp, ttg::MemDescTransOp, ttg::MemDescReshapeOp,
+            tlx::RequireLayoutOp>(def)) {
       root = def->getOperand(0);
       continue;
     }
@@ -284,35 +327,45 @@ static Value findMemDescRoot(Value memdesc) {
   return root;
 }
 
-// True if any sibling-subview user of the memdesc value's source alloc is
-// a TDM op (load or store). Used by the dot-path walk to hand off TDM-fed
-// buffers to the TDM anchor — both walks targeting the same alloc with
-// different encodings would otherwise conflict in the propagation lattice.
-// Stores are included so a store-anchored alloc isn't also targeted by the
-// dot-path walk; the store's hardware verifier requires the default
-// padded-shared encoding, which the dot-path swizzled anchor would clobber.
-static bool isFedByTDM(Value memdesc) {
+template <typename... ProducerOps>
+static bool isFedByAnyMemDescUser(Value memdesc) {
   llvm::SetVector<Value> worklist;
   worklist.insert(findMemDescRoot(memdesc));
   while (!worklist.empty()) {
     Value v = worklist.pop_back_val();
     for (Operation *u : v.getUsers()) {
-      if (isa<amdgpu::AsyncTDMCopyGlobalToLocalOp,
-              amdgpu::AsyncTDMCopyLocalToGlobalOp>(u))
+      if (isa<ProducerOps...>(u))
         return true;
-      // Follow sibling views from the root allocation so local_load(subslice)
-      // and local_load(transpose(subslice)) are recognized as TDM-fed too.
+      // Follow sibling views from the root allocation so local_load(subslice),
+      // local_load(transpose(subslice)), and already-constrained aliases are
+      // recognized as users of the same allocation.
       if (isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp,
               ttg::MemDescSubsliceOp, ttg::MemDescTransOp,
-              ttg::MemDescReshapeOp>(u))
+              ttg::MemDescReshapeOp, tlx::RequireLayoutOp>(u))
         worklist.insert(u->getResult(0));
     }
   }
   return false;
 }
 
-static void applyRequireLayout(ttg::SwizzledSharedEncodingAttr encoding,
-                               ttg::LocalLoadOp localLoadOp,
+// True if any sibling-subview user of the memdesc value's source alloc is
+// a TDM op (load or store). Used by the dot-path walk to hand off TDM-fed
+// buffers to the TDM anchor — both walks targeting the same alloc with
+// different encodings would otherwise conflict in the propagation lattice.
+// Stores are included so a store-anchored alloc isn't also targeted by the
+// dot-path walk; the store's hardware verifier requires the default
+// padded-shared encoding, which the dot-path anchor would clobber.
+static bool isFedByTDM(Value memdesc) {
+  return isFedByAnyMemDescUser<amdgpu::AsyncTDMCopyGlobalToLocalOp,
+                               amdgpu::AsyncTDMCopyLocalToGlobalOp>(memdesc);
+}
+
+static bool isFedByAsyncLdsProducer(Value memdesc) {
+  return isFedByAnyMemDescUser<ttg::AsyncCopyGlobalToLocalOp,
+                               amdgpu::BufferLoadToLocalOp>(memdesc);
+}
+
+static void applyRequireLayout(Attribute encoding, ttg::LocalLoadOp localLoadOp,
                                OpBuilder &builder) {
   auto loadMemDesc = localLoadOp->getOperand(0);
 
@@ -327,25 +380,11 @@ static void applyRequireLayout(ttg::SwizzledSharedEncodingAttr encoding,
   if (isFedByTDM(loadMemDesc))
     return;
 
-  // Respect user-specified order on the source memdesc.
-  if (auto srcType = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
-    if (auto srcEnc =
-            dyn_cast<ttg::SwizzledSharedEncodingAttr>(srcType.getEncoding())) {
-      if (srcEnc.getOrder() != encoding.getOrder()) {
-        LDBG("Respecting user-specified order "
-             << srcEnc << " instead of derived " << encoding);
-        encoding = ttg::SwizzledSharedEncodingAttr::get(
-            encoding.getContext(), encoding.getVec(), encoding.getPerPhase(),
-            encoding.getMaxPhase(), srcEnc.getOrder(), encoding.getCGALayout());
-      }
-    }
-  }
-
   builder.setInsertionPoint(localLoadOp);
   if (auto type = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
     auto newType = ttg::MemDescType::get(
-        type.getShape(), type.getElementType(), mlir::cast<Attribute>(encoding),
-        type.getMemorySpace(), type.getMutableMemory(), type.getAllocShape());
+        type.getShape(), type.getElementType(), encoding, type.getMemorySpace(),
+        type.getMutableMemory(), type.getAllocShape());
     auto requireOp = tlx::RequireLayoutOp::create(
         builder, localLoadOp->getLoc(), newType, loadMemDesc);
     localLoadOp->setOperand(0, requireOp.getResult());
@@ -712,8 +751,12 @@ LogicalResult insertRequireLayout(ModuleOp m) {
 
     LDBG("local_load needs dot encoding: " << dotEnc);
 
-    // Insert RequireLayoutOp for memdesc swizzling.
-    auto sharedEnc = computeSharedEncFromDotEnc(dotEnc, localLoadOp);
+    // Insert RequireLayoutOp for the memdesc-side dot layout. For explicit
+    // async direct-to-LDS producers, prefer AMD's padded shared layout when it
+    // is applicable and fall back to the dot-derived swizzled layout.
+    bool useAsyncCopy = isFedByAsyncLdsProducer(localLoadOp->getOperand(0));
+    auto sharedEnc =
+        computeSharedEncFromDotEnc(dotEnc, localLoadOp, useAsyncCopy);
     applyRequireLayout(sharedEnc, localLoadOp, builder);
   });
 

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -276,13 +276,13 @@ static Attribute computeSharedEncFromDotEnc(ttg::DotOperandEncodingAttr dotEnc,
   if (useAsyncCopy) {
     auto loadMemDesc = localLoadOp->getOperand(0);
     if (auto type = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
-      auto archStr = getAMDArch(localLoadOp->getParentOfType<ModuleOp>());
-      auto targetInfo = tt::AMD::TargetInfo(archStr.value_or("").str());
-      using tt::AMD::ISAFamily;
+      amdgpu::TargetFeatures targetFeatures(
+          getAMDArch(localLoadOp->getParentOfType<ModuleOp>()));
+      using amdgpu::ISAFamily;
       if (llvm::is_contained({ISAFamily::CDNA4, ISAFamily::GFX1250},
-                             targetInfo.getISAFamily())) {
+                             targetFeatures.getISAFamily())) {
         if (auto padded = composePaddedLayout(
-                targetInfo, dotEnc.getOpIdx(), dotEnc.getKWidth(),
+                targetFeatures, dotEnc.getOpIdx(), dotEnc.getKWidth(),
                 cast<ttg::TensorOrMemDesc>(type), paddedOrder, dotEnc,
                 /*useAsyncCopy=*/true)) {
           LDBG("Deduced async-copy padded shared encoding from dot layout: "


### PR DESCRIPTION
### Motivation

TLX InsertRequireLayout always picked a dot-derived swizzled shared layout for explicit local_load -> dot constraints. That is fine for generic LDS producers, but it does not match AMD's async-copy path. For CDNA4/GFX1250 async direct-to-LDS copies, AMD first tries composePaddedLayout and only falls back to swizzled when padded is not applicable.

In async_simple FA, the V tile has this shape:
```mlir
  %tok = ttg.async_copy_global_to_local %ptrs, %buf

  %v   = ttg.local_load %buf

  %vd  = ttg.convert_layout %v -> tensor<..., #ttg.dot_op<opIdx = 1, kWidth = 4>>

  %acc = tt.dot %p, %vd, %acc
```

With the swizzled-only TLX path, the async copy can lose the LDS layout properties needed for the expected vectorized buffer_load_dwordx4 ... lds form and may scalarize instead.

### Changes

Teach computeSharedEncFromDotEnc to try AMD's padded-layout heuristic when the local_load memdesc is fed by an async LDS producer and the target ISA is CDNA4 or GFX1250:

```cpp
  composePaddedLayout(targetInfo, dotEnc, useAsyncCopy=true)
```

If the producer, target, or heuristic does not qualify, the old swizzled fallback is used.

### Implementation Details

Add a templated memdesc-alias walk shared by the existing TDM check and the new async-LDS producer check. The walk treats memdesc views and tlx.require_layout as transparent aliases of the same LDS allocation.

Keep TDM separate: TDM-fed buffers still defer to the descriptor/TDM anchor so descriptor layout and local_load layout cannot fight each other.

Preserve the old swizzled user-order behavior: derive vec/perPhase/maxPhase from the dot layout, then only substitute the source memdesc order. Do not post-mutate padded layouts because order is part of the padding/bank-conflict heuristic.

### Performance w/ update

python third_party/tlx/tutorials/amd-fa-pipelined_test.py. Noncausal async_simple TFLOPS:

```
==============================================================================================
Summary (TFLOPS)
==============================================================================================
| Config                                  |     Torch SDPA |   async_simple | async_prefetch |
|-----------------------------------------|----------------|----------------|----------------|
| B=1, H=64, D=64, N=1024, causal=False   |          284.7 |          422.3 |          504.6 |
| B=1, H=64, D=64, N=8192, causal=False   |          558.1 |          642.6 |          706.3 |
| B=1, H=64, D=64, N=16384, causal=False  |          600.4 |          649.4 |          728.1 |
| B=1, H=64, D=128, N=1024, causal=False  |          345.7 |          490.7 |          595.1 |
| B=1, H=64, D=128, N=8192, causal=False  |          595.4 |          691.2 |          842.4 |
| B=1, H=64, D=128, N=16384, causal=False |          652.1 |          703.0 |          868.5 |
==============================================================================================
```

### Testing
Add a lit regression for CDNA4 ttg.async_copy_global_to_local -> ttg.local_load -> tt.dot, checking that InsertRequireLayout selects a padded shared encoding instead of the swizzled fallback.

Depends on https://github.com/facebookexperimental/triton/pull/1528
