### PR TITLE
[triton][autows] Fix ping-pong WGMMA grouping endpoints

### DIFF
--- a/test/Hopper/WarpSpecialization/pingpong_group_wgmma_endpoints.mlir
+++ b/test/Hopper/WarpSpecialization/pingpong_group_wgmma_endpoints.mlir
@@ -1,0 +1,83 @@
+// RUN: triton-opt %s --nvgpu-test-ping-pong-prep="capability=90 num-stages=3" | FileCheck %s
+
+// WGMMA has memory effects because it reads SMEM operands, but those endpoint
+// effects are not intervening effects between two WGMMA ops in the same
+// partition. All ten dots below should therefore be one ping-pong group.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: @pingpong_group_wgmma_endpoints
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 1>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST:[0-9]+]] : i32
+// CHECK-SAME: pingpong_id = [[ID:[0-9]+]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 1>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 1>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 1>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 1>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 2>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 2>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 2>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 2>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+// CHECK:      ttng.warp_group_dot
+// CHECK-SAME: async_task_id = array<i32: 2>
+// CHECK-SAME: pingpong_first_partition_id = [[FIRST]] : i32
+// CHECK-SAME: pingpong_id = [[ID]] : i32
+tt.func public @pingpong_group_wgmma_endpoints(
+    %lhs0: !ttg.memdesc<64x64xf16, #shared, #smem>,
+    %lhs1: !ttg.memdesc<64x64xf16, #shared, #smem>,
+    %rhs: !ttg.memdesc<64x128xf16, #shared, #smem>,
+    %num_tiles: i32
+) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %init = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #mma>
+  %result:2 = scf.for %iv = %c0 to %num_tiles step %c1
+      iter_args(%acc0 = %init, %acc1 = %init)
+      -> (tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>) : i32 {
+    %anchor = arith.addi %iv, %c0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+    %dot0 = ttng.warp_group_dot %lhs0, %rhs, %acc0 {async_task_id = array<i32: 1>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot1 = ttng.warp_group_dot %lhs0, %rhs, %dot0 {async_task_id = array<i32: 1>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot2 = ttng.warp_group_dot %lhs0, %rhs, %dot1 {async_task_id = array<i32: 1>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot3 = ttng.warp_group_dot %lhs0, %rhs, %dot2 {async_task_id = array<i32: 1>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot4 = ttng.warp_group_dot %lhs0, %rhs, %dot3 {async_task_id = array<i32: 1>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot5 = ttng.warp_group_dot %lhs1, %rhs, %acc1 {async_task_id = array<i32: 2>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot6 = ttng.warp_group_dot %lhs1, %rhs, %dot5 {async_task_id = array<i32: 2>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot7 = ttng.warp_group_dot %lhs1, %rhs, %dot6 {async_task_id = array<i32: 2>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot8 = ttng.warp_group_dot %lhs1, %rhs, %dot7 {async_task_id = array<i32: 2>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    %dot9 = ttng.warp_group_dot %lhs1, %rhs, %dot8 {async_task_id = array<i32: 2>, inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared, #smem> -> tensor<64x128xf32, #mma>
+    scf.yield {async_task_id = array<i32: 1, 2>} %dot4, %dot9 : tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>
+  } {tt.scheduled_max_stage = 1 : i32}
+  tt.return
+}
+
+} // module

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -288,6 +288,44 @@ Operation *findEndOp(CriticalRegionManager &crManager, Operation *keyOp,
   return nullptr;
 }
 
+/// Returns true if there is a region-splitting memory side effect strictly
+/// between two same-partition expensive ops.
+///
+/// This is the grouping-time question: can two expensive ops live in the same
+/// ping-pong region? It differs from findEndOp (which finds a region's *end*
+/// boundary and, for NonReorderable ops, returns the op itself) in two ways:
+///   - The two endpoint ops are excluded. An expensive op such as WarpGroupDotOp
+///     is NonReorderable: its own SMEM-operand read is the op itself, not an
+///     intervening effect, so it must not reject grouping (B-4 / T273470439).
+///   - Other expensive ops between the endpoints are skipped. They are peers in
+///     the same ping-pong region (managed by their own barriers), so they do not
+///     split the region either; skipping them lets a run of N expensive ops
+///     union into a single region.
+///
+/// Callers must ensure the two ops are control-flow equivalent
+/// (areControlFlowEquivalent), which guarantees they share a block with no
+/// intervening control flow, so a simple forward scan terminates at `b`.
+bool hasInterveningMemEffect(CriticalRegionManager &crManager, Operation *a,
+                             Operation *b, int capability) {
+  Operation *earlier = a;
+  Operation *later = b;
+  if (later->isBeforeInBlock(earlier))
+    std::swap(earlier, later);
+
+  for (Operation *curOp = earlier->getNextNode(); curOp && curOp != later;
+       curOp = curOp->getNextNode()) {
+    // Peer expensive ops are part of the same ping-pong region, not a barrier.
+    if (crManager.isExpensiveOp(curOp, capability))
+      continue;
+    if (!isMemoryEffectFree(curOp)) {
+      LDBG("Found intervening op with memory effects: " << curOp->getName());
+      dumpMemoryEffects(curOp);
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Returns the operation from startOps that is closest to the entry
 /// (executed earliest). All ops must be in the same block.
 Operation *firstOpInBlock(llvm::ArrayRef<Operation *> startOps) {
@@ -684,9 +722,12 @@ void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
           continue;
         }
         if (opTaskId == refTaskId) {
-          // If findEndOp returns nullptr when stopOp is provided,
-          // there's no memory effect between keyOp and stopOp
-          bool hasMemEffects = (findEndOp(crManager, op, refOp) != nullptr);
+          // Reject grouping only if a real (non-expensive) memory side effect
+          // sits strictly between the two ops. The endpoints themselves and any
+          // peer expensive ops in between are part of the same ping-pong region
+          // and must not split it (B-4 / T273470439).
+          bool hasMemEffects =
+              hasInterveningMemEffect(crManager, op, refOp, capability);
           LDBG("op in partition " << opTaskId
                                   << " has memory effects: " << hasMemEffects);
           if (hasMemEffects)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PingPongScheduling.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PingPongScheduling.md
@@ -29,7 +29,10 @@ Identification is architecture-dependent (`CriticalRegionManager::isExpensiveOp`
 
 Expensive ops are further classified as:
 - **NonReorderable** (e.g., `WarpGroupDotOp`): has memory effects, so the
-  critical region boundary is the op itself.
+  critical region boundary is the op itself. This self-effect (e.g. a wgmma's
+  SMEM-operand read) marks the op's own boundary; it must **not** be treated as
+  an intervening memory effect when deciding whether two expensive ops can be
+  grouped (see Step 1), otherwise consecutive WGMMAs never group.
 - **PureArithmetic** (e.g., `math::ExpOp`): memory-effect-free, so the
   boundary extends forward to the next op with memory effects.
 
@@ -52,7 +55,14 @@ Walk the function and group expensive ops. An op joins an existing group if:
 1. **Same operation type** as all ops in the group.
 2. **Same control flow context**: same block, no intervening `scf::ForOp` /
    `scf::IfOp` / `scf::WhileOp`.
-3. **No intervening memory effects** between ops in the same partition.
+3. **No intervening memory effects** between ops in the same partition. This is
+   evaluated *strictly between* the two ops: the **endpoint ops are excluded**,
+   and any **peer expensive ops in between are skipped** (they belong to the
+   same ping-pong region, so they do not split it). Only a non-expensive op
+   with memory side effects rejects grouping. Implemented by
+   `hasInterveningMemEffect`, which is distinct from `findEndOp` (the latter
+   finds a region's *end* boundary and, for NonReorderable ops, returns the op
+   itself).
 
 If no group matches, a new group is created.
 


### PR DESCRIPTION
Summary:
`doPingPongPrep`'s grouping check reused `findEndOp` to test for an intervening
memory effect between two same-partition expensive ops. `findEndOp` starts its
scan at one of the endpoint ops, and a `WarpGroupDotOp` reports an SMEM read for
its memdesc operands, so the endpoint WGMMA was immediately returned as the
alleged intervening effect. Every run of N same-partition WGMMAs therefore
fragmented into N ping-pong regions. Ping-pong has only four named-barrier pairs
(indices 7-14), so a 5+ region sequence exhausts the budget and the extra
region is silently left unsynchronized.

Add `hasInterveningMemEffect`, which evaluates the question strictly between the
two ops: it excludes the endpoints and skips peer expensive ops (which belong to
the same region), so only a non-expensive memory-effecting op rejects grouping.
`findEndOp` and the region boundary-computation path are unchanged. Also adds a
LIT regression and documents the rule in PingPongScheduling.md.

Authored with Claude.

Differential Revision: D106875813


