### PR TITLE
[TLX][AMD] Improve pipelined GEMM performance by sinking second load. (#1286)

### DIFF
--- a/third_party/tlx/tutorials/amd-gemm-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-gemm-pipelined_test.py
@@ -185,7 +185,6 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
         a_k_smem_view = tlx.local_view(buffers_A, k % NUM_BUFFERS)
         b_k_smem_view = tlx.local_view(buffers_B, k % NUM_BUFFERS)
         a_load_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K)
-        b_load_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K)
 
         # do compute on data fetched ahead by NUM_STAGES - 1
         buf = (k - NUM_STAGES - 1) % NUM_BUFFERS
@@ -193,6 +192,7 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
         b_k_prev_shmem = tlx.local_view(buffers_B, buf)
         a_k_prev_reg = tlx.local_load(a_k_prev_shmem)
         b_k_prev_reg = tlx.local_load(b_k_prev_shmem)
+        b_load_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K)
         acc = tl.dot(a_k_prev_reg, b_k_prev_reg, acc)
 
         # store data for k from regs to shmem, this is NUM_STAGES - 1 ahead of the k in the prev tl.dot


### PR DESCRIPTION
This is a backport of https://github.com/facebookexperimental/triton/pull/1286

We sink second load closert to dot S.T global_load instructions can be interleaved with mfmas to help hide global load issue latency.

This used to be default in AMD compiler pipeline but has been removed in With https://github.com/triton-lang/triton/pull/9119.

Perf improvements with this change:

Without sink second load:
matmul-performance-fp16:
        M       N       K  rocBLAS (TFLOPS)  Triton (TFLOPS)
0   256.0   256.0   256.0          4.345866         5.178153
1   512.0   512.0   512.0         29.433714        34.065411
2  1024.0  1024.0  1024.0        156.522130       178.362423
3  2048.0  2048.0  2048.0        589.158743       540.927876
4  4096.0  4096.0  4096.0       1046.906635       571.322067

With sink second load:
matmul-performance-fp16:
        M       N       K  rocBLAS (TFLOPS)  Triton (TFLOPS)
0   256.0   256.0   256.0          4.438417         5.083235
1   512.0   512.0   512.0         29.177766        33.718810
2  1024.0  1024.0  1024.0        158.369002       181.990133
3  2048.0  2048.0  2048.0        585.943702       574.962149
4  4096.0  4096.0  4096.0       1049.144343       615.760389