### PR TITLE
[ModuloSchedule] Occupancy cost model + memory-bound warp partitioning (#1660)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -35,6 +35,7 @@ unsigned DataDependenceGraph::addNode(Operation *op,
   node.latency = info.latency;
   node.selfLatency = info.selfLatency;
   node.minWarps = info.minWarps;
+  node.occupancy = info.occupancy;
   nodes.push_back(node);
   opToIdx[op] = idx;
   return idx;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -23,6 +23,16 @@ struct DDGNode {
   HWPipeline pipeline{HWPipeline::NONE};
   int latency{};
   int selfLatency{};
+  // How long this op ties up its hardware engine — i.e. when the NEXT op of the
+  // same kind can start. Different from `latency`, which is how long until this
+  // op's RESULT is ready for a consumer to use.
+  // They're equal for most ops, but differ for an async TMA load: the load
+  // engine is free again after ~bytes/bandwidth and can start the next load,
+  // while the loaded data isn't ready for ~700 more cycles — so occupancy is
+  // much smaller than latency. (TMA store: occupancy ≈ latency; TC = latency;
+  // CUDA/SFU = selfLatency.)
+  // See OpLatencyInfo::occupancy. 0 = unset → pipelineOccupancy() falls back.
+  int occupancy{};
   // Min warps assumed by the modeled `selfLatency`. If the containing WG has
   // fewer warps, effective selfLat scales up by minWarps/actualWarps. See
   // `notes/latency_vs_selflatency.md` and `LatencyModel::getMinWarps`.
@@ -37,16 +47,17 @@ struct DDGNode {
 /// How many cycles this op holds its pipeline resource. Used by ResMII and the
 /// modulo reservation table when placing ops.
 ///
-/// MEM (TMA engine) and TC (tcgen05.mma) are **async** hardware: the SM
-/// dispatches the op in `selfLatency` cycles and is then free, but the
-/// underlying engine keeps working for the full `latency` cycles. From the
-/// resource's perspective it is busy that whole time and cannot accept
-/// another op until done — so for ResMII / placement we must reserve the
-/// full `latency`.
+/// Prefer the per-op `occupancy` computed by the LatencyModel (validated on
+/// B200): TMA *store* and TC are bandwidth/serial-bound (occupancy ≈ latency),
+/// but a TMA *load* is multi-outstanding — it occupies the engine only
+/// ~bytes/bandwidth, far less than its round-trip latency. CUDA/SFU use the
+/// per-op pipe slot count (selfLatency).
 ///
-/// CUDA and SFU are pipelined synchronous units that accept a new op every
-/// cycle, so `selfLatency` (= 1 for these) is the correct slot count.
+/// Fallback (occupancy unset, e.g. manually-built super-nodes): the old rule —
+/// full `latency` for async TMA/TC, `selfLatency` otherwise.
 inline int pipelineOccupancy(const DDGNode &node) {
+  if (node.occupancy > 0)
+    return node.occupancy;
   if (node.pipeline == HWPipeline::NONE)
     return 1;
   if (node.pipeline == HWPipeline::TMA || node.pipeline == HWPipeline::TC)

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.cpp
@@ -105,23 +105,91 @@ static int lookupTMALoadOccupancy(int64_t totalBytes) {
                           kBaseBytes);
 }
 
-int LatencyModel::getTMALoadLatency(Operation *op) const {
-  if (op->getNumResults() == 0)
-    return lookupTMALoadOccupancy(128 * 64 * 2); // default: 128x64
-  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
-  if (!resultType)
-    return lookupTMALoadOccupancy(128 * 64 * 2);
-
-  int64_t elements = 1;
-  for (auto dim : resultType.getShape())
-    elements *= dim;
-  int64_t bytesPerElement = resultType.getElementTypeBitWidth() / 8;
-  return lookupTMALoadOccupancy(elements * bytesPerElement);
+// Tile geometry of a TMA op: total bytes and inner (contiguous, last-dim)
+// bytes. Reads the result tensor/memdesc first; for store-style ops (memdesc
+// result) falls back to the largest tensor/memdesc operand. innerBytes drives
+// the hardware instruction count (see getTMANumInsts).
+static void getTMATile(Operation *op, int64_t &totalBytes,
+                       int64_t &innerBytes) {
+  totalBytes = 0;
+  innerBytes = 0;
+  auto fromShape = [&](ArrayRef<int64_t> shape, int64_t esize) {
+    if (shape.empty())
+      return;
+    int64_t elems = 1;
+    for (auto d : shape)
+      elems *= d;
+    totalBytes = elems * esize;
+    innerBytes = shape.back() * esize;
+  };
+  for (auto r : op->getResults()) {
+    if (auto tt = dyn_cast<RankedTensorType>(r.getType()))
+      return fromShape(tt.getShape(), tt.getElementTypeBitWidth() / 8);
+    if (auto md = dyn_cast<triton::gpu::MemDescType>(r.getType()))
+      return fromShape(md.getShape(),
+                       md.getElementType().getIntOrFloatBitWidth() / 8);
+  }
+  int64_t best = 0;
+  for (auto v : op->getOperands()) {
+    if (auto tt = dyn_cast<RankedTensorType>(v.getType())) {
+      int64_t e = 1;
+      for (auto d : tt.getShape())
+        e *= d;
+      if (e * (tt.getElementTypeBitWidth() / 8) > best) {
+        best = e * (tt.getElementTypeBitWidth() / 8);
+        fromShape(tt.getShape(), tt.getElementTypeBitWidth() / 8);
+      }
+    } else if (auto md = dyn_cast<triton::gpu::MemDescType>(v.getType())) {
+      int64_t e = 1;
+      for (auto d : md.getShape())
+        e *= d;
+      int64_t es = md.getElementType().getIntOrFloatBitWidth() / 8;
+      if (e * es > best) {
+        best = e * es;
+        fromShape(md.getShape(), es);
+      }
+    }
+  }
 }
 
+// A source TMA op lowers to ceil(innerBytes/512) hardware cp.async.bulk.tensor
+// instructions (the box inner dim caps at 512 bytes); the outer (M) dim is not
+// split. Verified by PTX instruction counting on B200 (latency_model study).
+static int getTMANumInsts(Operation *op) {
+  int64_t totalBytes, innerBytes;
+  getTMATile(op, totalBytes, innerBytes);
+  if (innerBytes <= 0)
+    return 1;
+  return static_cast<int>((innerBytes + 511) / 512);
+}
+
+// TMA LOAD round-trip latency (cycles), B200-calibrated to the num_insts law:
+//   lat = base + perKB·KB + perInst·min(num_insts−1, cap)
+// Latency is driven by the instruction count (inner dim), ~independent of M,
+// and saturates by ~num_insts=3 (per-load instructions' DRAM drains overlap).
+// Fits the measured grid within ~10% (e.g. [8,512] N=2 ≈ 748, [128,64] N=1 ≈
+// 556).
+int LatencyModel::getTMALoadLatency(Operation *op) const {
+  constexpr int kBase = 460, kPerKB = 6, kPerInst = 240, kInstCap = 2;
+  int64_t totalBytes, innerBytes;
+  getTMATile(op, totalBytes, innerBytes);
+  if (totalBytes <= 0)
+    return lookupTMALoadOccupancy(128 * 64 * 2);
+  int nInsts = getTMANumInsts(op);
+  int kb = static_cast<int>(totalBytes / 1024);
+  return kBase + kPerKB * kb + kPerInst * std::min(nInsts - 1, kInstCap);
+}
+
+// TMA STORE latency (cycles): bandwidth-bound, ~linear in bytes (B200: 52
+// cyc/KB
+// + ~130 fixed). The store engine does not pipeline (occupancy ≈ latency).
 int LatencyModel::getTMAStoreLatency(Operation *op) const {
-  // TMA stores have similar latency profile to loads
-  return getTMALoadLatency(op);
+  constexpr int kBase = 130, kPerKB = 52;
+  int64_t totalBytes, innerBytes;
+  getTMATile(op, totalBytes, innerBytes);
+  if (totalBytes <= 0)
+    return lookupTMALoadOccupancy(128 * 64 * 2);
+  return kBase + kPerKB * static_cast<int>(totalBytes / 1024);
 }
 
 // MMA latencies from design doc microbenchmarks (Blackwell tcgen05.mma).
@@ -497,48 +565,40 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
   int selfLatency = 0;
   switch (pipeline) {
   case HWPipeline::TMA: {
-    // selfLatency = issue cost: cycles the SM is blocked dispatching the op.
-    // latency     = full delivery time: cycles from issue until a downstream
-    //               consumer can read the data. Single number per op — no
-    //               separate "occupancy" vs "DRAM overhead" split.
-    int fullLatency;
-    if (isa<tt::DescriptorStoreOp>(op))
-      fullLatency = getTMAStoreLatency(op);
-    else if (isa<ttng::AsyncTMACopyLocalToGlobalOp>(op)) {
-      fullLatency = lookupTMALoadOccupancy(128 * 64 * 2);
-    } else if (isa<triton::gpu::LocalAllocOp>(op)) {
-      // local_alloc fed by a TMA load is a pure IR-level rename: the TMA has
-      // already delivered the bytes to SMEM, this op just wraps the buffer in
-      // a memdesc. No pipeline occupancy, no extra wait.
-      selfLatency = 0;
-      latency = 0;
-      return OpLatencyInfo{pipeline, latency, selfLatency, /*minWarps=*/1};
-    } else if (auto tmaCopy = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
-      // Lowered TMA load (TLX path). Get size from the SMEM result type.
-      auto resultMemDesc =
-          dyn_cast<triton::gpu::MemDescType>(tmaCopy.getResult().getType());
-      if (resultMemDesc) {
-        int64_t elements = 1;
-        for (auto dim : resultMemDesc.getShape())
-          elements *= dim;
-        int64_t bytesPerElement =
-            resultMemDesc.getElementType().getIntOrFloatBitWidth() / 8;
-        fullLatency = lookupTMALoadOccupancy(elements * bytesPerElement);
-      } else {
-        fullLatency = lookupTMALoadOccupancy(128 * 64 * 2);
-      }
-    } else
-      fullLatency = getTMALoadLatency(op);
+    // local_alloc fed by a TMA load is a pure IR-level rename: the TMA already
+    // delivered the bytes to SMEM. No pipeline occupancy, no extra wait.
+    if (isa<triton::gpu::LocalAllocOp>(op))
+      return OpLatencyInfo{pipeline, /*latency=*/0, /*selfLatency=*/0,
+                           /*minWarps=*/1, /*occupancy=*/0};
+    // selfLatency = issue cost (SM blocked dispatching). latency = round-trip.
+    // occupancy = cycles the TMA engine is held for ResMII: a store is
+    // bandwidth-bound (occ ≈ latency), but a load is multi-outstanding so it
+    // occupies the engine only ~bytes/bandwidth (≈ 6 cyc/KB), NOT its latency.
+    bool isStore =
+        isa<tt::DescriptorStoreOp, ttng::AsyncTMACopyLocalToGlobalOp>(op);
+    int64_t totalBytes, innerBytes;
+    getTMATile(op, totalBytes, innerBytes);
     selfLatency = kTMAIssueLatency;
-    latency = fullLatency;
-    return OpLatencyInfo{pipeline, latency, selfLatency, /*minWarps=*/1};
+    int occupancy;
+    if (isStore) {
+      latency = getTMAStoreLatency(op);
+      occupancy = latency; // bandwidth-bound: engine held for the full transfer
+    } else {
+      latency = getTMALoadLatency(op);
+      occupancy =
+          std::max(kTMAIssueLatency, static_cast<int>(6 * (totalBytes / 1024)));
+    }
+    return OpLatencyInfo{pipeline, latency, selfLatency, /*minWarps=*/1,
+                         occupancy};
   }
   case HWPipeline::TC:
     latency = getMMALatency(op);
     // selfLatency = issue cost (SM dispatch pipeline occupancy).
-    // Design doc: 30 cycles for tcgen05.mma.
+    // Design doc: 30 cycles for tcgen05.mma. occupancy = latency: the tensor
+    // core genuinely serializes one MMA at a time (keeps GEMM/FA ResMII right).
     selfLatency = kMMAIssueLatency;
-    break;
+    return OpLatencyInfo{pipeline, latency, selfLatency, getMinWarps(op),
+                         /*occupancy=*/latency};
   case HWPipeline::CUDA:
     // latency  = full RAW-dep cost per op (clock64-chained microbench).
     //            Used by RecMII to size dependency recurrences.
@@ -565,7 +625,10 @@ OpLatencyInfo LatencyModel::getLatency(Operation *op) const {
     break;
   }
 
-  return OpLatencyInfo{pipeline, latency, selfLatency, getMinWarps(op)};
+  // CUDA/SFU are pipelined synchronous units: occupancy = selfLatency (the
+  // per-op pipe slot count). NONE → 0 (no resource).
+  return OpLatencyInfo{pipeline, latency, selfLatency, getMinWarps(op),
+                       /*occupancy=*/selfLatency};
 }
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/LatencyModel.h
@@ -57,6 +57,13 @@ struct OpLatencyInfo {
   int latency{0};
   int selfLatency{0};
   int minWarps{1};
+  // Cycles this op holds its hardware pipeline (for ResMII / reservation
+  // table). Distinct from `latency` for async TMA *loads*: the TMA engine is
+  // multi-outstanding, so a load occupies the engine only ~bytes/bandwidth, not
+  // its full round-trip latency (validated on B200, see latency_model study).
+  // TMA stores are bandwidth-bound (occupancy ≈ latency); TC = latency;
+  // CUDA/SFU = selfLatency. 0 means "unset" (fall back to the old rule).
+  int occupancy{0};
 };
 
 /// Hardware latency model for Blackwell SM100.

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -97,13 +97,18 @@ struct ScheduleNode {
 
   // Schedule assignment (from Phase 0 + Step 2.5)
   HWPipeline pipeline{HWPipeline::NONE};
-  int cycle{0};       // absolute cycle within the II
-  int stage{0};       // cycle / II
-  int cluster{0};     // dense rank of cycle within stage (Step 2.5)
-  int latency{0};     // cycles until result available
-  int selfLatency{0}; // cycles this op occupies its pipeline (at minWarps)
-  int minWarps{1};    // warp count assumed by selfLatency; effective scales
-                      // up by minWarps/actualWarps when WG has fewer warps
+  int cycle{0};   // absolute cycle within the II
+  int stage{0};   // cycle / II
+  int cluster{0}; // dense rank of cycle within stage (Step 2.5)
+  int latency{0}; // cycles until result available
+  int selfLatency{
+      0};           // warp-issue cost (cycles the warp is blocked dispatching)
+  int occupancy{0}; // cycles this op holds its hardware pipeline (for ResMII
+                    // / makespan). For TMA: bytes/bandwidth (≫ selfLatency for
+                    // BW-bound stores); for TC: latency; CUDA/SFU: selfLatency.
+                    // See OpLatencyInfo::occupancy. 0 = unset (fall back).
+  int minWarps{1};  // warp count assumed by selfLatency; effective scales
+                    // up by minWarps/actualWarps when WG has fewer warps
 
   // Frequency this op fires per outer-loop iteration. Outer-loop ops have
   // frequencyMultiplier = 1; inner K-loop ops have frequencyMultiplier =

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -387,6 +387,7 @@ convertDDGNode(const ttg::DDGNode &ddgNode, unsigned nodeId,
   sn.pipeline = ddgNode.pipeline;
   sn.latency = ddgNode.latency;
   sn.selfLatency = ddgNode.selfLatency;
+  sn.occupancy = ddgNode.occupancy;
   sn.minWarps = ddgNode.minWarps;
 
   auto cycleIt = sched.nodeToCycle.find(ddgNode.idx);
@@ -1631,6 +1632,11 @@ static int computeWGBarrierCost(
   llvm::SmallDenseSet<unsigned, 8> nodeSet;
   for (unsigned nid : nodeIds)
     nodeSet.insert(nid);
+  // Intrinsic per-op async-handshake barriers, counted for every loop (TC and
+  // TC-free alike). Each TMA op needs its expect_bytes + wait mbarriers, each
+  // MMA its operand waits, each tmem_store its tcgen05_commit — regardless of
+  // partition. These are part of every candidate's steady-state warp-issue
+  // stream, so they belong in the barrier cost on whichever WG owns the op.
   for (unsigned nid : nodeIds) {
     const auto &n = loop.nodes[nid];
     int freq = std::max(n.frequencyMultiplier, 1);
@@ -1754,25 +1760,13 @@ static int computeMultiPipelineMakespan(const SmallVector<unsigned> &nodeIds,
       auto it = opStart.find(edge.srcId);
       if (it == opStart.end())
         continue;
-      // Use EDGE latency, not source-node latency. The modulo scheduler
-      // already uses edge.latency for its placement constraints
-      // (consumer.cycle ≥ producer.cycle + edge.latency). Node latency
-      // can be a worst-case "result fully available" number (e.g., TMA
-      // load's full latency including async overhead) while edge latency
-      // captures the actual producer→consumer wait — e.g., edge
-      // (descriptor_load → local_alloc).latency = TMA hardware time only,
-      // because local_alloc is metadata that sits inline with the SMEM
-      // commit. Using node latency here double-counts the async overhead.
+      // Use EDGE latency, not source-node latency (the modulo scheduler's
+      // placement constraint already uses edge.latency).
       dataReady = std::max(dataReady, it->second + edge.latency);
     }
     int pipeReady = pipeAvail.lookup(node.pipeline);
     int start = std::max({dataReady, pipeReady, warpAvail});
     opStart[nid] = start;
-    // Inner-loop ops fire frequencyMultiplier times per outer iter; weight
-    // their pipeline occupancy accordingly. For non-flat callers (per-loop
-    // makespan in computeResMII) frequencyMultiplier defaults to 1.
-    // selfLat scales with the WG's warp count: an op tagged minWarps=4
-    // costs ~4× more on a 1-warp WG. See effectiveSelfLat doc comment.
     int dur = effectiveSelfLat(node, wgWarps) * node.frequencyMultiplier;
     pipeAvail[node.pipeline] = start + dur;
     warpAvail = start + dur;
@@ -2824,6 +2818,14 @@ static void propagateWarpGroupToInfraOps(ttg::ScheduleLoop &loop) {
 /// TMEM transfers (TC→CUDA) → named barrier.
 static void insertCrossGroupBarriers(ttg::ScheduleLoop &loop) {
   llvm::DenseSet<std::pair<unsigned, unsigned>> seenBarrierPairs;
+  // A TC-free, memory-bound loop (e.g. LayerNorm) pipelines load→compute→store
+  // across warp groups. Giving the TMA-load→compute channel depth-2 lets the
+  // load warp run a full iteration ahead of compute (prefetch), which is what
+  // turns the 3-WG split from "matches 1-WG" into "beats it ~1.2x". TC loops
+  // (GEMM/FA) keep their tuned depth-1 register channels untouched.
+  bool loopHasTC = llvm::any_of(loop.nodes, [](const ttg::ScheduleNode &n) {
+    return n.pipeline == ttg::HWPipeline::TC;
+  });
   for (const auto &edge : loop.edges) {
     const auto &src = loop.nodes[edge.srcId];
     const auto &dst = loop.nodes[edge.dstId];
@@ -2900,7 +2902,21 @@ static void insertCrossGroupBarriers(ttg::ScheduleLoop &loop) {
       ttg::ScheduleBuffer chan;
       chan.id = loop.buffers.size();
       chan.kind = ttg::MemoryKind::SMEM;
-      chan.count = 1; // single-buffered hand-off (depth>1 needs ring logic)
+      // Depth-2 for the TMA-load→compute channel of a TC-free pipelined loop
+      // so the load warp prefetches one iteration ahead; depth-1 elsewhere
+      // (SW-produced channels and all TC-loop channels keep the simple
+      // single-buffered hand-off).
+      //
+      // Depth>1 is safe to emit here: ring indexing for count>1 cross-WG
+      // channels already exists and is exercised today (e.g. case3 FA has a
+      // depth-2 cross-WG channel), and the channel's SMEM cost scales with
+      // count via ScheduleBuffer::totalBytes() (= sizeBytes() * count), which
+      // the Step-4 budget, the JSON `total_bytes`, and the emitter's
+      // local_alloc(..., count) all consume. The sched2tlx no-MMA lowering that
+      // makes a TC-free loop emit at all is stacked on top of this diff, so a
+      // depth-2 channel is only ever produced once that consumer is present.
+      chan.count = (!loopHasTC && src.pipeline == ttg::HWPipeline::TMA) ? 2 : 1;
+      depth = chan.count;
       chan.liveStart = src.cycle;
       chan.liveEnd = dst.cycle + std::max(dst.latency, 0);
       // Derive shape + element width from the producer's result type.
@@ -3248,10 +3264,20 @@ applyGlobalWarpPartition(MutableArrayRef<ScheduledLoop> scheduledLoops) {
     for (auto &schedLoop : sl.graph.loops) {
       if (schedLoop.II <= 0)
         continue;
-      if (useGreedy)
+      // All loops go through the same cost-model partitioner — no TC vs TC-free
+      // special-casing. The makespan (single-iteration latency chain over each
+      // WG's pipeAvail) plus barrier cost decides the split uniformly. This
+      // rewards warp specialization wherever it overlaps independent pipelines
+      // across groups: GEMM/FA (MEM/TC/softmax) AND memory-bound loops like
+      // LayerNorm, where putting TMA-load, compute, and TMA-store on separate
+      // warp groups frees the compute warps and removes the in-stream store
+      // drain (measured ~1.2x over 1-WG software pipelining). No env flag, no
+      // hard override.
+      if (useGreedy) {
         partitionIntoWarpGroups(schedLoop);
-      else
+      } else {
         partitionExhaustive(schedLoop);
+      }
       demoteScalarArithToInfra(schedLoop);
       propagateWarpGroupToInfraOps(schedLoop);
     }
@@ -4268,6 +4294,7 @@ buildListScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
     sn.pipeline = ddgNode.pipeline;
     sn.latency = ddgNode.latency;
     sn.selfLatency = ddgNode.selfLatency;
+    sn.occupancy = ddgNode.occupancy;
     sn.minWarps = ddgNode.minWarps;
     sn.stage = 0;
 


### PR DESCRIPTION
Summary:

Teaches the latency-driven modulo scheduler to model hardware-pipeline occupancy and to warp-specialize memory-bound (no-MMA) loops. This is the compiler half and is C++ only. The `sched2tlx` emitter changes (no-MMA warp specialization) and the case6 LayerNorm example that exercises this end-to-end are in the diff stacked directly on top (D107924018) — review that one for the Python and the runnable test.

Two substantive changes:

1. Occupancy / latency model (`LatencyModel.{h,cpp}`, `DataDependenceGraph.{h,cpp}`, `ModuloScheduleGraph.h`). Adds a per-op `occupancy` field — the hardware-pipeline hold time, distinct from the warp-issue `selfLatency` and the round-trip `latency`. `pipelineOccupancy()` prefers it and falls back to the old rule when it is unset (0), so manually-built super-nodes are unaffected. The TMA latency formulas are rewritten to a B200-calibrated instruction-count law (`getTMATile` / `getTMANumInsts`): a TMA load occupies the engine only ~bytes/bandwidth (multi-outstanding), while a TMA store is bandwidth-bound (occupancy ≈ latency). The partition cost model reads `occupancy` to size per-engine bottlenecks instead of conflating them with warp-issue cost.

   Caveat — this is NOT a strict no-op for tensor-core loops. A *lowered* TMA store (`ttng.async_tma_copy_local_to_global`, used in GEMM/FA epilogues) previously got a fixed `128x64` default; it now gets size-derived store latency with `occupancy = latency`. That changes its modeled cost. The TC-loop partitions and generated kernels are unchanged in practice, but that is established by measurement (see test plan), not by construction.

2. TC-free loops use the uniform partition path, plus a depth-2 prefetch channel (`ModuloSchedulePass.cpp`). There is no separate "TC-free → single-WG" path: `computeWGBarrierCost` counts intrinsic async-handshake barriers for every loop and the list-schedule makespan is shared, so with occupancy in place the cost model partitions a memory-bound loop (LayerNorm) into `[TMA load][TMA store][compute]` on its own. `insertCrossGroupBarriers` then gives the synthesized TMA-load→compute channel `count = 2` for TC-free loops so the load warp prefetches one iteration ahead (the ~1.2x lever). The channel's SMEM scales via `ScheduleBuffer::totalBytes() = sizeBytes() * count` — the Step-4 budget, the JSON `total_bytes`, and the emitter's `local_alloc(..., count)` all consume it — and depth-2 cross-WG ring indexing already exists (case3 FA carries a depth-2 cross-WG channel today). TC-loop channels keep depth-1.

This was authored with Claude.

Reviewed By: htyu

Differential Revision: D107922325


