### PR TITLE
[triton][beta] Upgrade `create-github-app-token` from v1 to v3 (#1657)

### DIFF
--- a/.github/workflows/pre-commit-autofix.yml
+++ b/.github/workflows/pre-commit-autofix.yml
@@ -67,9 +67,9 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Post or clean up bot comment
@@ -175,9 +175,9 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Validate PR is open


### PR DESCRIPTION
Summary:

Switch from legacy `app-id` (secret) to `client-id` (repo variable) per the upstream recommendation. Requires adding `APP_CLIENT_ID` as a repository variable in the GitHub repo settings.

https://github.com/actions/create-github-app-token#configure-git-cli-for-an-apps-bot-user

Reviewed By: dshi7

Differential Revision: D107433500


