### PR TITLE
[sched2tlx] fix outer-loop variable-name collision via a global name counter (#1758)

### DIFF
--- a/third_party/tlx/tools/sched2tlx/sched2tlx/emitter.py
+++ b/third_party/tlx/tools/sched2tlx/sched2tlx/emitter.py
@@ -219,6 +219,21 @@ class RenderCtx:
     # Used when an emitter resolves a buffer via alloc_op_var instead of
     # (loop_id, buf_id).
     partition_alloc_names: dict[str, list[str]] = field(default_factory=dict)
+    # Monotonic, globally-unique counter for auto-named variables. Every
+    # auto-named op draws a fresh index via `fresh_idx()`, so names minted in
+    # different scopes (preamble, each per-WG outer-loop body, epilogue,
+    # infra-deps, ...) can NEVER collide. The previous code used a separate
+    # counter per scope that each restarted at 0, which silently produced
+    # duplicate names like `div_4`; inside a loop a reassigned name is
+    # loop-carried, so an in-loop op auto-named `div_4 = tile_id // div_4`
+    # clobbered the preamble's `div_4 = cdiv(N, 128)` and corrupted the tile
+    # address arithmetic on every iteration after the first.
+    _var_seq: int = 0
+
+    def fresh_idx(self) -> int:
+        """Return the next globally-unique auto-name index."""
+        self._var_seq += 1
+        return self._var_seq
 
 
 def _render_operand(ref: OperandRef, rctx: RenderCtx) -> str:
@@ -1143,15 +1158,13 @@ def _kernel_sig_lines(g: ScheduleGraph, lines: _Lines) -> None:
 def _emit_preamble(g: ScheduleGraph, loop: Loop, rctx: RenderCtx, lines: _Lines) -> None:
     lines += "# ── Preamble (function-scope ops before the loop) ──"
     pre_ops = _ops_before_loop(g, loop)
-    var_idx = 0
     for op in pre_ops:
         if op.kind in _SKIP_FUNCTION_SCOPE:
             continue
         if op.kind not in _NAMED_FUNCTION_OPS:
             continue
         # Auto-name based on op kind (descriptors get nice names).
-        name = _auto_name(op, var_idx)
-        var_idx += 1
+        name = _auto_name(op, rctx.fresh_idx())
         rctx.op_var[op.op_id] = name
         rhs = _render_op_expr(op, rctx)
         lines += f"{name} = {rhs}"
@@ -1845,7 +1858,6 @@ def _emit_default_partition(g: ScheduleGraph, loop: Loop, rctx: RenderCtx, lines
             lines += f"{ch['var_name']} = tlx.local_load({ch['bufname']}[0])"
         # Find the tmem_load → arith.truncf → ttg.convert_layout → tt.descriptor_store chain.
         # Render each non-skipped epilogue op.
-        var_idx = 0
         for op in epi_ops:
             if op.kind in _SKIP_FUNCTION_SCOPE:
                 continue
@@ -1861,8 +1873,7 @@ def _emit_default_partition(g: ScheduleGraph, loop: Loop, rctx: RenderCtx, lines
                 rt = op.result_types[0] if op.result_types else ""
                 sd = _parse_tensor_shape(rt)
                 target = _dtype_str_to_tl(sd[1]) if sd else "tl.float16"
-                name = f"trunc_{var_idx}"
-                var_idx += 1
+                name = f"trunc_{rctx.fresh_idx()}"
                 rctx.op_var[op.op_id] = name
                 lines += f"{name} = {inner}.to({target})"
                 continue
@@ -1882,8 +1893,7 @@ def _emit_default_partition(g: ScheduleGraph, loop: Loop, rctx: RenderCtx, lines
                 lines += "tlx.async_descriptor_store_wait(0)"
                 continue
             if op.kind in _NAMED_FUNCTION_OPS:
-                name = _auto_name(op, var_idx)
-                var_idx += 1
+                name = _auto_name(op, rctx.fresh_idx())
                 rctx.op_var[op.op_id] = name
                 lines += f"{name} = {_render_op_expr(op, rctx)}"
 
@@ -2762,9 +2772,7 @@ def _emit_in_loop_node(
     if n.op_kind in _IN_LOOP_NAMED_OPS and n.op_kind != "arith.constant":
         if op.op_id in rctx.op_var:
             return  # already named earlier in this scope
-        seed = int(rctx.op_var.get("__inloop_var_seed__", "0"))
-        name = _auto_name(op, 100 + seed)
-        rctx.op_var["__inloop_var_seed__"] = str(seed + 1)
+        name = _auto_name(op, rctx.fresh_idx())
         rctx.op_var[op.op_id] = name
         lines += f"{name} = {_render_op_expr(op, rctx)}"
         if _use_semaphore_ir():
@@ -3176,10 +3184,8 @@ def _replicate_infra_deps(
             if isinstance(o, OpRef):
                 _collect_infra_deps_recursive(g, o.op_id, visited, rctx, to_emit)
 
-    var_idx = 1000  # avoid clashing with preamble names
     for op in to_emit:
-        name = _auto_name(op, var_idx)
-        var_idx += 1
+        name = _auto_name(op, rctx.fresh_idx())
         rctx.op_var[op.op_id] = name
         lines += f"{name} = {_render_op_expr(op, rctx)}"
 
@@ -3489,7 +3495,6 @@ def _emit_outer_epilogue_partitioned(
     g: ScheduleGraph,
     rctx: RenderCtx,
     lines: _Lines,
-    var_idx: list[int],
 ) -> None:
     """Emit Pass A.5 partitioned epilogue chain inside the outer loop body.
 
@@ -3537,8 +3542,7 @@ def _emit_outer_epilogue_partitioned(
                 rt = op.result_types[0] if op.result_types else ""
                 sd = _parse_tensor_shape(rt)
                 target = _dtype_str_to_tl(sd[1]) if sd else "tl.float16"
-                name = f"trunc_g{gi}_{var_idx[0]}"
-                var_idx[0] += 1
+                name = f"trunc_g{gi}_{rctx.fresh_idx()}"
                 rctx.op_var[op.op_id] = name
                 lines += f"{name} = {inner}.to({target})"
                 continue
@@ -3613,7 +3617,6 @@ def _emit_outer_epilogue_subtiled(
     g: ScheduleGraph,
     rctx: RenderCtx,
     lines: _Lines,
-    var_idx: list[int],
 ) -> None:
     """Emit a Pass A.7 subtiled epilogue chain inside the outer loop body.
 
@@ -3668,8 +3671,7 @@ def _emit_outer_epilogue_subtiled(
                 rt = op.result_types[0] if op.result_types else ""
                 sd = _parse_tensor_shape(rt)
                 target = _dtype_str_to_tl(sd[1]) if sd else "tl.float16"
-                name = f"trunc_{sub_n}_{var_idx[0]}"
-                var_idx[0] += 1
+                name = f"trunc_{sub_n}_{rctx.fresh_idx()}"
                 rctx.op_var[op.op_id] = name
                 lines += f"{name} = {inner}.to({target})"
                 continue
@@ -3701,7 +3703,7 @@ def _emit_outer_epilogue_subtiled(
     # the persistent for-loop to drain remaining in-flight stores.
 
 
-def _emit_outer_op(n: Node, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines, var_idx: list[int]) -> None:
+def _emit_outer_op(n: Node, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines) -> None:
     """Emit one outer-loop op (computational or epilogue side-effect)."""
     op = g.ops.get(n.op_ref) if n.op_ref else None
     if op is None or op.kind in _SKIP_FUNCTION_SCOPE:
@@ -3753,8 +3755,7 @@ def _emit_outer_op(n: Node, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines, va
         rt = op.result_types[0] if op.result_types else ""
         sd = _parse_tensor_shape(rt)
         target = _dtype_str_to_tl(sd[1]) if sd else "tl.float16"
-        name = f"trunc_{var_idx[0]}"
-        var_idx[0] += 1
+        name = f"trunc_{rctx.fresh_idx()}"
         rctx.op_var[op.op_id] = name
         lines += f"{name} = {inner}.to({target})"
         return
@@ -3772,8 +3773,7 @@ def _emit_outer_op(n: Node, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines, va
         lines += "tlx.async_descriptor_store_wait(0)"
         return
     if op.kind in _NAMED_FUNCTION_OPS:
-        name = _auto_name(op, var_idx[0])
-        var_idx[0] += 1
+        name = _auto_name(op, rctx.fresh_idx())
         rctx.op_var[op.op_id] = name
         lines += f"{name} = {_render_op_expr(op, rctx)}"
         return
@@ -3851,7 +3851,6 @@ def _emit_uwg_body_impl(
     lines += (f"# Outer persistent loop (loop {outer.loop_id}, II={outer.schedule.II}). "
               f"Each task replays it; body trimmed to this WG's ops.")
     with lines.block(f"for {out_iv} in range({out_lo}, {out_hi}, {out_step}):"):
-        var_idx = [0]
         # Per-tile TMEM ring-buffer indexing.
         if has_tmem:
             tc = rctx.tmem_count
@@ -3907,8 +3906,7 @@ def _emit_uwg_body_impl(
 
             in_loop_infra = [op for op in in_loop_infra if not _depends_on_outer_load(op.op_id)]
         for op in in_loop_infra:
-            name = _auto_name(op, var_idx[0])
-            var_idx[0] += 1
+            name = _auto_name(op, rctx.fresh_idx())
             rctx.op_var[op.op_id] = name
             lines += f"{name} = {_render_op_expr(op, rctx)}"
 
@@ -3924,7 +3922,7 @@ def _emit_uwg_body_impl(
             op = g.ops.get(n.op_ref) if n.op_ref else None
             if op is None or op.op_id in rctx.op_var:
                 continue
-            _emit_outer_op(n, g, rctx, lines, var_idx)
+            _emit_outer_op(n, g, rctx, lines)
 
         # Pass A.7: detect a subtiled epilogue chain. When present, the chain
         # nodes get emitted as a single `for sub_n` loop instead of per-op.
@@ -3943,7 +3941,7 @@ def _emit_uwg_body_impl(
                 continue
             if sub_info and i == subtile_start:
                 chain_nodes = outer_nodes[subtile_start:subtile_end]
-                _emit_outer_epilogue_subtiled(chain_nodes, sub_info[2], sub_info[3], g, rctx, lines, var_idx)
+                _emit_outer_epilogue_subtiled(chain_nodes, sub_info[2], sub_info[3], g, rctx, lines)
                 continue
             if sub_info and subtile_start < i < subtile_end:
                 continue  # already emitted inside the subtile loop
@@ -3956,12 +3954,11 @@ def _emit_uwg_body_impl(
                     g,
                     rctx,
                     lines,
-                    var_idx,
                 )
                 continue
             if part_info and part_start < i < part_end:
                 continue  # already emitted inside the partition loop
-            _emit_outer_op(n, g, rctx, lines, var_idx)
+            _emit_outer_op(n, g, rctx, lines)
 
         # Advance the TMEM ring counter at end of each tile (both default
         # and TC partitions, so tmem_buf/tmem_phase stay in sync).

--- a/third_party/tlx/tools/sched2tlx/test_outer_loop_name_collision.py
+++ b/third_party/tlx/tools/sched2tlx/test_outer_loop_name_collision.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Reproducer + regression test for the outer-persistent-loop variable-name
+collision in the sched2tlx emitter.
+
+Root cause
+----------
+The emitter auto-names ops (`div_2`, `mul_7`, ...) with a counter that USED TO
+restart at 0 in every scope. The function-scope preamble and each per-warp-group
+outer-loop body therefore minted overlapping names. An outer-loop body op then
+gets a name already used by the preamble — and because a name reassigned inside
+a loop is loop-carried, the body's `mul_7 = ...` (or `div_4 = tile_id // div_4`)
+CLOBBERS the preamble's `mul_7 = cdiv(M,128)*cdiv(N,128)` (the loop bound) /
+`div_4 = cdiv(N,128)`. The address arithmetic is then corrupt on every iteration
+after the first. It only manifests once a program executes >1 outer tile (a
+persistent kernel at scale), so small-shape / few-tile runs pass and the bug
+surfaces as a CUDA "illegal instruction" / wrong result only at scale.
+
+Fixture
+-------
+`test_outer_loop_name_collision.schedule_graph.json` is a hand-written minimal
+persistent kernel (4 ops, 2 loops): the preamble computes the loop bound as an
+`arith.muli` (auto-named `mul_0`), and the persistent outer-loop body has an
+`arith.muli` tile offset that the old per-scope counter ALSO auto-names `mul_0`.
+The emitted kernel is then `for tile_id in range(0, mul_0, 1): ...; mul_0 =
+(tile_id * 128)` — the body reassigns the loop bound `mul_0`, the exact clobber
+this bug causes. With the old per-scope counter `mul_0 = ...` appears TWICE; with
+the global counter (`RenderCtx.fresh_idx()`) every auto-named variable is unique.
+
+Run: `python3 test_outer_loop_name_collision.py` (stdlib only, no GPU).
+Exit 0 / "PASS" after the fix; raises AssertionError before it.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+FIXTURE = SCRIPT_DIR / "test_outer_loop_name_collision.schedule_graph.json"
+
+# Op-name prefixes minted by the emitter's `_auto_name` (see _OP_KIND_NAME_PREFIX)
+# plus the `trunc_` epilogue names — these are the collision-prone auto-names.
+_AUTO_NAME_RE = re.compile(
+    r"^(mul|div|rem|add|sub|ext|trunc|exp2|log2|maxf|minf|sqrt|rsqrt|"
+    r"addf|subf|mulf|divf|red|expand|bcast|splat|reshape|trans|join|"
+    r"addptr|cvt|mdt|tmload)_\d+$"
+)
+
+
+def _load_emitter():
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    from sched2tlx import emitter, schedule_graph  # noqa: E402
+
+    return emitter, schedule_graph
+
+
+def _duplicate_auto_names(src: str) -> list[str]:
+    seen: set[str] = set()
+    dups: set[str] = set()
+    for tgt in re.findall(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s", src, re.M):
+        if not _AUTO_NAME_RE.match(tgt):
+            continue
+        if tgt in seen:
+            dups.add(tgt)
+        seen.add(tgt)
+    return sorted(dups)
+
+
+def main() -> int:
+    emitter, schedule_graph = _load_emitter()
+    if not FIXTURE.exists():
+        raise SystemExit(f"fixture not found: {FIXTURE}")
+
+    src = emitter.emit(schedule_graph.load_graph(str(FIXTURE)))
+
+    dups = _duplicate_auto_names(src)
+    assert not dups, (
+        "outer-loop-body auto-names collide with the preamble: "
+        f"{dups} each assigned more than once. A loop-carried reassignment of a "
+        "preamble variable (e.g. `mul_7 = ...` / `div_4 = tile_id // div_4`) "
+        "corrupts the tile address arithmetic after the first iteration. Fix: "
+        "give every auto-named variable a globally-unique index via "
+        "RenderCtx.fresh_idx()."
+    )
+    print("PASS: all auto-named variables are unique across scopes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/tlx/tools/sched2tlx/test_outer_loop_name_collision.schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/test_outer_loop_name_collision.schedule_graph.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "0.1",
+  "kernel": {
+    "name": "repro_name_collision",
+    "args": []
+  },
+  "ops": {
+    "loop_bound_mul": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [
+        {
+          "const": 4,
+          "type": "i32"
+        },
+        {
+          "const": 8,
+          "type": "i32"
+        }
+      ],
+      "result_types": [
+        "i32"
+      ],
+      "attributes": {}
+    },
+    "inner_for": {
+      "kind": "scf.for",
+      "scope": "loop:1",
+      "operands": [],
+      "result_types": [],
+      "attributes": {}
+    },
+    "body_off_mul": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [
+        {
+          "iv": 1
+        },
+        {
+          "const": 128,
+          "type": "i32"
+        }
+      ],
+      "result_types": [
+        "i32"
+      ],
+      "attributes": {}
+    },
+    "epilogue_store": {
+      "kind": "tt.descriptor_store",
+      "scope": "loop:1",
+      "operands": [
+        {
+          "arg": "out"
+        },
+        {
+          "const": 0,
+          "type": "tensor<128x128xf16>"
+        },
+        {
+          "op": "body_off_mul"
+        }
+      ],
+      "result_types": [],
+      "attributes": {}
+    }
+  },
+  "loops": [
+    {
+      "loop_id": 0,
+      "is_outer": false,
+      "warp_groups": [],
+      "schedule_loop": {
+        "id": 0,
+        "II": 1,
+        "max_stage": 0,
+        "induction_var": {
+          "name": "iv",
+          "type": "i32"
+        },
+        "lower_bound": {
+          "const": 0,
+          "type": "i32"
+        },
+        "upper_bound": {
+          "const": 4,
+          "type": "i32"
+        },
+        "step": {
+          "const": 1,
+          "type": "i32"
+        },
+        "buffers": [],
+        "graph": {
+          "nodes": [],
+          "edges": [],
+          "cross_wg_barriers": []
+        }
+      }
+    },
+    {
+      "loop_id": 1,
+      "is_outer": true,
+      "warp_groups": [
+        {
+          "id": 0,
+          "num_warps": 4,
+          "pipelines": [
+            "TMA"
+          ]
+        }
+      ],
+      "schedule_loop": {
+        "id": 1,
+        "II": 1,
+        "max_stage": 0,
+        "induction_var": {
+          "name": "iv",
+          "type": "i32"
+        },
+        "lower_bound": {
+          "const": 0,
+          "type": "i32"
+        },
+        "upper_bound": {
+          "op": "loop_bound_mul"
+        },
+        "step": {
+          "const": 1,
+          "type": "i32"
+        },
+        "buffers": [],
+        "graph": {
+          "nodes": [
+            {
+              "id": 0,
+              "op_ref": "inner_for",
+              "op_kind": "scf.for",
+              "warp_group": 0,
+              "child_pipeline_id": 0,
+              "produces_buffer": null,
+              "consumes_buffers": []
+            },
+            {
+              "id": 1,
+              "op_ref": "epilogue_store",
+              "op_kind": "tt.descriptor_store",
+              "warp_group": 0,
+              "produces_buffer": null,
+              "consumes_buffers": []
+            }
+          ],
+          "edges": [],
+          "cross_wg_barriers": []
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Summary:

The emitter auto-named ops (`div_2`, `mul_7`, ...) with a counter that restarted at 0 in every scope, so the function-scope preamble and each per-warp-group outer-loop body minted overlapping names. A persistent-loop body op could thus reuse a preamble name; because a name reassigned inside a loop is loop-carried, the body's `mul_7 = ...` (or `div_4 = tile_id // div_4`) CLOBBERED the preamble's loop bound `mul_7 = cdiv(M,128)*cdiv(N,128)` / `div_4 = cdiv(N,128)`, corrupting the per-tile address arithmetic on every iteration after the first. The bug only manifests once a program runs more than one outer tile (a persistent kernel at scale), so small-shape / few-tile runs pass and it surfaces only at scale as a CUDA "illegal instruction" or wrong result. Whether any given kernel tripped it depended purely on op counts lining a body auto-name up with a preamble one.

Fix: route every auto-named variable through a single monotonic counter on `RenderCtx` (`fresh_idx()`) instead of a per-scope counter that restarts at 0. Names are now globally unique across the preamble, every per-WG outer-loop body, the epilogue/default partition, infra-deps, and subtile/partition chains, so no scope can shadow another's variable. This also subsumes the previous ad-hoc offsets (`var_idx = 1000  # avoid clashing with preamble names`, the `100 + seed` in-loop offset).

`test_outer_loop_name_collision.py` is a stdlib-only reproducer: it loads `test_outer_loop_name_collision.schedule_graph.json` — a hand-written minimal persistent kernel (4 ops, 2 loops) whose preamble computes the loop bound as an `arith.muli` (auto-named `mul_0`) and whose outer-loop body has an `arith.muli` tile offset that the old per-scope counter ALSO auto-names `mul_0`. The emitted kernel is then `for tile_id in range(0, mul_0, 1): ...; mul_0 = (tile_id * 128)` — the body reassigns the loop bound `mul_0`, the exact clobber this bug causes. The test emits and asserts every auto-named variable is assigned exactly once: before this fix it fails with `AssertionError: ... ['mul_0'] each assigned more than once`; after it, it prints PASS.

This PR was authored with Claude.

Reviewed By: wlei-llvm

Differential Revision: D108804400


