### PR TITLE
  [AutoWS] Add a peephole optimization for sinking broadcast inputs (#1582) (#1582)

### DIFF
--- a/test/Hopper/WarpSpecialization/sink_broadcast.mlir
+++ b/test/Hopper/WarpSpecialization/sink_broadcast.mlir
@@ -1,0 +1,112 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-sink-broadcast | FileCheck %s
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 128]], warp = [[16, 0], [32, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 256, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @sink_after_tmem_load
+  tt.func @sink_after_tmem_load(%bias: tensor<1x256xf32, #linear>,
+                                %acc: !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable>)
+                                -> tensor<64x256xf32, #linear> {
+    // CHECK: %[[LOAD:.*]] = ttng.tmem_load
+    // CHECK-NEXT: %[[BCAST:.*]] = tt.broadcast %{{.*}} : tensor<1x256xf32, #linear> -> tensor<64x256xf32, #linear>
+    // CHECK-NEXT: %[[ADD:.*]] = arith.addf %[[LOAD]], %[[BCAST]]
+    %bcast = tt.broadcast %bias : tensor<1x256xf32, #linear> -> tensor<64x256xf32, #linear>
+    %load = ttng.tmem_load %acc : !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x256xf32, #linear>
+    %add = arith.addf %load, %bcast : tensor<64x256xf32, #linear>
+    tt.return %add : tensor<64x256xf32, #linear>
+  }
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 128]], warp = [[16, 0], [32, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 256, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @sink_broadcast_chain_through_descriptor_load
+  tt.func @sink_broadcast_chain_through_descriptor_load(%bias_desc: !tt.tensordesc<tensor<1x256xf16>>,
+                                                        %acc: !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable>)
+                                                        -> tensor<64x256xf32, #linear> {
+    // CHECK: %[[TMEM:.*]] = ttng.tmem_load
+    // CHECK-NEXT: %[[BIAS:.*]] = tt.descriptor_load
+    // CHECK-NEXT: %[[EXT:.*]] = arith.extf %[[BIAS]]
+    // CHECK-NEXT: %[[BCAST:.*]] = tt.broadcast %[[EXT]]
+    // CHECK-NEXT: %[[ADD:.*]] = arith.addf %[[TMEM]], %[[BCAST]]
+    %c0 = arith.constant 0 : i32
+    %bias = tt.descriptor_load %bias_desc[%c0, %c0] : !tt.tensordesc<tensor<1x256xf16>> -> tensor<1x256xf16>
+    %bias_f32 = arith.extf %bias : tensor<1x256xf16> to tensor<1x256xf32>
+    %bcast = tt.broadcast %bias_f32 : tensor<1x256xf32> -> tensor<64x256xf32, #linear>
+    %load = ttng.tmem_load %acc : !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x256xf32, #linear>
+    %add = arith.addf %load, %bcast : tensor<64x256xf32, #linear>
+    tt.return %add : tensor<64x256xf32, #linear>
+  }
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 128]], warp = [[16, 0], [32, 0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @sink_multiple_broadcast_operands
+  tt.func @sink_multiple_broadcast_operands(%lhs: tensor<64x1xf32, #linear>,
+                                            %rhs: tensor<1x256xf32, #linear>,
+                                            %x: tensor<64x256xf32, #linear>)
+                                            -> tensor<64x256xf32, #linear> {
+    // CHECK: %[[PREP:.*]] = arith.mulf
+    // CHECK-NEXT: %[[LHS:.*]] = tt.broadcast
+    // CHECK-NEXT: %[[RHS:.*]] = tt.broadcast
+    // CHECK-NEXT: %[[ADD:.*]] = arith.addf %[[LHS]], %[[RHS]]
+    // CHECK-NEXT: %[[SUB:.*]] = arith.subf %[[ADD]], %[[PREP]]
+    %lhs_bcast = tt.broadcast %lhs : tensor<64x1xf32, #linear> -> tensor<64x256xf32, #linear>
+    %rhs_bcast = tt.broadcast %rhs : tensor<1x256xf32, #linear> -> tensor<64x256xf32, #linear>
+    %prep = arith.mulf %x, %x : tensor<64x256xf32, #linear>
+    %add = arith.addf %lhs_bcast, %rhs_bcast : tensor<64x256xf32, #linear>
+    %sub = arith.subf %add, %prep : tensor<64x256xf32, #linear>
+    tt.return %sub : tensor<64x256xf32, #linear>
+  }
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 128]], warp = [[16, 0], [32, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 256, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @clone_for_shared_broadcast
+  tt.func @clone_for_shared_broadcast(%bias: tensor<1x256xf32, #linear>,
+                                      %x: tensor<64x256xf32, #linear>,
+                                      %acc: !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable>)
+                                      -> tensor<64x256xf32, #linear> {
+    // CHECK: %[[CLONE:.*]] = tt.broadcast
+    // CHECK-NEXT: %[[ADD:.*]] = arith.addf %[[CLONE]], %{{.*}}
+    // CHECK: %[[LOAD:.*]] = ttng.tmem_load
+    // CHECK-NEXT: %[[ORIG:.*]] = tt.broadcast
+    // CHECK-NEXT: %[[MUL:.*]] = arith.mulf %[[LOAD]], %[[ORIG]]
+    %bcast = tt.broadcast %bias : tensor<1x256xf32, #linear> -> tensor<64x256xf32, #linear>
+    %add = arith.addf %bcast, %x : tensor<64x256xf32, #linear>
+    %load = ttng.tmem_load %acc : !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x256xf32, #linear>
+    %mul = arith.mulf %load, %bcast : tensor<64x256xf32, #linear>
+    %ret = arith.addf %add, %mul : tensor<64x256xf32, #linear>
+    tt.return %ret : tensor<64x256xf32, #linear>
+  }
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 128]], warp = [[16, 0], [32, 0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @do_not_sink_unary_op
+  tt.func @do_not_sink_unary_op(%bias: tensor<1x256xf32, #linear>,
+                                %x: tensor<64x256xf32, #linear>)
+                                -> tensor<64x256xf32, #linear> {
+    // CHECK: %[[BCAST:.*]] = tt.broadcast
+    // CHECK-NEXT: %[[ABS:.*]] = math.absf %[[BCAST]]
+    // CHECK-NEXT: %[[ADD:.*]] = arith.addf %[[ABS]], %{{.*}}
+    %bcast = tt.broadcast %bias : tensor<1x256xf32, #linear> -> tensor<64x256xf32, #linear>
+    %abs = math.absf %bcast : tensor<64x256xf32, #linear>
+    %add = arith.addf %abs, %x : tensor<64x256xf32, #linear>
+    tt.return %add : tensor<64x256xf32, #linear>
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -662,6 +662,7 @@ class CUDABackend(BaseBackend):
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, use_meta_swp_schedule)
             nvidia.passes.hopper.add_tma_store_lowering(pm)
             if knobs.nvidia.use_meta_ws:
+                nvidia.passes.hopper.add_sink_broadcast(pm)
                 nvidia.passes.hopper.add_partition_scheduling_meta(pm)
             smem_budget = _max_shared_mem_for_capability(capability)
             generate_subtiled = opt.generate_subtiled_region or knobs.nvidia.generate_subtiled_region
@@ -706,6 +707,7 @@ class CUDABackend(BaseBackend):
             else:
                 # use Meta's WS internally which supports both hopper and blackwell
                 nvidia.passes.hopper.add_tma_store_lowering(pm)
+                nvidia.passes.hopper.add_sink_broadcast(pm)
                 nvidia.passes.hopper.add_partition_scheduling_meta(pm)
                 smem_budget = _max_shared_mem_for_capability(capability)
                 generate_subtiled = opt.generate_subtiled_region or knobs.nvidia.generate_subtiled_region

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -209,6 +209,19 @@ def NVGPUWSTMAStoreLowering : Pass<"nvgpu-ws-tma-store-lowering", "mlir::ModuleO
                            "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
 }
 
+def NVGPUSinkBroadcast : Pass<"nvgpu-sink-broadcast", "mlir::ModuleOp"> {
+  let summary = "Sink broadcast ops to their elementwise users";
+
+  let description = [{
+    This pass moves or clones `tt.broadcast` ops so they are adjacent to their
+    memory-effect-free elementwise users. Running this before Meta warp
+    specialization partition scheduling keeps late broadcasts associated with
+    their use after other operands, such as TMEM loads, have been prepared.
+  }];
+
+  let dependentDialects = ["mlir::triton::TritonDialect"];
+}
+
 def NVGPUTestAnnotateTMAStoreWaits : Pass<"nvgpu-test-annotate-tma-store-waits", "mlir::ModuleOp"> {
   let summary = "Annotate TMA store waits with can_rotate_by_buffer_count";
 

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/WSLowerToken.cpp
   WarpSpecialization/WSMemoryPlanner.cpp
   WarpSpecialization/WSSpecialize.cpp
+  WarpSpecialization/SinkBroadcast.cpp
   WarpSpecialization/WSTMAStoreLowering.cpp
   WarpSpecialization/WSTaskIdPropagate.cpp
   WarpSpecialization/WSTaskPartition.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/SinkBroadcast.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/SinkBroadcast.cpp
@@ -1,0 +1,233 @@
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+
+namespace mlir {
+
+#define GEN_PASS_DEF_NVGPUSINKBROADCAST
+#include "nvidia/hopper/include/Transforms/Passes.h.inc"
+
+namespace {
+
+bool hasOnlyReadEffects(Operation *op) {
+  if (isMemoryEffectFree(op)) {
+    return true;
+  }
+
+  auto iface = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!iface) {
+    return false;
+  }
+
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  iface.getEffects(effects);
+  if (effects.empty()) {
+    return true;
+  }
+
+  return llvm::all_of(effects, [](const MemoryEffects::EffectInstance &effect) {
+    return isa<MemoryEffects::Read>(effect.getEffect());
+  });
+}
+
+bool mayWriteOrHaveUnknownEffects(Operation *op) {
+  if (isMemoryEffectFree(op)) {
+    return false;
+  }
+
+  auto iface = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!iface) {
+    return true;
+  }
+
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  iface.getEffects(effects);
+  return llvm::any_of(effects, [](const MemoryEffects::EffectInstance &effect) {
+    return !isa<MemoryEffects::Read>(effect.getEffect());
+  });
+}
+
+bool hasInterveningWriteOrUnknownEffects(Operation *producer, Operation *user) {
+  for (Operation *it = producer->getNextNode(); it && it != user;
+       it = it->getNextNode()) {
+    if (mayWriteOrHaveUnknownEffects(it)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool isSinkableProducer(Operation *producer, Operation *user) {
+  if (!producer || producer->getBlock() != user->getBlock() ||
+      !producer->isBeforeInBlock(user) || producer->getNumRegions() != 0 ||
+      producer->hasTrait<OpTrait::IsTerminator>()) {
+    return false;
+  }
+
+  if (!hasOnlyReadEffects(producer)) {
+    return false;
+  }
+
+  if (!isMemoryEffectFree(producer) &&
+      hasInterveningWriteOrUnknownEffects(producer, user)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool collectSinkableChain(Operation *producer, Operation *user,
+                          llvm::SetVector<Operation *> &chain) {
+  if (!isSinkableProducer(producer, user)) {
+    return false;
+  }
+
+  if (chain.contains(producer)) {
+    return true;
+  }
+
+  // Include read-only loads but do not pull their address arithmetic along.
+  // The goal is to keep the value materialization close to the broadcast use
+  // without unnecessarily perturbing shared descriptor/index setup.
+  if (isMemoryEffectFree(producer)) {
+    for (Value operand : producer->getOperands()) {
+      Operation *operandProducer = operand.getDefiningOp();
+      if (!operandProducer) {
+        continue;
+      }
+      if (!collectSinkableChain(operandProducer, user, chain)) {
+        return false;
+      }
+    }
+  }
+
+  chain.insert(producer);
+  return true;
+}
+
+bool allUsesAreInChainOrByUser(Operation *op,
+                               const llvm::DenseSet<Operation *> &chain,
+                               Operation *user) {
+  for (Value result : op->getResults()) {
+    for (OpOperand &use : result.getUses()) {
+      Operation *owner = use.getOwner();
+      if (owner != user && !chain.contains(owner)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+struct BroadcastChain {
+  triton::BroadcastOp broadcast;
+  SmallVector<Operation *> ops;
+};
+
+SmallVector<BroadcastChain> getSinkableBroadcastChains(Operation *op) {
+  SmallVector<BroadcastChain> chains;
+  llvm::SmallDenseSet<Operation *, 4> seenBroadcasts;
+
+  if (op->getNumOperands() < 2 || op->getNumRegions() != 0 ||
+      !op->hasTrait<OpTrait::Elementwise>() || !isMemoryEffectFree(op)) {
+    return chains;
+  }
+
+  for (Value operand : op->getOperands()) {
+    auto broadcast = operand.getDefiningOp<triton::BroadcastOp>();
+    if (!broadcast || !seenBroadcasts.insert(broadcast).second) {
+      continue;
+    }
+
+    llvm::SetVector<Operation *> chain;
+    if (!collectSinkableChain(broadcast, op, chain)) {
+      continue;
+    }
+
+    chains.push_back(
+        {broadcast, SmallVector<Operation *>(chain.begin(), chain.end())});
+  }
+
+  return chains;
+}
+
+bool sinkBroadcastOperands(Operation *op) {
+  SmallVector<BroadcastChain> chains = getSinkableBroadcastChains(op);
+  if (chains.empty()) {
+    return false;
+  }
+
+  bool changed = false;
+  OpBuilder builder(op);
+  for (const BroadcastChain &chain : chains) {
+    triton::BroadcastOp broadcast = chain.broadcast;
+    Value oldResult = broadcast.getResult();
+
+    llvm::DenseSet<Operation *> chainSet;
+    for (Operation *chainOp : chain.ops) {
+      chainSet.insert(chainOp);
+    }
+
+    bool canMoveOriginal = llvm::all_of(chain.ops, [&](Operation *chainOp) {
+      return allUsesAreInChainOrByUser(chainOp, chainSet, op);
+    });
+
+    if (canMoveOriginal) {
+      for (Operation *chainOp : chain.ops) {
+        if (chainOp->getNextNode() != op) {
+          chainOp->moveBefore(op);
+        }
+        changed = true;
+      }
+      continue;
+    }
+
+    IRMapping mapping;
+    for (Operation *chainOp : chain.ops) {
+      builder.clone(*chainOp, mapping);
+    }
+    Value newResult = mapping.lookup(oldResult);
+    for (OpOperand &operand : op->getOpOperands()) {
+      if (operand.get() == oldResult) {
+        operand.set(newResult);
+      }
+    }
+    if (oldResult.use_empty()) {
+      broadcast.erase();
+    }
+    changed = true;
+  }
+
+  return changed;
+}
+
+class NVGPUSinkBroadcastPass
+    : public impl::NVGPUSinkBroadcastBase<NVGPUSinkBroadcastPass> {
+public:
+  void runOnOperation() override {
+    SmallVector<Operation *> candidates;
+    getOperation()->walk([&](Operation *op) {
+      if (!getSinkableBroadcastChains(op).empty()) {
+        candidates.push_back(op);
+      }
+    });
+
+    for (Operation *op : candidates) {
+      if (!op->getBlock()) {
+        continue;
+      }
+      sinkBroadcastOperands(op);
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -29,6 +29,11 @@ On Blackwell, only `doTaskIdPropagate` runs for annotation (task partition and
 data partition are skipped). The task assignments are expected to come from
 an earlier partition scheduling pass (`PartitionSchedulingMeta`).
 
+Before `PartitionSchedulingMeta`, the Meta WS backend runs
+`nvgpu-sink-broadcast` to move `tt.broadcast` producer chains next to their
+elementwise users. This keeps broadcasts and their value materialization, such
+as a descriptor load followed by an extend, associated with their use after
+other operands, such as TMEM loads, have been prepared.
 ## Register Budgets
 
 `minRegAutoWS` and `maxRegAutoWS` control the per-thread register budgets used
@@ -41,6 +46,7 @@ the emitted register allocation matches the backend warp-group granularity.
 | File | Function / Pass | Description |
 |------|----------------|-------------|
 | `WarpSpecialization.cpp` | `NVGPUWarpSpecialization` | Top-level pipeline orchestration |
+| `SinkBroadcast.cpp` | `nvgpu-sink-broadcast` | Pre-partition peephole that sinks `tt.broadcast` producer chains to elementwise users |
 | `PartitionSchedulingMeta.cpp` | `nvgpu-partition-scheduling-meta` | Partition scheduling for Blackwell (assigns `ttg.partition` attributes) |
 | `WSTaskPartition.cpp` | `doTaskPartition` | Assigns `async_task_id` to anchor ops (loads, dots, stores) — Hopper only |
 | `TaskIdPropagation.cpp` | — | `TaskIdBackwardPropagation` sparse dataflow analysis |

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -101,6 +101,7 @@ void init_triton_hopper_passes(py::module &&m) {
                             mlir::createNVGPUWSDataPartition, int);
   ADD_PASS_WRAPPER_0("add_tma_store_lowering",
                      mlir::createNVGPUWSTMAStoreLowering);
+  ADD_PASS_WRAPPER_0("add_sink_broadcast", mlir::createNVGPUSinkBroadcast);
   ADD_PASS_WRAPPER_0("add_tma_store_token_wait_lowering",
                      mlir::createNVGPUTMAStoreTokenWaitLowering);
   ADD_PASS_WRAPPER_0("add_partition_scheduling_meta",


### PR DESCRIPTION
Summary:
In the addmm example the current code ordering causes the following order
- bias load
- cast + broadcast bias
- tmem load
- addf
- downcast

In configs that benefit from a large BLOCK_N this leads to significant spilling because we materialize all of `cast + broadcast bias`. To combat this we add a peephole optimization to sink the broadcast/bias load below the tmem_load. In practice on selected shapes this removes register spilling, enabling a ~30 TFLOP increase on the examined shapes.

However, this is not sufficient as we don't work well with subtiling yet and we may have gaps for data partitioning.

Pulled By:
njriasan


njriasan

Reviewed By: manman-ren

Differential Revision: D106467661


