### PR TITLE
[TLX][AMD] Pull updated reference gluon 1250 mxfp kernel and update TLX one to match

### DIFF
--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -30,8 +30,9 @@ def get_scale_blocked_layout(num_warps: gl.constexpr):
 
 
 @gluon.constexpr_function
-def get_wmma_layout(num_warps, packed, scale_preshuffle):
+def get_wmma_layout(num_warps, packed, scale_preshuffle, instr_m=16):
     assert (num_warps in (4, 8))
+    assert (instr_m in (16, 32))
     if scale_preshuffle:
         reg_bases = [[0, 1], [1, 0]]
         tiles_per_warp = 2
@@ -39,13 +40,12 @@ def get_wmma_layout(num_warps, packed, scale_preshuffle):
         reg_bases = []
         tiles_per_warp = 1
 
-    # [NUM_WARPS // 2, 2]
     if num_warps == 4:
         warp_bases = [[0, tiles_per_warp], [tiles_per_warp, 0]]
     else:
-        warp_bases = [[0, tiles_per_warp], [0, tiles_per_warp * 2], [tiles_per_warp, 0]]
+        warp_bases = [[0, tiles_per_warp], [tiles_per_warp, 0], [tiles_per_warp * 2, 0]]
 
-    instr_shape = [16, 16, 64] if packed else [16, 16, 128]
+    instr_shape = [instr_m, 16, 64] if packed else [instr_m, 16, 128]
 
     return gl.amd.AMDWMMALayout(3, True, warp_bases, reg_bases, instr_shape)
 
@@ -90,6 +90,7 @@ class MXFPGEMMConfig:
     BLOCK_K_SCALE_PRESHUFFLED: gl.constexpr
     SCALE_BLOCK: gl.constexpr
     ASYNC_COPY_SCALE: gl.constexpr
+    L2_PREFETCH_DISTANCE: gl.constexpr
 
     # Fused activation epilogue. For SwiGLU, BLOCK_N/N refer to
     # the packed (doubled) compute-path width. The store reduces it by 2.
@@ -97,7 +98,8 @@ class MXFPGEMMConfig:
 
     @gluon.constexpr_function
     def __init__(self, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A, DTYPE_B, SCALE_BLOCK, NUM_BUFFERS, TRANSPOSE_B, WITH_A_SCALE,
-                 SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE=False, NUM_SUBTILES=(1, 1, 1), ACTIVATION=""):
+                 SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE=False, NUM_SUBTILES=(1, 1, 1), L2_PREFETCH_DISTANCE=0,
+                 ACTIVATION=""):
         self.BLOCK_M = gl.constexpr(BLOCK_M)
         self.BLOCK_N = gl.constexpr(BLOCK_N)
         self.BLOCK_K = gl.constexpr(BLOCK_K)
@@ -114,6 +116,7 @@ class MXFPGEMMConfig:
         self.NUM_WARPS = gl.constexpr(NUM_WARPS)
         self.ASYNC_COPY_SCALE = gl.constexpr(ASYNC_COPY_SCALE)
         self.NUM_SUBTILES = gl.constexpr(NUM_SUBTILES)
+        self.L2_PREFETCH_DISTANCE = gl.constexpr(L2_PREFETCH_DISTANCE)
         self.ACTIVATION = gl.constexpr(ACTIVATION)
         if ACTIVATION == "swiglu":
             assert (BLOCK_N // NUM_SUBTILES[1]) % 2 == 0, \
@@ -131,8 +134,9 @@ class MXFPGEMMConfig:
         self.BLOCK_N_PRESHUFFLED = gl.constexpr(BLOCK_N // self.PRESHUFFLE_FACTOR)
         self.BLOCK_K_SCALE_PRESHUFFLED = gl.constexpr(BLOCK_K_SCALE * self.PRESHUFFLE_FACTOR)
 
-        WMMA_LAYOUT: gl.constexpr = get_wmma_layout(NUM_WARPS, False, SCALE_PRESHUFFLE)
-        WMMA_LAYOUT_PACKED: gl.constexpr = get_wmma_layout(NUM_WARPS, True, SCALE_PRESHUFFLE)
+        INSTR_M: gl.constexpr = 32 if (DTYPE_A == "e2m1" and DTYPE_B == "e2m1") else 16
+        WMMA_LAYOUT: gl.constexpr = get_wmma_layout(NUM_WARPS, False, SCALE_PRESHUFFLE, INSTR_M)
+        WMMA_LAYOUT_PACKED: gl.constexpr = get_wmma_layout(NUM_WARPS, True, SCALE_PRESHUFFLE, INSTR_M)
 
         self.dot_layout_a = gl.constexpr(
             gl.DotOperandLayout(operand_index=0, parent=WMMA_LAYOUT_PACKED if DTYPE_A == "e2m1" else WMMA_LAYOUT,
@@ -228,44 +232,120 @@ class MXFPGEMMProgramBase:
         pass
 
     @gluon.jit
-    def issue_loads(self, load_idx, a_buffer, b_buffer, a_scale_buffer, b_scale_buffer, pred=1, phase=None):
+    def issue_load_a_scale(self, a_scale_desc, load_idx, pred=1, phase=None):
         cfg = self.cfg
-        BLOCK_K_PACKED_A: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_A
-        BLOCK_K_PACKED_B: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_B
+        if cfg.WITH_A_SCALE:
+            # When phase is provided, derive the buffer slot from it so that loads
+            # and local_loads share the same SSA base value for index expressions,
+            # enabling membar to prove buffer-slot disjointness.
+            if phase is not None:
+                slot = phase % cfg.NUM_BUFFERS
+            else:
+                slot = load_idx % cfg.NUM_BUFFERS
+            gl.amd.gfx1250.tdm.async_load(a_scale_desc, [0, 0], self.a_scale_buffer.index(slot), pred=pred)
+            a_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(a_scale_desc,
+                                                                       add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
+        return a_scale_desc
 
-        # When phase is provided, derive the buffer slot from it so that loads
-        # and local_loads share the same SSA base value for index expressions,
-        # enabling membar to prove buffer-slot disjointness.
+    @gluon.jit
+    def issue_load_b_scale(self, b_scale_desc, load_idx, pred=1, phase=None):
+        cfg = self.cfg
         if phase is not None:
             slot = phase % cfg.NUM_BUFFERS
         else:
             slot = load_idx % cfg.NUM_BUFFERS
+        gl.amd.gfx1250.tdm.async_load(b_scale_desc, [0, 0], self.b_scale_buffer.index(slot), pred=pred)
+        b_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_scale_desc,
+                                                                   add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
+        return b_scale_desc
 
-        gl.amd.gfx1250.tdm.async_load(self.a_desc,  #
-                                      [0, load_idx * BLOCK_K_PACKED_A],  #
-                                      a_buffer.index(slot),  #
-                                      pred=pred)
-        if cfg.TRANSPOSE_B:
-            gl.amd.gfx1250.tdm.async_load(self.b_desc,  #
-                                          [0, load_idx * BLOCK_K_PACKED_B],  #
-                                          b_buffer.index(slot),  #
-                                          pred=pred)
+    @gluon.jit
+    def issue_load_a_data(self, a_desc, load_idx, pred=1, phase=None):
+        cfg = self.cfg
+        BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_A
+        if phase is not None:
+            slot = phase % cfg.NUM_BUFFERS
         else:
-            gl.amd.gfx1250.tdm.async_load(self.b_desc,  #
-                                          [load_idx * BLOCK_K_PACKED_B, 0],  #
-                                          b_buffer.index(slot),  #
-                                          pred=pred)
-        if cfg.WITH_A_SCALE:
-            gl.amd.gfx1250.tdm.async_load(self.a_scale_desc,  #
-                                          [0, load_idx * cfg.BLOCK_K_SCALE_PRESHUFFLED],  #
-                                          a_scale_buffer.index(slot),  #
-                                          pred=pred)
-        gl.amd.gfx1250.tdm.async_load(self.b_scale_desc,  #
-                                      [0, load_idx * cfg.BLOCK_K_SCALE_PRESHUFFLED],  #
-                                      b_scale_buffer.index(slot),  #
-                                      pred=pred)
+            slot = load_idx % cfg.NUM_BUFFERS
+        gl.amd.gfx1250.tdm.async_load(a_desc, [0, 0], self.a_buffer.index(slot), pred=pred)
+        return gl.amd.gfx1250.tdm.update_tensor_descriptor(a_desc, add_offsets=[0, BLOCK_K])
 
-        return load_idx + 1
+    @gluon.jit
+    def issue_load_b_data(self, b_desc, load_idx, pred=1, phase=None):
+        cfg = self.cfg
+        BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_B
+        if phase is not None:
+            slot = phase % cfg.NUM_BUFFERS
+        else:
+            slot = load_idx % cfg.NUM_BUFFERS
+        gl.amd.gfx1250.tdm.async_load(b_desc, [0, 0], self.b_buffer.index(slot), pred=pred)
+        if cfg.TRANSPOSE_B:
+            b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[0, BLOCK_K])
+        else:
+            b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[BLOCK_K, 0])
+        return b_desc
+
+    @gluon.jit
+    def issue_l2_prefetch_a(self, distance: gl.constexpr, load_idx, pred=True):
+        cfg = self.cfg
+        if distance < 0:
+            return
+
+        prefetch_iteration = load_idx + distance
+        BLOCK_K_PACKED_A: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_A
+        gl.amd.gfx1250.tdm.prefetch(self.a_desc, [0, prefetch_iteration * BLOCK_K_PACKED_A], pred=pred)
+
+    @gluon.jit
+    def issue_l2_prefetch_b(self, distance: gl.constexpr, load_idx, pred=True):
+        cfg = self.cfg
+        if distance < 0:
+            return
+
+        prefetch_iteration = load_idx + distance
+        BLOCK_K_PACKED_B: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_B
+        if cfg.TRANSPOSE_B:
+            gl.amd.gfx1250.tdm.prefetch(self.b_desc, [0, prefetch_iteration * BLOCK_K_PACKED_B], pred=pred)
+        else:
+            gl.amd.gfx1250.tdm.prefetch(self.b_desc, [prefetch_iteration * BLOCK_K_PACKED_B, 0], pred=pred)
+
+    @gluon.jit
+    def issue_l2_prefetch_a_scale(self, distance: gl.constexpr, load_idx, pred=True):
+        cfg = self.cfg
+        if distance < 0:
+            return
+
+        if not cfg.ASYNC_COPY_SCALE:
+            if cfg.WITH_A_SCALE:
+                prefetch_iteration = load_idx + distance
+                gl.amd.gfx1250.tdm.prefetch(self.a_scale_desc, [0, prefetch_iteration * cfg.BLOCK_K_SCALE_PRESHUFFLED],
+                                            pred=pred)
+
+    @gluon.jit
+    def issue_l2_prefetch_b_scale(self, distance: gl.constexpr, load_idx, pred=True):
+        cfg = self.cfg
+        if distance < 0:
+            return
+
+        if not cfg.ASYNC_COPY_SCALE:
+            prefetch_iteration = load_idx + distance
+            gl.amd.gfx1250.tdm.prefetch(self.b_scale_desc, [0, prefetch_iteration * cfg.BLOCK_K_SCALE_PRESHUFFLED],
+                                        pred=pred)
+
+    @gluon.jit
+    def issue_l2_prefetches(self, distance: gl.constexpr, load_idx, pred=True):
+        self.issue_l2_prefetch_a_scale(distance, load_idx, pred=pred)
+        self.issue_l2_prefetch_b_scale(distance, load_idx, pred=pred)
+        self.issue_l2_prefetch_a(distance, load_idx, pred=pred)
+        self.issue_l2_prefetch_b(distance, load_idx, pred=pred)
+
+    @gluon.jit
+    def issue_l2_prefetches_prologue(self, load_idx):
+        cfg = self.cfg
+        L2_PREFETCH_DISTANCE: gl.constexpr = cfg.L2_PREFETCH_DISTANCE
+        NUM_BUFFERS: gl.constexpr = cfg.NUM_BUFFERS
+
+        for i in gl.static_range(NUM_BUFFERS, NUM_BUFFERS + L2_PREFETCH_DISTANCE):
+            self.issue_l2_prefetches(i, load_idx)
 
     @gluon.jit
     def issue_local_loads(self, wmma_idx, a_buffer, b_buffer, a_scale_buffer, b_scale_buffer):
@@ -384,10 +464,21 @@ class MXFPGEMMPipelinedProgram:
         load_idx = 0
         wmma_idx = 0
 
+        self.issue_l2_prefetches_prologue(load_idx)
+
+        a_desc = self.a_desc
+        b_desc = self.b_desc
+        a_scale_desc = self.a_scale_desc
+        b_scale_desc = self.b_scale_desc
+
         # prologue
         for _ in gl.static_range(cfg.NUM_BUFFERS - 1):
-            load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                        self.b_scale_buffer)
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+            a_desc = self.issue_load_a_data(a_desc, load_idx)
+            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            load_idx = load_idx + 1
 
         accumulator = gl.zeros((cfg.BLOCK_M, cfg.BLOCK_N), dtype=gl.float32, layout=self.cfg.acc_layout)
         loop_ub = gl.cdiv(K, cfg.BLOCK_K)
@@ -396,8 +487,14 @@ class MXFPGEMMPipelinedProgram:
         for i in range(0, loop_ub):
             pred = i - epilogue_lb
             pred = (pred >> 31) & 1
-            load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                        self.b_scale_buffer, pred=pred, phase=wmma_idx + cfg.NUM_BUFFERS - 1)
+            phase = wmma_idx + cfg.NUM_BUFFERS - 1
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx, pred=pred, phase=phase)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx, pred=pred, phase=phase)
+            a_desc = self.issue_load_a_data(a_desc, load_idx, pred=pred, phase=phase)
+            b_desc = self.issue_load_b_data(b_desc, load_idx, pred=pred, phase=phase)
+            self.issue_l2_prefetches(cfg.L2_PREFETCH_DISTANCE, load_idx)
+            load_idx = load_idx + 1
 
             gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 1) * self.cfg.NUM_LOADS_IN_BATCH)
 
@@ -414,10 +511,21 @@ class MXFPGEMMPipelinedProgram:
         load_idx = 0
         wmma_idx = 0
 
+        self.issue_l2_prefetches_prologue(load_idx)
+
+        a_desc = self.a_desc
+        b_desc = self.b_desc
+        a_scale_desc = self.a_scale_desc
+        b_scale_desc = self.b_scale_desc
+
         # prologue
         for _ in gl.static_range(cfg.NUM_BUFFERS - 1):
-            load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                        self.b_scale_buffer)
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+            a_desc = self.issue_load_a_data(a_desc, load_idx)
+            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            load_idx = load_idx + 1
 
         accumulator = gl.zeros((cfg.BLOCK_M, cfg.BLOCK_N), dtype=gl.float32, layout=self.cfg.acc_layout)
         loop_ub = gl.cdiv(K, cfg.BLOCK_K) - (cfg.NUM_BUFFERS - 1)
@@ -428,11 +536,17 @@ class MXFPGEMMPipelinedProgram:
                 a, b, scale_a, scale_b = self.issue_local_loads(wmma_idx, self.a_buffer, self.b_buffer,
                                                                 self.a_scale_buffer, self.b_scale_buffer)
                 wmma_idx += 1
-                load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                            self.b_scale_buffer, phase=wmma_idx + cfg.NUM_BUFFERS - 2)
+                phase = wmma_idx + cfg.NUM_BUFFERS - 2
+                if cfg.WITH_A_SCALE:
+                    a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx, phase=phase)
+                b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx, phase=phase)
+                a_desc = self.issue_load_a_data(a_desc, load_idx, phase=phase)
+                b_desc = self.issue_load_b_data(b_desc, load_idx, phase=phase)
 
             gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 2) * self.cfg.NUM_LOADS_IN_BATCH)
             with gl.amd.warp_pipeline_stage("wmma", priority=0):
+                self.issue_l2_prefetches(cfg.L2_PREFETCH_DISTANCE, load_idx)
+                load_idx = load_idx + 1
                 accumulator = gl.amd.gfx1250.wmma_scaled(a, scale_a, cfg.DTYPE_A, b, scale_b, cfg.DTYPE_B, accumulator)
 
         # epilogue
@@ -562,64 +676,60 @@ class MXFPGEMMSliceKProgram:
         load_idx = 0
         wmma_idx = 0
 
-        # prologue
-        # iter 0
-        load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer, self.b_scale_buffer)
+        self.issue_l2_prefetches_prologue(load_idx)
 
-        # iter 1
-        load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer, self.b_scale_buffer)
-        # iter 0
-        gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 1) * cfg.NUM_LOADS_IN_BATCH)
+        a_desc = self.a_desc
+        b_desc = self.b_desc
+        a_scale_desc = self.a_scale_desc
+        b_scale_desc = self.b_scale_desc
+
+        for _ in gl.static_range(cfg.NUM_BUFFERS - 1):
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+            a_desc = self.issue_load_a_data(a_desc, load_idx)
+            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            load_idx = load_idx + 1
+
+        gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 2) * cfg.NUM_LOADS_IN_BATCH)
         a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
                                                                     self.a_scale_buffer, self.b_scale_buffer)
 
         accumulator = gl.zeros((cfg.BLOCK_M, cfg.BLOCK_N), dtype=gl.float32, layout=self.cfg.acc_layout)
-        loop_ub = gl.cdiv(K, cfg.BLOCK_K) - 1
-        for _ in range(0, loop_ub - 1):
+        main_iters = gl.cdiv(K, cfg.BLOCK_K) - (cfg.NUM_BUFFERS - 1)
+        gl.assume(main_iters >= 0)
+        for _ in range(0, main_iters):
             # iter i
             accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
 
-            # iter i
             a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
                                                                         self.a_scale_buffer, self.b_scale_buffer)
             wmma_idx += 1
 
-            # iter i + 2
-            load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                        self.b_scale_buffer, phase=wmma_idx + cfg.NUM_BUFFERS - 2)
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+            a_desc = self.issue_load_a_data(a_desc, load_idx)
+            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            self.issue_l2_prefetches(cfg.L2_PREFETCH_DISTANCE, load_idx)
+            load_idx = load_idx + 1
 
-            # iter i
             accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
 
-            # iter i + 1
-            gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 1) * cfg.NUM_LOADS_IN_BATCH)
+            gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 2) * cfg.NUM_LOADS_IN_BATCH)
             a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
                                                                         self.a_scale_buffer, self.b_scale_buffer)
 
-        # epilogue
-        # iter end - 2
-        accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
-
-        # iter end - 2
-        a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        wmma_idx += 1
-
-        # iter end - 2
-        accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
-        # iter end - 1
-        gl.amd.gfx1250.tdm.async_wait(0)
-        a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        # iter end - 1
-        accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
-
-        # iter end - 1
-        a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        wmma_idx += 1
-
-        accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
+        for i in gl.static_range(cfg.NUM_BUFFERS - 1):
+            if i > 0:
+                gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 2 - i) * cfg.NUM_LOADS_IN_BATCH)
+                a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
+                                                                            self.a_scale_buffer, self.b_scale_buffer)
+            accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
+            a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
+                                                                        self.a_scale_buffer, self.b_scale_buffer)
+            wmma_idx += 1
+            accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
 
         apply_activation_and_store(self.cfg, accumulator, self.c_ptr, self.c_offs, self.c_mask)
 
@@ -630,10 +740,21 @@ class MXFPGEMMSliceKProgram:
         wmma_idx = 0
         gl.static_assert(cfg.NUM_BUFFERS == 3)
 
+        self.issue_l2_prefetches_prologue(load_idx)
+
+        a_desc = self.a_desc
+        b_desc = self.b_desc
+        a_scale_desc = self.a_scale_desc
+        b_scale_desc = self.b_scale_desc
+
         # prologue
         for _ in gl.static_range(cfg.NUM_BUFFERS - 1):
-            load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                        self.b_scale_buffer)
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+            a_desc = self.issue_load_a_data(a_desc, load_idx)
+            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            load_idx = load_idx + 1
 
         accumulator = gl.zeros((cfg.BLOCK_M, cfg.BLOCK_N), dtype=gl.float32, layout=self.cfg.acc_layout)
         loop_ub = gl.cdiv(K, cfg.BLOCK_K) - (cfg.NUM_BUFFERS - 1)
@@ -647,8 +768,14 @@ class MXFPGEMMSliceKProgram:
 
             gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 3) * self.cfg.NUM_LOADS_IN_BATCH)
             with gl.amd.warp_pipeline_stage("tdm+wmma+lds1", priority=0):
-                load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                            self.b_scale_buffer, phase=wmma_idx + cfg.NUM_BUFFERS - 1)
+                phase = wmma_idx + cfg.NUM_BUFFERS - 1
+                if cfg.WITH_A_SCALE:
+                    a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx, phase=phase)
+                b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx, phase=phase)
+                a_desc = self.issue_load_a_data(a_desc, load_idx, phase=phase)
+                b_desc = self.issue_load_b_data(b_desc, load_idx, phase=phase)
+                self.issue_l2_prefetches(cfg.L2_PREFETCH_DISTANCE, load_idx)
+                load_idx = load_idx + 1
                 accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B,
                                                          accumulator)
                 a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
@@ -672,8 +799,11 @@ class MXFPGEMMSliceKProgram:
         apply_activation_and_store(self.cfg, accumulator, self.c_ptr, self.c_offs, self.c_mask)
 
 
+@composition
 @gluon.aggregate
 class MXFPGEMMSliceNKProgram:
+    base: MXFPGEMMProgramBase
+
     cfg: MXFPGEMMConfig
     a_buffer: gl.shared_memory_descriptor
     b_buffer: gl.shared_memory_descriptor
@@ -711,6 +841,8 @@ class MXFPGEMMSliceNKProgram:
         self.c_ptr = c_ptr
         self.c_offs = c_offs
         self.c_mask = c_mask
+
+        self.base = MXFPGEMMProgramBase()
 
     @gluon.jit
     def initialize(cfg: MXFPGEMMConfig, a_desc, b_desc, a_scale_desc, b_scale_desc, c_ptr, c_offs, c_mask):
@@ -793,47 +925,53 @@ class MXFPGEMMSliceNKProgram:
         return b, scale_b
 
     @gluon.jit
-    def issue_load_a(self, load_idx, a_buffer, a_scale_buffer, pred=1):
+    def issue_load_a_scale(self, a_scale_desc, load_idx, pred=1):
         cfg = self.cfg
-        BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_A
-        gl.amd.gfx1250.tdm.async_load(self.a_desc,  #
-                                      [0, load_idx * BLOCK_K],  #
-                                      a_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
-                                      pred=pred)
         if cfg.WITH_A_SCALE:
-            a_scale_buffer_slice = a_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
+            a_scale_buffer_slice = self.a_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
             if cfg.ASYNC_COPY_SCALE:
-                self.a_scale_desc.issue_async_load(load_idx, a_scale_buffer_slice, pred=pred)
+                a_scale_desc.issue_async_load(load_idx, a_scale_buffer_slice, pred=pred)
             else:
-                gl.amd.gfx1250.tdm.async_load(self.a_scale_desc,  #
-                                              [0, load_idx * cfg.BLOCK_K_SCALE_PRESHUFFLED],  #
-                                              a_scale_buffer_slice,  #
-                                              pred=pred)
-        return load_idx + 1
+                gl.amd.gfx1250.tdm.async_load(a_scale_desc, [0, 0],  #
+                                              a_scale_buffer_slice, pred=pred)
+                a_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
+                    a_scale_desc, add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
+        return a_scale_desc
 
     @gluon.jit
-    def issue_load_b(self, load_idx, b_buffer, b_scale_buffer, pred=1):
+    def issue_load_a_data(self, a_desc, load_idx, pred=1):
+        cfg = self.cfg
+        BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_A
+        gl.amd.gfx1250.tdm.async_load(a_desc, [0, 0],  #
+                                      self.a_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
+                                      pred=pred)
+        return gl.amd.gfx1250.tdm.update_tensor_descriptor(a_desc, add_offsets=[0, BLOCK_K])
+
+    @gluon.jit
+    def issue_load_b_scale(self, b_scale_desc, load_idx, pred=1):
+        cfg = self.cfg
+        b_scale_buffer_slice = self.b_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
+        if cfg.ASYNC_COPY_SCALE:
+            b_scale_desc.issue_async_load(load_idx, b_scale_buffer_slice, pred=pred)
+        else:
+            gl.amd.gfx1250.tdm.async_load(b_scale_desc, [0, 0],  #
+                                          b_scale_buffer_slice, pred=pred)
+            b_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_scale_desc,
+                                                                       add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
+        return b_scale_desc
+
+    @gluon.jit
+    def issue_load_b_data(self, b_desc, load_idx, pred=1):
         cfg = self.cfg
         BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_B
+        gl.amd.gfx1250.tdm.async_load(b_desc, [0, 0],  #
+                                      self.b_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
+                                      pred=pred)
         if cfg.TRANSPOSE_B:
-            gl.amd.gfx1250.tdm.async_load(self.b_desc,  #
-                                          [0, load_idx * BLOCK_K],  #
-                                          b_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
-                                          pred=pred)
+            b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[0, BLOCK_K])
         else:
-            gl.amd.gfx1250.tdm.async_load(self.b_desc,  #
-                                          [load_idx * BLOCK_K, 0],  #
-                                          b_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
-                                          pred=pred)
-        b_scale_buffer_slice = b_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
-        if cfg.ASYNC_COPY_SCALE:
-            self.b_scale_desc.issue_async_load(load_idx, b_scale_buffer_slice, pred=pred)
-        else:
-            gl.amd.gfx1250.tdm.async_load(self.b_scale_desc,  #
-                                          [0, load_idx * cfg.BLOCK_K_SCALE_PRESHUFFLED],  #
-                                          b_scale_buffer_slice,  #
-                                          pred=pred)
-        return load_idx + 1
+            b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[BLOCK_K, 0])
+        return b_desc
 
     @gluon.jit
     def async_wait(self, waitcnt: int):
@@ -847,38 +985,48 @@ class MXFPGEMMSliceNKProgram:
     @gluon.jit
     def pipeline(self, K):
         cfg = self.cfg
-        load_a_idx = 0
-        load_b_idx = 0
+        load_idx = 0
         wmma_idx = 0
 
-        # prologue
-        # iter 0
-        load_a_idx = self.issue_load_a(load_a_idx, self.a_buffer, self.a_scale_buffer)
-        load_b_idx = self.issue_load_b(load_b_idx, self.b_buffer, self.b_scale_buffer)
+        a_desc = self.a_desc
+        b_desc = self.b_desc
+        a_scale_desc = self.a_scale_desc
+        b_scale_desc = self.b_scale_desc
 
-        self.async_wait(0)
+        for _ in gl.static_range(cfg.NUM_BUFFERS - 1):
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+            a_desc = self.issue_load_a_data(a_desc, load_idx)
+            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            load_idx = load_idx + 1
+
+        self.async_wait((cfg.NUM_BUFFERS - 2) * 2)
         a0, scale_a0 = self.issue_local_load_a(wmma_idx, 0, self.a_buffer, self.a_scale_buffer)
         b00, scale_b00 = self.issue_local_load_b(wmma_idx, 0, 0, self.b_buffer, self.b_scale_buffer)
+
+        if cfg.WITH_A_SCALE:
+            a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+        b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+        a_desc = self.issue_load_a_data(a_desc, load_idx)
+        b_desc = self.issue_load_b_data(b_desc, load_idx)
 
         c0 = gl.zeros((cfg.BLOCK_M // cfg.NUM_SUBTILES[0], cfg.BLOCK_N // cfg.NUM_SUBTILES[1]), dtype=gl.float32,
                       layout=cfg.acc_layout)
         c1 = gl.zeros((cfg.BLOCK_M // cfg.NUM_SUBTILES[0], cfg.BLOCK_N // cfg.NUM_SUBTILES[1]), dtype=gl.float32,
                       layout=cfg.acc_layout)
-
         loop_ub = gl.cdiv(K, cfg.BLOCK_K)
         epilogue_lb = loop_ub - (cfg.NUM_BUFFERS - 1)
-        gl.assume(loop_ub > 0)
+        gl.assume(loop_ub >= cfg.NUM_BUFFERS)
         for i in range(0, loop_ub):
-            pred = i - epilogue_lb
-            pred = (pred >> 31) & 1
-
-            # iter i + 1
-            load_a_idx = self.issue_load_a(load_a_idx, self.a_buffer, self.a_scale_buffer, pred=pred)
-            load_b_idx = self.issue_load_b(load_b_idx, self.b_buffer, self.b_scale_buffer, pred=pred)
-
             # iter i
             c0 = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b00, scale_b00, cfg.DTYPE_B, c0)
             b01, scale_b01 = self.issue_local_load_b(wmma_idx, 0, 1, self.b_buffer, self.b_scale_buffer)
+
+            pred_prefetch = i - epilogue_lb
+            pred_prefetch = ((pred_prefetch >> 31) & 1).to(gl.int1)
+            self.issue_l2_prefetches(cfg.L2_PREFETCH_DISTANCE, load_idx, pred=pred_prefetch)
+            load_idx = load_idx + 1
 
             # iter i
             c1 = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b01, scale_b01, cfg.DTYPE_B, c1)
@@ -893,14 +1041,298 @@ class MXFPGEMMSliceNKProgram:
             wmma_idx += 1
             c1 = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b11, scale_b11, cfg.DTYPE_B, c1)
 
-            # iter i + 1
+            # iter i + NUM_BUFFERS - 1
+            pred_load = i + 1 - epilogue_lb
+            pred_load = (pred_load >> 31) & 1
             self.async_wait(0)
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx, pred=pred_load)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx, pred=pred_load)
+            a_desc = self.issue_load_a_data(a_desc, load_idx, pred=pred_load)
+            b_desc = self.issue_load_b_data(b_desc, load_idx, pred=pred_load)
+
             a0, scale_a0 = self.issue_local_load_a(wmma_idx, 0, self.a_buffer, self.a_scale_buffer)
             b00, scale_b00 = self.issue_local_load_b(wmma_idx, 0, 0, self.b_buffer, self.b_scale_buffer)
 
         accumulator = gl.join(c0, c1)
         accumulator = accumulator.permute(0, 2, 1).reshape((cfg.BLOCK_M, cfg.BLOCK_N))
         accumulator = gl.convert_layout(accumulator, cfg.acc_layout, assert_trivial=True)
+
+        apply_activation_and_store(self.cfg, accumulator, self.c_ptr, self.c_offs, self.c_mask)
+
+
+@composition
+@gluon.aggregate
+class MXFPGEMMSliceMNKProgram:
+    base: MXFPGEMMProgramBase
+
+    cfg: MXFPGEMMConfig
+    a_buffer: gl.shared_memory_descriptor
+    b_buffer: gl.shared_memory_descriptor
+    a_scale_buffer: gl.shared_memory_descriptor | gl.constexpr
+    b_scale_buffer: gl.shared_memory_descriptor
+
+    a_desc: tdm.tensor_descriptor
+    b_desc: tdm.tensor_descriptor
+    a_scale_desc: tdm.tensor_descriptor | ScaleAsyncCopyDescriptor | gl.constexpr
+    b_scale_desc: tdm.tensor_descriptor | ScaleAsyncCopyDescriptor
+
+    c_ptr: gl.tensor
+    c_offs: gl.tensor
+    c_mask: gl.tensor
+
+    @gluon.constexpr_function
+    def __init__(self, cfg: MXFPGEMMConfig, a_buffer, b_buffer, a_scale_buffer, b_scale_buffer, a_desc, b_desc,
+                 a_scale_desc, b_scale_desc, c_ptr, c_offs, c_mask):
+        self.cfg = cfg
+        self.a_buffer = a_buffer
+        self.b_buffer = b_buffer
+        if cfg.WITH_A_SCALE:
+            self.a_scale_buffer = a_scale_buffer
+        else:
+            self.a_scale_buffer = gl.constexpr(a_scale_buffer)
+
+        self.b_scale_buffer = b_scale_buffer
+        self.a_desc = a_desc
+        self.b_desc = b_desc
+        if cfg.WITH_A_SCALE:
+            self.a_scale_desc = a_scale_desc
+        else:
+            self.a_scale_desc = gl.constexpr(a_scale_desc)
+        self.b_scale_desc = b_scale_desc
+        self.c_ptr = c_ptr
+        self.c_offs = c_offs
+        self.c_mask = c_mask
+
+        self.base = MXFPGEMMProgramBase()
+
+    @gluon.jit
+    def initialize(cfg: MXFPGEMMConfig, a_desc, b_desc, a_scale_desc, b_scale_desc, c_ptr, c_offs, c_mask):
+        NUM_BUFFERS: gl.constexpr = cfg.NUM_BUFFERS
+        a_buffer = gl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape,
+                                             layout=a_desc.layout)
+        b_buffer = gl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape,
+                                             layout=b_desc.layout)
+        if cfg.WITH_A_SCALE:
+            a_scale_buffer = gl.allocate_shared_memory(a_scale_desc.dtype,
+                                                       shape=[NUM_BUFFERS] + a_scale_desc.block_shape,
+                                                       layout=a_scale_desc.layout)
+        else:
+            a_scale_buffer = gl.constexpr(0)
+
+        b_scale_buffer = gl.allocate_shared_memory(b_scale_desc.dtype, shape=[NUM_BUFFERS] + b_scale_desc.block_shape,
+                                                   layout=b_scale_desc.layout)
+
+        return MXFPGEMMSliceMNKProgram(cfg, a_buffer, b_buffer, a_scale_buffer, b_scale_buffer, a_desc, b_desc,
+                                       a_scale_desc, b_scale_desc, c_ptr, c_offs, c_mask)
+
+    @gluon.jit
+    def issue_local_load_a(self, wmma_idx, subtile_start_idx_m: gl.constexpr, subtile_start_idx_k: gl.constexpr,
+                           a_buffer, a_scale_buffer):
+        cfg = self.cfg
+        NUM_SUBTILES_M: gl.constexpr = cfg.NUM_SUBTILES[0]
+        NUM_SUBTILES_K: gl.constexpr = cfg.NUM_SUBTILES[2]
+        SUBTILE_LEN_M: gl.constexpr = cfg.BLOCK_M // NUM_SUBTILES_M
+        SUBTILE_LEN_K: gl.constexpr = cfg.BLOCK_K // NUM_SUBTILES_K
+        BLOCK_K_SCALE: gl.constexpr = cfg.BLOCK_K // cfg.SCALE_BLOCK
+        subtile_start_m: gl.constexpr = subtile_start_idx_m * SUBTILE_LEN_M
+        subtile_start_k: gl.constexpr = subtile_start_idx_k * SUBTILE_LEN_K
+        a = a_buffer.index(wmma_idx % cfg.NUM_BUFFERS).slice(subtile_start_m, SUBTILE_LEN_M, 0) \
+            .slice(subtile_start_k // cfg.DIV_FACTOR_A, SUBTILE_LEN_K // cfg.DIV_FACTOR_A, 1) \
+            .load(layout=cfg.dot_layout_a)
+        if cfg.WITH_A_SCALE:
+            a_scale_buffer_slice = a_scale_buffer.index(wmma_idx % cfg.NUM_BUFFERS)
+            if cfg.SCALE_PRESHUFFLE:
+                a_scale_buffer_slice = a_scale_buffer_slice.reshape((
+                    cfg.BLOCK_M_PRESHUFFLED,  #
+                    BLOCK_K_SCALE // cfg.SCALE_KWIDTH,  #
+                    cfg.PRESHUFFLE_FACTOR // 4,  #
+                    4,  #
+                    cfg.SCALE_KWIDTH)).permute((0, 3, 2, 1, 4)).reshape((cfg.BLOCK_M, BLOCK_K_SCALE))
+            a_scale_buffer_slice = a_scale_buffer_slice.slice(subtile_start_m, SUBTILE_LEN_M, 0) \
+                .slice(subtile_start_k // cfg.SCALE_BLOCK, SUBTILE_LEN_K // cfg.SCALE_BLOCK, 1)
+            scale_a = a_scale_buffer_slice.load(layout=cfg.layout_a_scale)
+        else:
+            scale_a = 0
+            scale_a = scale_a.to(gl.uint8)
+        return a, scale_a
+
+    @gluon.jit
+    def issue_local_load_b(self, wmma_idx, subtile_start_idx_k: gl.constexpr, subtile_start_idx_n: gl.constexpr,
+                           b_buffer, b_scale_buffer):
+        cfg = self.cfg
+        NUM_SUBTILES_N: gl.constexpr = cfg.NUM_SUBTILES[1]
+        NUM_SUBTILES_K: gl.constexpr = cfg.NUM_SUBTILES[2]
+        SUBTILE_LEN_K: gl.constexpr = cfg.BLOCK_K // NUM_SUBTILES_K
+        SUBTILE_LEN_N: gl.constexpr = cfg.BLOCK_N // NUM_SUBTILES_N
+        BLOCK_K_SCALE: gl.constexpr = cfg.BLOCK_K // cfg.SCALE_BLOCK
+        subtile_start_k: gl.constexpr = subtile_start_idx_k * SUBTILE_LEN_K
+        subtile_start_n: gl.constexpr = subtile_start_idx_n * SUBTILE_LEN_N
+        if cfg.TRANSPOSE_B:
+            b = b_buffer.index(wmma_idx % cfg.NUM_BUFFERS).slice(subtile_start_n, SUBTILE_LEN_N, 0) \
+            .slice(subtile_start_k // cfg.DIV_FACTOR_B, SUBTILE_LEN_K // cfg.DIV_FACTOR_B, 1) \
+            .permute([1, 0]).load(layout=cfg.dot_layout_b)
+        else:
+            b = b_buffer.index(wmma_idx % cfg.NUM_BUFFERS).slice(subtile_start_k // cfg.DIV_FACTOR_B,
+                                                                 SUBTILE_LEN_K // cfg.DIV_FACTOR_B, 0) \
+            .slice(subtile_start_n, SUBTILE_LEN_N, 1) \
+            .load(layout=cfg.dot_layout_b)
+        b_scale_buffer_slice = b_scale_buffer.index(wmma_idx % cfg.NUM_BUFFERS)
+        if cfg.SCALE_PRESHUFFLE:
+            b_scale_buffer_slice = b_scale_buffer_slice.reshape((
+                cfg.BLOCK_N_PRESHUFFLED,  #
+                BLOCK_K_SCALE // cfg.SCALE_KWIDTH,  #
+                cfg.PRESHUFFLE_FACTOR // 4,  #
+                4,  #
+                cfg.SCALE_KWIDTH)).permute((0, 3, 2, 1, 4)).reshape((cfg.BLOCK_N, BLOCK_K_SCALE))
+        b_scale_buffer_slice = b_scale_buffer_slice.slice(subtile_start_n, SUBTILE_LEN_N, 0) \
+            .slice(subtile_start_k // cfg.SCALE_BLOCK, SUBTILE_LEN_K // cfg.SCALE_BLOCK, 1)
+        scale_b = b_scale_buffer_slice.load(layout=cfg.layout_b_scale)
+        return b, scale_b
+
+    @gluon.jit
+    def issue_load_a_scale(self, a_scale_desc, load_idx, pred=1):
+        cfg = self.cfg
+        if cfg.WITH_A_SCALE:
+            a_scale_buffer_slice = self.a_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
+            if cfg.ASYNC_COPY_SCALE:
+                a_scale_desc.issue_async_load(load_idx, a_scale_buffer_slice, pred=pred)
+            else:
+                gl.amd.gfx1250.tdm.async_load(a_scale_desc, [0, 0],  #
+                                              a_scale_buffer_slice, pred=pred)
+                a_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
+                    a_scale_desc, add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
+        return a_scale_desc
+
+    @gluon.jit
+    def issue_load_a_data(self, a_desc, load_idx, pred=1):
+        cfg = self.cfg
+        BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_A
+        gl.amd.gfx1250.tdm.async_load(a_desc, [0, 0],  #
+                                      self.a_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
+                                      pred=pred)
+        return gl.amd.gfx1250.tdm.update_tensor_descriptor(a_desc, add_offsets=[0, BLOCK_K])
+
+    @gluon.jit
+    def issue_load_b_scale(self, b_scale_desc, load_idx, pred=1):
+        cfg = self.cfg
+        b_scale_buffer_slice = self.b_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
+        if cfg.ASYNC_COPY_SCALE:
+            b_scale_desc.issue_async_load(load_idx, b_scale_buffer_slice, pred=pred)
+        else:
+            gl.amd.gfx1250.tdm.async_load(b_scale_desc, [0, 0],  #
+                                          b_scale_buffer_slice, pred=pred)
+            b_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_scale_desc,
+                                                                       add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
+        return b_scale_desc
+
+    @gluon.jit
+    def issue_load_b_data(self, b_desc, load_idx, pred=1):
+        cfg = self.cfg
+        BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_B
+        gl.amd.gfx1250.tdm.async_load(b_desc, [0, 0],  #
+                                      self.b_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
+                                      pred=pred)
+        if cfg.TRANSPOSE_B:
+            b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[0, BLOCK_K])
+        else:
+            b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[BLOCK_K, 0])
+        return b_desc
+
+    @gluon.jit
+    def async_wait(self, waitcnt: int):
+        cfg = self.cfg
+        if cfg.ASYNC_COPY_SCALE:
+            gl.amd.gfx1250.tdm.async_wait(waitcnt)
+            cp.wait_group(waitcnt if cfg.WITH_A_SCALE else (waitcnt // 2))
+        else:
+            gl.amd.gfx1250.tdm.async_wait((waitcnt * 2) if cfg.WITH_A_SCALE else (waitcnt + waitcnt // 2))
+
+    @gluon.jit
+    def pipeline(self, K):
+        cfg = self.cfg
+        load_idx = 0
+        wmma_idx = 0
+
+        a_desc = self.a_desc
+        b_desc = self.b_desc
+        a_scale_desc = self.a_scale_desc
+        b_scale_desc = self.b_scale_desc
+
+        for _ in gl.static_range(cfg.NUM_BUFFERS - 1):
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+            a_desc = self.issue_load_a_data(a_desc, load_idx)
+            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            load_idx = load_idx + 1
+
+        self.async_wait((cfg.NUM_BUFFERS - 2) * 2)
+        a00, scale_a00 = self.issue_local_load_a(wmma_idx, 0, 0, self.a_buffer, self.a_scale_buffer)
+        b00, scale_b00 = self.issue_local_load_b(wmma_idx, 0, 0, self.b_buffer, self.b_scale_buffer)
+
+        if cfg.WITH_A_SCALE:
+            a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
+        b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
+        a_desc = self.issue_load_a_data(a_desc, load_idx)
+        b_desc = self.issue_load_b_data(b_desc, load_idx)
+
+        SUBTILE_M: gl.constexpr = cfg.BLOCK_M // cfg.NUM_SUBTILES[0]
+        SUBTILE_N: gl.constexpr = cfg.BLOCK_N // cfg.NUM_SUBTILES[1]
+        c00 = gl.zeros((SUBTILE_M, SUBTILE_N), dtype=gl.float32, layout=cfg.acc_layout)
+        c01 = gl.zeros((SUBTILE_M, SUBTILE_N), dtype=gl.float32, layout=cfg.acc_layout)
+        c10 = gl.zeros((SUBTILE_M, SUBTILE_N), dtype=gl.float32, layout=cfg.acc_layout)
+        c11 = gl.zeros((SUBTILE_M, SUBTILE_N), dtype=gl.float32, layout=cfg.acc_layout)
+
+        loop_ub = gl.cdiv(K, cfg.BLOCK_K)
+        epilogue_lb = loop_ub - (cfg.NUM_BUFFERS - 1)
+        gl.assume(loop_ub >= cfg.NUM_BUFFERS)
+        for i in range(0, loop_ub):
+            c00 = gl.amd.gfx1250.wmma_scaled(a00, scale_a00, cfg.DTYPE_A, b00, scale_b00, cfg.DTYPE_B, c00)
+            b01, scale_b01 = self.issue_local_load_b(wmma_idx, 0, 1, self.b_buffer, self.b_scale_buffer)
+
+            pred_prefetch = i - epilogue_lb
+            pred_prefetch = ((pred_prefetch >> 31) & 1).to(gl.int1)
+            self.issue_l2_prefetches(cfg.L2_PREFETCH_DISTANCE, load_idx, pred=pred_prefetch)
+            load_idx = load_idx + 1
+
+            c01 = gl.amd.gfx1250.wmma_scaled(a00, scale_a00, cfg.DTYPE_A, b01, scale_b01, cfg.DTYPE_B, c01)
+            a10, scale_a10 = self.issue_local_load_a(wmma_idx, 1, 0, self.a_buffer, self.a_scale_buffer)
+
+            c10 = gl.amd.gfx1250.wmma_scaled(a10, scale_a10, cfg.DTYPE_A, b00, scale_b00, cfg.DTYPE_B, c10)
+            b10, scale_b10 = self.issue_local_load_b(wmma_idx, 1, 0, self.b_buffer, self.b_scale_buffer)
+
+            c11 = gl.amd.gfx1250.wmma_scaled(a10, scale_a10, cfg.DTYPE_A, b01, scale_b01, cfg.DTYPE_B, c11)
+            a01, scale_a01 = self.issue_local_load_a(wmma_idx, 0, 1, self.a_buffer, self.a_scale_buffer)
+
+            c00 = gl.amd.gfx1250.wmma_scaled(a01, scale_a01, cfg.DTYPE_A, b10, scale_b10, cfg.DTYPE_B, c00)
+            b11, scale_b11 = self.issue_local_load_b(wmma_idx, 1, 1, self.b_buffer, self.b_scale_buffer)
+
+            c01 = gl.amd.gfx1250.wmma_scaled(a01, scale_a01, cfg.DTYPE_A, b11, scale_b11, cfg.DTYPE_B, c01)
+            a11, scale_a11 = self.issue_local_load_a(wmma_idx, 1, 1, self.a_buffer, self.a_scale_buffer)
+            wmma_idx += 1
+
+            c10 = gl.amd.gfx1250.wmma_scaled(a11, scale_a11, cfg.DTYPE_A, b10, scale_b10, cfg.DTYPE_B, c10)
+
+            c11 = gl.amd.gfx1250.wmma_scaled(a11, scale_a11, cfg.DTYPE_A, b11, scale_b11, cfg.DTYPE_B, c11)
+
+            # iter i + NUM_BUFFERS - 1
+            pred_load = i + 1 - epilogue_lb
+            pred_load = (pred_load >> 31) & 1
+            self.async_wait(0)
+            if cfg.WITH_A_SCALE:
+                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx, pred=pred_load)
+            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx, pred=pred_load)
+            a_desc = self.issue_load_a_data(a_desc, load_idx, pred=pred_load)
+            b_desc = self.issue_load_b_data(b_desc, load_idx, pred=pred_load)
+
+            a00, scale_a00 = self.issue_local_load_a(wmma_idx, 0, 0, self.a_buffer, self.a_scale_buffer)
+            b00, scale_b00 = self.issue_local_load_b(wmma_idx, 0, 0, self.b_buffer, self.b_scale_buffer)
+
+        acc_top = gl.join(c00, c01).permute(0, 2, 1).reshape((SUBTILE_M, cfg.BLOCK_N))
+        acc_bot = gl.join(c10, c11).permute(0, 2, 1).reshape((SUBTILE_M, cfg.BLOCK_N))
+        accumulator = gl.join(acc_top, acc_bot).permute(2, 0, 1).reshape((cfg.BLOCK_M, cfg.BLOCK_N))
+        accumulator = gl.convert_layout(accumulator, cfg.acc_layout)
 
         apply_activation_and_store(self.cfg, accumulator, self.c_ptr, self.c_offs, self.c_mask)
 
@@ -968,12 +1400,15 @@ def mxgemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr, a_scale, b_scale, M, N, K, 
                                 BLOCK_N: gl.constexpr, BLOCK_K: gl.constexpr, GROUP_SIZE_M: gl.constexpr,
                                 TRANSPOSE_B: gl.constexpr, NUM_BUFFERS: gl.constexpr, SCALE_PRESHUFFLE: gl.constexpr,
                                 ASYNC_COPY_SCALE: gl.constexpr, WITH_A_SCALE: gl.constexpr, SCHEDULE: gl.constexpr,
-                                NUM_WARPS: gl.constexpr, PINGPONG: gl.constexpr, ACTIVATION: gl.constexpr = ""):
+                                NUM_WARPS: gl.constexpr, PINGPONG: gl.constexpr, L2_PREFETCH_DISTANCE: gl.constexpr = 0,
+                                ACTIVATION: gl.constexpr = ""):
 
     if PINGPONG:
         gl.static_assert(NUM_WARPS == 8 and (SCHEDULE == 'baseline' or SCHEDULE == 'sliceK'))
 
-    if SCHEDULE == 'sliceNK':
+    if SCHEDULE == 'sliceMNK':
+        NUM_SUBTILES: gl.constexpr = (2, 2, 2)
+    elif SCHEDULE == 'sliceNK':
         NUM_SUBTILES: gl.constexpr = (1, 2, 2)
     elif SCHEDULE == 'sliceK':
         NUM_SUBTILES: gl.constexpr = (1, 1, 2)
@@ -988,7 +1423,8 @@ def mxgemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr, a_scale, b_scale, M, N, K, 
     N_PACKED = N * ACTIVATION_REDUCTION_N
 
     cfg = MXFPGEMMConfig(BLOCK_M, BLOCK_N_PACKED, BLOCK_K, DTYPE_A, DTYPE_B, SCALE_BLOCK, NUM_BUFFERS, TRANSPOSE_B,
-                         WITH_A_SCALE, SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE, NUM_SUBTILES, ACTIVATION)
+                         WITH_A_SCALE, SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE, NUM_SUBTILES,
+                         L2_PREFETCH_DISTANCE, ACTIVATION)
 
     pid = gl.program_id(axis=0)
     num_pid_m = gl.cdiv(M, BLOCK_M)
@@ -1014,7 +1450,9 @@ def mxgemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr, a_scale, b_scale, M, N, K, 
     c_offs = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
 
-    if SCHEDULE == 'sliceNK':
+    if SCHEDULE == 'sliceMNK':
+        pgm = MXFPGEMMSliceMNKProgram.initialize(cfg, a_desc, b_desc, a_scale_desc, b_scale_desc, c_ptr, c_offs, c_mask)
+    elif SCHEDULE == 'sliceNK':
         pgm = MXFPGEMMSliceNKProgram.initialize(cfg, a_desc, b_desc, a_scale_desc, b_scale_desc, c_ptr, c_offs, c_mask)
     elif SCHEDULE == 'sliceK':
         pgm = MXFPGEMMSliceKProgram.initialize(cfg, a_desc, b_desc, a_scale_desc, b_scale_desc, c_ptr, c_offs, c_mask)
@@ -1106,9 +1544,10 @@ def interleave_b_scale_rows(s_gate, s_up):
 @pytest.mark.parametrize("NUM_BUFFERS", [2, 3])
 @pytest.mark.parametrize("GROUP_SIZE_M", [8])
 @pytest.mark.parametrize("PINGPONG", [True, False])
+@pytest.mark.parametrize("L2_PREFETCH_DISTANCE", [-1, 0, 2])
 def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B,
                                             NUM_BUFFERS, SCALE_PRESHUFFLE, WITH_A_SCALE, SCHEDULE, ASYNC_COPY_SCALE,
-                                            GROUP_SIZE_M, PINGPONG):
+                                            GROUP_SIZE_M, PINGPONG, L2_PREFETCH_DISTANCE):
     SCALE_BLOCK = 32
     numWarps = 8
     numCtas = 1
@@ -1186,12 +1625,18 @@ def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, 
                                           stride_bn, stride_cm, stride_cn, stride_scale, dtype_converter[DTYPE_A],
                                           dtype_converter[DTYPE_B], SCALE_BLOCK, BLOCK_M, BLOCK_N, BLOCK_K,
                                           GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE,
-                                          WITH_A_SCALE, SCHEDULE, numWarps, PINGPONG, num_warps=numWarps,
+                                          WITH_A_SCALE, SCHEDULE, numWarps, PINGPONG,
+                                          L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, num_warps=numWarps,
                                           num_ctas=numCtas, waves_per_eu=(numWarps // 4))
     static_profile(k)
 
     if TRANSPOSE_B:
         assert 'ds_load_u8' not in k.asm['amdgcn']
+
+    if L2_PREFETCH_DISTANCE >= 0:
+        assert 'global_prefetch_b8' in k.asm['amdgcn']
+    else:
+        assert 'global_prefetch_b8' not in k.asm['amdgcn']
 
     torch.testing.assert_close(c_d.cpu(), c_ref.cpu(), rtol=1e-5, atol=1e-8)
     print('✅Pass')
@@ -1200,19 +1645,27 @@ def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, 
 @pytest.mark.parametrize(
     "DTYPE_A, DTYPE_B",
     [['float8_e5m2', 'float4'], ['float4', 'float8_e4m3'], ['float8_e4m3', 'float8_e5m2'], ['float4', 'float4']])
-@pytest.mark.parametrize("M,N,K", [(128, 128, 128), (256, 256, 512)])
-@pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(64, 64, 64), (128, 128, 128), (256, 256, 256)])
+@pytest.mark.parametrize("M,N,K", [(128, 128, 128), (256, 256, 512), (256, 256, 1024)])
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K,NUM_BUFFERS", [
+    (64, 64, 64, 2),
+    (64, 64, 64, 4),
+    (128, 128, 128, 2),
+    (128, 128, 128, 4),
+    (256, 256, 256, 2),
+    (128, 256, 256, 3),
+    (256, 256, 128, 4),
+])
 @pytest.mark.parametrize("TRANSPOSE_B", [True, False])
-@pytest.mark.parametrize("NUM_BUFFERS", [2, 4])
 @pytest.mark.parametrize("SCALE_PRESHUFFLE", [True, False])
 @pytest.mark.parametrize("WITH_A_SCALE", [True, False])
-@pytest.mark.parametrize("SCHEDULE", ['sliceNK', 'sliceK', 'baseline'])
+@pytest.mark.parametrize("SCHEDULE", ['sliceNK', 'sliceK', 'baseline', 'sliceMNK'])
 @pytest.mark.parametrize("ASYNC_COPY_SCALE", [True, False])
 @pytest.mark.parametrize("GROUP_SIZE_M", [8])
+@pytest.mark.parametrize("L2_PREFETCH_DISTANCE", [-1, 0, 2])
 @pytest.mark.parametrize("ACTIVATION", ['', 'swiglu'])
 def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B, NUM_BUFFERS,
                                       SCALE_PRESHUFFLE, WITH_A_SCALE, SCHEDULE, ASYNC_COPY_SCALE, GROUP_SIZE_M,
-                                      ACTIVATION):
+                                      L2_PREFETCH_DISTANCE, ACTIVATION):
     """
     Pipelined mxfp GEMM with optional fused SwiGLU epilogue.
 
@@ -1235,8 +1688,10 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
     if SCHEDULE != 'baseline' and not (SCALE_PRESHUFFLE and TRANSPOSE_B):
         pytest.skip('Only test with SCALE_PRESHUFFLE and TRANSPOSE_B in sliceK and sliceNK schedules')
 
-    if NUM_BUFFERS == 4 and BLOCK_M >= 256:
-        pytest.skip("Large block size with 4 buffers will exceed lds limit")
+    is_fp4fp4 = DTYPE_A == "float4" and DTYPE_B == "float4"
+
+    if NUM_BUFFERS >= 3 and (BLOCK_M >= 256 or EFFECTIVE_BLOCK_N >= 256 or BLOCK_K >= 256) and not is_fp4fp4:
+        pytest.skip("Skip large block size with >=3 buffers to not exceed lds limit")
 
     if SCHEDULE == 'sliceNK':
         if BLOCK_K < 256 or EFFECTIVE_BLOCK_N < 256:
@@ -1247,8 +1702,15 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
         if ASYNC_COPY_SCALE:
             pytest.skip('Only use ASYNC_COPY_SCALE in sliceNK schedule')
 
-    if SCHEDULE != 'baseline' and NUM_BUFFERS != 2:
-        pytest.skip('Only test 2 buffers in sliceK and sliceNK schedules')
+    if SCHEDULE == 'sliceK' and (K + BLOCK_K - 1) // BLOCK_K < NUM_BUFFERS - 1:
+        pytest.skip('sliceK pipeline requires K_iters >= NUM_BUFFERS - 1')
+
+    if SCHEDULE != 'baseline' and NUM_BUFFERS >= 3:
+        problem_size = BLOCK_M * EFFECTIVE_BLOCK_N * BLOCK_K
+        is_fp8_a = DTYPE_A in ('float8_e5m2', 'float8_e4m3')
+        is_fp8_b = DTYPE_B in ('float8_e5m2', 'float8_e4m3')
+        if is_fp8_a and is_fp8_b and problem_size >= 128 * 256 * 256:
+            pytest.skip('Large block size with fp8 inputs and >=3 buffers will exceed lds limit')
 
     if ASYNC_COPY_SCALE and (M < BLOCK_M or N < BLOCK_N or K < BLOCK_K):
         pytest.skip('NYI: Skipping small problem sizes for async copy scale')
@@ -1327,12 +1789,22 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
                                           dtype_converter[DTYPE_B], SCALE_BLOCK, BLOCK_M, BLOCK_N, BLOCK_K,
                                           GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE,
                                           WITH_A_SCALE, SCHEDULE, NUM_WARPS=numWarps, PINGPONG=False,
-                                          ACTIVATION=ACTIVATION, num_warps=numWarps, num_ctas=numCtas,
-                                          waves_per_eu=numWarps // 4)
+                                          L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, ACTIVATION=ACTIVATION,
+                                          num_warps=numWarps, num_ctas=numCtas, waves_per_eu=numWarps // 4)
     static_profile(k)
 
     if TRANSPOSE_B:
         assert 'ds_load_u8' not in k.asm['amdgcn']
+
+    if L2_PREFETCH_DISTANCE >= 0:
+        assert 'global_prefetch_b8' in k.asm['amdgcn']
+    else:
+        assert 'global_prefetch_b8' not in k.asm['amdgcn']
+
+    if is_fp4fp4:
+        assert 'v_wmma_scale_f32_32x16x128_f4' in k.asm['amdgcn']
+    else:
+        assert 'v_wmma_scale_f32_16x16x128_f8f6f4' in k.asm['amdgcn']
 
     # Relaxed tolerance for SwiGLU because of sigmoid/exp in the epilogue.
     if IS_SWIGLU:
@@ -1360,10 +1832,13 @@ if __name__ == '__main__':
     parser.add_argument('--scale_preshuffled', action='store_true')
     parser.add_argument('--with_a_scale', action='store_true')
     parser.add_argument('--async_copy_scale', action='store_true')
-    parser.add_argument('--schedule', type=str, choices=['sliceNK', 'sliceK', 'baseline'], default='sliceNK')
+    parser.add_argument('--schedule', type=str, choices=['sliceMNK', 'sliceNK', 'sliceK', 'baseline'],
+                        default='sliceNK')
     parser.add_argument('--dtype_a', type=str, default='float8_e4m3', choices=supported_dtypes)
     parser.add_argument('--dtype_b', type=str, default='float8_e4m3', choices=supported_dtypes)
     parser.add_argument('--pingpong', action='store_true')
+    parser.add_argument('--l2_prefetch_distance', type=int, default=-1, choices=[-1, 0, 1, 2, 3, 4, 5],
+                        help='Prefetch distance (in iterations) for operands into L2. -1 disables L2 prefetch.')
     parser.add_argument('--activation', type=str, default='', choices=['', 'swiglu'],
                         help='Optional fused activation epilogue')
 
@@ -1384,7 +1859,8 @@ if __name__ == '__main__':
                                                 SCHEDULE=args.schedule,  #
                                                 ASYNC_COPY_SCALE=False,  #
                                                 GROUP_SIZE_M=args.group_size_m,  #
-                                                PINGPONG=args.pingpong)
+                                                PINGPONG=args.pingpong,  #
+                                                L2_PREFETCH_DISTANCE=args.l2_prefetch_distance)
     else:
         assert (args.num_buffers in (2, 3, 4))
         test_runtime_mxgemm_tdm_pipelined(args.dtype_a, args.dtype_b,  #
@@ -1397,4 +1873,5 @@ if __name__ == '__main__':
                                           SCHEDULE=args.schedule,  #
                                           ASYNC_COPY_SCALE=args.async_copy_scale,  #
                                           GROUP_SIZE_M=args.group_size_m,  #
+                                          L2_PREFETCH_DISTANCE=args.l2_prefetch_distance,  #
                                           ACTIVATION=args.activation)

--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -50,6 +50,18 @@ def get_wmma_layout(num_warps, packed, scale_preshuffle, instr_m=16):
     return gl.amd.AMDWMMALayout(3, True, warp_bases, reg_bases, instr_shape)
 
 
+@gluon.constexpr_function
+def reverse_tdm_warp_used_hint(x: gl.constexpr, num_warps: gl.constexpr):
+    if x is None:
+        return None
+
+    result = 0
+    for i in range(num_warps):
+        if x & (1 << i):
+            result |= 1 << (num_warps - 1 - i)
+    return result
+
+
 @gluon.aggregate
 class MXFPGEMMConfig:
     BLOCK_M: gl.constexpr
@@ -65,6 +77,7 @@ class MXFPGEMMConfig:
     NUM_LOADS_IN_BATCH: gl.constexpr
     NUM_SUBTILES: gl.constexpr  # (M, N, K)
     NUM_WARPS: gl.constexpr
+    TDM_WARP_USED_HINT: gl.constexpr
 
     # Layouts
     shared_layout_a: gl.constexpr
@@ -98,8 +111,8 @@ class MXFPGEMMConfig:
 
     @gluon.constexpr_function
     def __init__(self, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A, DTYPE_B, SCALE_BLOCK, NUM_BUFFERS, TRANSPOSE_B, WITH_A_SCALE,
-                 SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE=False, NUM_SUBTILES=(1, 1, 1), L2_PREFETCH_DISTANCE=0,
-                 ACTIVATION=""):
+                 SCALE_PRESHUFFLE, NUM_WARPS, TDM_WARP_USED_HINT=None, ASYNC_COPY_SCALE=False, NUM_SUBTILES=(1, 1, 1),
+                 L2_PREFETCH_DISTANCE=0, ACTIVATION=""):
         self.BLOCK_M = gl.constexpr(BLOCK_M)
         self.BLOCK_N = gl.constexpr(BLOCK_N)
         self.BLOCK_K = gl.constexpr(BLOCK_K)
@@ -114,6 +127,7 @@ class MXFPGEMMConfig:
         self.DIV_FACTOR_B = gl.constexpr(2 if DTYPE_B == "e2m1" else 1)
         self.NUM_LOADS_IN_BATCH = gl.constexpr(4 if WITH_A_SCALE else 3)
         self.NUM_WARPS = gl.constexpr(NUM_WARPS)
+        self.TDM_WARP_USED_HINT = gl.constexpr(TDM_WARP_USED_HINT)
         self.ASYNC_COPY_SCALE = gl.constexpr(ASYNC_COPY_SCALE)
         self.NUM_SUBTILES = gl.constexpr(NUM_SUBTILES)
         self.L2_PREFETCH_DISTANCE = gl.constexpr(L2_PREFETCH_DISTANCE)
@@ -332,11 +346,19 @@ class MXFPGEMMProgramBase:
                                         pred=pred)
 
     @gluon.jit
-    def issue_l2_prefetches(self, distance: gl.constexpr, load_idx, pred=True):
+    def issue_l2_prefetches_scale(self, distance: gl.constexpr, load_idx, pred=True):
         self.issue_l2_prefetch_a_scale(distance, load_idx, pred=pred)
         self.issue_l2_prefetch_b_scale(distance, load_idx, pred=pred)
+
+    @gluon.jit
+    def issue_l2_prefetches_data(self, distance: gl.constexpr, load_idx, pred=True):
         self.issue_l2_prefetch_a(distance, load_idx, pred=pred)
         self.issue_l2_prefetch_b(distance, load_idx, pred=pred)
+
+    @gluon.jit
+    def issue_l2_prefetches(self, distance: gl.constexpr, load_idx, pred=True):
+        self.issue_l2_prefetches_scale(distance, load_idx, pred=pred)
+        self.issue_l2_prefetches_data(distance, load_idx, pred=pred)
 
     @gluon.jit
     def issue_l2_prefetches_prologue(self, load_idx):
@@ -1191,7 +1213,7 @@ class MXFPGEMMSliceMNKProgram:
         return b, scale_b
 
     @gluon.jit
-    def issue_load_a_scale(self, a_scale_desc, load_idx, pred=1):
+    def issue_load_a_scale(self, a_scale_desc, load_idx, pred=1, warp_used_hint=None):
         cfg = self.cfg
         if cfg.WITH_A_SCALE:
             a_scale_buffer_slice = self.a_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
@@ -1199,45 +1221,61 @@ class MXFPGEMMSliceMNKProgram:
                 a_scale_desc.issue_async_load(load_idx, a_scale_buffer_slice, pred=pred)
             else:
                 gl.amd.gfx1250.tdm.async_load(a_scale_desc, [0, 0],  #
-                                              a_scale_buffer_slice, pred=pred)
+                                              a_scale_buffer_slice, pred=pred, warp_used_hint=warp_used_hint)
                 a_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
                     a_scale_desc, add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
         return a_scale_desc
 
     @gluon.jit
-    def issue_load_a_data(self, a_desc, load_idx, pred=1):
+    def issue_load_a_data(self, a_desc, load_idx, pred=1, warp_used_hint=None):
         cfg = self.cfg
         BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_A
         gl.amd.gfx1250.tdm.async_load(a_desc, [0, 0],  #
                                       self.a_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
-                                      pred=pred)
+                                      pred=pred, warp_used_hint=warp_used_hint)
         return gl.amd.gfx1250.tdm.update_tensor_descriptor(a_desc, add_offsets=[0, BLOCK_K])
 
     @gluon.jit
-    def issue_load_b_scale(self, b_scale_desc, load_idx, pred=1):
+    def issue_load_b_scale(self, b_scale_desc, load_idx, pred=1, warp_used_hint=None):
         cfg = self.cfg
         b_scale_buffer_slice = self.b_scale_buffer.index(load_idx % cfg.NUM_BUFFERS)
         if cfg.ASYNC_COPY_SCALE:
             b_scale_desc.issue_async_load(load_idx, b_scale_buffer_slice, pred=pred)
         else:
             gl.amd.gfx1250.tdm.async_load(b_scale_desc, [0, 0],  #
-                                          b_scale_buffer_slice, pred=pred)
+                                          b_scale_buffer_slice, pred=pred, warp_used_hint=warp_used_hint)
             b_scale_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_scale_desc,
                                                                        add_offsets=[0, cfg.BLOCK_K_SCALE_PRESHUFFLED])
         return b_scale_desc
 
     @gluon.jit
-    def issue_load_b_data(self, b_desc, load_idx, pred=1):
+    def issue_load_b_data(self, b_desc, load_idx, pred=1, warp_used_hint=None):
         cfg = self.cfg
         BLOCK_K: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_B
         gl.amd.gfx1250.tdm.async_load(b_desc, [0, 0],  #
                                       self.b_buffer.index(load_idx % cfg.NUM_BUFFERS),  #
-                                      pred=pred)
+                                      pred=pred, warp_used_hint=warp_used_hint)
         if cfg.TRANSPOSE_B:
             b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[0, BLOCK_K])
         else:
             b_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(b_desc, add_offsets=[BLOCK_K, 0])
         return b_desc
+
+    @gluon.jit
+    def issue_load_scale(self, a_scale_desc, b_scale_desc, load_idx, pred=1, warp_used_hint=None):
+        if self.cfg.WITH_A_SCALE:
+            a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx, pred=pred, warp_used_hint=warp_used_hint)
+        b_scale_desc = self.issue_load_b_scale(
+            b_scale_desc, load_idx, pred=pred,
+            warp_used_hint=reverse_tdm_warp_used_hint(warp_used_hint, self.cfg.NUM_WARPS))
+        return a_scale_desc, b_scale_desc
+
+    @gluon.jit
+    def issue_load_data(self, a_desc, b_desc, load_idx, pred=1, warp_used_hint=None):
+        a_desc = self.issue_load_a_data(a_desc, load_idx, pred=pred, warp_used_hint=warp_used_hint)
+        b_desc = self.issue_load_b_data(b_desc, load_idx, pred=pred,
+                                        warp_used_hint=reverse_tdm_warp_used_hint(warp_used_hint, self.cfg.NUM_WARPS))
+        return a_desc, b_desc
 
     @gluon.jit
     def async_wait(self, waitcnt: int):
@@ -1260,22 +1298,22 @@ class MXFPGEMMSliceMNKProgram:
         b_scale_desc = self.b_scale_desc
 
         for _ in gl.static_range(cfg.NUM_BUFFERS - 1):
-            if cfg.WITH_A_SCALE:
-                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
-            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
-            a_desc = self.issue_load_a_data(a_desc, load_idx)
-            b_desc = self.issue_load_b_data(b_desc, load_idx)
+            a_scale_desc, b_scale_desc = self.issue_load_scale(a_scale_desc, b_scale_desc, load_idx,
+                                                               warp_used_hint=cfg.TDM_WARP_USED_HINT)
+            a_desc, b_desc = self.issue_load_data(a_desc, b_desc, load_idx, warp_used_hint=cfg.TDM_WARP_USED_HINT)
             load_idx = load_idx + 1
+
+        for d in gl.static_range(cfg.NUM_BUFFERS, cfg.NUM_BUFFERS + cfg.L2_PREFETCH_DISTANCE):
+            self.issue_l2_prefetches_data(d, 0)
+        for d in gl.static_range(cfg.NUM_BUFFERS, cfg.NUM_BUFFERS + cfg.L2_PREFETCH_DISTANCE):
+            self.issue_l2_prefetches_scale(d, 0)
 
         self.async_wait((cfg.NUM_BUFFERS - 2) * 2)
         a00, scale_a00 = self.issue_local_load_a(wmma_idx, 0, 0, self.a_buffer, self.a_scale_buffer)
         b00, scale_b00 = self.issue_local_load_b(wmma_idx, 0, 0, self.b_buffer, self.b_scale_buffer)
 
-        if cfg.WITH_A_SCALE:
-            a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx)
-        b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx)
-        a_desc = self.issue_load_a_data(a_desc, load_idx)
-        b_desc = self.issue_load_b_data(b_desc, load_idx)
+        a_desc, b_desc = self.issue_load_data(a_desc, b_desc, load_idx, warp_used_hint=cfg.TDM_WARP_USED_HINT)
+        scale_load_idx = load_idx
 
         SUBTILE_M: gl.constexpr = cfg.BLOCK_M // cfg.NUM_SUBTILES[0]
         SUBTILE_N: gl.constexpr = cfg.BLOCK_N // cfg.NUM_SUBTILES[1]
@@ -1288,16 +1326,28 @@ class MXFPGEMMSliceMNKProgram:
         epilogue_lb = loop_ub - (cfg.NUM_BUFFERS - 1)
         gl.assume(loop_ub >= cfg.NUM_BUFFERS)
         for i in range(0, loop_ub):
+            pred_scale_tdm = i - epilogue_lb
+            pred_scale_tdm = (pred_scale_tdm >> 31) & 1
+            pred_prefetch = pred_scale_tdm.to(gl.int1)
+            pred_load = i + 1 - epilogue_lb
+            pred_load = (pred_load >> 31) & 1
+
             c00 = gl.amd.gfx1250.wmma_scaled(a00, scale_a00, cfg.DTYPE_A, b00, scale_b00, cfg.DTYPE_B, c00)
+
+            a_scale_desc, b_scale_desc = self.issue_load_scale(a_scale_desc, b_scale_desc, scale_load_idx,
+                                                               pred=pred_scale_tdm,
+                                                               warp_used_hint=cfg.TDM_WARP_USED_HINT)
+            scale_load_idx = scale_load_idx + 1
+
             b01, scale_b01 = self.issue_local_load_b(wmma_idx, 0, 1, self.b_buffer, self.b_scale_buffer)
 
-            pred_prefetch = i - epilogue_lb
-            pred_prefetch = ((pred_prefetch >> 31) & 1).to(gl.int1)
-            self.issue_l2_prefetches(cfg.L2_PREFETCH_DISTANCE, load_idx, pred=pred_prefetch)
-            load_idx = load_idx + 1
+            self.issue_l2_prefetches_scale(cfg.L2_PREFETCH_DISTANCE, load_idx, pred=pred_prefetch)
 
             c01 = gl.amd.gfx1250.wmma_scaled(a00, scale_a00, cfg.DTYPE_A, b01, scale_b01, cfg.DTYPE_B, c01)
             a10, scale_a10 = self.issue_local_load_a(wmma_idx, 1, 0, self.a_buffer, self.a_scale_buffer)
+
+            self.issue_l2_prefetches_data(cfg.L2_PREFETCH_DISTANCE, load_idx, pred=pred_prefetch)
+            load_idx = load_idx + 1
 
             c10 = gl.amd.gfx1250.wmma_scaled(a10, scale_a10, cfg.DTYPE_A, b00, scale_b00, cfg.DTYPE_B, c10)
             b10, scale_b10 = self.issue_local_load_b(wmma_idx, 1, 0, self.b_buffer, self.b_scale_buffer)
@@ -1316,15 +1366,10 @@ class MXFPGEMMSliceMNKProgram:
 
             c11 = gl.amd.gfx1250.wmma_scaled(a11, scale_a11, cfg.DTYPE_A, b11, scale_b11, cfg.DTYPE_B, c11)
 
-            # iter i + NUM_BUFFERS - 1
-            pred_load = i + 1 - epilogue_lb
-            pred_load = (pred_load >> 31) & 1
-            self.async_wait(0)
-            if cfg.WITH_A_SCALE:
-                a_scale_desc = self.issue_load_a_scale(a_scale_desc, load_idx, pred=pred_load)
-            b_scale_desc = self.issue_load_b_scale(b_scale_desc, load_idx, pred=pred_load)
-            a_desc = self.issue_load_a_data(a_desc, load_idx, pred=pred_load)
-            b_desc = self.issue_load_b_data(b_desc, load_idx, pred=pred_load)
+            a_desc, b_desc = self.issue_load_data(a_desc, b_desc, load_idx, pred=pred_load,
+                                                  warp_used_hint=cfg.TDM_WARP_USED_HINT)
+
+            self.async_wait(1)
 
             a00, scale_a00 = self.issue_local_load_a(wmma_idx, 0, 0, self.a_buffer, self.a_scale_buffer)
             b00, scale_b00 = self.issue_local_load_b(wmma_idx, 0, 0, self.b_buffer, self.b_scale_buffer)
@@ -1401,7 +1446,7 @@ def mxgemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr, a_scale, b_scale, M, N, K, 
                                 TRANSPOSE_B: gl.constexpr, NUM_BUFFERS: gl.constexpr, SCALE_PRESHUFFLE: gl.constexpr,
                                 ASYNC_COPY_SCALE: gl.constexpr, WITH_A_SCALE: gl.constexpr, SCHEDULE: gl.constexpr,
                                 NUM_WARPS: gl.constexpr, PINGPONG: gl.constexpr, L2_PREFETCH_DISTANCE: gl.constexpr = 0,
-                                ACTIVATION: gl.constexpr = ""):
+                                ACTIVATION: gl.constexpr = "", PARTIAL_TDM: gl.constexpr = False):
 
     if PINGPONG:
         gl.static_assert(NUM_WARPS == 8 and (SCHEDULE == 'baseline' or SCHEDULE == 'sliceK'))
@@ -1422,8 +1467,17 @@ def mxgemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr, a_scale, b_scale, M, N, K, 
     BLOCK_N_PACKED: gl.constexpr = BLOCK_N * ACTIVATION_REDUCTION_N
     N_PACKED = N * ACTIVATION_REDUCTION_N
 
+    if PARTIAL_TDM:
+        if NUM_WARPS == 8:
+            TDM_WARP_USED_HINT: gl.constexpr = 0b01010101
+        else:
+            gl.static_assert(NUM_WARPS == 4)
+            TDM_WARP_USED_HINT: gl.constexpr = 0b00000101
+    else:
+        TDM_WARP_USED_HINT: gl.constexpr = None
+
     cfg = MXFPGEMMConfig(BLOCK_M, BLOCK_N_PACKED, BLOCK_K, DTYPE_A, DTYPE_B, SCALE_BLOCK, NUM_BUFFERS, TRANSPOSE_B,
-                         WITH_A_SCALE, SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE, NUM_SUBTILES,
+                         WITH_A_SCALE, SCALE_PRESHUFFLE, NUM_WARPS, TDM_WARP_USED_HINT, ASYNC_COPY_SCALE, NUM_SUBTILES,
                          L2_PREFETCH_DISTANCE, ACTIVATION)
 
     pid = gl.program_id(axis=0)
@@ -1545,9 +1599,10 @@ def interleave_b_scale_rows(s_gate, s_up):
 @pytest.mark.parametrize("GROUP_SIZE_M", [8])
 @pytest.mark.parametrize("PINGPONG", [True, False])
 @pytest.mark.parametrize("L2_PREFETCH_DISTANCE", [-1, 0, 2])
+@pytest.mark.parametrize("PARTIAL_TDM", [True, False])
 def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B,
                                             NUM_BUFFERS, SCALE_PRESHUFFLE, WITH_A_SCALE, SCHEDULE, ASYNC_COPY_SCALE,
-                                            GROUP_SIZE_M, PINGPONG, L2_PREFETCH_DISTANCE):
+                                            GROUP_SIZE_M, PINGPONG, L2_PREFETCH_DISTANCE, PARTIAL_TDM):
     SCALE_BLOCK = 32
     numWarps = 8
     numCtas = 1
@@ -1627,7 +1682,7 @@ def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, 
                                           GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE,
                                           WITH_A_SCALE, SCHEDULE, numWarps, PINGPONG,
                                           L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, num_warps=numWarps,
-                                          num_ctas=numCtas, waves_per_eu=(numWarps // 4))
+                                          num_ctas=numCtas, waves_per_eu=(numWarps // 4), PARTIAL_TDM=PARTIAL_TDM)
     static_profile(k)
 
     if TRANSPOSE_B:
@@ -1663,9 +1718,10 @@ def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, 
 @pytest.mark.parametrize("GROUP_SIZE_M", [8])
 @pytest.mark.parametrize("L2_PREFETCH_DISTANCE", [-1, 0, 2])
 @pytest.mark.parametrize("ACTIVATION", ['', 'swiglu'])
+@pytest.mark.parametrize("PARTIAL_TDM", [True, False])
 def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B, NUM_BUFFERS,
                                       SCALE_PRESHUFFLE, WITH_A_SCALE, SCHEDULE, ASYNC_COPY_SCALE, GROUP_SIZE_M,
-                                      L2_PREFETCH_DISTANCE, ACTIVATION):
+                                      L2_PREFETCH_DISTANCE, ACTIVATION, PARTIAL_TDM):
     """
     Pipelined mxfp GEMM with optional fused SwiGLU epilogue.
 
@@ -1784,13 +1840,12 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
 
     dtype_converter = {'float8_e5m2': "e5m2", "float8_e4m3": "e4m3", "float4": "e2m1"}
 
-    k = mxgemm_tdm_pipelined_kernel[grid](a_d, b_d, c_d, a_scale_d, b_scale_d, M, N, K, stride_am, stride_ak, stride_bk,
-                                          stride_bn, stride_cm, stride_cn, stride_scale, dtype_converter[DTYPE_A],
-                                          dtype_converter[DTYPE_B], SCALE_BLOCK, BLOCK_M, BLOCK_N, BLOCK_K,
-                                          GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE,
-                                          WITH_A_SCALE, SCHEDULE, NUM_WARPS=numWarps, PINGPONG=False,
-                                          L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, ACTIVATION=ACTIVATION,
-                                          num_warps=numWarps, num_ctas=numCtas, waves_per_eu=numWarps // 4)
+    k = mxgemm_tdm_pipelined_kernel[grid](
+        a_d, b_d, c_d, a_scale_d, b_scale_d, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+        stride_scale, dtype_converter[DTYPE_A], dtype_converter[DTYPE_B], SCALE_BLOCK, BLOCK_M, BLOCK_N, BLOCK_K,
+        GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE, WITH_A_SCALE, SCHEDULE,
+        NUM_WARPS=numWarps, PINGPONG=False, L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, ACTIVATION=ACTIVATION,
+        num_warps=numWarps, num_ctas=numCtas, waves_per_eu=numWarps // 4, PARTIAL_TDM=PARTIAL_TDM)
     static_profile(k)
 
     if TRANSPOSE_B:
@@ -1841,6 +1896,7 @@ if __name__ == '__main__':
                         help='Prefetch distance (in iterations) for operands into L2. -1 disables L2 prefetch.')
     parser.add_argument('--activation', type=str, default='', choices=['', 'swiglu'],
                         help='Optional fused activation epilogue')
+    parser.add_argument('--partial_tdm', action='store_true')
 
     args = parser.parse_args()
 
@@ -1860,7 +1916,8 @@ if __name__ == '__main__':
                                                 ASYNC_COPY_SCALE=False,  #
                                                 GROUP_SIZE_M=args.group_size_m,  #
                                                 PINGPONG=args.pingpong,  #
-                                                L2_PREFETCH_DISTANCE=args.l2_prefetch_distance)
+                                                L2_PREFETCH_DISTANCE=args.l2_prefetch_distance,  #
+                                                PARTIAL_TDM=args.partial_tdm)
     else:
         assert (args.num_buffers in (2, 3, 4))
         test_runtime_mxgemm_tdm_pipelined(args.dtype_a, args.dtype_b,  #
@@ -1874,4 +1931,5 @@ if __name__ == '__main__':
                                           ASYNC_COPY_SCALE=args.async_copy_scale,  #
                                           GROUP_SIZE_M=args.group_size_m,  #
                                           L2_PREFETCH_DISTANCE=args.l2_prefetch_distance,  #
-                                          ACTIVATION=args.activation)
+                                          ACTIVATION=args.activation,  #
+                                          PARTIAL_TDM=args.partial_tdm)

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -17,6 +17,7 @@ pybind11::class_<TritonOpBuilder> *getBuilderClass();
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
 #include "llvm/Support/Casting.h"
 
 namespace py = pybind11;
@@ -286,6 +287,21 @@ void init_triton_tlx_ir(py::module &&m) {
              return mlir::cast<Attribute>(ttg::NvidiaMmaEncodingAttr::get(
                  context, versionMajor, versionMinor, warpsPerCTA, CTALayout,
                  instrShape));
+           })
+      .def("make_amd_wmma_encoding_attr",
+           [](TritonOpBuilder &self, unsigned version, bool transposed,
+              std::vector<std::vector<int32_t>> &warpBases,
+              std::vector<std::vector<int32_t>> &regBases,
+              std::vector<unsigned> &instrShape, unsigned rank) -> Attribute {
+             auto ctx = self.getBuilder().getContext();
+             auto kReg = mlir::StringAttr::get(ctx, "register");
+             auto kWarp = mlir::StringAttr::get(ctx, "warp");
+             auto ctaLayout =
+                 tt::LinearLayout({{kReg, regBases}, {kWarp, warpBases}},
+                                  triton::standardOutDimNames(ctx, rank));
+             auto cgaLayout = ttg::CGAEncodingAttr::get1CTALayout(ctx, rank);
+             return mlir::cast<Attribute>(ttg::AMDWmmaEncodingAttr::get(
+                 ctx, version, ctaLayout, transposed, cgaLayout, instrShape));
            })
       .def(
           "make_i32_array_attr",

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -57,7 +57,7 @@ from .mem_ops import (
     subslice,
     tmem_copy,
 )
-from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, dot_scaled, tcgen05_commit
+from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, dot_scaled, require_amd_wmma_layout, tcgen05_commit
 from .types import (
     async_token,
     buffered_tensor,
@@ -173,6 +173,7 @@ __all__ = [
     "named_barrier_arrive",
     # mma_ops
     "dot_scaled",
+    "require_amd_wmma_layout",
     "async_dot",
     "async_dot_scaled",
     "async_dot_wait",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -65,6 +65,21 @@ def require_tmem_scales_layout(src: tlx.buffered_tensor, _builder=None):
 
 
 @tl.builtin
+def require_amd_wmma_layout(src, version: tl.constexpr = 3, transposed: tl.constexpr = True,
+                            warp_bases: tl.constexpr = ((0, 2), (2, 0)), reg_bases: tl.constexpr = ((0, 1), (1, 0)),
+                            instr_shape: tl.constexpr = (16, 16, 128), _semantic=None):
+    """Require an AMD WMMA register layout for a tensor value."""
+    warp_bases = [list(row) for row in tl._unwrap_if_constexpr(warp_bases)]
+    reg_bases = [list(row) for row in tl._unwrap_if_constexpr(reg_bases)]
+    instr_shape = list(tl._unwrap_if_constexpr(instr_shape))
+    rank = len(src.shape)
+    layout_handle = _semantic.builder.make_amd_wmma_encoding_attr(version, transposed, warp_bases, reg_bases,
+                                                                  instr_shape, rank)
+    handle = _semantic.builder.create_require_layout(src.handle, layout_handle)
+    return tl.tensor(handle, src.type)
+
+
+@tl.builtin
 def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None, fast_math=False, lhs_k_pack=True,
                rhs_k_pack=True, out_dtype=tl.float32, tiles_per_warp: tl.constexpr = None, _semantic=None):
     """Wrapper around tl.dot_scaled that optionally pins the AMD WMMA tiles-per-warp schedule.

--- a/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
@@ -425,6 +425,14 @@ def mxgemm_tdm_pipelined_kernel(
     BLOCK_M_PRESHUFFLED: tl.constexpr = BLOCK_M // 128
     BLOCK_N_PRESHUFFLED: tl.constexpr = BLOCK_N // 128
     BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr = BLOCK_K_SCALE * 128
+    STORE_INSTR_M: tl.constexpr = 32 if (DTYPE_A == "e2m1" and DTYPE_B == "e2m1") else 16
+    STORE_INSTR_SHAPE: tl.constexpr = (STORE_INSTR_M, 16, 128)
+    if SCALE_PRESHUFFLE:
+        STORE_WARP_BASES: tl.constexpr = ((0, 2), (2, 0))
+        STORE_REG_BASES: tl.constexpr = ((0, 1), (1, 0))
+    else:
+        STORE_WARP_BASES: tl.constexpr = ((0, 1), (1, 0))
+        STORE_REG_BASES: tl.constexpr = ()
     if TDM_FUSION == "4way":
         tl.static_assert(WITH_A_SCALE, "4-way TDM fusion requires WITH_A_SCALE")
         NUM_LOADS_IN_BATCH: tl.constexpr = 1
@@ -522,7 +530,7 @@ def mxgemm_tdm_pipelined_kernel(
 
     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    c_ptrs = c_ptr + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
+    c_offsets = (stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]).to(tl.int32)
     c_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
 
     a_layout: tl.constexpr = _operand_shared_layout([BLOCK_M, BLOCK_K_PACKED_A])
@@ -537,9 +545,10 @@ def mxgemm_tdm_pipelined_kernel(
     load_idx = 0
     wmma_idx = 0
 
-    _mxgemm_issue_l2_prefetches_prologue(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, L2_PREFETCH_DISTANCE,
-                                         NUM_BUFFERS, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B, BLOCK_K_SCALE_PRESHUFFLED,
-                                         TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
+    if SCHEDULE == "baseline" or SCHEDULE == "sliceK":
+        _mxgemm_issue_l2_prefetches_prologue(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, L2_PREFETCH_DISTANCE,
+                                             NUM_BUFFERS, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B, BLOCK_K_SCALE_PRESHUFFLED,
+                                             TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
 
     always = tl.full((), True, dtype=tl.int1)
     for _ in tl.static_range(NUM_BUFFERS - 1):
@@ -568,46 +577,103 @@ def mxgemm_tdm_pipelined_kernel(
     if SCHEDULE == "sliceMNK":
         SUBTILE_M: tl.constexpr = BLOCK_M // 2
         SUBTILE_N: tl.constexpr = BLOCK_N // 2
+        tlx.async_amd_descriptor_wait((NUM_BUFFERS - 2) * NUM_LOADS_IN_BATCH)
+        a00, scale_a00 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 0, 0, BLOCK_M, BLOCK_K, DIV_FACTOR_A,
+                                                SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED, SCALE_KWIDTH,
+                                                NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K, SCALE_PRESHUFFLE,
+                                                WITH_A_SCALE)
+        b00, scale_b00 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, 0, 0, BLOCK_N, BLOCK_K, DIV_FACTOR_B,
+                                                SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED, SCALE_KWIDTH,
+                                                NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K, TRANSPOSE_B,
+                                                SCALE_PRESHUFFLE)
+        load_idx = _mxgemm_issue_loads(
+            a_desc,
+            b_desc,
+            a_scale_desc,
+            b_scale_desc,
+            a_buf,
+            b_buf,
+            a_scale_buf,
+            b_scale_buf,
+            load_idx,
+            always,
+            BLOCK_K_PACKED_A,
+            BLOCK_K_PACKED_B,
+            BLOCK_K_SCALE_PRESHUFFLED,
+            NUM_BUFFERS,
+            TRANSPOSE_B,
+            SCALE_PRESHUFFLE,
+            WITH_A_SCALE,
+            TDM_FUSION,
+        )
         c00 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
         c01 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
         c10 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
         c11 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
         for i in tl.range(0, K_ITERS):
-            pred = i - epilogue_lb
-            pred = (pred >> 31) & 1
-            load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
-                                           b_scale_buf, load_idx, pred, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
-                                           BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
-                                           WITH_A_SCALE, TDM_FUSION)
+            c00 = tlx.dot_scaled(a00, scale_a00, DTYPE_A, b00, scale_b00, DTYPE_B, c00, tiles_per_warp=[2, 2])
+            b01, scale_b01 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, 0, 1, BLOCK_N, BLOCK_K, DIV_FACTOR_B,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K, TRANSPOSE_B,
+                                                    SCALE_PRESHUFFLE)
+            pred_prefetch = i - epilogue_lb
+            pred_prefetch = (pred_prefetch >> 31) & 1
             _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always,
                                         L2_PREFETCH_DISTANCE, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
                                         BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
-            tlx.async_amd_descriptor_wait((NUM_BUFFERS - 1) * NUM_LOADS_IN_BATCH)
-            for kt in tl.static_range(2):
-                a0, scale_a0 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 0, kt, BLOCK_M, BLOCK_K,
-                                                      DIV_FACTOR_A, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED,
-                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K,
-                                                      SCALE_PRESHUFFLE, WITH_A_SCALE)
-                a1, scale_a1 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 1, kt, BLOCK_M, BLOCK_K,
-                                                      DIV_FACTOR_A, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED,
-                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K,
-                                                      SCALE_PRESHUFFLE, WITH_A_SCALE)
-                b0, scale_b0 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, kt, 0, BLOCK_N, BLOCK_K,
-                                                      DIV_FACTOR_B, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED,
-                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K,
-                                                      TRANSPOSE_B, SCALE_PRESHUFFLE)
-                b1, scale_b1 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, kt, 1, BLOCK_N, BLOCK_K,
-                                                      DIV_FACTOR_B, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED,
-                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K,
-                                                      TRANSPOSE_B, SCALE_PRESHUFFLE)
-                c00 = tlx.dot_scaled(a0, scale_a0, DTYPE_A, b0, scale_b0, DTYPE_B, c00, tiles_per_warp=[2, 2])
-                c01 = tlx.dot_scaled(a0, scale_a0, DTYPE_A, b1, scale_b1, DTYPE_B, c01, tiles_per_warp=[2, 2])
-                c10 = tlx.dot_scaled(a1, scale_a1, DTYPE_A, b0, scale_b0, DTYPE_B, c10, tiles_per_warp=[2, 2])
-                c11 = tlx.dot_scaled(a1, scale_a1, DTYPE_A, b1, scale_b1, DTYPE_B, c11, tiles_per_warp=[2, 2])
+            c01 = tlx.dot_scaled(a00, scale_a00, DTYPE_A, b01, scale_b01, DTYPE_B, c01, tiles_per_warp=[2, 2])
+            a10, scale_a10 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 1, 0, BLOCK_M, BLOCK_K, DIV_FACTOR_A,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K, SCALE_PRESHUFFLE,
+                                                    WITH_A_SCALE)
+            c10 = tlx.dot_scaled(a10, scale_a10, DTYPE_A, b00, scale_b00, DTYPE_B, c10, tiles_per_warp=[2, 2])
+            b10, scale_b10 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, 1, 0, BLOCK_N, BLOCK_K, DIV_FACTOR_B,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K, TRANSPOSE_B,
+                                                    SCALE_PRESHUFFLE)
+            c11 = tlx.dot_scaled(a10, scale_a10, DTYPE_A, b01, scale_b01, DTYPE_B, c11, tiles_per_warp=[2, 2])
+            a01, scale_a01 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 0, 1, BLOCK_M, BLOCK_K, DIV_FACTOR_A,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K, SCALE_PRESHUFFLE,
+                                                    WITH_A_SCALE)
+            c00 = tlx.dot_scaled(a01, scale_a01, DTYPE_A, b10, scale_b10, DTYPE_B, c00, tiles_per_warp=[2, 2])
+            b11, scale_b11 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, 1, 1, BLOCK_N, BLOCK_K, DIV_FACTOR_B,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K, TRANSPOSE_B,
+                                                    SCALE_PRESHUFFLE)
+            c01 = tlx.dot_scaled(a01, scale_a01, DTYPE_A, b11, scale_b11, DTYPE_B, c01, tiles_per_warp=[2, 2])
+            a11, scale_a11 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 1, 1, BLOCK_M, BLOCK_K, DIV_FACTOR_A,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K, SCALE_PRESHUFFLE,
+                                                    WITH_A_SCALE)
             wmma_idx += 1
+            c10 = tlx.dot_scaled(a11, scale_a11, DTYPE_A, b10, scale_b10, DTYPE_B, c10, tiles_per_warp=[2, 2])
+            c11 = tlx.dot_scaled(a11, scale_a11, DTYPE_A, b11, scale_b11, DTYPE_B, c11, tiles_per_warp=[2, 2])
+            pred_load = i + 1 - epilogue_lb
+            pred_load = (pred_load >> 31) & 1
+            tlx.async_amd_descriptor_wait(0)
+            load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
+                                           b_scale_buf, load_idx, pred_load, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
+                                           BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
+                                           WITH_A_SCALE, TDM_FUSION)
+            a00, scale_a00 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 0, 0, BLOCK_M, BLOCK_K, DIV_FACTOR_A,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K, SCALE_PRESHUFFLE,
+                                                    WITH_A_SCALE)
+            b00, scale_b00 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, 0, 0, BLOCK_N, BLOCK_K, DIV_FACTOR_B,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K, TRANSPOSE_B,
+                                                    SCALE_PRESHUFFLE)
         acc_top = tl.join(c00, c01).permute(0, 2, 1).reshape((SUBTILE_M, BLOCK_N))
         acc_bot = tl.join(c10, c11).permute(0, 2, 1).reshape((SUBTILE_M, BLOCK_N))
         acc = tl.join(acc_top, acc_bot).permute(2, 0, 1).reshape((BLOCK_M, BLOCK_N))
+        acc = tlx.require_amd_wmma_layout(acc, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                          instr_shape=STORE_INSTR_SHAPE)
+        c_offsets_store = tlx.require_amd_wmma_layout(c_offsets, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                                      instr_shape=STORE_INSTR_SHAPE)
+        c_mask_store = tlx.require_amd_wmma_layout(c_mask, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                                   instr_shape=STORE_INSTR_SHAPE)
+        tlx.buffer_store(acc, c_ptr, c_offsets_store, mask=c_mask_store)
     elif SCHEDULE == "sliceNK":
         SUBTILE_N: tl.constexpr = BLOCK_N // 2
         c0 = tl.zeros((BLOCK_M, SUBTILE_N), dtype=tl.float32)
@@ -640,6 +706,13 @@ def mxgemm_tdm_pipelined_kernel(
                 c1 = tlx.dot_scaled(a, scale_a, DTYPE_A, b1, scale_b1, DTYPE_B, c1, tiles_per_warp=[2, 2])
             wmma_idx += 1
         acc = tl.join(c0, c1).permute(0, 2, 1).reshape((BLOCK_M, BLOCK_N))
+        acc = tlx.require_amd_wmma_layout(acc, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                          instr_shape=STORE_INSTR_SHAPE)
+        c_offsets_store = tlx.require_amd_wmma_layout(c_offsets, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                                      instr_shape=STORE_INSTR_SHAPE)
+        c_mask_store = tlx.require_amd_wmma_layout(c_mask, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                                   instr_shape=STORE_INSTR_SHAPE)
+        tlx.buffer_store(acc, c_ptr, c_offsets_store, mask=c_mask_store)
     else:
         acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
         for i in tl.range(0, K_ITERS):
@@ -664,8 +737,13 @@ def mxgemm_tdm_pipelined_kernel(
                                                     SCALE_PRESHUFFLE)
                 acc = tlx.dot_scaled(a, scale_a, DTYPE_A, b, scale_b, DTYPE_B, acc, tiles_per_warp=[2, 2])
             wmma_idx += 1
-
-    tl.store(c_ptrs, acc, mask=c_mask)
+        acc = tlx.require_amd_wmma_layout(acc, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                          instr_shape=STORE_INSTR_SHAPE)
+        c_offsets_store = tlx.require_amd_wmma_layout(c_offsets, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                                      instr_shape=STORE_INSTR_SHAPE)
+        c_mask_store = tlx.require_amd_wmma_layout(c_mask, warp_bases=STORE_WARP_BASES, reg_bases=STORE_REG_BASES,
+                                                   instr_shape=STORE_INSTR_SHAPE)
+        tlx.buffer_store(acc, c_ptr, c_offsets_store, mask=c_mask_store)
 
 
 DTYPE_TO_TRITON = {
@@ -818,22 +896,26 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250(TDM_FUSION):
 
 @pytest.mark.skipif(not is_gfx1250_available(), reason="Requires gfx1250 hardware")
 @pytest.mark.parametrize("TRANSPOSE_B", [False, True])
+@pytest.mark.parametrize("SEED", [0, 7])
 @pytest.mark.parametrize(
-    "SCHEDULE,DTYPE_A,DTYPE_B,BLOCK_M,BLOCK_N,BLOCK_K,NUM_BUFFERS,SCALE_PRESHUFFLE,WITH_A_SCALE,TDM_FUSION,L2_PREFETCH_DISTANCE",
+    "M,N,K,SCHEDULE,DTYPE_A,DTYPE_B,BLOCK_M,BLOCK_N,BLOCK_K,NUM_BUFFERS,SCALE_PRESHUFFLE,WITH_A_SCALE,TDM_FUSION,L2_PREFETCH_DISTANCE",
     [
-        ("baseline", "float8_e5m2", "float8_e5m2", 128, 128, 128, 2, True, True, "none", -1),
-        ("baseline", "float8_e4m3", "float8_e5m2", 128, 128, 128, 2, False, False, "none", 2),
-        ("sliceK", "float8_e4m3", "float8_e5m2", 128, 128, 256, 2, True, True, "2way", 2),
-        ("sliceNK", "float8_e5m2", "float4", 256, 256, 256, 2, True, True, "2way", 2),
-        ("sliceMNK", "float8_e4m3", "float8_e5m2", 128, 256, 256, 2, True, True, "4way", 2),
-        ("baseline", "float4", "float4", 128, 128, 128, 2, True, True, "4way", 2),
+        (256, 256, 512, "baseline", "float8_e5m2", "float8_e5m2", 128, 128, 128, 2, True, True, "none", -1),
+        (256, 256, 512, "baseline", "float8_e4m3", "float8_e5m2", 128, 128, 128, 2, False, False, "none", 2),
+        (256, 256, 512, "sliceK", "float8_e4m3", "float8_e5m2", 128, 128, 256, 2, True, True, "2way", 2),
+        (256, 512, 512, "sliceNK", "float8_e5m2", "float4", 256, 256, 256, 2, True, True, "2way", 2),
+        (256, 256, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "none", 2),
+        (256, 256, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "2way", 2),
+        (256, 256, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "4way", 2),
+        (256, 512, 512, "sliceMNK", "float8_e4m3", "float8_e5m2", 128, 256, 256, 2, True, True, "4way", 2),
+        (256, 256, 512, "baseline", "float4", "float4", 128, 128, 128, 2, True, True, "4way", 2),
+        (384, 384, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "4way", 2),
+        (384, 512, 768, "sliceMNK", "float8_e5m2", "float8_e4m3", 256, 256, 256, 2, True, True, "2way", 2),
     ],
 )
-def test_mxgemm_tdm_pipelined_gfx1250(TRANSPOSE_B, SCHEDULE, DTYPE_A, DTYPE_B, BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS,
-                                      SCALE_PRESHUFFLE, WITH_A_SCALE, TDM_FUSION, L2_PREFETCH_DISTANCE):
-    torch.manual_seed(0)
-    M = N = 256
-    K = 512
+def test_mxgemm_tdm_pipelined_gfx1250(TRANSPOSE_B, SEED, M, N, K, SCHEDULE, DTYPE_A, DTYPE_B, BLOCK_M, BLOCK_N, BLOCK_K,
+                                      NUM_BUFFERS, SCALE_PRESHUFFLE, WITH_A_SCALE, TDM_FUSION, L2_PREFETCH_DISTANCE):
+    torch.manual_seed(SEED)
     a = _init_data(DTYPE_A, M, K)
     b = _init_data(DTYPE_B, K, N)
     if WITH_A_SCALE:

--- a/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
@@ -202,8 +202,24 @@ def _mxgemm_issue_loads(
         else:
             _mxgemm_issue_load_b_scale(b_scale_desc, b_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED,
                                        NUM_BUFFERS, SCALE_PRESHUFFLE)
+    elif TDM_FUSION == "partial":
+        tl.static_assert(WITH_A_SCALE, "partial TDM fusion requires WITH_A_SCALE")
+        tlx.async_amd_descriptor_load_group(
+            [a_desc, b_desc],
+            [tlx.local_view(a_buf, slot), tlx.local_view(b_buf, slot)],
+            [[0, load_idx * BLOCK_K_PACKED_A], b_offsets],
+            [0b0101, 0b1010],
+            preds=[pred, pred],
+        )
+        tlx.async_amd_descriptor_load_group(
+            [a_scale_desc, b_scale_desc],
+            [tlx.local_view(a_scale_buf, slot), tlx.local_view(b_scale_buf, slot)],
+            [scale_offsets, scale_offsets],
+            [0b0101, 0b1010],
+            preds=[pred, pred],
+        )
     else:
-        tl.static_assert(TDM_FUSION == "none", "TDM_FUSION must be one of: none, 2way, 4way")
+        tl.static_assert(TDM_FUSION == "none", "TDM_FUSION must be one of: none, 2way, 4way, partial")
         _mxgemm_issue_load_a_scale(a_scale_desc, a_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
                                    SCALE_PRESHUFFLE, WITH_A_SCALE)
         _mxgemm_issue_load_b_scale(b_scale_desc, b_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
@@ -438,8 +454,11 @@ def mxgemm_tdm_pipelined_kernel(
         NUM_LOADS_IN_BATCH: tl.constexpr = 1
     elif TDM_FUSION == "2way":
         NUM_LOADS_IN_BATCH: tl.constexpr = 2
+    elif TDM_FUSION == "partial":
+        tl.static_assert(WITH_A_SCALE, "partial TDM fusion requires WITH_A_SCALE")
+        NUM_LOADS_IN_BATCH: tl.constexpr = 2
     else:
-        tl.static_assert(TDM_FUSION == "none", "TDM_FUSION must be one of: none, 2way, 4way")
+        tl.static_assert(TDM_FUSION == "none", "TDM_FUSION must be one of: none, 2way, 4way, partial")
         NUM_LOADS_IN_BATCH: tl.constexpr = 4 if WITH_A_SCALE else 3
     if SCHEDULE == "sliceMNK":
         NUM_SUBTILES_M: tl.constexpr = 2
@@ -838,7 +857,7 @@ def mxgemm_tdm_pipelined(
     return c
 
 
-@pytest.mark.parametrize("TDM_FUSION", ["none", "2way", "4way"])
+@pytest.mark.parametrize("TDM_FUSION", ["none", "2way", "4way", "partial"])
 def test_mxgemm_tdm_pipelined_compiles_gfx1250(TDM_FUSION):
     from triton.backends.compiler import GPUTarget
     from triton.compiler.compiler import ASTSource, compile as triton_compile
@@ -888,6 +907,12 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250(TDM_FUSION):
     else:
         assert "amdg.async_tdm_group_copy_global_to_local" in ttgir
         assert "amdg.async_tdm_copy_global_to_local" not in ttgir
+    if TDM_FUSION == "2way":
+        assert "warp_masks = array<i32: 3, 12>" in ttgir
+    elif TDM_FUSION == "4way":
+        assert "warp_masks = array<i32: 1, 2, 4, 8>" in ttgir
+    elif TDM_FUSION == "partial":
+        assert "warp_masks = array<i32: 5, 10>" in ttgir
     assert "amdg.tdm_prefetch" in ttgir
     assert "tt.dot_scaled" in ttgir
     assert "tensor_load_to_lds" in amdgcn or "tensor.load.to.lds" in amdgcn
@@ -907,6 +932,7 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250(TDM_FUSION):
         (256, 256, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "none", 2),
         (256, 256, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "2way", 2),
         (256, 256, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "4way", 2),
+        (256, 256, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "partial", 2),
         (256, 512, 512, "sliceMNK", "float8_e4m3", "float8_e5m2", 128, 256, 256, 2, True, True, "4way", 2),
         (256, 256, 512, "baseline", "float4", "float4", 128, 128, 128, 2, True, True, "4way", 2),
         (384, 384, 512, "sliceMNK", "float8_e4m3", "float8_e4m3", 256, 256, 256, 2, True, True, "4way", 2),

--- a/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
@@ -1,9 +1,9 @@
 """
-Baseline MXFP TDM-pipelined GEMM for AMD gfx1250 using TLX.
+MXFP TDM-pipelined GEMM for AMD gfx1250 using TLX.
 
-This ports the baseline Gluon ``mxgemm_tdm_pipelined_kernel`` schedule to
-TLX APIs: full-tile TDM loads for A/B and pre-shuffled scales, local LDS loads
-into registers, and ``tl.dot_scaled`` for the scaled WMMA.
+This mirrors the structure of the Gluon MXFP GEMM example: descriptor-backed
+loads for A/B and scales, optional A scales, L2 prefetch hints, and baseline or
+sliced K/N/MNK compute schedules.
 """
 import pytest
 import torch
@@ -11,7 +11,7 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.tools.mxfp import MXScaleTensor
+from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -37,6 +37,8 @@ def is_gfx1250_available():
 
 
 def pack_scale(x: torch.Tensor, preshuffle_factor: int = 128) -> torch.Tensor:
+    if x is None:
+        return x
     non_k, k_scale = x.shape
     scale_kwidth = 4 if k_scale >= 4 else k_scale
     num_chunk_m = non_k // preshuffle_factor
@@ -53,13 +55,85 @@ def fp8e8m0_to_float32(scale: torch.Tensor) -> torch.Tensor:
 
 
 def torch_gemm_mxfp(a, b, a_scale, b_scale, scale_block, M, N, K):
-    a_scale_f32 = fp8e8m0_to_float32(a_scale).repeat_interleave(scale_block, dim=1)[:M, :K]
+    if a_scale is None:
+        a_scale_f32 = torch.full((M, K), 1.0, dtype=torch.float32)
+    else:
+        a_scale_f32 = fp8e8m0_to_float32(a_scale).repeat_interleave(scale_block, dim=1)[:M, :K]
     b_scale_f32 = fp8e8m0_to_float32(b_scale).repeat_interleave(scale_block, dim=1).T.contiguous()[:K, :N]
     return torch.matmul(a.to(torch.float32) * a_scale_f32, b.to(torch.float32) * b_scale_f32)
 
 
 @triton.jit
-def _mxgemm_issue_tdm_loads(
+def _mxgemm_issue_load_a_scale(
+    a_scale_desc,
+    a_scale_buf,
+    load_idx,
+    pred,
+    BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+    WITH_A_SCALE: tl.constexpr,
+):
+    if WITH_A_SCALE:
+        slot = load_idx % NUM_BUFFERS
+        if SCALE_PRESHUFFLE:
+            scale_offsets = [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED]
+        else:
+            scale_offsets = [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED // 128]
+        tlx.async_amd_descriptor_load(a_scale_desc, tlx.local_view(a_scale_buf, slot), scale_offsets, pred=pred)
+
+
+@triton.jit
+def _mxgemm_issue_load_b_scale(
+    b_scale_desc,
+    b_scale_buf,
+    load_idx,
+    pred,
+    BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+):
+    slot = load_idx % NUM_BUFFERS
+    if SCALE_PRESHUFFLE:
+        scale_offsets = [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED]
+    else:
+        scale_offsets = [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED // 128]
+    tlx.async_amd_descriptor_load(b_scale_desc, tlx.local_view(b_scale_buf, slot), scale_offsets, pred=pred)
+
+
+@triton.jit
+def _mxgemm_issue_load_a_data(
+    a_desc,
+    a_buf,
+    load_idx,
+    pred,
+    BLOCK_K_PACKED_A: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+):
+    slot = load_idx % NUM_BUFFERS
+    tlx.async_amd_descriptor_load(a_desc, tlx.local_view(a_buf, slot), [0, load_idx * BLOCK_K_PACKED_A], pred=pred)
+
+
+@triton.jit
+def _mxgemm_issue_load_b_data(
+    b_desc,
+    b_buf,
+    load_idx,
+    pred,
+    BLOCK_K_PACKED_B: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    TRANSPOSE_B: tl.constexpr,
+):
+    slot = load_idx % NUM_BUFFERS
+    if TRANSPOSE_B:
+        b_offsets = [0, load_idx * BLOCK_K_PACKED_B]
+    else:
+        b_offsets = [load_idx * BLOCK_K_PACKED_B, 0]
+    tlx.async_amd_descriptor_load(b_desc, tlx.local_view(b_buf, slot), b_offsets, pred=pred)
+
+
+@triton.jit
+def _mxgemm_issue_loads(
     a_desc,
     b_desc,
     a_scale_desc,
@@ -75,113 +149,187 @@ def _mxgemm_issue_tdm_loads(
     BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr,
     NUM_BUFFERS: tl.constexpr,
     TRANSPOSE_B: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+    WITH_A_SCALE: tl.constexpr,
 ):
-    slot = load_idx % NUM_BUFFERS
-    if TRANSPOSE_B:
-        b_offsets = [0, load_idx * BLOCK_K_PACKED_B]
-    else:
-        b_offsets = [load_idx * BLOCK_K_PACKED_B, 0]
-    tlx.async_amd_descriptor_load_group(
-        [a_desc, b_desc, a_scale_desc, b_scale_desc],
-        [
-            tlx.local_view(a_buf, slot),
-            tlx.local_view(b_buf, slot),
-            tlx.local_view(a_scale_buf, slot),
-            tlx.local_view(b_scale_buf, slot),
-        ],
-        [
-            [0, load_idx * BLOCK_K_PACKED_A],
-            b_offsets,
-            [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED],
-            [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED],
-        ],
-        [0b0001, 0b0010, 0b0100, 0b1000],
-        preds=[pred, pred, pred, pred],
-    )
+    _mxgemm_issue_load_a_scale(a_scale_desc, a_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
+                               SCALE_PRESHUFFLE, WITH_A_SCALE)
+    _mxgemm_issue_load_b_scale(b_scale_desc, b_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
+                               SCALE_PRESHUFFLE)
+    _mxgemm_issue_load_a_data(a_desc, a_buf, load_idx, pred, BLOCK_K_PACKED_A, NUM_BUFFERS)
+    _mxgemm_issue_load_b_data(b_desc, b_buf, load_idx, pred, BLOCK_K_PACKED_B, NUM_BUFFERS, TRANSPOSE_B)
     return load_idx + 1
 
 
 @triton.jit
-def _mxgemm_issue_tdm_loads_unpredicated(
+def _mxgemm_issue_l2_prefetches(
     a_desc,
     b_desc,
     a_scale_desc,
     b_scale_desc,
-    a_buf,
-    b_buf,
-    a_scale_buf,
-    b_scale_buf,
     load_idx,
+    pred,
+    L2_PREFETCH_DISTANCE: tl.constexpr,
     BLOCK_K_PACKED_A: tl.constexpr,
     BLOCK_K_PACKED_B: tl.constexpr,
     BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr,
-    NUM_BUFFERS: tl.constexpr,
     TRANSPOSE_B: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+    WITH_A_SCALE: tl.constexpr,
 ):
-    slot = load_idx % NUM_BUFFERS
-    if TRANSPOSE_B:
-        b_offsets = [0, load_idx * BLOCK_K_PACKED_B]
-    else:
-        b_offsets = [load_idx * BLOCK_K_PACKED_B, 0]
-    tlx.async_amd_descriptor_load_group(
-        [a_desc, b_desc, a_scale_desc, b_scale_desc],
-        [
-            tlx.local_view(a_buf, slot),
-            tlx.local_view(b_buf, slot),
-            tlx.local_view(a_scale_buf, slot),
-            tlx.local_view(b_scale_buf, slot),
-        ],
-        [
-            [0, load_idx * BLOCK_K_PACKED_A],
-            b_offsets,
-            [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED],
-            [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED],
-        ],
-        [0b0001, 0b0010, 0b0100, 0b1000],
-    )
-    return load_idx + 1
+    if L2_PREFETCH_DISTANCE >= 0:
+        prefetch_iteration = load_idx + L2_PREFETCH_DISTANCE
+        if WITH_A_SCALE:
+            if SCALE_PRESHUFFLE:
+                a_scale_offsets = [0, prefetch_iteration * BLOCK_K_SCALE_PRESHUFFLED]
+            else:
+                a_scale_offsets = [0, prefetch_iteration * BLOCK_K_SCALE_PRESHUFFLED // 128]
+            tlx.amd_descriptor_prefetch_tensor(a_scale_desc, a_scale_offsets, pred=pred)
+        if SCALE_PRESHUFFLE:
+            b_scale_offsets = [0, prefetch_iteration * BLOCK_K_SCALE_PRESHUFFLED]
+        else:
+            b_scale_offsets = [0, prefetch_iteration * BLOCK_K_SCALE_PRESHUFFLED // 128]
+        tlx.amd_descriptor_prefetch_tensor(b_scale_desc, b_scale_offsets, pred=pred)
+        tlx.amd_descriptor_prefetch_tensor(a_desc, [0, prefetch_iteration * BLOCK_K_PACKED_A], pred=pred)
+        if TRANSPOSE_B:
+            tlx.amd_descriptor_prefetch_tensor(b_desc, [0, prefetch_iteration * BLOCK_K_PACKED_B], pred=pred)
+        else:
+            tlx.amd_descriptor_prefetch_tensor(b_desc, [prefetch_iteration * BLOCK_K_PACKED_B, 0], pred=pred)
 
 
 @triton.jit
-def _mxgemm_load_operands(
+def _mxgemm_issue_l2_prefetches_prologue(
+    a_desc,
+    b_desc,
+    a_scale_desc,
+    b_scale_desc,
+    load_idx,
+    L2_PREFETCH_DISTANCE: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    BLOCK_K_PACKED_A: tl.constexpr,
+    BLOCK_K_PACKED_B: tl.constexpr,
+    BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr,
+    TRANSPOSE_B: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+    WITH_A_SCALE: tl.constexpr,
+):
+    if L2_PREFETCH_DISTANCE >= 0:
+        always = tl.full((), True, dtype=tl.int1)
+        for i in tl.static_range(NUM_BUFFERS, NUM_BUFFERS + L2_PREFETCH_DISTANCE):
+            _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always, i,
+                                        BLOCK_K_PACKED_A, BLOCK_K_PACKED_B, BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B,
+                                        SCALE_PRESHUFFLE, WITH_A_SCALE)
+
+
+@triton.jit
+def _mxgemm_load_a_operand(
     a_buf,
-    b_buf,
     a_scale_buf,
-    b_scale_buf,
     wmma_idx,
+    subtile_start_idx_m: tl.constexpr,
+    subtile_start_idx_k: tl.constexpr,
     BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    DIV_FACTOR_A: tl.constexpr,
+    SCALE_BLOCK: tl.constexpr,
     BLOCK_K_SCALE: tl.constexpr,
     BLOCK_M_PRESHUFFLED: tl.constexpr,
-    BLOCK_N_PRESHUFFLED: tl.constexpr,
-    BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr,
     SCALE_KWIDTH: tl.constexpr,
     NUM_BUFFERS: tl.constexpr,
-    TRANSPOSE_B: tl.constexpr,
+    NUM_SUBTILES_M: tl.constexpr,
+    NUM_SUBTILES_K: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+    WITH_A_SCALE: tl.constexpr,
 ):
     slot = wmma_idx % NUM_BUFFERS
-    a = tlx.local_load(tlx.local_view(a_buf, slot))
+    subtile_m: tl.constexpr = BLOCK_M // NUM_SUBTILES_M
+    subtile_k: tl.constexpr = BLOCK_K // NUM_SUBTILES_K
+    subtile_start_m: tl.constexpr = subtile_start_idx_m * subtile_m
+    subtile_start_k: tl.constexpr = subtile_start_idx_k * subtile_k
+
+    a_view = tlx.local_view(a_buf, slot)
+    if NUM_SUBTILES_M != 1 or NUM_SUBTILES_K != 1:
+        a_view = tlx.local_slice(a_view, [subtile_start_m, subtile_start_k // DIV_FACTOR_A],
+                                 [subtile_m, subtile_k // DIV_FACTOR_A])
+    a = tlx.local_load(a_view)
+
+    if WITH_A_SCALE:
+        if SCALE_PRESHUFFLE:
+            scale_a_view = tlx.local_reshape(
+                tlx.local_view(a_scale_buf, slot),
+                [BLOCK_M_PRESHUFFLED, BLOCK_K_SCALE // SCALE_KWIDTH, 128 // 4, 4, SCALE_KWIDTH],
+            )
+            scale_a_view = tlx.local_trans(scale_a_view, (0, 3, 2, 1, 4))
+            scale_a_view = tlx.local_reshape(scale_a_view, [BLOCK_M, BLOCK_K_SCALE])
+        else:
+            scale_a_view = tlx.local_view(a_scale_buf, slot)
+        if NUM_SUBTILES_M != 1 or NUM_SUBTILES_K != 1:
+            scale_a_view = tlx.local_slice(scale_a_view, [subtile_start_m, subtile_start_k // SCALE_BLOCK],
+                                           [subtile_m, subtile_k // SCALE_BLOCK])
+        elif not SCALE_PRESHUFFLE:
+            scale_a_view = tlx.local_slice(scale_a_view, [0, 0], [BLOCK_M, BLOCK_K_SCALE])
+        scale_a = tlx.local_load(scale_a_view)
+    else:
+        scale_a = tl.full((subtile_m, subtile_k // SCALE_BLOCK), 127, dtype=tl.uint8)
+
+    return a, scale_a
+
+
+@triton.jit
+def _mxgemm_load_b_operand(
+    b_buf,
+    b_scale_buf,
+    wmma_idx,
+    subtile_start_idx_k: tl.constexpr,
+    subtile_start_idx_n: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    DIV_FACTOR_B: tl.constexpr,
+    SCALE_BLOCK: tl.constexpr,
+    BLOCK_K_SCALE: tl.constexpr,
+    BLOCK_N_PRESHUFFLED: tl.constexpr,
+    SCALE_KWIDTH: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    NUM_SUBTILES_N: tl.constexpr,
+    NUM_SUBTILES_K: tl.constexpr,
+    TRANSPOSE_B: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+):
+    slot = wmma_idx % NUM_BUFFERS
+    subtile_n: tl.constexpr = BLOCK_N // NUM_SUBTILES_N
+    subtile_k: tl.constexpr = BLOCK_K // NUM_SUBTILES_K
+    subtile_start_n: tl.constexpr = subtile_start_idx_n * subtile_n
+    subtile_start_k: tl.constexpr = subtile_start_idx_k * subtile_k
+
     b_view = tlx.local_view(b_buf, slot)
-    b = tlx.local_load(tlx.local_trans(b_view) if TRANSPOSE_B else b_view)
+    if TRANSPOSE_B:
+        if NUM_SUBTILES_N != 1 or NUM_SUBTILES_K != 1:
+            b_view = tlx.local_slice(b_view, [subtile_start_n, subtile_start_k // DIV_FACTOR_B],
+                                     [subtile_n, subtile_k // DIV_FACTOR_B])
+        b = tlx.local_load(tlx.local_trans(b_view))
+    else:
+        if NUM_SUBTILES_N != 1 or NUM_SUBTILES_K != 1:
+            b_view = tlx.local_slice(b_view, [subtile_start_k // DIV_FACTOR_B, subtile_start_n],
+                                     [subtile_k // DIV_FACTOR_B, subtile_n])
+        b = tlx.local_load(b_view)
 
-    scale_a_view = tlx.local_reshape(
-        tlx.local_view(a_scale_buf, slot),
-        [BLOCK_M_PRESHUFFLED, BLOCK_K_SCALE // SCALE_KWIDTH, 128 // 4, 4, SCALE_KWIDTH],
-    )
-    scale_a_view = tlx.local_trans(scale_a_view, (0, 3, 2, 1, 4))
-    scale_a_view = tlx.local_reshape(scale_a_view, [BLOCK_M, BLOCK_K_SCALE])
-
-    scale_b_view = tlx.local_reshape(
-        tlx.local_view(b_scale_buf, slot),
-        [BLOCK_N_PRESHUFFLED, BLOCK_K_SCALE // SCALE_KWIDTH, 128 // 4, 4, SCALE_KWIDTH],
-    )
-    scale_b_view = tlx.local_trans(scale_b_view, (0, 3, 2, 1, 4))
-    scale_b_view = tlx.local_reshape(scale_b_view, [BLOCK_N, BLOCK_K_SCALE])
-
-    scale_a = tlx.local_load(scale_a_view)
+    if SCALE_PRESHUFFLE:
+        scale_b_view = tlx.local_reshape(
+            tlx.local_view(b_scale_buf, slot),
+            [BLOCK_N_PRESHUFFLED, BLOCK_K_SCALE // SCALE_KWIDTH, 128 // 4, 4, SCALE_KWIDTH],
+        )
+        scale_b_view = tlx.local_trans(scale_b_view, (0, 3, 2, 1, 4))
+        scale_b_view = tlx.local_reshape(scale_b_view, [BLOCK_N, BLOCK_K_SCALE])
+    else:
+        scale_b_view = tlx.local_view(b_scale_buf, slot)
+    if NUM_SUBTILES_N != 1 or NUM_SUBTILES_K != 1:
+        scale_b_view = tlx.local_slice(scale_b_view, [subtile_start_n, subtile_start_k // SCALE_BLOCK],
+                                       [subtile_n, subtile_k // SCALE_BLOCK])
+    elif not SCALE_PRESHUFFLE:
+        scale_b_view = tlx.local_slice(scale_b_view, [0, 0], [BLOCK_N, BLOCK_K_SCALE])
     scale_b = tlx.local_load(scale_b_view)
 
-    return a, b, scale_a, scale_b
+    return b, scale_b
 
 
 @triton.jit
@@ -210,6 +358,10 @@ def mxgemm_tdm_pipelined_kernel(
     GROUP_SIZE_M: tl.constexpr,
     TRANSPOSE_B: tl.constexpr,
     NUM_BUFFERS: tl.constexpr,
+    SCALE_PRESHUFFLE: tl.constexpr,
+    WITH_A_SCALE: tl.constexpr,
+    SCHEDULE: tl.constexpr,
+    L2_PREFETCH_DISTANCE: tl.constexpr = -1,
 ):
     DIV_FACTOR_A: tl.constexpr = 2 if DTYPE_A == "e2m1" else 1
     DIV_FACTOR_B: tl.constexpr = 2 if DTYPE_B == "e2m1" else 1
@@ -220,7 +372,24 @@ def mxgemm_tdm_pipelined_kernel(
     BLOCK_M_PRESHUFFLED: tl.constexpr = BLOCK_M // 128
     BLOCK_N_PRESHUFFLED: tl.constexpr = BLOCK_N // 128
     BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr = BLOCK_K_SCALE * 128
-    NUM_LOADS_IN_BATCH: tl.constexpr = 1
+    NUM_LOADS_IN_BATCH: tl.constexpr = 4 if WITH_A_SCALE else 3
+    if SCHEDULE == "sliceMNK":
+        NUM_SUBTILES_M: tl.constexpr = 2
+        NUM_SUBTILES_N: tl.constexpr = 2
+        NUM_SUBTILES_K: tl.constexpr = 2
+    elif SCHEDULE == "sliceNK":
+        NUM_SUBTILES_M: tl.constexpr = 1
+        NUM_SUBTILES_N: tl.constexpr = 2
+        NUM_SUBTILES_K: tl.constexpr = 2
+    elif SCHEDULE == "sliceK":
+        NUM_SUBTILES_M: tl.constexpr = 1
+        NUM_SUBTILES_N: tl.constexpr = 1
+        NUM_SUBTILES_K: tl.constexpr = 2
+    else:
+        tl.static_assert(SCHEDULE == "baseline")
+        NUM_SUBTILES_M: tl.constexpr = 1
+        NUM_SUBTILES_N: tl.constexpr = 1
+        NUM_SUBTILES_K: tl.constexpr = 1
 
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_M)
@@ -259,18 +428,37 @@ def mxgemm_tdm_pipelined_kernel(
                                                                                      [1, 0])
         b_buf = tlx.local_alloc((BLOCK_K_PACKED_B, BLOCK_N), tlx.dtype_of(b_ptr), NUM_BUFFERS, layout=b_layout)
 
-    a_scale_desc = tl.make_tensor_descriptor(
-        a_scale + pid_m * BLOCK_M_PRESHUFFLED * stride_scale,
-        shape=[M // 128, K // SCALE_BLOCK * 128],
-        strides=[stride_scale, tl.constexpr(1)],
-        block_shape=[BLOCK_M_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED],
-    )
-    b_scale_desc = tl.make_tensor_descriptor(
-        b_scale + pid_n * BLOCK_N_PRESHUFFLED * stride_scale,
-        shape=[N // 128, K // SCALE_BLOCK * 128],
-        strides=[stride_scale, tl.constexpr(1)],
-        block_shape=[BLOCK_N_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED],
-    )
+    if SCALE_PRESHUFFLE:
+        a_scale_desc = tl.make_tensor_descriptor(
+            a_scale + pid_m * BLOCK_M_PRESHUFFLED * stride_scale,
+            shape=[M // 128, K // SCALE_BLOCK * 128],
+            strides=[stride_scale, tl.constexpr(1)],
+            block_shape=[BLOCK_M_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED],
+        )
+        b_scale_desc = tl.make_tensor_descriptor(
+            b_scale + pid_n * BLOCK_N_PRESHUFFLED * stride_scale,
+            shape=[N // 128, K // SCALE_BLOCK * 128],
+            strides=[stride_scale, tl.constexpr(1)],
+            block_shape=[BLOCK_N_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED],
+        )
+        a_scale_shape: tl.constexpr = (BLOCK_M_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED)
+        b_scale_shape: tl.constexpr = (BLOCK_N_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED)
+    else:
+        BLOCK_K_SCALE_LOAD: tl.constexpr = 16 if BLOCK_K_SCALE < 16 else BLOCK_K_SCALE
+        a_scale_desc = tl.make_tensor_descriptor(
+            a_scale + pid_m * BLOCK_M * stride_scale,
+            shape=[M, K // SCALE_BLOCK],
+            strides=[stride_scale, tl.constexpr(1)],
+            block_shape=[BLOCK_M, BLOCK_K_SCALE_LOAD],
+        )
+        b_scale_desc = tl.make_tensor_descriptor(
+            b_scale + pid_n * BLOCK_N * stride_scale,
+            shape=[N, K // SCALE_BLOCK],
+            strides=[stride_scale, tl.constexpr(1)],
+            block_shape=[BLOCK_N, BLOCK_K_SCALE_LOAD],
+        )
+        a_scale_shape: tl.constexpr = (BLOCK_M, BLOCK_K_SCALE_LOAD)
+        b_scale_shape: tl.constexpr = (BLOCK_N, BLOCK_K_SCALE_LOAD)
 
     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -278,21 +466,24 @@ def mxgemm_tdm_pipelined_kernel(
     c_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
 
     a_layout: tl.constexpr = _operand_shared_layout([BLOCK_M, BLOCK_K_PACKED_A])
-    a_scale_layout: tl.constexpr = _scale_shared_layout([BLOCK_M_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED])
-    b_scale_layout: tl.constexpr = _scale_shared_layout([BLOCK_N_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED])
+    a_scale_layout: tl.constexpr = _scale_shared_layout(a_scale_shape)
+    b_scale_layout: tl.constexpr = _scale_shared_layout(b_scale_shape)
     a_buf = tlx.local_alloc((BLOCK_M, BLOCK_K_PACKED_A), tlx.dtype_of(a_ptr), NUM_BUFFERS, layout=a_layout)
-    a_scale_buf = tlx.local_alloc((BLOCK_M_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED), tlx.dtype_of(a_scale), NUM_BUFFERS,
-                                  layout=a_scale_layout)
-    b_scale_buf = tlx.local_alloc((BLOCK_N_PRESHUFFLED, BLOCK_K_SCALE_PRESHUFFLED), tlx.dtype_of(b_scale), NUM_BUFFERS,
-                                  layout=b_scale_layout)
+    a_scale_buf = tlx.local_alloc(a_scale_shape, tlx.dtype_of(a_scale), NUM_BUFFERS, layout=a_scale_layout)
+    b_scale_buf = tlx.local_alloc(b_scale_shape, tlx.dtype_of(b_scale), NUM_BUFFERS, layout=b_scale_layout)
 
     K_ITERS = tl.cdiv(K, BLOCK_K)
     epilogue_lb = K_ITERS - (NUM_BUFFERS - 1)
     load_idx = 0
     wmma_idx = 0
 
+    _mxgemm_issue_l2_prefetches_prologue(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, L2_PREFETCH_DISTANCE,
+                                         NUM_BUFFERS, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B, BLOCK_K_SCALE_PRESHUFFLED,
+                                         TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
+
+    always = tl.full((), True, dtype=tl.int1)
     for _ in tl.static_range(NUM_BUFFERS - 1):
-        load_idx = _mxgemm_issue_tdm_loads_unpredicated(
+        load_idx = _mxgemm_issue_loads(
             a_desc,
             b_desc,
             a_scale_desc,
@@ -302,59 +493,130 @@ def mxgemm_tdm_pipelined_kernel(
             a_scale_buf,
             b_scale_buf,
             load_idx,
+            always,
             BLOCK_K_PACKED_A,
             BLOCK_K_PACKED_B,
             BLOCK_K_SCALE_PRESHUFFLED,
             NUM_BUFFERS,
             TRANSPOSE_B,
+            SCALE_PRESHUFFLE,
+            WITH_A_SCALE,
         )
 
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
     tl.assume(K_ITERS > 0)
-    for i in tl.range(0, K_ITERS):
-        pred = i - epilogue_lb
-        pred = (pred >> 31) & 1
-        load_idx = _mxgemm_issue_tdm_loads(
-            a_desc,
-            b_desc,
-            a_scale_desc,
-            b_scale_desc,
-            a_buf,
-            b_buf,
-            a_scale_buf,
-            b_scale_buf,
-            load_idx,
-            pred,
-            BLOCK_K_PACKED_A,
-            BLOCK_K_PACKED_B,
-            BLOCK_K_SCALE_PRESHUFFLED,
-            NUM_BUFFERS,
-            TRANSPOSE_B,
-        )
-        tlx.async_amd_descriptor_wait((NUM_BUFFERS - 1) * NUM_LOADS_IN_BATCH)
-        a, b, scale_a, scale_b = _mxgemm_load_operands(
-            a_buf,
-            b_buf,
-            a_scale_buf,
-            b_scale_buf,
-            wmma_idx,
-            BLOCK_M,
-            BLOCK_N,
-            BLOCK_K_SCALE,
-            BLOCK_M_PRESHUFFLED,
-            BLOCK_N_PRESHUFFLED,
-            BLOCK_K_SCALE_PRESHUFFLED,
-            SCALE_KWIDTH,
-            NUM_BUFFERS,
-            TRANSPOSE_B,
-        )
-        wmma_idx += 1
-        acc = tlx.dot_scaled(a, scale_a, DTYPE_A, b, scale_b, DTYPE_B, acc, tiles_per_warp=[2, 2])
+    if SCHEDULE == "sliceMNK":
+        SUBTILE_M: tl.constexpr = BLOCK_M // 2
+        SUBTILE_N: tl.constexpr = BLOCK_N // 2
+        c00 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
+        c01 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
+        c10 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
+        c11 = tl.zeros((SUBTILE_M, SUBTILE_N), dtype=tl.float32)
+        for i in tl.range(0, K_ITERS):
+            pred = i - epilogue_lb
+            pred = (pred >> 31) & 1
+            load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
+                                           b_scale_buf, load_idx, pred, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
+                                           BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
+                                           WITH_A_SCALE)
+            _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always,
+                                        L2_PREFETCH_DISTANCE, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
+                                        BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
+            tlx.async_amd_descriptor_wait((NUM_BUFFERS - 1) * NUM_LOADS_IN_BATCH)
+            for kt in tl.static_range(2):
+                a0, scale_a0 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 0, kt, BLOCK_M, BLOCK_K,
+                                                      DIV_FACTOR_A, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED,
+                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K,
+                                                      SCALE_PRESHUFFLE, WITH_A_SCALE)
+                a1, scale_a1 = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 1, kt, BLOCK_M, BLOCK_K,
+                                                      DIV_FACTOR_A, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED,
+                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K,
+                                                      SCALE_PRESHUFFLE, WITH_A_SCALE)
+                b0, scale_b0 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, kt, 0, BLOCK_N, BLOCK_K,
+                                                      DIV_FACTOR_B, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED,
+                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K,
+                                                      TRANSPOSE_B, SCALE_PRESHUFFLE)
+                b1, scale_b1 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, kt, 1, BLOCK_N, BLOCK_K,
+                                                      DIV_FACTOR_B, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED,
+                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K,
+                                                      TRANSPOSE_B, SCALE_PRESHUFFLE)
+                c00 = tlx.dot_scaled(a0, scale_a0, DTYPE_A, b0, scale_b0, DTYPE_B, c00, tiles_per_warp=[2, 2])
+                c01 = tlx.dot_scaled(a0, scale_a0, DTYPE_A, b1, scale_b1, DTYPE_B, c01, tiles_per_warp=[2, 2])
+                c10 = tlx.dot_scaled(a1, scale_a1, DTYPE_A, b0, scale_b0, DTYPE_B, c10, tiles_per_warp=[2, 2])
+                c11 = tlx.dot_scaled(a1, scale_a1, DTYPE_A, b1, scale_b1, DTYPE_B, c11, tiles_per_warp=[2, 2])
+            wmma_idx += 1
+        acc_top = tl.join(c00, c01).permute(0, 2, 1).reshape((SUBTILE_M, BLOCK_N))
+        acc_bot = tl.join(c10, c11).permute(0, 2, 1).reshape((SUBTILE_M, BLOCK_N))
+        acc = tl.join(acc_top, acc_bot).permute(2, 0, 1).reshape((BLOCK_M, BLOCK_N))
+    elif SCHEDULE == "sliceNK":
+        SUBTILE_N: tl.constexpr = BLOCK_N // 2
+        c0 = tl.zeros((BLOCK_M, SUBTILE_N), dtype=tl.float32)
+        c1 = tl.zeros((BLOCK_M, SUBTILE_N), dtype=tl.float32)
+        for i in tl.range(0, K_ITERS):
+            pred = i - epilogue_lb
+            pred = (pred >> 31) & 1
+            load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
+                                           b_scale_buf, load_idx, pred, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
+                                           BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
+                                           WITH_A_SCALE)
+            _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always,
+                                        L2_PREFETCH_DISTANCE, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
+                                        BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
+            tlx.async_amd_descriptor_wait((NUM_BUFFERS - 1) * NUM_LOADS_IN_BATCH)
+            for kt in tl.static_range(2):
+                a, scale_a = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 0, kt, BLOCK_M, BLOCK_K, DIV_FACTOR_A,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K, SCALE_PRESHUFFLE,
+                                                    WITH_A_SCALE)
+                b0, scale_b0 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, kt, 0, BLOCK_N, BLOCK_K,
+                                                      DIV_FACTOR_B, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED,
+                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K,
+                                                      TRANSPOSE_B, SCALE_PRESHUFFLE)
+                b1, scale_b1 = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, kt, 1, BLOCK_N, BLOCK_K,
+                                                      DIV_FACTOR_B, SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED,
+                                                      SCALE_KWIDTH, NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K,
+                                                      TRANSPOSE_B, SCALE_PRESHUFFLE)
+                c0 = tlx.dot_scaled(a, scale_a, DTYPE_A, b0, scale_b0, DTYPE_B, c0, tiles_per_warp=[2, 2])
+                c1 = tlx.dot_scaled(a, scale_a, DTYPE_A, b1, scale_b1, DTYPE_B, c1, tiles_per_warp=[2, 2])
+            wmma_idx += 1
+        acc = tl.join(c0, c1).permute(0, 2, 1).reshape((BLOCK_M, BLOCK_N))
+    else:
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for i in tl.range(0, K_ITERS):
+            pred = i - epilogue_lb
+            pred = (pred >> 31) & 1
+            load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
+                                           b_scale_buf, load_idx, pred, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
+                                           BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
+                                           WITH_A_SCALE)
+            _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always,
+                                        L2_PREFETCH_DISTANCE, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
+                                        BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
+            tlx.async_amd_descriptor_wait((NUM_BUFFERS - 1) * NUM_LOADS_IN_BATCH)
+            for kt in tl.static_range(NUM_SUBTILES_K):
+                a, scale_a = _mxgemm_load_a_operand(a_buf, a_scale_buf, wmma_idx, 0, kt, BLOCK_M, BLOCK_K, DIV_FACTOR_A,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_M_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_M, NUM_SUBTILES_K, SCALE_PRESHUFFLE,
+                                                    WITH_A_SCALE)
+                b, scale_b = _mxgemm_load_b_operand(b_buf, b_scale_buf, wmma_idx, kt, 0, BLOCK_N, BLOCK_K, DIV_FACTOR_B,
+                                                    SCALE_BLOCK, BLOCK_K_SCALE, BLOCK_N_PRESHUFFLED, SCALE_KWIDTH,
+                                                    NUM_BUFFERS, NUM_SUBTILES_N, NUM_SUBTILES_K, TRANSPOSE_B,
+                                                    SCALE_PRESHUFFLE)
+                acc = tlx.dot_scaled(a, scale_a, DTYPE_A, b, scale_b, DTYPE_B, acc, tiles_per_warp=[2, 2])
+            wmma_idx += 1
 
     tl.store(c_ptrs, acc, mask=c_mask)
 
 
-def _init_fp8(dtype: str, rows: int, cols: int):
+DTYPE_TO_TRITON = {
+    "float8_e5m2": "e5m2",
+    "float8_e4m3": "e4m3",
+    "float4": "e2m1",
+}
+
+
+def _init_data(dtype: str, rows: int, cols: int):
+    if dtype == "float4":
+        return MXFP4Tensor(size=(rows, cols)).random()
     if dtype == "float8_e5m2":
         return torch.randint(20, 40, (rows, cols), dtype=torch.uint8).view(torch.float8_e5m2)
     if dtype == "float8_e4m3":
@@ -372,21 +634,39 @@ def mxgemm_tdm_pipelined(
     BLOCK_K: int = 128,
     TRANSPOSE_B: bool = False,
     NUM_BUFFERS: int = 2,
+    DTYPE_A: str = "e5m2",
+    DTYPE_B: str = "e5m2",
+    SCALE_PRESHUFFLE: bool = True,
+    WITH_A_SCALE: bool = True,
+    SCHEDULE: str = "baseline",
+    L2_PREFETCH_DISTANCE: int = -1,
+    M: int | None = None,
+    N: int | None = None,
+    K: int | None = None,
 ) -> torch.Tensor:
-    M, K = a.shape
+    if M is None:
+        M = a.shape[0]
+    if K is None:
+        K = a.shape[1] * (2 if DTYPE_A == "e2m1" else 1)
+    if N is None:
+        if TRANSPOSE_B:
+            N = b.shape[0]
+        else:
+            N = b.shape[1]
     if TRANSPOSE_B:
-        N, Kb = b.shape
+        Kb = b.shape[1] * (2 if DTYPE_B == "e2m1" else 1)
     else:
-        Kb, N = b.shape
+        Kb = b.shape[0] * (2 if DTYPE_B == "e2m1" else 1)
     assert K == Kb
     c = torch.empty((M, N), device=a.device, dtype=torch.float32)
     stride_bk, stride_bn = (b.stride(0), b.stride(1)) if not TRANSPOSE_B else (b.stride(1), b.stride(0))
+    a_scale_arg = a_scale if WITH_A_SCALE else b_scale
     grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), )
     mxgemm_tdm_pipelined_kernel[grid](
         a,
         b,
         c,
-        a_scale,
+        a_scale_arg,
         b_scale,
         M,
         N,
@@ -397,9 +677,9 @@ def mxgemm_tdm_pipelined(
         stride_bn,
         c.stride(0),
         c.stride(1),
-        a_scale.stride(0),
-        DTYPE_A="e5m2",
-        DTYPE_B="e5m2",
+        b_scale.stride(0),
+        DTYPE_A=DTYPE_A,
+        DTYPE_B=DTYPE_B,
         SCALE_BLOCK=32,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
@@ -407,6 +687,10 @@ def mxgemm_tdm_pipelined(
         GROUP_SIZE_M=8,
         TRANSPOSE_B=TRANSPOSE_B,
         NUM_BUFFERS=NUM_BUFFERS,
+        SCALE_PRESHUFFLE=SCALE_PRESHUFFLE,
+        WITH_A_SCALE=WITH_A_SCALE,
+        SCHEDULE=SCHEDULE,
+        L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE,
         num_warps=4,
         waves_per_eu=1,
     )
@@ -446,13 +730,18 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250():
             "GROUP_SIZE_M": 8,
             "TRANSPOSE_B": True,
             "NUM_BUFFERS": 2,
+            "SCALE_PRESHUFFLE": True,
+            "WITH_A_SCALE": True,
+            "SCHEDULE": "baseline",
+            "L2_PREFETCH_DISTANCE": 2,
         },
     )
     compiled = triton_compile(src, target=GPUTarget("hip", "gfx1250", 32))
     ttgir = compiled.asm["ttgir"]
     amdgcn = compiled.asm["amdgcn"]
-    assert "amdg.async_tdm_group_copy_global_to_local" in ttgir
-    assert "amdg.async_tdm_copy_global_to_local" not in ttgir
+    assert "amdg.async_tdm_copy_global_to_local" in ttgir
+    assert "amdg.async_tdm_group_copy_global_to_local" not in ttgir
+    assert "amdg.tdm_prefetch" in ttgir
     assert "tt.dot_scaled" in ttgir
     assert "tensor_load_to_lds" in amdgcn or "tensor.load.to.lds" in amdgcn
     assert "wmma" in amdgcn
@@ -460,19 +749,48 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250():
 
 @pytest.mark.skipif(not is_gfx1250_available(), reason="Requires gfx1250 hardware")
 @pytest.mark.parametrize("TRANSPOSE_B", [False, True])
-@pytest.mark.parametrize("K", [512, 128])
-def test_mxgemm_tdm_pipelined_gfx1250(TRANSPOSE_B, K):
+@pytest.mark.parametrize(
+    "SCHEDULE,DTYPE_A,DTYPE_B,BLOCK_M,BLOCK_N,BLOCK_K,NUM_BUFFERS,SCALE_PRESHUFFLE,WITH_A_SCALE,L2_PREFETCH_DISTANCE",
+    [
+        ("baseline", "float8_e5m2", "float8_e5m2", 128, 128, 128, 2, True, True, -1),
+        ("baseline", "float8_e4m3", "float8_e5m2", 128, 128, 128, 2, False, False, 2),
+        ("sliceK", "float8_e4m3", "float8_e5m2", 128, 128, 256, 2, True, True, 2),
+        ("sliceNK", "float8_e5m2", "float4", 256, 256, 256, 2, True, True, 2),
+        ("sliceMNK", "float8_e4m3", "float8_e5m2", 128, 256, 256, 2, True, True, 2),
+        ("baseline", "float4", "float4", 128, 128, 128, 2, True, True, 2),
+    ],
+)
+def test_mxgemm_tdm_pipelined_gfx1250(TRANSPOSE_B, SCHEDULE, DTYPE_A, DTYPE_B, BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS,
+                                      SCALE_PRESHUFFLE, WITH_A_SCALE, L2_PREFETCH_DISTANCE):
     torch.manual_seed(0)
     M = N = 256
-    a = _init_fp8("float8_e5m2", M, K)
-    b = _init_fp8("float8_e5m2", K, N)
-    a_scale = MXScaleTensor(size=(M, triton.cdiv(K, 32))).random(high=32.0).data
+    K = 512
+    a = _init_data(DTYPE_A, M, K)
+    b = _init_data(DTYPE_B, K, N)
+    if WITH_A_SCALE:
+        a_scale = MXScaleTensor(size=(M, triton.cdiv(K, 32))).random(high=32.0).data
+    else:
+        a_scale = None
     b_scale = MXScaleTensor(size=(N, triton.cdiv(K, 32))).random(high=32.0).data
     ref = torch_gemm_mxfp(a, b, a_scale, b_scale, 32, M, N, K)
 
-    a_scale = pack_scale(a_scale)
-    b_scale = pack_scale(b_scale)
-    a_d = a.contiguous().cuda()
-    b_d = (b.T.contiguous() if TRANSPOSE_B else b.contiguous()).cuda()
-    out = mxgemm_tdm_pipelined(a_d, b_d, a_scale.cuda(), b_scale.cuda(), TRANSPOSE_B=TRANSPOSE_B)
+    a_scale_input = pack_scale(a_scale) if SCALE_PRESHUFFLE else a_scale
+    b_scale_input = pack_scale(b_scale) if SCALE_PRESHUFFLE else b_scale
+    if DTYPE_A == "float4":
+        a = a.to_packed_tensor(dim=1)
+    if DTYPE_B == "float4":
+        b = b.to_packed_tensor(dim=0)
+
+    a_d = a.data.contiguous().cuda() if DTYPE_A == "float4" else a.contiguous().cuda()
+    if DTYPE_B == "float4":
+        b_d = b.data.T.contiguous().cuda() if TRANSPOSE_B else b.data.contiguous().cuda()
+    else:
+        b_d = b.T.contiguous().cuda() if TRANSPOSE_B else b.contiguous().cuda()
+    if a_scale_input is not None:
+        a_scale_d = a_scale_input.cuda()
+    else:
+        a_scale_d = None
+    out = mxgemm_tdm_pipelined(a_d, b_d, a_scale_d, b_scale_input.cuda(), BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B,
+                               NUM_BUFFERS, DTYPE_TO_TRITON[DTYPE_A], DTYPE_TO_TRITON[DTYPE_B], SCALE_PRESHUFFLE,
+                               WITH_A_SCALE, SCHEDULE, L2_PREFETCH_DISTANCE, M, N, K)
     torch.testing.assert_close(out.cpu(), ref, rtol=1e-5, atol=2e-2)

--- a/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-mxfp-gemm-tdm-pipelined_test.py
@@ -151,13 +151,65 @@ def _mxgemm_issue_loads(
     TRANSPOSE_B: tl.constexpr,
     SCALE_PRESHUFFLE: tl.constexpr,
     WITH_A_SCALE: tl.constexpr,
+    TDM_FUSION: tl.constexpr,
 ):
-    _mxgemm_issue_load_a_scale(a_scale_desc, a_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
-                               SCALE_PRESHUFFLE, WITH_A_SCALE)
-    _mxgemm_issue_load_b_scale(b_scale_desc, b_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
-                               SCALE_PRESHUFFLE)
-    _mxgemm_issue_load_a_data(a_desc, a_buf, load_idx, pred, BLOCK_K_PACKED_A, NUM_BUFFERS)
-    _mxgemm_issue_load_b_data(b_desc, b_buf, load_idx, pred, BLOCK_K_PACKED_B, NUM_BUFFERS, TRANSPOSE_B)
+    slot = load_idx % NUM_BUFFERS
+    if TRANSPOSE_B:
+        b_offsets = [0, load_idx * BLOCK_K_PACKED_B]
+    else:
+        b_offsets = [load_idx * BLOCK_K_PACKED_B, 0]
+    if SCALE_PRESHUFFLE:
+        scale_offsets = [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED]
+    else:
+        scale_offsets = [0, load_idx * BLOCK_K_SCALE_PRESHUFFLED // 128]
+
+    if TDM_FUSION == "4way":
+        tl.static_assert(WITH_A_SCALE, "4-way TDM fusion requires WITH_A_SCALE")
+        tlx.async_amd_descriptor_load_group(
+            [a_desc, b_desc, a_scale_desc, b_scale_desc],
+            [
+                tlx.local_view(a_buf, slot),
+                tlx.local_view(b_buf, slot),
+                tlx.local_view(a_scale_buf, slot),
+                tlx.local_view(b_scale_buf, slot),
+            ],
+            [
+                [0, load_idx * BLOCK_K_PACKED_A],
+                b_offsets,
+                scale_offsets,
+                scale_offsets,
+            ],
+            [0b0001, 0b0010, 0b0100, 0b1000],
+            preds=[pred, pred, pred, pred],
+        )
+    elif TDM_FUSION == "2way":
+        tlx.async_amd_descriptor_load_group(
+            [a_desc, b_desc],
+            [tlx.local_view(a_buf, slot), tlx.local_view(b_buf, slot)],
+            [[0, load_idx * BLOCK_K_PACKED_A], b_offsets],
+            [0b0011, 0b1100],
+            preds=[pred, pred],
+        )
+        if WITH_A_SCALE:
+            tlx.async_amd_descriptor_load_group(
+                [a_scale_desc, b_scale_desc],
+                [tlx.local_view(a_scale_buf, slot),
+                 tlx.local_view(b_scale_buf, slot)],
+                [scale_offsets, scale_offsets],
+                [0b0011, 0b1100],
+                preds=[pred, pred],
+            )
+        else:
+            _mxgemm_issue_load_b_scale(b_scale_desc, b_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED,
+                                       NUM_BUFFERS, SCALE_PRESHUFFLE)
+    else:
+        tl.static_assert(TDM_FUSION == "none", "TDM_FUSION must be one of: none, 2way, 4way")
+        _mxgemm_issue_load_a_scale(a_scale_desc, a_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
+                                   SCALE_PRESHUFFLE, WITH_A_SCALE)
+        _mxgemm_issue_load_b_scale(b_scale_desc, b_scale_buf, load_idx, pred, BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS,
+                                   SCALE_PRESHUFFLE)
+        _mxgemm_issue_load_a_data(a_desc, a_buf, load_idx, pred, BLOCK_K_PACKED_A, NUM_BUFFERS)
+        _mxgemm_issue_load_b_data(b_desc, b_buf, load_idx, pred, BLOCK_K_PACKED_B, NUM_BUFFERS, TRANSPOSE_B)
     return load_idx + 1
 
 
@@ -361,6 +413,7 @@ def mxgemm_tdm_pipelined_kernel(
     SCALE_PRESHUFFLE: tl.constexpr,
     WITH_A_SCALE: tl.constexpr,
     SCHEDULE: tl.constexpr,
+    TDM_FUSION: tl.constexpr = "none",
     L2_PREFETCH_DISTANCE: tl.constexpr = -1,
 ):
     DIV_FACTOR_A: tl.constexpr = 2 if DTYPE_A == "e2m1" else 1
@@ -372,7 +425,14 @@ def mxgemm_tdm_pipelined_kernel(
     BLOCK_M_PRESHUFFLED: tl.constexpr = BLOCK_M // 128
     BLOCK_N_PRESHUFFLED: tl.constexpr = BLOCK_N // 128
     BLOCK_K_SCALE_PRESHUFFLED: tl.constexpr = BLOCK_K_SCALE * 128
-    NUM_LOADS_IN_BATCH: tl.constexpr = 4 if WITH_A_SCALE else 3
+    if TDM_FUSION == "4way":
+        tl.static_assert(WITH_A_SCALE, "4-way TDM fusion requires WITH_A_SCALE")
+        NUM_LOADS_IN_BATCH: tl.constexpr = 1
+    elif TDM_FUSION == "2way":
+        NUM_LOADS_IN_BATCH: tl.constexpr = 2
+    else:
+        tl.static_assert(TDM_FUSION == "none", "TDM_FUSION must be one of: none, 2way, 4way")
+        NUM_LOADS_IN_BATCH: tl.constexpr = 4 if WITH_A_SCALE else 3
     if SCHEDULE == "sliceMNK":
         NUM_SUBTILES_M: tl.constexpr = 2
         NUM_SUBTILES_N: tl.constexpr = 2
@@ -501,6 +561,7 @@ def mxgemm_tdm_pipelined_kernel(
             TRANSPOSE_B,
             SCALE_PRESHUFFLE,
             WITH_A_SCALE,
+            TDM_FUSION,
         )
 
     tl.assume(K_ITERS > 0)
@@ -517,7 +578,7 @@ def mxgemm_tdm_pipelined_kernel(
             load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
                                            b_scale_buf, load_idx, pred, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
                                            BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
-                                           WITH_A_SCALE)
+                                           WITH_A_SCALE, TDM_FUSION)
             _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always,
                                         L2_PREFETCH_DISTANCE, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
                                         BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
@@ -557,7 +618,7 @@ def mxgemm_tdm_pipelined_kernel(
             load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
                                            b_scale_buf, load_idx, pred, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
                                            BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
-                                           WITH_A_SCALE)
+                                           WITH_A_SCALE, TDM_FUSION)
             _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always,
                                         L2_PREFETCH_DISTANCE, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
                                         BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
@@ -587,7 +648,7 @@ def mxgemm_tdm_pipelined_kernel(
             load_idx = _mxgemm_issue_loads(a_desc, b_desc, a_scale_desc, b_scale_desc, a_buf, b_buf, a_scale_buf,
                                            b_scale_buf, load_idx, pred, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
                                            BLOCK_K_SCALE_PRESHUFFLED, NUM_BUFFERS, TRANSPOSE_B, SCALE_PRESHUFFLE,
-                                           WITH_A_SCALE)
+                                           WITH_A_SCALE, TDM_FUSION)
             _mxgemm_issue_l2_prefetches(a_desc, b_desc, a_scale_desc, b_scale_desc, load_idx, always,
                                         L2_PREFETCH_DISTANCE, BLOCK_K_PACKED_A, BLOCK_K_PACKED_B,
                                         BLOCK_K_SCALE_PRESHUFFLED, TRANSPOSE_B, SCALE_PRESHUFFLE, WITH_A_SCALE)
@@ -643,6 +704,7 @@ def mxgemm_tdm_pipelined(
     M: int | None = None,
     N: int | None = None,
     K: int | None = None,
+    TDM_FUSION: str = "none",
 ) -> torch.Tensor:
     if M is None:
         M = a.shape[0]
@@ -690,6 +752,7 @@ def mxgemm_tdm_pipelined(
         SCALE_PRESHUFFLE=SCALE_PRESHUFFLE,
         WITH_A_SCALE=WITH_A_SCALE,
         SCHEDULE=SCHEDULE,
+        TDM_FUSION=TDM_FUSION,
         L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE,
         num_warps=4,
         waves_per_eu=1,
@@ -697,7 +760,8 @@ def mxgemm_tdm_pipelined(
     return c
 
 
-def test_mxgemm_tdm_pipelined_compiles_gfx1250():
+@pytest.mark.parametrize("TDM_FUSION", ["none", "2way", "4way"])
+def test_mxgemm_tdm_pipelined_compiles_gfx1250(TDM_FUSION):
     from triton.backends.compiler import GPUTarget
     from triton.compiler.compiler import ASTSource, compile as triton_compile
 
@@ -733,14 +797,19 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250():
             "SCALE_PRESHUFFLE": True,
             "WITH_A_SCALE": True,
             "SCHEDULE": "baseline",
+            "TDM_FUSION": TDM_FUSION,
             "L2_PREFETCH_DISTANCE": 2,
         },
     )
     compiled = triton_compile(src, target=GPUTarget("hip", "gfx1250", 32))
     ttgir = compiled.asm["ttgir"]
     amdgcn = compiled.asm["amdgcn"]
-    assert "amdg.async_tdm_copy_global_to_local" in ttgir
-    assert "amdg.async_tdm_group_copy_global_to_local" not in ttgir
+    if TDM_FUSION == "none":
+        assert "amdg.async_tdm_copy_global_to_local" in ttgir
+        assert "amdg.async_tdm_group_copy_global_to_local" not in ttgir
+    else:
+        assert "amdg.async_tdm_group_copy_global_to_local" in ttgir
+        assert "amdg.async_tdm_copy_global_to_local" not in ttgir
     assert "amdg.tdm_prefetch" in ttgir
     assert "tt.dot_scaled" in ttgir
     assert "tensor_load_to_lds" in amdgcn or "tensor.load.to.lds" in amdgcn
@@ -750,18 +819,18 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250():
 @pytest.mark.skipif(not is_gfx1250_available(), reason="Requires gfx1250 hardware")
 @pytest.mark.parametrize("TRANSPOSE_B", [False, True])
 @pytest.mark.parametrize(
-    "SCHEDULE,DTYPE_A,DTYPE_B,BLOCK_M,BLOCK_N,BLOCK_K,NUM_BUFFERS,SCALE_PRESHUFFLE,WITH_A_SCALE,L2_PREFETCH_DISTANCE",
+    "SCHEDULE,DTYPE_A,DTYPE_B,BLOCK_M,BLOCK_N,BLOCK_K,NUM_BUFFERS,SCALE_PRESHUFFLE,WITH_A_SCALE,TDM_FUSION,L2_PREFETCH_DISTANCE",
     [
-        ("baseline", "float8_e5m2", "float8_e5m2", 128, 128, 128, 2, True, True, -1),
-        ("baseline", "float8_e4m3", "float8_e5m2", 128, 128, 128, 2, False, False, 2),
-        ("sliceK", "float8_e4m3", "float8_e5m2", 128, 128, 256, 2, True, True, 2),
-        ("sliceNK", "float8_e5m2", "float4", 256, 256, 256, 2, True, True, 2),
-        ("sliceMNK", "float8_e4m3", "float8_e5m2", 128, 256, 256, 2, True, True, 2),
-        ("baseline", "float4", "float4", 128, 128, 128, 2, True, True, 2),
+        ("baseline", "float8_e5m2", "float8_e5m2", 128, 128, 128, 2, True, True, "none", -1),
+        ("baseline", "float8_e4m3", "float8_e5m2", 128, 128, 128, 2, False, False, "none", 2),
+        ("sliceK", "float8_e4m3", "float8_e5m2", 128, 128, 256, 2, True, True, "2way", 2),
+        ("sliceNK", "float8_e5m2", "float4", 256, 256, 256, 2, True, True, "2way", 2),
+        ("sliceMNK", "float8_e4m3", "float8_e5m2", 128, 256, 256, 2, True, True, "4way", 2),
+        ("baseline", "float4", "float4", 128, 128, 128, 2, True, True, "4way", 2),
     ],
 )
 def test_mxgemm_tdm_pipelined_gfx1250(TRANSPOSE_B, SCHEDULE, DTYPE_A, DTYPE_B, BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS,
-                                      SCALE_PRESHUFFLE, WITH_A_SCALE, L2_PREFETCH_DISTANCE):
+                                      SCALE_PRESHUFFLE, WITH_A_SCALE, TDM_FUSION, L2_PREFETCH_DISTANCE):
     torch.manual_seed(0)
     M = N = 256
     K = 512
@@ -792,5 +861,5 @@ def test_mxgemm_tdm_pipelined_gfx1250(TRANSPOSE_B, SCHEDULE, DTYPE_A, DTYPE_B, B
         a_scale_d = None
     out = mxgemm_tdm_pipelined(a_d, b_d, a_scale_d, b_scale_input.cuda(), BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B,
                                NUM_BUFFERS, DTYPE_TO_TRITON[DTYPE_A], DTYPE_TO_TRITON[DTYPE_B], SCALE_PRESHUFFLE,
-                               WITH_A_SCALE, SCHEDULE, L2_PREFETCH_DISTANCE, M, N, K)
+                               WITH_A_SCALE, SCHEDULE, L2_PREFETCH_DISTANCE, M, N, K, TDM_FUSION)
     torch.testing.assert_close(out.cpu(), ref, rtol=1e-5, atol=2e-2)


### PR DESCRIPTION
This PR updates the gfx1250 TLX MXFP GEMM path to track the newer Gluon MXFP
GEMM structure and adds explicit TDM fusion/scheduling variants for performance
experiments.

The main TLX kernel now supports:

- descriptor-backed MXFP GEMM with optional A scales
- pre-shuffled and non-pre-shuffled scale layouts
- L2 prefetch hints through descriptor prefetch ops
- `baseline`, `sliceK`, `sliceNK`, and `sliceMNK` compute schedules
- TDM load modes: unfused, 2-way fused, 4-way fused, and partial fused
- fp8/fp8, fp8/fp4, and fp4/fp4 input coverage
- explicit AMD WMMA result/store layout control through a new TLX helper