### PR TITLE
[triton][AutoWS] Union reuse-group communication consumers (#1745)

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_code_partition_reuse_group_union_consumers.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_reuse_group_union_consumers.mlir
@@ -1,0 +1,76 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=3 post-channel-creation=1" | FileCheck %s
+
+// Reuse groups share a single communication channel.  The channel must be
+// built from the union of the logical buffers in the group, not just from the
+// representative buffer.  Here %a and %b share buffer.id=0; %a is consumed only
+// by task 1, while %b is consumed by both task 0 and task 1.
+//
+// The TMA producer (task 2) lives in the producer partition, while the two
+// consumers are split into their own warp partitions:
+//   - the `default` region is task 0, which reads only %b;
+//   - the `partition0` region is task 1, which reads both %a and %b.
+//
+// The union fix guarantees that every consumer of the reused buffer gets a
+// token and a barrier wait against the TMA producer.  Concretely:
+//   - task 0 must wait on %b's TMA producer before its single local_load,
+//     even though %a (the other buffer in the reuse group) is not consumed by
+//     task 0 -- without the union it would silently drop this wait;
+//   - task 1 must wait twice, once for each of %a and %b, before its two
+//     local_loads;
+//   - the producer acquires a token for both consumer tasks before each of
+//     its two TMA copies, so neither consumer can observe the reused buffer
+//     before its matching TMA load completes.
+
+// CHECK-LABEL: @reuse_group_union_consumers
+// CHECK: ttg.warp_specialize
+
+// default region == task 0: waits on %b's TMA producer, then reads %b.
+// CHECK:      default {
+// CHECK:        async_task_id = array<i32: 0>
+// CHECK:        ttng.wait_barrier
+// CHECK:        ttg.local_load
+
+// partition0 == task 1: waits for both %a and %b before reading them.
+// CHECK:      partition0(
+// CHECK:        ttng.wait_barrier
+// CHECK:        ttng.wait_barrier
+// CHECK:        ttg.local_load
+// CHECK:        ttg.local_load
+// CHECK:        arith.addf
+
+// partition1 == task 2 (producer): acquires the token for both consumer tasks
+// before each TMA copy of the reused buffer.
+// CHECK:      partition1(
+// CHECK:        nvws.producer_acquire
+// CHECK:        nvws.producer_acquire
+// CHECK:        ttng.async_tma_copy_global_to_local
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reuse_group_union_consumers(%a_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>, %b_desc: !tt.tensordesc<tensor<128x64xf16, #shared>>, %out0: !tt.ptr<f16>, %out1: !tt.ptr<f16>) attributes {noinline = false} {
+    %a = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %b = ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %c1 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : i32
+    %c4 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 4 : i32
+    %ptrs0 = tt.splat %out0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptrs1 = tt.splat %out1 {async_task_id = array<i32: 1>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    scf.for %iv = %c0 to %c4 step %c1 : i32 {
+      %a_tile = tt.descriptor_load %a_desc[%c0, %c0] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+      ttg.local_store %a_tile, %a {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %b_tile = tt.descriptor_load %b_desc[%c0, %c0] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+      ttg.local_store %b_tile, %b {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %b0 = ttg.local_load %b {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked>
+      tt.store %ptrs0, %b0 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+      %a1 = ttg.local_load %a {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked>
+      %b1 = ttg.local_load %b {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked>
+      %sum = arith.addf %a1, %b1 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked>
+      tt.store %ptrs1, %sum {async_task_id = array<i32: 1>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+      scf.yield {async_task_id = array<i32: 0, 1, 2>}
+    } {async_task_id = array<i32: 0, 1, 2>, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1405,104 +1405,125 @@ void createTokenPost(
           funcOp, channel->getNumBuffers(), channel->srcName);
       hasProdBar = true;
     }
-    // Check if this channel needs token-based synchronization.
-    // When srcOp and dstOp are both outside loops, we need to check if the
-    // actual consumers are inside loops. This can happen with both single and
-    // multiple consumer task IDs.
-    checkConsumersInLoops(channel);
-    for (auto consumerAsyncTaskId : channel->relation.second) {
-      // It is possible that this channel has two consumer taskIds.
-      // We can have multiple consumer ops for ChannelPost, or one consumer op
-      // has multiple actual consumers. Here we collect all consumer ops.
-      DenseSet<Operation *> actualConsumers;
-      SmallVector<Operation *> dstOps;
-      if (channel->channelKind == DataChannelKind::SMEMPost) {
-        auto *cPost = static_cast<ChannelPost *>(channel);
-        cPost->getDstOps(dstOps);
-      } else {
-        dstOps.push_back(dstOp);
-      }
-      // If it is used by gen5, we can create a gen5 barrier for consumer
-      // release.
-      bool useGen5Barrier = true;
-      for (auto *dst : dstOps) {
-        auto consumers = getActualConsumers(dst);
-        for (auto *t : consumers) {
-          SmallVector<AsyncTaskId> asyncTasks = getAsyncTaskIds(t);
+    SmallVector<Channel *> channelsForComm;
+    if (reuseGrp >= 0) {
+      auto *group = config->getGroup(reuseGrp);
+      channelsForComm.append(group->channels.begin(), group->channels.end());
+    } else {
+      channelsForComm.push_back(channel);
+    }
 
-          // Handle operations that belong to multiple tasks (e.g., boundary
-          // ops) Only include if this consumer belongs to the task we're
-          // processing
-          if (asyncTasks.empty()) {
-            LLVM_DEBUG({
-              LDBG("Skipping operation with no async tasks");
-              t->dump();
-            });
-            continue;
-          }
+    // Check if the channel group needs token-based synchronization.
+    // Reuse groups share one CommChannel, so this must consider every channel
+    // in the group. Otherwise the representative channel can drop consumer task
+    // IDs that only appear on another logical buffer sharing the same SMEM
+    // circular pool.
+    for (auto *commSourceChannel : channelsForComm) {
+      checkConsumersInLoops(commSourceChannel);
+      auto sourceDstOp = commSourceChannel->getDstOp();
+      for (auto consumerAsyncTaskId : commSourceChannel->relation.second) {
+        if (commChannel.tokens.count(consumerAsyncTaskId) &&
+            commChannel.consumerBarriers.count(consumerAsyncTaskId))
+          continue;
 
-          if (std::find(asyncTasks.begin(), asyncTasks.end(),
-                        consumerAsyncTaskId) != asyncTasks.end()) {
-            actualConsumers.insert(t);
-            // XXX: Op can have multiple async tasks
-
-            // If consumer and producer are not in the same block, but
-            // as long as all consumers are gen5, we can use a gen5 related
-            // barrier such as gen5.commit. Remove producerOp->getBlock() !=
-            // t->getBlock()
-            if (!isa<ttng::TCGen5MMAOp>(t))
-              useGen5Barrier = false;
-          }
-        }
-      }
-      assert(!actualConsumers.empty());
-      Operation *consumerOp =
-          *actualConsumers.begin(); // getLastOpInBlock(actualConsumers);
-
-      LLVM_DEBUG({
-        LDBG("-- createToken: useGen5Barrier = "
-             << useGen5Barrier << " channel " << channel->uniqID);
-        producerOp->dump();
-        dstOp->dump();
-        consumerOp->dump();
-      });
-      // Need token only when we are not using inline barriers
-      if (!hasProdBar || !useGen5Barrier) {
-        ttnvws::TokenLoadType tokenLoadType;
-        auto copyOp = channel->getSrcOp();
-        if (isa<ttg::AsyncCopyGlobalToLocalOp>(copyOp)) {
-          tokenLoadType = ttnvws::TokenLoadType::AsyncLoadOp;
-        } else if (isProducerTMA(channel, true)) {
-          tokenLoadType = ttnvws::TokenLoadType::TMALoadOp;
-        } else if (isa<ttg::LocalStoreOp>(copyOp)) {
-          tokenLoadType = ttnvws::TokenLoadType::LocalStoreOp;
-        } else if (isa<ttng::TMEMLoadOp>(copyOp) ||
-                   isa<ttng::TMEMStoreOp>(consumerOp)) {
-          // Wrap-around channel: tmem_load signals tmem_store that the
-          // buffer has been consumed and can be overwritten.
-          tokenLoadType = ttnvws::TokenLoadType::TmemLoadOp;
-        } else if (isa<ttng::TMEMLoadOp>(consumerOp)) {
-          tokenLoadType = ttnvws::TokenLoadType::TmemLoadOp;
-        } else if (isa<ttng::TCGen5MMAOp>(consumerOp)) {
-          // For operand A of gen5, we have tmem_store + gen5.
-          tokenLoadType = ttnvws::TokenLoadType::TmemLoadOp;
+        // It is possible that this channel has two consumer taskIds.
+        // We can have multiple consumer ops for ChannelPost, or one consumer op
+        // has multiple actual consumers. Here we collect all consumer ops.
+        DenseSet<Operation *> actualConsumers;
+        SmallVector<Operation *> dstOps;
+        if (commSourceChannel->channelKind == DataChannelKind::SMEMPost) {
+          auto *cPost = static_cast<ChannelPost *>(commSourceChannel);
+          cPost->getDstOps(dstOps);
         } else {
-          llvm_unreachable("Unexpected load type");
+          dstOps.push_back(sourceDstOp);
         }
-        Value v;
-        Location tokenLoc = funcOp.getLoc();
-        if (!channel->srcName.empty())
-          tokenLoc = NameLoc::get(
-              StringAttr::get(funcOp.getContext(), channel->srcName), tokenLoc);
-        v = ttnvws::CreateTokenOp::create(
-            builder, tokenLoc, channel->getNumBuffers(), tokenLoadType);
-        commChannel.tokens[consumerAsyncTaskId] = v;
-      }
+        // If it is used by gen5, we can create a gen5 barrier for consumer
+        // release.
+        bool useGen5Barrier = true;
+        for (auto *dst : dstOps) {
+          auto consumers = getActualConsumers(dst);
+          for (auto *t : consumers) {
+            SmallVector<AsyncTaskId> asyncTasks = getAsyncTaskIds(t);
 
-      if (useGen5Barrier) {
-        Value v = createBarrierAlloc(funcOp, channel->getNumBuffers(),
-                                     channel->srcName);
-        commChannel.consumerBarriers[consumerAsyncTaskId] = v;
+            // Handle operations that belong to multiple tasks (e.g., boundary
+            // ops) Only include if this consumer belongs to the task we're
+            // processing
+            if (asyncTasks.empty()) {
+              LLVM_DEBUG({
+                LDBG("Skipping operation with no async tasks");
+                t->dump();
+              });
+              continue;
+            }
+
+            if (std::find(asyncTasks.begin(), asyncTasks.end(),
+                          consumerAsyncTaskId) != asyncTasks.end()) {
+              actualConsumers.insert(t);
+              // XXX: Op can have multiple async tasks
+
+              // If consumer and producer are not in the same block, but
+              // as long as all consumers are gen5, we can use a gen5 related
+              // barrier such as gen5.commit. Remove producerOp->getBlock() !=
+              // t->getBlock()
+              if (!isa<ttng::TCGen5MMAOp>(t))
+                useGen5Barrier = false;
+            }
+          }
+        }
+        assert(!actualConsumers.empty());
+        Operation *consumerOp =
+            *actualConsumers.begin(); // getLastOpInBlock(actualConsumers);
+
+        LLVM_DEBUG({
+          LDBG("-- createToken: useGen5Barrier = "
+               << useGen5Barrier << " channel "
+               << commSourceChannel->uniqID);
+          commSourceChannel->getSrcOp()->dump();
+          sourceDstOp->dump();
+          consumerOp->dump();
+        });
+        // Need token only when we are not using inline barriers
+        if ((!hasProdBar || !useGen5Barrier) &&
+            !commChannel.tokens.count(consumerAsyncTaskId)) {
+          ttnvws::TokenLoadType tokenLoadType;
+          auto copyOp = commSourceChannel->getSrcOp();
+          if (isa<ttg::AsyncCopyGlobalToLocalOp>(copyOp)) {
+            tokenLoadType = ttnvws::TokenLoadType::AsyncLoadOp;
+          } else if (isProducerTMA(commSourceChannel, true)) {
+            tokenLoadType = ttnvws::TokenLoadType::TMALoadOp;
+          } else if (isa<ttg::LocalStoreOp>(copyOp)) {
+            tokenLoadType = ttnvws::TokenLoadType::LocalStoreOp;
+          } else if (isa<ttng::TMEMLoadOp>(copyOp) ||
+                     isa<ttng::TMEMStoreOp>(consumerOp)) {
+            // Wrap-around channel: tmem_load signals tmem_store that the
+            // buffer has been consumed and can be overwritten.
+            tokenLoadType = ttnvws::TokenLoadType::TmemLoadOp;
+          } else if (isa<ttng::TMEMLoadOp>(consumerOp)) {
+            tokenLoadType = ttnvws::TokenLoadType::TmemLoadOp;
+          } else if (isa<ttng::TCGen5MMAOp>(consumerOp)) {
+            // For operand A of gen5, we have tmem_store + gen5.
+            tokenLoadType = ttnvws::TokenLoadType::TmemLoadOp;
+          } else {
+            llvm_unreachable("Unexpected load type");
+          }
+          Value v;
+          Location tokenLoc = funcOp.getLoc();
+          if (!commSourceChannel->srcName.empty())
+            tokenLoc = NameLoc::get(
+                StringAttr::get(funcOp.getContext(), commSourceChannel->srcName),
+                tokenLoc);
+          v = ttnvws::CreateTokenOp::create(
+              builder, tokenLoc, commSourceChannel->getNumBuffers(),
+              tokenLoadType);
+          commChannel.tokens[consumerAsyncTaskId] = v;
+        }
+
+        if (useGen5Barrier &&
+            !commChannel.consumerBarriers.count(consumerAsyncTaskId)) {
+          Value v = createBarrierAlloc(funcOp, commSourceChannel->getNumBuffers(),
+                                       commSourceChannel->srcName);
+          commChannel.consumerBarriers[consumerAsyncTaskId] = v;
+        }
       }
     }
 


### PR DESCRIPTION
Summary:

Fixes Hopper warp-specialized code partitioning for buffer reuse groups. When multiple logical TMA load channels share a fused buffer id, the communication channel needs to represent the union of consumers across every channel in the reuse group.

This matters for Hopper data partitioning: a data-partitioned load may need to be checked by both consumer partitions, not only by the first or representative consumer selected for the reuse group. Using only that representative channel can drop a barrier wait for another consumer, allowing a local load or dot to observe the reused buffer before its matching TMA load is complete.

The fix builds the reuse-group communication channel from all grouped channels and deduplicates by consumer async task id, so each consumer that can read the reused buffer gets the required token and barrier wait.

Reviewed By: manman-ren

Differential Revision: D108824381


