### PR TITLE
[compile_iq] Zero-surface ptxas-ACF collect + apply for Triton (stages 1 & 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ docs/sg_execution_times.rst
 
 # Symlink after pip install
 python/triton/tlx
+python/triton/compile_iq
 
 # Vim
 *.swp

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -901,6 +901,18 @@ class JITFunction(JITCallable, KernelInterface[T]):
             kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup)
             if kernel is None:
                 return None
+            # compile_iq: dump a collection task for the offline ACF factory.
+            # Gated by FBTRITON_COMPILE_IQ_COLLECT; fires on the compile (cache-miss) path
+            # where signature/constexprs are in scope. Never affects the user run.
+            if os.environ.get("FBTRITON_COMPILE_IQ_COLLECT"):
+                try:
+                    from triton.compile_iq.collector import capture as _ciq_capture
+                    _ck = kernel.result() if hasattr(kernel, "result") else kernel
+                    _cg = grid(bound_args) if callable(grid) else grid
+                    _ciq_capture(jitfn=self, kernel=_ck, bound_args=bound_args, signature=signature,
+                                 constexprs=constexprs, grid=tuple(list(_cg) + [1, 1, 1])[:3])
+                except Exception:
+                    pass
             _fc_needs_insert = self.c_cache
         else:
             _fc_needs_insert = False

--- a/third_party/compile_iq/README.md
+++ b/third_party/compile_iq/README.md
@@ -1,0 +1,127 @@
+# compile_iq — decoupled ptxas-ACF tuning for Triton
+
+Productionizes the ptx-acf smoke test: instead of CompileIQ wrapping the kernel,
+the kernel run and the search are **decoupled via disk**, with **zero user surface**.
+
+```
+(1) COLLECTION            (2) FACTORY (offline)          (3) CONSUMPTION
+user runs kernel  ──►  compileIQ task  ──► CompileIQ ──► ACF store ──► user runs again
+ jit.py hook            on disk            search         on disk        make_cubin hook
+ (FBTRITON_COMPILE_IQ_COLLECT)                    best ACF→store     (FBTRITON_COMPILE_IQ_APPLY) applies ACF if hash hits
+```
+
+## Layout
+```
+third_party/compile_iq/compile_iq/
+  __init__.py    install/enable
+  store.py       sha256(PTX) hashing + ACF store ($COMPILE_IQ_STORE/<arch>/<sha>.acf)
+  collector.py   Stage 1: dump a self-contained task
+  replay.py      Stage 2a: re-run a kernel from a task, ACF applied via PTX_OPTIONS
+  factory.py     Stage 2b: task -> CompileIQ search -> best ACF -> store
+  consume.py     Stage 3: look up ACF by PTX hash -> --apply-controls args
+# symlink: python/triton/compile_iq -> ../../third_party/compile_iq/compile_iq
+# core hooks (env-gated, no-op by default):
+#   collection: python/triton/runtime/jit.py
+#   apply:      third_party/nvidia/backend/compiler.py  (make_cubin)
+```
+
+## Enable (zero user code change)
+```
+# collection (Triton users): just an env var; no kernel/Triton-user changes
+export FBTRITON_COMPILE_IQ_COLLECT=1                  # turn on collection
+export COMPILE_IQ_TASK_DIR=/path/to/tasks    # default ~/.compile_iq/tasks
+
+# factory (offline operators only): needs ptxas >= 13.3 + the search-space bin
+pip install nvidia-cuda-nvcc                 # ptxas 13.3 — auto-discovered, no path needed
+export COMPILE_IQ_STORE=/path/to/store       # default ~/.compile_iq/store
+export COMPILE_IQ_SEARCH_SPACE_BIN=/path/to/ptxas13.3_search_space.bin
+# (TRITON_PTXAS_BLACKWELL_PATH only needed to override auto-discovery)
+
+# consumption (gradual prod rollout): apply stored ACFs at compile time
+export FBTRITON_COMPILE_IQ_APPLY=1           # default OFF; needs ptxas>=13.3 (version-guarded, fail-open)
+```
+
+## Test plan / checkpoints
+
+- [x] **CP1 — collection (no-autotune, zero user surface)**: run a normal kernel
+      program (no compile_iq references) with collection enabled purely via env:
+      `FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks python examples/user_kernel.py`
+      (collection doesn't *apply* an ACF, but see the ptxas-version PIN below: the
+      captured PTX sha tracks the ptxas in effect, so collection & consumption must
+      use the same ptxas for the store key to line up — the Stage-3 hook runs inside
+      Triton's compile with that same ptxas, so it's consistent by construction.)
+      → `<task>/{kernel.ptx,source.py,task.json}` appears with ptx_sha256, arch,
+      launch dims, grid, arg metadata. `examples/user_kernel.py` is a plain Triton
+      matmul with zero compile_iq imports — proof the kernel needs no changes. ✅
+- [x] **CP2 — replay**: `replay.load_task/load_kernel/build_args/run_once` reproduces
+      correct output from the task alone (rel-err 0 vs torch). ✅
+- [x] **CP3 — factory → store**: `python -m triton.compile_iq.factory <task_dir>`
+      runs the search and writes `$COMPILE_IQ_STORE/<arch>/<sha>.acf` + `.acf.json`. ✅
+- [~] **CP4 — autotuned/TMA kernel (ws)**:
+      - [x] **Generic replay** of TMA + cluster kernels: `build_args` reconstructs
+        `TensorDescriptor`s (`empty_strided` base + captured `block_shape`); `run_once`
+        installs a TMA allocator and launches the raw `JITFunction` with `ctas_per_cga`
+        (cluster) — bypassing autotune. Verified on blackwell_gemm_ws: output rel-err 0
+        vs a@b. ✅
+      - [ ] **Winning-config selection**: autotune compiles ~hundreds of configs →
+        collection dumps a task per config (267 for one 2048³ ws run). Need to mark the
+        autotune winner so the factory tunes one task, not hundreds (and to avoid disk
+        bloat). Small autotuner-side hook. ⬜
+- [x] **CP5 — consumption (in-Triton `make_cubin` hook)**: a gated hook in
+      `nvidia/backend/compiler.py::make_cubin` (env `FBTRITON_COMPILE_IQ_APPLY`, default
+      OFF) hashes the PTX, looks up `store.read_acf(sha, arch)`, and appends
+      `--apply-controls` on a hit — fires per config during autotuning. Version-guarded
+      (only ptxas ≥13.3, via `packaging.Version`) + try/except → fail-open. Verified:
+      hook sha == collection sha (parity); HIT changes the cubin (40800→65304 B) and
+      applies in ~0.05s; MISS compiles unchanged; old ptxas → skipped (fail-open). ✅
+
+## Decisions / pins
+- **Replay = recompile-through-Triton with ACF via PTX_OPTIONS**, not raw cubin launch.
+  Rationale: Triton specializes/reorders/drops kernel args (the PTX `.entry` param list
+  != Python signature; `_dispatch_arg_indices` is often `None`), so raw-cubin launch
+  would mean reimplementing Triton's ABI. Recompiling the captured source is robust,
+  decoupled, and the regenerated PTX matches the captured sha. Raw-cubin = future
+  hardening (source-free / exact-byte fidelity).
+- **PIN (hash-key design)**: store key is `sha256(PTX) × arch` for now. PTX subsumes
+  autotune config + dtype/alignment specialization but NOT runtime shape (M,N,K). Tasks
+  capture shapes/identity so we *can* extend the key (per-shape ACFs) later.
+
+Status: CP1–CP3 + CP5 done+verified (no-autotune naive GEMM). CP4 (autotune) is the remaining checkpoint.
+
+## Dependencies (who needs what)
+- **Triton users (collection)**: nothing — the hook is a no-op unless `FBTRITON_COMPILE_IQ_COLLECT`
+  is set; collection imports only stdlib. CP1 is testable with just an fbtriton build.
+- **Factory operators (offline)**: `pip install nvidia-cuda-nvcc` (ptxas ≥13.3, auto-discovered),
+  the **CompileIQ engine** (the NVIDIA "Evo" wheel — bundles the proprietary core; no source
+  build / git-lfs), and the **search-space `.bin`** (a separate NVIDIA artifact) via
+  `COMPILE_IQ_SEARCH_SPACE_BIN`. None of these are vendored in this repo.
+
+## Factory setup — install the CompileIQ engine
+The factory imports `compileiq` (NVIDIA's proprietary search engine). Get it via either:
+```
+# (a) PREFERRED: the internal CompileIQ/Evo wheel (bundles the engine binary; no git-lfs)
+pip install <compileiq-evo-wheel>
+
+# (b) FALLBACK: from the CompileIQ source checkout (engine binary comes via git-lfs)
+git clone <NVIDIA CompileIQ repo> CompileIQ
+cd CompileIQ && git lfs install && git lfs pull   # fetch core / libciq.so
+pip install .                                     # installs the `compileiq` package
+
+# plus, for both paths:
+pip install nvidia-cuda-nvcc                       # ptxas 13.3 (auto-discovered)
+# obtain the ptxas13.3 search-space .bin (NVIDIA artifact) and point at it:
+export COMPILE_IQ_SEARCH_SPACE_BIN=/path/to/ptxas13.3_search_space.bin
+```
+Collection (Stage 1) needs **none** of the above — only an fbtriton build.
+
+## One-shot commands (collect → factory)
+```
+# 0) clean
+rm -rf /tmp/ciq_tasks /tmp/ciq_store
+
+# 1) collect: a normal kernel run; collection on via env only (no extra deps)
+FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks python third_party/compile_iq/examples/user_kernel.py
+
+# 2) factory: task -> CompileIQ search -> ACF store  (needs the Factory setup above)
+COMPILE_IQ_STORE=/tmp/ciq_store COMPILE_IQ_SEARCH_SPACE_BIN=/path/to/ptxas13.3_search_space.bin python -m triton.compile_iq.factory $(ls -d /tmp/ciq_tasks/*/ | head -1)
+```

--- a/third_party/compile_iq/compile_iq/__init__.py
+++ b/third_party/compile_iq/compile_iq/__init__.py
@@ -1,0 +1,20 @@
+"""compile_iq — decoupled ptxas-ACF tuning for Triton kernels.
+
+Three stages, communicating only through disk (zero user surface):
+  1. collection : a gated hook in jit.py dumps a "compileIQ task" per kernel.
+  2. factory    : offline binary tunes an ACF per task -> ACF store.
+  3. consumption: a ptxas shim applies the stored ACF during PTX->SASS (later).
+
+Enable collection by setting the env var FBTRITON_COMPILE_IQ_COLLECT=1. No kernel or
+Triton-user code changes are required.
+"""
+
+import os
+
+from . import collector, store
+
+__all__ = ["collector", "store", "collection_enabled"]
+
+
+def collection_enabled() -> bool:
+    return bool(os.environ.get("FBTRITON_COMPILE_IQ_COLLECT"))

--- a/third_party/compile_iq/compile_iq/collector.py
+++ b/third_party/compile_iq/compile_iq/collector.py
@@ -1,0 +1,127 @@
+"""Stage 1 — collection. A zero-user-surface hook (called from jit.py, gated by
+FBTRITON_COMPILE_IQ_COLLECT) that, when a kernel is launched, dumps a self-contained
+"compileIQ task" to disk for the offline factory.
+
+A task dir ($COMPILE_IQ_TASK_DIR/<ptx_sha[:16]>/) contains:
+    kernel.ptx        the emitted PTX (the ACF will be tuned for this)
+    task.json         identity, launch dims, arch, ptxas, arg metadata, grid
+    source.py         copy of the kernel's defining source (for replay)
+
+PINNED: arg shapes + kernel identity are captured here so the factory can replay,
+even though the store key (see store.py) is sha256(PTX) alone for now.
+"""
+
+import inspect
+import json
+import os
+import re
+import shutil
+
+from .store import dlog, ptx_sha256
+
+
+def task_root() -> str:
+    return os.environ.get("COMPILE_IQ_TASK_DIR", os.path.expanduser("~/.compile_iq/tasks"))
+
+
+def _dtype_str(dt) -> str:
+    return str(dt).replace("torch.", "")
+
+
+def _serialize_args(bound_args, signature, constexpr_map):
+    import torch
+
+    try:
+        from triton.tools.tensor_descriptor import TensorDescriptor
+    except Exception:
+        TensorDescriptor = None
+
+    out = []
+    for name, val in bound_args.items():
+        e = {"name": name, "sig_type": signature.get(name, "")}
+        if name in constexpr_map:
+            e["kind"] = "constexpr"
+            e["value"] = constexpr_map[name]
+        elif TensorDescriptor is not None and isinstance(val, TensorDescriptor):
+            e.update(kind="tensor_descriptor", base_shape=list(val.base.shape), base_dtype=_dtype_str(val.base.dtype),
+                     base_strides=list(val.base.stride()), block_shape=[int(s) for s in val.block_shape])
+        elif isinstance(val, torch.Tensor):
+            e.update(kind="tensor", shape=list(val.shape), dtype=_dtype_str(val.dtype), strides=list(val.stride()))
+        elif isinstance(val, (bool, int, float)):
+            e.update(kind="scalar", value=val, scalar_type=type(val).__name__)
+        else:
+            e.update(kind="scalar", value=str(val), scalar_type=type(val).__name__)
+        out.append(e)
+    return out
+
+
+def _arch_from_ptx(ptx: str) -> str:
+    m = re.search(r"\.target\s+(sm_\w+)", ptx)
+    return m.group(1) if m else "unknown"
+
+
+def capture(*, jitfn, kernel, bound_args, signature, constexprs, grid):
+    """Best-effort task dump. Never raises into the user's launch path."""
+    try:
+        ptx = kernel.asm["ptx"]
+        sha = ptx_sha256(ptx)
+        tdir = os.path.join(task_root(), sha[:16])
+        done = os.path.join(tdir, "task.json")
+        if os.path.exists(done):
+            dlog("collector", f"skip {sha[:16]} {_arch_from_ptx(ptx)} (already collected)")
+            return  # dedup: this PTX already collected
+        os.makedirs(tdir, exist_ok=True)
+
+        with open(os.path.join(tdir, "kernel.ptx"), "w") as f:
+            f.write(ptx)
+
+        # constexpr path-tuples -> name map (mirrors tlx_benchmark_gen)
+        names = list(bound_args.keys())
+        cmap = {}
+        for path, v in (constexprs or {}).items():
+            if isinstance(path, tuple) and len(path) == 1 and path[0] < len(names):
+                cmap[names[path[0]]] = v
+
+        md = kernel.metadata
+        ptxas = os.environ.get("TRITON_PTXAS_BLACKWELL_PATH") or os.environ.get("TRITON_PTXAS_PATH", "")
+        task = {
+            "kernel_name": getattr(md, "name", getattr(jitfn, "__name__", "kernel")),
+            "fn_name": getattr(jitfn, "__name__", None),
+            # Defining module of the kernel (and its wrapper) -- the factory must import the
+            # SAME installed module, not the source.py copy: Triton bakes module identity into
+            # the compile, so a copy yields a different PTX (-> wrong store key).
+            "module": getattr(getattr(jitfn, "fn", jitfn), "__module__", None),
+            "ptx_sha256": sha,
+            "arch": _arch_from_ptx(ptx),
+            "ptxas_path": ptxas,
+            "num_warps": getattr(md, "num_warps", None),
+            "num_ctas": getattr(md, "num_ctas", None),
+            "shared": getattr(md, "shared", None),
+            "cluster_dims": list(getattr(md, "cluster_dims", []) or []),
+            "grid": list(grid),
+            # Kernel-selecting env knobs (e.g. TLX_GEMM_USE_HEURISTIC) so the offline
+            # factory reproduces the SAME single-config launch that was collected --
+            # otherwise the factory autotunes a different (and slower) config and the
+            # tuned PTX no longer matches the collected key.
+            "env": {k: v for k, v in os.environ.items() if k.startswith("TLX_")},
+            "args": _serialize_args(bound_args, signature, cmap),
+            "constexprs": {k: (v if isinstance(v, (bool, int, float, str)) else str(v))
+                           for k, v in cmap.items()},
+        }
+
+        # copy source file for replay
+        try:
+            src = inspect.getsourcefile(jitfn.fn)
+            if src and os.path.exists(src):
+                shutil.copy(src, os.path.join(tdir, "source.py"))
+                task["source_file"] = "source.py"
+                task["source_origin"] = os.path.basename(src)
+        except Exception:
+            pass
+
+        with open(done, "w") as f:
+            json.dump(task, f, indent=2, default=str)
+        dlog("collector", f"collected {sha[:16]} {task['arch']} kernel={task['kernel_name']} "
+             f"grid={task['grid']} args={len(task['args'])} -> {tdir}")
+    except Exception as e:  # collection must never break the user's run
+        dlog("collector", f"capture failed: {type(e).__name__}: {e}")

--- a/third_party/compile_iq/compile_iq/consume.py
+++ b/third_party/compile_iq/compile_iq/consume.py
@@ -1,0 +1,35 @@
+"""Stage 3 — consumption helper. Given the PTX about to be assembled, return the
+ptxas args that apply a stored ACF (or [] on miss/error). Called by a gated hook in
+the NVIDIA backend's make_cubin, so the ACF is applied during normal PTX->SASS
+compilation, including each config compiled during autotuning.
+
+Fail-open by construction: any miss/error returns [] -> ptxas runs unchanged.
+"""
+
+import tempfile
+
+from . import store
+
+
+def _dbg(msg):
+    store.dlog("consume", msg)
+
+
+def acf_args_for(ptx: str, arch: str | None) -> list[str]:
+    """Return ['--apply-controls=<tmp.acf>'] if the store has an ACF for this PTX, else []."""
+    try:
+        if not arch:
+            return []
+        sha = store.ptx_sha256(ptx)
+        data = store.read_acf(sha, arch)
+        if not data:
+            _dbg(f"MISS {sha[:16]} {arch}")
+            return []
+        tmp = tempfile.NamedTemporaryFile(suffix=".acf", delete=False)
+        tmp.write(data)
+        tmp.close()
+        _dbg(f"HIT {sha[:16]} {arch} -> {tmp.name}")
+        return [f"--apply-controls={tmp.name}"]
+    except Exception as e:  # never break compilation
+        _dbg(f"error (fail-open): {type(e).__name__}: {e}")
+        return []

--- a/third_party/compile_iq/compile_iq/store.py
+++ b/third_party/compile_iq/compile_iq/store.py
@@ -1,0 +1,64 @@
+"""ACF store: content-addressed by sha256(PTX), partitioned by GPU arch.
+
+Layout:
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.acf          # the best ACF (opaque bytes)
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.acf.json     # provenance metadata
+
+PINNED (hash-key design): the key is sha256(PTX) x arch today. PTX subsumes the
+autotune config + dtype/alignment specialization, but NOT runtime shape (M,N,K).
+If per-shape ACFs are wanted later, extend the key with shape/identity.
+"""
+
+import hashlib
+import json
+import os
+import sys
+
+# Single debug knob for all of compile_iq, default OFF. Set FBTRITON_COMPILE_IQ_DEBUG=1
+# to trace when events are collected and when ACF lookups hit/miss.
+DEBUG_ENV = "FBTRITON_COMPILE_IQ_DEBUG"
+
+
+def debug_enabled() -> bool:
+    return bool(os.environ.get(DEBUG_ENV))
+
+
+def dlog(component: str, msg: str) -> None:
+    """Write a debug line to stderr iff the (default-False) debug knob is set."""
+    if debug_enabled():
+        sys.stderr.write(f"[compile_iq.{component}] {msg}\n")
+
+
+def ptx_sha256(ptx: str) -> str:
+    return hashlib.sha256(ptx.encode("utf-8")).hexdigest()
+
+
+def store_root() -> str:
+    return os.environ.get("COMPILE_IQ_STORE", os.path.expanduser("~/.compile_iq/store"))
+
+
+def acf_path(ptx_sha: str, arch: str) -> str:
+    return os.path.join(store_root(), arch, f"{ptx_sha}.acf")
+
+
+def has_acf(ptx_sha: str, arch: str) -> bool:
+    return os.path.exists(acf_path(ptx_sha, arch))
+
+
+def read_acf(ptx_sha: str, arch: str) -> bytes | None:
+    p = acf_path(ptx_sha, arch)
+    if not os.path.exists(p):
+        return None
+    with open(p, "rb") as f:
+        return f.read()
+
+
+def write_acf(ptx_sha: str, arch: str, data: bytes, meta: dict | None = None) -> str:
+    p = acf_path(ptx_sha, arch)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    with open(p, "wb") as f:
+        f.write(data)
+    if meta is not None:
+        with open(p + ".json", "w") as f:
+            json.dump(meta, f, indent=2, default=str)
+    return p

--- a/third_party/compile_iq/examples/user_kernel.py
+++ b/third_party/compile_iq/examples/user_kernel.py
@@ -1,0 +1,63 @@
+"""A normal Triton kernel + run — NO compile_iq / CompileIQ imports or references.
+
+This is exactly what a user would write. It demonstrates Stage-1 collection's
+**zero user surface**: nothing in this file is aware of compile_iq. Collection is
+triggered entirely by the environment, with no change to this code:
+
+    FBTRITON_COMPILE_IQ_COLLECT=1 \
+    COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks \
+    TRITON_PTXAS_BLACKWELL_PATH=/path/to/ptxas13.3 \
+    python user_kernel.py
+
+After the run, a compileIQ task appears under $COMPILE_IQ_TASK_DIR.
+"""
+
+import torch
+
+import triton
+import triton.language as tl
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+@triton.jit
+def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+                  BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
+        acc += tl.dot(a, b)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    c = acc.to(c_ptr.dtype.element_ty)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, c, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+
+def matmul(a, b):
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    BLOCK_M = BLOCK_N = 64
+    BLOCK_K = 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    matmul_kernel[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
+                        BLOCK_M, BLOCK_N, BLOCK_K)
+    return c
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    a = torch.randn((2048, 2048), device=DEVICE, dtype=torch.bfloat16)
+    b = torch.randn((2048, 2048), device=DEVICE, dtype=torch.bfloat16)
+    c = matmul(a, b)
+    torch.cuda.synchronize()
+    print("matmul ran:", tuple(c.shape), c.dtype)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -962,6 +962,20 @@ class CUDABackend(BaseBackend):
             # Add --regAllocOptLevel=2 to work around ptxas 13.x bug
             reg_alloc = ["--regAllocOptLevel=2"]
 
+            # compile_iq Stage-3 consumption (gated, default off; fail-open): if the
+            # PTX hash hits the ACF store, apply it via --apply-controls. Only when the
+            # ptxas in use supports it (>=13.3), so it stays fail-open otherwise. Fires
+            # per ptxas call, i.e. for each config compiled during autotuning.
+            apply_controls = []
+            if os.environ.get("FBTRITON_COMPILE_IQ_APPLY"):
+                try:
+                    from packaging.version import Version
+                    if Version(get_ptxas(self.target.arch).version) >= Version("13.3"):
+                        from triton.compile_iq.consume import acf_args_for
+                        apply_controls = acf_args_for(src, arch)
+                except Exception:
+                    apply_controls = []
+
             ptxas_cmd = [
                 ptxas,
                 *debug_info,
@@ -970,6 +984,7 @@ class CUDABackend(BaseBackend):
                 *disable_opt,
                 *reg_alloc,
                 *ptx_extra_options,
+                *apply_controls,
                 f"--gpu-name={arch}",
                 fsrc.name,
                 "-o",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1729
* __->__ #1728

Adds compile_iq: a decoupled, zero-user-surface path to (1) collect a self-contained "task" per Triton kernel run and (3) transparently apply a tuned ptxas Advanced Control File (ACF) at PTX->SASS time. The offline factory (stage 2) lands in the next diff; this diff is the always-on, dependency-light core.

Collection: a gated hook in runtime/jit.py (env FBTRITON_COMPILE_IQ_COLLECT, default off, fail-open) dumps per kernel a task -- emitted PTX, source, bound args, grid, defining module, and kernel-selecting env (e.g. TLX_GEMM_USE_HEURISTIC) -- under COMPILE_IQ_TASK_DIR. Imports only stdlib; no CompileIQ dependency.

Apply: a gated hook in nvidia/backend/compiler.py make_cubin (env FBTRITON_COMPILE_IQ_APPLY, default off) hashes the PTX, looks up the content-addressed store (sha256(PTX) x arch), and splices --apply-controls into the ptxas command on a hit. Version-guarded to ptxas >= 13.3 (packaging.Version) and wrapped in try/except, so it is fail-open: on a miss, an unsupported ptxas, or any error it compiles unchanged. With an empty store it is a clean no-op -> baseline.

store.py is the content-addressed ACF store + a single debug knob (FBTRITON_COMPILE_IQ_DEBUG) shared by collection (collected/skip) and apply (HIT/MISS). examples/user_kernel.py is a plain bf16 Triton matmul with zero compile_iq references -- proof the kernel needs no changes. The python/triton/compile_iq namespace symlink is gitignored (mirrors python/triton/tlx).

Test plan: FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/t python user_kernel.py writes a task (PTX/source/args/module/env); with an empty store, FBTRITON_COMPILE_IQ_APPLY=1 + ptxas>=13.3 is a clean MISS -> identical output. Testable with just an fbtriton build (no CompileIQ).

Authored with Claude.

## Test plan

Task collection
```
FBTRITON_COMPILE_IQ_DEBUG=1 FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks \
python third_party/compile_iq/examples/user_kernel.py
```
```
[compile_iq.collector] collected dd10218285261cae sm_100a kernel=matmul_kernel grid=[32, 32, 1] args=15 -> /tmp/ciq_tasks/dd10218285261cae
matmul ran: (2048, 2048) torch.bfloat16
```

ACF factory
```
COMPILE_IQ_STORE=/tmp/ciq_store COMPILE_IQ_SEARCH_SPACE_BIN=/data/users/daohang/CompileIQ/tests/compiler_ss/data/ptxas13.3.bin \
python -m triton.compile_iq.factory /tmp/ciq_tasks/dd10218285261cae/
```