### PR TITLE
[Triton][NVIDIA] Enable f32 redux on sm_103a (GB300), not just sm_100 (#1638)

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -96,7 +96,9 @@ static std::optional<NVVM::ReduxKind> matchReduxKind(triton::ReduceOp op,
   Operation *reduceOp = op.getSingleCombiner();
   if (!reduceOp)
     return std::nullopt;
-  if (computeCapability == 100 && reduceOp->getResultTypes()[0].isF32()) {
+  // redux.f32 is an sm_100-family feature; sm_120 lacks it.
+  if (computeCapability / 10 == 10 &&
+      reduceOp->getResultTypes()[0].isF32()) {
     if (isa<arith::MinimumFOp, arith::MaximumFOp>(reduceOp))
       useNanQualifier = true;
     if (isa<arith::MaxNumFOp, arith::MaximumFOp>(reduceOp))


### PR DESCRIPTION
Summary:

matchReduxKind gated the f32 min/max hardware warp-reduce (NVVM redux.f32 + .abs/.NaN qualifier) on computeCapability == 100, so GB300 (sm_103a / cc 103) silently fell to the non-redux path, losing the HW reduction and the NaN qualifier semantics. redux.f32 is an sm_100-family feature, so gate on the family (computeCapability / 10 == 10): this covers sm_100/sm_103 and excludes sm_120 (a different family that lacks it). Mirrors the existing isHopper (cc/10==9) idiom.

Standalone diff (independent of the NPOT stack) so it can land separately.

Reviewed By: stashuk-olek

Differential Revision: D106959142


