### PR TITLE
[triton][tlx] Defer WGMMA checks for no-verify layouts (#1747)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1036,6 +1036,9 @@ static LogicalResult verifyTMEMOperand(Operation *op, RankedTensorType type,
                                        MemDescType memdesc, StringRef regName) {
   if (type.getRank() != 2)
     return op->emitOpError(regName) << " must be a 2D tensor";
+  if (tlx::hasNoVerifyLayout(type.getEncoding()) ||
+      tlx::hasNoVerifyLayout(memdesc.getEncoding()))
+    return success();
   // Skip verification for placeholder layouts - they will be resolved later
   if (isa<triton::tlx::DummyTMEMLayoutAttr>(memdesc.getEncoding()))
     return success();

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -38,6 +38,6 @@ def test_layout_shape_stride_maps_to_linear():
 
     # 3 warp bases -> 2**3 = 8 warps; the layout requires num_warps == 8.
     compiled = kernel.warmup(_separable_qk_layout(), grid=(1, ), num_warps=8)
-    ttir = compiled.asm["ttir"]
-    assert "no_verify_layout" not in ttir
-    assert _SEPARABLE_QK_LINEAR in ttir
+    ttgir = compiled.asm["ttgir"]
+    assert "no_verify_layout" not in ttgir
+    assert _SEPARABLE_QK_LINEAR in ttgir

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -224,6 +224,15 @@ Attribute mlir::triton::tlx::wrapNoVerifyLayout(Attribute layout) {
     return layout;
   if (!isa<ttg::DistributedEncodingTrait>(layout))
     return layout;
+  if (auto mmaLayout = dyn_cast<ttg::NvidiaMmaEncodingAttr>(layout);
+      mmaLayout && mmaLayout.isHopper())
+    return layout;
+  if (auto dotLayout = dyn_cast<ttg::DotOperandEncodingAttr>(layout)) {
+    if (auto parentLayout =
+            dyn_cast<ttg::NvidiaMmaEncodingAttr>(dotLayout.getParent());
+        parentLayout && parentLayout.isHopper())
+      return layout;
+  }
   return NoVerifyLayoutAttr::get(layout.getContext(), layout);
 }
 


### PR DESCRIPTION
Summary:

TLX uses no-verify wrapper layouts to carry concrete distributed layouts through early pipeline stages without triggering the normal TritonGPU layout verifier before TLX's own layout-resolution stage. `ttng.warp_group_dot` still ran concrete layout inference and verification on those wrappers, which caused failures such as `WGMMA result layout must be Hopper NVMMA` and later generic dot operand validation before the wrappers were removed.

**Context:**
The wrapper layout is intentionally temporary. While it is present, TTNG verifier code should avoid interpreting it as a fully resolved TritonGPU layout and let TLX's placeholder-resolution path unwrap and validate the concrete layout later.

**Motivation:**
Allow TLX async dot kernels using no-verify wrapped WGMMA layouts to compile through the early TTIR pipeline without prematurely failing TTNG inference or verifier checks.

**This diff:**
- Skips `WarpGroupDotOp::inferReturnTypes()` layout inference when any operand/result layout is `tlx.no_verify_layout`.
- Skips concrete `WarpGroupDotOp::verify()` checks while result, A, or B layouts are no-verify wrapped.
- Treats no-verify layouts as deferred in `verifyTMEMOperand()` so TMEM compatibility checks do not run before layout resolution.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D108837173


