### PR TITLE
[triton] Route the JIT kernel launcher through one shared C launch core (#1768)

### DIFF
--- a/python/test/unit/runtime/test_launch_kernel_core.py
+++ b/python/test/unit/runtime/test_launch_kernel_core.py
@@ -1,0 +1,131 @@
+"""Tests that the JIT variadic launcher (driver.c::launchKernel) routes through
+the shared data-driven core ``triton_launch_kernel`` in ``triton/runtime/launch.h``.
+
+The default launch path (no ``TRITON_USE_TRITON_DISPATCHER``) goes through
+``kernel.run() -> CudaLauncher -> launchKernel``. To make these tests robust
+regardless of defaults, each test installs a ``launch_enter_hook``: jit.py only
+takes the C-dispatcher / c_cache fast paths when *no* launch hooks are set, so a
+hook guarantees the ``launchKernel`` path and — because the hook is invoked
+*inside* ``launchKernel`` — a non-zero hook-call count proves that path ran.
+"""
+
+import contextlib
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton import knobs
+from triton._internal_testing import is_cuda
+
+
+@contextlib.contextmanager
+def force_launch_kernel_path():
+    """Install a launch_enter_hook to force (and prove) the launchKernel path."""
+    counter = {"calls": 0}
+
+    def _enter(_metadata):
+        counter["calls"] += 1
+
+    prev = knobs.runtime.launch_enter_hook
+    knobs.runtime.launch_enter_hook = _enter
+    try:
+        yield counter
+    finally:
+        knobs.runtime.launch_enter_hook = prev
+
+
+@triton.jit
+def _add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x + y, mask=mask)
+
+
+@triton.jit
+def _nop_kernel():
+    pass
+
+
+@triton.jit
+def _scalar_mix_kernel(x_ptr, out_ptr, fscale, iadd, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x * fscale + iadd, mask=mask)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_add_numerics():
+    N = 4096
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    with force_launch_kernel_path() as counter:
+        _add_kernel[grid](x, y, out, N, BLOCK=256)
+    torch.testing.assert_close(out, x + y)
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_nop_zero_args():
+    with force_launch_kernel_path() as counter:
+        _nop_kernel[(1, )]()
+    torch.cuda.synchronize()
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_mixed_scalar_args():
+    N = 2048
+    x = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    with force_launch_kernel_path() as counter:
+        _scalar_mix_kernel[grid](x, out, 2.5, 3, N, BLOCK=128)
+    torch.testing.assert_close(out, x * 2.5 + 3)
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_empty_grid():
+    """An empty (0) grid must be a no-op, not a CUDA error — the shared core
+    skips a zero-sized grid (parity with the legacy JIT _launch)."""
+    N = 1024
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.zeros(N, device="cuda")
+    with force_launch_kernel_path() as counter:
+        _add_kernel[(0, )](x, y, out, N, BLOCK=256)  # empty grid: no work
+    torch.cuda.synchronize()
+    # out must be untouched (kernel never ran)
+    torch.testing.assert_close(out, torch.zeros(N, device="cuda"))
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_host_tma_passthrough():
+    """Host-side TMA: Python builds the CUtensorMap; launchKernel passes it
+    through args_buf as an ordinary (is_tma=0) param to the shared core."""
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    M, N = 128, 128
+    M_BLOCK, N_BLOCK = 64, 64
+
+    @triton.jit
+    def _td_kernel(out_ptr, desc, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        block = desc.load([0, 0])
+        idx = (tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :])
+        tl.store(out_ptr + idx, block)
+
+    t = torch.randn((M, N), device="cuda")
+    out = torch.empty((M_BLOCK, N_BLOCK), device="cuda")
+    desc = TensorDescriptor(t, shape=t.shape, strides=t.stride(), block_shape=[M_BLOCK, N_BLOCK])
+    with force_launch_kernel_path() as counter:
+        _td_kernel[(1, )](out, desc, M_BLOCK, N_BLOCK)
+    torch.testing.assert_close(out, t[:M_BLOCK, :N_BLOCK])
+    assert counter["calls"] > 0, "launchKernel path was not exercised"

--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -17,8 +17,14 @@ from triton.backends.nvidia.driver import (
     expand_signature,
     make_kernel_signature,
 )
+from triton._internal_testing import is_cuda
 from triton.compiler.compiler import ASTSource, compile as triton_compile, make_backend
 from triton.knobs import HookChain
+
+# These tests validate NVIDIA-specific launch metadata and the CUDA C
+# `launcher_src` (CUresult/CUdeviceptr/cuda.h/launch.h). The HIP backend has no
+# make_launcher_src, so skip the whole module on non-CUDA targets.
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="NVIDIA launch metadata / launcher_src is CUDA-only")
 
 
 @triton.jit
@@ -305,8 +311,10 @@ def test_launcher_src_bakes_constants():
     )
     src = compiled.asm["launcher_src"]
     md = compiled.metadata
-    assert f"/*num_warps=*/{md.num_warps}" in src
-    assert f"/*shared_mem=*/{md.shared}u" in src
+    assert f".num_warps = {md.num_warps}," in src
+    assert f".shared_mem = {md.shared}u," in src
+    # Param offsets use offsetof (C compiler owns layout, not Python).
+    assert "offsetof(" in src
 
 
 def test_launcher_src_has_abi_version_comment():
@@ -318,6 +326,94 @@ def test_launcher_src_has_abi_version_comment():
     )
     src = compiled.asm["launcher_src"]
     assert "ABI version: 1" in src
+
+
+def test_launcher_src_compiles_with_gcc():
+    """Generated C should compile with the system C compiler (validates struct
+    layout, offsetof usage, and launch.h compatibility)."""
+    import os
+    import shutil
+    import subprocess
+    import tempfile
+    import triton.backends.nvidia
+
+    @triton.jit
+    def _gcc_test_add(X, Y, OUT, N, BLOCK: tl.constexpr):
+        offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < N
+        tl.store(OUT + offs, tl.load(X + offs, mask=mask) + tl.load(Y + offs, mask=mask), mask=mask)
+
+    # Force a fresh triton compilation cache so we always run make_launcher_src
+    # (the disk cache keys on source hash + options, not compiler.py version).
+    with tempfile.TemporaryDirectory() as fresh_cache:
+        prev_cache = os.environ.get("TRITON_CACHE_DIR")
+        os.environ["TRITON_CACHE_DIR"] = fresh_cache
+        try:
+            compiled = _compile_kernel(
+                _gcc_test_add,
+                signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+                constexprs={"BLOCK": 1024},
+            )
+        finally:
+            if prev_cache is None:
+                os.environ.pop("TRITON_CACHE_DIR", None)
+            else:
+                os.environ["TRITON_CACHE_DIR"] = prev_cache
+
+    src = compiled.asm.get("launcher_src")
+    if not src:
+        # Diagnostic: understand WHY launcher_src is missing on this environment
+        target = triton.runtime.driver.active.get_current_target()
+        from triton.compiler.compiler import make_backend
+        backend = make_backend(target)
+        diag = (f"launcher_src not in asm. Diagnostics:\n"
+                f"  target: {target}\n"
+                f"  backend type: {type(backend).__name__}\n"
+                f"  has make_launcher_src: {hasattr(backend, 'make_launcher_src')}\n"
+                f"  asm keys: {sorted(compiled.asm.keys())}\n"
+                f"  TRITON_CACHE_DIR: {os.environ.get('TRITON_CACHE_DIR', '<not set>')}")
+        pytest.fail(diag)
+
+    # Find launch.h: try the canonical source location, then the packaged one.
+    backend_dir = os.path.dirname(os.path.realpath(triton.backends.nvidia.__file__))
+    candidates = [
+        os.path.join(backend_dir, "launch.h"),
+        os.path.join(backend_dir, "..", "..", "..", "python", "triton", "runtime", "launch.h"),
+    ]
+    launch_h = next((p for p in candidates if os.path.exists(p)), None)
+    if launch_h is None:
+        pytest.skip("launch.h not found for compile test")
+
+    # Find a C compiler
+    cc = shutil.which("gcc") or shutil.which("clang") or shutil.which("cc")
+    if cc is None:
+        pytest.skip("No C compiler available")
+
+    # Find cuda.h include dir
+    cuda_include = os.path.join(backend_dir, "include")
+    if not os.path.exists(os.path.join(cuda_include, "cuda.h")):
+        pytest.skip("cuda.h not found")
+
+    with tempfile.NamedTemporaryFile(suffix=".c", mode="w", delete=False) as f:
+        # Inline launch.h into the source (same as the JIT runtime compile does
+        # via driver.py) so we only need -I for cuda.h — avoids fragile
+        # triton_include path resolution in buck link-tree environments.
+        from pathlib import Path
+        launch_h_content = Path(launch_h).read_text()
+        test_src = src.replace('#include "triton/runtime/launch.h"', launch_h_content)
+        f.write(test_src)
+        f.flush()
+        try:
+            result = subprocess.run(
+                [cc, "-fsyntax-only", "-c", f.name, f"-I{cuda_include}"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 0, (f"Generated launcher_src failed to compile:\n"
+                                            f"stdout: {result.stdout}\nstderr: {result.stderr}")
+        finally:
+            os.unlink(f.name)
 
 
 # =============================================================================

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -559,7 +559,6 @@ class nvidia_knobs(base_knobs):
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
-    use_llvm_launcher: env_bool = env_bool("TRITON_USE_LLVM_LAUNCHER")
     use_triton_dispatcher: env_bool = env_bool("TRITON_USE_TRITON_DISPATCHER")
     use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")

--- a/python/triton/runtime/launch.h
+++ b/python/triton/runtime/launch.h
@@ -7,7 +7,11 @@
  * is a plain C function callable from C, C++, or via ctypes/cffi.
  *
  * Consumers: compiler-generated launcher sources (asm["launcher_src"]),
- *            TritonCC, AOT-T, custom integrations.
+ *            TritonCC, AOT-T, JIT (variadic launcher), custom integrations.
+ *
+ * ALL consumers call the same function: triton_launch_kernel().
+ * TMA construction, params[] layout, and launch attribute setup all happen
+ * inside this one function.  Changes to TMA promotion only need to update here.
  */
 
 #ifndef TRITON_RUNTIME_LAUNCH_H
@@ -19,6 +23,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,6 +80,14 @@ static triton_cuLaunchKernelEx_fn g_triton_launch_fn = NULL;
  * Note: dlopen handle is intentionally not closed — libcuda.so.1 must remain
  * loaded for the process lifetime since cuLaunchKernelEx is called on every
  * kernel launch.
+ *
+ * This (and g_triton_launch_fn) are `static`, so every translation unit that
+ * includes this header gets its own copy + its own constructor. When many
+ * generated launchers are linked into one binary (e.g. an AOT-T .so with many
+ * kernels, or a TritonCC bundle) each TU independently dlopen's libcuda at
+ * startup, bumping its (never-released) refcount. That is harmless — the
+ * library stays mapped regardless — just redundant; we accept it to keep
+ * launch.h header-only (no companion .c to compile/link per consumer).
  */
 __attribute__((constructor)) static void triton_init_launch_kernel_ex(void) {
   void *lib = dlopen("libcuda.so.1", RTLD_LAZY);
@@ -85,17 +98,12 @@ __attribute__((constructor)) static void triton_init_launch_kernel_ex(void) {
       (triton_cuLaunchKernelEx_fn)dlsym(lib, "cuLaunchKernelEx");
 }
 
-/**
- * Get cuLaunchKernelEx function pointer (loaded at startup).
- * Thread-safe — initialization happens before main().
- * Returns NULL if libcuda.so.1 is not available.
- */
 static inline triton_cuLaunchKernelEx_fn triton_get_launch_kernel_ex(void) {
   return g_triton_launch_fn;
 }
 
 /* -------------------------------------------------------------------------
- * Launch attribute helpers
+ * Launch descriptor (data-driven launch)
  * ------------------------------------------------------------------------- */
 
 /**
@@ -104,98 +112,283 @@ static inline triton_cuLaunchKernelEx_fn triton_get_launch_kernel_ex(void) {
  * cluster dim.
  */
 #define TRITON_MAX_LAUNCH_ATTRS 5
+#define TRITON_MAX_TMA_DESCS 8
+#define TRITON_MAX_TMA_DIMS 5
+#define TRITON_MAX_PARAMS 256
 
 /**
- * Build the CUlaunchAttribute array and return the number of attributes set.
- *
- * All parameters are compile-time constants baked into the generated launcher.
- * This function is meant to be called from generated code.
+ * ABI version of triton_kernel_launch_desc_t.  Bump this whenever the struct
+ * layout below changes in a backward-incompatible way.  Producers stamp this
+ * into desc->abi_version and triton_launch_kernel() rejects mismatches at
+ * runtime, so a stale ctypes mirror (launch_desc.py) or generated launcher is
+ * caught instead of silently corrupting kernel args.
  */
-static inline unsigned triton_build_launch_attrs(
-    CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS], int launch_pdl,
-    int launch_cooperative_grid, int num_ctas, int launch_cluster,
-    int preferred_cluster_dim_x, int preferred_cluster_dim_y,
-    int preferred_cluster_dim_z) {
-  unsigned n = 0;
+#define TRITON_LAUNCH_DESC_ABI_VERSION 1
 
-  if (launch_pdl) {
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
-    attrs[n].value.programmaticStreamSerializationAllowed = 1;
-    n++;
-  }
-
-  if (launch_cooperative_grid) {
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
-    attrs[n].value.cooperative = 1;
-    n++;
-  }
-
-  if (launch_cluster || num_ctas > 1) {
-    /* Triton clusters are always 1-D (num_ctas along x); multi-dimensional
-     * clusters use the ctas_per_cga / PTX .reqnctapercluster path where
-     * num_ctas == 1 and no runtime CLUSTER_DIMENSION attr is needed. */
-    if (num_ctas > 1) {
-      attrs[n].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-      attrs[n].value.clusterDim.x = (unsigned)num_ctas;
-      attrs[n].value.clusterDim.y = 1;
-      attrs[n].value.clusterDim.z = 1;
-      n++;
-    }
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
-    attrs[n].value.clusterSchedulingPolicyPreference =
-        CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
-    n++;
-  }
-
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
-  if (preferred_cluster_dim_x > 0) {
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
-    attrs[n].value.clusterDim.x = (unsigned)preferred_cluster_dim_x;
-    attrs[n].value.clusterDim.y = (unsigned)preferred_cluster_dim_y;
-    attrs[n].value.clusterDim.z = (unsigned)preferred_cluster_dim_z;
-    n++;
-  }
+/* static_assert spelling differs between C11 and C++; provide one name. */
+#if defined(__cplusplus)
+#define TRITON_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
 #else
-  (void)preferred_cluster_dim_x;
-  (void)preferred_cluster_dim_y;
-  (void)preferred_cluster_dim_z;
+#define TRITON_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 #endif
 
-  return n;
+/**
+ * TMA recipe: describes how to construct one CUtensorMap from user args.
+ *
+ * All offsets refer to byte positions within the args_buf passed to
+ * triton_launch_kernel(). The launcher reads ptr/shape/stride values
+ * from args_buf at these offsets and calls cuTensorMapEncodeTiled().
+ *
+ * Compile-time constants (block_shape, swizzle, elem_type, etc.) are baked
+ * directly into the struct by the compiler.
+ */
+typedef struct {
+  int ndim;
+  uint32_t block_shape[TRITON_MAX_TMA_DIMS];
+  int swizzle;
+  int elem_type;
+  int elem_size;
+  int fp4_padded;
+  int fill_mode;
+  int ptr_offset;
+  int shape_offsets[TRITON_MAX_TMA_DIMS];
+  int stride_offsets[TRITON_MAX_TMA_DIMS];
+  int desc_param_idx;
+} triton_tma_recipe_t;
+
+/**
+ * Parameter descriptor: where in args_buf each kernel param lives.
+ * 'size' is currently unused by triton_launch_kernel() (which only reads
+ * offset and is_tma) but reserved for future use (e.g. debug validation).
+ */
+typedef struct {
+  int offset;
+  int size;
+  int is_tma;
+} triton_param_desc_t;
+
+/**
+ * Per-kernel launch descriptor: everything needed to launch a kernel.
+ * Generated by the compiler as a static const, passed to
+ * triton_launch_kernel().
+ */
+typedef struct {
+  int abi_version; /* must equal TRITON_LAUNCH_DESC_ABI_VERSION */
+  int num_warps;
+  int num_ctas;
+  unsigned shared_mem;
+  int launch_pdl;
+  int launch_cooperative_grid;
+  int launch_cluster;
+  int preferred_cluster_dims[3];
+
+  int num_params;
+  triton_param_desc_t params[TRITON_MAX_PARAMS];
+
+  int num_tma_recipes;
+  triton_tma_recipe_t tma_recipes[TRITON_MAX_TMA_DESCS];
+} triton_kernel_launch_desc_t;
+
+/*
+ * Layout guards.  All fields are 4-byte (int / unsigned / int32 arrays /
+ * structs of ints) so the structs are tightly packed with no padding.  These
+ * asserts catch accidental layout drift between this header and the Python
+ * ctypes mirror in third_party/nvidia/backend/launch_desc.py (which assumes the
+ * same layout).
+ */
+TRITON_STATIC_ASSERT(sizeof(triton_param_desc_t) == 3 * sizeof(int),
+                     "triton_param_desc_t layout drift");
+TRITON_STATIC_ASSERT(sizeof(triton_tma_recipe_t) == 23 * sizeof(int),
+                     "triton_tma_recipe_t layout drift");
+TRITON_STATIC_ASSERT(sizeof(triton_kernel_launch_desc_t) ==
+                         11 * sizeof(int) +
+                             TRITON_MAX_PARAMS * sizeof(triton_param_desc_t) +
+                             sizeof(int) +
+                             TRITON_MAX_TMA_DESCS * sizeof(triton_tma_recipe_t),
+                     "triton_kernel_launch_desc_t layout drift");
+
+/* -------------------------------------------------------------------------
+ * Lazy-loaded cuTensorMapEncodeTiled (for TMA)
+ * ------------------------------------------------------------------------- */
+
+typedef CUresult (*triton_cuTensorMapEncodeTiled_fn)(
+    CUtensorMap *tensorMap, CUtensorMapDataType tensorDataType,
+    cuuint32_t tensorRank, void *globalAddress, const cuuint64_t *globalDim,
+    const cuuint64_t *globalStrides, const cuuint32_t *boxDim,
+    const cuuint32_t *elementStrides, CUtensorMapInterleave interleave,
+    CUtensorMapSwizzle swizzle, CUtensorMapL2promotion l2Promotion,
+    CUtensorMapFloatOOBfill oobFill);
+
+static triton_cuTensorMapEncodeTiled_fn g_triton_tma_encode_fn = NULL;
+
+/**
+ * Initialize cuTensorMapEncodeTiled at program startup (same pattern as
+ * triton_init_launch_kernel_ex). Thread-safe by running before main().
+ */
+__attribute__((constructor)) static void triton_init_tma_encode(void) {
+  void *lib = dlopen("libcuda.so.1", RTLD_LAZY);
+  if (!lib)
+    return;
+  g_triton_tma_encode_fn =
+      (triton_cuTensorMapEncodeTiled_fn)dlsym(lib, "cuTensorMapEncodeTiled");
+}
+
+static inline triton_cuTensorMapEncodeTiled_fn triton_get_tma_encode(void) {
+  return g_triton_tma_encode_fn;
 }
 
 /**
- * Build and execute a CUlaunchConfig.  Consolidates the common launch pattern.
+ * Construct a single CUtensorMap from a TMA recipe and user args.
  *
- * @param grid          Grid dimensions [x, y, z]
- * @param num_warps     Warps per block (compile-time constant)
- * @param num_ctas      CTAs per cluster (compile-time constant)
- * @param shared_mem    Dynamic shared memory in bytes (compile-time constant)
- * @param stream        CUDA stream
- * @param function      CUDA function handle
- * @param params        Kernel parameter array (void*[])
- * @param attrs         Pre-built launch attributes
- * @param num_attrs     Number of launch attributes
- * @return              CUDA_SUCCESS or error code
+ * STUB: only the shared-core skeleton (recipe struct + this launcher call site)
+ * lands in this diff. The encoder body must match the proven JIT encoder
+ * byte-for-byte (row-major -> column-major dim reversal, derived outermost
+ * stride, L2_128B promotion, small-tensor driver workaround); that correct
+ * implementation, with a byte-compare unit test, lands in a later diff. No
+ * consumer emits TMA recipes until then (num_tma_recipes == 0), so this path is
+ * never exercised in the meantime.
  */
 static inline CUresult
-triton_launch_kernel(const uint32_t grid[3], int num_warps, int num_ctas,
-                     unsigned shared_mem, CUstream stream, CUfunction function,
-                     void **params, CUlaunchAttribute *attrs,
-                     unsigned num_attrs) {
+triton_construct_tma_desc(CUtensorMap *desc, const triton_tma_recipe_t *recipe,
+                          const void *args_buf) {
+  (void)desc;
+  (void)recipe;
+  (void)args_buf;
+  return CUDA_ERROR_NOT_SUPPORTED;
+}
+
+/* -------------------------------------------------------------------------
+ * triton_launch_kernel — THE one function all consumers call.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Launch a Triton kernel.  This is the ONLY launch entry point.
+ *
+ * All consumers (JIT variadic launcher, TritonCC, AOT-T) call this function.
+ * It handles: TMA construction, params[] layout, launch attrs,
+ * cuLaunchKernelEx.
+ *
+ * @param grid       Grid dimensions [x, y, z]
+ * @param stream     CUDA stream
+ * @param function   CUDA function handle
+ * @param args_buf   Flat buffer containing user args at known offsets
+ * @param desc       Per-kernel static launch descriptor (compiler-generated)
+ * @return           CUDA_SUCCESS or error code
+ */
+static inline CUresult
+triton_launch_kernel(const uint32_t grid[3], CUstream stream,
+                     CUfunction function, void *args_buf,
+                     const triton_kernel_launch_desc_t *desc) {
+
+  if (!function)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (!desc)
+    return CUDA_ERROR_INVALID_VALUE;
+  /* Reject a descriptor built against a different ABI (e.g. a stale ctypes
+   * mirror or a generated launcher compiled against an older launch.h). */
+  if (desc->abi_version != TRITON_LAUNCH_DESC_ABI_VERSION)
+    return CUDA_ERROR_INVALID_VALUE;
+
+  /* Empty grid: nothing to launch. Matches the legacy JIT _launch skip and
+   * avoids cuLaunchKernelEx rejecting a zero-sized grid. */
+  if (grid[0] == 0 || grid[1] == 0 || grid[2] == 0)
+    return CUDA_SUCCESS;
 
   triton_cuLaunchKernelEx_fn launch_fn = triton_get_launch_kernel_ex();
   if (!launch_fn)
     return CUDA_ERROR_NOT_FOUND;
 
+  /* --- TMA: construct descriptors from recipes --- */
+  if (desc->num_tma_recipes > 0) {
+    if (desc->num_tma_recipes > TRITON_MAX_TMA_DESCS) {
+      fprintf(stderr,
+              "[triton] ERROR: num_tma_recipes (%d) exceeds "
+              "TRITON_MAX_TMA_DESCS (%d)\n",
+              desc->num_tma_recipes, TRITON_MAX_TMA_DESCS);
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    if (!triton_get_tma_encode()) {
+      fprintf(stderr,
+              "[triton] ERROR: kernel has %d TMA recipes but "
+              "cuTensorMapEncodeTiled is unavailable (driver too old?)\n",
+              desc->num_tma_recipes);
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+  }
+  __attribute__((aligned(64))) CUtensorMap tma_descs[TRITON_MAX_TMA_DESCS];
+  for (int i = 0; i < desc->num_tma_recipes; i++) {
+    TRITON_CUDA_CHECK(triton_construct_tma_desc(
+        &tma_descs[i], &desc->tma_recipes[i], args_buf));
+  }
+
+  /* --- Build kernel params[] array --- */
+  if (desc->num_params > TRITON_MAX_PARAMS)
+    return CUDA_ERROR_INVALID_VALUE;
+  void *params[TRITON_MAX_PARAMS];
+  int tma_idx = 0;
+  for (int i = 0; i < desc->num_params; i++) {
+    if (desc->params[i].is_tma) {
+      if (tma_idx >= desc->num_tma_recipes)
+        return CUDA_ERROR_INVALID_VALUE;
+      params[i] = (void *)&tma_descs[tma_idx++];
+    } else {
+      params[i] = (void *)((char *)args_buf + desc->params[i].offset);
+    }
+  }
+
+  /* --- Build launch attributes --- */
+  CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS];
+  unsigned num_attrs = 0;
+
+  if (desc->launch_pdl) {
+    attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+    attrs[num_attrs].value.programmaticStreamSerializationAllowed = 1;
+    num_attrs++;
+  }
+
+  if (desc->launch_cooperative_grid) {
+    attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+    attrs[num_attrs].value.cooperative = 1;
+    num_attrs++;
+  }
+
+  if (desc->launch_cluster || desc->num_ctas > 1) {
+    if (desc->num_ctas > 1) {
+      attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+      attrs[num_attrs].value.clusterDim.x = (unsigned)desc->num_ctas;
+      attrs[num_attrs].value.clusterDim.y = 1;
+      attrs[num_attrs].value.clusterDim.z = 1;
+      num_attrs++;
+    }
+    attrs[num_attrs].id =
+        CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+    attrs[num_attrs].value.clusterSchedulingPolicyPreference =
+        CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+    num_attrs++;
+  }
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+  if (desc->preferred_cluster_dims[0] > 0) {
+    attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
+    attrs[num_attrs].value.clusterDim.x =
+        (unsigned)desc->preferred_cluster_dims[0];
+    attrs[num_attrs].value.clusterDim.y =
+        (unsigned)desc->preferred_cluster_dims[1];
+    attrs[num_attrs].value.clusterDim.z =
+        (unsigned)desc->preferred_cluster_dims[2];
+    num_attrs++;
+  }
+#endif
+
+  /* --- Launch --- */
   CUlaunchConfig config;
-  config.gridDimX = grid[0] * (uint32_t)num_ctas;
+  config.gridDimX = grid[0] * (uint32_t)desc->num_ctas;
   config.gridDimY = grid[1];
   config.gridDimZ = grid[2];
-  config.blockDimX = 32 * (uint32_t)num_warps;
+  config.blockDimX = 32 * (uint32_t)desc->num_warps;
   config.blockDimY = 1;
   config.blockDimZ = 1;
-  config.sharedMemBytes = shared_mem;
+  config.sharedMemBytes = desc->shared_mem;
   config.hStream = stream;
   config.attrs = attrs;
   config.numAttrs = num_attrs;

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -468,6 +468,9 @@ class CUDABackend(BaseBackend):
 
         # ---- Args struct ----
         lines.append("typedef struct {")
+        if not args:
+            # Zero-arg kernel: empty struct is a GCC extension, not valid C.
+            lines.append("    char _unused;")
         for arg in args:
             c_ty = _c_type(arg["type"])
             if c_ty is None:
@@ -476,6 +479,44 @@ class CUDABackend(BaseBackend):
             lines.append(f"    {c_ty} {arg['name']};")
         lines.append(f"}} {safe_name}_args_t;")
         lines.append("")
+
+        # ---- Buffer type: args + scratch, used for offsetof in the descriptor.
+        # Natural (non-packed) alignment: each kernel param pointer (built from
+        # offsetof below) lands on a correctly-aligned, correctly-sized value.
+        # The C compiler — not Python — owns the args-buffer layout.
+        buf_t = f"{safe_name}_buf_t"
+        lines.append("typedef struct {")
+        lines.append(f"    {safe_name}_args_t k;")
+        lines.append("    CUdeviceptr _global_scratch;")
+        lines.append("    CUdeviceptr _profile_scratch;")
+        lines.append(f"}} {buf_t};")
+        lines.append("")
+
+        # Helper: offsetof expression for a field inside buf_t.k
+        def _off(field):
+            return f"(int)offsetof({buf_t}, k.{field})"
+
+        # Build param descriptors. offsetof gives the offset and sizeof gives
+        # the size, so the C compiler owns the layout end to end -- no Python
+        # type->size table that could silently disagree with the real ABI for an
+        # unmapped C type.
+        param_entries = []
+        for arg in args:
+            c_ty = _c_type(arg["type"])
+            param_entries.append((_off(arg["name"]), f"(int)sizeof({c_ty})", 0))
+        # Scratch params (device pointers).
+        param_entries.append((f"(int)offsetof({buf_t}, _global_scratch)", "(int)sizeof(CUdeviceptr)", 0))
+        param_entries.append((f"(int)offsetof({buf_t}, _profile_scratch)", "(int)sizeof(CUdeviceptr)", 0))
+        num_params = len(param_entries)
+        # Mirror the fixed cap in launch.h: triton_kernel_launch_desc_t.params is
+        # a triton_param_desc_t[TRITON_MAX_PARAMS] array, so a descriptor with
+        # more entries would overflow the static initializer. Bail out (the
+        # consumer falls back to the variadic launcher) instead of emitting C
+        # that overflows or silently truncates.
+        TRITON_MAX_PARAMS = 256  # keep in sync with launch.h
+        if num_params > TRITON_MAX_PARAMS:
+            return (f"/* Launcher not generated: {num_params} params exceeds "
+                    f"TRITON_MAX_PARAMS ({TRITON_MAX_PARAMS}) */\n")
 
         # ---- Launch function ----
         lines.append("/**")
@@ -491,58 +532,45 @@ class CUDABackend(BaseBackend):
             lines.append(f" *   profile_scratch_size={profile_scratch_size}")
         lines.append(" */")
 
+        # ---- Launch wrapper (descriptor is function-local to avoid name collisions
+        # when TritonCC puts multiple specs in the same .cpp) ----
         lines.append(f"CUresult triton_launch_{safe_name}(")
         lines.append("    const uint32_t grid[3],")
         lines.append("    CUstream stream,")
         lines.append("    CUfunction function,")
         lines.append(f"    {safe_name}_args_t *args,")
-        # Always include scratch params for stable ABI across all kernels.
-        # Callers pass 0/NULL when the kernel doesn't use scratch buffers.
         lines.append("    CUdeviceptr global_scratch,")
         lines.append("    CUdeviceptr profile_scratch")
         lines.append(") {")
-
-        # Null checks
         lines.append("    if (!args) return CUDA_ERROR_INVALID_VALUE;")
-        lines.append("    if (!function) return CUDA_ERROR_INVALID_HANDLE;")
         lines.append("")
 
-        # Build params array
-        param_names = [f"args->{arg['name']}" for arg in args]
-        param_names.append("global_scratch")
-        param_names.append("profile_scratch")
-
-        lines.append("    /* Kernel parameter pointers */")
-        for i, pname in enumerate(param_names):
-            lines.append(f"    void *_param{i} = (void *)&{pname};")
-        lines.append("    void *params[] = {")
-        for i in range(len(param_names)):
-            comma = "," if i < len(param_names) - 1 else ""
-            lines.append(f"        _param{i}{comma}")
+        # Static const descriptor inside function body
+        lines.append("    static const triton_kernel_launch_desc_t desc = {")
+        lines.append("        .abi_version = TRITON_LAUNCH_DESC_ABI_VERSION,")
+        lines.append(f"        .num_warps = {num_warps},")
+        lines.append(f"        .num_ctas = {num_ctas},")
+        lines.append(f"        .shared_mem = {shared_mem}u,")
+        lines.append(f"        .launch_pdl = {launch_pdl},")
+        lines.append(f"        .launch_cooperative_grid = {launch_coop},")
+        lines.append(f"        .launch_cluster = {launch_cluster_flag},")
+        lines.append(f"        .preferred_cluster_dims = {{{preferred[0]}, {preferred[1]}, {preferred[2]}}},")
+        lines.append(f"        .num_params = {num_params},")
+        lines.append("        .params = {")
+        for off_expr, sz, is_tma in param_entries:
+            lines.append(f"            {{{off_expr}, {sz}, {is_tma}}},")
+        lines.append("        },")
+        lines.append("        .num_tma_recipes = 0,")
+        lines.append("        /* tma_recipes zero-initialized by C default */")
         lines.append("    };")
         lines.append("")
-
-        # Build launch attributes (compile-time constants)
-        lines.append("    /* Launch attributes (compile-time constants) */")
-        lines.append("    CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS];")
-        lines.append("    unsigned num_attrs = triton_build_launch_attrs(")
-        lines.append("        attrs,")
-        lines.append(f"        /*launch_pdl=*/{launch_pdl},")
-        lines.append(f"        /*launch_cooperative_grid=*/{launch_coop},")
-        lines.append(f"        /*num_ctas=*/{num_ctas},")
-        lines.append(f"        /*launch_cluster=*/{launch_cluster_flag},")
-        lines.append(f"        /*preferred_cluster_dim_x=*/{preferred[0]},")
-        lines.append(f"        /*preferred_cluster_dim_y=*/{preferred[1]},")
-        lines.append(f"        /*preferred_cluster_dim_z=*/{preferred[2]}")
-        lines.append("    );")
+        lines.append("    /* Pack args + scratch into one buffer; launcher reads by offset. */")
+        lines.append(f"    {buf_t} buf;")
+        lines.append("    buf.k = *args;")
+        lines.append("    buf._global_scratch = global_scratch;")
+        lines.append("    buf._profile_scratch = profile_scratch;")
         lines.append("")
-
-        # Call triton_launch_kernel
-        lines.append("    return triton_launch_kernel(")
-        lines.append(f"        grid, /*num_warps=*/{num_warps}, /*num_ctas=*/{num_ctas},")
-        lines.append(f"        /*shared_mem=*/{shared_mem}u, stream, function,")
-        lines.append("        params, attrs, num_attrs")
-        lines.append("    );")
+        lines.append("    return triton_launch_kernel(grid, stream, function, &buf, &desc);")
         lines.append("}")
 
         return "\n".join(lines) + "\n"

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -9,6 +9,10 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+/* Shared, Python-free data-driven launch core (params[]/TMA/attrs/launch).
+ * The same core is used by TritonCC / AOT-T via make_launcher_src. */
+#include "triton/runtime/launch.h"
+
 typedef struct {
   PyObject_HEAD;
   _Alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
@@ -1660,61 +1664,197 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
     goto cleanup;
   }
 
-  // Number of parameters passed to kernel. + 2 for global & profile scratch.
-  int num_params = num_args + 2;
-  void **params = (void **)alloca(num_params * sizeof(void *));
-  int params_idx = 0;
-  // This loop has to stay in the same function that owns params, since we are
-  // using alloca to allocate pointers to it on the stack of the function.
+  // ---- Route through the shared data-driven core triton_launch_kernel() ----
+  // The CPython arg extraction above is unchanged.  Instead of building a
+  // void *params[] and calling the legacy _launch(), we pack the extracted
+  // values into one flat args_buf and build a per-launch descriptor, then call
+  // the shared core in launch.h (the same core used by TritonCC / AOT-T).
+  //
+  // Safety net: if triton_launch_kernel fails, we automatically fall back to
+  // the proven legacy _launch() path and print a warning, so a bug in the
+  // new path never silently breaks production.
+  int num_params = (int)num_args + 2; // + global & profile scratch
+  if (num_params > TRITON_MAX_PARAMS) {
+    PyErr_Format(PyExc_RuntimeError,
+                 "Triton kernel has %d params, exceeds TRITON_MAX_PARAMS (%d)",
+                 num_params, TRITON_MAX_PARAMS);
+    goto cleanup;
+  }
+
+  triton_kernel_launch_desc_t desc;
+  desc.abi_version = TRITON_LAUNCH_DESC_ABI_VERSION;
+  desc.num_warps = num_warps;
+  desc.num_ctas = num_ctas;
+  desc.shared_mem = (unsigned)shared_memory;
+  desc.launch_pdl = launch_pdl;
+  desc.launch_cooperative_grid = launch_cooperative_grid;
+  /* Behavior-preserving vs the legacy _launch: that path requested cluster
+   * attributes iff (num_ctas != 1 || preferredClusterDimX > 0). Here we only
+   * carry the preferred-dim bit; the shared core also fires on num_ctas > 1,
+   * so the combined condition reproduces the legacy set. (The JIT launcher has
+   * no separate compile-time launch_cluster signal -- unlike TritonCC/AOT-T,
+   * which pass it explicitly from make_launcher_src metadata.) */
+  desc.launch_cluster = (preferredClusterDimX > 0) ? 1 : 0;
+  desc.preferred_cluster_dims[0] = preferredClusterDimX;
+  desc.preferred_cluster_dims[1] = preferredClusterDimY;
+  desc.preferred_cluster_dims[2] = preferredClusterDimZ;
+  desc.num_params = num_params;
+  // JIT TMA descriptors are pre-built in Python and passed by value through
+  // args_buf as ordinary params (is_tma = 0); the launcher-built recipe path
+  // (num_tma_recipes > 0) is reserved for auto-TMA.
+  desc.num_tma_recipes = 0;
+
+  // First pass: compute the args_buf layout (offset + size per param) using the
+  // same per-type extractor size/alignment the legacy path used, so the kernel
+  // sees identically laid-out parameter values.
+  Extractor *extractors = (Extractor *)alloca(num_args * sizeof(Extractor));
+  size_t buf_size = 0;
+  size_t max_align = sizeof(void *); // scratch pointers need 8B alignment
   for (Py_ssize_t i = 0; i < num_args; ++i) {
-    // Get extractor that will send back a struct with
-    // * size for allocation
-    // * function to call to put the parameter in params buffer
-    Extractor extractor = getExtractor(extractor_data[i]);
-    if (extractor.extract == NULL) {
+    Extractor e = getExtractor(extractor_data[i]);
+    if (e.extract == NULL) {
       goto cleanup;
     }
+    extractors[i] = e;
+    size_t al = e.alignment ? e.alignment : (e.size ? e.size : 1);
+    // Round up to next power of two (required for bitmask alignment below).
+    {
+      size_t v = al;
+      v--;
+      v |= v >> 1;
+      v |= v >> 2;
+      v |= v >> 4;
+      v |= v >> 8;
+      v |= v >> 16;
+      /* On 32-bit builds (sizeof(size_t)==4) a literal `v >> 32` is UB and
+       * warns
+       * (-Wshift-count-overflow); fold the width at compile time so it is 0
+       * there and 32 only where size_t is 64-bit. */
+      v |= v >> (sizeof(size_t) > 4 ? 32 : 0);
+      v++;
+      al = v;
+    }
+    if (al > max_align) {
+      max_align = al;
+    }
+    buf_size = (buf_size + al - 1) & ~(al - 1);
+    desc.params[i].offset = (int)buf_size;
+    desc.params[i].size = (int)e.size;
+    desc.params[i].is_tma = 0;
+    buf_size += e.size;
+  }
+  // Scratch params: two device pointers, 8-byte aligned.
+  buf_size = (buf_size + 7) & ~((size_t)7);
+  desc.params[num_args].offset = (int)buf_size;
+  desc.params[num_args].size = (int)sizeof(void *);
+  desc.params[num_args].is_tma = 0;
+  buf_size += sizeof(void *);
+  desc.params[num_args + 1].offset = (int)buf_size;
+  desc.params[num_args + 1].size = (int)sizeof(void *);
+  desc.params[num_args + 1].is_tma = 0;
+  buf_size += sizeof(void *);
 
-    size_t alignment = extractor.alignment;
-    if (alignment != 0) {
-      // Allocate enough space on the stack to guarantee an aligned block.
-      size_t size_with_alignment = extractor.size + alignment - 1;
-      void *storage_ptr = alloca(size_with_alignment);
-      void *aligned_ptr = (void *)((((uintptr_t)storage_ptr) + alignment - 1) &
-                                   ~(alignment - 1));
-      if (aligned_ptr == NULL) {
-        PyErr_SetString(PyExc_MemoryError, "Failed to align parameter storage");
+  // Allocate args_buf aligned to the largest element alignment so that every
+  // offset (computed relative to an aligned base) is absolutely aligned.
+  void *args_buf_raw = alloca(buf_size + max_align - 1);
+  void *args_buf =
+      (void *)(((uintptr_t)args_buf_raw + max_align - 1) & ~(max_align - 1));
+
+  // Second pass: extract each arg value into args_buf at its offset.
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    if (!extractors[i].extract((char *)args_buf + desc.params[i].offset,
+                               args_data[i])) {
+      goto cleanup;
+    }
+  }
+  if (!extractPointer((char *)args_buf + desc.params[num_args].offset,
+                      global_scratch_obj)) {
+    goto cleanup;
+  }
+  if (!extractPointer((char *)args_buf + desc.params[num_args + 1].offset,
+                      profile_scratch_obj)) {
+    goto cleanup;
+  }
+
+  {
+    const uint32_t grid[3] = {(uint32_t)gridX, (uint32_t)gridY,
+                              (uint32_t)gridZ};
+    CUresult _launch_err = CUDA_SUCCESS;
+    Py_BEGIN_ALLOW_THREADS;
+    // Parity with legacy _launch: allow non-portable 16-CTA clusters.
+    // Runs without the GIL (matching legacy _launch behavior).
+    if (num_ctas == 16) {
+      cuFuncSetAttribute((CUfunction)_function,
+                         CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED,
+                         1);
+      /* Return value intentionally ignored: on hardware that doesn't support
+       * this attribute, the call fails harmlessly and the subsequent launch
+       * will fail with a more specific error if clusters are truly needed.
+       * Logging here would spam stderr on every 16-CTA launch. */
+    }
+    _launch_err = triton_launch_kernel(grid, (CUstream)_stream,
+                                       (CUfunction)_function, args_buf, &desc);
+    Py_END_ALLOW_THREADS;
+    if (_launch_err != CUDA_SUCCESS) {
+      /* TRITON_ASSERT_NEW_LAUNCHER: in test/debug mode, skip fallback and
+       * fail hard so we know the new launcher has a bug (not masked). */
+      if (getenv("TRITON_ASSERT_NEW_LAUNCHER")) {
+        const char *_err_str = NULL;
+        cuGetErrorString(_launch_err, &_err_str);
+        PyErr_Format(PyExc_RuntimeError,
+                     "Triton Error [CUDA]: triton_launch_kernel failed: %s "
+                     "(TRITON_ASSERT_NEW_LAUNCHER=1, no fallback)",
+                     _err_str ? _err_str : "unknown");
         goto cleanup;
       }
-      params[params_idx] = aligned_ptr;
-    } else {
-      params[params_idx] = alloca(extractor.size);
-    }
-
-    PyObject *current_arg = args_data[i];
-    if (!extractor.extract(params[params_idx++], current_arg)) {
+      /* Shared-core launch failed — fall back to the proven legacy _launch()
+       * path so the kernel still runs.  Print a warning so the failure is
+       * visible and can be investigated without blocking the user. */
+      const char *_err_str = NULL;
+      cuGetErrorString(_launch_err, &_err_str);
+      static int _fb_warned = 0;
+      if (!__atomic_exchange_n(&_fb_warned, 1, __ATOMIC_RELAXED)) {
+        fprintf(stderr,
+                "[triton] WARNING: triton_launch_kernel failed (%s, err=%d), "
+                "falling back to legacy _launch path\n",
+                _err_str ? _err_str : "unknown", (int)_launch_err);
+      }
+      /* Reuse the values already extracted into args_buf: extraction succeeded
+       * on the primary path (only the launch failed), and the legacy _launch
+       * wants void* params pointing at each value -- exactly the
+       * args_buf + desc.params[i].offset slots (kernel args followed by the two
+       * scratch pointers). Pointing into args_buf avoids re-invoking the
+       * extractors (no double side effects) and the separate alignment logic;
+       * the offsets were already laid out with correct per-param alignment. */
+      void **_fb_params = (void **)alloca((size_t)num_params * sizeof(void *));
+      for (int i = 0; i < num_params; ++i)
+        _fb_params[i] = (char *)args_buf + desc.params[i].offset;
+      Py_BEGIN_ALLOW_THREADS;
+      _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
+              launch_pdl, preferredClusterDimX, preferredClusterDimY,
+              preferredClusterDimZ, shared_memory, (CUstream)_stream,
+              (CUfunction)_function, _fb_params);
+      Py_END_ALLOW_THREADS;
+      if (!PyErr_Occurred())
+        goto launch_ok; /* fallback succeeded */
+      /* Both paths failed. If the fallback set a more specific Python
+       * exception (e.g. extractor TypeError), keep it; otherwise report
+       * the original shared-core CUDA error. */
+      if (!PyErr_Occurred()) {
+        PyErr_Format(PyExc_RuntimeError,
+                     "Triton Error [CUDA]: triton_launch_kernel failed: %s "
+                     "(legacy fallback also failed)",
+                     _err_str ? _err_str : "unknown");
+      }
       goto cleanup;
     }
   }
-  // Add scratch objects.
-  params[params_idx] = alloca(sizeof(void *));
-  if (!extractPointer(params[params_idx++], global_scratch_obj)) {
-    goto cleanup;
-  }
-  params[params_idx] = alloca(sizeof(void *));
-  if (!extractPointer(params[params_idx++], profile_scratch_obj)) {
-    goto cleanup;
-  }
+launch_ok:
 
-  Py_BEGIN_ALLOW_THREADS;
-  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
-          launch_pdl, preferredClusterDimX, preferredClusterDimY,
-          preferredClusterDimZ, shared_memory, (CUstream)_stream,
-          (CUfunction)_function, params);
-  Py_END_ALLOW_THREADS;
-  if (PyErr_Occurred()) {
+  /* Symmetry with the legacy path: never run the exit hook with a pending
+   * Python exception. */
+  if (PyErr_Occurred())
     goto cleanup;
-  }
 
   if (!launchHook(launch_exit_hook, launch_metadata)) {
     goto cleanup;

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -17,6 +17,20 @@ from triton.backends.driver import (
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dirs = [os.path.join(dirname, "include")]
+# Path(s) to the shared data-driven launcher core. driver.c is compiled via a
+# fixed Remote-Execution command that ignores include_dirs, so we inline this
+# header into the driver.c source at build time (see CudaUtils.__init__) rather
+# than relying on an -I path.
+#
+# The first candidate (backend/launch.h) is a vendored copy that ships with the
+# nvidia backend resources (the BUCK glob packages it next to driver.py), so it
+# is present in packaged/buck builds. The second is the canonical source used by
+# C/C++ consumers (cc_library triton_launch_h). Keep the two in sync; the
+# canonical is python/triton/runtime/launch.h.
+_launch_h_candidates = [
+    os.path.join(dirname, "launch.h"),
+    os.path.join(dirname, "..", "..", "..", "python", "triton", "runtime", "launch.h"),
+]
 libdevice_dir = os.path.join(dirname, "lib")
 libraries = ["libcuda.so.1"]
 PyCUtensorMap = None
@@ -68,8 +82,24 @@ class CudaUtils(object):
         return cls.instance
 
     def __init__(self):
+        # Inline the shared launcher core (launch.h) directly into the driver
+        # source: the fbcode Remote-Execution compile uses a fixed clang command
+        # that does not honor include_dirs, so an `#include "triton/runtime/
+        # launch.h"` would not resolve. Substituting the header text keeps a
+        # single source of truth (launch.h) while making the compile
+        # self-contained.
+        driver_src = Path(os.path.join(dirname, "driver.c")).read_text()
+        launch_h_path = next((p for p in _launch_h_candidates if os.path.exists(p)), None)
+        if launch_h_path is None:
+            raise FileNotFoundError(f"launch.h not found in any of: {_launch_h_candidates}")
+        launch_h_src = Path(launch_h_path).read_text()
+        include_marker = '#include "triton/runtime/launch.h"'
+        if include_marker not in driver_src:
+            raise RuntimeError(f"driver.c must contain the marker {include_marker!r} for "
+                               "launch.h inlining, but it was not found")
+        driver_src = driver_src.replace(include_marker, launch_h_src)
         mod = compile_module_from_src(
-            src=Path(os.path.join(dirname, "driver.c")).read_text(),
+            src=driver_src,
             name="cuda_utils",
             library_dirs=library_dirs(),
             include_dirs=include_dirs,


### PR DESCRIPTION
Summary:

### Background
Triton has several CPU-side kernel launchers — the triton.jit
runtime ("variadic") launcher and separate generated-C launchers for the
ahead-of-time consumers (TritonCC, AOT-T). Each carries its own copy of the
launch logic: packing the kernel parameter buffer, building TMA descriptors,
setting launch attributes (clusters / PDL / cooperative), and calling
cuLaunchKernelEx. Keeping N copies in sync is error-prone, and any host-side
launch feature (TMA promotion, persistent grid, ...) has to be implemented N
times.

### What this does
Introduces a single, Python-free launch core —
triton_launch_kernel() in triton/runtime/launch.h — that owns all CPU-side
launch mechanics, driven by data (a per-kernel descriptor plus a flat argument
buffer), and routes the consumers through it. The JIT launcher keeps its Python
argument extraction but calls the shared core for the actual launch; the
TritonCC / AOT-T generated C emits the same descriptor and calls the same core.
This is a consolidation with no intended user-visible behavior change, so future
host-side launch work lives in exactly one place.

### Before / after
- Before: JIT, TritonCC, and AOT-T each had their own launch implementation
  (params + TMA + attributes + launch call) — three copies to maintain.
- After: all three build a small descriptor and call one shared
  triton_launch_kernel().

### Scope
This diff covers the default JIT path plus TritonCC / AOT-T. The optional
fast-path "dispatcher" and auto-TMA are converged in follow-up diffs in this
stack.

### Implementation note
the fbcode JIT runtime compile is routed through Remote
Execution with a fixed compiler command that ignores include paths, so launch.h
is inlined into the generated driver source at build time. The single canonical
launch.h (python/triton/runtime/launch.h) is packaged next to driver.py via the
nvidia_files genrule (no second copy of the header), so the runtime compile can
read it.

Reviewed By: htyu

Differential Revision: D108687968


