### PR TITLE
[Triton] Allow local-only init_barrier in non-entry blocks under cluster mode

### DIFF
--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -163,9 +163,20 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
 
 // -----
 
-// Test that a local-only barrier init in a non-first block triggers an error
-// when remote barriers exist elsewhere in the module. The remote barrier is
-// in the first block, but the local init inside the WS region is not allowed.
+// Test that a *local-only* barrier init in a non-first block is ALLOWED,
+// even when remote barriers exist elsewhere in the module. The local
+// barrier (%4) is only used by init+arrive in the same partition body and
+// never reaches a cross-CTA op, so it does not require entry-block
+// placement for cluster-sync correctness. (The remote barrier %1 in the
+// entry block still anchors the cluster_arrive/cluster_wait insertion.)
+// This pattern is emitted by `SyncMMALowering` around `tc_gen5_mma`, so
+// rejecting it here would break the standard MMA-to-async lowering.
+// CHECK-LABEL: @local_bar_init_non_first_block_with_remote
+//       CHECK: mbarrier.init.shared::cta.b64
+//       CHECK: nvvm.cluster.arrive {aligned}
+//       CHECK: nvvm.cluster.wait {aligned}
+//       CHECK: nvvm.mapa
+//       CHECK: mbarrier.init.shared::cta.b64
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
@@ -176,16 +187,15 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    ttg.warp_specialize(%0)
+    ttg.warp_specialize(%0) attributes {warpGroupStartIds = array<i32: 4>}
     default {
       ttg.warp_yield
     }
     partition0(%arg0: !ttg.memdesc<1xi64, #shared, #smem, mutable>) num_warps(4) {
-      // Local-only barrier init in non-first block should error
+      // Local-only barrier init in non-first block — now allowed.
       %3 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
       %c0 = arith.constant 0 : i32
       %4 = ttg.memdesc_index %3[%c0] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-      // expected-error @+1 {{Barrier init outside of the first block in function is not supported}}
       ttng.init_barrier %4, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
       ttng.arrive_barrier %4, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
       ttg.warp_return
@@ -536,6 +546,60 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
        !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
        !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
        !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Regression test for the SyncMMALowering pattern: each call lowered from
+// sync `MMAv5OpInterface` op gets wrapped with an inline
+// `local_alloc + init_barrier + setIsAsync + wait_barrier + inval_barrier`
+// fence at the source location. When that source location is inside a
+// `warp_specialize` partition body, the inline `init_barrier` sits in a
+// non-first block. The fence barrier is purely intra-CTA — never reaches a
+// cross-CTA op — so the verifier must NOT reject it just because the
+// surrounding kernel is clustered. (Pre-fix, this errored with "Barrier
+// init outside of the first block in function is not supported for CTA
+// clusters" because the verifier collected every init_barrier regardless of
+// whether it participated in cluster sync.)
+// CHECK-LABEL: @sync_mma_lowering_inline_fence_in_partition
+//       CHECK: mbarrier.init.shared::cta.b64
+//       CHECK: nvvm.cluster.arrive {aligned}
+//       CHECK: nvvm.cluster.wait {aligned}
+//       CHECK: nvvm.mapa
+//       CHECK: mbarrier.init.shared::cta.b64
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  tt.func public @sync_mma_lowering_inline_fence_in_partition() attributes {noinline = false} {
+    // Remote barrier in entry block — keeps cluster_arrive/wait insertion path active.
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      // SyncMMALowering's inline fence pattern: alloc + init + arrive + wait
+      // + inval, all in the partition body. Pre-fix: init_barrier here
+      // would fail `ensureEarlyBarInit` since it's not in the function
+      // entry block. Post-fix: allowed because the barrier %fence is purely
+      // intra-CTA (never used by a cross-CTA op).
+      %fence_alloc = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      %c0 = arith.constant 0 : i32
+      %fence = ttg.memdesc_index %fence_alloc[%c0] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttng.init_barrier %fence, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttng.arrive_barrier %fence, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      %phase = arith.constant 0 : i32
+      %true = arith.constant true
+      ttng.wait_barrier %fence, %phase, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttng.inval_barrier %fence : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttg.warp_return
+    } : () -> ()
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -358,17 +358,22 @@ private:
       return success();
     }
 
-    bool hasRemoteBar = false;
-    // Find if we have a remote bar
+    // Collect the actual barrier Values that participate in cross-CTA ops
+    // (not just a boolean "has remote bar"). We need these to identify which
+    // `init_barrier` ops correspond to *cross-CTA* barriers — only those need
+    // to live in the entry block for cluster sync correctness. Pure-local
+    // barriers (e.g., the inline fence barriers `SyncMMALowering` emits
+    // around `tc_gen5_mma`) never participate in cluster sync and can live
+    // anywhere.
+    SetVector<Value> remoteBarValues;
     mod.walk([&](Operation *op) {
-      SetVector<Operation *> ops;
       auto remoteBar = getRemoteBarrier(op);
       if (remoteBar.has_value()) {
-        hasRemoteBar = true;
-        return WalkResult::interrupt();
+        for (Value v : *remoteBar)
+          remoteBarValues.insert(v);
       }
-      return WalkResult::advance();
     });
+    bool hasRemoteBar = !remoteBarValues.empty();
 
     // If we have remote mbar/SMEM access, or if we have 2cta TMEM allocation,
     // we need a cluster sync after mbar init and before TMEM alloc
@@ -377,10 +382,44 @@ private:
       return success();
     }
 
-    // Find all bar init ops
+    // Walk back through single-operand memdesc-view ops (memdesc_index,
+    // memdesc_subview, memdesc_trans, tmem_subslice, ...) to find the
+    // originating `local_alloc` for a barrier-typed Value. Returns nullptr
+    // if the chain reaches a block argument or unknown op.
+    auto findAllocOf = [](Value v) -> Operation * {
+      while (Operation *defOp = v.getDefiningOp()) {
+        if (isa<ttg::LocalAllocOp>(defOp))
+          return defOp;
+        if (defOp->getNumOperands() == 0)
+          return nullptr;
+        v = defOp->getOperand(0);
+      }
+      return nullptr;
+    };
+
+    // The set of `local_alloc` ops backing the cross-CTA barriers.
+    SetVector<Operation *> remoteAllocs;
+    for (Value v : remoteBarValues) {
+      if (auto alloc = findAllocOf(v))
+        remoteAllocs.insert(alloc);
+    }
+
+    // Find init_barrier ops. If we have cross-CTA barriers, only collect the
+    // init_barriers backing those barriers — `SyncMMALowering`'s inline fence
+    // barriers (used only intra-CTA around `tc_gen5_mma`) are excluded so
+    // they don't trigger `ensureEarlyBarInit`. For the rare 2cta-TMEM-only
+    // case (no remote barriers), fall back to collecting all init_barriers to
+    // preserve the existing cluster-sync placement heuristic.
     SetVector<Operation *> remoteOrLocalBarInitOps;
     mod.walk([&](ttng::InitBarrierOp barInitOp) {
-      remoteOrLocalBarInitOps.insert(barInitOp);
+      if (remoteAllocs.empty()) {
+        remoteOrLocalBarInitOps.insert(barInitOp);
+        return;
+      }
+      if (auto alloc = findAllocOf(barInitOp.getAlloc())) {
+        if (remoteAllocs.count(alloc))
+          remoteOrLocalBarInitOps.insert(barInitOp);
+      }
     });
 
     // It's almost impossible for a clustered kernel to not have any mbar but


### PR DESCRIPTION
Summary:
D105023652 ("[TLX] Unify cluster sync attempt 2") added a verifier in `maybeInsertClusterSync` that rejects any `ttng.init_barrier` op not in the function's entry block when running in cluster mode. The verifier walks all `init_barrier` ops indiscriminately and applies the entry-block requirement to every one of them.

The intent of the check is to make sure `scf.condition`-style cluster sync can be inserted after the last barrier init that *participates in cluster coordination* (cross-CTA arrivals, multicast TMA mbar signals, 2cta MMA commits, etc.). But the check also rejects barriers that are purely intra-CTA and never reach a cross-CTA op — and one such pattern is generated by the compiler itself: `SyncMMALowering` (in `lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp`) wraps every synchronous `MMAv5OpInterface` op (e.g. `tc_gen5_mma`) with an inline `local_alloc + init_barrier + setIsAsync + wait_barrier + inval_barrier` fence at the op's source location. When the MMA sits inside a `warp_specialize` partition body — the standard pattern for TLX kernels — the inline `init_barrier` lands in a non-first block, and the verifier rejects it with `Barrier init outside of the first block in function is not supported for CTA clusters`. The compiler-emitted fence barrier is single-use, intra-CTA, and never participates in cluster sync, so it has no reason to be in the entry block.

This change tightens the verifier so it only requires entry-block placement for barriers that are actually reachable from a cross-CTA op. We collect cross-CTA barrier values up front using the existing `getRemoteBarrier` helper (which already identifies barriers used by `MapToRemoteBufferOp`, multicast TMA, `AsyncCLCTryCancelOp`, `TCGen5CommitOp`, and 2cta `TMEMCopyOp` / `MMAv5OpInterface`), walk back through single-operand memdesc-view ops (`memdesc_index`, `memdesc_subview`, etc.) to their originating `LocalAllocOp`, and only include `init_barrier` ops backing those allocs in the entry-block check.

For the rare 2cta-TMEM-only case (no cross-CTA barriers but `tlxEnablePairedMMA`), we fall back to collecting every `init_barrier` so the existing cluster-sync placement heuristic still finds an anchor.

This fixes the `Barrier init outside of the first block` error on TLX kernels that use `tc_gen5_mma` inside `warp_specialize` partitions (e.g. the BWD GDPA kernels) without requiring kernel-side changes or moving the inline fence pattern out of `SyncMMALowering`.

Updates the existing lit test `local_bar_init_non_first_block_with_remote` to reflect the new policy (the previously-expected error no longer fires for the local-only barrier inside the partition) and adds a new regression test `sync_mma_lowering_inline_fence_in_partition` that mirrors the exact `SyncMMALowering`-emitted pattern (`local_alloc + init + arrive + wait + inval` in a non-entry block) under a clustered 2cta module.

Authored with Claude.

Differential Revision: D106142078


