### PR TITLE
Remove redundant TLX async-shared tutorial fences

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_clc.py
+++ b/third_party/tlx/tutorials/blackwell_fa_clc.py
@@ -823,7 +823,6 @@ def _attn_fwd_clc(
                 _, phase = get_bufidx_phase(tile_count, 1)
                 for cid in tl.static_range(0, NUM_MMA_GROUPS):
                     tlx.barrier_wait(o_fulls[cid], phase)
-                    tlx.fence("async_shared")
                     qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
                     tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
                     tlx.async_descriptor_store_wait(0)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -899,7 +899,6 @@ def _attn_fwd_ws(sm_scale, M,  #
                 _, phase = get_bufidx_phase(tile_count, 1)
                 for cid in tl.static_range(0, NUM_MMA_GROUPS):
                     tlx.barrier_wait(o_fulls[cid], phase)
-                    tlx.fence("async_shared")
                     qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
                     tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
                     tlx.async_descriptor_store_wait(0)
@@ -2496,7 +2495,6 @@ def _attn_bwd_ws(
                 dv = tlx.local_load(dv_slice)
                 tlx.async_descriptor_store_wait(0)
                 tlx.local_store(sdv_store_buf[kv_buf_id], dv.to(tlx.dtype_of(desc_dv)))
-                tlx.fence("async_shared")
                 tlx.async_descriptor_store(
                     desc_dv,
                     sdv_store_buf[kv_buf_id],
@@ -2520,7 +2518,6 @@ def _attn_bwd_ws(
                 dk *= sm_scale
                 tlx.async_descriptor_store_wait(0)
                 tlx.local_store(sdk_store_buf[kv_buf_id], dk.to(tlx.dtype_of(desc_dk)))
-                tlx.fence("async_shared")
                 tlx.async_descriptor_store(
                     desc_dk,
                     sdk_store_buf[kv_buf_id],
@@ -2557,7 +2554,6 @@ def _attn_bwd_ws(
                         dq_smem = dq_store_buf[slice_id % 2]
                         tlx.async_descriptor_store_wait(1)
                         tlx.local_store(dq_smem, dq_slices[slice_id].to(tlx.dtype_of(desc_dq)))
-                        tlx.fence("async_shared")
                         tlx.async_descriptor_store(
                             desc_dq,
                             dq_smem,
@@ -2584,7 +2580,6 @@ def _attn_bwd_ws(
                             dq_store_buf[dq_smem_idx],
                             dq.to(tlx.dtype_of(desc_dq)),
                         )
-                        tlx.fence("async_shared")
                         tlx.async_descriptor_store(
                             desc_dq,
                             dq_store_buf[dq_smem_idx],

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -1187,7 +1187,6 @@ def _attn_fwd_mxf8_ws(sm_scale, desc_m,  #
                 _, phase = get_bufidx_phase(i, 1)
                 for cid in tl.static_range(0, NUM_MMA_GROUPS):
                     tlx.barrier_wait(o_fulls[cid], phase)
-                    tlx.fence("async_shared")
                     qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
                     tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
                     tlx.async_descriptor_store_wait(0)
@@ -2005,7 +2004,6 @@ def _attn_bwd_mxf8_ws(
                         tlx.barrier_arrive(dv_empties[0])
                     tlx.async_descriptor_store_wait(0)
                     tlx.local_store(dkv_store_buf[0], dv.to(tl.bfloat16))
-                    tlx.fence("async_shared")
                     tlx.async_descriptor_store(
                         desc_dv,
                         dkv_store_buf[0],
@@ -2030,7 +2028,6 @@ def _attn_bwd_mxf8_ws(
                     dk *= sm_scale
                     tlx.async_descriptor_store_wait(0)
                     tlx.local_store(dkv_store_buf[0], dk.to(tl.bfloat16))
-                    tlx.fence("async_shared")
                     tlx.async_descriptor_store(
                         desc_dk,
                         dkv_store_buf[0],
@@ -2073,7 +2070,6 @@ def _attn_bwd_mxf8_ws(
                             dq_store_buf[dq_smem_idx],
                             dq.to(tlx.dtype_of(desc_dq)),
                         )
-                        tlx.fence("async_shared")
                         tlx.async_descriptor_store(
                             desc_dq,
                             dq_store_buf[dq_smem_idx],

--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -731,7 +731,6 @@ def _process_tile_epilogue_inner(
         c = result.to(tlx.dtype_of(out_desc))
         c_smem = c_smem_buffers[0]
         tlx.local_store(c_smem, c)
-        tlx.fence_async_shared()
         tlx.async_descriptor_store(
             out_desc,
             c_smem,
@@ -747,7 +746,6 @@ def _process_tile_epilogue_inner(
         c = result.to(tlx.dtype_of(out_desc))
         c_smem = c_smem_buffers[1]
         tlx.local_store(c_smem, c)
-        tlx.fence_async_shared()
         tlx.async_descriptor_store(
             out_desc,
             c_smem,
@@ -765,7 +763,6 @@ def _process_tile_epilogue_inner(
             c_smem = c_smem_buffers[0]
             tlx.async_descriptor_store_wait(1)
             tlx.local_store(c_smem, c)
-            tlx.fence("async_shared")
             tlx.async_descriptor_store(
                 out_desc,
                 c_smem,
@@ -781,7 +778,6 @@ def _process_tile_epilogue_inner(
             c_smem = c_smem_buffers[1]
             tlx.async_descriptor_store_wait(1)
             tlx.local_store(c_smem, c)
-            tlx.fence("async_shared")
             tlx.async_descriptor_store(
                 out_desc,
                 c_smem,
@@ -810,7 +806,6 @@ def _process_tile_epilogue_inner(
                 c_smem = c_smem_buffers[(group_id * EPILOGUE_SUBTILE + slice_id) % 2]
                 tlx.async_descriptor_store_wait(1)
                 tlx.local_store(c_smem, c)
-                tlx.fence_async_shared()
                 tlx.async_descriptor_store(
                     out_desc,
                     c_smem,


### PR DESCRIPTION
Summary:
Remove manual TLX async-shared fences before tutorial TMA descriptor stores where the compiler-generated fence insertion was validated to preserve `ttng.fence_async_shared` in generated IR. This covers Blackwell GEMM WS, FA CLC, FA WS persistent, and FA WS persistent MXFP8 tutorial sites.

These handle the fences produced for TMA store (the simplest case from sync -> async pipeline). There are two general cases I will investigate as followups:
- T275167119: Investigate compiler ownership for TLX remote-copy DSMEM fences
- T275167167: Investigate compiler ownership for TLX SMEM-to-TMEM scale fences

I believe at least the second one should be in the compiler after my back port, but this needs manual checking. I'll add the first one later this week.

Differential Revision: D108046782


