### PR TITLE
[lint-autofix] Fix pre-commit formatting issues

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -31,12 +31,8 @@ def test_compile_only_dot() -> None:
     @triton.jit
     def simple_dot(a_base, b_base, out):
         SIZE: tl.constexpr = 64
-        a_ptr = (
-            a_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
-        )
-        b_ptr = (
-            b_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
-        )
+        a_ptr = (a_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :])
+        b_ptr = (b_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :])
         a = tl.load(a_ptr)
         b = tl.load(b_ptr)
         c = tl.dot(a, b)
@@ -52,46 +48,40 @@ def test_compile_only_dot() -> None:
         target=GPUTarget("cuda", 100, 32),
     )
     ttgir = k.asm["ttgir"]
-    pattern = (
-        r"%(?P<A>\w+) = tt\.load"
-        r"(.|\n)*?"
-        r"%(?P<A_SHMEM>\w+) = ttg\.local_alloc %(?P=A)"
-        r"(.|\n)*?"
-        r"%(?P<B>\w+) = tt\.load"
-        r"(.|\n)*?"
-        r"%(?P<B_SHMEM>\w+) = ttg\.local_alloc %(?P=B)"
-        r"(.|\n)*?"
-        r"%(?P<TMEM_BASE>\w+) = ttng\.tmem_alloc"
-        r"(.|\n)*?"
-        r"ttng\.tc_gen5_mma %(?P=A_SHMEM), %(?P=B_SHMEM), %(?P=TMEM_BASE)"
-        r"(.|\n)*?"
-        r"ttng\.tmem_load %(?P=TMEM_BASE)"
-    )
+    pattern = (r"%(?P<A>\w+) = tt\.load"
+               r"(.|\n)*?"
+               r"%(?P<A_SHMEM>\w+) = ttg\.local_alloc %(?P=A)"
+               r"(.|\n)*?"
+               r"%(?P<B>\w+) = tt\.load"
+               r"(.|\n)*?"
+               r"%(?P<B_SHMEM>\w+) = ttg\.local_alloc %(?P=B)"
+               r"(.|\n)*?"
+               r"%(?P<TMEM_BASE>\w+) = ttng\.tmem_alloc"
+               r"(.|\n)*?"
+               r"ttng\.tc_gen5_mma %(?P=A_SHMEM), %(?P=B_SHMEM), %(?P=TMEM_BASE)"
+               r"(.|\n)*?"
+               r"ttng\.tmem_load %(?P=TMEM_BASE)")
 
-    assert re.search(
-        pattern, str(ttgir)
-    ), "The TTGIR does not match the expected pattern."
+    assert re.search(pattern, str(ttgir)), "The TTGIR does not match the expected pattern."
 
     ptx = k.asm["ptx"]
-    pattern = (
-        r"mov\.b32 	%r(?P<G>\d+), global_smem;"
-        r"(.|\n)*"
-        r"tcgen05\.alloc\.cta_group::1\.sync\.aligned\.shared::cta\.b32 \[%r(?P=G)], 64"
-        r"(.|\n)*"
-        r"tcgen05\.relinquish_alloc_permit\.cta_group::1\.sync\.aligned"
-        r"(.|\n)*"
-        r"tcgen05\.st\.sync\.aligned\.16x32bx2.x32.b32"
-        r"(.|\n)*"
-        r"tcgen05\.mma\.cta_group::1.kind::f16"
-        r"(.|\n)*"
-        r"tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
-        r"(.|\n)*"
-        r"mbarrier.try_wait.parity.shared::cta.b64"
-        r"(.|\n)*"
-        r"tcgen05.ld.sync.aligned.16x32bx2.x32.b32"
-        r"(.|\n)*"
-        r"tcgen05.wait::ld.sync.aligned"
-    )
+    pattern = (r"mov\.b32 	%r(?P<G>\d+), global_smem;"
+               r"(.|\n)*"
+               r"tcgen05\.alloc\.cta_group::1\.sync\.aligned\.shared::cta\.b32 \[%r(?P=G)], 64"
+               r"(.|\n)*"
+               r"tcgen05\.relinquish_alloc_permit\.cta_group::1\.sync\.aligned"
+               r"(.|\n)*"
+               r"tcgen05\.st\.sync\.aligned\.16x32bx2.x32.b32"
+               r"(.|\n)*"
+               r"tcgen05\.mma\.cta_group::1.kind::f16"
+               r"(.|\n)*"
+               r"tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+               r"(.|\n)*"
+               r"mbarrier.try_wait.parity.shared::cta.b64"
+               r"(.|\n)*"
+               r"tcgen05.ld.sync.aligned.16x32bx2.x32.b32"
+               r"(.|\n)*"
+               r"tcgen05.wait::ld.sync.aligned")
     assert re.search(pattern, str(ptx)), "The PTX does not match the expected pattern."
     assert k.asm["cubin"] != b""
 
@@ -128,29 +118,25 @@ def test_compile_only_k_loop() -> None:
     )
     ttgir = k.asm["ttgir"]
 
-    pattern = (
-        r"%(?P<TMEM_BASE>\w+) = arith.constant dense<0.000000e\+00>"
-        r"(.|\n)*?"
-        r"%(?P<TMEM>\w+) = ttng\.tmem_alloc (%(?P=TMEM_BASE))?"
-        r"(.|\n)*?"
-        r"scf\.for"
-        r"(.|\n)*?"
-        r"%(?P<A>\w+) = tt\.load"
-        r"(.|\n)*?"
-        r"%(?P<A_SHMEM>\w+) = ttg\.local_alloc %(?P=A)"
-        r"(.|\n)*?"
-        r"%(?P<B>\w+) = tt\.load"
-        r"(.|\n)*?"
-        r"%(?P<B_SHMEM>\w+) = ttg\.local_alloc %(?P=B)"
-        r"(.|\n)*?"
-        r"ttng\.tc_gen5_mma %(?P=A_SHMEM), %(?P=B_SHMEM), %(?P=TMEM)"
-        r"(.|\n)*?"
-        r"scf\.yield"
-    )
+    pattern = (r"%(?P<TMEM_BASE>\w+) = arith.constant dense<0.000000e\+00>"
+               r"(.|\n)*?"
+               r"%(?P<TMEM>\w+) = ttng\.tmem_alloc (%(?P=TMEM_BASE))?"
+               r"(.|\n)*?"
+               r"scf\.for"
+               r"(.|\n)*?"
+               r"%(?P<A>\w+) = tt\.load"
+               r"(.|\n)*?"
+               r"%(?P<A_SHMEM>\w+) = ttg\.local_alloc %(?P=A)"
+               r"(.|\n)*?"
+               r"%(?P<B>\w+) = tt\.load"
+               r"(.|\n)*?"
+               r"%(?P<B_SHMEM>\w+) = ttg\.local_alloc %(?P=B)"
+               r"(.|\n)*?"
+               r"ttng\.tc_gen5_mma %(?P=A_SHMEM), %(?P=B_SHMEM), %(?P=TMEM)"
+               r"(.|\n)*?"
+               r"scf\.yield")
 
-    assert re.search(
-        pattern, str(ttgir)
-    ), "The TTGIR does not match the expected pattern."
+    assert re.search(pattern, str(ttgir)), "The TTGIR does not match the expected pattern."
     assert k.asm["cubin"] != b""
 
 
@@ -169,39 +155,19 @@ def test_compile_only_dot_mxfp() -> None:
     ):
         PACKED_BLOCK_K_A: tl.constexpr = BLOCK_K
         PACKED_BLOCK_K_B: tl.constexpr = BLOCK_K
-        a_ptr = (
-            a_base
-            + tl.arange(0, BLOCK_M)[:, None] * PACKED_BLOCK_K_A
-            + tl.arange(0, PACKED_BLOCK_K_A)[None, :]
-        )
-        b_ptr = (
-            b_base
-            + tl.arange(0, PACKED_BLOCK_K_B)[:, None] * BLOCK_N
-            + tl.arange(0, BLOCK_N)[None, :]
-        )
+        a_ptr = (a_base + tl.arange(0, BLOCK_M)[:, None] * PACKED_BLOCK_K_A + tl.arange(0, PACKED_BLOCK_K_A)[None, :])
+        b_ptr = (b_base + tl.arange(0, PACKED_BLOCK_K_B)[:, None] * BLOCK_N + tl.arange(0, BLOCK_N)[None, :])
 
         SCALE_BLOCK_K: tl.constexpr = BLOCK_K // 32
-        scale_a_ptr = (
-            a_scale
-            + tl.arange(0, BLOCK_M)[:, None] * SCALE_BLOCK_K
-            + tl.arange(0, SCALE_BLOCK_K)[None, :]
-        )
-        scale_b_ptr = (
-            b_scale
-            + tl.arange(0, BLOCK_N)[:, None] * SCALE_BLOCK_K
-            + tl.arange(0, SCALE_BLOCK_K)[None, :]
-        )
+        scale_a_ptr = (a_scale + tl.arange(0, BLOCK_M)[:, None] * SCALE_BLOCK_K + tl.arange(0, SCALE_BLOCK_K)[None, :])
+        scale_b_ptr = (b_scale + tl.arange(0, BLOCK_N)[:, None] * SCALE_BLOCK_K + tl.arange(0, SCALE_BLOCK_K)[None, :])
 
         a = tl.load(a_ptr)
         b = tl.load(b_ptr)
         a_scale = tl.load(scale_a_ptr)
         b_scale = tl.load(scale_b_ptr)
         c = tl.dot_scaled(a, a_scale, "e4m3", b, b_scale, "e4m3")
-        out_ptr = (
-            out
-            + tl.arange(0, BLOCK_M)[:, None] * BLOCK_N
-            + tl.arange(0, BLOCK_N)[None, :]
-        )
+        out_ptr = (out + tl.arange(0, BLOCK_M)[:, None] * BLOCK_N + tl.arange(0, BLOCK_N)[None, :])
         tl.store(out_ptr, c)
 
     k = triton.compile(
@@ -223,9 +189,7 @@ def test_compile_only_dot_mxfp() -> None:
     )
     ttgir = k.asm["ttgir"]
     pattern = r"ttng.tc_gen5_mma_scaled (.*) lhs = e4m3 rhs = e4m3"
-    assert re.search(
-        pattern, str(ttgir)
-    ), "The TTGIR does not match the expected pattern."
+    assert re.search(pattern, str(ttgir)), "The TTGIR does not match the expected pattern."
 
     ptx = k.asm["ptx"]
     pattern = r"tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X"
@@ -272,9 +236,7 @@ def test_fp8_compiles_for_multiple_architectures_hip():
         idx = tl.arange(0, 64)
         tl.store(dst + idx, tl.load(src + idx).to(tl.float8e5))
 
-    src = ASTSource(
-        fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={}
-    )
+    src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
     triton.compile(src, target=GPUTarget("hip", "gfx950", 64))
     triton.compile(src, target=GPUTarget("hip", "gfx942", 64))
 
@@ -293,8 +255,6 @@ def test_fp8_compiles_for_multiple_architectures_cuda():
         idx = tl.arange(0, 64)
         tl.store(dst + idx, tl.load(src + idx).to(tl.float8e5))
 
-    src = ASTSource(
-        fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={}
-    )
+    src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
     triton.compile(src, target=GPUTarget("cuda", 90, 32))
     triton.compile(src, target=GPUTarget("cuda", 80, 32))

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -97,8 +97,7 @@ matchReduxKind(triton::ReduceOp op, int computeCapability,
   if (!reduceOp)
     return std::nullopt;
   // redux.f32 is an sm_100-family feature; sm_120 lacks it.
-  if (computeCapability / 10 == 10 &&
-      reduceOp->getResultTypes()[0].isF32()) {
+  if (computeCapability / 10 == 10 && reduceOp->getResultTypes()[0].isF32()) {
     if (isa<arith::MinimumFOp, arith::MaximumFOp>(reduceOp))
       useNanQualifier = true;
     if (isa<arith::MaxNumFOp, arith::MaximumFOp>(reduceOp))


### PR DESCRIPTION
Summary:
Automated formatting fix generated by running `pre-commit run --all-files`
and `pre-commit run clang-format --all-files` on the GitHub mirror
(facebookexperimental/triton). 2 file(s) fixed.

Differential Revision: D108775259


