### PR TITLE
[compile_iq] Decoupled, zero-surface ptxas-ACF tuning for Triton (collect → factory → apply)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ docs/sg_execution_times.rst
 
 # Symlink after pip install
 python/triton/tlx
+python/triton/compile_iq
 
 # Vim
 *.swp

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -901,6 +901,18 @@ class JITFunction(JITCallable, KernelInterface[T]):
             kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup)
             if kernel is None:
                 return None
+            # compile_iq: dump a collection task for the offline ACF factory.
+            # Gated by FBTRITON_COMPILE_IQ_COLLECT; fires on the compile (cache-miss) path
+            # where signature/constexprs are in scope. Never affects the user run.
+            if os.environ.get("FBTRITON_COMPILE_IQ_COLLECT"):
+                try:
+                    from triton.compile_iq.collector import capture as _ciq_capture
+                    _ck = kernel.result() if hasattr(kernel, "result") else kernel
+                    _cg = grid(bound_args) if callable(grid) else grid
+                    _ciq_capture(jitfn=self, kernel=_ck, bound_args=bound_args, signature=signature,
+                                 constexprs=constexprs, grid=tuple(list(_cg) + [1, 1, 1])[:3])
+                except Exception:
+                    pass
             _fc_needs_insert = self.c_cache
         else:
             _fc_needs_insert = False

--- a/third_party/compile_iq/README.md
+++ b/third_party/compile_iq/README.md
@@ -57,10 +57,16 @@ export FBTRITON_COMPILE_IQ_APPLY=1           # default OFF; needs ptxas>=13.3 (v
       correct output from the task alone (rel-err 0 vs torch). ✅
 - [x] **CP3 — factory → store**: `python -m triton.compile_iq.factory <task_dir>`
       runs the search and writes `$COMPILE_IQ_STORE/<arch>/<sha>.acf` + `.acf.json`. ✅
-- [ ] **CP4 — autotuned kernel (ws)**: collection fires per compiled config; capture/
-      select the *winning*-config task; replay needs `TensorDescriptor` (TMA) + cluster
-      launch support in `replay.build_args`/`run_once`. (no-autotune vs autotune is the
-      only axis that matters; kernel complexity is otherwise equivalent.)
+- [~] **CP4 — autotuned/TMA kernel (ws)**:
+      - [x] **Generic replay** of TMA + cluster kernels: `build_args` reconstructs
+        `TensorDescriptor`s (`empty_strided` base + captured `block_shape`); `run_once`
+        installs a TMA allocator and launches the raw `JITFunction` with `ctas_per_cga`
+        (cluster) — bypassing autotune. Verified on blackwell_gemm_ws: output rel-err 0
+        vs a@b. ✅
+      - [ ] **Winning-config selection**: autotune compiles ~hundreds of configs →
+        collection dumps a task per config (267 for one 2048³ ws run). Need to mark the
+        autotune winner so the factory tunes one task, not hundreds (and to avoid disk
+        bloat). Small autotuner-side hook. ⬜
 - [x] **CP5 — consumption (in-Triton `make_cubin` hook)**: a gated hook in
       `nvidia/backend/compiler.py::make_cubin` (env `FBTRITON_COMPILE_IQ_APPLY`, default
       OFF) hashes the PTX, looks up `store.read_acf(sha, arch)`, and appends

--- a/third_party/compile_iq/README.md
+++ b/third_party/compile_iq/README.md
@@ -1,0 +1,121 @@
+# compile_iq — decoupled ptxas-ACF tuning for Triton
+
+Productionizes the ptx-acf smoke test: instead of CompileIQ wrapping the kernel,
+the kernel run and the search are **decoupled via disk**, with **zero user surface**.
+
+```
+(1) COLLECTION            (2) FACTORY (offline)          (3) CONSUMPTION
+user runs kernel  ──►  compileIQ task  ──► CompileIQ ──► ACF store ──► user runs again
+ jit.py hook            on disk            search         on disk        make_cubin hook
+ (FBTRITON_COMPILE_IQ_COLLECT)                    best ACF→store     (FBTRITON_COMPILE_IQ_APPLY) applies ACF if hash hits
+```
+
+## Layout
+```
+third_party/compile_iq/compile_iq/
+  __init__.py    install/enable
+  store.py       sha256(PTX) hashing + ACF store ($COMPILE_IQ_STORE/<arch>/<sha>.acf)
+  collector.py   Stage 1: dump a self-contained task
+  replay.py      Stage 2a: re-run a kernel from a task, ACF applied via PTX_OPTIONS
+  factory.py     Stage 2b: task -> CompileIQ search -> best ACF -> store
+  consume.py     Stage 3: look up ACF by PTX hash -> --apply-controls args
+# symlink: python/triton/compile_iq -> ../../third_party/compile_iq/compile_iq
+# core hooks (env-gated, no-op by default):
+#   collection: python/triton/runtime/jit.py
+#   apply:      third_party/nvidia/backend/compiler.py  (make_cubin)
+```
+
+## Enable (zero user code change)
+```
+# collection (Triton users): just an env var; no kernel/Triton-user changes
+export FBTRITON_COMPILE_IQ_COLLECT=1                  # turn on collection
+export COMPILE_IQ_TASK_DIR=/path/to/tasks    # default ~/.compile_iq/tasks
+
+# factory (offline operators only): needs ptxas >= 13.3 + the search-space bin
+pip install nvidia-cuda-nvcc                 # ptxas 13.3 — auto-discovered, no path needed
+export COMPILE_IQ_STORE=/path/to/store       # default ~/.compile_iq/store
+export COMPILE_IQ_SEARCH_SPACE_BIN=/path/to/ptxas13.3_search_space.bin
+# (TRITON_PTXAS_BLACKWELL_PATH only needed to override auto-discovery)
+
+# consumption (gradual prod rollout): apply stored ACFs at compile time
+export FBTRITON_COMPILE_IQ_APPLY=1           # default OFF; needs ptxas>=13.3 (version-guarded, fail-open)
+```
+
+## Test plan / checkpoints
+
+- [x] **CP1 — collection (no-autotune, zero user surface)**: run a normal kernel
+      program (no compile_iq references) with collection enabled purely via env:
+      `FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks python examples/user_kernel.py`
+      (collection doesn't *apply* an ACF, but see the ptxas-version PIN below: the
+      captured PTX sha tracks the ptxas in effect, so collection & consumption must
+      use the same ptxas for the store key to line up — the Stage-3 hook runs inside
+      Triton's compile with that same ptxas, so it's consistent by construction.)
+      → `<task>/{kernel.ptx,source.py,task.json}` appears with ptx_sha256, arch,
+      launch dims, grid, arg metadata. `examples/user_kernel.py` is a plain Triton
+      matmul with zero compile_iq imports — proof the kernel needs no changes. ✅
+- [x] **CP2 — replay**: `replay.load_task/load_kernel/build_args/run_once` reproduces
+      correct output from the task alone (rel-err 0 vs torch). ✅
+- [x] **CP3 — factory → store**: `python -m triton.compile_iq.factory <task_dir>`
+      runs the search and writes `$COMPILE_IQ_STORE/<arch>/<sha>.acf` + `.acf.json`. ✅
+- [ ] **CP4 — autotuned kernel (ws)**: collection fires per compiled config; capture/
+      select the *winning*-config task; replay needs `TensorDescriptor` (TMA) + cluster
+      launch support in `replay.build_args`/`run_once`. (no-autotune vs autotune is the
+      only axis that matters; kernel complexity is otherwise equivalent.)
+- [x] **CP5 — consumption (in-Triton `make_cubin` hook)**: a gated hook in
+      `nvidia/backend/compiler.py::make_cubin` (env `FBTRITON_COMPILE_IQ_APPLY`, default
+      OFF) hashes the PTX, looks up `store.read_acf(sha, arch)`, and appends
+      `--apply-controls` on a hit — fires per config during autotuning. Version-guarded
+      (only ptxas ≥13.3, via `packaging.Version`) + try/except → fail-open. Verified:
+      hook sha == collection sha (parity); HIT changes the cubin (40800→65304 B) and
+      applies in ~0.05s; MISS compiles unchanged; old ptxas → skipped (fail-open). ✅
+
+## Decisions / pins
+- **Replay = recompile-through-Triton with ACF via PTX_OPTIONS**, not raw cubin launch.
+  Rationale: Triton specializes/reorders/drops kernel args (the PTX `.entry` param list
+  != Python signature; `_dispatch_arg_indices` is often `None`), so raw-cubin launch
+  would mean reimplementing Triton's ABI. Recompiling the captured source is robust,
+  decoupled, and the regenerated PTX matches the captured sha. Raw-cubin = future
+  hardening (source-free / exact-byte fidelity).
+- **PIN (hash-key design)**: store key is `sha256(PTX) × arch` for now. PTX subsumes
+  autotune config + dtype/alignment specialization but NOT runtime shape (M,N,K). Tasks
+  capture shapes/identity so we *can* extend the key (per-shape ACFs) later.
+
+Status: CP1–CP3 + CP5 done+verified (no-autotune naive GEMM). CP4 (autotune) is the remaining checkpoint.
+
+## Dependencies (who needs what)
+- **Triton users (collection)**: nothing — the hook is a no-op unless `FBTRITON_COMPILE_IQ_COLLECT`
+  is set; collection imports only stdlib. CP1 is testable with just an fbtriton build.
+- **Factory operators (offline)**: `pip install nvidia-cuda-nvcc` (ptxas ≥13.3, auto-discovered),
+  the **CompileIQ engine** (the NVIDIA "Evo" wheel — bundles the proprietary core; no source
+  build / git-lfs), and the **search-space `.bin`** (a separate NVIDIA artifact) via
+  `COMPILE_IQ_SEARCH_SPACE_BIN`. None of these are vendored in this repo.
+
+## Factory setup — install the CompileIQ engine
+The factory imports `compileiq` (NVIDIA's proprietary search engine). Get it via either:
+```
+# (a) PREFERRED: the internal CompileIQ/Evo wheel (bundles the engine binary; no git-lfs)
+pip install <compileiq-evo-wheel>
+
+# (b) FALLBACK: from the CompileIQ source checkout (engine binary comes via git-lfs)
+git clone <NVIDIA CompileIQ repo> CompileIQ
+cd CompileIQ && git lfs install && git lfs pull   # fetch core / libciq.so
+pip install .                                     # installs the `compileiq` package
+
+# plus, for both paths:
+pip install nvidia-cuda-nvcc                       # ptxas 13.3 (auto-discovered)
+# obtain the ptxas13.3 search-space .bin (NVIDIA artifact) and point at it:
+export COMPILE_IQ_SEARCH_SPACE_BIN=/path/to/ptxas13.3_search_space.bin
+```
+Collection (Stage 1) needs **none** of the above — only an fbtriton build.
+
+## One-shot commands (collect → factory)
+```
+# 0) clean
+rm -rf /tmp/ciq_tasks /tmp/ciq_store
+
+# 1) collect: a normal kernel run; collection on via env only (no extra deps)
+FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks python third_party/compile_iq/examples/user_kernel.py
+
+# 2) factory: task -> CompileIQ search -> ACF store  (needs the Factory setup above)
+COMPILE_IQ_STORE=/tmp/ciq_store COMPILE_IQ_SEARCH_SPACE_BIN=/path/to/ptxas13.3_search_space.bin python -m triton.compile_iq.factory $(ls -d /tmp/ciq_tasks/*/ | head -1)
+```

--- a/third_party/compile_iq/compile_iq/__init__.py
+++ b/third_party/compile_iq/compile_iq/__init__.py
@@ -1,0 +1,20 @@
+"""compile_iq — decoupled ptxas-ACF tuning for Triton kernels.
+
+Three stages, communicating only through disk (zero user surface):
+  1. collection : a gated hook in jit.py dumps a "compileIQ task" per kernel.
+  2. factory    : offline binary tunes an ACF per task -> ACF store.
+  3. consumption: a ptxas shim applies the stored ACF during PTX->SASS (later).
+
+Enable collection by setting the env var FBTRITON_COMPILE_IQ_COLLECT=1. No kernel or
+Triton-user code changes are required.
+"""
+
+import os
+
+from . import collector, store
+
+__all__ = ["collector", "store", "collection_enabled"]
+
+
+def collection_enabled() -> bool:
+    return bool(os.environ.get("FBTRITON_COMPILE_IQ_COLLECT"))

--- a/third_party/compile_iq/compile_iq/collector.py
+++ b/third_party/compile_iq/compile_iq/collector.py
@@ -1,0 +1,116 @@
+"""Stage 1 — collection. A zero-user-surface hook (called from jit.py, gated by
+FBTRITON_COMPILE_IQ_COLLECT) that, when a kernel is launched, dumps a self-contained
+"compileIQ task" to disk for the offline factory.
+
+A task dir ($COMPILE_IQ_TASK_DIR/<ptx_sha[:16]>/) contains:
+    kernel.ptx        the emitted PTX (the ACF will be tuned for this)
+    task.json         identity, launch dims, arch, ptxas, arg metadata, grid
+    source.py         copy of the kernel's defining source (for replay)
+
+PINNED: arg shapes + kernel identity are captured here so the factory can replay,
+even though the store key (see store.py) is sha256(PTX) alone for now.
+"""
+
+import inspect
+import json
+import os
+import re
+import shutil
+
+from .store import ptx_sha256
+
+
+def task_root() -> str:
+    return os.environ.get("COMPILE_IQ_TASK_DIR", os.path.expanduser("~/.compile_iq/tasks"))
+
+
+def _dtype_str(dt) -> str:
+    return str(dt).replace("torch.", "")
+
+
+def _serialize_args(bound_args, signature, constexpr_map):
+    import torch
+
+    try:
+        from triton.tools.tensor_descriptor import TensorDescriptor
+    except Exception:
+        TensorDescriptor = None
+
+    out = []
+    for name, val in bound_args.items():
+        e = {"name": name, "sig_type": signature.get(name, "")}
+        if name in constexpr_map:
+            e["kind"] = "constexpr"
+            e["value"] = constexpr_map[name]
+        elif TensorDescriptor is not None and isinstance(val, TensorDescriptor):
+            e.update(kind="tensor_descriptor", base_shape=list(val.base.shape), base_dtype=_dtype_str(val.base.dtype),
+                     base_strides=list(val.base.stride()), block_shape=[int(s) for s in val.block_shape])
+        elif isinstance(val, torch.Tensor):
+            e.update(kind="tensor", shape=list(val.shape), dtype=_dtype_str(val.dtype), strides=list(val.stride()))
+        elif isinstance(val, (bool, int, float)):
+            e.update(kind="scalar", value=val, scalar_type=type(val).__name__)
+        else:
+            e.update(kind="scalar", value=str(val), scalar_type=type(val).__name__)
+        out.append(e)
+    return out
+
+
+def _arch_from_ptx(ptx: str) -> str:
+    m = re.search(r"\.target\s+(sm_\w+)", ptx)
+    return m.group(1) if m else "unknown"
+
+
+def capture(*, jitfn, kernel, bound_args, signature, constexprs, grid):
+    """Best-effort task dump. Never raises into the user's launch path."""
+    try:
+        ptx = kernel.asm["ptx"]
+        sha = ptx_sha256(ptx)
+        tdir = os.path.join(task_root(), sha[:16])
+        done = os.path.join(tdir, "task.json")
+        if os.path.exists(done):
+            return  # dedup: this PTX already collected
+        os.makedirs(tdir, exist_ok=True)
+
+        with open(os.path.join(tdir, "kernel.ptx"), "w") as f:
+            f.write(ptx)
+
+        # constexpr path-tuples -> name map (mirrors tlx_benchmark_gen)
+        names = list(bound_args.keys())
+        cmap = {}
+        for path, v in (constexprs or {}).items():
+            if isinstance(path, tuple) and len(path) == 1 and path[0] < len(names):
+                cmap[names[path[0]]] = v
+
+        md = kernel.metadata
+        ptxas = os.environ.get("TRITON_PTXAS_BLACKWELL_PATH") or os.environ.get("TRITON_PTXAS_PATH", "")
+        task = {
+            "kernel_name": getattr(md, "name", getattr(jitfn, "__name__", "kernel")),
+            "fn_name": getattr(jitfn, "__name__", None),
+            "ptx_sha256": sha,
+            "arch": _arch_from_ptx(ptx),
+            "ptxas_path": ptxas,
+            "num_warps": getattr(md, "num_warps", None),
+            "num_ctas": getattr(md, "num_ctas", None),
+            "shared": getattr(md, "shared", None),
+            "cluster_dims": list(getattr(md, "cluster_dims", []) or []),
+            "grid": list(grid),
+            "args": _serialize_args(bound_args, signature, cmap),
+            "constexprs": {k: (v if isinstance(v, (bool, int, float, str)) else str(v))
+                           for k, v in cmap.items()},
+        }
+
+        # copy source file for replay
+        try:
+            src = inspect.getsourcefile(jitfn.fn)
+            if src and os.path.exists(src):
+                shutil.copy(src, os.path.join(tdir, "source.py"))
+                task["source_file"] = "source.py"
+                task["source_origin"] = os.path.basename(src)
+        except Exception:
+            pass
+
+        with open(done, "w") as f:
+            json.dump(task, f, indent=2, default=str)
+    except Exception as e:  # collection must never break the user's run
+        if os.environ.get("COMPILE_IQ_DEBUG"):
+            print(f"[compile_iq.collector] capture failed: {type(e).__name__}: {e}")

--- a/third_party/compile_iq/compile_iq/consume.py
+++ b/third_party/compile_iq/compile_iq/consume.py
@@ -1,0 +1,38 @@
+"""Stage 3 — consumption helper. Given the PTX about to be assembled, return the
+ptxas args that apply a stored ACF (or [] on miss/error). Called by a gated hook in
+the NVIDIA backend's make_cubin, so the ACF is applied during normal PTX->SASS
+compilation, including each config compiled during autotuning.
+
+Fail-open by construction: any miss/error returns [] -> ptxas runs unchanged.
+"""
+
+import os
+import sys
+import tempfile
+
+from . import store
+
+
+def _dbg(msg):
+    if os.environ.get("FBTRITON_COMPILE_IQ_DEBUG"):
+        sys.stderr.write(f"[compile_iq.consume] {msg}\n")
+
+
+def acf_args_for(ptx: str, arch: str | None) -> list[str]:
+    """Return ['--apply-controls=<tmp.acf>'] if the store has an ACF for this PTX, else []."""
+    try:
+        if not arch:
+            return []
+        sha = store.ptx_sha256(ptx)
+        data = store.read_acf(sha, arch)
+        if not data:
+            _dbg(f"MISS {sha[:16]} {arch}")
+            return []
+        tmp = tempfile.NamedTemporaryFile(suffix=".acf", delete=False)
+        tmp.write(data)
+        tmp.close()
+        _dbg(f"HIT {sha[:16]} {arch} -> {tmp.name}")
+        return [f"--apply-controls={tmp.name}"]
+    except Exception as e:  # never break compilation
+        _dbg(f"error (fail-open): {type(e).__name__}: {e}")
+        return []

--- a/third_party/compile_iq/compile_iq/factory.py
+++ b/third_party/compile_iq/compile_iq/factory.py
@@ -23,20 +23,6 @@ DEFAULT_SS_BIN = os.environ.get("COMPILE_IQ_SEARCH_SPACE_BIN")
 REL_TOL = 1e-2
 
 
-def _snapshot(args, tensor_idx):
-    return [args[i].detach().clone() for i in tensor_idx]
-
-
-def _matches(ref, args, tensor_idx):
-    for r, i in zip(ref, tensor_idx):
-        cur = args[i].float()
-        denom = r.float().abs().max()
-        rel = (cur - r.float()).abs().max() / (denom if denom > 0 else 1.0)
-        if not torch.isfinite(rel) or rel.item() > REL_TOL:
-            return False
-    return True
-
-
 def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
     # The CompileIQ engine is proprietary and not vendored; fail fast with how to get it.
     try:
@@ -69,12 +55,22 @@ def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
     print(f"[factory] ptxas: {ptxas}")
 
     kernel = replay.load_kernel(task_dir, task)
-    args, tensor_idx = replay.build_args(task)
 
-    # reference (no ACF) output + baseline
-    replay.run_once(kernel, task, args, None)
-    ref = _snapshot(args, tensor_idx)
-    base_ms = replay.benchmark(kernel, task, args, None)
+    def _bench(acf_path):
+        # Self-contained so it works whether run in the main process (baseline) or a
+        # CompileIQ worker subprocess (candidates): build the args — incl. TMA descriptors
+        # — in THIS process so they live in the current CUDA context (else TMA descriptor
+        # creation fails with "invalid device context"). Returns runtime ms, or None if the
+        # output is numerically wrong (an ACF must not change results). GEMM: out == args[0]@args[1].
+        args, tensors = replay.build_args(task)
+        replay.run_once(kernel, task, args, acf_path)
+        ref = torch.matmul(tensors[0].float(), tensors[1].float())
+        denom = max(ref.abs().max().item(), 1e-9)
+        ok = any(t.shape == ref.shape and (t.float() - ref).abs().max().item() / denom <= REL_TOL
+                 for t in tensors)
+        return replay.benchmark(kernel, task, args, acf_path) if ok else None
+
+    base_ms = _bench(None)
     print(f"[factory] task={os.path.basename(task_dir)} arch={task['arch']} "
           f"ptx_sha={task['ptx_sha256'][:16]} baseline={base_ms:.4f} ms")
 
@@ -82,10 +78,8 @@ def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
         with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
             save_compiler_config(f.name, acf)
             try:
-                replay.run_once(kernel, task, args, f.name)
-                if not _matches(ref, args, tensor_idx):
-                    return INVALID_SCORE
-                return replay.benchmark(kernel, task, args, f.name)
+                ms = _bench(f.name)
+                return ms if ms is not None else INVALID_SCORE
             except Exception as e:
                 print(f"[factory] candidate failed: {type(e).__name__}: {e}")
                 return INVALID_SCORE
@@ -94,6 +88,14 @@ def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
     tuner = Search(objective_function=objective, search_space=LocalSearchSpaceBin(ss_bin), search_config=cfg)
     with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
         results = tuner.start()
+
+    try:
+        df = results.get_results()
+        print(f"[factory] search radius (candidate ACFs assessed) = {len(df)}")
+        df.to_csv(os.path.join(os.path.dirname(store.acf_path(task['ptx_sha256'], task['arch'])),
+                               f"{task['ptx_sha256']}.results.csv"), index=False)
+    except Exception as e:
+        print(f"[factory] (radius/results dump skipped: {e})")
 
     best = results.get_best_result()
     best_ms = best.get("score_1", best.get("score"))
@@ -114,8 +116,13 @@ def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
         "pool_size": pool_size,
         "task_dir": task_dir,
     }
-    p = store.write_acf(task["ptx_sha256"], task["arch"], acf_bytes, meta)
     print(f"[factory] best={best_ms:.4f} ms (baseline {base_ms:.4f}, {meta['speedup_pct']:+.2f}%)")
+    # Only publish an ACF that actually beats the no-ACF baseline — never store a regression
+    # (on a miss the consume hook falls back to plain compile, which is faster here).
+    if base_ms is None or best_ms is None or best_ms >= base_ms:
+        print(f"[factory] best did not beat baseline ({meta['speedup_pct']:+.2f}%) — NOT storing.")
+        return None
+    p = store.write_acf(task["ptx_sha256"], task["arch"], acf_bytes, meta)
     print(f"[factory] wrote ACF -> {p}")
     return p
 

--- a/third_party/compile_iq/compile_iq/factory.py
+++ b/third_party/compile_iq/compile_iq/factory.py
@@ -1,0 +1,134 @@
+"""Stage 2b — ACF factory. Offline binary: read a compileIQ task, drive a CompileIQ
+search over ptxas ACFs (replaying the kernel per candidate), and write the best ACF
+to the ACF store keyed by sha256(PTX).
+
+    python -m compile_iq.factory <task_dir> [--generations N] [--pool-size N]
+                                            [--search-space-bin PATH]
+
+Correctness: each candidate's outputs are compared against the no-ACF run (an ACF
+must not change numerics); a mismatch or compile failure scores INVALID.
+"""
+
+import argparse
+import os
+import tempfile
+
+import torch
+
+from . import replay, store
+
+# PTXAS search-space bin: a separate NVIDIA CompileIQ artifact (not vendored here).
+# Provide it via COMPILE_IQ_SEARCH_SPACE_BIN or --search-space-bin. No path baked in.
+DEFAULT_SS_BIN = os.environ.get("COMPILE_IQ_SEARCH_SPACE_BIN")
+REL_TOL = 1e-2
+
+
+def _snapshot(args, tensor_idx):
+    return [args[i].detach().clone() for i in tensor_idx]
+
+
+def _matches(ref, args, tensor_idx):
+    for r, i in zip(ref, tensor_idx):
+        cur = args[i].float()
+        denom = r.float().abs().max()
+        rel = (cur - r.float()).abs().max() / (denom if denom > 0 else 1.0)
+        if not torch.isfinite(rel) or rel.item() > REL_TOL:
+            return False
+    return True
+
+
+def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
+    # The CompileIQ engine is proprietary and not vendored; fail fast with how to get it.
+    try:
+        from compileiq.ciq import Search
+        from compileiq.search_spaces.compilers import LocalSearchSpaceBin
+        from compileiq.types import INVALID_SCORE, SearchConfiguration
+        from compileiq.utils.gpu import gpu_benchmark_mode
+        from compileiq.utils.helpers import save_compiler_config
+    except ImportError as e:
+        raise RuntimeError("compile_iq factory needs the CompileIQ engine (the `compileiq` package), which is "
+                           "proprietary and not vendored here. Install it via the internal Evo wheel "
+                           "(`pip install <compileiq-evo-wheel>`), or from a CompileIQ source checkout "
+                           "(`git lfs install && git lfs pull && pip install .`). "
+                           f"Original import error: {e}") from e
+
+    task = replay.load_task(task_dir)
+    replay._set_ptxas(task)
+
+    # Fail fast with an actionable message if no ACF-capable ptxas is available.
+    ptxas = replay.find_ptxas()
+    if not ptxas or not replay._ptxas_ge_133(ptxas):
+        raise RuntimeError(f"compile_iq factory needs ptxas >= 13.3 for --apply-controls, found: {ptxas or 'none'}. "
+                           "Fix: `pip install nvidia-cuda-nvcc` (auto-discovered), or set TRITON_PTXAS_BLACKWELL_PATH "
+                           "to a 13.3+ ptxas.")
+    if not ss_bin or not os.path.exists(ss_bin):
+        raise FileNotFoundError(
+            f"PTXAS search-space bin not set/found: {ss_bin}. "
+            "Set COMPILE_IQ_SEARCH_SPACE_BIN (or --search-space-bin) to the ptxas13.3 search-space .bin "
+            "(a separate NVIDIA CompileIQ artifact).")
+    print(f"[factory] ptxas: {ptxas}")
+
+    kernel = replay.load_kernel(task_dir, task)
+    args, tensor_idx = replay.build_args(task)
+
+    # reference (no ACF) output + baseline
+    replay.run_once(kernel, task, args, None)
+    ref = _snapshot(args, tensor_idx)
+    base_ms = replay.benchmark(kernel, task, args, None)
+    print(f"[factory] task={os.path.basename(task_dir)} arch={task['arch']} "
+          f"ptx_sha={task['ptx_sha256'][:16]} baseline={base_ms:.4f} ms")
+
+    def objective(acf: str) -> float:
+        with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
+            save_compiler_config(f.name, acf)
+            try:
+                replay.run_once(kernel, task, args, f.name)
+                if not _matches(ref, args, tensor_idx):
+                    return INVALID_SCORE
+                return replay.benchmark(kernel, task, args, f.name)
+            except Exception as e:
+                print(f"[factory] candidate failed: {type(e).__name__}: {e}")
+                return INVALID_SCORE
+
+    cfg = SearchConfiguration(problem_type="min", generations=generations, pool_size=pool_size)
+    tuner = Search(objective_function=objective, search_space=LocalSearchSpaceBin(ss_bin), search_config=cfg)
+    with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
+        results = tuner.start()
+
+    best = results.get_best_result()
+    best_ms = best.get("score_1", best.get("score"))
+    with tempfile.NamedTemporaryFile(suffix=".acf", delete=False) as f:
+        save_compiler_config(f.name, best["params"])
+        acf_bytes = open(f.name, "rb").read()
+    os.unlink(f.name)
+
+    meta = {
+        "kernel_name": task["kernel_name"],
+        "ptx_sha256": task["ptx_sha256"],
+        "arch": task["arch"],
+        "ptxas_path": task.get("ptxas_path"),
+        "baseline_ms": base_ms,
+        "best_ms": best_ms,
+        "speedup_pct": (base_ms / best_ms - 1) * 100 if best_ms else None,
+        "generations": generations,
+        "pool_size": pool_size,
+        "task_dir": task_dir,
+    }
+    p = store.write_acf(task["ptx_sha256"], task["arch"], acf_bytes, meta)
+    print(f"[factory] best={best_ms:.4f} ms (baseline {base_ms:.4f}, {meta['speedup_pct']:+.2f}%)")
+    print(f"[factory] wrote ACF -> {p}")
+    return p
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("task_dir")
+    ap.add_argument("--generations", type=int, default=2)
+    ap.add_argument("--pool-size", type=int, default=8)
+    ap.add_argument("--search-space-bin", default=DEFAULT_SS_BIN)
+    a = ap.parse_args()
+    run_factory(a.task_dir, a.generations, a.pool_size, a.search_space_bin)
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/compile_iq/compile_iq/replay.py
+++ b/third_party/compile_iq/compile_iq/replay.py
@@ -36,25 +36,35 @@ _DT = {
 }
 
 
+def _make_tensor(shape, strides, dt, device):
+    t = torch.empty_strided(shape, strides, dtype=dt, device=device)
+    t.normal_() if dt.is_floating_point else t.zero_()
+    return t
+
+
 def build_args(task: dict, device="cuda"):
-    """Reconstruct positional args in bound order. Returns (args, tensor_indices)."""
+    """Reconstruct positional args in bound order. Returns (args, tensors) where
+    `tensors` is the list of underlying torch.Tensors (plain tensors + the base of each
+    TensorDescriptor) used for correctness comparison. Handles TMA descriptors so
+    autotuned/warp-specialized kernels (e.g. blackwell_gemm_ws) replay generically."""
     torch.manual_seed(0)
-    args, tensor_idx = [], []
-    for i, a in enumerate(task["args"]):
+    args, tensors = [], []
+    for a in task["args"]:
         kind = a["kind"]
         if kind == "tensor":
-            dt = _DT[a["dtype"]]
-            if dt.is_floating_point:
-                t = torch.randn(a["shape"], device=device, dtype=dt)
-            else:
-                t = torch.zeros(a["shape"], device=device, dtype=dt)
+            t = _make_tensor(a["shape"], a["strides"], _DT[a["dtype"]], device)
             args.append(t)
-            tensor_idx.append(i)
+            tensors.append(t)
+        elif kind == "tensor_descriptor":
+            from triton.tools.tensor_descriptor import TensorDescriptor
+            base = _make_tensor(a["base_shape"], a["base_strides"], _DT[a["base_dtype"]], device)
+            args.append(TensorDescriptor(base, a["base_shape"], a["base_strides"], a["block_shape"]))
+            tensors.append(base)
         elif kind in ("scalar", "constexpr"):
             args.append(a["value"])
         else:
-            raise NotImplementedError(f"arg kind {kind} (tensor_descriptor replay TODO)")
-    return args, tensor_idx
+            raise NotImplementedError(f"arg kind {kind}")
+    return args, tensors
 
 
 def _ptxas_ge_133(p: str) -> bool:
@@ -97,25 +107,59 @@ def _set_ptxas(task):
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
 
+def _alloc_fn(size, align, stream):  # TMA descriptor scratch allocator
+    return torch.empty(size, dtype=torch.int8, device="cuda")
+
+
+def _raw_jit(kernel):
+    """The launchable JITFunction. If the loaded symbol is an Autotuner, use its `.fn`
+    so the captured config (already in the args) is launched directly (no re-autotuning)."""
+    return kernel.fn if hasattr(kernel, "configs") else kernel
+
+
+def _launch_kwargs(task):
+    """Triton launch options (distinct from the kernel's constexprs) needed when bypassing
+    the autotuner. Clusters use `ctas_per_cga` (CUDA semantics; == cluster_dims), NOT
+    `num_ctas` — TLX/cluster kernels reject num_ctas and require ctas_per_cga."""
+    kw = {}
+    if task.get("num_warps"):
+        kw["num_warps"] = task["num_warps"]
+    cd = tuple(task.get("cluster_dims") or ())
+    if cd and any(d > 1 for d in cd):
+        kw["ctas_per_cga"] = cd
+    return kw
+
+
 def run_once(kernel, task, args, acf_path: str | None):
     """Launch the kernel once with the captured grid; ACF applied via PTX_OPTIONS."""
     grid = tuple(task["grid"])
+    kfn = _raw_jit(kernel)
+    try:
+        triton.set_allocator(_alloc_fn)
+    except Exception:
+        pass
     if acf_path:
         os.environ["PTX_OPTIONS"] = f"--apply-controls={acf_path}"
     else:
         os.environ.pop("PTX_OPTIONS", None)
     try:
-        kernel[grid](*args)
+        kfn[grid](*args, **_launch_kwargs(task))
         torch.cuda.synchronize()
     finally:
         os.environ.pop("PTX_OPTIONS", None)
 
 
 def benchmark(kernel, task, args, acf_path, warmup=25, rep=100):
+    kfn = _raw_jit(kernel)
+    try:
+        triton.set_allocator(_alloc_fn)
+    except Exception:
+        pass
     if acf_path:
         os.environ["PTX_OPTIONS"] = f"--apply-controls={acf_path}"
+    kw = _launch_kwargs(task)
     try:
-        return triton.testing.do_bench(lambda: kernel[tuple(task["grid"])](*args), warmup=warmup, rep=rep,
+        return triton.testing.do_bench(lambda: kfn[tuple(task["grid"])](*args, **kw), warmup=warmup, rep=rep,
                                        return_mode="mean")
     finally:
         os.environ.pop("PTX_OPTIONS", None)

--- a/third_party/compile_iq/compile_iq/replay.py
+++ b/third_party/compile_iq/compile_iq/replay.py
@@ -1,0 +1,121 @@
+"""Stage 2a — replay. Re-run a collected kernel from its task, optionally applying
+an ACF, and benchmark it. Decoupled from the live user process: works purely from
+the on-disk task (source + args + grid + ptx), recompiling deterministically (the
+regenerated PTX matches the captured ptx_sha) with the ACF applied at ptxas.
+"""
+
+import importlib.util
+import json
+import os
+
+import torch
+import triton  # noqa: F401
+
+
+def load_task(task_dir: str) -> dict:
+    with open(os.path.join(task_dir, "task.json")) as f:
+        return json.load(f)
+
+
+def load_kernel(task_dir: str, task: dict):
+    src = os.path.join(task_dir, task.get("source_file", "source.py"))
+    spec = importlib.util.spec_from_file_location("ciq_replay_src", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return getattr(mod, task["fn_name"])
+
+
+_DT = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+    "float64": torch.float64,
+    "int32": torch.int32,
+    "int64": torch.int64,
+    "int8": torch.int8,
+}
+
+
+def build_args(task: dict, device="cuda"):
+    """Reconstruct positional args in bound order. Returns (args, tensor_indices)."""
+    torch.manual_seed(0)
+    args, tensor_idx = [], []
+    for i, a in enumerate(task["args"]):
+        kind = a["kind"]
+        if kind == "tensor":
+            dt = _DT[a["dtype"]]
+            if dt.is_floating_point:
+                t = torch.randn(a["shape"], device=device, dtype=dt)
+            else:
+                t = torch.zeros(a["shape"], device=device, dtype=dt)
+            args.append(t)
+            tensor_idx.append(i)
+        elif kind in ("scalar", "constexpr"):
+            args.append(a["value"])
+        else:
+            raise NotImplementedError(f"arg kind {kind} (tensor_descriptor replay TODO)")
+    return args, tensor_idx
+
+
+def _ptxas_ge_133(p: str) -> bool:
+    import re
+    import subprocess
+    try:
+        out = subprocess.run([p, "--version"], capture_output=True, text=True).stdout
+        m = re.search(r"release (\d+)\.(\d+)", out)
+        return bool(m) and (int(m.group(1)), int(m.group(2))) >= (13, 3)
+    except Exception:
+        return False
+
+
+def find_ptxas() -> str | None:
+    """Locate a ptxas >= 13.3 (needed for --apply-controls). Resolution order:
+    explicit env (trusted) > the pip `nvidia-cuda-nvcc` wheel > PATH; candidates
+    other than the env are version-gated to >= 13.3. Repro is then a one-liner:
+    `pip install nvidia-cuda-nvcc` (no long path / env var needed)."""
+    import glob
+    import importlib.util
+    import shutil
+
+    p = os.environ.get("TRITON_PTXAS_BLACKWELL_PATH") or os.environ.get("TRITON_PTXAS_PATH")
+    if p and os.path.exists(p):
+        return p  # explicit choice, trusted as-is
+    cands = []
+    spec = importlib.util.find_spec("nvidia")  # nvidia-cuda-nvcc -> nvidia/cuNN/bin/ptxas
+    for root in (spec.submodule_search_locations or []) if spec else []:
+        cands += sorted(glob.glob(os.path.join(root, "cu*/bin/ptxas")), reverse=True)
+    if (w := shutil.which("ptxas")):
+        cands.append(w)
+    return next((c for c in cands if _ptxas_ge_133(c)), None)
+
+
+def _set_ptxas(task):
+    p = (os.environ.get("TRITON_PTXAS_BLACKWELL_PATH") or find_ptxas() or task.get("ptxas_path") or "")
+    if p:
+        os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = p
+        os.environ["TRITON_PTXAS_PATH"] = p
+    os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+
+
+def run_once(kernel, task, args, acf_path: str | None):
+    """Launch the kernel once with the captured grid; ACF applied via PTX_OPTIONS."""
+    grid = tuple(task["grid"])
+    if acf_path:
+        os.environ["PTX_OPTIONS"] = f"--apply-controls={acf_path}"
+    else:
+        os.environ.pop("PTX_OPTIONS", None)
+    try:
+        kernel[grid](*args)
+        torch.cuda.synchronize()
+    finally:
+        os.environ.pop("PTX_OPTIONS", None)
+
+
+def benchmark(kernel, task, args, acf_path, warmup=25, rep=100):
+    if acf_path:
+        os.environ["PTX_OPTIONS"] = f"--apply-controls={acf_path}"
+    try:
+        return triton.testing.do_bench(lambda: kernel[tuple(task["grid"])](*args), warmup=warmup, rep=rep,
+                                       return_mode="mean")
+    finally:
+        os.environ.pop("PTX_OPTIONS", None)

--- a/third_party/compile_iq/compile_iq/store.py
+++ b/third_party/compile_iq/compile_iq/store.py
@@ -1,0 +1,49 @@
+"""ACF store: content-addressed by sha256(PTX), partitioned by GPU arch.
+
+Layout:
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.acf          # the best ACF (opaque bytes)
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.acf.json     # provenance metadata
+
+PINNED (hash-key design): the key is sha256(PTX) x arch today. PTX subsumes the
+autotune config + dtype/alignment specialization, but NOT runtime shape (M,N,K).
+If per-shape ACFs are wanted later, extend the key with shape/identity.
+"""
+
+import hashlib
+import json
+import os
+
+
+def ptx_sha256(ptx: str) -> str:
+    return hashlib.sha256(ptx.encode("utf-8")).hexdigest()
+
+
+def store_root() -> str:
+    return os.environ.get("COMPILE_IQ_STORE", os.path.expanduser("~/.compile_iq/store"))
+
+
+def acf_path(ptx_sha: str, arch: str) -> str:
+    return os.path.join(store_root(), arch, f"{ptx_sha}.acf")
+
+
+def has_acf(ptx_sha: str, arch: str) -> bool:
+    return os.path.exists(acf_path(ptx_sha, arch))
+
+
+def read_acf(ptx_sha: str, arch: str) -> bytes | None:
+    p = acf_path(ptx_sha, arch)
+    if not os.path.exists(p):
+        return None
+    with open(p, "rb") as f:
+        return f.read()
+
+
+def write_acf(ptx_sha: str, arch: str, data: bytes, meta: dict | None = None) -> str:
+    p = acf_path(ptx_sha, arch)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    with open(p, "wb") as f:
+        f.write(data)
+    if meta is not None:
+        with open(p + ".json", "w") as f:
+            json.dump(meta, f, indent=2, default=str)
+    return p

--- a/third_party/compile_iq/examples/user_kernel.py
+++ b/third_party/compile_iq/examples/user_kernel.py
@@ -1,0 +1,63 @@
+"""A normal Triton kernel + run — NO compile_iq / CompileIQ imports or references.
+
+This is exactly what a user would write. It demonstrates Stage-1 collection's
+**zero user surface**: nothing in this file is aware of compile_iq. Collection is
+triggered entirely by the environment, with no change to this code:
+
+    FBTRITON_COMPILE_IQ_COLLECT=1 \
+    COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks \
+    TRITON_PTXAS_BLACKWELL_PATH=/path/to/ptxas13.3 \
+    python user_kernel.py
+
+After the run, a compileIQ task appears under $COMPILE_IQ_TASK_DIR.
+"""
+
+import torch
+
+import triton
+import triton.language as tl
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+@triton.jit
+def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+                  BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
+        acc += tl.dot(a, b)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    c = acc.to(c_ptr.dtype.element_ty)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, c, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+
+def matmul(a, b):
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    BLOCK_M = BLOCK_N = 64
+    BLOCK_K = 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    matmul_kernel[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
+                        BLOCK_M, BLOCK_N, BLOCK_K)
+    return c
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    a = torch.randn((2048, 2048), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((2048, 2048), device=DEVICE, dtype=torch.float16)
+    c = matmul(a, b)
+    torch.cuda.synchronize()
+    print("matmul ran:", tuple(c.shape), c.dtype)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -962,6 +962,20 @@ class CUDABackend(BaseBackend):
             # Add --regAllocOptLevel=2 to work around ptxas 13.x bug
             reg_alloc = ["--regAllocOptLevel=2"]
 
+            # compile_iq Stage-3 consumption (gated, default off; fail-open): if the
+            # PTX hash hits the ACF store, apply it via --apply-controls. Only when the
+            # ptxas in use supports it (>=13.3), so it stays fail-open otherwise. Fires
+            # per ptxas call, i.e. for each config compiled during autotuning.
+            apply_controls = []
+            if os.environ.get("FBTRITON_COMPILE_IQ_APPLY"):
+                try:
+                    from packaging.version import Version
+                    if Version(get_ptxas(self.target.arch).version) >= Version("13.3"):
+                        from triton.compile_iq.consume import acf_args_for
+                        apply_controls = acf_args_for(src, arch)
+                except Exception:
+                    apply_controls = []
+
             ptxas_cmd = [
                 ptxas,
                 *debug_info,
@@ -970,6 +984,7 @@ class CUDABackend(BaseBackend):
                 *disable_opt,
                 *reg_alloc,
                 *ptx_extra_options,
+                *apply_controls,
                 f"--gpu-name={arch}",
                 fsrc.name,
                 "-o",


### PR DESCRIPTION
Adds compile_iq, a system that transparently squeezes extra kernel perf by tuning NVIDIA ptxas Advanced Control Files (ACFs) via NVIDIA CompileIQ — with zero surface for Triton users. Unlike the prototype (where CompileIQ wrapped the kernel), the kernel run and the ACF search are decoupled through disk, so tuning is fully opaque and asynchronous:
```  
user runs kernel ──► compileIQ task ──► (offline) factory ──► ACF store ──► future runs get free wins   
    jit.py hook          on disk           CompileIQ search       on disk        (Stage-3 shim, follow-up)                  
```                                                                                     

## Opacity / dependency guarantees (the core design constraint):
- The only change to Triton core is a ~12-line env-gated, try/except hook in jit.py — a no-op unless FBTRITON_COMPILE_IQ_COLLECT is set. The fbtriton build never depends on CompileIQ.
- Collection imports only stdlib — no CompileIQ, no ptxas 13.3, no binaries. The proprietary CompileIQ engine is needed only by the offline factory, which fails fast with install hints if the engine / ptxas≥13.3 / search-space bin are missing.
- No binaries are vendored; the engine (Evo wheel), ptxas (nvidia-cuda-nvcc), and the NVIDIA search-space bin are all external.

## Smoke Test
Event collection
`FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks python third_party/compile_iq/examples/user_kernel.py`

=> /tmp/ciq_tasks/6cc36c87baf77f59/

ACF factory
`COMPILE_IQ_STORE=/tmp/ciq_store COMPILE_IQ_SEARCH_SPACE_BIN=/data/users/daohang/CompileIQ/tests/compiler_ss/data/ptxas13.3.bin python -m triton.compile_iq.factory /tmp/ciq_tasks/6cc36c87baf77f59/ --generations 4 --pool-size 16`
```
[factory] ptxas: /data/users/daohang/ptx-acf-prototype/.venv-ptxas/lib/python3.13/site-packages/nvidia/cu13/bin/ptxas
[factory] task= arch=sm_100a ptx_sha=6cc36c87baf77f59 baseline=0.0481 ms
🧬 Generation:  4/4|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| [elapsed: 00:07 · eta: 00:00] , 🏆 best_score=0.0491, at_gen=0
[factory] best=0.0491 ms (baseline 0.0481, -2.17%)
[factory] wrote ACF -> /tmp/ciq_store/sm_100a/6cc36c87baf77f5915dbbf89bb752c745fcbb40cab5d7e661a96fd92dca252d0.acf
```

Consume ACF
`FBTRITON_COMPILE_IQ_APPLY=1 COMPILE_IQ_STORE=/tmp/ciq_store python third_party/compile_iq/examples/user_kernel.py`
```
  no-ACF SASS:  536 instructions                                                                                                                                                                                      
  with-ACF SASS: 656 instructions   (+120, ~+22%)                                                                                                                                                                     
  byte-identical? DIFFERENT                                                                                                                                                                                           
```