### PR TITLE
[TLX] Fix B-scale TMEM shape in test_async_dot_scaled_tmem_scales

### DIFF
--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -1456,9 +1456,8 @@ def test_async_dot_scaled_tmem_scales(device):
         # Allocate TMEM for scales and accumulator
         # Scale shape in TMEM: flatten 5D to 2D for TMEM storage
         SCALE_K: tl.constexpr = BLOCK_K // 32
-        SCALE_N: tl.constexpr = BLOCK_N // 32
         a_scale_tmem = tlx.local_alloc((BLOCK_M, SCALE_K), tl.uint8, tl.constexpr(1), tlx.storage_kind.tmem)
-        b_scale_tmem = tlx.local_alloc((BLOCK_K, SCALE_N), tl.uint8, tl.constexpr(1), tlx.storage_kind.tmem)
+        b_scale_tmem = tlx.local_alloc((BLOCK_N, SCALE_K), tl.uint8, tl.constexpr(1), tlx.storage_kind.tmem)
 
         # Copy scales from SMEM to TMEM directly using tmem_copy
         tlx.tmem_copy(a_scale_smem[0], a_scale_tmem[0])


### PR DESCRIPTION
The B-scale TMEM destination was allocated as (BLOCK_K, SCALE_N), which disagrees with the SMEM source feeding it. In an mxfp8 scaled dot both scales are [outer, K/32], so B's TMEM scale should be (BLOCK_N, SCALE_K), matching the [1, rep_rows, rep_cols, 2, 256] source layout.

