### PR TITLE
[ci] install torchao, use main tritonbench

### DIFF
--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -72,6 +72,11 @@ jobs:
           . "${SETUP_SCRIPT}"
           . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
           install_triton $PWD
+      - name: Install torchao from source
+        run: |
+          . "${SETUP_SCRIPT}"
+          python -m pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
+          python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
       - name: Run TLX unit tests
         timeout-minutes: 5
         run: |

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install torchao from source
         run: |
           . "${SETUP_SCRIPT}"
-          python -m pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
+          uv pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
           python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
       - name: Run TLX unit tests
         timeout-minutes: 5

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: meta-pytorch/tritonbench
-          ref: xz9/add-install-wheel
           path: tritonbench
           submodules: recursive
       - name: Setup Tritonbench environment
@@ -63,7 +62,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: meta-pytorch/tritonbench
-          ref: xz9/add-install-wheel
           path: tritonbench
           submodules: recursive
       - name: Setup Tritonbench environment


### PR DESCRIPTION
For TLX H100 tests, install torchao as it is used in quantization kernels.

The testing branch has been merged: https://github.com/meta-pytorch/tritonbench/commit/6531a1a2029f300eb085eab6c47ca7cacd030757

Now switch to the main branch
