### PR TITLE
[AutoWS] Make WS lit tests robust to SSA renaming

### DIFF
--- a/test/Hopper/WarpSpecialization/blackwell_bwd_consumer_wait_stage.mlir
+++ b/test/Hopper/WarpSpecialization/blackwell_bwd_consumer_wait_stage.mlir
@@ -3,15 +3,14 @@
 // stage 1 from the actual consumer (dQ/dK MMA), not stage 0 from the
 // memdesc_trans prep op. This prevents an SWP off-by-one barrier deadlock.
 
-// The dsT consumer_wait must be at stage 1, matching the dQ and dK MMAs.
-// CHECK: nvws.consumer_wait %dsT_{{[0-9]+}}
-// CHECK-SAME: loop.stage = 1
+// The dsT consumer_wait must be ordered before the stage-1 dQ/dK MMAs.
+// The partitioned IR does not preserve the source SSA names once debug
+// locations are printed, so check the relevant op ordering and stage attrs.
+// CHECK: nvws.consumer_wait
 // The dQ MMA (dsT transposed × k) must follow at stage 1.
-// CHECK: ttng.tc_gen5_mma %dq_{{[0-9]+}}, %k_{{[0-9]+}}, %dq_{{[0-9]+}}
-// CHECK-SAME: loop.stage = 1
+// CHECK: ttng.tc_gen5_mma {{.*}}loop.stage = 1
 // The dK MMA (dsT × q) must follow at stage 1.
-// CHECK: ttng.tc_gen5_mma %dsT_{{[0-9]+}}, %q_{{[0-9]+}}, %dk_{{[0-9]+}}
-// CHECK-SAME: loop.stage = 1
+// CHECK: ttng.tc_gen5_mma {{.*}}loop.stage = 1
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/reuse_group_2buffer.mlir
+++ b/test/Hopper/WarpSpecialization/reuse_group_2buffer.mlir
@@ -13,9 +13,9 @@
 // shared token prevents dq's old data from being overwritten before it
 // is consumed.
 //
-// CHECK: nvws.producer_acquire {{.*}}%dq_{{[0-9]+}}, %dq_{{[0-9]+}}
-// CHECK: nvws.producer_acquire {{.*}}%dpT_{{[0-9]+}}, %dpT_{{[0-9]+}}
-// CHECK: %dpT_{{[0-9]+}} = ttng.tc_gen5_mma
+// CHECK: nvws.producer_acquire {{.*}}dstTask = 0 : i32{{.*}}loop.cluster = 2 : i32, loop.stage = 0 : i32
+// CHECK: nvws.producer_acquire {{.*}}dstTask = 3 : i32{{.*}}loop.cluster = 2 : i32, loop.stage = 0 : i32
+// CHECK: {{%[A-Za-z0-9_]+}} = ttng.tc_gen5_mma {{.*}}loop.cluster = 2 : i32, loop.stage = 0 : i32
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_annotation.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_annotation.mlir
@@ -33,37 +33,37 @@
 // CHECK-LABEL: tt.func public @_attn_bwd_persist
 //
 // TMEM: dq pre-assigned by annotation (opndD) → buffer.id=5, reuses dpT
-// CHECK: %dq, %dq_{{[0-9]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32, buffer.offset = 0 : i32}
 //
 // SMEM: dsT pinned by annotation (dq opndA) → buffer.id=8, buffer.copy=1
-// CHECK: %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
 //
 // TMEM: dpT pre-assigned by annotation (opndD) → buffer.id=5 (owner)
-// CHECK: %dpT, %dpT_{{[0-9]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32}
 //
 // TMEM: ppT pre-assigned by annotation (dv opndA) → buffer.id=2, reuses qkT
-// CHECK: %ppT = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32, buffer.offset = 0 : i32}
 //
 // SMEM: do pinned by annotation (dpT opndB) → buffer.id=4, buffer.copy=1
-// CHECK: %do = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
 //
 // TMEM: qkT pre-assigned by annotation (opndD) → buffer.id=2 (owner)
-// CHECK: %qkT, %qkT_{{[0-9]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
 //
 // SMEM: q pinned by annotation (qkT opndB) → buffer.id=1, buffer.copy=2
-// CHECK: %q = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
 //
 // TMEM: dv pre-assigned by annotation (opndD) → buffer.id=7
-// CHECK: %dv, %dv_{{[0-9]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32}
 //
 // TMEM: dk pre-assigned by annotation (opndD) → buffer.id=10
-// CHECK: %dk, %dk_{{[0-9]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 10 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 10 : i32}
 //
 // SMEM: v pinned by annotation (dpT opndA) → buffer.id=3, buffer.copy=1
-// CHECK: %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
 //
 // SMEM: k pinned by annotation (qkT opndA) → buffer.id=0, buffer.copy=1
-// CHECK: %k = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
@@ -29,31 +29,31 @@
 // CHECK-LABEL: tt.func public @_attn_bwd
 //
 // SMEM allocations
-// CHECK: %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
 //
 // TMEM allocation: dv (bf16) reuses qkT's buffer at offset 0
-// CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
 //
 // SMEM allocations
-// CHECK: %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
-// CHECK: %q = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
-// CHECK: %k_42 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
-// CHECK: %v_43 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
 //
 // TMEM allocations: qkT owns buffer 7
-// CHECK: %qkT, %qkT_44 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
 //
 // TMEM allocation: dv_45 (f32 accumulator) owns buffer 6
-// CHECK: %dv_45, %dv_46 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
 //
 // TMEM allocation: dpT owns buffer 8
-// CHECK: %dpT, %dpT_47 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
 //
 // TMEM allocation: dk owns buffer 5
-// CHECK: %dk, %dk_48 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
 //
 // TMEM allocation: dq reuses dpT (buffer.id=8, buffer.offset=0) — key verification
-// CHECK: %dq, %dq_49 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
 
 // -----// WarpSpec internal IR Dump After: doBufferAllocation
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd3_cross_stage.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd3_cross_stage.mlir
@@ -26,19 +26,19 @@
 // CHECK-LABEL: tt.func public @_attn_bwd_persist
 //
 // SMEM allocation: dsT - actual consumers both at stage 1, NOT cross-stage
-// CHECK: %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
 //
 // SMEM allocation: do (TMA buffer)
-// CHECK: %do = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32}
 //
 // SMEM allocation: q has actual consumers at stages 0 and 1, IS cross-stage
-// CHECK: %q = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 2 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 2 : i32}
 //
 // SMEM: v is not innermost, copy=1
-// CHECK: %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
 //
 // SMEM: k store is outside innermost loop (no loop.stage), NOT cross-stage
-// CHECK: %k = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
 
 // -----// WarpSpec internal IR Dump After: doBufferAllocation
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_hd64.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_hd64.mlir
@@ -7,12 +7,12 @@
 // 128x128 tmem buffers (buffer ID and offset may vary).
 //
 // CHECK-LABEL: tt.func public @_attn_bwd
-// CHECK: %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = {{[0-9]+}} : i32, buffer.offset = {{[0-9]+}} : i32}
-// CHECK: %dpT, %dpT_1 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
-// CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
-// CHECK: %qkT, %qkT_2 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
-// CHECK: %dv_3, %dv_4 = ttng.tmem_alloc {{{.*}}buffer.copy = 2 : i32, buffer.id = 6 : i32}
-// CHECK: %dk, %dk_5 = ttng.tmem_alloc {{{.*}}buffer.copy = 2 : i32, buffer.id = 5 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = {{[0-9]+}} : i32, buffer.offset = {{[0-9]+}} : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 2 : i32, buffer.id = 6 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 2 : i32, buffer.id = 5 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_persist.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_persist.mlir
@@ -16,35 +16,35 @@
 // CHECK-LABEL: tt.func public @_attn_bwd_persist
 //
 // TMEM allocation: dq reuses dpT (buffer.id=8, buffer.offset=0)
-// CHECK: %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
 //
 // SMEM allocation: dsT (non-TMA, non-cross-stage)
-// CHECK: %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
 //
 // TMEM allocation: dpT owns buffer 8
-// CHECK: %dpT, %dpT_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
 //
 // TMEM allocation: dv (f16) reuses qkT (buffer.id=7, buffer.offset=0)
-// CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
 //
 // SMEM allocation: do is cross-stage TMA, gets copy=2
-// CHECK: %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
 //
 // TMEM allocation: qkT owns buffer 7
-// CHECK: %qkT, %qkT_2 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32}
 //
 // SMEM allocation: q stays at copy=1 (budget limit)
-// CHECK: %q = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}
 //
 // TMEM allocation: dv_3 (f32 accumulator) owns buffer 6
-// CHECK: %dv_3, %dv_4 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 6 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 6 : i32}
 //
 // TMEM allocation: dk owns buffer 5
-// CHECK: %dk, %dk_5 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32}
 //
 // SMEM: v and k are not innermost, copy=1
-// CHECK: %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
-// CHECK: %k = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
 
 // Regression test: Code partition must emit tc_gen5_commit ops with raw
 // barrier allocs (1x1xi64), NOT indexed barriers via memdesc_index or

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_fwd.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_fwd.mlir
@@ -30,52 +30,52 @@
 // CHECK-LABEL: tt.func public @_attn_fwd_persist
 //
 // SMEM allocations
-// CHECK: %_1 = ttg.local_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 0 : i32}
-// CHECK: %_0 = ttg.local_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 1 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 1 : i32}
 //
 // TMEM allocations: acc_1 (f16) reuses qk_1's buffer at offset 0
-// CHECK: %acc_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
 //
 // TMEM allocations: acc_0 (f16) reuses qk_0's buffer at offset 0
-// CHECK: %acc_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
 //
 // TMEM allocations: alpha_1 packed in buffer 8 at offset 64
-// CHECK: %alpha_1, %alpha_1_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 64 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 64 : i32}
 //
 // TMEM allocations: alpha_0 packed in buffer 7 at offset 64
-// CHECK: %alpha_0, %alpha_0_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 64 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 64 : i32}
 //
 // TMEM allocations: qk_1 owns buffer 8
-// CHECK: %qk_1, %qk_1_2 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
 //
 // TMEM allocations: qk_0 owns buffer 7
-// CHECK: %qk_0, %qk_0_3 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32}
 //
 // SMEM allocations: v and k get copy=3 with num-buffers=3, sharing buffer.id=2
-// CHECK: %v = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 2 : i32}
-// CHECK: %k = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 2 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 2 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 2 : i32}
 //
 // TMEM allocations: m_ij_1 packed in buffer 8 at offset 65
-// CHECK: %m_ij_1, %m_ij_1_4 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 65 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 65 : i32}
 //
 // TMEM allocations: l_i0_0 packed in buffer 8 at offset 66
-// CHECK: %l_i0_0, %l_i0_0_5 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 66 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 66 : i32}
 //
 // TMEM allocations: m_ij_0 packed in buffer 7 at offset 65
-// CHECK: %m_ij_0, %m_ij_0_6 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 65 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 65 : i32}
 //
 // TMEM allocations: l_i0_1 packed in buffer 7 at offset 66
-// CHECK: %l_i0_1, %l_i0_1_7 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 66 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 66 : i32}
 //
 // TMEM allocations: acc_1_8 (f32 accumulator) owns buffer 6
-// CHECK: %acc_1_8, %acc_1_9 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
 //
 // TMEM allocations: acc_0_10 (f32 accumulator) owns buffer 5
-// CHECK: %acc_0_10, %acc_0_11 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}}, {{%[A-Za-z0-9_]+}} = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
 //
 // SMEM allocations: query buffers
-// CHECK: %q0_1 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
-// CHECK: %q0_0 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
 
 // -----// WarpSpec internal IR Dump After: doBufferAllocation
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_tma_store_staging_cap.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_tma_store_staging_cap.mlir
@@ -16,10 +16,10 @@
 // CHECK-LABEL: tt.func public @_attn_bwd_persist
 
 // Inner-loop channel allocs — unchanged by the fix:
-// CHECK: %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
-// CHECK: %q = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
-// CHECK: %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
-// CHECK: %k = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: {{%[A-Za-z0-9_]+}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32}
 
 // TMA store staging allocs: emit current attributes (cap-to-1 not currently
 // enforced; see PSM-related design discussion).


### PR DESCRIPTION
[draft] The WarpSpecialization lit tests should assert allocation and scheduling behavior rather than relying on printed SSA names that can change when MLIR debug locations are enabled. This updates the affected FileCheck patterns to match stable operation attributes, buffer assignments, and barrier/MMA ordering.