### PR TITLE
[ci] Expand fbtriton wheel matrix to cp312/cp313/cp314

### DIFF
--- a/.github/workflows/wheels_fb.yml
+++ b/.github/workflows/wheels_fb.yml
@@ -32,7 +32,7 @@ jobs:
       # ABIs/arches work and which break.
       fail-fast: false
       matrix:
-        python: [cp313]
+        python: [cp312, cp313, cp314]
         arch: [x86_64]
         # python: [cp310, cp311, cp312, cp313, cp314]
         # arch: [x86_64, aarch64]


### PR DESCRIPTION
Summary:

Build wheels for the three CPython ABIs we ship, instead of only cp313.

Test Plan:
gh workflow run wheels_fb.yml -R facebookexperimental/triton
