### PR TITLE
[triton][amd] Fix invalid tt.addptr when reconciling tensor-of-pointers scf.if in canonicalize-pointers (#1670)

### DIFF
--- a/test/TritonGPU/amd/amd-canonicalize-pointers-no-large-tensor.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-pointers-no-large-tensor.mlir
@@ -152,3 +152,84 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 // CHECK:   scf.yield
 // CHECK: }
 // CHECK: tt.load
+
+// -----
+// Regression test for a mixed promotable/non-promotable scf.if that yields a
+// *tensor* of pointers (concat/split-style kernels). The non-promotable branch
+// (no tt.pointer_range, treated as a large 64-bit pointer) yields a full tensor
+// of pointers, while the promotable branch (tt.pointer_range = 32) is
+// decomposed into a fat pointer. Reconciling the two must splat the scalar base
+// before the addptr; previously the pass emitted an invalid scalar-result
+// tt.addptr with a non-scalar (tensor) offset operand and crashed the verifier.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: split_2D_jagged
+  tt.func public @split_2D_jagged(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<i64> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg3: !tt.ptr<i64> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = tt.get_program_id y : i32
+    %1 = tt.get_program_id x : i32
+    %2 = tt.addptr %arg2, %0 : !tt.ptr<i64>, i32
+    %3 = tt.load %2 : !tt.ptr<i64>
+    %4 = tt.addptr %2, %c1_i32 : !tt.ptr<i64>, i32
+    %5 = tt.load %4 : !tt.ptr<i64>
+    %6 = arith.subi %5, %3 : i64
+    %7 = tt.addptr %arg3, %0 : !tt.ptr<i64>, i32
+    %8 = tt.load %7 : !tt.ptr<i64>
+    %9 = tt.addptr %7, %c1_i32 : !tt.ptr<i64>, i32
+    %10 = tt.load %9 : !tt.ptr<i64>
+    %11 = arith.subi %10, %8 : i64
+    %12 = arith.addi %6, %11 : i64
+    %13 = arith.extsi %1 : i32 to i64
+    %15 = arith.addi %3, %8 : i64
+    %16 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32, #blocked>
+    %17 = arith.addi %15, %13 : i64
+    %18 = arith.extsi %arg7 : i32 to i64
+    %19 = arith.muli %17, %18 : i64
+    %20 = tt.addptr %arg0, %19 : !tt.ptr<f32>, i64
+    %21 = tt.splat %20 : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>, #blocked>
+    %22 = tt.addptr %21, %16 : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
+    %23 = arith.cmpi slt, %13, %6 : i64
+    %24 = arith.cmpi sge, %1, %c0_i32 : i32
+    %25 = arith.andi %23, %24 : i1
+    %26 = scf.if %25 -> (tensor<512x!tt.ptr<f32>, #blocked>) {
+      %30 = arith.addi %13, %3 : i64
+      %31 = arith.extsi %arg8 : i32 to i64
+      %32 = arith.muli %30, %31 : i64
+      %33 = tt.addptr %arg4, %32 : !tt.ptr<f32>, i64
+      %34 = tt.splat %33 : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>, #blocked>
+      %35 = tt.addptr %34, %16 : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
+      scf.yield %35 : tensor<512x!tt.ptr<f32>, #blocked>
+    } else {
+      %30 = arith.subi %13, %6 : i64
+      %31 = arith.cmpi slt, %1, %c0_i32 : i32
+      %32 = arith.select %31, %13, %30 : i64
+      %33 = arith.addi %32, %8 : i64
+      %34 = arith.extsi %arg9 : i32 to i64
+      %35 = arith.muli %33, %34 : i64
+      %36 = tt.addptr %arg5, %35 : !tt.ptr<f32>, i64
+      %37 = tt.splat %36 : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>, #blocked>
+      %38 = tt.addptr %37, %16 : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
+      scf.yield %38 : tensor<512x!tt.ptr<f32>, #blocked>
+    }
+    %27 = tt.splat %arg6 : i32 -> tensor<512xi32, #blocked>
+    %28 = arith.cmpi slt, %16, %27 : tensor<512xi32, #blocked>
+    %29 = tt.load %22, %28 : tensor<512x!tt.ptr<f32>, #blocked>
+    tt.store %26, %29, %28 : tensor<512x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// The pass should complete without crashing. The scf.if yields a tensor of
+// pointers; the promotable (else) branch materializes its fat pointer back into
+// a tensor pointer with splat + addptr.
+// CHECK: %[[IF:.*]] = scf.if {{.*}} -> (tensor<512x!tt.ptr<f32>, #blocked>)
+// CHECK:   tt.splat
+// CHECK:   tt.addptr {{.*}} : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
+// CHECK:   scf.yield {{.*}} : tensor<512x!tt.ptr<f32>, #blocked>
+// CHECK: } else {
+// CHECK:   tt.splat
+// CHECK:   tt.addptr {{.*}} : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
+// CHECK:   scf.yield {{.*}} : tensor<512x!tt.ptr<f32>, #blocked>
+// CHECK: }
+// CHECK: tt.store %[[IF]]

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -1538,7 +1538,13 @@ public:
           reconciledTypes.push_back(
               thenYield.getOperand(thenIdx + 1).getType());
         } else {
-          reconciledTypes.push_back(thenYield.getOperand(thenIdx).getType());
+          // Exactly one branch is fat at this position. The reconciled value is
+          // the materialized full pointer, whose type matches the non-fat
+          // branch's operand (a single, possibly-tensor, pointer) — not the fat
+          // branch's scalar base.
+          reconciledTypes.push_back(
+              tIsFat ? elseYield.getOperand(elseIdx).getType()
+                     : thenYield.getOperand(thenIdx).getType());
         }
         thenIdx += tIsFat ? 2 : 1;
         elseIdx += eIsFat ? 2 : 1;
@@ -1576,8 +1582,13 @@ public:
             Value base = oldYield.getOperand(start);
             Value offset = oldYield.getOperand(start + 1);
             rewriter.setInsertionPoint(oldYield);
-            Value combined = tt::AddPtrOp::create(rewriter, ifOp.getLoc(),
-                                                  base.getType(), base, offset);
+            // The offset may be a tensor (e.g. concat/split kernels yield a
+            // tensor of pointers). createTensorPointer splats the scalar base
+            // before the addptr, avoiding an invalid scalar-result addptr with
+            // a non-scalar (tensor) offset operand.
+            Value combined =
+                createTensorPointer(rewriter, base, offset, ifOp.getLoc(),
+                                    fatPtrs.at({base, offset}));
             newOps.push_back(combined);
           } else {
             newOps.push_back(oldYield.getOperand(start));


### PR DESCRIPTION
Summary:

With AMDGCN_USE_BUFFER_OPS=1 and enable-large-tensor-ptr-canon=false, the AMD
TritonAMDGPUCanonicalizePointers pass crashed in the MLIR verifier while
compiling concat/split jagged kernels (e.g. concat_2D_jagged / split_2D_jagged):

  'tt.addptr' op if an operand is non-scalar, then there must be at least one
  non-scalar result

Root cause is in ConvertSCFIfOp's reconciliation path, which runs when an scf.if
has one promotable branch (tt.pointer_range = 32, decomposed into a fat pointer
(base, offset)) and one non-promotable branch (a >2GB 64-bit pointer that is
skipped and yields a full tensor of pointers). To make both branches yield the
same type, fixYield materialized the fat pointer back into a full pointer with a
raw tt.addptr using the scalar base type. When the offset is a tensor (which is
exactly the case for concat/split, where offsets come from tl.arange), this
produced tt.addptr(scalar_ptr, tensor_offset) -> scalar_ptr, an invalid op that
aborts the verifier.

The fix routes that materialization through createTensorPointer, which splats the
scalar base to a tensor before the addptr when the offset is a tensor (and is a
no-op for the scalar-offset case). The reconciled result type is also taken from
the non-fat branch's full pointer operand rather than the fat branch's scalar
base, so the mirror case (promotable branch in the then region) is handled too.

This only touches triton/beta. We land in beta and backport to triton/stable
separately.

Authored with Claude.

Reviewed By: robieta

Differential Revision: D107957186


