### PR TITLE
[TLX] [MXFP8] Increment the register usage on fwd

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -571,7 +571,7 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                 tile_idx += num_progs
 
         # softmax groups
-        with tlx.async_task(num_warps=4, registers=172, replicate=NUM_MMA_GROUPS):
+        with tlx.async_task(num_warps=4, registers=176, replicate=NUM_MMA_GROUPS):
             accum_cnt_qk = 0
             for i in range(0, tiles_per_sm):
                 # initialize offsets

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -571,7 +571,7 @@ def _attn_fwd_mxf8_ws(sm_scale, M,  #
                 tile_idx += num_progs
 
         # softmax groups
-        with tlx.async_task(num_warps=4, registers=168, replicate=NUM_MMA_GROUPS):
+        with tlx.async_task(num_warps=4, registers=172, replicate=NUM_MMA_GROUPS):
             accum_cnt_qk = 0
             for i in range(0, tiles_per_sm):
                 # initialize offsets


### PR DESCRIPTION
Increases the fwd register usage to reduce spilling. From local experimentation (incrementing by 4) this appears to be the local max.

On devgpu025:

Before:

```
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                              656.923726
1  2048.0                              745.654033
2  4096.0                              823.994307
3  8192.0                              884.460365
```

After:

```
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                              871.543723
1  2048.0                             1043.988129
2  4096.0                             1094.607780
3  8192.0                             1140.155892
```