### PR TITLE
[triton] Converge the JIT dispatcher fast-path onto the shared launch core (#1770)

### DIFF
--- a/python/test/unit/cuda/test_tensordesc_tma_dispatcher.py
+++ b/python/test/unit/cuda/test_tensordesc_tma_dispatcher.py
@@ -3,7 +3,7 @@
 Verifies that kernels using TMA-path TensorDescriptors (nvTmaDesc) produce
 correct results when launched via:
   1. C fast cache (c_cache=True) — cache key correctly built
-  2. _TritonDispatcher (TRITON_USE_TRITON_DISPATCHER=1) — nvTmaDesc dispatched
+  2. _TritonDispatcher (TRITON_USE_C_DISPATCHER=1) — nvTmaDesc dispatched
   3. Repeated calls hit cache and still produce correct results
 """
 
@@ -50,7 +50,7 @@ class TestTmaTensorDescCorrectness(TestCase):
     """Verify TMA TensorDescriptor produces correct results via fast cache + dispatcher."""
 
     def setUp(self):
-        patcher = patch.dict(os.environ, {"TRITON_USE_TRITON_DISPATCHER": "1"})
+        patcher = patch.dict(os.environ, {"TRITON_USE_C_DISPATCHER": "1"})
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -176,7 +176,7 @@ class TestTmaCacheKeyDiscrimination(TestCase):
     """Verify the C fast cache correctly distinguishes TMA TensorDescriptor specializations."""
 
     def setUp(self):
-        patcher = patch.dict(os.environ, {"TRITON_USE_TRITON_DISPATCHER": "1"})
+        patcher = patch.dict(os.environ, {"TRITON_USE_C_DISPATCHER": "1"})
         patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/python/test/unit/runtime/test_dispatcher_core.py
+++ b/python/test/unit/runtime/test_dispatcher_core.py
@@ -1,0 +1,163 @@
+"""Tests that the JIT C dispatcher (_TritonDispatcher) launches through the
+shared core triton_launch_kernel() for the converged (non-TMA) path.
+
+The dispatcher is only built when TRITON_USE_C_DISPATCHER=1 (see
+CompiledKernel._init_handles). For non-TMA, non multi-dim-cluster kernels the
+dispatcher sets use_core_launch and routes td_relaunch through the shared core
+(driver.c). These tests force the dispatcher on and verify both end-to-end
+numerics and the converged path directly.
+"""
+
+import contextlib
+import os
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton import knobs
+from triton._internal_testing import is_cuda
+
+
+@contextlib.contextmanager
+def force_dispatcher():
+    prev_env = os.environ.get("TRITON_USE_C_DISPATCHER")
+    knobs.nvidia.use_triton_dispatcher = True
+    os.environ["TRITON_USE_C_DISPATCHER"] = "1"
+    try:
+        yield
+    finally:
+        # Clear the cached knob value so subsequent reads fall through to env
+        # (assigning prev_knob would leave a stale bool in obj.__dict__).
+        del knobs.nvidia.use_triton_dispatcher
+        if prev_env is None:
+            os.environ.pop("TRITON_USE_C_DISPATCHER", None)
+        else:
+            os.environ["TRITON_USE_C_DISPATCHER"] = prev_env
+
+
+@triton.jit
+def _disp_add(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x + y, mask=mask)
+
+
+@triton.jit
+def _disp_scalar_mix(x_ptr, out_ptr, fscale, iadd, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x * fscale + iadd, mask=mask)
+
+
+@triton.jit
+def _disp_nop():
+    pass
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_dispatcher_core_add_numerics():
+    N = 4096
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    with force_dispatcher():
+        _disp_add[grid](x, y, out, N, BLOCK=256)
+    torch.testing.assert_close(out, x + y)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_dispatcher_core_mixed_scalar_args():
+    N = 2048
+    x = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    with force_dispatcher():
+        _disp_scalar_mix[grid](x, out, 2.5, 3, N, BLOCK=128)
+    torch.testing.assert_close(out, x * 2.5 + 3)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_dispatcher_core_nop():
+    with force_dispatcher():
+        _disp_nop[(1, )]()
+    torch.cuda.synchronize()
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_dispatcher_core_empty_grid():
+    N = 1024
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.zeros(N, device="cuda")
+    with force_dispatcher():
+        _disp_add[(0, )](x, y, out, N, BLOCK=256)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.zeros(N, device="cuda"))
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_dispatcher_built_and_converged_path():
+    """Directly verify a dispatcher is created (proves the dispatcher path is
+    active, not a launchKernel fallback) and that calling it launches correctly
+    through the shared core."""
+    N = 2048
+    BLOCK = 128
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    g = triton.cdiv(N, BLOCK)
+
+    with force_dispatcher():
+        compiled = _disp_add.warmup(x, y, out, N, BLOCK=BLOCK, grid=(g, ))
+        if hasattr(compiled, "_init_handles"):
+            compiled._init_handles()
+
+        disp = getattr(compiled, "_dispatcher", None)
+        assert disp is not None, ("expected a C dispatcher when TRITON_USE_C_DISPATCHER=1")
+
+        dev = triton.runtime.driver.active.get_current_device()
+        stream = triton.runtime.driver.active.get_current_stream(dev)
+        # Dispatcher ABI: (grid_x, grid_y, grid_z, stream, *kernel_args)
+        disp(g, 1, 1, stream, x, y, out, N)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, x + y)
+
+
+@triton.jit
+def _disp_pid_write(out_ptr, GX: tl.constexpr, GY: tl.constexpr):
+    pid_x = tl.program_id(0)
+    pid_y = tl.program_id(1)
+    pid_z = tl.program_id(2)
+    offset = pid_x + GX * (pid_y + GY * pid_z)
+    tl.store(out_ptr + offset, offset)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_dispatcher_core_multidim_cluster():
+    """An explicit multi-dimensional cluster (ctas_per_cga, which forces
+    cluster_dims=(x,y,z) and num_ctas==1) must launch correctly through the
+    shared core. With the dispatcher forced on, a non-TMA kernel now sets
+    use_core_launch even for multi-dim clusters (previously gated off), so
+    triton_launch_kernel builds the explicit
+    CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION. A wrong/missing cluster dim would
+    conflict with the PTX .reqnctapercluster baked into the cubin and fail the
+    launch; every program writing its linear id proves all CTAs in the
+    (2,1,3) cluster ran."""
+    from triton._internal_testing import is_hopper_or_newer
+
+    if not is_hopper_or_newer():
+        pytest.skip("clusters need Hopper or newer")
+
+    GX, GY, GZ = 4, 2, 3  # each divisible by the (2,1,3) cluster dims
+    out = torch.full((GX * GY * GZ, ), -1, device="cuda", dtype=torch.int32)
+    with force_dispatcher():
+        _disp_pid_write[(GX, GY, GZ)](out, GX, GY, ctas_per_cga=(2, 1, 3))
+    torch.cuda.synchronize()
+    expected = torch.arange(GX * GY * GZ, device="cuda", dtype=torch.int32)
+    torch.testing.assert_close(out, expected)

--- a/python/test/unit/runtime/test_fallback_warnings.py
+++ b/python/test/unit/runtime/test_fallback_warnings.py
@@ -1,6 +1,6 @@
 """Tests for C-to-Python fallback warnings.
 
-Validates that when TRITON_USE_TRITON_DISPATCHER=1 or TRITON_ENABLE_C_CACHE=1
+Validates that when TRITON_USE_C_DISPATCHER=1 or TRITON_ENABLE_C_CACHE=1
 is set but the C path cannot be used, a visible warning is emitted so users
 are aware of the fallback.
 """
@@ -33,11 +33,11 @@ def _compile_kernel(fn, signature, constexprs=None, attrs=None):
 
 
 class TestDispatcherFallbackWarning:
-    """Tests for TRITON_USE_TRITON_DISPATCHER fallback warnings."""
+    """Tests for TRITON_USE_C_DISPATCHER fallback warnings."""
 
     def test_dispatcher_fallback_warning_in_compiled_kernel_getitem(self, monkeypatch):
         """CompiledKernel.__getitem__ should warn when dispatcher flag is on but _dispatcher is None."""
-        monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+        monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
         compiled = _compile_kernel(
             add_kernel,
             signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
@@ -52,16 +52,16 @@ class TestDispatcherFallbackWarning:
             compiled[(1, 1, 1)]  # noqa: F841
             # Should have emitted a fallback warning
             dispatcher_warnings = [
-                x for x in w if "TRITON_USE_TRITON_DISPATCHER=1" in str(x.message)
-                and "falling back to Python runner" in str(x.message)
+                x for x in w
+                if "TRITON_USE_C_DISPATCHER=1" in str(x.message) and "falling back to Python runner" in str(x.message)
             ]
             assert len(dispatcher_warnings) == 1, (
                 f"Expected 1 dispatcher fallback warning, got {len(dispatcher_warnings)}. "
                 f"All warnings: {[str(x.message) for x in w]}")
 
     def test_no_warning_when_dispatcher_flag_off(self, monkeypatch):
-        """No warning when TRITON_USE_TRITON_DISPATCHER is not set."""
-        monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "0")
+        """No warning when TRITON_USE_C_DISPATCHER is not set."""
+        monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "0")
         compiled = _compile_kernel(
             add_kernel,
             signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
@@ -72,12 +72,12 @@ class TestDispatcherFallbackWarning:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             compiled[(1, 1, 1)]  # noqa: F841
-            dispatcher_warnings = [x for x in w if "TRITON_USE_TRITON_DISPATCHER" in str(x.message)]
+            dispatcher_warnings = [x for x in w if "TRITON_USE_C_DISPATCHER" in str(x.message)]
             assert len(dispatcher_warnings) == 0
 
     def test_dispatcher_fallback_warning_in_jit_run(self, monkeypatch):
         """JITFunction.run() should warn when dispatcher flag is on but kernel has no dispatcher."""
-        monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+        monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
         monkeypatch.setenv("TRITON_ENABLE_C_CACHE", "0")
 
         @triton.jit
@@ -106,8 +106,8 @@ class TestDispatcherFallbackWarning:
             warnings.simplefilter("always")
             simple_kernel[(1, )](x, N, BLOCK=1024)
             dispatcher_warnings = [
-                x for x in w if "TRITON_USE_TRITON_DISPATCHER=1" in str(x.message)
-                and "falling back to Python launch" in str(x.message)
+                x for x in w
+                if "TRITON_USE_C_DISPATCHER=1" in str(x.message) and "falling back to Python launch" in str(x.message)
             ]
             assert len(dispatcher_warnings) == 1, (
                 f"Expected 1 dispatcher fallback warning, got {len(dispatcher_warnings)}. "
@@ -120,7 +120,7 @@ class TestCCacheFallbackWarning:
     def test_c_cache_bypass_warning_with_hooks(self, monkeypatch):
         """C fast path should warn when bypassed due to launch hooks."""
         monkeypatch.setenv("TRITON_ENABLE_C_CACHE", "1")
-        monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "0")
+        monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "0")
 
         @triton.jit(c_cache=True)
         def hook_kernel(X, N, BLOCK: tl.constexpr):
@@ -155,7 +155,7 @@ class TestCCacheFallbackWarning:
     def test_no_c_cache_warning_when_fast_path_works(self, monkeypatch):
         """No warning should be emitted when C fast path is used successfully."""
         monkeypatch.setenv("TRITON_ENABLE_C_CACHE", "1")
-        monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+        monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
 
         @triton.jit(c_cache=True)
         def fast_kernel(X, N, BLOCK: tl.constexpr):
@@ -184,7 +184,7 @@ class TestCCacheFallbackWarning:
     def test_c_cache_hit_no_dispatcher_warning(self, monkeypatch):
         """When dispatcher flag is on but kernel has no dispatcher, run() should warn."""
         monkeypatch.setenv("TRITON_ENABLE_C_CACHE", "1")
-        monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+        monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
 
         @triton.jit(c_cache=True)
         def nodispatch_kernel(X, N, BLOCK: tl.constexpr):
@@ -213,8 +213,8 @@ class TestCCacheFallbackWarning:
             warnings.simplefilter("always")
             nodispatch_kernel[lambda meta: (1, )](x, N, BLOCK=1024)
             dispatcher_warnings = [
-                x for x in w if "TRITON_USE_TRITON_DISPATCHER=1" in str(x.message)
-                and "falling back to Python launch" in str(x.message)
+                x for x in w
+                if "TRITON_USE_C_DISPATCHER=1" in str(x.message) and "falling back to Python launch" in str(x.message)
             ]
             assert len(dispatcher_warnings) == 1, (
                 f"Expected 1 dispatcher fallback warning, got {len(dispatcher_warnings)}. "
@@ -227,7 +227,7 @@ class TestProxyFallbackWarning:
     def test_proxy_creation_failure_warning(self, monkeypatch):
         """Should warn when native_create_jit_proxy returns None."""
         monkeypatch.setenv("TRITON_ENABLE_C_CACHE", "1")
-        monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+        monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
 
         @triton.jit(c_cache=True)
         def proxy_kernel(X, N, BLOCK: tl.constexpr):

--- a/python/test/unit/runtime/test_launch_kernel_core.py
+++ b/python/test/unit/runtime/test_launch_kernel_core.py
@@ -1,0 +1,131 @@
+"""Tests that the JIT variadic launcher (driver.c::launchKernel) routes through
+the shared data-driven core ``triton_launch_kernel`` in ``triton/runtime/launch.h``.
+
+The default launch path (no ``TRITON_USE_TRITON_DISPATCHER``) goes through
+``kernel.run() -> CudaLauncher -> launchKernel``. To make these tests robust
+regardless of defaults, each test installs a ``launch_enter_hook``: jit.py only
+takes the C-dispatcher / c_cache fast paths when *no* launch hooks are set, so a
+hook guarantees the ``launchKernel`` path and — because the hook is invoked
+*inside* ``launchKernel`` — a non-zero hook-call count proves that path ran.
+"""
+
+import contextlib
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton import knobs
+from triton._internal_testing import is_cuda
+
+
+@contextlib.contextmanager
+def force_launch_kernel_path():
+    """Install a launch_enter_hook to force (and prove) the launchKernel path."""
+    counter = {"calls": 0}
+
+    def _enter(_metadata):
+        counter["calls"] += 1
+
+    prev = knobs.runtime.launch_enter_hook
+    knobs.runtime.launch_enter_hook = _enter
+    try:
+        yield counter
+    finally:
+        knobs.runtime.launch_enter_hook = prev
+
+
+@triton.jit
+def _add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x + y, mask=mask)
+
+
+@triton.jit
+def _nop_kernel():
+    pass
+
+
+@triton.jit
+def _scalar_mix_kernel(x_ptr, out_ptr, fscale, iadd, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x * fscale + iadd, mask=mask)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_add_numerics():
+    N = 4096
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    with force_launch_kernel_path() as counter:
+        _add_kernel[grid](x, y, out, N, BLOCK=256)
+    torch.testing.assert_close(out, x + y)
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_nop_zero_args():
+    with force_launch_kernel_path() as counter:
+        _nop_kernel[(1, )]()
+    torch.cuda.synchronize()
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_mixed_scalar_args():
+    N = 2048
+    x = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    with force_launch_kernel_path() as counter:
+        _scalar_mix_kernel[grid](x, out, 2.5, 3, N, BLOCK=128)
+    torch.testing.assert_close(out, x * 2.5 + 3)
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_empty_grid():
+    """An empty (0) grid must be a no-op, not a CUDA error — the shared core
+    skips a zero-sized grid (parity with the legacy JIT _launch)."""
+    N = 1024
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.zeros(N, device="cuda")
+    with force_launch_kernel_path() as counter:
+        _add_kernel[(0, )](x, y, out, N, BLOCK=256)  # empty grid: no work
+    torch.cuda.synchronize()
+    # out must be untouched (kernel never ran)
+    torch.testing.assert_close(out, torch.zeros(N, device="cuda"))
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_path_host_tma_passthrough():
+    """Host-side TMA: Python builds the CUtensorMap; launchKernel passes it
+    through args_buf as an ordinary (is_tma=0) param to the shared core."""
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    M, N = 128, 128
+    M_BLOCK, N_BLOCK = 64, 64
+
+    @triton.jit
+    def _td_kernel(out_ptr, desc, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        block = desc.load([0, 0])
+        idx = (tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :])
+        tl.store(out_ptr + idx, block)
+
+    t = torch.randn((M, N), device="cuda")
+    out = torch.empty((M_BLOCK, N_BLOCK), device="cuda")
+    desc = TensorDescriptor(t, shape=t.shape, strides=t.stride(), block_shape=[M_BLOCK, N_BLOCK])
+    with force_launch_kernel_path() as counter:
+        _td_kernel[(1, )](out, desc, M_BLOCK, N_BLOCK)
+    torch.testing.assert_close(out, t[:M_BLOCK, :N_BLOCK])
+    assert counter["calls"] > 0, "launchKernel path was not exercised"

--- a/python/test/unit/runtime/test_launch_kernel_core.py
+++ b/python/test/unit/runtime/test_launch_kernel_core.py
@@ -1,7 +1,7 @@
 """Tests that the JIT variadic launcher (driver.c::launchKernel) routes through
 the shared data-driven core ``triton_launch_kernel`` in ``triton/runtime/launch.h``.
 
-The default launch path (no ``TRITON_USE_TRITON_DISPATCHER``) goes through
+The default launch path (no ``TRITON_USE_C_DISPATCHER``) goes through
 ``kernel.run() -> CudaLauncher -> launchKernel``. To make these tests robust
 regardless of defaults, each test installs a ``launch_enter_hook``: jit.py only
 takes the C-dispatcher / c_cache fast paths when *no* launch hooks are set, so a

--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -17,8 +17,14 @@ from triton.backends.nvidia.driver import (
     expand_signature,
     make_kernel_signature,
 )
+from triton._internal_testing import is_cuda
 from triton.compiler.compiler import ASTSource, compile as triton_compile, make_backend
 from triton.knobs import HookChain
+
+# These tests validate NVIDIA-specific launch metadata and the CUDA C
+# `launcher_src` (CUresult/CUdeviceptr/cuda.h/launch.h). The HIP backend has no
+# make_launcher_src, so skip the whole module on non-CUDA targets.
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="NVIDIA launch metadata / launcher_src is CUDA-only")
 
 
 @triton.jit
@@ -305,8 +311,10 @@ def test_launcher_src_bakes_constants():
     )
     src = compiled.asm["launcher_src"]
     md = compiled.metadata
-    assert f"/*num_warps=*/{md.num_warps}" in src
-    assert f"/*shared_mem=*/{md.shared}u" in src
+    assert f".num_warps = {md.num_warps}," in src
+    assert f".shared_mem = {md.shared}u," in src
+    # Param offsets use offsetof (C compiler owns layout, not Python).
+    assert "offsetof(" in src
 
 
 def test_launcher_src_has_abi_version_comment():
@@ -318,6 +326,94 @@ def test_launcher_src_has_abi_version_comment():
     )
     src = compiled.asm["launcher_src"]
     assert "ABI version: 1" in src
+
+
+def test_launcher_src_compiles_with_gcc():
+    """Generated C should compile with the system C compiler (validates struct
+    layout, offsetof usage, and launch.h compatibility)."""
+    import os
+    import shutil
+    import subprocess
+    import tempfile
+    import triton.backends.nvidia
+
+    @triton.jit
+    def _gcc_test_add(X, Y, OUT, N, BLOCK: tl.constexpr):
+        offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < N
+        tl.store(OUT + offs, tl.load(X + offs, mask=mask) + tl.load(Y + offs, mask=mask), mask=mask)
+
+    # Force a fresh triton compilation cache so we always run make_launcher_src
+    # (the disk cache keys on source hash + options, not compiler.py version).
+    with tempfile.TemporaryDirectory() as fresh_cache:
+        prev_cache = os.environ.get("TRITON_CACHE_DIR")
+        os.environ["TRITON_CACHE_DIR"] = fresh_cache
+        try:
+            compiled = _compile_kernel(
+                _gcc_test_add,
+                signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+                constexprs={"BLOCK": 1024},
+            )
+        finally:
+            if prev_cache is None:
+                os.environ.pop("TRITON_CACHE_DIR", None)
+            else:
+                os.environ["TRITON_CACHE_DIR"] = prev_cache
+
+    src = compiled.asm.get("launcher_src")
+    if not src:
+        # Diagnostic: understand WHY launcher_src is missing on this environment
+        target = triton.runtime.driver.active.get_current_target()
+        from triton.compiler.compiler import make_backend
+        backend = make_backend(target)
+        diag = (f"launcher_src not in asm. Diagnostics:\n"
+                f"  target: {target}\n"
+                f"  backend type: {type(backend).__name__}\n"
+                f"  has make_launcher_src: {hasattr(backend, 'make_launcher_src')}\n"
+                f"  asm keys: {sorted(compiled.asm.keys())}\n"
+                f"  TRITON_CACHE_DIR: {os.environ.get('TRITON_CACHE_DIR', '<not set>')}")
+        pytest.fail(diag)
+
+    # Find launch.h: try the canonical source location, then the packaged one.
+    backend_dir = os.path.dirname(os.path.realpath(triton.backends.nvidia.__file__))
+    candidates = [
+        os.path.join(backend_dir, "launch.h"),
+        os.path.join(backend_dir, "..", "..", "..", "python", "triton", "runtime", "launch.h"),
+    ]
+    launch_h = next((p for p in candidates if os.path.exists(p)), None)
+    if launch_h is None:
+        pytest.skip("launch.h not found for compile test")
+
+    # Find a C compiler
+    cc = shutil.which("gcc") or shutil.which("clang") or shutil.which("cc")
+    if cc is None:
+        pytest.skip("No C compiler available")
+
+    # Find cuda.h include dir
+    cuda_include = os.path.join(backend_dir, "include")
+    if not os.path.exists(os.path.join(cuda_include, "cuda.h")):
+        pytest.skip("cuda.h not found")
+
+    with tempfile.NamedTemporaryFile(suffix=".c", mode="w", delete=False) as f:
+        # Inline launch.h into the source (same as the JIT runtime compile does
+        # via driver.py) so we only need -I for cuda.h — avoids fragile
+        # triton_include path resolution in buck link-tree environments.
+        from pathlib import Path
+        launch_h_content = Path(launch_h).read_text()
+        test_src = src.replace('#include "triton/runtime/launch.h"', launch_h_content)
+        f.write(test_src)
+        f.flush()
+        try:
+            result = subprocess.run(
+                [cc, "-fsyntax-only", "-c", f.name, f"-I{cuda_include}"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 0, (f"Generated launcher_src failed to compile:\n"
+                                            f"stdout: {result.stdout}\nstderr: {result.stderr}")
+        finally:
+            os.unlink(f.name)
 
 
 # =============================================================================

--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -317,6 +317,39 @@ def test_launcher_src_bakes_constants():
     assert "offsetof(" in src
 
 
+def test_launcher_src_emits_cluster_dims():
+    """The descriptor should carry the explicit multi-dim cluster_dims so the
+    shared core can build CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for the
+    ctas_per_cga path (converged onto triton_launch_kernel, not a separate
+    launcher)."""
+    import os
+    import tempfile
+
+    # Force a fresh triton cache so make_launcher_src always runs (the disk
+    # cache keys on source hash + options, not compiler.py version, so a stale
+    # entry from another rev could lack launcher_src). Mirrors
+    # test_launcher_src_compiles_with_gcc.
+    with tempfile.TemporaryDirectory() as fresh_cache:
+        prev_cache = os.environ.get("TRITON_CACHE_DIR")
+        os.environ["TRITON_CACHE_DIR"] = fresh_cache
+        try:
+            compiled = _compile_kernel(
+                add_kernel,
+                signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
+                constexprs={"BLOCK": 1024},
+            )
+        finally:
+            if prev_cache is None:
+                os.environ.pop("TRITON_CACHE_DIR", None)
+            else:
+                os.environ["TRITON_CACHE_DIR"] = prev_cache
+    src = compiled.asm["launcher_src"]
+    assert ".cluster_dims = {" in src
+    # Sanity: still emits the 1-D num_ctas path inputs too (both are present;
+    # the core gives num_ctas priority over cluster_dims).
+    assert ".num_ctas = " in src
+
+
 def test_launcher_src_has_abi_version_comment():
     """Generated source should contain the ABI version as a comment."""
     compiled = _compile_kernel(
@@ -539,7 +572,7 @@ def test_hookchain_bool_after_remove():
 
 def test_dispatcher_created_with_flag(monkeypatch):
     """CompiledKernel._dispatcher should be set when use_triton_dispatcher is enabled."""
-    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
     compiled = _compile_kernel(
         add_kernel,
         signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
@@ -551,7 +584,7 @@ def test_dispatcher_created_with_flag(monkeypatch):
 
 def test_dispatcher_not_created_without_flag(monkeypatch):
     """CompiledKernel._dispatcher should be None without the flag."""
-    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "0")
+    monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "0")
     compiled = _compile_kernel(
         add_kernel,
         signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
@@ -563,7 +596,7 @@ def test_dispatcher_not_created_without_flag(monkeypatch):
 
 def test_dispatcher_is_callable(monkeypatch):
     """_TritonDispatcher should be callable when created."""
-    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
     compiled = _compile_kernel(
         add_kernel,
         signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
@@ -589,7 +622,7 @@ def test_launch_metadata_returns_none_without_hooks():
 
 def test_dispatcher_e2e(monkeypatch):
     """End-to-end: _TritonDispatcher dispatches correctly on GPU."""
-    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
     compiled = _compile_kernel(
         add_kernel,
         signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
@@ -612,7 +645,7 @@ def test_dispatcher_e2e(monkeypatch):
 
 def test_dispatcher_getitem_jit_runner(monkeypatch):
     """CompiledKernel.__getitem__ should return a _TritonJITRunner when dispatcher is available."""
-    monkeypatch.setenv("TRITON_USE_TRITON_DISPATCHER", "1")
+    monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
     compiled = _compile_kernel(
         add_kernel,
         signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -757,7 +757,7 @@ class CompiledKernel:
 
         if knobs.nvidia.use_triton_dispatcher and dispatcher is None:
             warnings.warn(
-                f"[Triton] TRITON_USE_TRITON_DISPATCHER=1 but CompiledKernel '{self.name}' has no C dispatcher, "
+                f"[Triton] TRITON_USE_C_DISPATCHER=1 but CompiledKernel '{self.name}' has no C dispatcher, "
                 f"falling back to Python runner",
                 stacklevel=2,
             )

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -559,7 +559,6 @@ class nvidia_knobs(base_knobs):
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
-    use_llvm_launcher: env_bool = env_bool("TRITON_USE_LLVM_LAUNCHER")
     use_triton_dispatcher: env_bool = env_bool("TRITON_USE_TRITON_DISPATCHER")
     use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -559,7 +559,7 @@ class nvidia_knobs(base_knobs):
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
-    use_triton_dispatcher: env_bool = env_bool("TRITON_USE_TRITON_DISPATCHER")
+    use_triton_dispatcher: env_bool = env_bool("TRITON_USE_C_DISPATCHER")
     use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     # When True, run the triton-nvidia-interleave-tmem pass on Blackwell.

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -1016,7 +1016,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
             else:
                 if knobs.nvidia.use_triton_dispatcher and _disp is None:
                     warnings.warn(
-                        f"[Triton] TRITON_USE_TRITON_DISPATCHER=1 but kernel '{self._fn_name}' has no C dispatcher, "
+                        f"[Triton] TRITON_USE_C_DISPATCHER=1 but kernel '{self._fn_name}' has no C dispatcher, "
                         f"falling back to Python launch",
                         stacklevel=2,
                     )

--- a/python/triton/runtime/launch.h
+++ b/python/triton/runtime/launch.h
@@ -7,7 +7,11 @@
  * is a plain C function callable from C, C++, or via ctypes/cffi.
  *
  * Consumers: compiler-generated launcher sources (asm["launcher_src"]),
- *            TritonCC, AOT-T, custom integrations.
+ *            TritonCC, AOT-T, JIT (variadic launcher), custom integrations.
+ *
+ * ALL consumers call the same function: triton_launch_kernel().
+ * TMA construction, params[] layout, and launch attribute setup all happen
+ * inside this one function.  Changes to TMA promotion only need to update here.
  */
 
 #ifndef TRITON_RUNTIME_LAUNCH_H
@@ -19,6 +23,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,6 +80,14 @@ static triton_cuLaunchKernelEx_fn g_triton_launch_fn = NULL;
  * Note: dlopen handle is intentionally not closed — libcuda.so.1 must remain
  * loaded for the process lifetime since cuLaunchKernelEx is called on every
  * kernel launch.
+ *
+ * This (and g_triton_launch_fn) are `static`, so every translation unit that
+ * includes this header gets its own copy + its own constructor. When many
+ * generated launchers are linked into one binary (e.g. an AOT-T .so with many
+ * kernels, or a TritonCC bundle) each TU independently dlopen's libcuda at
+ * startup, bumping its (never-released) refcount. That is harmless — the
+ * library stays mapped regardless — just redundant; we accept it to keep
+ * launch.h header-only (no companion .c to compile/link per consumer).
  */
 __attribute__((constructor)) static void triton_init_launch_kernel_ex(void) {
   void *lib = dlopen("libcuda.so.1", RTLD_LAZY);
@@ -85,17 +98,12 @@ __attribute__((constructor)) static void triton_init_launch_kernel_ex(void) {
       (triton_cuLaunchKernelEx_fn)dlsym(lib, "cuLaunchKernelEx");
 }
 
-/**
- * Get cuLaunchKernelEx function pointer (loaded at startup).
- * Thread-safe — initialization happens before main().
- * Returns NULL if libcuda.so.1 is not available.
- */
 static inline triton_cuLaunchKernelEx_fn triton_get_launch_kernel_ex(void) {
   return g_triton_launch_fn;
 }
 
 /* -------------------------------------------------------------------------
- * Launch attribute helpers
+ * Launch descriptor (data-driven launch)
  * ------------------------------------------------------------------------- */
 
 /**
@@ -104,98 +112,283 @@ static inline triton_cuLaunchKernelEx_fn triton_get_launch_kernel_ex(void) {
  * cluster dim.
  */
 #define TRITON_MAX_LAUNCH_ATTRS 5
+#define TRITON_MAX_TMA_DESCS 8
+#define TRITON_MAX_TMA_DIMS 5
+#define TRITON_MAX_PARAMS 256
 
 /**
- * Build the CUlaunchAttribute array and return the number of attributes set.
- *
- * All parameters are compile-time constants baked into the generated launcher.
- * This function is meant to be called from generated code.
+ * ABI version of triton_kernel_launch_desc_t.  Bump this whenever the struct
+ * layout below changes in a backward-incompatible way.  Producers stamp this
+ * into desc->abi_version and triton_launch_kernel() rejects mismatches at
+ * runtime, so a stale ctypes mirror (launch_desc.py) or generated launcher is
+ * caught instead of silently corrupting kernel args.
  */
-static inline unsigned triton_build_launch_attrs(
-    CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS], int launch_pdl,
-    int launch_cooperative_grid, int num_ctas, int launch_cluster,
-    int preferred_cluster_dim_x, int preferred_cluster_dim_y,
-    int preferred_cluster_dim_z) {
-  unsigned n = 0;
+#define TRITON_LAUNCH_DESC_ABI_VERSION 1
 
-  if (launch_pdl) {
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
-    attrs[n].value.programmaticStreamSerializationAllowed = 1;
-    n++;
-  }
-
-  if (launch_cooperative_grid) {
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
-    attrs[n].value.cooperative = 1;
-    n++;
-  }
-
-  if (launch_cluster || num_ctas > 1) {
-    /* Triton clusters are always 1-D (num_ctas along x); multi-dimensional
-     * clusters use the ctas_per_cga / PTX .reqnctapercluster path where
-     * num_ctas == 1 and no runtime CLUSTER_DIMENSION attr is needed. */
-    if (num_ctas > 1) {
-      attrs[n].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-      attrs[n].value.clusterDim.x = (unsigned)num_ctas;
-      attrs[n].value.clusterDim.y = 1;
-      attrs[n].value.clusterDim.z = 1;
-      n++;
-    }
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
-    attrs[n].value.clusterSchedulingPolicyPreference =
-        CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
-    n++;
-  }
-
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
-  if (preferred_cluster_dim_x > 0) {
-    attrs[n].id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
-    attrs[n].value.clusterDim.x = (unsigned)preferred_cluster_dim_x;
-    attrs[n].value.clusterDim.y = (unsigned)preferred_cluster_dim_y;
-    attrs[n].value.clusterDim.z = (unsigned)preferred_cluster_dim_z;
-    n++;
-  }
+/* static_assert spelling differs between C11 and C++; provide one name. */
+#if defined(__cplusplus)
+#define TRITON_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
 #else
-  (void)preferred_cluster_dim_x;
-  (void)preferred_cluster_dim_y;
-  (void)preferred_cluster_dim_z;
+#define TRITON_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 #endif
 
-  return n;
+/**
+ * TMA recipe: describes how to construct one CUtensorMap from user args.
+ *
+ * All offsets refer to byte positions within the args_buf passed to
+ * triton_launch_kernel(). The launcher reads ptr/shape/stride values
+ * from args_buf at these offsets and calls cuTensorMapEncodeTiled().
+ *
+ * Compile-time constants (block_shape, swizzle, elem_type, etc.) are baked
+ * directly into the struct by the compiler.
+ */
+typedef struct {
+  int ndim;
+  uint32_t block_shape[TRITON_MAX_TMA_DIMS];
+  int swizzle;
+  int elem_type;
+  int elem_size;
+  int fp4_padded;
+  int fill_mode;
+  int ptr_offset;
+  int shape_offsets[TRITON_MAX_TMA_DIMS];
+  int stride_offsets[TRITON_MAX_TMA_DIMS];
+  int desc_param_idx;
+} triton_tma_recipe_t;
+
+/**
+ * Parameter descriptor: where in args_buf each kernel param lives.
+ * 'size' is currently unused by triton_launch_kernel() (which only reads
+ * offset and is_tma) but reserved for future use (e.g. debug validation).
+ */
+typedef struct {
+  int offset;
+  int size;
+  int is_tma;
+} triton_param_desc_t;
+
+/**
+ * Per-kernel launch descriptor: everything needed to launch a kernel.
+ * Generated by the compiler as a static const, passed to
+ * triton_launch_kernel().
+ */
+typedef struct {
+  int abi_version; /* must equal TRITON_LAUNCH_DESC_ABI_VERSION */
+  int num_warps;
+  int num_ctas;
+  unsigned shared_mem;
+  int launch_pdl;
+  int launch_cooperative_grid;
+  int launch_cluster;
+  int preferred_cluster_dims[3];
+
+  int num_params;
+  triton_param_desc_t params[TRITON_MAX_PARAMS];
+
+  int num_tma_recipes;
+  triton_tma_recipe_t tma_recipes[TRITON_MAX_TMA_DESCS];
+} triton_kernel_launch_desc_t;
+
+/*
+ * Layout guards.  All fields are 4-byte (int / unsigned / int32 arrays /
+ * structs of ints) so the structs are tightly packed with no padding.  These
+ * asserts catch accidental layout drift between this header and the Python
+ * ctypes mirror in third_party/nvidia/backend/launch_desc.py (which assumes the
+ * same layout).
+ */
+TRITON_STATIC_ASSERT(sizeof(triton_param_desc_t) == 3 * sizeof(int),
+                     "triton_param_desc_t layout drift");
+TRITON_STATIC_ASSERT(sizeof(triton_tma_recipe_t) == 23 * sizeof(int),
+                     "triton_tma_recipe_t layout drift");
+TRITON_STATIC_ASSERT(sizeof(triton_kernel_launch_desc_t) ==
+                         11 * sizeof(int) +
+                             TRITON_MAX_PARAMS * sizeof(triton_param_desc_t) +
+                             sizeof(int) +
+                             TRITON_MAX_TMA_DESCS * sizeof(triton_tma_recipe_t),
+                     "triton_kernel_launch_desc_t layout drift");
+
+/* -------------------------------------------------------------------------
+ * Lazy-loaded cuTensorMapEncodeTiled (for TMA)
+ * ------------------------------------------------------------------------- */
+
+typedef CUresult (*triton_cuTensorMapEncodeTiled_fn)(
+    CUtensorMap *tensorMap, CUtensorMapDataType tensorDataType,
+    cuuint32_t tensorRank, void *globalAddress, const cuuint64_t *globalDim,
+    const cuuint64_t *globalStrides, const cuuint32_t *boxDim,
+    const cuuint32_t *elementStrides, CUtensorMapInterleave interleave,
+    CUtensorMapSwizzle swizzle, CUtensorMapL2promotion l2Promotion,
+    CUtensorMapFloatOOBfill oobFill);
+
+static triton_cuTensorMapEncodeTiled_fn g_triton_tma_encode_fn = NULL;
+
+/**
+ * Initialize cuTensorMapEncodeTiled at program startup (same pattern as
+ * triton_init_launch_kernel_ex). Thread-safe by running before main().
+ */
+__attribute__((constructor)) static void triton_init_tma_encode(void) {
+  void *lib = dlopen("libcuda.so.1", RTLD_LAZY);
+  if (!lib)
+    return;
+  g_triton_tma_encode_fn =
+      (triton_cuTensorMapEncodeTiled_fn)dlsym(lib, "cuTensorMapEncodeTiled");
+}
+
+static inline triton_cuTensorMapEncodeTiled_fn triton_get_tma_encode(void) {
+  return g_triton_tma_encode_fn;
 }
 
 /**
- * Build and execute a CUlaunchConfig.  Consolidates the common launch pattern.
+ * Construct a single CUtensorMap from a TMA recipe and user args.
  *
- * @param grid          Grid dimensions [x, y, z]
- * @param num_warps     Warps per block (compile-time constant)
- * @param num_ctas      CTAs per cluster (compile-time constant)
- * @param shared_mem    Dynamic shared memory in bytes (compile-time constant)
- * @param stream        CUDA stream
- * @param function      CUDA function handle
- * @param params        Kernel parameter array (void*[])
- * @param attrs         Pre-built launch attributes
- * @param num_attrs     Number of launch attributes
- * @return              CUDA_SUCCESS or error code
+ * STUB: only the shared-core skeleton (recipe struct + this launcher call site)
+ * lands in this diff. The encoder body must match the proven JIT encoder
+ * byte-for-byte (row-major -> column-major dim reversal, derived outermost
+ * stride, L2_128B promotion, small-tensor driver workaround); that correct
+ * implementation, with a byte-compare unit test, lands in a later diff. No
+ * consumer emits TMA recipes until then (num_tma_recipes == 0), so this path is
+ * never exercised in the meantime.
  */
 static inline CUresult
-triton_launch_kernel(const uint32_t grid[3], int num_warps, int num_ctas,
-                     unsigned shared_mem, CUstream stream, CUfunction function,
-                     void **params, CUlaunchAttribute *attrs,
-                     unsigned num_attrs) {
+triton_construct_tma_desc(CUtensorMap *desc, const triton_tma_recipe_t *recipe,
+                          const void *args_buf) {
+  (void)desc;
+  (void)recipe;
+  (void)args_buf;
+  return CUDA_ERROR_NOT_SUPPORTED;
+}
+
+/* -------------------------------------------------------------------------
+ * triton_launch_kernel — THE one function all consumers call.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Launch a Triton kernel.  This is the ONLY launch entry point.
+ *
+ * All consumers (JIT variadic launcher, TritonCC, AOT-T) call this function.
+ * It handles: TMA construction, params[] layout, launch attrs,
+ * cuLaunchKernelEx.
+ *
+ * @param grid       Grid dimensions [x, y, z]
+ * @param stream     CUDA stream
+ * @param function   CUDA function handle
+ * @param args_buf   Flat buffer containing user args at known offsets
+ * @param desc       Per-kernel static launch descriptor (compiler-generated)
+ * @return           CUDA_SUCCESS or error code
+ */
+static inline CUresult
+triton_launch_kernel(const uint32_t grid[3], CUstream stream,
+                     CUfunction function, void *args_buf,
+                     const triton_kernel_launch_desc_t *desc) {
+
+  if (!function)
+    return CUDA_ERROR_INVALID_HANDLE;
+  if (!desc)
+    return CUDA_ERROR_INVALID_VALUE;
+  /* Reject a descriptor built against a different ABI (e.g. a stale ctypes
+   * mirror or a generated launcher compiled against an older launch.h). */
+  if (desc->abi_version != TRITON_LAUNCH_DESC_ABI_VERSION)
+    return CUDA_ERROR_INVALID_VALUE;
+
+  /* Empty grid: nothing to launch. Matches the legacy JIT _launch skip and
+   * avoids cuLaunchKernelEx rejecting a zero-sized grid. */
+  if (grid[0] == 0 || grid[1] == 0 || grid[2] == 0)
+    return CUDA_SUCCESS;
 
   triton_cuLaunchKernelEx_fn launch_fn = triton_get_launch_kernel_ex();
   if (!launch_fn)
     return CUDA_ERROR_NOT_FOUND;
 
+  /* --- TMA: construct descriptors from recipes --- */
+  if (desc->num_tma_recipes > 0) {
+    if (desc->num_tma_recipes > TRITON_MAX_TMA_DESCS) {
+      fprintf(stderr,
+              "[triton] ERROR: num_tma_recipes (%d) exceeds "
+              "TRITON_MAX_TMA_DESCS (%d)\n",
+              desc->num_tma_recipes, TRITON_MAX_TMA_DESCS);
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    if (!triton_get_tma_encode()) {
+      fprintf(stderr,
+              "[triton] ERROR: kernel has %d TMA recipes but "
+              "cuTensorMapEncodeTiled is unavailable (driver too old?)\n",
+              desc->num_tma_recipes);
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+  }
+  __attribute__((aligned(64))) CUtensorMap tma_descs[TRITON_MAX_TMA_DESCS];
+  for (int i = 0; i < desc->num_tma_recipes; i++) {
+    TRITON_CUDA_CHECK(triton_construct_tma_desc(
+        &tma_descs[i], &desc->tma_recipes[i], args_buf));
+  }
+
+  /* --- Build kernel params[] array --- */
+  if (desc->num_params > TRITON_MAX_PARAMS)
+    return CUDA_ERROR_INVALID_VALUE;
+  void *params[TRITON_MAX_PARAMS];
+  int tma_idx = 0;
+  for (int i = 0; i < desc->num_params; i++) {
+    if (desc->params[i].is_tma) {
+      if (tma_idx >= desc->num_tma_recipes)
+        return CUDA_ERROR_INVALID_VALUE;
+      params[i] = (void *)&tma_descs[tma_idx++];
+    } else {
+      params[i] = (void *)((char *)args_buf + desc->params[i].offset);
+    }
+  }
+
+  /* --- Build launch attributes --- */
+  CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS];
+  unsigned num_attrs = 0;
+
+  if (desc->launch_pdl) {
+    attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+    attrs[num_attrs].value.programmaticStreamSerializationAllowed = 1;
+    num_attrs++;
+  }
+
+  if (desc->launch_cooperative_grid) {
+    attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+    attrs[num_attrs].value.cooperative = 1;
+    num_attrs++;
+  }
+
+  if (desc->launch_cluster || desc->num_ctas > 1) {
+    if (desc->num_ctas > 1) {
+      attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+      attrs[num_attrs].value.clusterDim.x = (unsigned)desc->num_ctas;
+      attrs[num_attrs].value.clusterDim.y = 1;
+      attrs[num_attrs].value.clusterDim.z = 1;
+      num_attrs++;
+    }
+    attrs[num_attrs].id =
+        CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+    attrs[num_attrs].value.clusterSchedulingPolicyPreference =
+        CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+    num_attrs++;
+  }
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+  if (desc->preferred_cluster_dims[0] > 0) {
+    attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
+    attrs[num_attrs].value.clusterDim.x =
+        (unsigned)desc->preferred_cluster_dims[0];
+    attrs[num_attrs].value.clusterDim.y =
+        (unsigned)desc->preferred_cluster_dims[1];
+    attrs[num_attrs].value.clusterDim.z =
+        (unsigned)desc->preferred_cluster_dims[2];
+    num_attrs++;
+  }
+#endif
+
+  /* --- Launch --- */
   CUlaunchConfig config;
-  config.gridDimX = grid[0] * (uint32_t)num_ctas;
+  config.gridDimX = grid[0] * (uint32_t)desc->num_ctas;
   config.gridDimY = grid[1];
   config.gridDimZ = grid[2];
-  config.blockDimX = 32 * (uint32_t)num_warps;
+  config.blockDimX = 32 * (uint32_t)desc->num_warps;
   config.blockDimY = 1;
   config.blockDimZ = 1;
-  config.sharedMemBytes = shared_mem;
+  config.sharedMemBytes = desc->shared_mem;
   config.hStream = stream;
   config.attrs = attrs;
   config.numAttrs = num_attrs;

--- a/python/triton/runtime/launch.h
+++ b/python/triton/runtime/launch.h
@@ -123,7 +123,7 @@ static inline triton_cuLaunchKernelEx_fn triton_get_launch_kernel_ex(void) {
  * runtime, so a stale ctypes mirror (launch_desc.py) or generated launcher is
  * caught instead of silently corrupting kernel args.
  */
-#define TRITON_LAUNCH_DESC_ABI_VERSION 1
+#define TRITON_LAUNCH_DESC_ABI_VERSION 2
 
 /* static_assert spelling differs between C11 and C++; provide one name. */
 #if defined(__cplusplus)
@@ -180,6 +180,12 @@ typedef struct {
   int launch_pdl;
   int launch_cooperative_grid;
   int launch_cluster;
+  /* Explicit multi-dimensional cluster (the ctas_per_cga path): when num_ctas
+   * == 1 and any entry is > 1, these become
+   * CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION. All entries <= 1 means "no explicit
+   * cluster" -- the 1-D num_ctas path runs instead. (num_ctas takes priority,
+   * so the two are never both applied.) */
+  int cluster_dims[3];
   int preferred_cluster_dims[3];
 
   int num_params;
@@ -201,7 +207,7 @@ TRITON_STATIC_ASSERT(sizeof(triton_param_desc_t) == 3 * sizeof(int),
 TRITON_STATIC_ASSERT(sizeof(triton_tma_recipe_t) == 23 * sizeof(int),
                      "triton_tma_recipe_t layout drift");
 TRITON_STATIC_ASSERT(sizeof(triton_kernel_launch_desc_t) ==
-                         11 * sizeof(int) +
+                         14 * sizeof(int) +
                              TRITON_MAX_PARAMS * sizeof(triton_param_desc_t) +
                              sizeof(int) +
                              TRITON_MAX_TMA_DESCS * sizeof(triton_tma_recipe_t),
@@ -352,12 +358,23 @@ triton_launch_kernel(const uint32_t grid[3], CUstream stream,
     num_attrs++;
   }
 
-  if (desc->launch_cluster || desc->num_ctas > 1) {
+  int has_multidim_cluster =
+      (desc->cluster_dims[0] > 1 || desc->cluster_dims[1] > 1 ||
+       desc->cluster_dims[2] > 1);
+  if (desc->launch_cluster || desc->num_ctas > 1 || has_multidim_cluster) {
     if (desc->num_ctas > 1) {
+      /* 1-D cluster: num_ctas CTAs along x. */
       attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
       attrs[num_attrs].value.clusterDim.x = (unsigned)desc->num_ctas;
       attrs[num_attrs].value.clusterDim.y = 1;
       attrs[num_attrs].value.clusterDim.z = 1;
+      num_attrs++;
+    } else if (has_multidim_cluster) {
+      /* Explicit multi-dimensional cluster (ctas_per_cga). */
+      attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+      attrs[num_attrs].value.clusterDim.x = (unsigned)desc->cluster_dims[0];
+      attrs[num_attrs].value.clusterDim.y = (unsigned)desc->cluster_dims[1];
+      attrs[num_attrs].value.clusterDim.z = (unsigned)desc->cluster_dims[2];
       num_attrs++;
     }
     attrs[num_attrs].id =

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -554,6 +554,7 @@ class CUDABackend(BaseBackend):
         lines.append(f"        .launch_pdl = {launch_pdl},")
         lines.append(f"        .launch_cooperative_grid = {launch_coop},")
         lines.append(f"        .launch_cluster = {launch_cluster_flag},")
+        lines.append(f"        .cluster_dims = {{{cluster_dims[0]}, {cluster_dims[1]}, {cluster_dims[2]}}},")
         lines.append(f"        .preferred_cluster_dims = {{{preferred[0]}, {preferred[1]}, {preferred[2]}}},")
         lines.append(f"        .num_params = {num_params},")
         lines.append("        .params = {")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -468,6 +468,9 @@ class CUDABackend(BaseBackend):
 
         # ---- Args struct ----
         lines.append("typedef struct {")
+        if not args:
+            # Zero-arg kernel: empty struct is a GCC extension, not valid C.
+            lines.append("    char _unused;")
         for arg in args:
             c_ty = _c_type(arg["type"])
             if c_ty is None:
@@ -476,6 +479,44 @@ class CUDABackend(BaseBackend):
             lines.append(f"    {c_ty} {arg['name']};")
         lines.append(f"}} {safe_name}_args_t;")
         lines.append("")
+
+        # ---- Buffer type: args + scratch, used for offsetof in the descriptor.
+        # Natural (non-packed) alignment: each kernel param pointer (built from
+        # offsetof below) lands on a correctly-aligned, correctly-sized value.
+        # The C compiler — not Python — owns the args-buffer layout.
+        buf_t = f"{safe_name}_buf_t"
+        lines.append("typedef struct {")
+        lines.append(f"    {safe_name}_args_t k;")
+        lines.append("    CUdeviceptr _global_scratch;")
+        lines.append("    CUdeviceptr _profile_scratch;")
+        lines.append(f"}} {buf_t};")
+        lines.append("")
+
+        # Helper: offsetof expression for a field inside buf_t.k
+        def _off(field):
+            return f"(int)offsetof({buf_t}, k.{field})"
+
+        # Build param descriptors. offsetof gives the offset and sizeof gives
+        # the size, so the C compiler owns the layout end to end -- no Python
+        # type->size table that could silently disagree with the real ABI for an
+        # unmapped C type.
+        param_entries = []
+        for arg in args:
+            c_ty = _c_type(arg["type"])
+            param_entries.append((_off(arg["name"]), f"(int)sizeof({c_ty})", 0))
+        # Scratch params (device pointers).
+        param_entries.append((f"(int)offsetof({buf_t}, _global_scratch)", "(int)sizeof(CUdeviceptr)", 0))
+        param_entries.append((f"(int)offsetof({buf_t}, _profile_scratch)", "(int)sizeof(CUdeviceptr)", 0))
+        num_params = len(param_entries)
+        # Mirror the fixed cap in launch.h: triton_kernel_launch_desc_t.params is
+        # a triton_param_desc_t[TRITON_MAX_PARAMS] array, so a descriptor with
+        # more entries would overflow the static initializer. Bail out (the
+        # consumer falls back to the variadic launcher) instead of emitting C
+        # that overflows or silently truncates.
+        TRITON_MAX_PARAMS = 256  # keep in sync with launch.h
+        if num_params > TRITON_MAX_PARAMS:
+            return (f"/* Launcher not generated: {num_params} params exceeds "
+                    f"TRITON_MAX_PARAMS ({TRITON_MAX_PARAMS}) */\n")
 
         # ---- Launch function ----
         lines.append("/**")
@@ -491,58 +532,45 @@ class CUDABackend(BaseBackend):
             lines.append(f" *   profile_scratch_size={profile_scratch_size}")
         lines.append(" */")
 
+        # ---- Launch wrapper (descriptor is function-local to avoid name collisions
+        # when TritonCC puts multiple specs in the same .cpp) ----
         lines.append(f"CUresult triton_launch_{safe_name}(")
         lines.append("    const uint32_t grid[3],")
         lines.append("    CUstream stream,")
         lines.append("    CUfunction function,")
         lines.append(f"    {safe_name}_args_t *args,")
-        # Always include scratch params for stable ABI across all kernels.
-        # Callers pass 0/NULL when the kernel doesn't use scratch buffers.
         lines.append("    CUdeviceptr global_scratch,")
         lines.append("    CUdeviceptr profile_scratch")
         lines.append(") {")
-
-        # Null checks
         lines.append("    if (!args) return CUDA_ERROR_INVALID_VALUE;")
-        lines.append("    if (!function) return CUDA_ERROR_INVALID_HANDLE;")
         lines.append("")
 
-        # Build params array
-        param_names = [f"args->{arg['name']}" for arg in args]
-        param_names.append("global_scratch")
-        param_names.append("profile_scratch")
-
-        lines.append("    /* Kernel parameter pointers */")
-        for i, pname in enumerate(param_names):
-            lines.append(f"    void *_param{i} = (void *)&{pname};")
-        lines.append("    void *params[] = {")
-        for i in range(len(param_names)):
-            comma = "," if i < len(param_names) - 1 else ""
-            lines.append(f"        _param{i}{comma}")
+        # Static const descriptor inside function body
+        lines.append("    static const triton_kernel_launch_desc_t desc = {")
+        lines.append("        .abi_version = TRITON_LAUNCH_DESC_ABI_VERSION,")
+        lines.append(f"        .num_warps = {num_warps},")
+        lines.append(f"        .num_ctas = {num_ctas},")
+        lines.append(f"        .shared_mem = {shared_mem}u,")
+        lines.append(f"        .launch_pdl = {launch_pdl},")
+        lines.append(f"        .launch_cooperative_grid = {launch_coop},")
+        lines.append(f"        .launch_cluster = {launch_cluster_flag},")
+        lines.append(f"        .preferred_cluster_dims = {{{preferred[0]}, {preferred[1]}, {preferred[2]}}},")
+        lines.append(f"        .num_params = {num_params},")
+        lines.append("        .params = {")
+        for off_expr, sz, is_tma in param_entries:
+            lines.append(f"            {{{off_expr}, {sz}, {is_tma}}},")
+        lines.append("        },")
+        lines.append("        .num_tma_recipes = 0,")
+        lines.append("        /* tma_recipes zero-initialized by C default */")
         lines.append("    };")
         lines.append("")
-
-        # Build launch attributes (compile-time constants)
-        lines.append("    /* Launch attributes (compile-time constants) */")
-        lines.append("    CUlaunchAttribute attrs[TRITON_MAX_LAUNCH_ATTRS];")
-        lines.append("    unsigned num_attrs = triton_build_launch_attrs(")
-        lines.append("        attrs,")
-        lines.append(f"        /*launch_pdl=*/{launch_pdl},")
-        lines.append(f"        /*launch_cooperative_grid=*/{launch_coop},")
-        lines.append(f"        /*num_ctas=*/{num_ctas},")
-        lines.append(f"        /*launch_cluster=*/{launch_cluster_flag},")
-        lines.append(f"        /*preferred_cluster_dim_x=*/{preferred[0]},")
-        lines.append(f"        /*preferred_cluster_dim_y=*/{preferred[1]},")
-        lines.append(f"        /*preferred_cluster_dim_z=*/{preferred[2]}")
-        lines.append("    );")
+        lines.append("    /* Pack args + scratch into one buffer; launcher reads by offset. */")
+        lines.append(f"    {buf_t} buf;")
+        lines.append("    buf.k = *args;")
+        lines.append("    buf._global_scratch = global_scratch;")
+        lines.append("    buf._profile_scratch = profile_scratch;")
         lines.append("")
-
-        # Call triton_launch_kernel
-        lines.append("    return triton_launch_kernel(")
-        lines.append(f"        grid, /*num_warps=*/{num_warps}, /*num_ctas=*/{num_ctas},")
-        lines.append(f"        /*shared_mem=*/{shared_mem}u, stream, function,")
-        lines.append("        params, attrs, num_attrs")
-        lines.append("    );")
+        lines.append("    return triton_launch_kernel(grid, stream, function, &buf, &desc);")
         lines.append("}")
 
         return "\n".join(lines) + "\n"

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -9,6 +9,10 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+/* Shared, Python-free data-driven launch core (params[]/TMA/attrs/launch).
+ * The same core is used by TritonCC / AOT-T via make_launcher_src. */
+#include "triton/runtime/launch.h"
+
 typedef struct {
   PyObject_HEAD;
   _Alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
@@ -1660,61 +1664,197 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
     goto cleanup;
   }
 
-  // Number of parameters passed to kernel. + 2 for global & profile scratch.
-  int num_params = num_args + 2;
-  void **params = (void **)alloca(num_params * sizeof(void *));
-  int params_idx = 0;
-  // This loop has to stay in the same function that owns params, since we are
-  // using alloca to allocate pointers to it on the stack of the function.
+  // ---- Route through the shared data-driven core triton_launch_kernel() ----
+  // The CPython arg extraction above is unchanged.  Instead of building a
+  // void *params[] and calling the legacy _launch(), we pack the extracted
+  // values into one flat args_buf and build a per-launch descriptor, then call
+  // the shared core in launch.h (the same core used by TritonCC / AOT-T).
+  //
+  // Safety net: if triton_launch_kernel fails, we automatically fall back to
+  // the proven legacy _launch() path and print a warning, so a bug in the
+  // new path never silently breaks production.
+  int num_params = (int)num_args + 2; // + global & profile scratch
+  if (num_params > TRITON_MAX_PARAMS) {
+    PyErr_Format(PyExc_RuntimeError,
+                 "Triton kernel has %d params, exceeds TRITON_MAX_PARAMS (%d)",
+                 num_params, TRITON_MAX_PARAMS);
+    goto cleanup;
+  }
+
+  triton_kernel_launch_desc_t desc;
+  desc.abi_version = TRITON_LAUNCH_DESC_ABI_VERSION;
+  desc.num_warps = num_warps;
+  desc.num_ctas = num_ctas;
+  desc.shared_mem = (unsigned)shared_memory;
+  desc.launch_pdl = launch_pdl;
+  desc.launch_cooperative_grid = launch_cooperative_grid;
+  /* Behavior-preserving vs the legacy _launch: that path requested cluster
+   * attributes iff (num_ctas != 1 || preferredClusterDimX > 0). Here we only
+   * carry the preferred-dim bit; the shared core also fires on num_ctas > 1,
+   * so the combined condition reproduces the legacy set. (The JIT launcher has
+   * no separate compile-time launch_cluster signal -- unlike TritonCC/AOT-T,
+   * which pass it explicitly from make_launcher_src metadata.) */
+  desc.launch_cluster = (preferredClusterDimX > 0) ? 1 : 0;
+  desc.preferred_cluster_dims[0] = preferredClusterDimX;
+  desc.preferred_cluster_dims[1] = preferredClusterDimY;
+  desc.preferred_cluster_dims[2] = preferredClusterDimZ;
+  desc.num_params = num_params;
+  // JIT TMA descriptors are pre-built in Python and passed by value through
+  // args_buf as ordinary params (is_tma = 0); the launcher-built recipe path
+  // (num_tma_recipes > 0) is reserved for auto-TMA.
+  desc.num_tma_recipes = 0;
+
+  // First pass: compute the args_buf layout (offset + size per param) using the
+  // same per-type extractor size/alignment the legacy path used, so the kernel
+  // sees identically laid-out parameter values.
+  Extractor *extractors = (Extractor *)alloca(num_args * sizeof(Extractor));
+  size_t buf_size = 0;
+  size_t max_align = sizeof(void *); // scratch pointers need 8B alignment
   for (Py_ssize_t i = 0; i < num_args; ++i) {
-    // Get extractor that will send back a struct with
-    // * size for allocation
-    // * function to call to put the parameter in params buffer
-    Extractor extractor = getExtractor(extractor_data[i]);
-    if (extractor.extract == NULL) {
+    Extractor e = getExtractor(extractor_data[i]);
+    if (e.extract == NULL) {
       goto cleanup;
     }
+    extractors[i] = e;
+    size_t al = e.alignment ? e.alignment : (e.size ? e.size : 1);
+    // Round up to next power of two (required for bitmask alignment below).
+    {
+      size_t v = al;
+      v--;
+      v |= v >> 1;
+      v |= v >> 2;
+      v |= v >> 4;
+      v |= v >> 8;
+      v |= v >> 16;
+      /* On 32-bit builds (sizeof(size_t)==4) a literal `v >> 32` is UB and
+       * warns
+       * (-Wshift-count-overflow); fold the width at compile time so it is 0
+       * there and 32 only where size_t is 64-bit. */
+      v |= v >> (sizeof(size_t) > 4 ? 32 : 0);
+      v++;
+      al = v;
+    }
+    if (al > max_align) {
+      max_align = al;
+    }
+    buf_size = (buf_size + al - 1) & ~(al - 1);
+    desc.params[i].offset = (int)buf_size;
+    desc.params[i].size = (int)e.size;
+    desc.params[i].is_tma = 0;
+    buf_size += e.size;
+  }
+  // Scratch params: two device pointers, 8-byte aligned.
+  buf_size = (buf_size + 7) & ~((size_t)7);
+  desc.params[num_args].offset = (int)buf_size;
+  desc.params[num_args].size = (int)sizeof(void *);
+  desc.params[num_args].is_tma = 0;
+  buf_size += sizeof(void *);
+  desc.params[num_args + 1].offset = (int)buf_size;
+  desc.params[num_args + 1].size = (int)sizeof(void *);
+  desc.params[num_args + 1].is_tma = 0;
+  buf_size += sizeof(void *);
 
-    size_t alignment = extractor.alignment;
-    if (alignment != 0) {
-      // Allocate enough space on the stack to guarantee an aligned block.
-      size_t size_with_alignment = extractor.size + alignment - 1;
-      void *storage_ptr = alloca(size_with_alignment);
-      void *aligned_ptr = (void *)((((uintptr_t)storage_ptr) + alignment - 1) &
-                                   ~(alignment - 1));
-      if (aligned_ptr == NULL) {
-        PyErr_SetString(PyExc_MemoryError, "Failed to align parameter storage");
+  // Allocate args_buf aligned to the largest element alignment so that every
+  // offset (computed relative to an aligned base) is absolutely aligned.
+  void *args_buf_raw = alloca(buf_size + max_align - 1);
+  void *args_buf =
+      (void *)(((uintptr_t)args_buf_raw + max_align - 1) & ~(max_align - 1));
+
+  // Second pass: extract each arg value into args_buf at its offset.
+  for (Py_ssize_t i = 0; i < num_args; ++i) {
+    if (!extractors[i].extract((char *)args_buf + desc.params[i].offset,
+                               args_data[i])) {
+      goto cleanup;
+    }
+  }
+  if (!extractPointer((char *)args_buf + desc.params[num_args].offset,
+                      global_scratch_obj)) {
+    goto cleanup;
+  }
+  if (!extractPointer((char *)args_buf + desc.params[num_args + 1].offset,
+                      profile_scratch_obj)) {
+    goto cleanup;
+  }
+
+  {
+    const uint32_t grid[3] = {(uint32_t)gridX, (uint32_t)gridY,
+                              (uint32_t)gridZ};
+    CUresult _launch_err = CUDA_SUCCESS;
+    Py_BEGIN_ALLOW_THREADS;
+    // Parity with legacy _launch: allow non-portable 16-CTA clusters.
+    // Runs without the GIL (matching legacy _launch behavior).
+    if (num_ctas == 16) {
+      cuFuncSetAttribute((CUfunction)_function,
+                         CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED,
+                         1);
+      /* Return value intentionally ignored: on hardware that doesn't support
+       * this attribute, the call fails harmlessly and the subsequent launch
+       * will fail with a more specific error if clusters are truly needed.
+       * Logging here would spam stderr on every 16-CTA launch. */
+    }
+    _launch_err = triton_launch_kernel(grid, (CUstream)_stream,
+                                       (CUfunction)_function, args_buf, &desc);
+    Py_END_ALLOW_THREADS;
+    if (_launch_err != CUDA_SUCCESS) {
+      /* TRITON_ASSERT_NEW_LAUNCHER: in test/debug mode, skip fallback and
+       * fail hard so we know the new launcher has a bug (not masked). */
+      if (getenv("TRITON_ASSERT_NEW_LAUNCHER")) {
+        const char *_err_str = NULL;
+        cuGetErrorString(_launch_err, &_err_str);
+        PyErr_Format(PyExc_RuntimeError,
+                     "Triton Error [CUDA]: triton_launch_kernel failed: %s "
+                     "(TRITON_ASSERT_NEW_LAUNCHER=1, no fallback)",
+                     _err_str ? _err_str : "unknown");
         goto cleanup;
       }
-      params[params_idx] = aligned_ptr;
-    } else {
-      params[params_idx] = alloca(extractor.size);
-    }
-
-    PyObject *current_arg = args_data[i];
-    if (!extractor.extract(params[params_idx++], current_arg)) {
+      /* Shared-core launch failed — fall back to the proven legacy _launch()
+       * path so the kernel still runs.  Print a warning so the failure is
+       * visible and can be investigated without blocking the user. */
+      const char *_err_str = NULL;
+      cuGetErrorString(_launch_err, &_err_str);
+      static int _fb_warned = 0;
+      if (!__atomic_exchange_n(&_fb_warned, 1, __ATOMIC_RELAXED)) {
+        fprintf(stderr,
+                "[triton] WARNING: triton_launch_kernel failed (%s, err=%d), "
+                "falling back to legacy _launch path\n",
+                _err_str ? _err_str : "unknown", (int)_launch_err);
+      }
+      /* Reuse the values already extracted into args_buf: extraction succeeded
+       * on the primary path (only the launch failed), and the legacy _launch
+       * wants void* params pointing at each value -- exactly the
+       * args_buf + desc.params[i].offset slots (kernel args followed by the two
+       * scratch pointers). Pointing into args_buf avoids re-invoking the
+       * extractors (no double side effects) and the separate alignment logic;
+       * the offsets were already laid out with correct per-param alignment. */
+      void **_fb_params = (void **)alloca((size_t)num_params * sizeof(void *));
+      for (int i = 0; i < num_params; ++i)
+        _fb_params[i] = (char *)args_buf + desc.params[i].offset;
+      Py_BEGIN_ALLOW_THREADS;
+      _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
+              launch_pdl, preferredClusterDimX, preferredClusterDimY,
+              preferredClusterDimZ, shared_memory, (CUstream)_stream,
+              (CUfunction)_function, _fb_params);
+      Py_END_ALLOW_THREADS;
+      if (!PyErr_Occurred())
+        goto launch_ok; /* fallback succeeded */
+      /* Both paths failed. If the fallback set a more specific Python
+       * exception (e.g. extractor TypeError), keep it; otherwise report
+       * the original shared-core CUDA error. */
+      if (!PyErr_Occurred()) {
+        PyErr_Format(PyExc_RuntimeError,
+                     "Triton Error [CUDA]: triton_launch_kernel failed: %s "
+                     "(legacy fallback also failed)",
+                     _err_str ? _err_str : "unknown");
+      }
       goto cleanup;
     }
   }
-  // Add scratch objects.
-  params[params_idx] = alloca(sizeof(void *));
-  if (!extractPointer(params[params_idx++], global_scratch_obj)) {
-    goto cleanup;
-  }
-  params[params_idx] = alloca(sizeof(void *));
-  if (!extractPointer(params[params_idx++], profile_scratch_obj)) {
-    goto cleanup;
-  }
+launch_ok:
 
-  Py_BEGIN_ALLOW_THREADS;
-  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
-          launch_pdl, preferredClusterDimX, preferredClusterDimY,
-          preferredClusterDimZ, shared_memory, (CUstream)_stream,
-          (CUfunction)_function, params);
-  Py_END_ALLOW_THREADS;
-  if (PyErr_Occurred()) {
+  /* Symmetry with the legacy path: never run the exit hook with a pending
+   * Python exception. */
+  if (PyErr_Occurred())
     goto cleanup;
-  }
 
   if (!launchHook(launch_exit_hook, launch_metadata)) {
     goto cleanup;

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1695,6 +1695,11 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
    * no separate compile-time launch_cluster signal -- unlike TritonCC/AOT-T,
    * which pass it explicitly from make_launcher_src metadata.) */
   desc.launch_cluster = (preferredClusterDimX > 0) ? 1 : 0;
+  // JIT variadic launcher uses the 1-D num_ctas cluster + preferred-cluster
+  // hint only; it never emits an explicit multi-dim CLUSTER_DIMENSION.
+  desc.cluster_dims[0] = 0;
+  desc.cluster_dims[1] = 0;
+  desc.cluster_dims[2] = 0;
   desc.preferred_cluster_dims[0] = preferredClusterDimX;
   desc.preferred_cluster_dims[1] = preferredClusterDimY;
   desc.preferred_cluster_dims[2] = preferredClusterDimZ;
@@ -1969,6 +1974,12 @@ typedef struct {
                                                index */
   TMASlotMeta tma_meta[TD_MAX_TMA_DESCS];
   CUtensorMap tma_descs[TD_MAX_TMA_DESCS] __attribute__((aligned(128)));
+  /* Converged launch: when set, this kernel launches through the shared core
+   * triton_launch_kernel() instead of the dispatcher's own cuLaunchKernelEx.
+   * Enabled for the common non-TMA, non multi-dim-cluster case (see
+   * TritonDispatcher_new); core_desc is built once and reused every launch. */
+  int use_core_launch;
+  triton_kernel_launch_desc_t core_desc;
 } TritonDispatcher;
 
 /* Forward declarations */
@@ -2281,6 +2292,12 @@ static inline CUresult td_relaunch(TritonDispatcher *d, unsigned gx,
                                    unsigned gy, unsigned gz, CUstream stream) {
   if (gx * gy * gz == 0)
     return CUDA_SUCCESS;
+  if (d->use_core_launch) {
+    /* Converged path: launch through the shared core in launch.h. */
+    const uint32_t grid[3] = {gx, gy, gz};
+    return triton_launch_kernel(grid, stream, d->function,
+                                (void *)d->arg_storage, &d->core_desc);
+  }
   CUlaunchConfig cfg;
   cfg.gridDimX = gx * d->grid_mult;
   cfg.gridDimY = gy;
@@ -2516,6 +2533,45 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
     na++;
   }
   self->num_launch_attrs = na;
+
+  /* Build a shared-core launch descriptor so this dispatcher can launch via
+   * triton_launch_kernel() -- one launch implementation shared with the JIT
+   * variadic launcher and TritonCC / AOT-T.  arg_storage is already a flat,
+   * fixed-stride (sizeof(TDArgSlot)) buffer with one slot per param, so the
+   * descriptor just maps param i -> slot offset i*sizeof(TDArgSlot).
+   *
+   * Restricted to the case the core models exactly today: no TMA (the core's
+   * recipe-based TMA construction is converged separately).  The shared core
+   * now handles both the 1-D num_ctas cluster and the explicit
+   * multi-dimensional cluster (cluster_dims), so only TMA kernels keep the
+   * dispatcher's own td_relaunch path. */
+  self->use_core_launch =
+      (self->num_tma_descs == 0 && self->total_params <= TRITON_MAX_PARAMS);
+  if (self->use_core_launch) {
+    memset(&self->core_desc, 0, sizeof(self->core_desc));
+    self->core_desc.abi_version = TRITON_LAUNCH_DESC_ABI_VERSION;
+    self->core_desc.num_warps = num_warps;
+    self->core_desc.num_ctas = num_ctas;
+    self->core_desc.shared_mem = (unsigned)shared_mem;
+    self->core_desc.launch_pdl = launch_pdl;
+    self->core_desc.launch_cooperative_grid = launch_coop;
+    self->core_desc.launch_cluster = launch_cluster;
+    /* Explicit multi-dim cluster (ctas_per_cga). When all <= 1, the core uses
+     * the 1-D num_ctas path; num_ctas takes priority, so 1-D and multi-dim are
+     * never both applied. */
+    self->core_desc.cluster_dims[0] = cluster_dim_x;
+    self->core_desc.cluster_dims[1] = cluster_dim_y;
+    self->core_desc.cluster_dims[2] = cluster_dim_z;
+    self->core_desc.num_params = self->total_params;
+    self->core_desc.num_tma_recipes = 0;
+    for (int i = 0; i < self->total_params; i++) {
+      /* size is unused by the core for non-TMA params (it indexes args_buf by
+       * offset); record the storage slot size for clarity. */
+      self->core_desc.params[i].offset = (int)(i * (int)sizeof(TDArgSlot));
+      self->core_desc.params[i].size = (int)sizeof(TDArgSlot);
+      self->core_desc.params[i].is_tma = 0;
+    }
+  }
 
   return (PyObject *)self;
 }

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -17,6 +17,20 @@ from triton.backends.driver import (
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dirs = [os.path.join(dirname, "include")]
+# Path(s) to the shared data-driven launcher core. driver.c is compiled via a
+# fixed Remote-Execution command that ignores include_dirs, so we inline this
+# header into the driver.c source at build time (see CudaUtils.__init__) rather
+# than relying on an -I path.
+#
+# The first candidate (backend/launch.h) is a vendored copy that ships with the
+# nvidia backend resources (the BUCK glob packages it next to driver.py), so it
+# is present in packaged/buck builds. The second is the canonical source used by
+# C/C++ consumers (cc_library triton_launch_h). Keep the two in sync; the
+# canonical is python/triton/runtime/launch.h.
+_launch_h_candidates = [
+    os.path.join(dirname, "launch.h"),
+    os.path.join(dirname, "..", "..", "..", "python", "triton", "runtime", "launch.h"),
+]
 libdevice_dir = os.path.join(dirname, "lib")
 libraries = ["libcuda.so.1"]
 PyCUtensorMap = None
@@ -68,8 +82,24 @@ class CudaUtils(object):
         return cls.instance
 
     def __init__(self):
+        # Inline the shared launcher core (launch.h) directly into the driver
+        # source: the fbcode Remote-Execution compile uses a fixed clang command
+        # that does not honor include_dirs, so an `#include "triton/runtime/
+        # launch.h"` would not resolve. Substituting the header text keeps a
+        # single source of truth (launch.h) while making the compile
+        # self-contained.
+        driver_src = Path(os.path.join(dirname, "driver.c")).read_text()
+        launch_h_path = next((p for p in _launch_h_candidates if os.path.exists(p)), None)
+        if launch_h_path is None:
+            raise FileNotFoundError(f"launch.h not found in any of: {_launch_h_candidates}")
+        launch_h_src = Path(launch_h_path).read_text()
+        include_marker = '#include "triton/runtime/launch.h"'
+        if include_marker not in driver_src:
+            raise RuntimeError(f"driver.c must contain the marker {include_marker!r} for "
+                               "launch.h inlining, but it was not found")
+        driver_src = driver_src.replace(include_marker, launch_h_src)
         mod = compile_module_from_src(
-            src=Path(os.path.join(dirname, "driver.c")).read_text(),
+            src=driver_src,
             name="cuda_utils",
             library_dirs=library_dirs(),
             include_dirs=include_dirs,


### PR DESCRIPTION
Summary:

### Background 
The previous diff in this stack routed the JIT variadic launcher and
the TritonCC / AOT-T generated launchers through a single shared launch core
(triton_launch_kernel in triton/runtime/launch.h). The JIT "dispatcher"
fast-path (_TritonDispatcher, enabled by TRITON_USE_C_DISPATCHER and also
backing the c_cache ProxyRunner) was still launching kernels with its own
private cuLaunchKernelEx call -- another copy of the launch logic.

### What this does 
The dispatcher keeps its pre-bound, low-overhead argument
storage, but now builds a launch descriptor once at construction time and, at
launch, calls the shared triton_launch_kernel() instead of its own launch path.
A single relaunch helper feeds both the dispatcher and the c_cache ProxyRunner,
so both converge with one change.

### Scope 
This converges the common case: kernels with no TMA descriptors. Kernels that use TMA descriptors, keep the dispatcher's existing launch path for now.
TMA convergence -- which requires correct, validated recipe-based TMA
construction in the shared core -- is a follow-up diff in this stack.

### Before / after
- Before: the dispatcher fast-path had its own cuLaunchKernelEx + launch
  attribute logic, separate from every other consumer.
- After: the dispatcher builds a descriptor and calls the shared core, so
  non-TMA dispatcher launches share one launch implementation with the JIT
  variadic launcher and TritonCC / AOT-T.

Reviewed By: htyu

Differential Revision: D108690857


