### PR TITLE
[AutoWS] Update allocation ordering to match usage

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_memory_planner_load_order.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_load_order.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-ws-memory-planner="num-buffers=2 smem-alloc-algo=1 smem-budget=196608" | FileCheck %s
+
+// Test: Phase 4 chooses equal-priority multi-buffer candidates in producer
+// usage order, not local_alloc order. W is allocated first, but X's TMA load is
+// issued first. With only enough SMEM for one extra 128x256xf16 copy, X should
+// get buffer.copy = 2 and W should stay at buffer.copy = 1.
+
+// CHECK-LABEL: @load_order_breaks_multibuffer_tie
+// CHECK: ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = {{[0-9]+}} : i32}
+// CHECK-SAME: !ttg.memdesc<128x256xf16
+// CHECK: ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = {{[0-9]+}} : i32}
+// CHECK-SAME: !ttg.memdesc<128x256xf16
+
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @load_order_breaks_multibuffer_tie(
+      %x_desc: !tt.tensordesc<tensor<128x256xf16, #shared>>,
+      %w_desc: !tt.tensordesc<tensor<128x256xf16, #shared>>) {
+    %W_smem = ttg.local_alloc : () -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+    %X_smem = ttg.local_alloc : () -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : i32
+    %c1 = arith.constant {async_task_id = array<i32: 0, 1>} 1 : i32
+    %c10 = arith.constant {async_task_id = array<i32: 0, 1>} 10 : i32
+    scf.for %iv = %c0 to %c10 step %c1 : i32 {
+      %x = tt.descriptor_load %x_desc[%c0, %c0] {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x256xf16, #shared>> -> tensor<128x256xf16, #blocked1>
+      ttg.local_store %x, %X_smem {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x256xf16, #blocked1> -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+      %w = tt.descriptor_load %w_desc[%c0, %c0] {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x256xf16, #shared>> -> tensor<128x256xf16, #blocked1>
+      ttg.local_store %w, %W_smem {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x256xf16, #blocked1> -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+      %x_val = ttg.local_load %X_smem {async_task_id = array<i32: 0>} : !ttg.memdesc<128x256xf16, #shared, #smem, mutable> -> tensor<128x256xf16, #blocked1>
+      %w_val = ttg.local_load %W_smem {async_task_id = array<i32: 0>} : !ttg.memdesc<128x256xf16, #shared, #smem, mutable> -> tensor<128x256xf16, #blocked1>
+      %sum = arith.addf %x_val, %w_val {async_task_id = array<i32: 0>} : tensor<128x256xf16, #blocked1>
+      scf.yield {async_task_id = array<i32: 0, 1>}
+    } {async_task_id = array<i32: 0, 1>, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -227,6 +227,25 @@ static Channel *findChannelForOp(Operation *op,
   return TheCh;
 }
 
+/// Return the logical producer for a channel. For SMEM post channels created
+/// from a tensor value, the channel source is a local_store; use the value
+/// stored into SMEM so tie-breaking follows the original load/program order.
+static Operation *getLogicalProducerOp(Channel *ch) {
+  if (!ch)
+    return nullptr;
+
+  Operation *srcOp = ch->getSrcOp();
+  if (!srcOp)
+    return nullptr;
+
+  if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(srcOp)) {
+    if (Operation *defOp = storeOp.getSrc().getDefiningOp())
+      return defOp;
+  }
+
+  return srcOp;
+}
+
 /// Find the channel associated with a value's defining allocation operation.
 /// Convenience wrapper around findChannelForOp.
 /// @param value The value whose defining operation to find a channel for
@@ -798,6 +817,24 @@ struct WSBuffer {
   bool isAllocated =
       false; // Has dedicated SMEM; false = reuses another buffer.
 };
+
+static unsigned
+getWSBufferUsageOrder(const WSBuffer &buf, SmallVector<Channel *> &channels,
+                      const DenseMap<Operation *, unsigned> &opOrder) {
+  if (Channel *ch = findChannelForOp(buf.allocOp, channels)) {
+    if (Operation *producer = getLogicalProducerOp(ch)) {
+      auto it = opOrder.find(producer);
+      if (it != opOrder.end())
+        return it->second;
+    }
+  }
+
+  auto it = opOrder.find(buf.allocOp);
+  if (it != opOrder.end())
+    return it->second;
+
+  return std::numeric_limits<unsigned>::max();
+}
 
 /// Parsed channel annotation from tt.autows JSON on an MMA op.
 /// Format: "opndA,smem,2,0" → operand=opndA, memType=smem, numCopies=2,
@@ -1560,6 +1597,11 @@ static unsigned allocateSmemBuffers(
   if (wsBuffers.empty())
     return nextBufferId;
 
+  DenseMap<Operation *, unsigned> opOrder;
+  unsigned nextOpOrder = 0;
+  funcOp->walk<WalkOrder::PreOrder>(
+      [&](Operation *op) { opOrder[op] = nextOpOrder++; });
+
   // Ensure nextBufferId is past all pinned SMEM IDs too.
   for (auto &buf : wsBuffers)
     if (buf.isPinned)
@@ -1701,6 +1743,14 @@ static unsigned allocateSmemBuffers(
     }
     if (candidateIndices.empty())
       continue;
+
+    llvm::stable_sort(candidateIndices, [&](unsigned a, unsigned b) {
+      unsigned orderA = getWSBufferUsageOrder(wsBuffers[a], channels, opOrder);
+      unsigned orderB = getWSBufferUsageOrder(wsBuffers[b], channels, opOrder);
+      if (orderA != orderB)
+        return orderA < orderB;
+      return a < b;
+    });
 
     LDBG("Phase 4: processing priority=" << static_cast<int>(priority)
                                          << " with " << candidateIndices.size()

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/SmemAllocationDesign.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/SmemAllocationDesign.md
@@ -98,6 +98,7 @@ For a given priority level with a set of candidate WSBuffers:
 
 ```
 candidates = WSBuffers at this priority
+sort candidates by logical producer order
 
 # ── Step 0: Decide grouping upfront ──────────────────────────────
 #
@@ -189,6 +190,13 @@ if reuseGroup AND reuseGroup.numCopies is EVEN:
 if not foundValidSolution:
     report error: cannot fit SMEM allocation within budget
 ```
+
+The candidate order is only a tie-breaker among equal-priority buffers. It
+follows logical producer order when available: for post-channel SMEM buffers
+created from tensor values, the planner looks through the inserted
+`local_store` to the original producer such as a `descriptor_load`; otherwise
+it uses the channel source op. If the source cannot be found, the planner falls
+back to the `local_alloc` order.
 
 #### Initial value of `currentGroupCopies`
 


### PR DESCRIPTION
Fixes a bug in the memory planner where alloc hoisting wouldn't match the TMEM ordering in the code and therefore when scanning we wouldn't match the order of utility. This resulted in B getting an extra buffer slot before A in GEMM/ADDMM.