### PR TITLE
[ModuloSched 4/6] ScheduleGraph extensions + LatencyModel B200 refit + min_warps (#1558)

### DIFF
--- a/test/TritonGPU/iterative-schedule.mlir
+++ b/test/TritonGPU/iterative-schedule.mlir
@@ -18,8 +18,8 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // 3. Makespan is computed
 //
 // CHECK-LABEL: @gemm_iterative_list
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
 // CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 // CHECK: tt.list_schedule_makespan
 tt.func @gemm_iterative_list(

--- a/test/TritonGPU/list-schedule.mlir
+++ b/test/TritonGPU/list-schedule.mlir
@@ -12,12 +12,9 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // sorted by cycle. MEM ops get earlier cycles (lower clusters) than TC ops.
 //
 // CHECK-LABEL: @gemm_list_schedule
-// All ops get stage 0 (no cross-iteration pipelining)
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
-// TC op gets a later cluster than MEM ops
+// All ops get stage 0 (no cross-iteration pipelining), with dense cluster IDs
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
+// TC op gets cluster 4 (same cycle as local_alloc B)
 // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 // CUDA op (tmem_load) gets the latest cluster
 // CHECK: ttng.tmem_load {{.*}} {loop.cluster = 5 : i32, loop.stage = 0 : i32}

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -34,7 +34,7 @@ unsigned DataDependenceGraph::addNode(Operation *op,
   node.pipeline = info.pipeline;
   node.latency = info.latency;
   node.selfLatency = info.selfLatency;
-  node.transferLatency = info.transferLatency;
+  node.minWarps = info.minWarps;
   nodes.push_back(node);
   opToIdx[op] = idx;
   return idx;
@@ -94,11 +94,25 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
               "modulo schedule: inner-loop bounds are not compile-time "
               "constants; using a default trip count of 32 — schedule "
               "decisions may be suboptimal");
+
         }
         node.latency = static_cast<int>(
             std::min<int64_t>(INT_MAX, innerSched->II * tripCount));
         node.selfLatency = 0;
         node.pipeline = HWPipeline::NONE;
+
+        // Prologue latency: cycles before the first TC op fires inside the
+        // inner loop. The outer scheduler uses this to overlap outer-loop
+        // MEM ops with the inner loop's pre-MMA setup.
+        int tcStart = innerSched->II;
+        for (const auto &n : innerDDG.getNodes()) {
+          if (n.pipeline == HWPipeline::TC) {
+            auto it = innerSched->nodeToCycle.find(n.idx);
+            if (it != innerSched->nodeToCycle.end())
+              tcStart = std::min(tcStart, it->second);
+          }
+        }
+        node.prologueLatency = tcStart;
       } else {
         // Inner-loop scheduling failed. Emit a diagnostic and propagate
         // a clearly-infeasible latency so the outer schedule fails too
@@ -129,18 +143,50 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       if (it == ddg.opToIdx.end())
         continue;
       unsigned srcIdx = it->second;
-      // Edge latency = producer's latency (time until result available).
-      // Exception: for MEM → local_alloc edges, use transferLatency (the TMA
-      // transfer time) instead of the full async latency. local_alloc is a
-      // bookkeeping op that represents data arrival — it must wait for the
-      // transfer to complete, but not for the async DRAM overhead that only
-      // applies to the MMA consumer.
+      // Edge latency = producer's full latency (time until consumer can read
+      // the result). Uniform rule with no per-pair exceptions: each op carries
+      // a single `latency` that captures full delivery, and edges just
+      // propagate it.
       int edgeLatency = ddg.nodes[srcIdx].latency;
-      if (ddg.nodes[srcIdx].pipeline == HWPipeline::MEM &&
-          isa<triton::gpu::LocalAllocOp>(node.op)) {
-        edgeLatency = ddg.nodes[srcIdx].transferLatency;
-      }
       ddg.addEdge(srcIdx, node.idx, edgeLatency, /*distance=*/0);
+    }
+  }
+
+  // Phase 2.5: Memory-based edges for super-nodes.
+  // The DDG only captures SSA def-use edges. But super-nodes (inner
+  // loops) can write to memory (TMEM via MMA) that later ops read
+  // (tmem_load). Without an explicit edge, the scheduler places
+  // tmem_load BEFORE the K-loop finishes, breaking the store overlap.
+  //
+  // Detect: if a super-node's inner loop contains MMA writing to a
+  // TMEM memdesc, and a tmem_load outside the loop reads the same
+  // memdesc, add an edge super-node → tmem_load.
+  for (auto &node : ddg.nodes) {
+    if (!node.isSuperNode)
+      continue;
+    auto innerLoop = dyn_cast<scf::ForOp>(node.op);
+    if (!innerLoop)
+      continue;
+    // Find TMEM memdescs written by MMA inside the inner loop.
+    llvm::DenseSet<Value> tmemWritten;
+    innerLoop.walk([&](Operation *op) {
+      if (isa<triton::nvidia_gpu::TCGen5MMAOp,
+              triton::nvidia_gpu::TCGen5MMAScaledOp>(op)) {
+        // MMA operand 2 is the accumulator (TMEM memdesc).
+        if (op->getNumOperands() > 2)
+          tmemWritten.insert(op->getOperand(2));
+      }
+    });
+    // Find tmem_load ops outside the inner loop that read the same TMEM.
+    for (auto &other : ddg.nodes) {
+      if (other.idx == node.idx)
+        continue;
+      if (!isa<triton::nvidia_gpu::TMEMLoadOp>(other.op))
+        continue;
+      Value tmemSrc = other.op->getOperand(0);
+      if (tmemWritten.count(tmemSrc)) {
+        ddg.addEdge(node.idx, other.idx, node.latency, /*distance=*/0);
+      }
     }
   }
 
@@ -233,11 +279,13 @@ DataDependenceGraph::computeCriticalPathHeights() const {
 }
 
 int DataDependenceGraph::computeResMII() const {
+  // Per-pipeline busy time (cycles) bounds II from below: II ≥ pipeLoad / N
+  // where N is the number of identical units on the pipeline (assumed 1).
   llvm::DenseMap<HWPipeline, int> pipeLoad;
   for (const auto &node : nodes) {
     if (node.pipeline == HWPipeline::NONE)
       continue;
-    pipeLoad[node.pipeline] += node.selfLatency;
+    pipeLoad[node.pipeline] += pipelineOccupancy(node);
   }
   int maxLoad = 0;
   for (auto &[pipe, load] : pipeLoad) {

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -1,8 +1,10 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "DataDependenceGraph.h"
+#include "ModuloReservationTable.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -53,11 +55,43 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
   for (auto &op : body) {
     if (op.hasTrait<OpTrait::IsTerminator>())
       continue;
-    // Skip inner scf.for loops — this DDG handles flat loop bodies only.
-    // Inner loop super-node modeling is added in a follow-up diff for
-    // outer loop (persistent kernel) scheduling.
-    if (isa<scf::ForOp>(op))
+    // Inner scf.for loops become super-nodes. The super-node's latency
+    // is the inner loop's total execution time (II × trip_count), and
+    // its pipeline is NONE (handles its own internal pipelining).
+    if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
+      auto innerDDG = DataDependenceGraph::build(innerLoop, model);
+      auto innerSched = runModuloScheduling(innerDDG);
+
+      DDGNode node;
+      node.op = &op;
+      node.idx = ddg.nodes.size();
+      node.isSuperNode = true;
+
+      if (succeeded(innerSched)) {
+        node.innerII = innerSched->II;
+        int tripCount = 32; // default estimate
+        auto lb = innerLoop.getLowerBound()
+                      .getDefiningOp<arith::ConstantIntOp>();
+        auto ub = innerLoop.getUpperBound()
+                      .getDefiningOp<arith::ConstantIntOp>();
+        auto step = innerLoop.getStep()
+                        .getDefiningOp<arith::ConstantIntOp>();
+        if (lb && ub && step && step.value() > 0)
+          tripCount = (ub.value() - lb.value() + step.value() - 1) /
+                      step.value();
+        node.latency = innerSched->II * tripCount;
+        node.selfLatency = 0;
+        node.pipeline = HWPipeline::NONE;
+      } else {
+        node.selfLatency = 10000;
+        node.latency = 10000;
+        node.pipeline = HWPipeline::TC;
+      }
+
+      ddg.nodes.push_back(node);
+      ddg.opToIdx[&op] = node.idx;
       continue;
+    }
     ddg.addNode(&op, model);
   }
 
@@ -108,15 +142,10 @@ DataDependenceGraph DataDependenceGraph::build(scf::ForOp loop,
       auto userIt = ddg.opToIdx.find(user);
       if (userIt == ddg.opToIdx.end())
         continue;
-      // For async ops (TC, MEM), the loop-carried recurrence latency
-      // is the issue cost (selfLatency), not the full execution time.
-      // The hardware pipelines successive iterations internally — e.g.,
-      // tcgen05.mma with useAcc=true pipelines accumulator updates in
-      // TMEM, so the next MMA can issue after the dispatch cost.
+      // Loop-carried back-edge uses full latency so RecMII reflects
+      // the true recurrence depth. For MMA with accumulator, the next
+      // iteration can't read the result until the current MMA completes.
       int backEdgeLat = ddg.nodes[srcIdx].latency;
-      if (ddg.nodes[srcIdx].pipeline == HWPipeline::TC ||
-          ddg.nodes[srcIdx].pipeline == HWPipeline::MEM)
-        backEdgeLat = ddg.nodes[srcIdx].selfLatency;
       ddg.addEdge(srcIdx, userIt->second, backEdgeLat,
                   /*distance=*/1);
     }
@@ -264,8 +293,16 @@ int DataDependenceGraph::computeRecMII() const {
 int DataDependenceGraph::computeMinII() const {
   int resMII = computeResMII();
   int recMII = computeRecMII();
-  int minII = std::max(resMII, recMII);
+  // Super-node latency is a hard lower bound: one outer iteration can't
+  // finish faster than its inner loop. Without this, II is too small
+  // and the schedule produces hundreds of stages.
+  int superNodeII = 0;
+  for (const auto &node : nodes)
+    if (node.isSuperNode)
+      superNodeII = std::max(superNodeII, node.latency);
+  int minII = std::max({resMII, recMII, superNodeII});
   LLVM_DEBUG(llvm::dbgs() << "[DDG] ResMII=" << resMII << " RecMII=" << recMII
+                          << " SuperNodeII=" << superNodeII
                           << " MinII=" << minII << "\n");
   return minII;
 }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -23,13 +23,36 @@ struct DDGNode {
   HWPipeline pipeline{HWPipeline::NONE};
   int latency{};
   int selfLatency{};
-  int transferLatency{};
+  // Min warps assumed by the modeled `selfLatency`. If the containing WG has
+  // fewer warps, effective selfLat scales up by minWarps/actualWarps. See
+  // `notes/latency_vs_selflatency.md` and `LatencyModel::getMinWarps`.
+  int minWarps{1};
   bool isSuperNode{false}; // True if this node represents an inner loop
   int innerII{0};          // If super-node, the inner loop's II
   int prologueLatency{0};  // If super-node, cycles before TC starts (MEM busy)
   llvm::SmallVector<unsigned> succs;
   llvm::SmallVector<unsigned> preds;
 };
+
+/// How many cycles this op holds its pipeline resource. Used by ResMII and the
+/// modulo reservation table when placing ops.
+///
+/// MEM (TMA engine) and TC (tcgen05.mma) are **async** hardware: the SM
+/// dispatches the op in `selfLatency` cycles and is then free, but the
+/// underlying engine keeps working for the full `latency` cycles. From the
+/// resource's perspective it is busy that whole time and cannot accept
+/// another op until done — so for ResMII / placement we must reserve the
+/// full `latency`.
+///
+/// CUDA and SFU are pipelined synchronous units that accept a new op every
+/// cycle, so `selfLatency` (= 1 for these) is the correct slot count.
+inline int pipelineOccupancy(const DDGNode &node) {
+  if (node.pipeline == HWPipeline::NONE)
+    return 1;
+  if (node.pipeline == HWPipeline::MEM || node.pipeline == HWPipeline::TC)
+    return std::max(node.latency, 1);
+  return std::max(node.selfLatency, 1);
+}
 
 /// Data Dependence Graph for one scf.for loop body.
 /// Captures both intra-iteration and loop-carried (distance-1) edges.

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LLMSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LLMSchedulePass.cpp
@@ -106,8 +106,8 @@ static std::string formatDDG(const ttg::DataDependenceGraph &ddg,
        << "  pipe=" << ttg::getPipelineName(node.pipeline)
        << "  lat=" << node.latency
        << "  selfLat=" << node.selfLatency;
-    if (node.transferLatency != node.selfLatency)
-      os << "  transferLat=" << node.transferLatency;
+    if (node.minWarps > 1)
+      os << "  minWarps=" << node.minWarps;
     if (node.isSuperNode)
       os << "  [super: innerII=" << node.innerII
          << " prologueLat=" << node.prologueLatency << "]";

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -355,22 +355,17 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
       }
     } else
       occupancy = getTMALoadLatency(op);
-    // selfLatency = 1: GPU TMA unit is deeply pipelined and can accept
-    // new requests every cycle. The occupancy value reflects data transfer
-    // time, not issue blocking. Using occupancy as selfLatency inflates
-    // ResMII and causes modulo scheduling to fail on kernels with many
-    // loads (e.g., FA backward with 6 MEM ops would need ResMII=3400+).
-    selfLatency = 1;
+    // selfLatency = issue cost (SM dispatch pipeline occupancy).
+    // Design doc: 30 cycles for TMA ops.
+    selfLatency = kTMAIssueLatency;
     latency = occupancy + kTMAAsyncOverhead;
     return OpLatencyInfo{pipeline, latency, selfLatency, occupancy};
   }
   case HWPipeline::TC:
     latency = getMMALatency(op);
-    // selfLatency = 1: GPU tensor core pipeline is deeply pipelined —
-    // a new MMA can be issued every ~1-32 cycles while the previous one
-    // is still computing. Using latency (900 cycles) as selfLatency
-    // inflates ResMII to 4500 for 5 MMAs, causing SMS to fail.
-    selfLatency = 1;
+    // selfLatency = issue cost (SM dispatch pipeline occupancy).
+    // Design doc: 30 cycles for tcgen05.mma.
+    selfLatency = kMMAIssueLatency;
     break;
   case HWPipeline::CUDA:
     latency = getCUDALatency(op);

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -34,36 +34,49 @@ llvm::StringRef getPipelineName(HWPipeline pipeline) {
   llvm_unreachable("unknown pipeline");
 }
 
-// Estimate total elements in the result tensor of an op.
+// Estimate total elements in the tensor an op produces or consumes.
+// Tries result types first; for store ops (whose result is a memdesc handle)
+// scans operand types and picks the largest tensor/memdesc among them.
 int64_t LatencyModel::getTensorElements(Operation *op) const {
-  if (op->getNumResults() == 0)
-    return 0;
-  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
-  if (!resultType)
-    return 0;
-  int64_t elements = 1;
-  for (auto dim : resultType.getShape())
-    elements *= dim;
-  return elements;
+  auto countShape = [](auto shape) {
+    int64_t e = 1;
+    for (auto d : shape)
+      e *= d;
+    return e;
+  };
+  for (auto r : op->getResults()) {
+    if (auto tt = dyn_cast<RankedTensorType>(r.getType()))
+      return countShape(tt.getShape());
+  }
+  // Fall back to operand-derived size — needed for store-style ops
+  // (ttng.tmem_store, ttg.local_store) whose result is a memdesc handle.
+  int64_t best = 0;
+  for (auto v : op->getOperands()) {
+    if (auto tt = dyn_cast<RankedTensorType>(v.getType()))
+      best = std::max(best, countShape(tt.getShape()));
+    else if (auto md = dyn_cast<triton::gpu::MemDescType>(v.getType()))
+      best = std::max(best, countShape(md.getShape()));
+  }
+  return best;
 }
 
-// TMA load latencies from B200 microbenchmarks (cycles).
-// Key = total bytes, value = pipeline occupancy cycles.
-// Entries from NVIDIA_B200_latency_table.json.
+// TMA load full latencies (cycles): time from cp.async.bulk issue to data
+// available in SMEM for a consumer to read. Single number per size — there is
+// no separate "pipeline occupancy" vs "DRAM overhead" component in the model.
+//
+// Refit from B200 cycle-accurate microbenchmarks (Phase 0b, May 2026)
+// using k_tma_load_chained in users/wl/wlei/latency_table/ncu_bench.py:
+// barrier_expect → async_descriptor_load → barrier_wait, repeated.
 struct TMALatencyEntry {
   int64_t bytes;
   int cycles;
 };
 static constexpr TMALatencyEntry kTMALoadTable[] = {
-    {128 * 64 * 2, 518},  // 128x64 or 64x128 bf16/fp16 = 16KB
-    {128 * 128 * 2, 654}, // 128x128 bf16/fp16 = 32KB
-    {256 * 64 * 2, 653},  // 256x64 bf16 = 32KB
-    {256 * 128 * 2, 918}, // 256x128 bf16 = 64KB
+    {128 * 64 * 2, 530},  // 128x64 or 64x128 bf16/fp16 = 16KB (was 640)
+    {128 * 128 * 2, 663}, // 128x128 bf16/fp16 = 32KB (was 808)
+    {256 * 64 * 2, 654},  // 256x64 bf16 = 32KB (was 807)
+    {256 * 128 * 2, 925}, // 256x128 bf16 = 64KB (was 1134)
 };
-
-// Async overhead: additional cycles for data to travel through the memory
-// hierarchy (L2/DRAM) and arrive in SMEM. On top of pipeline occupancy.
-constexpr int kTMAAsyncOverhead = 700;
 
 // Issue latency for async TMA operations. The SM spends this many cycles
 // programming the TMA descriptor and triggering the copy, then the TMA engine
@@ -78,7 +91,7 @@ constexpr int kTMAIssueLatency = 30;
 // instructions (including more MMAs) after the issue cost.
 constexpr int kMMAIssueLatency = 30;
 
-/// Look up TMA load occupancy by total bytes. Table lookup first, then
+/// Look up TMA load latency (cycles) by total bytes. Table lookup first, then
 /// linear interpolation from 128x64 baseline as fallback.
 static int lookupTMALoadOccupancy(int64_t totalBytes) {
   for (const auto &entry : kTMALoadTable) {
@@ -87,7 +100,7 @@ static int lookupTMALoadOccupancy(int64_t totalBytes) {
   }
   // Fallback: linear interpolation from 128x64 baseline.
   constexpr int64_t kBaseBytes = 128 * 64 * 2;
-  constexpr int kBaseCycles = 518;
+  constexpr int kBaseCycles = 530;
   return static_cast<int>(kBaseCycles * static_cast<double>(totalBytes) /
                           kBaseBytes);
 }
@@ -117,22 +130,50 @@ constexpr int kMMALatency128x128x128 = 900;
 constexpr int kMMALatency128x128x64 = 559;
 
 int LatencyModel::getMMALatency(Operation *op) const {
-  if (op->getNumResults() == 0)
-    return kMMALatency128x128x128; // conservative default
-  // Try to extract the MMA shape from the MMAv5 interface
+  // Extract the K dimension of the MMA. tcgen05_mma operands A and B are
+  // SMEM/TMEM memdescs (NOT RankedTensorType), so dyn_cast against tensor
+  // alone misses them — accept either.
+  auto getShape = [](Value v) -> ArrayRef<int64_t> {
+    if (auto t = dyn_cast<RankedTensorType>(v.getType()))
+      return t.getShape();
+    if (auto md = dyn_cast<triton::gpu::MemDescType>(v.getType()))
+      return md.getShape();
+    return {};
+  };
   if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
-    auto aType = dyn_cast<RankedTensorType>(mma->getOperand(0).getType());
-    auto bType = dyn_cast<RankedTensorType>(mma->getOperand(1).getType());
-    if (aType && bType) {
-      auto aShape = aType.getShape(); // [M, K]
-      int64_t K = aShape.size() >= 2 ? aShape[1] : 64;
-      // Use K to select between known latencies
-      if (K >= 128)
-        return kMMALatency128x128x128;
-      return kMMALatency128x128x64;
+    auto aShape = getShape(mma->getOperand(0)); // [M, K]
+    if (aShape.size() >= 2) {
+      int64_t K = aShape[1];
+      return K >= 128 ? kMMALatency128x128x128 : kMMALatency128x128x64;
     }
   }
   return kMMALatency128x128x128; // conservative default
+}
+
+// Latency values refit from B200 cycle-accurate microbenchmarks
+// (users/wl/wlei/latency_table/cycle_bench.py, measured via tlx.clock64()).
+// These reflect SERIAL chain cost, which is what the modulo scheduler
+// uses for both ResMII (resource pressure) and RecMII (dep recurrence).
+//
+// All shape-aware: latency scales with `elements` (= prod of tensor shape)
+// using a per-element cost. Baseline measurements at 128x128 = 16384 elems:
+//   acc_update (mulf):  138 cyc → 0.0084 cyc/elem (treat as fixed-overhead)
+//   scale_sub (subf×2): 143 cyc → similar
+//   rowmax:             461 cyc / 128 rows = ~3.6 cyc/row + log2(N) tree
+//   rowsum:           1,691 cyc / 128 rows = ~13 cyc/row (multi-stage)
+//   exp2:             1,140 cyc → 0.07 cyc/elem
+//   log2:            11,268 cyc → 0.69 cyc/elem (slow!)
+//
+// For shapes outside 128x128, scale linearly with elements (verified up to
+// 256x128: rowsum 10455 ≈ 0.32 cyc/elem × 32768 elems ≈ 10485, matches).
+constexpr int kBaseElems = 128 * 128;
+
+static int scaleByElements(int baseCycles, int64_t elements) {
+  if (elements <= 0)
+    return baseCycles;
+  // Linear scaling from the 128x128 baseline. Rounded.
+  return static_cast<int>(
+      static_cast<int64_t>(baseCycles) * elements / kBaseElems);
 }
 
 int LatencyModel::getCUDALatency(Operation *op) const {
@@ -142,55 +183,154 @@ int LatencyModel::getCUDALatency(Operation *op) const {
     return 30;
   if (isa<ttng::ArriveBarrierOp, ttng::BarrierExpectOp>(op))
     return 20;
-  if (isa<ttng::TMEMLoadOp, ttng::TMEMStoreOp>(op))
-    return 105;
+
+  int64_t elements = getTensorElements(op);
+
+  // TMEM load: NCU bench shows 179 cyc at 128x64 (8192 elems) and
+  // 532 cyc at 128x128 (16384 elems). Non-linear — use scaled base 532
+  // at 16384, which matches at 128x128 and over-counts modestly at 128x64.
+  if (isa<ttng::TMEMLoadOp>(op)) {
+    if (elements == 0)
+      return 105;
+    return scaleByElements(532, elements);
+  }
+  // TMEM store: 64 cyc at 128x64, 96 cyc at 128x128. Roughly linear
+  // with elements at base ~96 / 16384.
+  if (isa<ttng::TMEMStoreOp>(op)) {
+    if (elements == 0)
+      return 105;
+    return scaleByElements(96, elements);
+  }
+
   if (isa<triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp>(op))
     return 105;
 
-  int64_t elements = getTensorElements(op);
   if (elements == 0)
-    return 0; // scalar
+    return 1; // scalar arith — 1 cycle on the SM CUDA cores
 
-  // Reductions: differentiate by reduction kind.
+  // Reductions — refit to NCU chained measurements:
+  //   rowmax 425 cyc at 128x64, 461 cyc at 128x128, 1407 cyc at 256x128
+  //   rowsum 574 cyc at 128x64, 1691 cyc at 128x128, 10460 at 256x128
+  // Take base at 128x128 (16384 elems) and scale linearly. This under-counts
+  // 128x64 (model says 230 vs real 425, 287 vs real 574) — but the cleanest
+  // simple rule. Reductions should ideally key off the reduce-axis size, not
+  // total elements; left as future work.
   if (auto reduceOp = dyn_cast<tt::ReduceOp>(op)) {
-    // RowMax ~336 cycles, RowSum ~508 cycles for 128-wide (from microbench).
-    // Heuristic: check if the reduction body contains an AddF (sum) or MaxF.
     bool isSum = false;
     reduceOp.getBody()->walk([&](Operation *inner) {
       if (isa<arith::AddFOp>(inner))
         isSum = true;
     });
-    return isSum ? 508 : 336; // RowSum vs RowMax
+    return scaleByElements(isSum ? 1691 : 461, elements);
   }
 
-  // Type conversions (truncf, extf): ~105 cycles for 128x128.
+  // Type conversions (truncf, extf, etc.). NCU benchmark reports the chain
+  // is folded by the compiler (~0–4 cyc), so the real cost is dominated by
+  // surrounding ops in production kernels. Keep modest 105-baseline as a
+  // reasonable upper bound until a forced-RAW microbench is added.
   if (isa<arith::TruncFOp, arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp,
           tt::FpToFpOp, tt::BitcastOp>(op))
-    return 105;
+    return scaleByElements(105, elements);
 
-  // Multiply (Acc x Alpha): ~105 cycles for 128x128.
+  // Multiply: keeping 138 baseline because that matches the broadcast
+  // pattern (data * alpha[:, None]) used in FA softmax. Pure element-wise
+  // mulf measures 254 at 128x128 — different cost profile, not refit here.
   if (isa<arith::MulFOp>(op))
-    return 105;
+    return scaleByElements(138, elements);
 
-  // TMEM load/store, SMEM load/store, layout conversions: ~105 cycles.
-  if (isa<ttng::TMEMLoadOp, ttng::TMEMStoreOp, triton::gpu::LocalLoadOp,
-          triton::gpu::LocalStoreOp, triton::gpu::ConvertLayoutOp>(op))
-    return 105;
+  if (isa<triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp,
+          triton::gpu::ConvertLayoutOp>(op))
+    return scaleByElements(105, elements);
 
-  // Integer type conversions: ~105 cycles (same as float conversions).
+  // Integer type conversions: same as float conversions.
   if (isa<arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp, arith::IndexCastOp>(
           op))
+    return scaleByElements(105, elements);
+
+  // Default elementwise (addf, subf, maxnumf, etc.): broadcast pattern at
+  // 128x64 measures ~66 cyc, scales to 130 at 128x128.
+  return scaleByElements(130, elements);
+}
+
+// CUDA per-op pipe-occupancy cost (selfLat) from NCU
+// `sm__pipe_fma_cycles_active.sum / N_op / 8 FMA-units-per-SM`.
+// Materially smaller than `latency` for ops where the chain is RAW-stall-
+// dominated (notably reductions). Used for ResMII (resource conflict),
+// while `latency` is used for RecMII (dependency recurrence).
+int LatencyModel::getCUDASelfLat(Operation *op) const {
+  if (isa<ttng::WaitBarrierOp>(op))
+    return 30;
+  if (isa<ttng::ArriveBarrierOp, ttng::BarrierExpectOp>(op))
+    return 20;
+
+  int64_t elements = getTensorElements(op);
+
+  // TMEM ops — pipe-active matches latency for load (RAW stall is small);
+  // for store the FMA pipe shows ~0 active (folded into surrounding ops).
+  if (isa<ttng::TMEMLoadOp>(op))
+    return elements == 0 ? 105 : scaleByElements(256, elements);
+  if (isa<ttng::TMEMStoreOp>(op))
+    return elements == 0 ? 105 : scaleByElements(48, elements);
+  if (isa<triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp>(op))
     return 105;
 
-  // Integer arithmetic, comparisons, selects, other elementwise: ~130 cycles.
-  return 130;
+  if (elements == 0)
+    return 1; // scalar arith — 1 cycle of pipe occupancy on the SM
+
+  // Reductions: NCU pipe_fma_active per unit per op
+  //   rowmax 128:304:520 at 8192/16384/32768 elems  → base 304 at 16384
+  //   rowsum 304:639:1280                           → base 639 at 16384
+  if (auto reduceOp = dyn_cast<tt::ReduceOp>(op)) {
+    bool isSum = false;
+    reduceOp.getBody()->walk([&](Operation *inner) {
+      if (isa<arith::AddFOp>(inner))
+        isSum = true;
+    });
+    return scaleByElements(isSum ? 639 : 304, elements);
+  }
+
+  // Conversions: compiler-folded in microbench, so use small selfLat.
+  if (isa<arith::TruncFOp, arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp,
+          tt::FpToFpOp, tt::BitcastOp, arith::ExtUIOp, arith::ExtSIOp,
+          arith::TruncIOp, arith::IndexCastOp>(op))
+    return std::max(1, static_cast<int>(elements / 256));
+
+  if (isa<triton::gpu::ConvertLayoutOp>(op))
+    return scaleByElements(105, elements);
+
+  // Element-wise (mulf, addf, subf, maxnumf, ...): NCU pipe_fma_active
+  // per unit per op ~ 64 at 128x64, 128 at 128x128 — linear with elems.
+  // Base 128 at 16384 elems → 0.0078 cyc/elem.
+  return scaleByElements(128, elements);
 }
 
 int LatencyModel::getSFULatency(Operation *op) const {
   int64_t elements = getTensorElements(op);
   if (elements == 0)
     return 43; // scalar exp2 (Alpha = Exp2(scalar))
-  return 662;  // elementwise exp2 for 128x128
+
+  // SFU ops scale steeply with shape (16x at 256x128 vs 128x128).
+  // Differentiate by op kind: log2 is ~10x slower than exp2.
+  if (isa<math::Log2Op, math::LogOp>(op))
+    return scaleByElements(11268, elements); // log2(128x128) = 11,268 cyc
+  // exp2, exp, sqrt, rsqrt, etc.
+  return scaleByElements(1140, elements); // exp2(128x128) = 1,140 cyc
+}
+
+// SFU per-op pipe-occupancy. Blackwell exposes no `pipe_xu_cycles_active`
+// counter, only `inst_executed_pipe_xu`. Estimate as warp-insts ÷ 4
+// subpartitions (XU is one unit per subpartition, ~1 inst/cycle/unit):
+//   exp2 128x64  : 256 insts → 64 cyc/subp self-occupancy
+//   exp2 128x128 : 512 insts → 128 cyc/subp
+//   exp2 1D 128  :   4 insts →   1 cyc/subp
+// log2 has same instruction count; same selfLat (latency differs, not
+// pipe occupancy).
+int LatencyModel::getSFUSelfLat(Operation *op) const {
+  int64_t elements = getTensorElements(op);
+  if (elements == 0)
+    return 1;
+  // 128x128 (16384 elems) → 128 cyc per subpartition; linear scaling.
+  return scaleByElements(128, elements);
 }
 
 HWPipeline LatencyModel::classifyPipeline(Operation *op) const {
@@ -264,32 +404,27 @@ HWPipeline LatencyModel::classifyPipeline(Operation *op) const {
   if (isa<tt::ReduceOp>(op))
     return HWPipeline::CUDA;
 
-  // CUDA: Tensor arithmetic (elementwise operations on tensors)
+  // CUDA: Float arithmetic (scalar AND tensor — both run on SM CUDA cores).
+  // Scalar ops cost ~1 cycle (handled in getCUDALatency); tensor ops scale
+  // with element count. Classifying scalars as CUDA (not NONE) gives the
+  // scheduler a realistic non-zero latency for index/offset chains.
   if (isa<arith::AddFOp, arith::SubFOp, arith::MulFOp, arith::DivFOp,
-          arith::MaximumFOp, arith::MinimumFOp, arith::NegFOp, arith::CmpFOp,
-          arith::CmpIOp, arith::SelectOp>(op)) {
-    if (op->getNumResults() > 0 &&
-        isa<RankedTensorType>(op->getResult(0).getType()))
-      return HWPipeline::CUDA;
-  }
+          arith::MaximumFOp, arith::MinimumFOp, arith::MaxNumFOp,
+          arith::MinNumFOp, arith::NegFOp, arith::CmpFOp, arith::CmpIOp,
+          arith::SelectOp>(op))
+    return HWPipeline::CUDA;
 
-  // CUDA: Integer tensor arithmetic (index computation, masking)
+  // CUDA: Integer arithmetic (index computation, masking) — scalar AND tensor.
   if (isa<arith::AddIOp, arith::SubIOp, arith::MulIOp, arith::DivUIOp,
           arith::DivSIOp, arith::RemUIOp, arith::RemSIOp, arith::AndIOp,
           arith::OrIOp, arith::XOrIOp, arith::ShLIOp, arith::ShRUIOp,
-          arith::ShRSIOp>(op)) {
-    if (op->getNumResults() > 0 &&
-        isa<RankedTensorType>(op->getResult(0).getType()))
-      return HWPipeline::CUDA;
-  }
+          arith::ShRSIOp>(op))
+    return HWPipeline::CUDA;
 
-  // CUDA: Integer type conversions on tensors
+  // CUDA: Integer type conversions — scalar AND tensor.
   if (isa<arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp, arith::IndexCastOp>(
-          op)) {
-    if (op->getNumResults() > 0 &&
-        isa<RankedTensorType>(op->getResult(0).getType()))
-      return HWPipeline::CUDA;
-  }
+          op))
+    return HWPipeline::CUDA;
 
   // CUDA: Float type conversions on tensors
   if (isa<arith::TruncFOp, arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp,
@@ -299,20 +434,60 @@ HWPipeline LatencyModel::classifyPipeline(Operation *op) const {
       return HWPipeline::CUDA;
   }
 
-  // MEM: local_alloc fed by a MEM load represents the async data arrival.
-  // It stays at the same stage as the load (edge uses selfLatency), but
-  // carries the async overhead latency to its consumers (MMA).
-  if (isa<triton::gpu::LocalAllocOp>(op)) {
-    // Check if operand comes from a load
-    if (op->getNumOperands() > 0) {
-      auto *srcOp = op->getOperand(0).getDefiningOp();
-      if (srcOp && (isa<tt::LoadOp, tt::DescriptorLoadOp>(srcOp)))
-        return HWPipeline::MEM;
-    }
-  }
-
-  // NONE: Scalar ops, index arithmetic, control flow, barriers, etc.
+  // NONE: Scalar ops, index arithmetic, control flow, barriers, and
+  // local_alloc (which is a pure IR-level rename — TMA wrote bytes directly
+  // to SMEM, local_alloc just wraps the buffer in a memdesc and does not
+  // consume any pipeline resource).
   return HWPipeline::NONE;
+}
+
+// Per-op minimum warp count to achieve the modeled `selfLatency`. If the
+// containing WG actually has fewer warps, `selfLatency` should scale up
+// roughly linearly: effective ≈ selfLat × min_warps / actual_warps.
+//
+// Rationale per category:
+//  - Async producers (TMA, MMA, barriers): 1 warp issues the instruction;
+//    the rest of the work is done by the TMA engine / tensor core / mbarrier
+//    hardware. Adding warps doesn't help.
+//  - TMEM load/store: TLX/Blackwell hardware requires numWarps == 4 or 8.
+//  - SMEM load/store, layout conversions: parallel across the 4
+//    subpartitions' LSUs.
+//  - SFU on tensors (math.exp2, log2, etc.): 1 SFU per subpartition × 4
+//    subpartitions per SM. With 1 warp on 1 subpartition, only 1 SFU pipe
+//    is used; with 4 warps spread across subpartitions, all 4 pipes run
+//    in parallel.
+//  - CUDA tile arith (mulf/addf/subf/maxnumf on tensors), reductions: same
+//    parallel-across-subpartitions argument as SFU.
+//  - Scalar ops, NONE pipeline: 1 warp suffices.
+int LatencyModel::getMinWarps(Operation *op) const {
+  // Async producers — 1 warp issues, hardware does the rest.
+  if (isa<tt::DescriptorLoadOp, tt::DescriptorStoreOp,
+          tt::DescriptorGatherOp, ttng::AsyncTMACopyGlobalToLocalOp,
+          ttng::AsyncTMACopyLocalToGlobalOp>(op))
+    return 1;
+  if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp,
+          ttng::WarpGroupDotOp, tt::DotOp>(op))
+    return 1;
+  // Synchronization primitives.
+  if (isa<ttng::WaitBarrierOp, ttng::ArriveBarrierOp,
+          ttng::BarrierExpectOp>(op))
+    return 1;
+  // TMEM ops — TLX/Blackwell hardware constraint requires 4 or 8 warps.
+  if (isa<ttng::TMEMLoadOp, ttng::TMEMStoreOp>(op))
+    return 4;
+  // SMEM load/store and layout conversions on tensors — parallel access.
+  if (isa<triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp,
+          triton::gpu::ConvertLayoutOp>(op)) {
+    if (op->getNumResults() > 0 &&
+        isa<RankedTensorType>(op->getResult(0).getType()))
+      return 4;
+    return 1;
+  }
+  // Tile-parallel work uses all 4 subpartitions; detect by tensor result.
+  if (op->getNumResults() > 0 &&
+      isa<RankedTensorType>(op->getResult(0).getType()))
+    return 4;
+  return 1;
 }
 
 OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
@@ -322,23 +497,22 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
   int selfLatency = 0;
   switch (pipeline) {
   case HWPipeline::MEM: {
-    // For async MEM ops, selfLatency (pipeline occupancy) and latency
-    // (time until data available for consumers) are different.
-    // selfLatency = how long the MEM pipeline is busy dispatching.
-    // latency = selfLatency + async overhead (DRAM round-trip).
-    int occupancy;
+    // selfLatency = issue cost: cycles the SM is blocked dispatching the op.
+    // latency     = full delivery time: cycles from issue until a downstream
+    //               consumer can read the data. Single number per op — no
+    //               separate "occupancy" vs "DRAM overhead" split.
+    int fullLatency;
     if (isa<tt::DescriptorStoreOp>(op))
-      occupancy = getTMAStoreLatency(op);
+      fullLatency = getTMAStoreLatency(op);
     else if (isa<ttng::AsyncTMACopyLocalToGlobalOp>(op)) {
-      // Lowered TMA store — use same logic as descriptor_store.
-      occupancy = lookupTMALoadOccupancy(128 * 64 * 2);
+      fullLatency = lookupTMALoadOccupancy(128 * 64 * 2);
     } else if (isa<triton::gpu::LocalAllocOp>(op)) {
-      // local_alloc fed by a load: represents async data arrival.
-      // selfLatency = 0 (no pipeline occupancy, it's a bookkeeping op).
-      // latency = async overhead (DRAM round-trip time).
+      // local_alloc fed by a TMA load is a pure IR-level rename: the TMA has
+      // already delivered the bytes to SMEM, this op just wraps the buffer in
+      // a memdesc. No pipeline occupancy, no extra wait.
       selfLatency = 0;
-      latency = kTMAAsyncOverhead;
-      break;
+      latency = 0;
+      return OpLatencyInfo{pipeline, latency, selfLatency, /*minWarps=*/1};
     } else if (auto tmaCopy = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
       // Lowered TMA load (TLX path). Get size from the SMEM result type.
       auto resultMemDesc =
@@ -349,17 +523,15 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
           elements *= dim;
         int64_t bytesPerElement =
             resultMemDesc.getElementType().getIntOrFloatBitWidth() / 8;
-        occupancy = lookupTMALoadOccupancy(elements * bytesPerElement);
+        fullLatency = lookupTMALoadOccupancy(elements * bytesPerElement);
       } else {
-        occupancy = lookupTMALoadOccupancy(128 * 64 * 2);
+        fullLatency = lookupTMALoadOccupancy(128 * 64 * 2);
       }
     } else
-      occupancy = getTMALoadLatency(op);
-    // selfLatency = issue cost (SM dispatch pipeline occupancy).
-    // Design doc: 30 cycles for TMA ops.
+      fullLatency = getTMALoadLatency(op);
     selfLatency = kTMAIssueLatency;
-    latency = occupancy + kTMAAsyncOverhead;
-    return OpLatencyInfo{pipeline, latency, selfLatency, occupancy};
+    latency = fullLatency;
+    return OpLatencyInfo{pipeline, latency, selfLatency, /*minWarps=*/1};
   }
   case HWPipeline::TC:
     latency = getMMALatency(op);
@@ -368,16 +540,24 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
     selfLatency = kMMAIssueLatency;
     break;
   case HWPipeline::CUDA:
+    // latency  = full RAW-dep cost per op (clock64-chained microbench).
+    //            Used by RecMII to size dependency recurrences.
+    // selfLat  = per-op pipe-occupancy (NCU pipe_fma_active per FMA-unit
+    //            per op). Used by ResMII to size resource conflicts.
+    // For RAW-stall-dominated ops (notably reductions) selfLat is
+    // materially smaller than latency; treating them as equal (Phase 0a)
+    // over-counted CUDA pipe pressure ~1.5–3× and led the WG partitioner
+    // to over-aggressively split softmax across warp groups.
     latency = getCUDALatency(op);
-    // selfLatency = 1: CUDA ALUs are wide vector units that can accept
-    // new instructions every cycle. The latency value reflects execution
-    // time, not issue blocking.
-    selfLatency = 1;
+    selfLatency = getCUDASelfLat(op);
     break;
   case HWPipeline::SFU:
+    // Same split as CUDA. SFU has no `cycles_active` counter on Blackwell
+    // so selfLat is estimated from `inst_executed_pipe_xu` (insts ÷ 4
+    // subpartitions × ~1 cyc/inst), which gives ~64 at 128x64, ~128 at
+    // 128x128. Latency includes the ~570/1140 cyc transcendental wait.
     latency = getSFULatency(op);
-    // selfLatency = 1: SFU is pipelined, accepts new instructions quickly.
-    selfLatency = 1;
+    selfLatency = getSFUSelfLat(op);
     break;
   case HWPipeline::NONE:
     latency = 0;
@@ -385,7 +565,7 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
     break;
   }
 
-  return OpLatencyInfo{pipeline, latency, selfLatency, selfLatency};
+  return OpLatencyInfo{pipeline, latency, selfLatency, getMinWarps(op)};
 }
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
@@ -21,19 +21,41 @@ enum class HWPipeline {
 llvm::StringRef getPipelineName(HWPipeline pipeline);
 
 /// Latency info for a single operation.
+///
+/// The two fields play DISTINCT roles in modulo scheduling. Always use the
+/// definitions below — confusing them inflates II and breaks scheduling.
+///
+/// `latency` = dependency edge weight. Cycles from this op's ISSUE to when
+///   a *dependent consumer* can issue. (Equivalently: result-available
+///   delay.) Drives RecMII = max over SCCs of Σ(latency)/Σ(distance).
+///
+/// `selfLatency` = resource reservation. Cycles this op OCCUPIES its pipe —
+///   how soon another *unrelated* op on the same pipe can issue. Drives
+///   ResMII = for each pipe, Σ(selfLat × freq).
+///
+/// Invariant: 0 ≤ selfLatency ≤ latency.
+///   - selfLat == latency: op fully serializes its pipe (no overlap).
+///   - selfLat == 1: "fire-and-forget" — next pipe op issues 1 cyc later
+///     even if this op's result isn't ready.
+///
+/// Examples on Blackwell (FA fwd inner loop):
+///   tcgen05.mma 128×128×128 : selfLat=30,  latency=900,  min_warps=1
+///   descriptor_load 128×64  : selfLat=30,  latency=530,  min_warps=1
+///   math.exp2 128×64 (SFU)  : selfLat=64,  latency=570,  min_warps=4
+///   arith.mulf 128×64 (FMA) : selfLat=64,  latency=67,   min_warps=4
+///
+/// `min_warps` = the warp count assumed by the modeled `selfLat`. If the
+/// containing WG actually has fewer warps, `selfLat` scales up roughly
+/// linearly: `effective = selfLat × min_warps / actual_warps`. Async ops
+/// (TMA, MMA) only need 1 warp to issue, so `min_warps=1`. Tile-parallel
+/// CUDA/SFU ops use all 4 subpartitions, so `min_warps=4`. Used by the
+/// partitioner to size each WG's warp count and avoid mis-charging the
+/// pipe-occupancy cost.
 struct OpLatencyInfo {
   HWPipeline pipeline{HWPipeline::NONE};
-  int latency{0}; // Total latency: cycles from op start to result available.
-                  // Used for dependency analysis (RecMII — how long a
-                  // consumer must wait for the result).
-  int selfLatency{0}; // Pipeline occupancy: cycles this op blocks its pipeline.
-                      // Used for resource conflict analysis (ResMII — how much
-                      // pipeline bandwidth is consumed).
-  int transferLatency{0}; // For async MEM ops: the full TMA transfer time
-                          // (pipeline occupancy from the TMA engine's
-                          // perspective). Used as edge weight from load to
-                          // local_alloc so the alloc stays at the right stage.
-                          // For non-async ops, equals selfLatency.
+  int latency{0};
+  int selfLatency{0};
+  int minWarps{1};
 };
 
 /// Hardware latency model for Blackwell SM100.
@@ -59,7 +81,10 @@ private:
   int getTMAStoreLatency(Operation *op) const;
   int getMMALatency(Operation *op) const;
   int getCUDALatency(Operation *op) const;
+  int getCUDASelfLat(Operation *op) const;
   int getSFULatency(Operation *op) const;
+  int getSFUSelfLat(Operation *op) const;
+  int getMinWarps(Operation *op) const;
 
   /// Estimate tensor size in elements from an op's result type.
   int64_t getTensorElements(Operation *op) const;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -101,7 +101,17 @@ struct ScheduleNode {
   int stage{0};       // cycle / II
   int cluster{0};     // dense rank of cycle within stage (Step 2.5)
   int latency{0};     // cycles until result available
-  int selfLatency{0}; // cycles this op occupies its pipeline
+  int selfLatency{0}; // cycles this op occupies its pipeline (at minWarps)
+  int minWarps{1};    // warp count assumed by selfLatency; effective scales
+                      // up by minWarps/actualWarps when WG has fewer warps
+
+  // Frequency this op fires per outer-loop iteration. Outer-loop ops have
+  // frequencyMultiplier = 1; inner K-loop ops have frequencyMultiplier =
+  // K_TRIPS so the flat-view warp-makespan and barrier costs reflect that
+  // an inner op runs K times per outer iteration. Set by buildFlatView
+  // based on each ScheduledLoop's nesting depth. Default 1 (single-loop
+  // kernels and non-flat callers don't need it).
+  int frequencyMultiplier{1};
 
   // Super-node: if this node represents a child pipeline (inner loop)
   unsigned childPipelineId{UINT_MAX}; // index into ScheduleGraph::pipelines
@@ -189,6 +199,28 @@ struct ScheduleLoop {
   // epilogue (all in cycles).
   int64_t regionStart{0};
   int64_t regionEnd{0};
+
+  // Cross-group synchronization (from Pass B Step 2)
+  enum class BarrierKind { MBARRIER, NAMED };
+  struct CrossGroupBarrier {
+    unsigned producerNodeId{};
+    unsigned consumerNodeId{};
+    int producerWarpGroup{};
+    int consumerWarpGroup{};
+    BarrierKind kind{BarrierKind::MBARRIER};
+    unsigned depth{1};                 // number of barrier phases
+    unsigned pairedBufferId{UINT_MAX}; // data buffer this barrier guards
+
+    // Arrive/wait placement: explicit node IDs for Phase 3 lowering.
+    // arriveAfterNodeId: emit mbarrier.arrive AFTER this node completes.
+    // waitBeforeNodeId: emit mbarrier.wait BEFORE this node starts.
+    unsigned arriveAfterNodeId{UINT_MAX};
+    unsigned waitBeforeNodeId{UINT_MAX};
+
+    // For mbarrier: expected bytes the producer writes (for expect_tx).
+    int64_t expectBytes{0};
+  };
+  llvm::SmallVector<CrossGroupBarrier, 4> crossGroupBarriers;
 
   // Lookup
   llvm::DenseMap<Operation *, unsigned> opToNodeId;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -325,6 +325,7 @@ convertDDGNode(const ttg::DDGNode &ddgNode, unsigned nodeId,
   sn.pipeline = ddgNode.pipeline;
   sn.latency = ddgNode.latency;
   sn.selfLatency = ddgNode.selfLatency;
+  sn.minWarps = ddgNode.minWarps;
 
   auto cycleIt = sched.nodeToCycle.find(ddgNode.idx);
   if (cycleIt != sched.nodeToCycle.end()) {

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -1417,6 +1417,67 @@ struct ScheduledLoop {
 };
 
 // ============================================================================
+// Loop discovery
+// ============================================================================
+
+/// A scf::ForOp candidate for modulo scheduling, with its nesting context
+/// and raw direct-body flags. Built once via `collectCandidates` so the rest
+/// of Pass A can iterate without re-walking the module.
+///
+/// This is intentionally a flag bag rather than a tagged enum: a loop may
+/// simultaneously carry direct compute AND wrap inner loops (e.g. an outer
+/// loop that does a few non-tiling ops then enters a K-loop), and the
+/// scheduling decision belongs to the caller, not to this struct. Each call
+/// site filters on whichever combination of flags it cares about.
+struct CandidateLoop {
+  scf::ForOp op;
+  scf::ForOp parent;          // null op if outermost
+  unsigned depth{0};          // 0 = outermost
+  bool hasMMA{false};         // direct body has tcgen5_mma{,Scaled}
+  bool hasTMA{false};         // direct body has descriptor_load / async TMA copy
+  bool hasInnerLoop{false};   // direct body has a nested scf::ForOp
+  bool hasExistingAnnotation{false}; // tt.autows on an MMA — user-tuned, skip
+};
+
+/// Walk `moduleOp` once and collect every `scf::ForOp` with its nesting
+/// context and direct-body flags.
+///
+/// CONTRACT: the result is sorted by `depth` non-increasing (deepest first).
+/// This is a load-bearing guarantee — Pass A iterates the result in that
+/// order and relies on every nested loop being scheduled before its
+/// parent, because the parent's DDG promotes the child to a super-node
+/// whose `innerII` field is the child's just-computed II. Use
+/// `stable_sort` so loops at the same depth keep their source-order
+/// relative position (deterministic across builds).
+static SmallVector<CandidateLoop> collectCandidates(ModuleOp moduleOp) {
+  SmallVector<CandidateLoop> result;
+  moduleOp.walk([&](scf::ForOp loop) {
+    CandidateLoop c;
+    c.op = loop;
+    c.parent = loop->getParentOfType<scf::ForOp>();
+    for (auto p = c.parent; p; p = p->getParentOfType<scf::ForOp>())
+      ++c.depth;
+    for (auto &op : loop.getBody()->without_terminator()) {
+      if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp,
+              ttng::AsyncTMACopyGlobalToLocalOp>(&op))
+        c.hasTMA = true;
+      if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(&op)) {
+        c.hasMMA = true;
+        if (op.hasAttr("tt.autows"))
+          c.hasExistingAnnotation = true;
+      }
+      if (isa<scf::ForOp>(&op))
+        c.hasInnerLoop = true;
+    }
+    result.push_back(c);
+  });
+  llvm::stable_sort(result, [](const auto &a, const auto &b) {
+    return a.depth > b.depth;
+  });
+  return result;
+}
+
+// ============================================================================
 // Pass A: Modulo Scheduling
 // ============================================================================
 
@@ -1494,34 +1555,34 @@ struct ModuloSchedulePass
       LDBG("=== Iterative scheduling: iteration " << iteration << " ===");
       scheduledLoops.clear();
 
-      SmallVector<std::pair<scf::ForOp, unsigned>> loopsWithDepth;
-      moduleOp.walk([&](scf::ForOp loop) {
-        bool hasSchedulableOps = false;
-        loop->walk([&](Operation *op) {
-          if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp,
-                  ttng::AsyncTMACopyGlobalToLocalOp, ttng::TCGen5MMAOp,
-                  ttng::TCGen5MMAScaledOp>(op))
-            hasSchedulableOps = true;
-        });
-        if (!hasSchedulableOps)
+      // Discover schedulable loops in a single walk and sort by depth
+      // (deepest first), so an inner K-loop is scheduled before the
+      // outer tile loop that promotes it to a super-node.
+      auto candidates = collectCandidates(moduleOp);
+
+      // 2-level nesting cap: the prologue expansion, super-node DDG, and
+      // outer-loop pipelining all assume at most a depth-2 nest. Refuse
+      // anything deeper rather than silently mis-scheduling.
+      for (const auto &c : candidates) {
+        if (c.depth >= 2) {
+          c.op->emitError("modulo schedule: loop nesting depth >= 2 is not "
+                          "supported (this loop is at depth ")
+              << c.depth << ")";
+          signalPassFailure();
           return;
-        unsigned depth = 0;
-        for (auto parent = loop->getParentOfType<scf::ForOp>(); parent;
-             parent = parent->getParentOfType<scf::ForOp>())
-          ++depth;
-        loopsWithDepth.push_back({loop, depth});
-      });
-      llvm::sort(loopsWithDepth, [](const auto &a, const auto &b) {
-        return a.second < b.second;
-      });
+        }
+      }
 
-      LDBG("Found " << loopsWithDepth.size() << " schedulable loop(s)");
+      LDBG("Found " << candidates.size() << " schedulable loop(s)");
 
-      for (auto &[loop, depth] : loopsWithDepth) {
-        auto result = scheduleOneLoop(loop, model, "Loop");
+      for (const auto &c : candidates) {
+        // Skip loops with no schedulable work and no inner loop to promote.
+        if (!c.hasMMA && !c.hasTMA && !c.hasInnerLoop)
+          continue;
+        auto result = scheduleOneLoop(c.op, model, "Loop");
         if (result) {
           scheduledLoops.push_back(
-              {loop, std::move(result->graph), std::move(result->ddg)});
+              {c.op, std::move(result->graph), std::move(result->ddg)});
         }
       }
 

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -38,29 +38,40 @@ namespace ttng = triton::nvidia_gpu;
 namespace {
 
 // ============================================================================
-// Emit loop.stage / loop.cluster attributes from modulo schedule
+// Emit all schedule annotations from the ScheduleGraph
 // ============================================================================
-
-static void emitScheduleAttributes(scf::ForOp loop,
-                                   const ttg::DataDependenceGraph &ddg,
-                                   const ttg::ModuloScheduleResult &schedule) {
-  const int II = schedule.II;
-  const int maxStage = schedule.getMaxStage();
+//
+// Single consolidated function that emits ALL modulo schedule annotations
+// onto the IR. Everything is derived from the ScheduleGraph (which contains
+// the DDG schedule + buffer allocations + budget adjustments).
+//
+// Per-op attrs:
+//   loop.stage   — pipeline stage (cycle / II)
+//   loop.cluster — within-stage ordering (dense cluster ID from cycle order)
+//
+// Per-loop attrs:
+//   tt.modulo_ii            — initiation interval
+//   tt.scheduled_max_stage  — maximum stage across all ops
+//
+// Per-buffer attrs (on producing local_alloc / tmem_alloc ops):
+//   tt.num_buffers — buffer depth (copies needed for lifetime coverage)
+//   buffer.id      — unique buffer index within the ScheduleGraph
+//
+static void emitScheduleFromGraph(scf::ForOp loop,
+                                  const ttg::ScheduleGraph &graph,
+                                  const ttg::DataDependenceGraph &ddg) {
+  const auto &schedLoop = graph.getLoop(0);
+  const int II = schedLoop.II;
   auto ctx = loop.getContext();
 
-  // Step 2.5: Compute per-stage cluster IDs from modulo cycles.
-  // Ops in the same stage are ordered by cycle: lower cycle → lower cluster ID.
-  // This preserves the modulo schedule's within-stage ordering for downstream
-  // pipelining, instead of relying on IR program order.
+  // ── 1. Per-op: loop.stage / loop.cluster ──
+  // Derive stage from cycle/II. Derive cluster from cycle ordering within
+  // each stage (lower cycle → lower cluster ID).
   llvm::DenseMap<int, SmallVector<int>> stageToCycles;
-  for (const auto &node : ddg.getNodes()) {
-    auto it = schedule.nodeToCycle.find(node.idx);
-    if (it == schedule.nodeToCycle.end())
-      continue;
-    int stage = it->second / II;
-    stageToCycles[stage].push_back(it->second);
+  for (const auto &node : schedLoop.nodes) {
+    int stage = node.cycle / II;
+    stageToCycles[stage].push_back(node.cycle);
   }
-  // Deduplicate and sort cycles per stage to assign dense cluster IDs.
   llvm::DenseMap<int, llvm::DenseMap<int, int>> stageAndCycleToCluster;
   for (auto &[stage, cycles] : stageToCycles) {
     llvm::sort(cycles);
@@ -69,30 +80,25 @@ static void emitScheduleAttributes(scf::ForOp loop,
       stageAndCycleToCluster[stage][cycles[i]] = i;
   }
 
-  for (const auto &node : ddg.getNodes()) {
-    auto it = schedule.nodeToCycle.find(node.idx);
-    if (it == schedule.nodeToCycle.end())
+  int maxStage = 0;
+  for (const auto &node : schedLoop.nodes) {
+    if (!node.op)
       continue;
-    // For multi-stage super-nodes (prologue/kloop/epilogue sharing the same
-    // Operation*), only write attrs from the node registered in opToIdx
-    // (the epilogue) to avoid overwrites.
+    // For multi-stage super-nodes sharing the same Operation*, only
+    // write attrs from the canonical node (registered in opToIdx).
     auto opIt = ddg.getOpToIdx().find(node.op);
-    if (opIt != ddg.getOpToIdx().end() && opIt->second != node.idx)
+    if (opIt != ddg.getOpToIdx().end() && opIt->second != node.id)
       continue;
-    int stage = it->second / II;
-    int cycle = it->second;
-    int clusterId = stageAndCycleToCluster[stage][cycle];
+    int stage = node.cycle / II;
+    int clusterId = stageAndCycleToCluster[stage][node.cycle];
+    maxStage = std::max(maxStage, stage);
     node.op->setAttr(tt::kLoopStageAttrName,
                      IntegerAttr::get(IntegerType::get(ctx, 32), stage));
     node.op->setAttr(tt::kLoopClusterAttrName,
                      IntegerAttr::get(IntegerType::get(ctx, 32), clusterId));
-    // Emit raw cycle for downstream buffer depth computation (Step 3).
-    node.op->setAttr("tt.modulo_cycle",
-                     IntegerAttr::get(IntegerType::get(ctx, 32), cycle));
   }
 
-  // Ensure ALL ops in the loop body have loop.stage/loop.cluster attrs.
-  // Downstream passes assert every op is in the schedule.
+  // Ensure ALL ops in the loop body have loop.stage/loop.cluster.
   for (auto &op : loop.getBody()->without_terminator()) {
     if (!op.hasAttr(tt::kLoopStageAttrName))
       op.setAttr(tt::kLoopStageAttrName,
@@ -102,12 +108,40 @@ static void emitScheduleAttributes(scf::ForOp loop,
                  IntegerAttr::get(IntegerType::get(ctx, 32), 0));
   }
 
-  LDBG("Emitted schedule: II=" << II << " maxStage=" << maxStage);
-
+  // ── 2. Per-loop: tt.modulo_ii, tt.scheduled_max_stage ──
+  // Do not set tt.num_stages — it is redundant with tt.scheduled_max_stage
+  // and causes conflicts when WS partitions the loop.
   loop->setAttr("tt.modulo_ii",
                 IntegerAttr::get(IntegerType::get(ctx, 32), II));
   loop->setAttr(tt::kScheduledMaxStageAttrName,
                 IntegerAttr::get(IntegerType::get(ctx, 32), maxStage));
+
+  // ── 3. Per-buffer: tt.num_buffers, buffer.id ──
+  for (const auto &buf : schedLoop.buffers) {
+    if (!buf.defOp || buf.kind == ttg::MemoryKind::BARRIER)
+      continue;
+    buf.defOp->setAttr("tt.num_buffers",
+                       IntegerAttr::get(IntegerType::get(ctx, 32), buf.count));
+    buf.defOp->setAttr("buffer.id",
+                       IntegerAttr::get(IntegerType::get(ctx, 32), buf.id));
+  }
+
+  // ── 4. Clean up internal attrs ──
+  for (auto &op : loop.getBody()->without_terminator())
+    op.removeAttr("tt.modulo_cycle");
+
+  llvm::errs() << "[MODULO] Emitted schedule: II=" << II
+               << " maxStage=" << maxStage
+               << " num_stages=" << (maxStage + 1)
+               << " buffers=" << schedLoop.buffers.size() << "\n";
+  for (const auto &buf : schedLoop.buffers) {
+    if (!buf.defOp || buf.kind == ttg::MemoryKind::BARRIER)
+      continue;
+    llvm::errs() << "[MODULO]   buf" << buf.id
+                 << " count=" << buf.count
+                 << " kind=" << (int)buf.kind
+                 << " op=" << buf.defOp->getName().getStringRef() << "\n";
+  }
 }
 
 /// Emit tt.autows annotations on MMA ops from the modulo schedule.
@@ -1321,7 +1355,12 @@ buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
 // Schedule a single loop
 // ============================================================================
 
-static std::optional<ttg::ScheduleGraph>
+struct ScheduleResult {
+  ttg::ScheduleGraph graph;
+  ttg::DataDependenceGraph ddg;
+};
+
+static std::optional<ScheduleResult>
 scheduleOneLoop(scf::ForOp loop, const ttg::LatencyModel &model,
                 StringRef label) {
   auto ddg = ttg::DataDependenceGraph::build(loop, model);
@@ -1362,42 +1401,20 @@ scheduleOneLoop(scf::ForOp loop, const ttg::LatencyModel &model,
 
   auto graph = buildScheduleGraph(loop, ddg, *schedResult, model);
 
-  auto &schedLoop = graph.getLoop(0);
-
-  bool hasInnerLoop = false;
-  loop.getBody()->walk([&](scf::ForOp) { hasInnerLoop = true; });
-
-  if (hasInnerLoop) {
-    if (schedLoop.II != schedResult->II) {
-      LDBG(label << " budget adjusted II: " << schedResult->II << " → "
-                 << schedLoop.II << ", maxStage=" << schedLoop.maxStage);
-      auto adjustedResult = *schedResult;
-      adjustedResult.II = schedLoop.II;
-      emitScheduleAttributes(loop, ddg, adjustedResult);
-    } else {
-      emitScheduleAttributes(loop, ddg, *schedResult);
-    }
-  } else {
-    emitMMAAnnotations(loop, ddg, *schedResult);
-
-    if (!loop->hasAttr(tt::kNumStagesAttrName)) {
-      int numStages = schedResult->getMaxStage() + 1;
-      auto ctx = loop.getContext();
-      loop->setAttr(tt::kNumStagesAttrName,
-                    IntegerAttr::get(IntegerType::get(ctx, 32), numStages));
-    }
-  }
-
   LLVM_DEBUG({
     llvm::dbgs() << "[PASS-A] === " << label << " ScheduleGraph ===\n";
     graph.dump();
   });
 
-  for (auto &op : loop.getBody()->without_terminator())
-    op.removeAttr("tt.modulo_cycle");
-
-  return graph;
+  return ScheduleResult{std::move(graph), std::move(ddg)};
 }
+
+// Keeps graph + DDG + loop together for deferred emission.
+struct ScheduledLoop {
+  scf::ForOp loop;
+  ttg::ScheduleGraph graph;
+  ttg::DataDependenceGraph ddg;
+};
 
 // ============================================================================
 // Pass A: Modulo Scheduling
@@ -1467,9 +1484,15 @@ struct ModuloSchedulePass
     // apply DDG transformations → re-run if any DDG changed.
     // Converges in 1-2 iterations.
     // ================================================================
+    // Collect scheduling results across iterations. Only the LAST
+    // iteration's results are emitted — earlier iterations are discarded
+    // when DDG transformations trigger re-scheduling.
+    SmallVector<ScheduledLoop, 2> scheduledLoops;
+
     constexpr int kMaxIterations = 3;
     for (int iteration = 0; iteration < kMaxIterations; ++iteration) {
       LDBG("=== Iterative scheduling: iteration " << iteration << " ===");
+      scheduledLoops.clear();
 
       SmallVector<std::pair<scf::ForOp, unsigned>> loopsWithDepth;
       moduleOp.walk([&](scf::ForOp loop) {
@@ -1494,8 +1517,13 @@ struct ModuloSchedulePass
 
       LDBG("Found " << loopsWithDepth.size() << " schedulable loop(s)");
 
-      for (auto &[loop, depth] : loopsWithDepth)
-        scheduleOneLoop(loop, model, "Loop");
+      for (auto &[loop, depth] : loopsWithDepth) {
+        auto result = scheduleOneLoop(loop, model, "Loop");
+        if (result) {
+          scheduledLoops.push_back(
+              {loop, std::move(result->graph), std::move(result->ddg)});
+        }
+      }
 
       // ================================================================
       // Iterative refinement: apply DDG transformations and check if
@@ -1510,9 +1538,6 @@ struct ModuloSchedulePass
         break;
       }
 
-      // Don't strip attrs on the last iteration — preserve the valid
-      // schedule from this iteration rather than leaving the loop
-      // unscheduled.
       if (iteration + 1 >= kMaxIterations) {
         LDBG("Hit iteration limit (" << kMaxIterations
                                      << ") — keeping last valid schedule");
@@ -1520,19 +1545,14 @@ struct ModuloSchedulePass
       }
 
       LDBG("DDG changed by transformation — re-scheduling");
-
-      // Strip OUTPUT schedule attrs before re-running. Do NOT strip
-      // INPUT attrs like tt.num_stages (user-provided pipeline depth).
-      moduleOp.walk([](Operation *op) {
-        op->removeAttr("loop.stage");
-        op->removeAttr("loop.cluster");
-        op->removeAttr("tt.modulo_cycle");
-        op->removeAttr("tt.modulo_ii");
-        op->removeAttr("tt.num_buffers");
-        op->removeAttr("tt.self_latency");
-        op->removeAttr("tt.scheduled_max_stage");
-      });
     } // end iterative loop
+
+    // ================================================================
+    // Emit phase: write all annotations from the final ScheduleGraphs.
+    // This runs ONCE after convergence, not per-iteration.
+    // ================================================================
+    for (auto &sl : scheduledLoops)
+      emitScheduleFromGraph(sl.loop, sl.graph, sl.ddg);
   }
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -495,11 +495,10 @@ static unsigned computeBufferCount(const ttg::ScheduleLoop &loop,
     if (edge.srcId != producerNodeId)
       continue;
     const auto &consumer = loop.getNode(edge.dstId);
-    // Consumer hold time: use selfLatency (pipeline occupancy) when
-    // available, falling back to latency (result-ready time). This
-    // matches computeBufferLifetimes so that count and lifetime are
-    // computed consistently.
-    int hold = consumer.selfLatency ? consumer.selfLatency : consumer.latency;
+    // Consumer hold time: use full latency (time until consumer finishes
+    // reading the buffer). Per design doc: "Last consumer finishes reading
+    // at: schedule[c][0] + latencies[c]".
+    int hold = consumer.latency;
     int consumerEnd = consumer.cycle + hold + edge.distance * II;
     lastConsumerEnd = std::max(lastConsumerEnd, consumerEnd);
   }
@@ -678,7 +677,7 @@ static int computeBufferLifetime(const ttg::ScheduleLoop &loop,
     if (edge.srcId != producerNodeId)
       continue;
     const auto &consumer = loop.getNode(edge.dstId);
-    int holdTime = std::max(consumer.selfLatency, consumer.latency);
+    int holdTime = consumer.latency;
     int end = consumer.cycle + holdTime + edge.distance * loop.II;
     lastConsumerEnd = std::max(lastConsumerEnd, end);
   }
@@ -1047,10 +1046,9 @@ static void computeBufferLifetimes(ttg::ScheduleLoop &loop) {
         if (edge.srcId != node.id)
           continue;
         const auto &consumer = loop.getNode(edge.dstId);
-        // Use selfLatency (occupancy) over latency (result-ready) for
-        // the consumer's hold time on the resource.
-        int hold =
-            consumer.selfLatency ? consumer.selfLatency : consumer.latency;
+        // Use full latency (time until consumer finishes reading).
+        // Matches computeBufferCount so count and lifetime agree.
+        int hold = consumer.latency;
         int end =
             consumer.cycle + hold + static_cast<int>(edge.distance) * loop.II;
         lastEnd = std::max(lastEnd, end);


### PR DESCRIPTION
Summary:

Foundational data-model extensions that subsequent diffs (cluster + cost model, Pass B, JSON dumper) build on. All additions are dormant on this commit alone — they will be consumed by the following diffs.

== ScheduleGraph.h ==
- `ScheduleNode::minWarps` — warp count assumed by the modeled `selfLatency`. When the containing WG has fewer warps, effective `selfLat` scales up by `minWarps / actualWarps`. Default 1 (no scaling).
- `ScheduleNode::frequencyMultiplier` — how often the op fires per outer-loop iteration. Inner-loop ops carry `K_TRIPS` so the flat-view warp-makespan reflects inner-loop iteration count. Default 1 (single-loop kernels).
- `ScheduleLoop::CrossGroupBarrier` (struct) + `crossGroupBarriers` (vector) — output of Pass B Step 2 (added in the next diff). Carries producer/consumer node IDs, the warp groups they belong to, barrier kind (mbarrier vs named), depth, paired data buffer, explicit arrive/wait placement, and expect_bytes for TMA.

== LatencyModel.h ==
- Replaced `OpLatencyInfo::transferLatency` with `minWarps`. The old `transferLatency` (TMA-only "transfer time" vs "issue cost" split) was a special-case hack for one edge kind; the uniform model uses `latency` for all edges. `minWarps` captures the cleaner orthogonal concept of subpartition parallelism.
- Added `getCUDASelfLat`, `getSFUSelfLat`, `getMinWarps` private method declarations on `LatencyModel`.
- Rewrote the `OpLatencyInfo` comment to make `latency` vs `selfLatency` invariants explicit and document `min_warps` semantics.

== LatencyModel.cpp ==
- B200 cycle-accurate refit from NCU microbenchmarks (`users/wl/wlei/latency_table/cycle_bench.py` + `ncu_bench.py`):
  - TMA load table: 128×64 530 cyc (was 640), 128×128 663 (was 808), 256×64 654 (was 807), 256×128 925 (was 1134).
  - CUDA tile ops: `tmem_load` 532 @ 16384 elems, `rowmax` 461, `rowsum` 1691, `mulf`/`subf` 138/143, `exp2` 1140, `log2` 11268. All shape-aware via `scaleByElements`.
  - SFU `exp2`/`log2` already covered above; SFU `selfLat` differentiated from `latency` via new `getSFUSelfLat` (selfLat ≈ 64 cyc per tile-parallel issue, latency includes the result-ready chain).
  - CUDA `selfLat` differentiated from `latency` via new `getCUDASelfLat` — barriers 30/20, tile ops 64.
- New `getMinWarps(Operation*)`: returns 1 for async producers (TMA, MMA) and 4 for tile-parallel CUDA/SFU ops, others default.
- `getLatency` now populates `OpLatencyInfo::minWarps` via `getMinWarps(op)` and uses the new selfLat helpers for CUDA/SFU.

== DataDependenceGraph.{h,cpp} ==
- `DDGNode::transferLatency` → `DDGNode::minWarps`. Edge construction no longer needs the MEM→`local_alloc` special-case — every edge takes the producer's full `latency`. Uniform rule fixes a class of mis-scheduled stage assignments where the consumer was placed too early because `transferLatency < latency`.
- Inline `pipelineOccupancy(node)` helper documenting and centralizing the "MEM/TC reserve full latency; CUDA/SFU reserve selfLatency" rule (used by ResMII and the modulo reservation table — split off into the next diff).
- Super-node construction now computes `prologueLatency` = cycle of the first TC op in the inner schedule, so the outer scheduler can overlap outer-loop MEM ops with the inner loop's pre-MMA prologue.

== ModuloSchedulePass.cpp ==
- `convertDDGNode` propagates `minWarps` from DDGNode to ScheduleNode (single line; everything else is unchanged).

Reviewed By: htyu

Differential Revision: D106001658


