### PR TITLE
[Triton] CSE elect.sync within basic blocks + round setmaxnreg to 8

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -718,6 +718,21 @@ tt.func @tc_gen5_commit(%arg0: !ttg.memdesc<1xi64, #shared, #smem, mutable>, %pr
   ttng.tc_gen5_commit %arg0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
   tt.return
 }
+
+// Two commits in the same block should reuse a single elect.sync
+// (createElectPredicate CSE within the same basic block).
+// CHECK-LABEL: @tc_gen5_commit_elect_cse
+tt.func @tc_gen5_commit_elect_cse(%bar0: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
+                                  %bar1: !ttg.memdesc<1xi64, #shared, #smem, mutable>,
+                                  %pred: i1) {
+  // CHECK: nvvm.elect.sync
+  // CHECK-NOT: nvvm.elect.sync
+  // CHECK: tcgen05.commit
+  // CHECK: tcgen05.commit
+  ttng.tc_gen5_commit %bar0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+  ttng.tc_gen5_commit %bar1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+  tt.return
+}
 }
 
 // -----

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -67,6 +67,9 @@ static void createRegRealloc(TritonLLVMIRRewriter &b, int curRegs,
                              int adjRegs) {
   curRegs = std::min(256, curRegs);
   adjRegs = std::min(256, adjRegs);
+  // Round to a multiple of 8 (hardware requirement).
+  adjRegs = adjRegs / 8 * 8;
+  curRegs = curRegs / 8 * 8;
   // Skip if no change is needed - generating inc/dec with same value is wrong
   if (curRegs == adjRegs)
     return;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -217,6 +217,23 @@ struct ConvertTritonGPUToLLVM
         id.replaceAllUsesWith(zero);
       });
     }
+    // Deduplicate elect.sync ops within each basic block. elect.sync with
+    // membermask=-1 always returns the same predicate within a convergence
+    // region, but MLIR's CSE won't touch it because it has side effects.
+    mod.walk([](Block *block) {
+      NVVM::ElectSyncOp first = nullptr;
+      for (auto &op : llvm::make_early_inc_range(*block)) {
+        if (auto elect = dyn_cast<NVVM::ElectSyncOp>(&op)) {
+          if (!first)
+            first = elect;
+          else {
+            elect.replaceAllUsesWith(first.getResult());
+            elect.erase();
+          }
+        }
+      }
+    });
+
     fixUpLoopAnnotation(mod);
 
     // Ensure warp group code is isolated from above.


### PR DESCRIPTION
Two small compiler fixes:

1. createElectPredicate now reuses an existing elect.sync in the same basic block instead of emitting a duplicate. elect.sync with membermask=-1 always returns the same predicate within a convergence region, so this is safe. Reduces register pressure from redundant elect ops in blocks with multiple TMA/barrier/commit lowerings.

2. Round setmaxnreg inc/dec values to a multiple of 8, which is a hardware requirement on Blackwell.

