### PR TITLE
[TLX][AMD] Add persistent kernel and performance regression guard for fused addmm + GLU

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -95,6 +95,12 @@ jobs:
           . "${VENV_DIR}/bin/activate"
           python3 third_party/tlx/tutorials/amd-fa-pipelined_test.py --mode perf_test
 
+      - name: Run TLX AMD Addmm+GLU performance guard
+        run: |
+          set -euxo pipefail
+          . "${VENV_DIR}/bin/activate"
+          python3 third_party/tlx/tutorials/amd-addmm-glu-opt_test.py --mode perf_test
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/tlx-amd-meta' }}

--- a/third_party/tlx/tutorials/amd-addmm-glu-opt_test.py
+++ b/third_party/tlx/tutorials/amd-addmm-glu-opt_test.py
@@ -28,6 +28,9 @@ M, N = 1024, 21568
 # gfx950 has 8 XCDs per chip
 NUM_XCDS = 8
 
+# Per-row padding (fp16 elements) on the async kernel's Y LDS buffer
+Y_PAD = 4
+
 # Autotuning winning configurations for K=256, K=512, and K=1024
 BEST_CONFIG = {
     256:
@@ -54,6 +57,47 @@ BASELINE_BEST_CONFIG = {
          matrix_instr_nonkdim=16, waves_per_eu=2, kpack=1),
 }
 
+# Autotuning winning configurations for the async-epilogue kernel (K=256, K=512, K=1024)
+ASYNC_BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=64, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, NUM_BUFFERS=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    512:
+    dict(BLOCK_SIZE_M=64, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, NUM_BUFFERS=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, NUM_BUFFERS=3, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+}
+
+# Autotuning winning configurations for the persistent warp-pipelined kernel
+# BN=256 with BK=32 (72KB LDS) beats BN=128 with BK=64 (96KB) at all K values
+# BN=256 with BK=64 (144KB) is rejected by hardware due to warp-pipeline overhead
+PERSISTENT_BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    512:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+}
+
+# Configs for the simple (non-pipelined) kernel with async-prefetched Y
+SIMPLE_BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    512:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+}
+
 
 # L2 swizzling
 @triton.jit
@@ -68,6 +112,12 @@ def chiplet_transform_chunked(pid, num_workgroups, num_xcds: tl.constexpr, chunk
     xcd = pid % num_xcds
     local_pid = pid // num_xcds
     return ((local_pid // chunk_size) * num_xcds * chunk_size + xcd * chunk_size + (local_pid % chunk_size))
+
+
+@triton.constexpr_function
+def _y_padded_layout(BM, BN, PAD):
+    # Pad each row of the (BM, BN) Y tile
+    return tlx.padded_shared_layout_encoding.with_identity_for([[BN, PAD]], [BM, BN], [1, 0])
 
 
 # Warp-pipelined async direct-to-LDS fused addmm + GLU optimized kernel
@@ -196,8 +246,8 @@ def tlx_addmm_glu_kernel_optimized(
     tlx.async_load_wait_group(1)
 
     # LR (Local Read) 0 where we transfer GR0 to registers
-    a_tile = tlx.local_load(tlx.local_view(smemA, 0))
-    b_tile = tlx.local_load(tlx.local_view(smemB, 0))
+    a_tile = tlx.local_load(tlx.local_view(smemA, 0), relaxed=True)
+    b_tile = tlx.local_load(tlx.local_view(smemB, 0), relaxed=True)
 
     # Create accumulator array
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
@@ -230,8 +280,8 @@ def tlx_addmm_glu_kernel_optimized(
             tlx.async_load_commit_group([tok_a, tok_b])
 
             # Perform local prefetching (LR i + 1)
-            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
-            b_tile = tlx.local_load(tlx.local_view(smemB, next_buf))
+            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf), relaxed=True)
+            b_tile = tlx.local_load(tlx.local_view(smemB, next_buf), relaxed=True)
 
         # Most recently committed buffers (GR i + NUM_BUFFERS) can be in flight
         tlx.async_load_wait_group(1)
@@ -248,8 +298,8 @@ def tlx_addmm_glu_kernel_optimized(
     for i in tl.static_range(0, NUM_BUFFERS - 1):
         buf = (k_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
 
-        a_tile = tlx.local_load(tlx.local_view(smemA, buf))
-        b_tile = tlx.local_load(tlx.local_view(smemB, buf))
+        a_tile = tlx.local_load(tlx.local_view(smemA, buf), relaxed=True)
+        b_tile = tlx.local_load(tlx.local_view(smemB, buf), relaxed=True)
 
         acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
 
@@ -300,6 +350,542 @@ def run_kernel_optimized(a, b, bias, y, out, cfg):
         GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
         NUM_XCDS=NUM_XCDS,
         XCD_CHUNK=cfg["XCD_CHUNK"],
+        num_warps=cfg["num_warps"],
+        num_stages=1,
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+    )
+
+
+# Warp-pipelined async direct-to-LDS fused addmm + GLU kernel, async-epilogue variant
+# Stages the epilogue Y tile into a padded LDS buffer via async_load so its 44MB HBM
+# read overlaps GEMM compute
+@triton.jit
+def tlx_addmm_glu_kernel_optimized_async(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    Y_PAD: tl.constexpr,
+):
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    pid = tl.program_id(axis=0)
+
+    # Num pids along M dim
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+
+    # Num pids along N dim
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    # How many pids we have in total grid
+    grid_mn = num_pid_m * num_pid_n
+
+    # Remap pids via L2 swizzle
+    pid = chiplet_transform_chunked(pid, grid_mn, NUM_XCDS, XCD_CHUNK)
+
+    # Num pids in the group (of shared rows along M dim pids)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    # Which group we are in
+    group_id = pid // num_pid_in_group
+
+    # Index of first pid in this group
+    first_pid_m = group_id * GROUP_SIZE_M
+
+    # Either GROUP_SIZE_M or smaller due to last group cutting off early
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+
+    # Which pid along m dim
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+
+    # Which pid along n dim
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+    # Get offsets this pid is responsible for in m dim
+    offs_m = offs_cm % M
+
+    # Get offsets this pid is responsible for in n dim
+    offs_n = offs_cn % N
+
+    # Get offsets this pid is responsible for in k dim
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Base pointers for A along m dim
+    a_base_off = offs_m[:, None] * sa0
+
+    # Base pointers for B along n dim
+    b_base_off = offs_n[None, :] * sb1
+
+    # How many times we need to iterate through blocks of size BLOCK_SIZE_K
+    k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+
+    # Create multibuffered shared memory arrays
+    smemA = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_BUFFERS)
+
+    # Prologue: issue NUM_BUFFERS global reads
+    for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
+        k_start = i * BLOCK_SIZE_K
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, i), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+    # Drain down to NUM_BUFFERS-2 in flight so buffers 0 and 1 are ready
+    tlx.async_load_wait_group(NUM_BUFFERS - 2)
+
+    # LR (Local Read) 0 where we transfer GR0 to registers
+    a_tile = tlx.local_load(tlx.local_view(smemA, 0), relaxed=True)
+    b_tile = tlx.local_load(tlx.local_view(smemB, 0), relaxed=True)
+
+    # Create accumulator array
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Hot loop: warp-pipelined MFMA / async-prefetch
+    for i in tl.range(0, k_iters - NUM_BUFFERS, loop_unroll_factor=0):
+        # Index within the multibuffered circular SMEM where we are storing the global prefetch
+        prefetch_buf = i % NUM_BUFFERS
+
+        # Index within the multibuffered circular SMEM where we will load from to transfer into regs
+        next_buf = (i + 1) % NUM_BUFFERS
+
+        # Which tile we need to prefetch globally along the k dim
+        k_prefetch = (i + NUM_BUFFERS) * BLOCK_SIZE_K
+
+        # Execute MFMA with the data we already have loaded into registers
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            # Perform global prefetching (GR i + NUM_BUFFERS)
+            a_offs = a_base_off + (k_prefetch + offs_k[None, :]) * sa1
+            b_offs = (k_prefetch + offs_k[:, None]) * sb0 + b_base_off
+
+            tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, prefetch_buf), mask=offs_k[None, :]
+                                   < K - k_prefetch)
+            tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, prefetch_buf), mask=offs_k[:, None]
+                                   < K - k_prefetch)
+
+            tlx.async_load_commit_group([tok_a, tok_b])
+
+            # Perform local prefetching (LR i + 1)
+            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf), relaxed=True)
+            b_tile = tlx.local_load(tlx.local_view(smemB, next_buf), relaxed=True)
+
+        # Keep the NUM_BUFFERS-2 most-recent prefetches in flight (pipeline depth)
+        tlx.async_load_wait_group(NUM_BUFFERS - 2)
+
+    # Async-prefetch Y into a padded LDS buffer
+    y_layout: tl.constexpr = _y_padded_layout(BLOCK_SIZE_M, BLOCK_SIZE_N, Y_PAD)
+    smemY = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tlx.dtype_of(y_ptr), 1, layout=y_layout)
+    y_ptrs = y_ptr + offs_m[:, None] * sy0 + offs_n[None, :] * sy1
+    y_tok = tlx.async_load(y_ptrs, tlx.local_view(smemY, 0))
+    tlx.async_load_commit_group([y_tok])
+
+    # Epilogue: drain the remaining in-flight tiles
+    acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+    # Keep Y (newest committed group) in flight; drain all A/B.
+    tlx.async_load_wait_group(1)
+
+    # Finish final set of LRs and MFMAs
+    for i in tl.static_range(0, NUM_BUFFERS - 1):
+        buf = (k_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
+
+        a_tile = tlx.local_load(tlx.local_view(smemA, buf), relaxed=True)
+        b_tile = tlx.local_load(tlx.local_view(smemB, buf), relaxed=True)
+
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+    # Fused epilogue: addmm + GLU. Add bias (broadcast over M), then GLU: X = X + X*Y.
+    bias = tl.load(bias_ptr + offs_n).to(tl.float32)
+    x = acc + bias[None, :]
+
+    # Wait for Y to finish loading, then read it back from the padded LDS buffer
+    tlx.async_load_wait_group(0)
+    y_regs = tlx.local_load(tlx.local_view(smemY, 0), relaxed=True).to(tl.float32)
+    out = x + x * y_regs
+
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    c_ptrs = c_ptr + offs_cm[:, None] * sc0 + offs_cn[None, :] * sc1
+
+    tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), mask=c_mask, cache_modifier=".cs")
+
+
+def run_kernel_optimized_async(a, b, bias, y, out, cfg):
+    M, K = a.shape
+    _, N = b.shape
+    grid = (triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"]), )
+    return tlx_addmm_glu_kernel_optimized_async[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=cfg["XCD_CHUNK"],
+        NUM_BUFFERS=cfg["NUM_BUFFERS"],
+        Y_PAD=Y_PAD,
+        num_warps=cfg["num_warps"],
+        num_stages=1,
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+    )
+
+
+# Simple (non-pipelined) GEMM with async-prefetched Y. The K-loop does a plain
+# blocking load of A and B each iteration (no multibuffering, no warp-pipeline,
+# no prefetch). Only the epilogue Y tile is staged async into LDS before the loop
+# so its HBM read latency can overlap the whole GEMM
+@triton.jit
+def tlx_addmm_glu_kernel_simple_async(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+    Y_PAD: tl.constexpr,
+):
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    grid_mn = num_pid_m * num_pid_n
+    pid = chiplet_transform_chunked(pid, grid_mn, NUM_XCDS, XCD_CHUNK)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_m = offs_cm % M
+    offs_n = offs_cn % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Async-prefetch Y into a padded LDS buffer before the K-loop
+    y_layout: tl.constexpr = _y_padded_layout(BLOCK_SIZE_M, BLOCK_SIZE_N, Y_PAD)
+    smemY = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tlx.dtype_of(y_ptr), 1, layout=y_layout)
+    y_ptrs = y_ptr + offs_m[:, None] * sy0 + offs_n[None, :] * sy1
+    y_tok = tlx.async_load(y_ptrs, tlx.local_view(smemY, 0))
+    tlx.async_load_commit_group([y_tok])
+
+    a_ptrs = a_ptr + offs_m[:, None] * sa0 + offs_k[None, :] * sa1
+    b_ptrs = b_ptr + offs_k[:, None] * sb0 + offs_n[None, :] * sb1
+
+    # Plain unpipelined K-loop: grab A and B for this iteration, dot, advance
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+    for k in tl.range(0, k_iters):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        acc = tl.dot(a, b, acc, allow_tf32=False)
+        a_ptrs += BLOCK_SIZE_K * sa1
+        b_ptrs += BLOCK_SIZE_K * sb0
+
+    # Fused epilogue: addmm + GLU
+    bias = tl.load(bias_ptr + offs_n).to(tl.float32)
+    x = acc + bias[None, :]
+
+    # Wait for Y to finish loading, then read it back from the padded LDS buffer
+    tlx.async_load_wait_group(0)
+    y_regs = tlx.local_load(tlx.local_view(smemY, 0), relaxed=True).to(tl.float32)
+    out = x + x * y_regs
+
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    c_ptrs = c_ptr + offs_cm[:, None] * sc0 + offs_cn[None, :] * sc1
+    tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), mask=c_mask, cache_modifier=".cs")
+
+
+# Persistent warp-pipelined fused addmm + GLU kernel.
+# Each CU is launched once and loops over its share of (num_pid_m * num_pid_n) tiles
+@triton.jit
+def tlx_addmm_glu_kernel_persistent(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+    NUM_CUS: tl.constexpr,
+):
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    NUM_BUFFERS: tl.constexpr = 3
+
+    start_pid = tl.program_id(axis=0)
+
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_tiles = num_pid_m * num_pid_n
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # LDS buffers are allocated once and reused across tiles (fully drained between tiles)
+    smemA = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_BUFFERS)
+
+    # Distribute tiles among CUs
+    for tile_id in tl.range(start_pid, num_tiles, NUM_CUS):
+        # Apply XCD swizzle to the flat tile_id for L2 locality
+        swizzled = chiplet_transform_chunked(tile_id, num_tiles, NUM_XCDS, XCD_CHUNK)
+
+        # Delinearize swizzled tile_id
+        group_id = swizzled // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((swizzled % num_pid_in_group) % group_size_m)
+        pid_n = (swizzled % num_pid_in_group) // group_size_m
+
+        offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+        a_base_off = offs_m[:, None] * sa0
+        b_base_off = offs_n[None, :] * sb1
+
+        k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+
+        # Prologue: issue 3 global reads
+        k_start = 0
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 0), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 0), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+        k_start = BLOCK_SIZE_K
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 1), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 1), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+        k_start = BLOCK_SIZE_K * 2
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 2), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 2), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+        # Make GR0 and GR1 finish
+        tlx.async_load_wait_group(1)
+
+        a_tile = tlx.local_load(tlx.local_view(smemA, 0), relaxed=True)
+        b_tile = tlx.local_load(tlx.local_view(smemB, 0), relaxed=True)
+
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        # Hot loop: warp-pipelined MFMA / async-prefetch
+        for i in tl.range(0, k_iters - NUM_BUFFERS, loop_unroll_factor=0):
+            prefetch_buf = i % NUM_BUFFERS
+            next_buf = (i + 1) % NUM_BUFFERS
+            k_prefetch = (i + NUM_BUFFERS) * BLOCK_SIZE_K
+
+            with tlx.warp_pipeline_stage("mfma", priority=0):
+                acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+            with tlx.warp_pipeline_stage("mem", priority=1):
+                a_offs = a_base_off + (k_prefetch + offs_k[None, :]) * sa1
+                b_offs = (k_prefetch + offs_k[:, None]) * sb0 + b_base_off
+
+                tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, prefetch_buf), mask=offs_k[None, :]
+                                       < K - k_prefetch)
+                tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, prefetch_buf), mask=offs_k[:, None]
+                                       < K - k_prefetch)
+
+                tlx.async_load_commit_group([tok_a, tok_b])
+
+                a_tile = tlx.local_load(tlx.local_view(smemA, next_buf), relaxed=True)
+                b_tile = tlx.local_load(tlx.local_view(smemB, next_buf), relaxed=True)
+
+            tlx.async_load_wait_group(1)
+
+        # Epilogue: drain remaining in-flight tiles
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        tlx.async_load_wait_group(0)
+
+        for i in tl.static_range(0, NUM_BUFFERS - 1):
+            buf = (k_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
+            a_tile = tlx.local_load(tlx.local_view(smemA, buf), relaxed=True)
+            b_tile = tlx.local_load(tlx.local_view(smemB, buf), relaxed=True)
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        # Fused addmm + GLU epilogue
+        bias = tl.load(bias_ptr + offs_n).to(tl.float32)
+        y_ptrs = y_ptr + offs_m[:, None] * sy0 + offs_n[None, :] * sy1
+        y = tl.load(y_ptrs, cache_modifier=".cs").to(tl.float32)
+        x = acc + bias[None, :]
+        out = x + x * y
+
+        offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+        c_ptrs = c_ptr + offs_cm[:, None] * sc0 + offs_cn[None, :] * sc1
+        tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), mask=c_mask, cache_modifier=".cs")
+
+
+def run_kernel_persistent(a, b, bias, y, out, cfg, num_cus):
+    M, K = a.shape
+    _, N = b.shape
+    grid = (min(num_cus, triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"])), )
+    return tlx_addmm_glu_kernel_persistent[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=cfg["XCD_CHUNK"],
+        NUM_CUS=num_cus,
+        num_warps=cfg["num_warps"],
+        num_stages=1,
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+    )
+
+
+def run_kernel_simple_async(a, b, bias, y, out, cfg):
+    M, K = a.shape
+    _, N = b.shape
+    grid = (triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"]), )
+    return tlx_addmm_glu_kernel_simple_async[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=cfg["XCD_CHUNK"],
+        Y_PAD=Y_PAD,
         num_warps=cfg["num_warps"],
         num_stages=1,
         matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
@@ -389,8 +975,8 @@ def tlx_addmm_glu_kernel_baseline(
         b_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
         prev = (k % (NUM_STAGES - 1))
-        a_prev = tlx.local_load(tlx.local_view(buffers_a, prev))
-        b_prev = tlx.local_load(tlx.local_view(buffers_b, prev))
+        a_prev = tlx.local_load(tlx.local_view(buffers_a, prev), relaxed=True)
+        b_prev = tlx.local_load(tlx.local_view(buffers_b, prev), relaxed=True)
         acc = tl.dot(a_prev, b_prev, acc)
 
         tlx.local_store(a_smem, a_reg)
@@ -400,8 +986,8 @@ def tlx_addmm_glu_kernel_baseline(
 
     for k in tl.range(k_iters - (NUM_STAGES - 1), k_iters, loop_unroll_factor=NUM_STAGES - 1):
         buf = k % (NUM_STAGES - 1)
-        a_prev = tlx.local_load(tlx.local_view(buffers_a, buf))
-        b_prev = tlx.local_load(tlx.local_view(buffers_b, buf))
+        a_prev = tlx.local_load(tlx.local_view(buffers_a, buf), relaxed=True)
+        b_prev = tlx.local_load(tlx.local_view(buffers_b, buf), relaxed=True)
         acc = tl.dot(a_prev, b_prev, acc)
 
     # === Fused epilogue: addmm + GLU ===
@@ -467,9 +1053,34 @@ def run_optimized(a, b, bias, y):
     return out
 
 
+def run_optimized_async(a, b, bias, y):
+    K = b.shape[0]
+    out = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float16)
+    run_kernel_optimized_async(a, b, bias, y, out, ASYNC_BEST_CONFIG[K])
+    return out
+
+
+def run_persistent(a, b, bias, y):
+    K = b.shape[0]
+    out = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float16)
+    num_cus = torch.cuda.get_device_properties(a.device).multi_processor_count
+    run_kernel_persistent(a, b, bias, y, out, PERSISTENT_BEST_CONFIG[K], num_cus)
+    return out
+
+
+def run_simple_async(a, b, bias, y):
+    K = b.shape[0]
+    out = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float16)
+    run_kernel_simple_async(a, b, bias, y, out, SIMPLE_BEST_CONFIG[K])
+    return out
+
+
 KERNEL_REGISTRY = {
     "tlx_baseline": run_baseline,
+    "tlx_simple_async": run_simple_async,
+    "tlx_optimized_async": run_optimized_async,
     "tlx_optimized": run_optimized,
+    "tlx_persistent": run_persistent,
 }
 
 

--- a/third_party/tlx/tutorials/amd-addmm-glu-opt_test.py
+++ b/third_party/tlx/tutorials/amd-addmm-glu-opt_test.py
@@ -16,6 +16,7 @@ Usage:
 """
 import argparse
 
+import pytest
 import torch
 import triton
 import triton.language as tl
@@ -1102,6 +1103,89 @@ def verify(name, got, ref, atol=2e-2, rtol=2e-2, log=True):
     return ok
 
 
+# ═══════════════════════════════════════════════════════════════════════════
+# Performance regression guard
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Baseline TFLOPS measured on gfx950/MI350 (fp16, M=1024, N=21568). A kernel must
+# stay within PERF_TOL below its baseline or the perf test fails (catches
+# regressions). Regenerate the numbers with:
+#   python amd-addmm-glu-opt_test.py
+# then copy the printed Summary table values here.
+PERF_TOL = 0.15  # allow 15% slack below baseline (run-to-run noise + minor drift)
+
+# key: (kernel, K) -> TFLOPS
+PERF_BASELINE_TFLOPS = {
+    ("tlx_baseline", 256): 237,
+    ("tlx_baseline", 512): 355,
+    ("tlx_baseline", 1024): 459,
+    ("tlx_simple_async", 256): 169,
+    ("tlx_simple_async", 512): 269,
+    ("tlx_simple_async", 1024): 349,
+    ("tlx_optimized_async", 256): 181,
+    ("tlx_optimized_async", 512): 279,
+    ("tlx_optimized_async", 1024): 406,
+    ("tlx_optimized", 256): 280,
+    ("tlx_optimized", 512): 442,
+    ("tlx_optimized", 1024): 597,
+    ("tlx_persistent", 256): 298,
+    ("tlx_persistent", 512): 449,
+    ("tlx_persistent", 1024): 613,
+}
+
+
+def measure_tflops(kernel_fn, M, N, K):
+    """Verify correctness then return achieved TFLOPS for one config."""
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+    bias = torch.randn(N, device=DEVICE, dtype=torch.float16)
+    y = torch.randn(M, N, device=DEVICE, dtype=torch.float16)
+    ref = pytorch_baseline(bias, a, b, y)
+    fn = lambda: kernel_fn(a, b, bias, y)
+    assert verify("", fn(), ref, log=False), "correctness check failed"
+    ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+    total_flops = 2.0 * M * N * K
+    return total_flops / ms * 1e-9
+
+
+@pytest.mark.parametrize("K", sorted(BEST_CONFIG))
+@pytest.mark.parametrize("kernel_name", list(KERNEL_REGISTRY))
+def test_addmm_glu_performance(kernel_name, K):
+    """Guard against perf regressions: achieved TFLOPS must stay within PERF_TOL
+    of the recorded gfx950 baseline (M=1024, N=21568, fp16)."""
+    baseline = PERF_BASELINE_TFLOPS[(kernel_name, K)]
+    floor = baseline * (1 - PERF_TOL)
+    got = measure_tflops(get_kernel(kernel_name), M, N, K)
+    print(f"  {kernel_name:20s} K={K:5d} {got:7.1f} TFLOPS (baseline {baseline}, floor {floor:.1f})")
+    assert got >= floor, (f"perf regression: {kernel_name} K={K} -> "
+                          f"{got:.1f} TFLOPS < floor {floor:.1f} (baseline {baseline}, tol {PERF_TOL:.0%})")
+
+
+def run_perf_test(args):
+    """CLI entry: run the perf guard over all baseline configs, print a report,
+    and return True iff every kernel is within PERF_TOL of its baseline."""
+    tol = args.perf_tol
+    all_ok = True
+    print(f"\nPerformance regression test (floor = baseline * (1 - {tol:.0%}))")
+    print("-" * 78)
+    for (kernel_name, K), baseline in sorted(PERF_BASELINE_TFLOPS.items()):
+        floor = baseline * (1 - tol)
+        try:
+            got = measure_tflops(get_kernel(kernel_name), M, N, K)
+        except Exception as e:
+            all_ok = False
+            print(f"  [FAIL] {kernel_name:20s} K={K:5d} -> ERROR ({e})")
+            continue
+        ok = got >= floor
+        all_ok &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] {kernel_name:20s} K={K:5d} "
+              f"{got:7.1f} TFLOPS (baseline {baseline}, floor {floor:.1f})")
+    print("-" * 78)
+    print("RESULT:", "PASS" if all_ok else "FAIL")
+    assert all_ok
+
+
 def print_summary_table(results, providers):
     """Print a markdown-style summary table of benchmark results."""
     rows = [(f"M={m} N={n} K={k}", results[(m, n, k)]) for (m, n, k) in sorted(results.keys())]
@@ -1180,8 +1264,16 @@ def parse_args():
                    help="K (contraction) sizes to benchmark; only stored-config sizes are supported")
     p.add_argument("--kernel", type=str, nargs="+", default=kernel_choices, choices=kernel_choices,
                    help="Kernel variants to benchmark")
+    p.add_argument("--mode", choices=["benchmark", "perf_test"], default="benchmark",
+                   help="benchmark: print TFLOPS table; perf_test: assert TFLOPS within PERF_TOL of baseline")
+    p.add_argument("--perf-tol", dest="perf_tol", type=float, default=PERF_TOL,
+                   help="perf_test slack below baseline (e.g. 0.15 = allow 15%% regression)")
     return p.parse_args()
 
 
 if __name__ == "__main__":
-    run_benchmark(parse_args())
+    args = parse_args()
+    if args.mode == "perf_test":
+        run_perf_test(args)
+    else:
+        run_benchmark(args)


### PR DESCRIPTION
## Summary

  Follow-up to #1690. Extends the gfx950 fused addmm + GLU tutorial
  (`third_party/tlx/tutorials/amd-addmm-glu-opt_test.py`) with additional kernel
  variants and a performance-regression guard wired into CI.

  ## Changes

  ### Kernel variants
  Three new kernels are added alongside the existing `tlx_baseline` /
  `tlx_optimized`:

  - **`tlx_persistent`**: persistent warp-pipelined kernel. Each CU is launched
    once and loops over its share of `(num_pid_m * num_pid_n)` tiles, reusing the
    LDS buffers across tiles. Best config is `BN=256, BK=32` (72KB LDS).
  - **`tlx_optimized_async`**: async-epilogue variant that stages the epilogue Y
    tile into a padded LDS buffer via `async_load`, overlapping its ~44MB HBM read
    with GEMM compute.
  - **`tlx_simple_async`**: simple (non-pipelined) GEMM with async-prefetched Y,
    as a readability/reference point.

  Supporting additions: per-kernel autotuned configs (`PERSISTENT_BEST_CONFIG`,
  `ASYNC_BEST_CONFIG`, `SIMPLE_BEST_CONFIG`), the `Y_PAD` / `_y_padded_layout`
  helper for the padded Y LDS buffer, the corresponding `run_*` wrappers, and new
  `KERNEL_REGISTRY` entries. The existing `tlx_optimized` kernel's `local_load`s
  are marked `relaxed=True`.

  ### Performance regression guard
  - `PERF_BASELINE_TFLOPS`: recorded gfx950/MI350X fp16 TFLOPS for every
    (kernel, K) pair (M=1024, N=21568), with `PERF_TOL = 0.15` (fails the job on >15% regression).
  - `test_addmm_glu_performance`: pytest-parametrized over kernel × K. Verifies
    correctness against the PyTorch reference, then asserts achieved TFLOPS stays
    within `PERF_TOL` of baseline.
  - `--mode {benchmark,perf_test}` and `--perf-tol` CLI flags
  - Baselines are regenerated by running the script with no args and copying the
    printed Summary table.

  ### CI
  Adds the TLX AMD Addmm+GLU performance guard step to
  `.github/workflows/ci-gpu.yml` that runs
  `amd-addmm-glu-opt_test.py --mode perf_test`.

  ### Performance Table
```
=================================================================================================================================================================================================
Summary (TFLOPS)   fp16
=================================================================================================================================================================================================
| Config                |         PyTorch_naive |          tlx_baseline |      tlx_simple_async |   tlx_optimized_async |         tlx_optimized |        tlx_persistent | ROCBLAS (matmul only) |
|-----------------------|-----------------------|-----------------------|-----------------------|-----------------------|-----------------------|-----------------------|-----------------------|
| M=1024 N=21568 K=256  |                  46.6 |                 236.0 |                 168.6 |                 179.4 |                 279.1 |                 298.2 |                 270.6 |
| M=1024 N=21568 K=512  |                  87.6 |                 355.2 |                 261.3 |                 279.6 |                 437.9 |                 450.3 |                 409.7 |
| M=1024 N=21568 K=1024 |                 160.7 |                 464.0 |                 350.3 |                 391.2 |                 597.5 |                 607.5 |                 578.6 |
=================================================================================================================================================================================================
```