### PR TITLE
Fix autotuner + C dispatcher for `ctas_per_cga` kernels (#1595)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -1558,8 +1558,19 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     }
     effective_args = merged_args;
     effective_nargs = total;
-  } else if (nargs != self->n_params) {
+  } else if (nargs > self->n_params) {
     goto fallback;
+  } else if (nargs < self->n_params) {
+    // Pad missing trailing args (constexpr params not passed positionally)
+    // with Py_None to match the FastCache insertion key.
+    int total = self->n_params;
+    merged_args = (PyObject **)alloca(total * sizeof(PyObject *));
+    for (int i = 0; i < (int)nargs; i++)
+      merged_args[i] = (PyObject *)args[i];
+    for (int i = (int)nargs; i < total; i++)
+      merged_args[i] = Py_None;
+    effective_args = merged_args;
+    effective_nargs = total;
   }
 
   {
@@ -1709,12 +1720,12 @@ static void _init_jit_cache_proxy_type() {
 }
 
 // native_create_jit_proxy(jit_fn, grid_tuple, params_list, options_hash,
-// stream_getter, device_getter)
+// stream_getter, device_getter[, extra_kwargs])
 PyObject *native_create_jit_proxy(PyObject *self_unused, PyObject *const *args,
                                   Py_ssize_t nargs) {
-  if (nargs != 6) {
+  if (nargs < 6 || nargs > 7) {
     PyErr_SetString(PyExc_TypeError,
-                    "native_create_jit_proxy expects 6 arguments");
+                    "native_create_jit_proxy expects 6 or 7 arguments");
     return nullptr;
   }
   PyObject *jit_fn = args[0];
@@ -1723,6 +1734,8 @@ PyObject *native_create_jit_proxy(PyObject *self_unused, PyObject *const *args,
   PyObject *options_hash_obj = args[3];
   PyObject *stream_getter = args[4];
   PyObject *device_getter = args[5];
+  PyObject *extra_kwargs =
+      (nargs >= 7 && args[6] != Py_None) ? args[6] : nullptr;
 
   uint64_t opts_hash = PyLong_AsUnsignedLongLong(options_hash_obj);
   if (PyErr_Occurred())
@@ -1767,6 +1780,15 @@ PyObject *native_create_jit_proxy(PyObject *self_unused, PyObject *const *args,
     Py_DECREF(kw);
     Py_DECREF(run_method);
     return nullptr;
+  }
+  // Merge extra_kwargs (e.g., ctas_per_cga) into the partial's kwargs so that
+  // the fallback path passes them to run() for correct compilation options.
+  if (extra_kwargs && PyDict_Check(extra_kwargs)) {
+    if (PyDict_Merge(kw, extra_kwargs, 1) < 0) {
+      Py_DECREF(kw);
+      Py_DECREF(run_method);
+      return nullptr;
+    }
   }
   PyObject *pack = PyTuple_Pack(1, run_method);
   Py_DECREF(run_method);

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -276,13 +276,26 @@ class Autotuner(KernelInterface):
             except (ImportError, AttributeError):
                 native_fast_dispatch_insert = None
             kernel = self.fn.run(*full_args, grid=evaluated_grid, warmup=False, **_meta)
+            # Update _fc_options_hash so C proxy and JIT.run fast path lookups
+            # use the same hash that JIT.run's insertion used (includes meta-params
+            # like ctas_per_cga that affect compilation options).
+            if _meta:
+                _meta_opts = {k: v for k, v in _meta.items() if k not in getattr(self.fn, '_param_name_to_idx', {})}
+                if _meta_opts:
+                    self.fn._fc_options_hash = hash(tuple(sorted(_meta_opts.items()))) & 0xFFFFFFFFFFFFFFFF
+                # Store meta kwargs for C proxy fallback forwarding.
+                self.fn._fc_meta_kwargs = _meta
+                # Invalidate proxy cache so next __getitem__ creates a new proxy
+                # with the updated options_hash and meta_kwargs.
+                self.fn._jit_proxy_cache = {}
             if native_fast_dispatch_insert is not None:
                 _disp = getattr(kernel, '_dispatcher', None)
                 if _disp is not None:
                     _padded = tuple(full_args)
                     if len(_padded) < len(self.fn.params):
                         _padded = _padded + (None, ) * (len(self.fn.params) - len(_padded))
-                    native_fast_dispatch_insert(self.fn, _padded, self.fn.params, 0, kernel, _disp,
+                    native_fast_dispatch_insert(self.fn, _padded, self.fn.params, self.fn._fc_options_hash, kernel,
+                                                _disp,
                                                 getattr(kernel, '_dispatch_arg_indices', None))
             self._fc_seeded.add(_seed_key)
             return kernel

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -406,8 +406,10 @@ class KernelInterface(Generic[T]):
             proxy = cache.get(grid_key)
             if proxy is None:
                 grid_tuple = grid_key
+                extra_kwargs = getattr(self, '_fc_meta_kwargs', None)
                 proxy = native_create_jit_proxy(self, grid_tuple, self.params, self._fc_options_hash,
-                                                driver.active.get_current_stream, driver.active.get_current_device)
+                                                driver.active.get_current_stream, driver.active.get_current_device,
+                                                extra_kwargs)
                 if proxy is not None:
                     cache[grid_key] = proxy
             if proxy is not None:

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -2148,6 +2148,7 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
   unsigned long long func_ptr;
   int num_warps, num_ctas, shared_mem;
   int launch_pdl, launch_coop, launch_cluster;
+  int cluster_dim_x = 1, cluster_dim_y = 1, cluster_dim_z = 1;
   PyObject *arg_type_codes;
   int has_global_scratch, has_profile_scratch;
   unsigned global_scratch_size = 0, global_scratch_align = 1;
@@ -2171,16 +2172,19 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
                            "allocator",
                            "profile_allocator",
                            "tma_meta",
+                           "cluster_dim_x",
+                           "cluster_dim_y",
+                           "cluster_dim_z",
                            NULL};
   PyObject *tma_meta_list = NULL;
 
   if (!PyArg_ParseTupleAndKeywords(
-          args, kwargs, "KiiiiiiOpp|IIIIOOO", kwlist, &func_ptr, &num_warps,
+          args, kwargs, "KiiiiiiOpp|IIIIOOOiii", kwlist, &func_ptr, &num_warps,
           &num_ctas, &shared_mem, &launch_pdl, &launch_coop, &launch_cluster,
           &arg_type_codes, &has_global_scratch, &has_profile_scratch,
           &global_scratch_size, &global_scratch_align, &profile_scratch_size,
           &profile_scratch_align, &allocator_obj, &profile_allocator_obj,
-          &tma_meta_list))
+          &tma_meta_list, &cluster_dim_x, &cluster_dim_y, &cluster_dim_z))
     return NULL;
 
   TritonDispatcher *self = (TritonDispatcher *)type->tp_alloc(type, 0);
@@ -2335,12 +2339,21 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
     self->launch_attrs[na].value.cooperative = 1;
     na++;
   }
-  if (launch_cluster || num_ctas > 1) {
+  if (launch_cluster || num_ctas > 1 || cluster_dim_x > 1 ||
+      cluster_dim_y > 1 || cluster_dim_z > 1) {
     if (num_ctas > 1) {
+      /* Legacy num_ctas path: 1-D cluster along x */
       self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
       self->launch_attrs[na].value.clusterDim.x = num_ctas;
       self->launch_attrs[na].value.clusterDim.y = 1;
       self->launch_attrs[na].value.clusterDim.z = 1;
+      na++;
+    } else if (cluster_dim_x > 1 || cluster_dim_y > 1 || cluster_dim_z > 1) {
+      /* ctas_per_cga path: explicit multi-dimensional cluster_dims */
+      self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+      self->launch_attrs[na].value.clusterDim.x = cluster_dim_x;
+      self->launch_attrs[na].value.clusterDim.y = cluster_dim_y;
+      self->launch_attrs[na].value.clusterDim.z = cluster_dim_z;
       na++;
     }
     self->launch_attrs[na].id =

--- a/third_party/nvidia/backend/triton_dispatcher_factory.py
+++ b/third_party/nvidia/backend/triton_dispatcher_factory.py
@@ -194,6 +194,8 @@ def make_triton_dispatcher(schema, cu_function: int):
         if not tma_meta_list:
             tma_meta_list = None
 
+    cluster_dims = schema.get("cluster_dims", [1, 1, 1])
+
     c_dispatcher = mod._TritonDispatcher(
         function=cu_function,
         num_warps=schema["num_warps"],
@@ -212,6 +214,9 @@ def make_triton_dispatcher(schema, cu_function: int):
         allocator=_allocation._allocator,
         profile_allocator=_allocation._profile_allocator,
         tma_meta=tma_meta_list,
+        cluster_dim_x=int(cluster_dims[0]) if len(cluster_dims) > 0 else 1,
+        cluster_dim_y=int(cluster_dims[1]) if len(cluster_dims) > 1 else 1,
+        cluster_dim_z=int(cluster_dims[2]) if len(cluster_dims) > 2 else 1,
     )
 
     # If there are host-side tensordescs (no TMA meta) that still need Python expansion,


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/1091


## Background

When running Triton kernels with `TRITON_USE_TRITON_DISPATCHER=1 TRITON_ENABLE_C_CACHE=1`,
kernels that use **cluster dimensions** (`ctas_per_cga > 1`, e.g., the `layernorm_gdpa_residual_rmsnorm_residual`
kernel) crash with:

```
RuntimeError: Unexpected buffer remote view in 1cta mode
```

This crash happens because the autotuner's fast dispatch path drops critical meta-parameters
(`ctas_per_cga`, `num_warps`, etc.) when dispatching via the C cache proxy, causing the kernel
to be recompiled with default `ctas_per_cga=1` instead of the autotuner's winning config
(e.g., `ctas_per_cga=(2,1,1)`).

## Root Cause

The dispatch flow has three layers:

```
Autotuner._try_fast_path()
  → JITFunction.__getitem__(grid) → JITCacheProxy (C extension)
    → vectorcall: FastCache lookup → dispatcher launch (fastest, zero Python)
    → fallback: run_partial(*args) → JITFunction.run()
```

**Two bugs existed:**

1. **Autotuner seeding**: The autotuner's `_try_fast_path` never seeded the C cache with the
   correct `options_hash` that includes meta-params. The C cache was inserted with hash=H
   (computed from `ctas_per_cga` etc.) during `JITFunction.run()`, but the proxy was created
   with `options_hash=0`, causing a permanent cache miss.

2. **C proxy fallback missing meta kwargs**: When the C proxy falls back to Python
   (`run_partial`), it called `JITFunction.run(*args, grid=.., warmup=False)` WITHOUT
   the meta kwargs (like `ctas_per_cga`). This caused `JITFunction.run()` to hit the
   Python kernel cache with a different key (missing `ctas_per_cga` in options) →
   cache miss → recompile with wrong defaults → crash.

## Before vs After

### Before (broken)

```
autotuner._try_fast_path:
  self.fn[grid](*full_args)
    → C proxy vectorcall:
      → hash=0 lookup → MISS (entry was stored with hash=H)
      → fallback → run_partial(*args)
        = self.fn.run(*args, grid=.., warmup=False)  ← NO meta kwargs!
        → Python cache MISS (different options key) → recompile
        → compile with ctas_per_cga=1 → CRASH
```

### After (fixed)

```
autotuner._try_fast_path:
  # Seeding: compile correctly, then set hash + meta on JITFunction
  self.fn.run(*full_args, **_meta)  → compile with correct ctas_per_cga
  self.fn._fc_options_hash = H     → matches insertion hash
  self.fn._fc_meta_kwargs = _meta  → for proxy fallback forwarding

  # Steady-state:
  self.fn[grid](*full_args)
    → C proxy vectorcall (options_hash=H, meta_kwargs baked into run_partial):
      → hash=H lookup → HIT → dispatcher launch (zero Python overhead) ✓
      → OR fallback → run_partial(*args)
        = self.fn.run(*args, grid=.., warmup=False, ctas_per_cga=(2,1,1), ...)
        → Python cache HIT → launch correctly ✓
```

## Changes

### 1. `autotuner.py` — Autotuner seeding + steady-state dispatch

- **Seeding**: After first compilation, compute correct `_fc_options_hash` from meta-params
  and store `_fc_meta_kwargs` on the JITFunction. Invalidate proxy cache so new proxies
  pick up the updated hash and meta.
- **Steady-state**: Use `self.fn[grid](*full_args)` (C proxy fast path) instead of
  the slower `self.fn.run(**_meta)` path.

### 2. `specialize.cc` — C proxy meta kwargs forwarding + nargs padding

- `native_create_jit_proxy()` accepts optional 7th argument: a `meta_kwargs` dict.
- Merges `meta_kwargs` into `run_partial`'s kwargs via `PyDict_Merge`, so the fallback
  path automatically includes meta-params like `ctas_per_cga`.
- **Padding fix**: When proxy receives fewer positional args than `n_params` (constexpr
  params not passed positionally by the autotuner), pads with `Py_None` to match the
  FastCache insertion key format. Without this, `nargs != n_params` caused immediate
  fallback (FastCache never consulted).

### 3. `jit.py` — Pass meta kwargs when creating proxy

- `KernelInterface.__getitem__()` passes `self._fc_meta_kwargs` as 7th arg to
  `native_create_jit_proxy()`.

### 4. `driver.c` — Cluster dimension support in C dispatcher (from prior session)

- `TritonDispatcher_new()` accepts `cluster_dim_x/y/z` parameters.
- Sets `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` when cluster dims > 1.

### 5. `triton_dispatcher_factory.py` — Pass cluster_dims from schema (from prior session)

- Extracts `cluster_dims` from kernel schema and passes to C dispatcher constructor.

## Performance

Comparison with non-cluster autotuned kernel (`nop_triton_kernel_autotuned`, `nop_triton_kernel_autotuned_nocache`):

| Case | Walltime | Speedup vs baseline |
|------|----------|---------------------|
| d=0, c=0 (no optimizations) | 25.2µs | 1.00x (baseline) |
| d=0, c=1 (C cache only) | 19.1µs | **1.32x** |
| d=1, c=0 (dispatcher only) | 21.5µs | 1.17x |
| d=1, c=1 (both) | **15.0µs** | **1.68x** |

Reviewed By: jackiexu77

Differential Revision: D106454376


