### PR TITLE
[AutoWS] Fix TMA store wait pipelining with a full loop wrap

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -141,6 +141,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// If K covers every TMA store in the loop, the next producer is in the next
+// iteration. A wait_barrier before the producer is part of that wraparound
+// interval and must be considered as the insertion target.
+// CHECK-LABEL: wraparound_considers_barrier_before_producer
+// CHECK: scf.for
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+  tt.func public @wraparound_considers_barrier_before_producer(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %barrier: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      ttng.wait_barrier %barrier, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %src {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok {"can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : !ttg.async.token
+    } {"tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Loop-carried token after an unrelated loop-carried value. The token wait

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -192,8 +192,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
 // CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-// CHECK: ttng.wait_barrier
-// CHECK: ttng.async_tma_copy_local_to_global
   tt.func public @k3_two_stores_wraparound_uses_first_wait(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -7,11 +7,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // wraps to the next iteration's copy, so the wait lands at stage 1.
 // CHECK-LABEL: single_buffer_k1
 // CHECK: scf.for
-// CHECK: ttg.local_store {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_store {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
   tt.func public @single_buffer_k1(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src: tensor<128x64xf16>,
@@ -37,11 +37,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // per wrap). Wait lands at stage 3.
 // CHECK-LABEL: double_buffer_k2
 // CHECK: scf.for
-// CHECK: ttg.local_store {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_store {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 3 : i32}
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 3 : i32}
   tt.func public @double_buffer_k2(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src: tensor<128x64xf16>,
@@ -90,11 +90,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // reorders. With K=1 and one copy, the wait wraps to stage 1.
 // CHECK-LABEL: no_schedule_creates_basic
 // CHECK: scf.for
-// CHECK: ttg.local_store {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
-// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_store {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
   tt.func public @no_schedule_creates_basic(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src: tensor<128x64xf16>,
@@ -113,6 +113,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Cross-partition case: after code partitioning the local_store ops are in a
@@ -120,19 +121,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // With K=1 and one copy, the wait wraps to stage 1.
 // CHECK-LABEL: cross_partition_memdesc_index
 // CHECK: scf.for
-// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
 // CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
   tt.func public @cross_partition_memdesc_index(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %multibuf: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>,
+      %barrier: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
       %lb: index, %ub: index, %step: index) {
     %c0 = arith.constant 0 : i32
     scf.for %iv = %lb to %ub step %step {
       %slot = ttg.memdesc_index %multibuf[%c0] {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
-      %tok = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %slot {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
-      ttng.async_tma_store_token_wait %tok {"can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !ttg.async.token
+      ttng.wait_barrier %barrier, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %slot {"loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok {"can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 3 : i32} : !ttg.async.token
     } {"tt.scheduled_max_stage" = 1 : i32}
     tt.return
   }
@@ -182,12 +186,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: scf.for
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = {{[0-9]+}} : i32, loop.stage = 2 : i32}
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK: ttng.wait_barrier
 // CHECK: ttng.async_tma_copy_local_to_global
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = {{[0-9]+}} : i32, loop.stage = 2 : i32}
+// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 3 : i32}
 // CHECK: ttng.wait_barrier
 // CHECK: ttng.async_tma_copy_local_to_global
   tt.func public @k3_two_stores_wraparound_uses_first_wait(
@@ -237,8 +241,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
 // CHECK-SAME: {loop.cluster = 4 : i32, loop.stage = 1 : i32}
-// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 14 : i32, loop.stage = 0 : i32}
-// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 15 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 13 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 14 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
 // CHECK-SAME: {loop.cluster = 8 : i32, loop.stage = 1 : i32}
@@ -278,6 +282,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Loop-carried token after an unrelated loop-carried value. The token wait
@@ -287,15 +292,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
 // CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
-// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
   tt.func public @loop_carried_token_with_dead_iter_arg(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %barrier: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
       %lb: index, %ub: index, %step: index, %i: i32) {
     %init_tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
     %result:2 = scf.for %iv = %lb to %ub step %step iter_args(%dead = %i, %carried = %init_tok) -> (i32, !ttg.async.token) {
       ttng.async_tma_store_token_wait %carried {"can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
-      %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.wait_barrier %barrier, %i {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src {"loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
       scf.yield %dead, %tok : i32, !ttg.async.token
     } {"tt.scheduled_max_stage" = 1 : i32}
     tt.return

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -182,14 +182,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: scf.for
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 2 : i32, loop.stage = 2 : i32}
-// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 3 : i32, loop.stage = 2 : i32}
-// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 4 : i32, loop.stage = 2 : i32}
+// CHECK-SAME: {loop.cluster = {{[0-9]+}} : i32, loop.stage = 2 : i32}
+// CHECK: ttng.wait_barrier
+// CHECK: ttng.async_tma_copy_local_to_global
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 2 : i32}
-// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 6 : i32, loop.stage = 1 : i32}
-// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 7 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: {loop.cluster = {{[0-9]+}} : i32, loop.stage = 2 : i32}
+// CHECK: ttng.wait_barrier
+// CHECK: ttng.async_tma_copy_local_to_global
   tt.func public @k3_two_stores_wraparound_uses_first_wait(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -214,6 +214,70 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Four TMA stores with K=3. The last three waits all wrap to earlier stores in
+// the next iteration. They must be scheduled before the wrapped store's
+// wait_barrier, not merely before the wrapped store.
+// CHECK-LABEL: k3_four_stores_all_waits_wraparound
+// CHECK: scf.for
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 12 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 5 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 6 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 9 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 10 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 4 : i32, loop.stage = 1 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 14 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 15 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 8 : i32, loop.stage = 1 : i32}
+  tt.func public @k3_four_stores_all_waits_wraparound(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src3: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %bar0: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %bar2: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %bar3: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    %c32 = arith.constant 32 : i32
+    %c64 = arith.constant 64 : i32
+    %c96 = arith.constant 96 : i32
+    scf.for %iv = %lb to %ub step %step {
+      ttng.wait_barrier %bar0, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %src0 {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok0 {"can_rotate_by_buffer_count" = 3 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : !ttg.async.token
+      ttng.wait_barrier %bar1, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 3 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%c0, %c32] %src1 {"loop.stage" = 0 : i32, "loop.cluster" = 4 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok1 {"can_rotate_by_buffer_count" = 3 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 5 : i32} : !ttg.async.token
+      ttng.wait_barrier %bar2, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 6 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok2 = ttng.async_tma_copy_local_to_global %desc[%c0, %c64] %src2 {"loop.stage" = 0 : i32, "loop.cluster" = 7 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok2 {"can_rotate_by_buffer_count" = 3 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 8 : i32} : !ttg.async.token
+      ttng.wait_barrier %bar3, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 9 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok3 = ttng.async_tma_copy_local_to_global %desc[%c0, %c96] %src3 {"loop.stage" = 0 : i32, "loop.cluster" = 10 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok3 {"can_rotate_by_buffer_count" = 3 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 11 : i32} : !ttg.async.token
+    } {"tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Loop-carried token after an unrelated loop-carried value. The token wait

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -172,6 +172,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Triple-buffered store staging with two TMA stores in the loop. For the
+// second store, counting K=3 stores forward wraps to the first store, so its
+// wait must be scheduled before the first store's wait_barrier.
+// CHECK-LABEL: k3_two_stores_wraparound_uses_first_wait
+// CHECK: scf.for
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 2 : i32, loop.stage = 2 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 3 : i32, loop.stage = 2 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 4 : i32, loop.stage = 2 : i32}
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 6 : i32, loop.stage = 1 : i32}
+// CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 7 : i32, loop.stage = 1 : i32}
+  tt.func public @k3_two_stores_wraparound_uses_first_wait(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %bar0: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    %c64 = arith.constant 64 : i32
+    scf.for %iv = %lb to %ub step %step {
+      ttng.wait_barrier %bar0, %c0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %src0 {"loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok0 {"can_rotate_by_buffer_count" = 3 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 2 : i32} : !ttg.async.token
+      ttng.wait_barrier %bar1, %c0 {"loop.stage" = 1 : i32, "loop.cluster" = 3 : i32} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%c0, %c64] %src1 {"loop.stage" = 1 : i32, "loop.cluster" = 4 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok1 {"can_rotate_by_buffer_count" = 3 : i32, "loop.stage" = 1 : i32, "loop.cluster" = 5 : i32} : !ttg.async.token
+    } {"tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Loop-carried token after an unrelated loop-carried value. The token wait

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_barrier_xfail.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_barrier_xfail.mlir
@@ -13,8 +13,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
 // CHECK: [[TOK0:%.*]] = ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait [[TOK0]]
-// CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 3 : i32, loop.stage = 0 : i32}
+// CHECK-SAME: {can_rotate_by_buffer_count = 1 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32}
   tt.func public @earlier_barrier_does_not_precede_producer(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
@@ -8,11 +8,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // should consume can_rotate_by_buffer_count and rotate the wait by K stores.
 // CHECK-LABEL: @single_buffer_reduce_token_k1
 // CHECK: scf.for
-// CHECK: ttg.local_store {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_store {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_reduce {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
   tt.func public @single_buffer_reduce_token_k1(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %src: tensor<128x64xf16>,
@@ -37,11 +37,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // defining TMA reduce, exercising the store-like linearization path.
 // CHECK-LABEL: @mixed_reduce_to_copy_k1
 // CHECK: scf.for
-// CHECK: [[REDTOK:%.*]] = ttng.async_tma_reduce {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK: [[REDTOK:%.*]] = ttng.async_tma_reduce {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait [[REDTOK]]
-// CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK-SAME: {can_rotate_by_buffer_count = 1 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32}
   tt.func public @mixed_reduce_to_copy_k1(
       %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
       %reduce_src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -262,14 +262,30 @@ void doValidateTMAStoreAnnotations(triton::FuncOp &funcOp) {
 
 static Operation *
 findScheduledWaitBarrierBetween(Operation *producer, Operation *insertionTarget,
-                                const tt::CoarseSchedule &schedule) {
-  if (!producer->isBeforeInBlock(insertionTarget))
+                                const tt::CoarseSchedule &schedule,
+                                bool includeBarrierBeforeProducer) {
+  auto findBefore = [&](Operation *op, Operation *stopOp) -> Operation * {
+    for (auto revIt = Block::reverse_iterator(op->getIterator());
+         revIt != op->getBlock()->rend(); ++revIt) {
+      Operation *candidate = &*revIt;
+      if (candidate == stopOp)
+        return nullptr;
+      if (isa<ttng::WaitBarrierOp>(candidate) && schedule.count(candidate))
+        return candidate;
+    }
+    return nullptr;
+  };
+
+  if (producer->isBeforeInBlock(insertionTarget))
+    return findBefore(insertionTarget, producer);
+
+  if (!includeBarrierBeforeProducer)
     return nullptr;
 
-  for (auto revIt = Block::reverse_iterator(insertionTarget->getIterator());
-       revIt != insertionTarget->getBlock()->rend(); ++revIt) {
+  for (auto revIt = Block::reverse_iterator(producer->getIterator());
+       revIt != producer->getBlock()->rend(); ++revIt) {
     Operation *candidate = &*revIt;
-    if (candidate == producer)
+    if (isTMAStoreLikeOp(candidate))
       return nullptr;
     if (isa<ttng::WaitBarrierOp>(candidate) && schedule.count(candidate))
       return candidate;
@@ -320,6 +336,12 @@ void doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
     if (waits.empty())
       return;
 
+    int numTMAStores = 0;
+    for (auto &op : forOp.getBody()->without_terminator()) {
+      if (isTMAStoreLikeOp(&op))
+        ++numTMAStores;
+    }
+
     bool changed = false;
     for (auto waitOp : waits) {
       auto attr = waitOp->getAttrOfType<IntegerAttr>(kCanRotateByBufferCount);
@@ -366,10 +388,12 @@ void doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
 
       if (insertionTarget) {
         // Look for a WaitBarrierOp between the defining store and the
-        // insertion target. Do not scan before the producer: unrelated earlier
-        // barriers must not pull the token wait before its defining TMA store.
+        // insertion target. If the rotation spans the whole loop's set of TMA
+        // stores, also consider the nearest wait_barrier before the producer:
+        // it is logically between the current store and the next rotated store
+        // in the following iteration.
         if (Operation *waitBarrier = findScheduledWaitBarrierBetween(
-                tmaStore, insertionTarget, schedule))
+                tmaStore, insertionTarget, schedule, k >= numTMAStores))
           insertionTarget = waitBarrier;
 
         // Split the cluster at the insertion target: ops before it remain

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -1,5 +1,7 @@
 #include "CodePartitionUtility.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -196,6 +198,34 @@ static Operation *getDefiningTMAStoreOp(ttng::TMAStoreTokenWaitOp waitOp,
   return nullptr;
 }
 
+static bool samePureValue(Value lhs, Value rhs, unsigned depth = 0) {
+  if (lhs == rhs)
+    return true;
+  if (lhs.getType() != rhs.getType() || depth > 8)
+    return false;
+
+  Operation *lhsDef = lhs.getDefiningOp();
+  Operation *rhsDef = rhs.getDefiningOp();
+  if (!lhsDef || !rhsDef)
+    return false;
+  if (lhsDef->getName() != rhsDef->getName())
+    return false;
+  if (cast<OpResult>(lhs).getResultNumber() !=
+      cast<OpResult>(rhs).getResultNumber())
+    return false;
+  if (!isMemoryEffectFree(lhsDef) || !isMemoryEffectFree(rhsDef))
+    return false;
+  if (lhsDef->getNumRegions() || rhsDef->getNumRegions())
+    return false;
+
+  return OperationEquivalence::isEquivalentTo(
+      lhsDef, rhsDef,
+      [depth](Value lhsOperand, Value rhsOperand) {
+        return success(samePureValue(lhsOperand, rhsOperand, depth + 1));
+      },
+      /*markEquivalent=*/nullptr, OperationEquivalence::IgnoreLocations);
+}
+
 static bool sameMemDescValue(Value lhs, Value rhs) {
   if (lhs == rhs)
     return true;
@@ -213,7 +243,7 @@ static bool sameMemDescValue(Value lhs, Value rhs) {
     return false;
 
   for (unsigned i = 0; i < lhsDef->getNumOperands(); ++i) {
-    if (lhsDef->getOperand(i) != rhsDef->getOperand(i))
+    if (!samePureValue(lhsDef->getOperand(i), rhsDef->getOperand(i)))
       return false;
   }
   return true;
@@ -462,10 +492,10 @@ LogicalResult doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
               tmaStore, targetTMAStore, schedule,
               k >= (numTMAStores - numPrevTMAStores));
           if (!waitBarrier) {
-            forOp.emitOpError(
-                "failed to find wait_barrier guarding target TMA store");
-            failedToReorder = true;
-            return;
+            LDBG("failed to find wait_barrier guarding target TMA store for "
+                 "loop at "
+                 << forOp.getLoc() << "; leaving TMA store wait unchanged");
+            continue;
           }
           insertionTarget = waitBarrier;
         }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -146,6 +146,14 @@ static bool isTMAStoreLikeOp(Operation *op) {
   return isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp>(op);
 }
 
+static Value getTMAStoreSource(Operation *op) {
+  if (auto copyOp = dyn_cast<ttng::AsyncTMACopyLocalToGlobalOp>(op))
+    return copyOp.getSrc();
+  if (auto reduceOp = dyn_cast<ttng::AsyncTMAReduceOp>(op))
+    return reduceOp.getSrc();
+  return {};
+}
+
 // Trace the token back to the defining TMA store-like op
 // (AsyncTMACopyLocalToGlobalOp or AsyncTMAReduceOp), handling both direct
 // definitions and loop-carried block arguments. Returns the SMEM source
@@ -185,6 +193,42 @@ static Operation *getDefiningTMAStoreOp(ttng::TMAStoreTokenWaitOp waitOp,
     }
   }
 
+  return nullptr;
+}
+
+static bool sameMemDescValue(Value lhs, Value rhs) {
+  if (lhs == rhs)
+    return true;
+
+  Operation *lhsDef = lhs.getDefiningOp();
+  Operation *rhsDef = rhs.getDefiningOp();
+  if (!lhsDef || !rhsDef)
+    return false;
+  if (lhsDef->getName() != rhsDef->getName())
+    return false;
+  if (!isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+           ttg::MemDescReinterpretOp>(lhsDef))
+    return false;
+  if (lhsDef->getNumOperands() != rhsDef->getNumOperands())
+    return false;
+
+  for (unsigned i = 0; i < lhsDef->getNumOperands(); ++i) {
+    if (lhsDef->getOperand(i) != rhsDef->getOperand(i))
+      return false;
+  }
+  return true;
+}
+
+static Operation *
+findLocalStoreWritingBuffer(scf::ForOp forOp, Value buffer,
+                            const tt::CoarseSchedule &schedule) {
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    auto localStore = dyn_cast<ttg::LocalStoreOp>(&op);
+    if (!localStore || !schedule.count(&op))
+      continue;
+    if (sameMemDescValue(localStore.getDst(), buffer))
+      return &op;
+  }
   return nullptr;
 }
 
@@ -296,8 +340,12 @@ findScheduledWaitBarrierBetween(Operation *producer, Operation *insertionTarget,
   return nullptr;
 }
 
-void doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
+LogicalResult doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
+  bool failedToReorder = false;
   funcOp.walk([&](scf::ForOp forOp) {
+    if (failedToReorder)
+      return;
+
     bool hasNestedFor = false;
     forOp.getBody()->walk([&](scf::ForOp) { hasNestedFor = true; });
     if (hasNestedFor)
@@ -389,6 +437,7 @@ void doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
       }
 
       if (insertionTarget) {
+        Operation *targetTMAStore = insertionTarget;
         int numPrevTMAStores = 0;
         for (auto &op : forOp.getBody()->without_terminator()) {
           if (&op == tmaStore)
@@ -397,15 +446,29 @@ void doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
             ++numPrevTMAStores;
         }
 
-        // Look for a WaitBarrierOp between the defining store and the
-        // insertion target. If the rotation spans the whole loop's set of TMA
-        // stores, also consider the nearest wait_barrier before the producer:
-        // it is logically between the current store and the next rotated store
-        // in the following iteration.
-        if (Operation *waitBarrier = findScheduledWaitBarrierBetween(
-                tmaStore, insertionTarget, schedule,
-                k >= (numTMAStores - numPrevTMAStores)))
+        Value targetBuffer = getTMAStoreSource(targetTMAStore);
+        Operation *targetWriter =
+            targetBuffer
+                ? findLocalStoreWritingBuffer(forOp, targetBuffer, schedule)
+                : nullptr;
+        if (targetWriter) {
+          insertionTarget = targetWriter;
+        } else {
+          // If the buffer is updated by a different partition, the TMA store
+          // must be guarded by that partition's wait_barrier. Reorder before
+          // the barrier so the token wait completes before the target buffer
+          // can be updated.
+          Operation *waitBarrier = findScheduledWaitBarrierBetween(
+              tmaStore, targetTMAStore, schedule,
+              k >= (numTMAStores - numPrevTMAStores));
+          if (!waitBarrier) {
+            forOp.emitOpError(
+                "failed to find wait_barrier guarding target TMA store");
+            failedToReorder = true;
+            return;
+          }
           insertionTarget = waitBarrier;
+        }
 
         // Split the cluster at the insertion target: ops before it remain
         // in the original cluster, the target and subsequent ops stay in
@@ -427,14 +490,20 @@ void doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
     if (changed)
       schedule.serialize(forOp);
   });
+  return failure(failedToReorder);
 }
 
 struct NVGPUTestTMAStoreTokenWaitReorderPass
     : public impl::NVGPUTestTMAStoreTokenWaitReorderBase<
           NVGPUTestTMAStoreTokenWaitReorderPass> {
   void runOnOperation() override {
-    getOperation()->walk(
-        [&](triton::FuncOp funcOp) { doTMAStoreWaitReorder(funcOp); });
+    bool passFailed = false;
+    getOperation()->walk([&](triton::FuncOp funcOp) {
+      if (failed(doTMAStoreWaitReorder(funcOp)))
+        passFailed = true;
+    });
+    if (passFailed)
+      signalPassFailure();
   }
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -282,7 +282,9 @@ findScheduledWaitBarrierBetween(Operation *producer, Operation *insertionTarget,
   if (!includeBarrierBeforeProducer)
     return nullptr;
 
-  for (auto revIt = Block::reverse_iterator(producer->getIterator());
+  Operation *wraparoundTarget =
+      insertionTarget->isBeforeInBlock(producer) ? insertionTarget : producer;
+  for (auto revIt = Block::reverse_iterator(wraparoundTarget->getIterator());
        revIt != producer->getBlock()->rend(); ++revIt) {
     Operation *candidate = &*revIt;
     if (isTMAStoreLikeOp(candidate))

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -389,13 +389,22 @@ void doTMAStoreWaitReorder(triton::FuncOp &funcOp) {
       }
 
       if (insertionTarget) {
+        int numPrevTMAStores = 0;
+        for (auto &op : forOp.getBody()->without_terminator()) {
+          if (&op == tmaStore)
+            break;
+          if (isTMAStoreLikeOp(&op))
+            ++numPrevTMAStores;
+        }
+
         // Look for a WaitBarrierOp between the defining store and the
         // insertion target. If the rotation spans the whole loop's set of TMA
         // stores, also consider the nearest wait_barrier before the producer:
         // it is logically between the current store and the next rotated store
         // in the following iteration.
         if (Operation *waitBarrier = findScheduledWaitBarrierBetween(
-                tmaStore, insertionTarget, schedule, k >= numTMAStores))
+                tmaStore, insertionTarget, schedule,
+                k >= (numTMAStores - numPrevTMAStores)))
           insertionTarget = waitBarrier;
 
         // Split the cluster at the insertion target: ops before it remain


### PR DESCRIPTION
Improving the DCE made the TMA store wait pipelining available for many more cases. In that situation a problem that arises is the existing code accidentally assumed that never needed to check barriers before the first store. However, if we wrap all the way around the loop that wasn't the case.

Before:
```
wait_barrier {stage=0, cluster=0}
local_to_global {stage=0, cluster=2}
...
tma_store_wait_token {stage=1, cluster=1}
```

After:
```
wait_barrier {stage=0, cluster=2}
local_to_global {stage=0, cluster=2}
...
tma_store_wait_token {stage=1, cluster=1}
```

In practice after SWP this means now the `tma_store_wait_token` (which is an arrive) comes before the wait rather after.

This fixes several other issues as well:
- Fix partial wrap around (subtile = 2, subtile = 4)
- Fix handling with the tma_store in the default partition with the tmem_load. 
