### PR TITLE
[TLX] Add proxy fence after clc response query

### DIFF
--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -438,6 +438,10 @@ def test_cluster_launch_control(BLOCK_SIZE, device):
     assert re.search((r"clusterlaunchcontrol.query_cancel.is_canceled.pred.b128"), ptx, flags=re.DOTALL)
     assert re.search((r"clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128"), ptx, flags=re.DOTALL)
 
+    query_instr = ptx.index("clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128")
+    fence_instr = ptx.index("fence.proxy.async.shared::cta")
+    assert 0 < query_instr < fence_instr
+
     assert torch.count_nonzero(output) == size
 
 

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -1,7 +1,7 @@
 import triton.language.core as tl
 
 from . import types as tlx
-from .mem_ops import local_view
+from .mem_ops import local_view, fence
 from .barrier import alloc_barriers, barrier_expect_bytes, barrier_wait, barrier_arrive
 from .utility import cluster_cta_rank
 
@@ -171,6 +171,8 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, return
     # Extract tile_id from the CLC response.
     stolen_tile_ids = _clc_query(response, _semantic=_semantic)
     stolen_tile_id = stolen_tile_ids[0]
+
+    fence(tl.constexpr("async_shared"), _semantic=_semantic)
 
     # Signal completion: all CTAs signal CTA 0's bar_empty
     # NOTE: if stolen_tile_id is -1, it means no more tile is available. We shouldn't expect


### PR DESCRIPTION
CLC try_cancel is running in async proxy but "query result" is in fact decoding an object in reg loaded from SMEM by `ld.shared`.

If we miss a fence here, try_cancel of next loop iteration could overwrite the SMEM buffer before current iteration's `ld.shared` finishes loading the results.

PTX ISA doc is using a pair of fence instructions:

`fence.proxy.async::generic.release.sync_restrict::shared::cta.cluster;` + `fence.proxy.async::generic.acquire.sync_restrict::shared::cluster.cluster;`

https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-try-cancel

CUTLASS is using a single `fence.proxy.async.shared::cta` (for any cluster shape): https://github.com/NVIDIA/cutlass/blob/cb37157db50d0528c4aea99feb37946ec278e3d9/include/cutlass/gemm/kernel/sm100_tile_scheduler.hpp#L430

We follow CUTLASS and insert one such fence right after each clc_query.

Test plan: added tests; compared ttgir and ptx and saw exactly one more `fence.proxy.async.shared::cta` after `clusterlaunchcontrol.query_cancel`