### PR TITLE
[AutoWS] Add explicit treatment of named barriers as blocker for WSBarrier movement.

### DIFF
--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -554,4 +554,35 @@ tt.func @rollback_when_overlap_profile_unchanged() {
   tt.return
 }
 
+// Named barriers are ordering barriers. WS barrier restore must not move an
+// arrive across one when searching for the guarded memory op.
+// CHECK-LABEL: @restore_ws_arrive_stops_at_named_barrier
+tt.func @restore_ws_arrive_stops_at_named_barrier(
+    %bar: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>)
+    -> (tensor<128x64xf32, #linear64>, tensor<128x64xf32, #linear64>) {
+  %c9 = arith.constant 9 : i32
+  %c128 = arith.constant 128 : i32
+  %true = arith.constant true
+  %bias0 = arith.constant dense<1.0> : tensor<128x64xf32, #linear64>
+  %bias1 = arith.constant dense<2.0> : tensor<128x64xf32, #linear64>
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #linear128>
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %noalias_alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %s0 = ttng.tmem_subslice %alloc {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+  %v0 = ttng.tmem_load %s0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear64>
+  %s1 = ttng.tmem_subslice %alloc {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+  %v1 = ttng.tmem_load %s1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear64>
+  %out0 = arith.addf %v0, %bias0 : tensor<128x64xf32, #linear64>
+  %out1 = arith.addf %v1, %bias1 : tensor<128x64xf32, #linear64>
+
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.wait_barrier_named
+  // CHECK-NEXT: ttng.arrive_barrier
+  // CHECK-SAME: channelGraph = array<i32: 4>
+  ttng.tmem_store %zero, %noalias_alloc, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.wait_barrier_named %c9, %c128 : i32, i32
+  ttng.arrive_barrier %bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 4>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return %out0, %out1 : tensor<128x64xf32, #linear64>, tensor<128x64xf32, #linear64>
+}
+
 }

--- a/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
+++ b/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
@@ -87,6 +87,15 @@ inline bool hasArriveLikeSemantics(Operation *op) {
              TCGen5CommitOp, MMAv5OpInterface>(op);
 }
 
+inline bool isBarrierLikeOp(Operation *op) {
+  return isa<ArriveBarrierOp, WaitBarrierOp, InitBarrierOp,
+             NamedBarrierArriveOp, NamedBarrierWaitOp>(op);
+}
+
+inline bool isNamedBarrierOp(Operation *op) {
+  return isa<NamedBarrierArriveOp, NamedBarrierWaitOp>(op);
+}
+
 inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraints,
                                 Operation *op) {
   if (op->getNumRegions() != 0)
@@ -96,6 +105,8 @@ inline bool canAdvanceWSBarrier(std::optional<DictionaryAttr> constraints,
   if (auto wait = dyn_cast<WaitBarrierOp>(op))
     return canAdvanceWSBarrierArrivePastWait(constraints,
                                              wait.getConstraints());
+  if (isNamedBarrierOp(op))
+    return false;
   return !hasArriveLikeSemantics(op);
 }
 
@@ -222,8 +233,7 @@ inline DenseMap<Operation *, Operation *>
 buildBarrierToMemoryOpMap(Block &block) {
   DenseMap<Operation *, Operation *> map;
   auto isMemoryOp = [](Operation *op) {
-    return !isMemoryEffectFree(op) &&
-           !isa<ArriveBarrierOp, WaitBarrierOp, InitBarrierOp>(op) &&
+    return !isMemoryEffectFree(op) && !isBarrierLikeOp(op) &&
            !op->hasTrait<OpTrait::IsTerminator>();
   };
 
@@ -232,6 +242,8 @@ buildBarrierToMemoryOpMap(Block &block) {
       if (!hasWSBarrierConstraints(arrive.getConstraints()))
         continue;
       for (auto *cur = arrive->getPrevNode(); cur; cur = cur->getPrevNode()) {
+        if (isNamedBarrierOp(cur))
+          break;
         if (isMemoryOp(cur)) {
           map[arrive] = cur;
           break;
@@ -241,6 +253,8 @@ buildBarrierToMemoryOpMap(Block &block) {
       if (!hasWSBarrierConstraints(wait.getConstraints()))
         continue;
       for (auto *cur = wait->getNextNode(); cur; cur = cur->getNextNode()) {
+        if (isNamedBarrierOp(cur))
+          break;
         if (isMemoryOp(cur)) {
           map[wait] = cur;
           break;


### PR DESCRIPTION
Named barriers are ordering barriers for WS barrier movement, so the reorder helper now refuses to advance across them and stops restore scans at named barriers. The interleave TMEM lit test covers the restore case.

I have no evidence this caused any production issues, but I saw this while debugging and assumed it was better for safety.

Authored with Claude.