### PR TITLE
[TLX][GEMM] Skip Split-K autotuning when SK=1 configs already saturate the GPU (#1579)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -387,7 +387,7 @@ def get_cuda_autotune_config():
         for BM in [64, 128, 256]
         for BN in [64, 128, 256]
         for BK in [64, 128]
-        for s in [2, 3, 4, 5, 6, 7]
+        for s in [2, 3, 4, 5, 6, 7, 8]
         for t in [1, 2, 3]
         for m in [1, 2]
         for subtile in [1, 2, 4, 8]
@@ -1062,6 +1062,16 @@ def _reduce_k_kernel(
     tl.store(c_ptr + base_offs, acc.to(OUTPUT_DTYPE), mask=mask)
 
 
+_l2_flush_buf = {}
+
+
+def _flush_l2_cache(device):
+    """Evict L2 cache by writing a buffer larger than L2 (64 MB for B200)."""
+    if device not in _l2_flush_buf:
+        _l2_flush_buf[device] = torch.empty(64 * 1024 * 1024, dtype=torch.int8, device=device)
+    _l2_flush_buf[device].zero_()
+
+
 def reduce_post_hook(nargs, exception=None):
     if exception is not None:
         return
@@ -1083,6 +1093,10 @@ def reduce_post_hook(nargs, exception=None):
             OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[workspace.dtype],
             num_warps=4,
         )
+        # Flush L2 cache after reduction so do_bench iterations don't
+        # benefit from artificially warm workspace data. In production,
+        # the workspace is cold on each forward pass.
+        _flush_l2_cache(workspace.device)
 
 
 @triton.autotune(


### PR DESCRIPTION
Summary:

The autotuner `do_bench` loop runs the kernel+post_hook many times in a tight loop. For Split-K configs, the reduction workspace stays hot in L2 cache after the first iteration, making the `_reduce_k_kernel` (called via `post_hook`) artificially fast. In production, the workspace is cold on each forward pass, so Split-K configs are slower than `do_bench` suggests.

Fix: flush L2 cache after the Split-K reduction in `reduce_post_hook` by zeroing a 64 MB buffer. This ensures each `do_bench` iteration sees cold workspace data, matching production behavior. With this fix, the autotuner correctly prefers SK=1 configs for shapes where they are faster end-to-end.

Also add a pruning heuristic: if any SK=1 config achieves >=90% SM utilization, prune all SK>1 configs from the search space. This reduces autotuning time and further eliminates noise from SK configs.

Also extend `NUM_SMEM_BUFFERS` search range from [2..7] to [2..8].

Reviewed By: wlei-llvm

Differential Revision: D106388151


