### PR TITLE
[lint-autofix] Fix pre-commit formatting issues (#1543)

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -103,9 +103,7 @@ unsigned ReduceOpHelper::getIntraWarpSizeWithUniqueData() {
   return getThreadsPerWarp(srcEncoding, srcShape)[axis];
 }
 
-unsigned ReduceOpHelper::getNumRegGroupsOnAxis() {
-  return 1;
-}
+unsigned ReduceOpHelper::getNumRegGroupsOnAxis() { return 1; }
 
 bool ReduceOpHelper::isWarpSynchronous() {
   if (srcShape[axis] == 1)

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -464,10 +464,10 @@ private:
     }
   }
 
-  SmallVector<Value> pairwiseInnerTreeReduceRegGroups(
-      Location loc, triton::ReduceOp op,
-      SmallVector<SmallVector<Value>> groupVals,
-      ConversionPatternRewriter &rewriter) const {
+  SmallVector<Value>
+  pairwiseInnerTreeReduceRegGroups(Location loc, triton::ReduceOp op,
+                                   SmallVector<SmallVector<Value>> groupVals,
+                                   ConversionPatternRewriter &rewriter) const {
     while (groupVals.size() > 1) {
       SmallVector<SmallVector<Value>> next;
       for (unsigned g = 0; g + 1 < groupVals.size(); g += 2) {
@@ -508,10 +508,11 @@ private:
                                             rewriter);
   }
 
-  SmallVector<Value> loadAndReduceScalarRegGroups(
-      Location loc, triton::ReduceOp op, ArrayRef<Value> smemBases,
-      unsigned numRegGroups, unsigned sizeInterWarps,
-      ConversionPatternRewriter &rewriter) const {
+  SmallVector<Value>
+  loadAndReduceScalarRegGroups(Location loc, triton::ReduceOp op,
+                               ArrayRef<Value> smemBases, unsigned numRegGroups,
+                               unsigned sizeInterWarps,
+                               ConversionPatternRewriter &rewriter) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     SmallVector<SmallVector<Value>> groupVals;
     groupVals.reserve(numRegGroups);
@@ -549,7 +550,8 @@ private:
     if (numRegGroups > 1) {
       if (auto firstResultTy =
               dyn_cast<RankedTensorType>(op.getResult()[0].getType())) {
-        auto resultLayout = cast<SliceEncodingAttr>(firstResultTy.getEncoding());
+        auto resultLayout =
+            cast<SliceEncodingAttr>(firstResultTy.getEncoding());
         unsigned resultElems = getTotalElemsPerThread(firstResultTy);
         auto resultIndices = emitIndices(loc, rewriter, targetInfo,
                                          resultLayout, firstResultTy, true);
@@ -618,8 +620,8 @@ private:
 
           Value readOffset =
               linearize(rewriter, loc, readIdx, smemShape, smemOrder);
-          Value readPtr = b.gep(smemBases[i].getType(), elemTy, smemBases[i],
-                                readOffset);
+          Value readPtr =
+              b.gep(smemBases[i].getType(), elemTy, smemBases[i], readOffset);
           resultVals[j] = b.load(elemTy, readPtr);
         }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -17,7 +17,8 @@ namespace triton {
 namespace nvidia_gpu {
 
 inline bool isWSBarrierReorderEnabled() {
-  auto disableReorder = triton::tools::getBoolEnv("TRITON_DISABLE_WSBARRIER_REORDER");
+  auto disableReorder =
+      triton::tools::getBoolEnv("TRITON_DISABLE_WSBARRIER_REORDER");
   return !disableReorder;
 }
 

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -318,39 +318,6 @@ class GluonSemantic(TritonSemantic[TensorTy]):
 
         self.builder.create_local_scatter(mem_desc.handle, values.handle, indices.handle, axis)
 
-    def shared_gather(self, mem_desc, indices, axis):
-        _check(isinstance(indices, ttgl.tensor),
-               lambda: f"expected 'indices' to be a tensor, but got a {type(indices)}")
-        _check(isinstance(axis, int), lambda: f"expected 'axis' to be an int, but got a {type(axis)}")
-        _check(
-            len(indices.shape) == mem_desc.rank,
-            lambda: f"indices rank must match memdesc rank: got {len(indices.shape)} and {mem_desc.rank}")
-        _check(0 <= axis < mem_desc.rank, lambda: f"axis {axis} is out of bounds for memdesc rank {mem_desc.rank}")
-        _check(indices.dtype.is_int(), lambda: f"indices must have integer dtype, got {indices.dtype}")
-
-        ret_ty = ttgl.distributed_type(mem_desc.dtype, indices.shape, indices.type.layout)
-        handle = self.builder.create_local_gather(ret_ty.to_ir(self.builder), mem_desc.handle, indices.handle, axis)
-        return ttgl.tensor(handle, ret_ty)
-
-    def shared_scatter(self, mem_desc, values, indices, axis):
-        _check(isinstance(indices, ttgl.tensor),
-               lambda: f"expected 'indices' to be a tensor, but got a {type(indices)}")
-        _check(isinstance(axis, int), lambda: f"expected 'axis' to be an int, but got a {type(axis)}")
-        _check(isinstance(values, ttgl.tensor), lambda: f"expected 'values' to be a tensor, but got a {type(values)}")
-        _check(
-            len(indices.shape) == mem_desc.rank,
-            lambda: f"indices rank must match memdesc rank: got {len(indices.shape)} and {mem_desc.rank}")
-        _check(0 <= axis < mem_desc.rank, lambda: f"axis {axis} is out of bounds for memdesc rank {mem_desc.rank}")
-        _check(indices.dtype.is_int(), lambda: f"indices must have integer dtype, got {indices.dtype}")
-        _check(values.shape == indices.shape,
-               lambda: f"values must have the same shape as indices: got {values.shape} and {indices.shape}")
-        _check(values.type.layout == indices.type.layout, lambda: "values must have the same layout as indices")
-        _check(
-            values.dtype == mem_desc.dtype,
-            lambda: f"values element type must match destination element type: got {values.dtype} and {mem_desc.dtype}")
-
-        self.builder.create_local_scatter(mem_desc.handle, values.handle, indices.handle, axis)
-
     def bank_conflicts(self, distr_ty, shared_ty):
         if not isinstance(distr_ty, ttgl.distributed_type):
             raise TypeError(

--- a/third_party/tlx/tutorials/blackwell-gdpa.py
+++ b/third_party/tlx/tutorials/blackwell-gdpa.py
@@ -763,7 +763,7 @@ def gdpa_kernel_tma_ws_blackwell(
                             pl.exit_scope("dot_wait_p1")
                         # done using v from previous iteration
                         bufIdx_o1, phase_o1 = get_bufidx_phase(accum_cnt_o1, NUM_BUFFERS_O,  # previous iteration
-                                                                   )
+                                                               )
                         o1_view = tlx.local_view(o1_buf, bufIdx_o1)
                         producer_commit_o1_view = tlx.local_view(producer_commit_o1, bufIdx_o1)
                         # release v for previous iteartion, accum_cnt_kv already advanced


### PR DESCRIPTION
Summary:

Automated formatting fix generated by running `pre-commit run --all-files`
and `pre-commit run clang-format --all-files` on the GitHub mirror
(facebookexperimental/triton). 4 file(s) fixed.

Reviewed By: jhou-jpg

Differential Revision: D105719306


