### PR TITLE
[triton][tlx] Require WS register budgets to be 8-aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ Examples: how mbarriers are communicated in warp specialization
 |-----------|-------------|
 | `"default"` | First positional argument to mark this as the default/trunk task |
 | `num_warps` | Number of warps to reserve for this task |
-| `num_regs` | Number of registers per thread (optional, for register allocation tuning) |
+| `num_regs` | Number of registers per thread (optional, for register allocation tuning). When provided, it must be divisible by 8. |
 | `replicate` | Number of replicas for this task (default: 1). Creates multiple copies of the task region |
 | `warp_group_start_id` | Starting warp ID for this task (optional). Allows explicit control over warp assignment |
 

--- a/python/test/unit/language/test_tlx_barriers.py
+++ b/python/test/unit/language/test_tlx_barriers.py
@@ -321,7 +321,7 @@ def test_named_wait_arrive(BLOCK_SIZE, device):
                 y = tl.load(y_ptr + offsets, mask=mask)
                 output = x + y
                 tl.store(z_ptr + offsets, output, mask=mask)
-            with tlx.async_task(num_warps=4, registers=100):
+            with tlx.async_task(num_warps=4, registers=96):
                 tlx.named_barrier_arrive(9, 256)
                 tlx.named_barrier_wait(10, 256)
                 offsets = block_start + tl.arange(0, BLOCK_SIZE)

--- a/python/test/unit/language/test_tlx_warp_specialization.py
+++ b/python/test/unit/language/test_tlx_warp_specialization.py
@@ -140,7 +140,7 @@ def test_async_tasks_constexpr_guard(BLOCK_SIZE, ENABLE_SECOND_TASK, device):
                 output = x + y
                 tl.store(z_ptr + offsets, output, mask=mask)
             if ENABLE_SECOND_TASK:
-                with tlx.async_task(num_warps=1, registers=100):
+                with tlx.async_task(num_warps=1, registers=96):
                     offsets = block_start + tl.arange(0, BLOCK_SIZE)
                     mask = offsets < n_elements
                     a = tl.load(a_ptr + offsets, mask=mask)
@@ -226,7 +226,7 @@ def test_async_tasks_constexpr_select_default(BLOCK_SIZE, USE_LARGE_DEFAULT, dev
                     x = tl.load(x_ptr + offsets, mask=mask)
                     y = tl.load(y_ptr + offsets, mask=mask)
                     tl.store(z_ptr + offsets, x * y, mask=mask)
-            with tlx.async_task(num_warps=1, registers=100):
+            with tlx.async_task(num_warps=1, registers=96):
                 offsets = block_start + tl.arange(0, BLOCK_SIZE)
                 mask = offsets < n_elements
                 a = tl.load(a_ptr + offsets, mask=mask)
@@ -293,6 +293,30 @@ def test_default_task_rejects_registers():
 
     with pytest.raises(AssertionError, match="Cannot specify registers"):
         tlx.async_task("default", num_regs=128)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"num_regs": 25},
+        {"registers": 25},
+    ],
+)
+def test_async_task_rejects_unaligned_registers(kwargs):
+    with pytest.raises(ValueError, match="divisible by 8"):
+        tlx.async_task(num_warps=1, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"minRegAutoWS": 25},
+        {"maxRegAutoWS": 153},
+    ],
+)
+def test_config_rejects_unaligned_reg_auto_ws(kwargs):
+    with pytest.raises(ValueError, match="divisible by 8"):
+        triton.Config({}, **kwargs)
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -448,6 +448,11 @@ class Config:
     :type preferred_ctas_per_cga: tuple[int, int, int]
     """
 
+    @staticmethod
+    def _check_reg_auto_ws_alignment(name, value):
+        if value is not None and value % 8 != 0:
+            raise ValueError(f"{name} must be divisible by 8, got {value}")
+
     def __init__(
         self,
         kwargs,
@@ -476,6 +481,8 @@ class Config:
         self.maxnreg = maxnreg
         self.pre_hook = pre_hook
         self.ir_override = ir_override
+        self._check_reg_auto_ws_alignment("minRegAutoWS", minRegAutoWS)
+        self._check_reg_auto_ws_alignment("maxRegAutoWS", maxRegAutoWS)
         self.minRegAutoWS = minRegAutoWS
         self.maxRegAutoWS = maxRegAutoWS
         self.pingpongAutoWS = pingpongAutoWS

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -136,6 +136,11 @@ def _max_shared_mem_for_capability(capability: int) -> int:
     return _SMEM_SIZES.get(capability, _SMEM_SIZES.get(capability // 10 * 10, 49152))
 
 
+def _check_reg_auto_ws_alignment(name: str, value: Optional[int]) -> None:
+    if value is not None and value % 8 != 0:
+        raise ValueError(f"{name} must be divisible by 8, got {value}")
+
+
 @dataclass(frozen=True)
 class CUDAOptions:
     num_warps: int = 4
@@ -182,6 +187,8 @@ class CUDAOptions:
         object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
         assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
             "num_warps must be a power of 2"
+        _check_reg_auto_ws_alignment("minRegAutoWS", self.minRegAutoWS)
+        _check_reg_auto_ws_alignment("maxRegAutoWS", self.maxRegAutoWS)
 
         # If ctas_per_cga is set, it overrides cluster_dims with CUDA semantics:
         # ctas_per_cga defines the cluster shape for regrouping grid CTAs.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -29,6 +29,13 @@ On Blackwell, only `doTaskIdPropagate` runs for annotation (task partition and
 data partition are skipped). The task assignments are expected to come from
 an earlier partition scheduling pass (`PartitionSchedulingMeta`).
 
+## Register Budgets
+
+`minRegAutoWS` and `maxRegAutoWS` control the per-thread register budgets used
+when AutoWS assigns registers to non-tensor and tensor partitions. If either
+knob is provided from the Python frontend, its value must be divisible by 8 so
+the emitted register allocation matches the backend warp-group granularity.
+
 ## File Map
 
 | File | Function / Pass | Description |

--- a/third_party/tlx/language/tlx/async_task_utils.py
+++ b/third_party/tlx/language/tlx/async_task_utils.py
@@ -1,6 +1,11 @@
 from triton.language import core
 
 
+def _validate_num_regs(num_regs):
+    if num_regs is not None and num_regs % 8 != 0:
+        raise ValueError(f"num_regs must be divisible by 8, got {num_regs}")
+
+
 class async_task:
     """
     Context manager to run code fragments asynchronously.
@@ -31,6 +36,7 @@ class async_task:
             self.is_explict = True
             self.num_warps = core._unwrap_if_constexpr(kwargs.get("num_warps", None))
             self.num_regs = core._unwrap_if_constexpr(kwargs.get("num_regs", kwargs.get("registers", None)))
+            _validate_num_regs(self.num_regs)
             self.replicate = core._unwrap_if_constexpr(kwargs.get("replicate", 1))
             self.warp_group_start_id = core._unwrap_if_constexpr(kwargs.get("warp_group_start_id", None))
 


### PR DESCRIPTION
Summary: Validate explicit TLX `async_task` register counts and AutoWS `minRegAutoWS`/`maxRegAutoWS` frontend options so provided per-thread register budgets must be divisible by 8. Update TLX and AutoWS documentation for the alignment requirement. This diff was authored with Claude.

Reviewed By: htyu

Differential Revision: D106540890


