### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[AMD][Backend] Lower PartitionedSharedEncodingAttr to LLVM (#9362)'

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -352,15 +352,49 @@ bool cvtAlwaysUseWarpShuffle(triton::gpu::ConvertLayoutOp cvt);
 namespace LLVM {
 using namespace mlir::triton;
 
+/// Represents a shared memory allocation for tensor operations.
+///
+/// For non-partitioned tensors, this contains a single base pointer.
+/// For partitioned tensors (PartitionedEncodingAttr), this contains multiple
+/// base pointers, one per partition.
 class SharedMemoryObject {
 public:
+  /// Single-base constructor (for non-partitioned tensors)
   SharedMemoryObject(Value base, Type baseElemType, ArrayRef<Value> offsets);
 
+  /// Multi-base constructor (for partitioned tensors)
+  SharedMemoryObject(ArrayRef<Value> bases, Type baseElemType,
+                     ArrayRef<Value> offsets);
+
+  /// Single-base constructor
   SharedMemoryObject(Value base, Type baseElemType, int64_t rank, Location loc,
                      RewriterBase &rewriter);
 
+  /// Multi-base constructor with zero offsets
+  SharedMemoryObject(ArrayRef<Value> bases, Type baseElemType, int64_t rank,
+                     Location loc, RewriterBase &rewriter);
+
   SmallVector<Value> getOffsets() const { return offsets; }
-  Value getBase() const { return base; }
+
+  /// Returns the single base pointer.
+  /// IMPORTANT: This asserts that there is exactly one base. For partitioned
+  /// tensors (multiple bases), use getBases() instead.
+  /// Callers should use getBases() and handle all partitions appropriately.
+  Value getBase() const {
+    assert(bases.size() == 1 &&
+           "getBase() called on partitioned tensor with multiple bases. "
+           "Use getBases() and handle all partitions.");
+    return bases[0];
+  }
+
+  /// Returns all base pointers. For partitioned tensors, returns one base
+  /// per partition.
+  ArrayRef<Value> getBases() const { return bases; }
+
+  /// Returns the number of base pointers (1 for non-partitioned, N for
+  /// partitioned).
+  size_t getNumBases() const { return bases.size(); }
+
   Type getBaseElemType() const { return baseElemType; }
 
   SmallVector<Value> getElems() const;
@@ -390,11 +424,10 @@ public:
     return offsets[dim];
   }
 
-  // TODO(Keren): deprecate the method once AMD backend has cleaned up
-  Value getBaseBeforeSlice(int dim, Location loc, RewriterBase &rewriter) const;
-
 private:
-  Value base; // i32 ptr. The start address of the shared memory object.
+  SmallVector<Value>
+      bases; // Shared memory base pointers. One for non-partitioned tensors,
+             // multiple for partitioned tensors (one per partition).
   Type baseElemType;
   SmallVector<Value>
       offsets; // i32 int. The offsets are zero at the initial allocation.
@@ -462,6 +495,19 @@ Value getProfileScratchPtr(Location loc, RewriterBase &rewriter,
 
 Value getSharedMemoryBase(Location loc, RewriterBase &rewriter,
                           const TargetInfoBase &target, Operation *op);
+
+/// Returns the allocation offsets for the given operation.
+/// For non-partitioned tensors, returns a single offset.
+/// For partitioned tensors, returns multiple offsets (one per partition).
+SmallVector<int64_t> getPartitionOffsets(Operation *op);
+
+/// Returns all shared memory bases for the given operation.
+/// For non-partitioned tensors, returns a single base pointer.
+/// For partitioned tensors, returns multiple base pointers (one per
+/// partition).
+SmallVector<Value> getSharedMemoryBases(Location loc, RewriterBase &rewriter,
+                                        const TargetInfoBase &target,
+                                        Operation *op);
 
 // -----------------------------------------------------------------------
 // MXFP utilities
@@ -554,7 +600,7 @@ uint32_t applyPadding(uint32_t baseOffset,
 SmallVector<Value> lowerLdStShared(
     Location loc, MLIRContext *ctx, LinearLayout cvt,
     ArrayRef<Value> valsArray, // Input for store, output for load
-    Type llvmElemTy, Value smemBase,
+    Type llvmElemTy, ArrayRef<Value> smemBases,
     ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Value affineOffset,
     uint64_t maskSpanAffineOffset, RewriterBase &rewriter,
     const TargetInfoBase &targetInfo, std::optional<int> maybeMaxVecElems = {},
@@ -570,7 +616,7 @@ SmallVector<Value> lowerLdStShared(
 SmallVector<Value> lowerLdSt(
     Location loc, MLIRContext *ctx, LinearLayout cvt,
     ArrayRef<Value> valsArray, // Input for store, output for load
-    Type llvmElemTy, Value smemBase,
+    Type llvmElemTy, ArrayRef<Value> smemBases,
     ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Value affineOffset,
     uint64_t maskSpanAffineOffset, Value laneId, Value warpId,
     RewriterBase &rewriter, const TargetInfoBase &targetInfo,

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -331,6 +331,19 @@ bool hasPartition(Operation *op);
 bool hasWarpSpecializeTag(Operation *op);
 std::optional<int> getWarpSpecializeTag(Operation *op);
 
+// Extract the PaddedSharedEncodingAttr from an encoding, whether standalone
+// or wrapped inside a PartitionedSharedEncodingAttr. Returns nullptr if the
+// encoding does not involve padding.
+PaddedSharedEncodingAttr getPaddedEncoding(Attribute encoding);
+
+// Returns true if the encoding is a PaddedSharedEncodingAttr, or a
+// PartitionedSharedEncodingAttr wrapping a PaddedSharedEncodingAttr.
+bool isPaddedEncoding(Attribute encoding);
+
+// Returns the minInterval for a padded encoding (standalone or
+// wrapped in partitioned).
+unsigned getMinInterval(Attribute encoding);
+
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_DIALECT_TRITONGPU_IR_DIALECT_H_

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -55,6 +55,13 @@ LinearLayout toLinearLayout(TensorOrMemDesc type);
 // with the allocShape as the shape, otherwise the layout will be incorrect!
 LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
 
+// Returns the linear component of a padded shared encoding. The encoding must
+// satisfy isPaddedEncoding (asserts otherwise).
+//
+// Unlike toLinearLayout, this makes explicit that the resulting linear layout
+// is incomplete — the padding information is not captured in the linear layout.
+LinearLayout paddedLinearLayout(MemDescType type);
+
 // Convert the shared encoding of a tensor with `nvmma_shared` layout to a
 // LinearLayout that maps from a linear shared memory offset to tensor index.
 //

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -27,15 +27,9 @@ SmallVector<Value> lowerLocalScGt(Location loc, MLIRContext *ctx,
   bool isScatter = !storeVals.empty();
 
   // Get the shared memory layout (linear component for padded layouts)
-  auto sharedEnc =
-      cast<triton::gpu::SharedEncodingTrait>(memDescTy.getEncoding());
-  auto paddedEnc = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(sharedEnc);
-  LinearLayout sharedLayout;
-  if (paddedEnc) {
-    sharedLayout = paddedEnc.getLinearComponent();
-  } else {
-    sharedLayout = toLinearLayout(memDescTy);
-  }
+  auto sharedLayout = isPaddedEncoding(memDescTy.getEncoding())
+                          ? paddedLinearLayout(memDescTy)
+                          : toLinearLayout(memDescTy);
   LinearLayout invSharedLayout = sharedLayout.invert();
 
   // Get layout dimension names for all dims
@@ -101,10 +95,10 @@ SmallVector<Value> lowerLocalScGt(Location loc, MLIRContext *ctx,
 
     // Add padding offset for padded layouts (non-linear component)
     Value ptr;
-    if (paddedEnc) {
+    if (isPaddedEncoding(memDescTy.getEncoding())) {
       // Convert offset to bytes for padding calculation
       Value offsetBytes = b.mul(offset, b.i32_val(bitwidth / 8));
-      auto shifts = getPaddedSharedShifts(paddedEnc, bitwidth,
+      auto shifts = getPaddedSharedShifts(memDescTy.getEncoding(), bitwidth,
                                           /*offsetInBytes=*/true);
       // GEP in bytes: base + offset*elemSize + padOffset
       Value totalOffset = applyPadding(loc, rewriter, offsetBytes, shifts);
@@ -136,17 +130,14 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx, Value regVal,
   auto regTy = cast<RankedTensorType>(regVal.getType());
   auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
 
+  auto regLayout = toLinearLayout(regTy);
   auto kReg = str_attr("register");
   auto kLane = str_attr("lane");
   auto kWarp = str_attr("warp");
   auto kOffset = str_attr("offset");
-  auto regLayout = toLinearLayout(regTy);
-  auto paddedEnc =
-      dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(memDescTy.getEncoding());
   LinearLayout cvt = LinearLayout::empty();
-  if (paddedEnc) {
-    const auto &sharedLL = paddedEnc.getLinearComponent();
-    cvt = regLayout.invertAndCompose(sharedLL);
+  if (isPaddedEncoding(memDescTy.getEncoding())) {
+    cvt = regLayout.invertAndCompose(paddedLinearLayout(memDescTy));
   } else {
     auto sharedLayout = toLinearLayout(memDescTy);
     cvt = regLayout.invertAndCompose(sharedLayout);
@@ -156,7 +147,13 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx, Value regVal,
   if (!cvt.isTrivialOver({kBlock})) {
     return failure();
   }
-  cvt = cvt.sublayout({kReg, kLane, kWarp}, {kOffset});
+  // Keep the "partition" output dim (PartitionedSharedEncoding) so lowerLdSt
+  // can select the per-partition base pointer; lowerLdSt strips it afterwards.
+  SmallVector<StringAttr> ldStOutDims = {kOffset};
+  auto kPartition = str_attr("partition");
+  if (cvt.hasOutDim(kPartition))
+    ldStOutDims.push_back(kPartition);
+  cvt = cvt.sublayout({kReg, kLane, kWarp}, ldStOutDims);
   lowerLocalLdSt(loc, ctx, cvt, inVals, llvmElemTy, memDescTy, smemObj,
                  rewriter, targetInfo, nullptr, clusterCTARank, barrierPtr);
 
@@ -209,21 +206,16 @@ struct LocalAllocOpConversion
     if (!op.isSharedMemoryAlloc())
       return failure();
     Location loc = op->getLoc();
+    // Get all shared memory bases (one for non-partitioned, multiple for
+    // partitioned tensors)
+    SmallVector<Value> smemBases = LLVM::getSharedMemoryBases(
+        loc, rewriter, targetInfo, op.getOperation());
     auto memDescTy = cast<MemDescType>(op.getType());
-    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
-    // PRs.
-    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
-            memDescTy.getEncoding())) {
-      return rewriter.notifyMatchFailure(
-          op, "PartitionedSharedEncoding not yet supported in lowering");
-    }
-    Value smemBase =
-        LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto typeConverter = getTypeConverter();
 
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
-    auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, memDescTy.getRank(),
-                                      loc, rewriter);
+    auto smemObj = SharedMemoryObject(smemBases, llvmElemTy,
+                                      memDescTy.getRank(), loc, rewriter);
     // If there is an initial tensor, store it into the shared memory.
     if (op.getSrc()) {
       auto *ctx = op.getContext();
@@ -273,13 +265,6 @@ public:
     auto memDescVal = op.getSrc();
     auto regVal = op.getResult();
     auto memDescTy = cast<MemDescType>(memDescVal.getType());
-    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
-    // PRs.
-    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
-            memDescTy.getEncoding())) {
-      return rewriter.notifyMatchFailure(
-          op, "PartitionedSharedEncoding not yet supported in lowering");
-    }
     auto regTy = cast<RankedTensorType>(regVal.getType());
     auto typeConverter = getTypeConverter();
 
@@ -287,18 +272,14 @@ public:
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                          llvmElemTy, rewriter);
 
-    auto sharedEnc =
-        cast<triton::gpu::SharedEncodingTrait>(memDescTy.getEncoding());
+    auto regLayout = toLinearLayout(regTy);
     auto kReg = str_attr("register");
     auto kLane = str_attr("lane");
     auto kWarp = str_attr("warp");
     auto kOffset = str_attr("offset");
-    auto regLayout = toLinearLayout(regTy);
-    auto paddedEnc = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(sharedEnc);
     LinearLayout cvt = LinearLayout::empty();
-    if (paddedEnc) {
-      const auto &sharedLL = paddedEnc.getLinearComponent();
-      cvt = regLayout.invertAndCompose(sharedLL);
+    if (isPaddedEncoding(memDescTy.getEncoding())) {
+      cvt = regLayout.invertAndCompose(paddedLinearLayout(memDescTy));
     } else {
       auto sharedLayout = toLinearLayout(memDescTy);
       cvt = regLayout.invertAndCompose(sharedLayout);
@@ -308,7 +289,13 @@ public:
     if (!cvt.isTrivialOver({kBlock})) {
       return failure();
     }
-    cvt = cvt.sublayout({kReg, kLane, kWarp}, {kOffset});
+    // Keep the "partition" output dim (PartitionedSharedEncoding) so lowerLdSt
+    // can select the per-partition base pointer; lowerLdSt strips it afterwards.
+    SmallVector<StringAttr> ldStOutDims = {kOffset};
+    auto kPartition = str_attr("partition");
+    if (cvt.hasOutDim(kPartition))
+      ldStOutDims.push_back(kPartition);
+    cvt = cvt.sublayout({kReg, kLane, kWarp}, ldStOutDims);
 
     auto outVals = lowerLocalLdSt(loc, ctx, cvt, {}, llvmElemTy, memDescTy,
                                   smemObj, rewriter, targetInfo, op);
@@ -344,13 +331,6 @@ public:
     Value memDescVal = op.getDst();
     auto typeConverter = getTypeConverter();
     auto memDescTy = cast<MemDescType>(memDescVal.getType());
-    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
-    // PRs.
-    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
-            memDescTy.getEncoding())) {
-      return rewriter.notifyMatchFailure(
-          op, "PartitionedSharedEncoding not yet supported in lowering");
-    }
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getDst(),
                                                          llvmElemTy, rewriter);

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -1,6 +1,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
 
 #include "mlir/Support/LLVM.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 using namespace mlir;
@@ -66,7 +67,20 @@ Type TritonGPUToLLVMTypeConverter::convertMemDescType(
   }
 
   SmallVector<Type, 4> types;
-  types.push_back(ptrType);
+
+  // Determine number of base pointers based on encoding.
+  // For partitioned tensors, we need one base pointer per partition.
+  size_t numBases = 1;
+  if (auto partitioned = dyn_cast<triton::gpu::PartitionedSharedEncodingAttr>(
+          type.getEncoding())) {
+    numBases = partitioned.getNumPartitions();
+  }
+
+  // Add base pointer(s)
+  for (size_t i = 0; i < numBases; ++i) {
+    types.push_back(ptrType);
+  }
+
   auto rank = type.getRank();
   // offsets
   for (auto i = 0; i < rank; i++) {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -499,7 +499,7 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
 
 SmallVector<std::pair<unsigned, unsigned>>
 getPaddedSharedShifts(Attribute enc, unsigned bitwidth, bool offsetInBytes) {
-  auto padded = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(enc);
+  auto padded = triton::gpu::getPaddedEncoding(enc);
   if (!padded)
     return {};
 
@@ -544,7 +544,7 @@ uint32_t applyPadding(uint32_t baseOffset,
 SmallVector<Value>
 lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                 ArrayRef<Value> valsArray, // Input for store, output for load
-                Type llvmElemTy, Value smemBase,
+                Type llvmElemTy, ArrayRef<Value> smemBases,
                 ArrayRef<std::pair<unsigned, unsigned>> paddingShifts,
                 Value affineOffset, uint64_t maskSpanAffineOffset,
                 RewriterBase &rewriter, const TargetInfoBase &targetInfo,
@@ -598,16 +598,30 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
     }
   };
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-  return lowerLdSt(loc, ctx, cvt, valsArray, llvmElemTy, smemBase,
+  return lowerLdSt(loc, ctx, cvt, valsArray, llvmElemTy, smemBases,
                    paddingShifts, affineOffset, maskSpanAffineOffset, laneId,
                    warpId, rewriter, targetInfo, maybeMaxVecElems, emitLdSt,
                    barrierPtr);
 }
 
+// Build a vector containing multiple base pointers for dynamic indexing.
+static Value buildBasePtrVector(Location loc, RewriterBase &rewriter,
+                                ArrayRef<Value> smemBases) {
+  assert(smemBases.size() > 1 && "Need multiple bases to build a vector");
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto ptrTy = smemBases[0].getType();
+  auto vecTy = VectorType::get({static_cast<int64_t>(smemBases.size())}, ptrTy);
+  Value basesVec = b.undef(vecTy);
+  for (size_t i = 0; i < smemBases.size(); ++i) {
+    basesVec = b.insert_element(basesVec, smemBases[i], b.i32_val(i));
+  }
+  return basesVec;
+}
+
 SmallVector<Value> lowerLdSt(
     Location loc, MLIRContext *ctx, LinearLayout cvt,
     ArrayRef<Value> valsArray, // Input for store, output for load
-    Type llvmElemTy, Value smemBase,
+    Type llvmElemTy, ArrayRef<Value> smemBases,
     ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Value affineOffset,
     uint64_t maskSpanAffineOffset, Value laneId, Value warpId,
     RewriterBase &rewriter, const TargetInfoBase &targetInfo,
@@ -616,6 +630,7 @@ SmallVector<Value> lowerLdSt(
                                      Value, int, VectorType)>
         lowerInst,
     std::optional<Value> barrierPtr) {
+  assert(!smemBases.empty() && "smemBases cannot be empty");
   auto vals = to_vector(valsArray);
   bool isStore = !vals.empty();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -624,7 +639,30 @@ SmallVector<Value> lowerLdSt(
   auto kLane = str_attr("lane");
   auto kWarp = str_attr("warp");
   auto kOffset = str_attr("offset");
+  auto kPartition = str_attr("partition");
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
+
+  // Either we have multiple bases with a matching partition dimension,
+  // or we have a single base.
+  assert((smemBases.size() == 1 ||
+          (cvt.hasOutDim(kPartition) &&
+           cvt.getOutDimSize(kPartition) == smemBases.size())) &&
+         "smemBases size must match partition dimension size");
+  bool isPartitioned = smemBases.size() > 1;
+
+  // Extract the partition sublayout before stripping it for vectorization.
+  auto inDimNames = to_vector(cvt.getInDimNames());
+  LinearLayout partitionLayout;
+  Value basesVec;
+  if (isPartitioned) {
+    partitionLayout = cvt.sublayout(inDimNames, {kPartition});
+    basesVec = buildBasePtrVector(loc, rewriter, smemBases);
+  }
+
+  // Strip kPartition output for vectorization analysis.
+  SmallVector<StringAttr> outDims = to_vector(cvt.getOutDimNames());
+  llvm::erase(outDims, kPartition);
+  cvt = cvt.sublayout(inDimNames, outDims);
 
   auto [elemsPerVec, permutation] =
       largestVectorisation(ctx, cvt, bitwidth, maybeMaxVecElems);
@@ -646,6 +684,11 @@ SmallVector<Value> lowerLdSt(
   auto [nAdditive, permStrides] =
       actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
   reps = permStrides.apply(reps);
+
+  if (isPartitioned) {
+    partitionLayout = permutation.apply(partitionLayout);
+    partitionLayout = permStrides.apply(partitionLayout);
+  }
   if (isStore) {
     vals = permStrides.apply(vals);
   }
@@ -684,6 +727,29 @@ SmallVector<Value> lowerLdSt(
       // disjoint, so we can calculate their padding contributions separately.
       regIdxAddI8 = applyPadding(regIdxAddI8, paddingShifts);
       Value innerOffset = b.add(offset, b.i32_val(regIdxAddI8));
+
+      // Select the appropriate base pointer for partitioned tensors. beta's
+      // lowerLdSt addressing does not thread a block id (CTA targeting is
+      // handled separately via ctaRank/barrierPtr), so the partition index is
+      // computed over this layout's in-dims with any block dim taken as CTA 0.
+      Value smemBase = smemBases[0];
+      if (isPartitioned) {
+        SmallVector<std::pair<StringAttr, Value>> partitionInputs;
+        for (StringAttr dim : inDimNames) {
+          if (dim == kReg)
+            partitionInputs.push_back({kReg, b.i32_val(i + j)});
+          else if (dim == kLane)
+            partitionInputs.push_back({kLane, laneId});
+          else if (dim == kWarp)
+            partitionInputs.push_back({kWarp, warpId});
+          else
+            partitionInputs.push_back({dim, b.i32_val(0)});
+        }
+        Value partitionIdx = applyLinearLayout(loc, rewriter, partitionLayout,
+                                               partitionInputs)[0]
+                                 .second;
+        smemBase = b.extract_element(basesVec, partitionIdx);
+      }
       auto vecAddr = b.gep(smemPtrTy, i8_ty, smemBase, innerOffset,
                            LLVM::GEPNoWrapFlags::inbounds);
       llvm::append_range(outVals,
@@ -703,7 +769,7 @@ SmallVector<Value> lowerLdSt(
 
 SmallVector<Value>
 lowerLocalLdSt(Location loc, MLIRContext *ctx,
-               LinearLayout cvt,          // Map from registers to offset
+               LinearLayout cvt, // Map from registers to offset[, partition]
                ArrayRef<Value> valsArray, // Input for store, empty for load
                Type llvmElemTy, triton::gpu::MemDescType srcTy,
                SharedMemoryObject smemObj, RewriterBase &rewriter,
@@ -732,20 +798,26 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
   auto affineOffset = smemObj.getShmemOffset(loc, rewriter, srcTy);
   auto maskSpanAffineOffset = smemObj.getMaskSpanOffsets(srcTy);
 
+  // Extract padding info from padded encoding (standalone or inside
+  // partitioned)
   std::optional<int> maybeMaxVecElems;
   SmallVector<std::pair<unsigned, unsigned>> paddingShifts;
-  if (auto paddedEnc = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
-          srcTy.getEncoding())) {
-    maybeMaxVecElems = paddedEnc.getMinInterval();
+  if (triton::gpu::isPaddedEncoding(srcTy.getEncoding())) {
+    maybeMaxVecElems = triton::gpu::getMinInterval(srcTy.getEncoding());
     auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
-    paddingShifts = getPaddedSharedShifts(paddedEnc, bitwidth,
+    paddingShifts = getPaddedSharedShifts(srcTy.getEncoding(), bitwidth,
                                           /*offsetInBytes=*/true);
   }
 
-  return lowerLdStShared(loc, ctx, cvt, valsArray, llvmElemTy,
-                         smemObj.getBase(), paddingShifts, affineOffset,
-                         maskSpanAffineOffset, rewriter, targetInfo,
-                         maybeMaxVecElems, localLoadOp, ctaRank, barrierPtr);
+  // Get shared memory bases from the SharedMemoryObject.
+  // For non-partitioned tensors, this returns a single base.
+  // For partitioned tensors, this returns all bases (one per partition).
+  SmallVector<Value> smemBases(smemObj.getBases().begin(),
+                               smemObj.getBases().end());
+  return lowerLdStShared(loc, ctx, cvt, valsArray, llvmElemTy, smemBases,
+                         paddingShifts, affineOffset, maskSpanAffineOffset,
+                         rewriter, targetInfo, maybeMaxVecElems, localLoadOp,
+                         ctaRank, barrierPtr);
 }
 
 SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
@@ -1015,38 +1087,50 @@ createLLVMIntrinsicCallOp(OpBuilder &builder, Location loc, StringRef intrinsic,
 
 SharedMemoryObject::SharedMemoryObject(Value base, Type baseElemType,
                                        ArrayRef<Value> offsets)
-    : base(base), baseElemType(baseElemType),
+    : bases({base}), baseElemType(baseElemType),
       offsets(offsets.begin(), offsets.end()) {}
+
+SharedMemoryObject::SharedMemoryObject(ArrayRef<Value> bases, Type baseElemType,
+                                       ArrayRef<Value> offsets)
+    : bases(bases.begin(), bases.end()), baseElemType(baseElemType),
+      offsets(offsets.begin(), offsets.end()) {
+  assert(!bases.empty() && "SharedMemoryObject must have at least one base");
+}
 
 SharedMemoryObject::SharedMemoryObject(Value base, Type baseElemType,
                                        int64_t rank, Location loc,
                                        RewriterBase &rewriter)
-    : base(base), baseElemType(baseElemType) {
+    : bases({base}), baseElemType(baseElemType) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  offsets.append(rank, b.i32_val(0));
+}
+
+SharedMemoryObject::SharedMemoryObject(ArrayRef<Value> bases, Type baseElemType,
+                                       int64_t rank, Location loc,
+                                       RewriterBase &rewriter)
+    : bases(bases.begin(), bases.end()), baseElemType(baseElemType) {
+  assert(!bases.empty() && "SharedMemoryObject must have at least one base");
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   offsets.append(rank, b.i32_val(0));
 }
 
 SmallVector<Value> SharedMemoryObject::getElems() const {
   SmallVector<Value> elems;
-  elems.push_back(base);
+  // All bases come first, then offsets
+  elems.append(bases.begin(), bases.end());
   elems.append(offsets.begin(), offsets.end());
   return elems;
 }
 
 SmallVector<Type> SharedMemoryObject::getTypes() const {
   SmallVector<Type> types;
-  types.push_back(base.getType());
-  types.append(offsets.size(), IntegerType::get(base.getContext(), 32));
+  // All base pointer types first
+  for (Value base : bases) {
+    types.push_back(base.getType());
+  }
+  // Then all offset types (i32)
+  types.append(offsets.size(), IntegerType::get(bases[0].getContext(), 32));
   return types;
-}
-
-Value SharedMemoryObject::getBaseBeforeSlice(int dim, Location loc,
-                                             RewriterBase &rewriter) const {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value cSwizzleOffset = getCSwizzleOffset(dim);
-  Value offset = b.sub(b.i32_val(0), cSwizzleOffset);
-  Type type = base.getType();
-  return b.gep(type, baseElemType, base, offset);
 }
 
 uint64_t
@@ -1062,12 +1146,11 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
   if (allocShape == shape) {
     return 0;
   }
-  if (auto paddedEncoding = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
-          srcTy.getEncoding())) {
+  if (triton::gpu::isPaddedEncoding(srcTy.getEncoding())) {
     // Mask is used in fusion of constant part of memory operation address as
     // immediate operand. Padded layout has additional address computations
     // between main offset computation and actual memory access, which breaks
-    // constand fusing. Full mask disables this optimization.
+    // constant fusing. Full mask disables this optimization.
     return ~uint64_t(0);
   }
   auto totalLl = triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding());
@@ -1106,13 +1189,11 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
     return b.i32_val(0);
   }
 
-  LinearLayout ll;
   // We return the offset without the padding. The padding will be added in the
   // lowering
-  if (auto paddedSharedEncoding =
-          dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
-              srcTy.getEncoding())) {
-    ll = paddedSharedEncoding.getLinearComponent();
+  LinearLayout ll;
+  if (triton::gpu::isPaddedEncoding(srcTy.getEncoding())) {
+    ll = triton::gpu::paddedLinearLayout(srcTy);
   } else {
     ll = triton::gpu::toLinearLayout(srcTy);
   }
@@ -1132,9 +1213,11 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
 Value SharedMemoryObject::getShmemAffineBase(
     Location loc, RewriterBase &rewriter,
     triton::gpu::MemDescType srcTy) const {
+  assert(bases.size() == 1 &&
+         "getShmemAffineBase does not support partitioned shared memory");
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value offset = getShmemOffset(loc, rewriter, srcTy);
-  return b.gep(base.getType(), baseElemType, base, offset);
+  return b.gep(bases[0].getType(), baseElemType, bases[0], offset);
 }
 
 Value getStructFromSharedMemoryObject(Location loc,
@@ -1166,9 +1249,18 @@ SharedMemoryObject getSharedMemoryObjectFromStruct(Location loc,
     Type type = types[i];
     elems[i] = b.extract_val(type, llvmStruct, i);
   }
-  return {/*base=*/elems[0],
+
+  // Determine how many bases there are by counting pointer types at the start.
+  // The struct layout is: [base0, base1, ..., baseN-1, offset0, offset1, ...]
+  // All bases are pointer types, all offsets are i32.
+  size_t numBases = llvm::count_if(
+      types, [](Type t) { return isa<LLVM::LLVMPointerType>(t); });
+  assert(numBases > 0 &&
+         "SharedMemoryObject struct must have at least one base");
+
+  return {/*bases=*/{elems.begin(), elems.begin() + numBases},
           /*baseElemType=*/elemTy,
-          /*offsets=*/{elems.begin() + 1, elems.end()}};
+          /*offsets=*/{elems.begin() + numBases, elems.end()}};
 }
 
 Value getStackPointer(RewriterBase &rewriter, FunctionOpInterface funcOp) {
@@ -1262,14 +1354,57 @@ Value getSharedMemoryBase(Location loc, RewriterBase &rewriter,
     func = cast<FunctionOpInterface>(op);
 
   assert(op->hasAttr("allocation.offset"));
-  size_t offset = cast<IntegerAttr>(op->getAttr("allocation.offset"))
-                      .getValue()
-                      .getZExtValue();
+  auto offsetAttr = op->getAttr("allocation.offset");
+  assert(isa<IntegerAttr>(offsetAttr) &&
+         "getSharedMemoryBase() called on partitioned tensor. "
+         "Use getSharedMemoryBases() instead.");
+  size_t offset = cast<IntegerAttr>(offsetAttr).getValue().getZExtValue();
+
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value offVal = b.i32_val(offset);
   Value base =
       b.gep(ptrTy, i8_ty, LLVM::getStackPointer(rewriter, func), offVal);
   return base;
+}
+
+SmallVector<int64_t> getPartitionOffsets(Operation *op) {
+  SmallVector<int64_t> offsets;
+  if (!op->hasAttr("allocation.offset"))
+    return offsets;
+
+  auto offsetAttr = op->getAttr("allocation.offset");
+  if (auto intAttr = dyn_cast<IntegerAttr>(offsetAttr)) {
+    // Single offset (non-partitioned tensor)
+    offsets.push_back(intAttr.getValue().getZExtValue());
+  } else if (auto arrayAttr = dyn_cast<ArrayAttr>(offsetAttr)) {
+    // Multiple offsets (partitioned tensor)
+    for (auto elem : arrayAttr) {
+      offsets.push_back(cast<IntegerAttr>(elem).getValue().getZExtValue());
+    }
+  }
+  return offsets;
+}
+
+SmallVector<Value> getSharedMemoryBases(Location loc, RewriterBase &rewriter,
+                                        const TargetInfoBase &target,
+                                        Operation *op) {
+  SmallVector<Value> bases;
+  auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext(),
+                                          target.getSharedAddressSpace());
+  auto func = op->template getParentOfType<FunctionOpInterface>();
+  if (!func)
+    func = cast<FunctionOpInterface>(op);
+
+  auto offsets = getPartitionOffsets(op);
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value stackPtr = LLVM::getStackPointer(rewriter, func);
+
+  for (int64_t offset : offsets) {
+    Value offVal = b.i32_val(offset);
+    Value base = b.gep(ptrTy, i8_ty, stackPtr, offVal);
+    bases.push_back(base);
+  }
+  return bases;
 }
 
 // Extract the bits of `a` that are set in `mask`
@@ -1698,18 +1833,20 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
   };
 
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-  lowerLdSt(loc, ctx, dstLayout, resultVals, valueElemTy, smemBase,
+  SmallVector<Value> smemBases = {smemBase};
+  lowerLdSt(loc, ctx, dstLayout, resultVals, valueElemTy, smemBases,
             /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
             /*maskSpanAffineOffset=*/0, laneId, warpId, rewriter, targetInfo,
             /*maybeMaxVecElems=*/{}, emitSt,
             /*barrierPtr=*/std::nullopt);
   b.barrier(triton::gpu::AddrSpace::Local);
 
-  resultVals = lowerLdSt(loc, ctx, dstLayout, resultVals, valueElemTy, smemBase,
-                         /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
-                         /*maskSpanAffineOffset=*/0, laneId, warpId, rewriter,
-                         targetInfo, /*maybeMaxVecElems=*/{}, emitLd,
-                         /*barrierPtr=*/std::nullopt);
+  resultVals =
+      lowerLdSt(loc, ctx, dstLayout, resultVals, valueElemTy, smemBases,
+                /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
+                /*maskSpanAffineOffset=*/0, laneId, warpId, rewriter,
+                targetInfo, /*maybeMaxVecElems=*/{}, emitLd,
+                /*barrierPtr=*/std::nullopt);
 
   // Create the result struct and replace the operation
   Value resultStruct =

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -371,7 +371,7 @@ struct MemDescTransOpConversion
     auto srcSmemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                       llvmElemTy, rewriter);
     auto dstSmemObj = SharedMemoryObject(
-        srcSmemObj.getBase(), srcSmemObj.getBaseElemType(),
+        srcSmemObj.getBases(), srcSmemObj.getBaseElemType(),
         /*offsets=*/applyPermutation(srcSmemObj.getOffsets(), op.getOrder()));
     auto retVal = getStructFromSharedMemoryObject(loc, dstSmemObj, rewriter);
     rewriter.replaceOp(op, retVal);
@@ -404,8 +404,9 @@ struct MemDescReshapeOpConversion
     SmallVector<Value> delinearizedOffset =
         LLVM::delinearize(rewriter, loc, linearOffset, dstShape);
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto dstSmemObj = SharedMemoryObject(
-        srcSmemObj.getBase(), srcSmemObj.getBaseElemType(), delinearizedOffset);
+    auto dstSmemObj =
+        SharedMemoryObject(srcSmemObj.getBases(), srcSmemObj.getBaseElemType(),
+                           delinearizedOffset);
     auto retVal = getStructFromSharedMemoryObject(loc, dstSmemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();
@@ -492,6 +493,15 @@ struct MemDescIndexOpConversion
     auto dstTy = op.getResult().getType();
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
 
+    if (auto partitionedEnc =
+            dyn_cast<PartitionedSharedEncodingAttr>(srcTy.getEncoding())) {
+      if (partitionedEnc.getPartitionDim() == 0) {
+        return rewriter.notifyMatchFailure(
+            op, "memdesc_index into partitioned dimension (partitionDim=0) "
+                "is not yet supported");
+      }
+    }
+
     // getAllocationShapePerCTA returns the correct number fp4 elements that we
     // need to skip when we have fp4Padded=True. getShapePerCTA does not account
     // for this
@@ -500,24 +510,31 @@ struct MemDescIndexOpConversion
     Value offset = b.mul(op.getIndex(), b.i32_val(stride));
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                    llvmElemTy, rewriter);
-    auto base = smemObj.getBase();
-    auto elemPtrTy = base.getType();
     auto prevOffsets = smemObj.getOffsets();
     SmallVector<Value> offsetVals(prevOffsets.end() - dstTy.getRank(),
                                   prevOffsets.end());
 
     // Apply padding based on the amount we move the base ptr
-    if (auto padEnc = dyn_cast<PaddedSharedEncodingAttr>(dstTy.getEncoding())) {
+    if (isPaddedEncoding(dstTy.getEncoding())) {
       auto bitwidth = dstTy.getElementTypeBitWidth();
-      auto paddingShifts = getPaddedSharedShifts(padEnc, bitwidth,
+      auto paddingShifts = getPaddedSharedShifts(dstTy.getEncoding(), bitwidth,
                                                  /*offsetInBytes=*/false);
       offset = applyPadding(loc, rewriter, offset, paddingShifts);
     }
 
-    // Advance the pointer and keep the opOffsets as the new shape
-    smemObj = SharedMemoryObject(b.gep(elemPtrTy, llvmElemTy, base, offset),
-                                 llvmElemTy, offsetVals);
-    auto retVal = getStructFromSharedMemoryObject(loc, smemObj, rewriter);
+    // For partitioned tensors (when partitionDim > 0), all partitions have the
+    // same layout structure. Each partition contains portions of every "buffer"
+    // along dimension 0. When we select buffer i, we advance all partition
+    // bases by the same offset.
+    SmallVector<Value> newBases;
+    for (Value base : smemObj.getBases()) {
+      auto elemPtrTy = base.getType();
+      newBases.push_back(b.gep(elemPtrTy, llvmElemTy, base, offset));
+    }
+
+    // Create new smemObj with advanced base pointers
+    auto newSmemObj = SharedMemoryObject(newBases, llvmElemTy, offsetVals);
+    auto retVal = getStructFromSharedMemoryObject(loc, newSmemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();
   }
@@ -539,6 +556,13 @@ struct MemDescSubsliceOpConversion
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
     auto layoutOrder = getOrder(srcTy);
     auto enc = srcTy.getEncoding();
+
+    // PartitionedSharedEncoding is not yet supported for memdesc_subslice
+    if (isa<PartitionedSharedEncodingAttr>(srcTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "PartitionedSharedEncoding not yet supported in memdesc_subslice");
+    }
 
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                    llvmElemTy, rewriter);
@@ -570,6 +594,13 @@ struct MemDescReinterpretOpConversion
     MemDescType dstTy = op.getType();
     Type srcElemTy = getTypeConverter()->convertType(srcTy.getElementType());
     Type dstElemTy = getTypeConverter()->convertType(dstTy.getElementType());
+
+    // PartitionedSharedEncoding is not yet supported for memdesc_reinterpret
+    if (isa<PartitionedSharedEncodingAttr>(srcTy.getEncoding())) {
+      return b.notifyMatchFailure(
+          op,
+          "PartitionedSharedEncoding not yet supported in memdesc_reinterpret");
+    }
 
     auto smemObj =
         getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(), srcElemTy, b);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1904,10 +1904,10 @@ LogicalResult PartitionedSharedEncodingAttr::verify(
     function_ref<InFlightDiagnostic()> emitError, unsigned numPartitions,
     unsigned numGroups, unsigned partitionDim,
     SharedEncodingTrait partitionLayout) {
-  // Check numPartitions is a power of 2 and > 0
-  if (numPartitions == 0 || !llvm::isPowerOf2_32(numPartitions))
-    return emitError()
-           << "numPartitions must be a power of 2 and greater than 0";
+  // Check numPartitions is a power of 2 and >= 2
+  // (numPartitions == 1 is just the inner layout, use that directly instead)
+  if (numPartitions < 2 || !llvm::isPowerOf2_32(numPartitions))
+    return emitError() << "numPartitions must be a power of 2 and at least 2";
 
   // Check numGroups is a power of 2 and > 0
   if (numGroups == 0 || !llvm::isPowerOf2_32(numGroups))
@@ -4369,4 +4369,22 @@ std::optional<int> triton::gpu::getWarpSpecializeTag(Operation *op) {
     return cast<IntegerAttr>(op->getAttr(kWarpSpecializeTagAttrName)).getInt();
   }
   return std::nullopt;
+}
+
+PaddedSharedEncodingAttr triton::gpu::getPaddedEncoding(Attribute encoding) {
+  if (auto padded = dyn_cast<PaddedSharedEncodingAttr>(encoding))
+    return padded;
+  if (auto partitioned = dyn_cast<PartitionedSharedEncodingAttr>(encoding))
+    return dyn_cast<PaddedSharedEncodingAttr>(partitioned.getPartitionLayout());
+  return nullptr;
+}
+
+bool triton::gpu::isPaddedEncoding(Attribute encoding) {
+  return getPaddedEncoding(encoding) != nullptr;
+}
+
+unsigned triton::gpu::getMinInterval(Attribute encoding) {
+  auto padded = getPaddedEncoding(encoding);
+  assert(padded && "expected padded encoding or partitioned wrapping padded");
+  return padded.getMinInterval();
 }

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1199,6 +1199,55 @@ tensorMemoryScalesToLinearLayout(ArrayRef<int64_t> shape,
   return ensureLayoutNotLargerThan(tile, shapeMap);
 }
 
+// Convert a PartitionedSharedEncodingAttr to a LinearLayout.
+//
+// PartitionedSharedEncoding splits a tensor along partitionDim into
+// numPartitions physical buffers to reduce partition conflicts.
+//
+// Example (numPartitions=2, numGroups=4, shape=[128,32], partitionDim=0):
+//   Logical pieces: [P0|P1|P2|P3|P4|P5|P6|P7]  (8 pieces of [16,32] each)
+//   Partition 0: [P0|P2|P4|P6]  (contiguous in buffer)
+//   Partition 1: [P1|P3|P5|P7]  (contiguous in buffer)
+//
+// LinearLayout inputs: "offset", "partition"
+// LinearLayout outputs: dim0, dim1, ... (tensor coordinates)
+LinearLayout
+partitionedSharedToLinearLayout(ArrayRef<int64_t> shape,
+                                PartitionedSharedEncodingAttr partitioned) {
+  unsigned numLogicalPieces = partitioned.getNumLogicalPieces();
+  unsigned partitionDim = partitioned.getPartitionDim();
+
+  // Each logical piece has this size along the partition dimension
+  int64_t pieceSize = shape[partitionDim] / numLogicalPieces;
+
+  // Shape of a single piece (full shape except partitionDim = pieceSize)
+  SmallVector<int64_t> partitionShape(shape.begin(), shape.end());
+  partitionShape[partitionDim] = pieceSize;
+
+  // baseLayout maps (offset, block) -> coordinates within ONE piece.
+  // For padded partition layouts, use the linear component (without padding).
+  auto partitionLayout = partitioned.getPartitionLayout();
+  LinearLayout baseLayout =
+      isa<PaddedSharedEncodingAttr>(partitionLayout)
+          ? cast<PaddedSharedEncodingAttr>(partitionLayout).getLinearComponent()
+          : toLinearLayout(partitionShape, partitionLayout);
+
+  auto *ctx = partitioned.getContext();
+  auto outDimNames = standardOutDimNames(ctx, baseLayout.getNumOutDims());
+
+  // partLayout maps "partition" -> piece selection along partitionDim.
+  auto kPartition = StringAttr::get(ctx, "partition");
+  LinearLayout partLayout = LinearLayout::identity1D(
+      partitioned.getNumPartitions(), kPartition, outDimNames[partitionDim]);
+
+  // Extend "offset" to address across groups.
+  auto kOffset = StringAttr::get(ctx, "offset");
+  LinearLayout extension = LinearLayout::identity1D(
+      partitioned.getNumGroups(), kOffset, outDimNames[partitionDim]);
+
+  return baseLayout * partLayout * extension;
+}
+
 LinearLayout TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape,
                                               Attribute layout) {
   CacheKey key{std::vector<int64_t>(shape.begin(), shape.end()), layout};
@@ -1226,6 +1275,12 @@ LinearLayout TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape,
       result = nvmmaSharedToLinearLayout(shape, shared, TMAMode::Tiled);
     } else if (auto sbl = dyn_cast<AMDRotatingSharedEncodingAttr>(layout)) {
       result = sharedToLinearLayoutAMDRotating(shape, sbl);
+    } else if (auto partitioned =
+                   dyn_cast<PartitionedSharedEncodingAttr>(layout)) {
+      assert(!isa<PaddedSharedEncodingAttr>(partitioned.getPartitionLayout()) &&
+             "toLinearLayout does not support partitioned layouts wrapping "
+             "padded layouts; use paddedLinearLayout instead");
+      result = partitionedSharedToLinearLayout(shape, partitioned);
     } else if (auto tensorMemoryEncoding =
                    dyn_cast<TensorMemoryEncodingAttr>(layout)) {
       result = tensorMemoryToLinearLayout(shape, tensorMemoryEncoding);
@@ -1271,6 +1326,20 @@ LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout) {
   auto *ctx = layout.getContext();
   return ctx->getLoadedDialect<TritonGPUDialect>()->toLinearLayout(shape,
                                                                    layout);
+}
+
+LinearLayout paddedLinearLayout(MemDescType type) {
+  auto encoding = type.getEncoding();
+  assert(isPaddedEncoding(encoding) &&
+         "expected padded encoding or partitioned wrapping padded");
+
+  if (auto padded = dyn_cast<PaddedSharedEncodingAttr>(encoding)) {
+    return padded.getLinearComponent();
+  }
+
+  auto partitioned = cast<PartitionedSharedEncodingAttr>(encoding);
+  auto shape = type.getAllocShape().take_back(type.getRank());
+  return partitionedSharedToLinearLayout(shape, partitioned);
 }
 
 LinearLayout getLayoutWithinBlock(const LinearLayout &layout) {

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -136,6 +136,7 @@ struct GluonLayouts {
   py::handle AMDMFMALayout;
   py::handle AMDWMMALayout;
   py::handle PaddedSharedLayout;
+  py::handle PartitionedSharedLayout;
 
   GluonLayouts() {
     auto layouts =
@@ -166,6 +167,10 @@ struct GluonLayouts {
     AMDWMMALayout = py::object(amdLayouts.attr("AMDWMMALayout")).release();
     PaddedSharedLayout =
         py::object(layouts.attr("PaddedSharedLayout")).release();
+    auto gfx1250Layouts = py::module::import(
+        "triton.experimental.gluon.language.amd.gfx1250._layouts");
+    PartitionedSharedLayout =
+        py::object(gfx1250Layouts.attr("PartitionedSharedLayout")).release();
 
     auto core = py::module::import("triton.language.core");
   }
@@ -280,6 +285,13 @@ py::object layoutToGluon(Attribute layout) {
     return layouts.PaddedSharedLayout(intervalPaddingPairs,
                                       ll.getBases().lookup(kOffset),
                                       ll.getBases().lookup(kBlock), shape);
+  } else if (auto partitioned =
+                 dyn_cast<ttg::PartitionedSharedEncodingAttr>(layout)) {
+    py::object partitionLayout =
+        layoutToGluon(partitioned.getPartitionLayout());
+    return layouts.PartitionedSharedLayout(
+        partitioned.getNumPartitions(), partitioned.getNumGroups(),
+        partitioned.getPartitionDim(), partitionLayout);
   } else if (auto tmemScales =
                  dyn_cast<ttng::TensorMemoryScalesEncodingAttr>(layout)) {
     return layouts.TensorMemoryScalesLayout(std::vector<unsigned>{
@@ -533,6 +545,15 @@ void init_gluon_ir(py::module &&m) {
              auto cgaLayout = buildCgaLayoutAttr(ctx, cgaBases, rank);
              return self.getChecked<ttg::SwizzledSharedEncodingAttr>(
                  ctx, vec, perPhase, maxPhase, order, cgaLayout);
+           })
+      .def("get_partitioned_shared_layout",
+           [](GluonOpBuilder &self, unsigned numPartitions, unsigned numGroups,
+              unsigned partitionDim, Attribute partitionLayout) -> Attribute {
+             auto ctx = self.getContext();
+             auto sharedLayout =
+                 cast<ttg::SharedEncodingTrait>(partitionLayout);
+             return self.getChecked<ttg::PartitionedSharedEncodingAttr>(
+                 ctx, numPartitions, numGroups, partitionDim, sharedLayout);
            })
       .def("get_tensor_memory_layout",
            [](GluonOpBuilder &self, std::vector<unsigned> &block,

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -5,6 +5,7 @@ import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton._internal_testing import is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
+from triton.experimental.gluon.language.amd.gfx1250 import PartitionedSharedLayout
 
 
 def _is_layout_applicable(layout) -> bool:
@@ -1328,3 +1329,101 @@ def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, device):
 
     out_ref = torch.arange(0, M * N, device=device).reshape((M, N)).to(torch.float16)
     torch.testing.assert_close(out, out_ref, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(is_cuda(), reason="PartitionedSharedLayout is not supported in NV backend")
+@pytest.mark.parametrize("M, K", [(64, 32), (128, 64)])
+@pytest.mark.parametrize("num_partitions", [2, 4])
+@pytest.mark.parametrize("num_groups", [1, 2])
+@pytest.mark.parametrize("partition_dim", [0, 1])
+@pytest.mark.parametrize("partition_layout_type", ["swizzled", "padded"])
+def test_partitioned_shared_layout(M, K, num_partitions, num_groups, partition_dim, partition_layout_type):
+    """
+    Test that PartitionedSharedLayout works correctly with various configurations.
+
+    This test allocates shared memory with partitioned layout, performs a
+    round-trip copy (global -> shared -> global), and verifies data integrity.
+
+    Parameters:
+    - M, K: Tensor dimensions
+    - num_partitions: Number of physical memory partitions (2 or 4)
+    - num_groups: Number of groups (1 or 2)
+    - partition_dim: Dimension along which to partition (0=rows, 1=cols)
+    - partition_layout_type: Layout within each piece ("swizzled" or "padded")
+    """
+
+    blocked_layout = ttgl.BlockedLayout(
+        size_per_thread=[1, 8],
+        threads_per_warp=[THREADS_PER_WARP // 4, 4],
+        warps_per_cta=[4, 1],
+        order=[1, 0],
+    )
+
+    @gluon.jit
+    def partitioned_copy_kernel(
+        input_ptr,
+        output_ptr,
+        M: ttgl.constexpr,
+        K: ttgl.constexpr,
+        blocked: ttgl.constexpr,
+        partitioned_layout: ttgl.constexpr,
+    ):
+        # Create 2D indices
+        row_idx = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, blocked))[:, None]
+        col_idx = ttgl.arange(0, K, layout=ttgl.SliceLayout(0, blocked))[None, :]
+        offsets = row_idx * K + col_idx
+
+        # Load data from global memory
+        data = ttgl.load(input_ptr + offsets)
+
+        # Allocate partitioned shared memory and store data
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [M, K], partitioned_layout, data)
+
+        # Load from shared memory
+        loaded = smem.load(blocked)
+
+        # Store back to global memory
+        ttgl.store(output_ptr + offsets, loaded)
+
+    # Create partition layout
+    if partition_layout_type == "swizzled":
+        inner_layout = ttgl.SwizzledSharedLayout(
+            vec=4,
+            per_phase=2,
+            max_phase=8,
+            order=[1, 0],
+        )
+    elif partition_layout_type == "padded":
+        inner_layout = ttgl.PaddedSharedLayout.with_identity_for(
+            interval_padding_pairs=[[16, 4]],
+            shape=[M, K],
+            order=[1, 0],
+        )
+    else:
+        raise ValueError(f"Unknown partition_layout_type: {partition_layout_type}")
+
+    # Create partitioned layout
+    partitioned_layout = PartitionedSharedLayout(
+        num_partitions=num_partitions,
+        num_groups=num_groups,
+        partition_dim=partition_dim,
+        partition_layout=inner_layout,
+    )
+
+    # Create input/output tensors
+    input_tensor = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    output_tensor = torch.empty_like(input_tensor)
+
+    # Run the kernel
+    partitioned_copy_kernel[(1, )](
+        input_tensor,
+        output_tensor,
+        M,
+        K,
+        blocked_layout,
+        partitioned_layout,
+        num_warps=4,
+    )
+
+    # Verify output matches input
+    torch.testing.assert_close(output_tensor, input_tensor, atol=0, rtol=0)

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -5,6 +5,7 @@ from ..._core import builtin
 from .._ops import _wmma, _verify_wmma, _mma_scaled
 from .._layouts import AMDWMMALayout
 from ..cdna3 import buffer_load, buffer_store
+from ._layouts import PartitionedSharedLayout
 from . import tdm
 from . import async_copy
 from . import mbarrier
@@ -12,7 +13,7 @@ from . import cluster
 
 __all__ = [
     "async_copy", "tdm", "mbarrier", "cluster", "wmma", "wmma_scaled", "buffer_load", "buffer_store",
-    "get_wmma_scale_layout"
+    "get_wmma_scale_layout", "PartitionedSharedLayout"
 ]
 
 

--- a/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from triton.language.core import _unwrap_if_constexpr
+
+from triton.experimental.gluon.language._layouts import SharedLayout
+
+__all__ = [
+    "PartitionedSharedLayout",
+]
+
+
+@dataclass(frozen=True)
+class PartitionedSharedLayout(SharedLayout):
+    """
+    Represents a partitioned shared memory layout that splits a tensor
+    across multiple physical shared memory partitions.
+
+    This reduces shared memory partition conflicts by placing different
+    pieces of a tensor in separate physical memory slots.
+
+    Args:
+        num_partitions (int): Number of physical memory partitions.
+        num_groups (int): Number of groups (each group has num_partitions pieces).
+        partition_dim (int): Dimension along which to partition.
+        partition_layout (SharedLayout): Inner layout for each piece
+            (e.g., SwizzledSharedLayout or PaddedSharedLayout).
+    """
+    num_partitions: int
+    num_groups: int
+    partition_dim: int
+    partition_layout: SharedLayout
+
+    def __post_init__(self):
+        super().__setattr__("num_partitions", _unwrap_if_constexpr(self.num_partitions))
+        super().__setattr__("num_groups", _unwrap_if_constexpr(self.num_groups))
+        super().__setattr__("partition_dim", _unwrap_if_constexpr(self.partition_dim))
+        super().__setattr__("partition_layout", _unwrap_if_constexpr(self.partition_layout))
+
+        is_power_of_2 = lambda n: n > 0 and n & (n - 1) == 0
+        assert is_power_of_2(self.num_partitions), \
+            f"PartitionedSharedLayout num_partitions must be a power of two, got {self.num_partitions}"
+        assert is_power_of_2(self.num_groups), \
+            f"PartitionedSharedLayout num_groups must be a power of two, got {self.num_groups}"
+        assert self.partition_dim >= 0, \
+            f"PartitionedSharedLayout partition_dim must be non-negative, got {self.partition_dim}"
+        assert isinstance(self.partition_layout, SharedLayout), \
+            f"PartitionedSharedLayout partition_layout must be a SharedLayout, got {type(self.partition_layout)}"
+
+    def _to_ir(self, builder):
+        partition_layout_ir = self.partition_layout._to_ir(builder)
+        return builder.get_partitioned_shared_layout(
+            self.num_partitions,
+            self.num_groups,
+            self.partition_dim,
+            partition_layout_ir,
+        )
+
+    def mangle(self) -> str:
+        partition_mangle = self.partition_layout.mangle()
+        return f"Partitioned_{self.num_partitions}_{self.num_groups}_{self.partition_dim}_{partition_mangle}_Partitioned"
+
+    def __hash__(self):
+        return hash((
+            self.num_partitions,
+            self.num_groups,
+            self.partition_dim,
+            self.partition_layout,
+        ))

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -27,3 +27,56 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
    tt.return
   }
 }
+
+// -----
+
+// Test lowering of operations with PartitionedSharedEncodingAttr using padded_shared layout
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // GFX1250-LABEL: partitioned_shared_padded_local_alloc
+  tt.func @partitioned_shared_padded_local_alloc(%arg0: tensor<16x16xf16, #blocked>) {
+    // GFX1250: llvm.mlir.addressof @global_smem
+    // GFX1250-COUNT-4: llvm.store {{.*}} : vector<{{[0-9]+}}xf16>, !llvm.ptr<3>
+    %0 = ttg.local_alloc %arg0 : (tensor<16x16xf16, #blocked>) -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // GFX1250-LABEL: partitioned_shared_padded_local_load
+  tt.func @partitioned_shared_padded_local_load() -> tensor<16x16xf16, #blocked> {
+    // Allocate and then load from partitioned shared memory
+    // GFX1250: llvm.mlir.addressof @global_smem
+    // GFX1250-COUNT-4: llvm.load {{.*}} : !llvm.ptr<3> -> vector<{{[0-9]+}}xf16>
+    %0 = ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32, 128 : i32, 65664 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %1 = ttg.local_load %0 : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16, #blocked>
+    tt.return %1 : tensor<16x16xf16, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // GFX1250-LABEL: partitioned_shared_padded_local_store
+  tt.func @partitioned_shared_padded_local_store(%arg0: tensor<16x16xf16, #blocked>) {
+    // Allocate and then store to partitioned shared memory
+    // GFX1250: llvm.mlir.addressof @global_smem
+    // GFX1250-COUNT-4: llvm.store {{.*}} : vector<{{[0-9]+}}xf16>, !llvm.ptr<3>
+    %0 = ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32, 128 : i32, 65664 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    ttg.local_store %arg0, %0 : tensor<16x16xf16, #blocked> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -536,8 +536,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: basic_alloc_tensor
   tt.func @basic_alloc_tensor() {
     // CHECK: llvm.mlir.addressof @global_smem
-    // CHECK-NEXT: llvm.getelementptr
-    // CHECK-NEXT: llvm.mlir.constant
+    // CHECK: llvm.getelementptr
     %0 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #shared0, #smem, mutable>
     tt.return
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -30,6 +30,11 @@ public:
     auto loc = op.getLoc();
     MemDescType srcTy = op.getSrc().getType();
     RankedTensorType dstTy = op.getType();
+
+    // Partitioned tensors have multiple bases; fall back to generic lowering.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(srcTy.getEncoding())) {
+      return failure();
+    }
     auto typeConverter = this->getTypeConverter();
     auto llvmElemTy = typeConverter->convertType(dstTy.getElementType());
     unsigned bitWidth = llvmElemTy.getIntOrFloatBitWidth();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -107,7 +107,9 @@ struct ConvertTritonAMDGPUToLLVM
     int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
 
     // Allocate shared memory and set barrier
-    ModuleAllocation allocation(mod);
+    ModuleAllocation allocation(mod,
+                                triton::defaultAllocationAnalysisScratchSizeFn,
+                                targetInfo.getSharedMemoryPartitionSize());
 
     if (targetInfo.requiresAliasInfoForAsyncOps())
       AMD::annotateLocalLoadsSyncedViaAsyncWait(mod);


### PR DESCRIPTION
Summary:
This is a cherry-pick of an upstream PR: https://github.com/triton-lang/triton/pull/9362

Upstream commit message:
```
> [AMD][Backend] Lower PartitionedSharedEncodingAttr to LLVM (#9362)

> This commit enables lowering of tensors with
> PartitionedSharedEncodingAttr
> to LLVM IR. Partitioned shared memory splits a tensor across multiple
> physical shared memory partitions to reduce partition conflicts.

> ---------

> Co-authored-by: Ognjen Plavsic <plognjen@amd.com>
```

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 3c995fc5d50fb025948b550f788cc7bdf0254829
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- cherrypick --num-commits 1
```

Reviewed By: dshi7

Differential Revision: D109031471


