### PR TITLE
[Triton][NPOT] SM90 support: NPOT-aware optimization passes for Hopper

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -342,7 +342,8 @@ LLVM::LLVMFuncOp appendOrGetExternFuncOp(RewriterBase &rewriter, Operation *op,
                                          StringRef libname = "",
                                          StringRef libpath = "");
 
-// Multiply a square layout with 1 input and output dimension with a vector
+// Multiply a square 1-in/1-out layout with a vector. NPOT out dim uses
+// ADD+mod, pow2 uses XOR (per isOutDimModular on the single out dim).
 Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x);
 
 // Whether the convert layout should be forced to use warp shuffles.
@@ -582,7 +583,7 @@ SmallVector<Value> lowerLdSt(
         lowerInst,
     std::optional<Value> barrierPtr = {});
 
-// Lower local_load/local_store via ld.shared/st.shared
+// Lower local_load/local_store via ld.shared/st.shared.
 SmallVector<Value> lowerLocalLdSt(
     Location loc, MLIRContext *ctx,
     LinearLayout cvt,          // Map from registers to offset

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -65,6 +65,25 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
                                        TMAMode mode,
                                        bool disableSwizzle = false);
 
+// Build a split-dim SMEM layout for NPOT swizzled shared memory.
+//
+// When the contiguous dim is NPOT and swizzle > 0, the standard
+// nvmmaSharedToLinearLayout merges swizzle-coupled (XOR) and phase (ADD+mod)
+// bases into a single NPOT output dim.  pseudoinvert() cannot handle this
+// mixed algebra correctly.
+//
+// This function builds the layout with 3 output dims for rank-2 tensors:
+//   dim0 (rows, pow2), dim1 (intra-phase columns, pow2), contig_phase (NPOT).
+// The pseudoinverse of this split layout is correct because each output dim
+// uses a single algebra (XOR or ADD+mod).
+//
+// Returns std::nullopt if the layout is pow2 or unswizzled (no split needed).
+// The returned layout does NOT include CGA/block dims -- it's the CTA-local
+// layout only, suitable for pseudoinversion in the MMA descriptor path.
+std::optional<LinearLayout>
+nvmmaSharedToSplitLinearLayout(ArrayRef<int64_t> shape,
+                               NVMMASharedEncodingAttr shared);
+
 // Given a linear layout where the input dimensions contain a "block" dimension,
 // this method sets the "block" dimension to 0 and removes the corresponding
 // output dimensions.

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -54,6 +54,48 @@ getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
                         triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
                         ArrayRef<int64_t> shape);
 
+// Returns true if any tensor dim is non-power-of-2. Pow2-assuming passes
+// should skip such tensors to avoid crashes in the layout algebra.
+inline bool hasNpotShape(RankedTensorType ty) {
+  return llvm::any_of(ty.getShape(), [](int64_t d) {
+    return d > 0 && !llvm::isPowerOf2_64(d);
+  });
+}
+
+// Returns true if the encoding's toLinearLayout can handle NPOT shapes
+// correctly.  Encodings that produce valid modular LinearLayouts for NPOT
+// include: blocked, slice (inherits from parent), linear, MMAv2 (Ampere),
+// MMAv3+ (Hopper/Blackwell), and dot_op whose parent is safe.
+// Encodings NOT safe: MMAv1 (Turing).
+inline bool npotSafeForLinearLayout(Attribute encoding) {
+  if (!encoding) {
+    return false;
+  }
+  // Blocked and linear encodings handle NPOT via combineCtaCgaWithShape.
+  if (isa<triton::gpu::BlockedEncodingAttr, triton::gpu::LinearEncodingAttr>(
+          encoding)) {
+    return true;
+  }
+  // NvidiaMma: v2 (Ampere) and v3+ (Hopper/Blackwell) are safe.
+  // nvidiaMmaTile uses modularIdentity1D for NPOT rep counts.
+  if (auto mma = dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(encoding)) {
+    return mma.getVersionMajor() >= 2;
+  }
+  // Dot operand encoding: safe if its parent encoding is safe.
+  if (auto dotOp = dyn_cast<triton::gpu::DotOperandEncodingAttr>(encoding)) {
+    return npotSafeForLinearLayout(dotOp.getParent());
+  }
+  // Slice encoding: inherits safety from parent.
+  if (auto slice = dyn_cast<triton::gpu::SliceEncodingAttr>(encoding)) {
+    return npotSafeForLinearLayout(slice.getParent());
+  }
+  // Shared encodings are safe (they don't use the distributed layout).
+  if (isa<triton::gpu::SharedEncodingTrait>(encoding)) {
+    return true;
+  }
+  return false;
+}
+
 // Returns whether the op is a "view op", i.e. doesn't move any data
 bool isView(Operation *op);
 

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -2,6 +2,7 @@
 #define TRITON_TOOLS_LAYOUTUTILS_H
 
 #include "triton/Tools/LinearLayout.h"
+#include "llvm/ADT/DenseMap.h"
 
 namespace mlir::triton {
 // Is the sublayout defined from dimNames to dimNames the identity?
@@ -188,6 +189,25 @@ LinearLayout removeStandardDim(const LinearLayout &layout, int dim);
 
 bool splitContiguousDim(int64_t tileCols, int64_t numPhases, int contigDim,
                         LinearLayout &smemLayout, LinearLayout &otherLayout);
+
+LinearLayout unfoldModularDimsForAlloc(const LinearLayout &layout);
+
+LinearLayout applyNpotKernelFix(const LinearLayout &cvt,
+                                const LinearLayout &smem);
+
+llvm::DenseMap<int, int> computeDeadPositionMap(const LinearLayout &layout,
+                                                StringAttr kPosition,
+                                                StringAttr kLane,
+                                                StringAttr kWarp);
+
+// Returns true if computeDeadPositionMap can produce a valid fixup map for
+// this layout. When false, lane/warp bases contribute to NPOT dims, so
+// dead-position fixup requires cross-thread communication and cannot be
+// done with a per-position register map. Callers should avoid unfolding
+// modular dims (unfoldModularDimsForAlloc) and instead let the modular
+// layout flow through the SMEM transfer directly.
+bool canFixupDeadPositions(const LinearLayout &layout, StringAttr kLane,
+                           StringAttr kWarp);
 } // namespace mlir::triton
 
 #endif // TRITON_TOOLS_LAYOUTUTILS_H

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -42,6 +42,27 @@ unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   auto *ctx = srcTy.getContext();
   auto srcLayout = gpu::toLinearLayout(srcTy);
   auto dstLayout = gpu::toLinearLayout(dstTy);
+
+  // Match the lowering: remove the block dimension (identity in the cvt).
+  auto kReg = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto outDimNames = llvm::to_vector(srcLayout.getOutDimNames());
+  srcLayout = srcLayout.sublayout({kReg, kLane, kWarp}, outDimNames);
+  dstLayout = dstLayout.sublayout({kReg, kLane, kWarp}, outDimNames);
+
+  // Unfold NPOT dims before removing broadcasts: a [0,N] reg basis is 0 mod N
+  // but nonzero in pow2 space; dropping it would under-size SMEM (OOB).
+  //
+  // However, when lane/warp contribute to an NPOT dim (e.g. MMAv2 NPOT M/N),
+  // the lowering skips the unfold and uses the modular layout directly. We
+  // must match that decision here to avoid over-allocating or mis-sizing SMEM.
+  bool canFixup = triton::canFixupDeadPositions(srcLayout, kLane, kWarp) &&
+                  triton::canFixupDeadPositions(dstLayout, kLane, kWarp);
+  if (canFixup) {
+    srcLayout = unfoldModularDimsForAlloc(srcLayout);
+    dstLayout = unfoldModularDimsForAlloc(dstLayout);
+  }
   srcLayout = actionRemoveBroadcastedRegs(srcLayout).apply(srcLayout);
   dstLayout = actionRemoveBroadcastedRegs(dstLayout).apply(dstLayout);
   auto bitwidth = getBitwidth(srcTy);

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
@@ -980,14 +981,27 @@ bool supportMMA(triton::DotOp op, int version) {
     // If k size is smaller than the native mma size, we cannot use MMA.
     if (k < 256 / aElemTy.getIntOrFloatBitWidth())
       return false;
+    // NPOT K with swizzle=0 (K*elemBytes not a multiple of 32/64/128):
+    // the SMEM alloc rounds K to pow2 and WGMMA would read uninitialized
+    // padding, so fall back to a non-MMA path.
+    if (!llvm::isPowerOf2_64(k)) {
+      int elemBytes = aElemTy.getIntOrFloatBitWidth() / 8;
+      int64_t contigBytes = (int64_t)k * elemBytes;
+      if (contigBytes % 32 != 0) {
+        return false;
+      }
+    }
     auto retShapePerCTA = getShapePerCTA(retType);
     auto rank = retShapePerCTA.size();
     int numWarps = lookupNumWarps(op);
     // TODO(Keren): for now, fallback to MMAv2 if handling batch matmul.
     if (rank == 3)
       return false;
-    if (!(numWarps % 4 == 0 && retShapePerCTA[rank - 2] % 64 == 0 &&
-          retShapePerCTA[rank - 1] % 16 == 0 &&
+    // Pow2 M requires M%64 (routes pow2 GEMMs to MMAv2); NPOT M only M%16.
+    int64_t mDimV3 = retShapePerCTA[rank - 2];
+    bool mOkV3 =
+        llvm::isPowerOf2_64(mDimV3) ? (mDimV3 % 64 == 0) : (mDimV3 % 16 == 0);
+    if (!(numWarps % 4 == 0 && mOkV3 && retShapePerCTA[rank - 1] % 16 == 0 &&
           (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(aElemTy) ||
            aElemTy.isInteger(8) || aElemTy.isF16() || aElemTy.isBF16() ||
            aElemTy.isF32()))) {
@@ -998,6 +1012,26 @@ bool supportMMA(triton::DotOp op, int version) {
         (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(aElemTy)) &&
         cast<RankedTensorType>(op.getType()).getElementType().isF32()) {
       return false;
+    }
+  }
+  // MMAv2 (reachable as a fallback on modern archs + Ampere) supports NPOT K
+  // (multiple of instrK); NPOT M/N are rejected and fall to FMA.
+  if (version == 2) {
+    RankedTensorType typeA2 = op.getA().getType();
+    int k2 = typeA2.getShape().back();
+    // Only NPOT K is constrained (must be a multiple of instrK); pow2 K
+    // (incl. K < instrK, e.g. f8 K=16) keeps upstream MMAv2 behaviour.
+    if (!llvm::isPowerOf2_64(k2)) {
+      int instrK = 256 / aElemTy.getIntOrFloatBitWidth();
+      if (k2 % instrK != 0) {
+        return false;
+      }
+    }
+    auto retShapePerCTA = getShapePerCTA(op.getType());
+    for (auto d : retShapePerCTA) {
+      if (d > 0 && !llvm::isPowerOf2_64(d)) {
+        return false;
+      }
     }
   }
   if (aElemTy.isF32() && bElemTy.isF32()) {
@@ -1058,7 +1092,31 @@ LinearLayout minimalCvtLayout(Type srcTy_, Type dstTy_) {
   return comp;
 }
 
+// Helper: returns true when NPOT shapes interact with MMA-family encodings,
+// making invertAndCompose (via minimalCvtLayout) potentially hang in the
+// modular solver.  Callers should bail out conservatively.
+static bool npotMmaConversion(RankedTensorType srcTy, RankedTensorType dstTy) {
+  if (!hasNpotShape(srcTy) && !hasNpotShape(dstTy)) {
+    return false;
+  }
+  auto hasMmaFamily = [](Attribute enc) {
+    if (isa<triton::gpu::NvidiaMmaEncodingAttr>(enc)) {
+      return true;
+    }
+    if (auto dot = dyn_cast<triton::gpu::DotOperandEncodingAttr>(enc)) {
+      return isa<triton::gpu::NvidiaMmaEncodingAttr>(dot.getParent());
+    }
+    return false;
+  };
+  return hasMmaFamily(srcTy.getEncoding()) || hasMmaFamily(dstTy.getEncoding());
+}
+
 bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // NPOT + MMA: modular solver in invertAndCompose can hang.
+  // Conservatively say "no" (can't reorder registers).
+  if (npotMmaConversion(srcTy, dstTy)) {
+    return false;
+  }
   auto layout = minimalCvtLayout(srcTy, dstTy);
   MLIRContext *ctx = srcTy.getContext();
   auto kRegister = StringAttr::get(ctx, "register");
@@ -1067,6 +1125,11 @@ bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // getWarpLayoutConvertDecomposition is a pow2-only GF(2) bit-permutation
+  // algorithm that never terminates on modular/NPOT layouts.
+  if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+    return false;
+  }
   auto layout = minimalCvtLayout(srcTy, dstTy);
   MLIRContext *ctx = srcTy.getContext();
   auto kRegister = StringAttr::get(ctx, "register");
@@ -1080,6 +1143,18 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // For NPOT shapes, toLinearLayout may crash if the encoding doesn't support
+  // modular layouts. Conservatively assume shared memory is needed for unsafe
+  // encodings.
+  if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+    bool srcSafe = npotSafeForLinearLayout(srcTy.getEncoding());
+    bool dstSafe = npotSafeForLinearLayout(dstTy.getEncoding());
+    if (!srcSafe || !dstSafe) {
+      return true;
+    }
+  }
+  // NPOT+MMA: the two guards above both return false, so this returns true
+  // without calling invertAndCompose.
   return !cvtReordersRegisters(srcTy, dstTy) &&
          !cvtNeedsWarpShuffle(srcTy, dstTy);
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -168,6 +168,8 @@ struct ConvertLayoutOpConversion
 
     // At this point we have a type that's at least 8-bit
     // and we don't have broadcasting in the registers
+
+    // For NPOT cases the caller has already replaced these with pow2 layouts.
     auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
     auto smem = optimalSwizzlingLdSt(srcLayout, dstLayout, bitwidth);
 
@@ -205,6 +207,9 @@ struct ConvertLayoutOpConversion
         loadCvt = loadCvt.reshapeOuts(
             {{kOffset,
               static_cast<int32_t>(loadCvt.getTotalOutDimSizeProduct())}});
+
+        storeCvt = triton::applyNpotKernelFix(storeCvt, smem);
+        loadCvt = triton::applyNpotKernelFix(loadCvt, smem);
 
         auto tileSize = storeCvt.getInDimSize(kReg);
 
@@ -272,10 +277,38 @@ struct ConvertLayoutOpConversion
     dstLayout = dstLayout.sublayout({kReg, kLane, kWarp},
                                     to_vector(dstLayout.getOutDimNames()));
 
+    // Compute the dead register fixup map BEFORE unfolding. For NPOT src
+    // layouts, some register positions hold garbage from dead hardware
+    // positions (e.g., TMEM columns beyond N). We need to replace those
+    // with the values from their canonical (wrapped) counterparts.
+    auto deadRegMap =
+        triton::computeDeadPositionMap(srcLayout, kReg, kLane, kWarp);
+
+    // Unfold NPOT modular dims to pow2 only when dead positions are fixable
+    // per-register (canFixup). When lane/warp feed the NPOT dim the canonical
+    // register may live in another thread, so leave the modular layout to wrap
+    // dead positions through the SMEM transfer.
+    bool canFixup = triton::canFixupDeadPositions(srcLayout, kLane, kWarp) &&
+                    triton::canFixupDeadPositions(dstLayout, kLane, kWarp);
+    if (canFixup) {
+      srcLayout = triton::unfoldModularDimsForAlloc(srcLayout);
+      dstLayout = triton::unfoldModularDimsForAlloc(dstLayout);
+    }
+
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
     auto smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto inVals = unpackLLElements(loc, src, rewriter);
+
+    // Dead-register fixup: alias each dead reg to its canonical (wrapped)
+    // value.
+    for (auto &[deadReg, canonReg] : deadRegMap) {
+      if (deadReg < static_cast<int>(inVals.size()) &&
+          canonReg < static_cast<int>(inVals.size())) {
+        inVals[deadReg] = inVals[canonReg];
+      }
+    }
+
     auto outVals = transferWithinBlockSwizzlingImpl(
         loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase);
 

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
@@ -1,5 +1,6 @@
 #include "triton/Conversion/TritonGPUToLLVM/FMADotUtility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 
 using namespace mlir;
 
@@ -55,6 +56,75 @@ ValueTableFMA getValueTableFromStructFMA(
   assert(kDim == 1 || kDim == 2);
   assert(nonKDim == 1 || nonKDim == 2);
   const unsigned bDim = 0;
+
+  // Any NPOT dim: register order is modular, not row-major.
+  bool hasNpotDim = llvm::any_of(
+      perRepShape, [](unsigned s) { return s > 0 && !llvm::isPowerOf2_32(s); });
+
+  if (hasNpotDim) {
+    // NPOT K register order follows the layout's modular arithmetic (ADD+mod),
+    // not delinearize's row-major. The register space is pow2-rounded, so index
+    // bits over pow2 sizes, then mod-reduce to the NPOT coordinate.
+
+    // Round perRepShape to pow2 for register bit counting.
+    SmallVector<unsigned> pow2PerRepShape(3);
+    for (int i = 0; i < 3; i++) {
+      unsigned s = perRepShape[i];
+      pow2PerRepShape[i] = (s <= 1)                 ? s
+                           : llvm::isPowerOf2_32(s) ? s
+                                                    : llvm::NextPowerOf2(s);
+    }
+    unsigned pow2NumElemsRep = product(pow2PerRepShape);
+
+    // Count register bits per dimension (in inRepOrder).
+    SmallVector<unsigned> bitsPerDim(3);
+    for (int i = 0; i < 3; i++) {
+      unsigned s = pow2PerRepShape[i];
+      bitsPerDim[i] = (s <= 1) ? 0 : llvm::Log2_32(s);
+    }
+
+    for (unsigned idx = 0; idx < elems.size(); ++idx) {
+      auto inRepLinearIdx = idx % pow2NumElemsRep;
+      auto repLinearIdx = idx / pow2NumElemsRep;
+
+      // Compute in-rep coordinates from register bits using basis
+      // accumulation. Bits are assigned to dims in inRepOrder
+      // (fastest-changing dim first).
+      SmallVector<unsigned> inRepCoords(3, 0);
+      unsigned bitOffset = 0;
+      for (auto d : inRepOrder) {
+        unsigned nBits = bitsPerDim[d];
+        unsigned dimSize = perRepShape[d];
+        if (nBits == 0) {
+          continue;
+        }
+        unsigned coord = 0;
+        for (unsigned bit = 0; bit < nBits; ++bit) {
+          if (inRepLinearIdx & (1u << (bitOffset + bit))) {
+            unsigned basisVal = (1u << bit);
+            coord += basisVal;
+          }
+        }
+        // Modular reduction: ADD+mod for NPOT, AND for pow2.
+        if (llvm::isPowerOf2_32(dimSize)) {
+          inRepCoords[d] = coord & (dimSize - 1);
+        } else {
+          inRepCoords[d] = coord % dimSize;
+        }
+        bitOffset += nBits;
+      }
+
+      // Rep coordinates: all dims in repetitions are pow2.
+      auto repSpatialIdx =
+          mlir::LLVM::delinearize(repLinearIdx, repetitions, repOrder);
+
+      OperandValueKey key{repSpatialIdx[0], repSpatialIdx[nonKDim],
+                          inRepCoords[0], inRepCoords[nonKDim],
+                          inRepCoords[kDim]};
+      res[key] = elems[idx];
+    }
+    return res;
+  }
 
   for (unsigned idx = 0; idx < elems.size(); ++idx) {
     auto inRepLinearIdx = idx % numElemsRep;
@@ -115,28 +185,42 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
   sizePerThread = expandMatrixShapeWithBatch(ArrayRef(sizePerThread));
 
   unsigned K = aShapePerCTA[2];
+  // NPOT K: the struct holds pow2-many K elements/thread (with wrap-around
+  // duplicates), so iterate over Kpow2; the dot loop sums only the real K.
+  unsigned Kpow2 = llvm::isPowerOf2_32(K) ? K : (unsigned)llvm::NextPowerOf2(K);
 
-  unsigned threadTileShape[3];
-  unsigned repetitions[3];
+  // NPOT non-K dims (M/N/batch): the dot_op layout rounds the register dim to
+  // pow2, so reps = NextPow2(shapePerCTA)/CTATile (may exceed the ceil count,
+  // e.g. M=96 -> 128). Tables and accumulator indexing must use this padded
+  // count; see the dot-loop comment for why the extra reps are correct.
+  unsigned repetitionsPadded[3];
   for (int i = 0; i < 3; ++i) {
-    repetitions[i] =
-        ceil(dShapePerCTA[i], static_cast<int64_t>(shapePerCTATile[i]));
+    int64_t shape = dShapePerCTA[i];
+    int64_t pow2Shape = llvm::isPowerOf2_64(shape)
+                            ? shape
+                            : (int64_t)llvm::NextPowerOf2((uint64_t)shape);
+    repetitionsPadded[i] =
+        ceil(pow2Shape, static_cast<int64_t>(shapePerCTATile[i]));
   }
 
   auto has = getValueTableFromStructFMA(
-      llA, {sizePerThread[0], sizePerThread[1], K},
-      {repetitions[0], repetitions[1], 1},
+      llA, {sizePerThread[0], sizePerThread[1], Kpow2},
+      {repetitionsPadded[0], repetitionsPadded[1], 1},
       /*kDim*/ 2, /*nonKDim*/ 1, rewriter, loc, inRepOrder, repOrder);
   auto hbs = getValueTableFromStructFMA(
-      llB, {sizePerThread[0], K, sizePerThread[2]},
-      {repetitions[0], 1, repetitions[2]},
+      llB, {sizePerThread[0], Kpow2, sizePerThread[2]},
+      {repetitionsPadded[0], 1, repetitionsPadded[2]},
       /*kDim*/ 1, /*nonKDim*/ 2, rewriter, loc, inRepOrder, repOrder);
 
   SmallVector<Value> acc = cc;
 
-  for (unsigned bRep = 0; bRep < repetitions[0]; ++bRep)
-    for (unsigned mRep = 0; mRep < repetitions[1]; ++mRep)
-      for (unsigned nRep = 0; nRep < repetitions[2]; ++nRep)
+  // Iterate the pow2-padded rep count. Padding reps cover dead rows
+  // [shapePerCTA, NextPow2); the layout's % origSize wraps them onto valid
+  // rows, so each padding rep recomputes its canonical row's value (harmless,
+  // not a clobber). linearAccumIdx uses the padded count to match the C struct.
+  for (unsigned bRep = 0; bRep < repetitionsPadded[0]; ++bRep)
+    for (unsigned mRep = 0; mRep < repetitionsPadded[1]; ++mRep)
+      for (unsigned nRep = 0; nRep < repetitionsPadded[2]; ++nRep)
         for (unsigned b = 0; b < sizePerThread[0]; ++b)
           for (unsigned m = 0; m < sizePerThread[1]; ++m)
             for (unsigned n = 0; n < sizePerThread[2]; ++n) {
@@ -145,7 +229,7 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
                   LLVM::linearize(multiDimAccumIdx, sizePerThread, inRepOrder);
               SmallVector<unsigned> multiDimRepIdx = {bRep, mRep, nRep};
               unsigned linearRepIdx =
-                  LLVM::linearize(multiDimRepIdx, repetitions, repOrder);
+                  LLVM::linearize(multiDimRepIdx, repetitionsPadded, repOrder);
               unsigned linearAccumIdx =
                   linearInRepIdx + linearRepIdx * numElemsPerThread;
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -210,6 +210,72 @@ struct LocalAllocOpConversion
       : ConvertOpToLLVMPattern<triton::gpu::LocalAllocOp>(converter, benefit),
         targetInfo(targetInfo) {}
 
+  // Check if this NVMMASharedEncoding allocation has NPOT contiguous dim with
+  // swizzle=0, which means the physical allocation is pow2-rounded and the
+  // padding elements must be zero-filled to avoid WGMMA reading garbage.
+  static bool needsZeroFillForNpotPadding(MemDescType memDescTy) {
+    auto encoding = dyn_cast<NVMMASharedEncodingAttr>(memDescTy.getEncoding());
+    if (!encoding || encoding.getSwizzlingByteWidth() != 0) {
+      return false;
+    }
+
+    auto shape = memDescTy.getAllocShape().take_back(memDescTy.getRank());
+    bool isTransposed = encoding.getTransposed();
+    int rank = shape.size();
+    int contigDim = isTransposed ? 0 : rank - 1;
+
+    if (llvm::isPowerOf2_64(shape[contigDim])) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // Cooperative zero-fill of the SMEM allocation; each thread writes i32 zeros.
+  void emitSmemZeroFill(Location loc, Value smemBase, MemDescType memDescTy,
+                        Operation *op,
+                        ConversionPatternRewriter &rewriter) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Compute allocation size in bytes using the rounded shape.
+    auto allocShape = getAllocationShapePerCTA(memDescTy);
+    int64_t numElems = 1;
+    for (auto s : allocShape) {
+      numElems *= s;
+    }
+    int elemBitWidth = cast<NVMMASharedEncodingAttr>(memDescTy.getEncoding())
+                           .getElementBitWidth();
+    int64_t allocBytes = numElems * elemBitWidth / 8;
+
+    // Use i32 stores for efficiency: allocBytes / 4 words to write.
+    int64_t numWords = allocBytes / 4;
+
+    // Get thread ID and total threads from the module.
+    Value tid = getThreadId(rewriter, loc);
+    int numWarps = lookupNumWarps(op);
+    int threadsPerWarp = 32; // NVIDIA warp size
+    int numThreads = numWarps * threadsPerWarp;
+
+    auto i32PtrTy = LLVM::LLVMPointerType::get(rewriter.getContext(), 3);
+    Value smemI32 = b.bitcast(smemBase, i32PtrTy);
+    Value zero32 = b.i32_val(0);
+
+    for (int64_t w = 0; w * numThreads < numWords; w++) {
+      // idx = tid + w * numThreads
+      Value idx = (w == 0) ? tid : b.add(tid, b.i32_val(w * numThreads));
+      // For threads past numWords, clamp to 0 so they harmlessly
+      // write to the first word (which will be overwritten by the
+      // actual data store).
+      Value safeIdx = idx;
+      if ((w + 1) * numThreads > numWords) {
+        Value cond = b.icmp_slt(idx, b.i32_val(numWords));
+        safeIdx = b.select(cond, idx, b.i32_val(0));
+      }
+      Value ptr = b.gep(i32PtrTy, i32_ty, smemI32, safeIdx);
+      b.store(zero32, ptr);
+    }
+  }
+
   LogicalResult
   matchAndRewrite(triton::gpu::LocalAllocOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -231,6 +297,15 @@ struct LocalAllocOpConversion
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
     auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, memDescTy.getRank(),
                                       loc, rewriter);
+
+    // swizzle=0 + NPOT contig dim: zero-fill the pow2-rounded padding so WGMMA
+    // can't read garbage from it.
+    if (op.getSrc() && needsZeroFillForNpotPadding(memDescTy)) {
+      emitSmemZeroFill(loc, smemBase, memDescTy, op.getOperation(), rewriter);
+      // Barrier to ensure zero-fill is complete before stores.
+      mlir::gpu::BarrierOp::create(rewriter, loc);
+    }
+
     // If there is an initial tensor, store it into the shared memory.
     if (op.getSrc()) {
       auto *ctx = op.getContext();

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -121,13 +121,13 @@ Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x) {
   SmallVector<int32_t> matrix = flatten(A.getBases().begin()->second);
   assert(matrix.size() == nCol);
 
-  // Dual-path codegen: for NPOT dimensions, use ADD instead of XOR.
+  // Per-dim dispatch: NPOT (single out) dims use ADD+mod, pow2 dims use XOR.
   // We accumulate without intermediate UREM; applyNpotModulo applies it once
   // at the end. This is equivalent to per-step modulo because for non-negative
   // integers: (a1+...+ak) mod N = (...((a1+a2) mod N)+a3) mod N...+ak) mod N.
   // No i32 overflow: nCol <= ~20 (register+lane+warp+block bits) and each
   // basisValue < 2*outDimSize, so max sum < 2^25 for any practical dim.
-  if (A.isModular()) {
+  if (A.isOutDimModular(*A.getOutDimNames().begin())) {
     // Fast-path: identity bases [1, 2, 4, ...] → single AND mask.
     // Stride-1 modular layouts always have identity bases, so this eliminates
     // the select+add loop (28 ops for N=127 → 1 AND).
@@ -366,6 +366,8 @@ applyNpotModulo(TritonLLVMOpBuilder &b, const LinearLayout &layout,
         outIdx = smallModulo(b, outIdx, outDimSize);
       else
         outIdx = barrettModulo(b, outIdx, outDimSize);
+    } else {
+      outIdx = b.and_(outIdx, b.i32_val(outDimSize - 1));
     }
   }
 }
@@ -692,6 +694,7 @@ uint32_t applyPadding(uint32_t baseOffset,
 static std::optional<LinearLayout::BasesT>
 tryReduceBasesModN(const LinearLayout &cvt, int32_t N) {
   LinearLayout::BasesT reducedBases;
+  bool npotN = !llvm::isPowerOf2_32(N);
   int32_t xorSeen = 0;
   for (auto &[inDim, inDimBases] : cvt.getBases()) {
     auto &newBases = reducedBases[inDim];
@@ -701,49 +704,20 @@ tryReduceBasesModN(const LinearLayout &cvt, int32_t N) {
       newBases.push_back({val});
       if (val == 0)
         continue;
-      if (!llvm::isPowerOf2_32(val) || (val & xorSeen) != 0)
-        return std::nullopt;
-      xorSeen |= val;
+      // For NPOT N, codegen uses ADD+mod (not XOR), so all reduced values
+      // in [0, N) are valid — skip XOR-soundness checks.
+      if (!npotN) {
+        if (!llvm::isPowerOf2_32(val) || (val & xorSeen) != 0) {
+          return std::nullopt;
+        }
+        xorSeen |= val;
+      }
     }
   }
-  if (xorSeen >= N)
+  if (!npotN && xorSeen >= N) {
     return std::nullopt;
-  return reducedBases;
-}
-
-// `cvt` is a register/lane/warp -> kOffset layout. `smem` is the optimal
-// SMEM layout — its total output dim product is the effective size N.
-static LinearLayout applyNpotKernelFix(const LinearLayout &cvt,
-                                       const LinearLayout &smem) {
-  if (!smem.isModular() || cvt.getNumOutDims() != 1)
-    return cvt;
-  int64_t effectiveSize = smem.getTotalOutDimSizeProduct();
-  int64_t currentSize = cvt.getOutDimSize(*cvt.getOutDimNames().begin());
-  if (effectiveSize >= currentSize)
-    return cvt;
-
-  StringAttr outDim = *cvt.getOutDimNames().begin();
-  int32_t N = static_cast<int32_t>(effectiveSize);
-
-  auto reducedOpt = tryReduceBasesModN(cvt, N);
-  if (!reducedOpt)
-    return cvt;
-
-  // Verify A(x) = A(x mod N) for all x. Bound is the input-dim element count
-  // (reg*lane*warp*block), always pow2 and well under 2^31, so x can't
-  // overflow. O(inDimSize) compile-time check; bails to the unfolded cvt if it
-  // fails.
-  auto smemFlat = smem.flattenIns();
-  StringAttr smemIn = *smemFlat.getInDimNames().begin();
-  for (int x = N; x < smemFlat.getTotalInDimSize(); x++) {
-    auto orig = smemFlat.apply({{smemIn, x}});
-    auto reduced = smemFlat.apply({{smemIn, x % N}});
-    if (orig != reduced)
-      return cvt;
   }
-
-  return LinearLayout(std::move(*reducedOpt), {{outDim, N}},
-                      /*requireSurjective=*/false);
+  return reducedBases;
 }
 
 LinearLayout applyNpotUremFold(const LinearLayout &cvt, int64_t effectiveSize) {
@@ -788,8 +762,8 @@ SmallVector<Value> runNpotFallback(
   // NPOT kernel equivalence: fold redundant SMEM offsets so that
   // kernel-equivalent register/lane/warp combos that map to the same
   // logical element collapse to the same SMEM offset.
-  storeCvt = applyNpotKernelFix(storeCvt, smem);
-  loadCvt = applyNpotKernelFix(loadCvt, smem);
+  storeCvt = triton::applyNpotKernelFix(storeCvt, smem);
+  loadCvt = triton::applyNpotKernelFix(loadCvt, smem);
 
   Value affineOffset = b.i32_val(0);
   uint64_t maskSpanAffineOffset = 0;
@@ -897,6 +871,24 @@ SmallVector<Value> lowerLdSt(
   auto kWarp = str_attr("warp");
   auto kOffset = str_attr("offset");
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
+
+  // Unfold modular (NPOT) output dims to pow2 so divideLeft (used by
+  // largestVectorisation and below) can proceed.  NPOT dims (e.g.
+  // offset=3072 for a 64x48 tensor) arise from buildWithNpotReduction in
+  // combineCtaCgaWithShape.  Rounding up preserves the bases and gives each
+  // register position a unique offset; the calcPaddedOffset / urem wrapping
+  // in the caller handles the real NPOT size.
+  if (cvt.isModular()) {
+    SmallVector<std::pair<StringAttr, int32_t>> newOutDims;
+    for (auto [dim, size] : cvt.getOutDims()) {
+      newOutDims.push_back(
+          {dim, llvm::isPowerOf2_32(size)
+                    ? size
+                    : static_cast<int32_t>(llvm::NextPowerOf2(size))});
+    }
+    cvt = LinearLayout(cvt.getBases(), newOutDims,
+                       /*requireSurjective=*/false);
+  }
 
   auto [elemsPerVec, permutation] =
       largestVectorisation(ctx, cvt, bitwidth, maybeMaxVecElems);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -319,12 +319,38 @@ SmallVector<int64_t> getAllocationShapePerCTA(Attribute layout,
       auto packedAxis = getOrder(sharedMMALayout, shapeLogical)[0];
       shape[packedAxis] *= 2;
     }
-    // For NPOT dims (e.g. M=144), nvmmaSharedToLinearLayout rounds to pow2
-    // internally. The allocation must cover the pow2-rounded size so MMA reps
-    // don't read past the buffer.
-    for (auto &d : shape) {
-      if (!llvm::isPowerOf2_64(d))
-        d = llvm::NextPowerOf2(d);
+    // Round NPOT dims to pow2 to match the SMEM layout (prevents OOB).
+    // Exception: the contiguous dim keeps its NPOT size when contigBytes is a
+    // multiple of the swizzle width (it uses modular split-dim phases).
+    int rank = shape.size();
+    bool isTransposed = sharedMMALayout.getTransposed();
+    int contigDim = isTransposed ? 0 : rank - 1;
+    int elemBytes = sharedMMALayout.getElementBitWidth() / 8;
+    int swizzleBytes = sharedMMALayout.getSwizzlingByteWidth();
+    int64_t contigBytes = shape[contigDim] * elemBytes;
+    bool contigHasSplitDim = !llvm::isPowerOf2_64(shape[contigDim]) &&
+                             swizzleBytes > 0 &&
+                             contigBytes % swizzleBytes == 0;
+
+    for (size_t i = 0; i < shape.size(); i++) {
+      if (!llvm::isPowerOf2_64(shape[i])) {
+        if ((int)i == contigDim && contigHasSplitDim) {
+        } else {
+          shape[i] = llvm::NextPowerOf2(shape[i]);
+        }
+      }
+    }
+  }
+  // SwizzledSharedEncodingAttr: the XOR-based swizzle in toLinearLayout creates
+  // basis vectors for each row power-of-2 below the row count. The XOR
+  // composition of these bases spans a pow2-rounded offset space. For NPOT row
+  // dims, the offset space exceeds the NPOT allocation, causing OOB writes.
+  // Round NPOT dims to pow2 to match the swizzle's address range.
+  if (isa<SwizzledSharedEncodingAttr>(layout)) {
+    for (size_t i = 0; i < shape.size(); i++) {
+      if (!llvm::isPowerOf2_64(shape[i])) {
+        shape[i] = llvm::NextPowerOf2(shape[i]);
+      }
     }
   }
   return getShapePerCTA(layout, shape);
@@ -1252,11 +1278,6 @@ LinearLayout LinearEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 
 SmallVector<unsigned>
 LinearEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape) const {
-  // When broadcasting the layout the shape changes, otherwise the shape is
-  // the same as the shape of the tensor
-  // We can either have BroadcastOp with SameOperandsAndResultEncoding, or keep
-  // the invariant that the shape of the LL is that of the tensor
-  // We choose the former for BC
   auto scaledLayout = get(getContext(), toLinearLayout(shape));
   auto kRegister = StringAttr::get(getContext(), "register");
   return scaledLayout.basesPerDim(kRegister, /*skipBroadcast=*/false);

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -246,12 +246,13 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
   }
 
   SmallVector<int64_t> pow2ShapePerCTA(shapePerCTA.size());
-  for (size_t i = 0; i < shapePerCTA.size(); i++)
+  for (size_t i = 0; i < shapePerCTA.size(); i++) {
     if (contigNpotSwizzleOk && (int)i == contigDim) {
       pow2ShapePerCTA[i] = shapePerCTA[i];
     } else {
       pow2ShapePerCTA[i] = roundToPow2(shapePerCTA[i]);
     }
+  }
   SmallVector<int64_t> pow2TmaShape(tmaShape.size());
   for (size_t i = 0; i < tmaShape.size(); i++)
     pow2TmaShape[i] = roundToPow2(tmaShape[i]);
@@ -320,10 +321,124 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
     reshapedLayout = transposeLinearLayout(reshapedLayout, order);
   }
 
-  reshapedLayout = ensureLayoutNotSmallerThan(
-      reshapedLayout, standardOutDimNames(ctx, pow2ShapePerCTA.size()),
-      pow2ShapePerCTA);
-  return combineCtaCgaWithShape(reshapedLayout, cgaLayout, shape);
+  if (contigNpotSwizzleOk) {
+    auto ndOutDimNames = standardOutDimNames(ctx, pow2ShapePerCTA.size());
+    int64_t contigSize = pow2ShapePerCTA[contigDim];
+    int64_t currentContigSize =
+        reshapedLayout.getOutDimSize(ndOutDimNames[contigDim]);
+    if (currentContigSize < contigSize) {
+      assert(contigSize % currentContigSize == 0 &&
+             "NPOT contig dim must be a multiple of the tile size");
+      int32_t numPhases = contigSize / currentContigSize;
+      reshapedLayout *= LinearLayout::modularIdentity1D(
+          numPhases, kOffset, ndOutDimNames[contigDim]);
+    }
+    SmallVector<int64_t> remainingShape(pow2ShapePerCTA);
+    remainingShape[contigDim] =
+        reshapedLayout.getOutDimSize(ndOutDimNames[contigDim]);
+    reshapedLayout = ensureLayoutNotSmallerThan(reshapedLayout, ndOutDimNames,
+                                                remainingShape);
+  } else {
+    reshapedLayout = ensureLayoutNotSmallerThan(
+        reshapedLayout, standardOutDimNames(ctx, pow2ShapePerCTA.size()),
+        pow2ShapePerCTA);
+  }
+  SmallVector<int64_t> effectiveShape(shape.begin(), shape.end());
+  for (int i = 0; i < rank; i++) {
+    if (i != contigDim && !llvm::isPowerOf2_64(effectiveShape[i])) {
+      effectiveShape[i] = llvm::NextPowerOf2(effectiveShape[i]);
+    }
+  }
+  return combineCtaCgaWithShape(reshapedLayout, cgaLayout, effectiveShape);
+}
+
+std::optional<LinearLayout>
+nvmmaSharedToSplitLinearLayout(ArrayRef<int64_t> shape,
+                               NVMMASharedEncodingAttr shared) {
+  MLIRContext *ctx = shared.getContext();
+  int rank = shape.size();
+  if (rank != 2) {
+    return std::nullopt;
+  }
+
+  int swizzleBytes = shared.getSwizzlingByteWidth();
+  if (swizzleBytes == 0) {
+    return std::nullopt;
+  }
+
+  auto shapePerCTA = getShapePerCTA(shared, shape);
+  int elemBitWidth = shared.getElementBitWidth();
+  int elemBytes = elemBitWidth / 8;
+  bool isTransposed = shared.getTransposed();
+  int contigDim = isTransposed ? 0 : rank - 1;
+
+  // Only applies when the contiguous dim is NPOT and swizzle-compatible.
+  if (llvm::isPowerOf2_64(shapePerCTA[contigDim])) {
+    return std::nullopt;
+  }
+  int64_t contigBytes = shapePerCTA[contigDim] * elemBytes;
+  if (contigBytes % swizzleBytes != 0) {
+    return std::nullopt;
+  }
+
+  // Build the core tile in the 2D collapsed space.
+  // getCoreMatrixLinearLayout always produces dim0=rows(8), dim1=tileCols.
+  auto coreTile = getCoreMatrixLinearLayout(shared, /*disableSwizzle=*/false);
+  auto kOffset = S("offset");
+  auto coreOutDims = standardOutDimNames(ctx, 2);
+  auto kRow2D = coreOutDims[0]; // "dim0"
+  auto kCol2D = coreOutDims[1]; // "dim1"
+  int tileRows = coreTile.getOutDimSize(kRow2D);
+  int tileCols = coreTile.getOutDimSize(kCol2D);
+
+  // Rename dim1 -> contig_intra to separate from phase dim.
+  auto kIntra = S("contig_intra");
+  auto kPhase = S("contig_phase");
+  {
+    auto bases = coreTile.getBases();
+    SmallVector<std::pair<StringAttr, int32_t>> newOutDims;
+    for (auto [name, size] : coreTile.getOutDims()) {
+      newOutDims.push_back({name == kCol2D ? kIntra : name, size});
+    }
+    coreTile = LinearLayout(std::move(bases), newOutDims,
+                            /*requireSurjective=*/false);
+  }
+
+  // Compute collapsed 2D shape following the same logic as
+  // nvmmaSharedToLinearLayout.
+  auto tmaShape = triton::nvidia_gpu::getTMABlockShape(
+      shared, shapePerCTA, /*packedSize=*/true, gpu::TMAMode::Tiled);
+  auto roundToPow2 = [](int64_t v) -> int64_t {
+    return llvm::isPowerOf2_64(v) ? v : llvm::NextPowerOf2(v);
+  };
+  SmallVector<int64_t> pow2TmaShape(tmaShape.size());
+  for (size_t i = 0; i < tmaShape.size(); i++) {
+    pow2TmaShape[i] = roundToPow2(tmaShape[i]);
+  }
+
+  std::array<int64_t, 2> collapsedTmaShape{1, pow2TmaShape.back()};
+  for (int i = 0; i + 1 < rank; i++) {
+    collapsedTmaShape[0] *= pow2TmaShape[i];
+  }
+  if (isTransposed) {
+    std::swap(collapsedTmaShape[0], collapsedTmaShape[1]);
+  }
+
+  // Extend rows (dim0) to match collapsedTmaShape[0].
+  if (collapsedTmaShape[0] > tileRows) {
+    int64_t ratio = collapsedTmaShape[0] / tileRows;
+    assert(llvm::isPowerOf2_64(ratio));
+    coreTile *= LinearLayout::identity1D(ratio, kOffset, kRow2D);
+  }
+
+  // Add NPOT phase dim instead of extending the contiguous dim.
+  int64_t contigSize = shapePerCTA[contigDim];
+  int32_t numPhases = contigSize / tileCols;
+  assert(numPhases > 1 && "Should have been caught by isPowerOf2 check");
+  coreTile *= LinearLayout::modularIdentity1D(numPhases, kOffset, kPhase);
+
+  // Result has output dims: (dim0, contig_intra, contig_phase)
+  return coreTile;
 }
 
 /// Function to generate lane and warp layout for dot operands.
@@ -936,7 +1051,15 @@ LinearLayout fmaDotToLinearLayout(DotOperandEncodingAttr operandLayout,
   SmallVector<StringAttr> repDimNames =
       permuteDimNames(standardOutDimNames(ctx, rank), repOrder);
 
-  auto registersLayout = identityStandardND(kReg, threadSize, regOrder);
+  // Round NPOT thread sizes (e.g. K=48) up to pow2; combineCtaCgaWithShape
+  // applies the modular reduction for the real shape.
+  SmallVector<unsigned> pow2ThreadSize(threadSize.begin(), threadSize.end());
+  for (auto &s : pow2ThreadSize) {
+    if (!llvm::isPowerOf2_32(s)) {
+      s = llvm::NextPowerOf2(s);
+    }
+  }
+  auto registersLayout = identityStandardND(kReg, pow2ThreadSize, regOrder);
   auto lanesLayout = broadcastedDotOperandLayout(ctx, threadShape, threadOrder,
                                                  kDimIdx, kLane);
   auto warpsLayout =
@@ -1207,37 +1330,29 @@ LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,
   auto blockM = encoding.getBlockM();
   auto blockN = std::min<int32_t>(encoding.getBlockN(), shape[1]);
   assert(blockM == 64 || blockM == 128);
+
   LinearLayout tile =
       LinearLayout::zeros1D(encoding.getColStride(), kCol, dims[1]);
   if (blockM == 64) {
-    // BlockM=64(per CTA) in 2cta mode has special layouts for both LHS (A) and
-    // RHS (D)
-    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-data-path-layout-b
     if (encoding.getCtaMode() ==
         triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_LHS) {
-      // This applies to all TMEM encoding in 2cta_m64 except accumulator of MMA
       tile *= LinearLayout::identity1D(blockM, kRow, dims[0]) *
               LinearLayout::identity1D(blockN, kCol, dims[1]);
       tile *= LinearLayout::zeros1D(2, kRow, dims[0]);
-
     } else if (encoding.getCtaMode() ==
                triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_RHS) {
-      // This applies to TMEM encoding in 2cta_m64 accumulator of MMA
       tile = LinearLayout::identity1D(blockM, kRow, dims[0]) *
              LinearLayout::identity1D(blockN / 2, kCol, dims[1]);
-      // row 64~127 stores the right half of the logical tensor (D[0:64, N/2:N])
       tile *= LinearLayout::identity1D(2, kRow, dims[1]);
     } else {
-      // non 2cta_m64 cases
       tile *= LinearLayout::identity1D(16, kRow, dims[0]) *
               LinearLayout::identity1D(blockN, kCol, dims[1]);
       auto bases = tile.getBases();
       if (shape[0] > blockM) {
         bases[kRow].push_back({64, 0});
       } else if (shape[1] > blockN) {
-        bases[kRow].push_back({0, blockN});
+        bases[kRow].push_back({0, static_cast<int32_t>(blockN)});
       } else {
-        // Empty, meaning the element is not defined
         bases[kRow].push_back({0, 0});
       }
       bases[kRow].push_back({16, 0});
@@ -1329,11 +1444,16 @@ LinearLayout TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape,
   if (auto distributed = dyn_cast<DistributedEncodingTrait>(layout)) {
     result = distributed.toLinearLayout(shape);
   } else {
-    // NVMMASharedEncodingAttr and TensorMemoryScalesEncodingAttr may have NPOT
-    // shapes (e.g. M=144, K=96). The layout construction rounds to pow2
-    // internally and combineCtaCgaWithShape applies modular reduction.
+    // NVMMASharedEncodingAttr, TensorMemoryScalesEncodingAttr, and
+    // TensorMemoryEncodingAttr may have NPOT shapes (e.g. M=144, K=96,
+    // blockN=96). The layout construction rounds to pow2 internally
+    // (modularIdentity1D for TMEM, ensureLayoutNotLargerThan for SMEM)
+    // and combineCtaCgaWithShape / applyNpotReductionForTmem applies
+    // modular reduction.
     if (!isa<TensorMemoryScalesEncodingAttr>(layout) &&
-        !isa<NVMMASharedEncodingAttr>(layout)) {
+        !isa<NVMMASharedEncodingAttr>(layout) &&
+        !isa<SwizzledSharedEncodingAttr>(layout) &&
+        !isa<TensorMemoryEncodingAttr>(layout)) {
       assert(llvm::all_of(shape,
                           [](int64_t dim) {
                             return llvm::isPowerOf2_32(dim) && dim >= 1;
@@ -1439,10 +1559,17 @@ LinearLayout combineCtaCgaWithShape(LinearLayout ctaLayout,
 
   // For NPOT shapes, round ctaShape up to pow2 so that
   // ensureLayoutNot{Smaller,Larger}Than's divisibility assumptions hold.
+  // Exception: keep an NPOT size the ctaLayout already matches (from modular
+  // phase extension) to avoid double pow2-extend + mod.
   llvm::SmallDenseMap<StringAttr, int64_t> pow2CtaShape;
   for (auto [dim, size] : ctaShape) {
-    pow2CtaShape[dim] =
-        llvm::isPowerOf2_64(size) ? size : llvm::NextPowerOf2(size);
+    if (!llvm::isPowerOf2_64(size) && ctaLayout.hasOutDim(dim) &&
+        ctaLayout.getOutDimSize(dim) == size) {
+      pow2CtaShape[dim] = size;
+    } else {
+      pow2CtaShape[dim] =
+          llvm::isPowerOf2_64(size) ? size : llvm::NextPowerOf2(size);
+    }
   }
 
   ctaLayout = ensureLayoutNotSmallerThan(ctaLayout, pow2CtaShape);

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -96,20 +96,17 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
   if (shape.empty()) {
     return emitError() << "rank 0 memdesc is not allowed";
   }
-  // The allocation shape determines the physical layout, and every dimension
-  // but the first (to allow for pipelining) must be a power of 2. Exemptions:
-  //  - NVMMASharedEncodingAttr: NPOT shapes (e.g. M=144, K=96) are valid;
-  //    getAllocationShapePerCTA rounds to pow2 for physical allocation.
-  //  - TMEM scale encodings: K=96 mxf4nvf4 produces NPOT scale columns.
-  if (!isa<nvidia_gpu::TensorMemoryScalesEncodingAttr>(encoding) &&
-      !isa<nvidia_gpu::TensorMemoryEncodingAttr>(encoding) &&
-      !isa<NVMMASharedEncodingAttr>(encoding) &&
-      !llvm::all_of(allocShape.drop_front(1), [](int64_t dim) {
-        return llvm::isPowerOf2_64(dim) && dim > 0;
+  bool allowNpot = isa<gpu::NVMMASharedEncodingAttr>(encoding) ||
+                   isa<gpu::SwizzledSharedEncodingAttr>(encoding) ||
+                   isa<nvidia_gpu::TensorMemoryEncodingAttr>(encoding) ||
+                   isa<nvidia_gpu::TensorMemoryScalesEncodingAttr>(encoding) ||
+                   isa<gpu::LinearEncodingAttr>(encoding);
+  if (!llvm::all_of(shape.drop_front(1), [&](int64_t dim) {
+        return dim > 0 && (allowNpot || llvm::isPowerOf2_64(dim));
       }))
     return emitError()
-           << "allocShape must have power-of-2 and non-zero dimensions; got "
-           << allocShape;
+           << "shape must have power-of-2 and non-zero dimensions; got "
+           << shape;
   if (shape.front() == 0)
     return emitError() << "shape has 0 dimension";
   if (allocShape.size() < shape.size())
@@ -137,11 +134,13 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     }
     shape = shape.take_back(2);
     allocShape = allocShape.take_back(2);
-    if (allocShape[0] < enc.getBlockM() * enc.getCTASplitM() ||
-        allocShape[1] < enc.getBlockN() * enc.getCTASplitN()) {
-      return emitError() << "the allocation shape must be at least "
-                         << enc.getBlockM() * enc.getCTASplitM() << "x"
-                         << enc.getBlockN() * enc.getCTASplitN() << ". Got "
+    // For TMEM, blockN is a physical-block upper bound (make_default clamps it
+    // to HW min 8; LL conversion clips via min(blockN, shape[1])), so
+    // allocShape may be smaller (e.g. (128,1) for FA). Enforce only blockM
+    // here.
+    if (allocShape[0] < enc.getBlockM() * enc.getCTASplitM()) {
+      return emitError() << "the allocation shape's first dim must be at least "
+                         << enc.getBlockM() * enc.getCTASplitM() << ". Got "
                          << allocShape;
     }
     auto ll = toLinearLayout(allocShape, enc);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -207,8 +207,6 @@ getSharedMemoryMMAOperand(Value v, mlir::PatternRewriter &rewriter, int opIdx,
   auto newLayout = NVMMASharedEncodingAttr::get(
       argType.getContext(), argType.getShape(), newOrder, CGALayout,
       argType.getElementType(), isMMAv5Fp4Padded);
-  // For NPOT dims (e.g. M=144), getAllocationShapePerCTA rounds to pow2
-  // so the SMEM allocation covers all MMA reps. No allocShape padding needed.
   auto newType = MemDescType::get(argType.getShape(), argType.getElementType(),
                                   newLayout, SharedMemorySpace);
   rewriter.setInsertionPointAfterValue(arg);

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -58,11 +58,24 @@ public:
     auto newLl =
         transposeLinearLayout(oldCGALayout.getLinearLayout(), trans.getOrder());
     auto newCGALayout = CGAEncodingAttr::get(ctx, std::move(newLl));
-    auto newInnerCvtEnc =
-        SwizzledSharedEncodingAttr::get(ctx, cvtEncoding, srcTy.getShape(),
-                                        /*order=*/getOrderForMemory(srcTy),
-                                        newCGALayout, srcTy.getElementType(),
-                                        /*needTrans=*/true);
+    // NPOT on SM90+: use NVMMAShared (SwizzledShared's XOR-coupled bases are
+    // incompatible with the modular solver).
+    Attribute newInnerCvtEnc;
+    auto mod = cvtOp->getParentOfType<ModuleOp>();
+    int cc = getNVIDIAComputeCapability(mod);
+    bool isNpot = hasNpotShape(srcTy);
+    if (isNpot && !npotSafeForLinearLayout(cvtEncoding.getParent())) {
+      return failure();
+    }
+    if (cc >= 90 && isNpot) {
+      newInnerCvtEnc = NVMMASharedEncodingAttr::get(
+          ctx, srcTy.getShape(), getOrderForMemory(srcTy), newCGALayout,
+          srcTy.getElementType(), /*fp4Padded=*/false);
+    } else {
+      newInnerCvtEnc = SwizzledSharedEncodingAttr::get(
+          ctx, cvtEncoding, srcTy.getShape(), getOrderForMemory(srcTy),
+          newCGALayout, srcTy.getElementType(), /*needTrans=*/true);
+    }
     if (newInnerCvtEnc == cvtEncoding)
       return failure();
     rewriter.setInsertionPoint(trans);

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -17,6 +17,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 namespace mlir {
 namespace triton {
@@ -42,16 +43,42 @@ public:
           dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
       if (!dstDotOp)
         return;
+      bool isNpot = hasNpotShape(dstType) || hasNpotShape(srcType);
+      // Guard NPOT shapes before cvtNeedsSharedMemory, which calls
+      // toLinearLayout and may crash on encodings that don't handle NPOT.
+      if (isNpot && !npotSafeForLinearLayout(dstDotOp.getParent())) {
+        return;
+      }
       if (!cvtNeedsSharedMemory(srcType, dstType))
         return;
       auto order = getOrderForMemory(srcType);
       auto sharedMemorySpace =
           triton::gpu::SharedMemorySpaceAttr::get(srcType.getContext());
+      auto CGALayout = triton::gpu::getCGALayout(srcEncoding);
+      Attribute sharedEnc;
+      auto parentMma =
+          dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(dstDotOp.getParent());
+      bool isMMAv3Plus = parentMma && parentMma.getVersionMajor() >= 3;
+      // Only query compute capability on the NVIDIA-MMA branch:
+      // getNVIDIAComputeCapability is invalid on HIP modules (this pass also
+      // runs in the AMD pipeline).
+      bool isNpotNvidiaMMAv3Plus =
+          isNpot && isMMAv3Plus && getNVIDIAComputeCapability(mod) >= 90;
+      if (isNpotNvidiaMMAv3Plus) {
+        sharedEnc = triton::gpu::NVMMASharedEncodingAttr::get(
+            mod.getContext(), srcType.getShape(), order, CGALayout,
+            srcType.getElementType(), /*fp4Padded=*/false);
+      } else if (isNpot) {
+        sharedEnc = triton::gpu::SwizzledSharedEncodingAttr::get(
+            mod.getContext(), dstDotOp, srcType.getShape(), order, CGALayout,
+            srcType.getElementType());
+      } else {
+        sharedEnc = triton::gpu::SwizzledSharedEncodingAttr::get(
+            mod.getContext(), dstDotOp, srcType.getShape(), order, CGALayout,
+            srcType.getElementType());
+      }
       auto tmpType = triton::gpu::MemDescType::get(
-          dstType.getShape(), dstType.getElementType(),
-          triton::gpu::SwizzledSharedEncodingAttr::get(
-              mod.getContext(), dstDotOp, srcType.getShape(), order,
-              triton::gpu::getCGALayout(srcEncoding), srcType.getElementType()),
+          dstType.getShape(), dstType.getElementType(), sharedEnc,
           sharedMemorySpace);
       auto tmp = triton::gpu::LocalAllocOp::create(builder, cvtOp.getLoc(),
                                                    tmpType, cvtOp.getSrc());

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -500,6 +500,14 @@ static unsigned estimateConvertScratchCost(Value value, Attribute encoding) {
     if (encTrait && srcTy.getRank() != encTrait.getRank())
       continue;
     auto dstTy = srcTy.cloneWithEncoding(encoding);
+    // Guard NPOT shapes before cvtNeedsSharedMemory, which calls
+    // toLinearLayout and may crash on encodings that don't handle NPOT.
+    if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+      if (!npotSafeForLinearLayout(srcTy.getEncoding()) ||
+          !npotSafeForLinearLayout(dstTy.getEncoding())) {
+        continue;
+      }
+    }
     if (cvtNeedsSharedMemory(srcTy, dstTy)) {
       unsigned elems = getNumScratchElemsSwizzledCvt(srcTy, dstTy);
       cost += elems * getElementBitWidth(srcTy) / 8;
@@ -2035,6 +2043,14 @@ public:
       funcOp->walk([&](ConvertLayoutOp cvt) {
         auto srcTy = cvt.getSrc().getType();
         auto dstTy = cvt.getType();
+        // Guard NPOT shapes before cvtNeedsSharedMemory, which calls
+        // toLinearLayout and may crash on encodings that don't handle NPOT.
+        if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+          if (!npotSafeForLinearLayout(srcTy.getEncoding()) ||
+              !npotSafeForLinearLayout(dstTy.getEncoding())) {
+            return;
+          }
+        }
         if (!cvtNeedsSharedMemory(srcTy, dstTy))
           return;
         unsigned scratchBytes = getNumScratchElemsSwizzledCvt(srcTy, dstTy) *

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -40,9 +40,12 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
     return ret;
   } else if (version == 3) {
     unsigned k = 256 / eltType.getIntOrFloatBitWidth();
-    if (shape[0] % 64 != 0 || shape[1] % 8 != 0) {
-      assert(false && "type not supported");
-      return {0, 0, 0};
+    // Pow2 M requires M%64; NPOT M only requires M%16.
+    bool mOkV3 = llvm::isPowerOf2_64(shape[0]) ? (shape[0] % 64 == 0)
+                                               : (shape[0] % 16 == 0);
+    if (!mOkV3 || shape[1] % 8 != 0) {
+      llvm::report_fatal_error("MMAv3 instrShape: M must be divisible by 64 "
+                               "(pow2) or 16 (NPOT), and N by 8");
     }
     SmallVector<unsigned> validN;
 
@@ -61,7 +64,11 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
     }
 
     unsigned m = 16;
-    unsigned mWarps = std::max<unsigned>(shape[0] / m, 1);
+    // Cap mWarps by numWarps only for NPOT M; pow2 M uses uncapped tiling.
+    unsigned mWarps =
+        llvm::isPowerOf2_64(shape[0])
+            ? std::max<unsigned>(shape[0] / m, 1)
+            : std::min<unsigned>(std::max<unsigned>(shape[0] / m, 1), numWarps);
     unsigned nWarps = std::max<unsigned>(numWarps / mWarps, 1);
     unsigned maxN = std::max<unsigned>(shape[1] / nWarps, 8);
     for (auto n : validN) {
@@ -70,10 +77,8 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
       }
     }
 
-    // Fail loudly: an opt build skips the assert and returns {0,0,0}, causing
-    // silent div-by-zero/garbage downstream.
     llvm::report_fatal_error(
-        "MMAv3 instrShape: no valid instrN found for the given BLOCK_N/dtype");
+        "MMAv3 instrShape: no valid N found for the given shape/warps");
   } else if (version == 5) {
     unsigned m = shape[0] >= 128 ? 128 : 64;
     unsigned k = 256 / eltType.getIntOrFloatBitWidth();
@@ -162,13 +167,31 @@ bool isView(Operation *op) {
   return isa<ExpandDimsOp, ReshapeOp, TransOp, JoinOp, SplitOp>(op);
 }
 
+static bool hasNpotMmaEncoding(RankedTensorType ty) {
+  auto enc = ty.getEncoding();
+  if (isa<ttg::NvidiaMmaEncodingAttr>(enc)) {
+    return true;
+  }
+  if (auto dot = dyn_cast<ttg::DotOperandEncodingAttr>(enc)) {
+    return isa<ttg::NvidiaMmaEncodingAttr>(dot.getParent());
+  }
+  return false;
+}
+
 bool isNoop(Operation *op) {
   if (isa<ReshapeOp, TransOp>(op))
     return true;
   if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    auto srcTy = cvt.getSrc().getType();
+    auto dstTy = cvt.getResult().getType();
+    // NPOT + MMA: skip minimalCvtLayout (modular solver may not terminate);
+    // treat as not-a-noop.
+    if ((hasNpotShape(srcTy) || hasNpotShape(dstTy)) &&
+        (hasNpotMmaEncoding(srcTy) || hasNpotMmaEncoding(dstTy))) {
+      return false;
+    }
     // The conversion op is a noop if the conversion layout is trivial
-    return minimalCvtLayout(cvt.getSrc().getType(),
-                            cvt.getResult().getType()) == LinearLayout::empty();
+    return minimalCvtLayout(srcTy, dstTy) == LinearLayout::empty();
   }
   return false;
 }
@@ -440,7 +463,9 @@ static Attribute inferDstEncoding(triton::gpu::Fp4ToFpOp op, Attribute srcEnc) {
           .getRegisteredInterface<triton::DialectInferLayoutInterface>()
           ->inferFp4ToFpOpEncoding(shape, op.getAxis(), srcEnc, dstEnc,
                                    /*fwdInference*/ true, std::nullopt);
-  assert(succeeded(result));
+  if (failed(result)) {
+    return {};
+  }
   return dstEnc;
 }
 
@@ -492,7 +517,9 @@ static Attribute inferReshapeOpDstEncoding(ArrayRef<int64_t> srcShape,
           .getRegisteredInterface<triton::DialectInferLayoutInterface>()
           ->inferReshapeOpEncoding(srcShape, srcEnc, dstShape, dstEnc,
                                    /*loc=*/std::nullopt);
-  assert(succeeded(result));
+  if (failed(result)) {
+    return {};
+  }
   return dstEnc;
 }
 
@@ -884,8 +911,17 @@ static bool isFreeConvert(Operation *op) {
   auto convertOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op);
   if (!convertOp)
     return false;
-  return cvtReordersRegisters(convertOp.getSrc().getType(),
-                              convertOp.getType());
+  // NPOT-unsafe encodings: cvtReordersRegisters' toLinearLayout may crash, so
+  // return false (not free).
+  auto srcTy = convertOp.getSrc().getType();
+  auto dstTy = convertOp.getType();
+  if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+    if (!npotSafeForLinearLayout(srcTy.getEncoding()) ||
+        !npotSafeForLinearLayout(dstTy.getEncoding())) {
+      return false;
+    }
+  }
+  return cvtReordersRegisters(srcTy, dstTy);
 }
 
 LogicalResult getConvertBackwardSlice(
@@ -1148,7 +1184,9 @@ swizzleDotOperandLike(RankedTensorType type, ttg::CGAEncodingAttr cgaLayout) {
   // 2, ...]
   auto repOrder = to_vector(llvm::seq<unsigned>(rank));
   auto tile = ttg::nvidiaMmaTile(ctx, microtileShape, kWidth, order, repOrder);
-  if (!divideLeft(layout.getLinearLayout(), tile).has_value()) {
+  // divideLeft does not support modular (NPOT) layouts; skip the swizzle probe.
+  if (layout.getLinearLayout().isModular() ||
+      !divideLeft(layout.getLinearLayout(), tile).has_value()) {
     return {};
   }
   return ttg::SwizzledSharedEncodingAttr::get(
@@ -1193,6 +1231,12 @@ getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible) {
 
       if (auto dot =
               dyn_cast<ttg::DotOperandEncodingAttr>(dstTy.getEncoding())) {
+        bool isNpot = llvm::any_of(srcTy.getShape(), [](int64_t d) {
+          return d > 0 && !llvm::isPowerOf2_64(d);
+        });
+        if (isNpot && !npotSafeForLinearLayout(dot.getParent())) {
+          return std::nullopt;
+        }
         auto order = getOrderForMemory(srcTy);
         unsigned bitWidth = srcTy.getElementTypeBitWidth();
         tempAttr = ttg::SwizzledSharedEncodingAttr::get(

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -115,8 +115,14 @@ LogicalResult WarpGroupDotOp::verify() {
   int rank = retShapePerCTA.size();
   if (rank != 2)
     return emitOpError("WGMMA result shape must be 2D");
-  if (retShapePerCTA[0] % 64 != 0)
-    return emitOpError("WGMMA result M dimension must be divisible by 64");
+  // Pow2 M requires M%64; NPOT M only requires M%16.
+  bool mOkWgmma = llvm::isPowerOf2_64(retShapePerCTA[0])
+                      ? (retShapePerCTA[0] % 64 == 0)
+                      : (retShapePerCTA[0] % 16 == 0);
+  if (!mOkWgmma) {
+    return emitOpError(
+        "WGMMA result M dimension must be divisible by 64 (pow2) or 16 (NPOT)");
+  }
   if (retShapePerCTA[1] % 8 != 0)
     return emitOpError("WGMMA result N dimension must be divisible by 8");
 

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -541,12 +541,38 @@ std::optional<LinearLayout> getReps(const LinearLayout &cvt,
     std::vector<std::vector<int32_t>> basesForDim;
     basesForDim.reserve(inA);
 
-    // 1) Validate the starting bases match exactly.
-    for (int i = 0; i < inB; ++i) {
+    // 1) Validate cvt and tile define the same function on [0, 2^inB) by
+    //    functional evaluation (NPOT layouts from lstsqModular can have
+    //    different bases than GF(2) lstsq yet define the same function).
+    //    NPOT dims combine via ADD+mod, pow2 dims via XOR.
+    for (int x = 0; x < (1 << inB); ++x) {
       for (StringAttr od : cvt.getOutDimNames()) {
-        int a = cvt.getBasis(id, i, od);
-        int b = tile.getBasis(id, i, od);
-        if (a != b) {
+        // Compute cvt's output for input x on dimension id.
+        int32_t cvtOut = 0;
+        bool odIsModular = cvt.isOutDimModular(od);
+        for (int bit = 0; bit < inB; ++bit) {
+          if (x & (1 << bit)) {
+            if (odIsModular) {
+              cvtOut =
+                  (cvtOut + cvt.getBasis(id, bit, od)) % cvt.getOutDimSize(od);
+            } else {
+              cvtOut ^= cvt.getBasis(id, bit, od);
+            }
+          }
+        }
+        // Compute tile's output for input x on dimension id.
+        // The tile is always GF(2) (it's the core swizzle tile), so
+        // we always use XOR. If tile doesn't have this out-dim,
+        // the expected output is 0.
+        int32_t tileOut = 0;
+        if (tile.hasOutDim(od)) {
+          for (int bit = 0; bit < inB; ++bit) {
+            if (x & (1 << bit)) {
+              tileOut ^= tile.getBasis(id, bit, od);
+            }
+          }
+        }
+        if (cvtOut != tileOut) {
           return std::nullopt;
         }
       }
@@ -623,6 +649,233 @@ bool splitContiguousDim(int64_t tileCols, int64_t numPhases, int contigDim,
 
   smemLayout = smemLayout.reshapeOuts(newOutDims);
   otherLayout = otherLayout.reshapeOuts(newOutDims);
+  return true;
+}
+
+LinearLayout unfoldModularDimsForAlloc(const LinearLayout &layout) {
+  if (!layout.isModular()) {
+    return layout;
+  }
+  SmallVector<std::pair<StringAttr, int32_t>> newOutDims;
+  bool changed = false;
+  for (auto [dim, size] : layout.getOutDims()) {
+    if (!llvm::isPowerOf2_32(size)) {
+      newOutDims.push_back({dim, llvm::NextPowerOf2(size - 1)});
+      changed = true;
+    } else {
+      newOutDims.push_back({dim, size});
+    }
+  }
+  if (!changed) {
+    return layout;
+  }
+  return LinearLayout(layout.getBases(), newOutDims,
+                      /*requireSurjective=*/false);
+}
+
+// Reduce each basis of `cvt` modulo N. Returns the reduced bases iff folding
+// is sound for emission as a pow2-rounded layout where outputs combine via
+// XOR. Soundness requires three things:
+//   1. Every reduced basis is a power of 2 or zero (so XOR acts on disjoint
+//      single-bit values).
+//   2. Distinct non-zero reduced bases share no bits -- without this XOR
+//      diverges from ADD, e.g. XOR(16, 16) = 0 vs ADD(16, 16) = 32.
+//   3. The XOR-sum of all bases stays strictly below N.
+// Returns std::nullopt when any condition fails.
+static std::optional<LinearLayout::BasesT>
+tryReduceBasesModN(const LinearLayout &cvt, int32_t N) {
+  LinearLayout::BasesT reducedBases;
+  int32_t xorSeen = 0;
+  for (auto &[inDim, inDimBases] : cvt.getBases()) {
+    auto &newBases = reducedBases[inDim];
+    for (auto &basis : inDimBases) {
+      assert(basis.size() == 1);
+      int32_t val = basis[0] % N;
+      newBases.push_back({val});
+      if (val == 0) {
+        continue;
+      }
+      if (!llvm::isPowerOf2_32(val) || (val & xorSeen) != 0) {
+        return std::nullopt;
+      }
+      xorSeen |= val;
+    }
+  }
+  if (xorSeen >= N) {
+    return std::nullopt;
+  }
+  return reducedBases;
+}
+
+LinearLayout applyNpotKernelFix(const LinearLayout &cvt,
+                                const LinearLayout &smem) {
+  if (!smem.isModular() || cvt.getNumOutDims() != 1) {
+    return cvt;
+  }
+  int64_t effectiveSize = smem.getTotalOutDimSizeProduct();
+  int64_t currentSize = cvt.getOutDimSize(*cvt.getOutDimNames().begin());
+  if (effectiveSize >= currentSize) {
+    return cvt;
+  }
+
+  StringAttr outDim = *cvt.getOutDimNames().begin();
+  int32_t N = static_cast<int32_t>(effectiveSize);
+
+  auto reducedOpt = tryReduceBasesModN(cvt, N);
+  if (!reducedOpt) {
+    return cvt;
+  }
+
+  // Verify A(x) = A(x mod N) for all x. The fold is unsound otherwise.
+  auto smemFlat = smem.flattenIns();
+  StringAttr smemIn = *smemFlat.getInDimNames().begin();
+  for (int x = N; x < smemFlat.getTotalInDimSize(); x++) {
+    auto orig = smemFlat.apply({{smemIn, x}});
+    auto reduced = smemFlat.apply({{smemIn, x % N}});
+    if (orig != reduced) {
+      return cvt;
+    }
+  }
+
+  return LinearLayout(std::move(*reducedOpt), {{outDim, N}},
+                      /*requireSurjective=*/false);
+}
+
+llvm::DenseMap<int, int> computeDeadPositionMap(const LinearLayout &srcLayout,
+                                                StringAttr kPosition,
+                                                StringAttr kLane,
+                                                StringAttr kWarp) {
+  DenseMap<int, int> deadToCanonical;
+  if (!srcLayout.isModular()) {
+    return deadToCanonical;
+  }
+
+  // Collect NPOT output dims and their indices within the output vector.
+  SmallVector<std::pair<int, int32_t>> npotDimIndices; // (outDimIdx, origSize)
+  int outIdx = 0;
+  for (auto [dim, size] : srcLayout.getOutDims()) {
+    if (!llvm::isPowerOf2_32(size)) {
+      npotDimIndices.push_back({outIdx, size});
+    }
+    outIdx++;
+  }
+  if (npotDimIndices.empty()) {
+    return deadToCanonical;
+  }
+
+  // We fix up "phantom" register positions: register combinations whose
+  // register-only NPOT coordinate R lands in the pow2 padding [N, P). These
+  // arise when the register-rep count along an NPOT output dim is itself NPOT
+  // (the register dimension is padded to the next pow2). The canonical
+  // counterpart is the register combination, at the SAME {lane, warp},
+  // producing R mod N.
+  //
+  // This per-register fixup is sound even when lane/warp ALSO contribute to
+  // the NPOT dim, because the dim is modular: for any (lane, warp)
+  // contribution L,
+  //   (R + L) mod N == ((R mod N) + L) mod N,
+  // so the dead and canonical register positions denote the same logical
+  // element for EVERY thread. We therefore do NOT bail when lane/warp touch
+  // the NPOT dim. We only emit a fixup entry when a register-only canonical
+  // actually exists at the same {lane, warp} (checked below via
+  // canonicalOutputToPos). When it does not, no entry is added and the dead
+  // value flows through unchanged -- callers that need cross-thread correctness
+  // must handle that case separately.
+
+  int numPositions = srcLayout.getInDimSize(kPosition);
+  int numOutDims = srcLayout.getNumOutDims();
+  int numPositionBits = srcLayout.getInDimSizeLog2(kPosition);
+
+  // Determine which output dim indices are NPOT (for per-dim arithmetic).
+  SmallVector<bool> dimIsNpot(numOutDims, false);
+  {
+    int d = 0;
+    for (auto [dim, size] : srcLayout.getOutDims()) {
+      dimIsNpot[d] = !llvm::isPowerOf2_32(size);
+      d++;
+    }
+  }
+
+  // Compute the raw output vector for each position. Uses integer addition
+  // for NPOT dims (matching the hardware's linear TMEM column addressing)
+  // and XOR for pow2 dims (matching GF(2) register-to-row addressing).
+  auto computeRawOutput = [&](int r) -> SmallVector<int32_t> {
+    SmallVector<int32_t> out(numOutDims, 0);
+    for (int bit = 0; bit < numPositionBits; bit++) {
+      if (r & (1 << bit)) {
+        auto basis = srcLayout.getBasis(kPosition, bit);
+        for (int d = 0; d < numOutDims; d++) {
+          if (dimIsNpot[d]) {
+            out[d] += basis[d];
+          } else {
+            out[d] ^= basis[d];
+          }
+        }
+      }
+    }
+    return out;
+  };
+
+  // Phase 1: index canonical (in-bounds) outputs -> position.
+  // Key multiplier 1<<20 avoids collisions (max TMEM dim is 512).
+  auto outKey = [&](const SmallVector<int32_t> &out) -> int64_t {
+    int64_t key = 0;
+    for (int d = 0; d < numOutDims; d++) {
+      key = key * (1 << 20) + out[d];
+    }
+    return key;
+  };
+
+  DenseMap<int64_t, int> canonicalOutputToPos;
+  for (int r = 0; r < numPositions; r++) {
+    auto out = computeRawOutput(r);
+    bool isDead = false;
+    for (auto [dimIdx, origSize] : npotDimIndices) {
+      if (out[dimIdx] >= origSize) {
+        isDead = true;
+        break;
+      }
+    }
+    if (!isDead) {
+      canonicalOutputToPos[outKey(out)] = r;
+    }
+  }
+
+  // Phase 2: For each dead position, find its canonical counterpart.
+  for (int r = 0; r < numPositions; r++) {
+    auto out = computeRawOutput(r);
+    bool isDead = false;
+    for (auto [dimIdx, origSize] : npotDimIndices) {
+      if (out[dimIdx] >= origSize) {
+        out[dimIdx] = out[dimIdx] % origSize; // Wrap to canonical.
+        isDead = true;
+      }
+    }
+    if (isDead) {
+      auto it = canonicalOutputToPos.find(outKey(out));
+      if (it != canonicalOutputToPos.end()) {
+        deadToCanonical[r] = it->second;
+      }
+    }
+  }
+
+  return deadToCanonical;
+}
+
+bool canFixupDeadPositions(const LinearLayout &layout, StringAttr kLane,
+                           StringAttr kWarp) {
+  if (!layout.isModular()) {
+    return true; // No NPOT dims, nothing to fix.
+  }
+  // Check that lane and warp bases don't contribute to any NPOT dim.
+  // When they do, dead positions depend on the thread's lane/warp index,
+  // and within-thread register remapping can't always find a canonical.
+  for (auto [dim, origSize] : layout.getOutDims()) {
+    if (!llvm::isPowerOf2_32(origSize) &&
+        !layout.sublayoutIsZero({kLane, kWarp}, {dim})) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -299,7 +299,9 @@ LinearLayout::LinearLayout(
   if (size == 0)
     return LinearLayout::empty();
 
-  assert(llvm::isPowerOf2_32(size));
+  // strided1D/identity1D are pow2-only; NPOT callers must use modularStrided1D.
+  assert(llvm::isPowerOf2_32(size) &&
+         "strided1D/identity1D require a power-of-2 size");
   std::vector<std::vector<int32_t>> bases;
   for (int32_t i = 1; i < size; i *= 2) {
     bases.emplace_back(std::vector<int32_t>{i * stride});
@@ -316,7 +318,7 @@ LinearLayout::LinearLayout(
   if (size == 0)
     return LinearLayout::empty();
 
-  assert(llvm::isPowerOf2_32(size));
+  assert(llvm::isPowerOf2_32(size) && "zeros1D requires a power-of-2 size");
   std::vector<std::vector<int32_t>> zeros;
   for (int i = 1; i < size; i *= 2) {
     zeros.emplace_back(std::vector<int32_t>{0});

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
@@ -7,6 +7,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
@@ -52,8 +53,22 @@ static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   auto *ctx = srcTy.getContext();
   auto srcLayout = triton::gpu::toLinearLayout(srcTy);
   auto dstLayout = triton::gpu::toLinearLayout(dstTy);
-  srcLayout = actionRemoveBroadcastedRegs(srcLayout).apply(srcLayout);
-  dstLayout = actionRemoveBroadcastedRegs(dstLayout).apply(dstLayout);
+  // For NPOT layouts, the nvidia-specific swizzling path returns failure()
+  // and the base class ConvertLayoutOpConversion handles it. The base class
+  // uses unfoldModularDims + optimalSwizzlingLdSt.
+  // Unfold NPOT dims before removing broadcasts: a [0,N] reg basis is 0 mod N
+  // but nonzero in pow2 space; dropping it would under-size SMEM (OOB).
+  if (srcLayout.isModular()) {
+    srcLayout = unfoldModularDimsForAlloc(srcLayout);
+    dstLayout = unfoldModularDimsForAlloc(dstLayout);
+    srcLayout = actionRemoveBroadcastedRegs(srcLayout).apply(srcLayout);
+    dstLayout = actionRemoveBroadcastedRegs(dstLayout).apply(dstLayout);
+    auto bitwidth = getBitwidth(srcTy);
+    auto smem =
+        triton::gpu::optimalSwizzlingLdSt(srcLayout, dstLayout, bitwidth);
+    auto reps = smem.getInDimSize(StringAttr::get(ctx, "reps"));
+    return smem.getTotalOutDimSizeProduct() / reps;
+  }
   auto bitwidth = getBitwidth(srcTy);
   auto [srcTiles, dstTiles] = gpu::getSrcDstTiles(targetInfo, bitwidth);
   auto [smem, _] = triton::gpu::optimalSwizzling(srcLayout, dstLayout, srcTiles,
@@ -68,6 +83,17 @@ getNvidiaAllocationAnalysisScratchSizeFn(TargetInfoBase &targetInfo) {
     if (auto cvtOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
       auto srcTy = cvtOp.getSrc().getType();
       auto dstTy = cvtOp.getType();
+      if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+        // For NPOT shapes, compute the allocation consistently with the
+        // lowering path. If both encodings are NPOT-safe, we can use the
+        // standard swizzled path. Otherwise, unfold modular dims to pow2,
+        // then compute the swizzled SMEM layout size.
+        if (!cvtNeedsSharedMemory(srcTy, dstTy)) {
+          return 0;
+        }
+        auto elems = getNumScratchElemsSwizzledCvt(srcTy, dstTy, targetInfo);
+        return elems * getBitwidth(srcTy) / 8;
+      }
       if (!cvtNeedsSharedMemory(srcTy, dstTy))
         return 0;
       // In cuda we always swizzle

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -1,6 +1,8 @@
 #include "Utility.h"
 #include "mlir/Support/LLVM.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 
 namespace mlir {
 namespace triton {
@@ -63,22 +65,80 @@ public:
         std::optional<RankedTensorType> mmaTy = std::nullopt) {
     auto ctx = rewriter.getContext();
     auto kOffset = str_attr("offset");
-    // The handling of subviews is not as fine as it could be
-    // We could compose with the identity of the memTy.getShape()
-    // (at the moment llInv will be of allocShape), but then
-    // we would need to handle the getReps part more carefuly
-    // This way we could support more subviews that we don't
-    // We can implement this generalisation in the future if needed
-    auto llInv = toLinearLayout(memTy).pseudoinvert();
     auto bitwidth = memTy.getElementType().getIntOrFloatBitWidth();
+
+    // Closed-form computeSMEMDescriptor path for NVMMASharedEncoding (serves
+    // both pow2 and NPOT shapes) -- gated on NPOT being enabled. When NPOT is
+    // off (the default), fall through to the legacy brute-force getDescriptor
+    // path below so pow2 descriptors stay byte-identical to baseline.
+    static const bool allowNpot =
+        ::mlir::triton::tools::getBoolEnv("TRITON_ALLOW_NPOT");
+    triton::gpu::NVMMASharedEncodingAttr encoding;
+    if (allowNpot)
+      encoding =
+          dyn_cast<triton::gpu::NVMMASharedEncodingAttr>(memTy.getEncoding());
+    if (encoding) {
+      auto allocShape = memTy.getAllocShape().take_back(memTy.getRank());
+      bool hasNpotDim = llvm::any_of(allocShape, [](int64_t s) {
+        return s > 0 && !llvm::isPowerOf2_64(s);
+      });
+
+      if (isFp4 && encoding.getFp4Padded() && hasNpotDim) {
+        // fp4Padded requires 128B swizzle and has a special padded packing
+        // format. NPOT dims are unlikely with fp4Padded (which requires
+        // contigBytes divisible by 128), but bail out if it happens.
+        return failure();
+      }
+
+      // Pseudoinverse for smemLoad coordinate routing: NPOT contiguous dim uses
+      // the 3-dim split layout (single algebra per dim); else the 2-dim layout.
+
+      LinearLayout llInv;
+      if (hasNpotDim) {
+        auto splitOpt =
+            gpu::nvmmaSharedToSplitLinearLayout(allocShape, encoding);
+        if (splitOpt) {
+          // NPOT contiguous dim: use 3-dim split pseudoinverse.
+          llInv = splitOpt->pseudoinvert();
+        } else {
+          // NPOT non-contiguous dim (e.g., NPOT M with pow2 K):
+          // standard 2-dim pseudoinverse is correct because the NPOT dim
+          // is uncoupled from swizzle.
+          auto fwdFull = toLinearLayout(memTy);
+          auto fwdWithBlock = gpu::getLayoutWithinBlock(fwdFull);
+          auto outDimNames = llvm::to_vector(fwdWithBlock.getOutDimNames());
+          auto fwdLocal =
+              fwdWithBlock.sublayout({str_attr("offset")}, outDimNames);
+          llInv = fwdLocal.pseudoinvert();
+        }
+      } else {
+        // Pow2: standard pseudoinverse.
+        llInv = toLinearLayout(memTy).pseudoinvert();
+      }
+
+      if (isFp4) {
+        // fp4 (E2M1): prepend identity1D(2) for packed-byte offset; halve
+        // bitwidth.
+        auto dims = to_vector(llInv.getInDimNames());
+        auto trans = llInv.getBasis(dims[0], 0, kOffset) == 1;
+        llInv =
+            LinearLayout::identity1D(2, dims[trans ? 0 : 1], kOffset) * llInv;
+        bitwidth /= 2;
+      }
+
+      return buildFromLL(loc, rewriter, llInv, bitwidth, smemBase, instrShape,
+                         MNdim, mmaVersion, memTy, mmaTy);
+    }
+
+    // Non-NVMMAShared (or NPOT disabled): brute-force getDescriptor build().
+    auto llInv = toLinearLayout(memTy).pseudoinvert();
     if (isFp4) {
-      // hacky but well
       auto dims = to_vector(llInv.getInDimNames());
       auto trans = llInv.getBasis(dims[0], 0, kOffset) == 1;
       llInv = LinearLayout::identity1D(2, dims[trans ? 0 : 1], kOffset) * llInv;
       bitwidth /= 2;
-      // The instr_shape comes in number of elements already
     }
+
     return build(loc, rewriter, llInv, bitwidth, smemBase, instrShape, MNdim,
                  mmaVersion, mmaTy);
   }
@@ -161,18 +221,58 @@ public:
     auto *ctx = loc.getContext();
     auto tb = TritonLLVMOpBuilder(loc, rewriter);
     auto dims = to_vector(ll.getInDimNames());
-    assert(to_vector(ll.getOutDimNames()) ==
-           llvm::to_vector(
-               ArrayRef<StringAttr>{str_attr("offset"), str_attr("block")}));
-    auto offsetBlock = ll.apply({{dims[0], a}, {dims[1], b}});
+    SmallVector<std::pair<StringAttr, int32_t>> applyArgs;
+    if (dims.size() == 3) {
+      // Split-dim pseudoinverse: dims = {dim0, contig_intra, contig_phase}
+      // The split layout is in core-tile coordinates (not tensor coords):
+      //   dim0 = rows (non-contiguous direction)
+      //   contig_intra + contig_phase = cols (contiguous direction, NPOT)
+      //
+      // The caller passes (a, b) in tensor coordinates:
+      //   For non-transposed: a = row (non-contig), b = col (contig)
+      //   For transposed: a = first tensor dim (contig), b = second
+      //   (non-contig)
+      //
+      // For non-transposed: a -> dim0, b -> contig_intra/contig_phase (correct)
+      // For transposed: a -> contig_intra/contig_phase, b -> dim0 (swap needed)
+      int32_t rowCoord, colCoord;
+      if (desc.transposed) {
+        rowCoord = b; // b = non-contiguous dim -> dim0 (rows)
+        colCoord = a; // a = contiguous dim -> dim1 (cols, split)
+      } else {
+        rowCoord = a; // a = non-contiguous dim -> dim0 (rows)
+        colCoord = b; // b = contiguous dim -> dim1 (cols, split)
+      }
+      int32_t phaseSize = ll.getInDimSize(dims[1]); // contig_intra is pow2
+      int32_t colIntra = colCoord % phaseSize;
+      int32_t colPhase = colCoord / phaseSize;
+      applyArgs = {
+          {dims[0], rowCoord}, {dims[1], colIntra}, {dims[2], colPhase}};
+    } else {
+      applyArgs = {{dims[0], a}, {dims[1], b}};
+    }
+    auto offsetBlock = ll.apply(applyArgs);
     int32_t offsetElems = offsetBlock[0].second;
-    int32_t block = offsetBlock[1].second;
-    assert(block == 0);
+    // NPOT (buildFromLL) pseudoinverse may lack the "block" out dim; the
+    // standard path has both "offset" and "block".
+    if (ll.getNumOutDims() == 2) {
+      int32_t block = offsetBlock[1].second;
+      assert(block == 0);
+    }
+    // For sub-byte types (e.g., fp4 with bitwidth=4), odd offsetElems would
+    // silently truncate (4/8 = 0). The fp4 path in build() prepends
+    // identity1D(2) to guarantee even offsets; assert that invariant here.
+    assert(desc.bitwidth >= 8 || offsetElems % 2 == 0);
     int32_t smemByteOffsetb8 = offsetElems * desc.bitwidth / 8;
     auto currDesc = desc.descriptor;
-    // Take the next 0/1/2/3 bits after the 128b tile
-    uint32_t mask = (desc.swizzlingByteWidth >> 4) - 1;
-    currDesc.matrixBaseOffset = (smemByteOffsetb8 / 128) & mask;
+    if (desc.swizzlingByteWidth > 0) {
+      uint32_t mask = (desc.swizzlingByteWidth >> 4) - 1;
+      currDesc.matrixBaseOffset = (smemByteOffsetb8 / 128) & mask;
+    } else {
+      // swizzle=0: the offset is carried entirely by the base address, so the
+      // matrixBaseOffset phase field is 0.
+      currDesc.matrixBaseOffset = 0;
+    }
     currDesc.baseAddress = 0;
     int32_t smemByteOffsetb128 = smemByteOffsetb8 >> 4;
     // Compute the base address at runtime to prevent LLVM from folding the
@@ -195,6 +295,140 @@ private:
   MMASMEMDescriptor desc;
   Value baseSrcb128;
   LinearLayout ll;
+
+  // Construct the descriptor and loader from encoding parameters and a
+  // pseudoinverse layout. Uses computeSMEMDescriptor (ISA-formula) for
+  // the descriptor and handles warp stride computation for MMAv3.
+  //
+  // Handles all layout shapes:
+  //   - 2-dim pseudoinverse (pow2, or NPOT in non-contiguous dim only)
+  //   - 3-dim pseudoinverse (NPOT in contiguous dim, split into
+  //     contig_intra + contig_phase)
+  static FailureOr<DotOpMmaSmemLoader>
+  buildFromLL(Location loc, RewriterBase &rewriter, const LinearLayout &llInv,
+              int bitwidth, Value smemBase, ArrayRef<unsigned> instrShapeArray,
+              unsigned MNdim, int mmaVersion, gpu::MemDescType memTy,
+              std::optional<RankedTensorType> mmaTy) {
+    auto ctx = rewriter.getContext();
+    auto kOffset = str_attr("offset");
+    auto instrShape = to_vector(instrShapeArray);
+    assert(instrShape.size() == 2);
+    assert(MNdim < 2);
+
+    // Extract encoding parameters directly.
+    auto encoding =
+        cast<triton::gpu::NVMMASharedEncodingAttr>(memTy.getEncoding());
+
+    // Compute LBO and SBO using ISA canonical formulas (PTX ISA 9.2,
+    // section 9.7.16.3) directly from encoding parameters. This avoids
+    // building core tile LLs, pseudoinverting them, and reading basis
+    // values -- which is fragile for NPOT dimensions.
+    auto descResult = computeSMEMDescriptor(encoding, instrShape, bitwidth,
+                                            MNdim, mmaVersion, memTy,
+                                            /*isFp4=*/bitwidth == 4);
+    if (failed(descResult)) {
+      return failure();
+    }
+    auto mmaSMEMDesc = *descResult;
+
+    // Base address computation (same as the standard build path).
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    smemBase = b.ptrtoint(i32_ty, smemBase);
+    Value baseSrcb128 = b.lshr(smemBase, b.i32_val(4));
+
+    if (mmaVersion == 3 && mmaTy.has_value()) {
+      // For MMAv3, compute warp stride arithmetically.
+      auto mmaLl = gpu::toLinearLayout(mmaTy.value());
+      auto outDims = to_vector(mmaLl.getOutDimNames());
+      auto kWarp = str_attr("warp");
+
+      auto mmaWarps = mmaLl.sublayout({kWarp}, {outDims[MNdim]}) *
+                      LinearLayout::identity1D(1, kWarp, outDims[1 - MNdim]);
+
+      // For 3-dim split pseudoinverse (dim0, contig_intra, contig_phase),
+      // reshape mmaWarps output to match llInv input dims.  Warps only
+      // advance in the MN dim, not K, so the split dims (which decompose
+      // the contiguous K dim) get zero contribution.
+      auto llInvInDims = to_vector(llInv.getInDimNames());
+      if (llInvInDims.size() == 3) {
+        SmallVector<std::pair<StringAttr, int32_t>> newOutDims;
+        for (auto dim : llInvInDims) {
+          newOutDims.push_back({dim, llInv.getInDimSize(dim)});
+        }
+        auto newProduct =
+            std::accumulate(newOutDims.begin(), newOutDims.end(), int64_t{1},
+                            [](int64_t a, auto &p) { return a * p.second; });
+        if (mmaWarps.getTotalOutDimSizeProduct() == newProduct) {
+          // Products match (typical SM100 path): reshape directly.
+          mmaWarps = mmaWarps.reshapeOuts(newOutDims);
+        } else {
+          // NPOT-SM90: mmaWarps has a pow2 K-dim but llInv's K is split (NPOT).
+          // Warps don't advance in K, so rebuild mmaWarps at llInv's dim sizes,
+          // zero-padding each basis for the K-split dims.
+          LinearLayout::BasesT adjustedBases;
+          for (auto &[inDim, dimBases] : mmaWarps.getBases()) {
+            std::vector<std::vector<int32_t>> paddedBases;
+            for (auto &basis : dimBases) {
+              std::vector<int32_t> padded(basis.begin(), basis.end());
+              while (padded.size() < newOutDims.size()) {
+                padded.push_back(0);
+              }
+              paddedBases.push_back(std::move(padded));
+            }
+            adjustedBases[inDim] = std::move(paddedBases);
+          }
+          mmaWarps = LinearLayout(std::move(adjustedBases), newOutDims,
+                                  /*requireSurjective=*/false);
+        }
+      }
+
+      auto warpToOffset = mmaWarps.compose(llInv);
+      auto bases = warpToOffset.getBases();
+      int numOutDims = warpToOffset.getNumOutDims();
+      // Zero out warp group bases (first 2 warp bases = intra-warp-group).
+      SmallVector<int32_t> zeroBasis(numOutDims, 0);
+      bases[kWarp][0] =
+          std::vector<int32_t>(zeroBasis.begin(), zeroBasis.end());
+      bases[kWarp][1] =
+          std::vector<int32_t>(zeroBasis.begin(), zeroBasis.end());
+      int elemsPer128b = 128 / bitwidth;
+      int offsetIdx = 0;
+      for (auto [dimName, dimSize] : warpToOffset.getOutDims()) {
+        if (dimName == kOffset) {
+          break;
+        }
+        offsetIdx++;
+      }
+      for (auto &[dimName, dimBases] : bases) {
+        for (auto &basisVec : dimBases) {
+          assert(basisVec[offsetIdx] % elemsPer128b == 0 &&
+                 "warp offset must be 128b-aligned");
+          basisVec[offsetIdx] /= elemsPer128b;
+        }
+      }
+      auto outDimsWarp = warpToOffset.getOutDims();
+      for (auto &[dimName, dimSize] : outDimsWarp) {
+        if (dimName == kOffset) {
+          dimSize = std::max(int32_t{1}, dimSize / elemsPer128b);
+        }
+      }
+      auto warpGroupToOffsetb128 = LinearLayout(std::move(bases), outDimsWarp,
+                                                /*requireSurjective=*/false);
+      Value warpId = mlir::triton::gpu::WarpIdOp::create(rewriter, loc);
+      Value warpStrideb128 =
+          applyLinearLayout(loc, rewriter, warpGroupToOffsetb128,
+                            {{kWarp, warpId}})[0]
+              .second;
+      baseSrcb128 = b.add(baseSrcb128, warpStrideb128);
+    }
+
+    // baseSrcb128 must remain i32: smemLoad() adds an i32 per-tile offset to
+    // it (line ~341) and only zexts the masked result to i64. Returning an i64
+    // here triggers "'llvm.add' op requires the same type for all operands
+    // and results" in ConvertTritonGPUToLLVM. The standard build() path stores
+    // the i32 value directly; mirror that here.
+    return DotOpMmaSmemLoader{mmaSMEMDesc, baseSrcb128, llInv};
+  }
 
   static FailureOr<MMASMEMDescriptor>
   getDescriptor(Location loc, const LinearLayout &ll,
@@ -330,6 +564,140 @@ private:
       }
     }
     return failure();
+  }
+
+  // Compute SMEM descriptor LBO/SBO directly from encoding parameters using
+  // ISA canonical formulas (PTX ISA 9.2, section 9.7.16.3).
+  // This is the unified descriptor computation used by both pow2 and NPOT
+  // paths. It replaces the brute-force getDescriptor() search and works
+  // correctly for all dimension sizes.
+  //
+  // The core matrix tile is always 8 (rows) x tileCols (cols) before transpose.
+  //   tileCols = 8 * max(16, swizzleBytes) / elemBitWidth
+  //
+  // Physical strides for one tile:
+  //   Contiguous-axis (tileCols elements): tileCols * elemBytes bytes
+  //   Non-contiguous-axis (8 rows): 8 * contigDimSize * elemBytes bytes
+  //
+  // LBO/SBO assignment:
+  //   Normal: LBO = contiguous-axis stride, SBO = non-contiguous-axis stride
+  //   MNContig + no-swizzle swap: LBO = non-contig stride, SBO = contig stride
+  //
+  // Strides derive independently from the encoding + allocShape.
+  static FailureOr<MMASMEMDescriptor>
+  computeSMEMDescriptor(triton::gpu::NVMMASharedEncodingAttr encoding,
+                        ArrayRef<unsigned> instrShape, int bitwidth,
+                        unsigned MNdim, int mmaVersion, gpu::MemDescType memTy,
+                        bool isFp4) {
+    int swizzling = encoding.getSwizzlingByteWidth();
+    bool transposed = encoding.getTransposed();
+    bool fp4Padded = encoding.getFp4Padded();
+
+    // Determine the contiguous dimension size from the alloc shape.
+    // transposed==false: last dim (dim1) is contiguous
+    // transposed==true:  first dim (dim0) is contiguous
+    auto allocShape = memTy.getAllocShape();
+    assert(allocShape.size() >= 2 && "Expected at least 2D allocation shape");
+    int contigDimIdx = transposed ? 0 : (allocShape.size() - 1);
+    int64_t contigDimSize = allocShape[contigDimIdx];
+
+    // Core matrix tile dimensions.
+    // tileRows = 8 (always, for the non-contiguous/strided axis)
+    // tileCols = number of elements along the contiguous axis per tile
+    int tileRows = 8;
+    int tileCols = 8 * std::max(16, swizzling) / bitwidth;
+
+    // Physical stride between rows in the SMEM allocation.
+    // For swizzle > 0, the core tile data is interleaved by the swizzle, so the
+    // tile is a contiguous block of tileCols * tileRows elements. The stride
+    // from one core tile to the next (in either direction) is based on the tile
+    // size: SBO = coreTileBytes, LBO = numRowGroups * coreTileBytes.
+    //
+    // For swizzle == 0, no interleaving occurs: rows are stored with stride
+    // = contigAllocStride (the pow2-rounded contiguous dim size, since
+    // getAllocationShapePerCTA rounds NPOT dims to pow2 for swizzle=0). The
+    // strides from one tile to the next are:
+    //   - Along non-contiguous (rows): tileRows * contigAllocStride * elemBytes
+    //   - Along contiguous (cols): tileCols * elemBytes
+    int64_t contigAllocStride = contigDimSize;
+    if (swizzling == 0 && !llvm::isPowerOf2_64(contigDimSize)) {
+      contigAllocStride = llvm::NextPowerOf2(contigDimSize);
+    }
+
+    int nonContigDimIdx = transposed ? (int)(allocShape.size() - 1) : 0;
+    int64_t nonContigDimSize = allocShape[nonContigDimIdx];
+    if (!llvm::isPowerOf2_64(nonContigDimSize)) {
+      nonContigDimSize = llvm::NextPowerOf2(nonContigDimSize);
+    }
+    int64_t numRowGroups = nonContigDimSize / tileRows;
+
+    // Compute stride bytes. For sub-byte types (FP4: bitwidth=4), compute in
+    // bits first to avoid integer truncation from bitwidth/8=0.
+    int64_t sboStrideBytes, lboStrideBytes;
+    if (swizzling > 0) {
+      // Swizzled: tiles are contiguous blocks in memory.
+      int64_t coreTileBytes = (int64_t)tileCols * tileRows * bitwidth / 8;
+      sboStrideBytes = coreTileBytes;
+      lboStrideBytes = numRowGroups * coreTileBytes;
+    } else {
+      // No swizzle: simple row-major layout with row stride =
+      // contigAllocStride. sboStrideBytes = stride from one 8-row tile-group to
+      // the next
+      //                = tileRows * contigAllocStride * elemBytes
+      // lboStrideBytes = stride from one tileCols-wide column-group to the next
+      //                = tileCols * elemBytes
+      sboStrideBytes = (int64_t)tileRows * contigAllocStride * bitwidth / 8;
+      lboStrideBytes = (int64_t)tileCols * bitwidth / 8;
+    }
+
+    int leadingDim = transposed ? 0 : 1;
+    int stridedDim = transposed ? 1 : 0;
+    int tileExtentLeading = tileCols;
+    int tileExtentStrided = tileRows;
+
+    bool MNContig = (MNdim == 0) == transposed;
+    bool swapLboSbo = (swizzling == 0 && MNContig);
+    if (swapLboSbo) {
+      std::swap(leadingDim, stridedDim);
+      std::swap(tileExtentLeading, tileExtentStrided);
+    }
+
+    int lboDescriptor = 0;
+    if ((int)instrShape[leadingDim] > tileExtentLeading) {
+      lboDescriptor = (swapLboSbo ? sboStrideBytes : lboStrideBytes) >> 4;
+    }
+
+    int sboDescriptor = 0;
+    if ((int)instrShape[stridedDim] > tileExtentStrided) {
+      sboDescriptor = (swapLboSbo ? lboStrideBytes : sboStrideBytes) >> 4;
+    }
+
+    // Construct the descriptor
+    SMEMDescriptor desc;
+    desc.descriptor = mmaVersion == 5 ? 1ULL << 46 : 0ULL;
+    desc.leadDimensionBaseOffset = lboDescriptor;
+    desc.strideDimensionBaseOffset = sboDescriptor;
+    switch (swizzling) {
+    case 0:
+      desc.swizzlingMode = 0;
+      break;
+    case 32:
+      desc.swizzlingMode = 3;
+      break;
+    case 64:
+      desc.swizzlingMode = 2;
+      break;
+    case 128:
+      desc.swizzlingMode = 1;
+      break;
+    default:
+      llvm_unreachable("Unsupported swizzling size.");
+    }
+    return MMASMEMDescriptor{/* .descriptor = */ desc,
+                             /* .swizzlingByteWidth = */ swizzling,
+                             /* .bitwidth = */ bitwidth,
+                             /* .transposed = */ transposed,
+                             /* .fp4Padded = */ fp4Padded};
   }
 };
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -4,13 +4,15 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Tools/LinearLayout.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace mlir;
 using namespace mlir::triton;
 
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
-using ::mlir::triton::gpu::getOrderForDotOperand;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 
 namespace {
@@ -83,187 +85,149 @@ struct BaseOffset {
 
 ValueTableV2 getValuesFromDotOperandLayoutStruct(
     const LLVMTypeConverter *typeConverter, Location loc,
-    ConversionPatternRewriter &rewriter, Value value, int batch, int repOuter,
-    int repK, RankedTensorType type, const NumRegisters &numRegisters) {
+    ConversionPatternRewriter &rewriter, Value value, RankedTensorType type,
+    const NumRegisters &numRegisters, int repBatch, int repOuter, int repK) {
+  // Use the LinearLayout to map register indices to element coordinates,
+  // then derive value table keys from coordinates. This naturally handles
+  // NPOT rep counts (via modularIdentity1D in the layout) and largeK
+  // (by computing the correct sub-MMA index from K coordinates), without
+  // any pow2 rounding or manual permutation.
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto elems = unpackLLElements(loc, value, rewriter);
   auto eltTy = typeConverter->convertType(type.getElementType());
-  int offset{};
   ValueTableV2 vals;
   auto bitwidth = eltTy.getIntOrFloatBitWidth();
   auto numElemsPerVec = std::max(32 / bitwidth, 1u);
   auto vecTy = vec_ty(eltTy, numElemsPerVec);
 
-  auto packVec = [&](std::array<int, 3> dstIdx) {
+  auto dot = cast<DotOperandEncodingAttr>(type.getEncoding());
+  auto kWidth = dot.getKWidth();
+  bool isA = (dot.getOpIdx() == 0);
+  auto rank = type.getRank();
+
+  // Get the LinearLayout for this dot operand encoding.
+  auto layout = triton::gpu::toLinearLayout(type);
+  auto *ctx = type.getContext();
+  auto kRegister = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kBlock = StringAttr::get(ctx, "block");
+
+  // Dimension indices in the layout output.
+  int kDimIdx = isA ? rank - 1 : rank - 2;
+  int outerDimIdx = isA ? rank - 2 : rank - 1;
+  int kDimSize = triton::gpu::getShapePerCTA(type)[kDimIdx];
+
+  // Get warp tiling info to compute coordinate-to-rep-index mapping.
+  auto mma = cast<NvidiaMmaEncodingAttr>(dot.getParent());
+  auto warpsPerCTA = mma.getWarpsPerCTA();
+  // For dot operands, the K dimension warps are broadcast (set to 1).
+  // The outer dimension (M for A, N for B) uses the remaining warps.
+  int warpsOuter = warpsPerCTA[outerDimIdx];
+
+  // The batch dimension (3D dots) is also tiled across warps.  Each MMA
+  // handles a single batch element (tile size 1), so consecutive batch reps
+  // for one warp are strided by the number of warps tiling the batch dim.
+  int warpsBatch = (rank == 3) ? warpsPerCTA[0] : 1;
+  int batchRepStride = 1 * warpsBatch;
+
+  // MMA tile sizes per warp in element coordinates.
+  int mmaTileOuter = isA ? 16 : 8; // M=16 for A, N=8 for B
+
+  // Stride between consecutive outer reps for one warp: the MMA tile
+  // times the number of warps tiling that dimension, since warps
+  // interleave across the outer dimension.
+  int outerRepStride = mmaTileOuter * warpsOuter;
+
+  // Number of outer registers per MMA tile (within-tile register groups).
+  int numRegOuter = isA ? numRegisters.m : numRegisters.n;
+  // Stride between consecutive within-tile register positions.
+  int innerOuterStride = mmaTileOuter / numRegOuter; // always 8
+
+  // K tile sizes and sub-MMA splitting parameters.
+  int dotTileK = kWidth * 8;
+  int numSubMmaPerDotTile = kWidth / numElemsPerVec;
+
+  auto numVecs = static_cast<int>(elems.size()) / numElemsPerVec;
+  for (int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
+    int regIdx = vecIdx * numElemsPerVec;
+
+    // Query the layout for this register's element coordinates.
+    auto coords = layout.apply(
+        {{kRegister, regIdx}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
+
+    int outerCoord = coords[outerDimIdx].second;
+    int kCoord = coords[kDimIdx].second;
+    // Map the absolute batch coordinate to a per-thread batch rep index
+    // (consumers index the value table by rep index, not absolute coord).
+    int batchCoord = (rank == 3) ? coords[0].second / batchRepStride : 0;
+
+    // Outer register index (M or N direction).
+    // outerRep = which rep of the MMA tile this coordinate belongs to.
+    // innerOuter = which register within the MMA tile.
+    int outerRep = outerCoord / outerRepStride;
+    int innerOuter = (outerCoord % mmaTileOuter) / innerOuterStride;
+    int outerReg = outerRep * numRegOuter + innerOuter;
+
+    // K register index.
+    int kReg;
+    if (bitwidth == 64) {
+      // fp64 is never largeK: K-registers are uniformly K-strided, so the
+      // emitter indexes them contiguously. Map kCoord back to its linear index.
+      int numKRegs = std::max(repK, 1) * numRegisters.k;
+      int kStep = std::max<int>(kDimSize / numKRegs, 1);
+      kReg = kCoord / kStep;
+    } else {
+      // Packed/largeK: account for sub-MMA splitting.
+      int dotTileIdx = kCoord / dotTileK;
+      int kInDotTile = kCoord % dotTileK;
+      int kWidthGroupIdx = kInDotTile / (kWidth * 4); // 0 or 1
+      int kInGroup = kInDotTile % kWidth;
+      int subMmaIdx = kInGroup / numElemsPerVec;
+      int kRepInTile = subMmaIdx * numRegisters.k + kWidthGroupIdx;
+      kReg = dotTileIdx * numSubMmaPerDotTile * numRegisters.k + kRepInTile;
+    }
+
+    // Pack numElemsPerVec elements into one i32 (or keep as-is for fp64).
     Value vec = b.undef(vecTy);
-    for (auto i = 0; i < numElemsPerVec; ++i) {
-      vec = b.insert_element(vec, b.bitcast(elems[offset + i], eltTy),
+    for (unsigned i = 0; i < numElemsPerVec; ++i) {
+      vec = b.insert_element(vec, b.bitcast(elems[regIdx + i], eltTy),
                              b.i32_val(i));
     }
     if (bitwidth == 64) {
-      vals[dstIdx] = vec;
+      vals[{batchCoord, outerReg, kReg}] = vec;
     } else {
-      vals[dstIdx] = b.bitcast(vec, i32_ty);
-    }
-    offset += numElemsPerVec;
-  };
-
-  auto dot = cast<DotOperandEncodingAttr>(type.getEncoding());
-  auto kWidth = dot.getKWidth();
-  auto largeK = bitwidth * kWidth > std::max(32u, bitwidth);
-
-  assert((bitwidth != 64 || largeK == false) &&
-         "Currently fp64 don't support largeK MMA");
-
-  if (largeK) {
-    // For layouts with a large K dimension, the original register layout needs
-    // to be divided into multiple MMAs, where each MMA has contiguous 32 bits
-    // along the K dimension per thread.
-    // Using kWidth = 8 and bitwidth = 2 as an example,
-    // we split the MMA into 4 sub-MMAs, each with a stride 4 x 32-bit along the
-    // K dimension.
-    llvm::SmallVector<unsigned> si;
-    auto kIters = kWidth / (std::max(32 / bitwidth, 1u));
-
-    if (dot.getOpIdx() == 0) {
-      // Original register layout:
-      //
-      //   [0, 1, 2, 3, 4, 5, 6, 7], [16, 17, 18, 19, 20, 21, 22, 23, 23]
-      //   [8, 9, 10, 11, 12, 13, 14, 15], [24, 25, 26, 27, 28, 29, 30, 31]
-      //
-      // Each element in the layout is a single bf16.
-      //
-      // To derive four independent MMA operations, a stride of 4 is applied to
-      // the original register layout:
-      //
-      //  1st MMA: [[0, 1], [8, 9], [16, 17], [24, 25]]
-      //  2nd MMA: [[2, 3], [10, 11], [18, 19], [26, 27]]
-      //  3rd MMA: [[4, 5], [12, 13], [20, 21], [28, 29]]
-      //  4th MMA: [[6, 7], [14, 15], [22, 23], [30, 31]]
-      if (kIters <= repK) {
-        for (size_t kRep = 0; kRep < kWidth / numElemsPerVec; ++kRep)
-          for (size_t tile = 0; tile < 4; ++tile)
-            for (size_t e = 0; e < numElemsPerVec; ++e) {
-              si.push_back(kRep * numElemsPerVec + tile * kWidth + e);
-            }
-      } else {
-        // Suppose kWidth=4 and type=fp32, so numElemsPerVec=1.
-        // Each tile of the dot operand layout has a size of 16x32.
-        // However, if the triton tensor size is 16x16, elements along the k
-        // dimension are duplicated. Within each tile, each register
-        // contains 2x8 elements arranged as follows:
-        //
-        //       tile0/0           tile0/1
-        //   |<--kWidth=4-->|   |<--kWidth-->|
-        //   |<-mmaWidth=2->|
-        //   [0,  1,  2,  3]    [0,  1,  2,  3]
-        //   [4,  5,  6,  7]    [4,  5,  6,  7]
-        //
-        // tile0/1 replicates the elements in tile0/0 along the k dimension.
-        // For a tensor size of 32x32, the next tile on the m dimension is as
-        // follows:
-        //
-        //       tile1/0              tile1/1
-        //   |<--kWidth-->|       |<--kWidth-->|
-        //   [8,  9, 10, 11],     [8,  9, 10, 11]
-        //   [12, 13, 14, 15],    [12, 13, 14, 15]
-        //
-        // Within a single tile, we can perform two MMAs, and the
-        // resulting register layout for each MMA is as follows:
-        //
-        //   1st MMA: [0, 4, 1, 5]
-        //   2nd MMA: [2, 6, 3, 7]
-        //   3rd MMA: [8, 12, 9, 13]
-        //   4th MMA: [10, 14, 11, 15]
-        //
-        // Additionally, we should reorder the elements by moving the duplicated
-        // elements to the end.  In the example above, we convert the order from
-        // tile0/0, tile0/1, tile1/0, tile1/1 to tile0/0, tile1/0, tile0/1,
-        // tile1/1, so that only the first two tiles will be used in the
-        // computation.
-        size_t elemsPerTile = 2 * 2 * kWidth;
-        size_t elemsPerMma = 2 * 2 * numElemsPerVec;
-        size_t mmaWidth = kWidth / numElemsPerVec / 2;
-        size_t repMma = elemsPerTile / (mmaWidth * elemsPerMma);
-        for (size_t rep = 0; rep < repMma; ++rep)
-          for (size_t tile = 0; tile < elems.size() / elemsPerTile; ++tile)
-            for (size_t mmaKWidth = 0; mmaKWidth < mmaWidth; ++mmaKWidth)
-              for (size_t kTile = 0; kTile < 2; ++kTile)
-                for (size_t mTile = 0; mTile < 2; ++mTile)
-                  for (size_t e = 0; e < numElemsPerVec; ++e) {
-                    si.push_back(rep * mmaWidth * elemsPerMma +
-                                 mmaKWidth * 2 * numElemsPerVec +
-                                 tile * elemsPerTile + mTile * kWidth +
-                                 kTile * numElemsPerVec + e);
-                  }
-      }
-    } else {
-      // Original register layout:
-      //
-      //   [0, 1, 2, 3, 4, 5, 6, 7]^T, [8, 9, 10, 11, 12, 13, 14, 15]^T
-      //
-      // A stride of 4 is applied to derive four independent MMA operations:
-      //
-      //  1st MMA: [[0, 1], [8, 9]]
-      //  2nd MMA: [[2, 3], [10, 11]]
-      //  3rd MMA: [[4, 5], [12, 13]]
-      //  4th MMA: [[6, 7], [14, 15]]
-      if (kIters <= repK) {
-        for (size_t kRep = 0; kRep < kWidth / numElemsPerVec; ++kRep)
-          for (size_t tile = 0; tile < 2; ++tile)
-            for (size_t e = 0; e < numElemsPerVec; ++e) {
-              si.push_back(kRep * numElemsPerVec + tile * kWidth + e);
-            }
-      } else {
-        // Suppose kWidth=4 and type=fp32.
-        // Original register layout:
-        //
-        //       tile0/0        tile0/1
-        //   [0, 1, 2, 3]^T, [0, 1, 2, 3]^T
-        //
-        // Similar to the opIdx=0 situation, we should reorder the elements by
-        // moving the duplicated elements to the end.
-        size_t elemsPerTile = 2 * kWidth;
-        size_t elemsPerMma = 2 * numElemsPerVec;
-        size_t mmaWidth = kWidth / numElemsPerVec / 2;
-        size_t repMma = elemsPerTile / (mmaWidth * elemsPerMma);
-        for (size_t rep = 0; rep < repMma; ++rep)
-          for (size_t tile = 0; tile < elems.size() / elemsPerTile; ++tile)
-            for (size_t mmaKWidth = 0; mmaKWidth < mmaWidth; ++mmaKWidth)
-              for (size_t kTile = 0; kTile < 2; ++kTile)
-                for (size_t e = 0; e < numElemsPerVec; ++e) {
-                  si.push_back(rep * mmaWidth * elemsPerMma +
-                               mmaKWidth * 2 * numElemsPerVec +
-                               tile * elemsPerTile + kTile * numElemsPerVec +
-                               e);
-                }
-      }
-    }
-
-    auto step = si.size();
-    SmallVector<Value> perm(step);
-    for (auto i = 0; i < elems.size() / step; ++i) {
-      for (auto j = 0; j < step; ++j) {
-        perm[j] = elems[i * step + si[j]];
-      }
-      std::copy(perm.begin(), perm.end(), elems.begin() + i * step);
+      vals[{batchCoord, outerReg, kReg}] = b.bitcast(vec, i32_ty);
     }
   }
 
-  if (dot.getOpIdx() == 0) {
-    for (auto b = 0; b < batch; ++b)
-      for (auto m = 0; m < repOuter; ++m)
-        for (auto k = 0; k < repK; ++k)
-          for (auto vk = 0; vk < numRegisters.k; ++vk)
-            for (auto vm = 0; vm < numRegisters.m; ++vm)
-              packVec({b, m * numRegisters.m + vm, k * numRegisters.k + vk});
-  } else {
-    for (auto b = 0; b < batch; ++b)
-      for (auto n = 0; n < repOuter; ++n)
-        for (auto k = 0; k < repK; ++k)
-          for (auto vk = 0; vk < numRegisters.k; ++vk)
-            for (auto vn = 0; vn < numRegisters.n; ++vn)
-              packVec({b, n * numRegisters.n + vn, k * numRegisters.k + vk});
+  // Fill broadcast slots. When the outer dim is smaller than the MMA fragment
+  // extent (e.g. M=1<16, N=2<8) the layout collapses broadcast registers, but
+  // the MMA emitter indexes every fragment slot. Alias each missing slot to a
+  // populated one (mod #present); otherwise the inline asm has fewer params
+  // than constraints (cantFail abort).
+  int numOuterRegs = repOuter * numRegOuter;
+  for (int bIdx = 0; bIdx < std::max(repBatch, 1); ++bIdx) {
+    for (int kReg = 0; kReg < std::max(repK, 1) * numRegisters.k; ++kReg) {
+      // Collect the outer-register slots that were actually produced for this
+      // (b, kReg).  Broadcast collapses to the low coordinates, so these form a
+      // contiguous prefix, but we don't rely on that here.
+      SmallVector<int> present;
+      for (int oReg = 0; oReg < numOuterRegs; ++oReg) {
+        if (vals.count({bIdx, oReg, kReg})) {
+          present.push_back(oReg);
+        }
+      }
+      if (present.empty()) {
+        continue; // nothing to broadcast from (handled elsewhere)
+      }
+      for (int oReg = 0; oReg < numOuterRegs; ++oReg) {
+        if (!vals.count({bIdx, oReg, kReg})) {
+          vals[{bIdx, oReg, kReg}] =
+              vals[{bIdx, present[oReg % present.size()], kReg}];
+        }
+      }
+    }
   }
   return vals;
 }
@@ -762,21 +726,13 @@ convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
   int repM = repA[1], repN = repB[2], repK = repA[2];
   int repBatch = repA[0];
 
-  // We can reuse the same iteration order in
-  // getValuesFromDotOperandLayoutStruct as both a and b are K-major
-  assert(dotOpA.getRepOrder() == getOrderForDotOperand(dotOpA.getOpIdx(),
-                                                       aShapePerCTA.size(),
-                                                       /*kContig=*/true));
   auto ha = getValuesFromDotOperandLayoutStruct(typeConverter, loc, rewriter,
-                                                llvmA, repBatch, repM, repK,
-                                                aTensorTy, numRegisters);
+                                                llvmA, aTensorTy, numRegisters,
+                                                repBatch, repM, repK);
 
-  assert(dotOpB.getRepOrder() == getOrderForDotOperand(dotOpB.getOpIdx(),
-                                                       bShapePerCTA.size(),
-                                                       /*kContig=*/true));
   auto hb = getValuesFromDotOperandLayoutStruct(typeConverter, loc, rewriter,
-                                                llvmB, repBatch, repN, repK,
-                                                bTensorTy, numRegisters);
+                                                llvmB, bTensorTy, numRegisters,
+                                                repBatch, repN, repK);
 
   auto fc = unpackLLElements(loc, loadedC, rewriter);
 
@@ -791,11 +747,12 @@ convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
   auto elemsPerThread = triton::gpu::getElemsPerThread(dTensorTy);
   auto batchOffset =
       elemsPerThread[rank - 2] * elemsPerThread[rank - 1] / numCPackedElem;
+  // The register layout uses a nextPow2(repN) stride per N-rep set; match it
+  // here so colsPerThread lines up with the LinearLayout register ordering.
+  unsigned colsPerThread = (1u << llvm::Log2_64_Ceil(std::max(repN, 1))) * 2;
   auto callMma = [&](unsigned b, unsigned m, unsigned n, unsigned k) {
     PTXBuilder builder;
     auto &mma = *builder.create(mmaInstructions.at(mmaType));
-    // using =r for float32 works but leads to less readable ptx.
-    unsigned colsPerThread = repN * 2;
     emitMma(builder, b, static_cast<int>(m), static_cast<int>(n),
             static_cast<int>(k), mma, numMmaRets, colsPerThread, batchOffset,
             ha, hb, fc, dTensorTy, repK);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -32,6 +32,7 @@ using namespace mlir::triton::NVIDIA;
 
 using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
 using ::mlir::triton::gpu::getShapePerCTA;
+using ::mlir::triton::gpu::getTotalElemsPerThread;
 using ::mlir::triton::gpu::MemDescType;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ::mlir::triton::gpu::SharedEncodingTrait;
@@ -261,12 +262,20 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
 
   auto func = op->getParentOfType<LLVM::LLVMFuncOp>();
   Operation *startSequence = NVVM::WgmmaFenceAlignedOp::create(rewriter, loc);
+  // Per-rep stride into the accumulator. Pow2 N: not padded, so
+  // fc.size()/totalReps == accSize (no-op). NPOT N: fc is pow2-padded, so index
+  // with that stride but read only the accSize real values per rep.
+  unsigned totalReps = static_cast<unsigned>(numRepM * numRepN);
+  unsigned inAccRepStride = accSize;
+  if (!fc.empty() && totalReps > 0 && fc.size() % totalReps == 0) {
+    inAccRepStride = fc.size() / totalReps;
+  }
   SmallVector<Value> mmaResults;
   for (int m = 0; m < numRepM; ++m) {
     for (int n = 0; n < numRepN; ++n) {
       llvm::SmallVector<Value> mmaOut =
-          loadReg(rewriter, loc, fc, (m * numRepN + n) * accSize, accSize,
-                  startSequence);
+          loadReg(rewriter, loc, fc, (m * numRepN + n) * inAccRepStride,
+                  accSize, startSequence);
       llvm::SmallVector<Type> elemTypes;
       for (Value accEl : mmaOut)
         elemTypes.push_back(accEl.getType());
@@ -338,6 +347,26 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
 
   SmallVector<Value> results =
       unpackAccumulator(rewriter, loc, mmaResults, dTensorTy);
+
+  // NPOT N: WGMMA produces accSize real values/rep but the register dim is
+  // pow2-padded, so pad with aliases of the modular-wrapped canonical values.
+  // Guard on expectedElems % totalReps == 0 (else paddedPerRep would truncate
+  // to a wrong-sized struct).
+  unsigned expectedElems = getTotalElemsPerThread(dTensorTy);
+  if (results.size() < expectedElems && totalReps > 0 &&
+      expectedElems % totalReps == 0) {
+    unsigned realPerRep = accSize;
+    unsigned paddedPerRep = expectedElems / totalReps;
+    SmallVector<Value> padded;
+    padded.reserve(expectedElems);
+    for (unsigned rep = 0; rep < totalReps; ++rep) {
+      unsigned base = rep * realPerRep;
+      for (unsigned r = 0; r < paddedPerRep; ++r) {
+        padded.push_back(results[base + r % realPerRep]);
+      }
+    }
+    results = std::move(padded);
+  }
 
   // replace with new packed result
   Type structTy = LLVM::LLVMStructType::getLiteral(

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -3,7 +3,10 @@
 #include <gtest/gtest.h>
 
 #include "mlir/AsmParser/AsmParser.h"
+#include "mlir/IR/Builders.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/StrUtil.h"
 #include "llvm/Support/Signals.h"
@@ -705,6 +708,76 @@ TEST_F(LinearEncodingTest, NpotBasesPerDimLaneCounts) {
     ASSERT_EQ(tpw[0], 3u) << "Expected 3 threads in dim 0, got " << tpw[0];
     ASSERT_EQ(tpw[1], 5u) << "Expected 5 threads in dim 1, got " << tpw[1];
   }
+}
+
+// Exercises the failure path of inferReshapeOpDstEncoding in
+// lib/Dialect/TritonGPU/Transforms/Utility.cpp, which D105735350 changed from
+// `assert(succeeded(result))` to `if (failed(result)) return {};`. The
+// reshape inference fails when the candidate encoding is not a
+// DistributedEncodingTrait (the legacy path bails and the LinearLayout
+// fallback is gated on DistributedEncodingTrait). Before the change this
+// asserted (debug abort / release UB); now inferDstEncoding/inferSrcEncoding
+// must return a null Attribute so callers (e.g. RemoveLayoutConversions'
+// setEncoding) skip propagation and leave the op in place.
+class InferReshapeFailurePathTest : public ::testing::Test {
+public:
+  InferReshapeFailurePathTest() {
+    ctx.getOrLoadDialect<triton::TritonDialect>();
+    ctx.getOrLoadDialect<TritonGPUDialect>();
+  }
+
+protected:
+  MLIRContext ctx;
+};
+
+TEST_F(InferReshapeFailurePathTest, NonDistributedEncodingReturnsNull) {
+  OpBuilder builder(&ctx);
+  Location loc = builder.getUnknownLoc();
+
+  // Build a real tt.reshape: src 2D blocked tensor -> 1D result. The op itself
+  // is well-formed; we then drive inference with a NON-distributed candidate
+  // encoding to force inferReshapeOpEncoding to fail.
+  SmallVector<int64_t> srcShape = {8, 4};
+  SmallVector<int64_t> dstShape = {32};
+  auto elemTy = builder.getF16Type();
+
+  auto blocked = triton::gpu::BlockedEncodingAttr::get(
+      &ctx, /*sizePerThread=*/{1, 1}, /*threadsPerWarp=*/{8, 4},
+      /*warpsPerCTA=*/{1, 1}, /*order=*/{1, 0},
+      triton::gpu::CGAEncodingAttr::get1CTALayout(&ctx, /*rank=*/2));
+  auto srcTy = RankedTensorType::get(srcShape, elemTy, blocked);
+
+  // Materialize a source Value of srcTy without needing a full module.
+  auto srcVal =
+      builder.create<UnrealizedConversionCastOp>(loc, srcTy, ValueRange{})
+          .getResult(0);
+  auto reshape = builder.create<triton::ReshapeOp>(loc, dstShape, srcVal,
+                                                   /*allowReorder=*/false);
+
+  // A shared encoding is NOT a DistributedEncodingTrait, so the reshape
+  // inference fails for it. Both directions must return a null Attribute, not
+  // assert/crash.
+  Attribute sharedEnc = triton::gpu::SwizzledSharedEncodingAttr::get(
+      &ctx, /*vec=*/1, /*perPhase=*/1, /*maxPhase=*/1, /*order=*/{1, 0},
+      triton::gpu::CGAEncodingAttr::get1CTALayout(&ctx, /*rank=*/2));
+
+  Attribute dstEnc = inferDstEncoding(reshape.getOperation(), sharedEnc);
+  EXPECT_FALSE(dstEnc)
+      << "inferDstEncoding should return null when reshape inference fails";
+
+  Attribute srcEnc = inferSrcEncoding(reshape.getOperation(), sharedEnc);
+  EXPECT_FALSE(srcEnc)
+      << "inferSrcEncoding should return null when reshape inference fails";
+
+  // Sanity: a valid distributed candidate still infers successfully (the LL
+  // fallback path), confirming the failure above is specific to the
+  // non-distributed encoding and not a broken op.
+  Attribute okEnc = inferDstEncoding(reshape.getOperation(), blocked);
+  EXPECT_TRUE(okEnc)
+      << "inferDstEncoding should succeed for a distributed candidate encoding";
+
+  reshape.erase();
+  srcVal.getDefiningOp()->erase();
 }
 
 } // namespace

--- a/unittest/Tools/LayoutUtilsTest.cpp
+++ b/unittest/Tools/LayoutUtilsTest.cpp
@@ -45,5 +45,65 @@ TEST_F(LayoutUtilsTest, SquareSublayoutIsIdentity) {
   EXPECT_TRUE(squareSublayoutIsIdentity(l3, {S("in1"), S("in2")}));
 }
 
+// computeDeadPositionMap must repair "phantom" register positions whose
+// register-only NPOT coordinate wraps onto a register-reachable canonical at
+// the SAME lane/warp -- even when lane/warp ALSO contribute to the NPOT dim.
+// This is the NPOT-M blocked->blocked FMA store case (M=96): a register-rep
+// count of 3 is padded to 4, and the phantom 4th rep (reg coord 96) wraps
+// (mod 96) onto reg coord 0, the canonical owned by the same thread.
+TEST_F(LayoutUtilsTest, DeadPositionMapRegisterPhantomWithLaneWarpOnNpotDim) {
+  auto kReg = S("register"), kLane = S("lane"), kWarp = S("warp");
+  // dim0 is modular (size 96). Register bases include the rep strides 32 and
+  // 64 (so reg coords 0,32,64,96 are reachable; 96 mod 96 = 0). Lane/warp also
+  // contribute to dim0 (strides 4 and 8/16), exercising the relaxed path.
+  LinearLayout layout({{kReg, {{0}, {0}, {1}, {2}, {32}, {64}}},
+                       {kLane, {{0}, {0}, {0}, {0}, {4}}},
+                       {kWarp, {{8}, {16}}}},
+                      {{S("dim0"), 96}}, /*requireSurjective=*/false);
+  ASSERT_TRUE(layout.isModular());
+
+  auto deadMap = computeDeadPositionMap(layout, kReg, kLane, kWarp);
+  EXPECT_FALSE(deadMap.empty());
+
+  int numRegBits = layout.getInDimSizeLog2(kReg);
+  auto regCoord = [&](int r) {
+    int c = 0;
+    for (int b = 0; b < numRegBits; ++b) {
+      if (r & (1 << b)) {
+        c += layout.getBasis(kReg, b)[0];
+      }
+    }
+    return c;
+  };
+  for (auto &[dead, canon] : deadMap) {
+    EXPECT_LT(canon, layout.getInDimSize(kReg));
+    // The dead register's reg-only coord must be >= N (it is a phantom)...
+    EXPECT_GE(regCoord(dead), 96);
+    // ...and the canonical's reg-only coord must equal it mod N (sound copy).
+    EXPECT_EQ(regCoord(canon), regCoord(dead) % 96);
+  }
+}
+
+// When the wrapped (canonical) coordinate is NOT register-reachable at the same
+// lane/warp (e.g. the MMAv2 N case where dead positions are driven by
+// lane/warp), no fixup entry must be produced -- copying would move data across
+// threads and corrupt results.
+TEST_F(LayoutUtilsTest, DeadPositionMapNoRegisterCanonicalEmits) {
+  auto kReg = S("register"), kLane = S("lane"), kWarp = S("warp");
+  // dim0 modular (size 48). The only register stride into dim0 is 32 (so reg
+  // coords 0 and 32 only); the wrap of any phantom would need coord 16, which
+  // is reachable ONLY via lane (stride 16), not registers. No register-only
+  // canonical exists for such phantoms, so they must be left unmapped.
+  LinearLayout layout({{kReg, {{0}, {32}}},
+                       {kLane, {{1}, {2}, {4}, {8}, {16}}},
+                       {kWarp, {{0}}}},
+                      {{S("dim0"), 48}}, /*requireSurjective=*/false);
+  ASSERT_TRUE(layout.isModular());
+  auto deadMap = computeDeadPositionMap(layout, kReg, kLane, kWarp);
+  // reg coord 32 < 48, so there is no register-only phantom at all here; map
+  // must be empty (nothing to repair within the thread).
+  EXPECT_TRUE(deadMap.empty());
+}
+
 } // namespace
 } // namespace mlir::triton


### PR DESCRIPTION
Summary:
SM90 (Hopper / MMAv3) compiler support for NPOT dot operations.

Key changes:
- MMAv3 M constraint relaxed from M%64 to M%16, enabling WGMMA for NPOT M
  values (96, 48, 80, 112). MMAv2 still rejects NPOT shapes (falls to FMA)
  since its toLinearLayout can't handle modular register layouts.
- WGMMA accumulator padding for NPOT N (e.g. instrShape [16,192,16]): pads
  accSize=96 results to getTotalElemsPerThread=128 with SSA aliases of
  modular-wrapped canonical values; LLVM copy propagation eliminates the
  duplicates. Fixes an accumulator stride bug that single-K-iteration tests
  had masked.
- NPOT pass guards: ReduceDataDuplication, RemoveLayoutConversions,
  AllocateSharedMemoryNv, and the centralized cvtNeedsSharedMemory guard
  prevent toLinearLayout crashes on non-MMAv3 NPOT layouts.
- mmaVersionToInstrShape: assert(false) -> llvm::report_fatal_error; mWarps
  capped to numWarps for NPOT M.
- MMAHelpers.h: buildFromLL and computeSMEMDescriptor for MMAv3 NPOT
  descriptor construction.
- ConvertLayoutOpToLLVM: dead-register fixup and unfoldModularDimsForAlloc
  for NPOT accumulators.
- MMAv2.cpp: getValuesFromDotOperandLayoutStruct maps registers via the
  LinearLayout, and fixes the fp64 K-register index (fp64 is non-largeK, so
  K-registers are uniformly K-strided and indexed linearly as kCoord/kStep).
  Without it, fp64 tl.dot on sm_90 aborts at compile ("number of input
  constraints does not match number of parameters", mma.sync.m16n8k16.f64)
  when TRITON_ALLOW_NPOT is set.

Reviewed By: stashuk-olek, dshi7

Differential Revision: D105735350
