### PR TITLE
[Triton][Cherry-pick] Improve cache modifiers support for loads (#9936) (#1788)

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -932,6 +932,8 @@ class TritonSemantic(Generic[TensorTy]):
                 cache = ir.CACHE_MODIFIER.CA
             elif cache_modifier == ".cg":
                 cache = ir.CACHE_MODIFIER.CG
+            elif cache_modifier == ".cs":
+                cache = ir.CACHE_MODIFIER.CS
             elif cache_modifier == ".cv":
                 cache = ir.CACHE_MODIFIER.CV
             else:

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -353,6 +353,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
                      .global()
                      .o("ca", op.getCache() == triton::CacheModifier::CA)
                      .o("cg", op.getCache() == triton::CacheModifier::CG)
+                     .o("cs", op.getCache() == triton::CacheModifier::CS)
+                     .o("cv", op.getCache() == triton::CacheModifier::CV)
                      .o("L1::evict_first",
                         op.getEvict() == triton::EvictionPolicy::EVICT_FIRST)
                      .o("L1::evict_last",


### PR DESCRIPTION
Summary:

Backport of upstream Triton PR #9936.

Upstream PR: https://github.com/triton-lang/triton/pull/9936
Upstream commit: b0f7aa58082bc59d8746b35c7516c5a5345571d7

Original commit message:

Improve cache modifiers support for loads (#9936)

This PR:
- Enables CS and CV load cache modifier in Nvidia backend
- Enables CS cache modifier in frontend
- Improves test coverage for CDNA3 and CDNA4

Co-authored-by: Alexander Efimov <efimov.alexander@gmail.com>

Reviewed By: wlei-llvm

Differential Revision: D109186035


