### PR TITLE
[triton][beta]Use GitHub App token for pre-commit autofix workflow

### DIFF
--- a/.github/workflows/pre-commit-autofix.yml
+++ b/.github/workflows/pre-commit-autofix.yml
@@ -222,11 +222,18 @@ jobs:
           gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content='eyes'
 
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-python@v6
         with:
@@ -291,8 +298,8 @@ jobs:
           CHANGED=$(git diff --name-only | wc -l | tr -d ' ')
           echo "fixed_count=$CHANGED" >> $GITHUB_OUTPUT
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "facebookexperimental-triton[bot]"
+          git config user.email "facebookexperimental-triton[bot]@users.noreply.github.com"
           git add -A
           git commit -m "[pre-commit autofix] Fix formatting in ${CHANGED} file(s)
 


### PR DESCRIPTION
Summary: The `/fix-precommit` workflow pushes formatting commits to PR branches, but the default `GITHUB_TOKEN` is blocked by the Meta CLA ruleset. This diff switches to a GitHub App token (`facebookexperimental-triton`) which bypasses CLA enforcement, allowing the bot to push formatting fixes.

Reviewed By: dshi7

Differential Revision: D107280632


