### PR TITLE
[TLX][AMD] Port InsertRequireLayout backward dataflow rewrite from tlx-amd-meta

### DIFF
--- a/test/TLX/insert-require-layout-pipeline-fallback.mlir
+++ b/test/TLX/insert-require-layout-pipeline-fallback.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt -split-input-file --tlx-insert-require-layout --tlx-propagate-layout %s | FileCheck %s
+
+// Test that when the combined insert+propagate pipeline cannot make all tensor
+// carrier predecessors agree on a concrete layout, it stays valid by keeping an
+// explicit layout conversion instead of retagging the carrier.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @conflicting_scf_if_result_types
+  tt.func public @conflicting_scf_if_result_types(%cond: i1) -> tensor<64x64xf32, #mma> {
+    %c0_i32 = arith.constant 0 : i32
+    %zero_a = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #blocked>
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared, #smem, mutable>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared, #smem, mutable>
+    // CHECK: scf.if {{.*}} -> (tensor<64x32xf16, #blocked>)
+    %if_a = scf.if %cond -> (tensor<64x32xf16, #blocked>) {
+      // CHECK: ttg.local_load {{.*}} -> tensor<64x32xf16, #blocked>
+      %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared, #smem, mutable> -> tensor<64x32xf16, #blocked>
+      scf.yield %a : tensor<64x32xf16, #blocked>
+    } else {
+      scf.yield %zero_a : tensor<64x32xf16, #blocked>
+    }
+    %b = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared, #smem, mutable> -> tensor<32x64xf16, #blocked>
+    // CHECK: %[[A_DOT:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot = ttg.convert_layout %if_a : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %b_dot = ttg.convert_layout %b : tensor<32x64xf16, #blocked> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_DOT]], %{{.*}}, %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %cst : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>> -> tensor<64x64xf32, #mma>
+    tt.return %dot : tensor<64x64xf32, #mma>
+  }
+}
+
+// -----
+// Test that when tensor propagation through an scf.for carrier cannot make the
+// init value and the backedge agree, the pipeline keeps an explicit layout
+// conversion instead of retagging the loop-carried tensor.
+
+#blocked_for = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_for = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_for = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_for = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @conflicting_scf_for_iter_arg_types
+  tt.func public @conflicting_scf_for_iter_arg_types() -> tensor<64x64xf32, #mma_for> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c0_i32 = arith.constant 0 : i32
+    %zero_a = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #blocked_for>
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_for>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_for, #smem_for, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared_for, #smem_for, mutable>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_for, #smem_for, mutable> -> !ttg.memdesc<64x32xf16, #shared_for, #smem_for, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_for, #smem_for, mutable> -> !ttg.memdesc<32x64xf16, #shared_for, #smem_for, mutable>
+    // CHECK: scf.for {{.*}} iter_args(%[[A_ARG:.*]] = %{{.*}}) -> (tensor<64x32xf16, #blocked>)
+    %loop_a = scf.for %i = %c0 to %c2 step %c1 iter_args(%a_reg = %zero_a) -> (tensor<64x32xf16, #blocked_for>) {
+      // CHECK: ttg.local_load {{.*}} -> tensor<64x32xf16, #blocked>
+      %a_next = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared_for, #smem_for, mutable> -> tensor<64x32xf16, #blocked_for>
+      scf.yield %a_next : tensor<64x32xf16, #blocked_for>
+    }
+    // CHECK: %[[B_LOAD:.*]] = ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %b = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared_for, #smem_for, mutable> -> tensor<32x64xf16, #blocked_for>
+    // CHECK: %[[A_DOT:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot = ttg.convert_layout %loop_a : tensor<64x32xf16, #blocked_for> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_for, kWidth = 4}>>
+    %b_dot = ttg.convert_layout %b : tensor<32x64xf16, #blocked_for> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_for, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_DOT]], %[[B_LOAD]], %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %cst : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_for, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_for, kWidth = 4}>> -> tensor<64x64xf32, #mma_for>
+    tt.return %dot : tensor<64x64xf32, #mma_for>
+  }
+}

--- a/test/TLX/insert-require-layout-propagate.mlir
+++ b/test/TLX/insert-require-layout-propagate.mlir
@@ -1,0 +1,263 @@
+// RUN: triton-opt --split-input-file --tlx-insert-require-layout --tlx-propagate-layout %s | FileCheck %s
+// RUN: triton-opt --split-input-file --tritongpu-remove-layout-conversions %s | FileCheck %s --check-prefix=UPSTREAM
+
+// Test 1: direct local_load -> dot path.
+// After both passes, the shared layout requirement should be propagated onto
+// the memdesc producer chain and the local_load results should carry the final
+// dot operand encodings directly.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @local_store_local_load_dot
+  tt.func public @local_store_local_load_dot(%arg0: !tt.ptr<f16>, %arg1: tensor<64x32x!tt.ptr<f16>, #blocked>, %arg2: tensor<32x64x!tt.ptr<f16>, #blocked>) -> tensor<64x64xf32, #mma> {
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
+    %a_val = tt.load %arg1 : tensor<64x32x!tt.ptr<f16>, #blocked>
+    %b_val = tt.load %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked>
+    ttg.local_store %a_val, %buf_a : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
+    ttg.local_store %b_val, %buf_b : tensor<32x64xf16, #blocked> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
+    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %{{.*}} : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared, #smem, mutable> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK: %[[B_LOAD:.*]] = ttg.local_load %{{.*}} : !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %b = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared1, #smem, mutable> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
+    %acc = ttg.convert_layout %cst : tensor<64x64xf32, #blocked> -> tensor<64x64xf32, #mma>
+    %a_dot = ttg.convert_layout %a : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %b_dot = ttg.convert_layout %b : tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_LOAD]], %[[B_LOAD]], %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>> -> tensor<64x64xf32, #mma>
+    tt.return %dot : tensor<64x64xf32, #mma>
+  }
+}
+
+// -----
+// Test 2: local_load feeds scf.for iter_args that eventually reach a dot.
+// The TLX pipeline should rewrite the prologue and loop-body loads and make the
+// loop carry the final dot encodings directly. For comparison, the upstream
+// remove-layout-conversions pass still leaves explicit dot converts on the
+// loop-carried values.
+
+#blocked_1 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_1 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#smem_1 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // UPSTREAM-LABEL: @local_load_through_iter_arg
+  // UPSTREAM: scf.for {{.*}} iter_args({{.*}}, %[[ARG_A:.*]] = %{{.*}}, %[[ARG_B:.*]] = %{{.*}}) -> (tensor<64x64xf32, #mma>, tensor<64x32xf16, #blocked>, tensor<32x64xf16, #blocked>)
+  // UPSTREAM: %[[A_CVT:.*]] = ttg.convert_layout %[[ARG_A]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+  // UPSTREAM: %[[B_CVT:.*]] = ttg.convert_layout %[[ARG_B]] : tensor<32x64xf16, #blocked> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+  // UPSTREAM: tt.dot %[[A_CVT]], %[[B_CVT]], %{{.*}}
+  // CHECK-LABEL: @local_load_through_iter_arg
+  tt.func public @local_load_through_iter_arg(%arg0: !tt.ptr<f16>) -> tensor<64x64xf32, #mma_1> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_1>
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x64x32xf16, #shared_1, #smem_1, mutable>
+    %buf0 = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<2x64x32xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable>
+    // CHECK: %[[PROLOGUE_A:.*]] = ttg.local_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_init = ttg.local_load %buf0 : !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable> -> tensor<64x32xf16, #blocked_1>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x32x64xf16, #shared_1, #smem_1, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<2x32x64xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable>
+    // CHECK: %[[PROLOGUE_B:.*]] = ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %b_init = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable> -> tensor<32x64xf16, #blocked_1>
+    // CHECK: scf.for {{.*}} iter_args({{.*}} = {{.*}}, %[[ARG_A:.*]] = %[[PROLOGUE_A]], %[[ARG_B:.*]] = %[[PROLOGUE_B]])
+    %result:3 = scf.for %i = %c0_i32 to %c4_i32 step %c1_i32
+        iter_args(%acc = %cst, %a_reg = %a_init, %b_reg = %b_init)
+        -> (tensor<64x64xf32, #mma_1>, tensor<64x32xf16, #blocked_1>, tensor<32x64xf16, #blocked_1>) : i32 {
+      // CHECK: tt.dot %[[ARG_A]], %[[ARG_B]]
+      %a_cvt = ttg.convert_layout %a_reg : tensor<64x32xf16, #blocked_1> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_1, kWidth = 4}>>
+      %b_cvt = ttg.convert_layout %b_reg : tensor<32x64xf16, #blocked_1> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_1, kWidth = 4}>>
+      %dot = tt.dot %a_cvt, %b_cvt, %acc : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_1, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_1, kWidth = 4}>> -> tensor<64x64xf32, #mma_1>
+      %buf_next = ttg.memdesc_index %alloc[%c1_i32] : !ttg.memdesc<2x64x32xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable>
+      // CHECK: ttg.local_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+      %a_next = ttg.local_load %buf_next : !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable> -> tensor<64x32xf16, #blocked_1>
+      %buf_b_next = ttg.memdesc_index %alloc_b[%c1_i32] : !ttg.memdesc<2x32x64xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable>
+      // CHECK: ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+      %b_next = ttg.local_load %buf_b_next : !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable> -> tensor<32x64xf16, #blocked_1>
+      scf.yield %dot, %a_next, %b_next : tensor<64x64xf32, #mma_1>, tensor<64x32xf16, #blocked_1>, tensor<32x64xf16, #blocked_1>
+    }
+    tt.return %result#0 : tensor<64x64xf32, #mma_1>
+  }
+}
+
+// -----
+// Test 3: local_load inside scf.if branches.
+// When all predecessors can agree, the TLX pipeline should rewrite the
+// branch-carried values to the final dot encodings and remove the need for a
+// downstream conversion on the scf.if results. For comparison, the upstream
+// remove-layout-conversions pass still leaves both dot operand converts after
+// the scf.if.
+
+#blocked_2 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_2 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#smem_2 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // UPSTREAM-LABEL: @local_load_through_scf_if
+  // UPSTREAM: %[[IF_RESULT:.*]]:2 = scf.if {{.*}} -> (tensor<64x32xf16, #blocked>, tensor<32x64xf16, #blocked>)
+  // UPSTREAM: %[[A_CVT:.*]] = ttg.convert_layout %[[IF_RESULT]]#0 : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+  // UPSTREAM: %[[B_CVT:.*]] = ttg.convert_layout %[[IF_RESULT]]#1 : tensor<32x64xf16, #blocked> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+  // UPSTREAM: tt.dot %[[A_CVT]], %[[B_CVT]], %{{.*}}
+  // CHECK-LABEL: @local_load_through_scf_if
+  tt.func public @local_load_through_scf_if(%arg0: !tt.ptr<f16>, %cond: i1) -> tensor<64x64xf32, #mma_2> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_2>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x64x32xf16, #shared_2, #smem_2, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x32x64xf16, #shared_2, #smem_2, mutable>
+    %buf_a0 = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<2x64x32xf16, #shared_2, #smem_2, mutable> -> !ttg.memdesc<64x32xf16, #shared_2, #smem_2, mutable>
+    %buf_b0 = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<2x32x64xf16, #shared_2, #smem_2, mutable> -> !ttg.memdesc<32x64xf16, #shared_2, #smem_2, mutable>
+    %buf_a1 = ttg.memdesc_index %alloc_a[%c1_i32] : !ttg.memdesc<2x64x32xf16, #shared_2, #smem_2, mutable> -> !ttg.memdesc<64x32xf16, #shared_2, #smem_2, mutable>
+    %buf_b1 = ttg.memdesc_index %alloc_b[%c1_i32] : !ttg.memdesc<2x32x64xf16, #shared_2, #smem_2, mutable> -> !ttg.memdesc<32x64xf16, #shared_2, #smem_2, mutable>
+    // CHECK: scf.if {{.*}} -> (tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>)
+    %if_result:2 = scf.if %cond -> (tensor<64x32xf16, #blocked_2>, tensor<32x64xf16, #blocked_2>) {
+      // CHECK: ttg.local_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+      %a = ttg.local_load %buf_a0 : !ttg.memdesc<64x32xf16, #shared_2, #smem_2, mutable> -> tensor<64x32xf16, #blocked_2>
+      // CHECK: ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+      %b = ttg.local_load %buf_b0 : !ttg.memdesc<32x64xf16, #shared_2, #smem_2, mutable> -> tensor<32x64xf16, #blocked_2>
+      // CHECK: scf.yield {{.*}} : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+      scf.yield %a, %b : tensor<64x32xf16, #blocked_2>, tensor<32x64xf16, #blocked_2>
+    } else {
+      // CHECK: ttg.local_load {{.*}} -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+      %a = ttg.local_load %buf_a1 : !ttg.memdesc<64x32xf16, #shared_2, #smem_2, mutable> -> tensor<64x32xf16, #blocked_2>
+      // CHECK: ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+      %b = ttg.local_load %buf_b1 : !ttg.memdesc<32x64xf16, #shared_2, #smem_2, mutable> -> tensor<32x64xf16, #blocked_2>
+      // CHECK: scf.yield {{.*}} : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+      scf.yield %a, %b : tensor<64x32xf16, #blocked_2>, tensor<32x64xf16, #blocked_2>
+    }
+    // CHECK: tt.dot %{{.*}}#0, %{{.*}}#1, %{{.*}}
+    %a_cvt = ttg.convert_layout %if_result#0 : tensor<64x32xf16, #blocked_2> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_2, kWidth = 4}>>
+    %b_cvt = ttg.convert_layout %if_result#1 : tensor<32x64xf16, #blocked_2> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_2, kWidth = 4}>>
+    %dot = tt.dot %a_cvt, %b_cvt, %cst : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_2, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_2, kWidth = 4}>> -> tensor<64x64xf32, #mma_2>
+    tt.return %dot : tensor<64x64xf32, #mma_2>
+  }
+}
+
+// -----
+// Test 4: user-specified order=[0,1] on the source memdesc survives the full
+// insert+propagate pipeline. The resulting local_loads should carry the final
+// dot operand encodings directly, while the rewritten shared encodings preserve
+// the source order contract.
+
+#blocked_3 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_3 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [32, 32, 16], isTransposed = true}>
+#shared_k_contig_3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared_default_3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #[[$SHARED_M:.*]] = #ttg.swizzled_shared<{vec = 8, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+// CHECK-DAG: #[[$SHARED_K:.*]] = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [0, 1]}>
+#smem_3 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @user_specified_order_preserved_pipeline
+  tt.func public @user_specified_order_preserved_pipeline() -> tensor<128x128xf32, #mma_3> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma_3>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x128x64xf16, #shared_default_3, #smem_3, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared_k_contig_3, #smem_3, mutable>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared_default_3, #smem_3, mutable> -> !ttg.memdesc<128x64xf16, #shared_default_3, #smem_3, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared_k_contig_3, #smem_3, mutable> -> !ttg.memdesc<64x128xf16, #shared_k_contig_3, #smem_3, mutable>
+    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %{{.*}} : !ttg.memdesc<128x64xf16, #[[$SHARED_M]], #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<128x64xf16, #shared_default_3, #smem_3, mutable> -> tensor<128x64xf16, #blocked_3>
+    // CHECK: %[[B_LOAD:.*]] = ttg.local_load %{{.*}} : !ttg.memdesc<64x128xf16, #[[$SHARED_K]], #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    %b = ttg.local_load %buf_b : !ttg.memdesc<64x128xf16, #shared_k_contig_3, #smem_3, mutable> -> tensor<64x128xf16, #blocked_3>
+    %a_dot = ttg.convert_layout %a : tensor<128x64xf16, #blocked_3> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_3, kWidth = 8}>>
+    %b_dot = ttg.convert_layout %b : tensor<64x128xf16, #blocked_3> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_3, kWidth = 8}>>
+    // CHECK: tt.dot %[[A_LOAD]], %[[B_LOAD]], %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %cst : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_3, kWidth = 8}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_3, kWidth = 8}>> -> tensor<128x128xf32, #mma_3>
+    tt.return %dot : tensor<128x128xf32, #mma_3>
+  }
+}
+
+// -----
+// Test 5: one local_load feeds both a dot path and a sibling non-dot path.
+// The full pipeline should keep the mixed-use load in its original blocked
+// layout, preserve the sibling conversion, and only propagate the clean dot-use
+// load to the final dot encoding.
+
+#blocked_4 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_4_alt = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mma_4 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_4 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_4 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @mixed_use_local_load_pipeline_fallback
+  tt.func public @mixed_use_local_load_pipeline_fallback() -> tensor<64x64xf32, #mma_4> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked_4>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared_4, #smem_4, mutable>
+    %alloc_sink = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable>
+    // CHECK: %[[DESC_A:.*]] = ttg.memdesc_index
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<32x64xf16, #shared_4, #smem_4, mutable>
+    %buf_sink = ttg.memdesc_index %alloc_sink[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
+    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %[[DESC_A]] : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #blocked>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable> -> tensor<64x32xf16, #blocked_4>
+    // CHECK: %[[A_ALT:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #{{.*}}>
+    %a_alt = ttg.convert_layout %a : tensor<64x32xf16, #blocked_4> -> tensor<64x32xf16, #blocked_4_alt>
+    // CHECK: ttg.local_store %[[A_ALT]], %{{.*}}
+    ttg.local_store %a_alt, %buf_sink : tensor<64x32xf16, #blocked_4_alt> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
+    // CHECK: %[[B_LOAD:.*]] = ttg.local_load %{{.*}} : !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %b = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared_4, #smem_4, mutable> -> tensor<32x64xf16, #blocked_4>
+    %acc = ttg.convert_layout %cst : tensor<64x64xf32, #blocked_4> -> tensor<64x64xf32, #mma_4>
+    // CHECK: %[[A_DOT:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot = ttg.convert_layout %a : tensor<64x32xf16, #blocked_4> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_4, kWidth = 4}>>
+    %b_dot = ttg.convert_layout %b : tensor<32x64xf16, #blocked_4> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_4, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_DOT]], %[[B_LOAD]], %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_4, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_4, kWidth = 4}>> -> tensor<64x64xf32, #mma_4>
+    tt.return %dot : tensor<64x64xf32, #mma_4>
+  }
+}
+
+// -----
+// Test 6: one local_load feeds two dot paths that demand different dot operand
+// encodings. The full pipeline should keep the A-side local_load blocked and
+// lower the residual tensor constraints to two explicit convert_layout bridges.
+
+#blocked_5 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_5 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#mma_5_alt = #ttg.amd_mfma<{version = 3, warpsPerCTA = [1, 4], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_5 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_5 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @conflicting_dot_operands_pipeline_fallback
+  tt.func public @conflicting_dot_operands_pipeline_fallback() -> tensor<64x64xf32, #mma_5> {
+    %c0_i32 = arith.constant 0 : i32
+    %acc0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_5>
+    %acc1 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_5_alt>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_5, #smem_5, mutable>
+    %alloc_b0 = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable>
+    %alloc_b1 = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_5, #smem_5, mutable> -> !ttg.memdesc<64x32xf16, #shared_5, #smem_5, mutable>
+    %buf_b0 = ttg.memdesc_index %alloc_b0[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable> -> !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable>
+    %buf_b1 = ttg.memdesc_index %alloc_b1[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable> -> !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable>
+    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %{{.*}} : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #blocked>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared_5, #smem_5, mutable> -> tensor<64x32xf16, #blocked_5>
+    %b0 = ttg.local_load %buf_b0 : !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable> -> tensor<32x64xf16, #blocked_5>
+    %b1 = ttg.local_load %buf_b1 : !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable> -> tensor<32x64xf16, #blocked_5>
+    // CHECK: %[[A_DOT0:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot0 = ttg.convert_layout %a : tensor<64x32xf16, #blocked_5> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5, kWidth = 4}>>
+    %b_dot0 = ttg.convert_layout %b0 : tensor<32x64xf16, #blocked_5> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5, kWidth = 4}>>
+    // CHECK: %[[A_DOT1:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 4}>>
+    %a_dot1 = ttg.convert_layout %a : tensor<64x32xf16, #blocked_5> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5_alt, kWidth = 4}>>
+    %b_dot1 = ttg.convert_layout %b1 : tensor<32x64xf16, #blocked_5> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5_alt, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_DOT0]], %{{.*}}, %{{.*}}
+    %dot0 = tt.dot %a_dot0, %b_dot0, %acc0 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5, kWidth = 4}>> -> tensor<64x64xf32, #mma_5>
+    // CHECK: tt.dot %[[A_DOT1]], %{{.*}}, %{{.*}}
+    %dot1 = tt.dot %a_dot1, %b_dot1, %acc1 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5_alt, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5_alt, kWidth = 4}>> -> tensor<64x64xf32, #mma_5_alt>
+    %dot1_to_mma0 = ttg.convert_layout %dot1 : tensor<64x64xf32, #mma_5_alt> -> tensor<64x64xf32, #mma_5>
+    %sum = arith.addf %dot0, %dot1_to_mma0 : tensor<64x64xf32, #mma_5>
+    tt.return %sum : tensor<64x64xf32, #mma_5>
+  }
+}

--- a/test/TLX/insert-require-layout.mlir
+++ b/test/TLX/insert-require-layout.mlir
@@ -1,37 +1,264 @@
-// RUN: triton-opt -split-input-file --tlx-insert-require-layout %s| FileCheck %s
+// RUN: triton-opt -split-input-file --tlx-insert-require-layout %s | FileCheck %s
+
+// Test 1: direct local_load -> convert_layout -> dot.
+// InsertRequireLayout should synthesize explicit memdesc and tensor TLX
+// constraints, but it should not retag the local_load result directly.
 
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
-#loc = loc("/home/kmanivannan/fb-triton/python/test/unit/language/test_tlx.py":158:0)
-#mma = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [32, 32], isTransposed = true}>
+#mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
-// CHECK-DAG: #[[shared2:.*]] = #ttg.swizzled_shared<{{.*}}>
-// CHECK-DAG: #[[shared3:.*]] = #ttg.swizzled_shared<{{.*}}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @local_store_local_load_dot
   tt.func public @local_store_local_load_dot(%arg0: !tt.ptr<f16>, %arg1: tensor<64x32x!tt.ptr<f16>, #blocked>, %arg2: tensor<32x64x!tt.ptr<f16>, #blocked>) -> tensor<64x64xf32, #mma> {
-    %24 = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable>
-    %25 = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable>
     %c0_i32 = arith.constant 0 : i32
     %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
-    // CHECK: %[[mem_desc1:.*]] = ttg.memdesc_index %{{.*}}
-    %26 = ttg.memdesc_index %24[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
-    // CHECK: %[[mem_desc2:.*]] = ttg.memdesc_index %{{.*}}
-    %27 = ttg.memdesc_index %25[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
-    %28 = tt.load %arg1 : tensor<64x32x!tt.ptr<f16>, #blocked>
-    %29 = tt.load %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked>
-    ttg.local_store %28, %26 : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
-    ttg.local_store %29, %27 : tensor<32x64xf16, #blocked> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
-    // CHECK: %[[req_layout_1:.*]] = tlx.require_layout %[[mem_desc1]] : !ttg.memdesc<64x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x32xf16, #[[shared2]], #smem, mutable>
-    // CHECK: ttg.local_load %[[req_layout_1]]
-    %30 = ttg.local_load %26 : !ttg.memdesc<64x32xf16, #shared, #smem, mutable> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
-    // CHECK: %[[req_layout_2:.*]] = tlx.require_layout %[[mem_desc2]] : !ttg.memdesc<32x64xf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x64xf16, #[[shared3]], #smem, mutable>
-    // CHECK: ttg.local_load %[[req_layout_2]]
-    %31 = ttg.local_load %27 : !ttg.memdesc<32x64xf16, #shared1, #smem, mutable> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
-    %32 = ttg.convert_layout %cst : tensor<64x64xf32, #blocked> -> tensor<64x64xf32, #mma>
-    %33 = ttg.convert_layout %30 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
-    %34 = ttg.convert_layout %31 : tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
-    %35 = tt.dot %33, %34, %32, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>> -> tensor<64x64xf32, #mma>
-    tt.return %35 : tensor<64x64xf32, #mma>
+    // CHECK: %[[DESC_A:.*]] = ttg.memdesc_index
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
+    // CHECK: %[[DESC_B:.*]] = ttg.memdesc_index
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
+    %a_val = tt.load %arg1 : tensor<64x32x!tt.ptr<f16>, #blocked>
+    %b_val = tt.load %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked>
+    ttg.local_store %a_val, %buf_a : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable>
+    ttg.local_store %b_val, %buf_b : tensor<32x64xf16, #blocked> -> !ttg.memdesc<32x64xf16, #shared1, #smem, mutable>
+    // CHECK: %[[REQ_A_MEM:.*]] = tlx.require_layout %[[DESC_A]] {{.*}} -> !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[A_LOAD:.*]] = ttg.local_load %[[REQ_A_MEM]] : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared, #smem, mutable> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK: %[[REQ_B_MEM:.*]] = tlx.require_layout %[[DESC_B]] {{.*}} -> !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[B_LOAD:.*]] = ttg.local_load %[[REQ_B_MEM]] : !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
+    %b = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared1, #smem, mutable> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
+    %acc = ttg.convert_layout %cst : tensor<64x64xf32, #blocked> -> tensor<64x64xf32, #mma>
+    // CHECK: %[[A_REQ:.*]] = tlx.require_layout %[[A_LOAD]] : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot = ttg.convert_layout %a : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    // CHECK: %[[B_REQ:.*]] = tlx.require_layout %[[B_LOAD]] : tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %b_dot = ttg.convert_layout %b : tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_REQ]], %[[B_REQ]], %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>> -> tensor<64x64xf32, #mma>
+    tt.return %dot : tensor<64x64xf32, #mma>
+  }
+}
+
+// -----
+// Test 2: local_load feeds scf.for iter_args that eventually reach a dot.
+// InsertRequireLayout keeps the loop-carried values in their original type and
+// materializes tensor constraints at the dot use.
+
+#blocked_1 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_1 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#smem_1 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @local_load_through_iter_arg
+  tt.func public @local_load_through_iter_arg(%arg0: !tt.ptr<f16>) -> tensor<64x64xf32, #mma_1> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_1>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x64x32xf16, #shared_1, #smem_1, mutable>
+    %buf_a0 = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<2x64x32xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable>
+    // CHECK: %[[REQ_A_MEM:.*]] = tlx.require_layout %{{.*}} {{.*}} -> !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[A_INIT:.*]] = ttg.local_load %[[REQ_A_MEM]] : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #{{.*}}>
+    %a_init = ttg.local_load %buf_a0 : !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable> -> tensor<64x32xf16, #blocked_1>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x32x64xf16, #shared_1, #smem_1, mutable>
+    %buf_b0 = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<2x32x64xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable>
+    // CHECK: %[[REQ_B_MEM:.*]] = tlx.require_layout %{{.*}} {{.*}} -> !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[B_INIT:.*]] = ttg.local_load %[[REQ_B_MEM]] : !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable> -> tensor<32x64xf16, #{{.*}}>
+    %b_init = ttg.local_load %buf_b0 : !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable> -> tensor<32x64xf16, #blocked_1>
+    // CHECK: scf.for {{.*}} iter_args({{.*}} = {{.*}}, %[[A_ARG:.*]] = %[[A_INIT]], %[[B_ARG:.*]] = %[[B_INIT]])
+    %result:3 = scf.for %i = %c0_i32 to %c4_i32 step %c1_i32
+        iter_args(%acc = %cst, %a_reg = %a_init, %b_reg = %b_init)
+        -> (tensor<64x64xf32, #mma_1>, tensor<64x32xf16, #blocked_1>, tensor<32x64xf16, #blocked_1>) : i32 {
+      // CHECK: %[[A_REQ:.*]] = tlx.require_layout %[[A_ARG]] : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+      %a_dot = ttg.convert_layout %a_reg : tensor<64x32xf16, #blocked_1> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_1, kWidth = 4}>>
+      // CHECK: %[[B_REQ:.*]] = tlx.require_layout %[[B_ARG]] : tensor<32x64xf16, #{{.*}}> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+      %b_dot = ttg.convert_layout %b_reg : tensor<32x64xf16, #blocked_1> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_1, kWidth = 4}>>
+      // CHECK: tt.dot %[[A_REQ]], %[[B_REQ]]
+      %dot = tt.dot %a_dot, %b_dot, %acc : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_1, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_1, kWidth = 4}>> -> tensor<64x64xf32, #mma_1>
+      %buf_a1 = ttg.memdesc_index %alloc_a[%c1_i32] : !ttg.memdesc<2x64x32xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable>
+      // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable>
+      // CHECK-NEXT: ttg.local_load {{.*}} -> tensor<64x32xf16, #{{.*}}>
+      %a_next = ttg.local_load %buf_a1 : !ttg.memdesc<64x32xf16, #shared_1, #smem_1, mutable> -> tensor<64x32xf16, #blocked_1>
+      %buf_b1 = ttg.memdesc_index %alloc_b[%c1_i32] : !ttg.memdesc<2x32x64xf16, #shared_1, #smem_1, mutable> -> !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable>
+      // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable>
+      // CHECK-NEXT: ttg.local_load {{.*}} -> tensor<32x64xf16, #{{.*}}>
+      %b_next = ttg.local_load %buf_b1 : !ttg.memdesc<32x64xf16, #shared_1, #smem_1, mutable> -> tensor<32x64xf16, #blocked_1>
+      scf.yield %dot, %a_next, %b_next : tensor<64x64xf32, #mma_1>, tensor<64x32xf16, #blocked_1>, tensor<32x64xf16, #blocked_1>
+    }
+    tt.return %result#0 : tensor<64x64xf32, #mma_1>
+  }
+}
+
+// -----
+// Test 3: user-specified order=[0,1] on the source memdesc is preserved.
+// The pass should still synthesize explicit tensor constraints at the dot use.
+
+#blocked_2 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_2 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [32, 32, 16], isTransposed = true}>
+#shared_k_contig = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared_default = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 8, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [0, 1]}>
+#smem_2 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @user_specified_order_preserved_insert
+  tt.func public @user_specified_order_preserved_insert(%arg0: !tt.ptr<f16>) -> tensor<128x128xf32, #mma_2> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma_2>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x128x64xf16, #shared_default, #smem_2, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared_k_contig, #smem_2, mutable>
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared_default, #smem_2, mutable> -> !ttg.memdesc<128x64xf16, #shared_default, #smem_2, mutable>
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared_k_contig, #smem_2, mutable> -> !ttg.memdesc<64x128xf16, #shared_k_contig, #smem_2, mutable>
+    // CHECK: %[[A_REQ_MEM:.*]] = tlx.require_layout %{{.*}} {{.*}} -> !ttg.memdesc<128x64xf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[A_LOAD:.*]] = ttg.local_load %[[A_REQ_MEM]] : !ttg.memdesc<128x64xf16, #{{.*}}, #smem, mutable> -> tensor<128x64xf16, #{{.*}}>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<128x64xf16, #shared_default, #smem_2, mutable> -> tensor<128x64xf16, #blocked_2>
+    // CHECK: %[[B_REQ_MEM:.*]] = tlx.require_layout %{{.*}} {{.*}} -> !ttg.memdesc<64x128xf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[B_LOAD:.*]] = ttg.local_load %[[B_REQ_MEM]] : !ttg.memdesc<64x128xf16, #{{.*}}, #smem, mutable> -> tensor<64x128xf16, #{{.*}}>
+    %b = ttg.local_load %buf_b : !ttg.memdesc<64x128xf16, #shared_k_contig, #smem_2, mutable> -> tensor<64x128xf16, #blocked_2>
+    // CHECK: tlx.require_layout %[[A_LOAD]] : tensor<128x64xf16, #{{.*}}> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %a_dot = ttg.convert_layout %a : tensor<128x64xf16, #blocked_2> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_2, kWidth = 8}>>
+    // CHECK: tlx.require_layout %[[B_LOAD]] : tensor<64x128xf16, #{{.*}}> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    %b_dot = ttg.convert_layout %b : tensor<64x128xf16, #blocked_2> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_2, kWidth = 8}>>
+    %dot = tt.dot %a_dot, %b_dot, %cst : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_2, kWidth = 8}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_2, kWidth = 8}>> -> tensor<128x128xf32, #mma_2>
+    tt.return %dot : tensor<128x128xf32, #mma_2>
+  }
+}
+
+// -----
+// Test 4: local_load inside scf.if branches.
+// InsertRequireLayout should leave the scf.if result types alone and rewrite
+// the downstream dot-path conversions into explicit tensor TLX constraints.
+
+#blocked_3 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_3 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #{{.*}} = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#smem_3 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @local_load_through_scf_if
+  tt.func public @local_load_through_scf_if(%arg0: !tt.ptr<f16>, %cond: i1) -> tensor<64x64xf32, #mma_3> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_3>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x64x32xf16, #shared_3, #smem_3, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x32x64xf16, #shared_3, #smem_3, mutable>
+    %buf_a0 = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<2x64x32xf16, #shared_3, #smem_3, mutable> -> !ttg.memdesc<64x32xf16, #shared_3, #smem_3, mutable>
+    %buf_b0 = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<2x32x64xf16, #shared_3, #smem_3, mutable> -> !ttg.memdesc<32x64xf16, #shared_3, #smem_3, mutable>
+    %buf_a1 = ttg.memdesc_index %alloc_a[%c1_i32] : !ttg.memdesc<2x64x32xf16, #shared_3, #smem_3, mutable> -> !ttg.memdesc<64x32xf16, #shared_3, #smem_3, mutable>
+    %buf_b1 = ttg.memdesc_index %alloc_b[%c1_i32] : !ttg.memdesc<2x32x64xf16, #shared_3, #smem_3, mutable> -> !ttg.memdesc<32x64xf16, #shared_3, #smem_3, mutable>
+    // CHECK: scf.if {{.*}} -> (tensor<64x32xf16, #{{.*}}>, tensor<32x64xf16, #{{.*}}>)
+    %if_result:2 = scf.if %cond -> (tensor<64x32xf16, #blocked_3>, tensor<32x64xf16, #blocked_3>) {
+      // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable>
+      // CHECK-NEXT: ttg.local_load {{.*}} -> tensor<64x32xf16, #{{.*}}>
+      %a = ttg.local_load %buf_a0 : !ttg.memdesc<64x32xf16, #shared_3, #smem_3, mutable> -> tensor<64x32xf16, #blocked_3>
+      // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable>
+      // CHECK-NEXT: ttg.local_load {{.*}} -> tensor<32x64xf16, #{{.*}}>
+      %b = ttg.local_load %buf_b0 : !ttg.memdesc<32x64xf16, #shared_3, #smem_3, mutable> -> tensor<32x64xf16, #blocked_3>
+      scf.yield %a, %b : tensor<64x32xf16, #blocked_3>, tensor<32x64xf16, #blocked_3>
+    } else {
+      // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable>
+      // CHECK-NEXT: ttg.local_load {{.*}} -> tensor<64x32xf16, #{{.*}}>
+      %a = ttg.local_load %buf_a1 : !ttg.memdesc<64x32xf16, #shared_3, #smem_3, mutable> -> tensor<64x32xf16, #blocked_3>
+      // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable>
+      // CHECK-NEXT: ttg.local_load {{.*}} -> tensor<32x64xf16, #{{.*}}>
+      %b = ttg.local_load %buf_b1 : !ttg.memdesc<32x64xf16, #shared_3, #smem_3, mutable> -> tensor<32x64xf16, #blocked_3>
+      scf.yield %a, %b : tensor<64x32xf16, #blocked_3>, tensor<32x64xf16, #blocked_3>
+    }
+    // CHECK: %[[IF_A_REQ:.*]] = tlx.require_layout %{{.*}}#0 : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot = ttg.convert_layout %if_result#0 : tensor<64x32xf16, #blocked_3> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_3, kWidth = 4}>>
+    // CHECK: %[[IF_B_REQ:.*]] = tlx.require_layout %{{.*}}#1 : tensor<32x64xf16, #{{.*}}> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %b_dot = ttg.convert_layout %if_result#1 : tensor<32x64xf16, #blocked_3> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_3, kWidth = 4}>>
+    // CHECK: tt.dot %[[IF_A_REQ]], %[[IF_B_REQ]], %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %cst : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_3, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_3, kWidth = 4}>> -> tensor<64x64xf32, #mma_3>
+    tt.return %dot : tensor<64x64xf32, #mma_3>
+  }
+}
+
+// -----
+// Test 5: one local_load feeds both a dot path and a sibling convert_layout
+// path into a non-dot user. Mixed-use should block memdesc-side rewriting for
+// A, but explicit tensor constraints can still model the dot uses.
+
+#blocked_4 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_4_alt = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mma_4 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_4 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_4 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @mixed_use_local_load_stays_blocked
+  tt.func public @mixed_use_local_load_stays_blocked(%arg0: !tt.ptr<f16>) -> tensor<64x64xf32, #mma_4> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked_4>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable>
+    %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared_4, #smem_4, mutable>
+    %alloc_sink = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable>
+    // CHECK: %[[DESC_A:.*]] = ttg.memdesc_index
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
+    // CHECK: %[[DESC_B:.*]] = ttg.memdesc_index
+    %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<32x64xf16, #shared_4, #smem_4, mutable>
+    %buf_sink = ttg.memdesc_index %alloc_sink[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
+    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %[[DESC_A]] : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #{{.*}}>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable> -> tensor<64x32xf16, #blocked_4>
+    // CHECK: %[[A_ALT:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #{{.*}}>
+    %a_alt = ttg.convert_layout %a : tensor<64x32xf16, #blocked_4> -> tensor<64x32xf16, #blocked_4_alt>
+    // CHECK: ttg.local_store %[[A_ALT]],
+    ttg.local_store %a_alt, %buf_sink : tensor<64x32xf16, #blocked_4_alt> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
+    // CHECK: %[[REQ_B_MEM:.*]] = tlx.require_layout %[[DESC_B]] {{.*}} -> !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable>
+    // CHECK-NEXT: %[[B_LOAD:.*]] = ttg.local_load %[[REQ_B_MEM]] : !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable> -> tensor<32x64xf16, #{{.*}}>
+    %b = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared_4, #smem_4, mutable> -> tensor<32x64xf16, #blocked_4>
+    %acc = ttg.convert_layout %cst : tensor<64x64xf32, #blocked_4> -> tensor<64x64xf32, #mma_4>
+    // CHECK: %[[A_REQ:.*]] = tlx.require_layout %[[A_LOAD]] : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot = ttg.convert_layout %a : tensor<64x32xf16, #blocked_4> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_4, kWidth = 4}>>
+    // CHECK: %[[B_REQ:.*]] = tlx.require_layout %[[B_LOAD]] : tensor<32x64xf16, #{{.*}}> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+    %b_dot = ttg.convert_layout %b : tensor<32x64xf16, #blocked_4> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_4, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_REQ]], %[[B_REQ]], %{{.*}}
+    %dot = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_4, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_4, kWidth = 4}>> -> tensor<64x64xf32, #mma_4>
+    tt.return %dot : tensor<64x64xf32, #mma_4>
+  }
+}
+
+// -----
+// Test 6: one local_load feeds two dot paths that demand different dot operand
+// encodings. Conflicting dot requirements should block memdesc-side rewriting,
+// while still materializing explicit tensor constraints for both dot uses.
+
+#blocked_5 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_5 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#mma_5_alt = #ttg.amd_mfma<{version = 3, warpsPerCTA = [1, 4], instrShape = [32, 32, 8], isTransposed = true}>
+#shared_5 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_5 = #ttg.shared_memory
+module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @conflicting_dot_operands_stay_explicit
+  tt.func public @conflicting_dot_operands_stay_explicit() -> tensor<64x64xf32, #mma_5> {
+    %c0_i32 = arith.constant 0 : i32
+    %acc0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_5>
+    %acc1 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma_5_alt>
+    %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_5, #smem_5, mutable>
+    %alloc_b0 = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable>
+    %alloc_b1 = ttg.local_alloc : () -> !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable>
+    // CHECK: %[[DESC_A:.*]] = ttg.memdesc_index
+    %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_5, #smem_5, mutable> -> !ttg.memdesc<64x32xf16, #shared_5, #smem_5, mutable>
+    %buf_b0 = ttg.memdesc_index %alloc_b0[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable> -> !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable>
+    %buf_b1 = ttg.memdesc_index %alloc_b1[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_5, #smem_5, mutable> -> !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable>
+    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %[[DESC_A]] : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #{{.*}}>
+    %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared_5, #smem_5, mutable> -> tensor<64x32xf16, #blocked_5>
+    %b0 = ttg.local_load %buf_b0 : !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable> -> tensor<32x64xf16, #blocked_5>
+    %b1 = ttg.local_load %buf_b1 : !ttg.memdesc<32x64xf16, #shared_5, #smem_5, mutable> -> tensor<32x64xf16, #blocked_5>
+    // CHECK: %[[A_REQ0:.*]] = tlx.require_layout %[[A_LOAD]] : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+    %a_dot0 = ttg.convert_layout %a : tensor<64x32xf16, #blocked_5> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5, kWidth = 4}>>
+    %b_dot0 = ttg.convert_layout %b0 : tensor<32x64xf16, #blocked_5> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5, kWidth = 4}>>
+    // CHECK: %[[A_REQ1:.*]] = tlx.require_layout %[[A_LOAD]] : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 4}>>
+    %a_dot1 = ttg.convert_layout %a : tensor<64x32xf16, #blocked_5> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5_alt, kWidth = 4}>>
+    %b_dot1 = ttg.convert_layout %b1 : tensor<32x64xf16, #blocked_5> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5_alt, kWidth = 4}>>
+    // CHECK: tt.dot %[[A_REQ0]], %{{.*}}, %{{.*}}
+    %dot0 = tt.dot %a_dot0, %b_dot0, %acc0 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5, kWidth = 4}>> -> tensor<64x64xf32, #mma_5>
+    // CHECK: tt.dot %[[A_REQ1]], %{{.*}}, %{{.*}}
+    %dot1 = tt.dot %a_dot1, %b_dot1, %acc1 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_5_alt, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_5_alt, kWidth = 4}>> -> tensor<64x64xf32, #mma_5_alt>
+    tt.return %dot0 : tensor<64x64xf32, #mma_5>
   }
 }

--- a/test/TLX/propagate-layout-memdesc-trans-errors.mlir
+++ b/test/TLX/propagate-layout-memdesc-trans-errors.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt -split-input-file --tlx-propagate-layout --verify-diagnostics %s
+
+// Test that tlx-propagate-layout emits a diagnostic for nontrivial
+// swizzled_shared backward propagation through ttg.memdesc_trans.
+
+#shared_src = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_trans = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+// Nontrivially swizzled encoding that triggers the backward memdesc_trans error.
+#shared_req = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reject_nontrivial_swizzled_memdesc_trans() -> tensor<128x64xf16, #blocked> {
+    %c0_i32 = arith.constant 0 : i32
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared_src, #smem, mutable>
+    %slice = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared_src, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared_src, #smem, mutable>
+    // expected-error @+1 {{swizzled_shared backward propagation through memdesc_trans only supports effectively unswizzled encodings}}
+    %trans = ttg.memdesc_trans %slice {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared_src, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_trans, #smem, mutable>
+    %req = tlx.require_layout %trans : !ttg.memdesc<128x64xf16, #shared_trans, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_req, #smem, mutable>
+    %val = ttg.local_load %req : !ttg.memdesc<128x64xf16, #shared_req, #smem, mutable> -> tensor<128x64xf16, #blocked>
+    tt.return %val : tensor<128x64xf16, #blocked>
+  }
+}
+
+// -----
+// Test that malformed ttg.memdesc_trans permutation metadata is rejected by the
+// op verifier before tlx-propagate-layout can run.
+
+#shared_src_perm = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_trans_perm = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared_req_perm = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#blocked_perm = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#smem_perm = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reject_invalid_memdesc_trans_permutation() -> tensor<128x64xf16, #blocked_perm> {
+    %c0_i32 = arith.constant 0 : i32
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared_src_perm, #smem_perm, mutable>
+    %slice = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared_src_perm, #smem_perm, mutable> -> !ttg.memdesc<64x128xf16, #shared_src_perm, #smem_perm, mutable>
+    // expected-error @+1 {{order must be a permutation}}
+    %trans = ttg.memdesc_trans %slice {order = array<i32: 0, 0>} : !ttg.memdesc<64x128xf16, #shared_src_perm, #smem_perm, mutable> -> !ttg.memdesc<128x64xf16, #shared_trans_perm, #smem_perm, mutable>
+    %req = tlx.require_layout %trans : !ttg.memdesc<128x64xf16, #shared_trans_perm, #smem_perm, mutable> -> !ttg.memdesc<128x64xf16, #shared_req_perm, #smem_perm, mutable>
+    %val = ttg.local_load %req : !ttg.memdesc<128x64xf16, #shared_req_perm, #smem_perm, mutable> -> tensor<128x64xf16, #blocked_perm>
+    tt.return %val : tensor<128x64xf16, #blocked_perm>
+  }
+}

--- a/test/TLX/propagate-layout-memdesc-trans.mlir
+++ b/test/TLX/propagate-layout-memdesc-trans.mlir
@@ -1,0 +1,61 @@
+// RUN: triton-opt -split-input-file --tlx-propagate-layout %s | FileCheck %s
+
+// Test that tlx-propagate-layout can propagate a swizzled_shared constraint
+// backward through ttg.memdesc_trans when the swizzle is effectively
+// unswizzled. This exercises the guarded SwizzledSharedEncodingAttr path in
+// LayoutBackwardPropagation.
+
+#shared_src = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_trans = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared_req = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #[[$SHARED_TRANS:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+// CHECK-DAG: #[[$SHARED_REQ:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @propagate_swizzled_shared_through_memdesc_trans
+  tt.func public @propagate_swizzled_shared_through_memdesc_trans() -> tensor<128x64xf16, #blocked> {
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #[[$SHARED_TRANS]], #smem, mutable>
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared_src, #smem, mutable>
+    // CHECK: %[[SLICE:.*]] = ttg.memdesc_index %{{.*}}[%c0_i32] : !ttg.memdesc<1x64x128xf16, #[[$SHARED_TRANS]], #smem, mutable> -> !ttg.memdesc<64x128xf16, #[[$SHARED_TRANS]], #smem, mutable>
+    %slice = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared_src, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared_src, #smem, mutable>
+    // CHECK: %[[TRANS:.*]] = ttg.memdesc_trans %[[SLICE]] {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #[[$SHARED_TRANS]], #smem, mutable> -> !ttg.memdesc<128x64xf16, #[[$SHARED_REQ]], #smem, mutable>
+    %trans = ttg.memdesc_trans %slice {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared_src, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_trans, #smem, mutable>
+    %req = tlx.require_layout %trans : !ttg.memdesc<128x64xf16, #shared_trans, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_req, #smem, mutable>
+    // CHECK: ttg.local_load %[[TRANS]] : !ttg.memdesc<128x64xf16, #[[$SHARED_REQ]], #smem, mutable> -> tensor<128x64xf16, #blocked>
+    %val = ttg.local_load %req : !ttg.memdesc<128x64xf16, #shared_req, #smem, mutable> -> tensor<128x64xf16, #blocked>
+    tt.return %val : tensor<128x64xf16, #blocked>
+  }
+}
+
+// -----
+// Test that tlx-propagate-layout can also propagate an nvmma_shared constraint
+// backward through ttg.memdesc_trans. This exercises the dedicated
+// NVMMASharedEncodingAttr branch in LayoutBackwardPropagation.
+
+#nvmma_src = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#nvmma_trans = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#nvmma_req = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+// CHECK-DAG: #[[$NVMMA_SRC:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+// CHECK-DAG: #[[$NVMMA_DST:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#blocked_nv = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#smem_nv = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @propagate_nvmma_shared_through_memdesc_trans
+  tt.func public @propagate_nvmma_shared_through_memdesc_trans() -> tensor<128x64xf16, #blocked_nv> {
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #[[$NVMMA_SRC]], #smem, mutable>
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #nvmma_src, #smem_nv, mutable>
+    // CHECK: %[[SLICE:.*]] = ttg.memdesc_index %{{.*}}[%c0_i32] : !ttg.memdesc<1x64x128xf16, #[[$NVMMA_SRC]], #smem, mutable> -> !ttg.memdesc<64x128xf16, #[[$NVMMA_SRC]], #smem, mutable>
+    %slice = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<1x64x128xf16, #nvmma_src, #smem_nv, mutable> -> !ttg.memdesc<64x128xf16, #nvmma_src, #smem_nv, mutable>
+    // CHECK: %[[TRANS:.*]] = ttg.memdesc_trans %[[SLICE]] {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #[[$NVMMA_SRC]], #smem, mutable> -> !ttg.memdesc<128x64xf16, #[[$NVMMA_DST]], #smem, mutable>
+    %trans = ttg.memdesc_trans %slice {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #nvmma_src, #smem_nv, mutable> -> !ttg.memdesc<128x64xf16, #nvmma_trans, #smem_nv, mutable>
+    %req = tlx.require_layout %trans : !ttg.memdesc<128x64xf16, #nvmma_trans, #smem_nv, mutable> -> !ttg.memdesc<128x64xf16, #nvmma_req, #smem_nv, mutable>
+    // CHECK: ttg.local_load %[[TRANS]] : !ttg.memdesc<128x64xf16, #[[$NVMMA_DST]], #smem, mutable> -> tensor<128x64xf16, #blocked>
+    %val = ttg.local_load %req : !ttg.memdesc<128x64xf16, #nvmma_req, #smem_nv, mutable> -> tensor<128x64xf16, #blocked_nv>
+    tt.return %val : tensor<128x64xf16, #blocked_nv>
+  }
+}

--- a/test/TLX/propagate-layout-tensor-residual.mlir
+++ b/test/TLX/propagate-layout-tensor-residual.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-opt -split-input-file --tlx-propagate-layout %s | FileCheck %s
+
+// Test that residual tensor require/release ops lower to convert_layout ops
+// after propagation.
+
+#blocked_a = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#blocked_b = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @lower_residual_tensor_constraints
+  tt.func public @lower_residual_tensor_constraints(%arg: tensor<8x8xf16, #blocked_a>) -> tensor<8x8xf16, #blocked_a> {
+    // CHECK: %[[REQ:.*]] = ttg.convert_layout %{{.*}} : tensor<8x8xf16, #{{.*}}> -> tensor<8x8xf16, #{{.*}}>
+    %req = tlx.require_layout %arg : tensor<8x8xf16, #blocked_a> -> tensor<8x8xf16, #blocked_b>
+    // CHECK: %[[REL:.*]] = ttg.convert_layout %[[REQ]] : tensor<8x8xf16, #{{.*}}> -> tensor<8x8xf16, #{{.*}}>
+    %rel = tlx.release_layout %req : tensor<8x8xf16, #blocked_b> -> tensor<8x8xf16, #blocked_a>
+    // CHECK: tt.return %[[REL]]
+    tt.return %rel : tensor<8x8xf16, #blocked_a>
+  }
+}
+
+// -----
+// Test that an identity tensor require_layout folds away.
+
+#blocked_req_id = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @erase_identity_require_layout
+  tt.func public @erase_identity_require_layout(%arg: tensor<8x8xf16, #blocked_req_id>) -> tensor<8x8xf16, #blocked_req_id> {
+    // CHECK-NOT: tlx.require_layout
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return %{{.*}} : tensor<8x8xf16, #{{.*}}>
+    %req = tlx.require_layout %arg : tensor<8x8xf16, #blocked_req_id> -> tensor<8x8xf16, #blocked_req_id>
+    tt.return %req : tensor<8x8xf16, #blocked_req_id>
+  }
+}
+
+// -----
+// Test that an identity tensor release_layout folds away.
+
+#blocked_id = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @erase_identity_release_layout
+  tt.func public @erase_identity_release_layout(%arg: tensor<8x8xf16, #blocked_id>) -> tensor<8x8xf16, #blocked_id> {
+    // CHECK-NOT: tlx.release_layout
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return %{{.*}} : tensor<8x8xf16, #{{.*}}>
+    %rel = tlx.release_layout %arg : tensor<8x8xf16, #blocked_id> -> tensor<8x8xf16, #blocked_id>
+    tt.return %rel : tensor<8x8xf16, #blocked_id>
+  }
+}

--- a/test/TLX/propagate-layout-warp-specialize.mlir
+++ b/test/TLX/propagate-layout-warp-specialize.mlir
@@ -1,0 +1,119 @@
+// RUN: triton-opt -split-input-file --tlx-propagate-layout %s | FileCheck %s
+
+// Test that warp-specialized TMEM paths remain valid after propagation. This
+// covers memdesc constraints in the consumer partition together with
+// tensor-side release/require cleanup around tmem_load/tmem_store.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#smem_1 = #ttg.shared_memory
+// Use two textual aliases for the same TMEM encoding so the input IR can model
+// a partition-local memdesc constraint without introducing an unsupported TMEM
+// layout mismatch.
+#tmem_1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1>
+#tmem_2 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1>
+// CHECK-DAG: #[[$TMEM:.*]] = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1>
+
+module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @warp_specialize_tmem_paths
+  tt.func public @warp_specialize_tmem_paths() {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1x64x16xf16, #shared, #smem_1, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<1x16x32xf16, #shared1, #smem_1, mutable>
+    %2 = ttg.local_alloc : () -> !ttg.memdesc<1x32x32xf16, #shared1, #smem_1, mutable>
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>
+    %result_0 = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf16, #tmem_2, #ttng.tensor_memory, mutable>
+    %result_1 = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>
+    ttg.warp_specialize(%0, %result, %1, %2, %result_1, %result_0)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg8: !ttg.memdesc<1x64x16xf16, #shared, #smem_1, mutable>, %arg9: !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>, %arg10: !ttg.memdesc<1x16x32xf16, #shared1, #smem_1, mutable>, %arg11: !ttg.memdesc<1x32x32xf16, #shared1, #smem_1, mutable>, %arg12: !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>, %arg13: !ttg.memdesc<1x64x32xf16, #tmem_2, #ttng.tensor_memory, mutable>) num_warps(1) {
+      %true = arith.constant true
+      %false = arith.constant false
+      %c0_i32 = arith.constant 0 : i32
+      %3 = ttg.memdesc_index %arg8[%c0_i32] : !ttg.memdesc<1x64x16xf16, #shared, #smem_1, mutable> -> !ttg.memdesc<64x16xf16, #shared, #smem_1, mutable>
+      %4 = ttg.memdesc_index %arg10[%c0_i32] : !ttg.memdesc<1x16x32xf16, #shared1, #smem_1, mutable> -> !ttg.memdesc<16x32xf16, #shared1, #smem_1, mutable>
+      %5 = ttg.memdesc_index %arg9[%c0_i32] : !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>
+      %6 = ttng.tc_gen5_mma %3, %4, %5[], %false, %true : !ttg.memdesc<64x16xf16, #shared, #smem_1, mutable>, !ttg.memdesc<16x32xf16, #shared1, #smem_1, mutable>, !ttg.memdesc<64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>
+      // CHECK: %[[TMEM_F16:.*]] = ttg.memdesc_index %arg5[%c0_i32] : !ttg.memdesc<1x64x32xf16, #[[$TMEM]], #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf16, #[[$TMEM]], #ttng.tensor_memory, mutable>
+      %7 = ttg.memdesc_index %arg13[%c0_i32] : !ttg.memdesc<1x64x32xf16, #tmem_2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf16, #tmem_2, #ttng.tensor_memory, mutable>
+      %8 = ttg.memdesc_index %arg11[%c0_i32] : !ttg.memdesc<1x32x32xf16, #shared1, #smem_1, mutable> -> !ttg.memdesc<32x32xf16, #shared1, #smem_1, mutable>
+      %9 = ttg.memdesc_index %arg12[%c0_i32] : !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>
+      %10 = tlx.require_layout %7 : !ttg.memdesc<64x32xf16, #tmem_2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf16, #tmem_1, #ttng.tensor_memory, mutable>
+      // CHECK: ttng.tc_gen5_mma %[[TMEM_F16]], %{{.*}}, %{{.*}}[], %false, %true : !ttg.memdesc<64x32xf16, #[[$TMEM]], #ttng.tensor_memory, mutable>, !ttg.memdesc<32x32xf16, #shared1, #smem, mutable>, !ttg.memdesc<64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable>
+      %11 = ttng.tc_gen5_mma %10, %8, %9[], %false, %true : !ttg.memdesc<64x32xf16, #tmem_1, #ttng.tensor_memory, mutable>, !ttg.memdesc<32x32xf16, #shared1, #smem_1, mutable>, !ttg.memdesc<64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    }
+    partition1(%arg8: !ttg.memdesc<1x64x16xf16, #shared, #smem_1, mutable>, %arg9: !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>, %arg10: !ttg.memdesc<1x16x32xf16, #shared1, #smem_1, mutable>, %arg11: !ttg.memdesc<1x32x32xf16, #shared1, #smem_1, mutable>, %arg12: !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>, %arg13: !ttg.memdesc<1x64x32xf16, #tmem_2, #ttng.tensor_memory, mutable>) num_warps(4) {
+      %true = arith.constant true
+      %c0_i32 = arith.constant 0 : i32
+      %3 = ttg.memdesc_index %arg9[%c0_i32] : !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>
+      // CHECK: %[[TMEM_LOAD:.*]] = ttng.tmem_load %{{.*}} : !ttg.memdesc<64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable> -> tensor<64x32xf32, #{{.*}}>
+      %result_2 = ttng.tmem_load %3 : !ttg.memdesc<64x32xf32, #tmem_1, #ttng.tensor_memory, mutable> -> tensor<64x32xf32, #blocked>
+      // CHECK: %[[REL_CVT:.*]] = ttg.convert_layout %[[TMEM_LOAD]] : tensor<64x32xf32, #blocked> -> tensor<64x32xf32, #blocked1>
+      %4 = tlx.release_layout %result_2 : tensor<64x32xf32, #blocked> -> tensor<64x32xf32, #blocked1>
+      %5 = arith.truncf %4 : tensor<64x32xf32, #blocked1> to tensor<64x32xf16, #blocked1>
+      %6 = ttg.memdesc_index %arg13[%c0_i32] : !ttg.memdesc<1x64x32xf16, #tmem_2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf16, #tmem_2, #ttng.tensor_memory, mutable>
+      // CHECK: %[[STORE_CVT:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf16, #blocked1> -> tensor<64x32xf16, #blocked>
+      %7 = tlx.require_layout %5 : tensor<64x32xf16, #blocked1> -> tensor<64x32xf16, #blocked>
+      // CHECK: ttng.tmem_store %[[STORE_CVT]], %{{.*}}, %true : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #[[$TMEM]], #ttng.tensor_memory, mutable>
+      ttng.tmem_store %7, %6, %true : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #tmem_2, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<1x64x16xf16, #shared, #smem_1, mutable>, !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x16x32xf16, #shared1, #smem_1, mutable>, !ttg.memdesc<1x32x32xf16, #shared1, #smem_1, mutable>, !ttg.memdesc<1x64x32xf32, #tmem_1, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x64x32xf16, #tmem_2, #ttng.tensor_memory, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Test that warp-specialize memdesc retagging only happens when all partitions
+// agree on the captured memdesc layout. Conflicting partition-local memdesc
+// constraints must stay explicit instead of retagging the capture or partition
+// block arguments.
+
+#blocked_ws = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared_ws_src = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_ws_a = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared_ws_b = #ttg.swizzled_shared<{vec = 2, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_ws = #ttg.shared_memory
+
+module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = true, tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @warp_specialize_partition_memdesc_conflict_fallback
+  tt.func public @warp_specialize_partition_memdesc_conflict_fallback() -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x64x32xf16, #shared_ws_src, #smem_ws, mutable>
+    %token = ttg.warp_specialize(%alloc)
+    default {
+      ttg.warp_yield %c0_i32 : i32
+    }
+    // CHECK: partition0(%[[ARG0:.*]]: !ttg.memdesc<1x64x32xf16, #[[$WS_SRC:[^,]+]], #smem, mutable>) num_warps(1)
+    partition0(%arg0: !ttg.memdesc<1x64x32xf16, #shared_ws_src, #smem_ws, mutable>) num_warps(1) {
+      %c0_i32_p0 = arith.constant 0 : i32
+      // CHECK: %[[BUF0:.*]] = ttg.memdesc_index %[[ARG0]][%{{.*}}] : !ttg.memdesc<1x64x32xf16, #[[$WS_SRC]], #smem, mutable> -> !ttg.memdesc<64x32xf16, #[[$WS_SRC]], #smem, mutable>
+      %buf = ttg.memdesc_index %arg0[%c0_i32_p0] : !ttg.memdesc<1x64x32xf16, #shared_ws_src, #smem_ws, mutable> -> !ttg.memdesc<64x32xf16, #shared_ws_src, #smem_ws, mutable>
+      // CHECK: %[[REQ0:.*]] = tlx.require_layout %[[BUF0]] : !ttg.memdesc<64x32xf16, #[[$WS_SRC]], #smem, mutable> -> !ttg.memdesc<64x32xf16, #[[$WS_A:[^,]+]], #smem, mutable>
+      %req = tlx.require_layout %buf : !ttg.memdesc<64x32xf16, #shared_ws_src, #smem_ws, mutable> -> !ttg.memdesc<64x32xf16, #shared_ws_a, #smem_ws, mutable>
+      // CHECK: ttg.local_load %[[REQ0]] : !ttg.memdesc<64x32xf16, #[[$WS_A]], #smem, mutable> -> tensor<64x32xf16, #{{.*}}>
+      %load = ttg.local_load %req : !ttg.memdesc<64x32xf16, #shared_ws_a, #smem_ws, mutable> -> tensor<64x32xf16, #blocked_ws>
+      // CHECK: ttg.local_store %{{.*}}, %[[REQ0]] : tensor<64x32xf16, #{{.*}}> -> !ttg.memdesc<64x32xf16, #[[$WS_A]], #smem, mutable>
+      ttg.local_store %load, %req : tensor<64x32xf16, #blocked_ws> -> !ttg.memdesc<64x32xf16, #shared_ws_a, #smem_ws, mutable>
+      ttg.warp_return
+    }
+    // CHECK: partition1(%[[ARG1:.*]]: !ttg.memdesc<1x64x32xf16, #[[$WS_SRC]], #smem, mutable>) num_warps(1)
+    partition1(%arg0: !ttg.memdesc<1x64x32xf16, #shared_ws_src, #smem_ws, mutable>) num_warps(1) {
+      %c0_i32_p1 = arith.constant 0 : i32
+      // CHECK: %[[BUF1:.*]] = ttg.memdesc_index %[[ARG1]][%{{.*}}] : !ttg.memdesc<1x64x32xf16, #[[$WS_SRC]], #smem, mutable> -> !ttg.memdesc<64x32xf16, #[[$WS_SRC]], #smem, mutable>
+      %buf = ttg.memdesc_index %arg0[%c0_i32_p1] : !ttg.memdesc<1x64x32xf16, #shared_ws_src, #smem_ws, mutable> -> !ttg.memdesc<64x32xf16, #shared_ws_src, #smem_ws, mutable>
+      // CHECK: %[[REQ1:.*]] = tlx.require_layout %[[BUF1]] : !ttg.memdesc<64x32xf16, #[[$WS_SRC]], #smem, mutable> -> !ttg.memdesc<64x32xf16, #[[$WS_B:[^,]+]], #smem, mutable>
+      %req = tlx.require_layout %buf : !ttg.memdesc<64x32xf16, #shared_ws_src, #smem_ws, mutable> -> !ttg.memdesc<64x32xf16, #shared_ws_b, #smem_ws, mutable>
+      // CHECK: ttg.local_load %[[REQ1]] : !ttg.memdesc<64x32xf16, #[[$WS_B]], #smem, mutable> -> tensor<64x32xf16, #{{.*}}>
+      %load = ttg.local_load %req : !ttg.memdesc<64x32xf16, #shared_ws_b, #smem_ws, mutable> -> tensor<64x32xf16, #blocked_ws>
+      // CHECK: ttg.local_store %{{.*}}, %[[REQ1]] : tensor<64x32xf16, #{{.*}}> -> !ttg.memdesc<64x32xf16, #[[$WS_B]], #smem, mutable>
+      ttg.local_store %load, %req : tensor<64x32xf16, #blocked_ws> -> !ttg.memdesc<64x32xf16, #shared_ws_b, #smem_ws, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<1x64x32xf16, #shared_ws_src, #smem_ws, mutable>) -> i32
+    tt.return %token : i32
+  }
+}

--- a/third_party/tlx/dialect/include/Analysis/LayoutPropagation.h
+++ b/third_party/tlx/dialect/include/Analysis/LayoutPropagation.h
@@ -3,13 +3,27 @@
 
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include <optional>
 
 using namespace mlir::dataflow;
 
 namespace mlir::triton::tlx {
+
+/// Region carriers are transparent to both the insert-time dot-path discovery
+/// and the later tensor-constraint propagation pass.
+inline bool isTransparentLayoutCarrierOp(Operation *op) {
+  return isa<RegionBranchOpInterface, RegionBranchTerminatorOpInterface>(op);
+}
+
+/// Dot-operand encodings are the currently supported explicit tensor-layout
+/// constraints that can be pushed back onto retaggable producers.
+inline bool isSupportedDotConstraintEncoding(Attribute encoding) {
+  return isa<::mlir::triton::gpu::DotOperandEncodingAttr>(encoding);
+}
 
 //===----------------------------------------------------------------------===//
 // LayoutEncoding
@@ -31,6 +45,11 @@ public:
   bool isUninitialized() const { return !encoding.has_value(); }
 
   /// Whether the state is unknown.
+  ///
+  /// Unknown is the conservative "conflicting or unsupported" state for layout
+  /// propagation: forward joins widen to unknown when distinct concrete
+  /// encodings meet at a merge point, and backward meets also collapse to
+  /// unknown when any side is already unknown.
   bool isUnknown() const { return encoding == nullptr; }
 
   Attribute getLayoutEncoding() const {
@@ -39,8 +58,24 @@ public:
   }
 
   void print(raw_ostream &os) const;
+  friend raw_ostream &operator<<(raw_ostream &os,
+                                 const LayoutEncoding &layout) {
+    layout.print(os);
+    return os;
+  }
+  /// Lattice meet used by backward propagation.
+  ///
+  /// Uninitialized yields to any concrete state, unknown dominates, equal
+  /// concrete encodings stay concrete, and conflicting concrete encodings widen
+  /// to unknown so backward propagation can conservatively fall back instead of
+  /// asserting on unsupported conflicts.
   static LayoutEncoding meet(const LayoutEncoding &lhs,
                              const LayoutEncoding &rhs);
+  /// Lattice join used by forward propagation.
+  ///
+  /// Uninitialized yields to any concrete state, unknown dominates, equal
+  /// concrete encodings stay concrete, and conflicting concrete encodings widen
+  /// to unknown so region merges stay conservative instead of asserting.
   static LayoutEncoding join(const LayoutEncoding &lhs,
                              const LayoutEncoding &rhs);
   static LayoutEncoding getUnknownLayout() {
@@ -79,6 +114,11 @@ public:
 
   void setToExitState(LayoutEncodingLattice *lattice) override;
 
+  void
+  visitNonControlFlowArguments(RegionSuccessor &successor,
+                               ArrayRef<BlockArgument> arguments) {
+    // Default: do nothing
+  }
   LogicalResult visitRegionInReverse(Operation *op);
 
   void visitWarpSpecRegionArgs(Operation *op, Value opnd,
@@ -105,6 +145,99 @@ public:
 
   LogicalResult visitWarpSpecRegionArgs(Operation *op, Value opnd,
                                         const LayoutEncoding &opndEncoding);
+};
+
+//===----------------------------------------------------------------------===//
+// TensorLayout
+//===----------------------------------------------------------------------===//
+
+/// Tracks the required register encoding for RankedTensor values.
+class TensorLayout {
+public:
+  /// Construct a TensorLayout value as uninitialized.
+  explicit TensorLayout() = default;
+
+  /// Construct a TensorLayout value with a known constant.
+  TensorLayout(Attribute encoding) : encoding(std::move(encoding)) {}
+
+  bool operator==(const TensorLayout &rhs) const {
+    return encoding == rhs.encoding;
+  }
+
+  /// Whether the state is uninitialized.
+  bool isUninitialized() const { return !encoding.has_value(); }
+
+  /// Whether the state is unknown.
+  ///
+  /// Unknown is the conservative "conflicting or unsupported" state for tensor
+  /// propagation: backward meets and forward joins both widen to unknown when a
+  /// component cannot be rewritten to satisfy a concrete dot constraint.
+  bool isUnknown() const { return encoding == nullptr; }
+
+  Attribute getLayoutEncoding() const {
+    assert(!isUninitialized());
+    assert(!isUnknown());
+    return *encoding;
+  }
+
+  void print(raw_ostream &os) const;
+  friend raw_ostream &operator<<(raw_ostream &os, const TensorLayout &layout) {
+    layout.print(os);
+    return os;
+  }
+  /// Lattice meet used by backward propagation.
+  ///
+  /// Uninitialized yields to any concrete state, unknown dominates, equal
+  /// concrete encodings stay concrete, and conflicting concrete encodings widen
+  /// to unknown so unsupported components fall back to explicit
+  /// `ttg.convert_layout` edges.
+  static TensorLayout meet(const TensorLayout &lhs, const TensorLayout &rhs);
+  /// Lattice join used by forward propagation.
+  ///
+  /// Matches `meet`: forward merges keep a concrete encoding only when every
+  /// incoming path agrees, otherwise they conservatively widen to unknown.
+  static TensorLayout join(const TensorLayout &lhs, const TensorLayout &rhs);
+  static TensorLayout getUnknownLayout() {
+    return TensorLayout{/*layoutEncoding=*/nullptr};
+  }
+
+private:
+  std::optional<Attribute> encoding;
+};
+
+//===----------------------------------------------------------------------===//
+// TensorLayoutLattice
+//===----------------------------------------------------------------------===//
+
+class TensorLayoutLattice : public Lattice<TensorLayout> {
+public:
+  using Lattice::Lattice;
+};
+
+//===----------------------------------------------------------------------===//
+// TensorBackwardPropagation
+//===----------------------------------------------------------------------===//
+
+class TensorBackwardPropagation
+    : public SparseBackwardDataFlowAnalysis<TensorLayoutLattice> {
+public:
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  LogicalResult
+  visitOperation(Operation *op, ArrayRef<TensorLayoutLattice *> operands,
+                 ArrayRef<const TensorLayoutLattice *> results) override;
+
+  void visitBranchOperand(OpOperand &operand) override;
+
+  void visitCallOperand(OpOperand &operand) override;
+
+  void setToExitState(TensorLayoutLattice *lattice) override;
+
+  void
+  visitNonControlFlowArguments(RegionSuccessor &successor,
+                               ArrayRef<BlockArgument> arguments) {
+    // Default: do nothing
+  }
 };
 
 } // namespace mlir::triton::tlx

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -247,7 +247,18 @@ def TLX_RequireLayoutOp : TLX_Op<"require_layout",
                                  [SameOperandsAndResultShape,
                                   SameOperandsAndResultElementType,
                                   Pure]> {
-  let summary = "require specific layout for a local memory buffer";
+  let summary = "materialize an explicit layout constraint on a memdesc or tensor value";
+
+  let description = [{
+    `tlx.require_layout` makes a layout requirement explicit in the IR.
+
+    - On memdesc values, it acts as a view-like layout constraint that
+      `tlx-propagate-layout` tries to absorb into the producing or carried
+      memdesc types.
+    - On tensor values, it acts as an explicit register-layout anchor that
+      `tlx-propagate-layout` propagates back to supported producers when
+      possible and otherwise lowers to `ttg.convert_layout`.
+  }];
 
   let arguments = (ins TTG_TensorOrMemDesc:$src);
 
@@ -269,6 +280,8 @@ def TLX_ReleaseLayoutOp : TLX_Op<"release_layout",
   let results = (outs TT_Tensor:$result);
 
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+
+  let hasFolder = 1;
 }
 
 def TLX_LocalAliasOp : TLX_Op<"local_alias",

--- a/third_party/tlx/dialect/include/Transforms/Passes.td
+++ b/third_party/tlx/dialect/include/Transforms/Passes.td
@@ -32,10 +32,22 @@ def TlxPropagateLayout : Pass<"tlx-propagate-layout", "mlir::ModuleOp"> {
   let summary = "Propagate layout information";
 
   let description = [{
-    This pass propagates layout information from the tlx::RequireLayoutOp and
-    tlx::ReleaseLayoutOp by doing a backward and forward dataflow analysis. It
-    is expected that these ops would be either completely eliminated or turned
-    into ttg::ConvertLayoutOp(s).
+    This pass propagates explicit layout constraints from tlx::RequireLayoutOp
+    and tlx::ReleaseLayoutOp using backward and forward dataflow analyses.
+
+    The pass owns the downstream consequences of those constraints:
+    - retagging memdesc producers and carriers when the memdesc lattice reaches
+      a concrete encoding
+    - retagging supported tensor producers (`ttg.local_load`) and region-carried
+      tensor values when the tensor lattice reaches a concrete encoding
+    - applying consensus-based updates for RegionBranchOpInterface carriers and
+      `ttg.warp_specialize` partition captures/arguments
+    - lowering residual tensor constraints to `ttg.convert_layout`
+    - validating post-conditions such as the absence of unresolved
+      DummyTMEMLayoutAttr allocations
+
+    Tensor and memdesc constraints are either folded away when propagation
+    successfully retags the producer, or lowered to `ttg.convert_layout`.
   }];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
@@ -45,11 +57,20 @@ def TlxPropagateLayout : Pass<"tlx-propagate-layout", "mlir::ModuleOp"> {
 }
 
 def TLXInsertRequireLayout : Pass<"tlx-insert-require-layout", "mlir::ModuleOp"> {
-  let summary = "Inserts a tlx::RequireLayoutOp op before the LocalLoad that feeds a tl.dot";
+  let summary = "Insert explicit TLX layout constraints for local_load-to-dot paths";
 
   let description = [{
-    This pass inserts a tlx::RequireLayoutOp op before the LocalLoad that feeds a tl.dot.
-    This layout will then be propagated to the local alloc, by the layout propagation pass.
+    This pass discovers dot-fed ttg.local_load operations and inserts the
+    missing tlx.require_layout constraints needed for the AMD local_load-to-dot
+    path.
+
+    The pass only synthesizes explicit TLX layout constraints:
+    - memdesc-side tlx.require_layout constraints for shared-memory swizzling
+    - tensor-side tlx.require_layout constraints in place of dot-path
+      ttg.convert_layout operations
+
+    It does not own tensor/register propagation or convert cleanup; those are
+    handled by tlx-propagate-layout and downstream cleanup passes.
   }];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -41,12 +41,17 @@ void LayoutEncoding::print(raw_ostream &os) const {
 
 LayoutEncoding LayoutEncoding::join(const LayoutEncoding &lhs,
                                     const LayoutEncoding &rhs) {
+  // Forward merges should stay conservative: distinct concrete layouts widen to
+  // unknown instead of asserting so region joins can fall back cleanly.
+  if (lhs.isUnknown() || rhs.isUnknown())
+    return LayoutEncoding::getUnknownLayout();
   if (lhs.isUninitialized())
     return rhs;
   if (rhs.isUninitialized())
     return lhs;
-  assert(lhs == rhs && "Conflicting layouts");
-  return lhs;
+  if (lhs == rhs)
+    return lhs;
+  return LayoutEncoding::getUnknownLayout();
 }
 
 LayoutEncoding LayoutEncoding::meet(const LayoutEncoding &lhs,
@@ -59,7 +64,28 @@ LayoutEncoding LayoutEncoding::meet(const LayoutEncoding &lhs,
     return lhs;
   if (lhs == rhs)
     return lhs;
-  llvm_unreachable("Conflicting layouts");
+  LDBG("Conflicting memdesc layouts " << lhs << " vs " << rhs
+                                      << "; widening to unknown");
+  return LayoutEncoding::getUnknownLayout();
+}
+
+static bool isValidPermutation(ArrayRef<int32_t> order, unsigned rank) {
+  if (order.size() != rank)
+    return false;
+
+  SmallVector<char> seen(rank, 0);
+  for (int32_t dim : order) {
+    if (dim < 0 || static_cast<unsigned>(dim) >= rank || seen[dim])
+      return false;
+    seen[dim] = 1;
+  }
+  return true;
+}
+
+static bool
+isEffectivelyUnswizzledShared(ttg::SwizzledSharedEncodingAttr encoding) {
+  return encoding.getVec() == 1 && encoding.getPerPhase() == 1 &&
+         encoding.getMaxPhase() == 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -91,8 +117,9 @@ void LayoutBackwardPropagation::visitWarpSpecRegionArgs(
     if (auto warpSpecializePartitionsOp =
             op->getParentOfType<ttg::WarpSpecializePartitionsOp>()) {
       auto warpSpecializeOp = warpSpecializePartitionsOp.getParentOp();
-      auto blockArgumentLattice = getLatticeElement(
-          warpSpecializePartitionsOp.getExplicitCaptures()[arg.getArgNumber()]);
+      auto blockArgumentLattice =
+          getLatticeElement(warpSpecializeOp.getPartitionOp()
+                                .getExplicitCaptures()[arg.getArgNumber()]);
       ChangeResult changed = blockArgumentLattice->meet(resultEncoding);
       propagateIfChanged(blockArgumentLattice, changed);
       // Propagate to all the partition regions
@@ -122,18 +149,55 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     auto resultLattice = results[0];
     LayoutEncoding resultLayoutEncoding = resultLattice->getValue();
     if (!resultLayoutEncoding.isUninitialized()) {
-      if (auto mmaEncoding = dyn_cast<ttg::NVMMASharedEncodingAttr>(
-              resultLattice->getValue().getLayoutEncoding())) {
-        SmallVector<unsigned, 4> newOrder;
-        llvm::transform(memDescTransOp.getOrder(), std::back_inserter(newOrder),
-                        [](int32_t x) { return static_cast<unsigned>(x); });
-        auto newMmaEncoding = ttg::NVMMASharedEncodingAttr::get(
+      Attribute resultEnc = resultLattice->getValue().getLayoutEncoding();
+      SmallVector<unsigned, 4> newOrder;
+      llvm::transform(memDescTransOp.getOrder(), std::back_inserter(newOrder),
+                      [](int32_t x) { return static_cast<unsigned>(x); });
+      Attribute srcEncoding;
+      if (auto mmaEncoding =
+              dyn_cast<ttg::NVMMASharedEncodingAttr>(resultEnc)) {
+        srcEncoding = ttg::NVMMASharedEncodingAttr::get(
             mmaEncoding.getContext(),
             memDescTransOp.getSrc().getType().getShape(), newOrder,
             mmaEncoding.getCGALayout(),
             memDescTransOp.getSrc().getType().getElementType(),
             mmaEncoding.getFp4Padded());
-        const auto updatedResultLayoutEncoding = LayoutEncoding(newMmaEncoding);
+      } else if (auto swizzledEncoding =
+                     dyn_cast<ttg::SwizzledSharedEncodingAttr>(resultEnc)) {
+        auto srcType =
+            cast<ttg::MemDescType>(memDescTransOp.getSrc().getType());
+        unsigned rank = srcType.getRank();
+        auto transOrder = memDescTransOp.getOrder();
+        if (!isValidPermutation(transOrder, rank) ||
+            swizzledEncoding.getOrder().size() != rank) {
+          memDescTransOp.emitOpError(
+              "swizzled_shared backward propagation through memdesc_trans "
+              "requires a valid transpose permutation");
+          return failure();
+        }
+        if (!isEffectivelyUnswizzledShared(swizzledEncoding)) {
+          memDescTransOp.emitOpError(
+              "swizzled_shared backward propagation through memdesc_trans "
+              "only supports effectively unswizzled encodings");
+          return failure();
+        }
+
+        // For effectively unswizzled shared layouts, inverting the transpose
+        // only needs to update the iteration order.
+        SmallVector<unsigned> invOrder(rank);
+        for (unsigned i = 0; i < rank; ++i)
+          invOrder[transOrder[i]] = i;
+        auto encOrder = swizzledEncoding.getOrder();
+        SmallVector<unsigned> permutedOrder(rank);
+        for (unsigned i = 0; i < rank; ++i)
+          permutedOrder[i] = invOrder[encOrder[i]];
+        srcEncoding = ttg::SwizzledSharedEncodingAttr::get(
+            swizzledEncoding.getContext(), swizzledEncoding.getVec(),
+            swizzledEncoding.getPerPhase(), swizzledEncoding.getMaxPhase(),
+            permutedOrder, swizzledEncoding.getCGALayout());
+      }
+      if (srcEncoding) {
+        const auto updatedResultLayoutEncoding = LayoutEncoding(srcEncoding);
         auto operandLattice = operands[0];
         ChangeResult changed =
             operandLattice->meet(updatedResultLayoutEncoding);
@@ -145,18 +209,23 @@ LogicalResult LayoutBackwardPropagation::visitOperation(
     return success();
   }
 
-  // Similar to MemDescTransOp, we need to specially handle TMEMSubSliceOp
+  // TMEMSubSliceOp preserves the source tile shape and only refines the
+  // column-stride/CTA-split details on the 2D slice view. The verifier already
+  // guarantees tensor-memory encodings on both source and result.
   if (auto tmemSliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
-    // Slice resultLayoutEncoding
     auto resultLattice = results[0];
     LayoutEncoding resultLayoutEncoding = resultLattice->getValue();
-    if (!resultLayoutEncoding.isUninitialized()) {
+    if (!resultLayoutEncoding.isUninitialized() && !resultLayoutEncoding.isUnknown()) {
       Attribute resultEncoding = resultLayoutEncoding.getLayoutEncoding();
       if (auto tmemEncoding =
               dyn_cast<ttng::TensorMemoryEncodingAttr>(resultEncoding)) {
         auto srcTy = cast<ttg::MemDescType>(tmemSliceOp.getSrc().getType());
         auto srcEncoding =
             dyn_cast<ttng::TensorMemoryEncodingAttr>(srcTy.getEncoding());
+        if (!srcEncoding)
+          return tmemSliceOp.emitOpError(
+              "expected tensor memory source encoding while propagating "
+              "through tmem_subslice");
         unsigned blockM =
             srcEncoding ? srcEncoding.getBlockM() : tmemEncoding.getBlockM();
         unsigned blockN =
@@ -277,6 +346,169 @@ void LayoutBackwardPropagation::setToExitState(LayoutEncodingLattice *lattice) {
 }
 
 //===----------------------------------------------------------------------===//
+// TensorLayout
+//===----------------------------------------------------------------------===//
+
+void TensorLayout::print(raw_ostream &os) const {
+  if (isUninitialized()) {
+    os << "<UNINITIALIZED>";
+    return;
+  }
+  if (isUnknown()) {
+    os << "<UNKNOWN>";
+    return;
+  }
+  return getLayoutEncoding().print(os);
+}
+
+TensorLayout TensorLayout::join(const TensorLayout &lhs,
+                                const TensorLayout &rhs) {
+  return meet(lhs, rhs);
+}
+
+TensorLayout TensorLayout::meet(const TensorLayout &lhs,
+                                const TensorLayout &rhs) {
+  if (lhs.isUnknown() || rhs.isUnknown())
+    return TensorLayout::getUnknownLayout();
+  if (lhs.isUninitialized())
+    return rhs;
+  if (rhs.isUninitialized())
+    return lhs;
+  if (lhs == rhs)
+    return lhs;
+  return TensorLayout::getUnknownLayout();
+}
+
+static bool isTrackedTensorValue(Value value) {
+  return isa<RankedTensorType>(value.getType());
+}
+
+static bool isAllowedTensorLayoutUser(Operation *op, unsigned operandIndex) {
+  // This mirrors InsertRequireLayout's pre-materialization policy. Before the
+  // insert pass runs, dot operands flow through convert_layout and transparent
+  // region carriers. After convert_layout is rewritten into explicit
+  // tlx.require_layout anchors, tensor propagation treats those anchors plus
+  // the same transparent carriers as the legal local_load-to-dot path.
+  if (auto requireLayoutOp = dyn_cast<RequireLayoutOp>(op)) {
+    if (!isa<RankedTensorType>(requireLayoutOp.getType()) || operandIndex != 0)
+      return false;
+    return isSupportedDotConstraintEncoding(
+        cast<RankedTensorType>(requireLayoutOp.getType()).getEncoding());
+  }
+
+  return isTransparentLayoutCarrierOp(op);
+}
+
+static bool canRewriteTensorResult(Operation *op) {
+  return isa<ttg::LocalLoadOp, RegionBranchOpInterface>(op);
+}
+
+//===----------------------------------------------------------------------===//
+// TensorBackwardPropagation
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorBackwardPropagation::visitOperation(
+    Operation *op, ArrayRef<TensorLayoutLattice *> operands,
+    ArrayRef<const TensorLayoutLattice *> results) {
+  LDBG("Visiting tensor operation " << *op << "\n");
+
+  if (auto requireLayoutOp = dyn_cast<RequireLayoutOp>(op)) {
+    if (!isa<RankedTensorType>(requireLayoutOp.getType()))
+      return success();
+
+    Attribute layout = requireLayoutOp.getType().getEncoding();
+    if (!isSupportedDotConstraintEncoding(layout))
+      return success();
+
+    const auto layoutLattice = TensorLayout(layout);
+    for (auto [operandLattice, operand] :
+         llvm::zip_equal(operands, requireLayoutOp->getOperands())) {
+      if (!isTrackedTensorValue(operand))
+        continue;
+      ChangeResult changed = operandLattice->meet(layoutLattice);
+      propagateIfChanged(operandLattice, changed);
+    }
+    return success();
+  }
+
+  if (isa<ReleaseLayoutOp>(op))
+    return success();
+
+  // If a tracked tensor value is used by an unsupported operation, rewriting
+  // the producer chain is no longer legal for that entire component.
+  for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
+    if (!isTrackedTensorValue(operand))
+      continue;
+    if (isAllowedTensorLayoutUser(op, index))
+      continue;
+
+    TensorLayout operandState = operands[index]->getValue();
+    if (operandState.isUninitialized())
+      continue;
+
+    LDBG("Marking tensor layout unknown due to unsupported user "
+         << op->getName() << " on operand #" << index);
+    ChangeResult changed =
+        operands[index]->meet(TensorLayout::getUnknownLayout());
+    propagateIfChanged(operands[index], changed);
+  }
+
+  // Only a narrow set of tensor-producing operations can absorb a propagated
+  // layout directly. Everything else falls back to a local convert.
+  if (!canRewriteTensorResult(op)) {
+    for (Value result : op->getResults()) {
+      if (!isTrackedTensorValue(result))
+        continue;
+
+      auto *resultLattice = getLatticeElement(result);
+      TensorLayout resultState = resultLattice->getValue();
+      if (resultState.isUninitialized())
+        continue;
+
+      LDBG("Keeping explicit tensor layout conversion because producer "
+           << op->getName() << " cannot be retagged directly");
+      ChangeResult changed =
+          resultLattice->meet(TensorLayout::getUnknownLayout());
+      propagateIfChanged(resultLattice, changed);
+    }
+  }
+
+  return success();
+}
+
+void TensorBackwardPropagation::visitBranchOperand(OpOperand &operand) {
+  if (!isTrackedTensorValue(operand.get()))
+    return;
+
+  Operation *owner = operand.getOwner();
+  if (isa<RegionBranchOpInterface, RegionBranchTerminatorOpInterface>(owner))
+    return;
+
+  auto *lattice = getLatticeElement(operand.get());
+  TensorLayout state = lattice->getValue();
+  if (state.isUninitialized())
+    return;
+
+  ChangeResult changed = lattice->meet(TensorLayout::getUnknownLayout());
+  propagateIfChanged(lattice, changed);
+}
+
+void TensorBackwardPropagation::visitCallOperand(OpOperand &operand) {
+  if (!isTrackedTensorValue(operand.get()))
+    return;
+
+  auto *lattice = getLatticeElement(operand.get());
+  TensorLayout state = lattice->getValue();
+  if (state.isUninitialized())
+    return;
+
+  ChangeResult changed = lattice->meet(TensorLayout::getUnknownLayout());
+  propagateIfChanged(lattice, changed);
+}
+
+void TensorBackwardPropagation::setToExitState(TensorLayoutLattice *lattice) {}
+
+//===----------------------------------------------------------------------===//
 // LayoutForwardPropagation
 //===----------------------------------------------------------------------===//
 
@@ -295,9 +527,11 @@ LogicalResult LayoutForwardPropagation::visitOperation(
       continue;
     LayoutEncoding operandLayoutEncoding = operandLattice->getValue();
 
-    // Slice operandLayoutEncoding
+    // Unknown layouts do not provide enough information to refine a TMEM slice
+    // result, so only splice concrete tensor-memory encodings through.
     if (auto sliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
-      if (!operandLayoutEncoding.isUninitialized()) {
+      if (!operandLayoutEncoding.isUninitialized() &&
+          !operandLayoutEncoding.isUnknown()) {
         Attribute operandEncoding = operandLayoutEncoding.getLayoutEncoding();
         if (auto encoding =
                 dyn_cast<ttng::TensorMemoryEncodingAttr>(operandEncoding)) {
@@ -319,6 +553,10 @@ LogicalResult LayoutForwardPropagation::visitOperation(
         } else if (isa<ttng::TensorMemoryScalesEncodingAttr,
                        triton::tlx::DummyTMEMLayoutAttr>(operandEncoding)) {
           operandLayoutEncoding = LayoutEncoding(operandEncoding);
+        } else {
+          return sliceOp.emitOpError(
+              "expected tensor memory layout while propagating through "
+              "tmem_subslice");
         }
       }
     }

--- a/third_party/tlx/dialect/lib/IR/Ops.cpp
+++ b/third_party/tlx/dialect/lib/IR/Ops.cpp
@@ -29,6 +29,16 @@ OpFoldResult RequireLayoutOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+//-- ReleaseLayoutOp --
+
+OpFoldResult ReleaseLayoutOp::fold(FoldAdaptor adaptor) {
+  if (getType() == getSrc().getType()) {
+    // no-op
+    return getSrc();
+  }
+  return {};
+}
+
 //-- StorageAliasSpecOp --
 
 LogicalResult StorageAliasSpecOp::verify() {

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -1,7 +1,11 @@
 #include "IR/Dialect.h"
-#include "mlir/Analysis/SliceAnalysis.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/Passes.h"
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Analysis/DataFlow/Utils.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "tlx/dialect/include/Analysis/LayoutPropagation.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
@@ -14,75 +18,358 @@
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 using namespace mlir;
+using namespace mlir::dataflow;
 namespace tt = ::mlir::triton;
 namespace ttg = ::mlir::triton::gpu;
 namespace tlx = ::mlir::triton::tlx;
 
 namespace mlir {
-std::optional<ttg::SwizzledSharedEncodingAttr>
-getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible);
-
 namespace triton {
 namespace tlx {
 
 #define GEN_PASS_DEF_TLXINSERTREQUIRELAYOUT
 #include "tlx/dialect/include/Transforms/Passes.h.inc"
 
-LogicalResult insertRequireLayout(ModuleOp m) {
-  OpBuilder builder(m.getContext());
-  LDBG("insertRequiredLayout\n");
-  WalkResult result = m.walk([&](tt::DotOp dotOp) -> WalkResult {
-    SetVector<Operation *> backwardSet;
-    BackwardSliceOptions options;
-    options.inclusive = false;
-    options.omitUsesFromAbove = false;
-    if (failed(mlir::getBackwardSlice(dotOp.getOperation(), &backwardSet,
-                                      options))) {
-      return WalkResult::interrupt();
+namespace {
+
+// ============================================================================
+// Backward dataflow analysis: propagate the required dot-operand encoding and
+// rewrite legality from tt.DotOp operands backward through convert_layout
+// chains and region-branch carriers to local_load ops.
+//
+// The analysis tracks both the desired dot encoding and whether rewriting the
+// value is still legal. We union convert_layout source/result anchors so mixed
+// uses that branch through sibling convert chains share the same legality
+// state.
+// ============================================================================
+
+class DotRewriteState {
+public:
+  enum class Kind {
+    Uninitialized,
+    Required,
+    Conflict,
+    Illegal,
+  };
+
+  DotRewriteState() = default;
+  explicit DotRewriteState(Attribute enc)
+      : kind(Kind::Required), encoding(enc) {}
+
+  static DotRewriteState getConflict() {
+    DotRewriteState state;
+    state.kind = Kind::Conflict;
+    return state;
+  }
+
+  static DotRewriteState getIllegal() {
+    DotRewriteState state;
+    state.kind = Kind::Illegal;
+    return state;
+  }
+
+  bool operator==(const DotRewriteState &rhs) const {
+    return kind == rhs.kind && encoding == rhs.encoding;
+  }
+
+  bool isUninitialized() const { return kind == Kind::Uninitialized; }
+  bool isRequired() const { return kind == Kind::Required; }
+  bool isConflict() const { return kind == Kind::Conflict; }
+  bool isIllegal() const { return kind == Kind::Illegal; }
+
+  Attribute getEncoding() const {
+    assert(isRequired() && "expected required dot encoding state");
+    return *encoding;
+  }
+
+  void print(raw_ostream &os) const {
+    if (isUninitialized()) {
+      os << "<uninitialized>";
+      return;
     }
-    LLVM_DEBUG({
-      llvm::dbgs() << "DotOp\n";
-      dotOp.dump();
+    if (isConflict()) {
+      os << "<conflict>";
+      return;
+    }
+    if (isIllegal()) {
+      os << "<illegal>";
+      return;
+    }
+    if (isRequired()) {
+      encoding->print(os);
+      return;
+    }
+    llvm_unreachable("unknown dot rewrite state");
+  }
+
+  friend raw_ostream &operator<<(raw_ostream &os,
+                                 const DotRewriteState &state) {
+    state.print(os);
+    return os;
+  }
+
+  static DotRewriteState meet(const DotRewriteState &lhs,
+                              const DotRewriteState &rhs) {
+    if (lhs.isIllegal() || rhs.isIllegal())
+      return getIllegal();
+    if (lhs.isUninitialized())
+      return rhs;
+    if (rhs.isUninitialized())
+      return lhs;
+    if (lhs == rhs)
+      return lhs;
+    if (lhs.isConflict() || rhs.isConflict())
+      return getConflict();
+    return getConflict();
+  }
+
+  static DotRewriteState join(const DotRewriteState &lhs,
+                              const DotRewriteState &rhs) {
+    return meet(lhs, rhs);
+  }
+
+private:
+  Kind kind = Kind::Uninitialized;
+  std::optional<Attribute> encoding;
+};
+
+class DotRewriteLattice : public Lattice<DotRewriteState> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DotRewriteLattice)
+  using Lattice::Lattice;
+};
+
+static bool isTrackedDotValue(Value value) {
+  return isa<RankedTensorType>(value.getType());
+}
+
+static bool
+isTransparentDotUserBeforeConstraintMaterialization(Operation *op,
+                                                    unsigned operandIndex) {
+  // This is the pre-materialization half of the shared dot-layout policy. The
+  // insert pass sees raw tt.dot users and the convert_layout chain that still
+  // connects them to local_load. After those converts are rewritten into
+  // explicit tlx.require_layout anchors, tlx-propagate-layout enforces the same
+  // transparent-carrier policy from the tlx.require_layout anchors instead.
+  if (auto dotOp = dyn_cast<tt::DotOp>(op))
+    return operandIndex < 2 && operandIndex < dotOp->getNumOperands();
+
+  return isa<ttg::ConvertLayoutOp>(op) || isTransparentLayoutCarrierOp(op);
+}
+
+class DotRewriteBackward
+    : public SparseBackwardDataFlowAnalysis<DotRewriteLattice> {
+public:
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  void initializeEquivalentLatticeAnchor(Operation *top) override {
+    top->walk([&](ttg::ConvertLayoutOp cvt) {
+      if (!isTrackedDotValue(cvt.getSrc()) ||
+          !isTrackedDotValue(cvt.getResult()))
+        return;
+      unionLatticeAnchors<DotRewriteLattice>(cvt.getSrc(), cvt.getResult());
     });
-    for (Operation *op : backwardSet) {
-      if (auto localLoadOp = dyn_cast<ttg::LocalLoadOp>(op)) {
-        LLVM_DEBUG({
-          llvm::dbgs() << "LocalLoadOp\n";
-          localLoadOp.dump();
-        });
-        // Get the shared encoding for this local load op based on the dot op
-        bool incompatible = false;
-        auto encoding = mlir::getSharedEncIfAllUsersAreDotEnc(
-                            localLoadOp->getResult(0), incompatible)
-                            .value_or(nullptr);
-        if (encoding) {
-          LLVM_DEBUG({
-            llvm::dbgs() << "SwizzledSharedEncodingAttr\n";
-            encoding.dump();
-          });
-          builder.setInsertionPoint(localLoadOp);
-          auto encodingAttr = mlir::cast<Attribute>(encoding);
-          auto loadMemDescTy = op->getOperands()[0];
-          if (auto type = dyn_cast<ttg::MemDescType>(loadMemDescTy.getType())) {
-            auto newType = ttg::MemDescType::get(
-                type.getShape(), type.getElementType(), encodingAttr,
-                type.getMemorySpace(), type.getMutableMemory());
-            auto converLayoutOp = tlx::RequireLayoutOp::create(
-                builder, op->getLoc(), newType, loadMemDescTy);
-            localLoadOp->setOperand(0, converLayoutOp.getResult());
-          }
-        } else {
-          localLoadOp->emitError(
-              "Cannot find appropriate shared encoding for local load op");
-          return WalkResult::interrupt();
+  }
+
+  LogicalResult
+  visitOperation(Operation *op, ArrayRef<DotRewriteLattice *> operands,
+                 ArrayRef<const DotRewriteLattice *> results) override {
+    // Seed from tt.DotOp: propagate the required dot-operand encoding to
+    // the values that define operands A and B.
+    if (auto dotOp = dyn_cast<tt::DotOp>(op)) {
+      for (unsigned i = 0; i < 2; ++i) {
+        auto type = cast<RankedTensorType>(dotOp.getOperand(i).getType());
+        if (auto dotEnc =
+                dyn_cast<ttg::DotOperandEncodingAttr>(type.getEncoding())) {
+          ChangeResult changed = operands[i]->meet(DotRewriteState(dotEnc));
+          propagateIfChanged(operands[i], changed);
         }
       }
+      return success();
     }
-    return WalkResult::advance();
-  });
-  if (result.wasInterrupted()) {
-    return failure();
+
+    // If a tracked tensor value is used by an unsupported operation, the
+    // require_layout rewrite is no longer legal for that entire carrier chain.
+    for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
+      if (!isTrackedDotValue(operand))
+        continue;
+      if (isTransparentDotUserBeforeConstraintMaterialization(op, index))
+        continue;
+
+      DotRewriteState operandState = operands[index]->getValue();
+      if (operandState.isUninitialized())
+        continue;
+
+      ChangeResult changed =
+          operands[index]->meet(DotRewriteState::getIllegal());
+      propagateIfChanged(operands[index], changed);
+    }
+
+    return success();
   }
+
+  void visitBranchOperand(OpOperand &operand) override {
+    poisonUnhandledCase(operand);
+  }
+
+  void visitCallOperand(OpOperand &operand) override {
+    poisonUnhandledCase(operand);
+  }
+
+  void
+  visitNonControlFlowArguments(RegionSuccessor &successor,
+                               ArrayRef<BlockArgument> arguments) {}
+  void setToExitState(DotRewriteLattice *lattice) override {}
+
+private:
+  void poisonUnhandledCase(OpOperand &operand) {
+    if (!isTrackedDotValue(operand.get()))
+      return;
+
+    auto *lattice = getLatticeElement(operand.get());
+    DotRewriteState state = lattice->getValue();
+    if (state.isUninitialized())
+      return;
+
+    ChangeResult changed = lattice->meet(DotRewriteState::getIllegal());
+    propagateIfChanged(lattice, changed);
+  }
+};
+
+// ============================================================================
+// Rewrite helpers
+// ============================================================================
+
+static ttg::SwizzledSharedEncodingAttr
+computeSharedEncFromDotEnc(ttg::DotOperandEncodingAttr dotEnc,
+                           ttg::LocalLoadOp localLoadOp) {
+  auto resultType = cast<RankedTensorType>(localLoadOp.getType());
+  auto order = ttg::getOrderForMemory(resultType);
+  auto ctaLayout = ttg::getCGALayout(resultType.getEncoding());
+  unsigned bitWidth = resultType.getElementType().getIntOrFloatBitWidth();
+  return ttg::SwizzledSharedEncodingAttr::get(localLoadOp->getContext(), dotEnc,
+                                              resultType.getShape(), order,
+                                              ctaLayout, bitWidth,
+                                              /*needTrans=*/false);
+}
+
+static void applyRequireLayout(ttg::SwizzledSharedEncodingAttr encoding,
+                               ttg::LocalLoadOp localLoadOp,
+                               OpBuilder &builder) {
+  auto loadMemDesc = localLoadOp->getOperand(0);
+
+  if (loadMemDesc.getDefiningOp<tlx::RequireLayoutOp>())
+    return;
+
+  // Respect user-specified order on the source memdesc.
+  if (auto srcType = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
+    if (auto srcEnc =
+            dyn_cast<ttg::SwizzledSharedEncodingAttr>(srcType.getEncoding())) {
+      if (srcEnc.getOrder() != encoding.getOrder()) {
+        LDBG("Respecting user-specified order "
+             << srcEnc << " instead of derived " << encoding);
+        encoding = ttg::SwizzledSharedEncodingAttr::get(
+            encoding.getContext(), encoding.getVec(), encoding.getPerPhase(),
+            encoding.getMaxPhase(), srcEnc.getOrder(), encoding.getCGALayout());
+      }
+    }
+  }
+
+  builder.setInsertionPoint(localLoadOp);
+  if (auto type = dyn_cast<ttg::MemDescType>(loadMemDesc.getType())) {
+    auto newType = ttg::MemDescType::get(
+        type.getShape(), type.getElementType(), mlir::cast<Attribute>(encoding),
+        type.getMemorySpace(), type.getMutableMemory());
+    auto requireOp = tlx::RequireLayoutOp::create(
+        builder, localLoadOp->getLoc(), newType, loadMemDesc);
+    localLoadOp->setOperand(0, requireOp.getResult());
+  }
+}
+
+static void materializeTensorRequireLayout(tt::DotOp dotOp,
+                                           unsigned operandIndex,
+                                           OpBuilder &builder) {
+  Value operand = dotOp.getOperand(operandIndex);
+  auto cvt = operand.getDefiningOp<ttg::ConvertLayoutOp>();
+  if (!cvt)
+    return;
+
+  auto dstType = dyn_cast<RankedTensorType>(cvt.getType());
+  if (!dstType || !isSupportedDotConstraintEncoding(dstType.getEncoding()))
+    return;
+
+  builder.setInsertionPoint(cvt);
+  auto requireOp = tlx::RequireLayoutOp::create(builder, cvt.getLoc(),
+                                                cvt.getType(), cvt.getSrc());
+  dotOp->setOperand(operandIndex, requireOp.getResult());
+  if (cvt.getResult().use_empty())
+    cvt.erase();
+}
+
+static void materializeDotUserTensorConstraints(ModuleOp m,
+                                                OpBuilder &builder) {
+  m.walk([&](tt::DotOp dotOp) {
+    for (unsigned i = 0; i < 2; ++i)
+      materializeTensorRequireLayout(dotOp, i, builder);
+  });
+}
+
+} // namespace
+
+// ============================================================================
+// Main pass logic
+// ============================================================================
+
+LogicalResult insertRequireLayout(ModuleOp m) {
+  OpBuilder builder(m.getContext());
+  LDBG("insertRequireLayout");
+
+  // --- Run backward dataflow analysis ---
+  // SparseBackwardDataFlowAnalysis requires a SymbolTableCollection even though
+  // this analysis does not query symbol tables directly.
+  SymbolTableCollection symbolTable;
+  DataFlowSolver solver;
+  loadBaselineAnalyses(solver);
+  solver.load<DotRewriteBackward>(symbolTable);
+  if (failed(solver.initializeAndRun(m)))
+    return failure();
+
+  // InsertRequireLayout owns constraint synthesis only:
+  // 1. Discover dot-fed local_load ops and add the missing memdesc-side
+  //    tlx.require_layout constraints for shared memory.
+  // 2. Rewrite matched dot-path ttg.convert_layout ops into explicit tensor
+  //    tlx.require_layout constraints.
+  // 3. Leave tensor/register propagation, region-branch retagging, and final
+  //    convert cleanup to tlx-propagate-layout and downstream cleanup passes.
+  m.walk([&](ttg::LocalLoadOp localLoadOp) {
+    auto *lattice =
+        solver.lookupState<DotRewriteLattice>(localLoadOp.getResult());
+    if (!lattice || lattice->getValue().isUninitialized())
+      return;
+
+    if (lattice->getValue().isIllegal() || lattice->getValue().isConflict()) {
+      LDBG("Skipping local_load rewrite due to state: " << lattice->getValue());
+      localLoadOp->emitRemark()
+          << "dot operand layout constraint cannot be folded into local_load "
+             "because the value has incompatible users or conflicting dot "
+             "requirements";
+      return;
+    }
+
+    auto dotEnc = dyn_cast<ttg::DotOperandEncodingAttr>(
+        lattice->getValue().getEncoding());
+    if (!dotEnc)
+      return;
+
+    LDBG("local_load needs dot encoding: " << dotEnc);
+
+    // Insert RequireLayoutOp for memdesc swizzling.
+    auto sharedEnc = computeSharedEncFromDotEnc(dotEnc, localLoadOp);
+    applyRequireLayout(sharedEnc, localLoadOp, builder);
+  });
+
+  materializeDotUserTensorConstraints(m, builder);
+
   return success();
 }
 
@@ -94,9 +381,8 @@ public:
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
-    if (failed(tlx::insertRequireLayout(m))) {
+    if (failed(tlx::insertRequireLayout(m)))
       signalPassFailure();
-    }
   }
 };
 

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -11,6 +11,7 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -41,7 +42,11 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     if (!isa<RankedTensorType>(requireLayoutOp.getSrc().getType()))
       return failure();
-    auto convertLayoutOp = rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
+    if (requireLayoutOp.getSrc().getType() == requireLayoutOp.getType()) {
+      rewriter.replaceOp(requireLayoutOp, requireLayoutOp.getSrc());
+      return success();
+    }
+    rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
         requireLayoutOp, requireLayoutOp.getType(), requireLayoutOp.getSrc());
     return success();
   }
@@ -54,11 +59,234 @@ public:
   mlir::LogicalResult
   matchAndRewrite(ReleaseLayoutOp releaseLayoutOp,
                   mlir::PatternRewriter &rewriter) const override {
-    auto convertLayoutOp = rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
+    if (releaseLayoutOp.getSrc().getType() == releaseLayoutOp.getType()) {
+      rewriter.replaceOp(releaseLayoutOp, releaseLayoutOp.getSrc());
+      return success();
+    }
+    rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
         releaseLayoutOp, releaseLayoutOp.getType(), releaseLayoutOp.getSrc());
     return success();
   }
 };
+
+static RankedTensorType getNewTensorType(RankedTensorType origType,
+                                         Attribute encoding) {
+  return RankedTensorType::get(origType.getShape(), origType.getElementType(),
+                               encoding);
+}
+
+static bool isRetaggableTensorProducerValue(Value value) {
+  if (!isa<RankedTensorType>(value.getType()))
+    return false;
+
+  Operation *definingOp = value.getDefiningOp();
+  return isa_and_nonnull<ttg::LocalLoadOp>(definingOp);
+}
+
+static Type getTensorCandidateType(Value value, DataFlowSolver &solver,
+                                   const llvm::DenseSet<Value> &blockedValues) {
+  auto tensorType = cast<RankedTensorType>(value.getType());
+  if (blockedValues.contains(value))
+    return tensorType;
+
+  auto *lattice = solver.lookupState<TensorLayoutLattice>(value);
+  if (!lattice || lattice->getValue().isUninitialized() ||
+      lattice->getValue().isUnknown())
+    return tensorType;
+
+  return getNewTensorType(tensorType, lattice->getValue().getLayoutEncoding());
+}
+
+static void
+rewriteTensorValueFromLattice(Value value, DataFlowSolver &solver,
+                              const llvm::DenseSet<Value> &blockedValues) {
+  if (!isRetaggableTensorProducerValue(value))
+    return;
+
+  auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+  if (!tensorType)
+    return;
+  auto newType = cast<RankedTensorType>(
+      getTensorCandidateType(value, solver, blockedValues));
+  if (newType != tensorType)
+    value.setType(newType);
+}
+
+static ttg::MemDescType getNewMemDescType(ttg::MemDescType origType,
+                                          Attribute encoding) {
+  return ttg::MemDescType::get(origType.getShape(), origType.getElementType(),
+                               encoding, origType.getMemorySpace(),
+                               origType.getMutableMemory());
+}
+
+static FailureOr<const LayoutEncodingLattice *>
+lookupMemDescLatticeOrEmitError(Value value, DataFlowSolver &solver,
+                                Operation *diagnosticOp) {
+  auto *lattice = solver.lookupState<LayoutEncodingLattice>(value);
+  if (lattice)
+    return lattice;
+
+  diagnosticOp->emitError()
+      << "expected memdesc layout lattice for value " << value;
+  return failure();
+}
+
+static FailureOr<LayoutEncoding>
+getMemDescConsensusLayout(ArrayRef<Value> values, DataFlowSolver &solver,
+                          Operation *diagnosticOp) {
+  LayoutEncoding consensus;
+  for (Value value : values) {
+    FailureOr<const LayoutEncodingLattice *> lattice =
+        lookupMemDescLatticeOrEmitError(value, solver, diagnosticOp);
+    if (failed(lattice))
+      return failure();
+    consensus = LayoutEncoding::join(consensus, (*lattice)->getValue());
+  }
+  return consensus;
+}
+
+static LogicalResult rewriteMemDescValueFromLattice(Value value,
+                                                    DataFlowSolver &solver,
+                                                    Operation *diagnosticOp) {
+  auto origType = dyn_cast<ttg::MemDescType>(value.getType());
+  if (!origType)
+    return success();
+
+  FailureOr<const LayoutEncodingLattice *> lattice =
+      lookupMemDescLatticeOrEmitError(value, solver, diagnosticOp);
+  if (failed(lattice))
+    return failure();
+
+  LayoutEncoding layout = (*lattice)->getValue();
+  if (layout.isUninitialized())
+    return success();
+  if (layout.isUnknown()) {
+    LDBG("Leaving memdesc value unchanged due to unknown layout: " << value);
+    return success();
+  }
+
+  auto newType = getNewMemDescType(origType, layout.getLayoutEncoding());
+  if (newType != origType)
+    value.setType(newType);
+  return success();
+}
+
+static void
+collectRegionBranchSuccessors(RegionBranchOpInterface branchOp,
+                              SmallVectorImpl<RegionSuccessor> &successors) {
+  auto appendUniqueSuccessors = [&](ArrayRef<RegionSuccessor> newSuccessors) {
+    for (RegionSuccessor successor : newSuccessors) {
+      if (!llvm::is_contained(successors, successor))
+        successors.push_back(successor);
+    }
+  };
+
+  SmallVector<RegionSuccessor> newSuccessors;
+  branchOp.getSuccessorRegions(RegionBranchPoint::parent(), newSuccessors);
+  appendUniqueSuccessors(newSuccessors);
+  for (Region &region : branchOp->getRegions()) {
+    newSuccessors.clear();
+    branchOp.getSuccessorRegions(region, newSuccessors);
+    appendUniqueSuccessors(newSuccessors);
+  }
+}
+
+static std::optional<Type>
+getTensorConsensusType(ValueRange values, DataFlowSolver &solver,
+                       const llvm::DenseSet<Value> &blockedValues) {
+  if (values.empty())
+    return std::nullopt;
+
+  std::optional<Type> consensusType;
+  for (Value value : values) {
+    if (!isa<RankedTensorType>(value.getType()))
+      return std::nullopt;
+
+    Type candidateType = getTensorCandidateType(value, solver, blockedValues);
+    if (!consensusType) {
+      consensusType = candidateType;
+      continue;
+    }
+    if (*consensusType != candidateType)
+      return std::nullopt;
+  }
+  return consensusType;
+}
+
+static llvm::DenseSet<Value>
+computeBlockedTensorValues(triton::FuncOp funcOp, DataFlowSolver &solver) {
+  llvm::DenseSet<Value> blockedValues;
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    funcOp.walk([&](RegionBranchOpInterface branchOp) {
+      SmallVector<RegionSuccessor> successors;
+      collectRegionBranchSuccessors(branchOp, successors);
+
+      for (RegionSuccessor successor : successors) {
+        ValueRange successorInputs = successor.getSuccessorInputs();
+        for (auto [index, successorInput] : llvm::enumerate(successorInputs)) {
+          if (!isa<RankedTensorType>(successorInput.getType()))
+            continue;
+
+          SmallVector<Value> predecessorValues;
+          branchOp.getPredecessorValues(successor, index, predecessorValues);
+          if (predecessorValues.empty())
+            continue;
+
+          if (getTensorConsensusType(ValueRange(predecessorValues), solver,
+                                     blockedValues))
+            continue;
+
+          LDBG("Blocking tensor carrier value due to inconsistent predecessor "
+               "layouts at "
+               << branchOp->getName());
+          changed |= blockedValues.insert(successorInput).second;
+          for (Value predecessorValue : predecessorValues) {
+            if (!isa<RankedTensorType>(predecessorValue.getType()))
+              continue;
+            changed |= blockedValues.insert(predecessorValue).second;
+          }
+        }
+      }
+
+      return WalkResult::advance();
+    });
+  }
+
+  return blockedValues;
+}
+
+static void
+updateTensorRegionBranchTypes(triton::FuncOp funcOp, DataFlowSolver &solver,
+                              const llvm::DenseSet<Value> &blockedValues) {
+  funcOp.walk<WalkOrder::PostOrder>([&](RegionBranchOpInterface branchOp) {
+    SmallVector<RegionSuccessor> successors;
+    collectRegionBranchSuccessors(branchOp, successors);
+
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (RegionSuccessor successor : successors) {
+        ValueRange successorInputs = successor.getSuccessorInputs();
+        for (auto [index, successorInput] : llvm::enumerate(successorInputs)) {
+          if (!isa<RankedTensorType>(successorInput.getType()))
+            continue;
+
+          SmallVector<Value> predecessorValues;
+          branchOp.getPredecessorValues(successor, index, predecessorValues);
+          std::optional<Type> consensusType = getTensorConsensusType(
+              ValueRange(predecessorValues), solver, blockedValues);
+          if (!consensusType || successorInput.getType() == *consensusType)
+            continue;
+
+          successorInput.setType(*consensusType);
+          changed = true;
+        }
+      }
+    }
+  });
+}
 
 class TlxPropagateLayoutPass
     : public impl::TlxPropagateLayoutBase<TlxPropagateLayoutPass> {
@@ -69,15 +297,13 @@ public:
   void runOnFuncOp(triton::FuncOp funcOp) {
     // We can terminate early if we don't have a layout constraint.
     WalkResult walkResult = funcOp.walk([&](mlir::Operation *op) {
-      if (auto requireLayoutOp = dyn_cast<tlx::RequireLayoutOp>(op))
-        if (isa<gpu::MemDescType>(requireLayoutOp.getType()))
-          return WalkResult::interrupt();
+      if (isa<tlx::RequireLayoutOp, tlx::ReleaseLayoutOp>(op))
+        return WalkResult::interrupt();
       return WalkResult::advance();
     });
     if (!walkResult.wasInterrupted())
       return;
 
-    PatternRewriter rewriter(&getContext());
     SymbolTableCollection symbolTable;
     Operation *op = getOperation();
     DataFlowSolver solver;
@@ -86,66 +312,70 @@ public:
     solver.load<SparseConstantPropagation>();
     solver.load<LayoutBackwardPropagation>(symbolTable);
     solver.load<LayoutForwardPropagation>();
+    solver.load<TensorBackwardPropagation>(symbolTable);
     if (failed(solver.initializeAndRun(op)))
       return signalPassFailure();
 
-    auto getNewMemDescType = [&](ttg::MemDescType origType,
-                                 Attribute encoding) {
-      return ttg::MemDescType::get(
-          origType.getShape(), origType.getElementType(), encoding,
-          origType.getMemorySpace(), origType.getMutableMemory());
-    };
+    llvm::DenseSet<Value> blockedTensorValues =
+        computeBlockedTensorValues(funcOp, solver);
 
-    funcOp.walk([&](mlir::Operation *op) {
+    WalkResult typeRewriteWalk = funcOp.walk([&](mlir::Operation *op) {
       if (isa<tlx::RequireLayoutOp>(op))
         return WalkResult::advance();
 
       if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
-        auto partitionsOp = wsOp.getPartitionOp();
-        Region *firstRegion = wsOp.getPartitionRegions()[0];
-        for (auto [i, blockArg] :
-             llvm::enumerate(firstRegion->getArguments())) {
-          if (!isa<ttg::MemDescType>(blockArg.getType()))
+        for (auto [i, capture] :
+             llvm::enumerate(wsOp.getPartitionOp().getExplicitCaptures())) {
+          auto captureType = dyn_cast<ttg::MemDescType>(capture.getType());
+          if (!captureType)
             continue;
-          auto lattice = solver.lookupState<LayoutEncodingLattice>(blockArg);
-          if (!lattice)
-            llvm_unreachable("Lattice not found.");
-          if (lattice->getValue().isUninitialized())
+
+          SmallVector<Value> relatedValues;
+          relatedValues.push_back(capture);
+          for (Region *partitionRegion : wsOp.getPartitionRegions())
+            relatedValues.push_back(partitionRegion->getArgument(i));
+
+          FailureOr<LayoutEncoding> consensus =
+              getMemDescConsensusLayout(relatedValues, solver, wsOp);
+          if (failed(consensus))
+            return WalkResult::interrupt();
+          if (consensus->isUninitialized())
             continue;
-          for (Region *partitionRegion : wsOp.getPartitionRegions()) {
-            if (auto origType =
-                    dyn_cast<ttg::MemDescType>(blockArg.getType())) {
-              auto newType = getNewMemDescType(
-                  origType, lattice->getValue().getLayoutEncoding());
-              partitionRegion->getArgument(i).setType(newType);
-            }
+          if (consensus->isUnknown()) {
+            LDBG("Leaving warp_specialize capture #" << i
+                                                     << " unchanged due to "
+                                                        "non-concrete "
+                                                        "partition consensus");
+            continue;
           }
-          // Also update the capture value's type on the partitions op.
-          if (auto origType = dyn_cast<ttg::MemDescType>(blockArg.getType())) {
-            auto newType = getNewMemDescType(
-                origType, lattice->getValue().getLayoutEncoding());
-            partitionsOp.getExplicitCaptures()[i].setType(newType);
+
+          auto newType =
+              getNewMemDescType(captureType, consensus->getLayoutEncoding());
+          if (capture.getType() != newType)
+            capture.setType(newType);
+          for (Region *partitionRegion : wsOp.getPartitionRegions()) {
+            if (partitionRegion->getArgument(i).getType() != newType)
+              partitionRegion->getArgument(i).setType(newType);
           }
         }
         return WalkResult::advance();
       }
 
       for (auto [i, result] : llvm::enumerate(op->getResults())) {
-        if (!isa<ttg::MemDescType>(result.getType()))
+        if (!isa<ttg::MemDescType>(result.getType())) {
+          rewriteTensorValueFromLattice(result, solver, blockedTensorValues);
           continue;
-        auto *lattice = solver.lookupState<LayoutEncodingLattice>(result);
-        if (!lattice)
-          llvm_unreachable("Lattice not found.");
-        if (lattice->getValue().isUninitialized())
-          continue;
-        if (auto origType = dyn_cast<ttg::MemDescType>(result.getType())) {
-          auto newType = getNewMemDescType(
-              origType, lattice->getValue().getLayoutEncoding());
-          op->getResult(i).setType(newType);
         }
+
+        if (failed(rewriteMemDescValueFromLattice(result, solver, op)))
+          return WalkResult::interrupt();
       }
       return WalkResult::advance();
     });
+    if (typeRewriteWalk.wasInterrupted())
+      return signalPassFailure();
+
+    updateTensorRegionBranchTypes(funcOp, solver, blockedTensorValues);
 
     // Verify that no DummyTMEMLayoutAttr remains after layout propagation
     bool hasDummyLayout = false;


### PR DESCRIPTION
  ## Summary
  Port of #1197 (including patch #1577) from `tlx-amd-meta` to `main`. Rewrites the InsertRequireLayout
  pass with backward dataflow analysis and adds tensor layout propagation
  through region branches.
  
  Key changes:
  - InsertRequireLayout: new `DotRewriteBackward` analysis propagates
    dot-operand encoding requirements backward through convert_layout chains
    to local_load ops, replacing the previous pattern-based approach
  - LayoutPropagation: adds forward propagation through memdesc_trans,
    TMEMSubSlice, and warp_specialize regions with consensus-based layout
    resolution
  - PropagateLayout: adds tensor type rewriting via `TensorBackwardPropagation`
    with blocked-value detection for inconsistent region-branch carriers
    
  API adaptations for main branch:
  - Remove `override` on `visitNonControlFlowArguments` (not virtual in main's MLIR)
  - `getCGALayout` → `getCTASplitM/N` + `getCtaMode` on `TensorMemoryEncodingAttr`
  - `branchOp.getSuccessorInputs(successor)` → `successor.getSuccessorInputs()`
  - Add `LocalAliasOp` to backward propagation skip list
  - Add `MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID` for `DotRewriteLattice`
  
  ## Test plan
  - `make dev-install-llvm` builds clean
  - 7 new LIT tests all pass (`lit build/.../test/TLX/`):
    insert-require-layout, insert-require-layout-propagate,
    insert-require-layout-pipeline-fallback, propagate-layout-memdesc-trans,
    propagate-layout-memdesc-trans-errors, propagate-layout-tensor-residual,
    propagate-layout-warp-specialize
  - 27/28 TLX LIT tests pass (1 pre-existing failure)
  - `pytest python/test/unit/language/test_tlx_amd.py` — all 6 tests pass