### PR TITLE
[Triton][WS] Fix 1-producer→N-consumer channel handling for multi-partition kernels

### DIFF
--- a/.llms/rules/partition-scheduler-bugs.md
+++ b/.llms/rules/partition-scheduler-bugs.md
@@ -60,6 +60,13 @@
 - **Fix**: Make the forward walk follow `scf.yield` → the parent `scf.if`'s corresponding result, using the specific yield operand index so multiple data partitions (e.g., flex attention) are not merged. For multi-result `scf.if`, the walk follows one value at a time from the worklist. With the enlarged forward set, the QK MMA's forward set overlaps the PV MMA's backward slice and they share a compute partition.
 - **Lit test**: `partition-scheduling-meta-causal-attention.mlir` (new) checks exactly 6 partitions / 2 computation (fails with 8 / 4 without the fix). Also removed a stale `CHECK-NOT` on `arith.mulf` scores ops in `partition-scheduling-meta-flex-attention.mlir`, which now correctly get computation partitions through the enlarged forward set.
 
+### 7. Empty-producer assertion from partition-less shared `local_alloc` (2026-06-10, fixed)
+- **Symptom**: `producerTaskIds.size() == 1` assertion in `CodePartitionUtility.cpp` `createChannelPost` (NDEBUG: `handleOperandD: expected exactly one producer task ID, got 0` + segfault).
+- **Manifestation**: FA3 backward (`_attn_bwd_persist`, `cuda:100`, `data_partition_factor=2`). `separateLocalAllocWithSrc` splits a shared `local_alloc` that carries no `async_task_id` (hoisted above all partitions) into `local_alloc + local_store`; the store inherits the empty task-id set, so `producerTaskIds` is empty in `createChannelPost`.
+- **Root cause**: `createChannelPost`'s `else` branch assumes exactly one producer task. An *empty* set (size 0) — not a multi-producer — is what trips the assert; the `size() > 1` branch already handles multiple producers.
+- **Fix**: Guard `if (producerTaskIds.empty()) return;` — an alloc that belongs to no partition needs no cross-partition channel. Companion: `separateLocalAllocWithSrc` now tags the split `local_store` with the source op's single task ID (e.g. the TMA load) so a single-source shared buffer forms a clean 1-producer→N-consumer channel instead of one buffer per consumer.
+- **Lit test**: `ws_code_partition_empty_producer_guard.mlir` runs `_attn_bwd_persist` through `--nvgpu-warp-specialization`; aborts without the guard, passes with it.
+
 ## Debugging Workflow
 - `t.dump` captures IR after each WarpSpec pass (doTaskIdPropagate → doBufferAllocation → doMemoryPlanner → doCodePartition → ...)
 - IR after PartitionSchedulingMeta uses `ttg.partition = array<i32: N>` attributes (not `async_task_id`)

--- a/test/Hopper/WarpSpecialization/ws_code_partition_empty_producer_guard.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_empty_producer_guard.mlir
@@ -1,0 +1,219 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100" | FileCheck %s
+
+// Regression guard for the empty-producer assertion (bug #7 in
+// .llms/rules/partition-scheduler-bugs.md): the `producerTaskIds.size() == 1`
+// assertion in CodePartitionUtility.cpp `createChannelPost`.
+//
+// Real FA3 backward kernel (same body as partition-scheduling-meta-fa-bwd.mlir)
+// driven through the full warp-specialization pipeline so it reaches
+// `createChannelPost`. `separateLocalAllocWithSrc` splits a shared alloc that
+// carries no async_task_id, leaving a `local_store` with an empty producer
+// set; the `if (producerTaskIds.empty()) return;` guard skips it (a producer
+// with no partition needs no channel). Without the guard the `else` branch
+// trips `assert(producerTaskIds.size() == 1)` and triton-opt aborts, so this
+// test fails with empty FileCheck input. The guard is the load-bearing change:
+// the separateLocalAllocWithSrc source-task-id and optimizeSchedule cleanup
+// hunks are not required to keep this kernel passing.
+
+// CHECK-LABEL: @_attn_bwd_persist
+// CHECK: scf.for
+// CHECK: tt.warp_specialize
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 32], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 32, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
+#blocked9 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked10 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_bwd_persist(%desc_q: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_q_0: i32, %desc_q_1: i32, %desc_q_2: i64, %desc_q_3: i64, %desc_k: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_k_4: i32, %desc_k_5: i32, %desc_k_6: i64, %desc_k_7: i64, %desc_v: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_v_8: i32, %desc_v_9: i32, %desc_v_10: i64, %desc_v_11: i64, %sm_scale: f32, %desc_do: !tt.tensordesc<tensor<128x128xf16, #shared>>, %desc_do_12: i32, %desc_do_13: i32, %desc_do_14: i64, %desc_do_15: i64, %desc_dq: !tt.tensordesc<tensor<128x32xf32, #shared1>>, %desc_dq_16: i32, %desc_dq_17: i32, %desc_dq_18: i64, %desc_dq_19: i64, %desc_dk: !tt.tensordesc<tensor<128x32xf16, #shared2>>, %desc_dk_20: i32, %desc_dk_21: i32, %desc_dk_22: i64, %desc_dk_23: i64, %desc_dv: !tt.tensordesc<tensor<128x32xf16, #shared2>>, %desc_dv_24: i32, %desc_dv_25: i32, %desc_dv_26: i64, %desc_dv_27: i64, %M: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %D: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32 {tt.divisibility = 16 : i32}, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %n_tile_num = arith.constant 127 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c96_i32 = arith.constant 96 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %cst_28 = arith.constant dense<0.693147182> : tensor<128x32xf32, #blocked1>
+    %n_tile_num_29 = arith.addi %N_CTX, %n_tile_num : i32
+    %n_tile_num_30 = arith.divsi %n_tile_num_29, %c128_i32 : i32
+    %prog_id = tt.get_program_id x : i32
+    %num_progs = tt.get_num_programs x : i32
+    %total_tiles = arith.muli %n_tile_num_30, %BATCH : i32
+    %total_tiles_31 = arith.muli %total_tiles, %H : i32
+    %tiles_per_sm = arith.divsi %total_tiles_31, %num_progs : i32
+    %0 = arith.remsi %total_tiles_31, %num_progs : i32
+    %1 = arith.cmpi slt, %prog_id, %0 : i32
+    %2 = scf.if %1 -> (i32) {
+      %tiles_per_sm_32 = arith.addi %tiles_per_sm, %c1_i32 : i32
+      scf.yield %tiles_per_sm_32 : i32
+    } else {
+      scf.yield %tiles_per_sm : i32
+    }
+    %off_bh = arith.extsi %stride_tok : i32 to i64
+    %num_steps = arith.divsi %N_CTX, %c128_i32 : i32
+    %offs_m = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked2>
+    %dkN = tt.splat %sm_scale : f32 -> tensor<128x32xf32, #blocked1>
+    %tile_idx = scf.for %_ = %c0_i32 to %2 step %c1_i32 iter_args(%tile_idx_32 = %prog_id) -> (i32)  : i32 {
+      %pid = arith.remsi %tile_idx_32, %n_tile_num_30 : i32
+      %bhid = arith.divsi %tile_idx_32, %n_tile_num_30 : i32
+      %off_chz = arith.muli %bhid, %N_CTX : i32
+      %off_chz_33 = arith.extsi %off_chz : i32 to i64
+      %off_bh_34 = arith.remsi %bhid, %H : i32
+      %off_bh_35 = arith.muli %stride_h, %off_bh_34 : i32
+      %off_bh_36 = arith.divsi %bhid, %H : i32
+      %off_bh_37 = arith.muli %stride_z, %off_bh_36 : i32
+      %off_bh_38 = arith.addi %off_bh_35, %off_bh_37 : i32
+      %off_bh_39 = arith.extsi %off_bh_38 : i32 to i64
+      %off_bh_40 = arith.divsi %off_bh_39, %off_bh : i64
+      %M_41 = tt.addptr %M, %off_chz_33 : !tt.ptr<f32>, i64
+      %D_42 = tt.addptr %D, %off_chz_33 : !tt.ptr<f32>, i64
+      %start_n = arith.muli %pid, %c128_i32 : i32
+      %k = arith.extsi %start_n : i32 to i64
+      %k_43 = arith.addi %off_bh_40, %k : i64
+      %k_44 = arith.trunci %k_43 : i64 to i32
+      %k_45 = tt.descriptor_load %desc_k[%k_44, %c0_i32] : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+      %k_46 = ttg.local_alloc %k_45 : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %v = tt.descriptor_load %desc_v[%k_44, %c0_i32] : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+      %v_47 = ttg.local_alloc %v : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %m = tt.splat %M_41 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %Di = tt.splat %D_42 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %qkT, %qkT_48 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dpT, %dpT_49 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dv, %dv_50 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dq, %dq_51 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dk, %dk_52 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dk_53 = ttng.tmem_store %cst, %dk[%dk_52], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dv_54 = ttng.tmem_store %cst, %dv[%dv_50], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %curr_m:7 = scf.for %curr_m_86 = %c0_i32 to %num_steps step %c1_i32 iter_args(%arg47 = %c0_i32, %arg48 = %false, %qkT_87 = %qkT_48, %dpT_88 = %dpT_49, %dv_89 = %dv_54, %dq_90 = %dq_51, %dk_91 = %dk_53) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+        %q = arith.extsi %arg47 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32 to i64
+        %q_92 = arith.addi %off_bh_40, %q {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+        %q_93 = arith.trunci %q_92 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+        %q_94 = tt.descriptor_load %desc_q[%q_93, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+        %q_95 = ttg.local_alloc %q_94 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %qT = ttg.memdesc_trans %q_95 {loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared3, #smem>
+        %offs_m_96 = tt.splat %arg47 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32 -> tensor<128xi32, #blocked2>
+        %offs_m_97 = arith.addi %offs_m_96, %offs_m {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128xi32, #blocked2>
+        %m_98 = tt.addptr %m, %offs_m_97 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %m_99 = tt.load %m_98 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %qkT_100 = ttng.tc_gen5_mma %k_46, %qT, %qkT[%qkT_87], %false, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,2,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %pT = ttg.convert_layout %m_99 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+        %pT_101 = tt.expand_dims %pT {axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xf32, #blocked>
+        %pT_102 = tt.broadcast %pT_101 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #blocked> -> tensor<128x128xf32, #blocked>
+        %qkT_103, %qkT_104 = ttng.tmem_load %qkT[%qkT_100] {loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %pT_105 = arith.subf %qkT_103, %pT_102 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked>
+        %pT_106 = math.exp2 %pT_105 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked>
+        %do = tt.descriptor_load %desc_do[%q_93, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf16, #shared>> -> tensor<128x128xf16, #blocked3>
+        %do_107 = ttg.local_alloc %do {loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #blocked3>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %ppT = arith.truncf %pT_106 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+        %dv_108 = ttng.tmem_alloc %ppT {loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+        %dpT_109 = ttg.memdesc_trans %do_107 {loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared3, #smem>
+        %dpT_110 = ttng.tc_gen5_mma %v_47, %dpT_109, %dpT[%dpT_88], %false, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %Di_111 = tt.addptr %Di, %offs_m_97 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %Di_112 = tt.load %Di_111 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %dv_113 = ttng.tc_gen5_mma %dv_108, %do_107, %dv[%dv_89], %arg48, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dsT = ttg.convert_layout %Di_112 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+        %dsT_114 = tt.expand_dims %dsT {axis = 0 : i32, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xf32, #blocked>
+        %dsT_115 = tt.broadcast %dsT_114 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked> -> tensor<128x128xf32, #blocked>
+        %dpT_116, %dpT_117 = ttng.tmem_load %dpT[%dpT_110] {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %dsT_118 = arith.subf %dpT_116, %dsT_115 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+        %dsT_119 = arith.mulf %pT_106, %dsT_118 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked>
+        %dsT_120 = arith.truncf %dsT_119 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+        %dsT_121 = ttg.local_alloc %dsT_120 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %dq_122 = ttg.memdesc_trans %dsT_121 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared3, #smem>
+        %dq_123 = ttng.tc_gen5_mma %dq_122, %k_46, %dq[%dq_90], %false, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}"} : !ttg.memdesc<128x128xf16, #shared3, #smem>, !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dk_124 = ttng.tc_gen5_mma %dsT_121, %q_95, %dk[%dk_91], %arg48, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndD,tmem,1,10\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dq_125, %dq_126 = ttng.tmem_load %dq[%dq_123] {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        %dqs = tt.reshape %dq_125 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+        %dqs_127 = tt.trans %dqs {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+        %dqs_128, %dqs_129 = tt.split %dqs_127 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+        %dqs_130 = tt.reshape %dqs_128 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_131 = tt.trans %dqs_130 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_132, %dqs_133 = tt.split %dqs_131 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+        %dqs_134 = tt.reshape %dqs_129 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_135 = tt.trans %dqs_134 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_136, %dqs_137 = tt.split %dqs_135 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+        %dqN = arith.mulf %dqs_132, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_138 = ttg.convert_layout %dqN {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c0_i32], %dqN_138 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_139 = arith.mulf %dqs_133, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_140 = ttg.convert_layout %dqN_139 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c32_i32], %dqN_140 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_141 = arith.mulf %dqs_136, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_142 = ttg.convert_layout %dqN_141 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c64_i32], %dqN_142 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %dqN_143 = arith.mulf %dqs_137, %cst_28 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1>
+        %dqN_144 = ttg.convert_layout %dqN_143 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked1> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq[%q_93, %c96_i32], %dqN_144 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<tensor<128x32xf32, #shared1>>, tensor<128x32xf32, #blocked9>
+        %curr_m_145 = arith.addi %arg47, %c128_i32 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+        scf.yield %curr_m_145, %true, %qkT_104, %dpT_117, %dv_113, %dq_126, %dk_124 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+      } {tt.scheduled_max_stage = 1 : i32}
+      %dv_55, %dv_56 = ttng.tmem_load %dv[%curr_m#4] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %dvs = tt.reshape %dv_55 : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+      %dvs_57 = tt.trans %dvs {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dvs_58, %dvs_59 = tt.split %dvs_57 : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dvs_60 = tt.reshape %dvs_58 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_61 = tt.trans %dvs_60 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_62, %dvs_63 = tt.split %dvs_61 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %dvs_64 = tt.reshape %dvs_59 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_65 = tt.trans %dvs_64 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_66, %dvs_67 = tt.split %dvs_65 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %3 = arith.truncf %dvs_62 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %4 = ttg.convert_layout %3 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c0_i32], %4 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %5 = arith.truncf %dvs_63 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %6 = ttg.convert_layout %5 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c32_i32], %6 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %7 = arith.truncf %dvs_66 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %8 = ttg.convert_layout %7 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c64_i32], %8 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %9 = arith.truncf %dvs_67 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %10 = ttg.convert_layout %9 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dv[%k_44, %c96_i32], %10 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dk_68, %dk_69 = ttng.tmem_load %dk[%curr_m#6] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %dks = tt.reshape %dk_68 : tensor<128x128xf32, #blocked> -> tensor<128x2x64xf32, #blocked4>
+      %dks_70 = tt.trans %dks {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dks_71, %dks_72 = tt.split %dks_70 : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dks_73 = tt.reshape %dks_71 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_74 = tt.trans %dks_73 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_75, %dks_76 = tt.split %dks_74 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %dks_77 = tt.reshape %dks_72 : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_78 = tt.trans %dks_77 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_79, %dks_80 = tt.split %dks_78 : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked1>
+      %dkN_81 = arith.mulf %dks_75, %dkN : tensor<128x32xf32, #blocked1>
+      %11 = arith.truncf %dkN_81 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %12 = ttg.convert_layout %11 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c0_i32], %12 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dkN_82 = arith.mulf %dks_76, %dkN : tensor<128x32xf32, #blocked1>
+      %13 = arith.truncf %dkN_82 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %14 = ttg.convert_layout %13 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c32_i32], %14 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dkN_83 = arith.mulf %dks_79, %dkN : tensor<128x32xf32, #blocked1>
+      %15 = arith.truncf %dkN_83 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %16 = ttg.convert_layout %15 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c64_i32], %16 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %dkN_84 = arith.mulf %dks_80, %dkN : tensor<128x32xf32, #blocked1>
+      %17 = arith.truncf %dkN_84 : tensor<128x32xf32, #blocked1> to tensor<128x32xf16, #blocked1>
+      %18 = ttg.convert_layout %17 : tensor<128x32xf16, #blocked1> -> tensor<128x32xf16, #blocked10>
+      tt.descriptor_store %desc_dk[%k_44, %c96_i32], %18 : !tt.tensordesc<tensor<128x32xf16, #shared2>>, tensor<128x32xf16, #blocked10>
+      %tile_idx_85 = arith.addi %tile_idx_32, %num_progs : i32
+      scf.yield %tile_idx_85 : i32
+    } {tt.merge_epilogue = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 200000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -2867,6 +2867,12 @@ static void createChannelPost(Operation *allocOp, mlir::DominanceInfo &dom,
   // happen with data-partitioned computation groups where one producer feeds
   // multiple consumer partitions. If all producer tasks are co-located with
   // consumers, no cross-partition channel is needed.
+  // If producer has no task ID (e.g., an alloc that was hoisted above
+  // all partitions or never assigned), skip channel creation — there is
+  // no producer partition to synchronize with.
+  if (producerTaskIds.empty())
+    return;
+
   AsyncTaskId producerTaskId = -1;
   if (producerTaskIds.size() > 1) {
     DenseSet<int> consumerTaskIdSet(consumerTaskIds.begin(),

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2277,9 +2277,16 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
   }
 }
 
-/// Walk over \p loop and clone Broadcast/ExpandDims ops into each
-/// partition that they have users in. This reduces the amount of data that
-/// needs to be transferred through memory.
+/// Walk over \p loop and clone cheap ops into each partition that uses them,
+/// rematerializing metadata-only or layout-only values instead of routing
+/// them through a cross-partition memory channel.
+///
+/// Cloneable: MemDescTransOp (metadata-only SMEM-layout reinterpretation),
+/// ConvertLayoutOp, BroadcastOp, ExpandDimsOp (cheap element rearrangement).
+/// LocalAllocOp is NOT cloned: a shared SMEM buffer (e.g. K/V in FA) is one
+/// producer feeding N consumer partitions, so cloning would duplicate the
+/// buffer. separateLocalAllocWithSrc instead tags the local_store with the
+/// source op's single task ID, letting createChannelPost build a 1→N channel.
 ///
 /// When a ConvertLayoutOp sits between an ExpandDimsOp/BroadcastOp and its
 /// consumer (e.g., due to upstream layout choices producing different
@@ -2297,12 +2304,13 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
     return schedule.getPartition(static_cast<unsigned>(ids[0]));
   };
 
-  // After cloning a BroadcastOp/ExpandDimsOp into a user partition, walk
-  // backward through the cloned op's operand chain and also clone any
-  // ConvertLayoutOp/BroadcastOp/ExpandDimsOp that feeds it from a different
-  // partition. This handles the pattern where upstream layout passes insert
-  // a ConvertLayoutOp between ExpandDimsOp and BroadcastOp, which would
-  // otherwise break the cloning chain and create a cross-partition boundary.
+  // After cloning a BroadcastOp/ExpandDimsOp/MemDescTransOp into a user
+  // partition, walk backward through the cloned op's operand chain and also
+  // clone any ConvertLayoutOp/BroadcastOp/ExpandDimsOp that feeds it from
+  // a different partition. This handles the pattern where upstream layout
+  // passes insert a ConvertLayoutOp between ExpandDimsOp and BroadcastOp,
+  // which would otherwise break the cloning chain and create a
+  // cross-partition boundary.
   auto cloneOperandChain = [&](Operation *clonedOp, Partition *userPartition) {
     Operation *current = clonedOp;
     while (true) {
@@ -2701,14 +2709,16 @@ void PartitionSchedulingMeta::runOnOperation() {
       loop->setAttr(
           kWarpSpecializeTagAttrName,
           IntegerAttr::get(IntegerType::get(loop.getContext(), 32), idx));
-      // Clean Broadcast/ExpandDims that were left with no users
-      // after optimizeSchedule. We wait until after the schedule is
-      // serialized to avoid invalidating pointers stored in the schedule.
+      // Clean ops left with no users after optimizeSchedule, waiting until
+      // after serialize() so we don't invalidate pointers held by the
+      // schedule. LocalAllocOp is impure but a use-empty alloc is dead, so
+      // it is erased explicitly alongside the pure ops.
       loop.walk<WalkOrder::PostOrder, ReverseIterator>([](Operation *op) {
         // By default, the walk is in postorder so it is safe to delete ops
         // while we walk.
-        if (op->use_empty() && isPure(op) && op->getNumResults() == 1 &&
-            !isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
+        if (op->use_empty() && op->getNumResults() == 1 &&
+            !isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op) &&
+            (isPure(op) || isa<LocalAllocOp>(op)))
           op->erase();
       });
     }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -4064,6 +4064,8 @@ static void cleanupTmemTokens(triton::FuncOp funcOp) {
 // Split local_alloc ops that have a tensor source into a separate
 // empty local_alloc + local_store. This ensures doCodePartitionPost
 // can detect cross-task SMEM channels via the LocalStoreOp producer.
+// The local_store's task ID (assigned below) determines the producer
+// partition for that channel.
 static void separateLocalAllocWithSrc(triton::FuncOp &funcOp) {
   SmallVector<ttg::LocalAllocOp> toSplit;
   funcOp.walk([&](ttg::LocalAllocOp allocOp) {
@@ -4085,7 +4087,26 @@ static void separateLocalAllocWithSrc(triton::FuncOp &funcOp) {
 
     auto originTaskIds = builder.getAsyncTaskIds();
     auto originLoopScheduleInfo = builder.getLoopScheduleInfo();
-    builder.setAsyncTaskIdsFromOp(allocOp);
+
+    // Determine the producer task IDs for the local_store. Prefer the
+    // source value's defining op's task IDs (the actual data producer)
+    // over the alloc's task IDs (which include all consumers from
+    // backward propagation). This enables 1->N channels where a single
+    // TMA load produces data consumed by multiple warp groups.
+    Value src = allocOp.getSrc();
+    Operation *srcOp = src.getDefiningOp();
+    SmallVector<AsyncTaskId> srcTaskIds;
+    if (srcOp)
+      srcTaskIds = getAsyncTaskIds(srcOp);
+
+    if (srcOp && srcTaskIds.size() == 1) {
+      // Source has a single task ID -- use it as the producer.
+      builder.setAsynTaskIdsFromArray(srcTaskIds);
+    } else {
+      // Fallback: source has no defining op, no task IDs, or multiple
+      // task IDs. Use the alloc's task IDs (original behavior).
+      builder.setAsyncTaskIdsFromOp(allocOp);
+    }
     builder.setLoopScheduleInfoFromOp(allocOp);
     auto storeOp = builder.createWithAsyncTaskIds<ttg::LocalStoreOp>(
         allocOp.getLoc(), allocOp.getSrc(), newAlloc);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BufferAllocation.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BufferAllocation.md
@@ -92,6 +92,14 @@ cross-partition SMEM dependencies as separate store ops, enabling
 downstream `doCodePartition`/`doCodePartitionPost` to detect them
 as channels.
 
+The `local_store`'s task ID determines the producer partition for the
+channel. When the source is produced by a single-partition op (e.g. a TMA
+`DescriptorLoadOp`), the store takes the source op's task ID rather than the
+alloc's, which also carries consumer partitions from backward propagation.
+This models a 1-producer to N-consumer channel — one TMA load writes the
+shared buffer and every consumer partition reads it — instead of duplicating
+the buffer per consumer.
+
 ## Key Distinction
 
 `doBufferAllocation` does **not** insert:

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -321,9 +321,22 @@ Cluster assignment rules:
 
 ### `optimizeSchedule`
 
-Clones `BroadcastOp` and `ExpandDimsOp` into each partition that has users.
-This allows cheap element-rearranging ops to be rematerialized in consumer
-partitions rather than creating cross-partition channels.
+Clones cheap ops into each partition that has users. This rematerializes
+metadata-only or layout-only ops in consumer partitions rather than creating
+cross-partition channels.
+
+**Cloneable ops**:
+- `MemDescTransOp`: metadata-only reinterpretation of shared memory layout
+- `ConvertLayoutOp`, `BroadcastOp`, `ExpandDimsOp`: cheap element rearrangement
+
+**Not cloned**: `LocalAllocOp`. When a shared SMEM buffer (e.g., K/V in
+Flash Attention) is consumed by ops in multiple partitions, the correct
+model is a 1-producer to N-consumer channel: one TMA load writes the buffer,
+all consumer partitions read from it. The downstream
+`separateLocalAllocWithSrc` assigns the `local_store` the source op's
+single task ID (the TMA load partition), and `createChannelPost` creates a
+proper 1-to-N channel. This avoids buffer duplication and the SMEM it costs
+(per-consumer copies pushed FA3 forward over H100's 228KB SMEM limit).
 
 The cloning walks in reverse post-order so that an `ExpandDimsOp` feeding a
 `BroadcastOp` is visited after the broadcast has already been cloned. When
@@ -336,10 +349,19 @@ The cloning walks in reverse post-order so that an `ExpandDimsOp` feeding a
 also clones any `ConvertLayoutOp`, `BroadcastOp`, or `ExpandDimsOp` that
 feeds it from a different partition. This handles the case where upstream
 layout passes insert a `ConvertLayoutOp` between `ExpandDimsOp` and
-`BroadcastOp` (e.g., `expand_dims → convert_layout → broadcast`). Without
-this backward walk, the `ConvertLayoutOp` would break the cloning chain
-and create an unintended cross-partition boundary, forcing the value
-through an smem channel instead of keeping it within the partition.
+`BroadcastOp` (e.g., `expand_dims -> convert_layout -> broadcast`).
+
+When a `MemDescTransOp` clone references a `LocalAllocOp` from a different
+partition (e.g., `local_alloc -> memdesc_trans -> dot`), the backward walk
+stops at the `LocalAllocOp` boundary. The `MemDescTransOp` clone keeps a
+reference to the original shared alloc, which is correct because the alloc
+is shared across partitions. The `separateLocalAllocWithSrc` pass later
+assigns the producer task ID from the source op, creating a 1-to-N channel.
+
+Without the backward walk, the cloned op would reference an operand in a
+different partition, creating an unintended cross-partition boundary and
+forcing the value through an smem channel instead of keeping it within the
+partition.
 
 ### `splitDataPartitionedIfOps`
 


### PR DESCRIPTION
Summary:
Fixes a warp-specialization crash on kernels where a single TMA load feeds a shared SMEM buffer consumed by multiple computation partitions (e.g. FA3 backward `_attn_bwd_persist` with `data_partition_factor=2`).

## Root cause

`createChannelPost` selects the producer task for a channel in two branches: `producerTaskIds.size() > 1` dedups multiple producers, and the `else` branch assumes exactly one and asserts it. `separateLocalAllocWithSrc` splits a shared `local_alloc` that belongs to no partition (carries no `async_task_id`, hoisted above all partitions) into `local_alloc + local_store`; the store inherits the empty task-id set, so `producerTaskIds` is empty (size 0) and the `else` branch trips `assert(producerTaskIds.size() == 1)`. In NDEBUG the assert is compiled out and the same root cause surfaces downstream as `handleOperandD: expected exactly one producer task ID, got 0` plus a segfault.

## The fix (review in this order)

1. `createChannelPost` (CodePartitionUtility.cpp): guard `if (producerTaskIds.empty()) return;`. An alloc with no partition has no producer to synchronize against, so no cross-partition channel is needed. This is the load-bearing change for `_attn_bwd_persist`.

2. `separateLocalAllocWithSrc` (WSCodePartition.cpp): when the alloc's source has a single task id (e.g. the TMA `DescriptorLoadOp`), tag the split `local_store` with that id instead of the alloc's backward-propagated consumer union. This models a clean 1-producer→N-consumer channel — K/V/Q stay a single shared buffer read by all consumer warp groups (the CUTLASS FA3 model) rather than one copy per consumer (per-consumer copies overflowed H100's 228KB SMEM on FA3 forward).

3. `optimizeSchedule` cleanup (PartitionSchedulingMeta.cpp): also erase use-empty `LocalAllocOp`s left after scheduling; they are impure, so the previous pure-only filter skipped them.

## Test

`ws_code_partition_empty_producer_guard.mlir` runs the real `_attn_bwd_persist` kernel through `--nvgpu-warp-specialization`: it aborts without the guard and passes with it.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D105377095


