### PR TITLE
[TLX] Fix proxy fence tmem alloc

### DIFF
--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -482,10 +482,6 @@ def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
         tlx.barrier_wait(bar_a, tl.constexpr(0))
         tlx.barrier_wait(bar_b, tl.constexpr(0))
 
-        # difference from 1cta: CTA0 waits for both CTAs before issuing MMA op
-        tlx.barrier_arrive(cta_bars[0], arrive_count=1, remote_cta_rank=0)
-        tlx.barrier_wait(cta_bars[0], phase=0, pred=pred_cta0)
-
         buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
         acc_tmem = tlx.local_view(buffers, 0)
 
@@ -494,9 +490,15 @@ def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
             buf_alloc_a_tmem = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, tl.constexpr(1), tlx.storage_kind.tmem)
             a_reg = tlx.local_load(a_smem)
             tlx.local_store(buf_alloc_a_tmem[0], a_reg)
+            # difference from 1cta: CTA0 waits for both CTAs before issuing MMA op
+            tlx.barrier_arrive(cta_bars[0], arrive_count=1, remote_cta_rank=0)
+            tlx.barrier_wait(cta_bars[0], phase=0, pred=pred_cta0)
             tlx.async_dot(buf_alloc_a_tmem[0], b_smem, acc_tmem, use_acc=False, mBarriers=[mma_bars[0]], two_ctas=True,
                           out_dtype=OUT_DTYPE)
         else:
+            # difference from 1cta: CTA0 waits for both CTAs before issuing MMA op
+            tlx.barrier_arrive(cta_bars[0], arrive_count=1, remote_cta_rank=0)
+            tlx.barrier_wait(cta_bars[0], phase=0, pred=pred_cta0)
             tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=False, mBarriers=[mma_bars[0]], two_ctas=True,
                           out_dtype=OUT_DTYPE)
         tlx.barrier_wait(mma_bars[0], 0)
@@ -554,14 +556,12 @@ def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
 
     ptx = kernel.asm["ptx"]
     assert ptx.count("fence.mbarrier_init.release.cluster") == 1
-    assert ptx.count("fence.proxy.async.shared::cluster") >= 1
     # Verify ordering: fences → cluster sync → tmem alloc
     fence_mbar_pos = ptx.index("fence.mbarrier_init.release.cluster")
-    fence_proxy_pos = ptx.index("fence.proxy.async.shared::cluster")
     cluster_arrive_pos = ptx.index("barrier.cluster.arrive.aligned")
     cluster_wait_pos = ptx.index("barrier.cluster.wait.aligned")
     tmem_alloc_pos = ptx.index("tcgen05.alloc.cta_group::2")
-    assert fence_mbar_pos < fence_proxy_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
+    assert fence_mbar_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
     # 2 cluster syncs: 1 for init (before tmem alloc, after bar init), 1 for cleanup (before tmem dealloc)
     assert ptx.count("barrier.cluster.arrive.aligned") == 2
     assert ptx.count("barrier.cluster.wait.aligned") == 2
@@ -706,16 +706,14 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
     ptx = kernel.asm["ptx"]
     # Verify cluster sync and tmem alloc ordering in PTX:
     #   fence.mbarrier_init.release.cluster
-    #   fence.proxy.async.shared::cluster
     #   barrier.cluster.arrive.aligned  (default side)
     #   barrier.cluster.wait.aligned
     #   tcgen05.alloc.cta_group::2      (tmem alloc after cluster sync)
     fence_mbar_pos = ptx.index("fence.mbarrier_init.release.cluster")
-    fence_proxy_pos = ptx.index("fence.proxy.async.shared::cluster")
-    cluster_arrive_pos = ptx.index("barrier.cluster.arrive.aligned", fence_proxy_pos)
+    cluster_arrive_pos = ptx.index("barrier.cluster.arrive.aligned", fence_mbar_pos)
     cluster_wait_pos = ptx.index("barrier.cluster.wait.aligned")
     tmem_alloc_pos = ptx.index("tcgen05.alloc.cta_group::2")
-    assert fence_mbar_pos < fence_proxy_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
+    assert fence_mbar_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
     # 6 cluster arrives: 1 init (default) + 1 init (non-default) +
     #   1 cleanup (default, before tmem dealloc) + 3 cleanup (non-default warps MMA/producer/idle, per partition end)
     # 2 cluster waits: 1 init (default) + 1 cleanup (default, before tmem dealloc)

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -107,7 +107,6 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %2 = ttg.memdesc_index %0[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK: fence.mbarrier_init.release.cluster
-    // CHECK-NEXT: nvvm.fence.proxy {kind = #nvvm.proxy_kind<async.shared>, space = #nvvm.shared_space<cluster>}
     // CHECK-NEXT: nvvm.cluster.arrive {aligned}
     // CHECK-NEXT: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
@@ -537,31 +536,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
        !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
        !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
        !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-// Test that fence.proxy.async.shared::cluster is inserted after
-// fence.mbarrier_init for all clustered kernels (not just paired MMA).
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
-  // CHECK-LABEL: @fence_proxy_async_all_clustered
-  tt.func public @fence_proxy_async_all_clustered() attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: fence.mbarrier_init.release.cluster
-    // CHECK-NEXT: nvvm.fence.proxy {kind = #nvvm.proxy_kind<async.shared>, space = #nvvm.shared_space<cluster>}
-    // CHECK-NEXT: nvvm.cluster.arrive {aligned}
-    // CHECK-NEXT: nvvm.cluster.wait {aligned}
-    ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
-
-    %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    ttng.arrive_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -550,11 +550,6 @@ static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
       /*onlyAttachMLIRArgs=*/true);
   auto voidTy = void_ty(func->getContext());
   ptxBuilder.launch(rewriter, loc, void_ty(func->getContext()));
-  NVVM::FenceProxyOp::create(
-      rewriter, loc, NVVM::ProxyKind::async_shared,
-      NVVM::SharedSpaceAttr::get(func->getContext(),
-                                 twoCTAs ? NVVM::SharedSpace::shared_cluster
-                                         : NVVM::SharedSpace::shared_cta));
   NVVM::Barrier0Op::create(rewriter, loc);
   Value address = b.load(i32_ty, sharedMem);
   NVVM::Barrier0Op::create(rewriter, loc);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -419,8 +419,6 @@ private:
     // need to insert fence to make mbar init visible to cluster
     ttng::FenceMBarrierInitReleaseClusterOp::create(builder,
                                                     lastBarInitOp.getLoc());
-    ttng::FenceAsyncSharedOp::create(builder, lastBarInitOp.getLoc(),
-                                     /*bCluster=*/true);
     // need to insert cluster arrive and wait to prevent CTA_X from arriving
     // CTA_Y's bar before CTA_Y inits it, as shown in ptx doc examples:
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-try-wait


### PR DESCRIPTION
`ttng::FenceAsyncSharedOp` lowers to `NVVM::FenceProxyOp`. They both map to PTX like "fence.proxy.async.shared::cluster".

We've confirmed proxy fence is not needed for tmem alloc or mbar init. Removing it for both.

Also made a real fix to a race in the test - cross CTA sync should be after TMEM store and before mma.