### PR TITLE
[sched2tlx] add before/after regression harness for example kernels (#1775)

### DIFF
--- a/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/bench_spec.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/bench_spec.py
@@ -1,0 +1,47 @@
+"""Benchmark spec for case1 (simple GEMM) consumed by examples/testing/perf_engine.py.
+
+Launch logic mirrors run_generated.py (generated) and handwritten.gemm (reference).
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+
+BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64
+TOL = 5e-3
+
+SHAPES = [(1024, 1024, 1024), (2048, 2048, 2048), (4096, 4096, 4096)]
+
+
+def make_inputs(shape):
+    M, N, K = shape
+    a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    b = torch.randn(K, N, device="cuda", dtype=torch.float16)
+    c = torch.full((M, N), float("nan"), device="cuda", dtype=torch.float16)
+    return {"a": a, "b": b, "c": c, "M": M, "N": N, "K": K}
+
+
+def gen_call(generated, inputs):
+    a, b, c = inputs["a"], inputs["b"], inputs["c"]
+    M, N, K = inputs["M"], inputs["N"], inputs["K"]
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    generated.gemm_kernel[grid](
+        a, b, c, M, N, K,
+        a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
+        num_warps=4, num_ctas=1, num_stages=2,
+    )
+    return c
+
+
+def hw_call(handwritten, inputs):
+    return handwritten.gemm(inputs["a"], inputs["b"])
+
+
+def metric(shape):
+    M, N, K = shape
+    return (2 * M * N * K, 1e12, "TFLOPS")
+
+
+def reference(inputs):
+    return torch.matmul(inputs["a"], inputs["b"])

--- a/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/bench_spec.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/bench_spec.py
@@ -1,0 +1,70 @@
+"""Benchmark spec for case2 (persistent GEMM) consumed by examples/testing/perf_engine.py.
+
+Launch logic mirrors run_generated.py (generated) and run_handwritten.py (reference).
+Large shapes are included so the persistent outer loop runs many tiles — the exact
+regime where the pre-fix emitter's name collision corrupts tile addressing.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64
+NUM_SMEM_BUFFERS = 2
+TOL = 5e-3
+
+SHAPES = [
+    (1024, 1024, 1024),
+    (4096, 4096, 4096),
+    (8192, 8192, 8192),
+    (8192, 8192, 256),
+]
+
+
+def _num_sms():
+    return torch.cuda.get_device_properties(0).multi_processor_count
+
+
+def make_inputs(shape):
+    M, N, K = shape
+    a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    b = torch.randn(K, N, device="cuda", dtype=torch.float16)
+    c = torch.full((M, N), float("nan"), device="cuda", dtype=torch.float16)
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_M, BLOCK_K])
+    b_t = b.t().contiguous()  # [N, K] so TMA loads [offs_bn, offs_k]
+    b_desc = TensorDescriptor.from_tensor(b_t, [BLOCK_N, BLOCK_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_M, BLOCK_N])
+    return {"a": a, "b": b, "c": c, "a_desc": a_desc, "b_desc": b_desc, "c_desc": c_desc,
+            "M": M, "N": N, "K": K}
+
+
+def gen_call(generated, inputs):
+    grid = (_num_sms(),)
+    generated.matmul_kernel_tma_persistent_simple[grid](
+        inputs["a_desc"], inputs["b_desc"], inputs["c_desc"],
+        inputs["M"], inputs["N"], inputs["K"],
+        num_warps=4, num_ctas=1, num_stages=2,
+    )
+    return inputs["c"]
+
+
+def hw_call(handwritten, inputs):
+    nsms = _num_sms()
+    handwritten.matmul_kernel[(nsms,)](
+        inputs["a_desc"], inputs["b_desc"], inputs["c_desc"],
+        inputs["M"], inputs["N"], inputs["K"],
+        NUM_SMS=nsms, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
+        NUM_SMEM_BUFFERS=NUM_SMEM_BUFFERS, num_warps=4, num_ctas=1, num_stages=2,
+    )
+    return inputs["c"]
+
+
+def metric(shape):
+    M, N, K = shape
+    return (2 * M * N * K, 1e12, "TFLOPS")
+
+
+def reference(inputs):
+    return torch.matmul(inputs["a"], inputs["b"])

--- a/third_party/tlx/tools/sched2tlx/examples/case3_FA/bench_spec.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case3_FA/bench_spec.py
@@ -1,0 +1,72 @@
+"""Benchmark spec for case3 (Flash-Attention fwd) consumed by examples/testing/perf_engine.py.
+
+Launch logic mirrors perf_generated_vs_handwritten.py (gen + hw side by side).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+import triton
+
+BLOCK_M, BLOCK_N, HEAD_DIM, NUM_BUFFERS_KV = 128, 64, 128, 2
+TOL = 1e-2
+
+SHAPES = [
+    (1, 4, 512),
+    (1, 8, 1024),
+    (2, 16, 2048),
+    (1, 16, 4096),
+    (2, 16, 4096),
+    (1, 32, 8192),
+]
+
+
+def make_inputs(shape):
+    Z, H, N_CTX = shape
+    q = torch.randn(Z, H, N_CTX, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(Z, H, N_CTX, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(Z, H, N_CTX, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    out = torch.empty_like(q)
+    m_lse = torch.empty(Z * H, N_CTX, device="cuda", dtype=torch.float32)
+    sm_scale = 1.0 / (HEAD_DIM**0.5)
+    return {
+        "q": q, "k": k, "v": v, "out": out, "m_lse": m_lse, "sm": sm_scale,
+        "Z": Z, "H": H, "N_CTX": N_CTX,
+        "qf": q.contiguous().view(-1, HEAD_DIM),
+        "kf": k.contiguous().view(-1, HEAD_DIM),
+        "vf": v.contiguous().view(-1, HEAD_DIM),
+        "of": out.view(-1, HEAD_DIM),
+    }
+
+
+def _grid(inputs):
+    return (triton.cdiv(inputs["N_CTX"], BLOCK_M), inputs["Z"] * inputs["H"])
+
+
+def gen_call(generated, inputs):
+    generated.fa_fwd_kernel_nows[_grid(inputs)](
+        inputs["qf"], inputs["kf"], inputs["vf"], inputs["of"], inputs["m_lse"], inputs["sm"],
+        inputs["Z"] * inputs["H"], inputs["N_CTX"],
+        num_warps=4, num_ctas=1, num_stages=2,
+    )
+    return inputs["out"]
+
+
+def hw_call(handwritten, inputs):
+    handwritten.fa_fwd_kernel[_grid(inputs)](
+        inputs["qf"], inputs["kf"], inputs["vf"], inputs["of"], inputs["m_lse"], inputs["sm"],
+        inputs["Z"], inputs["H"], inputs["N_CTX"],
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM, NUM_BUFFERS_KV=NUM_BUFFERS_KV,
+        num_warps=4, num_ctas=1, num_stages=2,
+    )
+    return inputs["out"]
+
+
+def metric(shape):
+    Z, H, N_CTX = shape
+    return (4 * Z * H * N_CTX * N_CTX * HEAD_DIM, 1e12, "TFLOPS")
+
+
+def reference(inputs):
+    return F.scaled_dot_product_attention(inputs["q"], inputs["k"], inputs["v"], scale=inputs["sm"])

--- a/third_party/tlx/tools/sched2tlx/examples/case6_layernorm/bench_spec.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case6_layernorm/bench_spec.py
@@ -1,0 +1,57 @@
+"""Benchmark spec for case6 (LayerNorm fwd) consumed by examples/testing/perf_engine.py.
+
+Launch logic mirrors perf_generated_vs_handwritten.py. Memory-bound → GB/s metric.
+The generated kernel bakes N=512 and BLOCK_M=8 in as literals.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+N = 512
+EPS = 1e-5
+BLOCK_M = 8
+TOL = 1e-2
+
+SHAPES = [(16384, N), (65536, N), (262144, N)]
+
+
+def _num_sms():
+    return torch.cuda.get_device_properties(0).multi_processor_count
+
+
+def make_inputs(shape):
+    M, n = shape
+    x = torch.randn(M, n, device="cuda", dtype=torch.float16)
+    w = torch.randn(n, device="cuda", dtype=torch.float16)
+    b = torch.randn(n, device="cuda", dtype=torch.float16)
+    y = torch.full((M, n), float("nan"), device="cuda", dtype=torch.float16)
+    yh = torch.empty((M, n), device="cuda", dtype=torch.float16)
+    return {"x": x, "w": w, "b": b, "y": y, "yh": yh, "M": M, "N": n}
+
+
+def gen_call(generated, inputs):
+    generated.layernorm_fwd_nows[(_num_sms(),)](
+        inputs["x"], inputs["w"], inputs["b"], inputs["y"], inputs["M"], EPS, num_warps=4
+    )
+    return inputs["y"]
+
+
+def hw_call(handwritten, inputs):
+    num_persist = _num_sms() * 4
+    handwritten.layernorm_fwd_tma[(num_persist,)](
+        inputs["x"], inputs["w"], inputs["b"], inputs["yh"], inputs["M"], EPS,
+        row_stride=inputs["x"].stride(0), N=N, BLOCK_M=BLOCK_M, BLOCK_N=512,
+        NUM_PERSIST=num_persist, num_warps=4,
+    )
+    return inputs["yh"]
+
+
+def metric(shape):
+    M, n = shape
+    return (M * n * 2 * 2, 1e9, "GB/s")  # read x + write y, fp16
+
+
+def reference(inputs):
+    return F.layer_norm(inputs["x"].float(), (inputs["N"],), inputs["w"].float(), inputs["b"].float(), EPS)

--- a/third_party/tlx/tools/sched2tlx/examples/testing/README.md
+++ b/third_party/tlx/tools/sched2tlx/examples/testing/README.md
@@ -1,0 +1,81 @@
+# sched2tlx example regression suite
+
+A generic **before-vs-after** harness for the sched2tlx emitter. Given any diff
+that touches the tool (default: the current commit) it re-emits every example
+case with the emitter *before* and *after* the change and checks:
+
+- **correctness** — the after-diff generated kernel agrees with the case's
+  hand-written reference (both pass the case's own `run_*.py` against the torch
+  reference, so they agree transitively);
+- **performance** — the after-diff kernel is no slower than the before-diff
+  kernel, per shape, within a tolerance.
+
+It is generic in two ways: it works for **any diff** (revisions are extracted
+via Sapling), and it **auto-discovers all cases** under `examples/` — a new
+`caseN_*` directory is included with no change to the harness.
+
+## Running
+
+The recommended way is the buck target (run from anywhere inside your fbsource
+checkout — the repo root is auto-detected from the working directory):
+
+```bash
+# default: test the current commit (before = .^, after = .)
+buck2 run @fbcode//mode/dev-nosan //third-party/triton/beta/triton:sched2tlx_regression
+
+# a specific diff / subset of cases / looser perf tolerance
+buck2 run @fbcode//mode/dev-nosan //third-party/triton/beta/triton:sched2tlx_regression -- --diff D108804400
+buck2 run @fbcode//mode/dev-nosan //third-party/triton/beta/triton:sched2tlx_regression -- --cases case1_simple_gemm,case3_FA --perf-tol 0.10
+```
+
+`@fbcode//mode/dev-nosan` is required: the default dev mode links ASAN, which
+disables CUDA in torch. Pass `--repo-root <path>` only if running from outside a
+checkout. With a plain triton-enabled interpreter you can also run
+`python3 run_regression.py --diff D108804400` directly.
+
+Correctness and perf need a Blackwell GPU (gated; reported as SKIP otherwise).
+If a launch hangs, run `third_party/tlx/killgpu.sh`.
+
+The generic perf engine can also be run on its own to compare a case's committed
+`generated.py` against its handwritten reference (the classic
+`perf_generated_vs_handwritten.py` behavior):
+
+```bash
+python3 perf_engine.py bench --cases case3_FA
+```
+
+## Files
+
+- `emit_helpers.py` — materializes coherent before/after copies of the tool tree
+  for any diff (Sapling `sl status --change` + `sl cat`) and re-emits each case's
+  `generated.py` on each side. Pure stdlib.
+- `perf_engine.py` — generic perf engine: CUDA-event timing, shape sweep,
+  correctness guard, throughput/ratio reporting. `worker` mode benchmarks one
+  `generated.py` and writes JSON (the driver runs it in a separate process per
+  side so a kernel that faults at scale can't poison the other run).
+- `run_regression.py` — the driver: discover cases → correctness → perf → table.
+
+## Adding a new case (so it's picked up automatically)
+
+A `caseN_<desc>/` directory under `examples/` is auto-discovered. To participate:
+
+1. Ship `schedule_graph.json` (emitter input) and `run_generated.py` that exits 0
+   iff the generated kernel is correct vs a torch reference (optionally
+   `run_handwritten.py` likewise for the reference).
+2. Ship a small `bench_spec.py` for the perf check, exposing:
+
+   ```python
+   SHAPES = [...]                       # shapes to sweep
+   TOL = 1e-2                           # rel-error tolerance for the correctness guard
+   def make_inputs(shape): ...          # -> dict of cuda tensors / scalars
+   def gen_call(generated, inputs): ... # launch generated kernel; return output tensor
+   def hw_call(handwritten, inputs): ...# launch handwritten kernel; return output tensor
+   def metric(shape): return (work, scale, unit)  # e.g. (2*M*N*K, 1e12, "TFLOPS")
+   def reference(inputs): ...           # torch reference; return output tensor
+   ```
+
+   See `examples/case1_simple_gemm/bench_spec.py` etc. for templates.
+
+A case whose emitter output still contains an `<..._unsupported>` placeholder is
+auto-skipped (no perf/correctness run) until the emitter gap is closed.
+```

--- a/third_party/tlx/tools/sched2tlx/examples/testing/emit_helpers.py
+++ b/third_party/tlx/tools/sched2tlx/examples/testing/emit_helpers.py
@@ -1,0 +1,188 @@
+"""Materialize before/after copies of the sched2tlx tool for any diff and
+re-emit each example's ``generated.py`` with both emitter versions.
+
+The regression driver compares the kernel produced by the emitter *before* a
+change against the one produced *after* it. To stay robust for an arbitrary
+diff (one that may touch more than ``emitter.py`` — including a case's
+``schedule_graph.json`` or ``handwritten.py``) we materialize two
+self-contained copies of the tool tree:
+
+  1. Copy the working-copy ``sched2tlx/`` package and ``examples/`` dirs into a
+     ``before/`` and an ``after/`` temp tree.
+  2. For every file the diff touched (``sl status --change <rev>``) that lives
+     under the tool subtree, overwrite the ``before`` copy with its pre-diff
+     content (``sl cat -r <before>``) and the ``after`` copy with its post-diff
+     content (``sl cat -r <after>``). Files the diff did not touch are identical
+     across revisions, so the working-copy version already present is correct.
+
+Each side is then a coherent snapshot of the tool, and ``emit_case`` runs
+``python -m sched2tlx`` against it to produce that side's ``generated.py``.
+
+Pure stdlib — no torch/triton/GPU needed for this module.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Repo-root-relative path of the sched2tlx tool (the dir holding ``sched2tlx/``
+# and ``examples/``). Kept relative so ``sl`` paths and tree copies line up.
+TOOL_RELPATH = "third-party/triton/beta/triton/third_party/tlx/tools/sched2tlx"
+
+# Only files under these tool subdirectories affect emission / running.
+_RELEVANT_SUBDIRS = ("sched2tlx/", "examples/")
+
+
+def _sl(repo_root: Path, args: list[str], reason: str) -> str:
+    """Run a read-only ``sl`` command and return stdout (text)."""
+    return subprocess.run(
+        ["sl", *args, "--reason", reason],
+        cwd=str(repo_root),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def find_repo_root(start: Path) -> Path:
+    """Walk upward until we find the fbsource checkout root."""
+    cur = start.resolve()
+    for parent in [cur, *cur.parents]:
+        if (parent / TOOL_RELPATH).is_dir():
+            return parent
+    raise RuntimeError(f"could not locate repo root containing {TOOL_RELPATH} from {start}")
+
+
+def changed_tool_files(repo_root: Path, diff_rev: str) -> list[tuple[str, str]]:
+    """Return ``(status_code, relpath)`` for diff-touched files under the tool.
+
+    ``status_code`` is ``M``/``A``/``R`` from ``sl status --change``.
+    """
+    out = _sl(
+        repo_root,
+        ["status", "--change", diff_rev],
+        "list files changed by diff for sched2tlx before/after regression - sl help status",
+    )
+    changed: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if len(line) < 3 or line[1] != " ":
+            continue
+        code, relpath = line[0], line[2:].strip()
+        if not relpath.startswith(TOOL_RELPATH + "/"):
+            continue
+        suffix = relpath[len(TOOL_RELPATH) + 1:]
+        if suffix.startswith(_RELEVANT_SUBDIRS):
+            changed.append((code, relpath))
+    return changed
+
+
+def _ignore_pycache(_dir: str, names: list[str]) -> list[str]:
+    return [n for n in names if n == "__pycache__"]
+
+
+def _place_file(side_dir: Path, suffix: str, repo_root: Path, relpath: str, rev: str, present: bool) -> None:
+    """Overwrite ``side_dir/suffix`` with file content at ``rev`` (or remove it)."""
+    dst = side_dir / suffix
+    if not present:
+        if dst.exists():
+            dst.unlink()
+        return
+    content = _sl(
+        repo_root,
+        ["cat", "-r", rev, relpath],
+        "fetch file at revision for sched2tlx before/after regression - sl help cat",
+    )
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(content)
+
+
+@dataclass
+class SideTree:
+    """A materialized snapshot of the tool at one revision."""
+
+    root: Path  # contains ``sched2tlx/`` (package) and ``examples/``
+
+    @property
+    def examples(self) -> Path:
+        return self.root / "examples"
+
+
+def materialize(repo_root: Path, workdir: Path, before_rev: str, after_rev: str) -> tuple[SideTree, SideTree]:
+    """Build coherent before/after copies of the tool tree under ``workdir``."""
+    tool = repo_root / TOOL_RELPATH
+    before = SideTree(workdir / "before")
+    after = SideTree(workdir / "after")
+    for side in (before, after):
+        if side.root.exists():
+            shutil.rmtree(side.root)
+        side.root.mkdir(parents=True)
+        shutil.copytree(tool / "sched2tlx", side.root / "sched2tlx", ignore=_ignore_pycache)
+        shutil.copytree(tool / "examples", side.root / "examples", ignore=_ignore_pycache)
+
+    for code, relpath in changed_tool_files(repo_root, after_rev):
+        suffix = relpath[len(TOOL_RELPATH) + 1:]
+        _place_file(before.root, suffix, repo_root, relpath, before_rev, present=(code != "A"))
+        _place_file(after.root, suffix, repo_root, relpath, after_rev, present=(code != "R"))
+
+    return before, after
+
+
+def emit_case(side: SideTree, case_name: str) -> Path:
+    """Run ``python -m sched2tlx`` for one case on this side; return the .py path.
+
+    Writes ``generated.py`` into the side's case dir, overwriting the copied
+    placeholder. Raises CalledProcessError if emission fails. Subprocess form —
+    needs a plain interpreter with the ``sched2tlx`` package importable. For
+    buck/par execution use :func:`emit_case_inproc`.
+    """
+    case_dir = side.examples / case_name
+    graph = case_dir / "schedule_graph.json"
+    out = case_dir / "generated.py"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(side.root) + os.pathsep + env.get("PYTHONPATH", "")
+    subprocess.run(
+        [sys.executable, "-m", "sched2tlx", str(graph), "-o", str(out)],
+        cwd=str(side.root),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return out
+
+
+def _purge_sched2tlx_modules() -> None:
+    for name in [m for m in sys.modules if m == "sched2tlx" or m.startswith("sched2tlx.")]:
+        del sys.modules[name]
+
+
+def emit_case_inproc(side: SideTree, case_name: str) -> Path:
+    """Emit one case's ``generated.py`` in-process (works inside a buck par).
+
+    Imports this side's ``sched2tlx`` package fresh (purging any other side's
+    copy first so before/after emitters never collide) and calls ``emit``.
+    """
+    case_dir = side.examples / case_name
+    graph = case_dir / "schedule_graph.json"
+    out = case_dir / "generated.py"
+    import importlib
+
+    _purge_sched2tlx_modules()
+    sys.path.insert(0, str(side.root))
+    try:
+        schedule_graph = importlib.import_module("sched2tlx.schedule_graph")
+        emitter = importlib.import_module("sched2tlx.emitter")
+        src = emitter.emit(schedule_graph.load_graph(str(graph)))
+    finally:
+        try:
+            sys.path.remove(str(side.root))
+        except ValueError:
+            pass
+        _purge_sched2tlx_modules()
+    out.write_text(src)
+    return out

--- a/third_party/tlx/tools/sched2tlx/examples/testing/perf_engine.py
+++ b/third_party/tlx/tools/sched2tlx/examples/testing/perf_engine.py
@@ -1,0 +1,198 @@
+"""Generic performance engine for sched2tlx example kernels.
+
+This factors out the machinery duplicated across each case's
+``perf_generated_vs_handwritten.py`` (CUDA-event timing, shape sweep, a
+correctness guard, and throughput/ratio reporting). The per-case specifics live
+in a tiny ``bench_spec.py`` next to each example (see ``README.md``), so a new
+case is picked up automatically once it ships one.
+
+Two entry points:
+
+* ``worker`` subcommand — benchmark the generated kernel for ONE case using a
+  caller-supplied ``generated.py`` path, and write the measurements as JSON.
+  The regression driver invokes this twice per case (before/after emitter) in
+  separate processes so a kernel that faults at scale (the exact failure the
+  before-emitter can produce) cannot poison the CUDA context of the other run.
+* ``bench`` subcommand (default) — benchmark a case's committed ``generated.py``
+  against its handwritten reference and print a human-readable table, i.e. the
+  classic ``perf_generated_vs_handwritten.py`` behavior, but generic.
+
+Requires torch + triton + a GPU (only when actually benchmarking).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(path: Path, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _alloc_fn(size: int, alignment: int, stream: Any):  # noqa: ANN401
+    import torch
+
+    return torch.empty(size, device="cuda", dtype=torch.int8)
+
+
+def _bench(call) -> float:
+    """Median kernel latency in ms.
+
+    Uses ``triton.testing.do_bench`` (warmup, many reps, L2-cache flush, robust
+    median) — far more stable than a hand-rolled CUDA-event loop, which matters
+    for the before/after comparison on small/fast kernels where jitter would
+    otherwise masquerade as a regression.
+    """
+    import triton
+
+    ms = triton.testing.do_bench(call, warmup=50, rep=200, quantiles=[0.5])
+    return float(ms[0] if isinstance(ms, (list, tuple)) else ms)
+
+
+def run_bench(case_dir: Path, generated_path: Path, want_hw: bool = True) -> dict[str, Any]:
+    """Benchmark the generated kernel (and optionally handwritten) for one case.
+
+    Returns a JSON-serializable dict with a per-shape row list. Each row carries
+    ``gen_ms``, ``hw_ms`` (or None), ``throughput``/``unit``, the relative error
+    of the generated output vs the torch reference, and an ``ok`` flag.
+    """
+    import torch
+    import triton
+
+    triton.set_allocator(_alloc_fn)
+    torch.manual_seed(0)
+
+    spec = _load_module(case_dir / "bench_spec.py", f"bench_spec_{case_dir.name}")
+    gen = _load_module(generated_path, f"gen_{case_dir.name}")
+    hw = None
+    hw_path = case_dir / "handwritten.py"
+    if want_hw and hw_path.exists():
+        try:
+            hw = _load_module(hw_path, f"hw_{case_dir.name}")
+        except Exception:  # noqa: BLE001 - handwritten import is best-effort for the table
+            hw = None
+
+    def _rel(a, b) -> float:
+        denom = max(b.float().abs().max().item(), 1e-9)
+        return (a.float() - b.float()).abs().max().item() / denom
+
+    rows: list[dict[str, Any]] = []
+    for shape in spec.SHAPES:
+        inputs = spec.make_inputs(shape)
+
+        # Correctness: generated vs torch reference, and (the user's ask) the
+        # generated output directly vs the hand-written reference output.
+        out = spec.gen_call(gen, inputs)
+        torch.cuda.synchronize()
+        ref = spec.reference(inputs)
+        rel_ref = _rel(out, ref)
+        nan = int(torch.isnan(out).sum().item())
+
+        rel_gh = None
+        rel_hw_ref = None
+        hw_ms = None
+        if hw is not None:
+            try:
+                hout = spec.hw_call(hw, inputs)
+                torch.cuda.synchronize()
+                rel_gh = _rel(out, hout)
+                rel_hw_ref = _rel(hout, ref)
+            except Exception:  # noqa: BLE001 - hw is only a reference baseline
+                hout = None
+            if hout is not None:
+                hw_ms = _bench(lambda inp=inputs: spec.hw_call(hw, inp))
+
+        # Re-run the generated kernel for timing after the hw call (which shares
+        # output buffers in some specs) so gen output isn't left clobbered.
+        gen_ms = _bench(lambda inp=inputs: spec.gen_call(gen, inp))
+
+        ok = bool(rel_ref <= spec.TOL and nan == 0 and (rel_gh is None or rel_gh <= spec.TOL))
+
+        work, scale, unit = spec.metric(shape)
+        rows.append(
+            {
+                "shape": list(shape),
+                "gen_ms": gen_ms,
+                "hw_ms": hw_ms,
+                "throughput": work / (gen_ms * 1e-3) / scale,
+                "hw_throughput": (work / (hw_ms * 1e-3) / scale) if hw_ms else None,
+                "unit": unit,
+                "rel": rel_ref,
+                "rel_gen_vs_hw": rel_gh,
+                "rel_hw_vs_ref": rel_hw_ref,
+                "ok": ok,
+            }
+        )
+    return {"case": case_dir.name, "shapes": rows}
+
+
+def _print_table(result: dict[str, Any]) -> None:
+    print(f"\n== {result['case']} ==")
+    print(f"{'shape':<22}{'gen':<12}{'hw':<12}{'gen/hw':<9}{'rel':<10}{'ok'}")
+    print("-" * 75)
+    for r in result["shapes"]:
+        unit = r["unit"]
+        gen = f"{r['throughput']:.1f} {unit}"
+        if r["hw_throughput"]:
+            hw = f"{r['hw_throughput']:.1f} {unit}"
+            ratio = f"{r['throughput'] / r['hw_throughput']:.2f}x"
+        else:
+            hw, ratio = "-", "-"
+        shape = "(" + ",".join(str(x) for x in r["shape"]) + ")"
+        print(f"{shape:<22}{gen:<12}{hw:<12}{ratio:<9}{r['rel']:<10.2e}{'PASS' if r['ok'] else 'FAIL'}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd")
+
+    w = sub.add_parser("worker", help="benchmark one case's generated.py, write JSON")
+    w.add_argument("--case-dir", required=True)
+    w.add_argument("--generated", required=True, help="path to the generated.py to benchmark")
+    w.add_argument("--out", required=True, help="path to write the JSON result")
+    w.add_argument("--no-hw", action="store_true", help="skip the handwritten baseline")
+
+    b = sub.add_parser("bench", help="benchmark cases' committed generated.py vs handwritten")
+    b.add_argument("--cases", help="comma-separated case dir names (default: all with bench_spec.py)")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "worker":
+        case_dir = Path(args.case_dir).resolve()
+        result = run_bench(case_dir, Path(args.generated).resolve(), want_hw=not args.no_hw)
+        Path(args.out).write_text(json.dumps(result))
+        return 0
+
+    # default / "bench": human table over committed generated.py
+    examples_dir = Path(__file__).resolve().parent.parent
+    if args.cmd == "bench" and args.cases:
+        names = args.cases.split(",")
+    else:
+        names = [
+            p.name
+            for p in sorted(examples_dir.iterdir())
+            if p.is_dir() and p.name.startswith("case") and (p / "bench_spec.py").exists()
+        ]
+    for name in names:
+        case_dir = examples_dir / name
+        gen = case_dir / "generated.py"
+        if not (case_dir / "bench_spec.py").exists() or not gen.exists():
+            print(f"== {name} == SKIP (missing bench_spec.py or generated.py)")
+            continue
+        _print_table(run_bench(case_dir, gen))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/tlx/tools/sched2tlx/examples/testing/run_regression.py
+++ b/third_party/tlx/tools/sched2tlx/examples/testing/run_regression.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Before-vs-after regression driver for the sched2tlx emitter.
+
+Given any diff that touches the sched2tlx tool (default: the current commit),
+this re-emits every example case with the emitter BEFORE and AFTER the diff and
+checks, for each auto-discovered case under ``examples/``:
+
+  * correctness — the after-diff generated kernel matches the case's hand-written
+    reference (the generated output is compared directly against the handwritten
+    output, and both against the torch reference);
+  * performance — the after-diff kernel is no slower than the before-diff kernel,
+    per shape, within ``--perf-tol``.
+
+Both checks are before-vs-after aware: a case that is already broken/slow *before*
+the diff is not counted against it (only a true regression — ok/fast before,
+broken/slow after — fails). Everything runs in-process so it works both under a
+plain triton-enabled interpreter and inside a buck ``python_binary`` (par).
+
+Run it from anywhere inside your fbsource checkout — the repo root is
+auto-detected from the working directory (pass ``--repo-root`` only if you run
+from outside the checkout).
+
+Usage:
+    # @fbcode//mode/dev-nosan is required: the default dev mode links ASAN,
+    # which disables CUDA in torch.
+    buck2 run @fbcode//mode/dev-nosan \
+        //third-party/triton/beta/triton:sched2tlx_regression -- --diff D108804400
+    # or, with a plain triton-enabled python:
+    python3 run_regression.py --diff D108804400 [--cases case1_simple_gemm,...]
+
+Needs a Blackwell GPU for the checks (gated; reported as SKIP otherwise). Run
+third_party/tlx/killgpu.sh if a launch hangs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+# Make sibling modules importable whether run as a script, a module, or inside a
+# par (where __file__ lives in the extracted tree).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import emit_helpers as eh  # noqa: E402
+import perf_engine as pe  # noqa: E402
+
+_UNSUPPORTED_MARKER = "_unsupported"
+
+
+def _gpu_ok() -> bool:
+    # Direct torch check (Blackwell == compute capability major 10/11) avoids
+    # pulling triton._internal_testing, which imports pytest.
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            print("GPU check: torch.cuda.is_available() is False")
+            return False
+        major, minor = torch.cuda.get_device_capability()
+        bw = major in (10, 11)
+        print(f"GPU check: device_count={torch.cuda.device_count()} capability={major}.{minor} blackwell={bw}")
+        return bw
+    except Exception as e:  # noqa: BLE001 - any import/runtime failure means "no usable GPU"
+        print(f"GPU check raised: {type(e).__name__}: {str(e)[:160]}")
+        return False
+
+
+def _all_ok(res: dict | None) -> bool:
+    return bool(res) and all(r["ok"] for r in res["shapes"])
+
+
+def _max_gh(res: dict) -> float | None:
+    vals = [r["rel_gen_vs_hw"] for r in res["shapes"] if r.get("rel_gen_vs_hw") is not None]
+    return max(vals) if vals else None
+
+
+def _perf_compare(before: dict | None, after: dict, tol: float) -> tuple[str, str]:
+    if not _all_ok(before):
+        return "OK", "BEFORE-BROKEN → after validated"
+    before_ms = {tuple(r["shape"]): r["gen_ms"] for r in before["shapes"]}
+    worst, worst_shape = 0.0, None
+    for r in after["shapes"]:
+        b = before_ms.get(tuple(r["shape"]))
+        if not b or b <= 0:
+            continue
+        ratio = r["gen_ms"] / b
+        if ratio > worst:
+            worst, worst_shape = ratio, tuple(r["shape"])
+    if worst > 1 + tol:
+        return "FAIL", f"REGRESSION {worst:.2f}x slower at {worst_shape}"
+    return "OK", f"{worst:.2f}x slowest-shape (no regression)"
+
+
+def _run_bench_safe(side, case: str, gen_path: Path, want_hw: bool) -> dict | None:
+    try:
+        return pe.run_bench(side.examples / case, gen_path, want_hw=want_hw)
+    except Exception as e:  # noqa: BLE001 - a kernel that faults is a data point, not a crash
+        print(f"    ({'after' if want_hw else 'before'} bench raised {type(e).__name__}: {str(e)[:120]})", flush=True)
+        return None
+
+
+def _evaluate(before_tree, after_tree, case: str, before_gen: Path, after_gen: Path,
+              tol: float) -> tuple[str, str, str, str]:
+    """Return (correctness, corr_detail, perf, perf_detail) for one case."""
+    after = _run_bench_safe(after_tree, case, after_gen, want_hw=True)
+    if after is None:
+        # after couldn't even run; only a regression if before could.
+        before = _run_bench_safe(before_tree, case, before_gen, want_hw=True)
+        if _all_ok(before):
+            return "FAIL", "REGRESSION: after kernel errors, before worked", "SKIP", ""
+        return "PREEXIST", "broken before+after (after errors)", "SKIP", ""
+
+    if _all_ok(after):
+        gh = _max_gh(after)
+        corr_detail = "gen==hw" + (f" (max rel {gh:.1e})" if gh is not None else " (no hw)")
+        before = _run_bench_safe(before_tree, case, before_gen, want_hw=False)
+        perf, perf_detail = _perf_compare(before, after, tol)
+        return "PASS", corr_detail, perf, perf_detail
+
+    # after incorrect — classify vs before.
+    bad = [r["shape"] for r in after["shapes"] if not r["ok"]]
+    before = _run_bench_safe(before_tree, case, before_gen, want_hw=True)
+    if _all_ok(before):
+        return "FAIL", f"REGRESSION: ok before, wrong after at {bad}", "SKIP", "skipped (incorrect)"
+    return "PREEXIST", f"broken before+after at {bad}", "SKIP", "skipped (incorrect)"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--diff", default=".", help="revision to test (before=<diff>^, after=<diff>); default current commit")
+    ap.add_argument("--before", help="explicit before revision (overrides --diff)")
+    ap.add_argument("--after", help="explicit after revision (overrides --diff)")
+    ap.add_argument("--cases", help="comma-separated case dir names (default: all discovered)")
+    ap.add_argument("--perf-tol", type=float, default=0.05, help="allowed per-shape slowdown fraction (default 0.05)")
+    ap.add_argument("--repo-root", help="fbsource checkout root (default: auto-detect from cwd)")
+    ap.add_argument("--keep", action="store_true", help="keep temp before/after trees for debugging")
+    args = ap.parse_args(argv)
+
+    before_rev = args.before or f"{args.diff}^"
+    after_rev = args.after or args.diff
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root)
+    else:
+        repo_root = eh.find_repo_root(Path.cwd())
+
+    gpu = _gpu_ok()
+    if not gpu:
+        print("NOTE: no Blackwell GPU detected — correctness/perf layers will be SKIPPED.\n")
+
+    workdir = Path(tempfile.mkdtemp(prefix="s2t_regression_"))
+    print(f"repo: {repo_root}")
+    print(f"diff: before={before_rev}  after={after_rev}")
+    print(f"workdir: {workdir}\n")
+
+    before_tree, after_tree = eh.materialize(repo_root, workdir, before_rev, after_rev)
+
+    discovered = sorted(
+        p.name for p in after_tree.examples.iterdir()
+        if p.is_dir() and p.name.startswith("case")
+    )
+    selected = args.cases.split(",") if args.cases else discovered
+
+    print(f"{'case':<24}{'correctness':<12}{'perf':<8} detail", flush=True)
+    print("-" * 92, flush=True)
+
+    results = []
+    failures = 0
+    for case in selected:
+        if not (after_tree.examples / case).is_dir():
+            results.append((case, "SKIP", "SKIP", "no such case dir"))
+            print(f"{case:<24}{'SKIP':<12}{'SKIP':<8} no such case dir", flush=True)
+            continue
+
+        try:
+            before_gen = eh.emit_case_inproc(before_tree, case)
+            after_gen = eh.emit_case_inproc(after_tree, case)
+        except Exception as e:  # noqa: BLE001
+            results.append((case, "FAIL", "SKIP", f"emit failed: {str(e)[:60]}"))
+            failures += 1
+            print(f"{case:<24}{'FAIL':<12}{'SKIP':<8} emit failed: {str(e)[:60]}", flush=True)
+            continue
+
+        if _UNSUPPORTED_MARKER in after_gen.read_text():
+            results.append((case, "SKIP", "SKIP", "emitter placeholder (<..._unsupported>)"))
+            print(f"{case:<24}{'SKIP':<12}{'SKIP':<8} emitter placeholder (<..._unsupported>)", flush=True)
+            continue
+
+        if not gpu:
+            results.append((case, "SKIP", "SKIP", "no GPU"))
+            print(f"{case:<24}{'SKIP':<12}{'SKIP':<8} no GPU", flush=True)
+            continue
+
+        if not (after_tree.examples / case / "bench_spec.py").exists():
+            results.append((case, "SKIP", "SKIP", "no bench_spec.py (not configured for this suite)"))
+            print(f"{case:<24}{'SKIP':<12}{'SKIP':<8} no bench_spec.py (not configured for this suite)", flush=True)
+            continue
+
+        corr, corr_detail, perf, perf_detail = _evaluate(
+            before_tree, after_tree, case, before_gen, after_gen, args.perf_tol
+        )
+        if corr == "FAIL" or perf == "FAIL":
+            failures += 1
+        detail = corr_detail if corr != "PASS" else f"{perf_detail}; {corr_detail}"
+        results.append((case, corr, perf, detail))
+        print(f"{case:<24}{corr:<12}{perf:<8} {detail}", flush=True)
+
+    if not args.keep:
+        shutil.rmtree(workdir, ignore_errors=True)
+    else:
+        print(f"\n(kept temp trees at {workdir})")
+
+    print(f"\n{'FAILED' if failures else 'OK'}: {failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Summary:

Adds a generic before-vs-after regression suite for the sched2tlx emitter under `third_party/tlx/tools/sched2tlx/examples/testing/`. Given any diff that touches the tool (default: the current commit), it re-emits every example case with the emitter before and after the change and checks, per auto-discovered `examples/case*/`: correctness (the after-diff generated kernel matches the hand-written reference, compared directly tensor-vs-tensor and against the torch reference) and performance (the after-diff kernel is no slower than the before-diff kernel per shape, within a tolerance). Both checks are before-vs-after aware, so a case already broken or slow before the diff is not counted against it — only a true regression fails.

It is generic in two dimensions: it works for any diff (the before/after tool trees are materialized from Sapling via `sl status --change` + `sl cat`), and it auto-discovers all cases — a new `caseN_*` directory is picked up once it ships a small `bench_spec.py`. The common perf machinery (timing via `triton.testing.do_bench`, shape sweep, throughput/ratio reporting, before-vs-after comparison) lives in a shared `perf_engine.py`; each case's `bench_spec.py` only supplies its shapes, input builders, kernel launches, metric, and reference. Everything runs in-process so it works both under a plain triton-enabled interpreter and inside the `sched2tlx_regression` buck `python_binary`.

This addresses the review request on D108804400 to verify all existing cases pass both correctness and perf (before vs after, no regression).

Authored with Claude.

Reviewed By: wlei-llvm

Differential Revision: D108940570


