### PR TITLE
[TLX] Push mbar init ops to kernel beginning for clustered kernel

### DIFF
--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -539,3 +539,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+
+// -----
+
+// Test that ensureEarlyBarInit moves all init_barriers before tcgen5_global_alloc,
+// even when some are on each side of it. The second init_barrier and its dep
+// (memdesc_index) are after tcgen5_global_alloc and must be reordered.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @reorder_multiple_bar_inits_before_tcgen5_alloc
+  // CHECK: mbarrier.init.shared::cta.b64
+  // CHECK: mbarrier.init.shared::cta.b64
+  // CHECK: nvvm.cluster.arrive {aligned}
+  // CHECK: nvvm.cluster.wait {aligned}
+  // CHECK: ttng.tcgen5_global_alloc
+  tt.func public @reorder_multiple_bar_inits_before_tcgen5_alloc() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.tcgen5_global_alloc {tensor_memory_size = 128 : i32, two_ctas = true}
+    %2 = ttg.memdesc_index %0[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %3 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    ttng.arrive_barrier %3, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -258,8 +258,9 @@ private:
       return WalkResult::advance();
     });
     assert(funcOp && "Expecting to find a kernel func but got none.");
+    Block *entryBlock = &funcOp.front();
     for (auto op : barInitOps) {
-      if (op->getBlock() != &funcOp.front()) {
+      if (op->getBlock() != entryBlock) {
         op->emitError() << "Barrier init outside of the first block in "
                            "function is not supported for CTA clusters";
         return failure();
@@ -267,11 +268,65 @@ private:
     }
 
     // ensure all tmem alloc ops are in the entry block too
+    SmallVector<Operation *> tmemOps;
+    funcOp.walk([&](Operation *op) {
+      if (isa<ttng::TCGen5GlobalAllocOp, ttng::TMEMAllocOp>(op))
+        tmemOps.push_back(op);
+    });
+    for (auto *op : tmemOps) {
+      if (op->getBlock() != entryBlock) {
+        op->emitError() << "TMEM allocation outside of the first block in "
+                           "function is not supported for CTA clusters";
+        return failure();
+      }
+    }
 
     // Move all mbar init ops (and their deps) to the beginning of the block
+    SetVector<Operation *> opsToMove;
+    SmallVector<Operation *> worklist(barInitOps.begin(), barInitOps.end());
+    while (!worklist.empty()) {
+      auto *op = worklist.pop_back_val();
+      if (!opsToMove.insert(op))
+        continue;
+      for (Value operand : op->getOperands()) {
+        if (auto *defOp = operand.getDefiningOp()) {
+          if (defOp->getBlock() == entryBlock)
+            worklist.push_back(defOp);
+        }
+      }
+    }
+    SmallVector<Operation *> opsInBlockOrder;
+    for (auto &op : *entryBlock) {
+      if (opsToMove.contains(&op))
+        opsInBlockOrder.push_back(&op);
+    }
+    Operation *insertPt = nullptr;
+    for (auto *op : opsInBlockOrder) {
+      if (!insertPt)
+        op->moveBefore(entryBlock, entryBlock->begin());
+      else
+        op->moveAfter(insertPt);
+      insertPt = op;
+    }
 
     // Check the block again to make sure all mbar init ops are earlier than
     // TCGen5GlobalAllocOp
+    Operation *firstTCGen5GlobalAlloc = nullptr;
+    for (auto &op : *entryBlock) {
+      if (isa<ttng::TCGen5GlobalAllocOp>(&op)) {
+        firstTCGen5GlobalAlloc = &op;
+        break;
+      }
+    }
+    if (firstTCGen5GlobalAlloc) {
+      for (auto *op : barInitOps) {
+        if (!op->isBeforeInBlock(firstTCGen5GlobalAlloc)) {
+          op->emitError() << "Barrier init is not before TMEM allocation. "
+                             "Cannot insert cluster sync between them.";
+          return failure();
+        }
+      }
+    }
 
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -242,6 +242,11 @@ private:
         static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared));
   }
 
+  // This function enforces that all mbar init and
+  // TCGen5GlobalAllocOp/TMEMAllocOp are in the entry block of kernel function.
+  // Then it pushes all mbar init ops to the earliest to ensure mbar init ->
+  // tmem alloc sequence such that we can safely insert a cluster sync in the
+  // middle
   LogicalResult ensureEarlyBarInit(ModuleOp &mod,
                                    SetVector<Operation *> &barInitOps) {
     triton::FuncOp funcOp = nullptr;
@@ -260,6 +265,13 @@ private:
         return failure();
       }
     }
+
+    // ensure all tmem alloc ops are in the entry block too
+
+    // Move all mbar init ops (and their deps) to the beginning of the block
+
+    // Check the block again to make sure all mbar init ops are earlier than
+    // TCGen5GlobalAllocOp
 
     return success();
   }
@@ -391,11 +403,8 @@ private:
            "Failed to find bar init op in a clustered kernel");
 
     // Enforcing front end for 2cta kernels:
-    // All remote barrier init ops need to happen at the first block of
-    // function. This is to make 2cta cluster sync insertion easier for WarpSpec
-    // case. If in the future there's a need to really alloc/init barriers after
-    // a WS op, we can seek to relax this limitation and fix cluster sync
-    // insertions.
+    // All mbarrier init and tmem alloc ops need to happen at the first block of
+    // function. This is to make 2cta cluster sync insertion easier
     if (failed(ensureEarlyBarInit(mod, remoteOrLocalBarInitOps))) {
       return failure();
     }


### PR DESCRIPTION
To ensure the compiler inserted cluster sync protects mbar init and TMEM alloc properly, we need to push mbar inits to earlier.

To be precise, we have to meet these two requirements for 2cta kernels to work properly:
- There has to be a cluster sync between mbar init and actual mbar usage if the mbar involves cross CTA arrive explicitly/implicitly
- There has to be a cluster sync between kernel start and tmem alloc

We make these enforcement for TLX clustered kernels (that have remote mbar access or pair MMA mode):
- All mbar init ops and TMEM alloc/global_alloc have to be in the kernel entry block. 
- They cannot be inside a nested block. This guarantees no control flow divergence and simplifies things quite a bit because we can reliably order them by just traversing the block.

Then we just push all mbar init ops and their dependencies to the entry block start, guaranteeing the `mbar init -> tcgen global tmem alloc` sequence. Then we just insert a cluster sync in the middle to protect both.

Test plan: added lit test