### PR TITLE
[AutoWS][2-CTA] Add dependency check for multi-MMA case, disabling FA

### DIFF
--- a/docs/design/2cta-autoWS-sync.md
+++ b/docs/design/2cta-autoWS-sync.md
@@ -471,14 +471,23 @@ buck2 run @fbcode//mode/opt -m ovr_config//triton:beta \
    instructions in a kernel to use the same `cta_group`. FA with selective 2-CTA
    on only some dots is impossible; a kernel must use 2-CTA on all dots or none.
 
-6. **Host-side TMA descriptor shape is updated through IR type metadata**:
+6. **Dependent 2-CTA MMA chains are rejected**: The current implementation
+   supports multiple independent 2-CTA MMAs in one loop, including Auto-WS data
+   partitioning. It does not yet support FA-style chains where one 2-CTA MMA
+   consumes a TMEM value derived from an earlier 2-CTA MMA result. The async
+   `tcgen05.mma` producer needs an explicit ordering contract before the
+   dependent consumer MMA can safely read that value. `CheckMatmulTwoCTAs`
+   rejects this pattern in the legality pass. `Transform2CTALoads` remains a
+   mechanical B-load split for already-legal 2-CTA MMAs.
+
+7. **Host-side TMA descriptor shape is updated through IR type metadata**:
    `Transform2CTALoads` supports host-side TMA by updating the function argument's
    `TensorDescType` to half-width block shape. The runtime reads that final IR
    type via `getTensorDescMetadata()` and creates the `CuTensorMap` accordingly.
    The `cta_group::2` mode is carried by the PTX instruction qualifier, not a
    separate descriptor-side flag.
 
-7. **Pointer-store epilogues are not recognized by Meta WS partitioning**:
+8. **Pointer-store epilogues are not recognized by Meta WS partitioning**:
    WS + 2-CTA test kernels must use descriptor/TMA stores for the output. Pointer
    stores do not currently create the expected epilogue partition.
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CheckMatmulTwoCTAs.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CheckMatmulTwoCTAs.cpp
@@ -1,3 +1,5 @@
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
@@ -5,7 +7,10 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/Visitors.h"
+#include "llvm/ADT/DenseSet.h"
 
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
 namespace mlir::triton::nvidia_gpu {
@@ -14,6 +19,121 @@ namespace mlir::triton::nvidia_gpu {
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
+
+static Value getBaseMemDesc(Value value) {
+  while (auto *def = value.getDefiningOp()) {
+    if (auto indexOp = dyn_cast<ttg::MemDescIndexOp>(def)) {
+      value = indexOp.getSrc();
+      continue;
+    }
+    if (auto subsliceOp = dyn_cast<ttg::MemDescSubsliceOp>(def)) {
+      value = subsliceOp.getSrc();
+      continue;
+    }
+    if (auto transOp = dyn_cast<ttg::MemDescTransOp>(def)) {
+      value = transOp.getSrc();
+      continue;
+    }
+    if (auto reshapeOp = dyn_cast<ttg::MemDescReshapeOp>(def)) {
+      value = reshapeOp.getSrc();
+      continue;
+    }
+    if (auto reinterpretOp = dyn_cast<ttg::MemDescReinterpretOp>(def)) {
+      value = reinterpretOp.getSrc();
+      continue;
+    }
+    if (auto tmemSubsliceOp = dyn_cast<ttng::TMEMSubSliceOp>(def)) {
+      value = tmemSubsliceOp.getSrc();
+      continue;
+    }
+    break;
+  }
+  return value;
+}
+
+static bool isViewOf(Value value, Value base) {
+  return getBaseMemDesc(value) == base;
+}
+
+static TCGen5MMAOp getTwoCTAMMAWriting(Value base) {
+  for (Operation *user : base.getUsers()) {
+    if (auto mmaOp = dyn_cast<TCGen5MMAOp>(user)) {
+      if (mmaOp.getTwoCtas() && isViewOf(mmaOp.getD(), base))
+        return mmaOp;
+    }
+  }
+  return nullptr;
+}
+
+static TCGen5MMAOp getTwoCTAMMAResultDependency(Value value,
+                                                DenseSet<Value> &visited) {
+  if (!value || !visited.insert(value).second)
+    return nullptr;
+
+  if (auto loadOp = value.getDefiningOp<TMEMLoadOp>()) {
+    Value loadBase = getBaseMemDesc(loadOp.getSrc());
+    if (auto producer = getTwoCTAMMAWriting(loadBase))
+      return producer;
+  }
+
+  if (auto base = getBaseMemDesc(value); base != value) {
+    if (auto producer = getTwoCTAMMAWriting(base))
+      return producer;
+  }
+
+  Operation *def = value.getDefiningOp();
+  if (!def)
+    return nullptr;
+  for (Value operand : def->getOperands()) {
+    if (auto producer = getTwoCTAMMAResultDependency(operand, visited))
+      return producer;
+  }
+  return nullptr;
+}
+
+static TCGen5MMAOp getDependentTwoCTAMMAProducer(Value operand) {
+  Value base = getBaseMemDesc(operand);
+  if (auto producer = getTwoCTAMMAWriting(base))
+    return producer;
+
+  if (auto allocOp = base.getDefiningOp<TMEMAllocOp>()) {
+    if (Value src = allocOp.getSrc()) {
+      DenseSet<Value> visited;
+      if (auto producer = getTwoCTAMMAResultDependency(src, visited))
+        return producer;
+    }
+  }
+
+  for (Operation *user : base.getUsers()) {
+    auto storeOp = dyn_cast<TMEMStoreOp>(user);
+    if (!storeOp || !isViewOf(storeOp.getDst(), base))
+      continue;
+    DenseSet<Value> visited;
+    if (auto producer = getTwoCTAMMAResultDependency(storeOp.getSrc(), visited))
+      return producer;
+  }
+  return nullptr;
+}
+
+static tt::DotOp getTwoCTADotDependency(Value value, DenseSet<Value> &visited) {
+  if (!value || !visited.insert(value).second)
+    return nullptr;
+
+  Operation *def = value.getDefiningOp();
+  if (!def)
+    return nullptr;
+
+  if (auto dotOp = dyn_cast<tt::DotOp>(def)) {
+    if (dotOp.getTwoCtas())
+      return dotOp;
+  }
+
+  for (Value operand : def->getOperands()) {
+    if (auto producer = getTwoCTADotDependency(operand, visited))
+      return producer;
+  }
+  return nullptr;
+}
 
 class TritonNvidiaGPUCheckMatmulTwoCTAPass
     : public impl::TritonNvidiaGPUCheckMatmulTwoCTAPassBase<
@@ -47,7 +167,46 @@ public:
       return WalkResult::advance();
     };
 
+    auto checkNoDependentTwoCTAMMA = [&](ttng::TCGen5MMAOp op) -> WalkResult {
+      if (!op.getTwoCtas())
+        return WalkResult::advance();
+      for (Value operand : {op.getA(), op.getB()}) {
+        auto producer = getDependentTwoCTAMMAProducer(operand);
+        if (!producer || producer == op)
+          continue;
+        auto diag = op->emitError()
+                    << "two_ctas=True does not currently support dependent "
+                       "matmul chains where one 2-CTA MMA consumes a TMEM "
+                       "value derived from another 2-CTA MMA result.";
+        diag.attachNote(producer->getLoc())
+            << "producer 2-CTA MMA result is consumed by this matmul.";
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    };
+
+    auto checkNoDependentTwoCTADot = [&](tt::DotOp op) -> WalkResult {
+      if (!op.getTwoCtas())
+        return WalkResult::advance();
+      for (Value operand : {op.getA(), op.getB()}) {
+        DenseSet<Value> visited;
+        auto producer = getTwoCTADotDependency(operand, visited);
+        if (!producer || producer == op)
+          continue;
+        auto diag = op->emitError()
+                    << "two_ctas=True does not currently support dependent "
+                       "matmul chains where one 2-CTA dot consumes a value "
+                       "derived from another 2-CTA dot result.";
+        diag.attachNote(producer->getLoc())
+            << "producer 2-CTA dot result is consumed by this dot.";
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    };
+
     WalkResult result = mod.walk([&](Operation *op) {
+      if (auto dotOp = dyn_cast<tt::DotOp>(op))
+        return checkTwoCTA(op, dotOp.getTwoCtas());
       if (auto mmaOp = dyn_cast<ttng::TCGen5MMAOp>(op))
         return checkTwoCTA(op, mmaOp.getTwoCtas());
       if (auto scaledOp = dyn_cast<ttng::TCGen5MMAScaledOp>(op))
@@ -55,6 +214,20 @@ public:
       return WalkResult::advance();
     });
 
+    if (result.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
+    result =
+        mod.walk([&](tt::DotOp op) { return checkNoDependentTwoCTADot(op); });
+    if (result.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
+    result = mod.walk(
+        [&](ttng::TCGen5MMAOp op) { return checkNoDependentTwoCTAMMA(op); });
     if (result.wasInterrupted()) {
       signalPassFailure();
       return;

--- a/test/Hopper/TwoCTA/check_matmul_two_cta.mlir
+++ b/test/Hopper/TwoCTA/check_matmul_two_cta.mlir
@@ -1,0 +1,121 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-check-matmul-two-cta --verify-diagnostics | FileCheck %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+// CHECK-LABEL: module
+// CHECK-SAME: "ttng.two-ctas" = true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32} {
+  tt.func @independent_two_cta_mmas(
+      %a0: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %a1: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %b: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      %acc0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %acc1: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %acc_tok0: !ttg.async.token,
+      %acc_tok1: !ttg.async.token) {
+    %true = arith.constant true
+    %tok0 = ttng.tc_gen5_mma %a0, %b, %acc0[%acc_tok0], %true, %true {two_ctas} :
+      !ttg.memdesc<128x64xf16, #shared, #smem>,
+      !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %tok1 = ttng.tc_gen5_mma %a1, %b, %acc1[%acc_tok1], %true, %true {two_ctas} :
+      !ttg.memdesc<128x64xf16, #shared, #smem>,
+      !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32} {
+  tt.func @dependent_two_cta_dot_chain(
+      %q: tensor<128x64xf16>,
+      %k: tensor<64x128xf16>,
+      %v: tensor<128x128xf16>,
+      %acc: tensor<128x128xf32>) {
+    // expected-note @+1 {{producer 2-CTA dot result is consumed by this dot.}}
+    %qk = tt.dot %q, %k, %acc {two_ctas} : tensor<128x64xf16> * tensor<64x128xf16> -> tensor<128x128xf32>
+    %qk_f16 = arith.truncf %qk : tensor<128x128xf32> to tensor<128x128xf16>
+    // expected-error @+1 {{two_ctas=True does not currently support dependent matmul chains}}
+    %pv = tt.dot %qk_f16, %v, %acc {two_ctas} : tensor<128x128xf16> * tensor<128x128xf16> -> tensor<128x128xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32} {
+  tt.func @dependent_two_cta_mma_chain(
+      %q: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %k: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      %v: !ttg.memdesc<128x128xf16, #shared1, #smem>,
+      %qk_acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %pv_a: !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>,
+      %out_acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %qk_tok: !ttg.async.token,
+      %out_tok: !ttg.async.token) {
+    %true = arith.constant true
+    // expected-note @+1 {{producer 2-CTA MMA result is consumed by this matmul.}}
+    %qk_tok_out = ttng.tc_gen5_mma %q, %k, %qk_acc[%qk_tok], %true, %true {two_ctas} :
+      !ttg.memdesc<128x64xf16, #shared, #smem>,
+      !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %qk, %qk_load_tok = ttng.tmem_load %qk_acc[%qk_tok_out] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %qk_bf16 = arith.truncf %qk : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+    ttng.tmem_store %qk_bf16, %pv_a, %true : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{two_ctas=True does not currently support dependent matmul chains}}
+    %pv_tok_out = ttng.tc_gen5_mma %pv_a, %v, %out_acc[%out_tok], %true, %true {two_ctas} :
+      !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<128x128xf16, #shared1, #smem>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32} {
+  tt.func @dependent_two_cta_tmem_alloc_operand(
+      %q: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %k: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      %v: !ttg.memdesc<128x128xf16, #shared1, #smem>,
+      %qk_acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %out_acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %qk_tok: !ttg.async.token,
+      %out_tok: !ttg.async.token) {
+    %true = arith.constant true
+    // expected-note @+1 {{producer 2-CTA MMA result is consumed by this matmul.}}
+    %qk_tok_out = ttng.tc_gen5_mma %q, %k, %qk_acc[%qk_tok], %true, %true {two_ctas} :
+      !ttg.memdesc<128x64xf16, #shared, #smem>,
+      !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %qk, %qk_load_tok = ttng.tmem_load %qk_acc[%qk_tok_out] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %qk_f16 = arith.truncf %qk : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+    %pv_a = ttng.tmem_alloc %qk_f16 : (tensor<128x128xf16, #linear>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+    // expected-error @+1 {{two_ctas=True does not currently support dependent matmul chains}}
+    %pv_tok_out = ttng.tc_gen5_mma %pv_a, %v, %out_acc[%out_tok], %true, %true {two_ctas} :
+      !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>,
+      !ttg.memdesc<128x128xf16, #shared1, #smem>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/test/Hopper/TwoCTA/transform_2cta_loads.mlir
+++ b/test/Hopper/TwoCTA/transform_2cta_loads.mlir
@@ -149,6 +149,57 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32,
 
 // -----
 
+// Test: Multiple B loads from the same host-side TMA descriptor should all use
+// the same original block shape. The descriptor argument must be halved once,
+// not once per MMA user.
+// CHECK-LABEL: @matmul_2cta_host_tma_reused_desc
+// CHECK-SAME: !tt.tensordesc<tensor<64x64xf16>>
+// CHECK-NOT: tensor<64x32xf16>
+// CHECK: tt.descriptor_load %{{.*}} : !tt.tensordesc<tensor<64x64xf16>> -> tensor<64x64xf16
+// CHECK: tt.descriptor_load %{{.*}} : !tt.tensordesc<tensor<64x64xf16>> -> tensor<64x64xf16
+// CHECK: ttng.tc_gen5_mma {{.*}} {two_ctas}
+// CHECK: ttng.tc_gen5_mma {{.*}} {two_ctas}
+
+#blocked_r = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1_r = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3_r = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_r = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem_r = #ttg.shared_memory
+#tmem_r = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_2cta_host_tma_reused_desc(
+      %a_desc: !tt.tensordesc<tensor<128x64xf16>>,
+      %b_desc: !tt.tensordesc<tensor<64x128xf16>>) attributes {noinline = false} {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_r>
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<128x64xf16>> -> tensor<128x64xf16, #blocked1_r>
+    %a_smem = ttg.local_alloc %a : (tensor<128x64xf16, #blocked1_r>) -> !ttg.memdesc<128x64xf16, #shared_r, #smem_r>
+
+    %b0 = tt.descriptor_load %b_desc[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked1_r>
+    %b0_smem = ttg.local_alloc %b0 : (tensor<64x128xf16, #blocked1_r>) -> !ttg.memdesc<64x128xf16, #shared_r, #smem_r>
+
+    %b1 = tt.descriptor_load %b_desc[%c64_i32, %c128_i32] : !tt.tensordesc<tensor<64x128xf16>> -> tensor<64x128xf16, #blocked1_r>
+    %b1_smem = ttg.local_alloc %b1 : (tensor<64x128xf16, #blocked1_r>) -> !ttg.memdesc<64x128xf16, #shared_r, #smem_r>
+
+    %acc_layout0 = ttg.convert_layout %cst : tensor<128x128xf32, #blocked_r> -> tensor<128x128xf32, #blocked3_r>
+    %acc_tmem0, %token0 = ttng.tmem_alloc %acc_layout0 : (tensor<128x128xf32, #blocked3_r>) -> (!ttg.memdesc<128x128xf32, #tmem_r, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_token0 = ttng.tc_gen5_mma %a_smem, %b0_smem, %acc_tmem0[%token0], %true, %true {two_ctas} : !ttg.memdesc<128x64xf16, #shared_r, #smem_r>, !ttg.memdesc<64x128xf16, #shared_r, #smem_r>, !ttg.memdesc<128x128xf32, #tmem_r, #ttng.tensor_memory, mutable>
+
+    %acc_layout1 = ttg.convert_layout %cst : tensor<128x128xf32, #blocked_r> -> tensor<128x128xf32, #blocked3_r>
+    %acc_tmem1, %token1 = ttng.tmem_alloc %acc_layout1 : (tensor<128x128xf32, #blocked3_r>) -> (!ttg.memdesc<128x128xf32, #tmem_r, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_token1 = ttng.tc_gen5_mma %a_smem, %b1_smem, %acc_tmem1[%token1], %true, %true {two_ctas} : !ttg.memdesc<128x64xf16, #shared_r, #smem_r>, !ttg.memdesc<64x128xf16, #shared_r, #smem_r>, !ttg.memdesc<128x128xf32, #tmem_r, #ttng.tensor_memory, mutable>
+
+    tt.return
+  }
+}
+
+// -----
+
 // Test: No two_ctas attribute - pass should not modify anything
 // CHECK-LABEL: @matmul_no_2cta
 // CHECK-NOT: nvg.cluster_id

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -623,6 +623,12 @@ class CUDABackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         dump_enabled = pm.enable_debug()
         emuTF32 = capability // 10 >= 8
+        # Check user-visible tt.dot 2-CTA legality before lowering rewrites
+        # dot dependencies into TMEM alloc/load/store chains. Later checks still
+        # verify the lowered TCGen5MMA form.
+        if (capability // 10 >= 10 and opt.cluster_dims is not None and max(opt.cluster_dims) >= 2
+                and opt.ctas_per_cga is not None):
+            nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
         passes.ttir.add_convert_to_ttgpuir(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
@@ -646,6 +652,7 @@ class CUDABackend(BaseBackend):
         # MMAv5.cpp's inline ClusterArriveOp for non-WS.
         if (capability // 10 >= 10 and opt.cluster_dims is not None and max(opt.cluster_dims) >= 2
                 and opt.ctas_per_cga is not None):
+            nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
             nvidia.passes.hopper.add_2cta_transform_loads(pm)
         nvidia.passes.ttnvgpuir.add_optimize_descriptor_encoding(pm)
         passes.ttir.add_loop_aware_cse(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
@@ -145,6 +145,7 @@ static FailureOr<BLoadTrace> traceToDescriptorLoad(Value bMemDesc) {
 
 struct Transform2CTALoads
     : public impl::NVGPU2CTATransformLoadsBase<Transform2CTALoads> {
+  DenseMap<Value, tt::TensorDescType> originalDescTypes;
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
@@ -155,6 +156,12 @@ struct Transform2CTALoads
     // TLX kernels manage their own 2-CTA load splitting and synchronization.
     if (moduleOp->hasAttr("tlx.has_tlx_ops"))
       return;
+
+    originalDescTypes.clear();
+    moduleOp.walk([&](tt::DescriptorLoadOp descLoad) {
+      auto descType = cast<tt::TensorDescType>(descLoad.getDesc().getType());
+      originalDescTypes.try_emplace(descLoad.getDesc(), descType);
+    });
 
     // Collect 2-CTA MMA ops.
     SmallVector<ttng::TCGen5MMAOp> twoCTAMMAOps;
@@ -187,7 +194,9 @@ struct Transform2CTALoads
     unsigned splitDim = trace->splitDim;
 
     // Get block shape from the descriptor's type.
-    auto descType = cast<tt::TensorDescType>(descLoad.getDesc().getType());
+    auto descType = originalDescTypes.lookup(descLoad.getDesc());
+    if (!descType)
+      descType = cast<tt::TensorDescType>(descLoad.getDesc().getType());
     auto blockShape = descType.getBlockType().getShape();
     assert(blockShape.size() == 2 && "Expected 2D block shape");
     SmallVector<int64_t> newBlockShape(blockShape.begin(), blockShape.end());


### PR DESCRIPTION
Add dependency check for 2-CTA multi-MMA cases, which are not currently supported in Triton. If a kernel has multiple MMAs with a data dependency (e.g. FA, where the first dot product feeds the second), reject 2-CTA.