### PR TITLE
[triton][tlx] Emit elementwise tl.minimum/maximum for int min/max

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -216,10 +216,12 @@ static const TTGIRToTLXMapping opMappings[] = {
     {"arith.maxnumf", "tl.maximum", "Float max (NaN-propagating)"},
     {"arith.minf", "tl.minimum", "Float min"},
     {"arith.minnumf", "tl.minimum", "Float min (NaN-propagating)"},
-    {"arith.maxsi", "tl.max", "Signed integer max"},
-    {"arith.maxui", "tl.max", "Unsigned integer max"},
-    {"arith.minsi", "tl.min", "Signed integer min"},
-    {"arith.minui", "tl.min", "Unsigned integer min"},
+    // Elementwise binary min/max. NOTE: tl.min/tl.max are reductions, so
+    // they are not used here. Use tl.minimum/maximum similar to float above.
+    {"arith.maxsi", "tl.maximum", "Signed integer max"},
+    {"arith.maxui", "tl.maximum", "Unsigned integer max"},
+    {"arith.minsi", "tl.minimum", "Signed integer min"},
+    {"arith.minui", "tl.minimum", "Unsigned integer min"},
 
     // Triton operations
     {"tt.splat", "tl.splat", "Splat scalar to tensor"},


### PR DESCRIPTION
Summary:
The TTGIR-to-TLX printer mapped the integer min/max ops `arith.minsi`, `arith.minui`, `arith.maxsi`, and `arith.maxui` to `tl.min`/`tl.max`. Those are Triton reduction builtins whose second argument is a reduction axis, not an elementwise binary min/max, so a plain two-operand `min(a, b)` from the source kernel was emitted as `tl.min(a, b)` and interpreted by Triton as "reduce `a` along axis `b`".

This surfaces in the persistent matmul kernels in `python/tutorials/09-persistent-matmul.py`. There, compiling the generated TLX then failed with `invalid axis 8`.

Map these four ops to the elementwise `tl.minimum`/`tl.maximum`, matching the existing float cases (`arith.minf`/`arith.maxf` to `tl.minimum`/`tl.maximum`).

Genuine reductions (for example flash attention's row max) are emitted through the reduce path and continue to use `tl.max(..., axis=...)`, so they are unaffected.

Authored with Claude.

Differential Revision: D107315744


