### PR TITLE
[Triton] Add mod-affine LinearLayout for non-power-of-2 dimensions (#1629)

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -324,8 +324,11 @@ private:
                   /*size=getInDimSizeLog2(inDim)*/>
       bases;
 
+  // Dim sizes are assumed to fit in int32_t, i.e. less than 2^31.
+  // This is a pre-existing upstream type decision.
   llvm::MapVector<StringAttr, int32_t /*size*/> outDims;
   int32_t rank = 0;
+  bool cachedIsModular = false;
 
 public:
   using BasesT = decltype(bases);
@@ -350,6 +353,18 @@ public:
   static LinearLayout identity1D(int32_t size, StringAttr inDim,
                                  StringAttr outDim) {
     return strided1D(size, /*stride=*/1, inDim, outDim);
+  }
+
+  // Creates a 1D -> 1D layout computing L(x) = (stride * x) % size
+  // for x in [0, 2^ceil(log2(size))).
+  static LinearLayout modularStrided1D(int32_t size, int32_t stride,
+                                       StringAttr inDim, StringAttr outDim);
+
+  // Creates a modular identity layout for non-power-of-2 dimensions.
+  // Computes L(x) = x % size for x in [0, 2^ceil(log2(size))).
+  static LinearLayout modularIdentity1D(int32_t size, StringAttr inDim,
+                                        StringAttr outDim) {
+    return modularStrided1D(size, /*stride=*/1, inDim, outDim);
   }
 
   // Creates a 1D -> 1D layout that maps every input value to 0, i.e. L(x) = 0
@@ -425,11 +440,36 @@ public:
       ArrayRef<std::pair<StringAttr, std::vector<std::vector<int32_t>>>> bases,
       ArrayRef<std::pair<StringAttr, int32_t>> outDims, bool requireSurjective);
 
-  bool isSurjective() const { return rank == getTotalOutDimSizeLog2(); }
-  bool isInjective() const { return rank == getTotalInDimSizeLog2(); }
+  // For modular (non-power-of-2) layouts, dispatch to modular surjectivity
+  // check
+  bool isSurjective() const {
+    if (isModular()) {
+      return isModularSurjective();
+    }
+    return rank == getTotalOutDimSizeLog2();
+  }
+  bool isInjective() const {
+    assert(!isModular() && "isInjective not implemented for modular layouts");
+    return rank == getTotalInDimSizeLog2();
+  }
 
   bool isInvertible() const {
-    return isSurjective() && getTotalInDimSize() == getTotalOutDimSize();
+    return isSurjective() && getTotalInDimSize() == getTotalOutDimSizeProduct();
+  }
+
+  // Check surjectivity for modular (non-power-of-2) layouts.
+  // Uses CRT factorization for efficient per-dimension surjectivity checking.
+  bool isModularSurjective() const;
+
+  // Returns true if this layout contains any non-power-of-2 output dimensions.
+  // Modular layouts use ADD+UREM instructions instead of XOR for composition.
+  bool isModular() const { return cachedIsModular; }
+
+  // Returns true if a specific output dimension is non-power-of-2 (modular).
+  // For mixed layouts (e.g. [32, 48]), pow2 dims use XOR while NPOT dims use
+  // ADD+UREM independently (product semimodule GF(2) x Z/N).
+  bool isOutDimModular(StringAttr outDim) const {
+    return !llvm::isPowerOf2_32(getOutDimSize(outDim));
   }
 
   // Remove a dimension of size 1 from the layout.
@@ -508,11 +548,31 @@ public:
   // Asserts if the dimension is not present.
   int32_t getOutDimSizeLog2(StringAttr outDim) const;
   int32_t getOutDimSize(StringAttr outDim) const {
-    return 1 << getOutDimSizeLog2(outDim);
+    // Return the actual stored size (may be non-power-of-2)
+    auto it = outDims.find(outDim);
+    assert(it != outDims.end() && "outDim not found in layout");
+    return it->second;
   }
 
   int32_t getTotalOutDimSizeLog2() const;
   int32_t getTotalOutDimSize() const { return 1 << getTotalOutDimSizeLog2(); }
+
+  // Returns the product of all output dimension sizes (works for both pow2
+  // and NPOT dims). Use this instead of getTotalOutDimSize() for mixed layouts.
+  int64_t getTotalOutDimSizeProduct() const {
+    return std::accumulate(getOutDimNames().begin(), getOutDimNames().end(),
+                           int64_t{1}, [&](int64_t acc, StringAttr outDim) {
+                             return acc * getOutDimSize(outDim);
+                           });
+  }
+
+  // Returns the total number of bits needed across all output dimensions.
+  int32_t getTotalOutDimSizeBits() const {
+    return std::accumulate(getOutDimNames().begin(), getOutDimNames().end(), 0,
+                           [&](int32_t acc, StringAttr outDim) {
+                             return acc + getOutDimSizeBits(outDim);
+                           });
+  }
 
   // Finds the number of consecutive input elements in the first input dimension
   // that map to consecutive output elements in the first output dimension.
@@ -564,7 +624,12 @@ public:
     if (getNumOutDims() == 0) {
       return reshapeOuts({});
     }
-    return reshapeOuts({{*getOutDimNames().begin(), getTotalOutDimSize()}});
+    // NB: int64_t -> int32_t truncation. Safe for layout sizes < 2^31.
+    auto totalSize = getTotalOutDimSizeProduct();
+    assert(totalSize <= INT32_MAX &&
+           "flattenOuts: total out dim size overflows int32_t");
+    return reshapeOuts(
+        {{*getOutDimNames().begin(), static_cast<int32_t>(totalSize)}});
   }
 
   // Resizes the dimension to one that is smallre or equal to the given size.
@@ -788,12 +853,23 @@ public:
 
   std::string toString() const;
 
+  // Build the GF(2) matrix for this layout (public convenience wrapper).
+  std::unique_ptr<uint64_t[]> getGF2Matrix() const { return getMatrix(*this); }
+
   friend bool operator==(const LinearLayout &lhs, const LinearLayout &rhs);
   friend bool operator!=(const LinearLayout &lhs, const LinearLayout &rhs) {
     return !(lhs == rhs);
   }
   bool equalIgnoringOutDimSizes(const LinearLayout &other) const;
   friend size_t hash_value(const LinearLayout &layout);
+
+  // Returns the number of bits needed to represent this output dimension.
+  // For power-of-2: floor(log2(size)). For NPOT: ceil(log2(size)).
+  int32_t getOutDimSizeBits(StringAttr outDim) const {
+    int32_t size = getOutDimSize(outDim);
+    return llvm::isPowerOf2_32(size) ? llvm::Log2_32(size)
+                                     : llvm::Log2_32(size - 1) + 1;
+  }
 
 private:
   // Factory function that gracefully fails rather than asserts if the layout is
@@ -809,6 +885,23 @@ private:
 
   [[nodiscard]] std::optional<std::string>
   checkInvariants(bool requireSurjective);
+
+  // Build a matrix of size sum(outDimSizeBits) x sum(inDimSizeLog2)
+  // representing the bases of the given layout.  This can then be used by
+  // f2reduce.
+  static std::unique_ptr<uint64_t[]> getMatrix(const LinearLayout &layout);
+
+  // Concatenate the GF(2) matrices of two layouts side-by-side for RREF
+  // solving.
+  static std::unique_ptr<uint64_t[]> concatMatrices(const LinearLayout &A,
+                                                    const LinearLayout &B);
+
+  // Modular lstsq: solve AX = B over Z/nZ using CRT factorization.
+  static LinearLayout lstsqModular(const LinearLayout &A,
+                                   const LinearLayout &B);
+
+  // Solve AX = B (least-squares over GF(2) or modular).
+  static LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B);
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
@@ -848,6 +941,7 @@ public:
     auto it = llvm::max_element(action);
     // Assert in the constructor... ugh
     assert(it == action.end() || *it < inSizeLog2);
+    (void)it; // Suppress unused variable warning in opt builds
     // In many cases the action will be the identity, so we save that as an
     // early return
     m_isIdentity = action.size() == inSizeLog2 &&
@@ -896,8 +990,6 @@ inline std::ostream &operator<<(std::ostream &os, const ColumnAction &action) {
   os << action.toString();
   return os;
 }
-
-std::unique_ptr<uint64_t[]> getMatrix(const LinearLayout &layout);
 
 } // namespace mlir::triton
 

--- a/include/triton/Tools/ModularArithmetic.h
+++ b/include/triton/Tools/ModularArithmetic.h
@@ -1,0 +1,86 @@
+#ifndef TRITON_TOOLS_MODULARARITHMETIC_H
+#define TRITON_TOOLS_MODULARARITHMETIC_H
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace mlir::triton {
+
+// Result of Extended Euclidean Algorithm: (gcd, x, y) where ax + by = gcd
+struct ExtGCDResult {
+  int64_t gcd;
+  int64_t x;
+  int64_t y;
+};
+
+// Extended Euclidean Algorithm: returns gcd(a,b) and Bezout coefficients
+ExtGCDResult extendedGCD(int64_t a, int64_t b);
+
+// Modular inverse: returns x such that (a*x) % m == 1, or nullopt if gcd(a,m)
+// != 1
+std::optional<int64_t> modInverse(int64_t a, int64_t m);
+
+// Chinese Remainder Theorem result: solution x where x ≡ r_i (mod m_i)
+struct CRTResult {
+  int64_t solution;
+  int64_t modulus;
+};
+
+// Solve system x ≡ r_i (mod m_i). Requires pairwise coprime moduli.
+std::optional<CRTResult> solveCRT(const std::vector<int64_t> &remainders,
+                                  const std::vector<int64_t> &moduli);
+
+// Integer exponentiation: a^b
+int64_t intPow(int64_t a, int b);
+
+// Matrix over Z/nZ in row-major order
+struct ModMatrix {
+  std::vector<int64_t> data;
+  int rows;
+  int cols;
+  int64_t modulus; // Modulus for matrix arithmetic
+
+  ModMatrix(int r, int c, int64_t mod) : rows(r), cols(c), modulus(mod) {
+    data.resize(r * c, 0);
+  }
+
+  int64_t &at(int r, int c) { return data[r * cols + c]; }
+  const int64_t &at(int r, int c) const { return data[r * cols + c]; }
+
+  void normalize();
+};
+
+// Gaussian elimination to RREF in Z/nZ. Modifies matrix in-place, returns rank.
+int modRREF(ModMatrix &mat);
+
+// Solve Ax = b (mod modulus) using Gaussian elimination.
+// The modulus parameter overrides A.modulus for the solve operation.
+std::vector<int64_t> modSolveLinear(const ModMatrix &A,
+                                    const std::vector<int64_t> &b,
+                                    int64_t modulus);
+
+// Solve Ax = b (mod p^e) using Hensel lifting
+std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
+                                          const std::vector<int64_t> &b,
+                                          int64_t prime, int exponent);
+
+// Solve Ax = b (mod N) using CRT: factor N, solve subsystems, combine
+// solutions. Precondition: modulus > 0. Returns {} on precondition violation.
+std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
+                                       const std::vector<int64_t> &b,
+                                       int64_t modulus);
+
+// Prime factorization: N = p1^e1 * p2^e2 * ... * pk^ek
+struct PrimeFactorization {
+  std::vector<std::pair<int64_t, int>> factors;
+
+  int64_t product() const;
+};
+
+// Compute prime factorization of n
+PrimeFactorization factorize(int64_t n);
+
+} // namespace mlir::triton
+
+#endif // TRITON_TOOLS_MODULARARITHMETIC_H

--- a/lib/Tools/CMakeLists.txt
+++ b/lib/Tools/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonTools
   GenericSwizzling.cpp
   LayoutUtils.cpp
   LinearLayout.cpp
+  ModularArithmetic.cpp
   PluginUtils.cpp
 
   DEPENDS

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -7,6 +7,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "third_party/f2reduce/f2reduce.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/ModularArithmetic.h"
 #include "triton/Tools/StrUtil.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
@@ -106,7 +107,36 @@ void assertDimsSubsetIgnoringOrder(T &&small, U &&big) {
                              triton::join(big, ", ") + "]");
   }
 }
+
+// Build integer basis matrix from LinearLayout in row-major order.
+// Each row is a basis vector; each column is an output dimension.
+// Used by lstsqModular for modular arithmetic solving (as opposed to
+// getMatrix() which builds the GF(2) bit-matrix for f2reduce).
+std::vector<int64_t> getIntegerBasisMatrix(const LinearLayout &L) {
+  int numRows = L.getTotalInDimSizeLog2();
+  int numCols = L.getNumOutDims();
+  std::vector<int64_t> mat(numRows * numCols, 0);
+
+  int row = 0;
+  for (auto inDim : L.getInDimNames()) {
+    for (int i = 0; i < L.getInDimSizeLog2(inDim); i++) {
+      auto basis = L.getBasis(inDim, i);
+      for (int col = 0; col < numCols; col++) {
+        mat[row * numCols + col] = basis[col];
+      }
+      row++;
+    }
+  }
+
+  return mat;
+}
+
 } // anonymous namespace
+
+// Forward declarations for surjectivity helpers used in checkInvariants
+bool checkPow2Surjectivity(const std::vector<int32_t> &bases, int64_t modulus);
+bool checkOddPrimePowerSurjectivity(const std::vector<int32_t> &bases,
+                                    int64_t modulus);
 
 /*static*/ std::optional<LinearLayout>
 LinearLayout::tryCreate(BasesT bases,
@@ -164,6 +194,17 @@ LinearLayout::LinearLayout(BasesT bases,
 std::optional<std::string>
 LinearLayout::checkInvariants(bool requireSurjective) {
   LDBG("checkInvariants: " << toString());
+
+  // Cache isModular result FIRST, before any validation that uses it.
+  // This is computed once during construction since outDims is immutable.
+  this->cachedIsModular = false;
+  for (const auto &[outDim, size] : outDims) {
+    if (!llvm::isPowerOf2_32(size)) {
+      this->cachedIsModular = true;
+      break;
+    }
+  }
+
   // Check that basis values are non-negative.
   for (const auto &[inDim, inDimBases] : bases) {
     for (const auto &basis : inDimBases) {
@@ -189,20 +230,23 @@ LinearLayout::checkInvariants(bool requireSurjective) {
     }
   }
 
-  // Check that the out-dim sizes are powers of 2.
+  // Per-dim validation: pow2 dims enforce strict basis < size (XOR semantics),
+  // NPOT dims allow bases >= size (modular reduction via ADD+UREM).
+  SmallVector<StringAttr> outDimNames = llvm::to_vector(getOutDimNames());
   for (const auto &[outDim, size] : outDims) {
-    if (!llvm::isPowerOf2_32(size)) {
+    if (size <= 0) {
       return "Invalid out-dim size " + std::to_string(size) + " for out-dim '" +
-             outDim.str() + "'.  Out-dim sizes must be powers of 2.\n";
+             outDim.str() + "'.  Out-dim sizes must be positive.\n";
     }
   }
 
-  // Check that the bases are smaller than the out-dim sizes.
-  SmallVector<StringAttr> outDimNames = llvm::to_vector(getOutDimNames());
+  // For pow2 dims, bases must be < size (XOR-based).
+  // For NPOT dims, bases may exceed size (modular reduction handles it).
   for (const auto &[inDim, inDimBases] : this->bases) {
     for (const auto &basis : inDimBases) {
       for (int i = 0; i < basis.size(); i++) {
-        if (basis[i] >= outDims[outDimNames[i]]) {
+        if (llvm::isPowerOf2_32(outDims[outDimNames[i]]) &&
+            basis[i] >= outDims[outDimNames[i]]) {
           return "Invalid basis " + std::to_string(basis[i]) + " for in-dim '" +
                  inDim.str() + "' and out-dim '" + outDimNames[i].str() +
                  "'.  Basis must be less than the out-dim size.\n";
@@ -216,14 +260,19 @@ LinearLayout::checkInvariants(bool requireSurjective) {
   //
   // It's prohibitively slow to calculate this naively, but thankfully, this
   // is equivalent to checking that the number of linearly-independent bases
-  // is equal to sum(getOutDimSizeLog2).  This can be computed by finding
+  // is equal to sum(getOutDimSizeBits).  This can be computed by finding
   // the rank of the matrix whose columns are those bases.  We can compute
   // the rank of our matrix using Gaussian elimination, which runs in O(n^3)
   // for an n x n matrix.  Our matrix size is sum(inDimSizeLog2) x
-  // sum(outDimSizeLog2), so this should be plenty fast.
-  this->rank =
-      getMatrixRank(getMatrix(*this), /*numRows=*/getTotalOutDimSizeLog2(),
-                    /*numCols=*/getTotalInDimSizeLog2());
+  // sum(outDimSizeBits), so this should be plenty fast.
+  if (!cachedIsModular) {
+    this->rank =
+        getMatrixRank(getMatrix(*this), /*numRows=*/getTotalOutDimSizeBits(),
+                      /*numCols=*/getTotalInDimSizeLog2());
+  } else {
+    // GF(2) rank is not meaningful for modular layouts.
+    this->rank = -1;
+  }
 
   if (requireSurjective && !isSurjective()) {
     return "Layout is expected to be surjective, i.e. every `out` coordinate "
@@ -255,9 +304,9 @@ LinearLayout::LinearLayout(
   for (int32_t i = 1; i < size; i *= 2) {
     bases.emplace_back(std::vector<int32_t>{i * stride});
   }
-  bool requiresSurjective = (stride == 1);
+  bool requireSurjective = (stride == 1);
   return LinearLayout({{inDimName, std::move(bases)}},
-                      {{outDimName, stride * size}}, requiresSurjective);
+                      {{outDimName, stride * size}}, requireSurjective);
 }
 
 /*static*/ LinearLayout LinearLayout::zeros1D(int32_t size,
@@ -273,7 +322,36 @@ LinearLayout::LinearLayout(
     zeros.emplace_back(std::vector<int32_t>{0});
   }
   return LinearLayout({{inDimName, zeros}}, {{outDimName, outDimSize}},
-                      /*requiresSurjective=*/outDimSize == 1);
+                      /*requireSurjective=*/outDimSize == 1);
+}
+
+/*static*/ LinearLayout LinearLayout::modularStrided1D(int32_t size,
+                                                       int32_t stride,
+                                                       StringAttr inDimName,
+                                                       StringAttr outDimName) {
+  if (size == 0)
+    return LinearLayout::empty();
+
+  assert(size > 0 && "size must be positive");
+  assert(stride > 0 && "stride must be positive");
+
+  // Generate ceil(log2(size)) basis vectors
+  int numBases = llvm::Log2_64_Ceil(size);
+
+  std::vector<std::vector<int32_t>> bases;
+  for (int i = 0; i < numBases; i++) {
+    // Basis value: (stride * 2^i) % size
+    // Use 1LL to avoid UB if a future caller passes a layout with > 2^31
+    // elements per input bit.
+    int32_t basisValue = static_cast<int32_t>(
+        (static_cast<int64_t>(stride) * (1LL << i)) % size);
+    bases.emplace_back(std::vector<int32_t>{basisValue});
+  }
+
+  // requireSurjective = false: modular layouts check surjectivity via
+  // isModularSurjective rather than the GF(2) RREF-based check.
+  return LinearLayout({{inDimName, std::move(bases)}}, {{outDimName, size}},
+                      /*requireSurjective=*/false);
 }
 
 int32_t LinearLayout::getOutDimIndex(StringAttr outDim) const {
@@ -304,14 +382,185 @@ int32_t LinearLayout::getTotalInDimSizeLog2() const {
 int32_t LinearLayout::getOutDimSizeLog2(StringAttr outDim) const {
   auto it = outDims.find(outDim);
   assert(it != outDims.end() && "outDim not found in layout");
+  assert(llvm::isPowerOf2_32(it->second) &&
+         "getOutDimSizeLog2 called on non-pow2 out-dim - use "
+         "getOutDimSizeBits() instead");
   return llvm::Log2_32(it->second);
 }
 
 int32_t LinearLayout::getTotalOutDimSizeLog2() const {
+  assert(!isModular() && "getTotalOutDimSizeLog2 called on modular layout - "
+                         "use getTotalOutDimSizeBits() instead");
   return std::accumulate(getOutDimNames().begin(), getOutDimNames().end(), 0,
                          [&](int32_t acc, StringAttr outDim) {
                            return acc + getOutDimSizeLog2(outDim);
                          });
+}
+
+// Check surjectivity for a single dimension modulo a power of 2.
+//
+// CORRECTNESS: apply() composes modular (NPOT) out-dims with ADD+mod (Z/N
+// arithmetic), NOT XOR (GF(2)). The previous GF(2)/XOR-rank check therefore
+// reported surjectivity for the wrong group structure: e.g. bases {1,3} mod 4
+// have full GF(2) rank (XOR reaches all of {0..3}) but their *subset sums*
+// mod 4 only reach {0,1,3} — value 2 is unreachable. This made non-surjective
+// layouts (e.g. bases {1,3,4,8} over size 12, which reaches only 9 of 12
+// values under ADD+mod) wrongly pass isSurjective(). Use the same additive
+// dynamic-programming reachability check as checkOddPrimePowerSurjectivity so
+// the surjectivity test matches apply()'s ADD+mod semantics.
+// Complexity: O(numBases * modulus) time, O(modulus) space.
+bool checkPow2Surjectivity(const std::vector<int32_t> &bases, int64_t modulus) {
+  assert(llvm::isPowerOf2_64(modulus) && "modulus must be power of 2");
+
+  // Filter out zero bases — they don't contribute to reachability.
+  std::vector<int32_t> nonZeroBases;
+  for (int32_t b : bases) {
+    if (b % modulus != 0) {
+      nonZeroBases.push_back(b);
+    }
+  }
+
+  int numBases = nonZeroBases.size();
+  if (numBases == 0) {
+    return modulus == 1;
+  }
+
+  // DP reachability over subset sums mod `modulus`, matching apply()'s ADD+mod
+  // composition of basis contributions. Uses two vectors with swap to avoid
+  // copying per iteration.
+  std::vector<bool> reachable(modulus, false);
+  std::vector<bool> next(modulus, false);
+  reachable[0] = true;
+  int reachableCount = 1;
+  for (int i = 0; i < numBases && reachableCount < modulus; i++) {
+    int32_t basis = ((nonZeroBases[i] % modulus) + modulus) % modulus;
+    next = reachable;
+    for (int64_t v = 0; v < modulus; v++) {
+      if (reachable[v] && !next[(v + basis) % modulus]) {
+        next[(v + basis) % modulus] = true;
+        reachableCount++;
+      }
+    }
+    std::swap(reachable, next);
+  }
+
+  // Check if all values mod modulus are reachable.
+  for (int64_t i = 0; i < modulus; i++) {
+    if (!reachable[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Check surjectivity modulo an odd prime power via DP reachability.
+// Complexity: O(numBases * modulus) time, O(modulus) space.
+bool checkOddPrimePowerSurjectivity(const std::vector<int32_t> &bases,
+                                    int64_t modulus) {
+  // Filter out zero bases — they don't contribute to reachability.
+  // Critical for multi-dimensional layouts where bases from unrelated
+  // input dimensions are all zero for the current output dimension.
+  std::vector<int32_t> nonZeroBases;
+  for (int32_t b : bases) {
+    if (b % modulus != 0) {
+      nonZeroBases.push_back(b);
+    }
+  }
+
+  int numBases = nonZeroBases.size();
+  if (numBases == 0) {
+    return modulus == 1;
+  }
+
+  // DP reachability: O(numBases * modulus) — correct for all basis patterns.
+  // Uses two vectors with swap to avoid copying per iteration.
+  std::vector<bool> reachable(modulus, false);
+  std::vector<bool> next(modulus, false);
+  reachable[0] = true;
+  int reachableCount = 1;
+  for (int i = 0; i < numBases && reachableCount < modulus; i++) {
+    int32_t basis = nonZeroBases[i] % modulus;
+    next = reachable;
+    for (int64_t v = 0; v < modulus; v++) {
+      if (reachable[v] && !next[(v + basis) % modulus]) {
+        next[(v + basis) % modulus] = true;
+        reachableCount++;
+      }
+    }
+    std::swap(reachable, next);
+  }
+
+  // Check if all values mod modulus are reachable
+  for (int64_t i = 0; i < modulus; i++) {
+    if (!reachable[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool LinearLayout::isModularSurjective() const {
+  assert(isModular() && "isModularSurjective() requires a modular layout; "
+                        "use isSurjective() for pow2 layouts");
+
+  // For modular layouts, we need to check if all values [0, size) can be
+  // reached using modular addition of bases. For multi-dimensional layouts,
+  // check each output dimension independently (product space is surjective iff
+  // each dimension is).
+
+  // Iterate over all output dimensions and check each independently
+  for (const auto &[outDim, size] : outDims) {
+    int32_t outDimIdx = getOutDimIndex(outDim);
+
+    // Collect all basis values for this output dimension
+    std::vector<int32_t> allBases;
+    for (const auto &[inDim, inDimBases] : bases) {
+      for (const auto &basis : inDimBases) {
+        allBases.push_back(basis[outDimIdx]);
+      }
+    }
+
+    int numBases = allBases.size();
+    if (numBases == 0) {
+      // Empty layout, only covers value 0
+      if (size != 1) {
+        return false;
+      }
+      continue; // Check next dimension
+    }
+
+    // Use CRT factorization: check surjectivity per prime power factor.
+    // For N = 2^k * p1^e1 * ... * pm^em, we check each factor separately.
+    // Each factor uses DP reachability, so the total cost is
+    // O(numBases * sum_i(pi^ei)) rather than the naive O(2^numBases).
+    auto factorization = factorize(size);
+
+    for (const auto &[prime, exponent] : factorization.factors) {
+      int64_t modulus = intPow(prime, exponent);
+
+      // Reduce all bases modulo this factor
+      std::vector<int32_t> basesModFactor;
+      for (int32_t base : allBases) {
+        basesModFactor.push_back(((base % modulus) + modulus) % modulus);
+      }
+
+      bool surjective;
+      if (prime == 2) {
+        // Power of 2: use GF(2) rank check (O(numBases^3))
+        surjective = checkPow2Surjectivity(basesModFactor, modulus);
+      } else {
+        // Odd prime power: DP reachability, O(numBases * modulus)
+        surjective = checkOddPrimePowerSurjectivity(basesModFactor, modulus);
+      }
+
+      if (!surjective) {
+        return false;
+      }
+    }
+  }
+
+  // All dimensions are surjective
+  return true;
 }
 
 int32_t LinearLayout::getNumConsecutiveInOut() const {
@@ -342,7 +591,15 @@ int32_t LinearLayout::getNumConsecutiveInOut() const {
   }
   int32_t trailingZeros = otherBits != 0 ? __builtin_ctz(otherBits) : 31;
 
-  return 1 << std::min(consec, trailingZeros);
+  int32_t result = 1 << std::min(consec, trailingZeros);
+  // For NPOT (modular) output dims, clamp to avoid mod-N wrap-around.
+  // Max safe V = largest pow2 dividing N (2-adic valuation).
+  StringAttr firstOutDim = outDims.begin()->first;
+  if (isOutDimModular(firstOutDim)) {
+    int32_t n = getOutDimSize(firstOutDim);
+    result = std::min(result, n & (-n));
+  }
+  return result;
 }
 
 LinearLayout LinearLayout::transposeIns(ArrayRef<StringAttr> newInDims) const {
@@ -418,29 +675,31 @@ LinearLayout LinearLayout::reshapeIns(
 
 LinearLayout LinearLayout::reshapeOuts(
     ArrayRef<std::pair<StringAttr, int32_t>> newOutDims) const {
-  assert(llvm::all_of(newOutDims, [&](auto &outDim) {
-    return llvm::isPowerOf2_32(outDim.second);
-  }));
-  assert(getTotalOutDimSize() ==
+  assert(getTotalOutDimSizeProduct() ==
          std::accumulate(
-             newOutDims.begin(), newOutDims.end(), 1,
-             [&](int32_t acc, auto &outDim) { return acc * outDim.second; }));
+             newOutDims.begin(), newOutDims.end(), int64_t{1},
+             [&](int64_t acc, auto &outDim) { return acc * outDim.second; }));
 
-  SmallVector<int32_t> shifts;
-  shifts.push_back(0);
+  // Mixed-radix encoding: use multipliers instead of bit-shifts.
+  // For pow2 dims, multiply is equivalent to shift. For NPOT, it's correct.
+  SmallVector<int64_t> multipliers;
+  multipliers.push_back(1);
   for (StringAttr outDim : getOutDimNames()) {
-    shifts.push_back(shifts.back() + getOutDimSizeLog2(outDim));
+    multipliers.push_back(multipliers.back() * getOutDimSize(outDim));
   }
 
   // Flatten into a single out-dimension.  Then split it up according to
   // `newOutDims`.
-  llvm::MapVector<StringAttr, std::vector<int32_t>> flatBases;
+  llvm::MapVector<StringAttr, std::vector<int64_t>> flatBases;
   for (const auto &[inDim, inDimBases] : bases) {
     auto &flatInBases = flatBases[inDim];
     for (const auto &basis : inDimBases) {
-      int b = 0;
+      int64_t b = 0;
       for (int i = 0; i < basis.size(); i++) {
-        b += basis[i] << shifts[i];
+        // Widen to int64 before multiplying: the flattened mixed-radix index
+        // can exceed int32 range for large layouts even though each basis[i]
+        // is int32. The widening is intentional overflow prevention.
+        b += static_cast<int64_t>(basis[i]) * multipliers[i];
       }
       flatInBases.push_back(b);
     }
@@ -449,7 +708,7 @@ LinearLayout LinearLayout::reshapeOuts(
   BasesT newBases;
   for (const auto &[inDim, flatInBases] : flatBases) {
     std::vector<std::vector<int32_t>> &newInDimBases = newBases[inDim];
-    for (int32_t b : flatInBases) {
+    for (int64_t b : flatInBases) {
       std::vector<int32_t> multiDimBasis;
       for (int32_t newSize : llvm::make_second_range(newOutDims)) {
         multiDimBasis.push_back(b % newSize);
@@ -469,12 +728,11 @@ LinearLayout LinearLayout::resizeInDim(StringAttr inDim,
   auto newBases = bases;
   newBases[inDim].resize(llvm::Log2_32(newSize));
   return LinearLayout(std::move(newBases), getOutDims(),
-                      /*requiresSurjective=*/false);
+                      /*requireSurjective=*/false);
 }
 
 LinearLayout LinearLayout::resizeOutDim(StringAttr outDim,
                                         int32_t newSize) const {
-  assert(llvm::isPowerOf2_32(newSize));
   assert(newSize <= getOutDimSize(outDim));
   auto newBases = bases;
   // Zero-out the basis vectors that are greater than or equal to the new size
@@ -487,13 +745,13 @@ LinearLayout LinearLayout::resizeOutDim(StringAttr outDim,
     }
   }
   auto outDims = getOutDims();
-  for (auto &[outDim, outDimSize] : outDims) {
-    if (outDim == outDim) {
-      outDimSize = newSize;
+  for (auto &[dim, dimSize] : outDims) {
+    if (dim == outDim) {
+      dimSize = newSize;
     }
   }
   return LinearLayout(std::move(newBases), outDims,
-                      /*requiresSurjective=*/false);
+                      /*requireSurjective=*/false);
 }
 
 LinearLayout LinearLayout::concatIns(const LinearLayout &other) const {
@@ -512,7 +770,7 @@ LinearLayout LinearLayout::concatIns(const LinearLayout &other) const {
   for (auto &[outDim, outDimSize] : outDims)
     newOutDims.emplace_back(outDim, outDimSize);
   return LinearLayout(std::move(resultBases), newOutDims,
-                      /*requiresSurjective=*/false);
+                      /*requireSurjective=*/false);
 }
 
 LinearLayout LinearLayout::concatOuts(const LinearLayout &other) const {
@@ -542,7 +800,7 @@ LinearLayout LinearLayout::concatOuts(const LinearLayout &other) const {
   for (auto &[outDim, outDimSize] : other.outDims)
     newOutDims.emplace_back(outDim, outDimSize);
   return LinearLayout(std::move(result), newOutDims,
-                      /*requiresSurjective=*/false);
+                      /*requireSurjective=*/false);
 }
 
 std::optional<LinearLayout> divideLeft(const LinearLayout &A,
@@ -561,15 +819,14 @@ std::optional<LinearLayout> divideLeft(const LinearLayout &A,
     if (!llvm::is_contained(A.getOutDimNames(), dim))
       return std::nullopt;
   }
-  // Compute candidate C's log-sizes for output dimensions.
+  // Compute candidate C’s sizes for output dimensions.
   llvm::MapVector<StringAttr, int32_t> cOutDimSizes;
   for (StringAttr outDim : A.getOutDimNames()) {
-    int outA = A.getOutDimSizeLog2(outDim);
-    int outB = B.hasOutDim(outDim) ? B.getOutDimSizeLog2(outDim) : 0;
-    int outC = outA - outB;
-    if (outC < 0)
+    int sizeA = A.getOutDimSize(outDim);
+    int sizeB = B.hasOutDim(outDim) ? B.getOutDimSize(outDim) : 1;
+    if (sizeA % sizeB != 0)
       return std::nullopt;
-    cOutDimSizes[outDim] = 1 << outC;
+    cOutDimSizes[outDim] = sizeA / sizeB;
   }
 
   LinearLayout::BasesT cBases;
@@ -591,17 +848,18 @@ std::optional<LinearLayout> divideLeft(const LinearLayout &A,
       }
     }
 
-    // Extract the candidate C bases from the remaining (shifted) entries in A.
+    // Extract the candidate C bases from the remaining entries in A.
+    // For A = B * C, outer bases are multiplied by B’s out-dim size.
     for (int i = inB; i < inA; ++i) {
       std::vector<int32_t> candidateBasis;
       for (StringAttr outDim : llvm::make_first_range(cOutDimSizes)) {
-        int outB = B.hasOutDim(outDim) ? B.getOutDimSizeLog2(outDim) : 0;
+        int sizeB = B.hasOutDim(outDim) ? B.getOutDimSize(outDim) : 1;
         int v = A.getBasis(inDim, i, outDim);
 
-        // The lower outB bits must be zero.
-        if ((v & ((1 << outB) - 1)) != 0)
+        // v must be divisible by B’s out-dim size.
+        if (v % sizeB != 0)
           return std::nullopt;
-        candidateBasis.push_back(v >> outB);
+        candidateBasis.push_back(v / sizeB);
       }
       basesForDim.push_back(std::move(candidateBasis));
     }
@@ -638,15 +896,14 @@ std::optional<LinearLayout> divideRight(const LinearLayout &A,
       return std::nullopt;
   }
 
-  // Compute candidate C's log-sizes for output dimensions.
+  // Compute candidate C's sizes for output dimensions.
   llvm::MapVector<StringAttr, int32_t> cOutDimSizes;
   for (StringAttr outDim : A.getOutDimNames()) {
-    int outA = A.getOutDimSizeLog2(outDim);
-    int outB = B.hasOutDim(outDim) ? B.getOutDimSizeLog2(outDim) : 0;
-    int outC = outA - outB;
-    if (outC < 0)
+    int sizeA = A.getOutDimSize(outDim);
+    int sizeB = B.hasOutDim(outDim) ? B.getOutDimSize(outDim) : 1;
+    if (sizeA % sizeB != 0)
       return std::nullopt;
-    cOutDimSizes[outDim] = 1 << outC;
+    cOutDimSizes[outDim] = sizeA / sizeB;
   }
 
   // For candidate C, its in-dim sizes come from subtracting B's in-dim sizes
@@ -669,20 +926,17 @@ std::optional<LinearLayout> divideRight(const LinearLayout &A,
       basesForDim.push_back(std::move(candidate));
     }
 
-    // The remaining inB basis vectors in A should correspond to B after being
-    // shifted.
+    // The remaining inB basis vectors in A should correspond to B, scaled
+    // by C's out-dim size (since A = C * B, B is the outer layout).
     for (int i = inC; i < inA; ++i) {
       int j = i - inC; // Index into B's basis vectors for this inDim.
       for (StringAttr outDim : B.getOutDimNames()) {
-        int outA = A.getOutDimSizeLog2(outDim);
-        int outB = B.getOutDimSizeLog2(outDim);
-        int outC = outA - outB; // Expected log2 size for C in this output.
-        int shift = outC;
+        int sizeC = cOutDimSizes[outDim];
         int v = A.getBasis(inDim, i, outDim);
-        // The lower shift bits must be zero.
-        if ((v & ((1 << shift) - 1)) != 0)
+        // v must be divisible by C's out-dim size.
+        if (v % sizeC != 0)
           return std::nullopt;
-        int recovered = v >> shift;
+        int recovered = v / sizeC;
         int expected = B.getBasis(inDim, j, outDim);
         if (recovered != expected)
           return std::nullopt;
@@ -708,21 +962,21 @@ LinearLayout operator*(LinearLayout inner, LinearLayout outer) {
   auto outDims = supremum(llvm::to_vector(inner.getOutDimNames()),
                           llvm::to_vector(outer.getOutDimNames()));
 
-  // Get the sizeLog2 of all input and output dimensions we're going to
-  // consider, in order.  `inner` is more minor, so its dimensions come
-  // first.
+  // Track input dim sizes as log2 (always pow2) and output dim sizes as actual
+  // values (may be NPOT). For shared output dims, the combined size is the
+  // product of inner and outer sizes (mixed-radix encoding).
   llvm::MapVector<StringAttr, int32_t> inDimSizesLog2;
-  llvm::MapVector<StringAttr, int32_t> outDimSizesLog2;
+  llvm::MapVector<StringAttr, int32_t> outDimActualSizes;
   for (const auto &dim : inDims)
     inDimSizesLog2.insert({dim, 0});
   for (const auto &dim : outDims)
-    outDimSizesLog2.insert({dim, 0});
+    outDimActualSizes.insert({dim, 1});
   for (const auto &layout : {inner, outer}) {
     for (StringAttr inDim : layout.getInDimNames()) {
       inDimSizesLog2[inDim] += layout.getInDimSizeLog2(inDim);
     }
     for (StringAttr outDim : layout.getOutDimNames()) {
-      outDimSizesLog2[outDim] += layout.getOutDimSizeLog2(outDim);
+      outDimActualSizes[outDim] *= layout.getOutDimSize(outDim);
     }
   }
 
@@ -732,10 +986,10 @@ LinearLayout operator*(LinearLayout inner, LinearLayout outer) {
 
     // Fill with zeros.
     inDimBases = std::vector<std::vector<int32_t>>(
-        inDimSizeLog2, std::vector<int32_t>(outDimSizesLog2.size(), 0));
+        inDimSizeLog2, std::vector<int32_t>(outDimActualSizes.size(), 0));
 
     for (auto [outDimIdx, outDimNameAndSize] :
-         llvm::enumerate(outDimSizesLog2)) {
+         llvm::enumerate(outDimActualSizes)) {
       auto [outDimName, outDimSize] = outDimNameAndSize;
       if (inner.hasInDim(inDimName) && inner.hasOutDim(outDimName)) {
         for (int i = 0; i < inner.getInDimSizeLog2(inDimName); i++) {
@@ -745,20 +999,21 @@ LinearLayout operator*(LinearLayout inner, LinearLayout outer) {
       if (outer.hasInDim(inDimName) && outer.hasOutDim(outDimName)) {
         int offset =
             inner.hasInDim(inDimName) ? inner.getInDimSizeLog2(inDimName) : 0;
-        int shift = inner.hasOutDim(outDimName)
-                        ? inner.getOutDimSizeLog2(outDimName)
-                        : 0;
+        // Use multiply instead of shift: correct for both pow2 and NPOT.
+        // For pow2, multiply by 2^k is equivalent to << k.
+        int multiplier =
+            inner.hasOutDim(outDimName) ? inner.getOutDimSize(outDimName) : 1;
         for (int i = 0; i < outer.getInDimSizeLog2(inDimName); i++) {
           inDimBases[offset + i][outDimIdx] =
-              outer.getBasis(inDimName, i, outDimName) << shift;
+              outer.getBasis(inDimName, i, outDimName) * multiplier;
         }
       }
     }
   }
 
   llvm::SmallVector<std::pair<StringAttr, int32_t>> outDimSizes;
-  for (auto [outDim, sizeLog2] : outDimSizesLog2) {
-    outDimSizes.push_back({outDim, 1 << sizeLog2});
+  for (auto [outDim, actualSize] : outDimActualSizes) {
+    outDimSizes.push_back({outDim, actualSize});
   }
   return LinearLayout(std::move(allBases), outDimSizes,
                       inner.isSurjective() && outer.isSurjective());
@@ -879,10 +1134,22 @@ LinearLayout::apply(ArrayRef<std::pair<StringAttr, int32_t>> ins) const {
   SmallVector<std::pair<StringAttr, int32_t>> ret;
   for (StringAttr outDim : getOutDimNames()) {
     int32_t outVal = 0;
+    // Per-dim dispatch: NPOT dims use ADD+mod (Z/N arithmetic), pow2 dims use
+    // XOR (GF(2)). With the split-dim layout, pow2 dims (dim0, contig_intra)
+    // are solved via GF(2) RREF while the NPOT dim (contig_phase) is solved via
+    // modSolveLinearCRT. S=0 between groups means no coupling, so per-dim
+    // dispatch is correct.
+    bool dimIsModular = isOutDimModular(outDim);
     for (auto &[inDim, val] : ins) {
       for (int i = 0; i < getInDimSizeLog2(inDim); i++) {
-        if (val & (1 << i))
-          outVal ^= getBasis(inDim, i, outDim);
+        if (val & (1 << i)) {
+          if (dimIsModular) {
+            outVal =
+                (outVal + getBasis(inDim, i, outDim)) % getOutDimSize(outDim);
+          } else {
+            outVal ^= getBasis(inDim, i, outDim);
+          }
+        }
       }
     }
     ret.push_back({outDim, outVal});
@@ -895,6 +1162,12 @@ LinearLayout LinearLayout::compose(const LinearLayout &outer) const {
   for (StringAttr outDim : getOutDimNames()) {
     assert(getOutDimSize(outDim) <= outer.getInDimSize(outDim));
   }
+
+  bool compositionIsSurjective =
+      isSurjective() && outer.isSurjective() &&
+      llvm::all_of(getOutDimNames(), [&](StringAttr outDim) {
+        return getOutDimSize(outDim) == outer.getInDimSize(outDim);
+      });
 
   BasesT newBases;
   for (const auto &[inDim, inDimBases] : bases) {
@@ -911,20 +1184,14 @@ LinearLayout LinearLayout::compose(const LinearLayout &outer) const {
     }
   }
 
-  bool compositionIsSurjective =
-      isSurjective() && outer.isSurjective() &&
-      llvm::all_of(getOutDimNames(), [&](StringAttr outDim) {
-        return getOutDimSize(outDim) == outer.getInDimSize(outDim);
-      });
   return LinearLayout(std::move(newBases), llvm::to_vector(outer.outDims),
                       compositionIsSurjective);
 }
 
-namespace {
-std::unique_ptr<uint64_t[]> concatMatrices(const LinearLayout &A,
-                                           const LinearLayout &B) {
+std::unique_ptr<uint64_t[]>
+LinearLayout::concatMatrices(const LinearLayout &A, const LinearLayout &B) {
   // conv
-  assert(A.getTotalOutDimSizeLog2() >= B.getTotalOutDimSizeLog2() &&
+  assert(A.getTotalOutDimSizeBits() >= B.getTotalOutDimSizeBits() &&
          "A must have at least as many output bits as B");
   int numColsA = A.getTotalInDimSizeLog2();
 
@@ -933,9 +1200,10 @@ std::unique_ptr<uint64_t[]> concatMatrices(const LinearLayout &A,
   auto BMat = getMatrix(B);
   int rowA = 0;
   int rowB = 0;
-  for (auto [outDim, outDimSize] : A.getOutDims()) {
-    for (int r = 0; r < llvm::Log2_32(outDimSize); r++) {
-      if (r < llvm::Log2_32(B.getOutDimSize(outDim))) {
+  for (auto outDim : A.getOutDimNames()) {
+    // Use getOutDimSizeBits() to handle NPOT dimensions correctly
+    for (int r = 0; r < A.getOutDimSizeBits(outDim); r++) {
+      if (B.hasOutDim(outDim) && r < B.getOutDimSizeBits(outDim)) {
         concat[rowA] |= BMat[rowB] << numColsA;
         rowB++;
       }
@@ -945,15 +1213,160 @@ std::unique_ptr<uint64_t[]> concatMatrices(const LinearLayout &A,
   return concat;
 }
 
-LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B) {
+// Modular lstsq implementation delegating to modSolveLinearCRT
+LinearLayout LinearLayout::lstsqModular(const LinearLayout &A,
+                                        const LinearLayout &B) {
+  assertDimsEqualIgnoringOrder(A.getOutDimNames(), B.getOutDimNames());
+
+  int numRowsA = A.getTotalInDimSizeLog2();
+  int numRowsB = B.getTotalInDimSizeLog2();
+  int numOutDims = A.getNumOutDims();
+
+  // Working modulus = LCM of all output dimension sizes
+  int64_t workingModulus = 1;
+  for (auto [outDim, size] : A.getOutDims()) {
+    int64_t g = std::gcd(workingModulus, static_cast<int64_t>(size));
+    workingModulus = (workingModulus / g) * size;
+  }
+
+  auto matA_data = getIntegerBasisMatrix(A);
+  auto matB_data = getIntegerBasisMatrix(B);
+
+  // Build ModMatrix for A (numOutDims rows x numRowsA cols)
+  ModMatrix matA_mod(numOutDims, numRowsA, workingModulus);
+  for (int r = 0; r < numRowsA; r++)
+    for (int c = 0; c < numOutDims; c++)
+      matA_mod.at(c, r) = matA_data[r * numOutDims + c];
+
+  // Solve per column of B
+  std::vector<std::vector<int64_t>> resultCols(numRowsB);
+  for (int bCol = 0; bCol < numRowsB; bCol++) {
+    std::vector<int64_t> rhs(numOutDims);
+    for (int outIdx = 0; outIdx < numOutDims; outIdx++)
+      rhs[outIdx] = matB_data[bCol * numOutDims + outIdx];
+
+    resultCols[bCol] = modSolveLinearCRT(matA_mod, rhs, workingModulus);
+    assert(!resultCols[bCol].empty() &&
+           "Precondition broken in lstsqModular: modSolveLinearCRT failed. "
+           "Im(B) not contained in Im(A)?");
+  }
+
+  // Build result layout from solution
+  assert(!A.getInDimNames().empty() &&
+         "A must have at least one input dimension");
+  StringAttr inDim1D = *B.getInDimNames().begin();
+  StringAttr outDim1D = *A.getInDimNames().begin();
+
+  LinearLayout::BasesT retBases;
+  auto &bs = retBases[inDim1D];
+
+  for (int bCol = 0; bCol < numRowsB; bCol++) {
+    std::vector<int32_t> basis(1);
+    basis[0] = 0;
+
+    for (int aRow = 0; aRow < numRowsA; aRow++) {
+      if (resultCols[bCol][aRow] != 0) {
+        basis[0] = (basis[0] + resultCols[bCol][aRow] * (int64_t{1} << aRow)) %
+                   static_cast<int32_t>(A.getTotalInDimSize());
+      }
+    }
+
+    bs.push_back(basis);
+  }
+
+  LinearLayout retFlattened(std::move(retBases),
+                            {{outDim1D, A.getTotalInDimSize()}},
+                            /*requireSurjective=*/false);
+
+  SmallVector<std::pair<StringAttr, int32_t>> retInDims;
+  SmallVector<std::pair<StringAttr, int32_t>> retOutDims;
+  for (StringAttr dim : B.getInDimNames()) {
+    retInDims.push_back({dim, B.getInDimSize(dim)});
+  }
+  for (StringAttr dim : A.getInDimNames()) {
+    retOutDims.push_back({dim, A.getInDimSize(dim)});
+  }
+  return retFlattened.reshapeIns(retInDims).reshapeOuts(retOutDims);
+}
+
+LinearLayout LinearLayout::lstsq(const LinearLayout &A, const LinearLayout &B) {
+  // Dispatch to modular solver if needed.
+  // Only use the modular solver when A (the layout being inverted) is modular.
+  // When only B is modular (e.g., NPOT output dim from msgToPackedOffset) but A
+  // is pow2 (e.g., smemLayout with pow2 alloc shape), the GF(2) solver is both
+  // correct and necessary: the modular solver's working modulus (LCM of output
+  // dim sizes) can be much smaller than A's input space, causing it to confuse
+  // distinct offsets that map to different coordinates. The GF(2) solver works
+  // correctly because it operates on individual bits and finds the exact input
+  // bit combination that produces B's output.
+  if (A.isModular()) {
+    // Mixed pow2/NPOT output dims: solve each group with its correct algebra.
+    // The split-dim construction (dim_intra=pow2, dim_phase=NPOT) guarantees
+    // S=0 cross-coupling, so the groups are algebraically independent.
+    SmallVector<StringAttr> pow2OutDims, npotOutDims;
+    for (auto [outDim, size] : A.getOutDims()) {
+      if (llvm::isPowerOf2_32(size))
+        pow2OutDims.push_back(outDim);
+      else
+        npotOutDims.push_back(outDim);
+    }
+
+    if (!pow2OutDims.empty() && !npotOutDims.empty()) {
+      auto inDimNames = llvm::to_vector(A.getInDimNames());
+      auto bInDimNames = llvm::to_vector(B.getInDimNames());
+
+      auto C_pow2 = lstsq(A.sublayout(inDimNames, pow2OutDims),
+                          B.sublayout(bInDimNames, pow2OutDims));
+      auto C_npot = lstsqModular(A.sublayout(inDimNames, npotOutDims),
+                                 B.sublayout(bInDimNames, npotOutDims));
+
+      // Combine: OR the per-basis coefficients (disjoint by S=0 decoupling).
+      auto C_pow2_flat = C_pow2.flattenIns().flattenOuts();
+      auto C_npot_flat = C_npot.flattenIns().flattenOuts();
+      StringAttr flatIn = *C_pow2_flat.getInDimNames().begin();
+      StringAttr flatOut = *C_pow2_flat.getOutDimNames().begin();
+
+      int numColsB = B.getTotalInDimSizeLog2();
+      LinearLayout::BasesT combinedBases;
+      auto &cbs = combinedBases[flatIn];
+      for (int c = 0; c < numColsB; c++) {
+        int32_t vp = C_pow2_flat.getBasis(flatIn, c, flatOut);
+        int32_t vn = C_npot_flat.getBasis(flatIn, c, flatOut);
+        // The pow2 (XOR) and NPOT (ADD) solves are supposed to be disjoint
+        // (S=0 decoupling). If any output bit is claimed by both solves, the
+        // factored OR-combine would conflate them, so fall back to a full
+        // modular solve.
+        bool crossCoupled = (vp & vn) != 0;
+        if (crossCoupled) {
+          LDBG("lstsq: mixed solve fallback (cross-coupled dims)");
+          return lstsqModular(A, B);
+        }
+        cbs.push_back({vp | vn});
+      }
+
+      LinearLayout ret(std::move(combinedBases),
+                       {{flatOut, A.getTotalInDimSize()}},
+                       /*requireSurjective=*/false);
+      SmallVector<std::pair<StringAttr, int32_t>> retInDims, retOutDims;
+      for (StringAttr dim : bInDimNames)
+        retInDims.push_back({dim, B.getInDimSize(dim)});
+      for (StringAttr dim : inDimNames)
+        retOutDims.push_back({dim, A.getInDimSize(dim)});
+      return ret.reshapeIns(retInDims).reshapeOuts(retOutDims);
+    }
+
+    return lstsqModular(A, B);
+  }
+
+  // Original GF(2) implementation
   // Solve the least square system AX = B
   // and return the least square solution X by computing RREF and setting
   // the free variables to zero.
   // A and B may not be surjective, but we assume that Im(B) \subset Im(A)
   // Sketch of the algorithm:
   // https://github.com/triton-lang/triton/pull/5309#discussion_r1869084111
-  int numRows = A.getTotalOutDimSizeLog2();
-  assert(numRows >= B.getTotalOutDimSizeLog2() &&
+  int numRows = A.getTotalOutDimSizeBits();
+  assert(numRows >= B.getTotalOutDimSizeBits() &&
          "A.lstsq(B) called with incompatible output shapes");
   int numColsA = A.getTotalInDimSizeLog2();
   int numColsB = B.getTotalInDimSizeLog2();
@@ -1017,8 +1430,6 @@ LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B) {
   }
   return retFlattened.reshapeIns(retInDims).reshapeOuts(retOutDims);
 }
-
-} // namespace
 
 LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   // TODO(Lezcano) Make friend and perhaps rename to `convertFrom` or `lstsq`
@@ -1085,12 +1496,77 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
 
   auto ret = isEmpty ? LinearLayout::empty() : lstsq(AReduced, BReduced);
 
+  // --- NPOT kernel equivalence fix ---
+  //
+  // For NPOT modular layouts with pure modular solving (no shear family),
+  // the lstsq result maps into A's input space of size 2^k, but A's output
+  // has only N < 2^k distinct values. Multiple inputs mapping to the same
+  // output (kernel elements) may get different result values. Reducing the
+  // output dim from 2^k to N folds kernel elements via mod-N arithmetic.
+  //
+  // The replacement layout declares its output dim as the NPOT size N, which
+  // makes it a modular layout: subsequent apply() calls use ADD+mod (Z/N)
+  // instead of XOR. This is why we only require each reduced basis to be a
+  // pow2 or zero (condition 1) and rely on the reachability check at the
+  // end (A(x) == A(x mod N) for all x) to validate the fold. We deliberately
+  // do NOT enforce the stricter pairwise-disjoint / XOR-sum-in-[0,N)
+  // conditions used by tryReduceBasesModN in TritonGPUToLLVM/Utility.cpp:
+  // those guard XOR-based SMEM emission, where the layout is later combined
+  // via XOR; here the resulting layout is itself modular, so XOR-overlap
+  // semantics are not in play. See the kernel-equivalence tests
+  // (PseudoinvertModular_KernelEquivalence,
+  // InvertAndCompose_KernelEquivalence_Store) for the cases (e.g. N=48)
+  // where the looser check is necessary.
+  if (!isEmpty && AReduced.isModular() && ret.getNumOutDims() == 1) {
+    int64_t effectiveOutSize = AReduced.getTotalOutDimSizeProduct();
+    int64_t totalInSize = AReduced.getTotalInDimSize();
+    if (effectiveOutSize < totalInSize) {
+      StringAttr outDim = *ret.getOutDimNames().begin();
+      int32_t N = static_cast<int32_t>(effectiveOutSize);
+
+      LinearLayout::BasesT npotBases;
+      bool basesNonOverlapping = true;
+      for (auto &[inDim, inDimBases] : ret.getBases()) {
+        auto &newBases = npotBases[inDim];
+        for (auto &basis : inDimBases) {
+          int32_t val = basis[0] % N;
+          newBases.push_back({val});
+          if (val != 0 && !llvm::isPowerOf2_32(val))
+            basesNonOverlapping = false;
+        }
+      }
+
+      if (basesNonOverlapping) {
+        auto AFlat = AReduced.flattenIns();
+        StringAttr aIn = *AFlat.getInDimNames().begin();
+        bool valid = true;
+        // O(2^k) where k = ceil(log2(N)) for NPOT dim N. K=48 gives 16
+        // iterations, K=96 gives 32. Max ~100 for any planned shape.
+        // Triple-guarded by iteration cap, convergence check, and result
+        // validation.
+        for (int x = N; x < AFlat.getTotalInDimSize() && valid; x++) {
+          if (AFlat.apply({{aIn, x}}) != AFlat.apply({{aIn, x % N}}))
+            valid = false;
+        }
+        if (valid) {
+          ret = LinearLayout(std::move(npotBases), {{outDim, N}},
+                             /*requireSurjective=*/false);
+        }
+      }
+    }
+  }
+
   // TODO(Lezcano): We should return the reduced layout instead of re-adding the
   // identity maps. With this, we'll be able to kill `minimalCvtLayout`
 
   // Add the identity maps for the dimensions that are the same for both layouts
   for (auto dim : identityDims) {
-    ret *= LinearLayout::identity1D(A.getInDimSize(dim), dim, dim);
+    auto size = A.getInDimSize(dim);
+    if (llvm::isPowerOf2_32(size)) {
+      ret *= LinearLayout::identity1D(size, dim, dim);
+    } else {
+      ret *= LinearLayout::modularIdentity1D(size, dim, dim);
+    }
   }
 
   // Reorder the dimensions in the result to match the order expected by the
@@ -1108,7 +1584,12 @@ LinearLayout LinearLayout::invert() const {
 LinearLayout LinearLayout::pseudoinvert() const {
   LinearLayout identity = LinearLayout::empty();
   for (auto outDim : getOutDimNames()) {
-    identity *= LinearLayout::identity1D(getOutDimSize(outDim), outDim, outDim);
+    auto size = getOutDimSize(outDim);
+    if (llvm::isPowerOf2_32(size)) {
+      identity *= LinearLayout::identity1D(size, outDim, outDim);
+    } else {
+      identity *= LinearLayout::modularIdentity1D(size, outDim, outDim);
+    }
   }
   return identity.invertAndCompose(*this);
 }
@@ -1137,8 +1618,30 @@ LinearLayout LinearLayout::unsqueezeOut(StringAttr dim) const {
 
 llvm::MapVector<StringAttr, int32_t>
 LinearLayout::getFreeVariableMasks() const {
+  // For modular layouts, GF(2) RREF is algebraically wrong (Z/N null space !=
+  // GF(2) null space). Use conservative zero-basis check instead.
+  if (isModular()) {
+    llvm::MapVector<StringAttr, int32_t> ret;
+    for (StringAttr inDim : getInDimNames()) {
+      int32_t mask = 0;
+      for (int i = 0; i < getInDimSizeLog2(inDim); i++) {
+        bool allZero = true;
+        for (StringAttr outDim : getOutDimNames()) {
+          if (getBasis(inDim, i, outDim) != 0) {
+            allZero = false;
+            break;
+          }
+        }
+        if (allZero)
+          mask |= (1 << i);
+      }
+      ret[inDim] = mask;
+    }
+    return ret;
+  }
+
   std::unique_ptr<uint64_t[]> mat = getMatrix(*this);
-  int numRows = getTotalOutDimSizeLog2();
+  int numRows = getTotalOutDimSizeBits();
   int numCols = getTotalInDimSizeLog2();
 
   // stride is specified in number of 64-bit words per row, and we pack our
@@ -1354,13 +1857,15 @@ std::string ColumnAction::toString() const {
   return ret;
 }
 
-// Build a matrix of size sum(outDimSizeLog2) x sum(inDimSizeLog2) representing
+// Build a matrix of size sum(outDimSizeBits) x sum(inDimSizeLog2) representing
 // the bases of the given layout.  This can then be used by f2reduce.
 //
 // This function is called from the constructor of LinearLayout, so be careful
 // not to use any functions that create LLs in here.
-std::unique_ptr<uint64_t[]> getMatrix(const LinearLayout &layout) {
-  int numRows = layout.getTotalOutDimSizeLog2();
+std::unique_ptr<uint64_t[]>
+LinearLayout::getMatrix(const LinearLayout &layout) {
+  // For NPOT dimensions, use ceil(log2) to avoid truncating high-order bits
+  int numRows = layout.getTotalOutDimSizeBits();
   int numCols = layout.getTotalInDimSizeLog2();
 
   // Don't handle giant LLs.  This makes some things easier; for example, each
@@ -1392,13 +1897,14 @@ std::unique_ptr<uint64_t[]> getMatrix(const LinearLayout &layout) {
     for (StringAttr inDim : layout.getInDimNames()) {
       for (int i = 0; i < layout.getInDimSizeLog2(inDim); i++) {
         uint64_t basis = layout.getBasis(inDim, i, outDim);
-        for (int j = 0; j < layout.getOutDimSizeLog2(outDim); j++) {
+        // Extract all bits needed for this dimension
+        for (int j = 0; j < layout.getOutDimSizeBits(outDim); j++) {
           m[r + j] |= ((basis >> j) & 1) << c;
         }
         c++;
       }
     }
-    r += layout.getOutDimSizeLog2(outDim);
+    r += layout.getOutDimSizeBits(outDim);
   }
 
   return m;

--- a/lib/Tools/ModularArithmetic.cpp
+++ b/lib/Tools/ModularArithmetic.cpp
@@ -1,0 +1,532 @@
+#include "triton/Tools/ModularArithmetic.h"
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <limits>
+#include <numeric>
+
+namespace mlir::triton {
+
+int64_t intPow(int64_t a, int b) {
+  assert(b >= 0 && "intPow requires non-negative exponent");
+  if (b == 0)
+    return 1;
+
+  int64_t result = 1;
+  int64_t base = a;
+
+  while (b > 0) {
+    if (b & 1) {
+      result *= base;
+    }
+    base *= base;
+    b >>= 1;
+  }
+
+  return result;
+}
+
+// gcd(0,0) returns {0, 0, 0} by convention. INT64_MIN inputs are rejected
+// (also returning {0, 0, 0}) because |INT64_MIN| does not fit in int64_t,
+// so std::abs(INT64_MIN) would be undefined behavior. Callers expecting to
+// operate at the bit-width limit should pre-check.
+ExtGCDResult extendedGCD(int64_t a, int64_t b) {
+  if (a == std::numeric_limits<int64_t>::min() ||
+      b == std::numeric_limits<int64_t>::min()) {
+    return {0, 0, 0};
+  }
+  bool a_neg = a < 0;
+  bool b_neg = b < 0;
+  a = std::abs(a);
+  b = std::abs(b);
+
+  if (a == 0) {
+    return {b, 0, b_neg ? -1 : 1};
+  }
+  if (b == 0) {
+    return {a, a_neg ? -1 : 1, 0};
+  }
+
+  // Iterative extended GCD maintaining r_i = s_i * a + t_i * b
+  int64_t r0 = a, r1 = b;
+  int64_t s0 = 1, s1 = 0;
+  int64_t t0 = 0, t1 = 1;
+
+  while (r1 != 0) {
+    int64_t q = r0 / r1;
+
+    int64_t r_new = r0 - q * r1;
+    r0 = r1;
+    r1 = r_new;
+
+    int64_t s_new = s0 - q * s1;
+    s0 = s1;
+    s1 = s_new;
+
+    int64_t t_new = t0 - q * t1;
+    t0 = t1;
+    t1 = t_new;
+  }
+
+  int64_t x = a_neg ? -s0 : s0;
+  int64_t y = b_neg ? -t0 : t0;
+
+  return {r0, x, y};
+}
+
+std::optional<int64_t> modInverse(int64_t a, int64_t m) {
+  if (m <= 0)
+    return std::nullopt;
+
+  a = ((a % m) + m) % m;
+  if (a == 0)
+    return std::nullopt;
+
+  auto result = extendedGCD(a, m);
+  if (result.gcd != 1) {
+    return std::nullopt;
+  }
+
+  int64_t inv = ((result.x % m) + m) % m;
+  return inv;
+}
+
+namespace {
+// Returns true iff the moduli are pairwise coprime (gcd == 1 for every pair).
+// Used only to validate the solveCRT precondition under assert().
+bool arePairwiseCoprime(const std::vector<int64_t> &moduli) {
+  for (size_t i = 0; i < moduli.size(); ++i)
+    for (size_t j = i + 1; j < moduli.size(); ++j)
+      if (std::gcd(moduli[i], moduli[j]) != 1)
+        return false;
+  return true;
+}
+} // namespace
+
+std::optional<CRTResult> solveCRT(const std::vector<int64_t> &remainders,
+                                  const std::vector<int64_t> &moduli) {
+  if (remainders.size() != moduli.size() || remainders.empty()) {
+    return std::nullopt;
+  }
+
+  size_t n = moduli.size();
+
+  for (auto m : moduli) {
+    if (m <= 0) {
+      return std::nullopt;
+    }
+  }
+
+  // Pairwise coprimality is a precondition; callers ensure via factorization.
+  assert(arePairwiseCoprime(moduli) &&
+         "solveCRT requires pairwise coprime moduli");
+
+  // NB: M can overflow int64 when the product of moduli exceeds ~3e9 (squared
+  // fits in int64). Callers must ensure moduli come from layout dimensions
+  // which are bounded well below this in practice.
+  int64_t M = 1;
+  for (auto m : moduli) {
+    M *= m;
+  }
+
+  // CRT: x = Σ(r_i * M_i * y_i) mod M, where M_i = M/m_i, y_i = M_i^{-1} mod
+  // m_i
+  int64_t solution = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    int64_t m_i = moduli[i];
+    int64_t r_i = ((remainders[i] % m_i) + m_i) % m_i;
+    int64_t M_i = M / m_i;
+
+    auto y_i_opt = modInverse(M_i, m_i);
+    if (!y_i_opt.has_value()) {
+      return std::nullopt;
+    }
+    int64_t y_i = y_i_opt.value();
+
+    int64_t term = ((r_i % M) * (M_i % M)) % M;
+    term = (term * y_i) % M;
+    solution = (solution + term) % M;
+  }
+
+  solution = ((solution % M) + M) % M;
+  return CRTResult{solution, M};
+}
+
+void ModMatrix::normalize() {
+  // Z/N arithmetic requires modulus > 0 (see ModMatrix invariant); assert here
+  // so misuse fails loudly before the % operations below.
+  assert(modulus > 0 && "ModMatrix modulus must be positive");
+  for (auto &val : data) {
+    val = ((val % modulus) + modulus) % modulus;
+  }
+}
+
+int modRREF(ModMatrix &mat) {
+  int64_t mod = mat.modulus;
+  int rows = mat.rows;
+  int cols = mat.cols;
+
+  // Normalize all entries first
+  mat.normalize();
+
+  int pivotRow = 0;
+
+  for (int col = 0; col < cols && pivotRow < rows; ++col) {
+    // Find pivot: row with non-zero entry in this column
+    int bestPivot = -1;
+    for (int r = pivotRow; r < rows; ++r) {
+      if (mat.at(r, col) % mod != 0) {
+        // Prefer entries coprime to mod (invertible)
+        if (std::gcd(mat.at(r, col), mod) == 1) {
+          bestPivot = r;
+          break;
+        }
+        if (bestPivot == -1) {
+          bestPivot = r;
+        }
+      }
+    }
+
+    if (bestPivot == -1) {
+      // No pivot in this column, move to next column
+      continue;
+    }
+
+    // Swap rows to bring pivot to pivotRow
+    if (bestPivot != pivotRow) {
+      for (int c = 0; c < cols; ++c) {
+        std::swap(mat.at(pivotRow, c), mat.at(bestPivot, c));
+      }
+    }
+
+    // Get the pivot value
+    int64_t pivotVal = mat.at(pivotRow, col);
+
+    // Try to get modular inverse
+    auto invOpt = modInverse(pivotVal, mod);
+
+    if (!invOpt.has_value()) {
+      // Pivot is not invertible — can't reduce this column.
+      // Swap the row back and skip without advancing pivotRow.
+      if (bestPivot != pivotRow) {
+        for (int c = 0; c < cols; ++c) {
+          std::swap(mat.at(pivotRow, c), mat.at(bestPivot, c));
+        }
+      }
+      continue;
+    }
+
+    int64_t pivotInv = invOpt.value();
+
+    // Scale pivot row to make pivot = 1
+    for (int c = 0; c < cols; ++c) {
+      mat.at(pivotRow, c) = (mat.at(pivotRow, c) * pivotInv) % mod;
+    }
+
+    // Eliminate all other rows in this column
+    for (int r = 0; r < rows; ++r) {
+      if (r == pivotRow)
+        continue;
+
+      int64_t factor = mat.at(r, col);
+      if (factor == 0)
+        continue;
+
+      // Subtract factor * pivotRow from row r
+      for (int c = 0; c < cols; ++c) {
+        int64_t val = mat.at(r, c) - factor * mat.at(pivotRow, c);
+        mat.at(r, c) = ((val % mod) + mod) % mod;
+      }
+    }
+
+    pivotRow++;
+  }
+
+  return pivotRow;
+}
+
+// NB: The `modulus` parameter is the modulus used for the solve, which may
+// differ from A.modulus (the modulus A was originally constructed with).
+// Callers (e.g. modSolveLinearCRT) re-reduce A's entries mod the new modulus.
+std::vector<int64_t> modSolveLinear(const ModMatrix &A,
+                                    const std::vector<int64_t> &b,
+                                    int64_t modulus) {
+  int n = A.rows;
+  int m = A.cols;
+
+  if (static_cast<int>(b.size()) != n) {
+    return {}; // Size mismatch
+  }
+
+  // Z/N arithmetic is only defined for N > 0. The downstream % modulus
+  // operations would otherwise crash (modulus == 0) or produce ill-defined
+  // results (modulus < 0).
+  if (modulus <= 0) {
+    return {};
+  }
+
+  // Create augmented matrix [A | b]
+  ModMatrix aug(n, m + 1, modulus);
+
+  // Copy A, reducing mod the target modulus
+  for (int r = 0; r < n; ++r) {
+    for (int c = 0; c < m; ++c) {
+      aug.at(r, c) = ((A.at(r, c) % modulus) + modulus) % modulus;
+    }
+  }
+
+  // Copy b
+  for (int r = 0; r < n; ++r) {
+    aug.at(r, m) = ((b[r] % modulus) + modulus) % modulus;
+  }
+
+  // Perform RREF
+  modRREF(aug);
+
+  // Check for inconsistent system (0 = c where c != 0)
+  for (int r = 0; r < n; ++r) {
+    bool rowIsZero = true;
+    for (int c = 0; c < m; ++c) {
+      if (aug.at(r, c) != 0) {
+        rowIsZero = false;
+        break;
+      }
+    }
+    if (rowIsZero && aug.at(r, m) != 0) {
+      // Inconsistent: 0 = aug.at(r, m) where aug.at(r, m) != 0
+      return {};
+    }
+  }
+
+  // Extract solution
+  std::vector<int64_t> x(m, 0);
+
+  for (int r = 0; r < n; ++r) {
+    // Find leading 1 in this row
+    int leadCol = -1;
+    for (int c = 0; c < m; ++c) {
+      if (aug.at(r, c) != 0) {
+        leadCol = c;
+        break;
+      }
+    }
+
+    if (leadCol >= 0) {
+      // Should be 1 after RREF, but normalize anyway
+      x[leadCol] = aug.at(r, m);
+    }
+  }
+
+  return x;
+}
+
+// Solve Ax = b (mod p^e) by solving mod p then lifting each power via
+// residual correction: r = (b - Ax) / p^k, delta = A^{-1} r (mod p).
+// NB: intermediate products can overflow int64 for large matrices or high
+// prime powers; layout dimensions keep values small enough in practice.
+std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
+                                          const std::vector<int64_t> &b,
+                                          int64_t prime, int exponent) {
+  int n = A.rows;
+  int m = A.cols;
+
+  if (static_cast<int>(b.size()) != n) {
+    return {};
+  }
+
+  if (exponent < 1) {
+    return {};
+  }
+
+  // Hensel lifting requires a genuine prime modulus base (prime >= 2). A base
+  // of 0 or 1 is not a valid prime: prime == 1 makes every modulus prime^k == 1
+  // (Z/1 is trivial), so modSolveLinear mod 1 yields the all-zero "solution"
+  // and the per-power lift never makes progress -- and `p_k *= prime` stays
+  // stuck at 1, so callers that loop until p_k reaches the modulus would spin
+  // forever. Reject prime < 2 up front rather than return a meaningless result
+  // or risk a non-terminating lift.
+  if (prime < 2) {
+    return {};
+  }
+
+  // modulus = prime^exponent. We accumulate sums of products A[r,c] * x[c]
+  // in int64; both factors are < modulus after reduction. To stay safe we
+  // require modulus <= 2^31 so that products fit in int64 and the per-row
+  // accumulation across m columns can't wrap (m bounded by tensor rank,
+  // well under 1000 in practice). Triton's layout-derived moduli stay
+  // below 2^20, so this leaves ~11 bits of headroom.
+  int64_t modulus = intPow(prime, exponent);
+  assert(modulus <= (int64_t{1} << 31) &&
+         "modSolveLinearHensel: modulus too large; "
+         "accumulation may overflow int64");
+  (void)modulus;
+
+  std::vector<int64_t> x_k = modSolveLinear(A, b, prime);
+  if (x_k.empty()) {
+    return {};
+  }
+
+  if (exponent == 1) {
+    return x_k;
+  }
+
+  int64_t p_k = prime;
+
+  for (int k = 2; k <= exponent; ++k) {
+    std::vector<int64_t> residual(n);
+
+    for (int r = 0; r < n; ++r) {
+      int64_t ax_r = 0;
+      for (int c = 0; c < m; ++c) {
+        ax_r += A.at(r, c) * x_k[c];
+      }
+
+      int64_t diff = b[r] - ax_r;
+      if (diff % p_k != 0) {
+        return {};
+      }
+      residual[r] = diff / p_k;
+    }
+
+    std::vector<int64_t> delta = modSolveLinear(A, residual, prime);
+    if (delta.empty()) {
+      return {};
+    }
+
+    for (int i = 0; i < m; ++i) {
+      x_k[i] += p_k * delta[i];
+    }
+
+    p_k *= prime;
+  }
+
+  int64_t p_e = intPow(prime, exponent);
+  for (auto &val : x_k) {
+    val = ((val % p_e) + p_e) % p_e;
+  }
+
+  return x_k;
+}
+
+std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
+                                       const std::vector<int64_t> &b,
+                                       int64_t modulus) {
+  int n = A.rows;
+  int m = A.cols;
+
+  if (static_cast<int>(b.size()) != n) {
+    return {};
+  }
+
+  // modulus must be a positive integer for Z/N arithmetic to be defined.
+  // factorize(0) returns no factors, which would leave moduli/subsolutions
+  // empty and silently fail at the per-variable solveCRT step. Negative
+  // moduli are similarly ill-defined.
+  if (modulus <= 0) {
+    return {};
+  }
+
+  if (modulus == 1) {
+    return std::vector<int64_t>(m, 0);
+  }
+
+  PrimeFactorization factors = factorize(modulus);
+
+  std::vector<std::vector<int64_t>> subsolutions;
+  std::vector<int64_t> moduli;
+
+  for (const auto &[p, e] : factors.factors) {
+    int64_t mod_i = intPow(p, e);
+    moduli.push_back(mod_i);
+
+    ModMatrix A_i(n, m, mod_i);
+    std::vector<int64_t> b_i(n);
+
+    for (int r = 0; r < n; ++r) {
+      for (int c = 0; c < m; ++c) {
+        A_i.at(r, c) = ((A.at(r, c) % mod_i) + mod_i) % mod_i;
+      }
+      b_i[r] = ((b[r] % mod_i) + mod_i) % mod_i;
+    }
+
+    std::vector<int64_t> x_i;
+    if (e == 1) {
+      x_i = modSolveLinear(A_i, b_i, p);
+    } else {
+      x_i = modSolveLinearHensel(A_i, b_i, p, e);
+    }
+
+    if (x_i.empty()) {
+      return {};
+    }
+
+    subsolutions.push_back(x_i);
+  }
+
+  std::vector<int64_t> x(m);
+
+  for (int var = 0; var < m; ++var) {
+    std::vector<int64_t> remainders;
+    for (const auto &sol : subsolutions) {
+      remainders.push_back(sol[var]);
+    }
+
+    auto crt_result = solveCRT(remainders, moduli);
+    if (!crt_result.has_value()) {
+      return {};
+    }
+
+    x[var] = crt_result->solution;
+  }
+
+  return x;
+}
+
+int64_t PrimeFactorization::product() const {
+  int64_t result = 1;
+  for (const auto &[prime, exp] : factors)
+    result *= intPow(prime, exp);
+  return result;
+}
+
+PrimeFactorization factorize(int64_t n) {
+  // Trial division O(sqrt(n)); for Triton's bounded moduli (typically < 2^20)
+  // this completes in microseconds.
+  PrimeFactorization result;
+
+  if (n <= 1) {
+    return result;
+  }
+
+  // Handle factor of 2
+  int exp2 = 0;
+  while (n % 2 == 0) {
+    exp2++;
+    n /= 2;
+  }
+  if (exp2 > 0) {
+    result.factors.push_back({2, exp2});
+  }
+
+  // Handle odd factors
+  for (int64_t i = 3; i * i <= n; i += 2) {
+    int exp = 0;
+    while (n % i == 0) {
+      exp++;
+      n /= i;
+    }
+    if (exp > 0) {
+      result.factors.push_back({i, exp});
+    }
+  }
+
+  // If n > 1, then it's a prime factor
+  if (n > 1) {
+    result.factors.push_back({n, 1});
+  }
+
+  return result;
+}
+
+} // namespace mlir::triton

--- a/python/src/linear_layout.cc
+++ b/python/src/linear_layout.cc
@@ -209,8 +209,8 @@ void init_linear_layout(py::module &&m) {
           },
           py::arg("inputs"))
       .def("get_matrix_view", [](const LinearLayout &self) {
-        std::unique_ptr<uint64_t[]> matrix = mlir::triton::getMatrix(self);
-        auto nRows = self.getTotalOutDimSizeLog2();
+        std::unique_ptr<uint64_t[]> matrix = self.getGF2Matrix();
+        auto nRows = self.getTotalOutDimSizeBits();
         auto nCols = self.getTotalInDimSizeLog2();
         std::vector<std::vector<int>> result(nRows, std::vector<int>(nCols));
         for (size_t i = 0; i < nRows; ++i) {

--- a/unittest/Tools/CMakeLists.txt
+++ b/unittest/Tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_triton_ut(
 	NAME LinearLayout
-	SRCS LayoutUtilsTest.cpp LinearLayoutTest.cpp
+	SRCS LayoutUtilsTest.cpp LinearLayoutTest.cpp ModularArithmeticTest.cpp
 	LIBS TritonTools
 )

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -5,6 +5,7 @@
 #include "llvm/Support/Signals.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <set>
 
 namespace mlir {
 std::ostream &operator<<(std::ostream &os, StringAttr str) {
@@ -186,7 +187,6 @@ TEST_F(LinearLayoutTest, TransposeIns) {
 }
 
 TEST_F(LinearLayoutTest, EmptyToString) {
-  // Mostly I just want to make sure it doesn't crash.
   EXPECT_EQ(LinearLayout::empty().toString(), "\n(empty layout)");
 }
 
@@ -603,6 +603,32 @@ TEST_F(LinearLayoutTest, InvertAndCompose_IdentityInDim) {
   EXPECT_EQ(dst.apply(k), src.apply(cvt.apply(k)));
 }
 
+// Test invertAndCompose with non-power-of-2 dimensions
+// Exercises the modular CRT-based least-squares solver path
+TEST_F(LinearLayoutTest, InvertAndCompose_NonPow2) {
+  // Create a simple layout with dimension 3 (non-pow2)
+  // Layout A: maps in1 -> out (dimension 3)
+  // Bases: 1, 1 (mod 3: 0->0, 1->1, 2->1, 3->2)
+  LinearLayout A({{S("in1"), {{1}, {1}}}}, {{S("out"), 3}},
+                 /*requireSurjective=*/false);
+
+  // Layout B: maps in2 -> out (dimension 3)
+  // Bases: 2, 1 (mod 3: 0->0, 1->2, 2->1, 3->0)
+  LinearLayout B({{S("in2"), {{2}, {1}}}}, {{S("out"), 3}},
+                 /*requireSurjective=*/false);
+
+  // Compute X = A.invertAndCompose(B)
+  // X should map in1's inputs to in2's inputs such that X ∘ B = A
+  LinearLayout X = A.invertAndCompose(B);
+
+  // Verify the composition property: X ∘ B = A
+  EXPECT_EQ(X.compose(B), A);
+
+  // The result should have in1 as inputs and in2 as outputs
+  EXPECT_THAT(to_vector(X.getInDimNames()), ElementsAre(S("in1")));
+  EXPECT_THAT(to_vector(X.getOutDimNames()), ElementsAre(S("in2")));
+}
+
 TEST_F(LinearLayoutTest, NumConsecutiveInOut) {
   EXPECT_EQ(
       1,
@@ -631,6 +657,24 @@ TEST_F(LinearLayoutTest, NumConsecutiveInOut) {
                        {S("in2"), {{8}, {18}}},
                    },
                    {S("out")})
+                   .getNumConsecutiveInOut());
+
+  // NPOT modular layouts: clamp to largest pow2 dividing N.
+  EXPECT_EQ(2, LinearLayout::modularIdentity1D(6, S("in"), S("out"))
+                   .getNumConsecutiveInOut());
+  EXPECT_EQ(1, LinearLayout::modularIdentity1D(5, S("in"), S("out"))
+                   .getNumConsecutiveInOut());
+  EXPECT_EQ(4, LinearLayout::modularIdentity1D(12, S("in"), S("out"))
+                   .getNumConsecutiveInOut());
+  EXPECT_EQ(1, LinearLayout::modularIdentity1D(15, S("in"), S("out"))
+                   .getNumConsecutiveInOut());
+  // Multi-dim: NPOT first out-dim gets clamped.
+  EXPECT_EQ(2, (LinearLayout::modularIdentity1D(6, S("in1"), S("out1")) *
+                LinearLayout::identity1D(8, S("in2"), S("out2")))
+                   .getNumConsecutiveInOut());
+  // Mixed: pow2 first out-dim, NPOT second — no clamp on pow2.
+  EXPECT_EQ(4, (LinearLayout::identity1D(4, S("in1"), S("out1")) *
+                LinearLayout::modularIdentity1D(6, S("in2"), S("out2")))
                    .getNumConsecutiveInOut());
 }
 
@@ -713,6 +757,16 @@ TEST_F(LinearLayoutTest, FreeVariableMasks) {
                                       {S("out1"), S("out2")})
                              .getFreeVariableMasks())),
             AR({{S("in1"), 0b100}, {S("in2"), 0b10}}));
+
+  // Modular layout: no zero bases → no free variables.
+  EXPECT_EQ(AR(to_vector(LinearLayout::modularIdentity1D(6, S("in"), S("out"))
+                             .getFreeVariableMasks())),
+            AR({{S("in"), 0}}));
+
+  // Modular layout: stride=3, size=6 → bases [3, 0, 0] → bits 1,2 are free.
+  EXPECT_EQ(AR(to_vector(LinearLayout::modularStrided1D(6, 3, S("in"), S("out"))
+                             .getFreeVariableMasks())),
+            AR({{S("in"), 0b110}}));
 }
 
 TEST_F(LinearLayoutTest, QuotientOneDimension) {
@@ -1093,6 +1147,38 @@ TEST_F(LinearLayoutTest, Divide_EliminateOutDim) {
   EXPECT_EQ(divideRight(l4, l5).value(), l6);
 }
 
+TEST_F(LinearLayoutTest, Divide_Modular) {
+  // Case 1: modular(6) * modular(4), both left and right
+  {
+    auto B = LinearLayout::modularStrided1D(6, 1, S("in"), S("out"));
+    auto C = LinearLayout::modularStrided1D(4, 1, S("in"), S("out"));
+    auto A = B * C;
+    ASSERT_TRUE(divideLeft(A, B).has_value());
+    EXPECT_EQ(divideLeft(A, B).value(), C);
+    ASSERT_TRUE(divideRight(A, C).has_value());
+    EXPECT_EQ(divideRight(A, C).value(), B);
+  }
+
+  // Case 2: mixed NPOT * pow2 (size 96 = 6 * 16)
+  {
+    auto B = LinearLayout::modularStrided1D(6, 1, S("in"), S("out"));
+    auto C = LinearLayout::identity1D(16, S("in"), S("out"));
+    auto A = B * C;
+    EXPECT_EQ(divideLeft(A, B).value(), C);
+    EXPECT_EQ(divideRight(A, C).value(), B);
+  }
+}
+
+TEST_F(LinearLayoutTest, Divide_Modular_2D_Mixed) {
+  auto B = LinearLayout::identity1D(4, S("in"), S("out1")) *
+           LinearLayout::modularStrided1D(3, 1, S("in2"), S("out2"));
+  auto C = LinearLayout::identity1D(2, S("in"), S("out1")) *
+           LinearLayout::modularStrided1D(5, 1, S("in2"), S("out2"));
+  auto A = B * C;
+  EXPECT_EQ(divideLeft(A, B).value(), C);
+  EXPECT_EQ(divideRight(A, C).value(), B);
+}
+
 TEST_F(LinearLayoutTest, ColumnActionApplyLayout) {
   // Create a simple LinearLayout with one input dimension "in" and one output
   // "out". The original bases for "in" are: [{1}, {2}, {4}]. According to the
@@ -1160,6 +1246,787 @@ TEST_F(LinearLayoutTest, ColumnActionApplyValues) {
 
   expected = std::vector<intptr_t>{1, 5, 3, 7};
   EXPECT_EQ(result, expected);
+}
+
+//===----------------------------------------------------------------------===//
+// Modular (Non-Power-of-2) Layout Tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(LinearLayoutTest, ModularStrided1D_Size3) {
+  // Test modularStrided1D with size=3 (smallest non-pow2)
+  LinearLayout layout = LinearLayout::modularStrided1D(3, 1, S("in"), S("out"));
+
+  // Should be marked as modular
+  EXPECT_TRUE(layout.isModular());
+
+  // Should have ceil(log2(3)) = 2 bases
+  EXPECT_EQ(layout.getInDimSizeLog2(S("in")), 2);
+
+  // Bases should be: (1*1) % 3 = 1, (1*2) % 3 = 2
+  EXPECT_EQ(layout.getBasis(S("in"), 0, S("out")), 1);
+  EXPECT_EQ(layout.getBasis(S("in"), 1, S("out")), 2);
+
+  // Output dimension should be size 3
+  EXPECT_EQ(layout.getOutDimSize(S("out")), 3);
+
+  // Check surjectivity: should cover all values 0, 1, 2
+  EXPECT_TRUE(layout.isModularSurjective());
+}
+
+TEST_F(LinearLayoutTest, ModularStrided1D_WithStride) {
+  // Test modularStrided1D with stride != 1
+  LinearLayout layout = LinearLayout::modularStrided1D(6, 2, S("in"), S("out"));
+
+  EXPECT_TRUE(layout.isModular());
+  EXPECT_EQ(layout.getInDimSizeLog2(S("in")), 3); // ceil(log2(6))
+
+  // Bases should be: (2*1) % 6 = 2, (2*2) % 6 = 4, (2*4) % 6 = 2
+  EXPECT_EQ(layout.getBasis(S("in"), 0, S("out")), 2);
+  EXPECT_EQ(layout.getBasis(S("in"), 1, S("out")), 4);
+  EXPECT_EQ(layout.getBasis(S("in"), 2, S("out")), 2);
+  EXPECT_EQ(layout.getOutDimSize(S("out")), 6);
+
+  // Test stride 5, size 6: L(x) = 5x mod 6 (gcd(5,6) = 1, surjective)
+  LinearLayout stride5_6 =
+      LinearLayout::modularStrided1D(6, 5, S("in"), S("out"));
+  EXPECT_TRUE(stride5_6.isModular());
+  EXPECT_TRUE(stride5_6.isSurjective());
+  EXPECT_THAT(to_vector(stride5_6.getInDimNames()), ElementsAre(S("in")));
+  EXPECT_THAT(to_vector(stride5_6.getOutDimNames()), ElementsAre(S("out")));
+}
+
+// ============================================================================
+// CRT-based invertAndCompose tests (for non-power-of-2 dimensions)
+// These tests exercise the CRT least-squares solver path.
+// ============================================================================
+
+TEST_F(LinearLayoutTest, InvertAndCompose_Modular_MultiDim_LCM) {
+  // Test that lstsqModular uses LCM instead of max for multiple NPOT output
+  // dims This is a regression test for NPOT-I1: lstsqModular was using
+  // max(outDimSizes) as working modulus, which is incorrect for
+  // multi-output-dim layouts where dims have different NPOT sizes. The correct
+  // modulus is LCM(outDimSizes).
+
+  // Create layout A with 2 output dimensions: size 6 and size 10
+  // LCM(6, 10) = 30, max(6, 10) = 10
+  LinearLayout::BasesT basesA;
+  auto &bsA = basesA[S("in")];
+  bsA.push_back({1, 0}); // bit 0: +1 to out0
+  bsA.push_back({2, 0}); // bit 1: +2 to out0
+  bsA.push_back({4, 0}); // bit 2: +4 to out0
+  bsA.push_back({0, 1}); // bit 3: +1 to out1
+  bsA.push_back({0, 2}); // bit 4: +2 to out1
+  bsA.push_back({0, 4}); // bit 5: +4 to out1
+  bsA.push_back({0, 8}); // bit 6: +8 to out1
+
+  llvm::SmallVector<std::pair<StringAttr, int32_t>> outDims;
+  outDims.push_back({S("out0"), 6});
+  outDims.push_back({S("out1"), 10});
+
+  LinearLayout A(std::move(basesA), outDims, false);
+
+  // Create layout B: subset of A
+  LinearLayout::BasesT basesB;
+  auto &bsB = basesB[S("in")];
+  bsB.push_back({1, 0});
+  bsB.push_back({2, 0});
+  bsB.push_back({4, 0});
+  bsB.push_back({0, 1});
+  bsB.push_back({0, 2});
+
+  LinearLayout B(std::move(basesB), outDims, false);
+
+  // Invert and compose - should use LCM(6, 10) = 30 as working modulus
+  LinearLayout result = A.invertAndCompose(B);
+
+  // Verify correctness: result should map B's inputs to A's inputs such that
+  // A(result(i)) = B(i) for all inputs i in B's domain
+  for (int i = 0; i < (1 << B.getTotalInDimSizeLog2()); ++i) {
+    auto b_out = B.apply({{S("in"), i}});
+    auto result_in = result.apply({{S("in"), i}});
+    auto actual = A.apply({{S("in"), result_in[0].second}});
+
+    EXPECT_EQ(actual, b_out)
+        << "Mismatch at i=" << i << ": B gives (" << b_out[0].second << ","
+        << b_out[1].second << "), A(result(i)) gives (" << actual[0].second
+        << "," << actual[1].second << ")";
+  }
+}
+
+// Test multi-dimensional NPOT layouts
+TEST_F(LinearLayoutTest, IsModularSurjectiveMultiDim) {
+  // Create a 2D layout with NPOT dimensions: 3x6
+  // out0: dim=3, out1: dim=6
+  LinearLayout::BasesT bases2D;
+  auto &inBases = bases2D[S("in")];
+
+  // Create bases for a surjective 2D layout
+  // For out0 (dim=3): bases [1, 2] mod 3 -> can reach {0, 1, 2}
+  // For out1 (dim=6): bases [1, 2, 4] mod 6 -> can reach all 6 values
+  inBases.push_back({1, 1}); // contributes 1 to out0, 1 to out1
+  inBases.push_back({2, 2}); // contributes 2 to out0, 2 to out1
+  inBases.push_back({0, 4}); // contributes 0 to out0, 4 to out1
+
+  LinearLayout layout2D(std::move(bases2D), {{S("out0"), 3}, {S("out1"), 6}},
+                        false);
+
+  EXPECT_TRUE(layout2D.isModular())
+      << "2D layout with dims 3x6 should be modular";
+  EXPECT_EQ(layout2D.getNumOutDims(), 2) << "Should have 2 output dimensions";
+  EXPECT_TRUE(layout2D.isModularSurjective())
+      << "2D modular layout should be surjective when both dimensions are "
+         "surjective";
+  EXPECT_TRUE(layout2D.isSurjective())
+      << "isSurjective() should dispatch to isModularSurjective() for "
+         "multi-dim NPOT";
+
+  // Test a non-surjective multi-dimensional layout
+  LinearLayout::BasesT basesNonSurj2D;
+  auto &inBases2 = basesNonSurj2D[S("in")];
+  // For out0 (dim=3): only basis [2] mod 3 -> can only reach {0, 2}, missing
+  // {1} For out1 (dim=6): bases [2, 4] mod 6 -> can only reach {0, 2, 4},
+  // missing odd values
+  inBases2.push_back({2, 2});
+  inBases2.push_back({0, 4});
+
+  LinearLayout layoutNonSurj2D(std::move(basesNonSurj2D),
+                               {{S("out0"), 3}, {S("out1"), 6}}, false);
+
+  EXPECT_TRUE(layoutNonSurj2D.isModular())
+      << "Non-surjective 2D layout should be modular";
+  EXPECT_FALSE(layoutNonSurj2D.isModularSurjective())
+      << "Non-surjective multi-dim layout should return false";
+}
+
+TEST_F(LinearLayoutTest, Pow2AdditiveSurjectivityRegression) {
+  // CORRECTNESS regression (T274241798 #1): apply() composes modular out-dims
+  // with ADD+mod, but checkPow2Surjectivity previously used a GF(2)/XOR-rank
+  // check. Bases {1,3,4,8} over out-dim size 12 are NON-surjective under
+  // ADD+mod — their subset sums reach only 9 of 12 values
+  // ({0,1,3,4,5,7,8,9,11}, missing {2,6,10}) — yet the XOR-rank check wrongly
+  // reported surjective.
+  LinearLayout layout({{S("in"), {{1}, {3}, {4}, {8}}}}, {{S("out"), 12}},
+                      /*requireSurjective=*/false);
+  EXPECT_TRUE(layout.isModular());
+
+  // Brute-force the actual reachable set under apply()'s ADD+mod semantics and
+  // confirm value 2 (among others) is unreachable.
+  std::set<int32_t> reachable;
+  for (int i = 0; i < (1 << layout.getInDimSizeLog2(S("in"))); ++i) {
+    reachable.insert(layout.apply({{S("in"), i}})[0].second);
+  }
+  EXPECT_EQ(reachable.size(), 9u);
+  EXPECT_EQ(reachable.count(2), 0u);
+
+  // The fix: surjectivity must agree with apply() and report NON-surjective.
+  EXPECT_FALSE(layout.isModularSurjective());
+  EXPECT_FALSE(layout.isSurjective());
+
+  // Sanity: a genuinely surjective modular layout still passes.
+  auto surj = LinearLayout::modularStrided1D(12, 1, S("in"), S("out"));
+  EXPECT_TRUE(surj.isModularSurjective());
+}
+
+TEST_F(LinearLayoutTest, SurjectivityTruncationRegression) {
+  // operator* with same inDim+outDim produces 6 non-zero bases for modulus 27,
+  // exceeding ceil(log2(27))=5. Old truncation gave false negative.
+  auto inner = LinearLayout::modularStrided1D(3, 1, S("A"), S("out"));
+  auto outer = LinearLayout::modularStrided1D(9, 1, S("A"), S("out"));
+  auto product = inner * outer;
+  EXPECT_EQ(product.getOutDimSize(S("out")), 27);
+  EXPECT_TRUE(product.isModularSurjective());
+}
+
+//===----------------------------------------------------------------------===//
+// Mixed-Shape Tests (pow2 + NPOT dims in the same layout)
+// Verifies that per-layout isModular is correct for mixed shapes.
+//===----------------------------------------------------------------------===//
+
+TEST_F(LinearLayoutTest, MixedShape_OperatorStar_SharedDim) {
+  // When inner and outer share an output dim, sizes multiply (not shift).
+  // inner: 4 -> dim0=4; outer: 6 -> dim0=6. Product should be 24, not 64.
+  auto inner = LinearLayout::identity1D(4, S("register"), S("dim0"));
+  auto outer = LinearLayout::modularStrided1D(6, 1, S("lane"), S("dim0"));
+  auto product = inner * outer;
+
+  EXPECT_EQ(product.getOutDimSize(S("dim0")), 24);
+  EXPECT_TRUE(product.isModular());
+
+  // Outer bases should be multiplied by inner size (4), not shifted.
+  // outer basis[0] = 1 -> product basis[2] = 1*4 = 4
+  // outer basis[1] = 2 -> product basis[3] = 2*4 = 8
+  // outer basis[2] = 4 -> product basis[4] = 4*4 = 16
+  EXPECT_EQ(product.getBasis(S("lane"), 0, S("dim0")), 4);
+  EXPECT_EQ(product.getBasis(S("lane"), 1, S("dim0")), 8);
+  EXPECT_EQ(product.getBasis(S("lane"), 2, S("dim0")), 16);
+}
+
+TEST_F(LinearLayoutTest, MixedShape_ReshapeOuts) {
+  // Flatten/unflatten roundtrip for mixed layout.
+  auto mixed = LinearLayout::identity1D(4, S("in"), S("dim0")) *
+               LinearLayout::modularStrided1D(6, 1, S("in2"), S("dim1"));
+
+  auto flat = mixed.flattenOuts();
+  EXPECT_EQ(flat.getOutDimSize(S("dim0")), 24);
+
+  // Verify that apply on the flattened layout matches mixed-radix encoding.
+  for (int r = 0; r < 4; ++r) {
+    for (int l = 0; l < 6; ++l) {
+      auto mixedResult = mixed.apply({{S("in"), r}, {S("in2"), l}});
+      auto flatResult = flat.apply({{S("in"), r}, {S("in2"), l}});
+      int expected = mixedResult[0].second + mixedResult[1].second * 4;
+      EXPECT_EQ(flatResult[0].second, expected) << "r=" << r << " l=" << l;
+    }
+  }
+}
+
+// invertAndCompose with mixed pow2 + NPOT output dims.
+// Exercises lstsqModular dispatch when only some dims are NPOT.
+TEST_F(LinearLayoutTest, InvertAndCompose_Mixed_Pow2AndNPOT) {
+  // Layout A: in(32) -> dim0(4, pow2) x dim1(6, NPOT)
+  LinearLayout::BasesT basesA;
+  auto &bsA = basesA[S("in")];
+  bsA.push_back({1, 0}); // bit 0: +1 to dim0
+  bsA.push_back({2, 0}); // bit 1: +2 to dim0
+  bsA.push_back({0, 1}); // bit 2: +1 to dim1
+  bsA.push_back({0, 2}); // bit 3: +2 to dim1
+  bsA.push_back({0, 4}); // bit 4: +4 to dim1
+
+  llvm::SmallVector<std::pair<StringAttr, int32_t>> outDims;
+  outDims.push_back({S("dim0"), 4});
+  outDims.push_back({S("dim1"), 6});
+  LinearLayout A(std::move(basesA), outDims, false);
+
+  // Layout B: in(16) -> dim0(4, pow2) x dim1(6, NPOT)
+  LinearLayout::BasesT basesB;
+  auto &bsB = basesB[S("in")];
+  bsB.push_back({1, 0}); // bit 0: +1 to dim0
+  bsB.push_back({2, 0}); // bit 1: +2 to dim0
+  bsB.push_back({0, 1}); // bit 2: +1 to dim1
+  bsB.push_back({0, 2}); // bit 3: +2 to dim1
+
+  LinearLayout B(std::move(basesB), outDims, false);
+
+  EXPECT_FALSE(A.isOutDimModular(S("dim0"))) << "dim0=4 is pow2";
+  EXPECT_TRUE(A.isOutDimModular(S("dim1"))) << "dim1=6 is NPOT";
+  EXPECT_TRUE(A.isModular()) << "mixed layout has NPOT dim";
+
+  LinearLayout result = A.invertAndCompose(B);
+
+  // Verify: A(result(i)) == B(i) for all i in B's domain
+  for (int i = 0; i < (1 << B.getTotalInDimSizeLog2()); ++i) {
+    auto b_out = B.apply({{S("in"), i}});
+    auto result_in = result.apply({{S("in"), i}});
+    auto actual = A.apply({{S("in"), result_in[0].second}});
+
+    EXPECT_EQ(actual, b_out)
+        << "Mismatch at i=" << i << ": B=(" << b_out[0].second << ","
+        << b_out[1].second << "), A(result(i))=(" << actual[0].second << ","
+        << actual[1].second << ")";
+  }
+}
+
+// Prove XOR and ADD diverge for NPOT dim, and layout picks the right algebra.
+TEST_F(LinearLayoutTest, MixedShape_XorVsAdd_Divergence) {
+  // dim0=8 (pow2, uses XOR), dim1=6 (NPOT, uses ADD+UREM)
+  auto pow2Part = LinearLayout::identity1D(8, S("in"), S("dim0"));
+  auto npotPart = LinearLayout::modularStrided1D(6, 1, S("in2"), S("dim1"));
+  auto mixed = pow2Part * npotPart;
+
+  EXPECT_FALSE(mixed.isOutDimModular(S("dim0")));
+  EXPECT_TRUE(mixed.isOutDimModular(S("dim1")));
+
+  // input=7 for dim1 (bits 0+1+2): XOR(1,2,4)=7, ADD(1+2+4)%6=1
+  // The NPOT dim must use ADD+UREM, giving 1 (not 7).
+  auto result = mixed.apply({{S("in"), 0}, {S("in2"), 7}});
+  int dim1val = result[1].second;
+  EXPECT_EQ(dim1val, 1)
+      << "NPOT dim should use ADD+UREM: (1+2+4)%6=1, not XOR=7";
+  EXPECT_LT(dim1val, 6) << "NPOT result must be in range [0, 6)";
+
+  // For pow2 dim, input=7: XOR(1,2,4)=7 == ADD(1+2+4)=7 (both agree for pow2)
+  auto result2 = mixed.apply({{S("in"), 7}, {S("in2"), 0}});
+  EXPECT_EQ(result2[0].second, 7) << "pow2 dim: 1 XOR 2 XOR 4 = 7";
+}
+
+// Verify isOutDimModular is preserved through compose and invertAndCompose.
+TEST_F(LinearLayoutTest, MixedShape_Compose_PreservesPerDimModular) {
+  // Build a mixed layout: dim0=4 (pow2), dim1=6 (NPOT)
+  auto mixed = LinearLayout::identity1D(4, S("in"), S("dim0")) *
+               LinearLayout::modularStrided1D(6, 1, S("in2"), S("dim1"));
+
+  EXPECT_FALSE(mixed.isOutDimModular(S("dim0")));
+  EXPECT_TRUE(mixed.isOutDimModular(S("dim1")));
+
+  // Compose with identity-like transform preserves per-dim sizes.
+  auto transform = LinearLayout::identity1D(4, S("dim0"), S("out0")) *
+                   LinearLayout::modularStrided1D(6, 1, S("dim1"), S("out1"));
+  auto composed = mixed.compose(transform);
+
+  EXPECT_FALSE(composed.isOutDimModular(S("out0")))
+      << "pow2 dim stays pow2 after compose";
+  EXPECT_TRUE(composed.isOutDimModular(S("out1")))
+      << "NPOT dim stays NPOT after compose";
+
+  // Verify compose matches sequential apply.
+  for (int r = 0; r < 4; ++r) {
+    for (int l = 0; l < 6; ++l) {
+      auto mixedResult = mixed.apply({{S("in"), r}, {S("in2"), l}});
+      auto transformResult = transform.apply(mixedResult);
+      auto composedResult = composed.apply({{S("in"), r}, {S("in2"), l}});
+      EXPECT_EQ(composedResult[0].second, transformResult[0].second);
+      EXPECT_EQ(composedResult[1].second, transformResult[1].second);
+    }
+  }
+
+  // invertAndCompose with mixed dims preserves per-dim modular status.
+  // Uses same layout structure as InvertAndCompose_Mixed_Pow2AndNPOT.
+  LinearLayout::BasesT basesA;
+  auto &bsA = basesA[S("in")];
+  bsA.push_back({1, 0});
+  bsA.push_back({2, 0});
+  bsA.push_back({0, 1});
+  bsA.push_back({0, 2});
+  bsA.push_back({0, 4});
+
+  llvm::SmallVector<std::pair<StringAttr, int32_t>> outDims;
+  outDims.push_back({S("d0"), 4});
+  outDims.push_back({S("d1"), 6});
+  LinearLayout A(std::move(basesA), outDims, false);
+
+  LinearLayout::BasesT basesB;
+  auto &bsB = basesB[S("in")];
+  bsB.push_back({1, 0});
+  bsB.push_back({2, 0});
+  bsB.push_back({0, 1});
+  bsB.push_back({0, 2});
+  LinearLayout B(std::move(basesB), outDims, false);
+
+  EXPECT_FALSE(A.isOutDimModular(S("d0")));
+  EXPECT_TRUE(A.isOutDimModular(S("d1")));
+
+  LinearLayout iac = A.invertAndCompose(B);
+  // Result maps B's input dim "in" -> A's input dim "in" (both pow2).
+  // Verify correctness: A(iac(i)) == B(i) for all i.
+  for (int i = 0; i < (1 << B.getTotalInDimSizeLog2()); ++i) {
+    auto b_out = B.apply({{S("in"), i}});
+    auto r_in = iac.apply({{S("in"), i}});
+    auto a_out = A.apply({{S("in"), r_in[0].second}});
+    EXPECT_EQ(a_out, b_out) << "invertAndCompose mismatch at i=" << i;
+  }
+}
+
+// Verify that final-UREM produces the same result as per-step UREM for all
+// inputs, confirming the codegen optimization is algebraically equivalent.
+TEST_F(LinearLayoutTest, CarryFreeEquivalence_FinalUremEqualsPerStep) {
+  for (int size : {3, 6, 48}) {
+    auto layout = LinearLayout::modularStrided1D(size, 1, S("in"), S("out"));
+    int nBits = layout.getInDimSizeLog2(S("in"));
+    int nInputs = 1 << nBits;
+
+    for (int input = 0; input < nInputs; ++input) {
+      // Per-step UREM (what apply() does)
+      auto perStep = layout.apply({{S("in"), input}});
+
+      // Final-UREM only: accumulate bases without intermediate modulo
+      int32_t finalSum = 0;
+      for (int bit = 0; bit < nBits; ++bit) {
+        if (input & (1 << bit))
+          finalSum += layout.getBasis(S("in"), bit, S("out"));
+      }
+      int32_t finalResult = finalSum % size;
+
+      EXPECT_EQ(perStep[0].second, finalResult)
+          << "size=" << size << " input=" << input;
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// NPOT x NPOT Apply Tests (both dims non-power-of-2)
+// Validates modularStrided1D apply() for shapes from the 2D NPOT benchmarks.
+//===----------------------------------------------------------------------===//
+
+TEST_F(LinearLayoutTest, MixedShape_Apply_NpotXNpot) {
+  // Jagged tensor shapes: (33, 48), (3, 768)
+  // Grouped operation shapes: (12, 48), (6, 96)
+  struct Shape {
+    int32_t m, n;
+  };
+  Shape shapes[] = {{33, 48}, {3, 768}, {12, 48}, {6, 96}};
+
+  for (auto [m, n] : shapes) {
+    auto layoutM = LinearLayout::modularStrided1D(m, 1, S("dim0"), S("out0"));
+    auto layoutN = LinearLayout::modularStrided1D(n, 1, S("dim1"), S("out1"));
+    auto product = layoutM * layoutN;
+
+    EXPECT_TRUE(product.isModular())
+        << m << "x" << n << " product should be modular";
+    EXPECT_EQ(product.getOutDimSize(S("out0")), m);
+    EXPECT_EQ(product.getOutDimSize(S("out1")), n);
+
+    // Verify apply() produces values in range [0, m) x [0, n)
+    int nBits0 = product.getInDimSizeLog2(S("dim0"));
+    int nBits1 = product.getInDimSizeLog2(S("dim1"));
+    for (int i = 0; i < (1 << nBits0); ++i) {
+      for (int j = 0; j < (1 << nBits1); ++j) {
+        auto result = product.apply({{S("dim0"), i}, {S("dim1"), j}});
+        EXPECT_GE(result[0].second, 0) << m << "x" << n << " i=" << i;
+        EXPECT_LT(result[0].second, m) << m << "x" << n << " i=" << i;
+        EXPECT_GE(result[1].second, 0) << m << "x" << n << " j=" << j;
+        EXPECT_LT(result[1].second, n) << m << "x" << n << " j=" << j;
+      }
+    }
+
+    // Verify surjectivity: all (m*n) output values are reachable
+    EXPECT_TRUE(product.isModularSurjective())
+        << m << "x" << n << " product should be surjective";
+  }
+}
+
+TEST_F(LinearLayoutTest, PseudoinvertNPOT) {
+  // pseudoinvert must not crash on NPOT output dimensions.
+  for (int size : {3, 5, 6, 7, 9, 10, 12}) {
+    auto layout = LinearLayout::modularIdentity1D(size, S("in"), S("out"));
+    auto inv = layout.pseudoinvert();
+
+    // pseudoinvert(A) composed with A should act as identity on reachable
+    // outputs: for each input i, apply(pseudoinvert(apply(i))) == i.
+    for (int i = 0; i < size; ++i) {
+      auto fwd = layout.apply({{S("in"), i}});
+      auto back = inv.apply({{S("out"), fwd[0].second}});
+      EXPECT_EQ(back[0].second, i) << "size=" << size << " i=" << i;
+    }
+  }
+}
+
+TEST_F(LinearLayoutTest, ModularIdentity1D_ExhaustiveApply) {
+  // Brute-force verify apply() covers every value in [0, dim).
+  for (int dim : {3, 5, 6, 7, 9, 10, 12, 15}) {
+    auto layout = LinearLayout::modularIdentity1D(dim, S("in"), S("out"));
+    int nBits = layout.getInDimSizeLog2(S("in"));
+    int nInputs = 1 << nBits;
+
+    std::set<int32_t> outputs;
+    for (int i = 0; i < nInputs; ++i) {
+      auto result = layout.apply({{S("in"), i}});
+      EXPECT_GE(result[0].second, 0) << "dim=" << dim << " i=" << i;
+      EXPECT_LT(result[0].second, dim) << "dim=" << dim << " i=" << i;
+      outputs.insert(result[0].second);
+    }
+
+    EXPECT_EQ(static_cast<int>(outputs.size()), dim)
+        << "dim=" << dim << ": apply() must cover all values in [0, " << dim
+        << ")";
+  }
+}
+
+// Compose two modular layouts sharing an output dimension.
+TEST_F(LinearLayoutTest, ComposeModularSharedOutDim) {
+  // 1D: inner maps in->dim0(6), outer maps dim0->out(6) with stride 2.
+  auto inner = LinearLayout::modularStrided1D(6, 1, S("in"), S("dim0"));
+  auto outer = LinearLayout::modularStrided1D(6, 2, S("dim0"), S("out"));
+  auto composed = inner.compose(outer);
+
+  for (int x = 0; x < (1 << inner.getInDimSizeLog2(S("in"))); ++x) {
+    auto inner_out = inner.apply({{S("in"), x}});
+    auto outer_out = outer.apply(inner_out);
+    EXPECT_EQ(composed.apply({{S("in"), x}}), outer_out) << "x=" << x;
+  }
+
+  // 2D: compose modular layouts over Z/3 x Z/5.
+  auto inner2D = LinearLayout::modularStrided1D(3, 1, S("in"), S("d0")) *
+                 LinearLayout::modularStrided1D(5, 1, S("in2"), S("d1"));
+  auto outer2D = LinearLayout::modularStrided1D(3, 2, S("d0"), S("out0")) *
+                 LinearLayout::modularStrided1D(5, 3, S("d1"), S("out1"));
+  auto composed2D = inner2D.compose(outer2D);
+
+  for (int i = 0; i < (1 << inner2D.getInDimSizeLog2(S("in"))); ++i) {
+    for (int j = 0; j < (1 << inner2D.getInDimSizeLog2(S("in2"))); ++j) {
+      auto in_out = inner2D.apply({{S("in"), i}, {S("in2"), j}});
+      auto out_out = outer2D.apply(in_out);
+      EXPECT_EQ(composed2D.apply({{S("in"), i}, {S("in2"), j}}), out_out)
+          << "i=" << i << " j=" << j;
+    }
+  }
+}
+
+// Flatten a 2D NPOT layout to 1D then unflatten back; verify round-trip.
+TEST_F(LinearLayoutTest, ReshapeOutsNPOT_FlattenUnflattenRoundtrip) {
+  // [3, 5] -> [15] -> [3, 5]
+  auto original = LinearLayout::modularStrided1D(3, 1, S("in1"), S("out0")) *
+                  LinearLayout::modularStrided1D(5, 1, S("in2"), S("out1"));
+
+  auto flat = original.flattenOuts();
+  EXPECT_EQ(flat.getOutDimSize(S("out0")), 15);
+
+  auto unflat = flat.reshapeOuts({{S("out0"), 3}, {S("out1"), 5}});
+
+  for (int i = 0; i < (1 << original.getInDimSizeLog2(S("in1"))); ++i) {
+    for (int j = 0; j < (1 << original.getInDimSizeLog2(S("in2"))); ++j) {
+      EXPECT_EQ(unflat.apply({{S("in1"), i}, {S("in2"), j}}),
+                original.apply({{S("in1"), i}, {S("in2"), j}}))
+          << "i=" << i << " j=" << j;
+    }
+  }
+
+  // Reversed dim order: [5, 3] -> [15] -> [5, 3]
+  auto origR = LinearLayout::modularStrided1D(5, 1, S("in1"), S("out0")) *
+               LinearLayout::modularStrided1D(3, 1, S("in2"), S("out1"));
+  auto flatR = origR.flattenOuts();
+  auto unflatR = flatR.reshapeOuts({{S("out0"), 5}, {S("out1"), 3}});
+
+  for (int i = 0; i < (1 << origR.getInDimSizeLog2(S("in1"))); ++i) {
+    for (int j = 0; j < (1 << origR.getInDimSizeLog2(S("in2"))); ++j) {
+      EXPECT_EQ(unflatR.apply({{S("in1"), i}, {S("in2"), j}}),
+                origR.apply({{S("in1"), i}, {S("in2"), j}}))
+          << "i=" << i << " j=" << j;
+    }
+  }
+}
+
+// Verify round-trip: A.invertAndCompose(B).compose(B) == A for modular layouts.
+TEST_F(LinearLayoutTest, InvertAndCompose_ModularRoundTrip) {
+  // 1D round-trips with various NPOT dim sizes and coprime strides.
+  struct Case {
+    int size, strideA, strideB;
+  };
+  Case cases[] = {{6, 1, 5}, {10, 3, 7}, {15, 4, 11}};
+  for (auto [size, sA, sB] : cases) {
+    auto A = LinearLayout::modularStrided1D(size, sA, S("in1"), S("out"));
+    auto B = LinearLayout::modularStrided1D(size, sB, S("in2"), S("out"));
+    auto X = A.invertAndCompose(B);
+    EXPECT_EQ(X.compose(B), A)
+        << "size=" << size << " sA=" << sA << " sB=" << sB;
+  }
+
+  // Multi-dim: both dims same prime size avoids LCM modulus aliasing.
+  auto Am = LinearLayout::modularStrided1D(3, 1, S("in1"), S("d0")) *
+            LinearLayout::modularStrided1D(3, 1, S("in1b"), S("d1"));
+  auto Bm = LinearLayout::modularStrided1D(3, 2, S("in2"), S("d0")) *
+            LinearLayout::modularStrided1D(3, 2, S("in2b"), S("d1"));
+  auto Xm = Am.invertAndCompose(Bm);
+  EXPECT_EQ(Xm.compose(Bm),
+            Am.transposeOuts(llvm::to_vector(Bm.getOutDimNames())));
+}
+
+// Multi-rep NPOT invertAndCompose: simulates a multi-rep shared memory
+// conversion with NPOT dimensions (e.g. size 12). Verifies that all output
+// values remain in bounds and the solution is correct.
+TEST_F(LinearLayoutTest, InvertAndCompose_MultiRepNPOT) {
+  // A: 2 input dims (register, lane), output dim with NPOT size 12.
+  // Simulates a layout where multiple reps tile an NPOT dimension.
+  auto A = LinearLayout::modularIdentity1D(12, S("register"), S("dim0")) *
+           LinearLayout::zeros1D(4, S("lane"), S("dim0"));
+
+  // B: different input structure mapping to same output space.
+  auto B = LinearLayout::modularIdentity1D(12, S("register"), S("dim0")) *
+           LinearLayout::zeros1D(4, S("lane"), S("dim0"));
+
+  EXPECT_TRUE(A.isOutDimModular(S("dim0")));
+
+  auto iac = A.invertAndCompose(B);
+
+  // Verify all output values are in bounds.
+  int regSize = iac.getInDimSize(S("register"));
+  int laneSize = iac.getInDimSize(S("lane"));
+  for (int reg = 0; reg < regSize; reg++) {
+    for (int lane = 0; lane < laneSize; lane++) {
+      auto result = iac.apply({{S("register"), reg}, {S("lane"), lane}});
+      for (auto &[dim, val] : result) {
+        EXPECT_GE(val, 0) << "Negative output at reg=" << reg
+                          << " lane=" << lane;
+        EXPECT_LT(val, iac.getOutDimSize(dim))
+            << "Out of bounds at reg=" << reg << " lane=" << lane
+            << " dim=" << dim.str();
+      }
+    }
+  }
+
+  // Verify correctness: A(iac(input)) == B(input) for all inputs.
+  for (int reg = 0; reg < regSize; reg++) {
+    for (int lane = 0; lane < laneSize; lane++) {
+      auto b_out = B.apply({{S("register"), reg}, {S("lane"), lane}});
+      auto r_vals = iac.apply({{S("register"), reg}, {S("lane"), lane}});
+      auto a_out = A.apply(r_vals);
+      EXPECT_EQ(a_out, b_out)
+          << "invertAndCompose mismatch at reg=" << reg << " lane=" << lane;
+    }
+  }
+}
+
+// Multi-rep NPOT invertAndCompose with mixed pow2 and NPOT output dims.
+// Simulates shared memory conversion for a tensor with shape like [32, 12].
+TEST_F(LinearLayoutTest, InvertAndCompose_MultiRepMixedNPOT) {
+  // A: maps register -> (dim0=8, dim1=12)
+  // Shear family: some bases touch only pow2 dim, others touch NPOT dim.
+  LinearLayout::BasesT basesA;
+  auto &bsA = basesA[S("register")];
+  // Group-0 bases (touch pow2 dim0)
+  bsA.push_back({1, 0}); // bit 0 -> dim0 += 1
+  bsA.push_back({2, 0}); // bit 1 -> dim0 += 2
+  bsA.push_back({4, 0}); // bit 2 -> dim0 += 4
+  // Group-1 bases (touch only NPOT dim1)
+  bsA.push_back({0, 1}); // bit 3 -> dim1 += 1
+  bsA.push_back({0, 2}); // bit 4 -> dim1 += 2
+  bsA.push_back({0, 4}); // bit 5 -> dim1 += 4
+  bsA.push_back({0, 8}); // bit 6 -> dim1 += 8
+
+  llvm::SmallVector<std::pair<StringAttr, int32_t>> outDims;
+  outDims.push_back({S("dim0"), 8});
+  outDims.push_back({S("dim1"), 12});
+  LinearLayout A(std::move(basesA), outDims, false);
+
+  // B: subset mapping
+  LinearLayout::BasesT basesB;
+  auto &bsB = basesB[S("register")];
+  bsB.push_back({1, 0});
+  bsB.push_back({2, 0});
+  bsB.push_back({4, 0});
+  bsB.push_back({0, 1});
+  bsB.push_back({0, 2});
+  bsB.push_back({0, 4});
+  LinearLayout B(std::move(basesB), outDims, false);
+
+  EXPECT_FALSE(A.isOutDimModular(S("dim0")));
+  EXPECT_TRUE(A.isOutDimModular(S("dim1")));
+
+  auto iac = A.invertAndCompose(B);
+
+  // Verify correctness.
+  int inSize = 1 << B.getTotalInDimSizeLog2();
+  for (int i = 0; i < inSize; i++) {
+    auto b_out = B.apply({{S("register"), i}});
+    auto r_vals = iac.apply({{S("register"), i}});
+    auto a_out = A.apply(r_vals);
+    EXPECT_EQ(a_out, b_out) << "invertAndCompose mismatch at i=" << i;
+  }
+}
+
+// Test the per-dim factored solve in lstsq for mixed pow2/NPOT layouts.
+// This exercises the code path where lstsq splits output dims into pow2
+// (solved via GF(2) RREF) and NPOT (solved via lstsqModular), then combines.
+TEST_F(LinearLayoutTest, Lstsq_PerDimFactoredSolve_MixedPow2NPOT) {
+  // A: maps input(128) -> dim0(8, pow2) x dim1(12, NPOT)
+  // Simulates the split-dim layout: dim0 uses XOR, dim1 uses ADD+mod.
+  // Bases are decoupled: pow2 bases have S=0 in dim1, NPOT bases have S=0 in
+  // dim0.
+  LinearLayout::BasesT basesA;
+  auto &bsA = basesA[S("in")];
+  // Pow2 dim0 bases (XOR algebra)
+  bsA.push_back({1, 0}); // bit 0 -> dim0 XOR 1
+  bsA.push_back({2, 0}); // bit 1 -> dim0 XOR 2
+  bsA.push_back({4, 0}); // bit 2 -> dim0 XOR 4
+  // NPOT dim1 bases (ADD+mod algebra)
+  bsA.push_back({0, 1}); // bit 3 -> dim1 ADD 1
+  bsA.push_back({0, 2}); // bit 4 -> dim1 ADD 2
+  bsA.push_back({0, 4}); // bit 5 -> dim1 ADD 4
+  bsA.push_back({0, 8}); // bit 6 -> dim1 ADD 8
+
+  llvm::SmallVector<std::pair<StringAttr, int32_t>> outDims;
+  outDims.push_back({S("dim0"), 8});
+  outDims.push_back({S("dim1"), 12});
+  LinearLayout A(std::move(basesA), outDims, false);
+
+  // B: maps input(64) -> dim0(8) x dim1(12), subset of A's image
+  LinearLayout::BasesT basesB;
+  auto &bsB = basesB[S("in")];
+  bsB.push_back({1, 0}); // bit 0 -> dim0 += 1
+  bsB.push_back({2, 0}); // bit 1 -> dim0 += 2
+  bsB.push_back({4, 0}); // bit 2 -> dim0 += 4
+  bsB.push_back({0, 1}); // bit 3 -> dim1 += 1
+  bsB.push_back({0, 2}); // bit 4 -> dim1 += 2
+  bsB.push_back({0, 4}); // bit 5 -> dim1 += 4
+  LinearLayout B(std::move(basesB), outDims, false);
+
+  EXPECT_TRUE(A.isModular());
+  EXPECT_FALSE(A.isOutDimModular(S("dim0")));
+  EXPECT_TRUE(A.isOutDimModular(S("dim1")));
+
+  // invertAndCompose calls lstsq internally.
+  auto result = A.invertAndCompose(B);
+
+  // Verify: A(result(i)) == B(i) for all i in B's domain.
+  int inSize = 1 << B.getTotalInDimSizeLog2();
+  for (int i = 0; i < inSize; i++) {
+    auto b_out = B.apply({{S("in"), i}});
+    auto r_in = result.apply({{S("in"), i}});
+    auto a_out = A.apply(r_in);
+    EXPECT_EQ(a_out, b_out) << "Per-dim factored solve mismatch at i=" << i;
+  }
+}
+
+// Test per-dim factored solve with multi-input-dim layout (register + lane).
+TEST_F(LinearLayoutTest, Lstsq_PerDimFactoredSolve_MultiInputDim) {
+  // A: maps (register x lane) -> dim0(4, pow2) x dim1(6, NPOT)
+  auto A_pow2 = LinearLayout::identity1D(4, S("register"), S("dim0"));
+  auto A_npot = LinearLayout::modularStrided1D(6, 1, S("lane"), S("dim1"));
+  auto A = A_pow2 * A_npot;
+
+  // B: maps (register x lane) -> dim0(4) x dim1(6), same structure
+  auto B_pow2 = LinearLayout::identity1D(4, S("register"), S("dim0"));
+  auto B_npot = LinearLayout::modularStrided1D(6, 1, S("lane"), S("dim1"));
+  auto B_layout = B_pow2 * B_npot;
+
+  EXPECT_TRUE(A.isModular());
+
+  auto result = A.invertAndCompose(B_layout);
+
+  // Verify: A(result(input)) == B(input) for all inputs.
+  int regSize = B_layout.getInDimSize(S("register"));
+  int laneSize = B_layout.getInDimSize(S("lane"));
+  for (int reg = 0; reg < regSize; reg++) {
+    for (int lane = 0; lane < laneSize; lane++) {
+      auto b_out = B_layout.apply({{S("register"), reg}, {S("lane"), lane}});
+      auto r_vals = result.apply({{S("register"), reg}, {S("lane"), lane}});
+      auto a_out = A.apply(r_vals);
+      EXPECT_EQ(a_out, b_out)
+          << "Multi-input-dim mismatch at reg=" << reg << " lane=" << lane;
+    }
+  }
+}
+
+// Verify modularIdentity1D(6, ...) composes correctly with other layouts,
+// simulating NPOT kWidth=6 for NVFp4 K=96.
+TEST_F(LinearLayoutTest, ModularIdentity1D_KWidth6_Compose) {
+  // kWidth=6 register layout along K dimension
+  auto regs = LinearLayout::modularIdentity1D(6, S("register"), S("dimK"));
+
+  // 4 lanes along non-K dimension (pow2)
+  auto lanes = LinearLayout::identity1D(4, S("lane"), S("dimNonK"));
+
+  // Compose: regs * lanes
+  auto tileLayout = regs * lanes;
+
+  EXPECT_EQ(tileLayout.getOutDimSize(S("dimK")), 6);
+  EXPECT_EQ(tileLayout.getOutDimSize(S("dimNonK")), 4);
+
+  // Verify all output values are in bounds.
+  int regSize = tileLayout.getInDimSize(S("register"));
+  int laneSize = tileLayout.getInDimSize(S("lane"));
+  for (int reg = 0; reg < regSize; reg++) {
+    for (int lane = 0; lane < laneSize; lane++) {
+      auto result = tileLayout.apply({{S("register"), reg}, {S("lane"), lane}});
+      for (auto &[dim, val] : result) {
+        EXPECT_GE(val, 0);
+        EXPECT_LT(val, tileLayout.getOutDimSize(dim))
+            << "Out of bounds: reg=" << reg << " lane=" << lane
+            << " dim=" << dim.str() << " val=" << val;
+      }
+    }
+  }
+
+  // Verify invertAndCompose with itself produces identity-like mapping.
+  auto iac = tileLayout.invertAndCompose(tileLayout);
+  for (int reg = 0; reg < regSize; reg++) {
+    for (int lane = 0; lane < laneSize; lane++) {
+      auto orig = tileLayout.apply({{S("register"), reg}, {S("lane"), lane}});
+      auto mapped = iac.apply({{S("register"), reg}, {S("lane"), lane}});
+      auto roundTrip = tileLayout.apply(mapped);
+      EXPECT_EQ(orig, roundTrip)
+          << "Round-trip mismatch at reg=" << reg << " lane=" << lane;
+    }
+  }
 }
 
 } // anonymous namespace

--- a/unittest/Tools/ModularArithmeticTest.cpp
+++ b/unittest/Tools/ModularArithmeticTest.cpp
@@ -1,0 +1,486 @@
+#include "triton/Tools/ModularArithmetic.h"
+
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+namespace mlir::triton {
+namespace {
+
+class ModularArithmeticTest : public ::testing::Test {};
+
+TEST_F(ModularArithmeticTest, ExtGCD_Basic) {
+  auto result = extendedGCD(240, 46);
+  EXPECT_EQ(result.gcd, 2);
+  EXPECT_EQ(240 * result.x + 46 * result.y, result.gcd);
+
+  result = extendedGCD(0, 5);
+  EXPECT_EQ(result.gcd, 5);
+  EXPECT_EQ(0 * result.x + 5 * result.y, result.gcd);
+
+  result = extendedGCD(7, 0);
+  EXPECT_EQ(result.gcd, 7);
+  EXPECT_EQ(7 * result.x + 0 * result.y, result.gcd);
+
+  result = extendedGCD(0, 0);
+  EXPECT_EQ(result.gcd, 0);
+
+  result = extendedGCD(0, -5);
+  EXPECT_EQ(result.gcd, 5);
+  EXPECT_EQ(0 * result.x + (-5) * result.y, result.gcd);
+
+  result = extendedGCD(-7, 0);
+  EXPECT_EQ(result.gcd, 7);
+  EXPECT_EQ((-7) * result.x + 0 * result.y, result.gcd);
+}
+
+TEST_F(ModularArithmeticTest, ExtGCD_NegativeInputs) {
+  // Both negative
+  auto result = extendedGCD(-12, -8);
+  EXPECT_EQ(result.gcd, 4);
+  EXPECT_EQ((-12) * result.x + (-8) * result.y, result.gcd);
+
+  // One negative
+  result = extendedGCD(-15, 10);
+  EXPECT_EQ(result.gcd, 5);
+  EXPECT_EQ((-15) * result.x + 10 * result.y, result.gcd);
+}
+
+TEST_F(ModularArithmeticTest, ModInverse_Basic) {
+  auto inv = modInverse(3, 11);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ((3 * (*inv)) % 11, 1);
+
+  inv = modInverse(2, 4);
+  EXPECT_FALSE(inv.has_value());
+
+  inv = modInverse(6, 9);
+  EXPECT_FALSE(inv.has_value());
+
+  // modInverse(1, N) always returns 1
+  inv = modInverse(1, 7);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ(*inv, 1);
+
+  inv = modInverse(1, 100);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ(*inv, 1);
+}
+
+TEST_F(ModularArithmeticTest, ModInverse_NegativeA) {
+  // -3 mod 11 = 8, inverse of 8 mod 11 = 7
+  auto inv = modInverse(-3, 11);
+  ASSERT_TRUE(inv.has_value());
+  EXPECT_EQ(((-3 % 11 + 11) % 11 * (*inv)) % 11, 1);
+}
+
+TEST_F(ModularArithmeticTest, IntPow_Basic) {
+  EXPECT_EQ(intPow(2, 10), 1024);
+  EXPECT_EQ(intPow(0, 0), 1);
+  EXPECT_EQ(intPow(5, 0), 1);
+  EXPECT_EQ(intPow(1, 100), 1);
+  EXPECT_EQ(intPow(3, 5), 243);
+  EXPECT_EQ(intPow(-2, 3), -8);
+}
+
+TEST_F(ModularArithmeticTest, CRT_Basic) {
+  // Single congruence: x ≡ 5 (mod 7)
+  auto result = solveCRT({5}, {7});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->solution, 5);
+  EXPECT_EQ(result->modulus, 7);
+
+  // x ≡ 2 (mod 3), x ≡ 3 (mod 5), x ≡ 2 (mod 7)
+  result = solveCRT({2, 3, 2}, {3, 5, 7});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->modulus, 105);
+  EXPECT_GE(result->solution, 0);
+  EXPECT_LT(result->solution, 105);
+  EXPECT_EQ(result->solution % 3, 2);
+  EXPECT_EQ(result->solution % 5, 3);
+  EXPECT_EQ(result->solution % 7, 2);
+}
+
+TEST_F(ModularArithmeticTest, CRT_RejectsInvalidInput) {
+  // Pairwise coprime moduli are required (documented precondition). In
+  // release builds the assertion compiles out and the implementation falls
+  // through to a per-modulus modInverse step that returns nullopt when
+  // M_i and m_i share a factor — verify the API surfaces nullopt rather
+  // than silently producing a wrong answer. (In debug builds the assertion
+  // fires before reaching this path; this test guards the release path.)
+#ifdef NDEBUG
+  // moduli 4 and 6 share factor 2 — not pairwise coprime.
+  auto noncoprime = solveCRT({1, 1}, {4, 6});
+  EXPECT_FALSE(noncoprime.has_value());
+#endif
+
+  // Empty inputs.
+  EXPECT_FALSE(solveCRT({}, {}).has_value());
+
+  // Size mismatch.
+  EXPECT_FALSE(solveCRT({1}, {2, 3}).has_value());
+
+  // Non-positive modulus.
+  EXPECT_FALSE(solveCRT({1, 1}, {3, 0}).has_value());
+  EXPECT_FALSE(solveCRT({1, 1}, {3, -5}).has_value());
+}
+
+TEST_F(ModularArithmeticTest, ExtendedGCD_RejectsInt64Min) {
+  // |INT64_MIN| does not fit in int64_t, so std::abs(INT64_MIN) is UB.
+  // The implementation rejects INT64_MIN inputs by returning {0, 0, 0}
+  // (matching the gcd(0, 0) convention).
+  auto r1 = extendedGCD(std::numeric_limits<int64_t>::min(), 7);
+  EXPECT_EQ(r1.gcd, 0);
+  auto r2 = extendedGCD(7, std::numeric_limits<int64_t>::min());
+  EXPECT_EQ(r2.gcd, 0);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_Mod5) {
+  ModMatrix mat(2, 2, 5);
+  mat.at(0, 0) = 1;
+  mat.at(0, 1) = 2;
+  mat.at(1, 0) = 3;
+  mat.at(1, 1) = 4;
+
+  int rank = modRREF(mat);
+  EXPECT_EQ(rank, 2);
+
+  EXPECT_EQ(mat.at(0, 0), 1);
+  EXPECT_EQ(mat.at(0, 1), 0);
+  EXPECT_EQ(mat.at(1, 0), 0);
+  EXPECT_EQ(mat.at(1, 1), 1);
+
+  // Singular matrix (mod 3): [[1, 2], [1, 2]] has rank 1
+  ModMatrix singularMat(2, 2, 3);
+  singularMat.at(0, 0) = 1;
+  singularMat.at(0, 1) = 2;
+  singularMat.at(1, 0) = 1;
+  singularMat.at(1, 1) = 2;
+  rank = modRREF(singularMat);
+  EXPECT_EQ(rank, 1);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_RectangularMatrix) {
+  // 3x2 over Z/7Z: [[1,2],[3,4],[5,6]] has rank 2
+  ModMatrix mat(3, 2, 7);
+  mat.at(0, 0) = 1;
+  mat.at(0, 1) = 2;
+  mat.at(1, 0) = 3;
+  mat.at(1, 1) = 4;
+  mat.at(2, 0) = 5;
+  mat.at(2, 1) = 6;
+
+  int rank = modRREF(mat);
+  ASSERT_EQ(rank, 2);
+
+  EXPECT_EQ(mat.at(0, 0), 1);
+  EXPECT_EQ(mat.at(0, 1), 0);
+  EXPECT_EQ(mat.at(1, 0), 0);
+  EXPECT_EQ(mat.at(1, 1), 1);
+  EXPECT_EQ(mat.at(2, 0), 0);
+  EXPECT_EQ(mat.at(2, 1), 0);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_CompositeModulus) {
+  // [[2, 0], [0, 3]] mod 6: neither pivot is invertible, rank should be 0
+  ModMatrix mat(2, 2, 6);
+  mat.at(0, 0) = 2;
+  mat.at(0, 1) = 0;
+  mat.at(1, 0) = 0;
+  mat.at(1, 1) = 3;
+  int rank = modRREF(mat);
+  EXPECT_EQ(rank, 0);
+
+  // [[1, 2], [3, 4]] mod 6: det=-2, gcd(2,6)!=1, so rank 1 not 2
+  ModMatrix mat2(2, 2, 6);
+  mat2.at(0, 0) = 1;
+  mat2.at(0, 1) = 2;
+  mat2.at(1, 0) = 3;
+  mat2.at(1, 1) = 4;
+  rank = modRREF(mat2);
+  EXPECT_EQ(rank, 1);
+
+  // [[1, 0], [0, 5]] mod 6: both pivots invertible, rank 2
+  ModMatrix mat3(2, 2, 6);
+  mat3.at(0, 0) = 1;
+  mat3.at(0, 1) = 0;
+  mat3.at(1, 0) = 0;
+  mat3.at(1, 1) = 5;
+  rank = modRREF(mat3);
+  EXPECT_EQ(rank, 2);
+}
+
+TEST_F(ModularArithmeticTest, ZnZ_RREF_CompositeModulus_PivotSwap) {
+  // Row swap needed: row 0 col 0 is 4 (gcd(4,6)=2), row 1 col 0 is 1
+  ModMatrix mat(2, 2, 6);
+  mat.at(0, 0) = 4;
+  mat.at(0, 1) = 2;
+  mat.at(1, 0) = 1;
+  mat.at(1, 1) = 3;
+  int rank = modRREF(mat);
+  EXPECT_EQ(rank, 1);
+
+  // Full-rank: det=-1, gcd(1,6)=1 → identity
+  ModMatrix mat2(2, 2, 6);
+  mat2.at(0, 0) = 5;
+  mat2.at(0, 1) = 2;
+  mat2.at(1, 0) = 3;
+  mat2.at(1, 1) = 1;
+  rank = modRREF(mat2);
+  EXPECT_EQ(rank, 2);
+  EXPECT_EQ(mat2.at(0, 0), 1);
+  EXPECT_EQ(mat2.at(0, 1), 0);
+  EXPECT_EQ(mat2.at(1, 0), 0);
+  EXPECT_EQ(mat2.at(1, 1), 1);
+
+  // 3x3 mod 10: row 1 is 2×row 0, rank=2
+  ModMatrix mat3(3, 3, 10);
+  mat3.at(0, 0) = 1;
+  mat3.at(0, 1) = 2;
+  mat3.at(0, 2) = 3;
+  mat3.at(1, 0) = 2;
+  mat3.at(1, 1) = 4;
+  mat3.at(1, 2) = 6;
+  mat3.at(2, 0) = 0;
+  mat3.at(2, 1) = 0;
+  mat3.at(2, 2) = 3;
+  rank = modRREF(mat3);
+  EXPECT_EQ(rank, 2);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinear_Basic) {
+  // Consistent 2x2 mod 7
+  ModMatrix A(2, 2, 7);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 3;
+  A.at(1, 1) = 1;
+  std::vector<int64_t> b = {5, 4};
+  auto x = modSolveLinear(A, b, 7);
+  ASSERT_EQ(x.size(), 2u);
+  EXPECT_EQ((A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 7, b[0] % 7);
+  EXPECT_EQ((A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 7, b[1] % 7);
+
+  // Inconsistent system mod 5
+  ModMatrix A2(2, 2, 5);
+  A2.at(0, 0) = 1;
+  A2.at(0, 1) = 0;
+  A2.at(1, 0) = 1;
+  A2.at(1, 1) = 0;
+  std::vector<int64_t> b2 = {1, 2};
+  auto x2 = modSolveLinear(A2, b2, 5);
+  EXPECT_TRUE(x2.empty());
+
+  // Underdetermined 1x2 mod 7
+  ModMatrix A3(1, 2, 7);
+  A3.at(0, 0) = 1;
+  A3.at(0, 1) = 3;
+  std::vector<int64_t> b3 = {4};
+  auto x3 = modSolveLinear(A3, b3, 7);
+  ASSERT_EQ(x3.size(), 2u);
+  EXPECT_EQ((A3.at(0, 0) * x3[0] + A3.at(0, 1) * x3[1]) % 7, b3[0] % 7);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Mod9) {
+  // modulus = 9 = 3^2
+  ModMatrix A(2, 2, 9);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 1;
+  A.at(1, 1) = 1;
+
+  std::vector<int64_t> b = {5, 4};
+  auto x = modSolveLinearHensel(A, b, 3, 2);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 2u);
+
+  int64_t res0 = (A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 9;
+  int64_t res1 = (A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 9;
+  EXPECT_EQ(res0, b[0] % 9);
+  EXPECT_EQ(res1, b[1] % 9);
+
+  // modulus = 27 = 3^3
+  ModMatrix A27(2, 2, 27);
+  A27.at(0, 0) = 1;
+  A27.at(0, 1) = 2;
+  A27.at(1, 0) = 1;
+  A27.at(1, 1) = 1;
+
+  std::vector<int64_t> b27 = {8, 7};
+  auto x27 = modSolveLinearHensel(A27, b27, 3, 3);
+
+  ASSERT_FALSE(x27.empty());
+  ASSERT_EQ(x27.size(), 2u);
+
+  int64_t res0_27 = (A27.at(0, 0) * x27[0] + A27.at(0, 1) * x27[1]) % 27;
+  int64_t res1_27 = (A27.at(1, 0) * x27[0] + A27.at(1, 1) * x27[1]) % 27;
+  EXPECT_EQ(res0_27, b27[0] % 27);
+  EXPECT_EQ(res1_27, b27[1] % 27);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Pow2_Mod16) {
+  // 2x2 system over Z/16 = 2^4. Tests Hensel lifting with exponent=4
+  // (the typical case for pow2 layout dims like 16, 32, 64).
+  ModMatrix A(2, 2, 16);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 3;
+  A.at(1, 1) = 5;
+  std::vector<int64_t> b = {7, 11};
+
+  auto x = modSolveLinearHensel(A, b, 2, 4);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 2u);
+
+  int64_t res0 = (A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 16;
+  int64_t res1 = (A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 16;
+  EXPECT_EQ(res0, b[0] % 16);
+  EXPECT_EQ(res1, b[1] % 16);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_NoSolution) {
+  // Inconsistent: 1x = 1 and 1x = 2 (mod 3)
+  ModMatrix A(2, 2, 9);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 0;
+  A.at(1, 0) = 1;
+  A.at(1, 1) = 0;
+
+  std::vector<int64_t> b = {1, 2};
+  auto x = modSolveLinearHensel(A, b, 3, 2);
+  EXPECT_TRUE(x.empty());
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Underdetermined) {
+  // 1x + 2y + 3z = 7 (mod 9)
+  ModMatrix A(1, 3, 9);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(0, 2) = 3;
+
+  std::vector<int64_t> b = {7};
+  auto x = modSolveLinearHensel(A, b, 3, 2);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 3u);
+
+  int64_t res0 =
+      (A.at(0, 0) * x[0] + A.at(0, 1) * x[1] + A.at(0, 2) * x[2]) % 9;
+  EXPECT_EQ(res0, b[0] % 9);
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearHensel_InvalidPrimeRejected) {
+  // prime < 2 is not a valid prime base for Hensel lifting. prime == 1 in
+  // particular makes every modulus prime^k == 1 (trivial ring) and the lift
+  // cannot make progress, so the solver must reject it cleanly (empty result)
+  // rather than return a meaningless answer or fail to terminate.
+  ModMatrix A(1, 1, 9);
+  A.at(0, 0) = 1;
+  std::vector<int64_t> b = {1};
+
+  EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/1, /*exponent=*/2).empty());
+  EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/0, /*exponent=*/2).empty());
+  EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/-3, /*exponent=*/2).empty());
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinearCRT_Composite_Mod15) {
+  // modulus = 15 = 3 × 5
+  ModMatrix A(2, 2, 15);
+  A.at(0, 0) = 1;
+  A.at(0, 1) = 2;
+  A.at(1, 0) = 1;
+  A.at(1, 1) = 1;
+
+  std::vector<int64_t> b = {7, 5};
+  auto x = modSolveLinearCRT(A, b, 15);
+
+  ASSERT_FALSE(x.empty());
+  ASSERT_EQ(x.size(), 2u);
+
+  int64_t res0 = (A.at(0, 0) * x[0] + A.at(0, 1) * x[1]) % 15;
+  int64_t res1 = (A.at(1, 0) * x[0] + A.at(1, 1) * x[1]) % 15;
+  EXPECT_EQ(res0, b[0] % 15);
+  EXPECT_EQ(res1, b[1] % 15);
+
+  // modulus = 48 = 2^4 × 3
+  ModMatrix A48(2, 2, 48);
+  A48.at(0, 0) = 1;
+  A48.at(0, 1) = 2;
+  A48.at(1, 0) = 1;
+  A48.at(1, 1) = 1;
+
+  std::vector<int64_t> b48 = {11, 7};
+  auto x48 = modSolveLinearCRT(A48, b48, 48);
+
+  ASSERT_FALSE(x48.empty());
+  ASSERT_EQ(x48.size(), 2u);
+
+  int64_t res0_48 = (A48.at(0, 0) * x48[0] + A48.at(0, 1) * x48[1]) % 48;
+  int64_t res1_48 = (A48.at(1, 0) * x48[0] + A48.at(1, 1) * x48[1]) % 48;
+  EXPECT_EQ(res0_48, b48[0] % 48);
+  EXPECT_EQ(res1_48, b48[1] % 48);
+
+  // No solution: inconsistent system
+  ModMatrix A_nosol(2, 2, 15);
+  A_nosol.at(0, 0) = 1;
+  A_nosol.at(0, 1) = 0;
+  A_nosol.at(1, 0) = 1;
+  A_nosol.at(1, 1) = 0;
+
+  std::vector<int64_t> b_nosol = {1, 2};
+  auto x_nosol = modSolveLinearCRT(A_nosol, b_nosol, 15);
+  EXPECT_TRUE(x_nosol.empty());
+
+  // Precondition: modulus must be > 0. Zero and negative moduli return {}
+  // explicitly rather than silently failing inside the per-variable CRT
+  // step (factorize(0) returns no factors, leaving the moduli vector empty).
+  ModMatrix A_ok(2, 2, 15);
+  A_ok.at(0, 0) = 1;
+  A_ok.at(0, 1) = 0;
+  A_ok.at(1, 0) = 0;
+  A_ok.at(1, 1) = 1;
+  std::vector<int64_t> b_ok = {0, 0};
+  EXPECT_TRUE(modSolveLinearCRT(A_ok, b_ok, 0).empty());
+  EXPECT_TRUE(modSolveLinearCRT(A_ok, b_ok, -1).empty());
+}
+
+TEST_F(ModularArithmeticTest, Factorize) {
+  // Negative and zero inputs return empty factorization
+  auto f0 = factorize(0);
+  EXPECT_TRUE(f0.factors.empty());
+
+  auto fn = factorize(-10);
+  EXPECT_TRUE(fn.factors.empty());
+
+  auto f1 = factorize(1);
+  EXPECT_TRUE(f1.factors.empty());
+
+  auto f2 = factorize(2);
+  ASSERT_EQ(f2.factors.size(), 1u);
+  EXPECT_EQ(f2.factors[0].first, 2);
+  EXPECT_EQ(f2.factors[0].second, 1);
+  EXPECT_EQ(f2.product(), 2);
+
+  auto f12 = factorize(12);
+  ASSERT_EQ(f12.factors.size(), 2u);
+  EXPECT_EQ(f12.factors[0].first, 2);
+  EXPECT_EQ(f12.factors[0].second, 2);
+  EXPECT_EQ(f12.factors[1].first, 3);
+  EXPECT_EQ(f12.factors[1].second, 1);
+  EXPECT_EQ(f12.product(), 12);
+
+  auto f60 = factorize(60);
+  ASSERT_EQ(f60.factors.size(), 3u);
+  EXPECT_EQ(f60.factors[0].first, 2);
+  EXPECT_EQ(f60.factors[0].second, 2);
+  EXPECT_EQ(f60.factors[1].first, 3);
+  EXPECT_EQ(f60.factors[1].second, 1);
+  EXPECT_EQ(f60.factors[2].first, 5);
+  EXPECT_EQ(f60.factors[2].second, 1);
+  EXPECT_EQ(f60.product(), 60);
+}
+
+} // namespace
+} // namespace mlir::triton


### PR DESCRIPTION
Summary:

Introduces modular-arithmetic extensions to `LinearLayout` so that non-power-of-2 (NPOT) dimension sizes are first-class citizens. Adds `modularIdentity1D`, `lstsqModular`, and `pseudoinvert` primitives that solve linear systems over modular rings. Updates `strided1D` and `zeros1D` to handle NPOT sizes natively by removing pow2 assertions and letting phantom entries wrap modulo `outDimSize`. Optimization fast-paths (`isShearFamily`, `lstsqShear`, `isHCompatible`, compose fast-path, `divideLeft/RightAllowingModular`) are intentionally deferred to T272164431 per review feedback in T272112093.

Reviewed By: stashuk-olek

Differential Revision: D99615185


