### PR TITLE
[TLX] [MXFP8] Use uniform amax for dQ-path dS quantization

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -9,6 +9,7 @@ from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _s
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.tools.tensor_descriptor import TensorDescriptor
 from triton.language.extra.tlx.mxfp8_utils import (
+    _amax_to_e8m0_and_quantize,
     _to_mxfp8_block,
     _to_mxfp8_block_with_block_amax,
 )
@@ -1429,10 +1430,11 @@ def _softmax_recompute_quantization_iter(
             ),
             ds_scale_packed,
         )
-        ds_dq_fp8, ds_scale_dq = _to_mxfp8_block(
-            tl.trans(dsT),
-            VEC_SIZE,
-            p_dtype,
+        dsT_t = tl.trans(dsT)
+        dq_amax = tl.max(tl.abs(dsT_t))
+        dq_amax_bcast = tl.full([DS_M_SUB, BLOCK_N1 // VEC_SIZE], 0.0, tl.float32) + dq_amax
+        ds_scale_dq, ds_dq_fp8 = _amax_to_e8m0_and_quantize(
+            dsT_t, dq_amax_bcast, VEC_SIZE, p_dtype,
         )
         tlx.local_store(
             tlx.local_slice(tlx.local_view(ds_dq_tiles_smem, ds_buf_id), [subtile_id * DS_M_SUB, 0],


### PR DESCRIPTION
Replace per-32-block amax computation for the dQ GEMM's dS quantization with a single tile-wide amax, matching FA4's approach. This eliminates the expensive per-block shuffle-tree reductions (SHFL.BFLY 264→76, FMNMX 488→236) for the dQ path while preserving per-block scales for the dK path.

The coarser quantization is acceptable because dQ accumulates via atomic reduce-add anyway. Runtime improved from 30.5ms to 24.9ms (-18%) on (4,32,8192,128).

Before:
```
flash-attention-bwd-performance-mxfp8-d128:
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                              472.556030
1  2048.0                              543.405350
2  4096.0                              584.444735
3  8192.0                              604.245185

```

After:

```
    N_CTX  ws_pipelined_persistent_mxfp8 (TFLOPS)
0  1024.0                              539.568763
1  2048.0                              633.681633
2  4096.0                              691.643416
3  8192.0                              722.183114
```