### PR TITLE
[autoWS][WSBarrier] Barrier-buffer association 

### DIFF
--- a/test/Hopper/WarpSpecialization/barrier_buffer_assoc.mlir
+++ b/test/Hopper/WarpSpecialization/barrier_buffer_assoc.mlir
@@ -1,0 +1,230 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1" | FileCheck %s
+//
+// Milestone 1 (barrier_analysis.md): barrier<->buffer association.
+//
+// Every token-based WSBarrier endpoint is stamped with discardable
+// barrier.guards / barrier.offsets attributes naming the physical buffer(s)
+// -- (buffer.id, buffer.offset) -- it guards. The guards are derived from the
+// channel's alloc (via getBufferId) and unioned across the reuse group.
+//
+// This bwd-attention IR reuses tmem buffers: dq and dpT share buffer.id 8 and
+// qkT and dv share buffer.id 7 (each a reuse group), plus standalone reused
+// buffers dv_3 (id 6) and dk (id 5). Each shared token therefore carries the
+// reuse-group-unioned id, and offsets default to 0 for whole-buffer guards.
+//
+// CHECK-DAG: nvws.create_token {barrier.guards = array<i32: 8>, barrier.offsets = array<i32: 0>
+// CHECK-DAG: nvws.create_token {barrier.guards = array<i32: 7>, barrier.offsets = array<i32: 0>
+// CHECK-DAG: nvws.create_token {barrier.guards = array<i32: 6>, barrier.offsets = array<i32: 0>
+// CHECK-DAG: nvws.create_token {barrier.guards = array<i32: 5>, barrier.offsets = array<i32: 0>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 32], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 32, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked9 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_bwd_persist(%desc_q: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_k: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_v: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %sm_scale: f32, %desc_do: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_dq: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %desc_dk: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_dv: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %M: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %D: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32 {tt.divisibility = 16 : i32}, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %dpT, %dpT_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %qkT, %qkT_2 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %q = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %dv_3, %dv_4 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 6 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dk, %dk_5 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %k = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %false = arith.constant {async_task_id = array<i32: 1>} false
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %n_tile_num = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 127 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 128 : i32
+    %c128_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 128 : i64
+    %c1_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 1 : i64
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<128x32xf32, #blocked>
+    %cst_6 = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %n_tile_num_7 = arith.addi %N_CTX, %n_tile_num {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %n_tile_num_8 = arith.divsi %n_tile_num_7, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %prog_id = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %num_progs = tt.get_num_programs x {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %total_tiles = arith.muli %n_tile_num_8, %BATCH {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %total_tiles_9 = arith.muli %total_tiles, %H {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %tiles_per_sm = arith.divsi %total_tiles_9, %num_progs {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %0 = arith.remsi %total_tiles_9, %num_progs {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %2 = scf.if %1 -> (i32) {
+      %tiles_per_sm_18 = arith.addi %tiles_per_sm, %c1_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %tiles_per_sm_18 : i32
+    } else {
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %tiles_per_sm : i32
+    } {async_task_id = array<i32: 0, 1, 2, 3>}
+    %y_dim = arith.muli %BATCH, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+    %y_dim_10 = arith.muli %y_dim, %N_CTX {async_task_id = array<i32: 0, 2, 3>} : i32
+    %desc_q_11 = tt.make_tensor_descriptor %desc_q, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_do_12 = tt.make_tensor_descriptor %desc_do, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_dq_13 = tt.make_tensor_descriptor %desc_dq, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 0>} : !tt.ptr<f32>, !tt.tensordesc<tensor<128x32xf32, #shared1>>
+    %desc_v_14 = tt.make_tensor_descriptor %desc_v, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_k_15 = tt.make_tensor_descriptor %desc_k, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x128xf16, #shared>>
+    %desc_dv_16 = tt.make_tensor_descriptor %desc_dv, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x32xf16, #shared2>>
+    %desc_dk_17 = tt.make_tensor_descriptor %desc_dk, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<tensor<128x32xf16, #shared2>>
+    %off_bh = arith.extsi %stride_tok {async_task_id = array<i32: 0, 2, 3>} : i32 to i64
+    %num_steps = arith.divsi %N_CTX, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %offs_m = tt.make_range {async_task_id = array<i32: 3>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked2>
+    %dkN = tt.splat %sm_scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x32xf32, #blocked>
+    %tile_idx = scf.for %_ = %c0_i32 to %2 step %c1_i32 iter_args(%tile_idx_18 = %prog_id) -> (i32)  : i32 {
+      %pid = arith.remsi %tile_idx_18, %n_tile_num_8 {async_task_id = array<i32: 2, 3>} : i32
+      %bhid = arith.divsi %tile_idx_18, %n_tile_num_8 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_chz = arith.muli %bhid, %N_CTX {async_task_id = array<i32: 3>} : i32
+      %off_chz_19 = arith.extsi %off_chz {async_task_id = array<i32: 3>} : i32 to i64
+      %off_bh_20 = arith.remsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_21 = arith.muli %stride_h, %off_bh_20 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_22 = arith.divsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_23 = arith.muli %stride_z, %off_bh_22 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_24 = arith.addi %off_bh_21, %off_bh_23 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_25 = arith.extsi %off_bh_24 {async_task_id = array<i32: 0, 2, 3>} : i32 to i64
+      %off_bh_26 = arith.divsi %off_bh_25, %off_bh {async_task_id = array<i32: 0, 2, 3>} : i64
+      %M_27 = tt.addptr %M, %off_chz_19 {async_task_id = array<i32: 3>} : !tt.ptr<f32>, i64
+      %D_28 = tt.addptr %D, %off_chz_19 {async_task_id = array<i32: 3>} : !tt.ptr<f32>, i64
+      %start_n = arith.muli %pid, %c128_i32 {async_task_id = array<i32: 2, 3>} : i32
+      %k_29 = arith.extsi %start_n {async_task_id = array<i32: 2, 3>} : i32 to i64
+      %k_30 = arith.addi %off_bh_26, %k_29 {async_task_id = array<i32: 2, 3>} : i64
+      %k_31 = arith.trunci %k_30 {async_task_id = array<i32: 2, 3>} : i64 to i32
+      %k_32 = tt.descriptor_load %desc_k_15[%k_31, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+      ttg.local_store %k_32, %k {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %v_33 = tt.descriptor_load %desc_v_14[%k_31, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+      ttg.local_store %v_33, %v {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %m = tt.splat %M_27 {async_task_id = array<i32: 3>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %Di = tt.splat %D_28 {async_task_id = array<i32: 3>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %dk_34 = ttng.tmem_store %cst_6, %dk[%dk_5], %true {async_task_id = array<i32: 0>, tmem.start = array<i32: 9>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dv_35 = ttng.tmem_store %cst_6, %dv_3[%dv_4], %true {async_task_id = array<i32: 0>, tmem.start = array<i32: 7>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %curr_m:7 = scf.for %curr_m_67 = %c0_i32 to %num_steps step %c1_i32 iter_args(%arg19 = %c0_i32, %arg20 = %false, %qkT_68 = %qkT_2, %dv_69 = %dv_35, %dpT_70 = %dpT_1, %dk_71 = %dk_34, %dq_72 = %dq_0) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+        %q_73 = arith.extsi %arg19 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 to i64
+        %q_74 = arith.addi %off_bh_26, %q_73 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i64
+        %q_75 = arith.trunci %q_74 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i64 to i32
+        %q_76 = tt.descriptor_load %desc_q_11[%q_75, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+        ttg.local_store %q_76, %q {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %qT = ttg.memdesc_trans %q {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>
+        %offs_m_77 = tt.splat %arg19 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 -> tensor<128xi32, #blocked2>
+        %offs_m_78 = arith.addi %offs_m_77, %offs_m {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128xi32, #blocked2>
+        %m_79 = tt.addptr %m, %offs_m_78 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %m_80 = tt.load %m_79 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %qkT_81 = ttng.tc_gen5_mma %k, %qT, %qkT[%qkT_68], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %pT = ttg.convert_layout %m_80 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+        %pT_82 = tt.expand_dims %pT {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xf32, #blocked1>
+        %pT_83 = tt.broadcast %pT_82 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked1> -> tensor<128x128xf32, #blocked1>
+        %qkT_84, %qkT_85 = ttng.tmem_load %qkT[%qkT_81] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+        %pT_86 = arith.subf %qkT_84, %pT_83 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
+        %pT_87 = math.exp2 %pT_86 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
+        %do_88 = tt.descriptor_load %desc_do_12[%q_75, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+        ttg.local_store %do_88, %do {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %ppT = arith.truncf %pT_87 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
+        %dv_89 = arith.constant {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} true
+        ttng.tmem_store %ppT, %dv, %dv_89 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %dv_90 = ttng.tc_gen5_mma %dv, %do, %dv_3[%dv_69], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 7>, tmem.start = array<i32: 8>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %Di_91 = tt.addptr %Di, %offs_m_78 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %Di_92 = tt.load %Di_91 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %dpT_93 = ttg.memdesc_trans %do {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>
+        %dpT_94 = ttng.tc_gen5_mma %v, %dpT_93, %dpT[%dpT_70], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dsT_95 = ttg.convert_layout %Di_92 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+        %dsT_96 = tt.expand_dims %dsT_95 {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xf32, #blocked1>
+        %dsT_97 = tt.broadcast %dsT_96 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked1> -> tensor<128x128xf32, #blocked1>
+        %dpT_98, %dpT_99 = ttng.tmem_load %dpT[%dpT_94] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+        %dsT_100 = arith.subf %dpT_98, %dsT_97 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
+        %dsT_101 = arith.mulf %pT_87, %dsT_100 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
+        %dsT_102 = arith.truncf %dsT_101 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
+        ttg.local_store %dsT_102, %dsT {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %dk_103 = ttng.tc_gen5_mma %dsT, %q, %dk[%dk_71], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dq_104 = ttg.memdesc_trans %dsT {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>
+        %dq_105 = ttng.tc_gen5_mma %dq_104, %k, %dq[%dq_72], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dq_106, %dq_107 = ttng.tmem_load %dq[%dq_105] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+        %dqs = tt.reshape %dq_106 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4>
+        %dqs_108 = tt.trans %dqs {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+        %dqs_109, %dqs_110 = tt.split %dqs_108 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+        %dqs_111 = tt.reshape %dqs_109 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_112 = tt.trans %dqs_111 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_113, %dqs_114 = tt.split %dqs_112 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+        %dqs_115 = tt.reshape %dqs_110 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_116 = tt.trans %dqs_115 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_117, %dqs_118 = tt.split %dqs_116 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+        %dqN = arith.mulf %dqs_113, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_119 = ttg.convert_layout %dqN {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_119 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_120 = arith.mulf %dqs_114, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_121 = ttg.convert_layout %dqN_120 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_121 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_122 = arith.mulf %dqs_117, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_123 = ttg.convert_layout %dqN_122 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_123 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_124 = arith.mulf %dqs_118, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_125 = ttg.convert_layout %dqN_124 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_125 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %curr_m_126 = arith.addi %arg19, %c128_i32 {async_task_id = array<i32: 0, 2, 3>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i32
+        scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %curr_m_126, %true, %qkT_85, %dv_90, %dpT_99, %dk_103, %dq_107 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2, 3>, tt.scheduled_max_stage = 1 : i32}
+      %dv_36, %dv_37 = ttng.tmem_load %dv_3[%curr_m#3] {async_task_id = array<i32: 3>, tmem.end = array<i32: 8>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+      %dvs = tt.reshape %dv_36 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4>
+      %dvs_38 = tt.trans %dvs {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dvs_39, %dvs_40 = tt.split %dvs_38 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dvs_41 = tt.reshape %dvs_40 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_42 = tt.reshape %dvs_39 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_43 = tt.trans %dvs_42 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_44, %dvs_45 = tt.split %dvs_43 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %3 = arith.truncf %dvs_45 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %4 = arith.truncf %dvs_44 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %dvs_46 = tt.trans %dvs_41 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_47, %dvs_48 = tt.split %dvs_46 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %5 = arith.truncf %dvs_48 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %6 = arith.truncf %dvs_47 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %7 = ttg.convert_layout %4 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %7 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %8 = ttg.convert_layout %3 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %8 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %9 = ttg.convert_layout %6 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %9 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %10 = ttg.convert_layout %5 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %10 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %dk_49, %dk_50 = ttng.tmem_load %dk[%curr_m#5] {async_task_id = array<i32: 3>, tmem.end = array<i32: 10>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+      %dks = tt.reshape %dk_49 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4>
+      %dks_51 = tt.trans %dks {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dks_52, %dks_53 = tt.split %dks_51 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dks_54 = tt.reshape %dks_53 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_55 = tt.reshape %dks_52 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_56 = tt.trans %dks_55 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_57, %dks_58 = tt.split %dks_56 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %dkN_59 = arith.mulf %dks_58, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %dkN_60 = arith.mulf %dks_57, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %dks_61 = tt.trans %dks_54 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_62, %dks_63 = tt.split %dks_61 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %dkN_64 = arith.mulf %dks_63, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %dkN_65 = arith.mulf %dks_62, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %11 = arith.truncf %dkN_60 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %12 = ttg.convert_layout %11 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %12 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %13 = arith.truncf %dkN_59 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %14 = ttg.convert_layout %13 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %14 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %15 = arith.truncf %dkN_65 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %16 = ttg.convert_layout %15 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %16 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %17 = arith.truncf %dkN_64 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %18 = ttg.convert_layout %17 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %18 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked9>
+      %tile_idx_66 = arith.addi %tile_idx_18, %num_progs {async_task_id = array<i32: 0, 2, 3>} : i32
+      scf.yield {async_task_id = array<i32: 0, 2, 3>} %tile_idx_66 : i32
+    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.merge_epilogue = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 200000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
+++ b/test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
@@ -1,8 +1,15 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-warp-specialization="num-stages=3 capability=100" | FileCheck %s
+// RUN: triton-opt %s -split-input-file --nvgpu-warp-specialization="num-stages=3 capability=100" | FileCheck %s --check-prefix=GUARDS
 
 // Test case: Basic Blackwell matrix multiplication with TMA and warp specialization.
 // This IR represents a GEMM kernel that uses tensor memory for accumulator
 // and has partition annotations on key operations.
+
+// Barrier<->buffer association (Milestone 1, barrier_analysis.md): the
+// barrier.guards / barrier.offsets stamped on the NVWS tokens at code-partition
+// time survive token lowering and land on the lowered HW barriers.
+// GUARDS-DAG: ttng.wait_barrier {{.*}}barrier.guards = array<i32: {{[0-9]+}}>{{.*}}barrier.offsets = array<i32: 0>
+// GUARDS-DAG: ttng.arrive_barrier {{.*}}barrier.guards = array<i32: {{[0-9]+}}>{{.*}}barrier.offsets = array<i32: 0>
 
 // CHECK-LABEL: @matmul_kernel_tma_ws
 // CHECK: ttg.warp_specialize

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(NVHopperTransforms
   MultiCTAReduction.cpp
   WarpSpecialization.cpp
+  WarpSpecialization/BarrierBufferAssoc.cpp
   WarpSpecialization/CodePartitionUtility.cpp
   WarpSpecialization/PingPong.cpp
   WarpSpecialization/TaskIdPropagation.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -50,6 +50,8 @@ void doHoistLoopInvariantTMEMStore(triton::FuncOp &funcOp);
 void removeRedundantTmemZeroStores(triton::FuncOp &funcOp);
 void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
+// M1 (barrier_analysis.md): gated barrier->buffer map dump after lowering.
+void dumpBarrierGuardsIfEnabled(triton::FuncOp funcOp);
 void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
                     int capability, int defaultNumStages);
 void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
@@ -286,6 +288,7 @@ public:
 
     doLowerSubtiledRegionsWithNVWSOps(funcOp);
     doTokenLowering(funcOp, numWarpGroups - 1);
+    dumpBarrierGuardsIfEnabled(funcOp);
     if (dumpIntermediateSteps) {
       llvm::dbgs()
           << "// -----// WarpSpec internal IR Dump After: doTokenLowering\n";

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/BarrierBufferAssoc.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/BarrierBufferAssoc.cpp
@@ -1,0 +1,173 @@
+#include "BarrierBufferAssoc.h"
+
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include <cstdlib>
+
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace ttnvws = ::mlir::triton::nvws;
+
+namespace mlir {
+
+// Nested WSBarrier key inside the `constraints` DictionaryAttr. Kept as a local
+// literal (rather than including WSBarrierAnalysis.h) to keep this module's
+// dependencies minimal; must stay in sync with WSBarrierAttr::kKey.
+static constexpr llvm::StringLiteral kWSBarrierKey = "WSBarrier";
+static constexpr llvm::StringLiteral kConstraintsAttr = "constraints";
+
+// Append the (buffer.id, buffer.offset) of `alloc` to `out`, deduplicated.
+static void appendGuard(llvm::SmallVectorImpl<GuardedBuffer> &out,
+                        Operation *alloc) {
+  if (!alloc)
+    return;
+  auto idAttr = alloc->getAttrOfType<IntegerAttr>("buffer.id");
+  if (!idAttr)
+    return;
+  GuardedBuffer gb;
+  gb.id = static_cast<int>(idAttr.getInt());
+  if (auto offAttr = alloc->getAttrOfType<IntegerAttr>("buffer.offset"))
+    gb.offset = static_cast<int>(offAttr.getInt());
+  if (!llvm::is_contained(out, gb))
+    out.push_back(gb);
+}
+
+llvm::SmallVector<GuardedBuffer, 2> computeChannelGuards(Channel *channel,
+                                                         ReuseConfig *config) {
+  llvm::SmallVector<GuardedBuffer, 2> guards;
+  if (!channel)
+    return guards;
+  appendGuard(guards, channel->getAllocOp());
+
+  // Union the whole reuse group: a single WSBarrier guards every physical
+  // buffer that shares the reused memory.
+  if (config) {
+    for (unsigned g = 0, e = config->getGroupSize(); g < e; ++g) {
+      ReuseGroup *grp = config->getGroup(g);
+      bool member = llvm::any_of(
+          grp->channels, [&](Channel *c) { return c == channel; });
+      if (!member)
+        continue;
+      for (Channel *c : grp->channels)
+        appendGuard(guards, c->getAllocOp());
+    }
+  }
+  llvm::sort(guards);
+  return guards;
+}
+
+void stampBarrierGuards(Operation *op, llvm::ArrayRef<GuardedBuffer> guards) {
+  if (!op || guards.empty())
+    return;
+  llvm::SmallVector<int32_t, 2> ids, offsets;
+  ids.reserve(guards.size());
+  offsets.reserve(guards.size());
+  for (const GuardedBuffer &g : guards) {
+    ids.push_back(g.id);
+    offsets.push_back(g.offset);
+  }
+  MLIRContext *ctx = op->getContext();
+  op->setAttr(kBarrierGuardsAttr, DenseI32ArrayAttr::get(ctx, ids));
+  op->setAttr(kBarrierOffsetsAttr, DenseI32ArrayAttr::get(ctx, offsets));
+}
+
+llvm::SmallVector<GuardedBuffer, 2> getBarrierGuards(Operation *op) {
+  llvm::SmallVector<GuardedBuffer, 2> guards;
+  if (!op)
+    return guards;
+  auto ids = op->getAttrOfType<DenseI32ArrayAttr>(kBarrierGuardsAttr);
+  if (!ids)
+    return guards;
+  auto offs = op->getAttrOfType<DenseI32ArrayAttr>(kBarrierOffsetsAttr);
+  for (int i = 0, e = ids.size(); i < e; ++i) {
+    GuardedBuffer gb;
+    gb.id = ids[i];
+    gb.offset = (offs && i < offs.size()) ? offs[i] : 0;
+    guards.push_back(gb);
+  }
+  return guards;
+}
+
+void forwardBarrierGuards(Operation *from, Operation *to) {
+  if (!from || !to)
+    return;
+  if (Attribute ids = from->getAttr(kBarrierGuardsAttr))
+    to->setAttr(kBarrierGuardsAttr, ids);
+  if (Attribute offs = from->getAttr(kBarrierOffsetsAttr))
+    to->setAttr(kBarrierOffsetsAttr, offs);
+}
+
+bool isBarrierEndpoint(Operation *op) {
+  return isa<ttnvws::ProducerAcquireOp, ttnvws::ProducerCommitOp,
+             ttnvws::ConsumerWaitOp, ttnvws::ConsumerReleaseOp,
+             ttng::WaitBarrierOp, ttng::ArriveBarrierOp>(op);
+}
+
+// Whether `op` carries the WSBarrier marker in its `constraints` dict. NVWS
+// token endpoints are always WS barriers; HW barriers are WS barriers only when
+// lowered from a WS token (which forwards the constraints).
+static bool isWSBarrier(Operation *op) {
+  if (isa<ttnvws::ProducerAcquireOp, ttnvws::ProducerCommitOp,
+          ttnvws::ConsumerWaitOp, ttnvws::ConsumerReleaseOp>(op))
+    return true;
+  if (auto dict = op->getAttrOfType<DictionaryAttr>(kConstraintsAttr))
+    return dict.get(kWSBarrierKey) != nullptr;
+  return false;
+}
+
+BarrierBufferMap buildBarrierBufferMap(triton::FuncOp funcOp) {
+  BarrierBufferMap map;
+  funcOp.walk([&](Operation *op) {
+    if (!isBarrierEndpoint(op))
+      return;
+    auto guards = getBarrierGuards(op);
+    if (!guards.empty())
+      map[op] = std::move(guards);
+  });
+  return map;
+}
+
+unsigned dumpAndVerifyBarrierBufferMap(triton::FuncOp funcOp,
+                                       const BarrierBufferMap &map,
+                                       llvm::raw_ostream &os) {
+  unsigned orphans = 0;
+  os << "==== barrier->buffer map for @" << funcOp.getName() << " ====\n";
+  funcOp.walk([&](Operation *op) {
+    if (!isBarrierEndpoint(op))
+      return;
+    auto it = map.find(op);
+    if (it == map.end() || it->second.empty()) {
+      // Only WS barriers are expected to resolve to a buffer; ignore
+      // non-WS HW barriers (e.g. TMA-store barriers).
+      if (isWSBarrier(op)) {
+        ++orphans;
+        os << "  [ORPHAN] " << op->getName() << " : <no guarded buffer>\n";
+      }
+      return;
+    }
+    os << "  " << op->getName() << " : {";
+    llvm::interleaveComma(it->second, os, [&](const GuardedBuffer &g) {
+      os << "id=" << g.id;
+      if (g.offset)
+        os << ",off=" << g.offset;
+    });
+    os << "}\n";
+  });
+  os << "==== orphans: " << orphans << " ====\n";
+  return orphans;
+}
+
+void dumpBarrierGuardsIfEnabled(triton::FuncOp funcOp) {
+  // Use std::getenv directly (mirroring TRITON_DUMP_WS_GRAPHS in
+  // WSMemoryPlanner) rather than getBoolEnv, which asserts the variable name
+  // is in Triton's recognized env-var registry.
+  if (!std::getenv("TRITON_DUMP_BARRIER_GUARDS"))
+    return;
+  BarrierBufferMap map = buildBarrierBufferMap(funcOp);
+  dumpAndVerifyBarrierBufferMap(funcOp, map, llvm::errs());
+}
+
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/BarrierBufferAssoc.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/BarrierBufferAssoc.h
@@ -1,0 +1,100 @@
+#ifndef NV_DIALECT_HOPPER_TRANSFORMS_BARRIERBUFFERASSOC_H_
+#define NV_DIALECT_HOPPER_TRANSFORMS_BARRIERBUFFERASSOC_H_
+
+// Milestone 1 of the Barrier Analysis & Verification subsystem
+// (see barrier_analysis.md).
+//
+// Associates every WSBarrier endpoint with the set of physical buffer(s)
+// (buffer.id, optional buffer.offset) it guards. The association is computed
+// from the autoWS `Channel` structures (where the guarded buffer is still
+// known), stamped as discardable dotted-key attributes -- mirroring the
+// `buffer.id` / `buffer.offset` mechanism of the memory planner -- and
+// forwarded through token lowering so it survives to the verifier stage.
+//
+// This module is analysis-only; it never mutates control flow or removes,
+// merges, or moves barriers.
+
+#include "CodePartitionUtility.h" // Channel, ReuseConfig (namespace mlir)
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir {
+
+// Discardable attribute keys stamped on barrier endpoints / token ops. Dotted
+// keys mirror the memory planner's `buffer.id` / `buffer.offset` convention so
+// there is zero op-schema (TableGen) churn.
+constexpr llvm::StringLiteral kBarrierGuardsAttr = "barrier.guards";
+constexpr llvm::StringLiteral kBarrierOffsetsAttr = "barrier.offsets";
+
+// A physical buffer (or TMEM column sub-range) guarded by a WSBarrier endpoint.
+// `offset` is the `buffer.offset` column offset for TMEM sub-range reuse; it is
+// 0 for whole-buffer guards.
+struct GuardedBuffer {
+  int id = -1;
+  int offset = 0;
+
+  bool operator==(const GuardedBuffer &o) const {
+    return id == o.id && offset == o.offset;
+  }
+  bool operator<(const GuardedBuffer &o) const {
+    return id != o.id ? id < o.id : offset < o.offset;
+  }
+};
+
+// barrier endpoint op -> the set of physical buffers it guards.
+using BarrierBufferMap =
+    llvm::DenseMap<Operation *, llvm::SmallVector<GuardedBuffer, 2>>;
+
+// autoWS frontend: compute the guarded buffers for `channel`, unioning the
+// whole reuse group when `channel` participates in one. Pure derivation from
+// `Channel::getAllocOp()` + the `buffer.id` / `buffer.offset` attributes that
+// the memory planner already set.
+llvm::SmallVector<GuardedBuffer, 2> computeChannelGuards(Channel *channel,
+                                                         ReuseConfig *config);
+
+// Writer: stamp `barrier.guards` / `barrier.offsets` onto `op`. No-op when
+// `guards` is empty. `op` is typically a token op (at emission) or a lowered
+// ttng.wait/arrive_barrier (after forwarding through lowering).
+void stampBarrierGuards(Operation *op, llvm::ArrayRef<GuardedBuffer> guards);
+
+// Reader: read the stamped guards off `op` (mirrors `getBufferId`). Returns an
+// empty vector when `op` carries no guards.
+llvm::SmallVector<GuardedBuffer, 2> getBarrierGuards(Operation *op);
+
+// Forward the guard attributes from `from` to `to`, mirroring the way
+// `getConstraintsAttr()` is forwarded in WSLowerToken.cpp. No-op when `from`
+// carries no guards.
+void forwardBarrierGuards(Operation *from, Operation *to);
+
+// True if `op` is a WSBarrier endpoint -- an NVWS token endpoint
+// (producer_acquire / producer_commit / consumer_wait / consumer_release) or a
+// lowered HW barrier (ttng.wait_barrier / ttng.arrive_barrier).
+bool isBarrierEndpoint(Operation *op);
+
+// Build the barrier->buffer map for `funcOp` by scanning every WSBarrier
+// endpoint and reading its stamped guards. Endpoints with no guards are
+// omitted from the map (use dumpAndVerifyBarrierBufferMap to flag them).
+BarrierBufferMap buildBarrierBufferMap(triton::FuncOp funcOp);
+
+// Debug dumper + self-consistency check. Prints `endpoint -> guarded buffers`
+// for every WSBarrier endpoint and returns the number of *orphan* endpoints
+// (WS barriers that resolve to zero buffers). Only WS barriers are counted as
+// orphans: ttng barriers without WSBarrier constraints (e.g. TMA-store
+// barriers) are ignored.
+unsigned dumpAndVerifyBarrierBufferMap(triton::FuncOp funcOp,
+                                       const BarrierBufferMap &map,
+                                       llvm::raw_ostream &os);
+
+// Gated debug entry point. When the TRITON_DUMP_BARRIER_GUARDS environment
+// variable is set, build and print the barrier->buffer map for `funcOp` (and
+// its orphan count) to llvm::errs(). No-op otherwise. Intended to be invoked
+// from the pipeline right after token lowering.
+void dumpBarrierGuardsIfEnabled(triton::FuncOp funcOp);
+
+} // namespace mlir
+
+#endif // NV_DIALECT_HOPPER_TRANSFORMS_BARRIERBUFFERASSOC_H_

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1,4 +1,5 @@
 #include "CodePartitionUtility.h"
+#include "BarrierBufferAssoc.h"
 #include "TMEMUtils.h"
 #include "WSBarrierAnalysis.h"
 #include "mlir/Analysis/SliceAnalysis.h"
@@ -1064,6 +1065,11 @@ void createToken(
           v = ttnvws::CreateTokenOp::create(builder, tokenLoc, 1,
                                             tokenLoadType);
         commChannel.tokens[consumerAsyncTaskId] = v;
+        // M1 (barrier_analysis.md): associate this WSBarrier token with the
+        // physical buffer(s) it guards, so the relationship survives token
+        // lowering (mbarrier-only $alloc cannot recover the guarded buffer).
+        stampBarrierGuards(v.getDefiningOp(),
+                           computeChannelGuards(channel, config));
       }
 
       if (useGen5Barrier) {
@@ -1495,6 +1501,11 @@ void createTokenPost(
         v = ttnvws::CreateTokenOp::create(
             builder, tokenLoc, channel->getNumBuffers(), tokenLoadType);
         commChannel.tokens[consumerAsyncTaskId] = v;
+        // M1 (barrier_analysis.md): associate this WSBarrier token with the
+        // physical buffer(s) it guards, so the relationship survives token
+        // lowering (mbarrier-only $alloc cannot recover the guarded buffer).
+        stampBarrierGuards(v.getDefiningOp(),
+                           computeChannelGuards(channel, config));
       }
 
       if (useGen5Barrier) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -1,4 +1,5 @@
 #include "Utility.h"
+#include "BarrierBufferAssoc.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 
@@ -48,7 +49,7 @@ Value getMBarrierPhaseBit(OpBuilder &builder, Operation *op,
 }
 
 void processProducerAcquireOp(OpBuilder &builder, ttnvws::ProducerAcquireOp op,
-                              Value bufferEmpty) {
+                              Value bufferEmpty, Operation *guardSrc) {
   auto loc = op.getLoc();
   Value phase = getMBarrierPhaseBit(builder, op, true);
   auto i32Ty = builder.getIntegerType(32);
@@ -59,11 +60,14 @@ void processProducerAcquireOp(OpBuilder &builder, ttnvws::ProducerAcquireOp op,
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
   copyLoopScheduleInfo(waitOp, op);
+  // M1 (barrier_analysis.md): forward barrier.guards onto the lowered HW
+  // barrier, mirroring how getConstraintsAttr() is forwarded above.
+  forwardBarrierGuards(guardSrc, waitOp.getOperation());
 }
 
 void processProducerCommitOp(OpBuilder &builder, ttnvws::ProducerCommitOp op,
                              Value bufferFull, ttnvws::TokenLoadType loadType,
-                             unsigned fullCnt) {
+                             unsigned fullCnt, Operation *guardSrc) {
   auto loc = op.getLoc();
   ttng::ArriveBarrierOp arriveOp;
 
@@ -75,10 +79,11 @@ void processProducerCommitOp(OpBuilder &builder, ttnvws::ProducerCommitOp op,
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
   copyLoopScheduleInfo(arriveOp, op);
+  forwardBarrierGuards(guardSrc, arriveOp.getOperation());
 }
 
 void processConsumerWaitOp(OpBuilder &builder, ttnvws::ConsumerWaitOp op,
-                           Value bufferFull) {
+                           Value bufferFull, Operation *guardSrc) {
   auto loc = op.getLoc();
   Value phase = getMBarrierPhaseBit(builder, op, false);
   auto i32Ty = builder.getIntegerType(32);
@@ -89,11 +94,12 @@ void processConsumerWaitOp(OpBuilder &builder, ttnvws::ConsumerWaitOp op,
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
   copyLoopScheduleInfo(waitOp, op);
+  forwardBarrierGuards(guardSrc, waitOp.getOperation());
 }
 
 void processConsumerReleaseOp(OpBuilder &builder, ttnvws::ConsumerReleaseOp op,
                               Value bufferEmpty, int numCTAs,
-                              unsigned emptyCnt) {
+                              unsigned emptyCnt, Operation *guardSrc) {
   auto loc = op.getLoc();
   auto arriveOp = ttng::ArriveBarrierOp::create(
       builder, loc, bufferEmpty, 1, /*pred=*/Value(), /*perThread=*/false,
@@ -101,6 +107,7 @@ void processConsumerReleaseOp(OpBuilder &builder, ttnvws::ConsumerReleaseOp op,
   assert(op.getOperation()->hasAttr("async_task_id"));
   setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
   copyLoopScheduleInfo(arriveOp, op);
+  forwardBarrierGuards(guardSrc, arriveOp.getOperation());
 }
 
 void lowerTokenOperations(Operation *parentOp, int numCTAs,
@@ -253,7 +260,8 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
         Value bufferEmpty = extractBufferEmpty(loc, op.getIdx());
         assert(user->hasAttr("async_task_id"));
         setAsyncTaskIds(bufferEmpty.getDefiningOp(), getAsyncTaskIds(user));
-        processProducerAcquireOp(builder, op, bufferEmpty);
+        processProducerAcquireOp(builder, op, bufferEmpty,
+                                 createTokenOp.getOperation());
         deprecatedOps.push_back(user);
         return true;
       } else if (auto op = dyn_cast<ttnvws::ProducerCommitOp>(user)) {
@@ -261,14 +269,15 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
         assert(user->hasAttr("async_task_id"));
         setAsyncTaskIds(bufferFull.getDefiningOp(), getAsyncTaskIds(user));
         processProducerCommitOp(builder, op, bufferFull, loadType,
-                                bufferFullCount);
+                                bufferFullCount, createTokenOp.getOperation());
         deprecatedOps.push_back(user);
         return true;
       } else if (auto op = dyn_cast<ttnvws::ConsumerWaitOp>(user)) {
         Value bufferFull = extractBufferFull(loc, op.getIdx());
         assert(user->hasAttr("async_task_id"));
         setAsyncTaskIds(bufferFull.getDefiningOp(), getAsyncTaskIds(user));
-        processConsumerWaitOp(builder, op, bufferFull);
+        processConsumerWaitOp(builder, op, bufferFull,
+                              createTokenOp.getOperation());
         deprecatedOps.push_back(user);
         return true;
       } else if (auto op = dyn_cast<ttnvws::ConsumerReleaseOp>(user)) {
@@ -276,7 +285,7 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
         assert(user->hasAttr("async_task_id"));
         setAsyncTaskIds(bufferEmpty.getDefiningOp(), getAsyncTaskIds(user));
         processConsumerReleaseOp(builder, op, bufferEmpty, numCTAs,
-                                 bufferEmptyCount);
+                                 bufferEmptyCount, createTokenOp.getOperation());
         deprecatedOps.push_back(user);
         return true;
       } else if (auto op = dyn_cast<ttng::TMAStoreTokenWaitOp>(user)) {


### PR DESCRIPTION
## Summary

First milestone of the barrier analysis & verification subsystem (see
`barrier_analysis.md`). It associates every WSBarrier endpoint with the physical
buffer(s) it guards, providing the foundation that later milestones (redundant-barrier
detection, legal relocation ranges, the verifier pass) build on.

### Why this is needed

After token lowering, a `ttng.wait_barrier` / `ttng.arrive_barrier`'s `$alloc` operand
is the **mbarrier** (the semaphore), not the guarded data buffer — so the guarded-buffer
identity cannot be recovered from the lowered op alone. It must be captured while the
channel is still known and forwarded through lowering.

### How it works

- **`BarrierBufferAssoc.{h,cpp}`** (new): derives the guarded `(buffer.id, buffer.offset)`
  set from the autoWS `Channel` and its reuse group (`computeChannelGuards`), and provides
  `stampBarrierGuards` / `getBarrierGuards` / `forwardBarrierGuards` plus a
  `buildBarrierBufferMap` query API and a dumper with an orphan check.
- **Stamping** (`WSCodePartition.cpp`): at the two `createToken` chokepoints, stamps
  discardable `barrier.guards` / `barrier.offsets` attributes on the `CreateTokenOp` —
  mirroring the memory planner's `buffer.id` mechanism, so there is **no op-schema /
  TableGen churn**.
- **Forwarding** (`WSLowerToken.cpp`): the four `processProducer/Consumer*` helpers carry
  the guards onto the lowered HW barriers, mirroring how the existing `constraints`
  DictionaryAttr is forwarded.
- **Gated dump** (`WarpSpecialization.cpp`): `TRITON_DUMP_BARRIER_GUARDS` prints the
  barrier→buffer map after lowering and flags orphan endpoints (those resolving to no
  buffer).

### Design note

Guards are stamped on the **token** (one site per channel/reuse group) rather than on each
of the ~13 endpoint emission sites. This keeps the integration to a few touchpoints and
sidesteps the `warp_specialize` region-capture problem, because `lowerTokenOperations`
holds the `CreateTokenOp` directly and reaches every lowered endpoint from it.

Analysis-only: no IR transforms, no control-flow changes.

### Known gaps (deferred)

Barriers from the gen5-MMA / operand-D / TMA-store fast paths (which don't go through a
`CreateTokenOp`) are not yet stamped and show up as orphans in the dump. These, plus the
TLX frontend, are tracked for follow-up milestones.

## Test Plan
```
triton-opt test/Hopper/WarpSpecialization/barrier_buffer_assoc.mlir
--nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1"
| FileCheck test/Hopper/WarpSpecialization/barrier_buffer_assoc.mlir
```
```
triton-opt test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
-split-input-file --nvgpu-warp-specialization="num-stages=3 capability=100"
| FileCheck test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
--check-prefix=GUARDS
```
