### PR TITLE
[triton][beta] [Cherry-pick][BUNDLE] Cherry-pick 10 upstream commits (#9219, #9220, #9337, #9221, #9361, #9396, #9317, #9318, #9327, #9392)

### DIFF
--- a/include/triton/Dialect/Triton/IR/Traits.h
+++ b/include/triton/Dialect/Triton/IR/Traits.h
@@ -28,7 +28,7 @@ LogicalResult verifyTensorLayouts(Operation *op);
 
 LogicalResult verifySameOperandsEncoding(Operation *op,
                                          bool allowTensorPointerType = false);
-LogicalResult verifyEquivalentType(Type typeA, Type typeB);
+LogicalResult verifyEquivalentTensorType(Type typeA, Type typeB);
 LogicalResult
 verifySameOperandsAndResultEncoding(Operation *op,
                                     bool allowTensorPointerType = false);

--- a/include/triton/Dialect/Triton/IR/TritonInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonInterfaces.td
@@ -16,13 +16,13 @@ def AsyncRegions : NativeOpTrait<"AsyncRegions">;
 
 // A trait equivalent to InferTypeOpAdaptor, but that checks for structural
 // equivalence of the layouts of the result rather than just layout equality.
-def InferTypeOpWithLayoutEquivalence : InferTypeOpAdaptorBase<[{
+def InferTensorTypeOpWithLayoutEquivalence : InferTypeOpAdaptorBase<[{
   static bool isCompatibleReturnTypes(TypeRange lhs, TypeRange rhs) {
     if (lhs.size() != rhs.size())
       return false;
     return llvm::all_of(llvm::zip(lhs, rhs), [](auto tup) {
       auto [lhs, rhs] = tup;
-      return succeeded(OpTrait::impl::verifyEquivalentType(lhs, rhs));
+      return succeeded(OpTrait::impl::verifyEquivalentTensorType(lhs, rhs));
     });
   }
 }]>;

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -558,7 +558,7 @@ def TT_JoinOp : TT_Op<"join", [
 
 def TT_SplitOp : TT_Op<"split", [
   Pure,
-  InferTypeOpWithLayoutEquivalence,
+  InferTensorTypeOpWithLayoutEquivalence,
   TypesMatchWith<"outLHS and outRHS types match",
                   "outLHS", "outRHS", "$_self">,
 ]> {
@@ -578,7 +578,7 @@ def TT_SplitOp : TT_Op<"split", [
 
 def TT_TransOp : TT_Op<"trans", [Pure,
                                  TransposeOpInterface,
-                                 InferTypeOpWithLayoutEquivalence,
+                                 InferTensorTypeOpWithLayoutEquivalence,
                                  SameOperandsAndResultElementType]> {
 
     let summary = "rearrange the dimensions of a tensor";

--- a/include/triton/Dialect/TritonGPU/IR/Traits.h
+++ b/include/triton/Dialect/TritonGPU/IR/Traits.h
@@ -10,6 +10,22 @@
 namespace mlir {
 namespace OpTrait {
 
+namespace impl {
+LogicalResult verifyEquivalentMemDescType(Type typeA, Type typeB);
+LogicalResult verifyMemDescLayouts(Operation *op);
+} // namespace impl
+
+// Trait applied to all Triton GPU MLIR ops.  Checks that the layouts of
+// MemDescs are valid.
+template <class ConcreteType>
+class VerifyMemDescLayoutsTrait
+    : public TraitBase<ConcreteType, VerifyMemDescLayoutsTrait> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return impl::verifyMemDescLayouts(op);
+  }
+};
+
 template <typename ConcreteType>
 class MemDescViewTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, MemDescViewTrait> {

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
@@ -2,6 +2,7 @@
 #define TRITONGPU_OP_INTERFACES
 
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 
 def UpcastFpOpInterface : OpInterface<"UpcastFpOpInterface"> {
     let description = [{
@@ -25,5 +26,20 @@ def UpcastFpOpInterface : OpInterface<"UpcastFpOpInterface"> {
         >
     ];
 }
+
+def VerifyMemDescLayoutsTrait : NativeOpTrait<"VerifyMemDescLayoutsTrait">;
+
+// A trait equivalent to InferTypeOpAdaptor, but that checks for structural
+// equivalence of the layouts of the result rather than just layout equality.
+def InferMemDescTypeOpWithLayoutEquivalence : InferTypeOpAdaptorBase<[{
+  static bool isCompatibleReturnTypes(TypeRange lhs, TypeRange rhs) {
+    if (lhs.size() != rhs.size())
+      return false;
+    return llvm::all_of(llvm::zip(lhs, rhs), [](auto tup) {
+      auto [lhs, rhs] = tup;
+      return succeeded(OpTrait::impl::verifyEquivalentMemDescType(lhs, rhs));
+    });
+  }
+}]>;
 
 #endif // TRITONGPU_OP_INTERFACES

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -6,6 +6,7 @@ include "triton/Dialect/TritonGPU/IR/TritonGPUEnums.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypeInterfaces.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td"
+include "triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td"
 include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
@@ -25,7 +26,7 @@ def SharedMemory : Resource<"::mlir::triton::gpu::SharedMemory">;
 
 class TTG_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonGPU_Dialect, mnemonic,
-       !listconcat(traits, [VerifyTensorLayoutsTrait])> {
+       !listconcat(traits, [VerifyTensorLayoutsTrait, VerifyMemDescLayoutsTrait])> {
 }
 
 def TTG_ConvertLayoutOp : TTG_Op<"convert_layout",
@@ -302,7 +303,7 @@ def TTG_MemDescSubsliceOp : TTG_Op<"memdesc_subslice", [Pure, MemDescViewTrait]>
 def TTG_MemDescTransOp : TTG_Op<"memdesc_trans", [Pure,
                                                   MemDescViewTrait,
                                                   TransposeOpInterface,
-                                                  InferTypeOpWithLayoutEquivalence,
+                                                  InferMemDescTypeOpWithLayoutEquivalence,
                                                   SameOperandsAndResultElementType]> {
   let summary = "transpose the descriptor";
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -33,6 +33,7 @@ include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypeInterfaces.td"
+include "triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td" // Pure
 include "mlir/Interfaces/InferTypeOpInterface.td" // SameOperandsAndResultType
@@ -46,7 +47,7 @@ def TensorMemory : Resource<"::mlir::triton::nvidia_gpu::TensorMemory">;
 
 class TTNG_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonNvidiaGPU_Dialect, mnemonic,
-       !listconcat(traits, [VerifyTensorLayoutsTrait])> {
+       !listconcat(traits, [VerifyTensorLayoutsTrait, VerifyMemDescLayoutsTrait])> {
 }
 
 def TTNG_FenceAsyncSharedOp : TTNG_Op<"fence_async_shared"> {
@@ -130,6 +131,99 @@ def TTNG_MapToRemoteBufferOp : TTNG_Op<"map_to_remote_buffer", [Pure, MemDescVie
   let assemblyFormat = [{$src`,` $ctaRank attr-dict `:` qualified(type($src)) `->` qualified(type($result))}];
 
   let hasVerifier = 1;
+}
+
+//
+// Cluster Launch Control (CLC) Ops - Blackwell SM100+
+//
+def TTNG_CLCTryCancelOp : TTNG_Op<"clc_try_cancel", []> {
+  let summary = "Issue CLC try_cancel to cancel a pending cluster";
+
+  let description = [{
+    Issues a clusterlaunchcontrol.try_cancel instruction to atomically cancel
+    a pending cluster launch. The result is written asynchronously to the
+    result buffer and the mbarrier is signaled on completion.
+
+    This is used for dynamic persistent kernels on Blackwell (SM100+).
+
+    The result buffer must be 16-byte aligned shared memory.
+    The mbarrier must be 8-byte aligned shared memory.
+  }];
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$mbarrier,
+    I1Attr:$multicast
+  );
+
+  let assemblyFormat = [{
+    $result `,` $mbarrier attr-dict `:` qualified(type($result)) `,` qualified(type($mbarrier))
+  }];
+  let hasVerifier = 1;
+}
+
+def TTNG_CLCLoadResultOp : TTNG_Op<"clc_load_result", []> {
+  let summary = "Load CLC response from shared memory into registers";
+
+  let description = [{
+    Loads the 128-bit CLC response from shared memory into two i64 registers.
+    This allows subsequent is_canceled and get_first_ctaid operations to
+    operate on registers without re-reading shared memory.
+  }];
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src
+  );
+
+  let results = (outs I128:$clcResult);
+
+  let assemblyFormat = [{
+    $src attr-dict `:` qualified(type($src)) `->` type($clcResult)
+  }];
+  let hasVerifier = 1;
+}
+
+def TTNG_CLCIsCanceledOp : TTNG_Op<"clc_is_canceled", [Pure]> {
+  let summary = "Check if CLC response indicates successful cancellation";
+
+  let description = [{
+    Decodes the CLC response to check if a cluster was successfully
+    canceled. Returns true if canceled, false otherwise.
+  }];
+
+  let arguments = (ins I128:$clcResult);
+
+  let results = (outs I1:$is_canceled);
+
+  let assemblyFormat = [{
+    $clcResult attr-dict `:` type($clcResult) `->` type($is_canceled)
+  }];
+}
+
+def TTNG_CLCGetProgramIdOp : TTNG_Op<"clc_get_program_id", [Pure]> {
+  let summary = "Get CTA ID coordinate from CLC response";
+
+  let description = [{
+    Decodes the CLC response to get the first CTA ID coordinate of the
+    canceled cluster. The dim attribute specifies which dimension (0=x, 1=y, 2=z).
+  }];
+
+  let arguments = (ins
+    I128:$clcResult,
+    TT_ProgramDim:$dim
+  );
+
+  let results = (outs I32:$result);
+
+  let assemblyFormat = [{
+    $clcResult `,` $dim attr-dict `:` type($clcResult) `->` type($result)
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$clcResult, "int":$axis), [{
+      build($_builder, $_state, clcResult, ProgramIDDim(axis));
+    }]>
+  ];
 }
 
 //

--- a/lib/Dialect/Triton/IR/Traits.cpp
+++ b/lib/Dialect/Triton/IR/Traits.cpp
@@ -6,42 +6,13 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
-#include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace mlir;
-using namespace mlir::triton::gpu;
 
-LogicalResult OpTrait::impl::verifyEquivalentType(Type typeA, Type typeB) {
-  auto memdescA = dyn_cast<MemDescType>(typeA);
-  auto memdescB = dyn_cast<MemDescType>(typeB);
-  if (memdescA || memdescB) {
-    if (!memdescA || !memdescB)
-      return failure();
-    if (memdescA.getShape() != memdescB.getShape())
-      return failure();
-    if (memdescA.getAllocShape() != memdescB.getAllocShape())
-      return failure();
-    if (memdescA.getElementType() != memdescB.getElementType())
-      return failure();
-    if (memdescA.getMemorySpace() != memdescB.getMemorySpace())
-      return failure();
-    if (memdescA.getMutableMemory() != memdescB.getMutableMemory())
-      return failure();
-
-    Attribute encodingA = memdescA.getEncoding();
-    Attribute encodingB = memdescB.getEncoding();
-    if (encodingA == encodingB)
-      return success();
-    if (static_cast<bool>(encodingA) != static_cast<bool>(encodingB))
-      return failure();
-
-    auto layoutInterface =
-        cast<triton::DialectInferLayoutInterface>(&encodingA.getDialect());
-    return layoutInterface->verifyLayoutsAreEqual(memdescA.getShape(),
-                                                  encodingA, encodingB, {});
-  }
+LogicalResult OpTrait::impl::verifyEquivalentTensorType(Type typeA,
+                                                        Type typeB) {
   auto tensorTypeA = dyn_cast<RankedTensorType>(typeA);
   auto tensorTypeB = dyn_cast<RankedTensorType>(typeB);
   if (!(bool(tensorTypeA) && bool(tensorTypeB)))
@@ -164,26 +135,10 @@ LogicalResult OpTrait::impl::verifyTensorLayouts(Operation *op) {
   auto checkLayout = [&](Value val, auto makeErr) -> LogicalResult {
     // Only ranked tensors can have layouts.
     auto rankedTy = dyn_cast<RankedTensorType>(val.getType());
-    if (rankedTy) {
-      mlir::Attribute layout = rankedTy.getEncoding();
-      if (!layout)
-        return success();
-
-      Dialect &dialect = layout.getDialect();
-      auto verifyLayoutInterface =
-          dyn_cast<mlir::triton::DialectVerifyTensorLayoutInterface>(&dialect);
-      if (verifyLayoutInterface) {
-        return verifyLayoutInterface->verifyTensorLayout(layout, rankedTy, op,
-                                                         makeErr);
-      }
-      return success();
-    }
-
-    auto memDescTy = dyn_cast<MemDescType>(val.getType());
-    if (!memDescTy)
+    if (!rankedTy)
       return success();
 
-    mlir::Attribute layout = memDescTy.getEncoding();
+    mlir::Attribute layout = rankedTy.getEncoding();
     if (!layout)
       return success();
 
@@ -191,8 +146,8 @@ LogicalResult OpTrait::impl::verifyTensorLayouts(Operation *op) {
     auto verifyLayoutInterface =
         dyn_cast<mlir::triton::DialectVerifyTensorLayoutInterface>(&dialect);
     if (verifyLayoutInterface) {
-      return verifyLayoutInterface->verifyMemDescLayout(layout, memDescTy, op,
-                                                        makeErr);
+      return verifyLayoutInterface->verifyTensorLayout(layout, rankedTy, op,
+                                                       makeErr);
     }
 
     return success();

--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonGPUIR
   LinearLayoutConversions.cpp
   Ops.cpp
   Types.cpp
+  Traits.cpp
 
   DEPENDS
   TritonGPUCGAAttrIncGen

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -606,7 +606,7 @@ LogicalResult MemDescReshapeOp::verify() {
   if (failed(inferReturnTypes(getContext(), getLoc(), srcType,
                               dstType.getShape(), expectedTy)))
     return failure();
-  return OpTrait::impl::verifyEquivalentType(expectedTy, dstType);
+  return OpTrait::impl::verifyEquivalentMemDescType(expectedTy, dstType);
 }
 
 static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,

--- a/lib/Dialect/TritonGPU/IR/Traits.cpp
+++ b/lib/Dialect/TritonGPU/IR/Traits.cpp
@@ -1,0 +1,104 @@
+#include "triton/Dialect/TritonGPU/IR/Traits.h"
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/LogicalResult.h"
+
+using namespace mlir;
+using namespace mlir::triton::gpu;
+
+LogicalResult OpTrait::impl::verifyEquivalentMemDescType(Type typeA,
+                                                         Type typeB) {
+  auto memdescA = dyn_cast<MemDescType>(typeA);
+  auto memdescB = dyn_cast<MemDescType>(typeB);
+  if (!memdescA || !memdescB)
+    return success(memdescA == memdescB);
+  if (memdescA.getShape() != memdescB.getShape())
+    return failure();
+  if (memdescA.getAllocShape() != memdescB.getAllocShape())
+    return failure();
+  if (memdescA.getElementType() != memdescB.getElementType())
+    return failure();
+  if (memdescA.getMemorySpace() != memdescB.getMemorySpace())
+    return failure();
+  if (memdescA.getMutableMemory() != memdescB.getMutableMemory())
+    return failure();
+
+  Attribute encodingA = memdescA.getEncoding();
+  Attribute encodingB = memdescB.getEncoding();
+  if (encodingA == encodingB)
+    return success();
+  if (static_cast<bool>(encodingA) != static_cast<bool>(encodingB))
+    return failure();
+
+  auto layoutInterface =
+      cast<triton::DialectInferLayoutInterface>(&encodingA.getDialect());
+  return layoutInterface->verifyLayoutsAreEqual(memdescA.getShape(), encodingA,
+                                                encodingB, {});
+}
+
+// Check that the Triton layouts on op's operands and return types are valid.
+// For example, we check that the number of warps per block in a Triton GPU
+// blocked layout matches that of its module.
+//
+// It's a little weird to check these properties of a layout only when the
+// layout is used in an op, since most of the properties don't actually depend
+// on the op.  They do depend on the *module*, though, and a layout is attached
+// to a module only by virtue of being used in one of the module's ops.
+LogicalResult OpTrait::impl::verifyMemDescLayouts(Operation *op) {
+  auto checkLayout = [&](Value val, auto makeErr) -> LogicalResult {
+    auto memDescTy = dyn_cast<MemDescType>(val.getType());
+    if (!memDescTy)
+      return success();
+
+    mlir::Attribute layout = memDescTy.getEncoding();
+    if (!layout)
+      return success();
+
+    Dialect &dialect = layout.getDialect();
+    auto verifyLayoutInterface =
+        dyn_cast<mlir::triton::DialectVerifyTensorLayoutInterface>(&dialect);
+    if (verifyLayoutInterface) {
+      return verifyLayoutInterface->verifyMemDescLayout(layout, memDescTy, op,
+                                                        makeErr);
+    }
+
+    return success();
+  };
+
+  for (size_t i = 0; i < op->getNumOperands(); i++) {
+    auto operand = op->getOperand(i);
+    auto err = checkLayout(operand, [&]() {
+      // Stringify the operand using `printAsOperand`.  This prints e.g. "%42"
+      // rather than the full definition.
+      std::string operandStr;
+      llvm::raw_string_ostream os(operandStr);
+      // If we don't assume verified, dump() will recursively call this
+      // function!
+      operand.printAsOperand(os, OpPrintingFlags().assumeVerified());
+
+      return op->emitError("Operand ")
+             << i << " (" << operand << ") has an invalid layout: ";
+    });
+    if (!err.succeeded())
+      return err;
+  }
+
+  for (size_t i = 0; i < op->getNumResults(); i++) {
+    auto result = op->getResult(i);
+    auto err = checkLayout(result, [&]() {
+      if (op->getNumResults() == 1) {
+        return op->emitError("Result has an invalid layout: ");
+      } else {
+        return op->emitError("Result ") << i << " has an invalid layout: ";
+      }
+    });
+    if (!err.succeeded())
+      return err;
+  }
+
+  return success();
+}

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -36,6 +36,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.cpp.inc"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
+#include "triton/Tools/StrUtil.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -1605,6 +1606,30 @@ LogicalResult TensormapCreateOp::verify() {
            << getElementStride().size() << " but expected " << rank;
   }
   return success();
+}
+
+// -- CLCTryCancelOp --
+static LogicalResult verifyCLCResultMemdesc(Location loc, MemDescType desc) {
+  auto int_ty = dyn_cast<IntegerType>(desc.getElementType());
+  if (!int_ty || int_ty.getWidth() != 64) {
+    return emitError(loc)
+           << "Expected CLC result buffer to have type int64, but got"
+           << desc.getElementType();
+  }
+  if (desc.getShape().size() != 1 || desc.getShape()[0] != 2) {
+    return emitError(loc)
+           << "Expected CLC result buffer to have shape [2], but got ["
+           << triton::join(desc.getShape(), ", ") << "]";
+  }
+  return success();
+}
+
+LogicalResult CLCTryCancelOp::verify() {
+  return verifyCLCResultMemdesc(getLoc(), getResult().getType());
+}
+
+LogicalResult CLCLoadResultOp::verify() {
+  return verifyCLCResultMemdesc(getLoc(), getSrc().getType());
 }
 
 } // namespace nvidia_gpu

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -859,6 +859,27 @@ void init_gluon_ir(py::module &&m) {
            })
       .def("create_cluster_wait",
            [](GluonOpBuilder &self) { self.create<ttng::ClusterWaitOp>(); })
+      // CLC (Cluster Launch Control) ops - SM100+
+      .def("create_clc_try_cancel",
+           [](GluonOpBuilder &self, Value result, Value mbarrier,
+              bool multicast) {
+             self.create<ttng::CLCTryCancelOp>(result, mbarrier, multicast);
+           })
+      .def("create_clc_load_result",
+           [](GluonOpBuilder &self, Value result) -> Value {
+             auto i64Ty = self.getBuilder().getI64Type();
+             return self.create<ttng::CLCLoadResultOp>(result);
+           })
+      .def("create_clc_is_canceled",
+           [](GluonOpBuilder &self, Value clcResult) -> Value {
+             auto i1Ty = self.getBuilder().getI1Type();
+             return self.create<ttng::CLCIsCanceledOp>(clcResult);
+           })
+      .def("create_clc_get_program_id",
+           [](GluonOpBuilder &self, Value clcResult, int dim) -> Value {
+             auto i32Ty = self.getBuilder().getI32Type();
+             return self.create<ttng::CLCGetProgramIdOp>(clcResult, dim);
+           })
       .def("create_tcgen05_mma",
            [](GluonOpBuilder &self, Value a, Value b, Value acc, Value useAcc,
               Value pred, std::vector<Value> &mbarriers,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1070,6 +1070,10 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getI64Type();
            })
+      .def("get_int128_ty",
+           [](TritonOpBuilder &self) -> Type {
+             return self.getBuilder().getIntegerType(128);
+           })
       .def("get_fp8e4nv_ty",
            [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getType<Float8E4M3FNType>();

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -40,6 +40,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     tcgen05_commit,
     tcgen05_copy,
     float2,
+    clc,
 )
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 
@@ -4605,3 +4606,50 @@ def test_tmem_reduction(red_op, use_abs, propagate_nan, M, N, num_warps):
     # Verify reduction output
     # Use equal_nan=True when testing NaN propagation
     torch.testing.assert_close(expected_red, red_output, atol=1e-5, rtol=1e-5, equal_nan=use_nan)
+
+
+@pytest.mark.parametrize("num_ctas", [1, 2])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_clc_basic(num_ctas):
+
+    @gluon.jit
+    def clc_kernel(WasLaunched, IsCancelled, ProgramId, smem_size: ttgl.constexpr):
+        # Large shared memory allocation to force 1 block per SM
+        cga_layout: ttgl.constexpr = [[0]] if ttgl.num_ctas() == 2 else []
+        layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=cga_layout)
+        dummy = ttgl.allocate_shared_memory(ttgl.int64, [smem_size // 8 - 32], layout)
+
+        clc_result = ttgl.allocate_shared_memory(ttgl.int64, [2], layout)
+        clc_mbar = mbarrier.allocate_mbarrier()
+        mbarrier.init(clc_mbar, count=1)
+
+        clc.try_cancel(clc_result, clc_mbar, multicast=True)
+        mbarrier.expect(clc_mbar, 16)
+        mbarrier.wait(clc_mbar, 0)
+
+        response = clc.load_result(clc_result)
+        pid = ttgl.program_id(0)
+        ttgl.store(WasLaunched + pid, True)
+        ttgl.store(IsCancelled + pid, response.is_canceled())
+        ttgl.store(ProgramId + pid, response.program_id(0))
+        dummy._keep_alive()
+
+    dev_props = torch.cuda.get_device_properties("cuda")
+    num_sms = dev_props.multi_processor_count
+    smem_size = dev_props.shared_memory_per_block_optin // num_ctas
+    grid = 2 * (num_sms // num_ctas)
+
+    was_launched = torch.zeros([grid], dtype=torch.bool, device="cuda")
+    is_cancelled = torch.zeros([grid], dtype=torch.bool, device="cuda")
+    program_ids = torch.zeros([grid], dtype=torch.int32, device="cuda")
+    clc_kernel[(grid, )](was_launched, is_cancelled, program_ids, smem_size, num_ctas=num_ctas)
+
+    num_launched = torch.sum(was_launched).item()
+    assert num_launched < grid
+
+    num_cancelled = torch.sum(is_cancelled).item()
+    assert num_launched + num_cancelled == grid
+
+    for pid in range(grid):
+        if is_cancelled[pid]:
+            assert not was_launched[program_ids[pid]]

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -8,6 +8,7 @@ from triton.experimental.gluon.language._core import builtin, base_type, base_va
 from triton.experimental.gluon.language._semantic import _check, _compute_tmem_reg_layout
 
 from . import tma
+from . import clc
 from ..hopper import fence_async_shared, mbarrier
 from ..ampere import async_copy, mma_v2
 
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 __all__ = [
     "allocate_tensor_memory",
     "async_copy",
+    "clc",
     "fence_async_shared",
     "get_tmem_reg_layout",
     "mbarrier",

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/clc.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/clc.py
@@ -1,0 +1,113 @@
+"""
+Cluster Launch Control (CLC) for Blackwell (SM100+) dynamic persistent kernels.
+
+CLC enables hardware-based dynamic work scheduling where running workers can
+cancel not-yet-launched clusters and take over their work via the
+clusterlaunchcontrol.try_cancel instruction.
+"""
+from __future__ import annotations
+
+import triton.experimental.gluon.language._core as gl
+from triton.experimental.gluon.language._core import builtin, tensor, shared_memory_descriptor, base_value, base_type
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from triton._C.libtriton.gluon_ir import GluonOpBuilder
+    from triton._C.libtriton import ir
+
+__all__ = [
+    "try_cancel",
+    "load_result",
+    "clc_result",
+]
+
+
+@builtin
+def try_cancel(result: shared_memory_descriptor, barrier, multicast=False, _semantic=None):
+    """
+    Issue a CLC try_cancel request to atomically cancel a pending cluster launch.
+
+    Args:
+        result (shared_memory_descriptor): 16-byte aligned shared memory for the response
+        barrier (shared_memory_descriptor): 8-byte aligned mbarrier for completion signaling
+        multicast (bool): If True, broadcast result to all CTAs in cluster
+
+    Only supported on SM100+ (Blackwell).
+    """
+    _semantic.builder.create_clc_try_cancel(result.handle, barrier.handle, multicast)
+
+
+@builtin
+def load_result(src, _semantic=None):
+    """
+    Load the CLC response from shared memory into registers.
+
+    Args:
+        src (shared_memory_descriptor): The CLC response buffer
+
+    Returns:
+        CLCResult: Object with is_canceled() and get_first_ctaid(dim) methods
+    """
+    handle = _semantic.builder.create_clc_load_result(src.handle)
+    return clc_result(handle)
+
+
+class clc_result_type(base_type):
+
+    def to_ir(self, builder: GluonOpBuilder) -> None:
+        return builder.get_int128_ty()
+
+    def _unflatten_ir(self, handles: List[ir.Value], cursor: int) -> Tuple[shared_memory_descriptor, int]:
+        value = clc_result(handles[cursor])
+        return value, cursor + 1
+
+    def _flatten_ir_types(self, builder: GluonOpBuilder, out: List[ir.type]) -> None:
+        out.append(self.to_ir(builder))
+
+    def __str__(self) -> str:
+        return "clc_result"
+
+    def __eq__(self, other) -> bool:
+        return type(self) is type(other)
+
+    def mangle(self) -> str:
+        return "CLC"
+
+
+class clc_result(base_value):
+    """CLC response loaded into registers. Query without re-reading memory."""
+
+    def __init__(self, handle):
+        self.handle = handle
+        self.type = clc_result_type()
+
+    def _flatten_ir(self, handles: List[ir.value]) -> None:
+        handles.append(self.handle)
+
+    def _set_name(self, builder: ir.builder, name: str) -> None:
+        self.handle.set_loc(builder.create_name_loc(name, self.handle.get_loc()))
+
+    @builtin
+    def is_canceled(self, _semantic=None):
+        """
+        Check if the CLC response indicates a successful cancellation.
+
+        Returns:
+            tensor: True if a cluster was successfully canceled, False otherwise
+        """
+        handle = _semantic.builder.create_clc_is_canceled(self.handle)
+        return tensor(handle, gl.int1)
+
+    @builtin
+    def program_id(self, dim, _semantic=None):
+        """
+        Get the Program ID of the canceled cluster.
+
+        Args:
+            dim (int): Dimension to get (0=x, 1=y, 2=z)
+
+        Returns:
+            tensor: The Program ID for the specified dimension
+        """
+        handle = _semantic.builder.create_clc_get_program_id(self.handle, dim)
+        return tensor(handle, gl.int32)

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -834,7 +834,8 @@ if __name__ == "__main__":
 #   Hopper and Blackwell: we are not double-buffering the accumulator and
 #   leaving 256 columns of TMEM unused.
 # - On Blackwell, we can use `clusterlaunchcontrol` to dynamically schedule
-#   work in conjunction with the GPU, getting the best of both worlds.
+#   work in conjunction with the GPU, getting the best of both worlds. This is
+#   explored further in tutorial 12.
 #
 # Main takeaways:
 #

--- a/python/tutorials/gluon/12-cluster-launch-control.py
+++ b/python/tutorials/gluon/12-cluster-launch-control.py
@@ -1,0 +1,317 @@
+"""
+Cluster Launch Control (CLC)
+============================
+
+Cluster Launch Control (CLC) is a Blackwell (SM100+) hardware feature that enables
+dynamic work distribution between thread blocks. When a block finishes early, it can
+cancel a not-yet-launched cluster and take over its work, improving load balancing.
+
+This tutorial demonstrates:
+1. The CLC API: try_cancel, is_canceled, get_first_ctaid
+2. How to overlap CLC with computation to hide latency
+3. A comparison with a statically scheduled persistent matmul
+
+Key Insight
+-----------
+The critical optimization is issuing CLC during the TMA prologue and checking
+the result after tile completion. This hides CLC latency behind computation.
+
+CLC API
+-------
+- ``clc.try_cancel(result, mbar)``: Issue async CLC request to cancel a pending cluster
+- ``clc_result = clc.load_result(result)``: Load CLC response into registers
+- ``clc_result.is_canceled()``: Returns True if a cluster was successfully canceled
+- ``clc_result.program_id(dim)``: Get the canceled cluster's program ID
+"""
+
+import torch
+import triton
+import pytest
+import importlib
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.nvidia.blackwell import TensorDescriptor
+from triton.experimental.gluon.language.nvidia.blackwell import tma, mbarrier, fence_async_shared, clc
+from triton.language.core import _aggregate as aggregate
+
+
+def is_blackwell():
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10
+
+
+if __name__ == "__main__" and not is_blackwell():
+    raise RuntimeError("This tutorial requires Blackwell (SM100+) GPU")
+
+# Re-use helpers from tutorial 7.
+t7 = importlib.import_module("07-persistence")
+
+# %%
+# CLC Matmul Kernel
+# -----------------
+# This kernel processes its assigned tile, then attempts to steal additional work.
+# CLC is issued during the prologue so the result is ready after tile completion.
+#
+# This is identical to the persistent_matmul_kernel from tutorial 7, except for the
+# changed ClcTileScheduler interface to support dynamic scheduling.
+
+
+@aggregate
+class ClcTileScheduler:
+    has_work: gl.tensor
+    tile_id: gl.tensor
+    clc_result_buf: gl.shared_memory_descriptor
+    barrier: gl.shared_memory_descriptor
+    phase: gl.tensor
+
+    @gluon.constexpr_function
+    def __init__(self, has_work, tile_id, clc_result_buf, barrier, phase):
+        self.has_work = has_work
+        self.tile_id = tile_id
+        self.clc_result_buf = clc_result_buf
+        self.barrier = barrier
+        self.phase = phase
+
+    @gluon.jit
+    def initialize(M, N, BLOCK_M, BLOCK_N):
+        has_work = gl.to_tensor(True)
+        starting_tile_id = gl.program_id(0)
+
+        clc_result_buffer = gl.allocate_shared_memory(gl.int64, [2], gl.SwizzledSharedLayout(1, 1, 1, [0]))
+        barrier = mbarrier.allocate_mbarrier()
+        mbarrier.init(barrier, count=1)
+        phase = gl.to_tensor(0)
+        return ClcTileScheduler(has_work, starting_tile_id, clc_result_buffer, barrier, phase)
+
+    @gluon.jit
+    def try_cancel(self) -> None:
+        clc.try_cancel(self.clc_result_buf, self.barrier, multicast=True)
+        mbarrier.expect(self.barrier, 16)
+
+    @gluon.jit
+    def advance(self):
+        mbarrier.wait(self.barrier, self.phase)
+        clc_res = clc.load_result(self.clc_result_buf)
+        has_work = clc_res.is_canceled()
+        next_tile_id = clc_res.program_id(0)
+        return ClcTileScheduler(has_work, next_tile_id, self.clc_result_buf, self.barrier, self.phase ^ 1)
+
+
+# %%
+# We also implement a static scheduler that conforms to the same interface,
+# so we can directly compare the benifits of dynamic scheduling.
+
+
+@aggregate
+class StaticTileScheduler:
+    has_work: gl.tensor
+    tile_id: gl.tensor
+    num_tiles: gl.tensor
+
+    @gluon.constexpr_function
+    def __init__(self, has_work, tile_id, num_tiles):
+        self.has_work = has_work
+        self.tile_id = tile_id
+        self.num_tiles = num_tiles
+
+    @gluon.jit
+    def initialize(M, N, BLOCK_M, BLOCK_N):
+        starting_tile_id = gl.program_id(0)
+        num_tiles = gl.cdiv(M, BLOCK_M) * gl.cdiv(N, BLOCK_N)
+        has_work = starting_tile_id < num_tiles
+        return StaticTileScheduler(has_work, starting_tile_id, num_tiles)
+
+    @gluon.jit
+    def try_cancel(self) -> None:
+        pass
+
+    @gluon.jit
+    def advance(self):
+        next_tile_id = self.tile_id + gl.num_programs(0)
+        has_work = next_tile_id < self.num_tiles
+        return StaticTileScheduler(has_work, next_tile_id, self.num_tiles)
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@gluon.jit
+def persistent_matmul_kernel(a_desc, b_desc, c_desc, MMAImpl: gl.constexpr, SchedulerImpl: gl.constexpr,
+                             num_buffers: gl.constexpr, num_warps: gl.constexpr):
+    BLOCK_M: gl.constexpr = c_desc.block_type.shape[0]
+    BLOCK_N: gl.constexpr = c_desc.block_type.shape[1]
+    BLOCK_K: gl.constexpr = a_desc.block_type.shape[1]
+    dtype: gl.constexpr = a_desc.dtype
+    K = a_desc.shape[1]
+    N = c_desc.shape[0]
+    M = c_desc.shape[1]
+
+    num_pid_n = gl.cdiv(N, BLOCK_N)
+    num_pid_m = gl.cdiv(M, BLOCK_M)
+    GROUP_SIZE_M: gl.constexpr = 8
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    for i in gl.static_range(num_buffers):
+        mbarrier.init(bars.index(i), count=1)
+    # Producer and consumer indices.
+    producer = 0
+    consumer = 0
+
+    mma = MMAImpl.initialize(dtype, BLOCK_M, BLOCK_N, num_warps)
+    scheduler = SchedulerImpl.initialize(M, N, BLOCK_M, BLOCK_N)
+    while scheduler.has_work:
+        pid_m, pid_n = _compute_pid(scheduler.tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+        off_m = pid_m * BLOCK_M
+        off_n = pid_n * BLOCK_N
+
+        scheduler.try_cancel()
+
+        a_bufs = gl.allocate_shared_memory(dtype, [num_buffers] + a_desc.block_type.shape, a_desc.layout)
+        b_bufs = gl.allocate_shared_memory(dtype, [num_buffers] + b_desc.block_type.shape, b_desc.layout)
+        for k in gl.static_range(0, BLOCK_K * (num_buffers - 2), BLOCK_K):
+            producer = t7.issue_loads(producer, a_desc, b_desc, off_m, off_n, k, bars, a_bufs, b_bufs, num_buffers)
+
+        for k in range(BLOCK_K * (num_buffers - 2), K, BLOCK_K):
+            producer = t7.issue_loads(producer, a_desc, b_desc, off_m, off_n, k, bars, a_bufs, b_bufs, num_buffers)
+            consumer, mma = t7.issue_mma(consumer, mma, bars, a_bufs, b_bufs, num_buffers)
+
+        for _ in gl.static_range(num_buffers - 2):
+            consumer, mma = t7.issue_mma(consumer, mma, bars, a_bufs, b_bufs, num_buffers)
+
+        mma = mma.wait_num_outstanding(0)
+        c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
+        c, mma = mma.take_result()
+        c_smem.store(c.to(dtype))
+        fence_async_shared()
+        tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+        tma.store_wait(pendings=0)
+        scheduler = scheduler.advance()
+
+
+def run_matmul_kernel(A, B, C, BLOCK_M=128, BLOCK_N=256, BLOCK_K=64, num_buffers=3, num_warps=4, use_clc=True):
+    M, N = C.shape
+    a_layout = gl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_K], gl.float16)
+    b_layout = gl.NVMMASharedLayout.get_default_for([BLOCK_K, BLOCK_N], gl.float16)
+    c_layout = gl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_N], gl.float16)
+    a_desc = TensorDescriptor.from_tensor(A, [BLOCK_M, BLOCK_K], a_layout)
+    b_desc = TensorDescriptor.from_tensor(B, [BLOCK_K, BLOCK_N], b_layout)
+    c_desc = TensorDescriptor.from_tensor(C, [BLOCK_M, BLOCK_N], c_layout)
+
+    if use_clc:
+        num_pid_m = triton.cdiv(M, BLOCK_M)
+        num_pid_n = triton.cdiv(N, BLOCK_N)
+        grid = num_pid_m * num_pid_n
+        SchedulerImpl = ClcTileScheduler
+    else:
+        dev_props = torch.cuda.get_device_properties(A.device)
+        grid = dev_props.multi_processor_count
+        SchedulerImpl = StaticTileScheduler
+
+    MMAImpl = t7.MMAv5
+    persistent_matmul_kernel[(grid, )](a_desc, b_desc, c_desc, MMAImpl, SchedulerImpl, num_buffers, num_warps=num_warps)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("M, N, K", [(8192, 8192, 8192), (1000, 1000, 1000)])
+@pytest.mark.parametrize("use_clc", [True, False])
+def test_op(M, N, K, use_clc):
+    A = torch.randn(M, K, device='cuda', dtype=torch.float16)
+    B = torch.randn(K, N, device='cuda', dtype=torch.float16)
+    C = torch.empty(M, N, device='cuda', dtype=torch.float16)
+
+    C_ref = torch.mm(A, B)
+    run_matmul_kernel(A, B, C, use_clc=use_clc)
+
+    torch.testing.assert_close(C, C_ref)
+
+
+# %%
+# Benchmark
+# ---------
+
+
+def benchmark():
+    print("=" * 60)
+    print("Cluster Launch Control (CLC) Matmul - Blackwell")
+    print("=" * 60)
+
+    props = torch.cuda.get_device_properties(0)
+    print(f"Device: {props.name}, SMs: {props.multi_processor_count}")
+
+    M, N, K = 8192, 8192, 8192
+    print(f"Matrix: {M}x{N}x{K}")
+
+    A = torch.randn(M, K, device='cuda', dtype=torch.float16)
+    B = torch.randn(K, N, device='cuda', dtype=torch.float16)
+    C = torch.empty(M, N, device='cuda', dtype=torch.float16)
+
+    # Static baseline
+    def static_fn():
+        run_matmul_kernel(A, B, C, use_clc=False)
+
+    ms = triton.testing.do_bench_cudagraph(static_fn)
+    static_tflops = t7.get_flops(ms, M, N, K)
+    print(f"\nStatic:     {static_tflops:7.2f} TFLOPS")
+
+    # CLC matmul
+    def clc_fn():
+        run_matmul_kernel(A, B, C)
+
+    ms = triton.testing.do_bench_cudagraph(clc_fn)
+    clc_tflops = t7.get_flops(ms, M, N, K)
+    print(f"CLC:        {clc_tflops:7.2f} TFLOPS ({100*clc_tflops/static_tflops:.1f}% of static)")
+
+    # Correctness check
+    print("\nVerifying correctness...")
+    A_test = torch.randn(1024, 1024, device='cuda', dtype=torch.float16)
+    B_test = torch.randn(1024, 1024, device='cuda', dtype=torch.float16)
+    C_ref = torch.mm(A_test, B_test)
+    C_clc = torch.empty_like(C_ref)
+    run_matmul_kernel(A_test, B_test, C_clc)
+    torch.cuda.synchronize()
+    max_diff = (C_ref - C_clc).abs().max().item()
+    print(f"Max diff: {max_diff:.6f}")
+    assert max_diff < 1.0, "Correctness check failed"
+    print("✓ Correctness verified")
+
+
+# %%
+# A sample run of this benchmark may look like,
+#
+# ============================================================
+# Cluster Launch Control (CLC) Matmul - Blackwell
+# ============================================================
+# Device: NVIDIA GB200, SMs: 152
+# Matrix: 8192x8192x8192
+#
+# Static:     1040.13 TFLOPS
+# CLC:        1080.74 TFLOPS (103.9% of static)
+#
+# Notice that we've achieved a 3.9% speedup (which will vary run to run),
+# without improving the actual matmul computation at all. This is because there
+# is always a slight variance between the time taken to compute each tile. For
+# example, one may have inputs already cached in L2 and another might suffer a
+# cache miss. With a static scheduler, the kernel takes as long as it takes the
+# slowest SM to complete it's assigned `num_tiles / num_sms` tiles. However, CLC
+# allows us to better balance the load by give more work to the SMs that finish
+# early and less to those that are taking longer.
+#
+# This effect will be even more pronounced in kernels that have more run-time
+# variation, e.g. in a ragged matmul where the k dim is different for different
+# output tiles.
+#
+# Note that a similar effect can be achieved on pre-blackwell by using a global
+# atomic counter to track the next available tile id. However, this requires
+# additional run time overhead to zero out the counter before launching the
+# kernel which may nullify the benefit for reasonably-balanced workloads.
+
+if __name__ == "__main__":
+    benchmark()

--- a/test/Conversion/clc_to_llvm.mlir
+++ b/test/Conversion/clc_to_llvm.mlir
@@ -1,0 +1,83 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=100 | FileCheck %s --dump-input-context=50
+
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: clc_try_cancel
+  tt.func @clc_try_cancel(%result: !ttg.memdesc<2xi64, #shared0, #smem>, %mbar: !ttg.memdesc<1xi64, #shared0, #smem>) {
+    // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128
+    ttng.clc_try_cancel %result, %mbar {multicast = false} : !ttg.memdesc<2xi64, #shared0, #smem>, !ttg.memdesc<1xi64, #shared0, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: clc_load_result
+  tt.func @clc_load_result(%result: !ttg.memdesc<2xi64, #shared0, #smem>) {
+    // CHECK: llvm.load %{{.*}} : !llvm.ptr<3> -> i128
+    %res = ttng.clc_load_result %result : !ttg.memdesc<2xi64, #shared0, #smem> -> i128
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: clc_is_canceled
+  tt.func @clc_is_canceled(%clcRes: i128) {
+    // CHECK: clusterlaunchcontrol.query_cancel.is_canceled.pred.b128
+    %is_canceled = ttng.clc_is_canceled %clcRes : i128 -> i1
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: clc_get_program_id_x
+  tt.func @clc_get_program_id_x(%clcResult: i128) {
+    // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid::x.b32.b128
+    // CHECK-NOT: sdiv
+    %ctaid = ttng.clc_get_program_id %clcResult, x : i128 -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: clc_get_program_id_x_multicta
+  tt.func @clc_get_program_id_x_multicta(%clcResult: i128) {
+    // CHECK: %[[ctaid:[^ ]*]] = {{.*}}clusterlaunchcontrol.query_cancel.get_first_ctaid::x.b32.b128
+    // CHECK-NEXT: %[[four:.*]] = llvm.mlir.constant(4 : i32)
+    // CHECK-NEXT: llvm.sdiv %[[ctaid]], %[[four]] : i32
+    %ctaid = ttng.clc_get_program_id %clcResult, x : i128 -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: clc_get_program_id_y
+  tt.func @clc_get_program_id_y(%clcResult: i128) {
+    // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid::y.b32.b128
+    %ctaid = ttng.clc_get_program_id %clcResult, y : i128 -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: clc_get_program_id_z
+  tt.func @clc_get_program_id_z(%clcResult: i128) {
+    // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid::z.b32.b128
+    %ctaid = ttng.clc_get_program_id %clcResult, z : i128 -> i32
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -853,7 +853,7 @@ class CUDABackend(BaseBackend):
         if "consan" in options.instrumentation_mode:
             # Call ConcurrencySanitizerPass here, before allocating global scratch memory but after allocating tensor and shared
             passes.ttgpuir.add_concurrency_sanitizer(pm)
-            passes.common.add_canonicalizer(pm)
+            passes.gluon.add_canonicalizer(pm)
             passes.common.add_cse(pm)
         passes.ttgpuir.add_allocate_global_scratch_memory(pm)
         nvidia.passes.ttnvgpuir.add_proxy_fence_insertion(pm, capability)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include "Utility.h"
@@ -37,6 +38,8 @@ using namespace mlir;
 using namespace mlir::triton;
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace ttg = mlir::triton::gpu;
 
 namespace {
 Value getElectWarp0OrThread0(const NVIDIA::TargetInfo &targetInfo,
@@ -605,6 +608,176 @@ struct VoteBallotSyncOpConversion
     return success();
   }
 };
+
+// CLC (Cluster Launch Control) Ops - Blackwell SM100+
+struct CLCTryCancelOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::CLCTryCancelOp> {
+  const NVIDIA::TargetInfo *targetInfo;
+  CLCTryCancelOpConversion(LLVMTypeConverter &typeConverter,
+                           PatternBenefit benefit,
+                           NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        targetInfo(&targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::CLCTryCancelOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (targetInfo->getComputeCapability() < 100) {
+      return op.emitError("CLC operations require SM100+ (Blackwell)");
+    }
+
+    auto loc = op.getLoc();
+
+    // Use elect predicate - only one thread should issue CLC
+    Value pred = LLVM::NVIDIA::createElectPredicateWarp0(loc, rewriter);
+
+    auto numCTAs = ttg::lookupNumCTAs(op);
+    if (numCTAs > 1) {
+      TritonLLVMOpBuilder b(loc, rewriter);
+      auto clusterCtaId = targetInfo->getClusterCTAId(rewriter, loc);
+      pred = b.and_(pred, b.icmp_eq(clusterCtaId, b.i32_val(0)));
+    }
+
+    std::string ptxAsm = "@$2 clusterlaunchcontrol.try_cancel.async.shared::cta"
+                         ".mbarrier::complete_tx::bytes";
+    if (op.getMulticast())
+      ptxAsm += ".multicast::cluster::all";
+    ptxAsm += ".b128 [$0], [$1];";
+
+    PTXBuilder ptxBuilder;
+    auto &clcOp = *ptxBuilder.create(ptxAsm);
+    auto *resultOp = ptxBuilder.newOperand(adaptor.getResult(), "r");
+    auto *mbarOp = ptxBuilder.newOperand(adaptor.getMbarrier(), "r");
+    auto *predOp = ptxBuilder.newOperand(pred, "b");
+    clcOp({resultOp, mbarOp, predOp}, /*onlyAttachMLIRArgs=*/true);
+
+    auto voidTy = void_ty(getContext());
+    ptxBuilder.launch(rewriter, loc, voidTy);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct CLCLoadResultOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::CLCLoadResultOp> {
+  const NVIDIA::TargetInfo *targetInfo;
+  CLCLoadResultOpConversion(LLVMTypeConverter &typeConverter,
+                            PatternBenefit benefit,
+                            NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        targetInfo(&targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::CLCLoadResultOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (targetInfo->getComputeCapability() < 100) {
+      return op.emitError("CLC operations require SM100+ (Blackwell)");
+    }
+
+    auto loc = op.getLoc();
+    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
+        loc, adaptor.getSrc(),
+        typeConverter->convertType(op.getSrc().getType().getElementType()),
+        rewriter);
+    TritonLLVMOpBuilder b(loc, rewriter);
+    auto i128Ty = rewriter.getIntegerType(128);
+    auto res = b.load(i128Ty, smemObj.getBase());
+    rewriter.replaceOp(op, res);
+    return success();
+  }
+};
+
+struct CLCIsCanceledOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::CLCIsCanceledOp> {
+  const NVIDIA::TargetInfo *targetInfo;
+  CLCIsCanceledOpConversion(LLVMTypeConverter &typeConverter,
+                            PatternBenefit benefit,
+                            NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        targetInfo(&targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::CLCIsCanceledOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (targetInfo->getComputeCapability() < 100) {
+      return op.emitError("CLC operations require SM100+ (Blackwell)");
+    }
+
+    auto loc = op.getLoc();
+    std::string ptxAsm =
+        "clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 $0, $1;";
+    PTXBuilder ptxBuilder;
+    auto &clcOp = *ptxBuilder.create(ptxAsm);
+    auto *resultOp = ptxBuilder.newOperand("=b");
+    auto *clcResultOp = ptxBuilder.newOperand(adaptor.getClcResult(), "q");
+    clcOp({resultOp, clcResultOp}, /*onlyAttachMLIRArgs=*/true);
+
+    Value result =
+        ptxBuilder.launch(rewriter, loc, i1_ty, /*hasSideEffects=*/false);
+    rewriter.replaceOp(op, result);
+
+    return success();
+  }
+};
+
+struct CLCGetProgramIdOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::CLCGetProgramIdOp> {
+  const NVIDIA::TargetInfo *targetInfo;
+  CLCGetProgramIdOpConversion(LLVMTypeConverter &typeConverter,
+                              PatternBenefit benefit,
+                              NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        targetInfo(&targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::CLCGetProgramIdOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (targetInfo->getComputeCapability() < 100) {
+      return op.emitError("CLC operations require SM100+ (Blackwell)");
+    }
+
+    auto loc = op.getLoc();
+
+    const char *dimName = [&] {
+      switch (op.getDim()) {
+      case ProgramIDDim::X:
+        return "x";
+      case ProgramIDDim::Y:
+        return "y";
+      case ProgramIDDim::Z:
+        return "z";
+      }
+      llvm::llvm_unreachable_internal("Invalid program id dim");
+    }();
+
+    auto ptxAsm = ("clusterlaunchcontrol.query_cancel.get_first_ctaid::" +
+                   llvm::Twine(dimName) + ".b32.b128 $0, $1;")
+                      .str();
+
+    PTXBuilder ptxBuilder;
+    auto &clcOp = *ptxBuilder.create(ptxAsm);
+    auto *resultOp = ptxBuilder.newOperand("=r");
+    auto *clcResultOp = ptxBuilder.newOperand(adaptor.getClcResult(), "q");
+    clcOp({resultOp, clcResultOp}, /*onlyAttachMLIRArgs=*/true);
+
+    Value result =
+        ptxBuilder.launch(rewriter, loc, i32_ty, /*hasSideEffects=*/false);
+
+    // Convert ctaid to clusterid, which is the real program id
+    // Note that all cluster CTAs are distributed in the X dim
+    if (op.getDim() == ProgramIDDim::X) {
+      auto numCTAs = ttg::lookupNumCTAs(op);
+      if (numCTAs > 1) {
+        TritonLLVMOpBuilder b(loc, rewriter);
+        result = b.sdiv(result, b.i32_val(numCTAs));
+      }
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
 } // namespace
 
 void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
@@ -619,9 +792,15 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<BarrierExpectConversion>(typeConverter, benefit);
   patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
+  // beta Meta CLC + named-barrier + vote-ballot patterns
   patterns.add<NamedBarrierArriveOpConversion>(typeConverter, benefit);
   patterns.add<NamedBarrierWaitOpConversion>(typeConverter, benefit);
   patterns.add<AsyncCLCTryCancelOpConversion>(typeConverter, benefit);
   patterns.add<CLCQueryCancelOpConversion>(typeConverter, benefit);
   patterns.add<VoteBallotSyncOpConversion>(typeConverter, benefit);
+  // upstream #9361 CLC patterns (distinct ops; coexist with beta's)
+  patterns.add<CLCTryCancelOpConversion>(typeConverter, benefit, targetInfo);
+  patterns.add<CLCLoadResultOpConversion>(typeConverter, benefit, targetInfo);
+  patterns.add<CLCIsCanceledOpConversion>(typeConverter, benefit, targetInfo);
+  patterns.add<CLCGetProgramIdOpConversion>(typeConverter, benefit, targetInfo);
 }


### PR DESCRIPTION
Summary:
Folded bundle of 10 upstream OAI Triton commits cherry-picked into triton/beta. Tested as one diff via `reactor lab reactor-ci` (native A/B against trunk). Hashes below are the upstream OAI commit hashes.

This batch is dominated by a deep beta<->upstream divergence in the reduce + multi-CTA + TMEM + cluster-membar subsystems. Only 3 of the 10 commits are cleanly adoptable; the other 7 are recorded as NO-OPs (reverted to beta) for feature-owner reconciliation. Each no-op was verified byte-identical to the bundle base (no build regression) and the 3 adopted commits were build- and lit-test-verified locally.

Reactor-Bundle:
- [1] 483327f0 PR #9219 '[BACKEND] Improve and simplify ReduceOp lowering' — NO-OP (reduce refactor not adopted; beta reduce diverged w/ Meta tree-reduction; partial-adopt = scratch-size mismatch risk)
- [2] b5e3800a PR #9220 '[BACKEND] Perform tree reductions on in-thread values' — NO-OP (depends on #9219; beta has own tree-reduction)
- [3] 880b4e4d PR #9337 '[FPSAN] Introducing FpSan' — NO-OP (FpSan TMEM path needs 3D->2D tmem_subslice; beta's tmem_subslice is 2D-only -> fpsan.mlir verifier error)
- [4] bb75a870 PR #9221 '[BACKEND] cross-CTA tt.reduce' — NO-OP (depends on #9219; beta has own cross-CTA path)
- [5] 97c02ff4 PR #9361 '[Gluon] CLC support for Blackwell' — ADOPTED (additive: beta Meta CLC + upstream CLC patterns; build+clc_to_llvm.mlir verified)
- [6] 80c62227 PR #9396 '[TritonGPU] Run Gluon canonicalizer in LLVM lowering when ConSan is on' — CLEAN/ADOPTED
- [7] c155e4a5 PR #9317 '[BACKEND] Support generic multi-cta convert_layouts' — NO-OP (29-file multi-CTA refactor vs beta diverged convert-layout(smem-budget)+reduce; unverifiable locally)
- [8] 05fc47ff PR #9318 '[Membar] Membar pass for clusters' — NO-OP (cluster membar coupled to diverged cross-CTA reduce; membar-cluster.mlir fails)
- [9] 03d956b4 PR #9327 '[Membar] Fix non-trivial function smem offsets' — NO-OP (coupled with #9318)
- [10] e86144be PR #9392 'Remove TritonIR dependence on TritonGPUIR' — ADOPTED (dropped unused TritonGPU/IR/Types.h; kept beta GetEnv.hpp for TRITON_ALLOW_NPOT; build verified)

OWNER FOLLOW-UP: #9219/#9220/#9221/#9317/#9318/#9327 (+ FpSan TMEM in #9337) form a coupled reduce / multi-CTA / TMEM / cluster-membar reconciliation between beta's Meta-diverged subsystems and upstream's evolution; they should be ported together by the subsystem owner, not as mechanical cherry-picks.

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: e86144be531df65bd8cd8f12ad328a2c493008d7

Reviewed By: dshi7

Differential Revision: D108895095


