### PR TITLE
[CI] Enable ARM (aarch64) and full Python matrix in fbtriton wheel build

### DIFF
--- a/.github/workflows/wheels_fb.yml
+++ b/.github/workflows/wheels_fb.yml
@@ -81,8 +81,6 @@ jobs:
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_aarch64:latest"
           fi
           export CIBW_BUILD="${{ matrix.python }}-manylinux_${{ matrix.arch }}"
-          # cp313t/cp314t are free-threaded ABIs; cibuildwheel skips them unless opted in.
-          export CIBW_ENABLE=cpython-freethreading
 
           # Defensive: tell auditwheel not to follow libtriton.so's deps into
           # triton.libs/. Currently a no-op because TRITON_BUILD_WITH_CLANG_LLD=1

--- a/.github/workflows/wheels_fb.yml
+++ b/.github/workflows/wheels_fb.yml
@@ -32,7 +32,7 @@ jobs:
       # ABIs/arches work and which break.
       fail-fast: false
       matrix:
-        python: [cp310, cp311, cp312, cp313, cp314, cp313t, cp314t]
+        python: [cp310, cp311, cp312, cp313, cp314]
         arch: [x86_64, aarch64]
 
     steps:

--- a/.github/workflows/wheels_fb.yml
+++ b/.github/workflows/wheels_fb.yml
@@ -32,10 +32,8 @@ jobs:
       # ABIs/arches work and which break.
       fail-fast: false
       matrix:
-        python: [cp312, cp313, cp314]
-        arch: [x86_64]
-        # python: [cp310, cp311, cp312, cp313, cp314]
-        # arch: [x86_64, aarch64]
+        python: [cp310, cp311, cp312, cp313, cp314, cp313t, cp314t]
+        arch: [x86_64, aarch64]
 
     steps:
       - name: Checkout
@@ -83,6 +81,8 @@ jobs:
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_aarch64:latest"
           fi
           export CIBW_BUILD="${{ matrix.python }}-manylinux_${{ matrix.arch }}"
+          # cp313t/cp314t are free-threaded ABIs; cibuildwheel skips them unless opted in.
+          export CIBW_ENABLE=cpython-freethreading
 
           # Defensive: tell auditwheel not to follow libtriton.so's deps into
           # triton.libs/. Currently a no-op because TRITON_BUILD_WITH_CLANG_LLD=1


### PR DESCRIPTION
Expands wheels_fb.yml's matrix from cp312/313/314 × x86_64 to cp310..cp314 + cp313t/cp314t × {x86_64, aarch64}, matching what upstream wheels.yml builds. Native ubuntu-22.04-arm runners handle aarch64 (no QEMU). CIBW_ENABLE=cpython-freethreading is set so the free-threaded ABIs are actually built.
