### PR TITLE
[Triton JIT] Support `dispatch_arg_indices` in C fast cache for kernels with None pointer args (#1583)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -709,6 +709,8 @@ struct FCEntry {
   PyObject **constexpr_vals;
   int *constexpr_positions;
   int n_constexpr;
+  int *dispatch_arg_indices; // Indices into call_args for dispatcher (or NULL)
+  int n_dispatch_args;       // Length of dispatch_arg_indices (0 = legacy path)
   bool occupied;
 };
 
@@ -735,6 +737,7 @@ struct FastCache {
             free(table[i].constexpr_vals);
           }
           free(table[i].constexpr_positions);
+          free(table[i].dispatch_arg_indices);
         }
       }
       free(table);
@@ -900,8 +903,15 @@ struct FastCache {
     table[idx].constexpr_vals = vals;
     table[idx].constexpr_positions = positions;
     table[idx].n_constexpr = n_ce;
+    table[idx].dispatch_arg_indices = nullptr;
+    table[idx].n_dispatch_args = 0;
     table[idx].occupied = true;
     count++;
+  }
+
+  void set_dispatch_indices(size_t idx, int *indices, int n) {
+    table[idx].dispatch_arg_indices = indices;
+    table[idx].n_dispatch_args = n;
   }
 };
 
@@ -1353,11 +1363,15 @@ PyObject *native_fast_dispatch(PyObject *self, PyObject *const *args,
     if (!PyTuple_Check(grid_tuple))
       Py_RETURN_NONE; // Non-tuple grid (e.g. kernel[1]) — let Python handle it
     Py_ssize_t grid_n = PyTuple_GET_SIZE(grid_tuple);
-    // Count kernel args (skip constexprs)
+    // Determine kernel args count and build vectorcall args
     int n_kernel_args = 0;
-    for (Py_ssize_t i = 0; i < n && i < cache->n_params; i++) {
-      if (!cache->param_meta[i].is_constexpr)
-        n_kernel_args++;
+    if (entry->n_dispatch_args > 0) {
+      n_kernel_args = entry->n_dispatch_args;
+    } else {
+      for (Py_ssize_t i = 0; i < n && i < cache->n_params; i++) {
+        if (!cache->param_meta[i].is_constexpr)
+          n_kernel_args++;
+      }
     }
     Py_ssize_t vc_nargs = 3 + 1 + n_kernel_args;
     PyObject **vc_args = (PyObject **)alloca(vc_nargs * sizeof(PyObject *));
@@ -1366,10 +1380,24 @@ PyObject *native_fast_dispatch(PyObject *self, PyObject *const *args,
     vc_args[1] = grid_n > 1 ? PyTuple_GET_ITEM(grid_tuple, 1) : one;
     vc_args[2] = grid_n > 2 ? PyTuple_GET_ITEM(grid_tuple, 2) : one;
     vc_args[3] = stream_obj;
-    int ki = 0;
-    for (Py_ssize_t i = 0; i < n && i < cache->n_params; i++) {
-      if (!cache->param_meta[i].is_constexpr)
-        vc_args[4 + ki++] = ca[i];
+    if (entry->n_dispatch_args > 0) {
+      // Use stored dispatch_arg_indices to select only the args the dispatcher
+      // expects
+      for (int j = 0; j < entry->n_dispatch_args; j++)
+        vc_args[4 + j] = ca[entry->dispatch_arg_indices[j]];
+    } else {
+      // Legacy path: pass all non-constexpr args
+      int ki = 0;
+      for (Py_ssize_t i = 0; i < n && i < cache->n_params; i++) {
+        if (!cache->param_meta[i].is_constexpr)
+          vc_args[4 + ki++] = ca[i];
+      }
+    }
+    // Guard: clear stale exceptions before calling the dispatcher to prevent
+    // SystemError ("returned a result with an exception set") in td_get_ptr.
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      return nullptr;
     }
     PyObject *result =
         PyObject_Vectorcall(dispatcher, vc_args, vc_nargs, nullptr);
@@ -1389,12 +1417,12 @@ PyObject *native_fast_dispatch(PyObject *self, PyObject *const *args,
 }
 
 // native_fast_dispatch_insert(jit_fn, args_tuple, params_list, options_hash,
-// kernel, dispatcher)
+// kernel, dispatcher, dispatch_indices)
 PyObject *native_fast_dispatch_insert(PyObject *self, PyObject *const *args,
                                       Py_ssize_t nargs) {
-  if (nargs != 6) {
+  if (nargs != 7) {
     PyErr_SetString(PyExc_TypeError,
-                    "native_fast_dispatch_insert expects 6 arguments");
+                    "native_fast_dispatch_insert expects 7 arguments");
     return nullptr;
   }
 
@@ -1404,6 +1432,7 @@ PyObject *native_fast_dispatch_insert(PyObject *self, PyObject *const *args,
   PyObject *options_hash_obj = args[3];
   PyObject *kernel = args[4];
   PyObject *dispatcher = args[5];
+  PyObject *dispatch_indices = args[6];
 
   if (!PyTuple_Check(call_args_tuple))
     Py_RETURN_NONE;
@@ -1431,6 +1460,40 @@ PyObject *native_fast_dispatch_insert(PyObject *self, PyObject *const *args,
 
   PyObject *disp = (dispatcher == Py_None) ? nullptr : dispatcher;
   cache->insert(key, kernel, disp, ca, (int)n);
+
+  // Store dispatch_arg_indices if provided
+  if (dispatch_indices != Py_None && PyTuple_Check(dispatch_indices)) {
+    Py_ssize_t n_indices = PyTuple_GET_SIZE(dispatch_indices);
+    if (n_indices > 0) {
+      int *indices = (int *)malloc(n_indices * sizeof(int));
+      if (indices) {
+        for (Py_ssize_t i = 0; i < n_indices; i++) {
+          indices[i] =
+              (int)PyLong_AsLong(PyTuple_GET_ITEM(dispatch_indices, i));
+        }
+        if (!PyErr_Occurred() && cache->table) {
+          // Find the just-inserted entry
+          FCCacheKeyHash hasher;
+          size_t idx = hasher(key) % cache->capacity;
+          bool found = false;
+          while (cache->table[idx].occupied) {
+            if (cache->table[idx].key == key) {
+              cache->set_dispatch_indices(idx, indices, (int)n_indices);
+              found = true;
+              break;
+            }
+            idx = (idx + 1) % cache->capacity;
+          }
+          if (!found)
+            free(indices);
+        } else {
+          PyErr_Clear();
+          free(indices);
+        }
+      }
+    }
+  }
+
   Py_RETURN_NONE;
 }
 
@@ -1536,9 +1599,13 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     // Build dispatcher vectorcall args: grid0, grid1, grid2, stream,
     // *kernel_args
     int n_kernel_args = 0;
-    for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
-      if (!cache->param_meta[i].is_constexpr)
-        n_kernel_args++;
+    if (entry->n_dispatch_args > 0) {
+      n_kernel_args = entry->n_dispatch_args;
+    } else {
+      for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
+        if (!cache->param_meta[i].is_constexpr)
+          n_kernel_args++;
+      }
     }
     Py_ssize_t vc_nargs = 3 + 1 + n_kernel_args;
     PyObject **vc_args = (PyObject **)alloca(vc_nargs * sizeof(PyObject *));
@@ -1546,10 +1613,24 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     vc_args[1] = self->grid_py[1];
     vc_args[2] = self->grid_py[2];
     vc_args[3] = stream_obj;
-    int ki = 0;
-    for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
-      if (!cache->param_meta[i].is_constexpr)
-        vc_args[4 + ki++] = effective_args[i];
+    if (entry->n_dispatch_args > 0) {
+      for (int j = 0; j < entry->n_dispatch_args; j++)
+        vc_args[4 + j] = effective_args[entry->dispatch_arg_indices[j]];
+    } else {
+      int ki = 0;
+      for (int i = 0; i < effective_nargs && i < cache->n_params; i++) {
+        if (!cache->param_meta[i].is_constexpr)
+          vc_args[4 + ki++] = effective_args[i];
+      }
+    }
+    // Guard: if any prior C-API call leaked a stale exception (e.g., from
+    // fc_build_key probing arg types), clear it before calling the dispatcher.
+    // Without this, td_get_ptr→data_ptr() may trigger CPython's SystemError:
+    // "returned a result with an exception set".
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      Py_DECREF(stream_obj);
+      goto fallback;
     }
     PyObject *result =
         PyObject_Vectorcall(dispatcher, vc_args, vc_nargs, nullptr);

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -262,10 +262,9 @@ class Autotuner(KernelInterface):
         # Separate meta-params (num_warps, etc.) from kernel args.
         _meta = {k: v for k, v in config_kwargs.items() if k not in _arg_name_set}
 
-        # Seed C cache with hash=0 for JITCacheProxy.
+        # Seed C cache with hash=0 for native_fast_dispatch.
         # During autotuning, run() stored the kernel with a non-zero hash.
-        # JITCacheProxy always uses hash=0, so without seeding it would miss
-        # and recompile with wrong default options.
+        # We use hash=0 as the canonical key for autotuned steady-state dispatch.
         if not hasattr(self, '_fc_seeded'):
             self._fc_seeded = set()
         # Use autotuner key to distinguish specializations that may select
@@ -283,9 +282,14 @@ class Autotuner(KernelInterface):
                     _padded = tuple(full_args)
                     if len(_padded) < len(self.fn.params):
                         _padded = _padded + (None, ) * (len(self.fn.params) - len(_padded))
-                    native_fast_dispatch_insert(self.fn, _padded, self.fn.params, 0, kernel, _disp)
+                    native_fast_dispatch_insert(self.fn, _padded, self.fn.params, 0, kernel, _disp,
+                                                getattr(kernel, '_dispatch_arg_indices', None))
             self._fc_seeded.add(_seed_key)
             return kernel
+
+        # Steady-state: dispatch via JITCacheProxy (fastest path).
+        # The C cache stores dispatch_arg_indices per entry so it correctly
+        # selects only the args the dispatcher expects (handles None ptr args).
         return self.fn[evaluated_grid](*full_args)
 
     def run(self, *args, **kwargs):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -966,7 +966,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 # Pad missing trailing args (same as lookup path)
                 if len(_ins_args) < len(self.params):
                     _ins_args = tuple(list(_ins_args) + [None] * (len(self.params) - len(_ins_args)))
-                native_fast_dispatch_insert(self, _ins_args, self.params, _ins_hash, kernel, _disp)
+                native_fast_dispatch_insert(self, _ins_args, self.params, _ins_hash, kernel, _disp,
+                                            getattr(kernel, '_dispatch_arg_indices', None))
         return kernel
 
     def repr(self, _):


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/1087


## Problem (Before)

When an autotuned Triton kernel is first compiled with real tensor arguments and then
dispatched with `None` for optional pointer parameters (common pattern in CMSL HSTU
attention), the C fast cache dispatcher crashes:

```
SystemError: <method 'run' ...> returned a result with an exception set
# Root cause: td_get_ptr() calls .data_ptr() on None → TypeError
```

**Concrete case study**: HSTU attention kernel has optional `bias`, `mask`, `scale` pointers.
During autotuning, all are real tensors. In steady-state inference, some are `None`.
The JITCacheProxy dispatcher blindly passes ALL non-constexpr args (including None) to
the kernel's `.run()` method which tries to extract `.data_ptr()` → crash.

## Solution (After)

Store per-entry `dispatch_arg_indices` in the C fast cache. These indices record exactly
which argument positions the kernel's dispatcher expects (computed at compilation time,
stored in `kernel._dispatch_arg_indices`). On cache hit, the dispatcher uses these indices
to select only the relevant args — skipping None pointers that the compiled kernel does
not actually reference.

**Dispatch flow (before fix)**:
```
cache hit → vc_args = [all non-constexpr args] → .data_ptr() on None → CRASH
```

**Dispatch flow (after fix)**:
```
cache hit → vc_args = [args at dispatch_arg_indices positions only] → skip None → OK
```

## Performance

### Micro-benchmark: `nop_autotuned_with_none_proxy` (19 args, 3 are None)

| Config | Latency (ms/dispatch) | vs Baseline |
|--------|:--------------------:|:-----------:|
| D=0, CC=0 (baseline) | 0.0196 | — |
| D=0, CC=1 (C cache only) | 0.0213 | +8.7% |
| D=1, CC=0 (dispatcher only) | 0.0155 | **−21%** |
| D=1, CC=1 (dispatcher + C cache) | 0.0158 | **−19%** |

The fix enables D=1 + CC=1 to work without crashing. The slight regression in D=0 + CC=1
is inherent to the C cache key-building cost (not from this fix) — the C cache's value is
only realized through the Dispatcher (D=1) path.

### E2E: CMSL HSTU Training (per-batch GPU time, A100 80GB)

| Config | p50 (ms) | vs Baseline |
|--------|:--------:|:-----------:|
| Baseline (D=0, CC=0) | 779.07 | — |
| Dispatcher only (D=1, CC=0) | 577.20 | **−25.9%** |
| Dispatcher + C Cache (D=1, CC=1) | 567.66 | **−27.1%** |

Without this fix, D=1 + CC=1 crashes on the None-arg kernels in HSTU. With the fix,
we unlock the full 27% speedup.

Differential Revision: D106004978


