### PR TITLE
[triton] visit_ListComp: accept constexpr range(...) iterables (#1733)

### DIFF
--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -383,3 +383,26 @@ def test_tuple_constexpr_function():
         tl.static_assert(passthrough_constexpr(TrivialTuple(0)).foo == 0)
 
     kernel[(1, )]()
+
+
+@triton.jit
+def _listcomp_range_kernel(X_ptr, Y_ptr, sb, si, sj, N: tl.constexpr):
+    b = tl.program_id(0)
+    Xb = X_ptr + b * sb
+    Yb = Y_ptr + b * sb
+    j = tl.arange(0, N)
+    row = [tl.load(Xb + i * si + j * sj) for i in range(N)]
+    row = [row[i] * (i + 1) for i in range(N)]
+    for i in tl.static_range(0, N):
+        tl.store(Yb + i * si + j * sj, row[i])
+
+
+@pytest.mark.parametrize("N", [4, 8, 32])
+def test_listcomp_range(N, device):
+    torch.manual_seed(0)
+    B = 4
+    x = torch.randn((B, N, N), dtype=torch.float32, device=device)
+    y = torch.empty_like(x)
+    _listcomp_range_kernel[(B, )](x, y, x.stride(0), x.stride(1), x.stride(2), N=N, num_warps=1)
+    scale = (torch.arange(N, device=device, dtype=torch.float32) + 1.0)[None, :, None]
+    torch.testing.assert_close(y, x * scale, rtol=0, atol=0)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -572,12 +572,19 @@ class CodeGenerator(ast.NodeVisitor):
             raise ValueError("nested comprehensions are not supported")
 
         comp = node.generators[0]
-        iter = self.visit(comp.iter)
-        if not isinstance(iter, tl_tuple):
-            raise NotImplementedError("only tuple comprehensions are supported")
+        if isinstance(comp.iter, ast.Call) and self.visit(comp.iter.func) is range:
+            args = [_unwrap_if_constexpr(self.visit(a)) for a in comp.iter.args]
+            items = [constexpr(i) for i in range(*args)]
+        else:
+            it = self.visit(comp.iter)
+            if not isinstance(it, tl_tuple):
+                raise NotImplementedError(
+                    "comprehension iterable must be a tuple or constexpr range(...)"
+                )
+            items = list(it)
 
         results = []
-        for item in iter:
+        for item in items:
             self.set_value(comp.target.id, item)
             results.append(self.visit(node.elt))
         return tl_tuple(results)


### PR DESCRIPTION
Summary:

Implementation of visit_ListComp only accepts tuple. If we try something like 
`[expr(i) for i in range(N)]` 

that will throw.

This diff extend that just like visitFor. See the small program that exhibits this behavior. 

Why we do this - some kernels might need an array of or-resident tensors with indices updates and that is really tedious to write (have that in gpu mode competition now) - this expands that and pretty small change.

Reviewed By: htyu

Differential Revision: D108672875


