### PR TITLE
[AMD] HSTU attention test example

### DIFF
--- a/third_party/tlx/tutorials/amd-hstu-attn-test.py
+++ b/third_party/tlx/tutorials/amd-hstu-attn-test.py
@@ -3,6 +3,9 @@ from typing import List, Optional, Tuple
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
+import torch
+import torch.nn.functional as F
+import pytest
 
 try:
     from triton.language.extra.libdevice import (
@@ -25,9 +28,212 @@ def prev_power_of_2(x: int) -> int:
     out = triton.next_power_of_2(x)
     return out // 2 if out > x else out
 
+
 def get_arch():
     return triton.runtime.driver.active.get_current_target().arch
 
+
+#----------------------------------------------------------------------
+# ref implementation 
+# create attention mask
+def _get_valid_attn_mask(
+    device: torch.device,
+    causal: bool,
+    N: int,
+    seq_lengths: torch.Tensor,
+    num_targets: Optional[torch.Tensor] = None,
+    max_attn_len: int = 0,
+    contextual_seq_len: int = 0,
+    min_full_attn_seq_len: int = 0,
+) -> torch.Tensor:
+    ids = torch.arange(0, N, device=device).view(1, N)
+    max_ids = seq_lengths.view(-1, 1, 1)
+    if contextual_seq_len > 0:
+        ids = ids - contextual_seq_len + 1
+        ids = torch.clamp(ids, min=0)
+        max_ids = max_ids - contextual_seq_len + 1
+    if num_targets is not None:
+        max_ids = max_ids - num_targets.view(-1, 1, 1)
+        ids = torch.clamp(
+            ids,
+            max=max_ids,
+        )
+        row_ids = ids.view(-1, N, 1).expand(-1, N, N)
+        col_ids = ids.view(-1, 1, N).expand(-1, N, N)
+    else:
+        row_ids = ids.view(N, 1).expand(N, N)
+        col_ids = row_ids.t()
+        row_ids = row_ids.view(1, N, N)
+        col_ids = col_ids.view(1, N, N)
+    row_col_dist = row_ids - col_ids
+    valid_attn_mask = torch.eye(N, device=device, dtype=torch.bool).view(1, N, N)
+    if not causal:
+        row_col_dist = torch.where(row_col_dist > 0, row_col_dist, -row_col_dist)
+    valid_attn_mask = torch.logical_or(valid_attn_mask, row_col_dist > 0)
+    if max_attn_len > 0:
+        if min_full_attn_seq_len > 0:
+            valid_attn_mask = torch.logical_and(
+                valid_attn_mask,
+                torch.logical_or(
+                    row_col_dist <= max_attn_len,
+                    row_ids >= max_ids - min_full_attn_seq_len,
+                ),
+            )
+        else:
+            valid_attn_mask = torch.logical_and(
+                valid_attn_mask, row_col_dist <= max_attn_len
+            )
+    if contextual_seq_len > 0:
+        valid_attn_mask = torch.logical_or(
+            valid_attn_mask, torch.logical_and(row_ids == 0, col_ids < max_ids)
+        )
+    return valid_attn_mask
+
+
+# convert sequence input from jagged format to padded dense format
+def jagged_to_padded_dense(
+    q: torch.Tensor, offsets: torch.Tensor, max_seq_len: int, padding_value
+):
+    assert len(q.shape) == 2, "q needs to be 2-dim tensor"
+    L, D = q.shape
+    B = offsets.shape[0] - 1
+    padded_shape = (B, max_seq_len, D)
+    padded_q = torch.full(padded_shape, padding_value, dtype=q.dtype, device=q.device)
+    for i in range(B):
+        s = offsets[i]
+        e = offsets[i + 1]
+        padded_q[i][0 : e - s] = q[s:e]
+
+    return padded_q
+
+
+# pad sequence according to max sequence len
+def pad_sequence(q: torch.Tensor, seq_offsets: torch.Tensor, N: int, padding_value):
+    L, D = q.shape
+    padded_q = jagged_to_padded_dense(
+        q.reshape(L, D), offsets=seq_offsets, max_seq_len=N, padding_value=0.0
+    )
+
+    return padded_q
+
+
+def qkv_to_padded_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    N: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    L, H, D = q.shape
+    padded_q = (
+        pad_sequence(q.reshape(L, H * D), seq_offsets, N, 0.0)
+        .view(-1, N, H, D)
+        .transpose(1, 2)
+    )
+    padded_k = (
+        pad_sequence(k.reshape(L, H * D), seq_offsets, N, 0.0)
+        .view(-1, N, H, D)
+        .transpose(1, 2)
+    )
+    padded_v = (
+        pad_sequence(v.reshape(L, H * D), seq_offsets, N, 0.0)
+        .view(-1, N, H, D)
+        .transpose(1, 2)
+    )
+
+    return padded_q, padded_k, padded_v
+
+
+# convert sequences from dense format to jagged format
+def dense_to_jagged(seq: torch.Tensor, offsets: torch.Tensor, L: int):
+    B, N, HV = seq.shape
+    assert L == offsets[-1], f"jagged dim mismatch {offsets[-1]} != {L}!"
+    out = torch.empty((L, HV), dtype=seq.dtype, device=seq.device)
+
+    for i in range(B):
+        s = offsets[i]
+        e = offsets[i + 1]
+        out[s:e] = seq[i][0 : e - s]
+
+    return out
+
+
+# torch hstu reference implementation
+def torch_hstu_attention(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    causal: bool = True,
+    dropout_pr: float = 0.0,
+    training: bool = True,
+    num_targets: Optional[torch.Tensor] = None,
+    max_attn_len: int = 0,
+    contextual_seq_len: int = 0,
+    min_full_attn_seq_len: int = 0,
+) -> torch.Tensor:
+    L, H, _ = q.shape
+    V = v.shape[2]
+    q, k, v = qkv_to_padded_dense(
+        q, k, v, seq_offsets, max_seq_len
+    )  # [B, H, N, D) and [B, H, N, V]
+    qk_attn = torch.einsum("bhxa,bhya->bhxy", q, k) * alpha
+    qk_attn = F.silu(qk_attn) / max_seq_len
+    valid_attn_mask = _get_valid_attn_mask(
+        device=q.device,
+        causal=causal,
+        N=max_seq_len,
+        seq_lengths=seq_offsets[1:] - seq_offsets[:-1],
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        contextual_seq_len=contextual_seq_len,
+        min_full_attn_seq_len=min_full_attn_seq_len,
+    )
+    # raise NotImplementedError(valid_attn_mask[0, :, :].to(torch.int32))
+    qk_attn = qk_attn * valid_attn_mask.unsqueeze(1)
+    if dropout_pr > 0.0:
+        qk_attn = F.dropout(qk_attn, p=dropout_pr, training=training)
+    attn_dense = torch.einsum("bhxd,bhdv->bhxv", qk_attn, v)  # [B, H, N, V]
+    return dense_to_jagged(
+        attn_dense.transpose(1, 2).flatten(2, 3),  # [B, N, H, V]->[B, N, H * V]
+        seq_offsets,
+        L,
+    ).view(L, H, V)
+#----------------------------------------------------------------------
+
+
+@triton.jit
+def remap_xcd(pid, GRID_MN, NUM_XCDS: tl.constexpr = 8):
+    ## pid remapping on xcds
+    # Number of pids per XCD in the new arrangement
+    pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+    # When GRID_MN cannot divide NUM_XCDS, some xcds will have
+    # pids_per_xcd pids, the other will have pids_per_xcd - 1 pids.
+    # We calculate the number of xcds that have pids_per_xcd pids as
+    # tall_xcds
+    tall_xcds = GRID_MN % NUM_XCDS
+    tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+    # Compute current XCD and local pid within the XCD
+    xcd = pid % NUM_XCDS
+    local_pid = pid // NUM_XCDS
+    # Calculate new pid based on the new grouping
+    # Note that we need to consider the following two cases:
+    # 1. the current pid is on a tall xcd
+    # 2. the current pid is on a short xcd
+    if xcd < tall_xcds:
+        pid = xcd * pids_per_xcd + local_pid
+    else:
+        pid = (
+            tall_xcds * pids_per_xcd
+            + (xcd - tall_xcds) * (pids_per_xcd - 1)
+            + local_pid
+        )
+
+    return pid
+
+FULL_TUNING=False
 
 def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
     configs = []
@@ -79,6 +285,8 @@ def _hstu_attn_fwd_one_block(  # noqa: C901
     stride_kn,
     stride_vn,
     n_targets,
+    lds_k,
+    lds_v,
     alpha,
     MAX_SEQ_LEN,
     contextual_seq_len,
@@ -95,13 +303,22 @@ def _hstu_attn_fwd_one_block(  # noqa: C901
     start_n = tl.multiple_of(start_n, BLOCK_N)
     offs_d_q = tl.arange(0, BLOCK_D_Q)
     offs_d_v = tl.arange(0, BLOCK_D_V)
-    k_ptrs = K_base + offs_d_q[:, None] + offs_n[None, :] * stride_kn
+
+
+    k_ptrs = K_base + offs_d_q[None, :] + offs_n[:, None] * stride_kn
     v_ptrs = V_base + offs_n[:, None] * stride_vn + offs_d_v[None, :]
+    k_local = tlx.local_view(lds_k, 0)
+    v_local = tlx.local_view(lds_v, 0)
 
     # -- compute qk ----
     mask_n = offs_n < seq_len
-    k = tl.load(k_ptrs, mask=mask_n[None, :], other=0.0)
-    qk = tl.dot(q, k, allow_tf32=ALLOW_TF32) * alpha
+    tok_k = tlx.async_load(k_ptrs, k_local, mask=mask_n[:, None])
+    tlx.async_load_commit_group([tok_k])
+    tlx.async_load_wait_group(0)
+    kt_local = tlx.local_trans(k_local)
+    k_dot_op = tlx.local_load(kt_local)
+
+    qk = tl.dot(q, k_dot_op, allow_tf32=ALLOW_TF32) * alpha
     invalid_mask = offs_m[:, None] == offs_n[None, :]
     max_ids = seq_len
     if HAS_CONTEXTUAL_SEQ_LEN:
@@ -141,11 +358,16 @@ def _hstu_attn_fwd_one_block(  # noqa: C901
             offs_m[:, None] == 0 and offs_n[None, :] < max_ids
         )
     # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
-    silu = fast_dividef(qk, 1.0 + fast_expf(-qk)) * (1.0 / MAX_SEQ_LEN)
+    silu = fast_dividef(qk, 1.0 + fast_expf(-1.0 * qk)) * (1.0 / MAX_SEQ_LEN)
     silu = tl.where(invalid_mask, silu, 0)
-    v = tl.load(v_ptrs, mask=mask_n[:, None], other=0.0)
-    silu = silu.to(v.dtype)
-    return tl.dot(silu, v, allow_tf32=ALLOW_TF32)
+
+    tok_v = tlx.async_load(v_ptrs, v_local, mask=mask_n[:, None])
+    tlx.async_load_commit_group([tok_v])
+    tlx.async_load_wait_group(0)
+    v_dot_op = tlx.local_load(v_local)
+
+    silu = silu.to(V_base.dtype.element_ty)
+    return tl.dot(silu, v_dot_op, allow_tf32=ALLOW_TF32)
 
 
 @triton.jit
@@ -246,6 +468,10 @@ def _hstu_attn_fwd_compute(  # noqa C901
             low = 0
             high = seq_len
 
+        # allocate lds for KV load
+        lds_k = tlx.local_alloc((BLOCK_N, BLOCK_D_Q), tlx.dtype_of(K), 1)
+        lds_v = tlx.local_alloc((BLOCK_N, BLOCK_D_V), tlx.dtype_of(V), 1)
+
         for start_n in range(low, high, BLOCK_N):
             acc += _hstu_attn_fwd_one_block(
                 start_n=start_n,
@@ -258,6 +484,8 @@ def _hstu_attn_fwd_compute(  # noqa C901
                 stride_kn=stride_kn,
                 stride_vn=stride_vn,
                 n_targets=n_targets if HAS_MULTIPLE_TARGETS else None,
+                lds_k=lds_k,
+                lds_v=lds_v,
                 alpha=alpha,
                 MAX_SEQ_LEN=MAX_SEQ_LEN,
                 contextual_seq_len=contextual_seq_len,
@@ -291,6 +519,8 @@ def _hstu_attn_fwd_compute(  # noqa C901
                         stride_kn=stride_kn,
                         stride_vn=stride_vn,
                         n_targets=n_targets if HAS_MULTIPLE_TARGETS else None,
+                        lds_k=lds_k,
+                        lds_v=lds_v,
                         alpha=alpha,
                         MAX_SEQ_LEN=MAX_SEQ_LEN,
                         contextual_seq_len=contextual_seq_len,
@@ -323,20 +553,20 @@ def _hstu_attn_fwd_compute(  # noqa C901
 
 
 
-# @triton.autotune(
-#     configs=_get_fw_configs(),
-#     key=[
-#         "AUTOTUNE_Z",
-#         "H",
-#         "AUTOTUNE_MAX_SEQ_LEN",
-#         "DimQ",
-#         "DimV",
-#         "BUCKET_FN",
-#         "ATTN_BIAS_TYPE",
-#         "DeltaSize",
-#         "IS_DELTA_Q",
-#     ],
-# )
+@triton.autotune(
+    configs=_get_fw_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+        "BUCKET_FN",
+        "ATTN_BIAS_TYPE",
+        "DeltaSize",
+        "IS_DELTA_Q",
+    ],
+)
 @triton.jit
 def _ragged_hstu_attn_fwd(  # noqa C901
     Q,
@@ -355,6 +585,7 @@ def _ragged_hstu_attn_fwd(  # noqa C901
     stride_om,
     stride_oh,
     alpha,
+    Z,
     H,
     MAX_SEQ_LEN,
     DeltaSize,
@@ -372,12 +603,19 @@ def _ragged_hstu_attn_fwd(  # noqa C901
     HAS_MAX_ATTN_LEN: tl.constexpr,
     HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
 ):
-    off_hz = tl.program_id(1)
-    off_z = off_hz // H
+    tpid = tl.program_id(0)
+
+    num_tiles = tl.cdiv(MAX_SEQ_LEN, BLOCK_M)
+    tpid = remap_xcd(tpid, num_tiles * Z * H, 8)
+
+    off_h = tpid % H
+    off_nz = tpid // H
+    pid = off_nz % num_tiles
+    off_z = off_nz // num_tiles
+
     if HAS_SORT_BY_LENGTH_INDICES:
         off_z = tl.load(sort_by_length_indices + off_z)
-    off_h = off_hz % H
-    pid = tl.program_id(0)
+
     _hstu_attn_fwd_compute(
         Q=Q,
         K=K,
@@ -414,3 +652,346 @@ def _ragged_hstu_attn_fwd(  # noqa C901
     )
 
 
+def triton_hstu_attention_fwd(
+    N: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    causal: bool,
+    num_targets: Optional[torch.Tensor],
+    max_attn_len: int,
+    contextual_seq_len: int,
+    sort_by_length_indices: Optional[torch.Tensor],
+    config: Optional[dict] = None,
+) -> torch.Tensor:
+    """
+    HSTU attention forward pass with SiLU activation: Y = silu(alpha * (Q @ K^T)) @ V.
+    Works with jagged tensors (variable-length sequences concatenated along batch dimension).
+
+    Args:
+        N (int): Maximum sequence length across all sequences.
+        alpha (float): Scale factor applied to Q @ K^T before SiLU activation.
+        q (torch.Tensor): Query jagged tensor with shape (total_tokens, num_heads, head_dim).
+        k (torch.Tensor): Key jagged tensor with shape (total_tokens, num_heads, head_dim).
+        v (torch.Tensor): Value jagged tensor with shape (total_tokens, num_heads, head_dim).
+        seq_offsets (torch.Tensor): Sequence boundaries with shape (batch_size + 1,).
+            Element i contains cumulative token count up to sequence i.
+        causal (bool): Apply causal masking.
+        num_targets (Optional[torch.Tensor]): Number of target tokens per sequence for masking.
+        max_attn_len (int): Maximum attention span limit. 0 disables limit.
+        contextual_seq_len (int): Contextual prefix length. 0 disables contextual masking.
+        sort_by_length_indices (Optional[torch.Tensor]): Indices to process sequences in descending length order.
+        config (Optional[dict]): Kernel tuning parameters (BLOCK_M, BLOCK_N).
+
+    Returns:
+        torch.Tensor: Output jagged tensor with shape (total_tokens, num_heads, head_dim).
+    """
+    Z = seq_offsets.numel() - 1
+    AUTOTUNE_Z = prev_power_of_2(Z)
+    L, H, DimQ = q.shape
+    _, _, DimV = v.shape
+    out = torch.empty_like(v)
+    has_multiple_targets = num_targets is not None
+    has_contextual_seq_len = contextual_seq_len > 0
+    has_max_attn_len = max_attn_len > 0
+    has_sort_by_length_indices = sort_by_length_indices is not None
+    if L == 0:
+        return out
+
+    DeltaSize = 0
+    IS_DELTA_Q = False
+
+    # if config is None:
+    #     config = _get_fwd_config(
+    #         AUTOTUNE_Z,
+    #     )
+
+    grid = lambda meta: (  # noqa E731
+        triton.cdiv(N, meta["BLOCK_M"]) *
+        Z * H,
+    )
+
+    _ragged_hstu_attn_fwd[grid](
+        Q=q,
+        K=k,
+        V=v,
+        sort_by_length_indices=sort_by_length_indices,
+        seq_offsets=seq_offsets,
+        num_targets=num_targets,
+        Out=out,
+        stride_qm=q.stride(0),
+        stride_qh=q.stride(1),
+        stride_kn=k.stride(0),
+        stride_kh=k.stride(1),
+        stride_vn=v.stride(0),
+        stride_vh=v.stride(1),
+        stride_om=out.stride(0),
+        stride_oh=out.stride(1),
+        alpha=alpha,
+        Z=Z,
+        H=H,
+        MAX_SEQ_LEN=N,
+        DeltaSize=DeltaSize,
+        contextual_seq_len=contextual_seq_len,
+        max_attn_len=max_attn_len,
+        CAUSAL=causal,
+        HAS_MULTIPLE_TARGETS=has_multiple_targets,
+        IS_DELTA_Q=IS_DELTA_Q,
+        ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+        BLOCK_D_Q=DimQ,
+        BLOCK_D_V=DimV,
+        HAS_CONTEXTUAL_SEQ_LEN=has_contextual_seq_len,
+        HAS_MAX_ATTN_LEN=has_max_attn_len,
+        HAS_SORT_BY_LENGTH_INDICES=has_sort_by_length_indices,
+        # **config,
+    )
+
+    return out
+
+
+
+def switch_to_contiguous_if_needed(x: torch.Tensor) -> torch.Tensor:
+    if not torch.jit.is_scripting() and torch.compiler.is_compiling():
+        # Tell Dynamo this data-dependent value is in the range (0, 10**9)
+        torch._check(x.size(0) > 0)
+        torch._check(x.size(0) < 10**9)
+    if x.stride(-1) == 1:
+        return x
+    return x.contiguous()
+
+
+# generate inputs
+def generate_sparse_seq_len(
+    size: int,
+    max_seq_len: int,
+    sparsity: float,
+    device: torch.device,
+) -> torch.Tensor:
+    torch.manual_seed(1)  # for reproducibility
+
+    if sparsity == 0.0:
+        return torch.zeros(size=(size,), device=device, dtype=torch.int)
+    elif sparsity == 1.0:
+        return torch.ones(size=(size,), device=device, dtype=torch.int) * max_seq_len
+    elif sparsity >= 0.5:
+        min_seq_len: int = int((2 * sparsity - 1.0) * max_seq_len)
+        max_seq_len: int = max_seq_len
+    else:
+        min_seq_len: int = 0
+        max_seq_len: int = int(2 * sparsity * max_seq_len)
+
+    return torch.randint(
+        low=min_seq_len,
+        high=max_seq_len,
+        size=(size,),
+        device=device,
+        dtype=torch.int,
+    )
+
+
+def apply_SL(
+    lengths: torch.Tensor,
+    alpha: float,
+    max_seq_len: int,
+) -> torch.Tensor:
+    threshold = int(max_seq_len ** (alpha / 2.0))
+    no_sample_prob = (max_seq_len**alpha) / torch.pow(lengths, 2)
+    users_to_sample = torch.logical_and(
+        lengths > threshold,
+        torch.rand_like(no_sample_prob) < 1 - no_sample_prob,
+    )
+    lengths = torch.where(users_to_sample, threshold, lengths)
+    return lengths
+
+
+def sanity_check_attention(
+    max_seq_len: int,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    invalid_attn_mask_type: str,
+    dropout_pr: float,
+    seq2_offsets: Optional[torch.Tensor] = None,
+    attn_bias: Optional[torch.Tensor] = None,
+    max_attn_len: Optional[int] = None,
+    contextual_seq_len: int = 0,
+) -> None:
+    _, H, _ = q.shape
+    torch._assert(max_seq_len > 0, "max_seq_len must be larger than 0")
+    torch._assert(q.dim() == 3, "q must be 3-D")
+    torch._assert(k.shape == q.shape, "k must be the same shape as q")
+    torch._assert(v.dim() == 3, "v must be 3-D")
+    torch._assert(v.shape[0] == q.shape[0], "wrong v shape[0]")
+    torch._assert(v.shape[1] == H, "wrong v shape[1]")
+    if attn_bias is not None:
+        assert seq2_offsets is not None
+        torch._assert(attn_bias.dim() == 1, "attn_bias must be 1-D")
+        torch._assert(
+            seq2_offsets is not None,
+            "must have seq2_offsets when using attn_bias",
+        )
+        torch._assert(seq2_offsets.dim() == 1, "seq2_offsets must be 1-D")
+    if max_attn_len is not None:
+        torch._assert(max_attn_len > 0, "max_attn_len must be larger than 0")
+    if invalid_attn_mask_type != "lower_triangular":
+        torch._assert(
+            contextual_seq_len == 0,
+            "user context mask not supported on non-lower triangular mask",
+        )
+    torch._assert(q.is_cuda, "q must be CUDA tensor")
+    torch._assert(k.is_cuda, "k must be CUDA tensor")
+    torch._assert(v.is_cuda, "v must be CUDA tensor")
+    torch._assert(seq_offsets.is_cuda, "seq_offsets must be CUDA tensor")
+    if attn_bias is not None:
+        torch._assert(attn_bias.is_cuda, "attn_bias must be CUDA tensor")
+        assert seq2_offsets is not None
+        torch._assert(seq2_offsets.is_cuda, "seq2_offsets must be CUDA tensor")
+    torch._assert(dropout_pr < 1e-6, "dropout for triton path not implemented")
+
+
+# calculate flops of the hstu attention
+# lower trigualar mask, so no need to multiple by 2
+# for flops calculation
+def get_flops(seq_offsets: torch.Tensor, heads: int, attn_dim: int, hidden_dim: int):
+    total_flops = 0.0
+    seq_num = seq_offsets.shape[0] - 1
+    for i in range(seq_num):
+        len = seq_offsets[i + 1] - seq_offsets[i]
+        flops = len * len * (attn_dim + hidden_dim) * heads
+        total_flops += flops
+
+    return total_flops
+
+
+def get_bytes(
+    seq_offsets: torch.Tensor,
+    heads: int,
+    attn_dim: int,
+    hidden_dim: int,
+    elem_size: int,
+):
+
+    seq_num = seq_offsets.shape[0] - 1
+    total_bytes = 0
+    for i in range(seq_num):
+        len = seq_offsets[i + 1] - seq_offsets[i]
+        bytes = len * (attn_dim + len + hidden_dim) * heads * elem_size
+        total_bytes += bytes
+
+    return total_bytes
+
+
+@pytest.mark.parametrize(
+    "batch_size, max_seq_len, sparsity", [(512, 3072, 0.366), (512, 512, 0.97)]
+)
+def test_hstu_attention(
+    batch_size: int,
+    max_seq_len: int,  # for repro
+    sparsity: float,  # for repro
+):
+    torch.cuda.empty_cache()  # Helps avoid hangs in large tests
+
+    dropout_pr = 0.0
+    heads: int = 4
+    attn_dim: int = 128
+    hidden_dim: int = 128
+    target_size: int = 20
+    sl_alpha: float = 2.0
+
+    # In prod, BF16 is used by HSTU attention
+    dtype = torch.bfloat16
+    invalid_attn_mask_type = "lower_triangular"
+    causal = True
+    alpha = 1.0 / attn_dim * 10000
+
+    # generate inputs
+    torch.manual_seed(1001)  # for reproducibility
+    lengths = generate_sparse_seq_len(
+        size=batch_size,
+        max_seq_len=max_seq_len,
+        sparsity=sparsity,
+        device=torch.device("cuda"),
+    )
+    lengths = apply_SL(lengths, sl_alpha, max_seq_len=max_seq_len)
+    num_targets = torch.randint(
+        1,
+        target_size + 1,
+        (batch_size,),
+        device=lengths.device,
+        dtype=lengths.dtype,
+    )
+    num_targets = torch.where(num_targets > lengths, lengths, num_targets)
+    seq_offsets = torch.zeros(
+        (batch_size + 1,), dtype=torch.int64, device=torch.device("cuda")
+    )
+    seq_offsets[1:] = torch.cumsum(lengths, dim=0)
+    L = int(seq_offsets[-1].item())
+    x = torch.empty(
+        (L, heads, attn_dim * 2 + hidden_dim),
+        dtype=dtype,
+        device=torch.device("cuda"),
+    ).uniform_(-0.01, 0.01)
+    q, k, v = torch.split(x, [attn_dim, attn_dim, hidden_dim], dim=-1)
+
+    q = switch_to_contiguous_if_needed(q)
+    k = switch_to_contiguous_if_needed(k)
+    v = switch_to_contiguous_if_needed(v)
+
+    sanity_check_attention(
+        max_seq_len=max_seq_len,
+        q=q,
+        k=k,
+        v=v,
+        seq_offsets=seq_offsets,
+        invalid_attn_mask_type=invalid_attn_mask_type,
+        dropout_pr=dropout_pr,
+        attn_bias=None,
+        max_attn_len=None,
+        contextual_seq_len=0,
+    )
+
+    def triton_attn():
+        sort_by_length = True
+        if sort_by_length:
+            seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
+            _, sort_by_length_indices = torch.sort(
+                seq_lengths, descending=True, stable=False
+            )
+        return triton_hstu_attention_fwd(
+            max_seq_len,
+            alpha,
+            q,
+            k,
+            v,
+            seq_offsets,
+            causal,
+            num_targets,
+            0,  # max_attn_len,
+            0,  # contextual_seq_len
+            sort_by_length_indices,
+            True,  # sort_by_length,
+        )
+
+    def torch_attn():
+        return torch_hstu_attention(
+            max_seq_len,
+            alpha,
+            q,
+            k,
+            v,
+            seq_offsets,
+            causal,
+            dropout_pr=0.0,
+            training=False,
+            num_targets=num_targets,
+            max_attn_len=0,
+            contextual_seq_len=0,
+            min_full_attn_seq_len=0,
+        )
+
+    out = triton_attn() * max_seq_len
+    out_ref = torch_attn() * max_seq_len
+    torch.testing.assert_close(out, out_ref, atol=1e-3, rtol=0)

--- a/third_party/tlx/tutorials/amd-hstu-attn-test.py
+++ b/third_party/tlx/tutorials/amd-hstu-attn-test.py
@@ -6,6 +6,8 @@ import triton.language.extra.tlx as tlx
 import torch
 import torch.nn.functional as F
 import pytest
+import sys
+import argparse
 
 try:
     from triton.language.extra.libdevice import (
@@ -32,6 +34,13 @@ def prev_power_of_2(x: int) -> int:
 def get_arch():
     return triton.runtime.driver.active.get_current_target().arch
 
+str_to_torch_dtype = {
+    "fp32": torch.float32,
+    "bfloat16": torch.bfloat16,
+    "bf16": torch.bfloat16,
+    "float16": torch.float16,
+    "fp16": torch.float16,
+}
 
 #----------------------------------------------------------------------
 # ref implementation 
@@ -663,7 +672,7 @@ def triton_hstu_attention_fwd(
     num_targets: Optional[torch.Tensor],
     max_attn_len: int,
     contextual_seq_len: int,
-    sort_by_length_indices: Optional[torch.Tensor],
+    sort_by_length: bool = False,
     config: Optional[dict] = None,
 ) -> torch.Tensor:
     """
@@ -689,24 +698,25 @@ def triton_hstu_attention_fwd(
         torch.Tensor: Output jagged tensor with shape (total_tokens, num_heads, head_dim).
     """
     Z = seq_offsets.numel() - 1
-    AUTOTUNE_Z = prev_power_of_2(Z)
     L, H, DimQ = q.shape
     _, _, DimV = v.shape
     out = torch.empty_like(v)
     has_multiple_targets = num_targets is not None
     has_contextual_seq_len = contextual_seq_len > 0
     has_max_attn_len = max_attn_len > 0
-    has_sort_by_length_indices = sort_by_length_indices is not None
+
+    if sort_by_length:
+        seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
+        _, sort_by_length_indices = torch.sort(
+            seq_lengths, descending=True, stable=False
+        )
+
+    has_sort_by_length_indices = sort_by_length
     if L == 0:
         return out
 
     DeltaSize = 0
     IS_DELTA_Q = False
-
-    # if config is None:
-    #     config = _get_fwd_config(
-    #         AUTOTUNE_Z,
-    #     )
 
     grid = lambda meta: (  # noqa E731
         triton.cdiv(N, meta["BLOCK_M"]) *
@@ -884,20 +894,36 @@ def get_bytes(
     return total_bytes
 
 
+#shape info
+def get_inputs():
+    input_info = [
+        (32, 1024, 0.5, 4, 128, 128),
+        (32, 2048, 0.5, 4, 128, 128),
+        (32, 4096, 0.5, 4, 128, 128),
+        (32, 8192, 0.5, 4, 128, 128),
+        (32, 16384, 0.5, 4, 128, 128),
+        (512, 512, 0.97, 4, 128, 128),
+        (512, 3072, 0.366, 4, 128, 128),
+        (1024, 1024, 0.768, 4, 128, 128),
+    ]
+
+    return input_info
+
+
 @pytest.mark.parametrize(
-    "batch_size, max_seq_len, sparsity", [(512, 3072, 0.366), (512, 512, 0.97)]
+    "batch_size, max_seq_len, sparsity, heads, attn_dim, hidden_dim", get_inputs()
 )
 def test_hstu_attention(
     batch_size: int,
     max_seq_len: int,  # for repro
     sparsity: float,  # for repro
+    heads: int,
+    attn_dim: int,
+    hidden_dim: int,
 ):
     torch.cuda.empty_cache()  # Helps avoid hangs in large tests
 
     dropout_pr = 0.0
-    heads: int = 4
-    attn_dim: int = 128
-    hidden_dim: int = 128
     target_size: int = 20
     sl_alpha: float = 2.0
 
@@ -955,11 +981,6 @@ def test_hstu_attention(
 
     def triton_attn():
         sort_by_length = True
-        if sort_by_length:
-            seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
-            _, sort_by_length_indices = torch.sort(
-                seq_lengths, descending=True, stable=False
-            )
         return triton_hstu_attention_fwd(
             max_seq_len,
             alpha,
@@ -971,7 +992,6 @@ def test_hstu_attention(
             num_targets,
             0,  # max_attn_len,
             0,  # contextual_seq_len
-            sort_by_length_indices,
             True,  # sort_by_length,
         )
 
@@ -995,3 +1015,254 @@ def test_hstu_attention(
     out = triton_attn() * max_seq_len
     out_ref = torch_attn() * max_seq_len
     torch.testing.assert_close(out, out_ref, atol=1e-3, rtol=0)
+
+
+# benchmark
+def run_benchmark(args):
+
+    x_names = [
+        "batch_size",
+        "max_seq_len",
+        "sparsity",
+        "heads",
+        "attn_dim",
+        "hidden_dim",
+    ]
+    if args.user_input:
+        x_val_list = [
+            (
+                args.b,
+                args.max_seq_len,
+                args.sparsity,
+                args.heads,
+                args.head_dim,
+                args.hidden_dim,
+            )
+        ]
+    else:
+        x_val_list = get_inputs()
+
+    if args.metric == "time":
+        ylabel = "Time (ms)"
+    elif args.metric == "throughput":
+        ylabel = "Throughput (TFLOPS)"
+    elif args.metric == "bandwidth":
+        ylabel = "Bandwidth (GBs)"
+    else:
+        raise NotImplementedError(f"{args.metric} is not supported")
+
+    evaluation_metric_to_unit = {
+        "throughput": "TFLOPS",
+        "time": "Time_(ms)",
+        "bandwidth": "Bandwidth_(GB/s)",  # spaces break prettytable parsing
+    }
+    line_names = [evaluation_metric_to_unit[args.metric]]
+    line_vals = line_names
+
+    configs = []
+    metric = args.metric
+    configs.append(
+        triton.testing.Benchmark(
+            x_names=x_names,
+            x_vals=x_val_list,
+            line_arg="unit",
+            line_vals=line_vals,
+            line_names=line_names,
+            styles=[("green", "-")],
+            ylabel=ylabel,
+            plot_name='hstu_attention perf numbers',
+            args={"metric": metric, "mode": 'fwd'},
+        )
+    )
+
+    @triton.testing.perf_report(configs)
+    def bench_hstu_attn(
+        batch_size,
+        max_seq_len,
+        sparsity,
+        heads,
+        attn_dim,
+        hidden_dim,
+        metric,
+        mode,
+        **kwargs,
+    ):
+        type_str = args.dtype
+        assert type_str in [
+            "fp16",
+            "bf16",
+        ], "only fp16 or bf16 data types are supported!"
+        dropout_pr = 0.0
+        target_size: int = 20
+        sl_alpha: float = 2.0
+        dtype = str_to_torch_dtype[type_str]
+
+        invalid_attn_mask_type = "lower_triangular"
+        causal = True
+        alpha = 1.0 / attn_dim * 10000
+
+        # generate inputs
+        torch.manual_seed(1001)  # for reproducibility
+        lengths = generate_sparse_seq_len(
+            size=batch_size,
+            max_seq_len=max_seq_len,
+            sparsity=sparsity,
+            device=torch.device("cuda"),
+        )
+        lengths = apply_SL(lengths, sl_alpha, max_seq_len=max_seq_len)
+        num_targets = torch.randint(
+            1,
+            target_size + 1,
+            (batch_size,),
+            device=lengths.device,
+            dtype=lengths.dtype,
+        )
+        num_targets = torch.where(num_targets > lengths, lengths, num_targets)
+        seq_offsets = torch.zeros(
+            (batch_size + 1,), dtype=torch.int64, device=torch.device("cuda")
+        )
+        seq_offsets[1:] = torch.cumsum(lengths, dim=0)
+        L = int(seq_offsets[-1].item())
+        x = torch.empty(
+            (L, heads, attn_dim * 2 + hidden_dim),
+            dtype=dtype,
+            device=torch.device("cuda"),
+        ).uniform_(-0.01, 0.01)
+        q, k, v = torch.split(x, [attn_dim, attn_dim, hidden_dim], dim=-1)
+
+        q = switch_to_contiguous_if_needed(q)
+        k = switch_to_contiguous_if_needed(k)
+        v = switch_to_contiguous_if_needed(v)
+
+        sanity_check_attention(
+            max_seq_len=max_seq_len,
+            q=q,
+            k=k,
+            v=v,
+            seq_offsets=seq_offsets,
+            invalid_attn_mask_type=invalid_attn_mask_type,
+            dropout_pr=dropout_pr,
+            attn_bias=None,
+            max_attn_len=None,
+            contextual_seq_len=0,
+        )
+
+        def attn_fwd():
+            return triton_hstu_attention_fwd(
+                max_seq_len,
+                alpha,
+                q,
+                k,
+                v,
+                seq_offsets,
+                causal,
+                num_targets,
+                0,  # max_attn_len,
+                0,  # contextual_seq_len
+                True,  # sort_by_length,
+            )
+        ms = triton.testing.do_bench(
+            attn_fwd,
+            warmup=25,
+            rep=100,
+        )
+
+        # Return exactly one scalar depending on which metric is active
+        if metric == "time":
+            return ms
+        elif metric == "throughput":
+            flops = get_flops(seq_offsets.cpu().numpy(), heads, attn_dim, hidden_dim)
+            tflops = flops / ms * 1e-9
+            return tflops
+        elif metric == "bandwidth":
+            elem_size = q.element_size()
+            bytes = get_bytes(
+                seq_offsets.cpu().numpy(), heads, attn_dim, hidden_dim, elem_size
+            )
+            bandwidth = bytes / (ms * 1e-3) * 1e-9  # GB/s
+            return bandwidth
+        else:
+            raise ValueError("Unknown metric: " + metric)
+
+    bench_hstu_attn.run(save_path="." if args.o else None, print_data=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark HSTU Attention",
+        allow_abbrev=False,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--b",
+        type=int,
+        default=512,
+        help="Batch dim of input sequences",
+    )
+    parser.add_argument(
+        "--max_seq_len",
+        type=int,
+        default=1024,
+        help="max sequence length",
+    )
+    parser.add_argument(
+        "--sparsity",
+        type=float,
+        default=0.5,
+        help="sparsity of input sequence lengths",
+    )
+    parser.add_argument(
+        "--heads",
+        type=int,
+        default=4,
+        help="number of heads",
+    )
+    parser.add_argument(
+        "--head_dim",
+        type=int,
+        default=128,
+        help="head dimension",
+    )
+    parser.add_argument(
+        "--hidden_dim",
+        type=int,
+        default=128,
+        help="hidden dimension",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bf16",
+        help="data type, default (bfloat16)",
+    )
+
+    parser.add_argument(
+        "--metric",
+        type=str,
+        choices=["time", "throughput", "bandwidth"],
+        default="throughput",
+        help="metric to plot",
+    )
+
+    parser.add_argument(
+        "--user_input",
+        action="store_true",
+        default=False,
+        help="Run user input info",
+    )
+
+    parser.add_argument(
+        "-o", action="store_true", help="Write performance results to CSV file"
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    run_benchmark(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/tlx/tutorials/amd-hstu-attn-test.py
+++ b/third_party/tlx/tutorials/amd-hstu-attn-test.py
@@ -945,7 +945,6 @@ def test_hstu_attention(
     )
 
     def triton_attn():
-        sort_by_length = True
         return triton_hstu_attention_fwd(max_seq_len, alpha, q, k, v, seq_offsets, causal, num_targets,
                                          0,  # max_attn_len,
                                          0,  # contextual_seq_len

--- a/third_party/tlx/tutorials/amd-hstu-attn-test.py
+++ b/third_party/tlx/tutorials/amd-hstu-attn-test.py
@@ -1,0 +1,416 @@
+from typing import List, Optional, Tuple
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+try:
+    from triton.language.extra.libdevice import (
+        fast_dividef,
+        fast_expf,
+    )  # @manual=//triton:triton
+except ImportError:
+    try:
+        # @manual=//triton:triton
+        from triton.language.extra.hip.libdevice import fast_dividef, fast_expf
+    except ImportError:
+        # pyre-ignore[21]
+        from triton.language.math import (
+            fast_dividef,
+            fast_expf,
+        )  # @manual=//triton:triton
+
+
+def prev_power_of_2(x: int) -> int:
+    out = triton.next_power_of_2(x)
+    return out // 2 if out > x else out
+
+def get_arch():
+    return triton.runtime.driver.active.get_current_target().arch
+
+
+def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
+    configs = []
+    if FULL_TUNING:
+        for BLOCK_M in [32, 64, 128]:
+            for BLOCK_N in [32, 64]:
+                for num_stages in [1, 2]:
+                    for num_warps in [4, 8]:
+                        for matrix_instr_nonkdim in [16, 32]:
+                            configs.append(
+                                triton.Config(
+                                    {
+                                        "BLOCK_M": BLOCK_M,
+                                        "BLOCK_N": BLOCK_N,
+                                        "matrix_instr_nonkdim": matrix_instr_nonkdim,
+                                        "waves_per_eu": 0,
+                                        "kpack": 2 if get_arch() == "gfx942" else 1,
+                                    },
+                                    num_stages=num_stages,
+                                    num_warps=num_warps,
+                                )
+                            )
+    else:
+        configs = [
+            triton.Config(
+                {
+                    "BLOCK_M": 64,
+                    "BLOCK_N": 32,
+                    "matrix_instr_nonkdim": 16,
+                    "waves_per_eu": 0,
+                    "kpack": 1,
+                },
+                num_stages=1,
+                num_warps=4,
+            ),
+        ]
+
+    return configs
+
+@triton.jit
+def _hstu_attn_fwd_one_block(  # noqa: C901
+    start_n,
+    seq_len,
+    offs_m,
+    offs_n,
+    q,
+    K_base,
+    V_base,
+    stride_kn,
+    stride_vn,
+    n_targets,
+    alpha,
+    MAX_SEQ_LEN,
+    contextual_seq_len,
+    max_attn_len,
+    CAUSAL: tl.constexpr,
+    HAS_MULTIPLE_TARGETS: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+):
+    start_n = tl.multiple_of(start_n, BLOCK_N)
+    offs_d_q = tl.arange(0, BLOCK_D_Q)
+    offs_d_v = tl.arange(0, BLOCK_D_V)
+    k_ptrs = K_base + offs_d_q[:, None] + offs_n[None, :] * stride_kn
+    v_ptrs = V_base + offs_n[:, None] * stride_vn + offs_d_v[None, :]
+
+    # -- compute qk ----
+    mask_n = offs_n < seq_len
+    k = tl.load(k_ptrs, mask=mask_n[None, :], other=0.0)
+    qk = tl.dot(q, k, allow_tf32=ALLOW_TF32) * alpha
+    invalid_mask = offs_m[:, None] == offs_n[None, :]
+    max_ids = seq_len
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        offs_m = offs_m - contextual_seq_len + 1
+        offs_m = tl.where(
+            offs_m > 0,
+            offs_m,
+            0,
+        )
+        offs_n = offs_n - contextual_seq_len + 1
+        offs_n = tl.where(
+            offs_n > 0,
+            offs_n,
+            0,
+        )
+        max_ids = max_ids - contextual_seq_len + 1
+    if HAS_MULTIPLE_TARGETS:
+        max_ids = max_ids - n_targets
+        offs_m = tl.where(
+            offs_m < max_ids,
+            offs_m,
+            max_ids,
+        )
+        offs_n = tl.where(
+            offs_n < max_ids,
+            offs_n,
+            max_ids,
+        )
+    offs_m_minus_n = offs_m[:, None] - offs_n[None, :]
+    if not CAUSAL:
+        offs_m_minus_n = tl.where(offs_m_minus_n > 0, offs_m_minus_n, -offs_m_minus_n)
+    invalid_mask = invalid_mask | (offs_m_minus_n > 0)
+    if HAS_MAX_ATTN_LEN:
+        invalid_mask = invalid_mask and offs_m_minus_n <= max_attn_len
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        invalid_mask = invalid_mask or (
+            offs_m[:, None] == 0 and offs_n[None, :] < max_ids
+        )
+    # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
+    silu = fast_dividef(qk, 1.0 + fast_expf(-qk)) * (1.0 / MAX_SEQ_LEN)
+    silu = tl.where(invalid_mask, silu, 0)
+    v = tl.load(v_ptrs, mask=mask_n[:, None], other=0.0)
+    silu = silu.to(v.dtype)
+    return tl.dot(silu, v, allow_tf32=ALLOW_TF32)
+
+
+@triton.jit
+def _hstu_attn_fwd_compute(  # noqa C901
+    Q,
+    K,
+    V,
+    seq_offsets,
+    num_targets,
+    Out,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    alpha,
+    MAX_SEQ_LEN,
+    DeltaSize,
+    contextual_seq_len,
+    max_attn_len,
+    off_z,
+    off_h,
+    pid,
+    CAUSAL: tl.constexpr,
+    HAS_MULTIPLE_TARGETS: tl.constexpr,
+    IS_DELTA_Q: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+):
+    seq_start = tl.load(seq_offsets + off_z).to(tl.int64)
+    off_h = off_h.to(tl.int64)
+    off_z = off_z.to(tl.int64)
+    seq_end = tl.load(seq_offsets + off_z + 1)
+    seq_len = (seq_end - seq_start).to(tl.int32)
+    if IS_DELTA_Q:
+        start_m_delta = pid * BLOCK_M
+        start_m = (start_m_delta + seq_len - DeltaSize).to(tl.int32)
+    else:
+        start_m_delta = 0
+        start_m = pid * BLOCK_M
+    if start_m < seq_len:
+        if HAS_MULTIPLE_TARGETS:
+            n_targets = tl.load(num_targets + off_z).to(tl.int32)
+        else:
+            n_targets = None
+
+        # initialize offsets
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        offs_n = tl.arange(0, BLOCK_N)
+        K_base = K + off_h * stride_kh + seq_start * stride_kn
+        V_base = V + off_h * stride_vh + seq_start * stride_vn
+        offs_d_q = tl.arange(0, BLOCK_D_Q)
+        mask_m = offs_m < seq_len
+        if IS_DELTA_Q:
+            Q_base = Q + off_h * stride_qh + off_z * DeltaSize * stride_qm
+            q_ptrs = Q_base + (start_m_delta + tl.arange(0, BLOCK_M))[:, None] * stride_qm + offs_d_q[None, :]
+            q = tl.load(q_ptrs, mask=((start_m_delta + tl.arange(0, BLOCK_M)) < DeltaSize)[:, None], other=0.0)
+        else:
+            Q_base = Q + off_h * stride_qh + seq_start * stride_qm
+            q_ptrs = Q_base + offs_m[:, None] * stride_qm + offs_d_q[None, :]
+            q = tl.load(q_ptrs, mask=mask_m[:, None], other=0.0)
+
+        acc = tl.zeros([BLOCK_M, BLOCK_D_V], dtype=tl.float32)
+        if CAUSAL:
+            if HAS_MULTIPLE_TARGETS:
+                uih_end = seq_len - n_targets
+            else:
+                uih_end = seq_len
+            if HAS_CONTEXTUAL_SEQ_LEN is True and start_m < contextual_seq_len:
+                # uih_end must be larger than start_m
+                low = 0
+                high = seq_len
+            else:
+                low = 0
+                high = start_m + BLOCK_M
+                if HAS_MAX_ATTN_LEN:
+                    if start_m > uih_end:
+                        low = uih_end - max_attn_len
+                    else:
+                        low = start_m - max_attn_len
+                    if HAS_CONTEXTUAL_SEQ_LEN:
+                        low = low if low > contextual_seq_len else 0
+                    else:
+                        low = low if low > 0 else 0
+                if HAS_MULTIPLE_TARGETS:
+                    uih_end = (uih_end + BLOCK_N - 1) // BLOCK_N * BLOCK_N
+                    if uih_end < start_m:
+                        high = seq_len - n_targets
+        else:
+            low = 0
+            high = seq_len
+
+        for start_n in range(low, high, BLOCK_N):
+            acc += _hstu_attn_fwd_one_block(
+                start_n=start_n,
+                seq_len=seq_len,
+                offs_m=offs_m,
+                offs_n=offs_n + start_n,
+                q=q,
+                K_base=K_base,
+                V_base=V_base,
+                stride_kn=stride_kn,
+                stride_vn=stride_vn,
+                n_targets=n_targets if HAS_MULTIPLE_TARGETS else None,
+                alpha=alpha,
+                MAX_SEQ_LEN=MAX_SEQ_LEN,
+                contextual_seq_len=contextual_seq_len,
+                max_attn_len=max_attn_len,
+                CAUSAL=CAUSAL,
+                HAS_MULTIPLE_TARGETS=HAS_MULTIPLE_TARGETS,
+                HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                ALLOW_TF32=ALLOW_TF32,
+                BLOCK_N=BLOCK_N,
+                BLOCK_D_Q=BLOCK_D_Q,
+                BLOCK_D_V=BLOCK_D_V,
+            )
+
+        if HAS_MULTIPLE_TARGETS and CAUSAL:
+            # pyre-ignore[61]
+            if uih_end < start_m:
+                low_delta = start_m
+                high_delta = start_m + BLOCK_M
+                for start_delta in tl.range(
+                    low_delta, high_delta, BLOCK_N, num_stages=0
+                ):
+                    acc += _hstu_attn_fwd_one_block(
+                        start_n=start_delta,
+                        seq_len=seq_len,
+                        offs_m=offs_m,
+                        offs_n=offs_n + start_delta,
+                        q=q,
+                        K_base=K_base,
+                        V_base=V_base,
+                        stride_kn=stride_kn,
+                        stride_vn=stride_vn,
+                        n_targets=n_targets if HAS_MULTIPLE_TARGETS else None,
+                        alpha=alpha,
+                        MAX_SEQ_LEN=MAX_SEQ_LEN,
+                        contextual_seq_len=contextual_seq_len,
+                        max_attn_len=max_attn_len,
+                        CAUSAL=CAUSAL,
+                        HAS_MULTIPLE_TARGETS=HAS_MULTIPLE_TARGETS,
+                        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                        ALLOW_TF32=ALLOW_TF32,
+                        BLOCK_N=BLOCK_N,
+                        BLOCK_D_Q=BLOCK_D_Q,
+                        BLOCK_D_V=BLOCK_D_V,
+                    )
+
+        if IS_DELTA_Q:
+            start_m_delta = pid * BLOCK_M
+            offs_m_delta = start_m_delta + tl.arange(0, BLOCK_M)
+            offs_v_d = tl.arange(0, BLOCK_D_V)
+            off_o = Out + off_z * DeltaSize * stride_om + off_h * stride_oh
+            out_ptrs = off_o + offs_m_delta[:, None] * stride_om + offs_v_d[None, :]
+            tl.store(out_ptrs, acc, mask=(offs_m_delta < DeltaSize)[:, None])
+        else:
+            # rematerialize offsets to save registers
+            start_m = pid * BLOCK_M
+            offs_m = start_m + tl.arange(0, BLOCK_M)
+            offs_v_d = tl.arange(0, BLOCK_D_V)
+            off_o = Out + seq_start * stride_om + off_h * stride_oh
+            out_ptrs = off_o + offs_m[:, None] * stride_om + offs_v_d[None, :]
+            tl.store(out_ptrs, acc, mask=(offs_m < seq_len)[:, None])
+
+
+
+# @triton.autotune(
+#     configs=_get_fw_configs(),
+#     key=[
+#         "AUTOTUNE_Z",
+#         "H",
+#         "AUTOTUNE_MAX_SEQ_LEN",
+#         "DimQ",
+#         "DimV",
+#         "BUCKET_FN",
+#         "ATTN_BIAS_TYPE",
+#         "DeltaSize",
+#         "IS_DELTA_Q",
+#     ],
+# )
+@triton.jit
+def _ragged_hstu_attn_fwd(  # noqa C901
+    Q,
+    K,
+    V,
+    sort_by_length_indices,
+    seq_offsets,
+    num_targets,
+    Out,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    alpha,
+    H,
+    MAX_SEQ_LEN,
+    DeltaSize,
+    contextual_seq_len,
+    max_attn_len,
+    CAUSAL: tl.constexpr,
+    HAS_MULTIPLE_TARGETS: tl.constexpr,
+    IS_DELTA_Q: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
+):
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    if HAS_SORT_BY_LENGTH_INDICES:
+        off_z = tl.load(sort_by_length_indices + off_z)
+    off_h = off_hz % H
+    pid = tl.program_id(0)
+    _hstu_attn_fwd_compute(
+        Q=Q,
+        K=K,
+        V=V,
+        seq_offsets=seq_offsets,
+        num_targets=num_targets,
+        Out=Out,
+        stride_qm=stride_qm,
+        stride_qh=stride_qh,
+        stride_kn=stride_kn,
+        stride_kh=stride_kh,
+        stride_vn=stride_vn,
+        stride_vh=stride_vh,
+        stride_om=stride_om,
+        stride_oh=stride_oh,
+        alpha=alpha,
+        MAX_SEQ_LEN=MAX_SEQ_LEN,
+        DeltaSize=DeltaSize,
+        contextual_seq_len=contextual_seq_len,
+        max_attn_len=max_attn_len,
+        off_z=off_z,
+        off_h=off_h,
+        pid=pid,
+        CAUSAL=CAUSAL,
+        HAS_MULTIPLE_TARGETS=HAS_MULTIPLE_TARGETS,
+        IS_DELTA_Q=IS_DELTA_Q,
+        ALLOW_TF32=ALLOW_TF32,
+        BLOCK_D_Q=BLOCK_D_Q,
+        BLOCK_D_V=BLOCK_D_V,
+        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+    )
+
+

--- a/third_party/tlx/tutorials/amd-hstu-attn-test.py
+++ b/third_party/tlx/tutorials/amd-hstu-attn-test.py
@@ -34,6 +34,7 @@ def prev_power_of_2(x: int) -> int:
 def get_arch():
     return triton.runtime.driver.active.get_current_target().arch
 
+
 str_to_torch_dtype = {
     "fp32": torch.float32,
     "bfloat16": torch.bfloat16,
@@ -42,8 +43,9 @@ str_to_torch_dtype = {
     "fp16": torch.float16,
 }
 
+
 #----------------------------------------------------------------------
-# ref implementation 
+# ref implementation
 # create attention mask
 def _get_valid_attn_mask(
     device: torch.device,
@@ -89,20 +91,14 @@ def _get_valid_attn_mask(
                 ),
             )
         else:
-            valid_attn_mask = torch.logical_and(
-                valid_attn_mask, row_col_dist <= max_attn_len
-            )
+            valid_attn_mask = torch.logical_and(valid_attn_mask, row_col_dist <= max_attn_len)
     if contextual_seq_len > 0:
-        valid_attn_mask = torch.logical_or(
-            valid_attn_mask, torch.logical_and(row_ids == 0, col_ids < max_ids)
-        )
+        valid_attn_mask = torch.logical_or(valid_attn_mask, torch.logical_and(row_ids == 0, col_ids < max_ids))
     return valid_attn_mask
 
 
 # convert sequence input from jagged format to padded dense format
-def jagged_to_padded_dense(
-    q: torch.Tensor, offsets: torch.Tensor, max_seq_len: int, padding_value
-):
+def jagged_to_padded_dense(q: torch.Tensor, offsets: torch.Tensor, max_seq_len: int, padding_value):
     assert len(q.shape) == 2, "q needs to be 2-dim tensor"
     L, D = q.shape
     B = offsets.shape[0] - 1
@@ -111,7 +107,7 @@ def jagged_to_padded_dense(
     for i in range(B):
         s = offsets[i]
         e = offsets[i + 1]
-        padded_q[i][0 : e - s] = q[s:e]
+        padded_q[i][0:e - s] = q[s:e]
 
     return padded_q
 
@@ -119,9 +115,7 @@ def jagged_to_padded_dense(
 # pad sequence according to max sequence len
 def pad_sequence(q: torch.Tensor, seq_offsets: torch.Tensor, N: int, padding_value):
     L, D = q.shape
-    padded_q = jagged_to_padded_dense(
-        q.reshape(L, D), offsets=seq_offsets, max_seq_len=N, padding_value=0.0
-    )
+    padded_q = jagged_to_padded_dense(q.reshape(L, D), offsets=seq_offsets, max_seq_len=N, padding_value=0.0)
 
     return padded_q
 
@@ -134,21 +128,9 @@ def qkv_to_padded_dense(
     N: int,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     L, H, D = q.shape
-    padded_q = (
-        pad_sequence(q.reshape(L, H * D), seq_offsets, N, 0.0)
-        .view(-1, N, H, D)
-        .transpose(1, 2)
-    )
-    padded_k = (
-        pad_sequence(k.reshape(L, H * D), seq_offsets, N, 0.0)
-        .view(-1, N, H, D)
-        .transpose(1, 2)
-    )
-    padded_v = (
-        pad_sequence(v.reshape(L, H * D), seq_offsets, N, 0.0)
-        .view(-1, N, H, D)
-        .transpose(1, 2)
-    )
+    padded_q = (pad_sequence(q.reshape(L, H * D), seq_offsets, N, 0.0).view(-1, N, H, D).transpose(1, 2))
+    padded_k = (pad_sequence(k.reshape(L, H * D), seq_offsets, N, 0.0).view(-1, N, H, D).transpose(1, 2))
+    padded_v = (pad_sequence(v.reshape(L, H * D), seq_offsets, N, 0.0).view(-1, N, H, D).transpose(1, 2))
 
     return padded_q, padded_k, padded_v
 
@@ -162,7 +144,7 @@ def dense_to_jagged(seq: torch.Tensor, offsets: torch.Tensor, L: int):
     for i in range(B):
         s = offsets[i]
         e = offsets[i + 1]
-        out[s:e] = seq[i][0 : e - s]
+        out[s:e] = seq[i][0:e - s]
 
     return out
 
@@ -185,9 +167,7 @@ def torch_hstu_attention(
 ) -> torch.Tensor:
     L, H, _ = q.shape
     V = v.shape[2]
-    q, k, v = qkv_to_padded_dense(
-        q, k, v, seq_offsets, max_seq_len
-    )  # [B, H, N, D) and [B, H, N, V]
+    q, k, v = qkv_to_padded_dense(q, k, v, seq_offsets, max_seq_len)  # [B, H, N, D) and [B, H, N, V]
     qk_attn = torch.einsum("bhxa,bhya->bhxy", q, k) * alpha
     qk_attn = F.silu(qk_attn) / max_seq_len
     valid_attn_mask = _get_valid_attn_mask(
@@ -210,6 +190,8 @@ def torch_hstu_attention(
         seq_offsets,
         L,
     ).view(L, H, V)
+
+
 #----------------------------------------------------------------------
 
 
@@ -234,15 +216,13 @@ def remap_xcd(pid, GRID_MN, NUM_XCDS: tl.constexpr = 8):
     if xcd < tall_xcds:
         pid = xcd * pids_per_xcd + local_pid
     else:
-        pid = (
-            tall_xcds * pids_per_xcd
-            + (xcd - tall_xcds) * (pids_per_xcd - 1)
-            + local_pid
-        )
+        pid = (tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid)
 
     return pid
 
-FULL_TUNING=False
+
+FULL_TUNING = False
+
 
 def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
     configs = []
@@ -263,8 +243,7 @@ def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
                                     },
                                     num_stages=num_stages,
                                     num_warps=num_warps,
-                                )
-                            )
+                                ))
     else:
         configs = [
             triton.Config(
@@ -281,6 +260,7 @@ def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
         ]
 
     return configs
+
 
 @triton.jit
 def _hstu_attn_fwd_one_block(  # noqa: C901
@@ -312,7 +292,6 @@ def _hstu_attn_fwd_one_block(  # noqa: C901
     start_n = tl.multiple_of(start_n, BLOCK_N)
     offs_d_q = tl.arange(0, BLOCK_D_Q)
     offs_d_v = tl.arange(0, BLOCK_D_V)
-
 
     k_ptrs = K_base + offs_d_q[None, :] + offs_n[:, None] * stride_kn
     v_ptrs = V_base + offs_n[:, None] * stride_vn + offs_d_v[None, :]
@@ -363,9 +342,7 @@ def _hstu_attn_fwd_one_block(  # noqa: C901
     if HAS_MAX_ATTN_LEN:
         invalid_mask = invalid_mask and offs_m_minus_n <= max_attn_len
     if HAS_CONTEXTUAL_SEQ_LEN:
-        invalid_mask = invalid_mask or (
-            offs_m[:, None] == 0 and offs_n[None, :] < max_ids
-        )
+        invalid_mask = invalid_mask or (offs_m[:, None] == 0 and offs_n[None, :] < max_ids)
     # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
     silu = fast_dividef(qk, 1.0 + fast_expf(-1.0 * qk)) * (1.0 / MAX_SEQ_LEN)
     silu = tl.where(invalid_mask, silu, 0)
@@ -514,9 +491,7 @@ def _hstu_attn_fwd_compute(  # noqa C901
             if uih_end < start_m:
                 low_delta = start_m
                 high_delta = start_m + BLOCK_M
-                for start_delta in tl.range(
-                    low_delta, high_delta, BLOCK_N, num_stages=0
-                ):
+                for start_delta in tl.range(low_delta, high_delta, BLOCK_N, num_stages=0):
                     acc += _hstu_attn_fwd_one_block(
                         start_n=start_delta,
                         seq_len=seq_len,
@@ -559,7 +534,6 @@ def _hstu_attn_fwd_compute(  # noqa C901
             off_o = Out + seq_start * stride_om + off_h * stride_oh
             out_ptrs = off_o + offs_m[:, None] * stride_om + offs_v_d[None, :]
             tl.store(out_ptrs, acc, mask=(offs_m < seq_len)[:, None])
-
 
 
 @triton.autotune(
@@ -707,9 +681,7 @@ def triton_hstu_attention_fwd(
 
     if sort_by_length:
         seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
-        _, sort_by_length_indices = torch.sort(
-            seq_lengths, descending=True, stable=False
-        )
+        _, sort_by_length_indices = torch.sort(seq_lengths, descending=True, stable=False)
 
     has_sort_by_length_indices = sort_by_length
     if L == 0:
@@ -719,9 +691,7 @@ def triton_hstu_attention_fwd(
     IS_DELTA_Q = False
 
     grid = lambda meta: (  # noqa E731
-        triton.cdiv(N, meta["BLOCK_M"]) *
-        Z * H,
-    )
+        triton.cdiv(N, meta["BLOCK_M"]) * Z * H, )
 
     _ragged_hstu_attn_fwd[grid](
         Q=q,
@@ -761,7 +731,6 @@ def triton_hstu_attention_fwd(
     return out
 
 
-
 def switch_to_contiguous_if_needed(x: torch.Tensor) -> torch.Tensor:
     if not torch.jit.is_scripting() and torch.compiler.is_compiling():
         # Tell Dynamo this data-dependent value is in the range (0, 10**9)
@@ -782,9 +751,9 @@ def generate_sparse_seq_len(
     torch.manual_seed(1)  # for reproducibility
 
     if sparsity == 0.0:
-        return torch.zeros(size=(size,), device=device, dtype=torch.int)
+        return torch.zeros(size=(size, ), device=device, dtype=torch.int)
     elif sparsity == 1.0:
-        return torch.ones(size=(size,), device=device, dtype=torch.int) * max_seq_len
+        return torch.ones(size=(size, ), device=device, dtype=torch.int) * max_seq_len
     elif sparsity >= 0.5:
         min_seq_len: int = int((2 * sparsity - 1.0) * max_seq_len)
         max_seq_len: int = max_seq_len
@@ -795,7 +764,7 @@ def generate_sparse_seq_len(
     return torch.randint(
         low=min_seq_len,
         high=max_seq_len,
-        size=(size,),
+        size=(size, ),
         device=device,
         dtype=torch.int,
     )
@@ -806,7 +775,7 @@ def apply_SL(
     alpha: float,
     max_seq_len: int,
 ) -> torch.Tensor:
-    threshold = int(max_seq_len ** (alpha / 2.0))
+    threshold = int(max_seq_len**(alpha / 2.0))
     no_sample_prob = (max_seq_len**alpha) / torch.pow(lengths, 2)
     users_to_sample = torch.logical_and(
         lengths > threshold,
@@ -910,9 +879,7 @@ def get_inputs():
     return input_info
 
 
-@pytest.mark.parametrize(
-    "batch_size, max_seq_len, sparsity, heads, attn_dim, hidden_dim", get_inputs()
-)
+@pytest.mark.parametrize("batch_size, max_seq_len, sparsity, heads, attn_dim, hidden_dim", get_inputs())
 def test_hstu_attention(
     batch_size: int,
     max_seq_len: int,  # for repro
@@ -945,14 +912,12 @@ def test_hstu_attention(
     num_targets = torch.randint(
         1,
         target_size + 1,
-        (batch_size,),
+        (batch_size, ),
         device=lengths.device,
         dtype=lengths.dtype,
     )
     num_targets = torch.where(num_targets > lengths, lengths, num_targets)
-    seq_offsets = torch.zeros(
-        (batch_size + 1,), dtype=torch.int64, device=torch.device("cuda")
-    )
+    seq_offsets = torch.zeros((batch_size + 1, ), dtype=torch.int64, device=torch.device("cuda"))
     seq_offsets[1:] = torch.cumsum(lengths, dim=0)
     L = int(seq_offsets[-1].item())
     x = torch.empty(
@@ -981,19 +946,11 @@ def test_hstu_attention(
 
     def triton_attn():
         sort_by_length = True
-        return triton_hstu_attention_fwd(
-            max_seq_len,
-            alpha,
-            q,
-            k,
-            v,
-            seq_offsets,
-            causal,
-            num_targets,
-            0,  # max_attn_len,
-            0,  # contextual_seq_len
-            True,  # sort_by_length,
-        )
+        return triton_hstu_attention_fwd(max_seq_len, alpha, q, k, v, seq_offsets, causal, num_targets,
+                                         0,  # max_attn_len,
+                                         0,  # contextual_seq_len
+                                         True,  # sort_by_length,
+                                         )
 
     def torch_attn():
         return torch_hstu_attention(
@@ -1029,16 +986,14 @@ def run_benchmark(args):
         "hidden_dim",
     ]
     if args.user_input:
-        x_val_list = [
-            (
-                args.b,
-                args.max_seq_len,
-                args.sparsity,
-                args.heads,
-                args.head_dim,
-                args.hidden_dim,
-            )
-        ]
+        x_val_list = [(
+            args.b,
+            args.max_seq_len,
+            args.sparsity,
+            args.heads,
+            args.head_dim,
+            args.hidden_dim,
+        )]
     else:
         x_val_list = get_inputs()
 
@@ -1052,9 +1007,8 @@ def run_benchmark(args):
         raise NotImplementedError(f"{args.metric} is not supported")
 
     evaluation_metric_to_unit = {
-        "throughput": "TFLOPS",
-        "time": "Time_(ms)",
-        "bandwidth": "Bandwidth_(GB/s)",  # spaces break prettytable parsing
+        "throughput": "TFLOPS", "time": "Time_(ms)", "bandwidth":
+        "Bandwidth_(GB/s)",  # spaces break prettytable parsing
     }
     line_names = [evaluation_metric_to_unit[args.metric]]
     line_vals = line_names
@@ -1072,8 +1026,7 @@ def run_benchmark(args):
             ylabel=ylabel,
             plot_name='hstu_attention perf numbers',
             args={"metric": metric, "mode": 'fwd'},
-        )
-    )
+        ))
 
     @triton.testing.perf_report(configs)
     def bench_hstu_attn(
@@ -1113,14 +1066,12 @@ def run_benchmark(args):
         num_targets = torch.randint(
             1,
             target_size + 1,
-            (batch_size,),
+            (batch_size, ),
             device=lengths.device,
             dtype=lengths.dtype,
         )
         num_targets = torch.where(num_targets > lengths, lengths, num_targets)
-        seq_offsets = torch.zeros(
-            (batch_size + 1,), dtype=torch.int64, device=torch.device("cuda")
-        )
+        seq_offsets = torch.zeros((batch_size + 1, ), dtype=torch.int64, device=torch.device("cuda"))
         seq_offsets[1:] = torch.cumsum(lengths, dim=0)
         L = int(seq_offsets[-1].item())
         x = torch.empty(
@@ -1148,19 +1099,12 @@ def run_benchmark(args):
         )
 
         def attn_fwd():
-            return triton_hstu_attention_fwd(
-                max_seq_len,
-                alpha,
-                q,
-                k,
-                v,
-                seq_offsets,
-                causal,
-                num_targets,
-                0,  # max_attn_len,
-                0,  # contextual_seq_len
-                True,  # sort_by_length,
-            )
+            return triton_hstu_attention_fwd(max_seq_len, alpha, q, k, v, seq_offsets, causal, num_targets,
+                                             0,  # max_attn_len,
+                                             0,  # contextual_seq_len
+                                             True,  # sort_by_length,
+                                             )
+
         ms = triton.testing.do_bench(
             attn_fwd,
             warmup=25,
@@ -1176,9 +1120,7 @@ def run_benchmark(args):
             return tflops
         elif metric == "bandwidth":
             elem_size = q.element_size()
-            bytes = get_bytes(
-                seq_offsets.cpu().numpy(), heads, attn_dim, hidden_dim, elem_size
-            )
+            bytes = get_bytes(seq_offsets.cpu().numpy(), heads, attn_dim, hidden_dim, elem_size)
             bandwidth = bytes / (ms * 1e-3) * 1e-9  # GB/s
             return bandwidth
         else:
@@ -1251,9 +1193,7 @@ def parse_args():
         help="Run user input info",
     )
 
-    parser.add_argument(
-        "-o", action="store_true", help="Write performance results to CSV file"
-    )
+    parser.add_argument("-o", action="store_true", help="Write performance results to CSV file")
 
     args = parser.parse_args()
     return args


### PR DESCRIPTION
[TLX] Add HSTU attention tutorial with TLX async local load                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                       
  Adds third_party/tlx/tutorials/amd-hstu-attn-test.py, a self-contained tutorial and benchmark for the HSTU (Hierarchical Sequential Transduction Unit) attention forward pass implemented in TLX.                                                                                                                    
                                                                                                                                                                                                                                                                                                                       
  What is HSTU attention                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                       
  HSTU attention replaces the standard softmax attention with a SiLU-gated variant: `Y = silu(alpha * Q @ K^T) / MAX_SEQ_LEN * V`. It operates on jagged (ragged) tensors — variable-length sequences stored concatenated along the batch dimension using a seq_offsets index — which avoids the memory overhead of      
  padding to a uniform sequence length.                     
                                                                                                                                                                                                                                                                                                                       
  Kernel design                                             

  The kernel (`_ragged_hstu_attn_fwd`) is structured as:                                                                                                                                                                                                                                                                 
   
  - XCD-aware block remapping (remap_xcd): redistributes program IDs across AMD compute dies to improve L2 cache locality and reduce cross-die traffic.                                                                                                                                                                
  - Sort-by-length scheduling: optionally reorders sequences by descending length so the most expensive tiles are dispatched first, improving GPU occupancy.
  - Configurable masking via `constexpr` flags: causal (lower-triangular), multi-target, max attention length window, and contextual prefix — all resolved at compile time with zero runtime branching overhead.                                                                                                         
  - TLX async loads for K and V: K and V tiles are loaded into LDS using `tlx.async_load` + `tlx.async_load_commit_group + tlx.async_load_wait_group`, then consumed from shared memory via `tlx.local_load` (with an explicit transpose for K via tlx.local_trans). This demonstrates the TLX async global-to-shared  
  pipeline as a concrete alternative to standard tl.load.                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                       
  The inner block function (`_hstu_attn_fwd_one_block`) pipelines the K load, mask computation, and `SiLU` activation before issuing the V load — overlapping memory latency with the QK dot product.                                                                                                                      
                                                            
  Reference implementation and tests                                                                                                                                                                                                                                                                                   
                                                            
  A pure-PyTorch reference (torch_hstu_attention) is included that converts jagged inputs to padded dense format, applies the same SiLU/masking logic, and converts back to jagged. Eight pytest cases cover a range of batch sizes (32–1024), sequence lengths (512–16384), and sparsity levels (0.37–0.97), all with 
  causal masking and multi-target support enabled.
                                                                                                                                                                                                                                                                                                                       
  Benchmarking                                              

  Running the file directly invokes a triton.testing.perf_report benchmark with configurable --metric (throughput, time, bandwidth), --dtype (fp16/bf16), and manual shape overrides. Default shapes cover workloads from 32×1024 to 1024×1024 sequences at 4 heads, dim-128.    

  Perf numbers:
 Compared to the Triton implementation for the shapes of batch size 32, we got the following speedup
```
  ┌─────────┬──────────┬───────────────┬────────────────────────────────┐                                                                                                                                                                                                                  
  │ max_len │Triton(ms)│ tlx (ms)      │ Speedup                        │                                                                                                                                                                                                                  
  ├─────────┼──────────┼───────────────┼────────────────────────────────┤                                                                                                                                                                                                                  
  │    1024 │  0.11090 │       0.05724 │                          1.94x │                                                                                                                                                                                                                  
  ├─────────┼──────────┼───────────────┼────────────────────────────────┤                                                                                                                                                                                                                  
  │    2048 │  0.37116 │       0.16608 │                          2.24x │                                                                                                                                                                                                                  
  ├─────────┼──────────┼───────────────┼────────────────────────────────┤                                                                                                                                                                                                                  
  │    4096 │  0.93597 │       0.35620 │                          2.63x │                                                                                                                                                                                                                  
  ├─────────┼──────────┼───────────────┼────────────────────────────────┤                                                                                                                                                                                                                  
  │    8192 │  5.78202 │       2.01046 │                          2.88x │
  ├─────────┼──────────┼───────────────┼────────────────────────────────┤                                                                                                                                                                                                                  
  │   16384 │ 21.94329 │       8.31289 │                          2.64x │
  ├─────────┼──────────┼───────────────┼────────────────────────────────┤                                                                                                                                                                                                                  
  │   32768 │ 74.52331 │      27.60785 │                          2.70x │
  └─────────┴──────────┴───────────────┴────────────────────────────────┘           
```