### PR TITLE
[triton][beta] [Cherry-pick] '[FenceAsync] Add async read dependencies to the pass (#9610)' (#1653)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -52,10 +52,45 @@ bool isAsyncProxyRead(Operation *op) {
   return isa<triton::nvidia_gpu::WarpGroupDotOp,
              triton::nvidia_gpu::TCGen5MMAOp,
              triton::nvidia_gpu::TCGen5MMAScaledOp,
+             triton::nvidia_gpu::TMEMCopyOp,
              triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp,
              triton::nvidia_gpu::AsyncTMAScatterOp,
              triton::nvidia_gpu::AsyncTMAReduceOp,
              triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp>(op);
+}
+
+bool isAsyncProxyReadSource(Operation *op, Value value) {
+  auto memDescType = dyn_cast<triton::gpu::MemDescType>(value.getType());
+  if (!memDescType ||
+      !isa<triton::gpu::SharedMemorySpaceAttr>(memDescType.getMemorySpace()))
+    return false;
+  if (auto asyncTMACopyLocalToGlobalOp =
+          dyn_cast<triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp>(op)) {
+    return value == asyncTMACopyLocalToGlobalOp.getSrc();
+  }
+  if (auto asyncTMAScatterOp =
+          dyn_cast<triton::nvidia_gpu::AsyncTMAScatterOp>(op)) {
+    return value == asyncTMAScatterOp.getSrc();
+  }
+  if (auto asyncTMAReduceOp =
+          dyn_cast<triton::nvidia_gpu::AsyncTMAReduceOp>(op)) {
+    return value == asyncTMAReduceOp.getSrc();
+  }
+  if (auto warpGroupDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
+    return value == warpGroupDotOp.getA() || value == warpGroupDotOp.getB();
+  }
+  if (auto tcGen5MMAOp = dyn_cast<triton::nvidia_gpu::TCGen5MMAOp>(op)) {
+    return value == tcGen5MMAOp.getA() || value == tcGen5MMAOp.getB();
+  }
+  if (auto tcGen5MMAScaledOp =
+          dyn_cast<triton::nvidia_gpu::TCGen5MMAScaledOp>(op)) {
+    return value == tcGen5MMAScaledOp.getA() ||
+           value == tcGen5MMAScaledOp.getB();
+  }
+  if (auto tmemCopyOp = dyn_cast<triton::nvidia_gpu::TMEMCopyOp>(op)) {
+    return value == tmemCopyOp.getSrc();
+  }
+  return false;
 }
 
 bool ignoreOpForProxyFence(Operation *op) {
@@ -123,16 +158,16 @@ void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
         if (auto value = effectInstance.getValue()) {
           for (auto bufferId : allocation->getBufferIds(value)) {
             if (bufferId != Allocation::InvalidBufferId) {
-              // TODO: handle proxy read cases. Those are currently handled in
-              // FenceInsertionPass where it can generate better placement for
-              // the fence. But we should support a safe fallback here.
               auto interval = allocation->getAllocatedInterval(bufferId);
               auto slice = AllocationSlice(value, interval);
 
-              if (isAsyncProxyWrite(op)) {
-                if (value == getSmemDest(op)) {
-                  proxyBlockInfo.syncWriteSlices[slice].insert(op);
-                }
+              if (isAsyncProxyWrite(op) && value == getSmemDest(op)) {
+                proxyBlockInfo.syncWriteSlices[slice].insert(op);
+              } else if (isAsyncProxyRead(op) &&
+                         isAsyncProxyReadSource(op, value)) {
+                // Safe fallback for async-proxy reads from shared memory when
+                // the earlier FenceInsertionPass did not place a fence.
+                proxyBlockInfo.syncReadSlices[slice].insert(op);
               } else if (isa<MemoryEffects::Write>(
                              effectInstance.getEffect())) {
                 curBlockInfo.syncWriteSlices[slice].insert(op);

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -404,7 +404,6 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch):
             res = acc.load(blocked_layout)
             smemAcc = ttgl.allocate_shared_memory(input_desc.dtype, [XBLOCK, XBLOCK], input_desc.layout,
                                                   res.to(input_desc.dtype))
-            blackwell.fence_async_shared()
             tma.async_copy_shared_to_global(input_desc, [0, 0], smemAcc)
             tma.store_wait(0)
         elif MEM_ACCESS_KIND == "tmem_store":
@@ -1853,7 +1852,6 @@ def load_local_alloc_mma_write_after_read_kernel(a_ptr, K, BLOCK_M: ttgl.constex
         a_value = ttgl.load(a_ptr + offs_m * BLOCK_K + (offs_k + k))
 
         a_smem = ttgl.allocate_shared_memory(ttgl.float16, [BLOCK_M, BLOCK_K], smem_layout, a_value)
-        blackwell.fence_async_shared()
         blackwell.tcgen05_mma(a_smem, b_smem, tmem, use_acc=use_acc)
         use_acc = True
     blackwell.tcgen05_commit(bar)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -23,7 +23,7 @@ from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia.ampere import async_copy, mma_v2
-from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
+from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
 from triton.experimental.gluon.language.extra import libdevice
@@ -478,7 +478,6 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
 
     if USE_TCGEN05:
         two_ctas: ttgl.constexpr = acc_layout.two_ctas
-        fence_async_shared(cluster=two_ctas)
         mma_barrier = mbarrier.allocate_mbarrier()
         mbarrier.init(mma_barrier, count=1)
         # Need to synchronise all the CTAs after the mbarrier initialisation
@@ -501,7 +500,6 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
         )
         acc = acc_tmem.load(tmem_reg_layout)
     else:
-        fence_async_shared()
         acc = ttgl.zeros([M, N], dtype=acc_dtype, layout=acc_layout)
         acc = hopper.warpgroup_mma(smem_a, smem_b, acc, is_async=ASYNC)
 
@@ -1343,7 +1341,6 @@ def test_tmem_copy_2d():
         mbarrier.init(barrier, count=1)
 
         smem.store(value)
-        fence_async_shared()
         tcgen05_copy(smem, tmem)
         tcgen05_commit(barrier)
         mbarrier.wait(barrier, phase=0)

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -triton-nvidia-gpu-proxy-fence-insertion --split-input-file -allow-unregistered-dialect | FileCheck %s
+// XFAIL: *
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
@@ -40,6 +41,47 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.async_tma_store_wait {pendings = 0 : i32}
     %2 = ttg.local_alloc {allocation.offset = 32 : i32} : () -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %2, %arg1, %true : !tt.tensordesc<tensor<64x64xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: missing_proxy_fence_local_store_before_async_tma_copy_local_to_global
+  tt.func @missing_proxy_fence_local_store_before_async_tma_copy_local_to_global(%arg0: !tt.tensordesc<tensor<128x256xf32, #shared>>, %arg1: tensor<128x256xf32, #blocked>) {
+    // CHECK: ttng.async_tma_store_wait {pendings = 1 : i32}
+    // CHECK-NEXT: ttg.local_store
+    // CHECK-NEXT: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.async_tma_copy_local_to_global
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<128x256xf32, #shared, #smem, mutable>
+    ttng.async_tma_store_wait {pendings = 1 : i32}
+    ttg.local_store %arg1, %0 : tensor<128x256xf32, #blocked> -> !ttg.memdesc<128x256xf32, #shared, #smem, mutable>
+    ttng.async_tma_copy_local_to_global %arg0[%c0_i32, %c0_i32] %0 : !tt.tensordesc<tensor<128x256xf32, #shared>>, !ttg.memdesc<128x256xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: missing_proxy_fence_local_store_before_tmem_copy
+  tt.func @missing_proxy_fence_local_store_before_tmem_copy(%arg0: tensor<128x4xi8, #blocked>,
+      %arg1: !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>) {
+    // CHECK: ttg.local_store
+    // CHECK-NEXT: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.tmem_copy
+    %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>
+    ttg.local_store %arg0, %0 : tensor<128x4xi8, #blocked> -> !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>
+    ttng.tmem_copy %0, %arg1 : !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>, !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/third_party/proton/tutorials/intra_kernel/example_dsl.py
+++ b/third_party/proton/tutorials/intra_kernel/example_dsl.py
@@ -12,7 +12,6 @@ import triton.profiler.language as pl
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.language.nvidia.hopper import (
-    fence_async_shared,
     mbarrier,
     tma,
     warpgroup_mma,
@@ -274,7 +273,6 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
 
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
     c_smem.store(acc.to(dtype))
-    fence_async_shared()
     tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
     tma.store_wait(pendings=0)
 


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9610

Upstream commit message:
```
> [FenceAsync] Add async read dependencies to the pass (#9610)

> Before we would not add a fence between an `st.shared` and a
> `copy_local_to_global` which is incorrect.

> TODO: Benchmark this see how bad this autofence is.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: eb706474c5d3ab03d3ddc8033cc68640a4b4d142
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 9610
```

Differential Revision: D107895143


