### PR TITLE
[ci] pin torch wheel version

### DIFF
--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 env:
+  MAX_JOBS: 16
   TORCH_NIGHTLY_URL: https://download-r2.pytorch.org/whl/nightly/rocm7.2/torch-2.13.0.dev20260513%2Brocm7.2-cp312-cp312-manylinux_2_28_x86_64.whl
 
 jobs:

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: linux-fb-triton-mi350-1
     env:
       WORKSPACE_DIR: /workspace
+      CONDA_ENV: pytorch
       UV_VENV_DIR: /workspace/uv_venvs
       SETUP_SCRIPT: /workspace/setup_instance.sh
     timeout-minutes: 30

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           set -eux
           . "${SETUP_SCRIPT}"
+          uv pip install pytest
           pytest python/test/unit/language/test_tlx_*.py -v
 
 concurrency:

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+env:
+  TORCH_NIGHTLY_URL: https://download-r2.pytorch.org/whl/nightly/rocm7.2/torch-2.13.0.dev20260513%2Brocm7.2-cp312-cp312-manylinux_2_28_x86_64.whl
+
 jobs:
   mi350-meta-triton-test:
     if: github.repository_owner == 'facebookexperimental'
@@ -25,13 +28,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: meta-pytorch/tritonbench
+          ref: xz9/add-install-wheel
           path: tritonbench
           submodules: recursive
       - name: Setup Tritonbench environment
         working-directory: tritonbench
         run: |
           set -eux
-          bash ./.ci/tritonbench/setup-env.sh --hip --no-build
+          bash ./.ci/tritonbench/setup-env.sh --hip --no-build --install-torch-wheel "${TORCH_NIGHTLY_URL}"
       - name: Compile Triton
         env:
           MAX_JOBS: 16
@@ -66,13 +70,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: meta-pytorch/tritonbench
+          ref: xz9/add-install-wheel
           path: tritonbench
           submodules: recursive
       - name: Setup Tritonbench environment
         working-directory: tritonbench
         run: |
           set -eux
-          bash ./.ci/tritonbench/setup-env.sh --hip --no-build
+          bash ./.ci/tritonbench/setup-env.sh --hip --no-build --install-torch-wheel "${TORCH_NIGHTLY_URL}"
       - name: Compile Triton
         env:
           MAX_JOBS: 16

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -16,7 +16,6 @@ jobs:
     env:
       WORKSPACE_DIR: /workspace
       UV_VENV_DIR: /workspace/uv_venvs
-      CONDA_ENV: pytorch
       SETUP_SCRIPT: /workspace/setup_instance.sh
     timeout-minutes: 240
     permissions:
@@ -50,7 +49,6 @@ jobs:
     env:
       WORKSPACE_DIR: /workspace
       UV_VENV_DIR: /workspace/uv_venvs
-      CONDA_ENV: pytorch
       SETUP_SCRIPT: /workspace/setup_instance.sh
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -35,15 +35,7 @@ jobs:
         working-directory: tritonbench
         run: |
           set -eux
-          bash ./.ci/tritonbench/setup-env.sh --hip --no-build --install-torch-wheel "${TORCH_NIGHTLY_URL}"
-      - name: Compile Triton
-        env:
-          MAX_JOBS: 16
-        run: |
-          set -eux
-          . "${SETUP_SCRIPT}"
-          . "${GITHUB_WORKSPACE}/tritonbench/.ci/triton/triton_install_utils.sh"
-          install_triton "${GITHUB_WORKSPACE}"
+          bash ./.ci/tritonbench/setup-env.sh --hip --custom-triton "${GITHUB_WORKSPACE}" --install-torch-wheel "${TORCH_NIGHTLY_URL}"
       - name: Run TritonBench
         working-directory: tritonbench
         run: |
@@ -77,15 +69,7 @@ jobs:
         working-directory: tritonbench
         run: |
           set -eux
-          bash ./.ci/tritonbench/setup-env.sh --hip --no-build --install-torch-wheel "${TORCH_NIGHTLY_URL}"
-      - name: Compile Triton
-        env:
-          MAX_JOBS: 16
-        run: |
-          set -eux
-          . "${SETUP_SCRIPT}"
-          . "${GITHUB_WORKSPACE}/tritonbench/.ci/triton/triton_install_utils.sh"
-          install_triton "${GITHUB_WORKSPACE}"
+          bash ./.ci/tritonbench/setup-env.sh --hip --custom-triton "${GITHUB_WORKSPACE}" --install-torch-wheel "${TORCH_NIGHTLY_URL}"
       - name: Run TLX unit tests
         timeout-minutes: 5
         run: |

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: linux-fb-triton-mi350-1
     env:
       WORKSPACE_DIR: /workspace
+      CONDA_ENV: pytorch
       UV_VENV_DIR: /workspace/uv_venvs
       SETUP_SCRIPT: /workspace/setup_instance.sh
     timeout-minutes: 240


### PR DESCRIPTION
Recent pytorch nightly build on rocm won't download: https://github.com/facebookexperimental/triton/actions/runs/26148047928/job/76908258729

Pin to an old nightly wheel.

X-REF: https://github.com/meta-pytorch/tritonbench/pull/1081