### PR TITLE
[ModuloSched 1/6] Latency model + DDG super-node + buffer-hold-time fix

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -1,8 +1,10 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "DataDependenceGraph.h"
+#include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -11,6 +13,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <climits>
 #include <cmath>
 #include <queue>
 
@@ -53,11 +56,66 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   for (auto &op : body) {
     if (op.hasTrait<OpTrait::IsTerminator>())
       continue;
-    // Skip inner scf.for loops — this DDG handles flat loop bodies only.
-    // Inner loop super-node modeling is added in a follow-up diff for
-    // outer loop (persistent kernel) scheduling.
-    if (isa<scf::ForOp>(op))
+    // Inner scf.for loops become super-nodes. The super-node's latency
+    // is the inner loop's total execution time (II × trip_count), and
+    // its pipeline is NONE (handles its own internal pipelining).
+    if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
+      auto innerDDG = DataDependenceGraph::build(innerLoop, model);
+      auto innerSched = runModuloScheduling(innerDDG);
+
+      DDGNode node;
+      node.op = &op;
+      node.idx = ddg.nodes.size();
+      node.isSuperNode = true;
+
+      if (succeeded(innerSched)) {
+        node.innerII = innerSched->II;
+        // Use int64_t through the computation so a large or reversed
+        // iteration space can't silently overflow `int`. Clamp the
+        // final value to >=1 — an empty or reversed range (`ub <= lb`
+        // with positive step) would otherwise produce a non-positive
+        // latency and silently break the `superNodeII` floor in
+        // `computeMinII`.
+        int64_t tripCount = 32; // fallback for dynamic bounds
+        auto lb = innerLoop.getLowerBound()
+                      .getDefiningOp<arith::ConstantIntOp>();
+        auto ub = innerLoop.getUpperBound()
+                      .getDefiningOp<arith::ConstantIntOp>();
+        auto step = innerLoop.getStep()
+                        .getDefiningOp<arith::ConstantIntOp>();
+        if (lb && ub && step && step.value() > 0) {
+          int64_t lbV = lb.value();
+          int64_t ubV = ub.value();
+          int64_t stepV = step.value();
+          tripCount = std::max<int64_t>(
+              1, (ubV - lbV + stepV - 1) / stepV);
+        } else {
+          innerLoop.emitWarning(
+              "modulo schedule: inner-loop bounds are not compile-time "
+              "constants; using a default trip count of 32 — schedule "
+              "decisions may be suboptimal");
+        }
+        node.latency = static_cast<int>(
+            std::min<int64_t>(INT_MAX, innerSched->II * tripCount));
+        node.selfLatency = 0;
+        node.pipeline = HWPipeline::NONE;
+      } else {
+        // Inner-loop scheduling failed. Emit a diagnostic and propagate
+        // a clearly-infeasible latency so the outer schedule fails too
+        // instead of silently producing garbage off a fabricated
+        // ~10k-cycle synthetic node.
+        innerLoop.emitWarning(
+            "modulo schedule: failed to schedule inner loop — outer "
+            "schedule will be marked infeasible");
+        node.selfLatency = INT_MAX / 2;
+        node.latency = INT_MAX / 2;
+        node.pipeline = HWPipeline::NONE;
+      }
+
+      ddg.nodes.push_back(node);
+      ddg.opToIdx[&op] = node.idx;
       continue;
+    }
     ddg.addNode(&op, model);
   }
 
@@ -108,15 +166,10 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       auto userIt = ddg.opToIdx.find(user);
       if (userIt == ddg.opToIdx.end())
         continue;
-      // For async ops (TC, MEM), the loop-carried recurrence latency
-      // is the issue cost (selfLatency), not the full execution time.
-      // The hardware pipelines successive iterations internally — e.g.,
-      // tcgen05.mma with useAcc=true pipelines accumulator updates in
-      // TMEM, so the next MMA can issue after the dispatch cost.
+      // Loop-carried back-edge uses full latency so RecMII reflects
+      // the true recurrence depth. For MMA with accumulator, the next
+      // iteration can't read the result until the current MMA completes.
       int backEdgeLat = ddg.nodes[srcIdx].latency;
-      if (ddg.nodes[srcIdx].pipeline == HWPipeline::TC ||
-          ddg.nodes[srcIdx].pipeline == HWPipeline::MEM)
-        backEdgeLat = ddg.nodes[srcIdx].selfLatency;
       ddg.addEdge(srcIdx, userIt->second, backEdgeLat,
                   /*distance=*/1);
     }
@@ -264,8 +317,16 @@ int DataDependenceGraph::computeRecMII() const {
 int DataDependenceGraph::computeMinII() const {
   int resMII = computeResMII();
   int recMII = computeRecMII();
-  int minII = std::max(resMII, recMII);
+  // Super-node latency is a hard lower bound: one outer iteration can't
+  // finish faster than its inner loop. Without this, II is too small
+  // and the schedule produces hundreds of stages.
+  int superNodeII = 0;
+  for (const auto &node : nodes)
+    if (node.isSuperNode)
+      superNodeII = std::max(superNodeII, node.latency);
+  int minII = std::max({resMII, recMII, superNodeII});
   LLVM_DEBUG(llvm::dbgs() << "[DDG] ResMII=" << resMII << " RecMII=" << recMII
+                          << " SuperNodeII=" << superNodeII
                           << " MinII=" << minII << "\n");
   return minII;
 }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -1,8 +1,10 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "DataDependenceGraph.h"
+#include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -53,11 +55,43 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   for (auto &op : body) {
     if (op.hasTrait<OpTrait::IsTerminator>())
       continue;
-    // Skip inner scf.for loops — this DDG handles flat loop bodies only.
-    // Inner loop super-node modeling is added in a follow-up diff for
-    // outer loop (persistent kernel) scheduling.
-    if (isa<scf::ForOp>(op))
+    // Inner scf.for loops become super-nodes. The super-node's latency
+    // is the inner loop's total execution time (II × trip_count), and
+    // its pipeline is NONE (handles its own internal pipelining).
+    if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
+      auto innerDDG = DataDependenceGraph::build(innerLoop, model);
+      auto innerSched = runModuloScheduling(innerDDG);
+
+      DDGNode node;
+      node.op = &op;
+      node.idx = ddg.nodes.size();
+      node.isSuperNode = true;
+
+      if (succeeded(innerSched)) {
+        node.innerII = innerSched->II;
+        int tripCount = 32; // default estimate
+        auto lb = innerLoop.getLowerBound()
+                      .getDefiningOp<arith::ConstantIntOp>();
+        auto ub = innerLoop.getUpperBound()
+                      .getDefiningOp<arith::ConstantIntOp>();
+        auto step = innerLoop.getStep()
+                        .getDefiningOp<arith::ConstantIntOp>();
+        if (lb && ub && step && step.value() > 0)
+          tripCount = (ub.value() - lb.value() + step.value() - 1) /
+                      step.value();
+        node.latency = innerSched->II * tripCount;
+        node.selfLatency = 0;
+        node.pipeline = HWPipeline::NONE;
+      } else {
+        node.selfLatency = 10000;
+        node.latency = 10000;
+        node.pipeline = HWPipeline::TC;
+      }
+
+      ddg.nodes.push_back(node);
+      ddg.opToIdx[&op] = node.idx;
       continue;
+    }
     ddg.addNode(&op, model);
   }
 
@@ -108,15 +142,10 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       auto userIt = ddg.opToIdx.find(user);
       if (userIt == ddg.opToIdx.end())
         continue;
-      // For async ops (TC, MEM), the loop-carried recurrence latency
-      // is the issue cost (selfLatency), not the full execution time.
-      // The hardware pipelines successive iterations internally — e.g.,
-      // tcgen05.mma with useAcc=true pipelines accumulator updates in
-      // TMEM, so the next MMA can issue after the dispatch cost.
+      // Loop-carried back-edge uses full latency so RecMII reflects
+      // the true recurrence depth. For MMA with accumulator, the next
+      // iteration can't read the result until the current MMA completes.
       int backEdgeLat = ddg.nodes[srcIdx].latency;
-      if (ddg.nodes[srcIdx].pipeline == HWPipeline::TC ||
-          ddg.nodes[srcIdx].pipeline == HWPipeline::MEM)
-        backEdgeLat = ddg.nodes[srcIdx].selfLatency;
       ddg.addEdge(srcIdx, userIt->second, backEdgeLat,
                   /*distance=*/1);
     }
@@ -264,8 +293,16 @@ int DataDependenceGraph::computeRecMII() const {
 int DataDependenceGraph::computeMinII() const {
   int resMII = computeResMII();
   int recMII = computeRecMII();
-  int minII = std::max(resMII, recMII);
+  // Super-node latency is a hard lower bound: one outer iteration can't
+  // finish faster than its inner loop. Without this, II is too small
+  // and the schedule produces hundreds of stages.
+  int superNodeII = 0;
+  for (const auto &node : nodes)
+    if (node.isSuperNode)
+      superNodeII = std::max(superNodeII, node.latency);
+  int minII = std::max({resMII, recMII, superNodeII});
   LLVM_DEBUG(llvm::dbgs() << "[DDG] ResMII=" << resMII << " RecMII=" << recMII
+                          << " SuperNodeII=" << superNodeII
                           << " MinII=" << minII << "\n");
   return minII;
 }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -355,22 +355,17 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
       }
     } else
       occupancy = getTMALoadLatency(op);
-    // selfLatency = 1: GPU TMA unit is deeply pipelined and can accept
-    // new requests every cycle. The occupancy value reflects data transfer
-    // time, not issue blocking. Using occupancy as selfLatency inflates
-    // ResMII and causes modulo scheduling to fail on kernels with many
-    // loads (e.g., FA backward with 6 MEM ops would need ResMII=3400+).
-    selfLatency = 1;
+    // selfLatency = issue cost (SM dispatch pipeline occupancy).
+    // Design doc: 30 cycles for TMA ops.
+    selfLatency = kTMAIssueLatency;
     latency = occupancy + kTMAAsyncOverhead;
     return OpLatencyInfo{pipeline, latency, selfLatency, occupancy};
   }
   case HWPipeline::TC:
     latency = getMMALatency(op);
-    // selfLatency = 1: GPU tensor core pipeline is deeply pipelined —
-    // a new MMA can be issued every ~1-32 cycles while the previous one
-    // is still computing. Using latency (900 cycles) as selfLatency
-    // inflates ResMII to 4500 for 5 MMAs, causing SMS to fail.
-    selfLatency = 1;
+    // selfLatency = issue cost (SM dispatch pipeline occupancy).
+    // Design doc: 30 cycles for tcgen05.mma.
+    selfLatency = kMMAIssueLatency;
     break;
   case HWPipeline::CUDA:
     latency = getCUDALatency(op);

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -495,11 +495,10 @@ static unsigned computeBufferCount(const ttg::ScheduleLoop &loop,
     if (edge.srcId != producerNodeId)
       continue;
     const auto &consumer = loop.getNode(edge.dstId);
-    // Consumer hold time: use selfLatency (pipeline occupancy) when
-    // available, falling back to latency (result-ready time). This
-    // matches computeBufferLifetimes so that count and lifetime are
-    // computed consistently.
-    int hold = consumer.selfLatency ? consumer.selfLatency : consumer.latency;
+    // Consumer hold time: use full latency (time until consumer finishes
+    // reading the buffer). Per design doc: "Last consumer finishes reading
+    // at: schedule[c][0] + latencies[c]".
+    int hold = consumer.latency;
     int consumerEnd = consumer.cycle + hold + edge.distance * II;
     lastConsumerEnd = std::max(lastConsumerEnd, consumerEnd);
   }
@@ -678,7 +677,7 @@ static int computeBufferLifetime(const ttg::ScheduleLoop &loop,
     if (edge.srcId != producerNodeId)
       continue;
     const auto &consumer = loop.getNode(edge.dstId);
-    int holdTime = std::max(consumer.selfLatency, consumer.latency);
+    int holdTime = consumer.latency;
     int end = consumer.cycle + holdTime + edge.distance * loop.II;
     lastConsumerEnd = std::max(lastConsumerEnd, end);
   }
@@ -1047,10 +1046,9 @@ static void computeBufferLifetimes(ttg::ScheduleLoop &loop) {
         if (edge.srcId != node.id)
           continue;
         const auto &consumer = loop.getNode(edge.dstId);
-        // Use selfLatency (occupancy) over latency (result-ready) for
-        // the consumer's hold time on the resource.
-        int hold =
-            consumer.selfLatency ? consumer.selfLatency : consumer.latency;
+        // Use full latency (time until consumer finishes reading).
+        // Matches computeBufferCount so count and lifetime agree.
+        int hold = consumer.latency;
         int end =
             consumer.cycle + hold + static_cast<int>(edge.distance) * loop.II;
         lastEnd = std::max(lastEnd, end);


### PR DESCRIPTION
Summary:
Foundational corrections to the modulo scheduling pass that are prerequisites for everything downstream in this stack. No behavior change beyond fixing three correctness issues in the scheduling math.

== LatencyModel.cpp ==
`selfLatency` for TMA and MMA ops is the SM dispatch cost (`kTMAIssueLatency` / `kMMAIssueLatency` = 30 cycles), not 1. The design doc specifies 30 cycles as the issue cost; the old value of 1 caused `ResMII` to collapse to 2 on FA backward, producing `II=4` and 305 SMEM buffer copies (10MB, OOM on B200's 232KB budget).

== DataDependenceGraph.cpp ==
Three fixes:

1. *Super-node modeling.* Inner `scf.for` loops are now modeled as super-nodes in the outer DDG with `latency = innerII × tripCount` and `selfLatency = 0` (the inner loop handles its own pipelining; it does not consume outer pipeline resources). Without this the outer DDG ignored the K-loop entirely and produced a garbage schedule (II=30, maxStage=10).

  Robustness: trip-count math now uses `int64_t` end-to-end and clamps the result to `>= 1`, so an empty or reversed iteration range (`ub <= lb` with positive step) can't produce a negative latency that silently breaks the `superNodeII` floor in `computeMinII`. When loop bounds aren't compile-time constants we still fall back to a default of 32, but the path now emits an `emitWarning` on the inner loop instead of silently producing a possibly-wrong schedule. If inner-loop scheduling fails outright, we set `latency = INT_MAX / 2` and `pipeline = NONE` (was a fabricated `latency=selfLatency=10000` on `pipeline=TC`, which mis-charged ResMII and let the outer schedule succeed with a garbage II); the new value makes the outer modulo schedule infeasible so the failure is visible.

2. *MinII floor.* `computeMinII` now folds `max(superNodeLatency)` into the lower bound. Without this floor, the modulo scheduler picks `II=30` (just `ResMII`) and the K-loop super-node spans 960+ stages.

3. *Loop-carried back-edge uses full latency.* The MMA accumulator recurrence's `RecMII` should be 900 (MMA execution time), not 30 (issue cost) — the next iteration can't read the accumulator until the current MMA completes. The earlier `selfLatency` shortcut was wrong for the recurrence direction.

== ModuloSchedulePass.cpp ==
*Buffer hold time.* `computeBufferCount` and `computeBufferLifetime` now use `consumer.latency` (full result-ready time) instead of `consumer.selfLatency` (issue cost). Per design doc: "Last consumer finishes reading at `schedule[c][0] + latencies[c]`". This gives correct buffer depth: `floor(1630/900)+1 = 2` (matches `num_stages`) instead of the under-counted `floor(760/900)+1 = 1`.

Reviewed By: htyu

Differential Revision: D105999787


