### PR TITLE
[compile_iq] WS/TMA e2e (skeleton) for the Blackwell warp-specialized GEMM

### DIFF
--- a/third_party/compile_iq/compile_iq/example_kernel.py
+++ b/third_party/compile_iq/compile_iq/example_kernel.py
@@ -1,0 +1,51 @@
+"""An importable, non-warp-specialized Triton matmul used to demonstrate the full
+collect -> factory -> consume loop with a SAFE ACF (clean HIT + different SASS, no crash).
+
+Unlike examples/user_kernel.py (a __main__ script), this is a real module, so the factory
+takes the REAL-LAUNCH path (imports this exact module -> PTX parity holds -> the consume-
+faithful admission gate validates each ACF for real). Unlike blackwell_gemm_ws, it has no
+async producer/consumer pipeline, so ptxas ACFs don't introduce timing hazards -> safe ACFs
+exist here.
+
+Exposes `matmul(a, b)` (the factory's GEMM driver convention).
+"""
+
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+                  BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    """Plain tiled matmul (fp32 accumulate). No warp specialization / async pipeline."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
+        acc += tl.dot(a, b)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    c = acc.to(c_ptr.dtype.element_ty)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, c, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+
+def matmul(a, b):
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    BLOCK_M = BLOCK_N = 64
+    BLOCK_K = 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    matmul_kernel[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
+                        BLOCK_M, BLOCK_N, BLOCK_K)
+    return c

--- a/third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
+++ b/third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
@@ -1,0 +1,92 @@
+"""Flattened, simplified ws-GEMM sample run — the collect -> factory -> consume target.
+
+This is a self-contained, single-file equivalent of:
+
+    third_party/tlx/denoise.sh \
+        python third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py --version ws
+
+with two deliberate simplifications so it's a clean compile_iq target:
+  (1) ONE shape         — M=N=K=8192 (constants below), instead of [2048,4096,8192].
+  (2) ONE autotune cfg  — TLX_GEMM_USE_HEURISTIC=1 makes `matmul` pick a single
+                          shape-dependent heuristic config and launch it directly
+                          (no autotuning). This is what makes collection dump ONE
+                          task instead of one-per-config (hundreds).
+
+Like examples/user_kernel.py, this file has ZERO compile_iq references — collection
+and consumption are driven purely by environment variables, with no code change:
+
+    # collect a task for this kernel/shape/config:
+    FBTRITON_COMPILE_IQ_COLLECT=1 COMPILE_IQ_TASK_DIR=/tmp/ciq_tasks \
+        python third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
+
+    # ...run the factory on the one task it produced, then consume:
+    FBTRITON_COMPILE_IQ_APPLY=1 COMPILE_IQ_STORE=/tmp/ciq_store \
+    FBTRITON_COMPILE_IQ_DEBUG=1 TRITON_ALWAYS_COMPILE=1 \
+        python third_party/compile_iq/examples/blackwell_gemm_ws_sample.py
+
+denoise.sh notes: its clock/power lock (`sudo nvidia-smi -lgc/-pm/--power-limit`) and
+`numactl -m 0 -c 0` pinning need root / a process wrapper, so they aren't done here.
+For locked-clock numbers, still run this script *under* denoise.sh. What this file does
+replicate is denoise-grade measurement: a fixed device and do_bench(warmup=2000, rep=2000).
+"""
+
+import os
+
+# Must be set before CUDA init / before `matmul` is called.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "4")  # mirrors denoise.sh default
+os.environ.setdefault("TLX_GEMM_USE_HEURISTIC", "1")  # (2) single heuristic config, no autotune
+
+import torch
+
+import triton
+
+from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import matmul
+
+try:
+    from triton._internal_testing import is_blackwell
+except Exception:  # pragma: no cover - fallback if helper moves
+    def is_blackwell():
+        return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# (1) ONE shape. 8192 overflows B200 smem with the current heuristic config; the compile_iq
+# e2e sets WS_GEMM_SIZE=2048 (a shape whose heuristic config fits) -- override as needed.
+M = N = K = int(os.environ.get("WS_GEMM_SIZE", "8192"))
+DTYPE = torch.float16  # matches `--version ws` default (no --dtype)
+REL_TOL = 1e-2
+
+
+def _tflops(ms):
+    return 2 * M * N * K * 1e-12 / (ms * 1e-3)
+
+
+def main():
+    if not is_blackwell():
+        print("Skipping: no Blackwell GPU found.")
+        return
+
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device=DEVICE, dtype=DTYPE)
+    b = torch.randn((K, N), device=DEVICE, dtype=DTYPE)
+
+    # Correctness vs torch (tolerant — fp16 accumulation).
+    c = matmul(a, b)
+    torch.cuda.synchronize()
+    ref = torch.matmul(a, b)
+    rel = (c.float() - ref.float()).abs().max() / ref.float().abs().max()
+    assert torch.isfinite(rel) and rel.item() <= REL_TOL, f"correctness failed: rel-err {rel.item():.3e}"
+
+    # Denoise-grade measurement: ws vs cuBLAS.
+    quantiles = [0.5, 0.2, 0.8]
+    ws_ms, ws_lo, ws_hi = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles, warmup=2000, rep=2000)
+    bl_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), warmup=2000, rep=2000, return_mode="mean")
+
+    print(f"shape M=N=K={M}  dtype={DTYPE}  heuristic-config (single)")
+    print(f"  ws     : {ws_ms:.4f} ms  =  {_tflops(ws_ms):.1f} TFLOPS  (rel-err {rel.item():.2e})")
+    print(f"  cuBLAS : {bl_ms:.4f} ms  =  {_tflops(bl_ms):.1f} TFLOPS")
+    print(f"  ws/cuBLAS speed: {bl_ms / ws_ms:.3f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/compile_iq/smoke/bench_one_ws.py
+++ b/third_party/compile_iq/smoke/bench_one_ws.py
@@ -1,0 +1,59 @@
+"""WS per-candidate evaluator (base Python 3.13) for the EVO bridge -- the warp-specialized
+counterpart of bench_one.py.
+
+Naive kernels are replayed from reconstructed args; WS/TMA kernels can't be (the reconstructed
+launch produces different PTX), so we use the REAL launch: import the kernel's `matmul` wrapper
+and run it, applying the candidate ACF via PTXAS_OPTIONS (which Triton's knobs read once at import,
+so it must be set BEFORE importing triton). Correctness is checked against torch (cuBLAS), which is
+the right oracle for a GEMM. This makes the validated PTX identical to collect/consume's real launch
+(parity for free).
+
+Usage: python bench_one_ws.py <acf_hex_file | NONE>   ; shape via WS_GEMM_SIZE env (default 2048)
+Prints exactly one line: "MS <float>" on success, or "INVALID" (diverged/crashed/wedged).
+"""
+import os
+import sys
+import tempfile
+
+REL_TOL = 1e-2
+
+acf_arg = sys.argv[1]
+if acf_arg != "NONE":
+    with open(acf_arg) as f:
+        acf_hex = f.read().strip()
+    t = tempfile.NamedTemporaryFile(suffix=".acf", delete=False)
+    t.write(bytes.fromhex(acf_hex))
+    t.close()
+    os.environ["PTXAS_OPTIONS"] = f"--apply-controls={t.name}"  # MUST precede triton import
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"  # force a fresh compile so the ACF is applied
+
+import torch  # noqa: E402
+import triton  # noqa: E402
+from triton.language.extra.tlx.tutorials.blackwell_gemm_ws import matmul  # noqa: E402
+
+
+def main():
+    s = int(os.environ.get("WS_GEMM_SIZE", "2048"))
+    dev = triton.runtime.driver.active.get_active_torch_device()
+    torch.manual_seed(0)
+    a = torch.randn((s, s), device=dev, dtype=torch.float16)
+    b = torch.randn((s, s), device=dev, dtype=torch.float16)
+    try:
+        c = matmul(a, b)
+        torch.cuda.synchronize()
+        ref = torch.matmul(a, b)
+        denom = max(ref.float().abs().max().item(), 1e-9)
+        rel = (c.float() - ref.float()).abs().max().item() / denom
+        if not (rel == rel and rel <= REL_TOL):  # NaN-safe
+            print("INVALID")
+            return
+        ms = triton.testing.do_bench(lambda: matmul(a, b), warmup=100, rep=200, return_mode="mean")
+        print(f"MS {ms}")
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        print("INVALID")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/compile_iq/smoke/evo_search_ws.py
+++ b/third_party/compile_iq/smoke/evo_search_ws.py
@@ -1,0 +1,95 @@
+"""Constrained EVO search for WS kernels -- REAL tuning (non-smoke).
+
+The warp-specialized counterpart of evo_search.py. EVO (3.10 env) drives a search over a .config
+space; the baseline and every candidate are evaluated in base 3.13 via bench_one_ws.py (real
+matmul launch + ACF via PTXAS_OPTIONS). NON-SMOKE: the best ACF is emitted only if it beats the
+no-ACF baseline (so consume HITs only on a genuine speedup; otherwise nothing is stored).
+
+Run: conda run -n evo python evo_search_ws.py <task_dir> <search_space.config> [per_cand_timeout_s]
+Env: BASE_PY (base interpreter), WS_GEMM_SIZE, EVO_GENERATIONS (default 1), EVO_POOL (default 8).
+"""
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import time
+
+from evo_solar.config.const import INVALID_SCORE
+from evo_solar.config.types import EvoConfiguration, ProblemType, WorkerTypes
+from evo_solar.evo import EvoSearch
+
+BASE_PY = os.environ.get("BASE_PY", "python")
+HERE = pathlib.Path(__file__).resolve().parent
+BENCH = str(HERE / "bench_one_ws.py")
+PER_CAND = 300
+GENERATIONS = int(os.environ.get("EVO_GENERATIONS", "1"))
+POOL = int(os.environ.get("EVO_POOL", "8"))
+
+
+def _bench(acf_arg):
+    """acf_arg = hex-file path, or 'NONE' for the baseline. Returns ms or None."""
+    try:
+        out = subprocess.run([BASE_PY, BENCH, acf_arg], capture_output=True, text=True,
+                             timeout=PER_CAND + 120)
+    except subprocess.TimeoutExpired:
+        return None
+    for line in out.stdout.splitlines():
+        if line.startswith("MS "):
+            return float(line.split()[1])
+    return None
+
+
+def objective(acf, *args, **kwargs):
+    with tempfile.NamedTemporaryFile("w", suffix=".hex", delete=False) as f:
+        f.write(acf if isinstance(acf, str) else str(acf))
+        hex_path = f.name
+    t = time.time()
+    ms = _bench(hex_path)
+    os.unlink(hex_path)
+    print(f"[evo-cand] wall={time.time()-t:.1f}s -> {'ms='+repr(ms) if ms is not None else 'INVALID'}",
+          file=sys.stderr, flush=True)
+    return ms if ms is not None else INVALID_SCORE
+
+
+def main():
+    global PER_CAND
+    task_dir = sys.argv[1]
+    ss = pathlib.Path(sys.argv[2])
+    if len(sys.argv) > 3:
+        PER_CAND = int(sys.argv[3])
+    print(f"[evo-ws] task={task_dir} space={ss.name} gens={GENERATIONS} pool={POOL} "
+          f"per_cand={PER_CAND}s size={os.environ.get('WS_GEMM_SIZE','2048')}", flush=True)
+
+    base_ms = _bench("NONE")
+    if base_ms is None:
+        print("[evo-ws] FAIL: baseline (no-ACF) did not run")
+        return 1
+    print(f"[evo-ws] baseline_ms={base_ms}", flush=True)
+
+    cfg = EvoConfiguration(problem_type=ProblemType.MIN, num_objectives=1, qualitative=True,
+                           generations=GENERATIONS, pool_size=POOL, cull_size=2, mutate_rate=0.5,
+                           enable_db=False)
+    result = EvoSearch(objective_function=objective, search_space=ss, evo_config=cfg,
+                       worker_type=WorkerTypes.DEFAULT, debug=False).start(num_workers=1)
+
+    df = result.get_results()
+    n = len(df) if df is not None else 0
+    best = result.get_best_result()
+    best_ms = best.get("score_1", best.get("score"))
+    print(f"[evo-ws] DONE evaluated={n} baseline_ms={base_ms} best_ms={best_ms}", flush=True)
+
+    # NON-SMOKE: store only if the best validated candidate beats baseline.
+    if isinstance(best_ms, (int, float)) and best_ms < base_ms:
+        out = os.path.join(task_dir, "best.acf.hex")
+        with open(out, "w") as f:
+            f.write(best["params"])
+        print(f"[evo-ws] SPEEDUP {100*(base_ms-best_ms)/base_ms:.2f}% -> wrote {out}", flush=True)
+        print("EVO_WS_OK stored")
+    else:
+        print(f"[evo-ws] no candidate beat baseline ({best_ms} vs {base_ms}) -> storing nothing", flush=True)
+        print("EVO_WS_OK nostore")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/compile_iq/smoke/run_e2e_ws.sh
+++ b/third_party/compile_iq/smoke/run_e2e_ws.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# compile_iq WS end-to-end: collect -> factory(EVO) -> consume on the warp-specialized
+# blackwell GEMM (examples/blackwell_gemm_ws_sample.py). EVO, ptxas 12.8, p2 search space,
+# NON-smoke (a candidate is stored only if it beats baseline). WS kernels can't be replayed
+# from reconstructed args, so the factory uses the REAL matmul launch (bench_one_ws.py) with
+# the ACF applied via PTXAS_OPTIONS.
+#
+# Defaults to WS_GEMM_SIZE=2048: the sample's 8192^3 config overflows B200 shared memory with
+# the current TLX heuristic; 2048^3 uses a fitting config and runs the real WS kernel.
+#
+# Usage: third_party/compile_iq/smoke/run_e2e_ws.sh
+# Optional env: WS_GEMM_SIZE, PTXAS_KNOBS, SS_CONFIG, PTXAS, PTXAS_MIN_VERSION, EVO_PY, PY,
+#   PER_CAND_TIMEOUT, CONSUME_TIMEOUT, EVO_GENERATIONS, EVO_POOL, CUDA_VISIBLE_DEVICES.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KERNEL="$HERE/../examples/blackwell_gemm_ws_sample.py"
+
+PY="${PY:-python}"
+EVO_PY="${EVO_PY:-$(conda info --base 2>/dev/null)/envs/evo/bin/python}"
+PTXAS="${PTXAS:-/usr/local/cuda-12.8/bin/ptxas}"
+PTXAS_KNOBS="${PTXAS_KNOBS:-/data/users/$USER/ptxas_knobs}"
+SS_CONFIG="${SS_CONFIG:-$PTXAS_KNOBS/cuda-12.8-ptxas-p2.config}"
+PTXAS_MIN_VERSION="${PTXAS_MIN_VERSION:-12.8}"
+PER_CAND_TIMEOUT="${PER_CAND_TIMEOUT:-300}"
+CONSUME_TIMEOUT="${CONSUME_TIMEOUT:-360}"
+
+export WS_GEMM_SIZE="${WS_GEMM_SIZE:-2048}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+export TRITON_PTXAS_BLACKWELL_PATH="$PTXAS"
+export BASE_PY="$PY"
+export COMPILE_IQ_TASK_DIR="${COMPILE_IQ_TASK_DIR:-$(mktemp -d)}"
+export COMPILE_IQ_STORE="${COMPILE_IQ_STORE:-$(mktemp -d)}"
+
+[ -x "$EVO_PY" ]    || { echo "FAIL: evo python not found at '$EVO_PY' -- set EVO_PY"; exit 1; }
+[ -f "$SS_CONFIG" ] || { echo "FAIL: search space not found at '$SS_CONFIG' -- set SS_CONFIG/PTXAS_KNOBS"; exit 1; }
+[ -x "$PTXAS" ]     || { echo "FAIL: ptxas not found at '$PTXAS' -- set PTXAS"; exit 1; }
+
+echo "ptxas=$PTXAS ($("$PTXAS" --version | grep -oE 'V[0-9.]+' | tail -1)) ; space=$(basename "$SS_CONFIG") ; size=${WS_GEMM_SIZE}^3"
+
+echo "== [1/3] collect =="
+FBTRITON_COMPILE_IQ_COLLECT=1 "$PY" "$KERNEL"
+TASK="$(ls -d "$COMPILE_IQ_TASK_DIR"/*/ | head -1)"
+echo "   task: $TASK"
+
+echo "== [2/3] factory: EVO ws search ($(basename "$SS_CONFIG"), non-smoke, per-candidate ${PER_CAND_TIMEOUT}s) =="
+"$EVO_PY" -u "$HERE/evo_search_ws.py" "$TASK" "$SS_CONFIG" "$PER_CAND_TIMEOUT" 2>&1 | grep -E "evo-ws|EVO_WS" || true
+if [ -f "$TASK/best.acf.hex" ]; then
+    "$PY" "$HERE/store_best.py" "$TASK" "$TASK/best.acf.hex"
+else
+    echo "   (no ACF beat baseline -- nothing stored; consume will MISS = baseline)"
+fi
+
+echo "== [3/3] consume (timeout ${CONSUME_TIMEOUT}s) =="
+rc=0
+timeout -k 10 "$CONSUME_TIMEOUT" env \
+    FBTRITON_COMPILE_IQ_APPLY=1 FBTRITON_COMPILE_IQ_DEBUG=1 TRITON_ALWAYS_COMPILE=1 \
+    COMPILE_IQ_PTXAS_MIN_VERSION="$PTXAS_MIN_VERSION" WS_GEMM_SIZE="$WS_GEMM_SIZE" \
+    "$PY" "$KERNEL" 2>&1 | grep -iE "compile_iq|HIT|MISS|ws *:|cuBLAS|speed" || rc=$?
+if [ "$rc" = 124 ] || [ "$rc" = 137 ]; then
+    echo "!! consume TIMED OUT -- applied ACF likely wedged the GPU. FAIL."; exit 1
+fi
+
+echo "== done; store: =="
+find "$COMPILE_IQ_STORE" -type f


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1780
* #1741

Stacks on the naive PTX-direct compile_iq PR to extend the collect -> factory -> consume flow to a
warp-specialized kernel (examples/blackwell_gemm_ws_sample.py), bringing in the WS sample, a WS
example kernel, and an EVO cross-env bridge for WS.

WIP SKELETON: this lands the WS-specific additions only. The base PR is PTX-direct (ptxas on a fixed
kernel.ptx + CUDA driver launch, no Triton recompile, source-free collection), so the per-candidate
WS evaluator still needs porting onto that path. WS/TMA launch additionally needs ptx_launch.build_spec
extended for tensordesc args + non-null global/profile scratch, which the naive base does not yet
cover -- so the *_ws helpers here do not run until that re-port lands.

New (smoke/):
- bench_one_ws.py   -- per-candidate WS evaluator (to be re-pointed at the PTX-direct bridge)
- evo_search_ws.py  -- EVO driver, NON-smoke: stores an ACF only if it beats the no-ACF baseline
- run_e2e_ws.sh     -- collect -> factory(EVO) -> consume; defaults to ptxas 12.8 + cuda-12.8 p2

Shape: the sample's M=N=K is env-configurable (WS_GEMM_SIZE, default 8192); the e2e uses 2048,
because the current TLX blackwell_gemm_ws heuristic config overflows B200 shared memory at 8192^3.
The NVIDIA search-space configs and (NDA) optimizer wheel are not checked in (see smoke/README.md).

Authored with Claude.