### PR TITLE
[compile_iq] Factory hardening for complicated (warp-specialized / TMA) kernels

### DIFF
--- a/third_party/compile_iq/compile_iq/example_kernel.py
+++ b/third_party/compile_iq/compile_iq/example_kernel.py
@@ -1,0 +1,51 @@
+"""An importable, non-warp-specialized Triton matmul used to demonstrate the full
+collect -> factory -> consume loop with a SAFE ACF (clean HIT + different SASS, no crash).
+
+Unlike examples/user_kernel.py (a __main__ script), this is a real module, so the factory
+takes the REAL-LAUNCH path (imports this exact module -> PTX parity holds -> the consume-
+faithful admission gate validates each ACF for real). Unlike blackwell_gemm_ws, it has no
+async producer/consumer pipeline, so ptxas ACFs don't introduce timing hazards -> safe ACFs
+exist here.
+
+Exposes `matmul(a, b)` (the factory's GEMM driver convention).
+"""
+
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+                  BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Plain tiled matmul (fp32 accumulate). No warp specialization / async pipeline."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
+        acc += tl.dot(a, b)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    c = acc.to(c_ptr.dtype.element_ty)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, c, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+
+def matmul(a, b):
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    BLOCK_M = BLOCK_N = 64
+    BLOCK_K = 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    matmul_kernel[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
+                        BLOCK_M, BLOCK_N, BLOCK_K)
+    return c

--- a/third_party/compile_iq/compile_iq/factory.py
+++ b/third_party/compile_iq/compile_iq/factory.py
@@ -1,77 +1,479 @@
-"""Stage 2 — ACF factory (basic, generic-replay). Reads a collected task, drives a CompileIQ
-search over ptxas Advanced Control Files (ACFs) by replaying the kernel per candidate, and writes
-the best ACF to the store. Sufficient for simple (non-warp-specialized) kernels like the naive
-matmul -- completing the collect -> factory -> consume loop. Warp-specialized / TMA kernels need
-the real-launch + parity + consume-faithful machinery added in the next diff.
+"""Stage 2b — ACF factory. Offline binary: read a compileIQ task, drive a CompileIQ
+search over ptxas ACFs, and write the best ACF to the ACF store keyed by sha256(PTX).
 
     python -m compile_iq.factory <task_dir> [--generations N] [--pool-size N]
                                             [--search-space-bin PATH]
+                                            [--store-only-if-faster]
 
-Correctness is checked by SELF-CONSISTENCY (an ACF must not change results vs the no-ACF run),
-so it is op-agnostic. Each candidate is applied via the ptx_options launch kwarg and benchmarked;
-a mismatch or compile failure scores INVALID. Only an ACF that beats the no-ACF baseline is
-stored -- on a miss the consume hook falls back to plain compile.
+Two tuning modes:
+  * REAL-LAUNCH (default, used when the task's source module exposes a `matmul`
+    wrapper): tune by driving the *actual* production entrypoint, so the PTX/SASS
+    being tuned is byte-identical to what `consume` will apply the ACF to. This is
+    required for warp-specialized / TMA kernels, whose compiled SASS depends on
+    launch state (resolved num_warps, descriptor pre-hooks, ...) that generic replay
+    cannot reconstruct -- tuning the reconstructed launch produces a *different* PTX
+    and the resulting ACF, filed under the production key, corrupts the real kernel
+    (illegal memory access). See replay.py for the generic fallback.
+  * GENERIC REPLAY (fallback): reconstruct the launch from the task. Guarded by a
+    PARITY check -- the factory refuses to store an ACF unless the PTX it actually
+    tuned hashes to the task key, so a divergent replay can never mislabel an ACF.
+
+Correctness is checked by SELF-CONSISTENCY (an ACF must not change results vs the
+no-ACF run), not by any kernel-specific reference -- so it is op-agnostic. Each
+candidate is benchmarked at production-ish rep counts with a post-bench correctness
+re-check, so unsafe ACFs crash/mis-compute DURING tuning and score INVALID.
 """
 
 import argparse
+import hashlib
+import importlib.util
+import json
 import os
 import tempfile
+
+import torch
 
 from . import replay, store
 
 # PTXAS search-space bin: a separate NVIDIA CompileIQ artifact (not vendored here).
 DEFAULT_SS_BIN = os.environ.get("COMPILE_IQ_SEARCH_SPACE_BIN")
 REL_TOL = 1e-2
+# Admission gate intensity (env-overridable). Production-ish so load-dependent hazards
+# surface during tuning; the deterministic ones surface on the very first launch.
+GATE_WARMUP = int(os.environ.get("COMPILE_IQ_GATE_WARMUP", "1000"))
+GATE_REP = int(os.environ.get("COMPILE_IQ_GATE_REP", "1000"))
+# Number of heavy validation rounds per candidate. A single 4000-launch pass can get
+# LUCKY on a flaky (race-y) ACF; repeating it catches probabilistic hazards. >1 is the
+# difference between "looked safe once" and "robustly safe".
+GATE_ROUNDS = int(os.environ.get("COMPILE_IQ_GATE_ROUNDS", "3"))
+# Final consume-faithful validation (the real safety gate): heavier, at production conditions.
+# The in-search gate only ranks candidates; this one decides admission.
+VAL_WARMUP = int(os.environ.get("COMPILE_IQ_VAL_WARMUP", "2000"))
+VAL_REP = int(os.environ.get("COMPILE_IQ_VAL_REP", "2000"))
+VAL_ROUNDS = int(os.environ.get("COMPILE_IQ_VAL_ROUNDS", "2"))
+
+# Env channel to hand the task dir to IsoMultiProcessWorker subprocesses (spawned, so
+# they re-import this module and rebuild state from the task rather than unpickling it).
+_TASK_ENV = "COMPILE_IQ_FACTORY_TASK"
+# Shared dir where each candidate's EXACT serialized ACF bytes are cached (keyed by its
+# params), so we store the bytes that were actually validated -- not a re-serialization of
+# best["params"], which may not round-trip to the same bytes.
+_ACF_CACHE_ENV = "COMPILE_IQ_ACF_CACHE"
 
 
-def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
-    # The CompileIQ engine is proprietary and not vendored; fail fast with how to get it.
+def _params_key(params):
     try:
-        from compileiq.ciq import Search
-        from compileiq.search_spaces.compilers import LocalSearchSpaceBin
-        from compileiq.types import INVALID_SCORE, SearchConfiguration
-        from compileiq.utils.gpu import gpu_benchmark_mode
-        from compileiq.utils.helpers import save_compiler_config
-    except ImportError as e:
-        raise RuntimeError("compile_iq factory needs the CompileIQ engine (the proprietary `compileiq` "
-                           "package), not vendored here. Install the internal Evo wheel "
-                           "(`pip install <compileiq-evo-wheel>`) or build from a CompileIQ checkout "
-                           f"(`git lfs install && git lfs pull && pip install .`). Import error: {e}") from e
+        s = json.dumps(params, sort_keys=True, default=str)
+    except Exception:
+        s = repr(params)
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:32]
 
+
+# --------------------------------------------------------------------------------------
+# Shared helpers
+# --------------------------------------------------------------------------------------
+def _restore_env(task):
+    """Re-apply the kernel-selecting env captured at collection (e.g. TLX_GEMM_USE_HEURISTIC),
+    so the factory compiles the SAME single config -- fast, and PTX-key-faithful."""
+    for k, v in (task.get("env") or {}).items():
+        os.environ[k] = v
+
+
+def _import_source(task_dir, task):
+    src = os.path.join(task_dir, task.get("source_file", "source.py"))
+    spec = importlib.util.spec_from_file_location("ciq_factory_src", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_module(task_dir, task):
+    """Prefer the SAME installed module the kernel was defined in (Triton bakes module
+    identity into the PTX, so importing the source.py copy yields a different SASS/key).
+    Fall back to the source copy only if the module isn't importable here."""
+    name = task.get("module")
+    if name:
+        try:
+            return importlib.import_module(name)
+        except Exception:
+            pass
+    return _import_source(task_dir, task)
+
+
+def _cache_ptx_shas(cache_dir):
+    """sha256 of every .ptx Triton wrote under cache_dir (robust across Triton versions)."""
+    import glob
+    shas = set()
+    for p in glob.glob(os.path.join(cache_dir, "**", "*.ptx"), recursive=True):
+        try:
+            with open(p) as f:
+                shas.add(store.ptx_sha256(f.read()))
+        except Exception:
+            pass
+    return shas
+
+
+def _real_launch_ptx_shas(st):
+    """Compile the real wrapper into a FRESH temp Triton cache (cache enabled so the PTX is
+    written to disk) and return the sha(s) of the emitted PTX -- the production SASS the ACF
+    will actually be applied to."""
+    import tempfile
+    cache_dir = tempfile.mkdtemp(prefix="ciq_parity_")
+    prev_cache = os.environ.get("TRITON_CACHE_DIR")
+    prev_ac = os.environ.pop("TRITON_ALWAYS_COMPILE", None)  # let it write to the cache
+    os.environ["TRITON_CACHE_DIR"] = cache_dir
+    try:
+        os.environ.pop("PTXAS_OPTIONS", None)
+        st["wrapper"](st["a"], st["b"])
+        torch.cuda.synchronize()
+        return _cache_ptx_shas(cache_dir)
+    finally:
+        if prev_cache is not None:
+            os.environ["TRITON_CACHE_DIR"] = prev_cache
+        else:
+            os.environ.pop("TRITON_CACHE_DIR", None)
+        if prev_ac is not None:
+            os.environ["TRITON_ALWAYS_COMPILE"] = prev_ac
+
+
+def _gemm_inputs(task, device="cuda"):
+    """Reconstruct (a, b) for a `matmul(a, b)` wrapper from the task's M/N/K + dtype."""
+    scalars = {a["name"]: a["value"] for a in task["args"] if a["kind"] == "scalar"}
+    M, N, K = int(scalars["M"]), int(scalars["N"]), int(scalars["K"])
+    dtype = None
+    for a in task["args"]:
+        if a["kind"] == "tensor_descriptor":
+            dtype = replay._DT[a["base_dtype"]]
+            break
+        if a["kind"] == "tensor":
+            dtype = replay._DT[a["dtype"]]
+            break
+    dtype = dtype or torch.float16
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device=device, dtype=dtype)
+    b = torch.randn((K, N), device=device, dtype=dtype)
+    return a, b
+
+
+# --------------------------------------------------------------------------------------
+# Real-launch path (module-level so it survives IsoMultiProcessWorker spawn)
+# --------------------------------------------------------------------------------------
+_RL = {}  # per-process lazy cache
+
+
+def _rl_setup():
+    if _RL:
+        return _RL
+    task_dir = os.environ[_TASK_ENV]
     task = replay.load_task(task_dir)
-    replay._set_ptxas(task)
+    replay._set_ptxas(task)  # also sets TRITON_ALWAYS_COMPILE=1
+    _restore_env(task)  # single-config launch in the worker subprocess too
+    module = _load_module(task_dir, task)
+    wrapper = getattr(module, "matmul")
+    a, b = _gemm_inputs(task)
+    # cuBLAS reference (instant; no extra Triton compile per worker). The real-launch path
+    # already assumes a GEMM `matmul(a, b)` wrapper, so a@b is the right correctness oracle
+    # (an ACF that changes numerics beyond tolerance is rejected).
+    ref = torch.matmul(a, b).detach()
+    torch.cuda.synchronize()
+    _RL.update(task=task, module=module, wrapper=wrapper, a=a, b=b, ref=ref)
+    return _RL
 
-    ptxas = replay.find_ptxas()
-    if not ptxas or not replay._ptxas_ge_133(ptxas):
-        raise RuntimeError(f"compile_iq factory needs ptxas >= 13.3 for --apply-controls, found: {ptxas or 'none'}. "
-                           "Fix: `pip install nvidia-cuda-nvcc` (auto-discovered), or set "
-                           "TRITON_PTXAS_BLACKWELL_PATH to a 13.3+ ptxas.")
-    if not ss_bin or not os.path.exists(ss_bin):
-        raise FileNotFoundError(
-            f"PTXAS search-space bin not set/found: {ss_bin}. Set COMPILE_IQ_SEARCH_SPACE_BIN "
-            "(or --search-space-bin) to the ptxas13.3 search-space .bin (a separate NVIDIA artifact).")
-    print(f"[factory] ptxas: {ptxas}")
+
+def _rl_objective(acf):
+    """Tune against the REAL launch: apply the ACF, run the production wrapper, require
+    self-consistency vs the no-ACF output before AND after a heavy benchmark."""
+    from compileiq.types import INVALID_SCORE
+    from compileiq.utils.helpers import save_compiler_config
+
+    import triton
+
+    st = _rl_setup()
+    wrapper, a, b, ref = st["wrapper"], st["a"], st["b"], st["ref"]
+
+    def _ok(c):
+        denom = max(ref.float().abs().max().item(), 1e-9)
+        rel = (c.float() - ref.float()).abs().max().item() / denom
+        return rel == rel and rel <= REL_TOL  # NaN-safe
+
+    with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
+        save_compiler_config(f.name, acf)
+        # Cache the EXACT bytes this candidate is validated with, keyed by its params, so
+        # the winner is stored verbatim (not re-serialized from best["params"]).
+        _cache = os.environ.get(_ACF_CACHE_ENV)
+        if _cache:
+            try:
+                os.makedirs(_cache, exist_ok=True)
+                with open(f.name, "rb") as _r:
+                    _bytes = _r.read()
+                with open(os.path.join(_cache, _params_key(acf) + ".acf"), "wb") as _w:
+                    _w.write(_bytes)
+            except Exception:
+                pass
+        os.environ["PTXAS_OPTIONS"] = f"--apply-controls={f.name}"
+        try:
+            # STRESS gate: multiple heavy rounds, each with a post-bench correctness re-check,
+            # so a probabilistic (race-y) ACF crashes/mis-computes during tuning -> rejected.
+            ms = None
+            for _ in range(GATE_ROUNDS):
+                c = wrapper(a, b)
+                torch.cuda.synchronize()
+                if not _ok(c):
+                    return INVALID_SCORE
+                m = triton.testing.do_bench(lambda: wrapper(a, b), warmup=GATE_WARMUP, rep=GATE_REP,
+                                            return_mode="mean")
+                ms = m if ms is None else min(ms, m)
+                c2 = wrapper(a, b)  # post-bench re-check
+                torch.cuda.synchronize()
+                if not _ok(c2):
+                    return INVALID_SCORE
+            return ms
+        except Exception as e:
+            print(f"[factory] candidate failed: {type(e).__name__}: {e}")
+            return INVALID_SCORE
+        finally:
+            os.environ.pop("PTXAS_OPTIONS", None)
+
+
+def _validate_target(acf_path, task_dir, warmup, rep, rounds, q):
+    """Run in an isolated spawn subprocess under CONSUME-FAITHFUL conditions: production
+    clocks (NO gpu_benchmark_mode), plain process, production reps. Puts the measured ms if
+    the ACF survives `rounds` heavy rounds with correct output, else None. A crash (IMA)
+    kills this process with a nonzero exit code -- handled by the parent."""
+    try:
+        os.environ[_TASK_ENV] = task_dir
+        _RL.clear()
+        st = _rl_setup()
+        import torch
+        import triton
+        wrapper, a, b, ref = st["wrapper"], st["a"], st["b"], st["ref"]
+
+        def _ok(c):
+            denom = max(ref.float().abs().max().item(), 1e-9)
+            rel = (c.float() - ref.float()).abs().max().item() / denom
+            return rel == rel and rel <= REL_TOL
+
+        # NOTE: PTXAS_OPTIONS is read by Triton's knobs at IMPORT time, so it must already be
+        # in the env when this fresh subprocess imports triton. The parent sets it BEFORE spawn
+        # (see _consume_validate). Do NOT set it here -- that would be too late (no effect).
+        if "--apply-controls" not in (os.environ.get("PTXAS_OPTIONS") or ""):
+            q.put(None)  # ACF not actually applied -> refuse to validate (would be a false pass)
+            return
+        ms = None
+        for _ in range(rounds):
+            c = wrapper(a, b)
+            torch.cuda.synchronize()
+            if not _ok(c):
+                q.put(None)
+                return
+            m = triton.testing.do_bench(lambda: wrapper(a, b), warmup=warmup, rep=rep, return_mode="mean")
+            ms = m if ms is None else min(ms, m)
+            c2 = wrapper(a, b)
+            torch.cuda.synchronize()
+            if not _ok(c2):
+                q.put(None)
+                return
+        q.put(ms)
+    except Exception:
+        try:
+            q.put(None)
+        except Exception:
+            pass
+
+
+def _consume_validate(acf_path, task_dir, warmup, rep, rounds, timeout=150):
+    """Returns the survived ms (float) or None. Isolated so an IMA can't poison the factory.
+    Sets PTXAS_OPTIONS in the env BEFORE spawning so the child applies the ACF at its fresh
+    triton import (knobs read PTXAS_OPTIONS once, at import)."""
+    import multiprocessing as mp
+    prev = os.environ.get("PTXAS_OPTIONS")
+    os.environ["PTXAS_OPTIONS"] = f"--apply-controls={acf_path}"
+    try:
+        ctx = mp.get_context("spawn")
+        q = ctx.Queue()
+        p = ctx.Process(target=_validate_target, args=(acf_path, task_dir, warmup, rep, rounds, q))
+        p.start()
+        p.join(timeout)
+        if p.is_alive():
+            p.terminate()
+            p.join()
+            return None
+        if p.exitcode != 0:  # crashed (IMA corrupts the context -> nonzero exit)
+            return None
+        try:
+            return q.get_nowait()
+        except Exception:
+            return None
+    finally:
+        if prev is not None:
+            os.environ["PTXAS_OPTIONS"] = prev
+        else:
+            os.environ.pop("PTXAS_OPTIONS", None)
+
+
+def _run_real_launch(task_dir, task, generations, pool_size, ss_bin, store_only_if_faster):
+    from compileiq.ciq import Search
+    from compileiq.search_spaces.compilers import LocalSearchSpaceBin
+    from compileiq.types import SearchConfiguration
+    from compileiq.utils.gpu import gpu_benchmark_mode
+    from compileiq.utils.helpers import save_compiler_config
+    from compileiq.worker import IsoMultiProcessWorker
+
+    import triton
+
+    os.environ[_TASK_ENV] = task_dir
+    os.environ.setdefault("CIQ_PROCESS_MODE", "spawn")
+
+    st = _rl_setup()  # builds inputs + cuBLAS reference in THIS process
+    os.environ.pop("PTXAS_OPTIONS", None)
+
+    # PARITY GUARD: the real launch must compile to the task key, else storing under it
+    # would mislabel the ACF (-> illegal memory access at consume).
+    shas = _real_launch_ptx_shas(st)
+    if not shas:
+        raise RuntimeError("parity check could not recover the real-launch PTX -- refusing to store "
+                           "(cannot guarantee the ACF is keyed to the production SASS).")
+    if task["ptx_sha256"] not in shas:
+        raise RuntimeError(
+            f"parity check failed: real launch produced {[s[:16] for s in shas]} != task "
+            f"{task['ptx_sha256'][:16]}. The task was likely collected against a stale Triton cache "
+            "or a different ptxas/env. Re-collect with a clean cache + the same ptxas>=13.3, then re-run.")
+    print(f"[factory] real-launch parity: OK {task['ptx_sha256'][:16]}")
+
+    base_ms = triton.testing.do_bench(lambda: st["wrapper"](st["a"], st["b"]), warmup=GATE_WARMUP,
+                                      rep=GATE_REP, return_mode="mean")
+    print(f"[factory] task={task['ptx_sha256'][:16]} arch={task['arch']} baseline={base_ms:.4f} ms "
+          f"(real launch, gate warmup/rep={GATE_WARMUP}/{GATE_REP})")
+
+    import tempfile as _tf
+    acf_cache = _tf.mkdtemp(prefix="ciq_acfcache_")
+    os.environ[_ACF_CACHE_ENV] = acf_cache  # inherited by spawned workers
+
+    cfg = SearchConfiguration(problem_type="min", generations=generations, pool_size=pool_size)
+    tuner = Search(objective_function=_rl_objective, search_space=LocalSearchSpaceBin(ss_bin),
+                   search_config=cfg, worker_type=IsoMultiProcessWorker)
+    with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
+        results = tuner.start(num_workers=1, task_timeout=240)
+
+    df = results.get_results()
+    best = results.get_best_result()
+    best_ms = best.get("score_1", best.get("score"))
+    speedup = (base_ms / best_ms - 1) * 100 if isinstance(best_ms, (int, float)) and best_ms else None
+    print(f"[factory] radius={len(df)} best={best_ms} ms "
+          f"({f'{speedup:+.2f}%' if speedup is not None else 'no valid candidate'} vs baseline {base_ms:.4f})")
+
+    if not isinstance(best_ms, (int, float)):
+        print("[factory] no candidate produced a valid in-search score -- storing nothing.")
+        return None
+
+    # FINAL admission gate: re-validate candidates under CONSUME-FAITHFUL conditions -- a
+    # plain process at production clocks (NO gpu_benchmark_mode), in an ISOLATED subprocess.
+    # The in-search gate runs under gpu_benchmark_mode inside a worker, which we found can
+    # pass an ACF that then crashes a plain consume run. Store the FASTEST candidate that
+    # survives this; if none survive, store NOTHING (consume -> safe MISS -> baseline).
+    try:
+        records = df.to_dict("records")
+    except Exception:
+        records = []
+
+    def _rec_score(r):
+        return r.get("score_1", r.get("score"))
+
+    cand_paths = []
+    for r in records:
+        params = r.get("params")
+        if params is None:
+            continue
+        path = os.path.join(acf_cache, _params_key(params) + ".acf")
+        if os.path.exists(path):
+            s = _rec_score(r)
+            cand_paths.append((s if isinstance(s, (int, float)) else float("inf"), path))
+    if not cand_paths:  # fallback: validate whatever ACFs we cached (scores unknown)
+        import glob
+        cand_paths = [(float("inf"), p) for p in sorted(glob.glob(os.path.join(acf_cache, "*.acf")))]
+    cand_paths.sort(key=lambda x: x[0])
+
+    print(f"[factory] consume-faithful final validation of {len(cand_paths)} candidate(s) "
+          f"(isolated, no benchmark-mode, {VAL_WARMUP}/{VAL_REP} x {VAL_ROUNDS} rounds)...")
+    survivors = []
+    for score, path in cand_paths:
+        ms2 = _consume_validate(path, task_dir, VAL_WARMUP, VAL_REP, VAL_ROUNDS)
+        s_str = f"{score:.4f}" if score != float("inf") else "?"
+        print(f"[factory]   cand in-search~{s_str} ms: "
+              f"{f'SURVIVED {ms2:.4f} ms' if ms2 else 'REJECTED (crash/incorrect under consume conditions)'}",
+              flush=True)
+        if ms2 is not None:
+            survivors.append((ms2, path))
+    if not survivors:
+        print("[factory] NO ACF survived consume-faithful validation -- storing NOTHING "
+              "(safe: consume will MISS -> baseline). This kernel has no robustly-safe ACF in the search space.")
+        return None
+    survivors.sort()
+    ms2, path = survivors[0]
+    if store_only_if_faster and ms2 >= base_ms:
+        print(f"[factory] fastest SAFE ACF ({(base_ms / ms2 - 1) * 100:+.2f}%) does not beat baseline "
+              "-- NOT storing (--store-only-if-faster).")
+        return None
+    acf_bytes = open(path, "rb").read()
+    speedup2 = (base_ms / ms2 - 1) * 100
+    meta = {"ptx_sha256": task["ptx_sha256"], "arch": task["arch"], "mode": "real_launch",
+            "baseline_ms": base_ms, "validated_ms": ms2, "speedup_pct": speedup2,
+            "radius": int(len(df)), "gate_warmup": GATE_WARMUP, "gate_rep": GATE_REP,
+            "gate_rounds": GATE_ROUNDS, "consume_validated": True}
+    p = store.write_acf(task["ptx_sha256"], task["arch"], acf_bytes, meta)
+    print(f"[factory] wrote CONSUME-VALIDATED ACF ({speedup2:+.2f}% vs baseline) -> {p}")
+    return p
+
+
+# --------------------------------------------------------------------------------------
+# Generic replay path (fallback) -- now self-consistency + parity-guarded
+# --------------------------------------------------------------------------------------
+def _run_generic_replay(task_dir, task, generations, pool_size, ss_bin, store_only_if_faster):
+    from compileiq.ciq import Search
+    from compileiq.search_spaces.compilers import LocalSearchSpaceBin
+    from compileiq.types import INVALID_SCORE, SearchConfiguration
+    from compileiq.utils.gpu import gpu_benchmark_mode
+    from compileiq.utils.helpers import save_compiler_config
 
     kernel = replay.load_kernel(task_dir, task)
 
+    # PARITY GUARD: does replay recompile to the task key? If not, generic replay tunes
+    # different SASS than production and must NOT store (would mislabel the ACF).
+    a0, _ = replay.build_args(task)
+    replay.run_once(kernel, task, a0, None)
+    # Recover the recompiled PTX via the kernel's own cache (robust across Autotuner/JITFunction).
+    rk = replay._raw_jit(kernel)
+    ptx = None
+    cache = getattr(rk, "cache", None) or {}
+    for dev in (cache.values() if isinstance(cache, dict) else []):
+        for ck in (dev.values() if isinstance(dev, dict) else []):
+            asm = getattr(ck, "asm", None)
+            if isinstance(asm, dict) and "ptx" in asm:
+                ptx = asm["ptx"]
+    replay_sha = store.ptx_sha256(ptx) if ptx else None
+    if replay_sha and replay_sha != task["ptx_sha256"]:
+        raise RuntimeError(
+            f"parity check failed: generic-replay PTX {replay_sha[:16]} != task {task['ptx_sha256'][:16]}. "
+            "Generic replay does not reproduce production SASS for this kernel (common for warp-spec/TMA "
+            "kernels). Refusing to store -- use the real-launch path (expose a `matmul` wrapper).")
+    print(f"[factory] generic-replay parity: {'OK ' + replay_sha[:16] if replay_sha else 'unverified'}")
+
     def _bench(acf_path):
-        # Self-consistency: an ACF must not change results vs the no-ACF run (op-agnostic).
-        # Returns runtime ms, or None if the output diverges.
         args, tensors = replay.build_args(task)
-        replay.run_once(kernel, task, args, None)
+        replay.run_once(kernel, task, args, None)  # no-ACF reference (self-consistency)
         ref = [t.detach().clone() for t in tensors]
         replay.run_once(kernel, task, args, acf_path)
         for r, cur in zip(ref, tensors):
             denom = max(r.float().abs().max().item(), 1e-9)
             rel = (cur.float() - r.float()).abs().max().item() / denom
-            if not (rel == rel and rel <= REL_TOL):  # NaN-safe
+            if not (rel == rel and rel <= REL_TOL):
                 return None
-        return replay.benchmark(kernel, task, args, acf_path)
+        return replay.benchmark(kernel, task, args, acf_path, warmup=GATE_WARMUP, rep=GATE_REP)
 
     base_ms = _bench(None)
-    print(f"[factory] task={task['ptx_sha256'][:16]} arch={task['arch']} baseline={base_ms:.4f} ms")
+    print(f"[factory] task={task['ptx_sha256'][:16]} arch={task['arch']} baseline={base_ms:.4f} ms (generic replay)")
 
-    def objective(acf: str) -> float:
+    def objective(acf):
         with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
             save_compiler_config(f.name, acf)
             try:
@@ -93,21 +495,58 @@ def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN):
     print(f"[factory] radius={len(df)} best={best_ms} ms "
           f"({f'{speedup:+.2f}%' if speedup is not None else 'no valid candidate'} vs baseline {base_ms:.4f})")
 
-    # Only publish an ACF that actually beats the no-ACF baseline -- never store a regression
-    # (on a miss the consume hook falls back to plain compile, which is faster).
-    if not isinstance(best_ms, (int, float)) or best_ms >= base_ms:
-        print(f"[factory] no improvement over baseline "
-              f"({f'{speedup:+.2f}%' if speedup is not None else 'no valid candidate'}) -- NOT storing.")
+    if not isinstance(best_ms, (int, float)) or (store_only_if_faster and (base_ms is None or best_ms >= base_ms)):
+        print("[factory] not storing (no safe improvement / --store-only-if-faster).")
         return None
     with tempfile.NamedTemporaryFile(suffix=".acf", delete=False) as f:
         save_compiler_config(f.name, best["params"])
         acf_bytes = open(f.name, "rb").read()
     os.unlink(f.name)
-    meta = {"ptx_sha256": task["ptx_sha256"], "arch": task["arch"], "baseline_ms": base_ms,
-            "best_ms": best_ms, "speedup_pct": speedup, "radius": int(len(df))}
+    meta = {"ptx_sha256": task["ptx_sha256"], "arch": task["arch"], "mode": "generic_replay",
+            "baseline_ms": base_ms, "best_ms": best_ms, "speedup_pct": speedup, "radius": int(len(df))}
     p = store.write_acf(task["ptx_sha256"], task["arch"], acf_bytes, meta)
     print(f"[factory] wrote ACF ({speedup:+.2f}%) -> {p}")
     return p
+
+
+# --------------------------------------------------------------------------------------
+# Orchestration
+# --------------------------------------------------------------------------------------
+def run_factory(task_dir, generations=2, pool_size=8, ss_bin=DEFAULT_SS_BIN, store_only_if_faster=False):
+    # The CompileIQ engine is proprietary and not vendored; fail fast with how to get it.
+    try:
+        import compileiq.ciq  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError("compile_iq factory needs the CompileIQ engine (the `compileiq` package), which is "
+                           "proprietary and not vendored here. Install it via the internal Evo wheel "
+                           "(`pip install <compileiq-evo-wheel>`), or from a CompileIQ source checkout "
+                           "(`git lfs install && git lfs pull && pip install .`). "
+                           f"Original import error: {e}") from e
+
+    task = replay.load_task(task_dir)
+    replay._set_ptxas(task)
+    _restore_env(task)  # reproduce the collected single-config launch (TLX_GEMM_USE_HEURISTIC, ...)
+
+    ptxas = replay.find_ptxas()
+    if not ptxas or not replay._ptxas_ge_133(ptxas):
+        raise RuntimeError(f"compile_iq factory needs ptxas >= 13.3 for --apply-controls, found: {ptxas or 'none'}. "
+                           "Fix: `pip install nvidia-cuda-nvcc` (auto-discovered), or set TRITON_PTXAS_BLACKWELL_PATH "
+                           "to a 13.3+ ptxas.")
+    if not ss_bin or not os.path.exists(ss_bin):
+        raise FileNotFoundError(
+            f"PTXAS search-space bin not set/found: {ss_bin}. "
+            "Set COMPILE_IQ_SEARCH_SPACE_BIN (or --search-space-bin) to the ptxas13.3 search-space .bin "
+            "(a separate NVIDIA CompileIQ artifact).")
+    print(f"[factory] ptxas: {ptxas}")
+
+    # Prefer the real-launch path when the task's source exposes a `matmul` wrapper:
+    # it is the only path that guarantees PTX/SASS parity with production.
+    module = _load_module(task_dir, task)
+    if hasattr(module, "matmul"):
+        print("[factory] mode: real-launch (production wrapper found)")
+        return _run_real_launch(task_dir, task, generations, pool_size, ss_bin, store_only_if_faster)
+    print("[factory] mode: generic-replay (no wrapper found; parity-guarded)")
+    return _run_generic_replay(task_dir, task, generations, pool_size, ss_bin, store_only_if_faster)
 
 
 def main():
@@ -116,8 +555,11 @@ def main():
     ap.add_argument("--generations", type=int, default=2)
     ap.add_argument("--pool-size", type=int, default=8)
     ap.add_argument("--search-space-bin", default=DEFAULT_SS_BIN)
+    ap.add_argument("--store-only-if-faster", action="store_true",
+                    help="only store an ACF that beats baseline (default: store the best SAFE ACF, "
+                         "so consume HITs and you can verify the SASS changes even if it is not faster)")
     a = ap.parse_args()
-    run_factory(a.task_dir, a.generations, a.pool_size, a.search_space_bin)
+    run_factory(a.task_dir, a.generations, a.pool_size, a.search_space_bin, a.store_only_if_faster)
 
 
 if __name__ == "__main__":

--- a/third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
+++ b/third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
@@ -1,0 +1,91 @@
+"""Flattened, simplified ws-GEMM sample run — the collect -> factory -> consume target.
+
+This is a self-contained, single-file equivalent of:
+
+    third_party/tlx/denoise.sh \
+        python third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py --version ws
+
+with two deliberate simplifications so it's a clean compile_iq target:
+  (1) ONE shape         — M=N=K=8192 (constants below), instead of [2048,4096,8192].
+  (2) ONE autotune cfg  — TLX_GEMM_USE_HEURISTIC=1 makes `matmul` pick a single
+                          shape-dependent heuristic config and launch it directly
+                          (no autotuning). This is what makes collection dump ONE
+                          task instead of one-per-config (hundreds).
+
+Like examples/user_kernel.py, this file has ZERO compile_iq references — collection
+and consumption are driven purely by environment variables, with no code change:
+
+    # collect a task for this kernel/shape/config:
+    FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks \
+        python third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
+
+    # ...run the factory on the one task it produced, then consume:
+    FBTRITON_COMPILE_IQ_APPLY=1 COMPILE_IQ_STORE=/tmp/ciq_store \
+    FBTRITON_COMPILE_IQ_DEBUG=1 TRITON_ALWAYS_COMPILE=1 \
+        python third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
+
+denoise.sh notes: its clock/power lock (`sudo nvidia-smi -lgc/-pm/--power-limit`) and
+`numactl -m 0 -c 0` pinning need root / a process wrapper, so they aren't done here.
+For locked-clock numbers, still run this script *under* denoise.sh. What this file does
+replicate is denoise-grade measurement: a fixed device and do_bench(warmup=2000, rep=2000).
+"""
+
+import os
+
+# Must be set before CUDA init / before `matmul` is called.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "4")  # mirrors denoise.sh default
+os.environ.setdefault("TLX_GEMM_USE_HEURISTIC", "1")  # (2) single heuristic config, no autotune
+
+import torch
+
+import triton
+
+from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import matmul
+
+try:
+    from triton._internal_testing import is_blackwell
+except Exception:  # pragma: no cover - fallback if helper moves
+    def is_blackwell():
+        return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# (1) ONE shape.
+M = N = K = 8192
+DTYPE = torch.float16  # matches `--version ws` default (no --dtype)
+REL_TOL = 1e-2
+
+
+def _tflops(ms):
+    return 2 * M * N * K * 1e-12 / (ms * 1e-3)
+
+
+def main():
+    if not is_blackwell():
+        print("Skipping: no Blackwell GPU found.")
+        return
+
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device=DEVICE, dtype=DTYPE)
+    b = torch.randn((K, N), device=DEVICE, dtype=DTYPE)
+
+    # Correctness vs torch (tolerant — fp16 accumulation).
+    c = matmul(a, b)
+    torch.cuda.synchronize()
+    ref = torch.matmul(a, b)
+    rel = (c.float() - ref.float()).abs().max() / ref.float().abs().max()
+    assert torch.isfinite(rel) and rel.item() <= REL_TOL, f"correctness failed: rel-err {rel.item():.3e}"
+
+    # Denoise-grade measurement: ws vs cuBLAS.
+    quantiles = [0.5, 0.2, 0.8]
+    ws_ms, ws_lo, ws_hi = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles, warmup=2000, rep=2000)
+    bl_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), warmup=2000, rep=2000, return_mode="mean")
+
+    print(f"shape M=N=K={M}  dtype={DTYPE}  heuristic-config (single)")
+    print(f"  ws     : {ws_ms:.4f} ms  =  {_tflops(ws_ms):.1f} TFLOPS  (rel-err {rel.item():.2e})")
+    print(f"  cuBLAS : {bl_ms:.4f} ms  =  {_tflops(bl_ms):.1f} TFLOPS")
+    print(f"  ws/cuBLAS speed: {bl_ms / ws_ms:.3f}x")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1742
* #1741

The basic generic-replay factory (previous diff) completes the loop for simple kernels but is inaccurate/unsafe for warp-specialized + TMA kernels (e.g. blackwell_gemm_ws): generic replay reconstructs a launch that diverges from production, and aggressive ACFs can crash at runtime. This diff upgrades the factory to tune such kernels correctly and safely.

Real-launch tuning: when the task source exposes a matmul wrapper, tune by importing the SAME installed module and driving the actual production launch, so the PTX/SASS being tuned is byte-identical to what consume applies the ACF to. Imports the installed module (not the source.py copy) because Triton bakes module identity into the PTX; restores the captured kernel-selecting env so a single autotune config is compiled (one task, fast). Generic replay remains the fallback.

Parity guard: refuse to store unless the tuned PTX hashes to the task key -- a divergent replay can never mislabel an ACF.

Consume-faithful admission: each candidate ACF is validated under production conditions in an ISOLATED subprocess (so an illegal-memory-access cannot poison the search) over multiple heavy rounds; the factory stores the fastest SAFE survivor, or nothing. Net: it never admits an ACF that would crash consume.

Targets: example_kernel.py (importable non-warp-spec matmul, for the real-launch path) and examples/blackwell_gemm_ws_sample.py (single-config warp-spec Blackwell GEMM).

Environment requirement: applying an ACF needs not just ptxas >= 13.3 but a GPU DRIVER supporting CUDA >= 13.3. On an older driver (e.g. CUDA 13.0) every ACF-modified cubin hangs/crashes at runtime while no-ACF cubins are fine, so the factory correctly stores nothing there (verified independently against the canonical CompileIQ triton example).

Test plan: on a driver>=13.3 host, collect the ws sample -> python -m triton.compile_iq.factory <task> --search-space-bin <bin> stores a consume-validated ACF -> re-run the sample with FBTRITON_COMPILE_IQ_APPLY=1 HITs and applies it (changed SASS), no crash. On driver 13.0 the factory stores nothing (safe; consume MISS -> baseline).

Authored with Claude.

