### PR TITLE
[TLX] Fix RewriteLocalAlias for size-mismatched aliases

### DIFF
--- a/test/TLX/rewrite-local-alias-errors.mlir
+++ b/test/TLX/rewrite-local-alias-errors.mlir
@@ -1,0 +1,52 @@
+// RUN: triton-opt --split-input-file %s --tlx-rewrite-local-alias --verify-diagnostics
+
+// Non-divisor sizes: the bf16 backing has 49152 bits (3 buffers), but the
+// f32 view asks for 32768 bits and 49152 is not a whole multiple of 32768,
+// so the size-mismatched alias recipe does not apply.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @non_divisor_alias() {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<3x32x32xbf16, #shared, #smem, mutable>
+    // expected-error @+1 {{TLXRewriteLocalAlias cannot view a 49152-bit allocation as a 32768-bit alias}}
+    %1 = tlx.local_alias %0 : !ttg.memdesc<3x32x32xbf16, #shared, #smem, mutable> -> !ttg.memdesc<1x32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Tensor memory size-mismatched alias: the pass only knows how to expand
+// shared memory views. The alias is larger than the base, so the pass first
+// creates a new tmem_alloc with the alias's f32 type and then needs to view
+// it back as the original f16 base type, which is where the size mismatch
+// surfaces.
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @tmem_alias_size_mismatch() {
+    // expected-error @+1 {{TLXRewriteLocalAlias only supports size-mismatched aliases for shared memory}}
+    %0 = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable>
+    %1 = tlx.local_alias %0 : !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Non-unit leading batch dim on a size-mismatched alias: the size-aware
+// expansion produces a fresh single-slot descriptor via memdesc_index[0]
+// and cannot reproduce a multi-slot view onto a partial backing buffer.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  tt.func @multi_slot_size_mismatch_alias() {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<8x32x32xf32, #shared, #smem, mutable>
+    // expected-error @+1 {{TLXRewriteLocalAlias cannot shrink a size-mismatched alias with leading batch dim 4 (only unit batch dim is supported)}}
+    %1 = tlx.local_alias %0 : !ttg.memdesc<8x32x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<4x32x32xbf16, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/rewrite-local-alias-padded.mlir
+++ b/test/TLX/rewrite-local-alias-padded.mlir
@@ -15,3 +15,29 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
     tt.return
   }
 }
+
+// -----
+
+// Size-mismatched alias: the c view only covers 1/8th of the a allocation
+// (2x32x128xf16 = 131072 bits, 1x32x32xbf16 = 16384 bits). Upstream PR
+// #10243 rejects a single memdesc_reinterpret across different sizes, so
+// the pass must emit reinterpret -> memdesc_index[0] -> reinterpret to
+// produce a fresh alias descriptor.
+#padded_a_small = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [32, 128]}>
+#padded_c_small = #ttg.padded_shared<[32:+8] {order = [1, 0], shape = [32, 32]}>
+#smem1 = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @shrink_alias
+  tt.func public @shrink_alias() {
+    // CHECK: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #[[$A:.*]], #smem, mutable>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #padded_a_small, #smem1, mutable>
+    // CHECK-NOT: tlx.local_alias
+    // CHECK: %[[BIG:.*]] = ttg.memdesc_reinterpret %[[ALLOC]] : !ttg.memdesc<2x32x128xf16, #[[$A]], #smem, mutable> -> !ttg.memdesc<8x32x32xbf16, #[[$C:.*]], #smem, mutable>
+    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+    // CHECK: %[[SLOT:.*]] = ttg.memdesc_index %[[BIG]][%[[C0]]] : !ttg.memdesc<8x32x32xbf16, #[[$C]], #smem, mutable> -> !ttg.memdesc<32x32xbf16, #[[$C]], #smem, mutable>
+    // CHECK: ttg.memdesc_reinterpret %[[SLOT]] : !ttg.memdesc<32x32xbf16, #[[$C]], #smem, mutable> -> !ttg.memdesc<1x32x32xbf16, #[[$C]], #smem, mutable>
+    %c = tlx.local_alias %a : !ttg.memdesc<2x32x128xf16, #padded_a_small, #smem1, mutable> -> !ttg.memdesc<1x32x32xbf16, #padded_c_small, #smem1, mutable>
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
@@ -1,9 +1,11 @@
 #include "IR/Dialect.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -24,6 +26,118 @@ namespace tlx {
 #define GEN_PASS_DEF_TLXREWRITELOCALALIAS
 
 #include "tlx/dialect/include/Transforms/Passes.h.inc"
+
+namespace {
+
+// Total logical storage bits for a memdesc view, matching the calculation in
+// MemDescReinterpretOp::verify (lib/Dialect/TritonGPU/IR/Ops.cpp).
+int64_t getMemDescStorageBits(ttg::MemDescType ty) {
+  auto rank = cast<ttg::LayoutEncodingTrait>(ty.getEncoding()).getRank();
+  auto shape = ty.getAllocShape().take_back(rank);
+  LinearLayout layout = isa<ttg::PaddedSharedEncodingAttr>(ty.getEncoding())
+                            ? ttg::paddedLinearLayout(shape, ty.getEncoding())
+                            : ttg::toLinearLayout(shape, ty.getEncoding());
+  int64_t numLayoutCopies = 1;
+  for (int64_t dim : ty.getAllocShape().drop_back(rank))
+    numLayoutCopies *= dim;
+  auto *ctx = ty.getContext();
+  bool isSharedMemory = isa<ttg::SharedMemorySpaceAttr>(ty.getMemorySpace());
+  auto dim = StringAttr::get(ctx, isSharedMemory ? "offset" : "col");
+  return numLayoutCopies * layout.getInDimSize(dim) *
+         ty.getElementTypeBitWidth();
+}
+
+// Emit IR that produces a value of type `dstTy` viewing the same storage as
+// `base`. When `base` and `dstTy` have the same logical size we emit a single
+// ttg.memdesc_reinterpret. When `base` is larger (the alias only covers part
+// of the backing buffer), upstream PR #10243 forbids the size-mismatched
+// reinterpret, so we instead emit three ops:
+//   1. memdesc_reinterpret base -> [ratio, ...layoutShape] in dstTy's enc;
+//   2. memdesc_index[0]      to drop the ratio dim and obtain a fresh
+//                              descriptor with shape == layoutShape;
+//   3. memdesc_reinterpret   to add dstTy's leading unit batch dim back, if
+//                              dstTy has one.
+// The intermediate type has at most one leading batch dim relative to the
+// encoding's layout rank, satisfying MemDescType's shape-vs-encoding-rank
+// constraint and memdesc_index's "not a subview" requirement. memdesc_index
+// produces a value with allocShape == shape, so subsequent users that index
+// into the alias keep working unchanged.
+FailureOr<Value> emitAliasView(OpBuilder &builder, Operation *errorOp,
+                               Location loc, Value base,
+                               ttg::MemDescType dstTy) {
+  auto srcTy = cast<ttg::MemDescType>(base.getType());
+  int64_t srcBits = getMemDescStorageBits(srcTy);
+  int64_t dstBits = getMemDescStorageBits(dstTy);
+
+  if (srcBits == dstBits) {
+    return ttg::MemDescReinterpretOp::create(builder, loc, dstTy, base)
+        .getResult();
+  }
+
+  if (srcBits < dstBits || srcBits % dstBits != 0)
+    return errorOp->emitError()
+           << "TLXRewriteLocalAlias cannot view a " << srcBits
+           << "-bit allocation as a " << dstBits << "-bit alias";
+  if (!isa<ttg::SharedMemorySpaceAttr>(dstTy.getMemorySpace()))
+    return errorOp->emitError()
+           << "TLXRewriteLocalAlias only supports size-mismatched aliases "
+              "for shared memory";
+
+  int64_t ratio = srcBits / dstBits;
+  unsigned encRank =
+      cast<ttg::LayoutEncodingTrait>(dstTy.getEncoding()).getRank();
+  int64_t dstRank = dstTy.getRank();
+  // MemDescType requires shape.size() to equal the encoding rank or be one
+  // greater (a single leading batch dim); enforced by MemDescType::verify.
+  assert((dstRank == (int64_t)encRank || dstRank == (int64_t)encRank + 1) &&
+         "MemDescType rank must equal encoding rank or be one greater");
+  // The recipe only handles the case where dstTy has at most a unit-sized
+  // leading batch dim. Larger batch dims would require a same-rank subslice,
+  // which produces a subview-typed result that downstream memdesc_index
+  // consumers reject.
+  int64_t dstBatch =
+      (dstRank == (int64_t)encRank + 1) ? dstTy.getShape()[0] : 1;
+  if (dstBatch != 1)
+    return errorOp->emitError()
+           << "TLXRewriteLocalAlias cannot shrink a size-mismatched alias "
+              "with leading batch dim "
+           << dstBatch << " (only unit batch dim is supported)";
+
+  auto layoutShape = dstTy.getShape().take_back(encRank);
+
+  // Step 1: reinterpret base to [ratio, ...layoutShape] in dstTy's encoding.
+  SmallVector<int64_t> intermediateShape;
+  intermediateShape.reserve(encRank + 1);
+  intermediateShape.push_back(ratio);
+  intermediateShape.append(layoutShape.begin(), layoutShape.end());
+  auto intermediateTy = ttg::MemDescType::get(
+      intermediateShape, dstTy.getElementType(), dstTy.getEncoding(),
+      dstTy.getMemorySpace(), dstTy.getMutableMemory(), intermediateShape);
+  Value intermediate =
+      ttg::MemDescReinterpretOp::create(builder, loc, intermediateTy, base)
+          .getResult();
+
+  // Step 2: drop the ratio dim with memdesc_index[0]; result is a fresh
+  // descriptor of shape == layoutShape.
+  SmallVector<int64_t> slotShape(layoutShape.begin(), layoutShape.end());
+  auto slotTy = ttg::MemDescType::get(
+      slotShape, dstTy.getElementType(), dstTy.getEncoding(),
+      dstTy.getMemorySpace(), dstTy.getMutableMemory(), slotShape);
+  Value zero = arith::ConstantIntOp::create(builder, loc, /*value=*/0,
+                                            /*width=*/32);
+  Value slot =
+      ttg::MemDescIndexOp::create(builder, loc, slotTy, intermediate, zero)
+          .getResult();
+
+  // Step 3: if dstTy has a leading unit batch dim, reattach it via a
+  // same-size reinterpret. Otherwise the slot is already the destination.
+  if (dstRank == (int64_t)encRank)
+    return slot;
+  return Value(
+      ttg::MemDescReinterpretOp::create(builder, loc, dstTy, slot).getResult());
+}
+
+} // namespace
 
 LogicalResult rewriteLocalAlias(ModuleOp m) {
   // Build a closure of all local_alloc and local_alias ops that share the same
@@ -166,14 +280,14 @@ LogicalResult rewriteLocalAlias(ModuleOp m) {
       });
 
       builder.setInsertionPoint(baseAllocOp);
-      auto newAllocType =
-          dyn_cast<ttg::MemDescType>(newAllocOp->getResult(0).getType());
       auto baseAllocType =
           dyn_cast<ttg::MemDescType>(baseAllocOp->getResult(0).getType());
-      auto newAllocToBaseAllocOp = builder.create<ttg::MemDescReinterpretOp>(
-          baseAllocOp->getLoc(), baseAllocType, newAllocOp->getResult(0));
-      baseAllocOp->getResult(0).replaceAllUsesWith(
-          newAllocToBaseAllocOp.getResult());
+      FailureOr<Value> newAllocToBaseAlloc =
+          emitAliasView(builder, baseAllocOp, baseAllocOp->getLoc(),
+                        newAllocOp->getResult(0), baseAllocType);
+      if (failed(newAllocToBaseAlloc))
+        return failure();
+      baseAllocOp->getResult(0).replaceAllUsesWith(*newAllocToBaseAlloc);
       baseAllocOp->erase();
       baseAllocOp = newAllocOp;
     }
@@ -187,10 +301,13 @@ LogicalResult rewriteLocalAlias(ModuleOp m) {
         aliasOp->dump();
       });
       builder.setInsertionPoint(aliasOp);
-      auto aliasType = aliasOp.getResult().getType();
-      auto baseAllocToAliasOp = builder.create<ttg::MemDescReinterpretOp>(
-          baseAllocOp->getLoc(), aliasType, baseAllocOp->getResult(0));
-      aliasOp.getResult().replaceAllUsesWith(baseAllocToAliasOp.getResult());
+      auto aliasType = cast<ttg::MemDescType>(aliasOp.getResult().getType());
+      FailureOr<Value> baseAllocToAlias =
+          emitAliasView(builder, aliasOp, baseAllocOp->getLoc(),
+                        baseAllocOp->getResult(0), aliasType);
+      if (failed(baseAllocToAlias))
+        return failure();
+      aliasOp.getResult().replaceAllUsesWith(*baseAllocToAlias);
       aliasOp->erase();
     }
   }


### PR DESCRIPTION
Upstream PR #10243 tightened MemDescReinterpretOp::verify to require src and dst to have the same logical storage size. The TLX local_alloc(reuse=) lowering routinely produces aliases that view only part of a larger backing buffer (e.g. a 1x32x32xbf16 view over a 2x32x128xf16 alloc), which the pass previously emitted as a single undersized reinterpret -- now invalid IR.

Emit the alias as a base-sized reinterpret to [ratio, ...layoutShape] in the alias's encoding, then memdesc_index[0] to obtain a fresh descriptor, then a same-size reinterpret to reattach the alias's leading unit batch dim. memdesc_index produces allocShape == shape so downstream consumers (notably tlx.local_view -> memdesc_index) still verify.

Cases the recipe cannot express -- non-shared memory, non-divisor sizes, or non-unit destination batch dims -- now emit clean emitDiagnostic errors instead of crashing or producing invalid IR. The TMEM tcgen5_fa_kernel XFAIL stays XFAIL; lifting it needs an upstream relaxation of memdesc_index's no-subview rule (or a dedicated overlay op).