### PR TITLE
general compilation-pipeline onboarding tutorials

### DIFF
--- a/python/test/unit/language/test_tutorial_compilation_pipeline.py
+++ b/python/test/unit/language/test_tutorial_compilation_pipeline.py
@@ -18,9 +18,7 @@ try:
 except Exception:  # pragma: no cover - torch always present in this env
     _HAS_CUDA = False
 
-_DIR = os.path.join(
-    os.path.dirname(__file__), "..", "..", "..", "tutorials", "compilation-pipeline"
-)
+_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "tutorials", "compilation-pipeline")
 _EXAMPLES = [
     "01_read_ttir.py",
     "02_layout_assignment.py",
@@ -28,7 +26,26 @@ _EXAMPLES = [
     "04_remove_layout_conversions.py",
     "05_software_pipelining.py",
     "06_warp_specialization.py",
+    "07_reduction_lowering.py",
+    "08_reduction_order_numerics.py",
+    "09_dot_to_mma_lowering.py",
+    "10_mma_precision_numerics.py",
 ]
+
+# Tutorials that demonstrate a single named compiler pass via the dump_passes /
+# pass_diff hook print a ">>> pass-diff: <PassName>" line. Asserting on it proves
+# the examples close the loop on *specific passes* (not just the final IR) —
+# 08/10 are numerics demos that diff whole configs instead.
+_PASS_DIFF_EXAMPLES = {
+    "01_read_ttir.py",
+    "02_layout_assignment.py",
+    "03_coalesce_vectorization.py",
+    "04_remove_layout_conversions.py",
+    "05_software_pipelining.py",
+    "06_warp_specialization.py",
+    "07_reduction_lowering.py",
+    "09_dot_to_mma_lowering.py",
+}
 
 
 @pytest.mark.skipif(not _HAS_CUDA, reason="compilation-pipeline examples need a CUDA GPU")
@@ -38,4 +55,9 @@ def test_example_runs(script):
     assert os.path.exists(path), path
     proc = subprocess.run([sys.executable, path], capture_output=True, text=True, timeout=600)
     assert proc.returncode == 0, f"{script} failed:\n{proc.stdout[-3000:]}\n{proc.stderr[-3000:]}"
-    assert "[OK]" in proc.stdout or "skipped" in proc.stdout, proc.stdout[-2000:]
+    skipped = "skipped" in proc.stdout
+    assert "[OK]" in proc.stdout or skipped, proc.stdout[-2000:]
+    # The per-pass hook must actually run (unless the example self-skipped on this
+    # hardware): a relevant pass name is printed as a ">>> pass-diff:" line.
+    if script in _PASS_DIFF_EXAMPLES and not skipped:
+        assert ">>> pass-diff:" in proc.stdout, proc.stdout[-2000:]

--- a/python/test/unit/language/test_tutorial_compilation_pipeline.py
+++ b/python/test/unit/language/test_tutorial_compilation_pipeline.py
@@ -5,6 +5,14 @@ transform, and asserts its own runtime correctness. We run each as a subprocess
 (the files are digit-prefixed, so they are scripts, not importable modules) and
 require a clean exit. The examples self-skip when hardware is missing, so this
 passes on any CUDA box and the Blackwell-only one no-ops off Blackwell.
+
+The tutorials live in a *different* source tree than this test
+(``python/tutorials/`` vs ``python/test/``). A hardcoded ``../../../`` relative
+path resolves under the OSS checkout but not under Buck, where each target gets
+its own link-tree. We instead anchor on the importable ``triton`` package
+(``tutorials/`` is a sibling of ``triton/`` under ``python/`` in both layouts)
+and fall back to walking up from this file; if the scripts are not packaged with
+this test target at all, the cases self-skip rather than hard-fail.
 """
 import os
 import subprocess
@@ -18,7 +26,39 @@ try:
 except Exception:  # pragma: no cover - torch always present in this env
     _HAS_CUDA = False
 
-_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "tutorials", "compilation-pipeline")
+
+def _find_examples_dir():
+    """Locate ``tutorials/compilation-pipeline`` in OSS or Buck layouts.
+
+    Returns the directory (verified to contain ``_ir_utils.py``) or ``None`` if
+    it cannot be found, in which case the tests self-skip.
+    """
+    rel = os.path.join("tutorials", "compilation-pipeline")
+    candidates = []
+    # Most robust: anchor on the installed triton package. `tutorials/` sits next
+    # to `triton/` under `python/` in both the OSS tree and the Buck link-tree.
+    try:
+        import triton
+        py_root = os.path.dirname(os.path.dirname(os.path.abspath(triton.__file__)))
+        candidates.append(os.path.join(py_root, rel))
+    except Exception:  # pragma: no cover - triton always importable in this env
+        pass
+    # OSS source layout: three levels up from this test file.
+    candidates.append(os.path.join(os.path.dirname(__file__), "..", "..", "..", rel))
+    # Fallback: walk up from this file, trying both `<d>/python/<rel>` and `<d>/<rel>`.
+    d = os.path.dirname(os.path.abspath(__file__))
+    for _ in range(10):
+        candidates.append(os.path.join(d, "python", rel))
+        candidates.append(os.path.join(d, rel))
+        d = os.path.dirname(d)
+    for c in candidates:
+        c = os.path.abspath(c)
+        if os.path.exists(os.path.join(c, "_ir_utils.py")):
+            return c
+    return None
+
+
+_DIR = _find_examples_dir()
 _EXAMPLES = [
     "01_read_ttir.py",
     "02_layout_assignment.py",
@@ -51,9 +91,17 @@ _PASS_DIFF_EXAMPLES = {
 @pytest.mark.skipif(not _HAS_CUDA, reason="compilation-pipeline examples need a CUDA GPU")
 @pytest.mark.parametrize("script", _EXAMPLES)
 def test_example_runs(script):
-    path = os.path.abspath(os.path.join(_DIR, script))
-    assert os.path.exists(path), path
-    proc = subprocess.run([sys.executable, path], capture_output=True, text=True, timeout=600)
+    if _DIR is None:
+        pytest.skip("compilation-pipeline tutorials are not packaged with this test target")
+    path = os.path.join(_DIR, script)
+    if not os.path.exists(path):
+        pytest.skip(f"{script} is not packaged with this test target")
+    # Make the sibling `_ir_utils` import resolve in the child interpreter. When a
+    # plain `python script.py` runs, CPython prepends the script's dir to sys.path,
+    # but a Buck par launched via sys.executable does not, so set it explicitly.
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([_DIR, env.get("PYTHONPATH", "")]).strip(os.pathsep)
+    proc = subprocess.run([sys.executable, path], capture_output=True, text=True, timeout=600, env=env)
     assert proc.returncode == 0, f"{script} failed:\n{proc.stdout[-3000:]}\n{proc.stderr[-3000:]}"
     skipped = "skipped" in proc.stdout
     assert "[OK]" in proc.stdout or skipped, proc.stdout[-2000:]

--- a/python/test/unit/language/test_tutorial_compilation_pipeline.py
+++ b/python/test/unit/language/test_tutorial_compilation_pipeline.py
@@ -1,0 +1,41 @@
+"""Smoke tests for the compilation-pipeline tutorials.
+
+Each tutorial is a runnable script that compiles a kernel, prints a per-stage IR
+transform, and asserts its own runtime correctness. We run each as a subprocess
+(the files are digit-prefixed, so they are scripts, not importable modules) and
+require a clean exit. The examples self-skip when hardware is missing, so this
+passes on any CUDA box and the Blackwell-only one no-ops off Blackwell.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+try:
+    import torch
+    _HAS_CUDA = torch.cuda.is_available()
+except Exception:  # pragma: no cover - torch always present in this env
+    _HAS_CUDA = False
+
+_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "tutorials", "compilation-pipeline"
+)
+_EXAMPLES = [
+    "01_read_ttir.py",
+    "02_layout_assignment.py",
+    "03_coalesce_vectorization.py",
+    "04_remove_layout_conversions.py",
+    "05_software_pipelining.py",
+    "06_warp_specialization.py",
+]
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="compilation-pipeline examples need a CUDA GPU")
+@pytest.mark.parametrize("script", _EXAMPLES)
+def test_example_runs(script):
+    path = os.path.abspath(os.path.join(_DIR, script))
+    assert os.path.exists(path), path
+    proc = subprocess.run([sys.executable, path], capture_output=True, text=True, timeout=600)
+    assert proc.returncode == 0, f"{script} failed:\n{proc.stdout[-3000:]}\n{proc.stderr[-3000:]}"
+    assert "[OK]" in proc.stdout or "skipped" in proc.stdout, proc.stdout[-2000:]

--- a/python/tutorials/compilation-pipeline/01_read_ttir.py
+++ b/python/tutorials/compilation-pipeline/01_read_ttir.py
@@ -1,0 +1,60 @@
+"""01 — Reading the first IR: TTIR (the hardware-agnostic tensor IR).
+
+Pipeline stage: **TTIR** (Triton IR), produced by the frontend before any GPU
+mapping. Source: ``python/triton/compiler/`` (``make_ttir`` in the NVIDIA backend
+``third_party/nvidia/backend/compiler.py``).
+
+What to notice: TTIR is *layout-free*. Tensor types are just ``tensor<256xf32>``
+with no ``#blocked`` / thread-mapping encoding — that mapping is added in the next
+stage (TTGIR). The ops are the high-level tensor ops you wrote: ``tt.make_range``,
+``tt.load``, ``arith.addf``, ``tt.store``.
+
+Bit-neutral mechanic: this stage only records *what* to compute, not *how* it maps
+onto threads, so it does not by itself decide FP bit results.
+
+Run:  python python/tutorials/compilation-pipeline/01_read_ttir.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, is_cuda, show
+
+
+@triton.jit
+def add_kernel(x_ptr, y_ptr, o_ptr, n, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(o_ptr + offs, x + y, mask=mask)
+
+
+def main():
+    n, BLOCK = 1024, 256
+    x = torch.randn(n, device="cuda")
+    y = torch.randn(n, device="cuda")
+    o = torch.empty_like(x)
+
+    # Compile only (no launch) to read the IR.
+    ck = compile_only(add_kernel, x, y, o, n, BLOCK=BLOCK, grid=(1, ))
+
+    banner("01 — TTIR: the hardware-agnostic tensor IR (no layouts yet)")
+    show(ck, "ttir", grep=["tt.", "arith."], limit=40)
+    print("\nNote: tensor types are plain `tensor<256xf32>` — NO #blocked encoding."
+          "\n      The thread/warp mapping is added in the next stage (see 02).")
+
+    # Correctness check (real launch): vector add is exact in fp32.
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]), )
+    add_kernel[grid](x, y, o, n, BLOCK=BLOCK)
+    torch.cuda.synchronize()
+    assert torch.equal(o, x + y), "vector add must match torch exactly"
+    print("\n[OK] runtime result is bitwise-equal to torch x + y")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/01_read_ttir.py
+++ b/python/tutorials/compilation-pipeline/01_read_ttir.py
@@ -19,7 +19,7 @@ import torch
 import triton
 import triton.language as tl
 
-from _ir_utils import banner, compile_only, is_cuda, show
+from _ir_utils import banner, compile_only, dump_passes, is_cuda, pass_diff, show
 
 
 @triton.jit
@@ -45,6 +45,25 @@ def main():
     show(ck, "ttir", grep=["tt.", "arith."], limit=40)
     print("\nNote: tensor types are plain `tensor<256xf32>` — NO #blocked encoding."
           "\n      The thread/warp mapping is added in the next stage (see 02).")
+
+    # Close the loop: don't just read the *stage* output — look at an individual
+    # PASS. dump_passes turns on Triton's MLIR_ENABLE_DUMP (the pass manager
+    # prints the IR around every pass) and captures it; pass_diff shows what one
+    # named pass rewrote. Equivalent on the CLI to:
+    #   MLIR_ENABLE_DUMP=add_kernel TRITON_ALWAYS_COMPILE=1 python 01_read_ttir.py
+    banner("01 — a specific TTIR pass (canonicalize), not just the stage output")
+    dumps = dump_passes(add_kernel, x, y, o, n, BLOCK=BLOCK, grid=(1, ))
+    ttir_passes = []
+    for r in dumps:
+        if "convert-triton-to-tritongpu" in r["pass"].lower():
+            break  # everything after this is TTGIR, not TTIR
+        if r["event"] == "Before":
+            ttir_passes.append(r["pass"])
+    print("    TTIR-stage passes that ran (in order):")
+    for p in ttir_passes:
+        print("      - " + p)
+    print("\n    What `canonicalize` did to the TTIR (folds the duplicate 256 constant):")
+    pass_diff(dumps, "canonicalize", grep=["tt.", "arith.", "scf."], limit=24)
 
     # Correctness check (real launch): vector add is exact in fp32.
     grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]), )

--- a/python/tutorials/compilation-pipeline/02_layout_assignment.py
+++ b/python/tutorials/compilation-pipeline/02_layout_assignment.py
@@ -1,0 +1,71 @@
+"""02 — Layout assignment: TTIR -> TTGIR (the defining TritonGPU step).
+
+Pipeline stage: **TTGIR**, entry pass ``convert-triton-to-tritongpu``
+(``third_party/nvidia/backend/compiler.py`` -> ``make_ttgir``).
+
+What to notice: every tensor type gains a **layout encoding** describing the
+thread/warp/CTA -> element mapping, e.g.
+``tensor<256xf32, #ttg.blocked<{sizePerThread=[..], threadsPerWarp=[32],
+warpsPerCTA=[N], order=[0]}>>``. ``num_warps`` flows straight into
+``warpsPerCTA``: compile the SAME kernel with ``num_warps=4`` vs ``8`` and the
+encoding changes.
+
+Bit-neutral here, but FOUNDATIONAL: this layout is exactly what later fixes a
+reduction's tree shape, which is what can make a reduction's FP result depend on
+accumulation order. For a plain elementwise add the layout does not change the
+bits.
+
+Run:  python python/tutorials/compilation-pipeline/02_layout_assignment.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, diff, is_cuda, show
+
+
+@triton.jit
+def add_kernel(x_ptr, y_ptr, o_ptr, n, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    tl.store(o_ptr + offs, tl.load(x_ptr + offs, mask=mask) + tl.load(y_ptr + offs, mask=mask), mask=mask)
+
+
+def main():
+    n, BLOCK = 4096, 1024
+    x = torch.randn(n, device="cuda")
+    y = torch.randn(n, device="cuda")
+    o = torch.empty_like(x)
+
+    ck4 = compile_only(add_kernel, x, y, o, n, BLOCK=BLOCK, num_warps=4, grid=(1, ))
+    ck8 = compile_only(add_kernel, x, y, o, n, BLOCK=BLOCK, num_warps=8, grid=(1, ))
+
+    banner("02 — same op, before vs after layout assignment")
+    print("TTIR (no layout) — note the plain tensor type on arith.addf:")
+    show(ck4, "ttir", grep="arith.addf", limit=3)
+    print("\nTTGIR (layout attached, num_warps=4):")
+    show(ck4, "ttgir", grep="#blocked =", limit=3)
+    print("TTGIR (layout attached, num_warps=8):")
+    show(ck8, "ttgir", grep="#blocked =", limit=3)
+
+    banner("02 — num_warps flows into warpsPerCTA (the thread mapping)")
+    diff(ck4, ck8, "ttgir", grep="#blocked =", label_a="num_warps=4", label_b="num_warps=8")
+
+    # Bit-neutral for elementwise add: both layouts give the exact same result.
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]), )
+    o4 = torch.empty_like(x)
+    o8 = torch.empty_like(x)
+    add_kernel[grid](x, y, o4, n, BLOCK=BLOCK, num_warps=4)
+    add_kernel[grid](x, y, o8, n, BLOCK=BLOCK, num_warps=8)
+    torch.cuda.synchronize()
+    assert torch.equal(o4, o8) and torch.equal(o4, x + y), "elementwise add is layout-invariant"
+    print("\n[OK] num_warps=4 and num_warps=8 give bitwise-identical results"
+          " (elementwise add is layout-invariant).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/02_layout_assignment.py
+++ b/python/tutorials/compilation-pipeline/02_layout_assignment.py
@@ -22,7 +22,7 @@ import torch
 import triton
 import triton.language as tl
 
-from _ir_utils import banner, compile_only, diff, is_cuda, show
+from _ir_utils import banner, compile_only, diff, dump_passes, is_cuda, pass_diff, show
 
 
 @triton.jit
@@ -52,6 +52,12 @@ def main():
 
     banner("02 — num_warps flows into warpsPerCTA (the thread mapping)")
     diff(ck4, ck8, "ttgir", grep="#blocked =", label_a="num_warps=4", label_b="num_warps=8")
+
+    # The pass that does it: `convert-triton-to-tritongpu`. pass_diff shows the
+    # exact rewrite — a `#blocked` layout appears and every tensor type gains it.
+    banner("02 — the pass responsible: convert-triton-to-tritongpu")
+    dumps = dump_passes(add_kernel, x, y, o, n, BLOCK=BLOCK, num_warps=4, grid=(1, ))
+    pass_diff(dumps, "convert-triton-to-tritongpu", grep=["#blocked =", "tensor<", "tt.func"], limit=24)
 
     # Bit-neutral for elementwise add: both layouts give the exact same result.
     grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]), )

--- a/python/tutorials/compilation-pipeline/03_coalesce_vectorization.py
+++ b/python/tutorials/compilation-pipeline/03_coalesce_vectorization.py
@@ -1,0 +1,72 @@
+"""03 — Coalescing & vectorization: how memory accesses become vector ld/st in PTX.
+
+Pipeline: **TTGIR** ``Coalesce`` pass (``lib/Dialect/TritonGPU/Transforms/Coalesce.cpp``)
++ ``lib/Analysis/AxisInfo.cpp`` (alignment/contiguity) decide how many elements each
+thread loads contiguously (``sizePerThread`` on the blocked layout). That width then
+lowers to **PTX** vector memory ops ``ld.global.v{2,4}`` / ``st.global.v{2,4}``.
+
+Knob: with a fixed ``BLOCK``, more ``num_warps`` => fewer elements per thread =>
+narrower (or scalar) vectorization. We compile the same copy kernel two ways and
+diff the PTX.
+
+Bit-neutral mechanic: vectorization changes the *shape* of the memory traffic, not
+the values copied — both versions are bitwise-identical. (It only becomes a numerics
+knob indirectly, when a wider ``sizePerThread`` changes an intra-thread reduction
+fold.)
+
+Run:  python python/tutorials/compilation-pipeline/03_coalesce_vectorization.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, count, is_cuda, show
+
+
+@triton.jit
+def copy_kernel(src, dst, n, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    tl.store(dst + offs, tl.load(src + offs, mask=mask), mask=mask)
+
+
+def main():
+    n, BLOCK = 1 << 16, 1024
+    src = torch.randn(n, device="cuda")
+    dst = torch.empty_like(src)
+
+    # Same BLOCK; num_warps controls elements/thread => vectorization width.
+    wide = compile_only(copy_kernel, src, dst, n, BLOCK=BLOCK, num_warps=4, grid=(1, ))  # sizePerThread=4
+    narrow = compile_only(copy_kernel, src, dst, n, BLOCK=BLOCK, num_warps=32, grid=(1, ))  # sizePerThread=1
+
+    banner("03 — vectorization width on the blocked layout (sizePerThread)")
+    show(wide, "ttgir", grep="#blocked =", limit=2, label="num_warps=4  TTGIR layout:")
+    show(narrow, "ttgir", grep="#blocked =", limit=2, label="num_warps=32 TTGIR layout:")
+
+    banner("03 — the same width in PTX (vector vs scalar global memory ops)")
+    for label, ck in (("num_warps=4 ", wide), ("num_warps=32", narrow)):
+        v4 = count(ck, "ptx", "ld.global.v4") + count(ck, "ptx", "st.global.v4")
+        v2 = count(ck, "ptx", "ld.global.v2") + count(ck, "ptx", "st.global.v2")
+        scalar = count(ck, "ptx", "ld.global.b32") + count(ck, "ptx", "st.global.b32")
+        print(f"    {label}:  v4 ops={v4}  v2 ops={v2}  scalar(b32) ops={scalar}")
+    print("\n    (sample PTX global-memory ops, num_warps=4)")
+    show(wide, "ptx", grep=["ld.global", "st.global"], limit=6)
+
+    # Bit-neutral: vectorization does not change the copied values.
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]), )
+    d4 = torch.empty_like(src)
+    d32 = torch.empty_like(src)
+    copy_kernel[grid](src, d4, n, BLOCK=BLOCK, num_warps=4)
+    copy_kernel[grid](src, d32, n, BLOCK=BLOCK, num_warps=32)
+    torch.cuda.synchronize()
+    assert torch.equal(d4, src) and torch.equal(d32, src), "copy must be exact"
+    assert torch.equal(d4, d32), "vectorization width is bit-neutral for a copy"
+    print("\n[OK] wide (v4) and scalar copies are bitwise-identical (vectorization is bit-neutral).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/03_coalesce_vectorization.py
+++ b/python/tutorials/compilation-pipeline/03_coalesce_vectorization.py
@@ -14,6 +14,9 @@ the values copied — both versions are bitwise-identical. (It only becomes a nu
 knob indirectly, when a wider ``sizePerThread`` changes an intra-thread reduction
 fold.)
 
+We also compile a looped ``num_stages=2`` variant to contrast a synchronous vector
+load (``ld.global.v4``) with an asynchronous pipelined load (``cp.async``).
+
 Run:  python python/tutorials/compilation-pipeline/03_coalesce_vectorization.py
 """
 import torch
@@ -21,7 +24,7 @@ import torch
 import triton
 import triton.language as tl
 
-from _ir_utils import banner, compile_only, count, is_cuda, show
+from _ir_utils import banner, compile_only, count, dump_passes, is_cuda, pass_diff, show
 
 
 @triton.jit
@@ -30,6 +33,19 @@ def copy_kernel(src, dst, n, BLOCK: tl.constexpr):
     offs = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offs < n
     tl.store(dst + offs, tl.load(src + offs, mask=mask), mask=mask)
+
+
+@triton.jit
+def copy_kernel_pipelined(src, dst, n, BLOCK: tl.constexpr, STEPS: tl.constexpr):
+    # Same copy, but over a loop with num_stages=2. The software pipeliner then
+    # multi-buffers the load and issues it ASYNCHRONOUSLY (cp.async) so the next
+    # iteration's data is fetched while this one stores — the synchronous vector
+    # `ld.global` becomes `cp.async`.
+    base = tl.program_id(0) * BLOCK * STEPS
+    for i in tl.range(0, STEPS, num_stages=2):
+        offs = base + i * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        tl.store(dst + offs, tl.load(src + offs, mask=mask), mask=mask)
 
 
 def main():
@@ -54,16 +70,37 @@ def main():
     print("\n    (sample PTX global-memory ops, num_warps=4)")
     show(wide, "ptx", grep=["ld.global", "st.global"], limit=6)
 
-    # Bit-neutral: vectorization does not change the copied values.
+    # The pass that picks sizePerThread: `tritongpu-coalesce`. pass_diff shows it
+    # introducing the coalesced (wider sizePerThread) #blocked layout.
+    banner("03 — the pass responsible: tritongpu-coalesce")
+    dumps = dump_passes(copy_kernel, src, dst, n, BLOCK=BLOCK, num_warps=4, grid=(1, ))
+    pass_diff(dumps, "tritongpu-coalesce", grep=["#blocked", "tt.load", "tt.store"], limit=20)
+
+    # num_stages=2 in a for loop: synchronous vector load becomes async cp.async.
+    STEPS = 8
+    pipelined = compile_only(copy_kernel_pipelined, src, dst, n, BLOCK=BLOCK, STEPS=STEPS, num_warps=4, grid=(1, ))
+    banner("03 — num_stages=2 loop: vector ld.global vs asynchronous cp.async")
+    for label, ck in (("flat (1 stage) ", wide), ("looped (2 stages)", pipelined)):
+        ld_v = count(ck, "ptx", "ld.global.v4") + count(ck, "ptx", "ld.global.v2")
+        cp = count(ck, "ptx", "cp.async")
+        print(f"    {label}:  vector ld.global ops={ld_v:>2}   cp.async ops={cp:>2}")
+    print("\n    (the loop's load is now async — sample TTGIR)")
+    show(pipelined, "ttgir", grep="async_copy", limit=3)
+
+    # Bit-neutral: neither vectorization width nor pipelining changes the copy.
     grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]), )
     d4 = torch.empty_like(src)
     d32 = torch.empty_like(src)
     copy_kernel[grid](src, d4, n, BLOCK=BLOCK, num_warps=4)
     copy_kernel[grid](src, d32, n, BLOCK=BLOCK, num_warps=32)
+    dp = torch.empty_like(src)
+    copy_kernel_pipelined[(triton.cdiv(n, BLOCK * STEPS), )](src, dp, n, BLOCK=BLOCK, STEPS=STEPS, num_warps=4)
     torch.cuda.synchronize()
     assert torch.equal(d4, src) and torch.equal(d32, src), "copy must be exact"
     assert torch.equal(d4, d32), "vectorization width is bit-neutral for a copy"
-    print("\n[OK] wide (v4) and scalar copies are bitwise-identical (vectorization is bit-neutral).")
+    assert torch.equal(dp, src), "pipelined (cp.async) copy must be exact too"
+    print("\n[OK] vector (v4), scalar, and async (cp.async) copies are all bitwise-identical"
+          " (vectorization and pipelining are bit-neutral).")
 
 
 if __name__ == "__main__":

--- a/python/tutorials/compilation-pipeline/04_remove_layout_conversions.py
+++ b/python/tutorials/compilation-pipeline/04_remove_layout_conversions.py
@@ -1,0 +1,78 @@
+"""04 — RemoveLayoutConversions: the convert_layout-elimination workhorse.
+
+Pipeline: **TTGIR** ``RemoveLayoutConversions``
+(``lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp``), which runs
+5+ times during ``make_ttgir``. A ``ttg.convert_layout`` shuffles data between
+threads (often through shared memory) — pure overhead — so the pass propagates
+layouts to delete every conversion that isn't genuinely required.
+
+What to notice: an **elementwise** kernel needs ZERO conversions (one layout
+serves the whole kernel). A **transpose** needs exactly ONE: transposing changes
+which thread owns which element, so the data must physically move — that lone
+``convert_layout`` is irreducible and survives the pass.
+
+Bit-neutral mechanic: moving an element between threads does not change its value.
+(But *which* layout survives is what later fixes a reduction's tree, so for a
+reduction kernel it can change the FP accumulation order.)
+
+Watch redundant conversions disappear pass-by-pass:
+    MLIR_ENABLE_DUMP=transpose_kernel TRITON_ALWAYS_COMPILE=1 \\
+        python python/tutorials/compilation-pipeline/04_remove_layout_conversions.py
+
+Run:  python python/tutorials/compilation-pipeline/04_remove_layout_conversions.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, count, is_cuda, show
+
+
+@triton.jit
+def elementwise_kernel(x_ptr, o_ptr, n, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    tl.store(o_ptr + offs, tl.load(x_ptr + offs, mask=offs < n) * 2.0, mask=offs < n)
+
+
+@triton.jit
+def transpose_kernel(x_ptr, o_ptr, M: tl.constexpr, N: tl.constexpr):
+    rm = tl.arange(0, M)
+    rn = tl.arange(0, N)
+    x = tl.load(x_ptr + rm[:, None] * N + rn[None, :])
+    tl.store(o_ptr + rn[:, None] * M + rm[None, :], tl.trans(x))
+
+
+def main():
+    n, BLOCK = 1024, 1024
+    x1 = torch.randn(n, device="cuda")
+    o1 = torch.empty_like(x1)
+    M = N = 64
+    x2 = torch.randn(M, N, device="cuda")
+    o2 = torch.empty(N, M, device="cuda")
+
+    ck_elem = compile_only(elementwise_kernel, x1, o1, n, BLOCK=BLOCK, grid=(1, ))
+    ck_trans = compile_only(transpose_kernel, x2, o2, M, N, grid=(1, ))
+
+    banner("04 — convert_layout count = irreducible cross-thread data movement")
+    print(f"    elementwise (x*2):  ttg.convert_layout ops = {count(ck_elem, 'ttgir', 'convert_layout')}")
+    print(f"    transpose  (x.T) :  ttg.convert_layout ops = {count(ck_trans, 'ttgir', 'convert_layout')}")
+    print("\n    The pass deleted every *redundant* conversion. The transpose's one")
+    print("    survivor is necessary — transposing genuinely re-assigns elements to threads.")
+
+    banner("04 — the surviving conversion and the two layouts it bridges")
+    show(ck_trans, "ttgir", grep="#blocked", limit=2,
+         label="layout encodings (note the transposed order [1,0] vs [0,1]):")
+    show(ck_trans, "ttgir", grep="convert_layout", limit=4, label="the convert_layout op:")
+
+    # Bit-neutral: the transpose moves elements but preserves their values exactly.
+    transpose_kernel[(1, )](x2, o2, M, N)
+    torch.cuda.synchronize()
+    assert torch.equal(o2, x2.T.contiguous()), "transpose must be exact"
+    print("\n[OK] transpose result is bitwise-equal to x.T (layout conversion is bit-neutral).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/04_remove_layout_conversions.py
+++ b/python/tutorials/compilation-pipeline/04_remove_layout_conversions.py
@@ -26,7 +26,7 @@ import torch
 import triton
 import triton.language as tl
 
-from _ir_utils import banner, compile_only, count, is_cuda, show
+from _ir_utils import banner, compile_only, count, dump_passes, is_cuda, pass_diff, show
 
 
 @triton.jit
@@ -64,6 +64,12 @@ def main():
     show(ck_trans, "ttgir", grep="#blocked", limit=2,
          label="layout encodings (note the transposed order [1,0] vs [0,1]):")
     show(ck_trans, "ttgir", grep="convert_layout", limit=4, label="the convert_layout op:")
+
+    # The pass at work: `tritongpu-remove-layout-conversions` (it runs several
+    # times). pass_diff shows the first run deleting the redundant conversions.
+    banner("04 — the pass responsible: tritongpu-remove-layout-conversions")
+    dumps = dump_passes(transpose_kernel, x2, o2, M, N, grid=(1, ))
+    pass_diff(dumps, "remove-layout-conversions", grep="convert_layout", limit=16)
 
     # Bit-neutral: the transpose moves elements but preserves their values exactly.
     transpose_kernel[(1, )](x2, o2, M, N)

--- a/python/tutorials/compilation-pipeline/05_software_pipelining.py
+++ b/python/tutorials/compilation-pipeline/05_software_pipelining.py
@@ -21,7 +21,7 @@ import torch
 import triton
 import triton.language as tl
 
-from _ir_utils import banner, compile_only, count, is_cuda, show
+from _ir_utils import banner, compile_only, count, dump_passes, is_cuda, pass_diff, show
 
 
 @triton.jit
@@ -54,6 +54,12 @@ def main():
         print(f"    {label}:  async-copy ops = {count(ck, 'ttgir', 'async_copy'):>2}   "
               f"smem buffers (!ttg.memdesc) = {count(ck, 'ttgir', '!ttg.memdesc'):>2}")
     show(ck3, "ttgir", grep="async_copy", limit=3, label="\nsample async copies (num_stages=3):")
+
+    # The pass that does it: `tritongpu-pipeline`. pass_diff shows the K-loop's
+    # synchronous loads becoming multi-buffered async copies into shared memory.
+    banner("05 — the pass responsible: tritongpu-pipeline")
+    dumps = dump_passes(matmul_kernel, *args, num_stages=3, grid=(1, ))
+    pass_diff(dumps, "tritongpu-pipeline", grep=["async_copy", "memdesc_index", "local_alloc"], limit=20)
 
     # Bit-neutral: pipelining preserves the k-accumulation order exactly.
     c1 = torch.empty(M, N, device="cuda")

--- a/python/tutorials/compilation-pipeline/05_software_pipelining.py
+++ b/python/tutorials/compilation-pipeline/05_software_pipelining.py
@@ -1,0 +1,72 @@
+"""05 — Software pipelining: overlap loads with compute via num_stages.
+
+Pipeline: **TTGIR** ``AssignLatencies -> ScheduleLoops -> Pipeline``
+(``lib/Dialect/TritonGPU/Transforms/Pipeliner/``). With ``num_stages > 1`` the
+pipeliner multi-buffers a loop's loads and issues them **asynchronously**
+(``ttg.async_copy_global_to_local`` / ``cp.async`` / TMA) so iteration *k+1*'s data
+is fetched while iteration *k* computes.
+
+What to notice: in a matmul K-loop, ``num_stages=1`` has no async ops; ``num_stages=3``
+introduces many async copies + shared-memory buffers (``!ttg.memdesc``). The loop's
+*accumulation order over k is unchanged* — pipelining only moves *when loads happen*.
+
+Bit-neutral mechanic (a NEGATIVE example for the equivalence checker): reordering
+loads does not reassociate the FP accumulation, so results are bitwise-identical
+across ``num_stages``. We assert that.
+
+Run:  python python/tutorials/compilation-pipeline/05_software_pipelining.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, count, is_cuda, show
+
+
+@triton.jit
+def matmul_kernel(a_ptr, b_ptr, c_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, BM: tl.constexpr,
+                  BN: tl.constexpr, BK: tl.constexpr):
+    rm = tl.arange(0, BM)
+    rn = tl.arange(0, BN)
+    acc = tl.zeros([BM, BN], dtype=tl.float32)
+    for k in range(0, K, BK):
+        rk = k + tl.arange(0, BK)
+        a = tl.load(a_ptr + rm[:, None] * K + rk[None, :])
+        b = tl.load(b_ptr + rk[:, None] * N + rn[None, :])
+        acc += tl.dot(a, b, input_precision="ieee")  # ieee => deterministic FMA path
+    tl.store(c_ptr + rm[:, None] * N + rn[None, :], acc)
+
+
+def main():
+    M = N = K = 256
+    BM = BN = 64
+    BK = 32
+    a = torch.randn(M, K, device="cuda")
+    b = torch.randn(K, N, device="cuda")
+    args = (a, b, torch.empty(M, N, device="cuda"), M, N, K, BM, BN, BK)
+
+    ck1 = compile_only(matmul_kernel, *args, num_stages=1, grid=(1, ))
+    ck3 = compile_only(matmul_kernel, *args, num_stages=3, grid=(1, ))
+
+    banner("05 — num_stages multi-buffers the K-loop loads (async copies appear)")
+    for label, ck in (("num_stages=1", ck1), ("num_stages=3", ck3)):
+        print(f"    {label}:  async-copy ops = {count(ck, 'ttgir', 'async_copy'):>2}   "
+              f"smem buffers (!ttg.memdesc) = {count(ck, 'ttgir', '!ttg.memdesc'):>2}")
+    show(ck3, "ttgir", grep="async_copy", limit=3, label="\nsample async copies (num_stages=3):")
+
+    # Bit-neutral: pipelining preserves the k-accumulation order exactly.
+    c1 = torch.empty(M, N, device="cuda")
+    c3 = torch.empty(M, N, device="cuda")
+    matmul_kernel[(1, )](a, b, c1, M, N, K, BM, BN, BK, num_stages=1)
+    matmul_kernel[(1, )](a, b, c3, M, N, K, BM, BN, BK, num_stages=3)
+    torch.cuda.synchronize()
+    assert torch.equal(c1, c3), "software pipelining must be bitwise-neutral"
+    print("\n[OK] num_stages=1 and num_stages=3 give bitwise-identical results"
+          " (pipelining does not reassociate the accumulation).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/06_warp_specialization.py
+++ b/python/tutorials/compilation-pipeline/06_warp_specialization.py
@@ -1,0 +1,105 @@
+"""06 — Warp specialization (AutoWS): split warps into producer/consumer roles.
+
+Pipeline: **TTGIR** automatic warp specialization
+(``lib/Dialect/TritonGPU/Transforms/WarpSpecialization/`` +
+``third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/``). Enabled by
+``TRITON_USE_META_WS`` (``knobs.nvidia.use_meta_ws``) on a loop marked
+``tl.range(..., warp_specialize=True)``, the pass partitions a warp group into
+**producer** warps (TMA loads) and **consumer** warps (MMA), wrapping them in a
+``ttg.warp_specialize`` region and tagging ops with ``async_task_id``.
+
+What to notice: with AutoWS on, the persistent matmul's TTGIR gains
+``ttg.warp_specialize`` and ``async_task_id`` annotations that are absent otherwise.
+
+Bit-neutral mechanic: WS is a *scheduling* transform (who does what), not a change
+to the MMA math — the numeric result is the same. Requires datacenter Blackwell
+(MMAv5/tcgen05 + TMA); self-skips elsewhere.
+
+Run:  python python/tutorials/compilation-pipeline/06_warp_specialization.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from _ir_utils import banner, compile_only, count, is_blackwell, is_cuda, show
+
+
+@triton.jit
+def _matmul_persistent_ws(a_desc, b_desc, c_desc, M, N, K, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                          BLOCK_K: tl.constexpr, GROUP_M: tl.constexpr, NUM_SMS: tl.constexpr, FLATTEN: tl.constexpr):
+    start_pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    k_tiles = tl.cdiv(K, BLOCK_K)
+    num_tiles = num_pid_m * num_pid_n
+    num_pid_in_group = GROUP_M * num_pid_n
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=FLATTEN, warp_specialize=True,
+                            disallow_acc_multi_buffer=True, separate_epilogue_store=True):
+        group_id = tile_id // num_pid_in_group
+        first_pid_m = group_id * GROUP_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
+        pid_m = first_pid_m + (tile_id % group_size_m)
+        pid_n = (tile_id % num_pid_in_group) // group_size_m
+        offs_am = pid_m * BLOCK_M
+        offs_bn = pid_n * BLOCK_N
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            acc = tl.dot(a, b.T, acc)
+        c_desc.store([offs_am, offs_bn], acc.to(tl.float16))
+
+
+@triton.jit
+def matmul(a_desc, b_desc, c_desc, M, N, K, FLATTEN: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+           BLOCK_K: tl.constexpr, GROUP_M: tl.constexpr, NUM_SMS: tl.constexpr):
+    _matmul_persistent_ws(a_desc, b_desc, c_desc, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, NUM_SMS, FLATTEN)
+
+
+def main():
+    M, N, K = 512, 512, 256
+    BM, BN, BK, GROUP = 128, 128, 64, 8
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b = torch.randn((N, K), device="cuda", dtype=torch.float16)
+    c = torch.empty((M, N), device="cuda", dtype=torch.float16)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    a_desc = TensorDescriptor(a, [M, K], [K, 1], [BM, BK])
+    b_desc = TensorDescriptor(b, [N, K], [K, 1], [BN, BK])
+    c_desc = TensorDescriptor(c, [M, N], [N, 1], [BM, BN])
+    grid = (min(NUM_SMS, triton.cdiv(M, BM) * triton.cdiv(N, BN)), )
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True  # == TRITON_USE_META_WS=1
+        # FLATTEN=False is the warp-specializing config.
+        ck = compile_only(matmul, a_desc, b_desc, c_desc, M, N, K, False, BLOCK_M=BM, BLOCK_N=BN, BLOCK_K=BK,
+                          GROUP_M=GROUP, NUM_SMS=NUM_SMS, grid=grid)
+        banner("06 — AutoWS partitions warps (producer TMA loads / consumer MMA)")
+        print(f"    ttg.warp_specialize ops = {count(ck, 'ttgir', 'warp_specialize')}")
+        print(f"    async_task_id tags      = {count(ck, 'ttgir', 'async_task_id')}")
+        show(ck, "ttgir", grep="warp_specialize", limit=3, label="\nwarp_specialize region(s):")
+
+        matmul[grid](a_desc, b_desc, c_desc, M, N, K, False, BLOCK_M=BM, BLOCK_N=BN, BLOCK_K=BK, GROUP_M=GROUP,
+                     NUM_SMS=NUM_SMS)
+    torch.cuda.synchronize()
+
+    ref = (a.float() @ b.float().T).to(torch.float16)
+    torch.testing.assert_close(c, ref, atol=1e-2, rtol=1e-2)
+    print("\n[OK] warp-specialized matmul matches the torch reference"
+          " (WS is a scheduling transform, not a math change).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    if not is_blackwell():
+        print("[06] skipped — AutoWS example requires datacenter Blackwell (MMAv5 + TMA).")
+        raise SystemExit(0)
+    main()

--- a/python/tutorials/compilation-pipeline/06_warp_specialization.py
+++ b/python/tutorials/compilation-pipeline/06_warp_specialization.py
@@ -23,7 +23,7 @@ import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from _ir_utils import banner, compile_only, count, is_blackwell, is_cuda, show
+from _ir_utils import banner, compile_only, count, dump_passes, is_blackwell, is_cuda, pass_diff, show
 
 
 @triton.jit
@@ -85,6 +85,14 @@ def main():
         print(f"    ttg.warp_specialize ops = {count(ck, 'ttgir', 'warp_specialize')}")
         print(f"    async_task_id tags      = {count(ck, 'ttgir', 'async_task_id')}")
         show(ck, "ttgir", grep="warp_specialize", limit=3, label="\nwarp_specialize region(s):")
+
+        # The pass responsible: `nvgpu-warp-specialization`. pass_diff shows it
+        # wrapping the loop body in a ttg.warp_specialize region and tagging ops
+        # with async_task_id (producer vs consumer).
+        banner("06 — the pass responsible: nvgpu-warp-specialization")
+        dumps = dump_passes(matmul, a_desc, b_desc, c_desc, M, N, K, False, BLOCK_M=BM, BLOCK_N=BN, BLOCK_K=BK,
+                            GROUP_M=GROUP, NUM_SMS=NUM_SMS, grid=grid)
+        pass_diff(dumps, "warp-specialization", grep=["warp_specialize", "async_task_id"], limit=20)
 
         matmul[grid](a_desc, b_desc, c_desc, M, N, K, False, BLOCK_M=BM, BLOCK_N=BN, BLOCK_K=BK, GROUP_M=GROUP,
                      NUM_SMS=NUM_SMS)

--- a/python/tutorials/compilation-pipeline/07_reduction_lowering.py
+++ b/python/tutorials/compilation-pipeline/07_reduction_lowering.py
@@ -1,0 +1,69 @@
+"""07 — Reduction lowering: tt.reduce becomes a warp-shuffle tree.
+
+Pipeline: a ``tl.sum`` is a ``tt.reduce`` op (with a combine region holding
+``arith.addf``) all the way through TTGIR. The tree is materialized in the
+**TTGIR -> LLVM** step, ``convert-triton-gpu-to-llvm``
+(``lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp``): each thread first folds
+its own elements, then warps combine across a butterfly **shuffle** tree
+(``nvvm.shfl.sync bfly`` -> PTX ``shfl.sync.bfly``).
+
+What to notice: the ``tt.reduce`` region survives untouched until the LLVM step,
+where ``shfl.sync`` instructions appear — that is the cross-lane reduction tree.
+
+Bit-neutral mechanic: for a *fixed* layout the tree is fixed, so the result is
+deterministic (re-running is bitwise-identical). The reduction order is only
+``layout``-dependent — change the layout and the bits can move (see 08).
+
+Run:  python python/tutorials/compilation-pipeline/07_reduction_lowering.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, count, dump_passes, is_cuda, pass_diff, show
+
+
+@triton.jit
+def sum_kernel(src, dst, N, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    x = tl.load(src + offs, mask=offs < N, other=0.0)
+    tl.store(dst, tl.sum(x, axis=0))
+
+
+def main():
+    N = 4096
+    torch.manual_seed(0)
+    src = torch.randn(N, device="cuda", dtype=torch.float32)
+    dst = torch.empty(1, device="cuda", dtype=torch.float32)
+
+    ck = compile_only(sum_kernel, src, dst, N, BLOCK=N, num_warps=4, grid=(1, ))
+
+    banner("07 — the reduction is a tt.reduce op with a combine region (TTGIR)")
+    show(ck, "ttgir", grep=["tt.reduce", "arith.addf", "reduce.return"], limit=6)
+
+    banner("07 — lowering to LLVM materializes the warp-shuffle tree")
+    print(f"    shuffle ops in LLVM IR: nvvm.shfl.sync = {count(ck, 'llir', 'shfl')}")
+    print(f"    shuffle ops in PTX    : shfl.sync       = {count(ck, 'ptx', 'shfl.sync')}")
+
+    # The pass that builds the tree: `convert-triton-gpu-to-llvm`.
+    banner("07 — the pass responsible: convert-triton-gpu-to-llvm (grep=shfl)")
+    dumps = dump_passes(sum_kernel, src, dst, N, BLOCK=N, num_warps=4, grid=(1, ))
+    pass_diff(dumps, "convert-triton-gpu-to-llvm", grep="shfl", limit=8)
+
+    # Bit-neutral for a fixed layout: the tree is fixed => deterministic result.
+    a = torch.empty(1, device="cuda")
+    b = torch.empty(1, device="cuda")
+    sum_kernel[(1, )](src, a, N, BLOCK=N, num_warps=4)
+    sum_kernel[(1, )](src, b, N, BLOCK=N, num_warps=4)
+    torch.cuda.synchronize()
+    assert torch.equal(a, b), "same layout must give a bitwise-identical reduction"
+    torch.testing.assert_close(a, src.sum().reshape(1), atol=1e-3, rtol=1e-3)
+    print("\n[OK] the tree-reduction is deterministic for a fixed layout and matches torch.sum"
+          " (which reduction *order* the layout picks is the subject of 08).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/08_reduction_order_numerics.py
+++ b/python/tutorials/compilation-pipeline/08_reduction_order_numerics.py
@@ -1,0 +1,73 @@
+"""08 — Reduction order is layout-dependent: a POSITIVE numerics example.
+
+This is the core mechanism of the bitwise-equivalence project. A ``tl.sum`` over
+one axis lowers to a per-thread fold followed by a cross-warp shuffle tree (see
+07). WHICH element lives in which lane/warp is the **layout** along the reduce
+axis, and ``num_warps`` changes it. A different layout => a different tree => a
+different summation order => (FP add is non-associative) **different bits**.
+
+Unlike 01-06 (all bit-neutral), this one is BIT-CHANGING: we compile the same
+kernel at ``num_warps in {1,2,4,8}``, show the shuffle tree differs, then run each
+and group the *exact* results into bitwise-equivalence classes.
+
+Subtlety worth seeing: not every layout difference moves the bits — here 2/4/8
+coincide and only 1 stands apart. You cannot eyeball which configs are equivalent;
+that is exactly why the project builds an equivalence checker (see
+``bitequiv/examples/layout_numerics/`` for the static-signature + runtime checker).
+
+Run:  python python/tutorials/compilation-pipeline/08_reduction_order_numerics.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, count, is_cuda
+
+
+@triton.jit
+def sum_kernel(src, dst, N, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    x = tl.load(src + offs, mask=offs < N, other=0.0)
+    tl.store(dst, tl.sum(x, axis=0))
+
+
+def _run(src, N, num_warps):
+    out = torch.empty(1, device="cuda", dtype=torch.float32)
+    sum_kernel[(1, )](src, out, N, BLOCK=N, num_warps=num_warps)
+    torch.cuda.synchronize()
+    return out
+
+
+def main():
+    N = 4096
+    torch.manual_seed(0)
+    src = torch.randn(N, device="cuda", dtype=torch.float32)
+    warps = [1, 2, 4, 8]
+
+    banner("08 — same reduction, the layout (and its shuffle tree) changes with num_warps")
+    for nw in warps:
+        ck = compile_only(sum_kernel, src, torch.empty(1, device="cuda"), N, BLOCK=N, num_warps=nw, grid=(1, ))
+        layout = next((ln for ln in ck.asm["ttgir"].splitlines() if "#blocked =" in ln), "")
+        print(f"    num_warps={nw}:  shfl.sync={count(ck, 'llir', 'shfl'):>2}   {layout.split('= ', 1)[-1]}")
+
+    banner("08 — run each config and group EXACT results into equivalence classes")
+    results = {nw: _run(src, N, nw).item() for nw in warps}
+    classes = {}
+    for nw in warps:
+        classes.setdefault(results[nw].hex(), []).append(nw)
+    for bits, members in classes.items():
+        print(f"    {bits}  <- num_warps={members}")
+
+    ref = src.sum()
+    for nw in warps:
+        torch.testing.assert_close(torch.tensor(results[nw]), ref.cpu(), atol=1e-3, rtol=1e-3)
+    assert len(classes) > 1, "expected at least two bitwise-equivalence classes (1 vs the rest)"
+    print(f"\n[OK] all {len(warps)} configs match torch.sum within tolerance, but split into"
+          f" {len(classes)} bitwise classes — layout changes the reduction order, hence the bits.")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/09_dot_to_mma_lowering.py
+++ b/python/tutorials/compilation-pipeline/09_dot_to_mma_lowering.py
@@ -1,0 +1,81 @@
+"""09 — GEMM lowering: tl.dot becomes a tensor-core MMA.
+
+Pipeline: **TTGIR** ``tritongpu-accelerate-matmul``
+(``lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp``) rewrites a generic
+``tt.dot`` into a hardware MMA: it assigns an ``#ttg.nvidia_mma`` layout to the
+result, puts the operands in shared memory, and emits ``ttng.warp_group_dot``
+(Hopper wgmma) / ``ttng.tc_gen5_mma`` (Blackwell). That lowers to PTX
+``wgmma.mma_async`` (or ``mma.sync``).
+
+What to notice: before the pass the body is ``tt.dot`` on ``#blocked`` operands;
+after it, a ``warp_group_dot`` on ``!ttg.memdesc`` (shared) operands producing an
+``#mma`` result, with a single ``convert_layout`` back to the blocked epilogue.
+
+Bit-neutral mechanic: choosing the MMA *instruction* does not by itself change the
+math (given the same input precision) — the accumulation is the tensor core's. The
+numeric knob is the input precision, which 10 explores.
+
+Run:  python python/tutorials/compilation-pipeline/09_dot_to_mma_lowering.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, count, dump_passes, is_cuda, pass_diff, show
+
+
+@triton.jit
+def matmul_kernel(a_ptr, b_ptr, c_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, BM: tl.constexpr,
+                  BN: tl.constexpr, BK: tl.constexpr):
+    rm = tl.arange(0, BM)
+    rn = tl.arange(0, BN)
+    acc = tl.zeros([BM, BN], dtype=tl.float32)
+    for k in range(0, K, BK):
+        rk = k + tl.arange(0, BK)
+        a = tl.load(a_ptr + rm[:, None] * K + rk[None, :])
+        b = tl.load(b_ptr + rk[:, None] * N + rn[None, :])
+        acc += tl.dot(a, b)  # fp16 inputs => natural tensor-core path
+    tl.store(c_ptr + rm[:, None] * N + rn[None, :], acc.to(tl.float16))
+
+
+def main():
+    # One full tile (BM=M, BN=N) so the kernel computes the whole output and we
+    # can check it against a torch reference directly.
+    M = N = 128
+    K = 64
+    BM = BN = 128
+    BK = 32
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    b = torch.randn(K, N, device="cuda", dtype=torch.float16)
+    c = torch.empty(M, N, device="cuda", dtype=torch.float16)
+    args = (a, b, c, M, N, K, BM, BN, BK)
+
+    ck = compile_only(matmul_kernel, *args, num_stages=3, grid=(1, ))
+
+    banner("09 — tl.dot lowered to an MMA: layout, op, and PTX instruction")
+    print(f"    #mma layout in TTGIR        = {count(ck, 'ttgir', 'nvidia_mma')}")
+    print(f"    ttng.warp_group_dot ops     = {count(ck, 'ttgir', 'warp_group_dot')}")
+    print(f"    PTX wgmma.mma_async ops     = {count(ck, 'ptx', 'wgmma.mma_async')}")
+    show(ck, "ttgir", grep=["nvidia_mma =", "warp_group_dot"], limit=3, label="\nthe MMA in TTGIR:")
+
+    # The pass that does the rewrite: `tritongpu-accelerate-matmul`.
+    banner("09 — the pass responsible: tritongpu-accelerate-matmul")
+    dumps = dump_passes(matmul_kernel, *args, num_stages=3, grid=(1, ))
+    pass_diff(dumps, "accelerate-matmul", grep=["tt.dot", "warp_group_dot", "nvidia_mma"], limit=14)
+
+    # Correctness (allclose: tensor-core fp16 accumulation differs from a plain
+    # fp32 reference by rounding, but is numerically equivalent).
+    matmul_kernel[(1, )](*args, num_stages=3)
+    torch.cuda.synchronize()
+    ref = (a.float() @ b.float()).to(torch.float16)
+    torch.testing.assert_close(c, ref, atol=1e-2, rtol=1e-2)
+    print("\n[OK] the wgmma matmul matches the fp32 reference within tolerance"
+          " (the MMA instruction choice is numerically faithful).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    main()

--- a/python/tutorials/compilation-pipeline/10_mma_precision_numerics.py
+++ b/python/tutorials/compilation-pipeline/10_mma_precision_numerics.py
@@ -1,0 +1,79 @@
+"""10 — MMA input precision: a POSITIVE numerics example on GEMM.
+
+Pipeline: for an fp32 ``tl.dot`` the **input precision** picks the lowering.
+``input_precision="tf32"`` rounds each operand to TF32 (10-bit mantissa) and uses
+one tensor-core pass (PTX ``wgmma...f32.tf32.tf32``); ``input_precision="ieee"``
+keeps full fp32 (no tensor-core wgmma — an FMA / 3xTF32 path). Same ``tl.dot``,
+different ``tritongpu-accelerate-matmul`` / ``tritongpu-F32DotTC`` outcome.
+
+Unlike 09 (instruction choice is bit-neutral), this knob is BIT-CHANGING: TF32
+truncates the inputs, so the products differ from the IEEE result. We compile both,
+show the PTX instruction differs, and assert the runtime results differ in bits
+while both stay close to a high-precision reference.
+
+Run:  python python/tutorials/compilation-pipeline/10_mma_precision_numerics.py
+"""
+import torch
+
+import triton
+import triton.language as tl
+
+from _ir_utils import banner, compile_only, count, diff, is_cuda
+
+
+@triton.jit
+def dot_kernel(a_ptr, b_ptr, c_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, PREC: tl.constexpr):
+    rm = tl.arange(0, M)
+    rn = tl.arange(0, N)
+    rk = tl.arange(0, K)
+    a = tl.load(a_ptr + rm[:, None] * K + rk[None, :])
+    b = tl.load(b_ptr + rk[:, None] * N + rn[None, :])
+    c = tl.dot(a, b, input_precision=PREC)
+    tl.store(c_ptr + rm[:, None] * N + rn[None, :], c)
+
+
+def _run(a, b, M, N, K, prec):
+    out = torch.empty(M, N, device="cuda", dtype=torch.float32)
+    dot_kernel[(1, )](a, b, out, M, N, K, prec)
+    torch.cuda.synchronize()
+    return out
+
+
+def main():
+    M = N = K = 128
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.float32)
+    b = torch.randn(K, N, device="cuda", dtype=torch.float32)
+
+    tf32 = compile_only(dot_kernel, a, b, torch.empty(M, N, device="cuda"), M, N, K, "tf32", grid=(1, ))
+    ieee = compile_only(dot_kernel, a, b, torch.empty(M, N, device="cuda"), M, N, K, "ieee", grid=(1, ))
+
+    banner("10 — same tl.dot, the input-precision knob picks a different PTX instruction")
+    print(f"    tf32:  PTX wgmma(...tf32) ops = {count(tf32, 'ptx', 'wgmma.mma_async')}")
+    print(f"    ieee:  PTX wgmma         ops = {count(ieee, 'ptx', 'wgmma')}")
+    # The instruction kind (note `f32.tf32.tf32`) shows up in the warp_group_dot's
+    # inputPrecision attribute — diff the two TTGIRs to see only that op differ.
+    diff(tf32, ieee, "ttgir", grep="warp_group_dot", label_a="tf32", label_b="ieee", limit=8)
+
+    banner("10 — the precision knob changes the BITS (TF32 truncates the inputs)")
+    c_tf32 = _run(a, b, M, N, K, "tf32")
+    c_ieee = _run(a, b, M, N, K, "ieee")
+    ref = (a.double() @ b.double())  # high-precision reference
+
+    assert not torch.equal(c_tf32, c_ieee), "tf32 and ieee must differ in bits"
+    err_tf32 = (c_tf32.double() - ref).abs().max().item()
+    err_ieee = (c_ieee.double() - ref).abs().max().item()
+    print(f"    max|tf32 - ref| = {err_tf32:.3e}")
+    print(f"    max|ieee - ref| = {err_ieee:.3e}   (ieee is closer — it keeps full fp32 inputs)")
+    assert err_ieee < err_tf32, "ieee should track the high-precision reference more closely"
+    print("\n[OK] tf32 and ieee dots are NOT bitwise-equal — input precision is a real numerics"
+          " knob (the equivalence checker must treat these configs as inequivalent).")
+
+
+if __name__ == "__main__":
+    if not is_cuda():
+        raise SystemExit("Requires a CUDA GPU.")
+    if torch.cuda.get_device_capability()[0] < 8:
+        print("[10] skipped — TF32 tensor-core path requires Ampere or newer (sm_80+).")
+        raise SystemExit(0)
+    main()

--- a/python/tutorials/compilation-pipeline/_ir_utils.py
+++ b/python/tutorials/compilation-pipeline/_ir_utils.py
@@ -11,8 +11,17 @@ a bare checkout. The one primitive every example needs is:
 kernel **without launching** it, so the IR can be read on a machine whose GPUs
 can't run kernels. Launching (for the runtime correctness check) is done
 separately with the normal ``kernel[grid](...)`` call.
+
+To look at *individual compiler passes* (not just the per-stage output IR), use
+``dump_passes`` + ``pass_diff``: they drive Triton's own ``MLIR_ENABLE_DUMP``
+machinery and show the IR a single named pass rewrote (before vs after).
 """
+import contextlib
 import difflib
+import os
+import re
+import sys
+import tempfile
 
 import torch
 
@@ -81,3 +90,131 @@ def diff(ck_a, ck_b, name, grep=None, label_a="A", label_b="B", limit=80):
         print(f"    ... ({len(d) - limit} more diff lines)")
     if not d:
         print("    (identical)")
+
+
+# --------------------------------------------------------------------------- #
+# Per-pass IR hook
+#
+# ``ck.asm[...]`` only exposes the *stage* outputs (ttir/ttgir/llir/ptx). To see
+# what an individual MLIR pass did, we turn on Triton's ``MLIR_ENABLE_DUMP``,
+# which makes the pass manager print the whole module before and after EVERY
+# pass. That output goes to ``llvm::dbgs()`` (a C-level, unbuffered stderr), so
+# we capture it by redirecting fd 2 — not Python's ``sys.stderr`` — around a
+# single ``warmup`` call. ``knobs.compilation.always_compile`` defeats the
+# on-disk kernel cache so the passes actually re-run and dump.
+# --------------------------------------------------------------------------- #
+
+# e.g. "// -----// IR Dump Before Coalesce (tritongpu-coalesce) ... //----- //"
+_PASS_HDR = re.compile(r"^// -----// IR Dump (Before|After)\s+(\S+)(?:\s+\(([^)]*)\))?")
+
+
+@contextlib.contextmanager
+def _redirect_fd(fd=2):
+    """Redirect a C-level file descriptor (default stderr) to a temp file.
+
+    MLIR's pass dumps go to ``llvm::dbgs()``, a C++ stream that is NOT Python's
+    ``sys.stderr``, so we must redirect at the fd level to capture them.
+    """
+    saved = os.dup(fd)
+    tmp = tempfile.TemporaryFile(mode="w+b")
+    try:
+        os.dup2(tmp.fileno(), fd)
+        yield tmp
+    finally:
+        os.dup2(saved, fd)
+        os.close(saved)
+
+
+def _parse_pass_dumps(text):
+    """Split a raw ``MLIR_ENABLE_DUMP`` capture into ordered per-pass records."""
+    records, cur = [], None
+    for line in text.splitlines():
+        m = _PASS_HDR.match(line)
+        if m:
+            event, cls, arg = m.group(1), m.group(2), m.group(3)
+            cur = {"event": event, "pass": cls + (f" ({arg})" if arg else ""), "lines": []}
+            records.append(cur)
+        elif cur is not None:
+            cur["lines"].append(line)
+    return [{"event": r["event"], "pass": r["pass"], "ir": "\n".join(r["lines"]).strip()} for r in records]
+
+
+def dump_passes(kernel, *args, kernel_name=None, grid=(1, ), **meta):
+    """Compile ``kernel`` with per-pass IR dumping on; return the parsed dumps.
+
+    Returns an ordered list of records ``{"event": "Before"|"After", "pass":
+    "<Name> (<arg>)", "ir": "<module text>"}``. Triton enables IR printing with
+    ``printAfterOnlyOnFailure``, so on a successful compile MLIR emits one
+    **Before** snapshot per pass (the state *after* a pass is simply the *Before*
+    snapshot of the next pass — that is how :func:`pass_diff` reconstructs it).
+    Use :func:`pass_names` to discover what ran.
+    """
+    import triton  # local import: keep this helper module dependency-light
+
+    name = kernel_name or kernel.__name__
+    prev_dump = os.environ.get("MLIR_ENABLE_DUMP")
+    prev_always = triton.knobs.compilation.always_compile
+    os.environ["MLIR_ENABLE_DUMP"] = name  # filter dumps to just this kernel
+    triton.knobs.compilation.always_compile = True  # bypass the on-disk cache
+    # ...and evict the in-memory cache, which is consulted *before* always_compile
+    # (a prior compile_only of the same signature would otherwise be reused with
+    # no recompile and so no dump).
+    for entry in getattr(kernel, "device_caches", {}).values():
+        entry[0].clear()  # entry[0] is the per-device kernel_cache dict
+    try:
+        with _redirect_fd(2) as cap:
+            kernel.warmup(*args, grid=grid, **meta)
+            sys.stderr.flush()
+        cap.seek(0)
+        text = cap.read().decode("utf-8", "replace")
+    finally:
+        triton.knobs.compilation.always_compile = prev_always
+        if prev_dump is None:
+            os.environ.pop("MLIR_ENABLE_DUMP", None)
+        else:
+            os.environ["MLIR_ENABLE_DUMP"] = prev_dump
+    return _parse_pass_dumps(text)
+
+
+def pass_names(dumps):
+    """Ordered, de-duplicated list of pass names seen in ``dumps`` (for discovery)."""
+    seen = []
+    for r in dumps:
+        if r["pass"] not in seen:
+            seen.append(r["pass"])
+    return seen
+
+
+def pass_diff(dumps, pass_substr, grep=None, limit=80):
+    """Print the IR diff a single named pass produced (its before vs after).
+
+    ``pass_substr`` is matched case-insensitively as a substring of the pass
+    name, so ``pass_diff(dumps, "coalesce")`` finds ``Coalesce
+    (tritongpu-coalesce)`` regardless of exact registration spelling. Since MLIR
+    only emits Before snapshots, "after" is the Before snapshot of the next pass.
+    Returns ``(before_ir, after_ir)``.
+    """
+    key = pass_substr.lower()
+    befores = [r for r in dumps if r["event"] == "Before"]
+    idx = next((i for i, r in enumerate(befores) if key in r["pass"].lower()), None)
+    if idx is None:
+        avail = ", ".join(pass_names(dumps)) or "(none)"
+        raise ValueError(f"no pass matching {pass_substr!r} in dumps; available: {avail}")
+    matched = befores[idx]["pass"]
+    before = befores[idx]["ir"]
+    # State after this pass == the next pass's Before snapshot (nothing runs in
+    # between). The very last pass has no successor, so fall back to itself.
+    after = befores[idx + 1]["ir"] if idx + 1 < len(befores) else before
+    # ">>> pass-diff:" is the marker the smoke test greps for to prove the
+    # per-pass loop actually ran (not just the final stage IR).
+    print(f">>> pass-diff: {matched}" + (f"  (grep={grep})" if grep else ""))
+    d = list(
+        difflib.unified_diff(_filtered(before, grep), _filtered(after, grep), fromfile="before", tofile="after",
+                             lineterm=""))
+    for ln in d[:limit]:
+        print("    " + ln)
+    if len(d) > limit:
+        print(f"    ... ({len(d) - limit} more diff lines)")
+    if not d:
+        print("    (no change under this grep filter)")
+    return before, after

--- a/python/tutorials/compilation-pipeline/_ir_utils.py
+++ b/python/tutorials/compilation-pipeline/_ir_utils.py
@@ -1,0 +1,83 @@
+"""Tiny IR-capture helpers shared by the compilation-pipeline tutorials.
+
+Self-contained on purpose (no project-specific imports) so each tutorial runs on
+a bare checkout. The one primitive every example needs is:
+
+    ck = compile_only(kernel, *args, grid=(...,), CONSTEXPR=...)   # NO launch
+    ck.asm["ttir" | "ttgir" | "llir" | "ptx"]                     # per-stage IR
+    ck.metadata.num_warps, ck.metadata.shared, ...                # compile metadata
+
+``compile_only`` uses Triton's ``warmup`` path, which compiles a ``@triton.jit``
+kernel **without launching** it, so the IR can be read on a machine whose GPUs
+can't run kernels. Launching (for the runtime correctness check) is done
+separately with the normal ``kernel[grid](...)`` call.
+"""
+import difflib
+
+import torch
+
+
+def is_cuda():
+    return torch.cuda.is_available()
+
+
+def is_blackwell():
+    """Datacenter Blackwell (cc major 10/11): MMAv5 / tcgen05 + TMEM + AutoWS."""
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major in (10, 11)
+
+
+def compile_only(kernel, *args, grid=(1, ), **meta):
+    """Compile a ``@triton.jit`` kernel WITHOUT launching; return the CompiledKernel.
+
+    The result exposes ``.asm`` (keyed ``ttir|ttgir|llir|ptx|cubin|...``) and
+    ``.metadata`` (``num_warps``, ``num_stages``, ``shared``, ``target`` ...).
+    """
+    return kernel.warmup(*args, grid=grid, **meta)
+
+
+def banner(title):
+    print("\n" + "=" * 78)
+    print(title)
+    print("=" * 78)
+
+
+def _filtered(text, grep):
+    lines = text.splitlines()
+    if grep:
+        subs = [grep] if isinstance(grep, str) else list(grep)
+        lines = [ln for ln in lines if any(s in ln for s in subs)]
+    return lines
+
+
+def show(ck, name, grep=None, limit=40, label=None):
+    """Print one IR stage, optionally only lines containing any substring in ``grep``."""
+    lines = _filtered(ck.asm[name], grep)
+    print(label or (f"--- {name.upper()}" + (f"  (grep={grep})" if grep else "") + " ---"))
+    for ln in lines[:limit]:
+        print("    " + ln.rstrip())
+    if len(lines) > limit:
+        print(f"    ... ({len(lines) - limit} more lines)")
+    if not lines:
+        print("    (no matching lines)")
+
+
+def count(ck, name, needle):
+    """How many times ``needle`` appears in an IR stage (handy for op-presence checks)."""
+    return ck.asm[name].count(needle)
+
+
+def diff(ck_a, ck_b, name, grep=None, label_a="A", label_b="B", limit=80):
+    """Unified diff of one IR stage between two compiled kernels (e.g. two configs)."""
+    d = list(
+        difflib.unified_diff(_filtered(ck_a.asm[name], grep), _filtered(ck_b.asm[name], grep), fromfile=label_a,
+                             tofile=label_b, lineterm=""))
+    print(f"--- diff {name.upper()} ({label_a} vs {label_b})" + (f"  grep={grep}" if grep else "") + " ---")
+    for ln in d[:limit]:
+        print("    " + ln)
+    if len(d) > limit:
+        print(f"    ... ({len(d) - limit} more diff lines)")
+    if not d:
+        print("    (identical)")


### PR DESCRIPTION
A set of six runnable scripts under python/tutorials/compilation-pipeline/ that walk the Triton compilation stages (TTIR -> TTGIR layout assignment -> coalesce/vectorize -> remove-layout-conversions -> software pipelining -> warp specialization), each compiling a kernel, printing the per-stage IR transform, and asserting its own runtime correctness. A smoke test lives at python/test/unit/language/test_tutorial_compilation_pipeline.py.

Authored with Claude.