### PR TITLE
Add AutoWS static-analysis regression tests (#1636)

### DIFF
--- a/test/Hopper/WarpSpecialization/1D_tmem_invalid_rank.mlir
+++ b/test/Hopper/WarpSpecialization/1D_tmem_invalid_rank.mlir
@@ -1,0 +1,16 @@
+// XFAIL: *
+// RUN: not triton-opt %s -split-input-file --nvgpu-test-1D-tmem-alloc 2>&1 | FileCheck %s --check-prefix=ERR
+
+// Regression test for B-8-F1 / T273479230.
+// ERR: expected `tmem.start` producer to have rank 1
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+  tt.func public @invalid_2d_tmem_start(%arg0: tensor<128x1xf32, #blocked2>) attributes {noinline = false} {
+    %cst = arith.constant dense<1.000000e+00> : tensor<128x1xf32, #blocked2>
+    %producer = arith.addf %arg0, %cst {tmem.start = 0 : i32, async_task_id = array<i32: 0>} : tensor<128x1xf32, #blocked2>
+    %consumer = arith.addf %producer, %cst {async_task_id = array<i32: 1>} : tensor<128x1xf32, #blocked2>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-merge-reduction.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-merge-reduction.mlir
@@ -1,0 +1,68 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-reduction merge-epilogue-to-computation" | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-3-F1 / T273467650.
+// `merge-reduction` should route TMA reduction ops and their producers to the
+// computation partition for the relevant dpId, without creating a dedicated
+// reduction partition. The current pass tries to schedule them before the
+// computation partition exists and dereferences a null fallback partition.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#load_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#reduce_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_T = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#shared_reduce = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+
+#smem = #ttg.shared_memory
+#tmem_acc = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @merge_reduction_routes_descriptor_reduce
+//
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
+// CHECK: arith.mulf {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
+// CHECK: tt.descriptor_reduce {{.*}}ttg.partition = array<i32: [[COMP]]>
+//
+// CHECK: tt.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["computation", "load", "gemm"]
+// CHECK-NOT: "reduction"
+tt.func public @merge_reduction_routes_descriptor_reduce(
+  %A_shared: !ttg.memdesc<128x64xf16, #shared, #smem>,
+  %B_desc: !tt.tensordesc<tensor<64x64xf16, #shared>>,
+  %D_desc: !tt.tensordesc<tensor<128x64xf32, #shared_reduce>>,
+  %n_tiles: i32
+) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x64xf32, #blocked>
+  %scale = arith.constant dense<1.0> : tensor<128x64xf32, #blocked>
+
+  scf.for %i = %c0_i32 to %n_tiles step %c64_i32 iter_args(
+    %acc = %zero
+  ) -> (tensor<128x64xf32, #blocked>) : i32 {
+    %B = tt.descriptor_load %B_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
+    %B_shared = ttg.local_alloc %B : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+    %B_trans = ttg.memdesc_trans %B_shared {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
+
+    %C_tmem, %C_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %A_shared, %B_trans, %C_tmem[%C_tok], %false, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared_T, #smem>, !ttg.memdesc<128x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>
+
+    %result, %result_tok = ttng.tmem_load %C_tmem[%mma_tok] : !ttg.memdesc<128x64xf32, #tmem_acc, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    %scaled = arith.mulf %result, %scale : tensor<128x64xf32, #blocked>
+    %reduced = ttg.convert_layout %scaled : tensor<128x64xf32, #blocked> -> tensor<128x64xf32, #reduce_blocked>
+    tt.descriptor_reduce add, %D_desc[%i, %c0_i32], %reduced : !tt.tensordesc<tensor<128x64xf32, #shared_reduce>>, tensor<128x64xf32, #reduce_blocked>
+
+    %new_acc = arith.addf %acc, %result : tensor<128x64xf32, #blocked>
+    scf.yield %new_acc : tensor<128x64xf32, #blocked>
+  } {tt.warp_specialize}
+
+  tt.return
+}
+
+}

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-pointer-dpid-fallback.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-pointer-dpid-fallback.mlir
@@ -1,0 +1,122 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta --verify-each=false | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-3-F2 / T273467682.
+// A pointer tensor with no MMA dpId ancestry should not be forced into
+// computation partition 0. It should remain unscheduled until sink-aware
+// propagation can route it to the computation partition that consumes it.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: pointer_tensor_uses_sink_partition
+//
+// CHECK: warp_group_dot{{.*}}ttg.partition = array<i32: [[COMP_A:[0-9]+]]>
+// CHECK: warp_group_dot{{.*}}ttg.partition = array<i32: [[COMP_B:[0-9]+]]>
+// CHECK: tt.splat {{.*}}ttg.partition = array<i32: [[COMP_B]]>
+// CHECK: tt.load {{.*}}ttg.partition = array<i32: [[COMP_B]]>
+// CHECK: arith.addf {{.*}}ttg.partition = array<i32: [[COMP_B]]>
+// CHECK: truncf{{.*}}ttg.partition = array<i32: [[COMP_A]]>
+// CHECK: truncf{{.*}}ttg.partition = array<i32: [[COMP_B]]>
+tt.func public @pointer_tensor_uses_sink_partition(
+    %a_desc: !tt.tensordesc<tensor<64x64xf16, #shared>>,
+    %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+    %c_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>,
+    %bias_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+    %M: i32 {tt.divisibility = 16 : i32},
+    %N: i32 {tt.divisibility = 16 : i32},
+    %K: i32 {tt.divisibility = 16 : i32}
+) {
+  %c132_i32 = arith.constant 132 : i32
+  %c8_i32 = arith.constant 8 : i32
+  %c128_i32 = arith.constant 128 : i32
+  %c64_i32 = arith.constant 64 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c127_i32 = arith.constant 127 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #mma>
+
+  %start_pid = tt.get_program_id x : i32
+  %num_pid_m = arith.addi %M, %c127_i32 : i32
+  %num_pid_m_div = arith.divsi %num_pid_m, %c128_i32 : i32
+  %num_pid_n = arith.addi %N, %c127_i32 : i32
+  %num_pid_n_div = arith.divsi %num_pid_n, %c128_i32 : i32
+  %k_tiles = arith.addi %K, %c64_i32 : i32
+  %k_tiles_div = arith.divsi %k_tiles, %c64_i32 : i32
+  %num_tiles = arith.muli %num_pid_m_div, %num_pid_n_div : i32
+  %tile_id_c_init = arith.subi %start_pid, %c132_i32 : i32
+  %num_pid_in_group = arith.muli %num_pid_n_div, %c8_i32 : i32
+
+  %tile_id_c_out = scf.for %tile_id = %start_pid to %num_tiles step %c132_i32
+      iter_args(%tile_id_c = %tile_id_c_init) -> (i32) : i32 {
+    %group_id = arith.divsi %tile_id, %num_pid_in_group : i32
+    %first_pid_m = arith.muli %group_id, %c8_i32 : i32
+    %group_size_m = arith.subi %num_pid_m_div, %first_pid_m : i32
+    %group_size_m_clamped = arith.minsi %group_size_m, %c8_i32 : i32
+    %pid_m = arith.remsi %tile_id, %group_size_m_clamped : i32
+    %pid_m_final = arith.addi %first_pid_m, %pid_m : i32
+    %pid_n_tmp = arith.remsi %tile_id, %num_pid_in_group : i32
+    %pid_n = arith.divsi %pid_n_tmp, %group_size_m_clamped : i32
+    %offs_am = arith.muli %pid_m_final, %c128_i32 : i32
+    %offs_am_1 = arith.addi %offs_am, %c64_i32 : i32
+    %offs_bn = arith.muli %pid_n, %c128_i32 : i32
+
+    %acc:2 = scf.for %ki = %c0_i32 to %k_tiles_div step %c1_i32
+        iter_args(%acc0 = %cst, %acc1 = %cst) -> (tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>) : i32 {
+      %offs_k = arith.muli %ki, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+
+      %a0 = tt.descriptor_load %a_desc[%offs_am, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #blocked>
+      %a1 = tt.descriptor_load %a_desc[%offs_am_1, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #blocked>
+      %b = tt.descriptor_load %b_desc[%offs_bn, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+
+      %a0_smem = ttg.local_alloc %a0 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+      %a1_smem = ttg.local_alloc %a1 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+      %b_smem = ttg.local_alloc %b {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %b_trans = ttg.memdesc_trans %b_smem {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+
+      %dot0 = ttng.warp_group_dot %a0_smem, %b_trans, %acc0 {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared1, #smem> -> tensor<64x128xf32, #mma>
+      %dot1 = ttng.warp_group_dot %a1_smem, %b_trans, %acc1 {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared1, #smem> -> tensor<64x128xf32, #mma>
+
+      %bias_ptrs = tt.splat %bias_ptr : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #mma>
+      %bias = tt.load %bias_ptrs : tensor<64x128x!tt.ptr<f32>, #mma>
+      %dot1_biased = arith.addf %dot1, %bias : tensor<64x128xf32, #mma>
+
+      scf.yield %dot0, %dot1_biased : tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>
+    } {tt.scheduled_max_stage = 1 : i32}
+
+    %tile_id_c_next = arith.addi %tile_id_c, %c132_i32 : i32
+    %group_id_c = arith.divsi %tile_id_c_next, %num_pid_in_group : i32
+    %first_pid_m_c = arith.muli %group_id_c, %c8_i32 : i32
+    %group_size_m_c = arith.subi %num_pid_m_div, %first_pid_m_c : i32
+    %group_size_m_c_clamped = arith.minsi %group_size_m_c, %c8_i32 : i32
+    %pid_m_c = arith.remsi %tile_id_c_next, %group_size_m_c_clamped : i32
+    %pid_m_c_final = arith.addi %first_pid_m_c, %pid_m_c : i32
+    %pid_n_c_tmp = arith.remsi %tile_id_c_next, %num_pid_in_group : i32
+    %pid_n_c = arith.divsi %pid_n_c_tmp, %group_size_m_c_clamped : i32
+    %offs_am_c = arith.muli %pid_m_c_final, %c128_i32 : i32
+    %offs_am_c_1 = arith.addi %offs_am_c, %c64_i32 : i32
+    %offs_bn_c = arith.muli %pid_n_c, %c128_i32 : i32
+
+    %c0_f16 = arith.truncf %acc#0 : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %c1_f16 = arith.truncf %acc#1 : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %c0_cvt = ttg.convert_layout %c0_f16 : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked1>
+    %c1_cvt = ttg.convert_layout %c1_f16 : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked1>
+    %c0_smem = ttg.local_alloc %c0_cvt : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    %store_tok0 = ttng.async_tma_copy_local_to_global %c_desc[%offs_am_c, %offs_bn_c] %c0_smem : !tt.tensordesc<tensor<64x128xf16, #shared>>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %store_tok0 : !ttg.async.token
+    %c1_smem = ttg.local_alloc %c1_cvt : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    %store_tok1 = ttng.async_tma_copy_local_to_global %c_desc[%offs_am_c_1, %offs_bn_c] %c1_smem : !tt.tensordesc<tensor<64x128xf16, #shared>>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %store_tok1 : !ttg.async.token
+
+    scf.yield %tile_id_c_next : i32
+  } {tt.data_partition_factor = 2 : i32, tt.smem_alloc_algo = 0 : i32, tt.warp_specialize}
+  tt.return
+}
+
+}

--- a/test/Hopper/WarpSpecialization/pingpong_group_wgmma_endpoints.mlir
+++ b/test/Hopper/WarpSpecialization/pingpong_group_wgmma_endpoints.mlir
@@ -1,5 +1,5 @@
 // RUN: triton-opt %s --nvgpu-test-ping-pong-prep="capability=90 num-stages=3" | FileCheck %s
-
+// Regression test for B-4-F1 / T273470439.
 // WGMMA has memory effects because it reads SMEM operands, but those endpoint
 // effects are not intervening effects between two WGMMA ops in the same
 // partition. All ten dots below should therefore be one ping-pong group.

--- a/test/Hopper/WarpSpecialization/ws_buffer_else_accumcnt.mlir
+++ b/test/Hopper/WarpSpecialization/ws_buffer_else_accumcnt.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=2 post-channel-creation=1" | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-12-F1 / T273486918.
+//
+// The only post-code-partition SMEM channel is directly inside the else block
+// of an scf.if. WSBuffer accumulator rewriting must leave the then branch's
+// accumulator unchanged and increment the else branch's accumulator. The
+// current implementation increments the then yield and leaves else unchanged.
+
+// CHECK-LABEL: @else_direct_smem_channel
+// CHECK: scf.if {{.*}} -> (i64) {
+// CHECK-NEXT: %[[THEN_ZERO:.*]] = arith.constant{{.*}} 0 : i64
+// CHECK-NEXT: scf.yield {{.*}}%[[THEN_ZERO]] : i64
+// CHECK-NEXT: } else {
+// CHECK: %[[ELSE_ONE:.*]] = arith.constant{{.*}} 1 : i64
+// CHECK-NEXT: scf.yield {{.*}}%[[ELSE_ONE]] : i64
+// CHECK: tt.return
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @else_direct_smem_channel(%src: tensor<16xf32, #blocked>) attributes {noinline = false} {
+    %alloc = ttg.local_alloc {async_task_id = array<i32: 0>, buffer.copy = 2 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1>} 1 : i32
+    %pred = arith.cmpi eq, %c0_i32, %c1_i32 {async_task_id = array<i32: 0, 1>} : i32
+    scf.if %pred {
+      scf.yield
+    } else {
+      %stored = arith.addf %src, %src {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked>
+      ttg.local_store %stored, %alloc {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked> -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+      %loaded = ttg.local_load %alloc {async_task_id = array<i32: 1>} : !ttg.memdesc<16xf32, #shared, #smem, mutable> -> tensor<16xf32, #blocked>
+      %used = arith.addf %loaded, %loaded {async_task_id = array<i32: 1>} : tensor<16xf32, #blocked>
+      scf.yield
+    } {async_task_id = array<i32: 0, 1>}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_code_partition_post_smem_multi_task_producer.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_post_smem_multi_task_producer.mlir
@@ -1,0 +1,24 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition='num-buffers=2 post-channel-creation=1' | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-1-F2 / T273462656.
+// Multi-task SMEM producers can have consumers in multiple task partitions.
+// The post channel collector should filter per partition instead of asserting
+// when both the producer and consumer task-id sets contain more than one id.
+
+// CHECK-LABEL: @multi_task_smem_producer_multiple_consumers
+// CHECK: tt.return
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @multi_task_smem_producer_multiple_consumers(%src: tensor<16xf32, #blocked>) attributes {noinline = false} {
+    %alloc = ttg.local_alloc {async_task_id = array<i32: 0, 1>, buffer.copy = 2 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+    ttg.local_store %src, %alloc {async_task_id = array<i32: 0, 1>} : tensor<16xf32, #blocked> -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+    %loaded0 = ttg.local_load %alloc {async_task_id = array<i32: 0>} : !ttg.memdesc<16xf32, #shared, #smem, mutable> -> tensor<16xf32, #blocked>
+    %loaded1 = ttg.local_load %alloc {async_task_id = array<i32: 1>} : !ttg.memdesc<16xf32, #shared, #smem, mutable> -> tensor<16xf32, #blocked>
+    %used = arith.addf %loaded0, %loaded1 {async_task_id = array<i32: 0, 1>} : tensor<16xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_code_partition_post_smem_same_task.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_post_smem_same_task.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition='num-buffers=2 post-channel-creation=1' | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-1-F1 / T273462573.
+// Same-partition SMEM producer/consumer pairs are not cross-partition channels.
+// The post code partition path should leave the pre-planned allocation shape
+// alone instead of creating a multi-buffered ChannelPost for an empty consumer
+// task set.
+
+// CHECK-LABEL: @same_partition_smem_post_no_channel
+// CHECK-NOT: memdesc<2x16xf32
+// CHECK: tt.return
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @same_partition_smem_post_no_channel(%src: tensor<16xf32, #blocked>) attributes {noinline = false} {
+    %alloc = ttg.local_alloc {async_task_id = array<i32: 0>, buffer.copy = 2 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+    ttg.local_store %src, %alloc {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked> -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+    %loaded = ttg.local_load %alloc {async_task_id = array<i32: 0>} : !ttg.memdesc<16xf32, #shared, #smem, mutable> -> tensor<16xf32, #blocked>
+    %used = arith.addf %loaded, %loaded {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_code_partition_replace_dp_commits.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_replace_dp_commits.mlir
@@ -1,11 +1,15 @@
 // RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=3 post-channel-creation=1" | FileCheck %s
+// XFAIL: *
 
+// Regression test for B-13-F1 / T273488617.
+//
 // Test: data-partitioned D-channel commits for a persistent GEMM with
 // tt.data_partition_factor = 2, producing two tc_gen5_mma ops in the inner
 // k-loop.
 //
-// With multiple MMAs in the loop, each MMA gets a plain tc_gen5_commit
-// with raw barrier allocs for D-channel completion tracking.
+// With multiple MMAs in the loop, D-channel completion tracking should avoid
+// global tc_gen5_commit ops. Each MMA should wait on its A/B inline barrier
+// and arrive on the corresponding D barrier.
 
 // CHECK-LABEL: @matmul_kernel_tma_persistent
 // CHECK: ttg.warp_specialize
@@ -20,12 +24,18 @@
 // The k-loop ends:
 // CHECK: scf.yield
 //
-// After the inner k-loop: each MMA gets a plain tc_gen5_commit with raw
-// barrier allocs for D-channel completion tracking.
+// After the inner k-loop: D-channel completion must use per-MMA wait/arrive
+// pairs, with no raw global tc_gen5_commit fallback before the outer yield.
 //
-// CHECK: ttng.tc_gen5_commit {{%[a-z0-9_]+}} {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64
-// CHECK: ttng.tc_gen5_commit {{%[a-z0-9_]+}} {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64
-// CHECK: ttng.tc_gen5_commit {{%[a-z0-9_]+}} {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64
+// CHECK-NOT: ttng.tc_gen5_commit
+// CHECK: ttng.wait_barrier
+// CHECK-NOT: ttng.tc_gen5_commit
+// CHECK: ttng.arrive_barrier
+// CHECK-NOT: ttng.tc_gen5_commit
+// CHECK: ttng.wait_barrier
+// CHECK-NOT: ttng.tc_gen5_commit
+// CHECK: ttng.arrive_barrier
+// CHECK-NOT: ttng.tc_gen5_commit
 //
 // Outer loop yield:
 // CHECK: scf.yield

--- a/test/Hopper/WarpSpecialization/ws_code_partition_subtiled_region.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_subtiled_region.mlir
@@ -1,6 +1,10 @@
 // RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1" | FileCheck %s
+// XFAIL: *
 
 // Test: Code partition with SubtiledRegionOps for epilogue subtiling.
+// Regression test for B-11-F1 / T273485415.
+// Inline consumer-side subtiled NVWS tokens must carry WSBarrier destination
+// metadata so WSBarrierAnalysis can inject channel graph metadata.
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
@@ -23,8 +27,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: partition1
   // CHECK:   ttng.subtiled_region
   // CHECK:     nvws.consumer_wait
+  // CHECK-SAME: channelGraph = array<i32: 1>
+  // CHECK-SAME: dstTask = 1 : i32
   // CHECK:     ttng.async_tma_copy_local_to_global
   // CHECK:     nvws.consumer_release
+  // CHECK-SAME: channelGraph = array<i32: 1>
+  // CHECK-SAME: dstTask = 1 : i32
   tt.func @subtiled_smem_channel(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %off0: i32, %off1: i32, %off2: i32,

--- a/test/Hopper/WarpSpecialization/ws_code_partition_tmem_pre_alloc.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_tmem_pre_alloc.mlir
@@ -1,0 +1,34 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition=num-buffers=2 | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-2-F1 / T273465371.
+//
+// A TMEM allocation with a source tensor is produced in task 0 and consumed by
+// a Gen5 MMA in task 1. The pre-allocation channel discovery path classifies
+// this as DataChannelKind::TMEM, but currently stores it in a plain Channel.
+// TMEM memory lowering then casts it to TmemDataChannel and crashes/reads an
+// invalid allocation contract. Once fixed, the pre-allocated TMEM channel
+// should be multi-buffered and accessed through a memdesc_index subview.
+
+// CHECK-LABEL: @tmem_alloc_src_cross_partition
+// CHECK: ttg.warp_specialize
+// CHECK: ttng.tmem_alloc
+// CHECK: ttg.memdesc_index
+// CHECK: ttng.tmem_store
+// CHECK: ttng.tc_gen5_mma
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tmem_alloc_src_cross_partition(%b_smem: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>) attributes {noinline = false} {
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %false = arith.constant {async_task_id = array<i32: 0, 1>} false
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<1.000000e+00> : tensor<128x128xbf16, #blocked>
+    %acc, %acc_token = ttng.tmem_alloc {async_task_id = array<i32: 1>} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %p_tmem = ttng.tmem_alloc %cst {async_task_id = array<i32: 0>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>
+    %mma_token = ttng.tc_gen5_mma %p_tmem, %b_smem, %acc[%acc_token], %false, %true {async_task_id = array<i32: 1>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_data_partition_dot_k_no_atomic.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition_dot_k_no_atomic.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-opt %s --nvgpu-ws-data-partition=num-warp-groups=3 | FileCheck %s
+// Regression test for B-14-F3 / T273489833.
+// If partitioning a dot result through another dot's K operand is not backed
+// by an atomic store/reduce, the pass should reject that trial direction
+// deterministically and choose the legal N-dimension direction here.
+
+// CHECK-LABEL: @dot_k_operand_without_atomic_store
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
+// CHECK-SAME: !ttg.memdesc<64x128xf16, #shared, #smem>
+// CHECK-SAME: -> tensor<128x128xf32, #mma>
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
+// CHECK-SAME: !ttg.memdesc<64x128xf16, #shared, #smem>
+// CHECK-SAME: -> tensor<128x128xf32, #mma>
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: !ttg.memdesc<128x128xf16, #shared, #smem>
+// CHECK-SAME: !ttg.memdesc<128x128xf16, #shared, #smem>
+// CHECK-SAME: -> tensor<128x128xf32, #mma>
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: !ttg.memdesc<128x128xf16, #shared, #smem>
+// CHECK-SAME: !ttg.memdesc<128x128xf16, #shared, #smem>
+// CHECK-SAME: -> tensor<128x128xf32, #mma>
+// CHECK: tt.store
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @dot_k_operand_without_atomic_store(
+      %desc_a0: !tt.tensordesc<tensor<128x64xf16>>,
+      %desc_b0: !tt.tensordesc<tensor<64x256xf16>>,
+      %desc_a1: !tt.tensordesc<tensor<128x128xf16>>,
+      %out: !tt.ptr<f16>) {
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %acc0 = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %acc1 = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+
+    %a0 = tt.descriptor_load %desc_a0[%c0_i32, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked1>
+    %a0_smem = ttg.local_alloc %a0 {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b0 = tt.descriptor_load %desc_b0[%c0_i32, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<64x256xf16>> -> tensor<64x256xf16, #blocked>
+    %b0_smem = ttg.local_alloc %b0 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+    %dot0 = ttng.warp_group_dot %a0_smem, %b0_smem, %acc0 {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    %dot0_f16 = arith.truncf %dot0 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+    %dot0_smem = ttg.local_alloc %dot0_f16 {async_task_id = array<i32: 1, 2>} : (tensor<128x256xf16, #mma>) -> !ttg.memdesc<128x256xf16, #shared, #smem>
+
+    %a1 = tt.descriptor_load %desc_a1[%c0_i32, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x128xf16>> -> tensor<128x128xf16, #blocked1>
+    %a1_smem = ttg.local_alloc %a1 {async_task_id = array<i32: 1, 2>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %dot1 = ttng.warp_group_dot %a1_smem, %dot0_smem, %acc1 {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem> * !ttg.memdesc<128x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    %dot1_f16 = arith.truncf %dot1 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+    %dot1_out = ttg.convert_layout %dot1_f16 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked>
+    %out_ptr = tt.splat %out {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked>
+    tt.store %out_ptr, %dot1_out {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_data_partition_single_task_dot.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition_single_task_dot.mlir
@@ -1,0 +1,61 @@
+// RUN: triton-opt %s --nvgpu-ws-data-partition=num-warp-groups=3 | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-14-F1 / T273489733.
+// Data partitioning is driven by dots with multiple consumer task ids. An
+// unrelated dot with a single consumer task id should not be sliced merely
+// because another dot in the same function needs partitioning.
+
+// CHECK-LABEL: @single_task_dot_not_partitioned
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: {async_task_id = array<i32: 1>
+// CHECK-SAME: -> tensor<64x256xf32, #mma>
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: {async_task_id = array<i32: 2>
+// CHECK-SAME: -> tensor<64x256xf32, #mma>
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: {async_task_id = array<i32: 1>
+// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
+// CHECK-SAME: !ttg.memdesc<64x256xf16, #shared, #smem>
+// CHECK-SAME: -> tensor<128x256xf32, #mma>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @single_task_dot_not_partitioned(
+      %desc_a_multi: !tt.tensordesc<tensor<128x64xf16>>,
+      %desc_b_multi: !tt.tensordesc<tensor<64x256xf16>>,
+      %desc_a_single: !tt.tensordesc<tensor<128x64xf16>>,
+      %desc_b_single: !tt.tensordesc<tensor<64x256xf16>>,
+      %out_multi: !tt.ptr<f16>,
+      %out_single: !tt.ptr<f16>) {
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %acc_multi = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %acc_single = arith.constant {async_task_id = array<i32: 1>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+
+    %a_multi = tt.descriptor_load %desc_a_multi[%c0_i32, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %a_multi_smem = ttg.local_alloc %a_multi {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_multi = tt.descriptor_load %desc_b_multi[%c0_i32, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<64x256xf16>> -> tensor<64x256xf16, #blocked1>
+    %b_multi_smem = ttg.local_alloc %b_multi {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+    %dot_multi = ttng.warp_group_dot %a_multi_smem, %b_multi_smem, %acc_multi {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    %multi_f16 = arith.truncf %dot_multi {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+    %multi_out = ttg.convert_layout %multi_f16 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+    %multi_ptr = tt.splat %out_multi {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
+    tt.store %multi_ptr, %multi_out {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
+
+    %a_single = tt.descriptor_load %desc_a_single[%c0_i32, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+    %a_single_smem = ttg.local_alloc %a_single {async_task_id = array<i32: 1>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_single = tt.descriptor_load %desc_b_single[%c0_i32, %c0_i32] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<64x256xf16>> -> tensor<64x256xf16, #blocked1>
+    %b_single_smem = ttg.local_alloc %b_single {async_task_id = array<i32: 1>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+    %dot_single = ttng.warp_group_dot %a_single_smem, %b_single_smem, %acc_single {async_task_id = array<i32: 1>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    %single_f16 = arith.truncf %dot_single {async_task_id = array<i32: 1>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+    %single_out = ttg.convert_layout %single_f16 {async_task_id = array<i32: 1>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+    %single_ptr = tt.splat %out_single {async_task_id = array<i32: 1>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
+    tt.store %single_ptr, %single_out {async_task_id = array<i32: 1>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_hoist_tmem_store.mlir
+++ b/test/Hopper/WarpSpecialization/ws_hoist_tmem_store.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-hoist-tmem-store | FileCheck %s
+// XFAIL: *
 
 // Test hoisting a loop-invariant TMEMStore out of an outer ForOp when the inner
 // loop's MMA has useD=false (statically).
@@ -38,6 +39,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       scf.yield %load_tok, %result : !ttg.async.token, tensor<128x128xf32, #blocked>
     }
     tt.return %outer#1 : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// Regression test for B-15-F1 / T273491852.
+// Negative test: the stored TMEM buffer feeds MMA operand A, not the MMA
+// accumulator. The accumulator useD=false flag does not make the operand-A
+// store redundant, so the store must remain inside the outer loop.
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @no_hoist_operand_a_tmem_store
+  // CHECK: %[[A_INIT:.*]] = arith.constant dense<0.000000e+00>
+  // CHECK: %[[A_TM:.*]], %[[A_ALLOC_TOK:.*]] = ttng.tmem_alloc : ()
+  // CHECK: %[[ACC_TM:.*]], %[[ACC_ALLOC_TOK:.*]] = ttng.tmem_alloc : ()
+  // CHECK: scf.for {{.*}} iter_args(%[[A_TOK:.*]] = %[[A_ALLOC_TOK]], %[[ACC_TOK:.*]] = %[[ACC_ALLOC_TOK]]
+  // CHECK:   %[[A_STORE_TOK:.*]] = ttng.tmem_store %[[A_INIT]], %[[A_TM]][%[[A_TOK]]]
+  // CHECK:   scf.for {{.*}} iter_args(%[[INNER_A_TOK:.*]] = %[[A_STORE_TOK]], %[[INNER_ACC_TOK:.*]] = %[[ACC_TOK]]
+  // CHECK:     ttng.tc_gen5_mma %[[A_TM]], %{{.*}}, %[[ACC_TM]][%[[INNER_ACC_TOK]]], %false
+  tt.func public @no_hoist_operand_a_tmem_store(
+      %B_sh: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>,
+      %N: i32, %K: i32) -> tensor<128x128xf32, #blocked> {
+    %true = arith.constant true
+    %false = arith.constant false
+    %a_init = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #blocked>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %a_tm, %a_tok0 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %acc_tm, %acc_tok0 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %outer:3 = scf.for %i = %c0_i32 to %N step %c1_i32 iter_args(%a_tok = %a_tok0, %acc_tok = %acc_tok0, %out = %cst) -> (!ttg.async.token, !ttg.async.token, tensor<128x128xf32, #blocked>)  : i32 {
+      %a_store_tok = ttng.tmem_store %a_init, %a_tm[%a_tok], %true : tensor<128x128xf16, #blocked> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+      %inner:2 = scf.for %j = %c0_i32 to %K step %c1_i32 iter_args(%inner_a_tok = %a_store_tok, %inner_acc_tok = %acc_tok) -> (!ttg.async.token, !ttg.async.token)  : i32 {
+        %mma_tok = ttng.tc_gen5_mma %a_tm, %B_sh, %acc_tm[%inner_acc_tok], %false, %true : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %inner_a_tok, %mma_tok : !ttg.async.token, !ttg.async.token
+      }
+      %result, %load_tok = ttng.tmem_load %acc_tm[%inner#1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      scf.yield %inner#0, %load_tok, %result : !ttg.async.token, !ttg.async.token, tensor<128x128xf32, #blocked>
+    }
+    tt.return %outer#2 : tensor<128x128xf32, #blocked>
   }
 }
 

--- a/test/Hopper/WarpSpecialization/ws_lower_mem_preserve_same_task_uses.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_mem_preserve_same_task_uses.mlir
@@ -1,0 +1,26 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=2 post-channel-creation=1" | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-16-F1 / T273493462.
+//
+// A producer load can have both same-task and cross-task consumers. WSLowerMem
+// must only lower the cross-task channel operand through SMEM; the same-task
+// use must stay on the original load result.
+
+// CHECK-LABEL: @preserve_same_task_load_use
+// CHECK: %[[LOAD:.*]] = tt.load
+// CHECK: arith.addf %[[LOAD]], %[[LOAD]] {{.*}}async_task_id = array<i32: 0}
+// CHECK: %[[LOCAL:.*]] = ttg.local_load
+// CHECK: arith.addf %[[LOCAL]], %[[LOCAL]] {{.*}}async_task_id = array<i32: 1}
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @preserve_same_task_load_use(%ptr: !tt.ptr<f32>) attributes {noinline = false} {
+    %ptrs = tt.splat %ptr {async_task_id = array<i32: 0>} : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>, #blocked>
+    %loaded = tt.load %ptrs {async_task_id = array<i32: 0>} : tensor<16x!tt.ptr<f32>, #blocked>
+    %same_task = arith.addf %loaded, %loaded {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked>
+    %cross_task = arith.addf %loaded, %loaded {async_task_id = array<i32: 1>} : tensor<16xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multi_consumer_task_ids.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multi_consumer_task_ids.mlir
@@ -1,0 +1,34 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=2" | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-16-F2 / T273493463.
+//
+// A TMA descriptor load feeding multiple consumer tasks needs the replacement
+// local_load to survive in every consumer partition. The fused barrier path
+// already creates waits for each task; the data load must carry the same full
+// consumer task-id set instead of inheriting only the last extra task.
+
+// CHECK-LABEL: @tma_multi_consumer_task_ids
+// CHECK: ttng.wait_barrier {{.*}}async_task_id = array<i32: 1}
+// CHECK: ttng.wait_barrier {{.*}}async_task_id = array<i32: 2}
+// CHECK: %[[LOCAL:.*]] = ttg.local_load {{.*}}async_task_id = array<i32: 1, 2}
+// CHECK: arith.addf %[[LOCAL]], %[[LOCAL]] {{.*}}async_task_id = array<i32: 1}
+// CHECK: arith.subf %[[LOCAL]], %[[LOCAL]] {{.*}}async_task_id = array<i32: 2}
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tma_multi_consumer_task_ids(%desc: !tt.tensordesc<tensor<128x64xf16, #shared>>) attributes {noinline = false} {
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %c1 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : i32
+    %c4 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 4 : i32
+    scf.for %iv = %c0 to %c4 step %c1 {
+      %tile = tt.descriptor_load %desc[%c0, %c0] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+      %consumer0 = arith.addf %tile, %tile {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked>
+      %consumer1 = arith.subf %tile, %tile {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked>
+      scf.yield
+    } {async_task_id = array<i32: 0, 1, 2>, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_lower_token_async_load_commit.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_token_async_load_commit.mlir
@@ -1,0 +1,19 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-17-F1 / T273495688.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @async_load_producer_commit
+  // CHECK: ttng.async_copy_mbarrier_arrive
+  // CHECK-NOT: nvws.producer_commit
+  // CHECK: ttng.wait_barrier
+  tt.func public @async_load_producer_commit() {
+    %tok = nvws.create_token {loadType = 1 : i32, numBuffers = 1 : i32} : tensor<1x!nvws.token>
+    %idx = arith.constant {async_task_id = array<i32: 0, 1>} 0 : i32
+    %phase = arith.constant {async_task_id = array<i32: 1>} false
+
+    nvws.producer_commit %tok, %idx {async_task_id = array<i32: 0>} : tensor<1x!nvws.token>, i32
+    nvws.consumer_wait %tok, %idx, %phase {async_task_id = array<i32: 1>} : tensor<1x!nvws.token>, i32, i1
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_lower_token_tma_store_multi_nvws_tokens.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_token_tma_store_multi_nvws_tokens.mlir
@@ -1,0 +1,26 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-17-F2 / T273495687.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tma_store_wait_two_nvws_tokens
+  // CHECK: ttg.local_alloc
+  // CHECK: %[[EMPTY0:.*]] = ttg.local_alloc
+  // CHECK: ttg.local_alloc
+  // CHECK: %[[EMPTY1:.*]] = ttg.local_alloc
+  // CHECK: %[[BAR0:.*]] = ttg.memdesc_index %[[EMPTY0]][%{{.*}}]
+  // CHECK: %[[BAR1:.*]] = ttg.memdesc_index %[[EMPTY1]][%{{.*}}]
+  // CHECK: ttng.async_tma_store_token_wait %arg0, %[[BAR0]][%{{.*}}], %[[BAR1]][%{{.*}}]
+  // CHECK-NOT: nvws_token
+  tt.func public @tma_store_wait_two_nvws_tokens(%store_tok: !ttg.async.token) {
+    %tok0 = nvws.create_token {loadType = 3 : i32, numBuffers = 2 : i32} : tensor<2x!nvws.token>
+    %tok1 = nvws.create_token {loadType = 3 : i32, numBuffers = 2 : i32} : tensor<2x!nvws.token>
+    %idx0 = arith.constant {async_task_id = array<i32: 1>} 0 : i32
+    %idx1 = arith.constant {async_task_id = array<i32: 1>} 1 : i32
+
+    "ttng.async_tma_store_token_wait"(%store_tok, %tok0, %tok1, %idx0, %idx1)
+        <{operandSegmentSizes = array<i32: 1, 0, 0, 2, 2>, async_task_id = array<i32: 1>}>
+        : (!ttg.async.token, tensor<2x!nvws.token>, tensor<2x!nvws.token>, i32, i32) -> ()
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_autows_malformed_numeric.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_autows_malformed_numeric.mlir
@@ -1,0 +1,6 @@
+// RUN: sed 's/opndA,smem,1,0/opndA,smem,two,0/' %S/ws_memory_planner_annotation.mlir | triton-opt --nvgpu-test-ws-memory-planner=num-buffers=2 -o /dev/null
+// XFAIL: *
+
+// Regression test for B-18-F3 / T273497320.
+// Malformed numeric fields in user-provided tt.autows channel annotations
+// should be rejected without letting std::stoi terminate the pass.

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_decision_replay_buffer_offset.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_decision_replay_buffer_offset.mlir
@@ -1,0 +1,12 @@
+// RUN: triton-opt %S/ws_memory_planner_annotation.mlir --nvgpu-test-ws-memory-planner="num-buffers=2 write-decision-file=%t.decisions" --mlir-print-debuginfo --mlir-use-nameloc-as-prefix -o /dev/null
+// RUN: triton-opt %S/ws_memory_planner_annotation.mlir --nvgpu-test-ws-memory-planner="read-decision-file=%t.decisions" --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-18-F1 / T273497319.
+// A replayed decision file must preserve the absence of buffer.offset on the
+// owner of a TMEM reuse group. Reusers keep buffer.offset = 0, but the owner
+// remains distinguishable by not carrying the attribute.
+
+// CHECK-LABEL: tt.func public @_attn_bwd_persist
+// CHECK: %ppT = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32, buffer.offset = 0 : i32}
+// CHECK: %qkT, %qkT_{{[0-9]+}} = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32}

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_smem_no_self_reuse.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_smem_no_self_reuse.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-alloc-algo=1 smem-budget=65536" | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-18-F2 / T273497318.
+// The only non-innermost SMEM buffer is larger than every distinct allocated
+// target, so the planner must not satisfy the budget by making it reuse itself.
+
+// CHECK-LABEL: @smem_no_self_reuse
+// CHECK-NOT: allocation.shareGroup = 2 : i32, buffer.copy = 1 : i32, buffer.id = 2 : i32
+// CHECK: tt.return
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @smem_no_self_reuse(
+      %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %b_desc: !tt.tensordesc<tensor<64x256xf16, #shared>>,
+      %c_desc: !tt.tensordesc<tensor<128x256xf16, #shared>>) {
+    %A_smem = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %B_smem = ttg.local_alloc : () -> !ttg.memdesc<64x256xf16, #shared, #smem, mutable>
+    %C_smem = ttg.local_alloc : () -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %false = arith.constant false
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c10 = arith.constant 10 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+
+    %outer = scf.for %iv = %c0 to %c10 step %c1 iter_args(%arg0 = %c0) -> (i32) : i32 {
+      %init = ttng.tmem_store %cst, %result[%token], %true : tensor<128x256xf32, #blocked> -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+      %inner:2 = scf.for %kv = %c0 to %c10 step %c1 iter_args(%acc_flag = %false, %acc_tok = %init) -> (i1, !ttg.async.token) : i32 {
+        %a = tt.descriptor_load %a_desc[%c0, %c0] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+        ttg.local_store %a, %A_smem : tensor<128x64xf16, #blocked1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %b = tt.descriptor_load %b_desc[%c0, %c0] : !tt.tensordesc<tensor<64x256xf16, #shared>> -> tensor<64x256xf16, #blocked2>
+        ttg.local_store %b, %B_smem : tensor<64x256xf16, #blocked2> -> !ttg.memdesc<64x256xf16, #shared, #smem, mutable>
+        %mma = ttng.tc_gen5_mma %A_smem, %B_smem, %result[%acc_tok], %acc_flag, %true : !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x256xf16, #shared, #smem, mutable>, !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %true, %mma : i1, !ttg.async.token
+      }
+
+      %res, %res_tok = ttng.tmem_load %result[%inner#1] {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
+      %res_f16 = arith.truncf %res {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x256xf32, #blocked> to tensor<128x256xf16, #blocked>
+      %res_cvt = ttg.convert_layout %res_f16 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x256xf16, #blocked> -> tensor<128x256xf16, #blocked2>
+      ttg.local_store %res_cvt, %C_smem {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x256xf16, #blocked2> -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+      %c_val = ttg.local_load %C_smem {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x256xf16, #shared, #smem, mutable> -> tensor<128x256xf16, #blocked2>
+      tt.descriptor_store %c_desc[%c0, %c0], %c_val {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x256xf16, #shared>>, tensor<128x256xf16, #blocked2>
+      scf.yield %arg0 : i32
+    } {tt.warp_specialize}
+
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_specialize_if_result_task_use.mlir
+++ b/test/Hopper/WarpSpecialization/ws_specialize_if_result_task_use.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1" | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-19-F1 / T273499456.
+//
+// The task-1 partition consumes the result of an scf.if even though the then
+// branch yields an untagged rematerializable value. Specialization must keep
+// the if result in partition0 instead of dropping it based on the producer of
+// the then-yielded value.
+
+// CHECK-LABEL: @if_result_used_by_task
+// CHECK: ttg.warp_specialize
+// CHECK: partition0
+// CHECK: %[[IF:.*]] = scf.if {{.*}} -> (i32) {
+// CHECK: scf.yield {{.*}} : i32
+// CHECK: } else {
+// CHECK: scf.yield {{.*}} : i32
+// CHECK: }
+// CHECK: %[[USE:.*]] = arith.addi %[[IF]],
+// CHECK: tt.splat %[[USE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @if_result_used_by_task(%src: tensor<16xf32, #blocked>, %dst: tensor<16x!tt.ptr<f32>, #blocked>) {
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : index
+    %c1 = arith.constant {async_task_id = array<i32: 0, 1>} 1 : index
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1>} 1 : i32
+    %zero_vec = arith.constant {async_task_id = array<i32: 1>} dense<0> : tensor<16xi32, #blocked>
+    %alloc = ttg.local_alloc {async_task_id = array<i32: 0>, buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+    scf.for %iv = %c0 to %c1 step %c1 {
+      %c7_i32 = arith.constant 7 : i32
+      %pred = arith.cmpi eq, %c0_i32, %c1_i32 {async_task_id = array<i32: 0, 1>} : i32
+      %selected = scf.if %pred -> (i32) {
+        scf.yield {async_task_id = array<i32: 0, 1>} %c7_i32 : i32
+      } else {
+        %task_value = arith.addi %c0_i32, %c1_i32 {async_task_id = array<i32: 1>} : i32
+        scf.yield {async_task_id = array<i32: 0, 1>} %task_value : i32
+      } {async_task_id = array<i32: 0, 1>}
+      %used = arith.addi %selected, %c1_i32 {async_task_id = array<i32: 1>} : i32
+      %used_vec = tt.splat %used {async_task_id = array<i32: 1>} : i32 -> tensor<16xi32, #blocked>
+      %mask = arith.cmpi sge, %used_vec, %zero_vec {async_task_id = array<i32: 1>} : tensor<16xi32, #blocked>
+      %stored = arith.addf %src, %src {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked>
+      ttg.local_store %stored, %alloc {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked> -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+      %loaded = ttg.local_load %alloc {async_task_id = array<i32: 1>} : !ttg.memdesc<16xf32, #shared, #smem, mutable> -> tensor<16xf32, #blocked>
+      tt.store %dst, %loaded, %mask {async_task_id = array<i32: 1>} : tensor<16x!tt.ptr<f32>, #blocked>
+    } {async_task_id = array<i32: 0, 1>, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32], ttg.partition.types = ["compute", "compute"]}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_specialize_loop_result_region_use.mlir
+++ b/test/Hopper/WarpSpecialization/ws_specialize_loop_result_region_use.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1" | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-19-F2 / T273499458.
+//
+// The first task-1 loop result is consumed only as the init arg of a second
+// task-1 loop. Specialization must keep that first loop result and feed it to
+// the second cloned loop instead of substituting the first loop's original init
+// value.
+
+// CHECK-LABEL: @loop_result_feeds_second_loop
+// CHECK: ttg.warp_specialize
+// CHECK: partition0
+// CHECK: %[[FIRST:.*]] = scf.for {{.*}} -> (i32) {
+// CHECK: arith.index_cast
+// CHECK: scf.yield {{.*}} : i32
+// CHECK: %[[SECOND:.*]] = scf.for {{.*}} iter_args(%{{.*}} = %[[FIRST]]) -> (i32) {
+// CHECK: arith.addi
+// CHECK: scf.yield {{.*}} : i32
+// CHECK: tt.splat %[[SECOND]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @loop_result_feeds_second_loop(%src: tensor<16xf32, #blocked>, %dst: tensor<16x!tt.ptr<f32>, #blocked>) {
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : index
+    %c1 = arith.constant {async_task_id = array<i32: 0, 1>} 1 : index
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1>} 1 : i32
+    %zero_vec = arith.constant {async_task_id = array<i32: 1>} dense<0> : tensor<16xi32, #blocked>
+    %alloc = ttg.local_alloc {async_task_id = array<i32: 0>, buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+    scf.for %iv = %c0 to %c1 step %c1 {
+      %first = scf.for %i = %c0 to %c1 step %c1 iter_args(%ignored = %c0_i32) -> (i32) {
+        %cast_i = arith.index_cast %i {async_task_id = array<i32: 1>} : index to i32
+        %next = arith.addi %cast_i, %c1_i32 {async_task_id = array<i32: 1>} : i32
+        scf.yield {async_task_id = array<i32: 1>} %next : i32
+      } {async_task_id = array<i32: 1>}
+      %second = scf.for %j = %c0 to %c1 step %c1 iter_args(%carry = %first) -> (i32) {
+        %next_second = arith.addi %carry, %c1_i32 {async_task_id = array<i32: 1>} : i32
+        scf.yield {async_task_id = array<i32: 1>} %next_second : i32
+      } {async_task_id = array<i32: 1>}
+      %used_vec = tt.splat %second {async_task_id = array<i32: 1>} : i32 -> tensor<16xi32, #blocked>
+      %mask = arith.cmpi sge, %used_vec, %zero_vec {async_task_id = array<i32: 1>} : tensor<16xi32, #blocked>
+      %stored = arith.addf %src, %src {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked>
+      ttg.local_store %stored, %alloc {async_task_id = array<i32: 0>} : tensor<16xf32, #blocked> -> !ttg.memdesc<16xf32, #shared, #smem, mutable>
+      %loaded = ttg.local_load %alloc {async_task_id = array<i32: 1>} : !ttg.memdesc<16xf32, #shared, #smem, mutable> -> tensor<16xf32, #blocked>
+      tt.store %dst, %loaded, %mask {async_task_id = array<i32: 1>} : tensor<16x!tt.ptr<f32>, #blocked>
+    } {async_task_id = array<i32: 0, 1>, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32], ttg.partition.types = ["compute", "compute"]}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation_async_only_bounds.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation_async_only_bounds.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-opt %s --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-6-F2 / T273474506.
+//
+// This is the Hopper async-only variant of `nested_for_constant_bounds` from
+// `ws_task_id_propagation.mlir`: anchors already have `async_task_id`, but no
+// op has `ttg.partition`. Loop bound constants should still receive the union
+// of all task IDs.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: @nested_for_async_only_constant_bounds
+  // CHECK:       %[[C0:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+  // CHECK-NEXT:  %[[C1:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : i32
+  // CHECK:       scf.for
+  // CHECK:         scf.for %{{.*}} = %[[C0]] to %{{.*}} step %[[C1]]
+
+  tt.func public @nested_for_async_only_constant_bounds(%arg0: !tt.tensordesc<tensor<128x64xf16>>, %arg1: !tt.tensordesc<tensor<64x256xf16>>, %arg2: !tt.tensordesc<tensor<128x256xf16>>, %arg3: i32, %arg4: i32, %arg5: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c64 = arith.constant 64 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %pid = tt.get_program_id x : i32
+    %nprogs = tt.get_num_programs x : i32
+    scf.for %tile = %pid to %arg3 step %nprogs : i32 {
+      // Inner loop: only tasks 1 (loads) and 2 (dot/alloc) are present.
+      // Bounds %c0 and %c1 are constants defined at function scope.
+      %inner:2 = scf.for %k = %c0 to %arg5 step %c1 iter_args(%acc = %cst, %off = %c0) -> (tensor<128x256xf32, #mma>, i32) : i32 {
+        %a = tt.descriptor_load %arg0[%tile, %off] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked>
+        %a_alloc = ttg.local_alloc %a {async_task_id = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b = tt.descriptor_load %arg1[%off, %tile] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<64x256xf16>> -> tensor<64x256xf16, #blocked1>
+        %b_alloc = ttg.local_alloc %b {async_task_id = array<i32: 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %dot = ttng.warp_group_dot %a_alloc, %b_alloc, %acc {async_task_id = array<i32: 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        %new_off = arith.addi %off, %c64 {async_task_id = array<i32: 1>} : i32
+        scf.yield %dot, %new_off : tensor<128x256xf32, #mma>, i32
+      }
+      // Epilogue: only task 0 ops. This task has no ops inside the inner loop.
+      %trunc = arith.truncf %inner#0 {async_task_id = array<i32: 0>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+      %cvt = ttg.convert_layout %trunc {async_task_id = array<i32: 0>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+      tt.descriptor_store %arg2[%tile, %tile], %cvt {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x256xf16>>, tensor<128x256xf16, #blocked1>
+    }
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation_b20_async_union.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation_b20_async_union.mlir
@@ -1,0 +1,58 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s
+// XFAIL: *
+
+// Regression tests for B-20-F1 / T273501459.
+//
+// Existing Hopper-style `async_task_id` anchors must contribute to the global
+// allTasks union used to mark assumes, loops, and loop-bound constants. The
+// second case is the equivalent `ttg.partition` control shape.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @async_anchors_mark_assume_loop_and_bounds
+  // CHECK:       %[[C0:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+  // CHECK-NEXT:  %[[C1:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : i32
+  // CHECK-NEXT:  %[[C16:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 16 : i32
+  // CHECK:       llvm.intr.assume {{.*}} {async_task_id = array<i32: 0, 1, 2>} : i1
+  // CHECK:       scf.for %{{.*}} = %[[C0]] to %[[C16]] step %[[C1]]  : i32 {
+  // CHECK:       } {async_task_id = array<i32: 0, 1, 2>}
+  tt.func public @async_anchors_mark_assume_loop_and_bounds() {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c16 = arith.constant 16 : i32
+    %pid = tt.get_program_id x {async_task_id = array<i32: 0>} : i32
+    %cmp = arith.cmpi slt, %pid, %c16 : i32
+    llvm.intr.assume %cmp : i1
+    scf.for %iv = %c0 to %c16 step %c1 : i32 {
+      %producer = tt.get_program_id y {async_task_id = array<i32: 1>} : i32
+      %consumer = tt.get_program_id z {async_task_id = array<i32: 2>} : i32
+      %sum = arith.addi %producer, %consumer : i32
+    }
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @partition_anchors_mark_assume_loop_and_bounds
+  // CHECK:       %[[C0:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+  // CHECK-NEXT:  %[[C1:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : i32
+  // CHECK-NEXT:  %[[C16:.*]] = arith.constant {async_task_id = array<i32: 0, 1, 2>} 16 : i32
+  // CHECK:       llvm.intr.assume {{.*}} {async_task_id = array<i32: 0, 1, 2>} : i1
+  // CHECK:       scf.for %{{.*}} = %[[C0]] to %[[C16]] step %[[C1]]  : i32 {
+  // CHECK:       } {async_task_id = array<i32: 0, 1, 2>}
+  tt.func public @partition_anchors_mark_assume_loop_and_bounds() {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c16 = arith.constant 16 : i32
+    %pid = tt.get_program_id x {"ttg.partition" = array<i32: 3>} : i32
+    %cmp = arith.cmpi slt, %pid, %c16 : i32
+    llvm.intr.assume %cmp : i1
+    scf.for %iv = %c0 to %c16 step %c1 : i32 {
+      %producer = tt.get_program_id y {"ttg.partition" = array<i32: 4>} : i32
+      %consumer = tt.get_program_id z {"ttg.partition" = array<i32: 5>} : i32
+      %sum = arith.addi %producer, %consumer : i32
+    }
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation_b20_derived_tmem_d.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation_b20_derived_tmem_d.mlir
@@ -1,0 +1,91 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s
+// XFAIL: *
+
+// Regression tests for B-20-F2 / T273501458.
+//
+// Operand-D init propagation must find the pre-loop TMEM store even when the
+// MMA D operand is a descriptor derived from the TMEM allocation.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @direct_tmem_d_init_store_gets_mma_task
+  // CHECK:       ttng.tmem_store {{.*}} {async_task_id = array<i32: 1>}
+  // CHECK:       ttng.tc_gen5_mma {{.*}} {async_task_id = array<i32: 1>}
+  tt.func public @direct_tmem_d_init_store_gets_mma_task(%a: !ttg.memdesc<128x64xf16, #shared, #smem>, %b: !ttg.memdesc<64x128xf16, #shared1, #smem>, %n_tiles: i32) {
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %acc, %acc_token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %init_token = ttng.tmem_store %zero, %acc[%acc_token], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %result = scf.for %iv = %c0 to %n_tiles step %c1 iter_args(%dep = %acc_token) -> (!ttg.async.token) : i32 {
+      %mma_token = ttng.tc_gen5_mma %a, %b, %acc[%dep], %false, %true {async_task_id = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %mma_token : !ttg.async.token
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @subslice_tmem_d_init_store_gets_mma_task
+  // CHECK:       ttng.tmem_subslice
+  // CHECK:       ttng.tmem_store {{.*}} {async_task_id = array<i32: 1>}
+  // CHECK:       ttng.tc_gen5_mma {{.*}} {async_task_id = array<i32: 1>}
+  tt.func public @subslice_tmem_d_init_store_gets_mma_task(%a: !ttg.memdesc<128x64xf16, #shared, #smem>, %b: !ttg.memdesc<64x64xf16, #shared1, #smem>, %n_tiles: i32) {
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #blocked>
+    %acc_base, %acc_token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %acc = ttng.tmem_subslice %acc_base {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 128x128>
+    %init_token = ttng.tmem_store %zero, %acc[%acc_token], %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 128x128>
+    %result = scf.for %iv = %c0 to %n_tiles step %c1 iter_args(%dep = %acc_token) -> (!ttg.async.token) : i32 {
+      %mma_token = ttng.tc_gen5_mma %a, %b, %acc[%dep], %false, %true {async_task_id = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared1, #smem>, !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 128x128>
+      scf.yield %mma_token : !ttg.async.token
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @indexed_tmem_d_init_store_gets_mma_task
+  // CHECK:       ttg.memdesc_index
+  // CHECK:       ttng.tmem_store {{.*}} {async_task_id = array<i32: 1>}
+  // CHECK:       ttng.tc_gen5_mma {{.*}} {async_task_id = array<i32: 1>}
+  tt.func public @indexed_tmem_d_init_store_gets_mma_task(%a: !ttg.memdesc<128x64xf16, #shared, #smem>, %b: !ttg.memdesc<64x128xf16, #shared1, #smem>, %n_tiles: i32) {
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %acc_base, %acc_token = ttng.tmem_alloc : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %acc = ttg.memdesc_index %acc_base[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %init_token = ttng.tmem_store %zero, %acc[%acc_token], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %result = scf.for %iv = %c0 to %n_tiles step %c1 iter_args(%dep = %acc_token) -> (!ttg.async.token) : i32 {
+      %mma_token = ttng.tc_gen5_mma %a, %b, %acc[%dep], %false, %true {async_task_id = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %mma_token : !ttg.async.token
+    }
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation_reduce_region_anchor.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation_reduce_region_anchor.mlir
@@ -1,0 +1,30 @@
+// RUN: triton-opt %s --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-5-F1 / T273472464.
+// A region-bodied anchor op should propagate its own task ID into its scalar
+// region body, not a downstream consumer's task ID.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: @reduce_body_keeps_anchor_task
+  // CHECK:      %[[REDUCE:.*]] = "tt.reduce"(%{{.*}}) <{axis = 1 : i32}> ({
+  // CHECK-NEXT: ^bb0(%[[LHS:.*]]: f32, %[[RHS:.*]]: f32):
+  // CHECK-NEXT:   %[[BODY_ADD:.*]] = arith.addf %[[LHS]], %[[RHS]] {{.*}}async_task_id = array<i32: 1>{{.*}} : f32
+  // CHECK-NEXT:   tt.reduce.return %[[BODY_ADD]] {{.*}}async_task_id = array<i32: 1>{{.*}} : f32
+  // CHECK-NEXT: }) {{.*}} :
+  // CHECK:      arith.addf %[[REDUCE]], %{{.*}} {{.*}}async_task_id = array<i32: 0>{{.*}} : tensor<16xf32,
+  tt.func public @reduce_body_keeps_anchor_task(%input: tensor<16x16xf32, #blocked>) {
+    %bias = arith.constant dense<1.000000e+00> : tensor<16xf32, #slice>
+    %sum = "tt.reduce"(%input) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %add = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %add : f32
+    }) {"ttg.partition" = array<i32: 1>} : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #slice>
+    %out = arith.addf %sum, %bias {"ttg.partition" = array<i32: 0>} : tensor<16xf32, #slice>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation_task_id_normalization.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation_task_id_normalization.mlir
@@ -1,0 +1,19 @@
+// RUN: triton-opt %s --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-9-F1 / T273481168.
+//
+// `getAsyncTaskIds` is documented to return sorted task IDs. The test task-id
+// propagation pass normalizes pre-existing task annotations through that helper
+// before propagation. A non-canonical spelling with a repeated, non-adjacent
+// task ID should therefore become the sorted unique set `{0, 1}`.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @async_task_id_attribute_is_canonicalized
+  // CHECK:       tt.get_program_id x {async_task_id = array<i32: 0, 1>} : i32
+  // CHECK-NOT:   async_task_id = array<i32: 0, 1, 1>
+  tt.func public @async_task_id_attribute_is_canonicalized() {
+    %pid = tt.get_program_id x {async_task_id = array<i32: 1, 0, 1>} : i32
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_task_partition_descriptor_gather.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_partition_descriptor_gather.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-ws-task-partition=num-warp-groups=3 | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-21-F1 / T273503312.
+// CHECK-LABEL: @matmul_ws_gather_and_descriptor_load
+// CHECK: %[[#GA:]] = tt.descriptor_gather {{.*}} {async_task_id = array<i32: 0>}
+// CHECK: %[[#LA:]] = ttg.local_alloc %[[#GA]]
+// CHECK: %[[#GB:]] = tt.descriptor_load {{.*}} {async_task_id = array<i32: 0>}
+// CHECK: %[[#LB:]] = ttg.local_alloc %[[#GB]]
+// CHECK: %[[#C:]] = ttng.warp_group_dot %[[#LA]], %[[#LB]], {{.*}} {async_task_id = array<i32: 1, 2>
+// CHECK: tt.descriptor_store {{.*}} {async_task_id = array<i32: 1, 2>
+
+// CHECK-LABEL: @matmul_ws_all_descriptor_gather
+// CHECK: %[[#GAA:]] = tt.descriptor_gather {{.*}} {async_task_id = array<i32: 0>}
+// CHECK: %[[#LAA:]] = ttg.local_alloc %[[#GAA]]
+// CHECK: %[[#GAB:]] = tt.descriptor_gather {{.*}} {async_task_id = array<i32: 0>}
+// CHECK: %[[#LAB:]] = ttg.local_alloc %[[#GAB]]
+// CHECK: %[[#AC:]] = ttng.warp_group_dot %[[#LAA]], %[[#LAB]], {{.*}} {async_task_id = array<i32: 1, 2>
+// CHECK: tt.descriptor_store {{.*}} {async_task_id = array<i32: 1, 2>
+
+#indices = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_ws_gather_and_descriptor_load(%arg0: !tt.tensordesc<tensor<1x64xf16, #shared>>, %arg1: !tt.tensordesc<tensor<64x256xf16>>, %arg2: !tt.tensordesc<tensor<128x256xf16>>, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_num_programs x : i32
+    scf.for %arg6 = %0 to %arg3 step %1  : i32 {
+      %2:2 = scf.for %arg7 = %c0_i32 to %arg5 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %c0_i32) -> (tensor<128x256xf32, #mma>, i32)  : i32 {
+        %5 = tt.splat %arg6 : i32 -> tensor<128xi32, #indices>
+        %6 = tt.descriptor_gather %arg0[%5, %arg9] : (!tt.tensordesc<tensor<1x64xf16, #shared>>, tensor<128xi32, #indices>, i32) -> tensor<128x64xf16, #blocked>
+        %7 = ttg.local_alloc %6 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %8 = tt.descriptor_load %arg1[%arg9, %arg6] : !tt.tensordesc<tensor<64x256xf16>> -> tensor<64x256xf16, #blocked1>
+        %9 = ttg.local_alloc %8 : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %10 = ttng.warp_group_dot %7, %9, %arg8 {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        %11 = arith.addi %arg9, %c64_i32 : i32
+        scf.yield %10, %11 : tensor<128x256xf32, #mma>, i32
+      }
+      %3 = arith.truncf %2#0 : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+      %4 = ttg.convert_layout %3 : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+      tt.descriptor_store %arg2[%arg6, %arg6], %4 : !tt.tensordesc<tensor<128x256xf16>>, tensor<128x256xf16, #blocked1>
+    }
+    tt.return
+  }
+
+  tt.func public @matmul_ws_all_descriptor_gather(%arg0: !tt.tensordesc<tensor<1x64xf16, #shared>>, %arg1: !tt.tensordesc<tensor<1x256xf16, #shared>>, %arg2: !tt.tensordesc<tensor<128x256xf16>>, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_num_programs x : i32
+    scf.for %arg6 = %0 to %arg3 step %1  : i32 {
+      %2:2 = scf.for %arg7 = %c0_i32 to %arg5 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %c0_i32) -> (tensor<128x256xf32, #mma>, i32)  : i32 {
+        %5 = tt.splat %arg6 : i32 -> tensor<128xi32, #indices>
+        %6 = tt.descriptor_gather %arg0[%5, %arg9] : (!tt.tensordesc<tensor<1x64xf16, #shared>>, tensor<128xi32, #indices>, i32) -> tensor<128x64xf16, #blocked>
+        %7 = ttg.local_alloc %6 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %8 = tt.splat %arg9 : i32 -> tensor<64xi32, #indices>
+        %9 = tt.descriptor_gather %arg1[%8, %arg6] : (!tt.tensordesc<tensor<1x256xf16, #shared>>, tensor<64xi32, #indices>, i32) -> tensor<64x256xf16, #blocked1>
+        %10 = ttg.local_alloc %9 : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %11 = ttng.warp_group_dot %7, %10, %arg8 {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        %12 = arith.addi %arg9, %c64_i32 : i32
+        scf.yield %11, %12 : tensor<128x256xf32, #mma>, i32
+      }
+      %3 = arith.truncf %2#0 : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+      %4 = ttg.convert_layout %3 : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+      tt.descriptor_store %arg2[%arg6, %arg6], %4 : !tt.tensordesc<tensor<128x256xf16>>, tensor<128x256xf16, #blocked1>
+    }
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_barrier_xfail.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_barrier_xfail.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-tma-store-token-wait-reorder | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-22-F1 / T273504812.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// A wait_barrier before the producer is unrelated to the TMA store token.
+// The reorder must not use it as the insertion target and assign the token
+// wait a schedule position before the producing TMA store.
+// CHECK-LABEL: @earlier_barrier_does_not_precede_producer
+// CHECK: scf.for
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: [[TOK0:%.*]] = ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait [[TOK0]]
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 3 : i32, loop.stage = 0 : i32}
+  tt.func public @earlier_barrier_does_not_precede_producer(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %barrier: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      ttng.wait_barrier %barrier, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %src0 {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %dummy = arith.addi %c0, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : i32
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%dummy, %c0] %src1 {"loop.stage" = 0 : i32, "loop.cluster" = 3 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok0 {"can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 4 : i32} : !ttg.async.token
+    } {"tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-test-tma-store-token-wait-reorder | FileCheck %s
+// XFAIL: *
+
+// Regression test for B-22-F2 / T273504813.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// TMA reduce tokens use the same wait op as TMA stores. The reorder pass
+// should consume can_rotate_by_buffer_count and rotate the wait by K stores.
+// CHECK-LABEL: @single_buffer_reduce_token_k1
+// CHECK: scf.for
+// CHECK: ttg.local_store {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_reduce {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+  tt.func public @single_buffer_reduce_token_k1(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src: tensor<128x64xf16>,
+      %lb: index, %ub: index, %step: index) {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      ttg.local_store %src, %buf {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok = ttng.async_tma_reduce add, %desc[%c0, %c0] %buf {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok {"can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : !ttg.async.token
+    } {"tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Mixed reduce/copy coverage makes the K-th target a TMA copy after the
+// defining TMA reduce, exercising the store-like linearization path.
+// CHECK-LABEL: @mixed_reduce_to_copy_k1
+// CHECK: scf.for
+// CHECK: [[REDTOK:%.*]] = ttng.async_tma_reduce {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait [[REDTOK]]
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 3 : i32, loop.stage = 0 : i32}
+  tt.func public @mixed_reduce_to_copy_k1(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %reduce_src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %copy_src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      %reduce_tok = ttng.async_tma_reduce add, %desc[%c0, %c0] %reduce_src {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %dummy = arith.addi %c0, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : i32
+      %copy_tok = ttng.async_tma_copy_local_to_global %desc[%dummy, %c0] %copy_src {"loop.stage" = 0 : i32, "loop.cluster" = 3 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %reduce_tok {"can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 4 : i32} : !ttg.async.token
+    } {"tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Analysis)
 add_subdirectory(Dialect)
+add_subdirectory(Hopper)
 add_subdirectory(Tools)

--- a/unittest/Hopper/CMakeLists.txt
+++ b/unittest/Hopper/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_triton_ut(
+  NAME HopperWarpSpecializationUtilityTest
+  SRCS append_to_name_loc_test.cpp
+  LIBS
+    MLIRIR
+    MLIRSupport
+)

--- a/unittest/Hopper/append_to_name_loc_test.cpp
+++ b/unittest/Hopper/append_to_name_loc_test.cpp
@@ -1,0 +1,34 @@
+#include "third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include <gtest/gtest.h>
+
+namespace mlir {
+namespace {
+
+// Regression test for B-10-F1 / T273483074.
+TEST(HopperWarpSpecializationUtilityTest,
+     DISABLED_AppendToNameLocUsesInnermostName) {
+  MLIRContext context;
+  auto fileLoc = FileLineColLoc::get(&context, "kernel.mlir", 3, 5);
+  auto innerLoc =
+      NameLoc::get(StringAttr::get(&context, "inner"), fileLoc);
+  auto outerLoc =
+      NameLoc::get(StringAttr::get(&context, "outer"), innerLoc);
+
+  Location result = appendToNameLoc(outerLoc, "_suffix", &context);
+
+  auto resultOuterLoc = dyn_cast<NameLoc>(result);
+  ASSERT_TRUE(resultOuterLoc);
+  EXPECT_EQ(resultOuterLoc.getName().str(), "outer");
+
+  auto resultInnerLoc = dyn_cast<NameLoc>(resultOuterLoc.getChildLoc());
+  ASSERT_TRUE(resultInnerLoc);
+  EXPECT_EQ(resultInnerLoc.getName().str(), "inner_suffix");
+  EXPECT_EQ(resultInnerLoc.getChildLoc(), fileLoc);
+}
+
+} // namespace
+} // namespace mlir


### PR DESCRIPTION
Summary:

Consolidate the generated AutoWS static-analysis regression coverage into a single diff. Each test file includes a comment mapping the regression to its originating `T273...` task, and this diff intentionally excludes the generated investigation reports and plan-update bookkeeping. Authored with Claude.

Reviewed By: PaulZhang12

Differential Revision: D106935883
