### PR TITLE
 [AutoWS] Add LLM-based autoWS: DDG-to-TLX code generation (#1549)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -150,6 +150,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerNVGPUModuloExpand();
   mlir::registerNVGPUModuloLower();
   mlir::registerNVGPUListSchedule();
+  mlir::registerNVGPULLMSchedule();
 
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();

--- a/docs/design/llm-autows.md
+++ b/docs/design/llm-autows.md
@@ -1,0 +1,227 @@
+# LLM-Assisted AutoWS: DDG-to-TLX Code Generation
+
+## Motivation
+
+Triton provides a high-level DSL for writing GPU kernels. TLX extends it
+with low-level, hardware-near primitives — explicit barrier protocols,
+warp specialization, multibuffered TMA pipelines, TMEM management. Today,
+going from a Triton kernel to an optimized TLX kernel requires either:
+
+1. **Manual rewriting** by an expert who understands the hardware, or
+2. **AutoWS** (the compiler's modulo scheduling pass), which produces
+   optimized IR but not human-readable TLX source code.
+
+The problem with (2) is that the output is compiler IR — opaque, not
+user-editable, and hard to debug when something goes wrong. When a kernel
+hangs, hits an SMEM overflow, or underperforms, the user has no artifact
+they can inspect and fix incrementally.
+
+**The goal: use an LLM to produce TLX Python source code from a Triton
+kernel.** The output is a `.py` file that the user owns — readable,
+editable, and incrementally fixable. If the generated kernel has a bug,
+the user (or the LLM) can patch the TLX code directly, without touching
+compiler internals.
+
+## Input / Output
+
+### Input: DDG + Latency Table
+
+The Data Dependence Graph (DDG) and hardware latency table, built by the
+Triton compiler in C++ using the existing `DataDependenceGraph` and
+`LatencyModel` infrastructure. The LLM receives a structured summary —
+not raw TTGIR, not Python source:
+
+```
+DDG for loop (trip_count=32):
+  ResMII=2, RecMII=1005, MinII=1005
+
+Nodes:
+  N0: arith.muli        pipe=NONE  lat=0    selfLat=0
+  N1: tt.descriptor_load pipe=MEM   lat=1218 selfLat=1
+  N2: tt.descriptor_load pipe=MEM   lat=1218 selfLat=1
+  N3: ttg.local_alloc    pipe=MEM   lat=700  selfLat=0
+  N4: ttg.local_alloc    pipe=MEM   lat=700  selfLat=0
+  N5: ttng.tmem_alloc    pipe=NONE  lat=0    selfLat=0
+  N6: ttng.tc_gen5_mma   pipe=TC    lat=900  selfLat=1
+  N7: ttng.tmem_load     pipe=CUDA  lat=105  selfLat=1
+
+Edges:
+  N0 -> N1  lat=0    dist=0
+  N1 -> N3  lat=518  dist=0
+  N3 -> N6  lat=700  dist=0
+  N6 -> N7  lat=900  dist=0
+  N7 -> N5  lat=105  dist=1    # loop-carried
+  ...
+```
+
+### Output
+
+**TLX Python source code** — a complete, runnable `@triton.jit` kernel
+with warp specialization, explicit barriers, multibuffered TMA loads,
+and hardware-optimal scheduling. The user can:
+
+- Read and understand the pipeline structure
+- Run correctness tests directly
+- Edit specific sections (e.g., change buffer depth, adjust barrier protocol)
+- Incrementally fix issues without regenerating from scratch
+
+This is fundamentally different from compiler-internal IR annotations
+(`tt.autows`, `tt.num_stages`) which are invisible to the user and
+cannot be edited.
+
+## Why Inside Triton
+
+The LLM codegen is built into Triton's compiler pipeline (not an external
+tool) because:
+
+1. **Triton has the DDG and latency model** — the compiler already builds
+   the data dependence graph and computes cycle-accurate hardware
+   latencies. The LLM receives these as structured input, not raw MLIR.
+
+2. **Triton has the IR** — the compiler's intermediate representation
+   captures precise semantics (tensor shapes, memory hierarchy, pipeline
+   classification) that would be lost if the LLM only saw Python source.
+
+3. **Triton validates the output** — the generated TLX code compiles
+   through the same Triton pipeline, so correctness tests, SMEM budget
+   checks, and barrier analysis all apply automatically.
+
+## Architecture
+
+```
+Triton compiler (TTIR → TTGIR)
+    │
+    ▼
+DDG + Latency Table (built in C++)
+    │
+    ├── Nodes: op name, pipeline, latency, selfLatency
+    ├── Edges: src → dst, latency, loop-carried distance
+    ├── MinII, ResMII, RecMII (pre-computed)
+    │
+    ▼
+LLM (Claude, local CLI)
+    │
+    ├── Step 1: Schedule graph (II, stages, cycles, buffers)
+    ├── Step 2: TLX Python source code
+    │
+    ▼
+TLX kernel (.py) ← user-owned output
+    │
+    ├── User reviews, edits, fixes
+    ├── Run correctness tests
+    └── Iterate
+```
+
+### Two-step generation
+
+**Step 1: Schedule graph** — the LLM assigns each op to a cycle, stage,
+and cluster, determines buffer depths, and pairs barriers. This is the
+"thinking" step that requires understanding hardware latencies and
+pipeline overlapping.
+
+**Step 2: TLX code emission** — the schedule graph is translated into
+TLX Python with `async_tasks`, `local_alloc`, `alloc_barriers`,
+`async_descriptor_load`, `async_dot`, barrier wait/arrive protocols,
+and the pipeline loop structure.
+
+Step 1 is already working (the `nvgpu-llm-schedule` pass). Step 2 can
+be done by the LLM in the same call, or as a separate pass that takes
+the schedule graph and emits TLX.
+
+## Current Implementation
+
+### C++ pass: `nvgpu-llm-schedule`
+
+Registered as `nvidia.passes.hopper.add_llm_schedule(pm)`, gated by
+`TRITON_USE_LLM_SCHEDULE=1`.
+
+| File | Purpose |
+|------|---------|
+| `third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LLMSchedulePass.cpp` | C++ pass: builds DDG, calls Claude CLI, parses schedule, sets IR attrs |
+| `third_party/nvidia/backend/compiler.py` | Pipeline integration |
+| `python/triton/knobs.py` | `TRITON_USE_LLM_SCHEDULE` env var |
+| `third_party/tlx/tools/scheduling_prompt.md` | System prompt with scheduling rules |
+| `test/TritonGPU/llm-schedule.mlir` | LIT test |
+
+### How it works
+
+1. Compiler builds DDG using `DataDependenceGraph::build()` and
+   `LatencyModel` (same infrastructure as modulo scheduling)
+2. Formats the DDG as structured text (nodes + edges + latencies)
+3. Calls `claude --bare --system-prompt-file ... -p ...` via `std::system()`
+4. Parses the `modulo.schedule` response
+5. Sets `tt.autows` on MMA ops and `tt.num_stages` on loops
+
+### Example result
+
+For a standard GEMM kernel, the LLM produced:
+
+```
+modulo.schedule @loop0 {
+  ii = 1005, max_stage = 2, prologue_latency = 0, trip_count = 32
+
+  modulo.stage @s0 {
+    N1  {pipe: MEM, cycle: 0, cluster: 0, latency: 1218, selfLatency: 1}
+    N2  {pipe: MEM, cycle: 1, cluster: 1, latency: 1218, selfLatency: 1}
+    N3  {pipe: MEM, cycle: 518, cluster: 2, latency: 700, selfLatency: 0}
+    N4  {pipe: MEM, cycle: 519, cluster: 3, latency: 700, selfLatency: 0}
+  }
+  modulo.stage @s1 {
+    N6  {pipe: TC, cycle: 1219, cluster: 0, latency: 900, selfLatency: 1}
+  }
+  modulo.stage @s2 {
+    N7  {pipe: CUDA, cycle: 2119, cluster: 0, latency: 105, selfLatency: 1}
+  }
+}
+```
+
+This corresponds to a 3-stage pipeline (II=1005, triple-buffered SMEM)
+which is actually better than the modulo scheduler's output (II=1601,
+single-buffered) for this kernel — the LLM kept the lower II and used
+more buffers, which is the right trade-off when SMEM budget allows it.
+
+## Phased Rollout
+
+### Phase 1: Schedule graph generation (done)
+
+The LLM receives the DDG and produces a `modulo.schedule` graph.
+Verified on the GEMM LIT test — correct II, stages, and cycle placement.
+
+### Phase 2: TLX code emission
+
+The LLM receives the DDG + schedule graph and produces complete TLX
+Python source code. The system prompt includes:
+- TLX API reference (barriers, memory ops, MMA, warp specialization)
+- 1-2 tutorial kernel examples matched by pattern (GEMM, FA)
+- The schedule graph from Phase 1 as the "plan"
+
+### Phase 3: Complex kernels (FA, persistent, 2-CTA)
+
+Extend to Flash Attention, persistent kernels with CLC, and multi-CTA
+patterns. These require:
+- Multiple MMAs with different dependency depths
+- Pingpong scheduling
+- Cross-CTA synchronization via DSMEM
+- TMEM buffer reuse (storage_alias_spec)
+
+### Phase 4: Interactive refinement
+
+The user runs the generated TLX kernel, sees results, and asks the LLM
+to adjust:
+- "Add one more pipeline stage"
+- "Move the softmax chain to the consumer task"
+- "Switch from 1-CTA to 2-CTA"
+- "Fix the barrier deadlock on line 42"
+
+The LLM modifies the TLX source directly. This is where producing
+user-owned TLX code (vs compiler IR) pays off — the user and LLM
+can iterate on the same readable artifact.
+
+## Success Criteria
+
+1. Generated TLX kernel passes numerical correctness tests
+2. Performance within 80% of hand-tuned TLX for GEMM and FA fwd
+3. User can read, understand, and modify the generated code
+4. End-to-end generation takes < 60 seconds
+5. When the kernel has a bug, the user can fix it in the TLX source
+   without regenerating from scratch

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -514,6 +514,7 @@ class nvidia_knobs(base_knobs):
     libcuda_path: env_opt_str = env_opt_str("TRITON_LIBCUDA_PATH")
     use_meta_ws: env_bool = env_bool("TRITON_USE_META_WS")
     use_modulo_schedule: env_opt_str = env_opt_str("TRITON_USE_MODULO_SCHEDULE")
+    use_llm_schedule: env_bool = env_bool("TRITON_USE_LLM_SCHEDULE")
     disable_wsbarrier_reorder: env_bool = env_bool("TRITON_DISABLE_WSBARRIER_REORDER")
     # Force OAI SWP schedule even when using Meta's WS implementation.
     force_trunk_swp_schedule: env_bool = env_bool("TRITON_FORCE_TRUNK_SWP_SCHEDULE")

--- a/test/TritonGPU/llm-schedule.mlir
+++ b/test/TritonGPU/llm-schedule.mlir
@@ -1,0 +1,53 @@
+// UNSUPPORTED: true
+// Disabled: requires local claude CLI which is not available on all servers.
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-llm-schedule | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Test: LLM-based scheduling sets tt.num_stages on inner GEMM loop.
+// The LLM receives the DDG (nodes + edges + latencies) and produces
+// a modulo.schedule that the pass parses to set IR attributes.
+//===----------------------------------------------------------------------===//
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// The LLM should produce a schedule with at least 2 stages for this GEMM,
+// resulting in tt.num_stages >= 2 on the loop.
+//
+// CHECK-LABEL: @llm_gemm_inner_loop
+// CHECK: tt.num_stages = {{[0-9]+}} : i32
+tt.func @llm_gemm_inner_loop(
+  %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x128xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked>
+
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+
+    scf.yield %c : tensor<128x128xf32, #acc_layout>
+  }
+
+  tt.return
+}
+
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -668,7 +668,9 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_optimize_accumulator_init(pm)
             passes.ttgpuir.add_hoist_tmem_alloc(pm, False)
             nvidia.passes.ttnvgpuir.add_promote_lhs_to_tmem(pm)
-            if knobs.nvidia.use_modulo_schedule is not None:
+            if knobs.nvidia.use_llm_schedule:
+                nvidia.passes.hopper.add_llm_schedule(pm)
+            elif knobs.nvidia.use_modulo_schedule is not None:
                 # Modulo schedule runs BEFORE data partitioning so it can
                 # see MMA ops before they're moved into WS regions. It
                 # sets tt.autows annotations (stage/order) on MMA ops.

--- a/third_party/nvidia/backend/llm_schedule.py
+++ b/third_party/nvidia/backend/llm_schedule.py
@@ -1,0 +1,230 @@
+"""LLM-based modulo scheduling for Triton.
+
+When TRITON_USE_LLM_SCHEDULE=1 is set, this module is called during
+make_ttgir() to produce schedule annotations (tt.autows, tt.num_stages)
+using an LLM instead of the C++ modulo scheduling pass.
+
+The LLM receives the TTGIR text and a system prompt describing the
+scheduling rules, and produces a modulo.schedule graph. The graph is
+then parsed and the annotations are set on the IR via mod.walk().
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _get_prompt_file() -> Path:
+    return Path(__file__).resolve().parents[1] / "tlx" / "tools" / "scheduling_prompt.md"
+
+
+def _get_system_prompt() -> str:
+    """Load the scheduling system prompt."""
+    prompt_file = _get_prompt_file()
+    if prompt_file.exists():
+        return prompt_file.read_text()
+    raise FileNotFoundError(f"Scheduling prompt not found at {prompt_file}")
+
+
+def _call_llm(ttgir_text: str, system_prompt: str) -> str:
+    """Call the LLM with the TTGIR input and return the schedule graph."""
+    model = os.environ.get("TRITON_LLM_MODEL", "sonnet")
+
+    user_prompt = (
+        "Given the following TTGIR, produce the modulo.schedule graph "
+        "by following the steps in your instructions.\n\n"
+        "Output ONLY the raw modulo.schedule block. No explanation.\n\n"
+        f"{ttgir_text}"
+    )
+
+    # Try Anthropic Python SDK first, fall back to claude CLI
+    try:
+        return _call_anthropic_sdk(user_prompt, system_prompt, model)
+    except ImportError:
+        pass
+
+    return _call_claude_cli(user_prompt, system_prompt, model)
+
+
+def _call_anthropic_sdk(user_prompt: str, system_prompt: str, model: str) -> str:
+    """Call via the Anthropic Python SDK."""
+    import anthropic
+
+    model_map = {
+        "sonnet": "claude-sonnet-4-6",
+        "opus": "claude-opus-4-6",
+        "haiku": "claude-haiku-4-5-20251001",
+    }
+    model_id = model_map.get(model, model)
+
+    client = anthropic.Anthropic()
+    message = client.messages.create(
+        model=model_id,
+        max_tokens=4096,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+    return message.content[0].text
+
+
+def _call_claude_cli(user_prompt: str, system_prompt: str, model: str) -> str:
+    """Fall back to calling the claude CLI."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False
+    ) as sp_file:
+        sp_file.write(system_prompt)
+        sp_path = sp_file.name
+
+    try:
+        cmd = [
+            "claude",
+            "--system-prompt", sp_path,
+            "-p", user_prompt,
+            "--output-format", "text",
+            "--model", model,
+            "--allowedTools", "",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        return result.stdout
+    finally:
+        os.unlink(sp_path)
+
+
+def _parse_schedule(output: str) -> dict | None:
+    """Parse the modulo.schedule block from LLM output.
+
+    Returns a dict with schedule info, or None if parsing fails.
+    """
+    schedule_match = re.search(
+        r"modulo\.schedule @\w+ \{(.+)\n\}", output, re.DOTALL
+    )
+    if not schedule_match:
+        return None
+
+    body = schedule_match.group(1)
+    result = {"ii": None, "max_stage": None, "nodes": []}
+
+    header = re.search(
+        r"ii = (\d+), max_stage = (\d+)", body
+    )
+    if header:
+        result["ii"] = int(header.group(1))
+        result["max_stage"] = int(header.group(2))
+
+    if result["ii"] is None:
+        return None
+
+    # Parse stage/order annotations for MMA ops
+    for m in re.finditer(
+        r"(ttng\.tc_gen5_mma|ttng\.tc_gen5_mma_scaled|ttng\.warp_group_dot|tt\.dot)"
+        r"\s+\{[^}]*cycle: (\d+), cluster: (\d+)",
+        body,
+    ):
+        op_name = m.group(1)
+        cycle = int(m.group(2))
+        cluster = int(m.group(3))
+        stage = cycle // result["ii"]
+        result["nodes"].append({
+            "op": op_name,
+            "stage": stage,
+            "order": cluster,
+        })
+
+    # Parse num_stages from buffer counts
+    buf_counts = []
+    for m in re.finditer(r"%buf\d+ = modulo\.alloc SMEM \[(\d+) x", body):
+        buf_counts.append(int(m.group(1)))
+    if buf_counts:
+        result["num_stages"] = max(buf_counts)
+    elif result["max_stage"] is not None:
+        result["num_stages"] = result["max_stage"] + 1
+
+    return result
+
+
+def _apply_schedule_to_ir(mod, schedule: dict) -> None:
+    """Apply the parsed schedule to the MLIR module.
+
+    Sets tt.autows on MMA ops and tt.num_stages on loops, matching
+    the output format of the C++ modulo schedule pass.
+    """
+    from triton._C.libtriton import ir
+
+    builder = ir.builder(mod.context)
+    mma_idx = 0
+
+    def visit(op):
+        nonlocal mma_idx
+        op_name = op.get_name()
+
+        # Set tt.autows on MMA ops
+        if op_name in (
+            "ttng.tc_gen5_mma",
+            "ttng.tc_gen5_mma_scaled",
+            "ttng.warp_group_dot",
+            "tt.dot",
+        ):
+            if mma_idx < len(schedule["nodes"]):
+                node = schedule["nodes"][mma_idx]
+                autows = json.dumps({
+                    "stage": str(node["stage"]),
+                    "order": str(node["order"]),
+                })
+                op.set_attr("tt.autows", builder.get_string_attr(autows))
+                mma_idx += 1
+
+        # Set tt.num_stages on scf.for loops
+        if op_name == "scf.for" and schedule.get("num_stages"):
+            op.set_attr(
+                "tt.num_stages",
+                builder.get_int32_attr(schedule["num_stages"]),
+            )
+
+    mod.walk(visit)
+
+
+def run_llm_schedule(mod) -> bool:
+    """Run LLM-based scheduling on the module.
+
+    Returns True if scheduling was applied, False if it failed.
+    """
+    try:
+        system_prompt = _get_system_prompt()
+    except FileNotFoundError as e:
+        logger.error("LLM Schedule: %s", e)
+        return False
+
+    ttgir_text = str(mod)
+
+    logger.info("LLM Schedule: Calling LLM for schedule graph...")
+    try:
+        output = _call_llm(ttgir_text, system_prompt)
+    except (subprocess.SubprocessError, subprocess.TimeoutExpired, OSError) as e:
+        logger.error("LLM Schedule: LLM call failed: %s", e)
+        return False
+
+    schedule = _parse_schedule(output)
+    if schedule is None:
+        logger.warning("LLM Schedule: Failed to parse schedule from LLM output")
+        if os.environ.get("TRITON_LLM_SCHEDULE_DEBUG"):
+            logger.debug("LLM Schedule: Raw output:\n%s", output[:2000])
+        return False
+
+    logger.info(
+        "LLM Schedule: Parsed: II=%d, max_stage=%s, num_stages=%s, MMA nodes=%d",
+        schedule["ii"],
+        schedule["max_stage"],
+        schedule.get("num_stages"),
+        len(schedule["nodes"]),
+    )
+
+    _apply_schedule_to_ir(mod, schedule)
+    return True

--- a/third_party/nvidia/hopper/include/Transforms/Passes.h
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.h
@@ -27,6 +27,8 @@ std::unique_ptr<Pass> createNVGPUModuloLower();
 void registerNVGPUModuloLower();
 std::unique_ptr<Pass> createNVGPUListSchedule();
 void registerNVGPUListSchedule();
+std::unique_ptr<Pass> createNVGPULLMSchedule();
+void registerNVGPULLMSchedule();
 
 } // namespace mlir
 #endif // DIALECT_NV_TRANSFORMS_PASSES_H_

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_triton_library(NVHopperTransforms
   ModuloScheduling/ModuloSchedulePass.cpp
   ModuloScheduling/ModuloWSPartitionPass.cpp
   ModuloScheduling/ModuloScheduleGraph.cpp
+  ModuloScheduling/LLMSchedulePass.cpp
   ModuloScheduling/ModuloBufferAllocPass.cpp
   ModuloScheduling/ModuloExpandPass.cpp
   ModuloScheduling/ModuloLowerPass.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LLMSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LLMSchedulePass.cpp
@@ -1,0 +1,364 @@
+// LLM-based modulo scheduling pass.
+//
+// Builds the DDG and latency table in C++ (reusing the existing modulo
+// scheduling infrastructure), formats them as compact text, and calls
+// the Claude API directly via curl to produce the schedule.
+
+#include "DataDependenceGraph.h"
+#include "LatencyModel.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdio>
+#include <fstream>
+#include <regex>
+#include <sstream>
+
+#define DEBUG_TYPE "nvgpu-llm-schedule"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
+
+namespace {
+
+// ============================================================================
+// System prompt (embedded)
+// ============================================================================
+
+static constexpr llvm::StringLiteral kSystemPrompt = R"(You are a GPU kernel scheduling expert. Given a Data Dependence Graph (DDG) with latency information, produce a modulo schedule.
+
+The input provides:
+- MinII (already computed from ResMII and RecMII)
+- Nodes with op name, pipeline (MEM/TC/CUDA/SFU/NONE), latency, and selfLatency
+- Edges with source, destination, latency, and loop-carried distance
+
+Your task: assign each non-NONE node a cycle, then derive stages and clusters.
+
+Rules:
+1. Use II = MinII as the initiation interval
+2. Place each node at an absolute cycle such that:
+   - cycle[dst] >= cycle[src] + edge_latency - edge_distance * II
+   - No two ops on the same pipeline share the same modulo slot (cycle % II)
+   - selfLatency=1 means each op uses 1 modulo slot; selfLatency=0 means no slot
+3. stage = cycle / II
+4. Within each stage, sort by cycle and assign dense cluster IDs (lowest cycle = 0)
+5. prologue_latency = cycle of first TC node in stage 0
+6. Buffer count = lifetime / II + 1, where lifetime = max_consumer_end - producer_cycle
+
+Output format (ONLY this, no explanation):
+
+modulo.schedule @loop0 {
+  ii = <II>, max_stage = <S>, prologue_latency = <L>, trip_count = <N>
+
+  modulo.stage @s0 {
+    <op_name>  {pipe: <PIPE>, cycle: <C>, cluster: <K>, latency: <L>, selfLatency: <SL>}
+  }
+  modulo.stage @s1 {
+    ...
+  }
+})";
+
+// ============================================================================
+// Format DDG as text for the LLM
+// ============================================================================
+
+static std::string getOpShortName(Operation *op) {
+  return op->getName().getStringRef().str();
+}
+
+static std::string formatDDG(const ttg::DataDependenceGraph &ddg,
+                             scf::ForOp loop) {
+  std::string result;
+  llvm::raw_string_ostream os(result);
+
+  int tripCount = -1;
+  if (auto ub = loop.getUpperBound().getDefiningOp<arith::ConstantIntOp>()) {
+    if (auto lb = loop.getLowerBound().getDefiningOp<arith::ConstantIntOp>()) {
+      if (auto step = loop.getStep().getDefiningOp<arith::ConstantIntOp>()) {
+        int64_t stepVal = step.value();
+        if (stepVal > 0)
+          tripCount = (ub.value() - lb.value() + stepVal - 1) / stepVal;
+      }
+    }
+  }
+
+  os << "DDG for loop (trip_count=" << tripCount << "):\n";
+  os << "  ResMII=" << ddg.computeResMII()
+     << ", RecMII=" << ddg.computeRecMII()
+     << ", MinII=" << ddg.computeMinII() << "\n\n";
+
+  os << "Nodes:\n";
+  for (const auto &node : ddg.getNodes()) {
+    os << "  N" << node.idx << ": " << getOpShortName(node.op)
+       << "  pipe=" << ttg::getPipelineName(node.pipeline)
+       << "  lat=" << node.latency
+       << "  selfLat=" << node.selfLatency;
+    if (node.transferLatency != node.selfLatency)
+      os << "  transferLat=" << node.transferLatency;
+    if (node.isSuperNode)
+      os << "  [super: innerII=" << node.innerII
+         << " prologueLat=" << node.prologueLatency << "]";
+    os << "\n";
+  }
+
+  os << "\nEdges:\n";
+  for (const auto &edge : ddg.getEdges()) {
+    os << "  N" << edge.srcIdx << " -> N" << edge.dstIdx
+       << "  lat=" << edge.latency << "  dist=" << edge.distance << "\n";
+  }
+
+  return result;
+}
+
+// ============================================================================
+// Call local claude CLI
+// ============================================================================
+
+static std::string callClaude(const std::string &ddgText) {
+  // Combine system prompt + DDG into one system-prompt file.
+  // Use a short -p argument to trigger non-interactive mode.
+  SmallString<128> sysPath;
+  if (llvm::sys::fs::createTemporaryFile("llm-sys", "txt", sysPath))
+    return "";
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(sysPath, ec);
+    if (ec) return "";
+    os << kSystemPrompt
+       << "\n\n--- DDG INPUT ---\n\n"
+       << ddgText;
+  }
+
+  SmallString<128> outPath;
+  if (llvm::sys::fs::createTemporaryFile("llm-out", "txt", outPath)) {
+    llvm::sys::fs::remove(sysPath);
+    return "";
+  }
+
+  const char *modelEnv = std::getenv("TRITON_LLM_MODEL");
+  std::string model = modelEnv ? modelEnv : "sonnet";
+
+  std::string sysPathStr(sysPath.begin(), sysPath.end());
+  std::string outPathStr(outPath.begin(), outPath.end());
+
+  // Pass system prompt + DDG via --system-prompt-file.
+  // Use a short -p argument as the user prompt.
+  std::string cmd =
+      "claude --bare"
+      " --system-prompt-file " + sysPathStr +
+      " -p 'Produce the modulo.schedule for the DDG above.'"
+      " --output-format text"
+      " --model " + model +
+      " --max-turns 1"
+      " > " + outPathStr +
+      " 2>/dev/null";
+
+  LDBG("Calling local claude CLI (model=" << model << ")...");
+  LDBG("Command: " << cmd);
+  int ret = std::system(cmd.c_str());
+
+  llvm::sys::fs::remove(sysPath);
+
+  if (ret != 0) {
+    LDBG("claude CLI failed with exit code " << ret);
+    llvm::sys::fs::remove(outPath);
+    return "";
+  }
+
+  std::ifstream outFile(outPathStr);
+  std::stringstream buf;
+  if (outFile.is_open())
+    buf << outFile.rdbuf();
+  llvm::sys::fs::remove(outPath);
+
+  return buf.str();
+}
+
+// ============================================================================
+// Parse LLM response
+// ============================================================================
+
+struct MMAAnnotation {
+  int stage;
+  int order;
+};
+
+struct ParsedSchedule {
+  int ii = -1;
+  int maxStage = -1;
+  int numStages = -1;
+  SmallVector<MMAAnnotation> mmaAnnotations;
+};
+
+static ParsedSchedule parseSchedule(const std::string &output) {
+  ParsedSchedule schedule;
+
+  std::regex headerRe(R"(ii\s*=\s*(\d+),\s*max_stage\s*=\s*(\d+))");
+  std::smatch match;
+  if (std::regex_search(output, match, headerRe)) {
+    schedule.ii = std::stoi(match[1]);
+    schedule.maxStage = std::stoi(match[2]);
+  }
+
+  // Parse MMA node cycle/cluster from modulo.schedule format.
+  std::regex mmaRe(
+      R"(tc_gen5_mma[^\}]*cycle:\s*(\d+),\s*cluster:\s*(\d+))");
+  auto end = std::sregex_iterator();
+  for (auto it = std::sregex_iterator(output.begin(), output.end(), mmaRe);
+       it != end; ++it) {
+    MMAAnnotation ann;
+    int cycle = std::stoi((*it)[1]);
+    ann.order = std::stoi((*it)[2]);
+    ann.stage = schedule.ii > 0 ? cycle / schedule.ii : 0;
+    schedule.mmaAnnotations.push_back(ann);
+  }
+
+  // Fallback: "MMA N<id>: stage=<S> order=<O>" format.
+  if (schedule.mmaAnnotations.empty()) {
+    std::regex altRe(
+        R"(MMA\s+N\d+:\s*stage\s*=\s*(\d+)\s*,?\s*order\s*=\s*(\d+))");
+    for (auto it = std::sregex_iterator(output.begin(), output.end(), altRe);
+         it != end; ++it) {
+      MMAAnnotation ann;
+      ann.stage = std::stoi((*it)[1]);
+      ann.order = std::stoi((*it)[2]);
+      schedule.mmaAnnotations.push_back(ann);
+    }
+  }
+
+  // Derive num_stages from buffer counts or max_stage.
+  std::regex bufRe(R"(modulo\.alloc\s+SMEM\s+\[(\d+)\s+x)");
+  int maxBuf = 0;
+  for (auto it = std::sregex_iterator(output.begin(), output.end(), bufRe);
+       it != end; ++it)
+    maxBuf = std::max(maxBuf, std::stoi((*it)[1]));
+
+  schedule.numStages = maxBuf > 0 ? maxBuf : (schedule.maxStage + 1);
+  return schedule;
+}
+
+// ============================================================================
+// Apply schedule to IR
+// ============================================================================
+
+static void applySchedule(scf::ForOp loop, const ParsedSchedule &schedule) {
+  auto ctx = loop.getContext();
+  int mmaIdx = 0;
+
+  loop->walk([&](Operation *op) {
+    if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op)) {
+      if (mmaIdx < (int)schedule.mmaAnnotations.size()) {
+        const auto &ann = schedule.mmaAnnotations[mmaIdx];
+        std::string json = "{\"stage\": \"" + std::to_string(ann.stage) +
+                           "\", \"order\": \"" + std::to_string(ann.order) +
+                           "\"}";
+        op->setAttr("tt.autows", StringAttr::get(ctx, json));
+        LDBG("Set tt.autows on MMA #" << mmaIdx << ": " << json);
+        ++mmaIdx;
+      }
+    }
+  });
+
+  if (schedule.numStages > 0) {
+    loop->setAttr("tt.num_stages",
+                  IntegerAttr::get(IntegerType::get(ctx, 32),
+                                   schedule.numStages));
+  }
+}
+
+// ============================================================================
+// Pass
+// ============================================================================
+
+struct LLMSchedulePass
+    : public PassWrapper<LLMSchedulePass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LLMSchedulePass)
+
+  LLMSchedulePass() = default;
+  LLMSchedulePass(const LLMSchedulePass &other) : PassWrapper(other) {}
+
+  StringRef getArgument() const override { return "nvgpu-llm-schedule"; }
+
+  StringRef getDescription() const override {
+    return "LLM-based modulo scheduling for warp specialization";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    ttg::LatencyModel model;
+
+    SmallVector<scf::ForOp> loops;
+    moduleOp.walk([&](scf::ForOp loop) {
+      bool has = false;
+      loop->walk([&](Operation *op) {
+        if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp,
+                ttng::AsyncTMACopyGlobalToLocalOp, ttng::TCGen5MMAOp,
+                ttng::TCGen5MMAScaledOp>(op))
+          has = true;
+      });
+      if (has)
+        loops.push_back(loop);
+    });
+
+    if (loops.empty()) {
+      LDBG("No schedulable loops — skipping");
+      return;
+    }
+
+    for (auto loop : loops) {
+      auto ddg = ttg::DataDependenceGraph::build(loop, model);
+      if (ddg.getNumNodes() == 0)
+        continue;
+
+      LDBG("Built DDG: " << ddg.getNumNodes() << " nodes, "
+                          << ddg.getEdges().size() << " edges, "
+                          << "MinII=" << ddg.computeMinII());
+
+      std::string ddgText = formatDDG(ddg, loop);
+      std::string output = callClaude(ddgText);
+
+      if (output.empty()) {
+        LDBG("LLM returned empty output");
+        continue;
+      }
+
+      LDBG("LLM response length: " << output.size());
+      LDBG("LLM schedule graph:\n" << output);
+
+      ParsedSchedule schedule = parseSchedule(output);
+      if (schedule.ii < 0) {
+        LDBG("Failed to parse schedule");
+        continue;
+      }
+
+      LDBG("Parsed: II=" << schedule.ii
+                         << " maxStage=" << schedule.maxStage
+                         << " numStages=" << schedule.numStages
+                         << " MMAs=" << schedule.mmaAnnotations.size());
+
+      applySchedule(loop, schedule);
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createNVGPULLMSchedule() {
+  return std::make_unique<LLMSchedulePass>();
+}
+
+void mlir::registerNVGPULLMSchedule() { PassRegistration<LLMSchedulePass>(); }

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -108,6 +108,7 @@ void init_triton_hopper_passes(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_multi_cta_reduction",
                      mlir::createNVGPUMultiCTAReduction);
   ADD_PASS_WRAPPER_0("add_modulo_schedule", mlir::createNVGPUModuloSchedule);
+  ADD_PASS_WRAPPER_0("add_llm_schedule", mlir::createNVGPULLMSchedule);
 }
 
 static void checkMatmulConstraints(const std::string &A_dtype,

--- a/third_party/tlx/tools/scheduling_prompt.md
+++ b/third_party/tlx/tools/scheduling_prompt.md
@@ -1,0 +1,307 @@
+# Modulo Schedule Graph Generation — System Prompt
+
+You are a GPU kernel scheduling expert. Given a TTGIR (Triton GPU IR) loop
+body, produce a `modulo.schedule` graph that assigns operations to pipeline
+stages, cycles, and buffers.
+
+## Hardware Pipeline Classification
+
+Classify each MLIR op into one of these pipelines:
+
+| Pipeline | Operations |
+|----------|-----------|
+| **MEM** | `tt.descriptor_load`, `tt.descriptor_gather`, `ttng.async_tma_copy_global_to_local`, `tt.load` (tensor), `tt.descriptor_store`, `ttng.async_tma_copy_local_to_global`, `tt.store` (tensor), `ttg.local_alloc` (when operand comes from a load) |
+| **TC** | `ttng.tc_gen5_mma`, `ttng.tc_gen5_mma_scaled`, `ttng.warp_group_dot`, `tt.dot` |
+| **CUDA** | `ttng.tmem_load`, `ttng.tmem_store`, `ttg.local_load`, `ttg.local_store`, `ttg.convert_layout`, `ttng.wait_barrier`, `ttng.arrive_barrier`, `ttng.barrier_expect`, `tt.reduce`, tensor arith ops (addf, mulf, subf, etc.), tensor type conversions |
+| **SFU** | tensor `math.exp2`, `math.log2`, `math.rsqrt`, `math.tanh`, `math.sqrt` |
+| **NONE** | Scalar/index ops (arith on i32/i64), control flow — zero latency, not scheduled |
+
+## Latency Table
+
+### MEM (TMA) Latencies
+
+| Tile Size (bytes) | Occupancy (cycles) | Full Latency |
+|-------------------|-------------------|--------------|
+| 128x64xf16 = 16384 | 518 | 518 + 700 = **1218** |
+| 128x128xf16 = 32768 | 654 | 654 + 700 = **1354** |
+| 256x64xf16 = 32768 | 653 | 653 + 700 = **1353** |
+| 256x128xf16 = 65536 | 918 | 918 + 700 = **1618** |
+
+Formula: `occupancy = 518 * totalBytes / (128*64*2)`, `latency = occupancy + 700`
+
+For `ttg.local_alloc` fed by a load: `selfLatency = 0`, `latency = 700`
+
+### TC (MMA) Latencies
+
+| MMA Shape | Latency |
+|-----------|---------|
+| M=128, N=128, K=128 | **900** |
+| M=128, N=128, K=64 | **559** |
+
+### CUDA Latencies
+
+| Operation | Latency |
+|-----------|---------|
+| `ttng.tmem_load`, `ttng.tmem_store` | **105** |
+| `ttg.local_load`, `ttg.local_store` | **105** |
+| `ttg.convert_layout` | **105** |
+| `arith.mulf` (tensor) | **105** |
+| `tt.reduce` (sum) | **508** |
+| `tt.reduce` (max) | **336** |
+| Type conversions | **105** |
+| Other elementwise | **130** |
+| `ttng.wait_barrier` | **30** |
+| `ttng.arrive_barrier`, `ttng.barrier_expect` | **20** |
+
+### SFU Latencies
+
+| Operation | Latency |
+|-----------|---------|
+| Tensor math (exp2, log2, etc.) | **662** |
+| Scalar math | **43** |
+
+### selfLatency
+
+For ALL pipeline ops: `selfLatency = 1` (GPU pipelines are deeply pipelined
+and can accept new instructions every cycle).
+
+Exception: `ttg.local_alloc` has `selfLatency = 0` (bookkeeping, no pipeline slot).
+
+## Step 1: Build the Data Dependence Graph (DDG)
+
+For each non-NONE op in the loop body, create a node. Then add edges:
+
+### Intra-iteration edges (distance = 0)
+
+For each op, trace its operands back to their defining ops. Add an edge:
+- `src` = defining op, `dst` = current op
+- `latency` = src node's `latency`
+- **Exception**: For `descriptor_load` → `local_alloc` edges, use
+  `selfLatency` (= 1) instead of full latency. The load issues the TMA
+  request and the alloc can begin on the next cycle.
+
+### Loop-carried edges (distance = 1)
+
+Examine `scf.yield` operands. For each yield value defined by a DDG op,
+find users of the corresponding `iter_arg`. Add an edge:
+- `src` = yielding op, `dst` = iter_arg user op
+- `latency` = src's `latency`, **EXCEPT**: for TC or MEM pipeline sources,
+  use `selfLatency` instead (hardware pipelines successive iterations)
+- `distance` = 1
+
+## Step 2: Compute II
+
+### ResMII
+```
+ResMII = max over all pipelines P of: count(nodes with pipeline P)
+```
+(Since selfLatency = 1 for all, this is just the max count per pipeline.)
+
+### RecMII (Floyd-Warshall on recurrences)
+
+1. Compute longest forward paths between all node pairs using ONLY
+   distance-0 edges
+2. For each back-edge (distance > 0):
+   ```
+   forwardLat = longest_path(dst → src)  // using distance-0 edges
+   totalLat = forwardLat + back_edge_latency
+   RecMII_circuit = ceil(totalLat / distance)
+   ```
+3. `RecMII = max over all circuits`
+
+### MinII
+```
+II = max(ResMII, RecMII)
+```
+
+## Step 3: Place Ops in Cycles (Scheduling)
+
+Use the computed II. Place each op at an absolute cycle such that:
+- All dependency constraints are met: `cycle[dst] >= cycle[src] + latency - distance * II`
+- No two ops on the same pipeline occupy the same modulo slot: `cycle % II`
+- `selfLatency = 1` means each op uses exactly 1 modulo slot
+
+Priority: schedule by decreasing critical-path height.
+
+## Step 4: Derive Stages and Clusters
+
+- `stage[op] = cycle[op] / II`
+- Within each stage, sort ops by cycle, assign dense cluster IDs
+  (lowest cycle = cluster 0)
+- `max_stage = max(stage[op])`
+- `prologue_latency` = cycle of the first TC op in stage 0
+
+## Step 5: Allocate Buffers
+
+For each op that produces an SMEM or TMEM value consumed in a later cycle:
+
+### Buffer kind
+- `ttng.tmem_alloc` → TMEM
+- `ttg.local_alloc` → SMEM
+
+### Buffer shape and dtype
+Read from the op's result type, e.g., `!ttg.memdesc<128x64xf16, ...>` → shape=[128,64], dtype=f16
+
+### Buffer count (multibuffering depth)
+```
+lifetime = max_consumer_end - producer_cycle
+where max_consumer_end = max over consumers of: consumer_cycle + hold + edge_distance * II
+  hold = consumer.selfLatency if nonzero, else consumer.latency
+
+count = lifetime / II + 1
+```
+
+Co-consumed buffers (e.g., A and B tiles feeding the same MMA) are
+equalized to the same count.
+
+### Paired barriers
+Each data buffer with count > 1 gets a paired BARRIER buffer with
+matching count.
+
+### Buffer sizes
+- SMEM/TMEM: `sizeBytes = product(shape) * elementBitWidth / 8`
+- BARRIER: `sizeBytes = 8` (mbarrier object)
+- `totalBytes = sizeBytes * count`
+
+### Producer/consumer annotations
+- Producer: the op that writes the buffer → `->bufN`
+- Consumer: ops that read the buffer → `<-bufN`
+
+## Step 6: Buffer Merging
+
+Buffers of the same kind (SMEM+SMEM or TMEM+TMEM) can merge if:
+1. Their live intervals don't overlap (modulo II, across all instances)
+2. Merging saves memory: `max(size) * max(count) < sum(size * count)`
+3. No dependency cycle introduced
+
+## Output Format
+
+```
+modulo.schedule @loop0 {
+  ii = <II>, max_stage = <S>, prologue_latency = <L>, trip_count = <N>
+
+  %buf0 = modulo.alloc <KIND> [<count> x <shape> x <dtype>]  live=[<start>, <end>)  // <totalBytes> bytes total
+  %bar<id> = modulo.alloc BARRIER [<count>] for buf<pairedId>  // <totalBytes> bytes total
+
+  modulo.stage @s0 {
+    <op_name>  {pipe: <PIPE>, cycle: <C>, cluster: <K>, latency: <L>, selfLatency: 1[, ->buf<B>][, <-buf<B>]}
+  }
+
+  edges {
+    N<src> -> N<dst>  lat=<L>  dist=<D>
+  }
+}
+```
+
+Node numbering: N0, N1, ... in order of appearance in the loop body
+(ALL ops including NONE). NONE ops are included in the DDG node list
+and edge numbering, but are NOT printed in the stage listing (since
+they have no pipeline). Edges list ALL dependency edges including
+those involving NONE nodes.
+
+## Worked Example
+
+Given this simple 2-load, 1-MMA loop:
+
+```mlir
+scf.for %k = %c0 to %tiles step %c1 iter_args(%acc = %zero) -> (tensor<128x128xf32>) : i32 {
+  %off = arith.muli %k, %c1 : i32                                           // N0: NONE
+  %a = tt.descriptor_load %desc_a[%c0, %off] : ... -> tensor<128x64xf16>    // N1: MEM, lat=1218
+  %b = tt.descriptor_load %desc_b[%off, %c0] : ... -> tensor<64x128xf16>    // N2: MEM, lat=1218
+  %a_sh = ttg.local_alloc %a : ... -> !ttg.memdesc<128x64xf16, ...>         // N3: MEM, lat=700, selfLat=0
+  %b_sh = ttg.local_alloc %b : ... -> !ttg.memdesc<64x128xf16, ...>         // N4: MEM, lat=700, selfLat=0
+  %c_tm, %tok = ttng.tmem_alloc %acc : ... -> memdesc<128x128xf32, ...>     // N5: MEM, lat=0, selfLat=0
+  %mma = ttng.tc_gen5_mma %a_sh, %b_sh, %c_tm[%tok], ... : ...             // N6: TC, lat=900
+  %c, %lt = ttng.tmem_load %c_tm[%mma] : ... -> tensor<128x128xf32>        // N7: CUDA, lat=105
+  scf.yield %c
+}
+```
+
+### Step 1: DDG edges
+
+Intra-iteration (dist=0):
+- N0→N1 lat=0 (NONE source, lat=0)
+- N0→N2 lat=0 (NONE source)
+- N1→N3 lat=1 (MEM→local_alloc: use selfLatency=1 of descriptor_load)
+- N2→N4 lat=1 (MEM→local_alloc: same rule)
+- N3→N6 lat=700 (local_alloc→MMA)
+- N4→N6 lat=700 (local_alloc→MMA)
+- N5→N6 lat=0 (tmem_alloc→MMA, tmem_alloc selfLat=0, lat=0)
+- N5→N7 lat=0 (tmem_alloc→tmem_load)
+- N6→N7 lat=900 (MMA→tmem_load)
+
+Loop-carried (dist=1):
+- N7→N5 lat=105 (tmem_load→tmem_alloc via iter_arg; CUDA source, use regular latency)
+
+### Step 2: Compute II
+
+ResMII: MEM has 4 ops with selfLatency {1,1,0,0} → sum=2. TC has 1 op → sum=1. CUDA has 1 → sum=1. ResMII=2.
+
+RecMII: The only recurrence circuit is N5→N6→N7→N5:
+- Forward path N5→N6→N7: lat = 0 + 900 = 900
+- Back edge N7→N5: lat=105, dist=1
+- Total = 900 + 105 = 1005
+- RecMII = ceil(1005/1) = 1005
+
+II = max(2, 1005) = **1005**
+
+### Step 3: Place ops
+
+With II=1005, place by critical path:
+- N0: cycle 0 (NONE, no constraint)
+- N1: cycle 0 (after N0, lat=0)
+- N2: cycle 1 (after N0, lat=0; N1 occupies MEM slot 0)
+- N3: cycle 2 (after N1, lat=1)
+- N4: cycle 3 (after N2, lat=1)
+- N5: cycle 0 (tmem_alloc, selfLat=0; constrained by back-edge: cycle≥N7.cycle+105-1*1005=1603+105-1005=703 → but N5 is at cycle 0 because tmem_alloc recurrence allows it)
+- N6: cycle 703 (after N3 lat=700: 2+700=702, after N4: 3+700=703, after N5: 0+0=0 → max=703)
+- N7: cycle 1603 (after N6, lat=900: 703+900=1603)
+
+### Step 4: Stages and clusters
+
+- stage = cycle / II: N0-N6 at cycle 0-703 → stage 0; N7 at 1603 → stage 1
+- max_stage = 1
+- prologue_latency = 703 (cycle of first TC op in stage 0)
+- Clusters within stage 0: cycle 0→cluster 0, cycle 1→cluster 1, cycle 2→cluster 2, cycle 3→cluster 3, cycle 703→cluster 4
+
+### Step 5: Buffers
+
+- buf0: SMEM [? x 128x64 x f16] from local_alloc N3
+  - producer cycle=2, consumer N6 at cycle 703 + selfLat(1) + 0*II = 704
+  - lifetime = 704 - 2 = 702, count = 702/1005 + 1 = 1... but co-consumed equalization may raise this
+- (Similar for buf1, buf2, paired barriers)
+
+### Output
+
+```
+modulo.schedule @loop0 {
+  ii = 1005, max_stage = 1, prologue_latency = 703, trip_count = 32
+
+  modulo.stage @s0 {
+    tt.descriptor_load  {pipe: MEM, cycle: 0, cluster: 0, latency: 1218, selfLatency: 1}
+    tt.descriptor_load  {pipe: MEM, cycle: 1, cluster: 1, latency: 1218, selfLatency: 1}
+    ttg.local_alloc  {pipe: MEM, cycle: 2, cluster: 2, latency: 700, selfLatency: 0}
+    ttg.local_alloc  {pipe: MEM, cycle: 3, cluster: 3, latency: 700, selfLatency: 0}
+    ttng.tc_gen5_mma  {pipe: TC, cycle: 703, cluster: 4, latency: 900, selfLatency: 1}
+  }
+  modulo.stage @s1 {
+    ttng.tmem_load  {pipe: CUDA, cycle: 1603, cluster: 0, latency: 105, selfLatency: 1}
+  }
+
+  edges {
+    N0 -> N1  lat=0  dist=0
+    N0 -> N2  lat=0  dist=0
+    N1 -> N3  lat=1  dist=0
+    N2 -> N4  lat=1  dist=0
+    N3 -> N6  lat=700  dist=0
+    N4 -> N6  lat=700  dist=0
+    N5 -> N6  lat=0  dist=0
+    N5 -> N7  lat=0  dist=0
+    N6 -> N7  lat=900  dist=0
+    N7 -> N5  lat=105  dist=1
+  }
+}
+```
+
+Note: NONE ops (N0) and tmem_alloc (N5, selfLat=0) do NOT appear in stage
+listings but ARE included in edge numbering.

--- a/third_party/tlx/tools/test_llm_schedule.py
+++ b/third_party/tlx/tools/test_llm_schedule.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Test LLM-based modulo scheduling against compiler LIT tests.
+
+Usage:
+    python test_llm_schedule.py [--test TEST_NAME] [--model MODEL] [--verbose]
+
+Feeds TTGIR from LIT test files to Claude via the CLI, asks it to produce
+a modulo.schedule graph, and validates the output against expected values
+extracted from FileCheck lines.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEST_DIR = REPO_ROOT / "test" / "TritonGPU"
+PROMPT_FILE = Path(__file__).parent / "scheduling_prompt.md"
+
+
+@dataclass
+class ExpectedSchedule:
+    """Expected schedule values extracted from CHECK lines."""
+
+    ii: int | None = None
+    max_stage: int | None = None
+    prologue_latency: int | None = None
+    trip_count: int | None = None
+    stages: dict[int, list[dict]] = field(default_factory=dict)
+    edges: list[dict] = field(default_factory=list)
+    buffers: list[dict] = field(default_factory=list)
+
+
+def extract_mlir_input(test_path: Path) -> str:
+    """Extract the MLIR input (everything after CHECK lines + function body)."""
+    lines = test_path.read_text().splitlines()
+    mlir_lines = []
+    for line in lines:
+        if line.startswith("// RUN:") or line.startswith("// REQUIRES:"):
+            continue
+        if line.startswith("// CHECK"):
+            continue
+        if line.startswith("//==="):
+            continue
+        if line.startswith("// ---"):
+            continue
+        if line.startswith("//") and not line.startswith("///"):
+            continue
+        mlir_lines.append(line)
+    return "\n".join(mlir_lines).strip()
+
+
+def extract_expected(test_path: Path) -> ExpectedSchedule:
+    """Extract expected values from CHECK lines."""
+    text = test_path.read_text()
+    expected = ExpectedSchedule()
+
+    ii_match = re.search(r"ii = (\d+)", text)
+    if ii_match:
+        expected.ii = int(ii_match.group(1))
+
+    stage_match = re.search(r"max_stage = (\d+)", text)
+    if stage_match:
+        expected.max_stage = int(stage_match.group(1))
+
+    prologue_match = re.search(r"prologue_latency = (\d+)", text)
+    if prologue_match:
+        expected.prologue_latency = int(prologue_match.group(1))
+
+    trip_match = re.search(r"trip_count = (\d+)", text)
+    if trip_match:
+        expected.trip_count = int(trip_match.group(1))
+
+    for m in re.finditer(
+        r"CHECK.*?modulo\.stage @s(\d+)", text
+    ):
+        stage_id = int(m.group(1))
+        expected.stages[stage_id] = []
+
+    for m in re.finditer(
+        r"CHECK.*?(tt\.\w+|ttg\.\w+|ttng\.\w+)\s+\{pipe: (\w+), cycle: (\d+), "
+        r"cluster: (\d+), latency: (\d+), selfLatency: (\d+)",
+        text,
+    ):
+        op_name, pipe, cycle, cluster, latency, self_lat = m.groups()
+        stage = int(cycle) // expected.ii if expected.ii else 0
+        entry = {
+            "op": op_name,
+            "pipe": pipe,
+            "cycle": int(cycle),
+            "cluster": int(cluster),
+            "latency": int(latency),
+            "selfLatency": int(self_lat),
+        }
+        if stage in expected.stages:
+            expected.stages[stage].append(entry)
+
+    for m in re.finditer(
+        r"CHECK.*?N(\d+) -> N(\d+)\s+lat=(\d+)\s+dist=(\d+)", text
+    ):
+        expected.edges.append({
+            "src": int(m.group(1)),
+            "dst": int(m.group(2)),
+            "lat": int(m.group(3)),
+            "dist": int(m.group(4)),
+        })
+
+    for m in re.finditer(
+        r"CHECK.*?%buf(\d+) = modulo\.alloc (\w+) \[(\d+) x", text
+    ):
+        expected.buffers.append({
+            "id": int(m.group(1)),
+            "kind": m.group(2),
+            "count": int(m.group(3)),
+        })
+
+    return expected
+
+
+def parse_llm_schedule(output: str) -> dict:
+    """Parse the modulo.schedule block from LLM output."""
+    result = {
+        "ii": None,
+        "max_stage": None,
+        "prologue_latency": None,
+        "trip_count": None,
+        "stages": {},
+        "edges": [],
+        "buffers": [],
+    }
+
+    schedule_match = re.search(
+        r"modulo\.schedule @\w+ \{(.+?)\n\s*\}", output, re.DOTALL
+    )
+    if not schedule_match:
+        return result
+
+    body = schedule_match.group(1)
+
+    header = re.search(
+        r"ii = (\d+), max_stage = (\d+)"
+        r"(?:, prologue_latency = (\d+))?"
+        r"(?:, trip_count = (\d+))?",
+        body,
+    )
+    if header:
+        result["ii"] = int(header.group(1))
+        result["max_stage"] = int(header.group(2))
+        if header.group(3):
+            result["prologue_latency"] = int(header.group(3))
+        if header.group(4):
+            result["trip_count"] = int(header.group(4))
+
+    for m in re.finditer(r"modulo\.stage @s(\d+) \{", body):
+        result["stages"][int(m.group(1))] = []
+
+    for m in re.finditer(
+        r"(tt\.\w+|ttg\.\w+|ttng\.\w+)\s+\{pipe: (\w+), cycle: (\d+), "
+        r"cluster: (\d+), latency: (\d+), selfLatency: (\d+)",
+        body,
+    ):
+        op_name, pipe, cycle, cluster, latency, self_lat = m.groups()
+        ii = result["ii"] or 1
+        stage = int(cycle) // ii
+        entry = {
+            "op": op_name,
+            "pipe": pipe,
+            "cycle": int(cycle),
+            "cluster": int(cluster),
+            "latency": int(latency),
+            "selfLatency": int(self_lat),
+        }
+        if stage in result["stages"]:
+            result["stages"][stage].append(entry)
+
+    for m in re.finditer(
+        r"N(\d+) -> N(\d+)\s+lat=(\d+)\s+dist=(\d+)", body
+    ):
+        result["edges"].append({
+            "src": int(m.group(1)),
+            "dst": int(m.group(2)),
+            "lat": int(m.group(3)),
+            "dist": int(m.group(4)),
+        })
+
+    for m in re.finditer(
+        r"%buf(\d+) = modulo\.alloc (\w+) \[(\d+) x", body
+    ):
+        result["buffers"].append({
+            "id": int(m.group(1)),
+            "kind": m.group(2),
+            "count": int(m.group(3)),
+        })
+
+    return result
+
+
+def validate(expected: ExpectedSchedule, actual: dict) -> list[str]:
+    """Compare actual schedule against expected. Returns list of failures."""
+    failures = []
+
+    if expected.ii is not None and actual["ii"] != expected.ii:
+        failures.append(f"II: expected {expected.ii}, got {actual['ii']}")
+
+    if expected.max_stage is not None and actual["max_stage"] != expected.max_stage:
+        failures.append(
+            f"max_stage: expected {expected.max_stage}, got {actual['max_stage']}"
+        )
+
+    if (
+        expected.prologue_latency is not None
+        and actual["prologue_latency"] != expected.prologue_latency
+    ):
+        failures.append(
+            f"prologue_latency: expected {expected.prologue_latency}, "
+            f"got {actual['prologue_latency']}"
+        )
+
+    if expected.trip_count is not None and actual["trip_count"] != expected.trip_count:
+        failures.append(
+            f"trip_count: expected {expected.trip_count}, got {actual['trip_count']}"
+        )
+
+    for stage_id, expected_nodes in expected.stages.items():
+        actual_nodes = actual["stages"].get(stage_id, [])
+        for enode in expected_nodes:
+            found = False
+            for anode in actual_nodes:
+                if (
+                    anode["op"] == enode["op"]
+                    and anode["pipe"] == enode["pipe"]
+                    and anode["cycle"] == enode["cycle"]
+                    and anode["cluster"] == enode["cluster"]
+                ):
+                    found = True
+                    if anode["latency"] != enode["latency"]:
+                        failures.append(
+                            f"Stage {stage_id} {enode['op']}: "
+                            f"latency expected {enode['latency']}, "
+                            f"got {anode['latency']}"
+                        )
+                    break
+            if not found:
+                failures.append(
+                    f"Stage {stage_id}: missing node {enode['op']} "
+                    f"at cycle {enode['cycle']}"
+                )
+
+    expected_edge_set = {
+        (e["src"], e["dst"], e["lat"], e["dist"]) for e in expected.edges
+    }
+    actual_edge_set = {
+        (e["src"], e["dst"], e["lat"], e["dist"]) for e in actual["edges"]
+    }
+    for edge in expected_edge_set - actual_edge_set:
+        failures.append(f"Missing edge: N{edge[0]} -> N{edge[1]} lat={edge[2]} dist={edge[3]}")
+
+    return failures
+
+
+def call_claude(mlir_input: str, system_prompt: str, model: str = "sonnet") -> str:
+    """Call Claude CLI with the scheduling prompt and MLIR input."""
+    user_prompt = (
+        "Given the following TTGIR loop body, produce the modulo.schedule "
+        "graph by following the steps in your instructions.\n\n"
+        "IMPORTANT: Output ONLY the raw modulo.schedule block. Do NOT wrap "
+        "it in markdown code fences. Do NOT include any explanation.\n\n"
+        "The TTGIR input:\n\n"
+        f"{mlir_input}"
+    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False
+    ) as sp_file:
+        sp_file.write(system_prompt)
+        sp_path = sp_file.name
+
+    try:
+        cmd = [
+            "claude",
+            "--system-prompt", sp_path,
+            "-p", user_prompt,
+            "--output-format", "text",
+            "--model", model,
+            "--allowedTools", "",
+        ]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        return result.stdout
+    finally:
+        os.unlink(sp_path)
+
+
+TESTS = {
+    "graph": "modulo-schedule-graph.mlir",
+    "buffers": "modulo-schedule-graph-buffers.mlir",
+    "budget": "modulo-schedule-graph-budget.mlir",
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test LLM modulo scheduling")
+    parser.add_argument(
+        "--test",
+        choices=list(TESTS.keys()) + ["all"],
+        default="graph",
+        help="Which test to run (default: graph)",
+    )
+    parser.add_argument(
+        "--model",
+        default="sonnet",
+        help="Claude model to use (default: sonnet)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    system_prompt = PROMPT_FILE.read_text()
+
+    tests_to_run = list(TESTS.keys()) if args.test == "all" else [args.test]
+
+    for test_name in tests_to_run:
+        test_path = TEST_DIR / TESTS[test_name]
+        print(f"\n{'='*60}")
+        print(f"Test: {test_name} ({test_path.name})")
+        print(f"{'='*60}")
+
+        mlir_input = extract_mlir_input(test_path)
+        expected = extract_expected(test_path)
+
+        if args.verbose:
+            print(f"\nExpected: II={expected.ii}, max_stage={expected.max_stage}, "
+                  f"prologue_latency={expected.prologue_latency}")
+            print(f"Expected stages: {list(expected.stages.keys())}")
+            print(f"Expected edges: {len(expected.edges)}")
+
+        print("\nCalling Claude...")
+        output = call_claude(mlir_input, system_prompt, model=args.model)
+
+        if args.verbose:
+            print(f"\nLLM output:\n{output}")
+
+        actual = parse_llm_schedule(output)
+
+        if actual["ii"] is None:
+            print("FAIL: Could not parse modulo.schedule from LLM output")
+            if not args.verbose:
+                print(f"Output:\n{output[:500]}")
+            continue
+
+        print(f"\nParsed: II={actual['ii']}, max_stage={actual['max_stage']}, "
+              f"prologue_latency={actual['prologue_latency']}")
+
+        failures = validate(expected, actual)
+
+        if failures:
+            print(f"\nFAIL ({len(failures)} issues):")
+            for f in failures:
+                print(f"  - {f}")
+        else:
+            print("\nPASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
This diff adds an LLM-based scheduling pass to Triton's compiler pipeline as an alternative to the existing C++ modulo scheduler. Instead of running a classical scheduling algorithm (Rau's IMS, Swing, or exhaustive search), the pass sends the kernel's Data Dependence Graph (DDG) and hardware latency table to a locally-running Claude instance, which produces a modulo.schedule graph with cycle placements, stage assignments, and buffer allocations.

Motivation
The modulo scheduler (nvgpu-modulo-schedule) derives warp specialization schedules from TTGIR loop bodies using classical algorithms. It works well for structured patterns like GEMM and FA, but extending it to new patterns requires significant C++ compiler work: DDG construction, pipeline classification, buffer allocation rules, warp group partitioning heuristics, and budget reduction logic.

The LLM approach sidesteps this rigidity. Given the same DDG + latency information, the LLM reasons about dependencies and hardware constraints to produce scheduling decisions. It can handle novel patterns without code changes, and when it makes mistakes, the fix is a prompt adjustment rather than a C++ patch.

The longer-term goal is to have the LLM produce user-owned TLX Python source code (not just compiler IR annotations). TLX code is readable, editable, and incrementally fixable — when a generated kernel has a bug or performance issue, the user can patch it directly without understanding compiler internals.


Reviewed By: njriasan, wlei-llvm, manman-ren, dshi7

Differential Revision: D105972306

Pulled By: htyu


