### PR TITLE
[TLX] Respect user pending count for token-less async_wait

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -111,8 +111,12 @@ static int minNumInterleavedCommitOps(Operation *waitOp) {
     return 0;
   };
 
+  // For AsyncWaitOp ops that do not come with a token to track the specific
+  // copy group, respect the original pending number. Such case is most likely
+  // from user code. The compiler should not generate a non-zero pending number
+  // if it does not know exactly which group to track.
   if (waitOp->getNumOperands() == 0)
-    return 0;
+    return cast<ttg::AsyncWaitOp>(waitOp).getNum();
   // Multi-token waits: take the min of minOverHistories across operands. Both
   // the captured `minCommitNumber` and the returned bailout-0s are folded in.
   int minCommits = INT_MAX;

--- a/python/test/unit/language/test_warp_pipeline.py
+++ b/python/test/unit/language/test_warp_pipeline.py
@@ -274,6 +274,40 @@ def test_warp_pipeline_lowering():
     assert "s_setprio" in asm, "Expected s_setprio from warp pipeline priority hints"
 
 
+@pytest.mark.skipif(not is_hip(), reason="warp pipeline is AMD-only")
+def test_warp_pipeline_preserves_user_wait_count():
+    """User-set async_load_wait_group(n) counts must survive the pipeliner.
+
+    A manual warp-pipeline emits a token-less ttg.async_wait whose `num` is set
+    deliberately. minNumInterleavedCommitOps must respect that count instead of
+    recomputing it to 0 (a full drain), which would silently serialize the
+    pipeline. Regression: the prologue async_load_wait_group(NUM_BUFFERS - 2)
+    below was being clobbered from 1 to 0.
+    """
+    import re
+
+    if not is_gfx950():
+        pytest.skip("shared-memory warp-pipeline lowering is currently tested on gfx950")
+
+    torch.manual_seed(0)
+    M = N = K = 192
+    a = torch.randn((M, K), dtype=torch.float16, device="cuda")
+    b = torch.randn((K, N), dtype=torch.float16, device="cuda")
+    c = torch.zeros((M, N), dtype=torch.float32, device="cuda")
+    BM, BN, BK = 64, 64, 32
+    grid = (triton.cdiv(M, BM) * triton.cdiv(N, BN), )
+
+    kernel = _smem_warp_pipeline_kernel[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1),
+                                              c.stride(0), c.stride(1), BLOCK_M=BM, BLOCK_N=BN, BLOCK_K=BK,
+                                              NUM_BUFFERS=3, num_warps=8)
+
+    # The prologue wait is async_load_wait_group(NUM_BUFFERS - 2) == 1; it must
+    # still be num = 1 after the pipeliner's wait-count recompute.
+    ttgir = kernel.asm["ttgir"]
+    nums = [int(n) for n in re.findall(r"async_wait \{num = (\d+)", ttgir)]
+    assert 1 in nums, f"user async_wait count was clobbered (expected a num=1 wait, got {nums}):\n{ttgir}"
+
+
 # --- Validation tests ---
 
 


### PR DESCRIPTION
Backport : https://github.com/facebookexperimental/triton/commit/3931ef6f7ea3c26aacf2c720d3906e06beba386a
(minNumInterleavedCommitOps token-less handling part in )
Backport of internal master's minNumInterleavedCommitOps token-less handling to the `tlx-amd-meta` branch (the code change; the test below is new).


TLX manual warp-pipelines set explicit wait depths via `tlx.async_load_wait_group(n)`, which lowers to a ttg.async_wait with NO token operands (ordering is expressed by program order + the explicit count, not by SSA token threading). The pipeliner's wait-count recompute walks every async_wait and re-derives num via minNumInterleavedCommitOps; for a wait with zero operands it returned 0, clobbering the user's count to a full drain -- correct but serialized, so the manual pipeline loses its intended depth.

Internal master already handles this: when the wait carries no token to track a specific copy group, it respects the original pending number (getNum()) instead of returning 0 -- the compiler should not invent a pending count when it cannot tell which group to track. tlx-amd-meta was missing this and was left returning 0. This backports master's zero-operand handling.

Scope: only the zero-operand path changes. The multi-token loop (>=1 operand) is left intact, so mi350 BlockPingpong and any auto-pipelined waits are unaffected.

Also adds (new, not from master) test_warp_pipeline_preserves_user_wait_count (gfx950): compiles a manual warp-pipeline whose prologue async_load_wait_group(1) must keep num=1 in the final TTGIR. Fails (num clobbered to 0) without this fix.