### PR TITLE
[TLX] Fix async_remote_shmem_copy for subsliced buffers + warp0 elect

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -559,19 +559,19 @@ public:
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto typeConverter = getTypeConverter();
 
-    // Get src SMEM base pointer.
+    // Get src SMEM pointer including subslice offset.
     auto srcTy = cast<MemDescType>(op.getSrc().getType());
     auto llvmElemTy = typeConverter->convertType(srcTy.getElementType());
     auto srcSmemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getSrc(), llvmElemTy, rewriter);
-    Value srcPtr = srcSmemObj.getBase();
+    Value srcPtr = srcSmemObj.getShmemAffineBase(loc, rewriter, srcTy);
 
-    // Get dst SMEM base pointer (will be mapa'd to remote CTA).
+    // Get dst SMEM pointer including subslice offset (will be mapa'd).
     auto dstTy = cast<MemDescType>(op.getDst().getType());
     auto dstLLVMElemTy = typeConverter->convertType(dstTy.getElementType());
     auto dstSmemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getDst(), dstLLVMElemTy, rewriter);
-    Value dstPtr = dstSmemObj.getBase();
+    Value dstPtr = dstSmemObj.getShmemAffineBase(loc, rewriter, dstTy);
 
     // Get barrier SMEM base pointer (will be mapa'd to remote CTA).
     auto barrierTy = cast<MemDescType>(op.getBarrier().getType());

--- a/test/TritonNvidiaGPU/async_remote_shmem_copy.mlir
+++ b/test/TritonNvidiaGPU/async_remote_shmem_copy.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-opt --split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm=compute-capability=100 %s | FileCheck %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// Test that async_remote_shmem_copy generates cp.async.bulk and
+// elects only one thread (warp 0) to issue the copy.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @async_remote_shmem_copy_basic
+  tt.func @async_remote_shmem_copy_basic(%arg0: i32) {
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %dst = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: nvvm.mapa
+    // CHECK: nvvm.mapa
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att{{.*}}cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes
+    ttg.async_remote_shmem_copy %src, rank %arg0, %dst barrier %bar : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> barrier_ty !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// Test that async_remote_shmem_copy with a subsliced destination
+// includes the subslice offset in the address passed to mapa.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @async_remote_shmem_copy_subslice
+  tt.func @async_remote_shmem_copy_subslice(%arg0: i32) {
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %parent = ttg.local_alloc : () -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %dst = ttg.memdesc_subslice %parent[128, 0] : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64>
+    // The subslice at [128, 0] adds an offset to the base pointer.
+    // Verify GEP (offset computation) appears before mapa for the dst.
+    // CHECK: llvm.getelementptr
+    // CHECK: nvvm.mapa
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att{{.*}}cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes
+    ttg.async_remote_shmem_copy %src, rank %arg0, %dst barrier %bar : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64> barrier_ty !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -332,9 +332,8 @@ void TargetInfo::copyBulkSharedToRemoteShared(RewriterBase &rewriter,
                                               Value dstPtr, Value barrierPtr,
                                               Value ctaId, Value size) const {
   auto *ctx = rewriter.getContext();
-  // Elect one thread per warp to issue the bulk copy. This works correctly
-  // under warp specialization where the issuing warp may not be warp 0.
-  Value pred = LLVM::NVIDIA::createElectPredicate(loc, rewriter);
+  // Elect one thread across all warps to issue the bulk copy.
+  Value pred = LLVM::NVIDIA::createElectPredicateWarp0(loc, rewriter);
   // Map dst and barrier to the remote CTA's address space via mapa.
   Value remoteDstPtr = mapa(rewriter, loc, dstPtr, ctaId, pred);
   Value remoteMbarPtr = mapa(rewriter, loc, barrierPtr, ctaId, pred);


### PR DESCRIPTION
Two fixes for cp.async.bulk.shared::cluster (TMA DSMEM bulk copy):

1. AsyncRemoteShmemCopyOp lowering: use getShmemAffineBase() instead of getBase() for src and dst pointers. The old code ignored MemDescSubslice offsets, so the bulk copy targeted the wrong SMEM address in the remote CTA when the destination was a subslice of a larger buffer.

2. copyBulkSharedToRemoteShared: use createElectPredicateWarp0 instead of createElectPredicate. The old elect selected one thread per warp, so with N compute warps, N bulk copies were issued, each arriving on the remote barrier and corrupting the TX byte count.