### PR TITLE
[AutoWS] Fix WSBarrier accuracy error with moving waits after TMEM load with subtile > 1

### DIFF
--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -426,7 +426,8 @@ tt.func @tmem_load_does_not_sink_with_later_wait_region(
 }
 
 // All split tmem_loads should inherit the channelGraph from their arrive
-// barrier and sink past store-channel barriers independently.
+// barrier and sink past store-channel barriers independently, without sinking
+// their shared wait below either guarded load.
 // CHECK-LABEL: @split_tmem_loads_all_sink
 tt.func @split_tmem_loads_all_sink(
     %tmem_wait_bar: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
@@ -459,19 +460,20 @@ tt.func @split_tmem_loads_all_sink(
   ttg.local_store %t1, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
   ttng.arrive_barrier %store_bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
 
-  // Expected: both tmem_loads sink past the store waits, interleaved with
-  // the store pipeline.
+  // Expected: both tmem_loads are interleaved with the store pipeline, but the
+  // tmem_load wait remains before both guarded loads. A single wait can guard
+  // multiple split loads, so it cannot be restored to just one recorded load.
   //
   // CHECK:      ttng.wait_barrier %{{.*}}, %{{.*}} :
+  // CHECK-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
   // CHECK-NEXT: ttng.tmem_load
   // CHECK-NEXT: arith.truncf
-  // CHECK-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
   // CHECK-NEXT: ttg.local_store
   // CHECK-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
+  // CHECK-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
   // CHECK-NEXT: ttng.tmem_load
   // CHECK-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1, 3>
   // CHECK-NEXT: arith.truncf
-  // CHECK-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
   // CHECK-NEXT: ttg.local_store
   // CHECK-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
   tt.return

--- a/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
+++ b/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
@@ -253,8 +253,11 @@ buildBarrierToMemoryOpMap(Block &block) {
 
 // After tmem_load sinking, relocate WS barriers back to optimal positions
 // relative to their associated memory ops. Arrives go right after their memory
-// op, or after later same-block operand definitions required by SSA. Waits go
-// right before their memory op. Skips moves that would break SSA dominance.
+// op, or after later same-block operand definitions required by SSA. Waits may
+// move earlier to guard their memory op, but must not be sunk later: one wait
+// can guard multiple later memory ops, and sinking it to a single recorded op
+// can let another guarded op execute before the wait. Skips moves that would
+// break SSA dominance.
 inline void optimizeWSBarrierLocations(
     const DenseMap<Operation *, Operation *> &barrierToMemOp) {
   for (auto [barrier, memOp] : barrierToMemOp) {
@@ -268,7 +271,7 @@ inline void optimizeWSBarrierLocations(
           barrier->moveAfter(anchor);
       }
     } else {
-      if (barrier->getNextNode() != memOp) {
+      if (memOp->isBeforeInBlock(barrier)) {
         if (!wouldBreakOperandDominance(barrier, memOp))
           barrier->moveBefore(memOp);
       }


### PR DESCRIPTION
`WSBarrier` had an accuracy error with `epilogue_subtile > 1` cases, where the reordering pass pushed waits to after their associated TMEM load. Since one wait can guard multiple TMEM load ops, pushing waits to after 1 TMEM load let other TMEM load ops execute before the wait, which caused ops to read stale accumulator data.

This modification maintains the optimization that moves waits earlier when necessary but blocks moving waits to after the TMEM loads.

Related to internal failure https://www.internalfb.com/intern/test/562950280530987.