### PR TITLE
Add TLX GPU CI workflow

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           set -euxo pipefail
           . "${VENV_DIR}/bin/activate"
-          python3 -m pytest -s --tb=short \
+          python3 -m pytest -vv -s --tb=short \
             python/test/unit/language/test_compile_only.py \
             python/test/unit/language/test_core.py::test_dtype_codegen
 
@@ -83,7 +83,7 @@ jobs:
         run: |
           set -euxo pipefail
           . "${VENV_DIR}/bin/activate"
-          python3 -m pytest -s --tb=short \
+          python3 -m pytest -vv -s --tb=short \
             python/test/unit/language/test_tlx.py \
             python/test/unit/language/test_tlx_amd.py \
             python/test/unit/language/test_warp_pipeline.py

--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -41,6 +41,7 @@ jobs:
           python3 --version
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install -r python/requirements.txt -r python/test-requirements.txt
+          python3 -m pip install filelock fsspec jinja2 networkx sympy typing_extensions
           python3 -m pip install --force-reinstall --no-deps "${TORCH_NIGHTLY_URL}"
           python3 -m pip uninstall -y triton triton-rocm pytorch-triton || true
 

--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -41,8 +41,8 @@ jobs:
           python3 --version
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install -r python/requirements.txt -r python/test-requirements.txt
-          python3 -m pip install --force-reinstall "${TORCH_NIGHTLY_URL}"
-          python3 -m pip uninstall -y triton pytorch-triton || true
+          python3 -m pip install --force-reinstall --no-deps "${TORCH_NIGHTLY_URL}"
+          python3 -m pip uninstall -y triton triton-rocm pytorch-triton || true
 
       - name: Build Triton
         run: |

--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -1,0 +1,94 @@
+name: TLX GPU Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - tlx-amd-meta
+  pull_request:
+    branches:
+      - tlx-amd-meta
+
+permissions: read-all
+
+env:
+  MAX_JOBS: 16
+  TORCH_NIGHTLY_URL: https://download-r2.pytorch.org/whl/nightly/rocm7.2/torch-2.13.0.dev20260513%2Brocm7.2-cp312-cp312-manylinux_2_28_x86_64.whl
+
+jobs:
+  gpu-tlx:
+    if: github.repository_owner == 'facebookexperimental'
+    runs-on: linux-fb-triton-mi350-1
+    timeout-minutes: 180
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      WORKSPACE_DIR: /workspace
+      CONDA_ENV: pytorch
+      UV_VENV_DIR: /workspace/uv_venvs
+      SETUP_SCRIPT: /workspace/setup_instance.sh
+      PYTHONPATH: ${{ github.workspace }}/python
+      TRITON_ALWAYS_COMPILE: "1"
+      TRITON_CACHE_DIR: /tmp/triton-cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare Python environment
+        run: |
+          set -euxo pipefail
+          . "${SETUP_SCRIPT}"
+          python3 --version
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r python/requirements.txt -r python/test-requirements.txt
+          python3 -m pip install --force-reinstall "${TORCH_NIGHTLY_URL}"
+          python3 -m pip uninstall -y triton pytorch-triton || true
+
+      - name: Build Triton
+        run: |
+          set -euxo pipefail
+          . "${SETUP_SCRIPT}"
+          python3 -m pip install -e . --no-build-isolation -v
+          make
+
+      - name: Check GPU availability
+        run: |
+          set -euxo pipefail
+          . "${SETUP_SCRIPT}"
+          python3 - <<'PY'
+          import torch
+          import triton
+
+          assert torch.cuda.is_available(), "GPU runner did not expose a torch CUDA/HIP device"
+          print("torch.version.hip:", torch.version.hip)
+          print("device:", torch.cuda.get_device_name(0))
+          print("triton target:", triton.runtime.driver.active.get_current_target())
+          PY
+
+      - name: Run lit tests
+        run: |
+          set -euxo pipefail
+          . "${SETUP_SCRIPT}"
+          make test-lit
+
+      - name: Run codegen tests
+        run: |
+          set -euxo pipefail
+          . "${SETUP_SCRIPT}"
+          python3 -m pytest -s --tb=short \
+            python/test/unit/language/test_compile_only.py \
+            python/test/unit/language/test_core.py::test_dtype_codegen
+
+      - name: Run TLX language tests
+        run: |
+          set -euxo pipefail
+          . "${SETUP_SCRIPT}"
+          python3 -m pytest -s --tb=short \
+            python/test/unit/language/test_tlx.py \
+            python/test/unit/language/test_tlx_amd.py \
+            python/test/unit/language/test_warp_pipeline.py
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/tlx-amd-meta' }}

--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -24,10 +24,7 @@ jobs:
       id-token: write
       contents: read
     env:
-      WORKSPACE_DIR: /workspace
-      CONDA_ENV: pytorch
-      UV_VENV_DIR: /workspace/uv_venvs
-      SETUP_SCRIPT: /workspace/setup_instance.sh
+      VENV_DIR: ${{ github.workspace }}/.venv
       PYTHONPATH: ${{ github.workspace }}/python
       TRITON_ALWAYS_COMPILE: "1"
       TRITON_CACHE_DIR: /tmp/triton-cache
@@ -38,9 +35,11 @@ jobs:
       - name: Prepare Python environment
         run: |
           set -euxo pipefail
-          . "${SETUP_SCRIPT}"
+          python3 -m venv "${VENV_DIR}"
+          . "${VENV_DIR}/bin/activate"
+          echo "${VENV_DIR}/bin" >> "${GITHUB_PATH}"
           python3 --version
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install -r python/requirements.txt -r python/test-requirements.txt
           python3 -m pip install --force-reinstall "${TORCH_NIGHTLY_URL}"
           python3 -m pip uninstall -y triton pytorch-triton || true
@@ -48,14 +47,14 @@ jobs:
       - name: Build Triton
         run: |
           set -euxo pipefail
-          . "${SETUP_SCRIPT}"
+          . "${VENV_DIR}/bin/activate"
           python3 -m pip install -e . --no-build-isolation -v
           make
 
       - name: Check GPU availability
         run: |
           set -euxo pipefail
-          . "${SETUP_SCRIPT}"
+          . "${VENV_DIR}/bin/activate"
           python3 - <<'PY'
           import torch
           import triton
@@ -69,13 +68,13 @@ jobs:
       - name: Run lit tests
         run: |
           set -euxo pipefail
-          . "${SETUP_SCRIPT}"
+          . "${VENV_DIR}/bin/activate"
           make test-lit
 
       - name: Run codegen tests
         run: |
           set -euxo pipefail
-          . "${SETUP_SCRIPT}"
+          . "${VENV_DIR}/bin/activate"
           python3 -m pytest -s --tb=short \
             python/test/unit/language/test_compile_only.py \
             python/test/unit/language/test_core.py::test_dtype_codegen
@@ -83,7 +82,7 @@ jobs:
       - name: Run TLX language tests
         run: |
           set -euxo pipefail
-          . "${SETUP_SCRIPT}"
+          . "${VENV_DIR}/bin/activate"
           python3 -m pytest -s --tb=short \
             python/test/unit/language/test_tlx.py \
             python/test/unit/language/test_tlx_amd.py \

--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -78,7 +78,8 @@ jobs:
           . "${VENV_DIR}/bin/activate"
           python3 -m pytest -vv -s --tb=short \
             python/test/unit/language/test_compile_only.py \
-            python/test/unit/language/test_core.py::test_dtype_codegen
+            python/test/unit/language/test_core.py::test_dtype_codegen \
+            python/test/unit/language/test_tlx_amd.py
 
       - name: Run TLX language tests
         run: |
@@ -86,7 +87,6 @@ jobs:
           . "${VENV_DIR}/bin/activate"
           python3 -m pytest -vv -s --tb=short \
             python/test/unit/language/test_tlx.py \
-            python/test/unit/language/test_tlx_amd.py \
             python/test/unit/language/test_warp_pipeline.py
 
 concurrency:

--- a/python/test/unit/language/test_tlx.py
+++ b/python/test/unit/language/test_tlx.py
@@ -2612,7 +2612,7 @@ def tlx_square_non_ws(
     # mbarrier ops
 
     bars = tlx.alloc_barriers(num_barriers=1)  # create
-    bar = tlx.local_view(bars, 0)
+    bar = bars[0]
 
     x = tl.load(x_ptr + offsets, mask=mask)  # Do something
 
@@ -2647,8 +2647,8 @@ def tlx_square_ws(
 
     # mbarrier ops
     bars = tlx.alloc_barriers(num_barriers=2)  # create
-    b0 = tlx.local_view(bars, 0)
-    b1 = tlx.local_view(bars, 1)
+    b0 = bars[0]
+    b1 = bars[1]
 
     phase = 0
     with tlx.async_tasks():
@@ -2684,7 +2684,7 @@ def run_tlx_square(func, BLOCK_SIZE, device, expected_arrival_count=1):
 
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]), )
 
-    kernel = func[grid](x, z, n_elements, BLOCK_SIZE)
+    kernel = func[grid](x, z, n_elements, BLOCK_SIZE, expected_arrival_count)
 
     z_ref = x * x
 
@@ -2693,7 +2693,7 @@ def run_tlx_square(func, BLOCK_SIZE, device, expected_arrival_count=1):
 
 
 # Unit test for arrive/wait
-@pytest.mark.skipif(not (is_hip() or is_hopper_or_newer()), reason="Need Hopper or newer or AMD")
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")
 @pytest.mark.parametrize("BLOCK_SIZE", [(1024)])
 def test_wait_arrive_non_ws(BLOCK_SIZE, device):
     kernel = run_tlx_square(tlx_square_non_ws, BLOCK_SIZE, device)

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -59,6 +59,16 @@ def is_gfx1250_available():
         return False
 
 
+def skip_if_insufficient_shared_memory(required_bytes):
+    try:
+        device = triton.runtime.driver.active.get_current_device()
+        max_shared = triton.runtime.driver.active.utils.get_device_properties(device)["max_shared_mem"]
+    except Exception:
+        return
+    if required_bytes >= max_shared:
+        pytest.skip(f"Requires more shared memory than this device exposes ({max_shared} bytes)")
+
+
 # ---------------------------------------------------------------------------
 # Test: async_load compiles on gfx950 and produces the expected ops.
 # ---------------------------------------------------------------------------
@@ -316,6 +326,7 @@ def local_gather_kernel(
 @pytest.mark.parametrize("N,M", [(32, 32), (64, 64), (128, 128)])
 def test_local_gather(N, M):
     """Test gathering from 1D reshaped shared memory (diagonal of 2D matrix)."""
+    skip_if_insufficient_shared_memory(N * M * torch.float32.itemsize)
     device = torch.device("cuda")
 
     # Create a test matrix with known values
@@ -380,6 +391,7 @@ def local_scatter_kernel(
 @pytest.mark.parametrize("N,M", [(32, 32), (64, 64), (128, 128)])
 def test_local_scatter(N, M):
     """Test scattering to 1D reshaped shared memory (diagonal of 2D matrix)."""
+    skip_if_insufficient_shared_memory(N * M * torch.float32.itemsize)
     device = torch.device("cuda")
 
     # Create scatter indices for diagonal elements: 0, M+1, 2*(M+1), ...

--- a/python/test/unit/language/test_warp_pipeline.py
+++ b/python/test/unit/language/test_warp_pipeline.py
@@ -12,6 +12,10 @@ def is_hip():
     return triton.runtime.driver.active.get_current_target().backend == "hip"
 
 
+def is_gfx950():
+    return triton.runtime.driver.active.get_current_target().arch == "gfx950"
+
+
 # --- Runtime test: simple GEMM with warp pipeline ---
 
 
@@ -229,6 +233,9 @@ def _smem_warp_pipeline_kernel(
 @pytest.mark.skipif(not is_hip(), reason="warp pipeline is AMD-only")
 def test_warp_pipeline_lowering():
     """Verify that shared-memory GEMM with warp pipeline produces barriers in assembly."""
+    if not is_gfx950():
+        pytest.skip("shared-memory warp-pipeline lowering is currently tested on gfx950")
+
     torch.manual_seed(0)
     M = N = K = 192
     a = torch.randn((M, K), dtype=torch.float16, device="cuda")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -282,7 +282,6 @@ class CUDABackend(BaseBackend):
         tlx.tlx_passes.add_tlx_storage_alias_lowering(pm)
         # Only determine layouts after inlining is finished.
         tlx.tlx_passes.add_tlx_resolve_placeholder_layouts(pm)
-        passes.ttir.add_rewrite_tensor_pointer(pm)
         if capability // 10 < 9:
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_canonicalizer(pm)
@@ -300,23 +299,20 @@ class CUDABackend(BaseBackend):
         if opt.maxnreg is not None:
             mod.set_attr("ttg.maxnreg", ir.builder(mod.context).get_int32_attr(opt.maxnreg))
 
-        cluster_info = nvidia.ClusterInfo()
+        cluster_dims = tuple(opt.cluster_dims or (1, 1, 1))
         if opt.cluster_dims is not None:
-            cluster_info.clusterDimX = opt.cluster_dims[0]
-            cluster_info.clusterDimY = opt.cluster_dims[1]
-            cluster_info.clusterDimZ = opt.cluster_dims[2]
-            # Set cluster_info attributes on the module
+            # Set cluster dimension attributes on the module.
             mod.set_attr(
                 "ttg.cluster-dim-x",
-                ir.builder(mod.context).get_int32_attr(cluster_info.clusterDimX),
+                ir.builder(mod.context).get_int32_attr(cluster_dims[0]),
             )
             mod.set_attr(
                 "ttg.cluster-dim-y",
-                ir.builder(mod.context).get_int32_attr(cluster_info.clusterDimY),
+                ir.builder(mod.context).get_int32_attr(cluster_dims[1]),
             )
             mod.set_attr(
                 "ttg.cluster-dim-z",
-                ir.builder(mod.context).get_int32_attr(cluster_info.clusterDimZ),
+                ir.builder(mod.context).get_int32_attr(cluster_dims[2]),
             )
         pm = ir.pass_manager(mod.context)
         dump_enabled = pm.enable_debug()
@@ -393,7 +389,7 @@ class CUDABackend(BaseBackend):
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()
-        metadata["cluster_dims"] = (cluster_info.clusterDimX, cluster_info.clusterDimY, cluster_info.clusterDimZ)
+        metadata["cluster_dims"] = cluster_dims
         # Track whether ctas_per_cga was explicitly set to distinguish between
         # Triton's way (num_ctas > 1) and TLX/CUDA way (ctas_per_cga set).
         metadata["ctas_per_cga"] = opt.ctas_per_cga

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -184,6 +184,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUOptimizeDescriptorEncodingPass);
   ADD_PASS_WRAPPER_0("add_optimize_tmem_layouts",
                      ttng::createTritonNvidiaGPUOptimizeTMemLayoutsPass);
+  ADD_PASS_WRAPPER_0("add_prune_unused_barriers",
+                     ttng::createTritonNvidiaGPUPruneUnusedBarriersPass);
   ADD_PASS_WRAPPER_0("add_interleave_tmem",
                      ttng::createTritonNvidiaGPUInterleaveTMemPass);
   ttng::registerConSanNVIDIAHooks();

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -362,8 +362,8 @@ void init_triton_tlx_ir(py::module &&m) {
              auto context = self.getBuilder().getContext();
              auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
              auto barriersMemDescType = ttg::MemDescType::get(
-                 {numBarriers}, self.getBuilder().getI64Type(), barrierEncoding,
-                 memorySpace, /*mutableMemory=*/true);
+                 {numBarriers, 1}, self.getBuilder().getI64Type(),
+                 barrierEncoding, memorySpace, /*mutableMemory=*/true);
 
              auto singleBarrierMemDescType = ttg::MemDescType::get(
                  {1}, self.getBuilder().getI64Type(), barrierEncoding,

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -984,7 +984,7 @@ class mbarrier_type(buffered_tensor_type):
 
     def to_ir(self, builder: ir.builder) -> None:
         if self.num >= 1:
-            shape = [self.num]
+            shape = [self.num] + self.shape
         else:
             shape = self.shape
         return builder.get_memdesc_type(


### PR DESCRIPTION
- Add `ci-gpu.yml` for the `tlx-amd-meta` branch using the MI350 runner `linux-fb-triton-mi350-1`.
- Build Triton in CI, check that torch sees a GPU, run lit, run targeted codegen pytest coverage, and run the TLX-specific GPU language/e2e tests.
- Keep the GPU pytest scope limited to TLX files instead of the full `python/test/unit/language` suite.
- Fix TLX mbarrier allocation shape and test call sites so barrier views are represented as `[num_barriers, 1]`.
- Tighten hardware filtering for TLX tests that are Hopper-only, `gfx950`-specific, or require more shared memory than the current device exposes.
- Fix codegen test regressions by updating compiler metadata/pass handling and exposing the missing `prune_unused_barriers` binding.