### PR TITLE
[AutoWS] Fix token_wait pending count across if statements

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_pendings.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_pendings.mlir
@@ -96,3 +96,164 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// scf.for result tokens use the minimum of the loop-yield path and the
+// zero-iteration initial iter_arg path.
+// CHECK-LABEL: for_result_token_drain
+  tt.func public @for_result_token_drain(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %init0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    %init1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    %init2 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src2 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    %result:3 = scf.for %iv = %c0 to %c8 step %c1 iter_args(%carried0 = %init0, %carried1 = %init1, %carried2 = %init2) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token) {
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %tok2 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src2 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      scf.yield %tok0, %tok1, %tok2 : !ttg.async.token, !ttg.async.token, !ttg.async.token
+    }
+    // CHECK: ttng.async_tma_store_wait {pendings = 2 : i32}
+    ttng.async_tma_store_token_wait %result#0 : !ttg.async.token
+    // CHECK: ttng.async_tma_store_wait {pendings = 1 : i32}
+    ttng.async_tma_store_token_wait %result#1 : !ttg.async.token
+    // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+    ttng.async_tma_store_token_wait %result#2 : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Intervening scf.if contributes the minimum store count across branches.
+// CHECK-LABEL: direct_with_intervening_if
+  tt.func public @direct_with_intervening_if(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32,
+      %cond: i1) {
+    %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    scf.if %cond {
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    } else {
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %tok2 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src2 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    }
+    // CHECK: ttng.async_tma_store_wait {pendings = 1 : i32}
+    ttng.async_tma_store_token_wait %tok0 : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// scf.if result tokens exclude the defining if and count later stores.
+// CHECK-LABEL: if_result_token_min
+  tt.func public @if_result_token_min(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32,
+      %cond: i1) {
+    %tok = scf.if %cond -> (!ttg.async.token) {
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      scf.yield %tok0 : !ttg.async.token
+    } else {
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      %tok2 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src2 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      scf.yield %tok0 : !ttg.async.token
+    }
+    %tok3 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src2 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    // CHECK: ttng.async_tma_store_wait {pendings = 1 : i32}
+    ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Matching wait guard selects the same branch for later sibling scf.if ops.
+// CHECK-LABEL: if_result_token_same_guard
+  tt.func public @if_result_token_same_guard(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32,
+      %cond: i1) {
+    %init = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    %tok = scf.if %cond -> (!ttg.async.token) {
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      scf.yield %tok0 : !ttg.async.token
+    } else {
+      scf.yield %init : !ttg.async.token
+    }
+    scf.if %cond {
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    }
+    scf.if %cond {
+      %tok2 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src2 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    }
+    scf.if %cond {
+      // CHECK: ttng.async_tma_store_wait {pendings = 2 : i32}
+      ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Equivalent pure conditions also select the same branch.
+// CHECK-LABEL: if_result_token_equivalent_guard
+  tt.func public @if_result_token_equivalent_guard(
+      %desc: !tt.tensordesc<tensor<128x64xf16, #shared>>,
+      %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %src1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32) {
+    %cond0 = arith.cmpi eq, %i, %i : i32
+    %cond1 = arith.cmpi eq, %i, %i : i32
+    %init = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    %tok = scf.if %cond0 -> (!ttg.async.token) {
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src0 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      scf.yield %tok0 : !ttg.async.token
+    } else {
+      scf.yield %init : !ttg.async.token
+    }
+    scf.if %cond0 {
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src1 : !tt.tensordesc<tensor<128x64xf16, #shared>>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    }
+    scf.if %cond1 {
+      // CHECK: ttng.async_tma_store_wait {pendings = 1 : i32}
+      ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    }
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -10,6 +10,8 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "llvm/Support/Debug.h"
+#include <algorithm>
+#include <optional>
 
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
@@ -544,37 +546,180 @@ struct NVGPUTestTMAStoreTokenWaitReorderPass
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
 
 // Count TMA store-like ops (AsyncTMACopyLocalToGlobalOp and AsyncTMAReduceOp)
-// in [from, to) within a block.
-static int countTMAStoresInRange(Block::iterator from, Block::iterator to) {
+// in [from, to) within a block. An scf.if contributes the minimum store count
+// across its branches; if there is no else region, the else contribution is 0.
+struct ConditionBranch {
+  Value condition;
+  bool takeThen;
+};
+
+using ConditionContext = SmallVector<ConditionBranch, 4>;
+
+static bool isInRegion(Operation *op, Region &region) {
+  return region.findAncestorOpInRegion(*op) != nullptr;
+}
+
+static ConditionContext getConditionContext(Operation *op) {
+  ConditionContext context;
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    auto ifOp = dyn_cast<scf::IfOp>(parent);
+    if (!ifOp)
+      continue;
+
+    if (isInRegion(op, ifOp.getThenRegion())) {
+      context.push_back({ifOp.getCondition(), /*takeThen=*/true});
+    } else if (isInRegion(op, ifOp.getElseRegion())) {
+      context.push_back({ifOp.getCondition(), /*takeThen=*/false});
+    }
+  }
+  return context;
+}
+
+static std::optional<bool>
+getConsistentBranch(scf::IfOp ifOp, const ConditionContext &context) {
+  for (const ConditionBranch &branch : context) {
+    if (samePureValue(ifOp.getCondition(), branch.condition))
+      return branch.takeThen;
+  }
+  return std::nullopt;
+}
+
+static int countTMAStoresInRange(Block::iterator from, Block::iterator to,
+                                 const ConditionContext &context);
+
+static int countTMAStoresInRegion(Region &region,
+                                  const ConditionContext &context) {
+  if (region.empty())
+    return 0;
+
+  Block &block = region.front();
+  return countTMAStoresInRange(block.begin(), block.end(), context);
+}
+
+static int countTMAStoreContribution(Operation *op,
+                                     const ConditionContext &context) {
+  if (isTMAStoreLikeOp(op))
+    return 1;
+
+  if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    if (std::optional<bool> branch = getConsistentBranch(ifOp, context)) {
+      Region &selectedRegion =
+          *branch ? ifOp.getThenRegion() : ifOp.getElseRegion();
+      return countTMAStoresInRegion(selectedRegion, context);
+    }
+
+    int thenCount = countTMAStoresInRegion(ifOp.getThenRegion(), context);
+    int elseCount = ifOp.getElseRegion().empty()
+                        ? 0
+                        : countTMAStoresInRegion(ifOp.getElseRegion(), context);
+    return std::min(thenCount, elseCount);
+  }
+
+  return 0;
+}
+
+static int countTMAStoresInRange(Block::iterator from, Block::iterator to,
+                                 const ConditionContext &context) {
   int count = 0;
   for (auto it = from; it != to; ++it) {
-    if (isTMAStoreLikeOp(&*it))
-      ++count;
+    count += countTMAStoreContribution(&*it, context);
   }
   return count;
 }
 
-// Compute the pendings value for a TMAStoreTokenWaitOp.
-// pendings = number of TMA store-like ops issued after the token's defining
-// store and before this wait, in program execution order.
-static int computePendings(ttng::TMAStoreTokenWaitOp waitOp) {
-  Value token = waitOp.getToken();
+static std::optional<int>
+countTMAStoresUntilWait(Block *block, Block::iterator from,
+                        ttng::TMAStoreTokenWaitOp waitOp,
+                        const ConditionContext &context) {
+  if (waitOp->getBlock() == block)
+    return countTMAStoresInRange(from, waitOp->getIterator(), context);
+
+  int count = 0;
+  for (auto it = from; it != block->end(); ++it) {
+    Operation *op = &*it;
+    if (!op->isProperAncestor(waitOp)) {
+      count += countTMAStoreContribution(op, context);
+      continue;
+    }
+
+    for (Region &region : op->getRegions()) {
+      if (!isInRegion(waitOp, region))
+        continue;
+      if (region.empty())
+        return count;
+      if (std::optional<int> inner = countTMAStoresUntilWait(
+              &region.front(), region.front().begin(), waitOp, context))
+        return count + *inner;
+      return std::nullopt;
+    }
+    return std::nullopt;
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<int>
+computePendingsFromToken(Value token, ttng::TMAStoreTokenWaitOp waitOp,
+                         const ConditionContext &context, unsigned depth = 0) {
+  if (depth > 8)
+    return std::nullopt;
 
   // Direct case: token defined by a TMA store-like op in same block.
   auto directDef = token.getDefiningOp();
   if (directDef && isTMAStoreLikeOp(directDef)) {
-    if (directDef->getBlock() == waitOp->getBlock()) {
-      return countTMAStoresInRange(std::next(directDef->getIterator()),
-                                   waitOp->getIterator());
-    }
-    return 0;
+    return countTMAStoresUntilWait(directDef->getBlock(),
+                                   std::next(directDef->getIterator()), waitOp,
+                                   context);
+  }
+
+  // If-result case: count after the defining if, excluding the defining if
+  // itself to match direct-token semantics.
+  if (auto ifOp = token.getDefiningOp<scf::IfOp>()) {
+    return countTMAStoresUntilWait(
+        ifOp->getBlock(), std::next(ifOp->getIterator()), waitOp, context);
+  }
+
+  // Loop result case: the result may come from the loop body yield, or from the
+  // initial iter_arg if the loop executes zero times. Use the conservative
+  // minimum across both paths.
+  if (auto forOp = token.getDefiningOp<scf::ForOp>()) {
+    auto result = cast<OpResult>(token);
+    unsigned iterArgIdx = result.getResultNumber();
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    if (iterArgIdx >= yieldOp.getNumOperands() ||
+        iterArgIdx >= forOp.getInitArgs().size())
+      return std::nullopt;
+
+    Value yieldedVal = yieldOp.getOperand(iterArgIdx);
+    auto yieldDef = yieldedVal.getDefiningOp();
+    if (!yieldDef || !isTMAStoreLikeOp(yieldDef) ||
+        yieldDef->getBlock() != forOp.getBody())
+      return std::nullopt;
+
+    Block *body = forOp.getBody();
+    std::optional<int> afterLoop = countTMAStoresUntilWait(
+        forOp->getBlock(), std::next(forOp->getIterator()), waitOp, context);
+    if (!afterLoop)
+      return std::nullopt;
+
+    int loopPath = countTMAStoresInRange(std::next(yieldDef->getIterator()),
+                                         body->end(), context) +
+                   *afterLoop;
+
+    std::optional<int> initPath = computePendingsFromToken(
+        forOp.getInitArgs()[iterArgIdx], waitOp, context, depth + 1);
+    if (!initPath)
+      return std::nullopt;
+
+    return std::min(loopPath, *initPath);
   }
 
   // Loop-carried case: token is a block argument of an scf.for body.
   if (auto blockArg = dyn_cast<BlockArgument>(token)) {
     auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
     if (!forOp)
-      return 0;
+      return std::nullopt;
 
     unsigned iterArgIdx = blockArg.getArgNumber() - 1;
     auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
@@ -584,20 +729,32 @@ static int computePendings(ttng::TMAStoreTokenWaitOp waitOp) {
     auto defOp = yieldedVal.getDefiningOp();
     if (!defOp || !isTMAStoreLikeOp(defOp) ||
         defOp->getBlock() != forOp.getBody())
-      return 0;
+      return std::nullopt;
 
     Block *body = forOp.getBody();
 
     // Stores after the def until end of loop body (excluding yield).
-    int storesAfterDef =
-        countTMAStoresInRange(std::next(defOp->getIterator()), body->end());
+    int storesAfterDef = countTMAStoresInRange(std::next(defOp->getIterator()),
+                                               body->end(), context);
 
     // Stores from start of loop body until the wait.
     int storesBeforeWait =
-        countTMAStoresInRange(body->begin(), waitOp->getIterator());
+        countTMAStoresInRange(body->begin(), waitOp->getIterator(), context);
 
     return storesAfterDef + storesBeforeWait;
   }
+
+  return std::nullopt;
+}
+
+// Compute the pendings value for a TMAStoreTokenWaitOp.
+// pendings = number of TMA store-like ops issued after the token's defining
+// store and before this wait, in program execution order.
+static int computePendings(ttng::TMAStoreTokenWaitOp waitOp) {
+  ConditionContext context = getConditionContext(waitOp);
+  if (std::optional<int> count =
+          computePendingsFromToken(waitOp.getToken(), waitOp, context))
+    return *count;
 
   // Fallback: unknown pattern, drain all stores.
   return 0;


### PR DESCRIPTION
Handles the trailing token_wait pending count that comes from the unrolled epilogue count. Previously this couldn't be determined because there was a corresponding if statement, setting the pending to 0. Now this update the pending to the correct count based on the tokens. 

This has 3 main changes:
1. For op tokens are yielded, producing the min of the distance in the body and the distance in the prologue.
2. if/else bodies are yielded. this produces the min of the if/else.
3. For if statements blocks are evaluated if they share a condition with the wait. In SWP this condition is typically K != 0, so this ensures an accurate count (both the wait in the epilogue and the tma store in the prologue with have the same condition).

This update the wait from GEMM pending count with 3 buffers from: 
Body: 2, 2, 2, 2 + Epilogue: 0, 0, 0, 0

To:
Body: 2, 2, 2, 2 + Epilogue: 2, 2, 1, 0