### PR TITLE
Add barrier.cluster arrive/wait for tmem free in ws

### DIFF
--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -575,22 +575,27 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     auto ctx = ret->getContext();
     auto loc = ret.getLoc();
     auto voidTy = void_ty(ctx);
-    // In WS mode, this code runs only in the default warp group's exit
-    // path. Workers are in the switch loop and cannot participate in a
-    // cluster-wide barrier. Use a CTA-level barrier instead (same as TLX).
     bool hasWarpSpecialize = false;
     func.walk([&](Operation *op) {
       if (isa<triton::gpu::WarpSpecializeOp>(op))
         hasWarpSpecialize = true;
     });
-    if ((twoCTAs || tlxPairedMMA) && !hasWarpSpecialize) {
+    if (tlxPairedMMA) {
+      // TLX paired MMA: do a cluster sync before tmem de-alloc. This works
+      // even in WS mode because the WS lowering inserts matching cluster
+      // arrives for the non-default warps right before their warp_return
+      // (gated by the cluster_sync_kernel_cleanup mod attr set below).
       NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
       NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));
-      if (tlxPairedMMA) {
-        // mark mod attr so that WS lowering is aware of this cluster sync point
-        tlx::setClusterSyncKernelCleanupOnMod(func, true);
-      }
+      // mark mod attr so that WS lowering is aware of this cluster sync point
+      tlx::setClusterSyncKernelCleanupOnMod(func, true);
+    } else if (twoCTAs && !hasWarpSpecialize) {
+      NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
+      NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));
     } else {
+      // Non-TLX 2-CTA AutoWS: this code runs only in the default warp group's
+      // exit path. Workers are in the switch loop and cannot participate in a
+      // cluster-wide barrier, so use a CTA-level barrier instead.
       NVVM::Barrier0Op::create(b, loc);
     }
     PTXBuilder ptxBuilder;


### PR DESCRIPTION
The test asserts the PTX contains 6 barrier.cluster.arrive.aligned and 2 barrier.cluster.wait.aligned, but only 2 arrives / 1 wait were emitted. The missing ones were the cluster sync around the TMEM de-allocation in the cleanup phase. The fix restores it for the TLX paired-MMA path under warp specialization, without disturbing the AutoWS path.


The issue was introduced here https://github.com/facebookexperimental/triton/pull/1490/changes#diff-1776ff084697538ae3bf61a60eb350c758b428a3f9dbc59893201917cb788fcaR578-R586 

Fix https://github.com/facebookexperimental/triton/issues/1694

authored with claude.

Also attaching a doc I created with claude helping me understand how warp specialization is involved, why barrier.cluster is needed before freeing tmem etc: https://www.internalfb.com/phabricator/paste/view/P2375272046