### PR TITLE
[TLX] Support AMD GPUs in killgpu.sh + fix pre-commit linter errors  

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,5 +76,6 @@ exclude: |
     ^third_party/tlx/language/__init__.py|
     ^third_party/f2reduce|
     ^third_party/tileir|
-    ^python/test/gluon/
+    ^python/test/gluon/|
+    ^python/triton/experimental/gluon/
   )

--- a/python/test/unit/language/test_autows_addmm.py
+++ b/python/test/unit/language/test_autows_addmm.py
@@ -311,8 +311,11 @@ def addmm_kernel_1d_bias_ws(
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
 
     for tile_id in tl.range(
-            start_pid, num_tiles, NUM_SMS,
-            flatten=False, warp_specialize=True,
+            start_pid,
+            num_tiles,
+            NUM_SMS,
+            flatten=False,
+            warp_specialize=True,
             disallow_acc_multi_buffer=True,
             separate_epilogue_store=True,
     ):
@@ -367,7 +370,7 @@ def test_autows_addmm_hoist_convert_before_broadcast():
         torch.manual_seed(42)
         A = torch.randn((M, K), dtype=dtype, device=device)
         B = torch.randn((N, K), dtype=dtype, device=device)
-        bias_1d = torch.randn((N,), dtype=dtype, device=device)
+        bias_1d = torch.randn((N, ), dtype=dtype, device=device)
         C = torch.empty((M, N), dtype=dtype, device=device)
 
         def alloc_fn(size, align, stream):
@@ -386,12 +389,20 @@ def test_autows_addmm_hoist_convert_before_broadcast():
         ), )
 
         kernel = addmm_kernel_1d_bias_ws[grid](
-            a_desc, b_desc, c_desc, bias_desc,
-            M, N, K,
-            BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N,
-            BLOCK_SIZE_K=BLOCK_SIZE_K, GROUP_SIZE_M=GROUP_SIZE_M,
+            a_desc,
+            b_desc,
+            c_desc,
+            bias_desc,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
             NUM_SMS=NUM_SMS,
-            num_stages=num_stages, num_warps=num_warps,
+            num_stages=num_stages,
+            num_warps=num_warps,
             early_tma_store_lowering=True,
         )
 
@@ -402,12 +413,9 @@ def test_autows_addmm_hoist_convert_before_broadcast():
 
         # Check that convert_layout on bias happens before broadcast (on 1xN, not MxN)
         import re
-        cvt_before_bc = re.search(
-            r'convert_layout.*tensor<1x\d+xf32.*\n.*tt\.broadcast.*tensor<1x\d+xf32',
-            ttgir)
+        cvt_before_bc = re.search(r'convert_layout.*tensor<1x\d+xf32.*\n.*tt\.broadcast.*tensor<1x\d+xf32', ttgir)
         bc_before_cvt = re.search(
-            r'tt\.broadcast.*tensor<1x\d+xf32.*tensor<128x\d+xf32.*\n.*convert_layout.*tensor<128x\d+xf32',
-            ttgir)
+            r'tt\.broadcast.*tensor<1x\d+xf32.*tensor<128x\d+xf32.*\n.*convert_layout.*tensor<128x\d+xf32', ttgir)
         assert cvt_before_bc or not bc_before_cvt, \
             "Expected convert_layout before broadcast (on small 1xN tensor)"
 

--- a/third_party/tlx/killgpu.sh
+++ b/third_party/tlx/killgpu.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 
-# Script to kill all GPU processes owned by the current user
+# Script to kill all GPU processes owned by the current user (NVIDIA and AMD)
 
-# Check if nvidia-smi is available
-if ! command -v nvidia-smi &>/dev/null; then
-  echo "nvidia-smi command not found. Are NVIDIA drivers installed?"
-  exit 1
-fi
-
-# Get current username
 CURRENT_USER=$(whoami)
 echo "Current user: $CURRENT_USER"
 
-# Get all process IDs using GPUs
+# Detect GPU vendor
+get_gpu_pids() {
+  if command -v nvidia-smi &>/dev/null; then
+    nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits
+  elif command -v rocm-smi &>/dev/null; then
+    rocm-smi --showpids 2>/dev/null | awk 'NR>1 && /^[0-9]/ {print $1}'
+  else
+    echo "No GPU tools found (nvidia-smi or rocm-smi)." >&2
+    exit 1
+  fi
+}
+
 echo "Fetching GPU processes..."
-GPU_PIDS=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)
+GPU_PIDS=$(get_gpu_pids)
 
 if [ -z "$GPU_PIDS" ]; then
   echo "No GPU processes found."
@@ -63,7 +67,7 @@ echo "Sleeping for 2 seconds to verify..."
 sleep 2
 
 # Verify all user's processes are gone
-REMAINING=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)
+REMAINING=$(get_gpu_pids)
 if [ -z "$REMAINING" ]; then
   echo "Verification complete: No GPU processes remaining."
 else

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma_dp.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma_dp.py
@@ -805,7 +805,7 @@ class _attention_opt(torch.autograd.Function):
 
         M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
         warp_specialize = baseVariant == "ws" or baseVariant == "ws_persistent"
-        if not FORCE_ON_DEVICE and supports_host_descriptor() and not (is_hopper() and warp_specialize):
+        if (not FORCE_ON_DEVICE and supports_host_descriptor() and not (is_hopper() and warp_specialize)):
             y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
             dummy_block = [1, 1]


### PR DESCRIPTION
  ## Summary
  - Auto-detect GPU vendor in killgpu.sh: use nvidia-smi on NVIDIA, rocm-smi
    on AMD via a `get_gpu_pids()` function. Same kill logic for both.
  - Fix pre-commit linter errors: auto-fix formatting (ruff, yapf, clang-format,
    trailing whitespace) and fix F841 unused variable warnings in
    fused_attention_ws_device_tma_dp.py
  - Add python/triton/experimental/gluon/ to pre-commit global exclude list
    (upstream-synced, should not be reformatted locally)

  ## Test plan
  - Verified killgpu.sh runs on AMD (ROCm 7.0 / gfx950)
  - `pre-commit run --all` passes