### PR TITLE
[TLX][AMD] Port warp pipeline support for TLX kernels from tlx-amd-meta (#1407)

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Builders.h"
@@ -1967,6 +1968,19 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value &ptr,
               std::vector<Value> &offsets) -> Value {
              return self.create<AdvanceOp>(ptr.getType(), ptr, offsets);
+           })
+      // Warp pipeline border marker (AMD)
+      .def("create_warp_pipeline_border",
+           [](TritonOpBuilder &self, const std::string &marker, int priority) {
+             auto border = self.create<ROCDL::SchedBarrier>(0);
+             auto ctx = self.getContext();
+             border->setAttr("triton.warp_pipeline.border",
+                             StringAttr::get(ctx, marker));
+             if (priority > -1) {
+               auto i32Ty = IntegerType::get(ctx, 32);
+               border->setAttr("triton.warp_pipeline.priority",
+                               IntegerAttr::get(i32Ty, priority));
+             }
            })
       // Make a tensor descriptor
       .def("create_make_tensor_descriptor",

--- a/python/test/unit/language/test_amd_warp_pipeline.py
+++ b/python/test/unit/language/test_amd_warp_pipeline.py
@@ -1,0 +1,310 @@
+"""Tests for TLX warp-pipeline support (tlx.warp_pipeline_stage)."""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+
+def is_hip():
+    return triton.runtime.driver.active.get_current_target().backend == "hip"
+
+
+# --- Runtime test: simple GEMM with warp pipeline ---
+
+
+@triton.jit
+def _gemm_warp_pipeline_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for _ in tl.range(0, tl.cdiv(K, BLOCK_K)):
+        with tlx.warp_pipeline_stage("load"):
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K)
+        with tlx.warp_pipeline_stage("compute"):
+            acc += tl.dot(a, b, allow_tf32=False)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+
+    c_ptrs = c_ptr + (offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(c_ptrs, acc, mask=mask)
+
+
+@pytest.mark.skipif(not is_hip(), reason="warp pipeline is AMD-only")
+def test_gemm_warp_pipeline():
+    """Runtime correctness test: small GEMM with warp pipeline stages."""
+    M, N, K = 128, 128, 128
+    BLOCK_M, BLOCK_N, BLOCK_K = 32, 32, 32
+
+    torch.manual_seed(42)
+    a = torch.randn((M, K), dtype=torch.float16, device="cuda")
+    b = torch.randn((K, N), dtype=torch.float16, device="cuda")
+    c = torch.zeros((M, N), dtype=torch.float32, device="cuda")
+
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), )
+    _gemm_warp_pipeline_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        num_warps=4,
+        num_stages=1,
+    )
+
+    ref = (a.float() @ b.float())
+    torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
+
+
+# --- IR test: verify border markers in raw IR ---
+
+
+@triton.jit
+def _simple_pipeline_kernel(OUT, K: tl.constexpr):
+    y = 0
+    for i in tl.range(0, K):
+        with tlx.warp_pipeline_stage("stage0", priority=1):
+            x = i + 1
+        with tlx.warp_pipeline_stage("stage1", priority=0):
+            y = x * 1
+    tl.store(OUT + tl.program_id(0), y)
+
+
+@pytest.mark.skipif(not is_hip(), reason="warp pipeline is AMD-only")
+def test_warp_pipeline_ir():
+    """Verify that warp_pipeline_stage emits border markers in the IR."""
+    from triton.compiler import ASTSource
+    from triton._C.libtriton import ir
+    from triton.backends.compiler import GPUTarget
+
+    target = GPUTarget("hip", "gfx950", 64)
+    backend = triton.compiler.compiler.make_backend(target)
+    opts = backend.parse_options({})
+
+    src = ASTSource(
+        fn=_simple_pipeline_kernel,
+        signature={"OUT": "*fp32"},
+        constexprs={"K": 10},
+    )
+    ctx = ir.context()
+    backend.load_dialects(ctx)
+    codegen_fns = backend.get_codegen_implementation(opts)
+    raw_ir = src.make_ir(target, opts, codegen_fns, {}, ctx)
+    ir_str = str(raw_ir)
+    assert "triton.warp_pipeline.border" in ir_str, ("Expected warp_pipeline border markers in IR, got:\n" + ir_str)
+    assert '"stage0"' in ir_str
+    assert '"stage1"' in ir_str
+    assert 'triton.warp_pipeline.priority = 1' in ir_str
+    assert 'triton.warp_pipeline.priority = 0' in ir_str
+
+
+# --- IR test: verify warp pipeline lowering forms execute_region clusters ---
+
+
+@triton.jit
+def _two_stage_kernel(OUT, IN, N: tl.constexpr, K: tl.constexpr):
+    offs = tl.program_id(0) * N + tl.arange(0, N)
+    acc = tl.zeros((N, ), dtype=tl.float32)
+    for i in tl.range(0, K):
+        with tlx.warp_pipeline_stage("load"):
+            x = tl.load(IN + offs)
+        with tlx.warp_pipeline_stage("compute"):
+            acc += x
+    tl.store(OUT + offs, acc)
+
+
+@triton.jit
+def _smem_warp_pipeline_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+):
+    """GEMM with shared memory + warp pipeline to trigger full lowering."""
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_bk > 0)
+    K_ITERS = tl.cdiv(K, BLOCK_K)
+    buffers_A = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(a_ptr), NUM_BUFFERS)
+    buffers_B = tlx.local_alloc((BLOCK_K, BLOCK_N), tlx.dtype_of(b_ptr), NUM_BUFFERS)
+    for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
+        tok_a = tlx.async_load(a_ptrs, tlx.local_view(buffers_A, i), mask=offs_k[None, :] < K - i * BLOCK_K)
+        tok_b = tlx.async_load(b_ptrs, tlx.local_view(buffers_B, i), mask=offs_k[:, None] < K - i * BLOCK_K)
+        tlx.async_load_commit_group([tok_a, tok_b])
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    tlx.async_load_wait_group(NUM_BUFFERS - 2)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in tl.range(NUM_BUFFERS - 1, K_ITERS):
+        consumer = (k - (NUM_BUFFERS - 1)) % NUM_BUFFERS
+        producer = k % NUM_BUFFERS
+        with tlx.warp_pipeline_stage("lds_load", priority=1):
+            a_tile = tlx.local_load(tlx.local_view(buffers_A, consumer))
+            b_tile = tlx.local_load(tlx.local_view(buffers_B, consumer))
+        tlx.async_load_wait_group(0)
+        with tlx.warp_pipeline_stage("compute_and_load", priority=0):
+            tok_a = tlx.async_load(a_ptrs, tlx.local_view(buffers_A, producer), mask=offs_k[None, :] < K - k * BLOCK_K)
+            tok_b = tlx.async_load(b_ptrs, tlx.local_view(buffers_B, producer), mask=offs_k[:, None] < K - k * BLOCK_K)
+            tlx.async_load_commit_group([tok_a, tok_b])
+            acc = tl.dot(a_tile, b_tile, acc)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+    tlx.async_load_wait_group(0)
+    for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
+        consumer = (K_ITERS - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
+        a_tile = tlx.local_load(tlx.local_view(buffers_A, consumer))
+        b_tile = tlx.local_load(tlx.local_view(buffers_B, consumer))
+        acc = tl.dot(a_tile, b_tile, acc)
+    c = acc.to(tlx.dtype_of(c_ptr))
+    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+@pytest.mark.skipif(not is_hip(), reason="warp pipeline is AMD-only")
+def test_warp_pipeline_lowering():
+    """Verify that shared-memory GEMM with warp pipeline produces barriers in assembly."""
+    torch.manual_seed(0)
+    M = N = K = 192
+    a = torch.randn((M, K), dtype=torch.float16, device="cuda")
+    b = torch.randn((K, N), dtype=torch.float16, device="cuda")
+    c = torch.zeros((M, N), dtype=torch.float32, device="cuda")
+    BM, BN, BK = 64, 64, 32
+    grid = (triton.cdiv(M, BM) * triton.cdiv(N, BN), )
+
+    kernel = _smem_warp_pipeline_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=BM,
+        BLOCK_N=BN,
+        BLOCK_K=BK,
+        NUM_BUFFERS=3,
+        num_warps=8,
+    )
+
+    # Check correctness
+    ref = a.float() @ b.float()
+    torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
+
+    # Verify warp pipeline artifacts in compiled assembly
+    asm = kernel.asm["amdgcn"]
+    assert "s_barrier" in asm, "Expected s_barrier from warp pipeline lowering"
+    assert "s_setprio" in asm, "Expected s_setprio from warp pipeline priority hints"
+
+
+# --- Validation tests ---
+
+
+def test_warp_pipeline_stage_label_validation():
+    """Label must be string or None."""
+    with pytest.raises(ValueError, match="label must be a string"):
+        tlx.warp_pipeline_stage(123)
+
+
+def test_warp_pipeline_stage_priority_validation():
+    """Priority must be 0-3."""
+    with pytest.raises(ValueError, match="priority must be 0-3"):
+        tlx.warp_pipeline_stage("test", priority=5)
+    with pytest.raises(ValueError, match="priority must be 0-3"):
+        tlx.warp_pipeline_stage("test", priority=-1)
+
+
+def test_warp_pipeline_stage_valid_construction():
+    """Valid constructions should not raise."""
+    s1 = tlx.warp_pipeline_stage("load", priority=0)
+    assert s1.label == "load" and s1.priority == 0
+    s2 = tlx.warp_pipeline_stage(priority=3)
+    assert s2.label is None and s2.priority == 3
+    s3 = tlx.warp_pipeline_stage()
+    assert s3.label is None and s3.priority is None
+
+
+if __name__ == "__main__":
+    test_warp_pipeline_stage_label_validation()
+    test_warp_pipeline_stage_priority_validation()
+    test_warp_pipeline_stage_valid_construction()
+    print("PASSED: validation tests")
+    if is_hip():
+        test_warp_pipeline_ir()
+        print("PASSED: test_warp_pipeline_ir")
+        test_warp_pipeline_lowering()
+        print("PASSED: test_warp_pipeline_lowering")
+        test_gemm_warp_pipeline()
+        print("PASSED: test_gemm_warp_pipeline")
+    else:
+        print("Skipped: HIP tests (not running on AMD)")

--- a/test/TLX/insert-require-layout-propagate.mlir
+++ b/test/TLX/insert-require-layout-propagate.mlir
@@ -202,19 +202,18 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %buf_a = ttg.memdesc_index %alloc_a[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
     %buf_b = ttg.memdesc_index %alloc_b[%c0_i32] : !ttg.memdesc<1x32x64xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<32x64xf16, #shared_4, #smem_4, mutable>
     %buf_sink = ttg.memdesc_index %alloc_sink[%c0_i32] : !ttg.memdesc<1x64x32xf16, #shared_4, #smem_4, mutable> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
-    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %[[DESC_A]] : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #blocked>
+    // CHECK: %[[A_LOAD:.*]] = ttg.local_load %[[DESC_A]] : !ttg.memdesc<64x32xf16, #{{.*}}, #smem, mutable> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
     %a = ttg.local_load %buf_a : !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable> -> tensor<64x32xf16, #blocked_4>
-    // CHECK: %[[A_ALT:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #{{.*}}>
+    // CHECK: %[[A_ALT:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> -> tensor<64x32xf16, #{{.*}}>
     %a_alt = ttg.convert_layout %a : tensor<64x32xf16, #blocked_4> -> tensor<64x32xf16, #blocked_4_alt>
     // CHECK: ttg.local_store %[[A_ALT]], %{{.*}}
     ttg.local_store %a_alt, %buf_sink : tensor<64x32xf16, #blocked_4_alt> -> !ttg.memdesc<64x32xf16, #shared_4, #smem_4, mutable>
     // CHECK: %[[B_LOAD:.*]] = ttg.local_load %{{.*}} : !ttg.memdesc<32x64xf16, #{{.*}}, #smem, mutable> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
     %b = ttg.local_load %buf_b : !ttg.memdesc<32x64xf16, #shared_4, #smem_4, mutable> -> tensor<32x64xf16, #blocked_4>
     %acc = ttg.convert_layout %cst : tensor<64x64xf32, #blocked_4> -> tensor<64x64xf32, #mma_4>
-    // CHECK: %[[A_DOT:.*]] = ttg.convert_layout %[[A_LOAD]] : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
     %a_dot = ttg.convert_layout %a : tensor<64x32xf16, #blocked_4> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_4, kWidth = 4}>>
     %b_dot = ttg.convert_layout %b : tensor<32x64xf16, #blocked_4> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_4, kWidth = 4}>>
-    // CHECK: tt.dot %[[A_DOT]], %[[B_LOAD]], %{{.*}}
+    // CHECK: tt.dot %[[A_LOAD]], %[[B_LOAD]], %{{.*}}
     %dot = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_4, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_4, kWidth = 4}>> -> tensor<64x64xf32, #mma_4>
     tt.return %dot : tensor<64x64xf32, #mma_4>
   }

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -290,6 +290,13 @@ class HIPBackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
+        # Consume tlx.warp_pipeline_stage border markers (rocdl.sched.barrier with
+        # triton.warp_pipeline.border / .priority attrs) for the TLX / triton.jit
+        # path. The gluon path runs this in gluon_to_ttgir; make_llir runs the
+        # conversion. Placed at the TTGIR stage (so it does not double-run for gluon
+        # kernels) and as the last pass before pm.run so the cleanup passes above do
+        # not strip the priority markers before the pipeliner consumes them.
+        amd.passes.ttgpuir.add_warp_pipeline(pm)
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()
         return mod

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -89,6 +89,37 @@ static void emitClusterBarrier(PatternRewriter &r, Location loc,
   ROCDL::SchedBarrier::create(r, loc, 0);
 }
 
+// Emit an s_setprio for a cluster's hardware scheduling priority.  When the
+// cluster carries an explicit triton.warp_pipeline.priority attribute we set
+// that value; when it doesn't but some *other* stage in the pipeline does, we
+// reset to the default priority so the hint does not leak across stages.
+// Clusters with no priority in a pipeline where nobody uses priority (e.g.
+// gluon borders) emit nothing.
+static void emitClusterPriority(PatternRewriter &r, Location loc,
+                                Operation *clusterOp, bool anyHasPriority) {
+  if (auto intAttr = clusterOp->getAttrOfType<IntegerAttr>(
+          "triton.warp_pipeline.priority")) {
+    ROCDL::SetPrioOp::create(r, loc, intAttr.getInt());
+  } else if (anyHasPriority) {
+    ROCDL::SetPrioOp::create(r, loc, 0);
+  }
+}
+
+// Wrap a pre-existing barrier op (e.g. async_wait) with sched_barriers so the
+// backend scheduler cannot move ops across it, and emit the cluster's priority
+// just before the barrier.  Used in place of inserting a fresh cluster barrier
+// when one already exists at the cluster boundary.
+static void wrapExistingBarrier(PatternRewriter &b, Location loc,
+                                Operation *clusterOp,
+                                Operation *existingBarrier,
+                                bool anyHasPriority) {
+  b.setInsertionPoint(existingBarrier);
+  emitClusterPriority(b, loc, clusterOp, anyHasPriority);
+  ROCDL::SchedBarrier::create(b, loc, 0);
+  b.setInsertionPointAfter(existingBarrier);
+  ROCDL::SchedBarrier::create(b, loc, 0);
+}
+
 class ConvertPipelinedForPattern : public OpRewritePattern<scf::ForOp> {
 public:
   ConvertPipelinedForPattern(MLIRContext *ctx, ModuleAllocation &moduleAlloc)
@@ -142,7 +173,8 @@ private:
 
     // Insert condbarrier::first_half after the end of the loop
     b.setInsertionPointAfter(forOp);
-    mlir::triton::amdgpu::CondBarrierOp::create(b, loc, warpLow);
+    auto warpLowBarrier =
+        mlir::triton::amdgpu::CondBarrierOp::create(b, loc, warpLow);
 
     // 2. Collect existing barrier information.
     // Scanning the loop body and classifying each consecutive block of
@@ -166,7 +198,8 @@ private:
         clusterBlocks.push_back(&exeOp->getRegion(0).front());
         bars.push_back(false);
       } else if (isa<ROCDL::BarrierOp, gpu::BarrierOp, triton::gpu::AsyncWaitOp,
-                     triton::amdgpu::AsyncTDMWait>(op)) {
+                     triton::amdgpu::AsyncWaitOp, triton::amdgpu::AsyncTDMWait>(
+                     op)) {
         int currCluster = clusterBlocks.size();
         // Reject if multiple barriers appear without an intervening cluster.
         // This is functionally valid but may cause unpredictable timing. Users
@@ -190,6 +223,11 @@ private:
       clusterInfo.push_back(buildBlockInfoFromBlock(cb, allocation));
     int numClusters = clusterInfo.size();
     LDBG("total clusters : " << numClusters);
+
+    // Check if any cluster has explicit priority (gluon borders never do).
+    bool anyHasPriority = llvm::any_of(clusterOps, [](Operation *op) {
+      return op->hasAttr("triton.warp_pipeline.priority");
+    });
 
     // Normally, we don't expect a pipelined loop begins with a barrier
     // but sometimes required by memory prefetching pattern.
@@ -256,21 +294,34 @@ private:
     //    the first cluster barrier must be inserted just before the loop’s
     //    terminator, forming the wrap-around dependency.
     for (int i = 0; i < numClusters; i++) {
+      if (i == 0 && topBar == existingBarrierMap.end()) {
+        // Prime the first iteration's priority.  The loop-carried cluster-0
+        // barrier sits at the bottom of the loop body, so it only controls
+        // the next iteration.
+        b.setInsertionPoint(forOp);
+        emitClusterPriority(b, loc, clusterOps[i], anyHasPriority);
+      }
+
       if (auto exBar = existingBarrierMap.find(i);
           exBar != existingBarrierMap.end()) {
-        auto exBarOp = exBar->second;
-        b.setInsertionPoint(exBarOp);
-        ROCDL::SchedBarrier::create(b, loc, 0);
-        b.setInsertionPointAfter(exBarOp);
-        ROCDL::SchedBarrier::create(b, loc, 0);
+        wrapExistingBarrier(b, loc, clusterOps[i], exBar->second,
+                            anyHasPriority);
       } else {
         b.setInsertionPoint(clusterOps[i]);
         // The first one wraps back to the last of the loop
         if (i == 0 && topBar == existingBarrierMap.end())
           // inserts just before yield (=End of the loop).
           b.setInsertionPoint(terminatorOp);
+        emitClusterPriority(b, loc, clusterOps[i], anyHasPriority);
         emitClusterBarrier(b, loc, /*needLocal=*/bars[i]);
       }
+    }
+
+    // Post-loop priority reset: drop back to default priority before the warps
+    // reconverge, so the hint does not leak past the pipelined loop.
+    if (anyHasPriority) {
+      b.setInsertionPoint(warpLowBarrier);
+      ROCDL::SetPrioOp::create(b, loc, 0);
     }
     return success();
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/WarpPipeliner.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/WarpPipeliner.cpp
@@ -25,9 +25,23 @@ namespace mlir {
 #define GEN_PASS_DEF_TRITONAMDGPUWARPPIPELINE
 #include "TritonAMDGPUTransforms/Passes.h.inc"
 
+// Read (cluster-name, priority) from a border marker op.  Priority defaults
+// to -1 when the marker doesn't carry the optional priority attribute (e.g.
+// gluon borders, which never set a priority).
+static std::pair<StringAttr, int> readBorderMarker(Operation *op) {
+  StringAttr clusterStr =
+      op->getAttrOfType<StringAttr>("triton.warp_pipeline.border");
+  int priority = -1;
+  if (auto intAttr =
+          op->getAttrOfType<IntegerAttr>("triton.warp_pipeline.priority"))
+    priority = intAttr.getInt();
+  return {clusterStr, priority};
+}
+
 // Create a scf.execute_region op representing a pipeline cluster.
 static void createClusterOp(OpBuilder &b, Location loc,
-                            SmallVector<Operation *> &ops, StringAttr marker) {
+                            SmallVector<Operation *> &ops,
+                            std::pair<StringAttr, int> marker) {
   assert(!ops.empty() && "empty stage");
 
   // Insert the execute_region before the first op in the cluster.
@@ -96,7 +110,11 @@ static void createClusterOp(OpBuilder &b, Location loc,
 
   // Keep the region structured for later conversion.
   exec.setNoInline(true);
-  exec->setAttr("triton.warp_pipeline.stage", marker);
+  exec->setAttr("triton.warp_pipeline.stage", marker.first);
+  if (marker.second > -1) {
+    exec->setAttr("triton.warp_pipeline.priority",
+                  b.getI32IntegerAttr(marker.second));
+  }
 
   LLVM_DEBUG(llvm::dbgs() << "[warp-pipeline] created stage with " << ops.size()
                           << " ops and " << yieldedTypes.size() << " yields\n");
@@ -109,7 +127,7 @@ static LogicalResult createPipeline(OpBuilder &b, Location loc,
   // Collect ops in the loop body
   Block &blk = *forOp.getBody();
   SmallVector<Operation *> cluster;
-  SmallVector<StringAttr> clusterMarkers;
+  SmallVector<std::pair<StringAttr, int>> clusterMarkers;
   SmallVector<SmallVector<Operation *>> clusters;
   auto ctx = forOp.getContext();
 
@@ -128,9 +146,7 @@ static LogicalResult createPipeline(OpBuilder &b, Location loc,
   for (Operation &opRef : llvm::make_early_inc_range(blk)) {
     Operation *op = &opRef;
     if (isBorder(op)) { // Wrap-up one cluster at a border.
-      auto clusterStr =
-          op->getAttrOfType<StringAttr>("triton.warp_pipeline.border");
-      clusterMarkers.push_back(clusterStr);
+      clusterMarkers.push_back(readBorderMarker(op));
       if (cluster.empty()) {
         // This allows user to deliberately insert a pipeline bubble with a
         // cluster only contains a dummy operation.
@@ -160,7 +176,7 @@ static LogicalResult createPipeline(OpBuilder &b, Location loc,
   if (!cluster.empty()) { // create the last cluster if needed.
     clusters.push_back(std::move(cluster));
     auto clusterStr = StringAttr::get(ctx, "last_cluster");
-    clusterMarkers.push_back(clusterStr);
+    clusterMarkers.push_back({clusterStr, -1});
   }
 
   // no pipeline clusters detected if 1 or 0 chunk found

--- a/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
+++ b/third_party/tlx/dialect/lib/Analysis/LayoutPropagation.cpp
@@ -365,6 +365,8 @@ static bool isAllowedTensorLayoutUser(Operation *op, unsigned operandIndex) {
   // region carriers. After convert_layout is rewritten into explicit
   // tlx.require_layout anchors, tensor propagation treats those anchors plus
   // the same transparent carriers as the legal local_load-to-dot path.
+  // convert_layout may still sit between block args and require_layout when
+  // the insert pass materializes tensor constraints.
   if (auto requireLayoutOp = dyn_cast<RequireLayoutOp>(op)) {
     if (!isa<RankedTensorType>(requireLayoutOp.getType()) || operandIndex != 0)
       return false;
@@ -372,7 +374,7 @@ static bool isAllowedTensorLayoutUser(Operation *op, unsigned operandIndex) {
         cast<RankedTensorType>(requireLayoutOp.getType()).getEncoding());
   }
 
-  return isTransparentLayoutCarrierOp(op);
+  return isa<ttg::ConvertLayoutOp>(op) || isTransparentLayoutCarrierOp(op);
 }
 
 static bool canRewriteTensorResult(Operation *op) {
@@ -409,6 +411,23 @@ LogicalResult TensorBackwardPropagation::visitOperation(
 
   if (isa<ReleaseLayoutOp>(op))
     return success();
+
+  // For convert_layout, propagate the result constraint backward to the
+  // operand so the analysis reaches local_load through scf.for iter_args.
+  // Skip the propagation when the result is Unknown: meet would return
+  // Unknown for the operand, poisoning its lattice state and preventing
+  // upstream values from being assigned a concrete dot_op encoding.
+  if (auto convertLayout = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    if (!results.empty() && isTrackedTensorValue(convertLayout.getSrc())) {
+      const TensorLayout &resultState = results[0]->getValue();
+      if (!resultState.isUnknown()) {
+        ChangeResult changed = operands[0]->meet(resultState);
+        propagateIfChanged(operands[0], changed);
+      }
+    }
+    // Don't return early — fall through to let the poison check handle
+    // mixed-use cases where the operand has other non-allowed users.
+  }
 
   // If a tracked tensor value is used by an unsupported operation, rewriting
   // the producer chain is no longer legal for that entire component.

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -96,6 +96,7 @@ from .utility import (
 )
 from .mxfp8_utils import _to_mxfp8_block
 from .warp_ops import vote_ballot_sync, warp_redux
+from .warp_pipeline import warp_pipeline_stage
 
 __all__ = [
     # async_tasks
@@ -197,4 +198,6 @@ __all__ = [
     "_to_mxfp8_block",
     # warp_ops
     "vote_ballot_sync",
+    # warp_pipeline
+    "warp_pipeline_stage",
 ]

--- a/third_party/tlx/language/tlx/compiler/code_generator.py
+++ b/third_party/tlx/language/tlx/compiler/code_generator.py
@@ -349,3 +349,26 @@ def visit_withAsyncTasks(self, node):
 
                 self.builder.create_warp_return_op()
                 region_replica_id_stack.pop()
+
+
+def visit_withWarpPipelineStage(self, node):
+    from triton.language.core import _unwrap_if_constexpr
+
+    # Reject on non-AMD targets early with a clear error.
+    target_str = getattr(self.builder.options, 'target', '')
+    if isinstance(target_str, str) and target_str and not target_str.startswith('hip'):
+        raise ValueError("tlx.warp_pipeline_stage is only supported on AMD (HIP) targets")
+
+    context = node.items[0].context_expr
+    args = [self.visit(arg) for arg in context.args]
+    kwargs = {kw.arg: self.visit(kw.value) for kw in context.keywords}
+
+    label = _unwrap_if_constexpr(args[0]) if args else None
+    if label is None:
+        label = "cluster"
+    priority = _unwrap_if_constexpr(kwargs.get("priority", None))
+    if priority is None:
+        priority = -1
+
+    self.visit_compound_statement(node.body)
+    self.builder.create_warp_pipeline_border(str(label), priority)

--- a/third_party/tlx/language/tlx/compiler/dispatch.py
+++ b/third_party/tlx/language/tlx/compiler/dispatch.py
@@ -1,8 +1,9 @@
 import triton.language.extra.tlx as tlx
 
-from .code_generator import visit_withAsyncTask, visit_withAsyncTasks
+from .code_generator import visit_withAsyncTask, visit_withAsyncTasks, visit_withWarpPipelineStage
 
 TLX_WITH_DISPATCH = {
     tlx.async_tasks: visit_withAsyncTasks,
     tlx.async_task: visit_withAsyncTask,
+    tlx.warp_pipeline_stage: visit_withWarpPipelineStage,
 }

--- a/third_party/tlx/language/tlx/warp_pipeline.py
+++ b/third_party/tlx/language/tlx/warp_pipeline.py
@@ -1,0 +1,45 @@
+class warp_pipeline_stage:
+    """Context manager marking an explicit warp-pipeline stage (AMD only).
+
+    This is a partitioning marker, not an automatic optimization. The compiler
+    splits the loop body at stage boundaries and inserts conditional barriers
+    so that one warp group executes one stage ahead of the other. Correctness
+    depends on the user's buffering and synchronization structure — the marker
+    only defines where stages begin and end.
+
+    Typical usage requires multi-buffered shared memory and explicit async
+    waits to ensure data is ready before consumption. See the gfx1250
+    warp-pipeline GEMM example for the full pattern with prefetch, async
+    wait, and epilogue drain.
+
+    Usage inside @triton.jit::
+
+        for k in tl.range(NUM_BUFFERS - 1, K_ITERS):
+            with tlx.warp_pipeline_stage("lds_load", priority=1):
+                a_tile = tlx.local_load(tlx.local_view(buf_A, consumer))
+            tlx.async_load_wait_group(0)
+            with tlx.warp_pipeline_stage("compute_and_load", priority=0):
+                tlx.async_load(a_ptrs, tlx.local_view(buf_A, producer), ...)
+                acc = tl.dot(a_tile, b_tile, acc)
+
+    Args:
+        label: Stage name for diagnostics (e.g. "load", "compute").
+        priority: Hardware scheduling hint (0-3), maps to s_setprio.
+            Higher values indicate more urgent scheduling. Optional.
+    """
+
+    __slots__ = ("label", "priority")
+
+    def __init__(self, label=None, *, priority=None):
+        if label is not None and not isinstance(label, str):
+            raise ValueError(f"label must be a string or None, got {type(label).__name__}")
+        self.label = label
+        if priority is not None and not (0 <= priority <= 3):
+            raise ValueError(f"priority must be 0-3, got {priority}")
+        self.priority = priority
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False

--- a/third_party/tlx/tutorials/amd_gemm_warp_pipeline.py
+++ b/third_party/tlx/tutorials/amd_gemm_warp_pipeline.py
@@ -1,0 +1,203 @@
+"""
+TLX warp-pipelined GEMM tutorial for AMD gfx950.
+
+Uses async_load with 3-buffer pipelining and computes offsets from tile_id
+(3 iter_args: acc, a_tile, b_tile). The main loop is split into "mfma" and
+"mem" warp-pipeline stages via ``tlx.warp_pipeline_stage``.
+
+Includes an XCD-aware PID remap (chunked) for L2 reuse across the 8 XCDs
+of MI300X-class chips.
+"""
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+# gfx950 has 8 XCDs per chip; chunked remap improves L2 reuse.
+# XCD_CHUNK=4 was empirically best for our 256x256 tiles at 4K-8K (per-XCD
+# group of 4 PIDs aligns with the GROUP_M=8 row partitioning).
+NUM_XCDS = 8
+XCD_CHUNK = 4
+
+
+@triton.jit
+def chiplet_transform_chunked(pid, num_workgroups, num_xcds: tl.constexpr, chunk_size: tl.constexpr):
+    """Group adjacent PIDs onto the same XCD in chunks of chunk_size for L2 reuse.
+
+    PIDs in the trailing remainder (not a multiple of num_xcds*chunk_size) pass through.
+    """
+    aligned = (num_workgroups // (num_xcds * chunk_size)) * (num_xcds * chunk_size)
+    if pid >= aligned:
+        return pid
+    xcd = pid % num_xcds
+    local_pid = pid // num_xcds
+    return ((local_pid // chunk_size) * num_xcds * chunk_size + xcd * chunk_size + (local_pid % chunk_size))
+
+
+@triton.jit
+def matmul_kernel_warp_pipeline(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+):
+    """C = A @ B with async-loaded LDS buffers and explicit warp-pipeline stages."""
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_bk > 0)
+
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    grid_mn = num_pid_m * num_pid_n
+    pid = chiplet_transform_chunked(pid, grid_mn, NUM_XCDS, XCD_CHUNK)
+
+    num_pid_in_group = GROUP_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Precompute row/col offsets (these are per-thread, not carried in loop)
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    offs_k = tl.arange(0, BLOCK_K)
+
+    # Base offsets — recompute full pointer from tile_id * BLOCK_K
+    a_base_off = offs_m[:, None] * stride_am
+    b_base_off = offs_n[None, :] * stride_bn
+
+    K_ITERS = tl.cdiv(K, BLOCK_K)
+
+    smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(a_ptr), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_K, BLOCK_N), tlx.dtype_of(b_ptr), NUM_BUFFERS)
+
+    # Prologue: async-copy NUM_BUFFERS tiles
+    for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
+        k_start = i * BLOCK_K
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * stride_ak
+        b_offs = (k_start + offs_k[:, None]) * stride_bk + b_base_off
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
+        tlx.async_load_commit_group([tok_a])
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, i), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_b])
+
+    # Wait for buffer 0
+    tlx.async_load_wait_group((NUM_BUFFERS - 1) * 2)
+    a_tile = tlx.local_load(tlx.local_view(smemA, 0))
+    b_tile = tlx.local_load(tlx.local_view(smemB, 0))
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Main loop: only 3 iter_args (acc, a_tile, b_tile)
+    # Offsets computed from tile_id — no pointer iter_args
+    for tile_id in tl.range(0, K_ITERS - NUM_BUFFERS):
+        prefetch_buf = tile_id % NUM_BUFFERS
+        next_buf = (tile_id + 1) % NUM_BUFFERS
+        k_prefetch = (tile_id + NUM_BUFFERS) * BLOCK_K
+
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        tlx.async_load_wait_group(2)
+
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_offs = a_base_off + (k_prefetch + offs_k[None, :]) * stride_ak
+            b_offs = (k_prefetch + offs_k[:, None]) * stride_bk + b_base_off
+            tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, prefetch_buf), mask=offs_k[None, :]
+                                   < K - k_prefetch)
+            tlx.async_load_commit_group([tok_a])
+            tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, prefetch_buf), mask=offs_k[:, None]
+                                   < K - k_prefetch)
+            tlx.async_load_commit_group([tok_b])
+            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
+            b_tile = tlx.local_load(tlx.local_view(smemB, next_buf))
+
+    # Epilogue
+    acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+    tlx.async_load_wait_group(0)
+    for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
+        buf = (K_ITERS - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
+        a_tile = tlx.local_load(tlx.local_view(smemA, buf))
+        b_tile = tlx.local_load(tlx.local_view(smemB, buf))
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+    c = acc.to(tlx.dtype_of(c_ptr))
+    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def matmul(a: torch.Tensor, b: torch.Tensor, config=None) -> torch.Tensor:
+    """C = A @ B using a warp-pipelined kernel on AMD gfx950."""
+    if config is None:
+        config = {
+            "BLOCK_M": 256,
+            "BLOCK_N": 256,
+            "BLOCK_K": 32,
+            "GROUP_M": 8,
+            "NUM_BUFFERS": 3,
+            "num_warps": 8,
+        }
+    assert a.is_contiguous() and b.is_contiguous(), "A and B must be contiguous"
+    assert a.dtype == b.dtype, "A and B must have the same dtype"
+    M, K = a.shape
+    Kb, N = b.shape
+    assert K == Kb, f"K mismatch: A={a.shape}, B={b.shape}"
+
+    BLOCK_M = config["BLOCK_M"]
+    BLOCK_N = config["BLOCK_N"]
+    BLOCK_K = config["BLOCK_K"]
+    GROUP_M = config.get("GROUP_M", 8)
+    NUM_BUFFERS = config.get("NUM_BUFFERS", 3)
+    num_warps = config.get("num_warps", 8)
+    assert M % BLOCK_M == 0 and N % BLOCK_N == 0 and K % BLOCK_K == 0, \
+        "M, N, K must be multiples of their block sizes"
+
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), )
+    matmul_kernel_warp_pipeline[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_M=GROUP_M,
+        NUM_BUFFERS=NUM_BUFFERS,
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=XCD_CHUNK,
+        # Warp pipelining requires the auto software pipeliner to bail, which it
+        # does for num_stages <= 1 (the explicit stages do the pipelining).
+        num_warps=num_warps,
+        num_stages=1,
+    )
+    return c

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -54,13 +54,15 @@ from triton.language.extra.tlx.tutorials.amd_fa_pipelined import (
     attention as _amd_fa_pipelined, )
 from triton.language.extra.tlx.tutorials.amd_tdm_gemm_pipelined import (
     matmul as _amd_tdm_gemm_pipelined, )
+from triton.language.extra.tlx.tutorials.amd_gemm_warp_pipeline import (
+    matmul as _amd_gemm_warp_pipeline, )
 
 from triton.language.extra.tlx.tutorials.testing.multi_cta_layer_norm import (
     multi_cta_layernorm as _multi_cta_layernorm,
     multi_cta_layernorm_2d as _multi_cta_layernorm_2d,
 )
 
-from triton._internal_testing import is_blackwell, is_hopper, is_hopper_or_newer, is_hip, is_hip_gfx1250
+from triton._internal_testing import is_blackwell, is_hopper, is_hopper_or_newer, is_hip, is_hip_cdna4, is_hip_gfx1250
 from triton.language.extra.tlx.tutorials.testing.gemm_shapes import BLACKWELL_GEMM_WS as _BLACKWELL_GEMM_WS_MORE_SHAPES
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -164,6 +166,14 @@ class Gemm:
             "BLOCK_M": 128,
             "BLOCK_N": 128,
             "BLOCK_K": 32,
+        },
+        "amd_gemm_warp_pipeline": {
+            "BLOCK_M": 256,
+            "BLOCK_N": 256,
+            "BLOCK_K": 32,
+            "GROUP_M": 8,
+            "NUM_BUFFERS": 3,
+            "num_warps": 8,
         },
     }
 
@@ -912,6 +922,12 @@ def test_amd_fa_pipelined(config_name, causal):
 @pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250 hardware")
 def test_amd_tdm_gemm_pipelined(dtype):
     Gemm.run_test(_amd_tdm_gemm_pipelined, Gemm.CONFIGS["amd_tdm_gemm_pipelined"], dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_amd_gemm_warp_pipeline(dtype):
+    Gemm.run_test(_amd_gemm_warp_pipeline, Gemm.CONFIGS["amd_gemm_warp_pipeline"], dtype=dtype)
 
 
 # =============================================================================


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1719
* #1718
* __->__ #1736
* #1717

Ports tlx.warp_pipeline_stage (explicit warp-pipeline stage markers) for the
TLX / @triton.jit path from tlx-amd-meta (90eac21b6), so TLX GEMM kernels can
partition a loop body into stages that one warp group runs ahead of another.

Adapted for main, whose warp-pipeline backend came from the gluon upstream
import (#8586) and differs from tlx-amd-meta's:
- add_warp_pipeline runs at the TTGIR stage in make_ttgir (mirroring the gluon
  path) rather than make_llir, so it does not double-run for gluon kernels; the
  conversion keeps main's no-arch signature.
- Ported the priority -> s_setprio path that main's backend lacked: WarpPipeliner
  threads the optional priority from the border marker onto the stage op, and
  ConvertWarpPipeline emits ROCDL::SetPrioOp per cluster plus a post-loop reset.
  Guarded so gluon (no priority) is unaffected.
- ConvertWarpPipeline now recognizes triton::amdgpu::AsyncWaitOp as an inter-
  cluster barrier; update-async-wait-count rewrites ttg.async_wait into it before
  the conversion runs, which otherwise made the conversion bail.

The warp-pipeline GEMM tutorial follows the canonical importable matmul()
format (amd_gemm_warp_pipeline.py, no _test suffix / no __main__) and is
registered in test_correctness.py with a gfx950-gated test, matching the
Hopper/Blackwell and amd_tdm_gemm_pipelined GEMM tutorials.

Dropped from the original commit: the do-not-commit debug tutorial, the
third_party/tlx/README.md docs (file no longer exists on main), and the gluon
cdna3 mfma allow_tf32 edit (Gluon is upstream-synced / do-not-modify here).

Authored with Claude.

Co-authored-by: Lei Wang <wlei@fb.com>