### PR TITLE
[TLX][AMD] Port async_load, local_load, and async_token fixes from tlx-amd-meta

### DIFF
--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -1,0 +1,187 @@
+"""
+Tests for TLX AMD support (async_load, local_load with relaxed, async_token in loops).
+
+These tests compile kernels targeting gfx950 via triton.compile() with an
+explicit GPUTarget and verify the generated TTGIR/AMDGCN. No AMD hardware is
+required for the compilation checks. Correctness checks (actual execution) run
+only when gfx950 hardware is available.
+"""
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton._internal_testing import is_hip
+from triton.compiler.compiler import ASTSource, compile as triton_compile
+from triton.backends.compiler import GPUTarget
+
+# Skip the entire module if no HIP runtime is available.
+pytestmark = pytest.mark.skipif(not is_hip(), reason="Requires HIP runtime")
+
+GFX950 = GPUTarget("hip", "gfx950", 64)
+
+
+def compile_for_gfx950(fn, signature, constexprs):
+    """Compile a TLX kernel for gfx950 and return the compiled object."""
+    src = ASTSource(fn=fn, signature=signature, constexprs=constexprs)
+    return triton_compile(src, target=GFX950)
+
+
+def is_gfx950_available():
+    """Check if the current device is gfx950."""
+    try:
+        target = triton.runtime.driver.active.get_current_target()
+        return target.arch == "gfx950"
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Test: async_load compiles on gfx950 and produces the expected ops.
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _async_load_kernel(
+    x_ptr, y_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    buffers = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 2)
+
+    buf0 = tlx.local_view(buffers, 0)
+    buf1 = tlx.local_view(buffers, 1)
+    tok_x = tlx.async_load(x_ptr + offs, buf0, mask=mask)
+    tok_y = tlx.async_load(y_ptr + offs, buf1, mask=mask)
+    tlx.async_load_commit_group([tok_x, tok_y])
+    tlx.async_load_wait_group(0)
+
+    x = tlx.local_load(buf0)
+    y = tlx.local_load(buf1)
+    tl.store(output_ptr + offs, x + y, mask=mask)
+
+
+def test_async_load_compiles_gfx950(device):
+    """async_load should produce async_copy_global_to_local in TTGIR on gfx950."""
+    compiled = compile_for_gfx950(
+        _async_load_kernel,
+        signature={"x_ptr": "*fp32", "y_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
+        constexprs={"BLOCK_SIZE": 64},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "async_copy_global_to_local" in ttgir or "buffer_load_to_local" in ttgir
+    assert "async_commit_group" in ttgir
+    assert "async_wait" in ttgir
+    assert "local_load" in ttgir
+
+    # Verify the kernel compiled all the way to AMDGCN.
+    assert "amdgcn" in compiled.asm
+    assert len(compiled.asm["amdgcn"]) > 0
+
+
+def test_async_load_correctness(device):
+    """async_load produces correct results on gfx950 hardware."""
+    if not is_gfx950_available():
+        pytest.skip("Requires gfx950 hardware")
+    size = 256
+    x = torch.rand(size, dtype=torch.float32, device=device)
+    y = torch.rand(size, dtype=torch.float32, device=device)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(size, 64),)
+    _async_load_kernel[grid](x, y, output, size, BLOCK_SIZE=64)
+    torch.testing.assert_close(x + y, output)
+
+
+# ---------------------------------------------------------------------------
+# Test: local_load with relaxed=True sets the syncedViaAsyncWait attribute.
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _relaxed_load_kernel(
+    x_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    buf = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 1)
+    buf0 = tlx.local_view(buf, 0)
+    tok = tlx.async_load(x_ptr + offs, buf0, mask=mask)
+    tlx.async_load_commit_group([tok])
+    tlx.async_load_wait_group(0)
+
+    x = tlx.local_load(buf0, relaxed=True)
+    tl.store(output_ptr + offs, x, mask=mask)
+
+
+def test_relaxed_local_load_compiles_gfx950(device):
+    """local_load(relaxed=True) should compile and produce local_load in TTGIR."""
+    compiled = compile_for_gfx950(
+        _relaxed_load_kernel,
+        signature={"x_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
+        constexprs={"BLOCK_SIZE": 64},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "local_load" in ttgir
+
+
+def test_relaxed_local_load_correctness(device):
+    """local_load(relaxed=True) produces correct results on gfx950 hardware."""
+    if not is_gfx950_available():
+        pytest.skip("Requires gfx950 hardware")
+    size = 256
+    x = torch.rand(size, dtype=torch.float32, device=device)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(size, 64),)
+    _relaxed_load_kernel[grid](x, output, size, BLOCK_SIZE=64)
+    torch.testing.assert_close(x, output)
+
+
+# ---------------------------------------------------------------------------
+# Test: async_token survives in scope around tl.range without crashing.
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _token_in_loop_kernel(
+    x_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_ITERS: tl.constexpr,
+):
+    """async_token from async_load_commit_group is live when tl.range is
+    entered. If async_token._flatten_ir is broken, the code generator
+    crashes with NotImplementedError when collecting carries."""
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    buf = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 1)
+    buf0 = tlx.local_view(buf, 0)
+
+    tok = tlx.async_load(x_ptr + offs, buf0, mask=mask)
+    tlx.async_load_commit_group([tok])
+
+    acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+    # tok is in scope here -- that's what we're testing.
+    for i in tl.range(0, NUM_ITERS, num_stages=0):
+        tlx.async_load_wait_group(0)
+        x = tlx.local_load(buf0)
+        acc += x
+
+    tl.store(output_ptr + offs, acc, mask=mask)
+
+
+def test_async_token_loop_compiles_gfx950(device):
+    """async_token in scope around tl.range should compile without crashing."""
+    compiled = compile_for_gfx950(
+        _token_in_loop_kernel,
+        signature={"x_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
+        constexprs={"BLOCK_SIZE": 64, "NUM_ITERS": 4},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "local_load" in ttgir
+    assert "async_wait" in ttgir

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -1,5 +1,5 @@
 """
-Tests for TLX AMD support (async_load, local_load with relaxed, async_token in loops).
+Tests for TLX AMD support (async_load, local_load, async_token in loops).
 
 These tests compile kernels targeting gfx950 via triton.compile() with an
 explicit GPUTarget and verify the generated TTGIR/AMDGCN. No AMD hardware is
@@ -12,7 +12,7 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton._internal_testing import is_hip
+from triton._internal_testing import is_hip, is_hip_cdna4
 from triton.compiler.compiler import ASTSource, compile as triton_compile
 from triton.backends.compiler import GPUTarget
 
@@ -26,15 +26,6 @@ def compile_for_gfx950(fn, signature, constexprs):
     """Compile a TLX kernel for gfx950 and return the compiled object."""
     src = ASTSource(fn=fn, signature=signature, constexprs=constexprs)
     return triton_compile(src, target=GFX950)
-
-
-def is_gfx950_available():
-    """Check if the current device is gfx950."""
-    try:
-        target = triton.runtime.driver.active.get_current_target()
-        return target.arch == "gfx950"
-    except Exception:
-        return False
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +55,7 @@ def _async_load_kernel(
     tl.store(output_ptr + offs, x + y, mask=mask)
 
 
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_async_load_compiles_gfx950(device):
     """async_load should produce async_copy_global_to_local in TTGIR on gfx950."""
     compiled = compile_for_gfx950(
@@ -82,10 +74,9 @@ def test_async_load_compiles_gfx950(device):
     assert len(compiled.asm["amdgcn"]) > 0
 
 
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_async_load_correctness(device):
     """async_load produces correct results on gfx950 hardware."""
-    if not is_gfx950_available():
-        pytest.skip("Requires gfx950 hardware")
     size = 256
     x = torch.rand(size, dtype=torch.float32, device=device)
     y = torch.rand(size, dtype=torch.float32, device=device)
@@ -96,11 +87,11 @@ def test_async_load_correctness(device):
 
 
 # ---------------------------------------------------------------------------
-# Test: local_load with relaxed=True sets the syncedViaAsyncWait attribute.
+# Test: local_load after async_wait compiles and runs correctly.
 # ---------------------------------------------------------------------------
 
 @triton.jit
-def _relaxed_load_kernel(
+def _local_load_kernel(
     x_ptr, output_ptr, n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -114,14 +105,15 @@ def _relaxed_load_kernel(
     tlx.async_load_commit_group([tok])
     tlx.async_load_wait_group(0)
 
-    x = tlx.local_load(buf0, relaxed=True)
+    x = tlx.local_load(buf0)
     tl.store(output_ptr + offs, x, mask=mask)
 
 
-def test_relaxed_local_load_compiles_gfx950(device):
-    """local_load(relaxed=True) should compile and produce local_load in TTGIR."""
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_local_load_compiles_gfx950(device):
+    """local_load after async_wait should compile and produce local_load in TTGIR."""
     compiled = compile_for_gfx950(
-        _relaxed_load_kernel,
+        _local_load_kernel,
         signature={"x_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
         constexprs={"BLOCK_SIZE": 64},
     )
@@ -129,15 +121,14 @@ def test_relaxed_local_load_compiles_gfx950(device):
     assert "local_load" in ttgir
 
 
-def test_relaxed_local_load_correctness(device):
-    """local_load(relaxed=True) produces correct results on gfx950 hardware."""
-    if not is_gfx950_available():
-        pytest.skip("Requires gfx950 hardware")
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_local_load_correctness(device):
+    """local_load after async_wait produces correct results on gfx950 hardware."""
     size = 256
     x = torch.rand(size, dtype=torch.float32, device=device)
     output = torch.empty_like(x)
     grid = (triton.cdiv(size, 64),)
-    _relaxed_load_kernel[grid](x, output, size, BLOCK_SIZE=64)
+    _local_load_kernel[grid](x, output, size, BLOCK_SIZE=64)
     torch.testing.assert_close(x, output)
 
 
@@ -175,6 +166,7 @@ def _token_in_loop_kernel(
     tl.store(output_ptr + offs, acc, mask=mask)
 
 
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_async_token_loop_compiles_gfx950(device):
     """async_token in scope around tl.range should compile without crashing."""
     compiled = compile_for_gfx950(

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -6,6 +6,8 @@ explicit GPUTarget and verify the generated TTGIR/AMDGCN. No AMD hardware is
 required for the compilation checks. Correctness checks (actual execution) run
 only when gfx950 hardware is available.
 """
+import re
+
 import pytest
 import torch
 
@@ -119,6 +121,38 @@ def test_local_load_compiles_gfx950(device):
     )
     ttgir = compiled.asm["ttgir"]
     assert "local_load" in ttgir
+
+
+@triton.jit
+def _local_load_with_token_kernel(
+    x_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    buf = tlx.local_alloc((BLOCK_SIZE,), tl.float32, 1)
+    buf0 = tlx.local_view(buf, 0)
+    tok = tlx.async_load(x_ptr + offs, buf0, mask=mask)
+    tlx.async_load_commit_group([tok])
+    wait_tok = tlx.async_load_wait_group(0)
+
+    x = tlx.local_load(buf0, token=wait_tok)
+    tl.store(output_ptr + offs, x, mask=mask)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_local_load_with_token_compiles_gfx950(device):
+    """local_load with a wait token should set syncedViaAsyncWait in TTGIR."""
+    compiled = compile_for_gfx950(
+        _local_load_with_token_kernel,
+        signature={"x_ptr": "*fp32", "output_ptr": "*fp32", "n_elements": "i32"},
+        constexprs={"BLOCK_SIZE": 64},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "local_load" in ttgir
+    assert re.search(r'ttg\.local_load .* \{ttg\.amdg\.syncedViaAsyncWait = true\}', ttgir, re.MULTILINE)
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -622,15 +622,8 @@ def async_load(
         # unsupported for now
         raise NotImplementedError("async_load by block pointer is not supported yet")
     else:
-        # Load by a tensor of pointers or a pointer of scalar.
-        if src.type.is_block():
-            if mask is not None:
-                src, mask = _semantic.broadcast_impl_value(src, mask)
-            if other is not None:
-                src, other = _semantic.broadcast_impl_value(src, other)
-        elt_ty = src.type.scalar.element_ty
-        if other is not None:
-            other = _semantic.cast(other, elt_ty)
+        # Load by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
+        _, src, mask, other, _ = _semantic._prepare_legacy_load(src, mask, other, None, None)
 
     cache = _semantic._str_to_load_cache_modifier(cache_modifier)
     eviction = _semantic._str_to_eviction_policy(eviction_policy)
@@ -681,16 +674,10 @@ def async_load_wait_group(
 def local_load(
     src: tlx.buffered_tensor,
     token: tlx.async_token = None,
-    relaxed: bool = False,
     _semantic=None,
 ) -> tl.tensor:
     """
     Loads buffer from local or tensor memory into a distributed tensor.
-
-    When relaxed=True, the load is annotated as synchronized via async_wait,
-    telling the AMD backend that no additional vmcnt wait is needed before
-    this LDS read. Use this when the load is preceded by an async_wait +
-    barrier that guarantees the data is ready.
     """
     block_type = tl.block_type(src.type.element_ty, src.type.shape)
     storage = src.type.storage
@@ -704,7 +691,7 @@ def local_load(
     else:
         output = _semantic.builder.create_local_load(src.handle, token.handle if token else None)
         result = tl.tensor(output, block_type)
-        if relaxed:
+        if token is not None and _semantic.builder.options.backend_name == "hip":
             result.handle.set_attr("ttg.amdg.syncedViaAsyncWait",
                                    _semantic.builder.get_bool_attr(True))
         return result

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -622,8 +622,15 @@ def async_load(
         # unsupported for now
         raise NotImplementedError("async_load by block pointer is not supported yet")
     else:
-        # Load by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
-        _, src, mask, other, _ = _semantic._prepare_legacy_load(src, mask, other, None, None)
+        # Load by a tensor of pointers or a pointer of scalar.
+        if src.type.is_block():
+            if mask is not None:
+                src, mask = _semantic.broadcast_impl_value(src, mask)
+            if other is not None:
+                src, other = _semantic.broadcast_impl_value(src, other)
+        elt_ty = src.type.scalar.element_ty
+        if other is not None:
+            other = _semantic.cast(other, elt_ty)
 
     cache = _semantic._str_to_load_cache_modifier(cache_modifier)
     eviction = _semantic._str_to_eviction_policy(eviction_policy)
@@ -674,10 +681,16 @@ def async_load_wait_group(
 def local_load(
     src: tlx.buffered_tensor,
     token: tlx.async_token = None,
+    relaxed: bool = False,
     _semantic=None,
 ) -> tl.tensor:
     """
     Loads buffer from local or tensor memory into a distributed tensor.
+
+    When relaxed=True, the load is annotated as synchronized via async_wait,
+    telling the AMD backend that no additional vmcnt wait is needed before
+    this LDS read. Use this when the load is preceded by an async_wait +
+    barrier that guarantees the data is ready.
     """
     block_type = tl.block_type(src.type.element_ty, src.type.shape)
     storage = src.type.storage
@@ -690,7 +703,11 @@ def local_load(
         return tl.tensor(output, block_type)
     else:
         output = _semantic.builder.create_local_load(src.handle, token.handle if token else None)
-        return tl.tensor(output, block_type)
+        result = tl.tensor(output, block_type)
+        if relaxed:
+            result.handle.set_attr("ttg.amdg.syncedViaAsyncWait",
+                                   _semantic.builder.get_bool_attr(True))
+        return result
 
 
 @tl.builtin

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -990,10 +990,10 @@ class async_token(tl.base_value):
         self.type = async_token_type(handle)
 
     def _flatten_ir(self, handles) -> None:
-        handles.append(self.handle)
-
-    def _unflatten_ir(self, handles, cursor):
-        raise NotImplementedError
+        # Async tokens are zero-width: they are not carried across loop
+        # iterations. Do not append to handles so _flatten_ir_types (which
+        # also emits nothing) stays consistent.
+        pass
 
 
 class async_token_type(tl.base_type):

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -990,10 +990,10 @@ class async_token(tl.base_value):
         self.type = async_token_type(handle)
 
     def _flatten_ir(self, handles) -> None:
-        # Async tokens are zero-width: they are not carried across loop
-        # iterations. Do not append to handles so _flatten_ir_types (which
-        # also emits nothing) stays consistent.
-        pass
+        handles.append(self.handle)
+
+    def _unflatten_ir(self, handles, cursor):
+        return async_token(handles[cursor]), cursor + 1
 
 
 class async_token_type(tl.base_type):
@@ -1011,7 +1011,7 @@ class async_token_type(tl.base_type):
         return repr(self)
 
     def _flatten_ir_types(self, builder: ir.builder, out: List[ir.type]) -> None:
-        return
+        out.append(self.value.get_type())
 
     def _unflatten_ir(self, handles: List[ir.value], cursor: int):
         return async_token(handles[cursor]), cursor + 1


### PR DESCRIPTION
  Port of #1170 from `tlx-amd-meta` branch to `main` for fbsource import.

  - Fix `async_token._flatten_ir` to be zero-width (matching `_flatten_ir_types`),  
    preventing crash when a token is live across a `tl.range` loop
  - Auto-set `syncedViaAsyncWait` on `local_load` when a token is provided and
    backend is AMD, replacing the user-facing `relaxed` flag from tlx-amd-meta
  - Revert `async_load` inline broadcast refactor — `_prepare_legacy_load` still    
    exists on main

## Test plan

MI350x `pytest python/test/unit/language/test_tlx_amd.py`
B200 `pytest python/test/unit/language/test_tlx_*.py` (no regression)