### PR TITLE
[triton][tlx] Map arith.ceildivsi/ui to tl.cdiv

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -216,10 +216,12 @@ static const TTGIRToTLXMapping opMappings[] = {
     {"arith.maxnumf", "tl.maximum", "Float max (NaN-propagating)"},
     {"arith.minf", "tl.minimum", "Float min"},
     {"arith.minnumf", "tl.minimum", "Float min (NaN-propagating)"},
-    {"arith.maxsi", "tl.max", "Signed integer max"},
-    {"arith.maxui", "tl.max", "Unsigned integer max"},
-    {"arith.minsi", "tl.min", "Signed integer min"},
-    {"arith.minui", "tl.min", "Unsigned integer min"},
+    // Elementwise binary min/max. NOTE: tl.min/tl.max are reductions, so
+    // they are not used here. Use tl.minimum/maximum similar to float above.
+    {"arith.maxsi", "tl.maximum", "Signed integer max"},
+    {"arith.maxui", "tl.maximum", "Unsigned integer max"},
+    {"arith.minsi", "tl.minimum", "Signed integer min"},
+    {"arith.minui", "tl.minimum", "Unsigned integer min"},
 
     // Triton operations
     {"tt.splat", "tl.splat", "Splat scalar to tensor"},

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -222,6 +222,9 @@ static const TTGIRToTLXMapping opMappings[] = {
     {"arith.maxui", "tl.maximum", "Unsigned integer max"},
     {"arith.minsi", "tl.minimum", "Signed integer min"},
     {"arith.minui", "tl.minimum", "Unsigned integer min"},
+    // Ceiling division: tl.cdiv(a, b) == (a + b - 1) // b.
+    {"arith.ceildivsi", "tl.cdiv", "Signed integer ceil-division"},
+    {"arith.ceildivui", "tl.cdiv", "Unsigned integer ceil-division"},
 
     // Triton operations
     {"tt.splat", "tl.splat", "Splat scalar to tensor"},


### PR DESCRIPTION
Summary:
The TTGIR-to-TLX printer had no mapping for the ceiling-division ops `arith.ceildivsi` and `arith.ceildivui`, so they were emitted verbatim as `arith.ceildivsi(...)` which then fails to parse per:
```counterexample
NameError: arith is not defined`.
```
This shows up in any persistent kernel that uses a flattened persistent loop. In `python/tutorials/09-persistent-matmul.py`, `matmul_kernel_persistent` iterates with `tl.range(start_pid, num_tiles, NUM_SMS, flatten=True)`; the flatten lowering computes the trip count with a ceiling division, which the printer emitted as `arith.ceildivsi(tile_id_c_37, 148)`.

Map both ops to `tl.cdiv`, the Triton builtin for ceiling division (`tl.cdiv(a, b) == (a + b - 1) // b`).

This is the second diff in a series cleaning up the TTGIR-to-TLX printing path; it stacks on the integer min/max fix.

Authored with Claude.

Differential Revision: D107322914


