### PR TITLE
[ci] Fix H100 TLX and MI350 Tritonbench workflows

### DIFF
--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -70,11 +70,9 @@ jobs:
           nvidia-smi
       - name: Compile Triton
         run: |
-          set -x
           . "${SETUP_SCRIPT}"
           . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
           install_triton $PWD
-          python -c "import triton.language.extra.tlx as tlx"
       - name: Install torchao from source
         run: |
           . "${SETUP_SCRIPT}"
@@ -83,18 +81,13 @@ jobs:
       - name: Run TLX unit tests
         timeout-minutes: 5
         run: |
-          set -x
-          . ${UV_VENV_DIR}/${CONDA_ENV}/bin/activate
-          cat ${SETUP_SCRIPT}
           . "${SETUP_SCRIPT}"
-          . ${UV_VENV_DIR}/${CONDA_ENV}/bin/activate
-          pytest python/test/unit/language/test_tlx_*.py -v
+          uv run pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          . ${UV_VENV_DIR}/${CONDA_ENV}/bin/activate
-          pytest third_party/tlx/tutorials/testing/test_correctness.py -v
+          uv run pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -91,6 +91,7 @@ jobs:
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
+          . ${UV_VENV_DIRS}/${CONDA_ENV}/activate
           pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -78,17 +78,23 @@ jobs:
         run: |
           . "${SETUP_SCRIPT}"
           uv pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
-          uv run --active python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
+          python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
       - name: Run TLX unit tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          uv run --active pytest python/test/unit/language/test_tlx_*.py -v
+          ls $UV_ENV_DIR/$CONDA_ENV/bin
+          echo $PATH
+          which pytest
+          which python
+          $UV_ENVS/$CONDA_ENV/bin/pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          uv run --active pytest third_party/tlx/tutorials/testing/test_correctness.py -v
+          ls $UV_ENV_DIR/$CONDA_ENV/bin
+          echo $PATH
+          $UV_ENVS/$CONDA_ENV/bin/pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -83,12 +83,12 @@ jobs:
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          ${UV_VENV_DIR}/${CONDA_ENV}/bin/pytest python/test/unit/language/test_tlx_*.py -v
+          python -m pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          ${UV_VENV_DIR}/$CONDA_ENV/bin/pytest third_party/tlx/tutorials/testing/test_correctness.py -v
+          python -m pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -73,11 +73,11 @@ jobs:
           . "${SETUP_SCRIPT}"
           . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
           install_triton $PWD
-          uv run --active python -m pip install pytest
+          uv pip install pytest
       - name: Install torchao from source
         run: |
           . "${SETUP_SCRIPT}"
-          uv run --active python -m pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
+          uv pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
           uv run --active python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
       - name: Run TLX unit tests
         timeout-minutes: 5

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -54,7 +54,6 @@ jobs:
     runs-on: linux-gcp-h100
     env:
       CONDA_ENV: meta-triton
-      UV_VENV_DIR: /workspace/uv_venvs
       SETUP_SCRIPT: /workspace/setup_instance.sh
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -69,9 +69,11 @@ jobs:
           nvidia-smi
       - name: Compile Triton
         run: |
+          set -x
           . "${SETUP_SCRIPT}"
           . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
           install_triton $PWD
+          python -c "import triton.language.extra.tlx as tlx"
       - name: Install torchao from source
         run: |
           . "${SETUP_SCRIPT}"
@@ -80,6 +82,7 @@ jobs:
       - name: Run TLX unit tests
         timeout-minutes: 5
         run: |
+          set -x
           . "${SETUP_SCRIPT}"
           pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -84,16 +84,16 @@ jobs:
         timeout-minutes: 5
         run: |
           set -x
-          . ${UV_VENV_DIR}/${CONDA_ENV}/activate
+          . ${UV_VENV_DIR}/${CONDA_ENV}/bin/activate
           cat ${SETUP_SCRIPT}
           . "${SETUP_SCRIPT}"
-          . ${UV_VENV_DIR}/${CONDA_ENV}/activate
+          . ${UV_VENV_DIR}/${CONDA_ENV}/bin/activate
           pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          . ${UV_VENV_DIR}/${CONDA_ENV}/activate
+          . ${UV_VENV_DIR}/${CONDA_ENV}/bin/activate
           pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -84,6 +84,8 @@ jobs:
         timeout-minutes: 5
         run: |
           set -x
+          . ${UV_VENV_DIR}/${CONDA_ENV}/activate
+          cat ${SETUP_SCRIPT}
           . "${SETUP_SCRIPT}"
           . ${UV_VENV_DIR}/${CONDA_ENV}/activate
           pytest python/test/unit/language/test_tlx_*.py -v

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -73,22 +73,22 @@ jobs:
           . "${SETUP_SCRIPT}"
           . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
           install_triton $PWD
-          uv pip install pytest
+          uv run --active python -m pip install pytest
       - name: Install torchao from source
         run: |
           . "${SETUP_SCRIPT}"
-          uv pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
-          python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
+          uv run --active python -m pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
+          uv run --active python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
       - name: Run TLX unit tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          uv run pytest python/test/unit/language/test_tlx_*.py -v
+          uv run --active pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          uv run pytest third_party/tlx/tutorials/testing/test_correctness.py -v
+          uv run --active pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -73,6 +73,7 @@ jobs:
           . "${SETUP_SCRIPT}"
           . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
           install_triton $PWD
+          uv pip install pytest
       - name: Install torchao from source
         run: |
           . "${SETUP_SCRIPT}"

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -83,7 +83,7 @@ jobs:
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          ls $UV_ENV_DIR/$CONDA_ENV/bin
+          ls ${UV_VENV_DIR}/${CONDA_ENV}/bin
           echo $PATH
           which pytest
           which python
@@ -92,9 +92,7 @@ jobs:
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          ls $UV_ENV_DIR/$CONDA_ENV/bin
-          echo $PATH
-          $UV_ENVS/$CONDA_ENV/bin/pytest third_party/tlx/tutorials/testing/test_correctness.py -v
+          ${UV_VENV_DIR}/$CONDA_ENV/bin/pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -85,13 +85,13 @@ jobs:
         run: |
           set -x
           . "${SETUP_SCRIPT}"
-          . ${UV_VENV_DIRS}/${CONDA_ENV}/activate
+          . ${UV_VENV_DIR}/${CONDA_ENV}/activate
           pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          . ${UV_VENV_DIRS}/${CONDA_ENV}/activate
+          . ${UV_VENV_DIR}/${CONDA_ENV}/activate
           pytest third_party/tlx/tutorials/testing/test_correctness.py -v
 
 concurrency:

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -83,11 +83,7 @@ jobs:
         timeout-minutes: 5
         run: |
           . "${SETUP_SCRIPT}"
-          ls ${UV_VENV_DIR}/${CONDA_ENV}/bin
-          echo $PATH
-          which pytest
-          which python
-          $UV_ENVS/$CONDA_ENV/bin/pytest python/test/unit/language/test_tlx_*.py -v
+          ${UV_VENV_DIR}/${CONDA_ENV}/bin/pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5
         run: |

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -54,6 +54,7 @@ jobs:
     runs-on: linux-gcp-h100
     env:
       CONDA_ENV: meta-triton
+      UV_VENV_DIR: /workspace/uv_venvs
       SETUP_SCRIPT: /workspace/setup_instance.sh
     timeout-minutes: 30
     permissions:
@@ -84,6 +85,7 @@ jobs:
         run: |
           set -x
           . "${SETUP_SCRIPT}"
+          . ${UV_VENV_DIRS}/${CONDA_ENV}/activate
           pytest python/test/unit/language/test_tlx_*.py -v
       - name: Run TLX tutorial correctness tests
         timeout-minutes: 5

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: linux-fb-triton-mi350-1
     env:
       WORKSPACE_DIR: /workspace
-      CONDA_ENV: pytorch
+      CONDA_ENV: meta-triton
       UV_VENV_DIR: /workspace/uv_venvs
       SETUP_SCRIPT: /workspace/setup_instance.sh
     timeout-minutes: 240

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           repository: meta-pytorch/tritonbench
           path: tritonbench
+          ref: xz9/disable-more-amd
           submodules: recursive
       - name: Setup Tritonbench environment
         working-directory: tritonbench


### PR DESCRIPTION
Fixes https://github.com/facebookexperimental/triton/issues/1614.

The reason is because the `meta-triton` and `triton-main` envs are generated via copying `pytorch` venv to save network traffic and speedup installation time (don't need to download pytorch three times for three venvs). As a result, executable scripts like `pytest` keeps their shebangs like `#!/workspace/venvs/pytorch/bin/python`, causing it to invoke the python in `pytorch`, instead of `meta-triton`.

We will replace the shebang later to fix this bug. 

As a workaround, using `python -m` to invoke pytest will fix this issue.