### PR TITLE
[triton][beta] [Cherry-pick][BUNDLE] Cherry-pick 6 upstream commits (#9314, #9360, #9367, #9194, #9374, #9366) (#1753)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -93,6 +93,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::gpu::registerAllocateSharedMemoryPass();
   mlir::triton::gpu::registerTritonGPUAllocateWarpGroups();
   mlir::triton::gpu::registerTritonGPUGlobalScratchAllocationPass();
+  mlir::triton::gpu::registerCanonicalizeLLVMIR();
   mlir::triton::registerConvertWarpSpecializeToLLVM();
   mlir::triton::registerConvertTritonGPUToLLVMPass();
   mlir::triton::registerConvertNVGPUToLLVMPass();

--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -72,8 +72,11 @@ public:
   explicit Allocation(Operation *operation) : operation(operation) {}
 
   /// Runs allocation analysis on the given top-level operation.
+  /// \param sharedMemoryPartitionSize The size of each shared memory partition
+  ///        in bytes. A value of 0 means shared memory is not partitioned.
   void run(FuncAllocMapT &funcAllocMap,
-           triton::AllocationAnalysisScratchSizeFn scratchSizeGetter);
+           triton::AllocationAnalysisScratchSizeFn scratchSizeGetter,
+           size_t sharedMemoryPartitionSize = 0);
 
   /// Returns the operation this analysis was constructed from.
   Operation *getOperation() const { return operation; }
@@ -94,24 +97,29 @@ public:
     return Interval<size_t>(buffer.offset, buffer.offset + buffer.size);
   }
 
-  /// Returns the buffer id of the given value.
-  /// This interface only returns the allocated buffer id.
-  /// If you want to get all the buffer ids that are associated with the given
-  /// value, including alias buffers, use getBufferIds.
-  BufferId getBufferId(Value value) const {
-    if (valueBuffer.count(value)) {
-      return valueBuffer.lookup(value)->id;
-    } else {
-      return InvalidBufferId;
+  /// Returns all buffer ids for a value.
+  /// For partitioned tensors, returns all logical piece buffer ids.
+  /// For non-partitioned values, returns a single-element vector.
+  /// Returns empty vector if value has no associated buffer.
+  SmallVector<BufferId> getBufferIds(Value value) const {
+    SmallVector<BufferId> bufferIds;
+    auto it = valueBuffer.find(value);
+    if (it == valueBuffer.end())
+      return bufferIds;
+
+    for (auto *buffer : it->second) {
+      bufferIds.push_back(buffer->id);
     }
+    return bufferIds;
   }
 
-  /// Returns all the buffer ids of the given value, including alias buffers.
-  BufferIdSetT getBufferIds(Value value) const {
+  /// Returns all buffer ids of the given value, including alias buffers.
+  /// This is a superset of getBufferIds that also includes aliased buffers.
+  BufferIdSetT getAllBufferIdsWithAliases(Value value) const {
     BufferIdSetT bufferIds;
-    auto allocBufferId = getBufferId(value);
-    if (allocBufferId != InvalidBufferId)
-      bufferIds.insert(allocBufferId);
+    for (auto bufferId : getBufferIds(value)) {
+      bufferIds.insert(bufferId);
+    }
     for (auto *buffer : aliasBuffer.lookup(value)) {
       if (buffer->id != InvalidBufferId)
         bufferIds.insert(buffer->id);
@@ -165,6 +173,10 @@ private:
     size_t reuseOffset;  // when isOwnerOfSpace is true
     BufferT *reuseOwner; // when isOwnerOfSpace is false
 
+    /// For partitioned tensors: buffers that reside in different physical
+    /// partitions.
+    SmallVector<BufferT *> neighbors;
+
     bool operator==(const BufferT &other) const { return id == other.id; }
     bool operator<(const BufferT &other) const { return id < other.id; }
 
@@ -180,8 +192,8 @@ private:
 
   /// Op -> Scratch Buffer
   using OpScratchMapT = llvm::MapVector<Operation *, BufferT *>;
-  /// Value -> Explicit Buffer
-  using ValueBufferMapT = llvm::MapVector<Value, BufferT *>;
+  /// Value -> Explicit Buffers (vector for partitioned tensors)
+  using ValueBufferMapT = llvm::MapVector<Value, SmallVector<BufferT *>>;
   /// Value -> Alias Buffer
   using AliasBufferMapT = llvm::MapVector<Value, llvm::SetVector<BufferT *>>;
   /// BufferId -> Buffer
@@ -195,7 +207,7 @@ private:
         nextId, BufferT(Kind, nextId, key, std::forward<Args>(args)...));
     BufferT *buffer = &it->second;
     if constexpr (Kind == BufferT::BufferKind::Explicit) {
-      valueBuffer[key] = buffer;
+      valueBuffer[key].push_back(buffer);
     } else if constexpr (Kind == BufferT::BufferKind::Virtual) {
       opVirtual[key] = buffer;
     } else {
@@ -203,8 +215,20 @@ private:
     }
   }
 
+  /// Create multiple buffers for partitions where all different partitions
+  /// are neighbors (must be placed in different physical shared memory slots).
+  ///
+  /// \param key The value that owns these buffers
+  /// \param numPartitions Number of partition buffers to create
+  /// \param partitionSize Size of each partition buffer in bytes
+  /// \param alignment Required alignment for each buffer
+  void addPartitionBuffers(Value key, unsigned numPartitions,
+                           size_t partitionSize, size_t alignment);
+
   void addAlias(Value value, Value alloc) {
-    aliasBuffer[value].insert(valueBuffer[alloc]);
+    for (auto *buffer : valueBuffer[alloc]) {
+      aliasBuffer[value].insert(buffer);
+    }
   }
 
 private:
@@ -235,7 +259,8 @@ public:
 
   ModuleAllocation(ModuleOp moduleOp,
                    triton::AllocationAnalysisScratchSizeFn scratchSizeGetter =
-                       triton::defaultAllocationAnalysisScratchSizeFn)
+                       triton::defaultAllocationAnalysisScratchSizeFn,
+                   size_t sharedMemoryPartitionSize = 0)
       : triton::CallGraph<Allocation>(moduleOp) {
     walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
         // Pre-order edge walk callback
@@ -244,7 +269,8 @@ public:
         [&](FunctionOpInterface funcOp) {
           auto [iter, inserted] = funcMap.try_emplace(funcOp, funcOp);
           if (inserted)
-            iter->second.run(funcMap, scratchSizeGetter);
+            iter->second.run(funcMap, scratchSizeGetter,
+                             sharedMemoryPartitionSize);
         });
   }
 

--- a/include/triton/Conversion/TritonGPUToLLVM/Passes.td
+++ b/include/triton/Conversion/TritonGPUToLLVM/Passes.td
@@ -42,4 +42,8 @@ def TritonGPUAllocateWarpGroups : Pass<"tritongpu-allocate-warp-groups", "mlir::
   }];
 }
 
+def CanonicalizeLLVMIR : Pass<"canonicalize-llvm-ir", "mlir::LLVM::LLVMFuncOp"> {
+  let summary = "Canonicalize LLVM IR";
+}
+
 #endif

--- a/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -103,9 +103,7 @@ void populatePrintOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                   PatternBenefit benefit);
 
 void populateInstrumentationToLLVMPatterns(LLVMTypeConverter &typeConverter,
-                                           const TargetInfoBase &targetInfo,
-                                           RewritePatternSet &patterns,
-                                           PatternBenefit benefit);
+                                           RewritePatternSet &patterns);
 
 } // namespace triton
 } // namespace mlir

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -104,6 +104,10 @@ public:
   virtual bool supportLdStMatrixB8() const { return false; }
   virtual bool isCuda() const { return false; }
 
+  // Returns the shared memory partition size in bytes. A value of 0 means
+  // shared memory is not partitioned.
+  virtual size_t getSharedMemoryPartitionSize() const { return 0; }
+
   // Annotate target specific information to local load operations during
   // lowering to LLVM. `llLoadOp` is the generated LLVM load op.
   virtual void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -344,6 +344,9 @@ LLVM::LLVMFuncOp appendOrGetExternFuncOp(RewriterBase &rewriter, Operation *op,
 
 // Multiply a square layout with 1 input and output dimension with a vector
 Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x);
+
+// Whether the convert layout should be forced to use warp shuffles.
+bool cvtAlwaysUseWarpShuffle(triton::gpu::ConvertLayoutOp cvt);
 } // namespace gpu
 
 } // namespace triton
@@ -443,6 +446,9 @@ Value linearize(RewriterBase &rewriter, Location loc, ArrayRef<Value> multiDim,
 
 size_t linearize(ArrayRef<unsigned> multiDim, ArrayRef<unsigned> shape,
                  ArrayRef<unsigned> order);
+
+GlobalOp getOrInsertGlobalConstant(RewriterBase &rewriter, ModuleOp module,
+                                   Type type, Attribute content, StringRef key);
 
 Value addStringToModule(Location loc, RewriterBase &rewriter, StringRef key,
                         StringRef content);
@@ -688,6 +694,14 @@ SmallVector<Value> inlineRegion(RewriterBase &rewriter, Region &region,
   return inlineRegionImpl(rewriter, region, args,
                           mlir::TypeID::get<TerminatorOp>(), loc);
 }
+
+// #prevBlock
+// if (condition) {
+//   #ifBlock
+// }
+// #thenBlock
+std::tuple</*prevBlock=*/Block *, /*ifBlock=*/Block *, /*thenBlock=*/Block *>
+createIfBlock(ConversionPatternRewriter &b, Location loc, Value cnd);
 
 void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
                                  ConversionPatternRewriter &rewriter,

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -359,6 +359,72 @@ For identity mappings a short form based on order and shape is used to increase 
   let genVerifyDecl = 1;
 }
 
+
+def PartitionedSharedEncodingAttr
+    : TritonGPU_Attr<"PartitionedSharedEncoding", "partitioned_shared_encoding",
+                     [SharedEncodingTrait, DeclareLayoutEncodingMethods,  LayoutEncodingTrait]> {
+  let mnemonic = "partitioned_shared";
+
+  let description = [{
+    An encoding for tensors whose elements are partitioned across multiple
+    separate shared memory allocations. This reduces shared memory partition
+    conflicts by splitting a tensor along a specific dimension into separate
+    allocations.
+
+    Parameters:
+    - numPartitions: Number of distinct memory partitions (and separate buffers).
+      Buffers in different partitions MUST be placed in different physical
+      shared memory slots.
+    - numGroups: Number of groups. Each group contains numPartitions
+      consecutive pieces of the tensor.
+    - partitionDim: The dimension along which the tensor is partitioned.
+    - partitionLayout: The shared memory layout used within each piece.
+
+    The total number of logical pieces is numPartitions * numGroups.
+    Pieces are organized as:
+      [Group 0: pieces 0..numPartitions-1]
+      [Group 1: pieces numPartitions..2*numPartitions-1]
+      ...
+
+    ## Memory Allocation
+
+    The allocator creates numPartitions buffers (NOT numLogicalPieces buffers).
+    Each buffer contains all pieces from all groups that belong to that partition,
+    concatenated together. Buffer size = pieceSize * numGroups.
+
+    For example, with numPartitions=2, numGroups=4 and
+    partitionDim=0 on a [128, 32] tensor:
+    - Total 8 logical pieces, each of size [16, 32] (pieceSize = 16*32 elements)
+    - Piece layout: [0, 1, 2, 3, 4, 5, 6, 7]
+    - Partitions:    0  1  0  1  0  1  0  1
+    - Groups:       |Grp0||Grp1||Grp2||Grp3|
+
+    Physical allocation (2 buffers, each containing 4 pieces):
+    - Buffer 0 (Partition 0): [Piece0 | Piece2 | Piece4 | Piece6]
+    - Buffer 1 (Partition 1): [Piece1 | Piece3 | Piece5 | Piece7]
+
+    Physical allocation guarantee: Buffers in different partitions MUST reside
+    in distinct physical shared memory partitions.
+  }];
+
+  let parameters = (ins
+      "unsigned":$numPartitions,
+      "unsigned":$numGroups,
+      "unsigned":$partitionDim,
+      "SharedEncodingTrait":$partitionLayout
+  );
+
+  let extraClassDeclaration = [{
+    /// Returns the total number of logical pieces.
+    unsigned getNumLogicalPieces() const {
+      return getNumPartitions() * getNumGroups();
+    }
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+}
+
 def SharedLinearEncodingAttr
     : TritonGPU_Attr<"SharedLinearEncoding", "shared_linear_encoding",
                      [SharedEncodingTrait, LayoutEncodingTrait,

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -21,18 +21,16 @@ class TTI_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonInstrument_Dialect, mnemonic, traits> {
 }
 
-def TTI_ExperimentalAssertInThreadOp : TTI_Op<"experimental_assert_in_thread", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "assert the condition within the current thread";
+def TTI_ExperimentalAssertUniformOp : TTI_Op<"experimental_assert_uniform", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "assert the uniform condition";
   let description = [{
-    Assert that the condition is true given all the values are available in the current thread.
-    If the condition is false, the message is printed, and the program is aborted.
-    If check_any is true, any of the values in the condition must be true. Otherwise, all the
-    values in the condition must be true.
+    Assert that the condition is true given all threads in the warp group have
+    the same value, so only one thread needs to evaluate the assert and print
+    the message.
   }];
-  let arguments = (ins AnyTypeOf<[I1, I1Tensor]>:$condition, StrAttr:$message, BoolAttr:$check_any);
-  let assemblyFormat = "$condition `,` $message attr-dict `:` type($condition)";
+  let arguments = (ins I1:$condition, StrAttr:$message);
+  let assemblyFormat = "$condition `,` $message attr-dict-with-keyword";
 }
-
 
 def TTI_ExperimentalBufferDescriptorsOp
     : TTI_Op<"experimental_buffer_descriptors", [Pure]> {

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -20,6 +20,13 @@
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+// Returns partition index when partitionSize > 0, otherwise returns 0.
+static size_t getPartitionIndex(size_t offset, size_t partitionSize) {
+  if (partitionSize == 0)
+    return 0;
+  return offset / partitionSize;
+}
+
 namespace ttng = mlir::triton::nvidia_gpu;
 namespace ttg = mlir::triton::gpu;
 
@@ -117,9 +124,11 @@ public:
   AllocationAnalysis(Operation *operation,
                      Allocation::FuncAllocMapT *funcAllocMap,
                      Allocation *allocation,
-                     AllocationAnalysisScratchSizeFn scratchSizeGetter)
+                     AllocationAnalysisScratchSizeFn scratchSizeGetter,
+                     size_t partitionSize)
       : operation(operation), funcAllocMap(funcAllocMap),
-        allocation(allocation), scratchSizeGetter(scratchSizeGetter) {
+        allocation(allocation), scratchSizeGetter(scratchSizeGetter),
+        partitionSize(partitionSize) {
     run();
   }
 
@@ -144,6 +153,47 @@ private:
     if (!alloc || !alloc.isSharedMemoryAlloc())
       return;
     auto allocType = alloc.getType();
+    auto alignment = alloc.getAlignmentOrDefault();
+
+    // Handle PartitionedSharedEncodingAttr: create one buffer per partition,
+    // where each buffer contains all groups for that partition concatenated.
+    // With numPartitions=2, numGroups=4: creates 2 buffers, each containing
+    // 4 concatenated pieces.
+    if (auto partitionedEnc = dyn_cast<gpu::PartitionedSharedEncodingAttr>(
+            allocType.getEncoding())) {
+      unsigned numPartitions = partitionedEnc.getNumPartitions();
+      unsigned numGroups = partitionedEnc.getNumGroups();
+      unsigned numLogicalPieces = partitionedEnc.getNumLogicalPieces();
+
+      // Calculate size per logical piece
+      auto partitionLayout = partitionedEnc.getPartitionLayout();
+      int64_t totalNumElems = 0;
+
+      if (auto paddedEnc =
+              dyn_cast<gpu::PaddedSharedEncodingAttr>(partitionLayout)) {
+        SmallVector<int64_t> unpaddedShape = gpu::getShapePerCTA(allocType);
+        totalNumElems = paddedEnc.getPaddedSize(unpaddedShape);
+      } else {
+        auto shapePerCTA = gpu::getAllocationShapePerCTA(allocType);
+        totalNumElems = product<int64_t>(shapePerCTA);
+      }
+
+      int64_t totalBytes =
+          totalNumElems *
+          getIntOrFloatOrPtrBitWidth(allocType.getElementType()) / 8;
+      int64_t pieceSize = totalBytes / numLogicalPieces;
+
+      // Each partition buffer contains all groups concatenated
+      int64_t partitionBufferSize = pieceSize * numGroups;
+
+      // Create buffers for each partition. All partition buffers are neighbors
+      // (must be placed in different physical shared memory partitions).
+      allocation->addPartitionBuffers(alloc, numPartitions, partitionBufferSize,
+                                      alignment);
+      return;
+    }
+
+    // Standard (non-partitioned) buffer allocation
     int64_t numElems = 0;
     if (auto paddedEnc =
             dyn_cast<gpu::PaddedSharedEncodingAttr>(allocType.getEncoding())) {
@@ -156,7 +206,6 @@ private:
     int64_t bytes =
         numElems * getIntOrFloatOrPtrBitWidth(allocType.getElementType()) / 8;
 
-    auto alignment = alloc.getAlignmentOrDefault();
     allocation->addBuffer<BufferT::BufferKind::Explicit>(alloc, bytes,
                                                          alignment);
   }
@@ -248,16 +297,23 @@ private:
 
   /// Computes the liveness range of the allocated value.
   /// Each buffer is allocated only once.
+  /// For partitioned tensors, all partition buffers share the same liveness
+  /// range.
   void resolveExplicitBufferLiveness(
       function_ref<Interval<size_t>(Value value)> getLiveness) {
-    for (auto valueBufferIter : allocation->valueBuffer) {
+    for (auto &valueBufferIter : allocation->valueBuffer) {
       auto value = valueBufferIter.first;
-      auto *buffer = valueBufferIter.second;
-      bufferRange[buffer] = getLiveness(value);
-      LLVM_DEBUG({
-        llvm::dbgs() << "-- buffer " << buffer->id << "; value: ";
-        value.dump();
-      });
+      auto &buffers = valueBufferIter.second;
+      auto range = getLiveness(value);
+
+      // Apply the same liveness range to all buffers for this value
+      for (auto *buffer : buffers) {
+        bufferRange[buffer] = range;
+        LLVM_DEBUG({
+          llvm::dbgs() << "-- buffer " << buffer->id << "; value: ";
+          value.dump();
+        });
+      }
     }
   }
 
@@ -549,7 +605,8 @@ private:
   }
 
   /// Builds a graph of all shared memory values. Edges are created between
-  /// shared memory values that are overlapping.
+  /// shared memory values that are overlapping, or between partition neighbors
+  /// that are placed in the same physical partition.
   void buildInterferenceGraph(const SmallVector<BufferT *> &buffers,
                               GraphT &interference) {
     // Reset interference graph
@@ -585,12 +642,27 @@ private:
           interference[x].insert(y);
         }
       }
+
+      // Partition neighbors interfere if they are in the same
+      // physical partition. This ensures that different partitions of the
+      // same partitioned tensor are placed in different physical partitions.
+      // Only check this when partitioning is enabled (partitionSize > 0).
+      if (partitionSize > 0) {
+        for (auto *neighbor : x->neighbors) {
+          if (getPartitionIndex(x->offset, partitionSize) ==
+              getPartitionIndex(neighbor->offset, partitionSize)) {
+            interference[x].insert(neighbor);
+          }
+        }
+      }
     }
 
     LLVM_DEBUG(dumpInterferenceGraph(interference));
   }
 
   /// Finalizes shared memory offsets considering interference.
+  /// For partition neighbors, bumps to the next physical partition boundary
+  /// to ensure they are placed in different physical partitions.
   void allocate(const SmallVector<BufferT *> &buffers,
                 const GraphT &interference) {
     // Reset shared memory size
@@ -628,7 +700,20 @@ private:
     for (auto x : buffers) {
       size_t newOffset = 0;
       for (auto y : interference.lookup(x)) {
-        newOffset = std::max(newOffset, y->offset + y->size);
+        // Check if y is a partition neighbor of x
+        bool isPartitionNeighbor =
+            std::find(x->neighbors.begin(), x->neighbors.end(), y) !=
+            x->neighbors.end();
+        if (isPartitionNeighbor && partitionSize > 0) {
+          // For partition neighbors, bump to the next partition
+          // boundary to ensure they are in different physical partitions
+          size_t nextPartitionStart =
+              (getPartitionIndex(y->offset, partitionSize) + 1) * partitionSize;
+          newOffset = std::max(newOffset, nextPartitionStart);
+        } else {
+          // Regular interference - just move past the interfering buffer
+          newOffset = std::max(newOffset, y->offset + y->size);
+        }
       }
       if (colors.lookup(x) != 0)
         x->setOffsetAligned(newOffset);
@@ -644,15 +729,48 @@ private:
   Allocation *allocation;
   BufferRangeMapT bufferRange;
   AllocationAnalysisScratchSizeFn scratchSizeGetter;
+  size_t partitionSize;
 };
 
 } // namespace triton
 
-void Allocation::run(
-    FuncAllocMapT &funcAllocMap,
-    triton::AllocationAnalysisScratchSizeFn scratchSizeGetter) {
+void Allocation::run(FuncAllocMapT &funcAllocMap,
+                     triton::AllocationAnalysisScratchSizeFn scratchSizeGetter,
+                     size_t sharedMemoryPartitionSize) {
   triton::AllocationAnalysis(getOperation(), &funcAllocMap, this,
-                             scratchSizeGetter);
+                             scratchSizeGetter, sharedMemoryPartitionSize);
+}
+
+void Allocation::addPartitionBuffers(Value key, unsigned numPartitions,
+                                     size_t partitionSize, size_t alignment) {
+  SmallVector<BufferT *> partitionBuffers;
+  partitionBuffers.reserve(numPartitions);
+
+  Operation *ownerOp = key.getDefiningOp();
+
+  // Create all partition buffers first
+  for (unsigned i = 0; i < numPartitions; ++i) {
+    BufferId nextId = bufferIdCounter++;
+    auto [it, inserted] = bufferSet.insert_or_assign(
+        nextId, BufferT(BufferT::BufferKind::Explicit, nextId, ownerOp,
+                        partitionSize, alignment));
+    partitionBuffers.push_back(&it->second);
+  }
+
+  // Link all different partitions as neighbors.
+  // This ensures they are placed in different physical shared memory
+  // partitions.
+  for (unsigned i = 0; i < numPartitions; ++i) {
+    for (unsigned j = 0; j < numPartitions; ++j) {
+      if (i != j) {
+        partitionBuffers[i]->neighbors.push_back(partitionBuffers[j]);
+      }
+    }
+  }
+
+  // Store all partition buffers in valueBuffer
+  // (all partitions share the same liveness range via their owner)
+  valueBuffer[key] = std::move(partitionBuffers);
 }
 
 std::map<Operation *, SmallVector<Allocation::BufferId>>
@@ -666,12 +784,14 @@ Allocation::getLiveBuffers() {
     if (scratchBuffer != InvalidBufferId)
       liveBuffers[op].push_back(scratchBuffer);
     for (auto result : op->getOpResults()) {
-      auto bufferId = getBufferId(result);
-      if (bufferId == Allocation::InvalidBufferId)
+      auto bufferIds = getBufferIds(result);
+      if (bufferIds.empty())
         continue;
       auto liveOperations = liveness.resolveLiveness(result);
-      for (auto depOp : liveOperations)
-        liveBuffers[depOp].push_back(bufferId);
+      for (auto depOp : liveOperations) {
+        for (auto bufferId : bufferIds)
+          liveBuffers[depOp].push_back(bufferId);
+      }
     }
   };
   rootOperation->walk(analyzeOperation);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -334,7 +334,8 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
         memoryEffectOpInterface.getEffects(effectInstances);
         for (auto effectInstance : effectInstances) {
           if (auto value = effectInstance.getValue()) {
-            for (auto bufferId : allocation->getBufferIds(value)) {
+            for (auto bufferId :
+                 allocation->getAllBufferIdsWithAliases(value)) {
               if (bufferId != Allocation::InvalidBufferId) {
                 auto interval = allocation->getAllocatedInterval(bufferId);
                 auto slice = AllocationSlice(value, interval);

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -89,24 +89,42 @@ void addSharedMemoryAnnotations(ModuleOp mod) {
 void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
                                        ModuleAllocation &allocation) {
   MLIRContext *ctx = mod.getContext();
+  auto i32Ty = IntegerType::get(ctx, 32);
 
   mod.walk<mlir::WalkOrder::PreOrder>([&](FunctionOpInterface funcOp) {
     auto *funcAllocation = allocation.getFuncData(funcOp);
     funcOp.walk([&](Operation *op) {
+      // Handle scratch buffers (from operations like convert_layout)
       auto oBufferId = funcAllocation->getBufferId(op);
-      int offset = -1;
-      if (oBufferId != Allocation::InvalidBufferId)
-        offset = funcAllocation->getOffset(oBufferId);
-      else if (op->getNumResults() == 1) {
-        Value value = op->getResult(0);
-        auto vBufferId = funcAllocation->getBufferId(value);
-        if (vBufferId != Allocation::InvalidBufferId)
-          offset = funcAllocation->getOffset(vBufferId);
-      }
-      if (offset == -1)
+      if (oBufferId != Allocation::InvalidBufferId) {
+        int offset = funcAllocation->getOffset(oBufferId);
+        op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
         return;
-      op->setAttr("allocation.offset",
-                  IntegerAttr::get(IntegerType::get(ctx, 32), offset));
+      }
+
+      // Handle explicit buffers (from values like local_alloc results)
+      if (op->getNumResults() != 1)
+        return;
+
+      Value value = op->getResult(0);
+      auto bufferIds = funcAllocation->getBufferIds(value);
+      if (bufferIds.empty())
+        return;
+
+      // For partitioned tensors, set an array of offsets (one per partition)
+      if (bufferIds.size() > 1) {
+        SmallVector<Attribute> offsetAttrs;
+        for (auto bufferId : bufferIds) {
+          int partitionOffset = funcAllocation->getOffset(bufferId);
+          offsetAttrs.push_back(IntegerAttr::get(i32Ty, partitionOffset));
+        }
+        op->setAttr("allocation.offset", ArrayAttr::get(ctx, offsetAttrs));
+        return;
+      }
+
+      // Standard single offset for non-partitioned tensors
+      int offset = funcAllocation->getOffset(bufferIds[0]);
+      op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
     });
     return WalkResult::skip();
   });

--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonGPUToLLVM
     AllocateSharedMemoryUtility.cpp
     AllocateWarpGroups.cpp
     AssertOpToLLVM.cpp
+    CanonicalizeLLVMIR.cpp
     ControlFlowOpToLLVM.cpp
     ConvertLayoutOpToLLVM.cpp
     ElementwiseOpToLLVM.cpp

--- a/lib/Conversion/TritonGPUToLLVM/CanonicalizeLLVMIR.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/CanonicalizeLLVMIR.cpp
@@ -1,0 +1,50 @@
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace mlir::triton::gpu {
+#define GEN_PASS_DEF_CANONICALIZELLVMIR
+#include "triton/Conversion/TritonGPUToLLVM/Passes.h.inc"
+} // namespace mlir::triton::gpu
+
+namespace {
+class SelectConstantConditionPattern : public OpRewritePattern<LLVM::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::SelectOp op,
+                                PatternRewriter &b) const override {
+    BoolAttr cond;
+    if (!matchPattern(op.getCondition(), m_Constant(&cond)))
+      return failure();
+    Value val = cond.getValue() ? op.getTrueValue() : op.getFalseValue();
+    b.replaceOp(op, ValueRange{val});
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+struct CanonicalizeLLVMIR
+    : public mlir::triton::gpu::impl::CanonicalizeLLVMIRBase<
+          CanonicalizeLLVMIR> {
+  void runOnOperation() override {
+    LLVM::LLVMFuncOp func = getOperation();
+    RewritePatternSet patterns(&getContext());
+    patterns.add<SelectConstantConditionPattern>(&getContext());
+
+    getContext()
+        .getLoadedDialect<LLVM::LLVMDialect>()
+        ->getCanonicalizationPatterns(patterns);
+    for (mlir::RegisteredOperationName op :
+         getContext().getRegisteredOperationsByDialect(
+             LLVM::LLVMDialect::getDialectNamespace()))
+      op.getCanonicalizationPatterns(patterns, &getContext());
+
+    (void)applyPatternsGreedily(func, std::move(patterns));
+  }
+};
+} // namespace

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -23,7 +23,6 @@ using namespace mlir::triton;
 // allocation is still passed in as the last argument. Though here the scratch
 // memory is shared between all programs, so a linear offset based on the
 // program id is required to get the local scratch base.
-
 struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
   FuncOpConversion(LLVMTypeConverter &converter,
                    const TargetInfoBase &targetInfo, PatternBenefit benefit)
@@ -31,7 +30,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
 
   // Map the MLIR attribute `tt.nv_tma_desc` to the appropriate LLVM and NVVM
   // attributes.
-  static void handleByvalTmaDescArgs(LLVM::LLVMFuncOp &llvmFuncOp) {
+  static LogicalResult handleByvalTmaDescArgs(LLVM::LLVMFuncOp &llvmFuncOp) {
     const bool isKernel = triton::isKernel(llvmFuncOp);
     for (unsigned i = 0; i < llvmFuncOp.getNumArguments(); ++i) {
       const auto attrs = llvmFuncOp.getArgAttrDict(i);
@@ -41,11 +40,12 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
 
       for (const auto &attr : attrs) {
         if (attr.getName() == "tt.nv_tma_desc") {
-          const auto i32_type =
-              mlir::IntegerType::get(llvmFuncOp.getContext(), 32);
+          const auto i32_type = IntegerType::get(llvmFuncOp.getContext(), 32);
           assert(attr.getValue() == mlir::IntegerAttr::get(i32_type, 1));
-          assert(isKernel &&
-                 "tt.nv_tma_desc is not supported for device functions");
+          if (!isKernel) {
+            return llvmFuncOp.emitError(
+                "tt.nv_tma_desc is not supported for device functions");
+          }
 
           // See
           // https://github.com/google/jax/blob/main/jaxlib/mosaic/gpu/passes.cc
@@ -63,39 +63,15 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
         }
       }
     }
+    return success();
   }
 
-  LogicalResult
-  matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    // Prevent LLVM's inliner to inline this function
-    auto amendedFuncOp = amendFuncOp(funcOp, rewriter, targetInfo);
-
-    FailureOr<LLVM::LLVMFuncOp> maybeNewFuncOp =
-        mlir::convertFuncOpToLLVMFuncOp(amendedFuncOp, rewriter,
-                                        *getTypeConverter());
-    if (failed(maybeNewFuncOp)) {
-      return failure();
-    }
-
-    LLVM::LLVMFuncOp newFuncOp = *maybeNewFuncOp;
-    handleArgPtrDatatype(funcOp, newFuncOp);
-
-    auto ctx = funcOp->getContext();
-
-    if (triton::isKernel(funcOp)) {
-      // Set an attribute to indicate this function is a kernel entry.
-      newFuncOp->setAttr(NVVM::NVVMDialect::getKernelFuncAttrName(),
-                         rewriter.getIntegerAttr(type::u1Ty(ctx), 1));
-      newFuncOp.setLinkage(LLVM::Linkage::External);
-    } else {
-      // The noinline attribute will be used by the LLVM codegen to prevent
-      // inlining.
-      // https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/LLVMIR/IR/LLVMInlining.cpp#L267
-      newFuncOp.setPassthroughAttr(
-          ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
-      newFuncOp.setLinkage(LLVM::Linkage::Internal);
-    }
+  static void attachKernelAttributes(LLVM::LLVMFuncOp newFuncOp,
+                                     triton::FuncOp funcOp,
+                                     ConversionPatternRewriter &rewriter) {
+    newFuncOp->setAttr(
+        NVVM::NVVMDialect::getKernelFuncAttrName(),
+        rewriter.getIntegerAttr(type::u1Ty(rewriter.getContext()), 1));
 
     // Determine the actual number of required warps.
     int numWarps = triton::gpu::lookupNumWarps(funcOp);
@@ -139,14 +115,46 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     // for `nvvm.annotation` metadata.
     newFuncOp->setAttr(NVVM::NVVMDialect::getReqntidAttrName(),
                        rewriter.getDenseI32ArrayAttr(32 * numWarps));
+  }
+
+  LogicalResult
+  matchAndRewrite(triton::FuncOp funcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Prevent LLVM's inliner to inline this function
+    auto amendedFuncOp = amendFuncOp(funcOp, rewriter, targetInfo);
+
+    FailureOr<LLVM::LLVMFuncOp> maybeNewFuncOp =
+        mlir::convertFuncOpToLLVMFuncOp(amendedFuncOp, rewriter,
+                                        *getTypeConverter());
+    if (failed(maybeNewFuncOp)) {
+      return failure();
+    }
+
+    LLVM::LLVMFuncOp newFuncOp = *maybeNewFuncOp;
+    handleArgPtrDatatype(funcOp, newFuncOp);
+
+    auto ctx = funcOp->getContext();
+
+    if (triton::isKernel(funcOp)) {
+      // Set an attribute to indicate this function is a kernel entry.
+      attachKernelAttributes(newFuncOp, funcOp, rewriter);
+      newFuncOp.setLinkage(LLVM::Linkage::External);
+    } else {
+      // The noinline attribute will be used by the LLVM codegen to prevent
+      // inlining.
+      // https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/LLVMIR/IR/LLVMInlining.cpp#L267
+      newFuncOp.setPassthroughAttr(
+          ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
+      newFuncOp.setLinkage(LLVM::Linkage::Internal);
+      if (Attribute numWarps = funcOp->getAttr(triton::gpu::AttrNumWarpsName))
+        newFuncOp->setAttr("ws_num_warps", numWarps);
+    }
 
     rewriter.eraseOp(funcOp);
     rewriter.eraseOp(amendedFuncOp);
 
     // Add attributes for by-value TMA descriptor args (nvidia)
-    handleByvalTmaDescArgs(newFuncOp);
-
-    return success();
+    return handleByvalTmaDescArgs(newFuncOp);
   }
 
 private:

--- a/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
@@ -2,11 +2,15 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Tools/LayoutUtils.h"
 
 namespace {
 
 using namespace mlir;
 using namespace mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
 struct MakeRangeOpConversion
     : public ConvertOpToLLVMPattern<triton::MakeRangeOp> {
   MakeRangeOpConversion(LLVMTypeConverter &converter,
@@ -45,10 +49,76 @@ private:
   const TargetInfoBase &targetInfo;
 };
 
+// Convert arith::ConstantOp with an array DenseElementsAttr to a
+// LLVM::StructType value.
+class ArithConstantArrayOpConversion
+    : public ConvertOpToLLVMPattern<arith::ConstantOp> {
+public:
+  ArithConstantArrayOpConversion(LLVMTypeConverter &typeConverter,
+                                 const TargetInfoBase &targetInfo,
+                                 PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
+  }
+
+  LogicalResult matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &b) const override {
+    auto value = op.getValue();
+    auto values = dyn_cast<DenseElementsAttr>(value);
+    if (!values || isa<SplatElementsAttr>(value))
+      return failure();
+    auto tensorTy = cast<RankedTensorType>(op.getType());
+    if (!tensorTy.getElementType().isIntOrFloat())
+      return failure();
+
+    MLIRContext *ctx = op->getContext();
+    Location loc = op->getLoc();
+    TritonLLVMOpBuilder tb(loc, b);
+    auto kBlock = str_attr("block");
+    auto kWarp = str_attr("warp");
+    auto kLane = str_attr("lane");
+    auto kRegister = str_attr("register");
+
+    SmallVector<Attribute> attrs = to_vector(values.getValues<Attribute>());
+    auto type =
+        LLVM::LLVMArrayType::get(tensorTy.getElementType(), attrs.size());
+    auto module = op->getParentOfType<ModuleOp>();
+    LLVM::GlobalOp global = LLVM::getOrInsertGlobalConstant(
+        b, module, type, b.getArrayAttr(attrs), "tensor_constant_");
+
+    LinearLayout ll = ttg::toLinearLayout(tensorTy);
+    auto [laneId, warpId] = getLaneAndWarpId(b, loc);
+    Value blockId = targetInfo.getClusterCTAId(b, loc);
+    SmallVector<Value> llValues;
+    for (unsigned reg : llvm::seq(ll.getInDimSize(kRegister))) {
+      auto indices = applyLinearLayout(loc, b, ll,
+                                       {{kRegister, tb.i32_val(reg)},
+                                        {kLane, laneId},
+                                        {kWarp, warpId},
+                                        {kBlock, blockId}});
+      Value index =
+          LLVM::linearize(b, loc, to_vector(make_second_range(indices)),
+                          convertType<unsigned>(tensorTy.getShape()));
+      Value addr = tb.address_of(global);
+      addr = tb.gep(ptr_ty(ctx), tensorTy.getElementType(), addr, index);
+      llValues.push_back(tb.load(tensorTy.getElementType(), addr));
+    }
+
+    Value result =
+        packLLElements(loc, getTypeConverter(), llValues, b, tensorTy);
+    b.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  const TargetInfoBase &targetInfo;
+};
+
 } // namespace
 
 void mlir::triton::populateMakeRangeOpToLLVMPattern(
     LLVMTypeConverter &typeConverter, const TargetInfoBase &targetInfo,
     RewritePatternSet &patterns, PatternBenefit benefit) {
+  patterns.add<ArithConstantArrayOpConversion>(typeConverter, targetInfo,
+                                               benefit);
   patterns.add<MakeRangeOpConversion>(typeConverter, targetInfo, benefit);
 }

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -216,9 +216,16 @@ struct LocalAllocOpConversion
     if (!op.isSharedMemoryAlloc())
       return failure();
     Location loc = op->getLoc();
+    auto memDescTy = cast<MemDescType>(op.getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     Value smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
-    auto memDescTy = cast<MemDescType>(op.getType());
     auto typeConverter = getTypeConverter();
 
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
@@ -273,6 +280,13 @@ public:
     auto memDescVal = op.getSrc();
     auto regVal = op.getResult();
     auto memDescTy = cast<MemDescType>(memDescVal.getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto regTy = cast<RankedTensorType>(regVal.getType());
     auto typeConverter = getTypeConverter();
 
@@ -344,6 +358,13 @@ public:
     Value memDescVal = op.getDst();
     auto typeConverter = getTypeConverter();
     auto memDescTy = cast<MemDescType>(memDescVal.getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getDst(),
                                                          llvmElemTy, rewriter);
@@ -434,6 +455,13 @@ public:
     auto loc = op.getLoc();
     auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getSrc().getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto regTy = cast<RankedTensorType>(op.getType());
     auto typeConverter = getTypeConverter();
 
@@ -527,6 +555,13 @@ public:
     auto loc = op.getLoc();
     auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getDst().getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto valuesTy = cast<RankedTensorType>(op.getValues().getType());
     auto typeConverter = getTypeConverter();
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -297,6 +297,10 @@ Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x) {
   return b.or_(orPart, xorPart, /*disjoint=*/true);
 }
 
+bool cvtAlwaysUseWarpShuffle(ConvertLayoutOp cvt) {
+  return cvt->getParentOp()->hasAttrOfType<UnitAttr>("always_use_warp_shuffle");
+}
+
 } // namespace triton::gpu
 
 // Cheap modulo for inputs provably < 2N: just compare-and-subtract.
@@ -1746,31 +1750,40 @@ size_t linearize(ArrayRef<unsigned> multiDim, ArrayRef<unsigned> shape,
   return linear;
 }
 
+LLVM::GlobalOp getOrInsertGlobalConstant(RewriterBase &rewriter,
+                                         ModuleOp module, Type type,
+                                         Attribute content, StringRef key) {
+  for (auto op : module.getOps<LLVM::GlobalOp>()) {
+    if (op.getConstant() && op.getLinkage() == LLVM::Linkage::Internal &&
+        op.getType() == type && op.getValueAttr() == content)
+      return op;
+  }
+
+  unsigned stringNumber = 0;
+  SmallString<16> name;
+  do {
+    name.clear();
+    (key + Twine(stringNumber++)).toStringRef(name);
+  } while (module.lookupSymbol(name));
+  RewriterBase::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(module.getBody());
+  return LLVM::GlobalOp::create(rewriter, UnknownLoc::get(type.getContext()),
+                                type, /*isConstant=*/true,
+                                LLVM::Linkage::Internal, name, content);
+}
+
 Value addStringToModule(Location loc, RewriterBase &rewriter, StringRef key,
                         StringRef content) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   auto ctx = moduleOp.getContext();
-  unsigned stringNumber = 0;
-  SmallString<16> stringConstName;
-  do {
-    stringConstName.clear();
-    (key + Twine(stringNumber++)).toStringRef(stringConstName);
-  } while (moduleOp.lookupSymbol(stringConstName));
 
   llvm::SmallString<64> contentStr(content);
   size_t contentSize = contentStr.size_in_bytes();
   auto globalType = LLVM::LLVMArrayType::get(i8_ty, contentSize);
-
-  LLVM::GlobalOp global;
-  {
-    RewriterBase::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPointToStart(moduleOp.getBody());
-    global = LLVM::GlobalOp::create(rewriter, UnknownLoc::get(ctx), globalType,
-                                    /*isConstant=*/true,
-                                    LLVM::Linkage::Internal, stringConstName,
-                                    rewriter.getStringAttr(contentStr));
-  }
+  auto contentAttr = rewriter.getStringAttr(contentStr);
+  LLVM::GlobalOp global = getOrInsertGlobalConstant(
+      rewriter, moduleOp, globalType, contentAttr, key);
 
   Value zero = b.i32_val(0);
   Type globalPtrType = LLVM::LLVMPointerType::get(ctx, global.getAddrSpace());
@@ -1892,6 +1905,22 @@ SmallVector<Value> inlineRegionImpl(RewriterBase &rewriter, Region &region,
     vals.push_back(val);
   }
   return vals;
+}
+
+std::tuple<Block *, Block *, Block *>
+createIfBlock(ConversionPatternRewriter &b, Location loc, Value cnd) {
+  Block *prevBlock = b.getInsertionBlock();
+  Block *ifBlock = b.splitBlock(prevBlock, b.getInsertionPoint());
+
+  // Split a block after the call.
+  Block *thenBlock = b.splitBlock(ifBlock, ifBlock->begin());
+  b.setInsertionPointToEnd(ifBlock);
+  LLVM::BrOp::create(b, loc, thenBlock);
+  b.setInsertionPointToEnd(prevBlock);
+  LLVM::CondBrOp::create(b, loc, cnd, ifBlock, thenBlock);
+  b.setInsertionPointToStart(thenBlock);
+
+  return {prevBlock, ifBlock, thenBlock};
 }
 
 void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -93,11 +93,11 @@ struct ArithConstantSplatOpConversion
   matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto value = op.getValue();
-    if (!mlir::dyn_cast<SplatElementsAttr>(value))
+    auto values = dyn_cast<SplatElementsAttr>(op.getValue());
+    if (!values)
       return failure();
     auto loc = op->getLoc();
     LLVM::ConstantOp arithConstantOp;
-    auto values = mlir::dyn_cast<SplatElementsAttr>(op.getValue());
     auto elemType = values.getElementType();
     Attribute val;
     if (type::isFloat(elemType)) {
@@ -118,43 +118,6 @@ struct ArithConstantSplatOpConversion
     auto llStruct = SplatOpConversion::convertSplatLikeOp(
         elemType, op.getType(), constOp, typeConverter, rewriter, loc);
     rewriter.replaceOp(op, llStruct);
-    return success();
-  }
-};
-
-// Convert arith::ConstantOp with an array DenseElementsAttr to a
-// LLVM::StructType value.
-struct ArithConstantArrayOpConversion
-    : public ConvertOpToLLVMPattern<arith::ConstantOp> {
-  using ConvertOpToLLVMPattern<arith::ConstantOp>::ConvertOpToLLVMPattern;
-  LogicalResult
-  matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto value = op.getValue();
-    if (!mlir::dyn_cast<DenseElementsAttr>(value))
-      return failure();
-    if (mlir::isa<SplatElementsAttr>(value))
-      return failure();
-    auto tensorTy = cast<RankedTensorType>(op.getType());
-    auto loc = op->getLoc();
-    auto values = mlir::dyn_cast<DenseElementsAttr>(op.getValue());
-    auto elemType = values.getElementType();
-    SmallVector<Value> llVals;
-    for (auto v : values.getValues<APInt>()) {
-      auto ll = LLVM::ConstantOp::create(rewriter, loc, elemType, v);
-      llVals.push_back(ll);
-    }
-    size_t elemsPerThread = getTotalElemsPerThread(tensorTy);
-
-    if (elemsPerThread != llVals.size()) {
-      op->emitError(
-          "Right now we only support constant arrays with the same number of "
-          "elements as the number of threads per warp");
-      return failure();
-    }
-    auto llStruct =
-        packLLElements(loc, getTypeConverter(), llVals, rewriter, op.getType());
-    rewriter.replaceOp(op, {llStruct});
     return success();
   }
 };
@@ -626,7 +589,6 @@ void mlir::triton::populateViewOpToLLVMPatterns(
   patterns.add<SplatOpConversion>(typeConverter, benefit);
   patterns.add<UnsplatOpConversion>(typeConverter, benefit);
   patterns.add<ArithConstantSplatOpConversion>(typeConverter, benefit);
-  patterns.add<ArithConstantArrayOpConversion>(typeConverter, benefit);
   patterns.add<CatOpConversion>(typeConverter, benefit);
   patterns.add<JoinOpConversion>(typeConverter, benefit);
   patterns.add<SplitOpConversion>(typeConverter, benefit);

--- a/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
@@ -1,6 +1,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -13,6 +14,188 @@
 using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
+
+//===----------------------------------------------------------------------===//
+// lowerWarpSpecializeBarriers
+//===----------------------------------------------------------------------===//
+
+LogicalResult WarpSpecializeBarrierHelper::createBarrier(
+    TritonLLVMIRRewriter &b, unsigned numWarps,
+    std::optional<unsigned> partitionIdx) {
+  FailureOr<Value> handle = getBarrierHandle(b, partitionIdx);
+  if (failed(handle))
+    return failure();
+  createBarrier(b, numWarps, *handle);
+  return success();
+}
+
+static std::string mangleFunctionName(StringRef name) {
+  return (name + "_ws").str();
+}
+
+static LogicalResult lowerBarrier(Operation *op, unsigned numWarps,
+                                  std::optional<unsigned> partitionIdx,
+                                  WarpSpecializeBarrierHelper &barrierHelper) {
+  TritonLLVMIRRewriter b(op->getLoc(), op);
+  if (failed(barrierHelper.createBarrier(b, numWarps, partitionIdx)))
+    return failure();
+  op->erase();
+  return success();
+}
+
+static LogicalResult lowerCallOp(LLVM::CallOp callOp, unsigned numWarps,
+                                 std::optional<unsigned> partitionIdx,
+                                 WarpSpecializeBarrierHelper &barrierHelper) {
+  TritonLLVMIRRewriter b(callOp->getLoc(), callOp);
+  FailureOr<Value> handle = barrierHelper.getBarrierHandle(b, partitionIdx);
+  if (failed(handle))
+    return failure();
+  // Forward the barrier handle.
+  callOp.setCallee(mangleFunctionName(*callOp.getCallee()));
+  callOp.getCalleeOperandsMutable().append(*handle);
+  return success();
+}
+
+static LogicalResult
+lowerKernelBarriers(LLVM::LLVMFuncOp func,
+                    const DenseSet<StringAttr> &innerFunctions,
+                    WarpSpecializeBarrierHelper &barrierHelper) {
+  unsigned defaultNumWarps = lookupNumWarps(func);
+
+  // Turn all barrier ops into warp group barriers.
+  // HACK: Right now, higher-level passes generate all barriers that we
+  // interpret as warp group barriers, but they generate explicit warp group
+  // barriers.
+  SmallVector<WarpSpecializeOp> wsOps;
+  WalkResult result = func.walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
+    // Walk into default regions but not partition regions.
+    if (auto wsOp = dyn_cast<WarpSpecializePartitionsOp>(op)) {
+      wsOps.push_back(wsOp.getParentOp());
+      return WalkResult::skip();
+    }
+    if (barrierHelper.isBarrierOp(op)) {
+      return WalkResult(lowerBarrier(op, defaultNumWarps, /*partitionIdx=*/{},
+                                     barrierHelper));
+    }
+    if (auto callOp = dyn_cast<LLVM::CallOp>(op)) {
+      if (!innerFunctions.contains(callOp.getCalleeAttr().getAttr()))
+        return WalkResult::advance();
+      return WalkResult(lowerCallOp(callOp, defaultNumWarps,
+                                    /*partitionIdx=*/{}, barrierHelper));
+    }
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted())
+    return failure();
+
+  // Each partition executes simultaneously, so each will get a different
+  // barrier ID, but note this means there is a maximum of 16 barriers.
+  for (WarpSpecializeOp op : wsOps) {
+    for (auto [idx, partition] : llvm::enumerate(op.getPartitionRegions())) {
+      unsigned numWarps = op.getPartitionNumWarps()[idx];
+      WalkResult result = partition->walk([&, idx = idx](Operation *op) {
+        if (barrierHelper.isBarrierOp(op)) {
+          return WalkResult(lowerBarrier(op, numWarps, idx, barrierHelper));
+        }
+        if (auto callOp = dyn_cast<LLVM::CallOp>(op)) {
+          if (!innerFunctions.contains(callOp.getCalleeAttr().getAttr()))
+            return WalkResult::advance();
+          return WalkResult(lowerCallOp(callOp, numWarps, idx, barrierHelper));
+        }
+        return WalkResult::advance();
+      });
+      if (result.wasInterrupted())
+        return failure();
+    }
+  }
+
+  return success();
+}
+
+static LogicalResult
+lowerInnerFunctionBarriers(LLVM::LLVMFuncOp func,
+                           const DenseSet<StringAttr> &innerFunctions,
+                           WarpSpecializeBarrierHelper &barrierHelper) {
+  // Append a barrier handle argument.
+  LLVM::LLVMFunctionType type = func.getFunctionType();
+  SmallVector<Type> newArgTypes = to_vector(type.getParams());
+  newArgTypes.push_back(barrierHelper.getBarrierHandleType(type.getContext()));
+  func.setFunctionType(LLVM::LLVMFunctionType::get(
+      type.getReturnType(), newArgTypes, type.isVarArg()));
+  Value handle = func.getBody().addArgument(newArgTypes.back(), func.getLoc());
+
+  // Mangle the function to distinguish it from non-warp-specialized versions.
+  func.setSymName(mangleFunctionName(func.getSymName()));
+  if (ArrayAttr argAttrs = func.getArgAttrsAttr()) {
+    SmallVector<Attribute> newArgAttrs = to_vector(argAttrs.getValue());
+    newArgAttrs.push_back(DictionaryAttr::get(func.getContext(), {}));
+    func.setArgAttrsAttr(ArrayAttr::get(func.getContext(), newArgAttrs));
+  }
+
+  // Lower barrier ops.
+  auto numWarpsAttr = func->getAttrOfType<IntegerAttr>("ws_num_warps");
+  if (!numWarpsAttr) {
+    return func.emitError("function missing '") << "ws_num_warps"
+                                                << "' attribute";
+  }
+  unsigned numWarps = numWarpsAttr.getInt();
+
+  func.walk([&](Operation *op) {
+    if (barrierHelper.isBarrierOp(op)) {
+      TritonLLVMIRRewriter b(op->getLoc(), op);
+      barrierHelper.createBarrier(b, numWarps, handle);
+      op->erase();
+    } else if (auto callOp = dyn_cast<LLVM::CallOp>(op)) {
+      if (!innerFunctions.contains(callOp.getCalleeAttr().getAttr()))
+        return;
+      callOp.setCallee(mangleFunctionName(*callOp.getCallee()));
+      callOp.getCalleeOperandsMutable().append(handle);
+    }
+  });
+
+  return success();
+}
+
+LogicalResult mlir::triton::lowerWarpSpecializeBarriers(
+    ModuleOp module, WarpSpecializeBarrierHelper &barrierHelper) {
+  SmallVector<LLVM::LLVMFuncOp> wsKernels;
+  // Find all kernels and the warp specialize ops in them.
+  for (LLVM::LLVMFuncOp func : module.getOps<LLVM::LLVMFuncOp>()) {
+    WalkResult result =
+        func.walk([&](WarpSpecializeOp op) { return WalkResult::interrupt(); });
+    // Nothing to do. This kernel is not warp specialized.
+    if (!result.wasInterrupted())
+      continue;
+    if (func.getLinkage() != LLVM::Linkage::External) {
+      return func.emitError(
+          "only top-level kernel functions can be warp-specialized");
+    }
+    wsKernels.push_back(func);
+  }
+  // No warp specialization found.
+  if (wsKernels.empty())
+    return success();
+
+  DenseSet<StringAttr> innerFunctions;
+  for (LLVM::LLVMFuncOp func : module.getOps<LLVM::LLVMFuncOp>()) {
+    if (func.getLinkage() != LLVM::Linkage::External)
+      innerFunctions.insert(func.getSymNameAttr());
+  }
+
+  for (LLVM::LLVMFuncOp func : wsKernels) {
+    if (failed(lowerKernelBarriers(func, innerFunctions, barrierHelper)))
+      return failure();
+  }
+
+  for (LLVM::LLVMFuncOp func : module.getOps<LLVM::LLVMFuncOp>()) {
+    if (func.getLinkage() == LLVM::Linkage::External)
+      continue;
+    if (failed(lowerInnerFunctionBarriers(func, innerFunctions, barrierHelper)))
+      return failure();
+  }
+
+  return success();
+}
 
 //===----------------------------------------------------------------------===//
 // convertOpTypes

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1931,6 +1931,96 @@ SharedLinearEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 }
 
 //===----------------------------------------------------------------------===//
+// PartitionedShared encoding
+//===----------------------------------------------------------------------===//
+
+void PartitionedSharedEncodingAttr::print(AsmPrinter &printer) const {
+  printer << "<{numPartitions = " << getNumPartitions()
+          << ", numGroups = " << getNumGroups()
+          << ", partitionDim = " << getPartitionDim()
+          << ", partitionLayout = " << getPartitionLayout() << "}>";
+}
+
+Attribute PartitionedSharedEncodingAttr::parse(AsmParser &parser, Type type) {
+  if (parser.parseLess().failed())
+    return {};
+  DictionaryAttr dict;
+  if (parser.parseAttribute(dict).failed())
+    return {};
+  if (parser.parseGreater().failed())
+    return {};
+
+  unsigned numPartitions = 0;
+  unsigned numGroups = 0;
+  unsigned partitionDim = 0;
+  Attribute partitionLayout = nullptr;
+
+  for (const NamedAttribute &attr : dict) {
+    if (attr.getName() == "numPartitions") {
+      if (parseUInt(parser, attr, numPartitions, "numPartitions").failed())
+        return {};
+    } else if (attr.getName() == "numGroups") {
+      if (parseUInt(parser, attr, numGroups, "numGroups").failed())
+        return {};
+    } else if (attr.getName() == "partitionDim") {
+      if (parseUInt(parser, attr, partitionDim, "partitionDim").failed())
+        return {};
+    } else if (attr.getName() == "partitionLayout") {
+      partitionLayout = attr.getValue();
+    } else {
+      parser.emitError(parser.getNameLoc(), "unexpected key: ")
+          << attr.getName().strref();
+      return {};
+    }
+  }
+
+  if (!partitionLayout) {
+    parser.emitError(parser.getNameLoc(), "missing partitionLayout");
+    return {};
+  }
+
+  auto sharedEnc = mlir::dyn_cast<SharedEncodingTrait>(partitionLayout);
+
+  if (!sharedEnc) {
+    parser.emitError(parser.getNameLoc(),
+                     "partitionLayout must be a SharedEncodingTrait");
+    return {};
+  }
+
+  return PartitionedSharedEncodingAttr::get(parser.getContext(), numPartitions,
+                                            numGroups, partitionDim, sharedEnc);
+}
+
+CGAEncodingAttr PartitionedSharedEncodingAttr::getCGALayout() const {
+  auto layoutEncTrait = cast<LayoutEncodingTrait>(getPartitionLayout());
+  return layoutEncTrait.getCGALayout();
+}
+
+LogicalResult PartitionedSharedEncodingAttr::verify(
+    function_ref<InFlightDiagnostic()> emitError, unsigned numPartitions,
+    unsigned numGroups, unsigned partitionDim,
+    SharedEncodingTrait partitionLayout) {
+  // Check numPartitions is a power of 2 and > 0
+  if (numPartitions == 0 || !llvm::isPowerOf2_32(numPartitions))
+    return emitError()
+           << "numPartitions must be a power of 2 and greater than 0";
+
+  // Check numGroups is a power of 2 and > 0
+  if (numGroups == 0 || !llvm::isPowerOf2_32(numGroups))
+    return emitError() << "numGroups must be a power of 2 and greater than 0";
+
+  // Check partitionDim is within bounds of the layout rank
+  auto layoutEncTrait = cast<LayoutEncodingTrait>(partitionLayout);
+  unsigned rank = layoutEncTrait.getRank();
+  if (partitionDim >= rank)
+    return emitError() << "partitionDim (" << partitionDim
+                       << ") must be less than the layout rank (" << rank
+                       << ")";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // PaddedShared encoding
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -121,7 +121,8 @@ private:
 
 class LayoutRematerialization {
 public:
-  LayoutRematerialization(FuncOp F) : funcOp(F) {}
+  LayoutRematerialization(FuncOp F, unsigned smemBudget = 0)
+      : funcOp(F), smemBudget(smemBudget) {}
 
   // Map the original value to the remat'ed one.
   void addRematValue(Value old, Attribute encoding, Value newV);
@@ -168,6 +169,9 @@ private:
   // DenseMap<std::pair<Operation*, Attribute>, Operation*>
   SetVector<Operation *> opToDelete;
   FuncOp funcOp;
+  // Meta extension: when > 0, the remove-layout pass is operating under a SMEM
+  // budget and convert-elimination hoists bypass the upstream perf cost gate.
+  unsigned smemBudget;
   DominanceInfo domInfo;
   PostDominanceInfo postDomInfo;
 };
@@ -1341,45 +1345,26 @@ static int64_t getByteCount(Value result, int64_t minElementCount = 0,
   return (elementCount * dtypeBitWidth) >> 3;
 }
 
-void LayoutRematerialization::backwardRematerialization(
-    ConvertLayoutOp convertOp) {
-  RankedTensorType targetType = convertOp.getType();
-  if (isa<DotOperandEncodingAttr>(targetType.getEncoding())) {
-    // DotOperand is hoisted by hoistDotOperand for pipelining purposes.
-    if (auto parentForOp = convertOp->getParentOfType<scf::ForOp>()) {
-      if (getNumStagesOrDefault(parentForOp, 3) > 1) {
-        return;
-      }
-    }
-  }
+/// Compute the cost of a ConvertLayoutOp with source \p convertSrc.
+int64_t getConvertCost(Value convertSrc) {
+  // Measure the number of bytes that we're manipulating with the
+  // ConvertLayoutOp. We pessimistically assume that we round-trip
+  // through shared memory and that we cannot vectorise sub-register
+  // loads/stores, so we set a minimum element count of 32 (the warp
+  // size and number of shared memory banks) and minimum bitwidth of
+  // 32 (the width per bank of the shared memory load/store unit).
+  auto convertLayoutBytes = getByteCount(convertSrc, 32, 32);
+  // We measure costs in standardised milli-SM-cycles. The smem load
+  // and store each cost 8 * convertLayoutBytes, and then we double
+  // it to account for extra cost due to synchronisation.
+  return 32 * convertLayoutBytes;
+}
 
-  Value oldV = convertOp.getSrc();
-  LDBG("check backward remat with source " << oldV << " encoding "
-                                           << targetType.getEncoding());
-  // Check to see if there are existing remat'ed values for the pair of oldValue
-  // and encoding. Make sure it dominates the current conversion.
-  Value newV = getRematValue(oldV, targetType.getEncoding());
-  if (newV && domInfo.properlyDominates(newV, convertOp)) {
-    // Replace it with the remat'ed value.
-    convertOp.replaceAllUsesWith(newV);
-    opToDelete.insert(convertOp);
-    LDBG("found remat'ed value" << newV);
-    return;
-  }
-
-  // 1. Take a backward slice of all the tensor dependencies that can be
-  // rematerialized.
-  SetVector<Value> slice;
-  DenseMap<Value, Attribute> layout;
-  LogicalResult result = getRematerializableSlice(
-      convertOp.getSrcMutable(), targetType.getEncoding(), slice, layout);
-  if (result.failed()) {
-    LDBG("  getRematerializableSlice failed");
-    return;
-  }
-
-  // 2. Determine whether rematerialisation is beneficial.
-
+/// Determine whether rematerializing \p slice is beneficial given that it will
+/// eliminate \p convertOp and require creating new convert ops with cost \p
+/// newCvtCost.
+bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
+                       int64_t newCvtCost) {
   // Identify all operations in the slice
   SetVector<Operation *> sliceOps;
   for (Value v : slice) {
@@ -1425,19 +1410,8 @@ void LayoutRematerialization::backwardRematerialization(
     return singleUse;
   };
 
-  // Measure the number of bytes that we're manipulating with the
-  // ConvertLayoutOp. We pessimistically assume that we round-trip
-  // through shared memory and that we cannot vectorise sub-register
-  // loads/stores, so we set a minimum element count of 32 (the warp
-  // size and number of shared memory banks) and minimum bitwidth of
-  // 32 (the width per bank of the shared memory load/store unit).
-  int64_t convertLayoutBytes = getByteCount(convertOp.getSrc(), 32, 32);
-
-  // We measure costs in standardised milli-SM-cycles. The smem load
-  // and store each cost 8 * convertLayoutBytes, and then we double
-  // it to account for extra cost due to synchronisation.
-  int64_t convertLayoutCost = 32 * convertLayoutBytes;
-  int64_t rematerialisationCost = 0;
+  int64_t convertLayoutCost = getConvertCost(convertOp.getSrc());
+  int64_t rematerialisationCost = newCvtCost;
 
   // Evaluate single-use status for every operation in slice
   for (Operation *op : sliceOps) {
@@ -1473,7 +1447,7 @@ void LayoutRematerialization::backwardRematerialization(
         // use chain.
         LDBG("  skipped rematerialization due to non-associative reduce in the "
              "slice");
-        return;
+        return false;
       }
       rematerialisationCost += helper.getIntraWarpSizeWithUniqueData();
       rematerialisationCost += 8 * helper.getInterWarpSizeWithUniqueData();
@@ -1485,7 +1459,47 @@ void LayoutRematerialization::backwardRematerialization(
     DBGS() << "  rematerialisation cost: " << rematerialisationCost << "\n";
   });
 
-  if (rematerialisationCost > convertLayoutCost) {
+  return convertLayoutCost >= rematerialisationCost;
+}
+
+void LayoutRematerialization::backwardRematerialization(
+    ConvertLayoutOp convertOp) {
+  RankedTensorType targetType = convertOp.getType();
+  if (isa<DotOperandEncodingAttr>(targetType.getEncoding())) {
+    // DotOperand is hoisted by hoistDotOperand for pipelining purposes.
+    if (auto parentForOp = convertOp->getParentOfType<scf::ForOp>()) {
+      if (getNumStagesOrDefault(parentForOp, 3) > 1) {
+        return;
+      }
+    }
+  }
+  Value oldV = convertOp.getSrc();
+  LDBG("check backward remat with source " << oldV << " encoding "
+                                           << targetType.getEncoding());
+  // Check to see if there are existing remat'ed values for the pair of oldValue
+  // and encoding. Make sure it dominates the current conversion.
+  Value newV = getRematValue(oldV, targetType.getEncoding());
+  if (newV && domInfo.properlyDominates(newV, convertOp)) {
+    // Replace it with the remat'ed value.
+    convertOp.replaceAllUsesWith(newV);
+    opToDelete.insert(convertOp);
+    LDBG("found remat'ed value" << newV);
+    return;
+  }
+
+  // 1. Take a backward slice of all the tensor dependencies that can be
+  // rematerialized.
+  SetVector<Value> slice;
+  DenseMap<Value, Attribute> layout;
+  LogicalResult result = getRematerializableSlice(
+      convertOp.getSrcMutable(), targetType.getEncoding(), slice, layout);
+  if (result.failed()) {
+    LDBG("  getRematerializableSlice failed");
+    return;
+  }
+
+  // 2. Determine whether rematerialisation is beneficial.
+  if (!isRematBeneficial(convertOp, slice, /*newCvtCost=*/0)) {
     LDBG("  skipped rematerialization due to higher cost");
     return;
   }
@@ -1685,6 +1699,14 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   Attribute srcEncoding = inferSrcEncoding(extOrBroadcastOp, dstEncoding);
   if (!srcEncoding)
     return;
+  // Under a SMEM budget (a Meta extension) eliminating convert-layout scratch
+  // takes priority over the upstream perf-cost heuristic (#9194), so force the
+  // hoist. Without a budget, keep the upstream cost gate.
+  if (smemBudget == 0) {
+    int64_t newCvtCost = getConvertCost(extOrBroadcastOp->getOperand(0));
+    if (!isRematBeneficial(convertOp, slice, newCvtCost))
+      return;
+  }
   // Move the convert before the ext op and rewrite the slice.
   OpBuilder builder(extOrBroadcastOp);
   auto tensorType =
@@ -1827,10 +1849,10 @@ bool backwardRematerialization(ModuleOp module) {
   return changed;
 }
 
-void hoistConvert(ModuleOp module) {
+void hoistConvert(ModuleOp module, unsigned smemBudget = 0) {
   SmallVector<ConvertLayoutOp> convertOps;
-  module.walk([](FuncOp funcOp) {
-    LayoutRematerialization layoutRemat(funcOp);
+  module.walk([smemBudget](FuncOp funcOp) {
+    LayoutRematerialization layoutRemat(funcOp, smemBudget);
     layoutRemat.hoistConvertOnTopOfExtOrBroadcast();
     layoutRemat.cleanup();
 
@@ -1967,7 +1989,7 @@ public:
     } while (changed);
     // 3. For remaining converts, try to hoist them above cast generating larger
     // size types in order to reduce the cost of the convert op.
-    hoistConvert(m);
+    hoistConvert(m, smemBudget);
     LLVM_DEBUG({
       DBGS() << "Module after hoisting converts:\n";
       m.dump();
@@ -1994,7 +2016,7 @@ public:
     // eliminate them by propagating the source encoding through their users.
     if (smemBudget > 0) {
       eliminateOverBudgetConverts(m);
-      hoistConvert(m);
+      hoistConvert(m, smemBudget);
       cleanupConvertOps();
     }
   }

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -4,7 +4,10 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Support/DebugStringHelper.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -14,6 +17,29 @@ namespace mlir::triton::instrument {
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 namespace tti = mlir::triton::instrument;
+
+std::string mangleType(Type t) {
+  if (auto intType = dyn_cast<IntegerType>(t)) {
+    return ("I" + Twine(intType.getWidth())).str();
+  }
+  if (auto floatType = dyn_cast<FloatType>(t)) {
+    return ("F" + Twine(floatType.getWidth())).str();
+  }
+  if (auto ptrType = dyn_cast<PointerType>(t)) {
+    return "P";
+  }
+  if (auto tensorType = dyn_cast<RankedTensorType>(t)) {
+    std::string result = "T";
+    llvm::raw_string_ostream os(result);
+    for (int s : tensorType.getShape()) {
+      os << s << "x";
+    }
+    os << mangleType(tensorType.getElementType());
+    return result;
+  }
+  // Fallback to hash of the type's string representation.
+  return "U" + llvm::utohexstr(llvm::hash_value(mlir::debugString(t)));
+}
 
 namespace {
 
@@ -108,6 +134,13 @@ FuncOp getOrCreateFunction(
   func.setVisibility(SymbolTable::Visibility::Private);
   func->setAttr(ttg::AttrNumWarpsName,
                 moduleBuilder.getI32IntegerAttr(numWarps));
+  func->setAttr("always_use_warp_shuffle", moduleBuilder.getUnitAttr());
+  for (auto [i, argType] : llvm::enumerate(argTypes)) {
+    if (isa<PointerType>(argType)) {
+      func.setArgAttr(i, "tt.divisibility",
+                      moduleBuilder.getI32IntegerAttr(16));
+    }
+  }
   Block *entryBlock = func.addEntryBlock();
   OpBuilder bodyBuilder = OpBuilder::atBlockBegin(entryBlock);
   ImplicitLocOpBuilder fb(loc, bodyBuilder);
@@ -140,7 +173,7 @@ void createCallToCachedFunction(
   if (assertInfo) {
     Value result = callOp->getResult(0);
     StringRef message = b.getStringAttr(assertInfo->message);
-    tti::ExperimentalAssertInThreadOp::create(b, result, message, false);
+    createAssertInThread(b, result, message);
   }
 }
 
@@ -189,28 +222,27 @@ std::tuple<Block *, Block *, Block *> createIfBlock(ImplicitLocOpBuilder &b,
   return {prevBlock, ifBlock, thenBlock};
 }
 
-Value convertAndBroadcast(ImplicitLocOpBuilder &b, Value tensor, int dim,
-                          RankedTensorType dstType) {
-  auto loc = b.getLoc();
-  ArrayRef<int64_t> shape = dstType.getShape();
-  auto tensorType = cast<RankedTensorType>(tensor.getType());
-  auto encoding = cast<ttg::BlockedEncodingAttr>(dstType.getEncoding());
-  RankedTensorType resultType =
-      RankedTensorType::get(shape, tensorType.getElementType(), encoding);
-  auto slicedEncoding =
-      ttg::SliceEncodingAttr::get(b.getContext(), dim, encoding);
-  tensor = ttg::ConvertLayoutOp::create(
-      b, tensorType.cloneWithEncoding(slicedEncoding), tensor);
-  tensor = tti::expandOuterSlicedDim(b, loc, tensor);
-  tensor = triton::BroadcastOp::create(b, resultType, tensor);
-  return tensor;
-}
-
 Value createConvertLayout(ImplicitLocOpBuilder &b, Value tensor,
                           Attribute encoding) {
   auto tensorType = cast<RankedTensorType>(tensor.getType());
   auto dstType = tensorType.cloneWithEncoding(encoding);
   return ttg::ConvertLayoutOp::create(b, dstType, tensor);
+}
+
+Value convertAndBroadcast(ImplicitLocOpBuilder &b, Value tensor, int dim,
+                          RankedTensorType dstType) {
+  auto loc = b.getLoc();
+  ArrayRef<int64_t> shape = dstType.getShape();
+  auto tensorType = cast<RankedTensorType>(tensor.getType());
+  auto encoding = cast<ttg::DistributedEncodingTrait>(dstType.getEncoding());
+  RankedTensorType resultType =
+      RankedTensorType::get(shape, tensorType.getElementType(), encoding);
+  auto slicedEncoding =
+      ttg::SliceEncodingAttr::get(b.getContext(), dim, encoding);
+  tensor = createConvertLayout(b, tensor, slicedEncoding);
+  tensor = tti::expandOuterSlicedDim(b, loc, tensor);
+  tensor = triton::BroadcastOp::create(b, resultType, tensor);
+  return tensor;
 }
 
 Value expandAliases(ImplicitLocOpBuilder &b, Value bufferMask,
@@ -225,40 +257,26 @@ Value expandAliases(ImplicitLocOpBuilder &b, Value bufferMask,
   return createConvertLayout(b, aliasVector, bufferMaskType.getEncoding());
 }
 
-Value createOneHot(ImplicitLocOpBuilder &b, int size, int index,
-                   Attribute encoding) {
-  auto loc = b.getLoc();
-  auto type = RankedTensorType::get({size}, b.getI32Type(), encoding);
-  Value arange =
-      triton::MakeRangeOp::create(b, type, /*start=*/0, /*end=*/size);
-  Value indexTensor =
-      tti::createConstIntTensor(b, loc, index, type, /*isSigned=*/false);
-  return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, arange,
-                               indexTensor);
-}
-
-Value createColumnMask(ImplicitLocOpBuilder &b, int column,
-                       RankedTensorType tensorType) {
-  auto encoding = cast<ttg::BlockedEncodingAttr>(tensorType.getEncoding());
-  auto columnEncoding = tti::getSingleDimSliceEncoding(encoding, /*dim=*/1);
-  Value oneHot =
-      createOneHot(b, tensorType.getShape()[1], column, columnEncoding);
-  return convertAndBroadcast(b, oneHot, /*dim=*/0, tensorType);
-}
-
+// Given a constexpr integer mask `columnMask` and `tensor<MxNxiD>`, codegen
+// a mask `tensor<Nxi1>` whose elements correspond to the bits in `columnMask`.
+// Then, it is broadcasted to the shape of the tensor.
 Value createMultiColumnMask(ImplicitLocOpBuilder &b, uint64_t columnMask,
                             RankedTensorType tensorType) {
-  auto loc = b.getLoc();
-  auto i1TensorType =
-      cast<RankedTensorType>(tensorType.cloneWith(std::nullopt, b.getI1Type()));
-  Value maskTensor = tti::createConstIntTensor(b, loc, 0, i1TensorType);
-  for (int i = 0; i < 64; ++i) {
-    if (columnMask & (1ULL << i)) {
-      Value columnMaskTensor = createColumnMask(b, i, tensorType);
-      maskTensor = arith::OrIOp::create(b, maskTensor, columnMaskTensor);
-    }
-  }
-  return maskTensor;
+  unsigned size = tensorType.getShape()[1];
+  SmallVector<bool> maskBits(size);
+  for (unsigned i : llvm::seq(size))
+    maskBits[i] = (columnMask >> i) & 1;
+
+  SmallVector<bool> allMaskBits;
+  for (unsigned i : llvm::seq(tensorType.getShape()[0]))
+    allMaskBits.append(maskBits);
+
+  // This will lower because the tensors have a thread-local layout with the
+  // same number of elements per thread as the whole tensor.
+  auto maskType = RankedTensorType::get(tensorType.getShape(), b.getI1Type(),
+                                        tensorType.getEncoding());
+  auto valueAttr = DenseElementsAttr::get(maskType, allMaskBits);
+  return arith::ConstantOp::create(b, valueAttr);
 }
 
 Value adjustIntegerWidth(ImplicitLocOpBuilder &b, Value value,
@@ -274,7 +292,7 @@ Value adjustIntegerWidth(ImplicitLocOpBuilder &b, Value value,
 Value createThreadColumnMask(ImplicitLocOpBuilder &b, Value threadMask,
                              RankedTensorType tensorType) {
   auto loc = b.getLoc();
-  auto encoding = cast<ttg::BlockedEncodingAttr>(tensorType.getEncoding());
+  auto encoding = cast<ttg::DistributedEncodingTrait>(tensorType.getEncoding());
   auto sliceEncoding = tti::getSingleDimSliceEncoding(encoding, /*dim=*/1);
   int columns = tensorType.getShape()[1];
 
@@ -304,7 +322,7 @@ Value createThreadColumnMask(ImplicitLocOpBuilder &b, Value threadMask,
 Value createColumnMask(ImplicitLocOpBuilder &b, Value column,
                        RankedTensorType tensorType) {
   auto loc = b.getLoc();
-  auto encoding = cast<ttg::BlockedEncodingAttr>(tensorType.getEncoding());
+  auto encoding = cast<ttg::DistributedEncodingTrait>(tensorType.getEncoding());
   auto sliceEncoding = tti::getSingleDimSliceEncoding(encoding, /*dim=*/1);
   auto colType = RankedTensorType::get({tensorType.getShape()[1]},
                                        b.getI32Type(), sliceEncoding);
@@ -317,6 +335,21 @@ Value createColumnMask(ImplicitLocOpBuilder &b, Value column,
 }
 
 } // namespace
+
+void FunctionBuilder::createFillGlobalTensorCall(ImplicitLocOpBuilder &b,
+                                                 Value ptr,
+                                                 RankedTensorType type,
+                                                 Value scalar) {
+  createCallToCachedFunction(
+      b, "fill_global_tensor", {ptr, scalar}, /*assertInfo=*/std::nullopt,
+      {type}, [type](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value ptr = entryBlock->getArgument(0);
+        Value scalar = entryBlock->getArgument(1);
+        Value tensor = triton::SplatOp::create(fb, type, scalar);
+        createStoreScratchMemory(fb, fb.getLoc(), ptr, tensor, type);
+        triton::ReturnOp::create(fb);
+      });
+}
 
 void FunctionBuilder::createSetWaitingCall(ImplicitLocOpBuilder &b, Value mbar,
                                            int thread, Value phase, Value pred,
@@ -837,7 +870,7 @@ void FunctionBuilder::createSetWriteVisibilityCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "set_write_visibility", args,
       /*assertInfo=*/std::nullopt,
-      {buffersType, writeVisibilityType, (int)memType},
+      {buffersType, writeVisibilityType, (uint64_t)memType},
       [buffersType, writeVisibilityType](ImplicitLocOpBuilder &fb,
                                          Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
@@ -895,7 +928,7 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "set_read_visibility", args,
       /*assertInfo=*/std::nullopt,
-      {buffersType, readVisibilityType, (int)memType},
+      {buffersType, readVisibilityType, (uint64_t)memType},
       [buffersType, readVisibilityType](ImplicitLocOpBuilder &fb,
                                         Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
@@ -958,7 +991,7 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "clear_write_tracking", args,
       /*assertInfo=*/std::nullopt,
-      {buffersType, writeTrackingType, (int)memType},
+      {buffersType, writeTrackingType, (uint64_t)memType},
       [buffersType, writeTrackingType](ImplicitLocOpBuilder &fb,
                                        Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
@@ -1012,7 +1045,7 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "clear_read_visibility", args,
       /*assertInfo=*/std::nullopt,
-      {buffersType, readVisibilityType, (int)memType},
+      {buffersType, readVisibilityType, (uint64_t)memType},
       [buffersType, readVisibilityType](ImplicitLocOpBuilder &fb,
                                         Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
@@ -1067,7 +1100,7 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "clear_read_tracking", args,
       /*assertInfo=*/std::nullopt,
-      {buffersType, readTrackingType, (int)memType},
+      {buffersType, readTrackingType, (uint64_t)memType},
       [buffersType, readTrackingType](ImplicitLocOpBuilder &fb,
                                       Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
@@ -1129,7 +1162,7 @@ void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "track_visible_writes", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, writeVisibilityType, writeTrackingType, (int)memType},
+      {barriersType, writeVisibilityType, writeTrackingType, (uint64_t)memType},
       [barriersType, writeVisibilityType,
        writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -1211,7 +1244,7 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "track_visible_reads", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, readVisibilityType, readTrackingType, (int)memType},
+      {barriersType, readVisibilityType, readTrackingType, (uint64_t)memType},
       [barriersType, readVisibilityType,
        readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -1287,7 +1320,7 @@ void FunctionBuilder::createTransferVisibleWritesCall(
   createCallToCachedFunction(
       b, "transfer_visible_writes", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, writeVisibilityType, writeTrackingType, (int)memType},
+      {barriersType, writeVisibilityType, writeTrackingType, (uint64_t)memType},
       [barriersType, writeVisibilityType,
        writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -1374,7 +1407,7 @@ void FunctionBuilder::createTransferVisibleReadsCall(
   createCallToCachedFunction(
       b, "transfer_visible_reads", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, readVisibilityType, readTrackingType, (int)memType},
+      {barriersType, readVisibilityType, readTrackingType, (uint64_t)memType},
       [barriersType, readVisibilityType,
        readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -1446,7 +1479,8 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
   AssertInfo assertInfo{message,
                         buffersType.cloneWith(std::nullopt, b.getI1Type())};
   Type aliasMatrixTypeBase;
-  auto buildVerifyWriteBody = [&](bool useAlias) {
+  auto buildVerifyWriteBody = [&writeVisibilityType,
+                               &aliasMatrixTypeBase](bool useAlias) {
     return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
       Value bufOffset = entryBlock->getArgument(0);
       Value lengthVal = entryBlock->getArgument(1);
@@ -1503,15 +1537,15 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
                                aliasMatrixVal};
     createCallToCachedFunction(
         b, "verify_write_visibility", args, assertInfo,
-        {buffersType, writeVisibilityType, aliasMatrixType, (int)memType},
+        {buffersType, writeVisibilityType, aliasMatrixType, (uint64_t)memType},
         buildVerifyWriteBody(/*useAlias=*/true));
   } else {
     SmallVector<Value> args = {bufOffset, lengthVal,  pred,
                                threadVal, buffersVal, writeVisibilityVal};
-    createCallToCachedFunction(b, "verify_write_visibility_noalias", args,
-                               assertInfo,
-                               {buffersType, writeVisibilityType, (int)memType},
-                               buildVerifyWriteBody(/*useAlias=*/false));
+    createCallToCachedFunction(
+        b, "verify_write_visibility_noalias", args, assertInfo,
+        {buffersType, writeVisibilityType, (uint64_t)memType},
+        buildVerifyWriteBody(/*useAlias=*/false));
   }
 }
 
@@ -1543,7 +1577,8 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
   AssertInfo assertInfo{message,
                         buffersType.cloneWith(std::nullopt, b.getI1Type())};
   Type aliasMatrixTypeBase;
-  auto buildVerifyReadBody = [&](bool useAlias) {
+  auto buildVerifyReadBody = [&buffersType, &readVisibilityType,
+                              &aliasMatrixTypeBase](bool useAlias) {
     return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
       Value bufOffset = entryBlock->getArgument(0);
       Value lengthVal = entryBlock->getArgument(1);
@@ -1601,15 +1636,15 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
                                aliasMatrixVal};
     createCallToCachedFunction(
         b, "verify_read_visibility", args, assertInfo,
-        {buffersType, readVisibilityType, aliasMatrixType, (int)memType},
+        {buffersType, readVisibilityType, aliasMatrixType, (uint64_t)memType},
         buildVerifyReadBody(/*useAlias=*/true));
   } else {
     SmallVector<Value> args = {bufOffset, lengthVal,  pred,
                                threadVal, buffersVal, readVisibilityVal};
-    createCallToCachedFunction(b, "verify_read_visibility_noalias", args,
-                               assertInfo,
-                               {buffersType, readVisibilityType, (int)memType},
-                               buildVerifyReadBody(/*useAlias=*/false));
+    createCallToCachedFunction(
+        b, "verify_read_visibility_noalias", args, assertInfo,
+        {buffersType, readVisibilityType, (uint64_t)memType},
+        buildVerifyReadBody(/*useAlias=*/false));
   }
 }
 
@@ -1632,7 +1667,7 @@ void FunctionBuilder::createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b,
                              writeVis.value};
   createCallToCachedFunction(
       b, "copy_write_visibility", args,
-      /*assertInfo=*/std::nullopt, {writeVisibilityType, (int)memType},
+      /*assertInfo=*/std::nullopt, {writeVisibilityType, (uint64_t)memType},
       [writeVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value sourceThread = entryBlock->getArgument(0);
         Value destMaskVal = entryBlock->getArgument(1);
@@ -1706,7 +1741,8 @@ void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
                              pred, readVis.value};
   createCallToCachedFunction(
       b, "copy_read_visibility", args,
-      /*assertInfo=*/std::nullopt, {readVisibilityType, (int)memType},
+      /*assertInfo=*/std::nullopt,
+      {readVisibilityType, destMask, (uint64_t)memType},
       [readVisibilityType, destMask](ImplicitLocOpBuilder &fb,
                                      Block *entryBlock) {
         Value sourceThread = entryBlock->getArgument(0);
@@ -2050,7 +2086,8 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
   AssertInfo assertInfo{message,
                         commitsType.cloneWith(std::nullopt, b.getI1Type())};
   Type aliasMatrixTypeBase;
-  auto buildCheckOutstandingCommitsBody = [&](bool useAlias) {
+  auto buildCheckOutstandingCommitsBody = [&commitsType, &aliasMatrixTypeBase](
+                                              bool useAlias) {
     return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
       Value bufOffset = entryBlock->getArgument(0);
       Value lengthVal = entryBlock->getArgument(1);
@@ -2095,7 +2132,7 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
         aliasMatrix.value};
     createCallToCachedFunction(
         b, "check_outstanding_commits", args, assertInfo,
-        {buffersType, commitsType, aliasMatrixType, (int)thread},
+        {buffersType, commitsType, aliasMatrixType, (uint64_t)thread},
         buildCheckOutstandingCommitsBody(/*useAlias=*/true));
   } else {
     SmallVector<Value> args = {bufOffset,     lengthVal,
@@ -2103,7 +2140,7 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
                                buffers.value, outstandingCommits.value};
     createCallToCachedFunction(
         b, "check_outstanding_commits_noalias", args, assertInfo,
-        {buffersType, commitsType, (int)thread},
+        {buffersType, commitsType, (uint64_t)thread},
         buildCheckOutstandingCommitsBody(/*useAlias=*/false));
   }
 }

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -3,8 +3,11 @@
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
+#include "triton/Dialect/TritonInstrument/IR/FunctionBuilder.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 
@@ -19,52 +22,68 @@ using mlir::triton::BufferRegion;
 
 namespace {
 
-BlockedEncodingAttr getThreadLocalBlockedEncoding(MLIRContext *ctx,
-                                                  unsigned int size,
-                                                  unsigned int warps,
-                                                  unsigned int numCTAs) {
-  auto cgaLayout = CGAEncodingAttr::get1DLayout(ctx, numCTAs);
-  return BlockedEncodingAttr::get(ctx,
-                                  /*sizePerThread=*/{size},
-                                  /*threadsPerWarp=*/{32},
-                                  /*warpsPerCTA=*/{warps},
-                                  /*order=*/{0}, cgaLayout);
+constexpr unsigned kMaxVectorLengthBits = 128;
+
+DistributedEncodingTrait getWarpLocalEncoding(MLIRContext *ctx, unsigned size,
+                                              unsigned warps, unsigned numCTAs,
+                                              unsigned bitwidth) {
+  auto d0 = standardOutDimNames(ctx, 1).front();
+  auto kBlock = StringAttr::get(ctx, "block");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kRegister = StringAttr::get(ctx, "register");
+
+  // A warp-local layout ensures each warp has a copy of the whole tensor, so
+  // reductions, layout conversions, etc. don't require shared memory. Attempt
+  // to pick a decent coalesced layout, assuming the inner dimension is
+  // contiguous and the tensor is 16-byte aligned. However, pick the widest
+  // vector length to reduce the number of instructions, speeding up
+  // compilation.
+  // unsigned vecLen = kMaxVectorLengthBits / bitwidth;
+  unsigned vecLen = 1;
+
+  // Zero layout along the blocks and warps to broadcast.
+  LinearLayout llBlock = LinearLayout::zeros1D(numCTAs, kBlock, d0);
+  LinearLayout llWarp = LinearLayout::zeros1D(warps, kWarp, d0);
+  LinearLayout llLane = LinearLayout::identity1D(/*size=*/32, kLane, d0);
+  LinearLayout llReg = LinearLayout::identity1D(vecLen, kRegister, d0);
+  // Order of multiplication matters: linearly map along registers first.
+  LinearLayout ll = llReg * llLane * llWarp * llBlock;
+  ll = ensureLayoutNotLargerThan(ll, {{d0, size}});
+  ll = ensureLayoutNotSmallerThan(ll, {{d0, size}});
+
+  return LinearEncodingAttr::get(ctx, ll);
 }
 
-BlockedEncodingAttr getThreadLocalBlockedEncoding(MLIRContext *ctx,
-                                                  unsigned int buffers,
-                                                  unsigned int barriers,
-                                                  unsigned int warps,
-                                                  unsigned int numCTAs) {
-  auto kBlocks = StringAttr::get(ctx, "block");
+DistributedEncodingTrait
+getWarpLocalEncoding(MLIRContext *ctx, unsigned buffers, unsigned barriers,
+                     unsigned warps, unsigned numCTAs, unsigned bitwidth) {
   auto dims = standardOutDimNames(ctx, 2);
-  auto ll = LinearLayout::identity1D(1, kBlocks, dims[0]) *
-            LinearLayout::identity1D(numCTAs, kBlocks, dims[1]);
-  auto cgaLayout = CGAEncodingAttr::get(ctx, std::move(ll));
-  return BlockedEncodingAttr::get(ctx,
-                                  /*sizePerThread=*/{buffers, barriers},
-                                  /*threadsPerWarp=*/{1, 32},
-                                  /*warpsPerCTA=*/{1, warps},
-                                  /*order=*/{0, 1}, std::move(cgaLayout));
-}
+  auto d0 = dims[0];
+  auto d1 = dims[1];
+  auto kBlock = StringAttr::get(ctx, "block");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kRegister = StringAttr::get(ctx, "register");
+  // unsigned vecLen = kMaxVectorLengthBits / bitwidth;
+  unsigned vecLen = 1;
 
-RankedTensorType getIntTensorType(Region *region, ArrayRef<int64_t> shape,
-                                  unsigned bitWidth) {
-  MLIRContext *ctx = region->getContext();
-  unsigned int warps = lookupNumWarps(region);
-  unsigned int numCTAs = lookupNumCTAs(region->getParentOp());
-  BlockedEncodingAttr encoding;
-  if (shape.size() == 1) {
-    encoding = getThreadLocalBlockedEncoding(
-        ctx, static_cast<unsigned>(shape[0]), warps, numCTAs);
-  } else {
-    assert(shape.size() == 2 && "Only 1D and 2D shapes are supported");
-    encoding = getThreadLocalBlockedEncoding(
-        ctx, static_cast<unsigned>(shape[0]), static_cast<unsigned>(shape[1]),
-        warps, numCTAs);
-  }
-  Type elType = IntegerType::get(ctx, bitWidth);
-  return RankedTensorType::get(shape, elType, encoding);
+  // See above: broadcast along blocks and warps.
+  LinearLayout llBlock = LinearLayout::zeros1D(numCTAs, kBlock, d0) *
+                         LinearLayout::zeros1D(/*size=*/1, kBlock, d1);
+  LinearLayout llWarp = LinearLayout::zeros1D(warps, kWarp, d0) *
+                        LinearLayout::zeros1D(/*size=*/1, kWarp, d1);
+  // `d1` is the inner dimension.
+  LinearLayout llLane = LinearLayout::identity1D(1, kLane, d0) *
+                        LinearLayout::identity1D(32, kLane, d1);
+  LinearLayout llReg = LinearLayout::identity1D(1, kRegister, d0) *
+                       LinearLayout::identity1D(vecLen, kRegister, d1);
+
+  LinearLayout ll = llReg * llLane * llWarp * llBlock;
+  ll = ensureLayoutNotLargerThan(ll, {{d0, buffers}, {d1, barriers}});
+  ll = ensureLayoutNotSmallerThan(ll, {{d0, buffers}, {d1, barriers}});
+
+  return LinearEncodingAttr::get(ctx, ll);
 }
 
 std::pair<Value, RankedTensorType>
@@ -143,22 +162,34 @@ Value createInitializedScratchMemory(ImplicitLocOpBuilder &b,
   int numEls = product(tensor.getType().getShape());
   int64_t sizeInBytes = numEls * elSize;
   Type ptrType = triton::getPointerType(elType);
-  auto alloc = GlobalScratchAllocOp::create(b, ptrType, sizeInBytes, elSize);
+  // Allocate scratch buffers with 16-byte alignment so global loads and stores
+  // can be vectorized if possible.
+  auto alloc =
+      GlobalScratchAllocOp::create(b, ptrType, sizeInBytes, /*alignment=*/16);
   createStoreScratchMemory(b, b.getLoc(), alloc, tensor, tensor.getType());
   return alloc;
 }
 
 Value createZeroInitStateTensor(ImplicitLocOpBuilder &b, int m, int n,
-                                int bitWidth) {
+                                int bitWidth, FunctionBuilder &funcBuilder) {
   SmallVector<int64_t> shape = {m};
   if (n > 0) {
     shape.push_back(n);
   }
   auto type =
       getIntTensorType(b.getInsertionBlock()->getParent(), shape, bitWidth);
-  TypedValue<RankedTensorType> tensor =
-      createConstIntTensor(b, b.getLoc(), 0, type);
-  return createInitializedScratchMemory(b, tensor);
+  Type elType = type.getElementType();
+  int elSize = elType.getIntOrFloatBitWidth() / 8;
+  int numEls = product(type.getShape());
+  int64_t sizeInBytes = numEls * elSize;
+  Type ptrType = triton::getPointerType(elType);
+  // Allocate scratch buffers with 16-byte alignment so global loads and stores
+  // can be vectorized if possible.
+  auto alloc =
+      GlobalScratchAllocOp::create(b, ptrType, sizeInBytes, /*alignment=*/16);
+  Value cstZero = arith::ConstantIntOp::create(b, 0, bitWidth);
+  funcBuilder.createFillGlobalTensorCall(b, alloc, type, cstZero);
+  return alloc;
 }
 
 TypedValue<RankedTensorType>
@@ -230,6 +261,45 @@ Value createLockVariable(ImplicitLocOpBuilder &b) {
 
 namespace mlir::triton::instrument {
 
+void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
+                          StringRef message) {
+  if (auto tensorTy = dyn_cast<RankedTensorType>(condition.getType())) {
+    if (tensorTy.getRank() != 1) {
+      condition = triton::ReshapeOp::create(b, {tensorTy.getNumElements()},
+                                            condition, /*allowReorder=*/true);
+    }
+    auto reduceOp = triton::ReduceOp::create(b, condition, /*axis=*/0,
+                                             /*reduction_ordering=*/nullptr);
+    Block *block = &reduceOp.getRegion().emplaceBlock();
+    b.setInsertionPointToStart(block);
+    Value lhs = block->addArgument(b.getI1Type(), b.getLoc());
+    Value rhs = block->addArgument(b.getI1Type(), b.getLoc());
+    Value result = arith::AndIOp::create(b, lhs, rhs);
+    triton::ReduceReturnOp::create(b, result);
+
+    b.setInsertionPointAfter(reduceOp);
+    condition = reduceOp.getResult().front();
+  }
+  ExperimentalAssertUniformOp::create(b, condition, message);
+}
+
+RankedTensorType getIntTensorType(Region *region, ArrayRef<int64_t> shape,
+                                  unsigned bitWidth) {
+  MLIRContext *ctx = region->getContext();
+  unsigned int warps = lookupNumWarps(region);
+  unsigned int numCTAs = lookupNumCTAs(region->getParentOp());
+  DistributedEncodingTrait encoding;
+  if (shape.size() == 1) {
+    encoding = getWarpLocalEncoding(ctx, shape[0], warps, numCTAs, bitWidth);
+  } else {
+    assert(shape.size() == 2 && "Only 1D and 2D shapes are supported");
+    encoding =
+        getWarpLocalEncoding(ctx, shape[0], shape[1], warps, numCTAs, bitWidth);
+  }
+  Type elType = IntegerType::get(ctx, bitWidth);
+  return RankedTensorType::get(shape, elType, encoding);
+}
+
 TypedValue<RankedTensorType> createConstIntTensor(OpBuilder &builder,
                                                   Location loc, int64_t val,
                                                   RankedTensorType tensorType,
@@ -242,9 +312,9 @@ TypedValue<RankedTensorType> createConstIntTensor(OpBuilder &builder,
           .getResult());
 }
 
-DistributedEncodingTrait getSingleDimSliceEncoding(BlockedEncodingAttr encoding,
-                                                   int dim) {
-  int rank = encoding.getOrder().size();
+DistributedEncodingTrait
+getSingleDimSliceEncoding(DistributedEncodingTrait encoding, int dim) {
+  int rank = encoding.getRepOrder().size();
   MLIRContext *ctx = encoding.getContext();
   assert(dim < rank && "Expected dim to be less than rank");
   DistributedEncodingTrait sliceEncoding = encoding;
@@ -284,7 +354,7 @@ static Value expandAllSlicedDims(OpBuilder &b, Location loc, Value tensor) {
 
 static Value createPointerTensor(OpBuilder &b, Location loc, Value base,
                                  RankedTensorType tensorType) {
-  auto encoding = cast<BlockedEncodingAttr>(tensorType.getEncoding());
+  auto encoding = cast<DistributedEncodingTrait>(tensorType.getEncoding());
   Value ptrTensor = SplatOp::create(
       b, loc,
       RankedTensorType::get(tensorType.getShape(), base.getType(), encoding),
@@ -364,7 +434,8 @@ Region *AuxDataMap::RegionToValueMap::getEnclosingParitionOrFunctionRegion(
   return nullptr;
 }
 
-void AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module) {
+void AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module,
+                                                 FunctionBuilder &fb) {
   SmallVector<SmallVector<BufferRegion>, numMemTypes> bufRegions(numMemTypes);
   SmallVector<BufferRegion> barrierRegions;
   getBuffersAndBarriers(module, bufRegions, barrierRegions);
@@ -415,13 +486,13 @@ void AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module) {
     }
 
     writeVisibility[iMemType].insert(
-        entryRegion, {createZeroInitStateTensor(b, numBufs, 0, 64),
+        entryRegion, {createZeroInitStateTensor(b, numBufs, 0, 64, fb),
                       getIntTensorType(entryRegion, {numBufs}, 64)});
     passToWarpSpecialize(entryPoint, writeVisibility[iMemType].at(entryRegion),
                          writeVisibility[iMemType]);
     readVisibility[iMemType].insert(
         entryRegion,
-        {createZeroInitStateTensor(b, numBufs, THREADS_BITMASK_SIZE, 64),
+        {createZeroInitStateTensor(b, numBufs, THREADS_BITMASK_SIZE, 64, fb),
          getIntTensorType(entryRegion, {numBufs, THREADS_BITMASK_SIZE}, 64)});
     passToWarpSpecialize(entryPoint, readVisibility[iMemType].at(entryRegion),
                          readVisibility[iMemType]);
@@ -440,7 +511,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module) {
 
     int numBarriers = barrierRegions.size();
     barrierStates.insert(entryRegion,
-                         {createZeroInitStateTensor(b, numBarriers, 0, 32),
+                         {createZeroInitStateTensor(b, numBarriers, 0, 32, fb),
                           getIntTensorType(entryRegion, {numBarriers}, 32)});
     passToWarpSpecialize(entryPoint, barrierStates.at(entryRegion),
                          barrierStates);
@@ -448,7 +519,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module) {
     // Deadlock detection aux data: waiting (i32[K]) storing waiting flag and
     // phase bits per thread (two bits per thread).
     waiting.insert(entryRegion,
-                   {createZeroInitStateTensor(b, numBarriers, 0, 32),
+                   {createZeroInitStateTensor(b, numBarriers, 0, 32, fb),
                     getIntTensorType(entryRegion, {numBarriers}, 32)});
     passToWarpSpecialize(entryPoint, waiting.at(entryRegion), waiting);
 
@@ -460,14 +531,14 @@ void AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module) {
       if (numBufs > 0) {
         writeTracking[iMemType].insert(
             entryRegion,
-            {createZeroInitStateTensor(b, numBufs, numBarriers, 8),
+            {createZeroInitStateTensor(b, numBufs, numBarriers, 8, fb),
              getIntTensorType(entryRegion, {numBufs, numBarriers}, 8)});
         passToWarpSpecialize(entryPoint,
                              writeTracking[iMemType].at(entryRegion),
                              writeTracking[iMemType]);
         readTracking[iMemType].insert(
             entryRegion,
-            {createZeroInitStateTensor(b, numBufs, numBarriers, 64),
+            {createZeroInitStateTensor(b, numBufs, numBarriers, 64, fb),
              getIntTensorType(entryRegion, {numBufs, numBarriers}, 64)});
         passToWarpSpecialize(entryPoint, readTracking[iMemType].at(entryRegion),
                              readTracking[iMemType]);
@@ -488,7 +559,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module) {
     // operates on base threads.
     commits[commitKind].insert(
         entryRegion,
-        {createZeroInitStateTensor(b, numBufs, NUM_THREADS, 8),
+        {createZeroInitStateTensor(b, numBufs, NUM_THREADS, 8, fb),
          getIntTensorType(entryRegion, {numBufs, NUM_THREADS}, 8)});
     passToWarpSpecialize(entryPoint, commits[commitKind].at(entryRegion),
                          commits[commitKind]);

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -158,18 +158,19 @@ public:
   void runOnOperation() override {
     module = getOperation();
 
-    auxData.populateAndPassToWarpSpecialize(module);
+    tti::FunctionBuilder funcBuilder(module, auxData);
+    auxData.populateAndPassToWarpSpecialize(module, funcBuilder);
 
     tt::FuncOp entryPoint = tti::getEntryPoint(module);
 
     ImplicitLocOpBuilder b(entryPoint.getLoc(), entryPoint);
     b.setInsertionPointToStart(&entryPoint.getBody().front());
-    instrumentMemoryOperations(b);
+    instrumentMemoryOperations(b, funcBuilder);
   }
 
 private:
-  void instrumentMemoryOperations(ImplicitLocOpBuilder &b) {
-    tti::FunctionBuilder funcBuilder(module, auxData);
+  void instrumentMemoryOperations(ImplicitLocOpBuilder &b,
+                                  tti::FunctionBuilder &funcBuilder) {
     module.walk([&](Operation *op) {
       CriticalSectionListener listener;
       b.setListener(&listener);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -155,7 +155,7 @@ void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
       memoryEffectOpInterface.getEffects(effectInstances);
       for (auto effectInstance : effectInstances) {
         if (auto value = effectInstance.getValue()) {
-          for (auto bufferId : allocation->getBufferIds(value)) {
+          for (auto bufferId : allocation->getAllBufferIdsWithAliases(value)) {
             if (bufferId != Allocation::InvalidBufferId) {
               auto interval = allocation->getAllocatedInterval(bufferId);
               auto slice = AllocationSlice(value, interval);

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -100,6 +100,9 @@ void init_triton_passes_ttgpuir(py::module &&m) {
                      createTritonGPUOptimizePartitionWarps);
   ADD_PASS_WRAPPER_0("add_partition_scheduling",
                      createTritonGPUPartitionScheduling);
+  m.def("add_canonicalize_llvm_ir", [](mlir::PassManager &pm) {
+    pm.addNestedPass<mlir::LLVM::LLVMFuncOp>(createCanonicalizeLLVMIR());
+  });
 }
 
 void init_plugin_passes(py::module &&m) {

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -316,14 +316,16 @@ def test_warp_specialize_tma_matmul(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_S
 
 
 @pytest.mark.parametrize("M, N, K", [(512, 512, 512)])
-@pytest.mark.parametrize("a_use_tma, b_use_tma", [(False, True), (True, True)])
+@pytest.mark.parametrize("num_stages", [0, 3])
+@pytest.mark.parametrize("a_use_tma", [False, True])
+@pytest.mark.parametrize("b_use_tma", [False, True])
 @pytest.mark.skipif(not is_hopper_or_blackwell(), reason="Requires Hopper or Blackwell")
-def test_warp_specialize_tma_matmul_consan(M, N, K, a_use_tma, b_use_tma, fresh_knobs):
+def test_warp_specialize_tma_matmul_consan(M, N, K, num_stages, a_use_tma, b_use_tma, fresh_knobs):
     if is_hopper():
         # FIXME: Hopper warp specialization generates incorrect debug info.
         triton.knobs.compilation.disable_line_info = True
     triton.knobs.compilation.instrumentation_mode = "consan"
-    test_warp_specialize_tma_matmul(M, N, K, BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, num_stages=3,
+    test_warp_specialize_tma_matmul(M, N, K, BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, num_stages=num_stages,
                                     num_warps=4, use_fp8=False, a_use_tma=a_use_tma, b_use_tma=b_use_tma)
 
 
@@ -439,7 +441,8 @@ def test_warp_specialize_tma_matmul_persistent(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE
 
 
 @pytest.mark.parametrize("M, N, K", [(512, 512, 512)])
-@pytest.mark.parametrize("a_use_tma, b_use_tma", [(False, True), (True, True)])
+@pytest.mark.parametrize("a_use_tma", [False, True])
+@pytest.mark.parametrize("b_use_tma", [False, True])
 @pytest.mark.parametrize("flatten", [False, True] if is_blackwell() else [True])
 @pytest.mark.skipif(not is_hopper_or_blackwell(), reason="Requires Hopper or Blackwell")
 def test_warp_specialize_tma_matmul_persistent_consan(M, N, K, a_use_tma, b_use_tma, flatten, fresh_knobs):

--- a/test/Analysis/test-allocation-partitioned.mlir
+++ b/test/Analysis/test-allocation-partitioned.mlir
@@ -1,0 +1,133 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -test-print-allocation="partition-size=65536" -verify-diagnostics -o /dev/null
+
+// Test allocation with shared memory partitioning enabled (64KB partition size like for AMD GFX1250)
+// With partition-size=65536, partition buffers should be placed in different 64KB physical partitions
+
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+#PADDED_SHARED = #ttg.padded_shared<[256:+8] {order = [1, 0], shape = [16, 32]}>
+
+// 2 partitions, 2 groups each
+// Each piece is 1052 bytes, so each partition buffer is 1052 * 2 = 2104 bytes
+#PARTITIONED_2P_2G = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #PADDED_SHARED}>
+
+// 4 partitions, 1 group each
+// Each piece is 1052 bytes, each partition buffer is 1052 * 1 = 1052 bytes
+#PARTITIONED_4P_1G = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 0, partitionLayout = #PADDED_SHARED}>
+
+// 2 partitions, 4 groups each (using swizzled layout)
+// 64x32xf16 = 4096 bytes total, 8 pieces = 512 bytes each, partition buffer = 512 * 4 = 2048 bytes
+#PARTITIONED_2P_4G = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 4, partitionDim = 0, partitionLayout = #A_SHARED}>
+
+// 4 partitions, 2 groups each (using swizzled layout)
+// 64x32xf16 = 4096 bytes total, 8 pieces = 512 bytes each, partition buffer = 512 * 2 = 1024 bytes
+#PARTITIONED_4P_2G = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 2, partitionDim = 0, partitionLayout = #A_SHARED}>
+
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+
+// Test basic 2 partitions, 2 groups allocation
+// expected-remark @below {{partitioned_2p_2g}}
+// expected-remark @below {{size = 67640}}
+tt.func @partitioned_2p_2g() {
+  // 2 partition buffers: one for partition 0 (contains groups 0,1) and one for partition 1 (contains groups 0,1)
+  // Each partition buffer is 2104 bytes (1052 bytes per piece * 2 groups)
+  // With 64KB partition size, the two partition buffers are placed in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test 4 partitions, 1 group each - each partition is a neighbor to all others
+// expected-remark @below {{partitioned_4p_1g}}
+// expected-remark @below {{size = 197660}}
+tt.func @partitioned_4p_1g() {
+  // 4 partition buffers, each containing 1 group = 1052 bytes each
+  // All 4 partitions are neighbors, so they must be in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 1052}}
+  // expected-remark @below {{offset = 65536, size = 1052}}
+  // expected-remark @below {{offset = 131072, size = 1052}}
+  // expected-remark @below {{offset = 196608, size = 1052}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_4P_1G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test 2 partitions, 4 groups each with swizzled layout
+// expected-remark @below {{partitioned_2p_4g}}
+// expected-remark @below {{size = 67584}}
+tt.func @partitioned_2p_4g() {
+  // 2 partition buffers, each containing 4 groups concatenated = 2048 bytes each
+  // With 64KB partition size, the two partition buffers are placed in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 2048}}
+  // expected-remark @below {{offset = 65536, size = 2048}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test 4 partitions, 2 groups each - four partitions need four different physical partitions
+// expected-remark @below {{partitioned_4p_2g}}
+// expected-remark @below {{size = 197632}}
+tt.func @partitioned_4p_2g() {
+  // 4 partition buffers, each containing 2 groups concatenated = 1024 bytes each
+  // All 4 partitions are neighbors, so they must be in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 1024}}
+  // expected-remark @below {{offset = 65536, size = 1024}}
+  // expected-remark @below {{offset = 131072, size = 1024}}
+  // expected-remark @below {{offset = 196608, size = 1024}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_4P_2G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test partitioned allocation alongside non-partitioned allocation
+// expected-remark @below {{partitioned_with_regular}}
+// expected-remark @below {{size = 67640}}
+tt.func @partitioned_with_regular() {
+  // Non-partitioned allocation: 1024 bytes (placed after the partitioned buffer in partition 0)
+  // expected-remark @below {{offset = 4224, size = 1024}}
+  %regular = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Partitioned allocation: 2 partition buffers of 2104 bytes each
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %partitioned = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  // Use both allocations so they overlap in liveness
+  "use"(%regular) : (!ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>) -> ()
+  "use"(%partitioned) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Test multiple partitioned allocations (both live at the same time)
+// expected-remark @below {{multiple_partitioned}}
+// expected-remark @below {{size = 69696}}
+tt.func @multiple_partitioned() {
+  // First partitioned allocation: 2 partition buffers of 2104 bytes each
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %alloc1 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  // Second partitioned allocation: 2 partition buffers of 2048 bytes each
+  // Both allocations are live, so they must be at different offsets within each physical partition
+  // expected-remark @below {{offset = 4224, size = 2048}}
+  // expected-remark @below {{offset = 67648, size = 2048}}
+  %alloc2 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
+  // Use both allocations so they overlap in liveness
+  "use"(%alloc1) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>) -> ()
+  "use"(%alloc2) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Test liveness/reuse of partitioned buffers
+// expected-remark @below {{partitioned_reuse}}
+// expected-remark @below {{size = 67640}}
+tt.func @partitioned_reuse() {
+  // First allocation: 2 partition buffers of 2104 bytes each
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %alloc1 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %alloc1 : !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  // Second allocation after dealloc: should reuse the same memory
+  // expected-remark @below {{offset = 0, size = 2048}}
+  // expected-remark @below {{offset = 65536, size = 2048}}
+  %alloc2 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
+  tt.return
+}
+}

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -31,6 +31,10 @@
 #PADDED_SHARED_1_16x256 = #ttg.padded_shared<[128:+4, 256:+8] {order = [1, 0], shape = [16, 256]}>
 #PADDED_SHARED_2_16x256 = #ttg.padded_shared<[64:+2, 128:+4, 256:+8] {order = [1, 0], shape = [16, 256]}>
 
+// PartitionedSharedEncoding attributes for testing
+#PARTITIONED_SHARED_SWIZZLE = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #A_SHARED}>
+#PARTITIONED_SHARED_PADDED = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 1, partitionLayout = #PADDED_SHARED_0_16x32}>
+
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -1084,4 +1088,29 @@ tt.func public @remote_shmem_store_kernel(%store_val: tensor<1xf32>) {
   tt.return
 }
 
+// PartitionedSharedEncoding with swizzled inner layout: 64x32xf16, 2 partitions, 2 groups each
+// Without partition-size, pieces are placed consecutively
+// expected-remark @below {{partitioned_shared_swizzle_alloc}}
+// expected-remark @below {{size = 4096}}
+tt.func @partitioned_shared_swizzle_alloc() {
+  // 2 partition buffers, each containing 2 groups = 2048 bytes each
+  // expected-remark @below {{offset = 0, size = 2048}}
+  // expected-remark @below {{offset = 2048, size = 2048}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_SHARED_SWIZZLE, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// PartitionedSharedEncoding with padded inner layout: 64x32xf16, 4 partitions, 1 group each
+// Without partition-size, pieces are placed consecutively
+// expected-remark @below {{partitioned_shared_padded_alloc}}
+// expected-remark @below {{size = 4220}}
+tt.func @partitioned_shared_padded_alloc() {
+  // 4 partition buffers, each containing 1 group = 1052 bytes each
+  // expected-remark @below {{offset = 0, size = 1052}}
+  // expected-remark @below {{offset = 1056, size = 1052}}
+  // expected-remark @below {{offset = 2112, size = 1052}}
+  // expected-remark @below {{offset = 3168, size = 1052}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_SHARED_PADDED, #ttg.shared_memory, mutable>
+  tt.return
+}
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2573,62 +2573,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 
-#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 2 : i32, ttg.target = "cuda:90"} {
+// CHECK: llvm.mlir.global internal constant @tensor_constant_0([0 : i32, 1 : i32, {{.*}}, 15 : i32]) {addr_space = 0 : i32} : !llvm.array<16 x i32>
+
 // CHECK-LABEL: @arith_constant_array
 tt.func private @arith_constant_array() {
-  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: %[[C1:.+]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK: %[[C2:.+]] = llvm.mlir.constant(2 : i32) : i32
-  // CHECK: %[[C3:.+]] = llvm.mlir.constant(3 : i32) : i32
-  // CHECK: %[[S0:.+]] = llvm.mlir.undef : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S1:.+]] = llvm.insertvalue %[[C0]], %[[S0]][0] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S2:.+]] = llvm.insertvalue %[[C1]], %[[S1]][1] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S3:.+]] = llvm.insertvalue %[[C2]], %[[S2]][2] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S4:.+]] = llvm.insertvalue %[[C3]], %[[S3]][3] : !llvm.struct<(i32, i32, i32, i32)>
-  %0 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32, #blocked>
-  tt.return
-}
-}
-
-// -----
-
-
-#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @arith_constant_array
-tt.func private @arith_constant_array() {
-  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: %[[C1:.+]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK: %[[C2:.+]] = llvm.mlir.constant(2 : i32) : i32
-  // CHECK: %[[C3:.+]] = llvm.mlir.constant(3 : i32) : i32
-  // CHECK: %[[S0:.+]] = llvm.mlir.undef : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S1:.+]] = llvm.insertvalue %[[C0]], %[[S0]][0] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S2:.+]] = llvm.insertvalue %[[C1]], %[[S1]][1] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S3:.+]] = llvm.insertvalue %[[C2]], %[[S2]][2] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S4:.+]] = llvm.insertvalue %[[C3]], %[[S3]][3] : !llvm.struct<(i32, i32, i32, i32)>
-  %0 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32, #blocked>
-  tt.return
-}
-}
-
-// -----
-
-
-#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @arith_constant_array
-tt.func private @arith_constant_array() {
-  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: %[[C1:.+]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK: %[[C2:.+]] = llvm.mlir.constant(2 : i32) : i32
-  // CHECK: %[[C3:.+]] = llvm.mlir.constant(3 : i32) : i32
-  // CHECK: %[[S0:.+]] = llvm.mlir.undef : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S1:.+]] = llvm.insertvalue %[[C0]], %[[S0]][0] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S2:.+]] = llvm.insertvalue %[[C1]], %[[S1]][1] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S3:.+]] = llvm.insertvalue %[[C2]], %[[S2]][2] : !llvm.struct<(i32, i32, i32, i32)>
-  // CHECK: %[[S4:.+]] = llvm.insertvalue %[[C3]], %[[S3]][3] : !llvm.struct<(i32, i32, i32, i32)>
-  %0 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32, #blocked>
+  %0 = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : tensor<16xi32, #blocked>
+  // CHECK: nvvm.read.ptx.sreg.tid.x
+  // CHECK: [[ADDR:%.*]] = llvm.mlir.addressof @tensor_constant_0
+  // CHECK: [[OFFSET:%.*]] = llvm.getelementptr [[ADDR]]
+  // CHECK: [[VALUE:%.*]] = llvm.load [[OFFSET]]
+  // CHECK: llvm.insertvalue [[VALUE]], %{{.*}}[0]
   tt.return
 }
 }

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -3,10 +3,11 @@
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK: global internal constant @tensor_constant_1([34359738368, 68719476736]) {addr_space = 0 : i32} : !llvm.array<2 x i64>
+// CHECK: global internal constant @tensor_constant_0([0, 42]) {addr_space = 0 : i32} : !llvm.array<2 x i64>
+
 // CHECK-LABEL: @experimental_buffer_descriptors_tmem
 // CHECK: llvm.mlir.constant(4294967295 : i64) : i64
-// CHECK: llvm.mlir.constant(34359738368 : i64) : i64
-// CHECK: llvm.mlir.constant(68719476736 : i64) : i64
 tt.func private @experimental_buffer_descriptors_tmem() {
   tti.experimental_buffer_descriptors [0, 42], [8, 16], tensor_mem : tensor<2xi64, #blocked>
   tt.return
@@ -18,60 +19,13 @@ tt.func private @experimental_buffer_descriptors_tmem() {
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK: global internal constant @tensor_constant_1([17179869184, 51539607552])
+// CHECK: global internal constant @tensor_constant_0([0, 42])
+
 // CHECK-LABEL: @experimental_buffer_descriptors_shared
 // CHECK: llvm.mlir.constant(4294967295 : i64) : i64
-// CHECK: llvm.mlir.constant(17179869184 : i64) : i64
-// CHECK: llvm.mlir.constant(51539607552 : i64) : i64
 tt.func private @experimental_buffer_descriptors_shared() {
   tti.experimental_buffer_descriptors [0, 42], [4, 12], shared_mem : tensor<2xi64, #blocked>
-  tt.return
-}
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-
-module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_assert_in_thread_any
-// CHECK: %[[E0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(i1, i1)>
-// CHECK: %[[E1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(i1, i1)>
-// CHECK: %[[INIT:.+]] = llvm.mlir.constant(false) : i1
-// CHECK: %[[FALSE:.+]] = llvm.mlir.constant(false) : i1
-// CHECK: %[[OR0:.+]] = llvm.or %[[INIT]], %[[E0]] : i1
-// CHECK: %[[OR1:.+]] = llvm.or %[[OR0]], %[[E1]] : i1
-// CHECK: %[[XOR:.+]] = llvm.xor %[[OR1]]
-
-// CHECK: @__assertfail
-tt.func private @experimental_assert_in_thread_any(
-  %condition: tensor<2xi1, #blocked>,
-  %message: !llvm.ptr<8>
-) {
-  tti.experimental_assert_in_thread %condition, "test" {check_any = true} : tensor<2xi1, #blocked>
-  tt.return
-}
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-
-module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_assert_in_thread_all
-// CHECK: %[[E0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(i1, i1)>
-// CHECK: %[[E1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(i1, i1)>
-// CHECK: %[[INIT:.+]] = llvm.mlir.constant(true) : i1
-// CHECK: %[[FALSE:.+]] = llvm.mlir.constant(false) : i1
-// CHECK: %[[AND0:.+]] = llvm.and %[[INIT]], %[[E0]] : i1
-// CHECK: %[[AND1:.+]] = llvm.and %[[AND0]], %[[E1]] : i1
-// CHECK: %[[XOR:.+]] = llvm.xor %[[AND1]]
-
-// CHECK: @__assertfail
-tt.func private @experimental_assert_in_thread_all(
-  %condition: tensor<2xi1, #blocked>,
-  %message: !llvm.ptr<8>
-) {
-  tti.experimental_assert_in_thread %condition, "test" {check_any = false} : tensor<2xi1, #blocked>
   tt.return
 }
 }

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -99,6 +99,78 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 11 : i32} 
 
 llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 
+// CHECK: llvm.func internal @inner_func_nw4_ws(%arg0: i32)
+llvm.func internal @inner_func_nw4() attributes {"ws_num_warps" = 4 : i32} {
+  // CHECK: [[C128:%.*]] = llvm.mlir.constant(128 : i32)
+  // CHECK: nvvm.barrier id = %arg0 number_of_threads = [[C128]]
+  // CHECK: llvm.call @inner_func_nw4_ws(%arg0) : (i32) -> ()
+  nvvm.barrier0
+  llvm.call @inner_func_nw4() : () -> ()
+  llvm.return
+}
+
+// CHECK: llvm.func internal @inner_func_nw2_ws(%arg0: f32 {some.attr = "some_value"}, %arg1: i32)
+llvm.func internal @inner_func_nw2(%arg0: f32 {some.attr = "some_value"}) attributes {"ws_num_warps" = 2 : i32} {
+  // CHECK: [[C64:%.*]] = llvm.mlir.constant(64 : i32)
+  // CHECK: nvvm.barrier id = %arg1 number_of_threads = [[C64]]
+  nvvm.barrier0
+  llvm.return
+}
+
+// CHECK: llvm.func internal @inner_func_nw1_ws(%arg0: i32)
+llvm.func internal @inner_func_nw1() attributes {"ws_num_warps" = 1 : i32} {
+  // CHECK: nvvm.bar.warp.sync
+  nvvm.barrier0
+  llvm.return
+}
+
+llvm.func @__libdevice_function()
+
+// CHECK: llvm.func @rewrite_barriers()
+llvm.func @rewrite_barriers() attributes {allocation.offset = 32 : i32} {
+  // CHECK-DAG: [[CST:%.*]] = llvm.mlir.constant({{.*}}) : f32
+  // CHECK-DAG: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
+  // CHECK-DAG: [[C2:%.*]] = llvm.mlir.constant(2 : i32)
+  // CHECK-DAG: [[C3:%.*]] = llvm.mlir.constant(3 : i32)
+  // CHECK-DAG: [[C4:%.*]] = llvm.mlir.constant(4 : i32)
+  ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 4, 8, 10>}
+  default {
+    llvm.call @inner_func_nw4() : () -> ()
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
+    // CHECK: call @inner_func_nw4_ws([[C2]]) : (i32) -> ()
+    llvm.call @inner_func_nw4() : () -> ()
+    // CHEC: call @__libdevice_function() : () -> ()
+    llvm.call @__libdevice_function() : () -> ()
+    ttg.warp_return
+  }
+  partition1() num_warps(2) {
+    // CHECK: call @inner_func_nw2_ws([[CST]], [[C3]]) : (f32, i32) -> ()
+    %cst = llvm.mlir.constant(4.2 : f32) : f32
+    llvm.call @inner_func_nw2(%cst) : (f32) -> ()
+    ttg.warp_return
+  }
+  partition2() num_warps(1) {
+    // CHECK: call @inner_func_nw1_ws([[C4]]) : (i32) -> ()
+    llvm.call @inner_func_nw1() : () -> ()
+    ttg.warp_return
+  } : () -> ()
+  // CHECK: call @inner_func_nw4_ws([[C0]]) : (i32) -> ()
+
+  // CHECK: call @inner_func_nw4_ws([[C0]]) : (i32) -> ()
+  llvm.call @inner_func_nw4() : () -> ()
+  llvm.return
+}
+
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 11 : i32} {
+
+llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
 // COMMON-LABEL: @generate_switch_loop
 llvm.func @generate_switch_loop() attributes {allocation.offset = 32 : i32} {
   // CHECK-DAG: [[CNEG1:%.*]] = llvm.mlir.constant(-1 : i32)

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -4121,3 +4121,32 @@ tt.func @whileop_tensor_after_cond(%ptr: tensor<1024x!tt.ptr<f32>, #blocked>, %i
   tt.return
 }
 }
+
+// -----
+
+// Test that we do not hoist a convert if the resulting convert would  be more
+// expensive than the original.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 8, 4], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 1, 4], order = [2, 1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @hoist_convert_unprofitable(%arg0: tensor<1x32x32xf32, #blocked>) -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 0, parent = #blocked1}>}>> {
+    // CHECK: tt.broadcast
+    // CHECK: tt.reduce
+    // CHECK: tt.reduce
+    // CHECK: ttg.convert_layout
+    %0 = tt.broadcast %arg0 : tensor<1x32x32xf32, #blocked> -> tensor<32x32x32xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %4 = arith.addf %arg1, %arg2 : f32
+      tt.reduce.return %4 : f32
+    }) : (tensor<32x32x32xf32, #blocked>) -> tensor<32x32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %2 = "tt.reduce"(%1) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %4 = arith.addf %arg1, %arg2 : f32
+      tt.reduce.return %4 : f32
+    }) : (tensor<32x32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 0, parent = #blocked}>}>>
+    %3 = ttg.convert_layout %2 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 0, parent = #blocked}>}>> -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 0, parent = #blocked1}>}>>
+    tt.return %3 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 0, parent = #blocked1}>}>>
+  }
+}

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -29,6 +29,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: missing_proxy_fence_memdesc_index_alias_single
+  tt.func @missing_proxy_fence_memdesc_index_alias_single(%arg0: !tt.tensordesc<tensor<64x64xf32, #shared>>, %arg1: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) {
+    // Keep the first fence to clear dependencies from local_alloc.
+    // CHECK: ttng.fence_async_shared
+    // CHECK: ttg.local_load
+    // CHECK-NEXT: "test.keep"
+    // CHECK-NEXT: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1x64x64xf32, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1x64x64xf32, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    ttng.fence_async_shared {bCluster = false}
+    %2 = ttg.local_load %1 : !ttg.memdesc<64x64xf32, #shared, #smem, mutable> -> tensor<64x64xf32, #blocked>
+    "test.keep"(%2) : (tensor<64x64xf32, #blocked>) -> ()
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %1, %arg1, %true : !tt.tensordesc<tensor<64x64xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: async_proxy_after_async_proxy
   tt.func @async_proxy_after_async_proxy(%arg0: !tt.tensordesc<tensor<64x64xf32, #shared>>, %arg1: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) {
     // CHECK: ttng.async_tma_copy_global_to_local

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -769,8 +769,20 @@ LogicalResult AsyncTDMCopyLocalToGlobalOp::verify() {
 
   auto paddedEnc =
       llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(smemTy.getEncoding());
-  if (paddedEnc)
-    return emitOpError("TDM store does not support padding");
+  if (paddedEnc) {
+    // Check if we can apply the padding workaround, see the lowering to LLVM
+    // for more details.
+    auto intervals = paddedEnc.getIntervals();
+    if (intervals.size() != 1)
+      return emitOpError("TDM store only supports single interval paddings.");
+
+    if (intervals[0] != blockShape.back())
+      return emitOpError("TDM store padding is only supported when padding "
+                         "interval equals the innermost block dimension (got "
+                         "padInterval=")
+             << intervals[0] << ", innermost dimension=" << blockShape.back()
+             << ")";
+  }
 
   if (!paddedEnc && !swizzledEnc)
     return emitOpError("Invalid shared memory layout for TDM");

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -23,6 +23,7 @@
 #include "TargetInfo.h"
 #include "TritonAMDGPUToLLVM/MembarUtility.h"
 #include "TritonAMDGPUToLLVM/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -62,7 +63,7 @@ static BlockInfo buildBlockInfoFromBlock(Block *block, Allocation *allocation) {
       mei.getEffects(effs);
       for (auto &eff : effs) {
         if (Value v = eff.getValue()) {
-          for (auto bufId : allocation->getBufferIds(v)) {
+          for (auto bufId : allocation->getAllBufferIdsWithAliases(v)) {
             if (bufId == Allocation::InvalidBufferId)
               continue;
             auto interval = allocation->getAllocatedInterval(bufId);
@@ -357,8 +358,12 @@ public:
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
-    ModuleAllocation moduleAllocation(m);
+
     mlir::triton::AMD::TargetInfo targetInfo(arch.getValue());
+    size_t partitionSize = targetInfo.getSharedMemoryPartitionSize();
+    ModuleAllocation moduleAllocation(
+        m, triton::defaultAllocationAnalysisScratchSizeFn, partitionSize);
+
     if (targetInfo.getISAFamily() == mlir::triton::AMD::ISAFamily::Unknown) {
       m.emitError("unsupported target: '") << arch.getValue() << "'";
       return signalPassFailure();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1315,8 +1315,21 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
       barrierPtr = smemObj.getBase();
     }
 
+    auto paddedEnc = dyn_cast<PaddedSharedEncodingAttr>(smemTy.getEncoding());
+    unsigned padInterval = 0;
+    unsigned padAmount = 0;
+    triton::LinearLayout sharedLayout;
+
+    if (paddedEnc) {
+      // Verifier ensures that there is exactly one interval-padding pair
+      padInterval = paddedEnc.getIntervals()[0];
+      padAmount = paddedEnc.getPaddings()[0];
+      sharedLayout = paddedEnc.getLinearComponent();
+    } else {
+      sharedLayout = triton::gpu::toLinearLayout(smemTy);
+    }
+
     // Verifier ensures smem is not usind a PaddedSharedEncodingAttr
-    auto sharedLayout = triton::gpu::toLinearLayout(smemTy);
     auto kBlock = rewriter.getStringAttr("block");
     auto cgaLayout = sharedLayout.sublayout(
         {kBlock}, to_vector(sharedLayout.getOutDimNames()));
@@ -1326,7 +1339,7 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
     Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
     mlir::LLVM::AMD::emitTDMLoadStore(
         rewriter, loc, getTypeConverter(), desc, shapePerCTA, numWarps,
-        /*padInterval=*/0, /*padAmount=*/0, offset, dstPtr, pred,
+        padInterval, padAmount, offset, dstPtr, pred,
         /*multicastMask=*/{}, elementType, barrierPtr,
         /*isLoad=*/false, cgaLayout, ctaId);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -38,8 +38,8 @@ bool filterAsyncLocalLoadsDependencies(Operation *op1, Operation *op2,
   Value op2Memdesc = getMemdescValue(op2);
   if (!op1Memdesc || !op2Memdesc)
     return false;
-  auto op1BufferIds = allocation->getBufferIds(op1Memdesc);
-  auto op2BufferIds = allocation->getBufferIds(op2Memdesc);
+  auto op1BufferIds = allocation->getAllBufferIdsWithAliases(op1Memdesc);
+  auto op2BufferIds = allocation->getAllBufferIdsWithAliases(op2Memdesc);
 
   // Check if operations access the same buffer
   bool sameBuffer = llvm::any_of(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -462,7 +462,8 @@ void fillTDMDescriptor(
     std::optional<std::reference_wrapper<SmallVector<Value>>> group2,
     std::optional<std::reference_wrapper<SmallVector<Value>>> group3,
     SmallVector<Value> offset, Value dstPtr, Value pred, Value multicastMask,
-    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId) {
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
+    bool isStore) {
   size_t numDims = offset.size();
   assert(numDims >= 1 && numDims <= 5 && "TDM supports 1D to 5D tensors.");
 
@@ -550,6 +551,32 @@ void fillTDMDescriptor(
     tensorShape[i] = b.smax(b.i32_val(0), b.sub(tensorShape[i], fullOffset));
   }
 
+  // TDM store does not support padding in general. However, if the padding
+  // interval equals the innermost dimension, we can support it by:
+  // 1. Adjusting fastest tile_dim0 to include padding (tile_dim0 + padding).
+  // Note that in triton numDims-1 is the fastest dim whereas dim0 is the
+  // fastest in the TDM descriptor.
+  // 2. Setting tensor_dim0 (fastest) to min(tensor_dim0, original_tile_dim0).
+  // We have to do this after adjusting the tensor shape based on the offset and
+  // cga offset.
+  // This leverages HW OOB checking to skip padding elements while
+  // preserving the original tensor shape if smaller. Note that the pre
+  // conditions are checked in the verifier already
+  bool adjustedBlockShape = false;
+  if (isStore && padInterval > 0 && padAmount > 0) {
+    adjustedBlockShape = true;
+    Value originalTileDim0 = decodedBlockShape[numDims - 1];
+
+    // Adjust block shape (tile dimension) to include padding
+    decodedBlockShape[numDims - 1] =
+        b.add(originalTileDim0, b.i32_val(padAmount));
+
+    // Adjust tensor dimension to be min(tensor_dim0, original_tile_dim0)
+    Value cmp = b.icmp_ult(tensorShape[numDims - 1], originalTileDim0);
+    tensorShape[numDims - 1] =
+        b.select(cmp, tensorShape[numDims - 1], originalTileDim0);
+  }
+
   // Update group0 with addresses
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
   Value ldsAddr = b.ptrtoint(i32_ty, dstPtr);
@@ -582,6 +609,14 @@ void fillTDMDescriptor(
                           b.i32_val(0x00FFFF)));
   } else {
     group1[0] = b.and_(group1[0], b.i32_val(0xFFFBFFFF));
+  }
+
+  if (adjustedBlockShape) {
+    // Re-encode the adjusted tile_dim0 (block shape) into upper 16 bits of
+    // group1[3]. This is the same for 1D-5D tensors.
+    group1[3] = b.and_(group1[3], b.i32_val(0xFFFF));
+    group1[3] =
+        b.or_(group1[3], b.shl(decodedBlockShape[numDims - 1], b.i32_val(16)));
   }
 
   // Update group2/group3 for higher dimensions
@@ -761,7 +796,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       to_vector(blockShape), numWarps, padInterval, padAmount,
                       group0Vec, group1Vec, std::ref(group2Vec),
                       std::ref(group3Vec), to_vector(offset), dstPtr, pred,
-                      multicastMask, barrierPtr, cgaLayout, ctaId);
+                      multicastMask, barrierPtr, cgaLayout, ctaId, !isLoad);
 
     auto group0 = packLLVector(loc, group0Vec, rewriter);
     auto group1 = packLLVector(loc, group1Vec, rewriter);
@@ -782,7 +817,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       to_vector(blockShape), numWarps, padInterval, padAmount,
                       group0Vec, group1Vec, std::nullopt, std::nullopt,
                       to_vector(offset), dstPtr, pred, multicastMask,
-                      barrierPtr, cgaLayout, ctaId);
+                      barrierPtr, cgaLayout, ctaId, !isLoad);
 
     auto group0 = packLLVector(loc, group0Vec, rewriter);
     auto group1 = packLLVector(loc, group1Vec, rewriter);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -44,7 +44,8 @@ void fillTDMDescriptor(
     std::optional<std::reference_wrapper<SmallVector<Value>>> group2,
     std::optional<std::reference_wrapper<SmallVector<Value>>> group3,
     SmallVector<Value> offset, Value dstPtr, Value pred, Value multicastMask,
-    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId);
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
+    bool isStore);
 
 // Fill TDM descriptor for gather/scatter operations (2D only).
 // Gather reads from non-contiguous rows in global memory to LDS.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -85,7 +85,7 @@ int TargetInfo::getWarpSize() const {
 }
 
 int TargetInfo::getSharedMemorySize() const {
-  // Should return the maximum capacity in kbyte
+  // Should return the maximum capacity in bytes
   switch (getISAFamily()) {
   case ISAFamily::GFX1250:
     return 320 * 1024;
@@ -93,6 +93,16 @@ int TargetInfo::getSharedMemorySize() const {
     return 160 * 1024;
   default:
     return 64 * 1024;
+  }
+}
+
+size_t TargetInfo::getSharedMemoryPartitionSize() const {
+  switch (getISAFamily()) {
+  case ISAFamily::GFX1250:
+    return 64 * 1024;
+  default:
+    // No partitioning on other targets
+    return 0;
   }
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -22,6 +22,8 @@ public:
 
   int getSharedMemorySize() const;
 
+  size_t getSharedMemoryPartitionSize() const override;
+
   bool supportMaximumMinimum() const override;
 
   bool supportDppBroadcast() const;

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -1422,14 +1422,8 @@ def tensor_descriptor_load_store_nd_kernel_host_tdm(out_desc, inp_desc):
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
 
-@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
-@pytest.mark.parametrize("INNER_BLOCK", [4, 8, 16, 32, 64, 128])
-@pytest.mark.parametrize("dtype_str", sorted(set(dtypes_with_bfloat16) - {"int64", "uint64", "float64"}))
-@pytest.mark.parametrize("TDM_TYPE", ["DEVICE_TDM", "HOST_TDM"])
-def test_tensor_descriptor_load_store_nd(dtype_str, ndim, INNER_BLOCK, TDM_TYPE):
-    SHARED_LAYOUT: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1,
-                                                              order=[ndim - 1 - i for i in range(ndim)])
-
+def _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYPE, SHARED_LAYOUT):
+    """Utility function to run TDM load/store tests with a given shared layout."""
     alloc_shape = [1, 1, 3, 7, INNER_BLOCK][-ndim:]
 
     BLOCK_SHAPE = (2, 2, 4, 8, INNER_BLOCK)[-ndim:]
@@ -1473,6 +1467,36 @@ def test_tensor_descriptor_load_store_nd(dtype_str, ndim, INNER_BLOCK, TDM_TYPE)
     actual[idx].zero_()
     expect = expect.new_zeros(BLOCK_SHAPE)
     assert torch.equal(expect, actual)
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("INNER_BLOCK", [4, 8, 16, 32, 64, 128])
+@pytest.mark.parametrize("dtype_str", sorted(set(dtypes_with_bfloat16) - {"int64", "uint64", "float64"}))
+@pytest.mark.parametrize("TDM_TYPE", ["DEVICE_TDM", "HOST_TDM"])
+def test_tensor_descriptor_load_store_nd(dtype_str, ndim, INNER_BLOCK, TDM_TYPE):
+    """Test TDM load/store with swizzled shared layout."""
+    SHARED_LAYOUT: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1,
+                                                              order=[ndim - 1 - i for i in range(ndim)])
+    _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYPE, SHARED_LAYOUT)
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("INNER_BLOCK", [16, 64])
+@pytest.mark.parametrize("dtype_str", ["float16", "int32"])
+def test_tensor_descriptor_load_store_nd_with_padding(dtype_str, ndim, INNER_BLOCK):
+    """Test TDM load/store with padded shared memory layout.
+    TDM store only supports padding when:
+    1. There is a single padding interval
+    2. The padding interval equals the innermost block dimension
+    """
+    # Create padded shared layout where padding interval = innermost block dimension
+    BLOCK_SHAPE = (2, 2, 4, 8, INNER_BLOCK)[-ndim:]
+    PADDED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[INNER_BLOCK, 8]], BLOCK_SHAPE,
+                                                                              [ndim - 1 - i
+                                                                               for i in range(ndim)]  # standard order
+                                                                              )
+
+    _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, "DEVICE_TDM", PADDED_LAYOUT)
 
 
 def test_tensor_descriptor_load_store_invalid_blocksize():

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -848,6 +848,8 @@ class CUDABackend(BaseBackend):
         if "consan" in options.instrumentation_mode:
             # Call ConcurrencySanitizerPass here, before allocating global scratch memory but after allocating tensor and shared
             passes.ttgpuir.add_concurrency_sanitizer(pm)
+            passes.common.add_canonicalizer(pm)
+            passes.common.add_cse(pm)
         passes.ttgpuir.add_allocate_global_scratch_memory(pm)
         nvidia.passes.ttnvgpuir.add_proxy_fence_insertion(pm, capability)
         # Print TTGIR to TLX mapping before final emission (for debugging/analysis)
@@ -865,7 +867,7 @@ class CUDABackend(BaseBackend):
             CUDABackend.instrumentation.patch("ttgpuir_to_llvmir", pm, mod.context)
         nvidia.passes.hopper.add_tma_store_token_wait_lowering(pm)
         nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version)
-        passes.common.add_canonicalizer(pm)
+        passes.ttgpuir.add_canonicalize_llvm_ir(pm)
         passes.common.add_cse(pm)
         nvidia.passes.ttnvgpuir.add_nvgpu_to_llvm(pm)
         nvidia.passes.ttnvgpuir.add_warp_specialize_to_llvm(pm)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -511,12 +511,14 @@ private:
       function_ref<Interval<size_t>(Value value)> getLiveness) {
     for (auto valueBufferIter : allocation->valueBuffer) {
       auto value = valueBufferIter.first;
-      auto *buffer = valueBufferIter.second;
-      bufferRange[buffer] = getLiveness(value);
-      LLVM_DEBUG({
-        llvm::dbgs() << "-- buffer " << buffer->id << "; value: ";
-        value.dump();
-      });
+      // After #9314 a value can map to multiple buffers (partitioned tensors).
+      for (auto *buffer : valueBufferIter.second) {
+        bufferRange[buffer] = getLiveness(value);
+        LLVM_DEBUG({
+          llvm::dbgs() << "-- buffer " << buffer->id << "; value: ";
+          value.dump();
+        });
+      }
     }
   }
 
@@ -2277,7 +2279,9 @@ public:
     for (auto alloc : allocs) {
       // size is 0, alignment is default, offset is default
       allocation.addBuffer<BufferT::BufferKind::Explicit>(alloc, 0);
-      BufferT *tBuf = allocation.valueBuffer[alloc];
+      // addBuffer maps the value to a single explicit buffer; take it. (After
+      // #9314 valueBuffer maps to a SmallVector<BufferT *>.)
+      BufferT *tBuf = allocation.valueBuffer[alloc].back();
       auto iter1 = allocToSize.find(alloc.getOperation());
       tBuf->rowSize = iter1->second.numRows;
       tBuf->colSize = iter1->second.numCols;
@@ -2310,11 +2314,13 @@ public:
     }
 
     for (auto valueBufferIter : allocation.valueBuffer) {
-      auto *buffer = valueBufferIter.second;
-      // valueBuffer maps value to BufferT
+      // valueBuffer maps a value to its BufferT(s). After #9314 a value can map
+      // to multiple buffers (partitioned tensors), so iterate over all of them.
       Operation *alloc = valueBufferIter.first.getDefiningOp();
       // bufferRange maps BufferT to interval
-      bufferRange[buffer] = allocToIntervals[alloc];
+      for (auto *buffer : valueBufferIter.second) {
+        bufferRange[buffer] = allocToIntervals[alloc];
+      }
     }
     // For each innermost loop according to program order (via
     // getIntervalForCtrlOp)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -50,7 +50,7 @@ struct ConvertLayoutOpSwizzlingConversion
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));
     auto dims = conversion.getInDimNames();
-    if (!llvm::is_contained(dims, kBlock) &&
+    if (!llvm::is_contained(dims, kBlock) && !cvtAlwaysUseWarpShuffle(op) &&
         cvtNeedsSharedMemory(srcTy, dstTy)) {
       auto loc = op.getLoc();
       // Remove the kBlock dimension from the layout as it's the identity in the

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -40,25 +40,53 @@ enum BarrierIndex {
   kNumBarriers = 16
 };
 
-static void createBarrier(TritonLLVMIRRewriter &b, unsigned barIdx,
-                          unsigned numThreads) {
-  assert(barIdx < kNumBarriers && "not enough barriers");
-  // If a partition has only 1 warp, use `bar.warp.sync`.
-  if (numThreads == 32)
-    LLVM::NVIDIA::createSyncWarp(b.getLoc(), b);
-  else
-    NVVM::BarrierOp::create(b, b.getLoc(), mlir::TypeRange{}, b.i32_val(barIdx),
-                            b.i32_val(numThreads),
-                            /*reductionOp=*/nullptr,
-                            /*reductionPredicate=*/nullptr);
-}
+class NVIDIAWarpSpecializeBarrierHelper : public WarpSpecializeBarrierHelper {
+public:
+  NVIDIAWarpSpecializeBarrierHelper(unsigned numThreadsPerWarp)
+      : numThreadsPerWarp(numThreadsPerWarp) {}
 
-static void createAllBarrier(TritonLLVMIRRewriter &b, unsigned barIdx) {
-  assert(barIdx < kNumBarriers && "not enough barriers");
-  LLVM::createLLVMIntrinsicCallOp(b, b.getLoc(),
-                                  "llvm.nvvm.barrier.cta.sync.all",
-                                  void_ty(b.getContext()), b.i32_val(barIdx));
-}
+  bool isBarrierOp(Operation *op) const override {
+    return isa<NVVM::Barrier0Op>(op);
+  }
+
+  Type getBarrierHandleType(MLIRContext *ctx) const override {
+    return IntegerType::get(ctx, 32);
+  }
+
+  FailureOr<Value>
+  getBarrierHandle(TritonLLVMIRRewriter &b,
+                   std::optional<unsigned> partitionIdx) override {
+    unsigned barIdx;
+    if (!partitionIdx) {
+      barIdx = kDefaultWarpGroupBarrierIdx;
+    } else {
+      barIdx = *partitionIdx + kNumReservedBarriers;
+      if (barIdx >= kNumBarriers) {
+        return mlir::emitError(b.getLoc(), "cannot support more than ")
+               << (kNumBarriers - kNumReservedBarriers)
+               << " warp group partitions";
+      }
+    }
+    return b.i32_val(barIdx);
+  }
+
+  void createBarrier(TritonLLVMIRRewriter &b, unsigned numWarps,
+                     Value handle) override {
+    unsigned numThreads = numWarps * numThreadsPerWarp;
+    // If a partition has only 1 warp, use `bar.warp.sync`.
+    if (numThreads == 32) {
+      LLVM::NVIDIA::createSyncWarp(b.getLoc(), b);
+    } else {
+      NVVM::BarrierOp::create(b, b.getLoc(), mlir::TypeRange{}, handle,
+                              b.i32_val(numThreads),
+                              /*reductionOp=*/nullptr,
+                              /*reductionPredicate=*/nullptr);
+    }
+  }
+
+private:
+  unsigned numThreadsPerWarp;
+};
 
 //===----------------------------------------------------------------------===//
 // lowerWarpSpecialize
@@ -79,49 +107,6 @@ static void createRegRealloc(TritonLLVMIRRewriter &b, int curRegs,
   NVVM::SetMaxRegisterOp::create(b, b.getLoc(), adjRegs, action);
 }
 
-// Assign hardware barriers to each warp group and rewrite warp group barriers
-// into `barrier.sync` instructions. There is a maximum number of barriers.
-static LogicalResult rewriteWarpGroupBarriers(LLVM::LLVMFuncOp func,
-                                              ArrayRef<WarpSpecializeOp> wsOps,
-                                              unsigned threadsPerWarp,
-                                              unsigned defaultWarpGroupSize) {
-  // HACK: Turn all `nvvm.barrier0` ops into warp group barriers.
-  func.walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
-    // Walk into default regions but not partition regions.
-    if (isa<WarpSpecializePartitionsOp>(op))
-      return WalkResult::skip();
-
-    if (auto bar = dyn_cast<NVVM::Barrier0Op>(op)) {
-      TritonLLVMIRRewriter b(bar.getLoc(), bar);
-      createBarrier(b, kDefaultWarpGroupBarrierIdx, defaultWarpGroupSize);
-      bar.erase();
-      return WalkResult::skip();
-    }
-    return WalkResult::advance();
-  });
-
-  // Each partition executes simultaneously, so each will get a different
-  // barrier ID, but note this means there is a maximum of 16 barriers.
-  for (WarpSpecializeOp op : wsOps) {
-    for (auto [idx, partition] : llvm::enumerate(op.getPartitionRegions())) {
-      unsigned barIdx = idx + kNumReservedBarriers;
-      if (barIdx >= kNumBarriers) {
-        return func.emitError("cannot support more than ")
-               << (kNumBarriers - kNumReservedBarriers)
-               << " warp group partitions";
-      }
-      unsigned warpGroupSize = threadsPerWarp * op.getPartitionNumWarps()[idx];
-      partition->walk([&](NVVM::Barrier0Op bar) {
-        TritonLLVMIRRewriter b(bar.getLoc(), bar);
-        createBarrier(b, barIdx, warpGroupSize);
-        bar.erase();
-      });
-    }
-  }
-
-  return success();
-}
-
 static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
                                          const NVIDIA::TargetInfo &targetInfo) {
   SmallVector<WarpSpecializeOp> wsOps;
@@ -134,10 +119,6 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
   auto module = cast<ModuleOp>(func->getParentOp());
   unsigned threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(module);
   unsigned defaultNumWarps = lookupNumWarps(func);
-  unsigned defaultWarpGroupSize = threadsPerWarp * defaultNumWarps;
-  if (failed(rewriteWarpGroupBarriers(func, wsOps, threadsPerWarp,
-                                      defaultWarpGroupSize)))
-    return failure();
 
   auto totalNumWarpsAttr =
       module->getAttrOfType<IntegerAttr>("ttg.total-num-warps");
@@ -221,7 +202,9 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
 
   WarpSpecializeCallbacks callbacks;
   callbacks.createAllBarrier = [](TritonLLVMIRRewriter &b, unsigned barIdx) {
-    createAllBarrier(b, barIdx);
+    assert(barIdx < kNumBarriers && "not enough barriers");
+    LLVM::createLLVMIntrinsicCallOp(
+        b, b.getLoc(), "llvm.nvvm.barrier.cta.sync.all", {}, b.i32_val(barIdx));
   };
 
   callbacks.reallocRegisters = [&](TritonLLVMIRRewriter &b, WarpSpecializeOp ws,
@@ -291,9 +274,14 @@ struct ConvertWarpSpecializeToLLVM
     if (failed(runPipeline(pm, mod)))
       return signalPassFailure();
 
+    unsigned threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
+    NVIDIAWarpSpecializeBarrierHelper barrierHelper(threadsPerWarp);
+    if (failed(lowerWarpSpecializeBarriers(mod, barrierHelper)))
+      return signalPassFailure();
+
     SmallVector<LLVM::LLVMFuncOp> kernels;
     for (auto func : mod.getOps<LLVM::LLVMFuncOp>()) {
-      if (func.isPublic())
+      if (func.getLinkage() == LLVM::Linkage::External)
         kernels.push_back(func);
     }
     for (LLVM::LLVMFuncOp kernel : kernels)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -189,8 +189,8 @@ struct ConvertTritonGPUToLLVM
                                                            patterns, benefit);
     mlir::triton::NVIDIA::populateFp4ToFpToLLVMPatterns(typeConverter, patterns,
                                                         benefit);
-    mlir::triton::populateInstrumentationToLLVMPatterns(
-        typeConverter, targetInfo, patterns, benefit);
+    mlir::triton::populateInstrumentationToLLVMPatterns(typeConverter,
+                                                        patterns);
 
     TritonLLVMConversionTarget convTarget(*context);
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))


### PR DESCRIPTION
Summary:

Folded bundle of 6 upstream OAI Triton commits cherry-picked into triton/beta. Tested as one diff via `reactor lab reactor-ci` (native A/B against trunk). Hashes below are the upstream OAI commit hashes.

This batch stops at #9366: the next upstream commit #9219 ("[BACKEND] Improve and simplify ReduceOp's lowering") is a 514-line refactor that collides with a Meta-only tree-reduction feature (isInnerTree / inner_tree, getContigPerThreadOnReductionAxis, getThreadOffsetOnReductionAxis) and needs domain review; it is deferred to a follow-up and is NOT part of this bundle.

Reactor-Bundle:
- [1] 7505c8c1 PR #9314 '[AMD] Introduce PartitionedSharedEncodingAttr' — RESOLVED(Membar.cpp, AllocateSharedMemoryUtility.cpp, test-allocation.mlir)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2381813018/  Resolution diff: https://www.internalfb.com/intern/paste/P2381818900/  Comparison: https://www.internalfb.com/intern/paste/P2381821858/
- [2] b5d4cd8e PR #9360 '[AMD][BACKEND] Support padding in TDM store if interval equals the inner dimension' — CLEAN
- [3] f9dc962f PR #9367 'Revert "[AMD] Introduce PartitionedSharedEncodingAttr"' — RESOLVED(Membar.cpp, AllocateSharedMemoryUtility.cpp)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2381873291/  Resolution diff: https://www.internalfb.com/intern/paste/P2381876357/  Comparison: https://www.internalfb.com/intern/paste/P2381878822/
- [4] a9cdb41e PR #9194 'Consider rematerialisation cost when hoisting over ext' — RESOLVED(RemoveLayoutConversions.cpp)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2381880362/  Resolution diff: https://www.internalfb.com/intern/paste/P2381884593/  Comparison: https://www.internalfb.com/intern/paste/P2381886516/
- [5] dca670e8 PR #9374 'Reapply "[AMD] Introduce PartitionedSharedEncodingAttr"' — RESOLVED(Membar.cpp, AllocateSharedMemoryUtility.cpp)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2381887796/  Resolution diff: https://www.internalfb.com/intern/paste/P2381889187/  Comparison: https://www.internalfb.com/intern/paste/P2381890046/
- [6] 0bc402c9 PR #9366 '[ConSan] First pass at improving ConSan compile times' — RESOLVED(WarpSpecializeUtility.cpp, passes.cc, ConvertWarpSpecializeToLLVM.cpp)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2381893681/  Resolution diff: https://www.internalfb.com/intern/paste/P2381897635/  Comparison: https://www.internalfb.com/intern/paste/P2381898862/

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 0bc402c968b069a45ab326526b08232e55eb2cee

Reviewed By: dshi7

Differential Revision: D108807716
