### PR TITLE
[TLX] Fix BF16 FA perf test calling convention

### DIFF
--- a/third_party/tlx/tutorials/testing/test_blackwell_fa_perf.py
+++ b/third_party/tlx/tutorials/testing/test_blackwell_fa_perf.py
@@ -65,7 +65,7 @@ def create_benchmark(versions, mode="fwd"):
             elif provider in ATTENTION_METHODS:
                 attention = ATTENTION_METHODS[provider]
                 if provider == "ws_pipelined_persistent":
-                    o = attention(q, k, v, sm_scale, causal, 64, 1)
+                    o = attention(q, k, v, sm_scale, causal)
                 elif provider == "ws":
                     o = attention(q, k, v, sm_scale)
                 else:
@@ -77,7 +77,7 @@ def create_benchmark(versions, mode="fwd"):
         elif provider in ATTENTION_METHODS:
             attention = ATTENTION_METHODS[provider]
             if provider == "ws_pipelined_persistent":
-                fn = lambda: attention(q, k, v, sm_scale, causal, 64, 1)
+                fn = lambda: attention(q, k, v, sm_scale, causal)
             elif provider == "ws":
                 fn = lambda: attention(q, k, v, sm_scale)
             else:


### PR DESCRIPTION

The ws_pipelined_persistent attention() signature changed to
(q, k, v, sm_scale, causal, config=None) but the perf test
was still passing two stale positional args (64, 1).

