### PR TITLE
[TLX][AMD] Fix TypeID crash for anonymous-namespace lattice classes in Ins…

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -138,6 +138,7 @@ private:
 
 class DotRewriteLattice : public Lattice<DotRewriteState> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DotRewriteLattice)
   using Lattice::Lattice;
 };
 
@@ -522,6 +523,7 @@ private:
 
 class DotConsumerLattice : public Lattice<DotConsumerState> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DotConsumerLattice)
   using Lattice::Lattice;
 };
 


### PR DESCRIPTION
…ertRequireLayout

Summary: Fix `LLVM ERROR: TypeID::get<mlir::triton::tlx::(anonymous namespace)::DotRewriteLattice>(): Using TypeID on a class with an anonymous namespace requires an explicit TypeID definition` crash when running the `TLXInsertRequireLayout` pass on AMD (gfx950) targets.

Add `MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID` to `DotRewriteLattice` and `DotConsumerLattice`, which are defined in anonymous namespaces and require explicit TypeID registration per MLIR conventions.

