### PR TITLE
[TLX][blackwell_gemm_ws] Remove _flush_l2_cache from reduce_post_hook

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1092,10 +1092,6 @@ def reduce_post_hook(nargs, exception=None):
             OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[workspace.dtype],
             num_warps=4,
         )
-        # Flush L2 cache after reduction so do_bench iterations don't
-        # benefit from artificially warm workspace data. In production,
-        # the workspace is cold on each forward pass.
-        _flush_l2_cache(workspace.device)
 
 
 @triton.autotune(


### PR DESCRIPTION
Summary:
Context: tritonbench reports 698 TFLOPS for tlx_matmul_ws on Blackwell B200
(M=1152, N=1024, K=24576, bf16) vs aten_matmul's 928 TFLOPS — a 25% gap that
shouldn't exist for a well-tuned Triton GEMM on this hardware.

Investigation: wrote bench_mm_configs.py to compare the config selected by the
autotuner (via GEO's _tlx_matmul path) vs tritonbench's path, and to check
whether statistical method differences (mean vs IQR p50) explain the gap.

Findings:
1. Statistical method is NOT the issue: mean (924.5 TFLOPS) vs IQR p50
   (928.2 TFLOPS) differ by only 0.4% for the same kernel.

2. _flush_l2_cache in reduce_post_hook corrupts config selection:
   - With flush: autotuner picks SPLIT_K=1, BM=64, BN=128 → 698 TFLOPS
   - Without flush: autotuner picks SPLIT_K=6, BM=256, BN=256 → 843 TFLOPS

   _flush_l2_cache was originally added to simulate cold L2 between do_bench
   iterations, ensuring measured kernel time reflects production (cold workspace)
   behavior. This is now redundant because triton's do_bench already flushes L2
   before each measurement (testing.py:181 `runtime.driver.active.clear_cache`).

   The redundant flush inside the timed region distorts relative timing between
   configs — SPLIT_K>1 configs have larger workspaces, so the flush after
   reduction is more expensive for them, biasing the autotuner toward SPLIT_K=1.

3. GEO's _tlx_matmul is missing the manual _reduce_k_kernel call after
   autotuner dispatch for SPLIT_K > 1 (fix in separate diff).

This diff removes _flush_l2_cache, fixing config selection from SPLIT_K=1
(698 TFLOPS) to SPLIT_K=6 (843 TFLOPS) — a 21% improvement.

Differential Revision: D108095816


