### PR TITLE
 [AutoWS] Maintain ordering during buffer fusion (#1669)

### DIFF
--- a/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
+++ b/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
@@ -9,11 +9,16 @@
 // CHECK-LABEL: @swap_transposed_alloc
 //
 // After buffer allocation, the dsT alloc is swapped to non-transposed #shared
-// layout and hoisted above the loop.
+// layout and hoisted above the loop. The first two allocs are the original
+// k_smem/q_smem buffers; dsT remains after them because hoisting preserves
+// producer order.
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
 // CHECK: %[[B0:.*]] = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
 //
 // Inside the loop, memdesc_trans goes from #shared (non-transposed) to #shared1
 // (transposed), confirming the swap happened:
+// CHECK: ttg.local_store {{.*}}, %[[B0]]
 // CHECK: gen5_mma %[[B0]]
 // CHECK: %[[T0:.*]] = ttg.memdesc_trans %[[B0]]{{.*}} !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
 // CHECK: gen5_mma %[[T0]]

--- a/test/Hopper/WarpSpecialization/ws_buffer_allocation_hoist_order.mlir
+++ b/test/Hopper/WarpSpecialization/ws_buffer_allocation_hoist_order.mlir
@@ -1,0 +1,29 @@
+// RUN: triton-opt %s --nvgpu-test-ws-buffer-allocation | FileCheck %s
+
+// createBuffer sorts channels by producer program order before hoisting their
+// buffers. Hoisting must insert each new allocation after the previous hoisted
+// allocation; otherwise every allocation is inserted at function entry and the
+// final order is reversed.
+
+// CHECK-LABEL: @hoist_preserves_producer_order
+// CHECK: %[[A_BUF:.*]] = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16
+// CHECK: %[[B_BUF:.*]] = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16
+// CHECK: ttg.local_store {{.*}}, %[[A_BUF]]
+// CHECK: ttg.local_store {{.*}}, %[[B_BUF]]
+
+#blocked_a = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_b = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @hoist_preserves_producer_order(
+      %a_desc: !tt.tensordesc<tensor<128x64xf16, #shared_a>>,
+      %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared_b>>) {
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : i32
+    %a = tt.descriptor_load %a_desc[%c0, %c0] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<128x64xf16, #shared_a>> -> tensor<128x64xf16, #blocked_a>
+    %b = tt.descriptor_load %b_desc[%c0, %c0] {async_task_id = array<i32: 1>} : !tt.tensordesc<tensor<64x128xf16, #shared_b>> -> tensor<64x128xf16, #blocked_b>
+    %a_use = arith.addf %a, %a {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked_a>
+    %b_use = arith.addf %b, %b {async_task_id = array<i32: 0>} : tensor<64x128xf16, #blocked_b>
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1847,6 +1847,19 @@ DenseMap<Channel *, Value> createBuffer(const SmallVector<Channel *> &channels,
   });
 
   OpBuilderWithAsyncTaskIds builder(funcOp->getContext());
+  Operation *lastHoistedAlloc = nullptr;
+  auto setHoistInsertionPoint = [&]() {
+    if (lastHoistedAlloc)
+      builder.setInsertionPointAfter(lastHoistedAlloc);
+    else
+      builder.setInsertionPointToStart(&(funcOp.getBody().front()));
+  };
+  auto updateHoistInsertionPoint = [&](Value buffer) {
+    Operation *defOp = buffer.getDefiningOp();
+    if (defOp && defOp->getBlock() == &funcOp.getBody().front() &&
+        (!lastHoistedAlloc || lastHoistedAlloc->isBeforeInBlock(defOp)))
+      lastHoistedAlloc = defOp;
+  };
   llvm::MapVector<Channel *, SmallVector<Channel *>> channelsGroupedByProducers;
 
   // Group channels by source values
@@ -1946,7 +1959,7 @@ DenseMap<Channel *, Value> createBuffer(const SmallVector<Channel *> &channels,
       DBGS() << *dstOp << "\n";
     });
 
-    builder.setInsertionPointToStart(&(funcOp.getBody().front()));
+    setHoistInsertionPoint();
 
     Value newProducer;
 
@@ -1992,6 +2005,7 @@ DenseMap<Channel *, Value> createBuffer(const SmallVector<Channel *> &channels,
     } else {
       llvm_unreachable("Unexpected result type");
     }
+    updateHoistInsertionPoint(buffer);
 
     LLVM_DEBUG({
       LDBG("resulting buffer:");


### PR DESCRIPTION
Summary:
Uncovered while fixing/cleaning up tests. When hoisting buffers the order was not being maintained. The would often "reverse" the order of fused buffers based on usage (since the usage location is likely earlier in program order).

This was resulting:

```
B -> index 0
A -> index 1
```

while we have
```
load A
load B
```

With 3 buffers we can clearly see that we waste the extra buffer slot because it makes use wait for slot 0 to be free while slot 2 is empty.


Differential Revision: D108826043

Pulled By: njriasan


