### PR TITLE
[Backport][TLX][AMD] Add fused addmm + GLU tutorial kernel for gfx950 (#1690) (#1789)

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -932,6 +932,8 @@ class TritonSemantic(Generic[TensorTy]):
                 cache = ir.CACHE_MODIFIER.CA
             elif cache_modifier == ".cg":
                 cache = ir.CACHE_MODIFIER.CG
+            elif cache_modifier == ".cs":
+                cache = ir.CACHE_MODIFIER.CS
             elif cache_modifier == ".cv":
                 cache = ir.CACHE_MODIFIER.CV
             else:

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -353,6 +353,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
                      .global()
                      .o("ca", op.getCache() == triton::CacheModifier::CA)
                      .o("cg", op.getCache() == triton::CacheModifier::CG)
+                     .o("cs", op.getCache() == triton::CacheModifier::CS)
+                     .o("cv", op.getCache() == triton::CacheModifier::CV)
                      .o("L1::evict_first",
                         op.getEvict() == triton::EvictionPolicy::EVICT_FIRST)
                      .o("L1::evict_last",

--- a/third_party/tlx/tutorials/amd-addmm-glu-opt_test.py
+++ b/third_party/tlx/tutorials/amd-addmm-glu-opt_test.py
@@ -1,0 +1,1281 @@
+"""
+AMD TLX fused addmm + GLU (out = x + x*y, x = A@B + bias).
+
+Benchmarks the baseline and optimized TLX kernels against a PyTorch reference
+(naive matmul + add, then GLU) and ROCBLAS (pure matmul, no add/GLU).
+
+Usage:
+  # Sweep all K, both kernels (default)
+  python amd-addmm-glu-opt_test.py
+
+  # Single K, optimized kernel only
+  python amd-addmm-glu-opt_test.py -K 1024 --kernel tlx_optimized
+
+  # A couple of sizes, both kernels
+  python amd-addmm-glu-opt_test.py -K 256 512 --kernel tlx_baseline tlx_optimized
+"""
+import argparse
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton._internal_testing import is_hip_cdna4
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+M, N = 1024, 21568
+
+# gfx950 has 8 XCDs per chip
+NUM_XCDS = 8
+
+# Per-row padding (fp16 elements) on the async kernel's Y LDS buffer
+Y_PAD = 4
+
+# Autotuning winning configurations for K=256, K=512, and K=1024
+BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=4,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    512:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32, GROUP_SIZE_M=8, XCD_CHUNK=4, num_warps=4,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=64, GROUP_SIZE_M=8, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+}
+
+# Autotuning winning configurations for the baseline kernel (K=256, K=512, K=1024)
+BASELINE_BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=1, XCD_CHUNK=4, NUM_STAGES=2, num_warps=4,
+         matrix_instr_nonkdim=16, waves_per_eu=2, kpack=1),
+    512:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=1, XCD_CHUNK=4, NUM_STAGES=2, num_warps=4,
+         matrix_instr_nonkdim=16, waves_per_eu=2, kpack=1),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=1, XCD_CHUNK=4, NUM_STAGES=2, num_warps=4,
+         matrix_instr_nonkdim=16, waves_per_eu=2, kpack=1),
+}
+
+# Autotuning winning configurations for the async-epilogue kernel (K=256, K=512, K=1024)
+ASYNC_BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=64, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, NUM_BUFFERS=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    512:
+    dict(BLOCK_SIZE_M=64, BLOCK_SIZE_N=128, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, NUM_BUFFERS=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, NUM_BUFFERS=3, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+}
+
+# Autotuning winning configurations for the persistent warp-pipelined kernel
+# BN=256 with BK=32 (72KB LDS) beats BN=128 with BK=64 (96KB) at all K values
+# BN=256 with BK=64 (144KB) is rejected by hardware due to warp-pipeline overhead
+PERSISTENT_BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    512:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=32, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+}
+
+# Configs for the simple (non-pipelined) kernel with async-prefetched Y
+SIMPLE_BEST_CONFIG = {
+    256:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    512:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+    1024:
+    dict(BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, GROUP_SIZE_M=4, XCD_CHUNK=4, num_warps=8,
+         matrix_instr_nonkdim=16, waves_per_eu=0),
+}
+
+
+# L2 swizzling
+@triton.jit
+def chiplet_transform_chunked(pid, num_workgroups, num_xcds: tl.constexpr, chunk_size: tl.constexpr):
+    """Group adjacent PIDs onto the same XCD in chunks of chunk_size for L2 reuse.
+
+    PIDs in the trailing remainder (not a multiple of num_xcds*chunk_size) pass through.
+    """
+    aligned = (num_workgroups // (num_xcds * chunk_size)) * (num_xcds * chunk_size)
+    if pid >= aligned:
+        return pid
+    xcd = pid % num_xcds
+    local_pid = pid // num_xcds
+    return ((local_pid // chunk_size) * num_xcds * chunk_size + xcd * chunk_size + (local_pid % chunk_size))
+
+
+@triton.constexpr_function
+def _y_padded_layout(BM, BN, PAD):
+    # Pad each row of the (BM, BN) Y tile
+    return tlx.padded_shared_layout_encoding.with_identity_for([[BN, PAD]], [BM, BN], [1, 0])
+
+
+# Warp-pipelined async direct-to-LDS fused addmm + GLU optimized kernel
+@triton.jit
+def tlx_addmm_glu_kernel_optimized(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+):
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    pid = tl.program_id(axis=0)
+
+    # Num pids along M dim
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+
+    # Num pids along N dim
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    # How many pids we have in total grid
+    grid_mn = num_pid_m * num_pid_n
+
+    # Remap pids via L2 swizzle
+    pid = chiplet_transform_chunked(pid, grid_mn, NUM_XCDS, XCD_CHUNK)
+
+    # Num pids in the group (of shared rows along M dim pids)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    # Which group we are in
+    group_id = pid // num_pid_in_group
+
+    # Index of first pid in this group
+    first_pid_m = group_id * GROUP_SIZE_M
+
+    # Either GROUP_SIZE_M or smaller due to last group cutting off early
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+
+    # Which pid along m dim
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+
+    # Which pid along n dim
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Get offsets this pid is responsible for in m dim
+    offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+
+    # Get offsets this pid is responsible for in n dim
+    offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+    # Get offsets this pid is responsible for in k dim
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Base pointers for A along m dim
+    a_base_off = offs_m[:, None] * sa0
+
+    # Base pointers for B along n dim
+    b_base_off = offs_n[None, :] * sb1
+
+    # The number of buffers for this kernel is fixed to be 3 which allows
+    # for the async_load_wait_group in the hotloop to not wait on the directly
+    # previous global read (GR) to finish because the GR that it actually
+    # needs was fetched much earlier (possibly in the prologue)
+    NUM_BUFFERS: tl.constexpr = 3
+
+    # How many times we need to iterate through blocks of size BLOCK_SIZE_K
+    k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+
+    # Create multibuffered shared memory arrays
+    smemA = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_BUFFERS)
+
+    # GR (Global Read) 0
+    k_start = 0
+    a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+    b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+
+    tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 0), mask=offs_k[None, :] < K - k_start)
+    tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 0), mask=offs_k[:, None] < K - k_start)
+    tlx.async_load_commit_group([tok_a, tok_b])
+
+    # GR 1
+    k_start = BLOCK_SIZE_K
+    a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+    b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+
+    tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 1), mask=offs_k[None, :] < K - k_start)
+    tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 1), mask=offs_k[:, None] < K - k_start)
+    tlx.async_load_commit_group([tok_a, tok_b])
+
+    # GR 2
+    k_start = BLOCK_SIZE_K * 2
+    a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+    b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+
+    tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 2), mask=offs_k[None, :] < K - k_start)
+    tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 2), mask=offs_k[:, None] < K - k_start)
+    tlx.async_load_commit_group([tok_a, tok_b])
+
+    # Make GR0 and GR1 finish
+    tlx.async_load_wait_group(1)
+
+    # LR (Local Read) 0 where we transfer GR0 to registers
+    a_tile = tlx.local_load(tlx.local_view(smemA, 0))
+    b_tile = tlx.local_load(tlx.local_view(smemB, 0))
+
+    # Create accumulator array
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Hot loop: warp-pipelined MFMA / async-prefetch
+    for i in tl.range(0, k_iters - NUM_BUFFERS, loop_unroll_factor=0):
+        # Index within the multibuffered circular SMEM where we are storing the global prefetch
+        prefetch_buf = i % NUM_BUFFERS
+
+        # Index within the multibuffered circular SMEM where we will load from to transfer into regs
+        next_buf = (i + 1) % NUM_BUFFERS
+
+        # Which tile we need to prefetch globally along the k dim
+        k_prefetch = (i + NUM_BUFFERS) * BLOCK_SIZE_K
+
+        # Execute MFMA with the data we already have loaded into registers
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            # Perform global prefetching (GR i + NUM_BUFFERS)
+            a_offs = a_base_off + (k_prefetch + offs_k[None, :]) * sa1
+            b_offs = (k_prefetch + offs_k[:, None]) * sb0 + b_base_off
+
+            tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, prefetch_buf), mask=offs_k[None, :]
+                                   < K - k_prefetch)
+            tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, prefetch_buf), mask=offs_k[:, None]
+                                   < K - k_prefetch)
+
+            tlx.async_load_commit_group([tok_a, tok_b])
+
+            # Perform local prefetching (LR i + 1)
+            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
+            b_tile = tlx.local_load(tlx.local_view(smemB, next_buf))
+
+        # Most recently committed buffers (GR i + NUM_BUFFERS) can be in flight
+        tlx.async_load_wait_group(1)
+
+    # Can potentially async load the y and bias here
+
+    # Epilogue: drain the remaining in-flight tiles
+    acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+    # Wait for all buffers to be loaded before draining in epilogue loop
+    tlx.async_load_wait_group(0)
+
+    # Finish final set of LRs and MFMAs
+    for i in tl.static_range(0, NUM_BUFFERS - 1):
+        buf = (k_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
+
+        a_tile = tlx.local_load(tlx.local_view(smemA, buf))
+        b_tile = tlx.local_load(tlx.local_view(smemB, buf))
+
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+    # Fused epilogue: addmm + GLU
+    # Add bias (broadcast over M), then GLU: X = X + X*Y
+    # Streaming cache hints (.cs) on Y and C: both are touched once and never
+    # reused, so we avoid polluting L2 with this 44MB+44MB epilogue traffic
+
+    bias = tl.load(bias_ptr + offs_n).to(tl.float32)
+
+    y_ptrs = y_ptr + offs_m[:, None] * sy0 + offs_n[None, :] * sy1
+
+    y = tl.load(y_ptrs, cache_modifier=".cs").to(tl.float32)
+
+    x = acc + bias[None, :]
+
+    out = x + x * y
+
+    c_ptrs = c_ptr + offs_m[:, None] * sc0 + offs_n[None, :] * sc1
+
+    tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), cache_modifier=".cs")
+
+
+def run_kernel_optimized(a, b, bias, y, out, cfg):
+    M, K = a.shape
+    _, N = b.shape
+    grid = (triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"]), )
+    return tlx_addmm_glu_kernel_optimized[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=cfg["XCD_CHUNK"],
+        num_warps=cfg["num_warps"],
+        num_stages=1,
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+    )
+
+
+# Warp-pipelined async direct-to-LDS fused addmm + GLU kernel, async-epilogue variant
+# Stages the epilogue Y tile into a padded LDS buffer via async_load so its 44MB HBM
+# read overlaps GEMM compute
+@triton.jit
+def tlx_addmm_glu_kernel_optimized_async(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+    Y_PAD: tl.constexpr,
+):
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    pid = tl.program_id(axis=0)
+
+    # Num pids along M dim
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+
+    # Num pids along N dim
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    # How many pids we have in total grid
+    grid_mn = num_pid_m * num_pid_n
+
+    # Remap pids via L2 swizzle
+    pid = chiplet_transform_chunked(pid, grid_mn, NUM_XCDS, XCD_CHUNK)
+
+    # Num pids in the group (of shared rows along M dim pids)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    # Which group we are in
+    group_id = pid // num_pid_in_group
+
+    # Index of first pid in this group
+    first_pid_m = group_id * GROUP_SIZE_M
+
+    # Either GROUP_SIZE_M or smaller due to last group cutting off early
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+
+    # Which pid along m dim
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+
+    # Which pid along n dim
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+    # Get offsets this pid is responsible for in m dim
+    offs_m = offs_cm % M
+
+    # Get offsets this pid is responsible for in n dim
+    offs_n = offs_cn % N
+
+    # Get offsets this pid is responsible for in k dim
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Base pointers for A along m dim
+    a_base_off = offs_m[:, None] * sa0
+
+    # Base pointers for B along n dim
+    b_base_off = offs_n[None, :] * sb1
+
+    # How many times we need to iterate through blocks of size BLOCK_SIZE_K
+    k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+
+    # Create multibuffered shared memory arrays
+    smemA = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_BUFFERS)
+
+    # Prologue: issue NUM_BUFFERS global reads
+    for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
+        k_start = i * BLOCK_SIZE_K
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, i), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+    # Drain down to NUM_BUFFERS-2 in flight so buffers 0 and 1 are ready
+    tlx.async_load_wait_group(NUM_BUFFERS - 2)
+
+    # LR (Local Read) 0 where we transfer GR0 to registers
+    a_tile = tlx.local_load(tlx.local_view(smemA, 0))
+    b_tile = tlx.local_load(tlx.local_view(smemB, 0))
+
+    # Create accumulator array
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Hot loop: warp-pipelined MFMA / async-prefetch
+    for i in tl.range(0, k_iters - NUM_BUFFERS, loop_unroll_factor=0):
+        # Index within the multibuffered circular SMEM where we are storing the global prefetch
+        prefetch_buf = i % NUM_BUFFERS
+
+        # Index within the multibuffered circular SMEM where we will load from to transfer into regs
+        next_buf = (i + 1) % NUM_BUFFERS
+
+        # Which tile we need to prefetch globally along the k dim
+        k_prefetch = (i + NUM_BUFFERS) * BLOCK_SIZE_K
+
+        # Execute MFMA with the data we already have loaded into registers
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            # Perform global prefetching (GR i + NUM_BUFFERS)
+            a_offs = a_base_off + (k_prefetch + offs_k[None, :]) * sa1
+            b_offs = (k_prefetch + offs_k[:, None]) * sb0 + b_base_off
+
+            tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, prefetch_buf), mask=offs_k[None, :]
+                                   < K - k_prefetch)
+            tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, prefetch_buf), mask=offs_k[:, None]
+                                   < K - k_prefetch)
+
+            tlx.async_load_commit_group([tok_a, tok_b])
+
+            # Perform local prefetching (LR i + 1)
+            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
+            b_tile = tlx.local_load(tlx.local_view(smemB, next_buf))
+
+        # Keep the NUM_BUFFERS-2 most-recent prefetches in flight (pipeline depth)
+        tlx.async_load_wait_group(NUM_BUFFERS - 2)
+
+    # Async-prefetch Y into a padded LDS buffer
+    y_layout: tl.constexpr = _y_padded_layout(BLOCK_SIZE_M, BLOCK_SIZE_N, Y_PAD)
+    smemY = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tlx.dtype_of(y_ptr), 1, layout=y_layout)
+    y_ptrs = y_ptr + offs_m[:, None] * sy0 + offs_n[None, :] * sy1
+    y_tok = tlx.async_load(y_ptrs, tlx.local_view(smemY, 0))
+    tlx.async_load_commit_group([y_tok])
+
+    # Epilogue: drain the remaining in-flight tiles
+    acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+    # Keep Y (newest committed group) in flight; drain all A/B.
+    tlx.async_load_wait_group(1)
+
+    # Finish final set of LRs and MFMAs
+    for i in tl.static_range(0, NUM_BUFFERS - 1):
+        buf = (k_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
+
+        a_tile = tlx.local_load(tlx.local_view(smemA, buf))
+        b_tile = tlx.local_load(tlx.local_view(smemB, buf))
+
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+    # Fused epilogue: addmm + GLU. Add bias (broadcast over M), then GLU: X = X + X*Y.
+    bias = tl.load(bias_ptr + offs_n).to(tl.float32)
+    x = acc + bias[None, :]
+
+    # Wait for Y to finish loading, then read it back from the padded LDS buffer
+    tlx.async_load_wait_group(0)
+    y_regs = tlx.local_load(tlx.local_view(smemY, 0)).to(tl.float32)
+    out = x + x * y_regs
+
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    c_ptrs = c_ptr + offs_cm[:, None] * sc0 + offs_cn[None, :] * sc1
+
+    tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), mask=c_mask, cache_modifier=".cs")
+
+
+def run_kernel_optimized_async(a, b, bias, y, out, cfg):
+    M, K = a.shape
+    _, N = b.shape
+    grid = (triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"]), )
+    return tlx_addmm_glu_kernel_optimized_async[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=cfg["XCD_CHUNK"],
+        NUM_BUFFERS=cfg["NUM_BUFFERS"],
+        Y_PAD=Y_PAD,
+        num_warps=cfg["num_warps"],
+        num_stages=1,
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+    )
+
+
+# Simple (non-pipelined) GEMM with async-prefetched Y. The K-loop does a plain
+# blocking load of A and B each iteration (no multibuffering, no warp-pipeline,
+# no prefetch). Only the epilogue Y tile is staged async into LDS before the loop
+# so its HBM read latency can overlap the whole GEMM
+@triton.jit
+def tlx_addmm_glu_kernel_simple_async(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+    Y_PAD: tl.constexpr,
+):
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    grid_mn = num_pid_m * num_pid_n
+    pid = chiplet_transform_chunked(pid, grid_mn, NUM_XCDS, XCD_CHUNK)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_m = offs_cm % M
+    offs_n = offs_cn % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Async-prefetch Y into a padded LDS buffer before the K-loop
+    y_layout: tl.constexpr = _y_padded_layout(BLOCK_SIZE_M, BLOCK_SIZE_N, Y_PAD)
+    smemY = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_N), tlx.dtype_of(y_ptr), 1, layout=y_layout)
+    y_ptrs = y_ptr + offs_m[:, None] * sy0 + offs_n[None, :] * sy1
+    y_tok = tlx.async_load(y_ptrs, tlx.local_view(smemY, 0))
+    tlx.async_load_commit_group([y_tok])
+
+    a_ptrs = a_ptr + offs_m[:, None] * sa0 + offs_k[None, :] * sa1
+    b_ptrs = b_ptr + offs_k[:, None] * sb0 + offs_n[None, :] * sb1
+
+    # Plain unpipelined K-loop: grab A and B for this iteration, dot, advance
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+    for k in tl.range(0, k_iters):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        acc = tl.dot(a, b, acc, allow_tf32=False)
+        a_ptrs += BLOCK_SIZE_K * sa1
+        b_ptrs += BLOCK_SIZE_K * sb0
+
+    # Fused epilogue: addmm + GLU
+    bias = tl.load(bias_ptr + offs_n).to(tl.float32)
+    x = acc + bias[None, :]
+
+    # Wait for Y to finish loading, then read it back from the padded LDS buffer
+    tlx.async_load_wait_group(0)
+    y_regs = tlx.local_load(tlx.local_view(smemY, 0)).to(tl.float32)
+    out = x + x * y_regs
+
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    c_ptrs = c_ptr + offs_cm[:, None] * sc0 + offs_cn[None, :] * sc1
+    tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), mask=c_mask, cache_modifier=".cs")
+
+
+# Persistent warp-pipelined fused addmm + GLU kernel.
+# Each CU is launched once and loops over its share of (num_pid_m * num_pid_n) tiles
+@triton.jit
+def tlx_addmm_glu_kernel_persistent(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    XCD_CHUNK: tl.constexpr,
+    NUM_CUS: tl.constexpr,
+):
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    NUM_BUFFERS: tl.constexpr = 3
+
+    start_pid = tl.program_id(axis=0)
+
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_tiles = num_pid_m * num_pid_n
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # LDS buffers are allocated once and reused across tiles (fully drained between tiles)
+    smemA = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_BUFFERS)
+
+    # Distribute tiles among CUs
+    for tile_id in tl.range(start_pid, num_tiles, NUM_CUS):
+        # Apply XCD swizzle to the flat tile_id for L2 locality
+        swizzled = chiplet_transform_chunked(tile_id, num_tiles, NUM_XCDS, XCD_CHUNK)
+
+        # Delinearize swizzled tile_id
+        group_id = swizzled // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((swizzled % num_pid_in_group) % group_size_m)
+        pid_n = (swizzled % num_pid_in_group) // group_size_m
+
+        offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+        a_base_off = offs_m[:, None] * sa0
+        b_base_off = offs_n[None, :] * sb1
+
+        k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+
+        # Prologue: issue 3 global reads
+        k_start = 0
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 0), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 0), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+        k_start = BLOCK_SIZE_K
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 1), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 1), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+        k_start = BLOCK_SIZE_K * 2
+        a_offs = a_base_off + (k_start + offs_k[None, :]) * sa1
+        b_offs = (k_start + offs_k[:, None]) * sb0 + b_base_off
+        tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, 2), mask=offs_k[None, :] < K - k_start)
+        tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, 2), mask=offs_k[:, None] < K - k_start)
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+        # Make GR0 and GR1 finish
+        wait_tok = tlx.async_load_wait_group(1)
+
+        a_tile = tlx.local_load(tlx.local_view(smemA, 0), token=wait_tok)
+        b_tile = tlx.local_load(tlx.local_view(smemB, 0), token=wait_tok)
+
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        # Hot loop: warp-pipelined MFMA / async-prefetch
+        for i in tl.range(0, k_iters - NUM_BUFFERS, loop_unroll_factor=0):
+            prefetch_buf = i % NUM_BUFFERS
+            next_buf = (i + 1) % NUM_BUFFERS
+            k_prefetch = (i + NUM_BUFFERS) * BLOCK_SIZE_K
+
+            with tlx.warp_pipeline_stage("mfma", priority=0):
+                acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+            with tlx.warp_pipeline_stage("mem", priority=1):
+                a_offs = a_base_off + (k_prefetch + offs_k[None, :]) * sa1
+                b_offs = (k_prefetch + offs_k[:, None]) * sb0 + b_base_off
+
+                tok_a = tlx.async_load(a_ptr + a_offs, tlx.local_view(smemA, prefetch_buf), mask=offs_k[None, :]
+                                       < K - k_prefetch)
+                tok_b = tlx.async_load(b_ptr + b_offs, tlx.local_view(smemB, prefetch_buf), mask=offs_k[:, None]
+                                       < K - k_prefetch)
+
+                tlx.async_load_commit_group([tok_a, tok_b])
+
+                a_tile = tlx.local_load(tlx.local_view(smemA, next_buf), token=wait_tok)
+                b_tile = tlx.local_load(tlx.local_view(smemB, next_buf), token=wait_tok)
+
+            wait_tok = tlx.async_load_wait_group(1)
+
+        # Epilogue: drain remaining in-flight tiles
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        wait_tok = tlx.async_load_wait_group(0)
+
+        for i in tl.static_range(0, NUM_BUFFERS - 1):
+            buf = (k_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS
+            a_tile = tlx.local_load(tlx.local_view(smemA, buf), token=wait_tok)
+            b_tile = tlx.local_load(tlx.local_view(smemB, buf), token=wait_tok)
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=False)
+
+        # Fused addmm + GLU epilogue
+        bias = tl.load(bias_ptr + offs_n).to(tl.float32)
+        y_ptrs = y_ptr + offs_m[:, None] * sy0 + offs_n[None, :] * sy1
+        y = tl.load(y_ptrs, cache_modifier=".cs").to(tl.float32)
+        x = acc + bias[None, :]
+        out = x + x * y
+
+        offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+        c_ptrs = c_ptr + offs_cm[:, None] * sc0 + offs_cn[None, :] * sc1
+        tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), mask=c_mask, cache_modifier=".cs")
+
+
+def run_kernel_persistent(a, b, bias, y, out, cfg, num_cus):
+    M, K = a.shape
+    _, N = b.shape
+    grid = (min(num_cus, triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"])), )
+    return tlx_addmm_glu_kernel_persistent[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=cfg["XCD_CHUNK"],
+        NUM_CUS=num_cus,
+        num_warps=cfg["num_warps"],
+        num_stages=1,
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+    )
+
+
+def run_kernel_simple_async(a, b, bias, y, out, cfg):
+    M, K = a.shape
+    _, N = b.shape
+    grid = (triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"]), )
+    return tlx_addmm_glu_kernel_simple_async[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_XCDS=NUM_XCDS,
+        XCD_CHUNK=cfg["XCD_CHUNK"],
+        Y_PAD=Y_PAD,
+        num_warps=cfg["num_warps"],
+        num_stages=1,
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+    )
+
+
+def pytorch_baseline(bias, a, b, y):
+    # Reference: matmul (a@b) and bias add done separately, then GLU (out = x + x*y)
+    x = torch.matmul(a, b).to(torch.float32)
+    x = x + bias.to(torch.float32)[None, :]
+    return (x + x * y.to(torch.float32)).to(torch.float16)
+
+
+# Baseline Addmm kernel
+@triton.jit
+def tlx_addmm_glu_kernel_baseline(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    y_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    sa0,
+    sa1,
+    sb0,
+    sb1,
+    sy0,
+    sy1,
+    sc0,
+    sc1,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+    tl.assume(sa0 > 0)
+    tl.assume(sa1 > 0)
+    tl.assume(sb0 > 0)
+    tl.assume(sb1 > 0)
+    tl.assume(sy0 > 0)
+    tl.assume(sy1 > 0)
+    tl.assume(sc0 > 0)
+    tl.assume(sc1 > 0)
+
+    offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + offs_m[:, None] * sa0 + offs_k[None, :] * sa1
+    b_ptrs = b_ptr + offs_k[:, None] * sb0 + offs_n[None, :] * sb1
+    k_iters = tl.cdiv(K, BLOCK_SIZE_K)
+
+    buffers_a = tlx.local_alloc((BLOCK_SIZE_M, BLOCK_SIZE_K), tlx.dtype_of(a_ptr), NUM_STAGES - 1)
+    buffers_b = tlx.local_alloc((BLOCK_SIZE_K, BLOCK_SIZE_N), tlx.dtype_of(b_ptr), NUM_STAGES - 1)
+
+    # TLX prologue: prefetch the first stages from HBM into LDS.
+    for stage in tl.range(0, NUM_STAGES - 1, loop_unroll_factor=NUM_STAGES - 1):
+        a_smem = tlx.local_view(buffers_a, stage)
+        b_smem = tlx.local_view(buffers_b, stage)
+        a_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - stage * BLOCK_SIZE_K, other=0.0)
+        b_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - stage * BLOCK_SIZE_K, other=0.0)
+        tlx.local_store(a_smem, a_reg)
+        tlx.local_store(b_smem, b_reg)
+        a_ptrs += BLOCK_SIZE_K * sa1
+        b_ptrs += BLOCK_SIZE_K * sb0
+
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in tl.range(NUM_STAGES - 1, k_iters, num_stages=0):
+        a_smem = tlx.local_view(buffers_a, k % (NUM_STAGES - 1))
+        b_smem = tlx.local_view(buffers_b, k % (NUM_STAGES - 1))
+        a_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b_reg = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+
+        prev = (k % (NUM_STAGES - 1))
+        a_prev = tlx.local_load(tlx.local_view(buffers_a, prev))
+        b_prev = tlx.local_load(tlx.local_view(buffers_b, prev))
+        acc = tl.dot(a_prev, b_prev, acc)
+
+        tlx.local_store(a_smem, a_reg)
+        tlx.local_store(b_smem, b_reg)
+        a_ptrs += BLOCK_SIZE_K * sa1
+        b_ptrs += BLOCK_SIZE_K * sb0
+
+    for k in tl.range(k_iters - (NUM_STAGES - 1), k_iters, loop_unroll_factor=NUM_STAGES - 1):
+        buf = k % (NUM_STAGES - 1)
+        a_prev = tlx.local_load(tlx.local_view(buffers_a, buf))
+        b_prev = tlx.local_load(tlx.local_view(buffers_b, buf))
+        acc = tl.dot(a_prev, b_prev, acc)
+
+    # === Fused epilogue: addmm + GLU ===
+    ocm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    ocn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    cmask = (ocm[:, None] < M) & (ocn[None, :] < N)
+
+    bias = tl.load(bias_ptr + ocn, mask=ocn < N, other=0.0).to(tl.float32)
+    x = acc + bias[None, :]
+
+    y_ptrs = y_ptr + ocm[:, None] * sy0 + ocn[None, :] * sy1
+    y = tl.load(y_ptrs, mask=cmask, other=0.0).to(tl.float32)
+    out = x + x * y
+
+    c_ptrs = c_ptr + ocm[:, None] * sc0 + ocn[None, :] * sc1
+    tl.store(c_ptrs, out.to(c_ptr.dtype.element_ty), mask=cmask)
+
+
+def run_kernel_baseline(bias, a, b, y, cfg):
+    M, K = a.shape
+    K2, N = b.shape
+    out = torch.empty((M, N), device=a.device, dtype=torch.float16)
+    grid = (triton.cdiv(M, cfg["BLOCK_SIZE_M"]) * triton.cdiv(N, cfg["BLOCK_SIZE_N"]), )
+    tlx_addmm_glu_kernel_baseline[grid](
+        a,
+        b,
+        bias,
+        y,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        y.stride(0),
+        y.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_M=cfg["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=cfg["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=cfg["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=cfg["GROUP_SIZE_M"],
+        NUM_STAGES=cfg["NUM_STAGES"],
+        num_warps=cfg["num_warps"],
+        matrix_instr_nonkdim=cfg.get("matrix_instr_nonkdim", 0),
+        waves_per_eu=cfg.get("waves_per_eu", 0),
+        kpack=cfg.get("kpack", 1),
+    )
+    return out
+
+
+def run_baseline(a, b, bias, y):
+    K = b.shape[0]
+    return run_kernel_baseline(bias, a, b, y, BASELINE_BEST_CONFIG[K])
+
+
+def run_optimized(a, b, bias, y):
+    K = b.shape[0]
+    out = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float16)
+    run_kernel_optimized(a, b, bias, y, out, BEST_CONFIG[K])
+    return out
+
+
+def run_optimized_async(a, b, bias, y):
+    K = b.shape[0]
+    out = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float16)
+    run_kernel_optimized_async(a, b, bias, y, out, ASYNC_BEST_CONFIG[K])
+    return out
+
+
+def run_persistent(a, b, bias, y):
+    K = b.shape[0]
+    out = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float16)
+    num_cus = torch.cuda.get_device_properties(a.device).multi_processor_count
+    run_kernel_persistent(a, b, bias, y, out, PERSISTENT_BEST_CONFIG[K], num_cus)
+    return out
+
+
+def run_simple_async(a, b, bias, y):
+    K = b.shape[0]
+    out = torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=torch.float16)
+    run_kernel_simple_async(a, b, bias, y, out, SIMPLE_BEST_CONFIG[K])
+    return out
+
+
+KERNEL_REGISTRY = {
+    "tlx_baseline": run_baseline,
+    "tlx_simple_async": run_simple_async,
+    "tlx_optimized_async": run_optimized_async,
+    "tlx_optimized": run_optimized,
+    "tlx_persistent": run_persistent,
+}
+
+
+def get_kernel(name):
+    if name not in KERNEL_REGISTRY:
+        raise ValueError(f"Unknown kernel: {name!r}. "
+                         f"Available: {list(KERNEL_REGISTRY.keys())}")
+    return KERNEL_REGISTRY[name]
+
+
+def verify(name, got, ref, atol=2e-2, rtol=2e-2, log=True):
+    diff = (got.float() - ref.float()).abs()
+    ok = torch.allclose(ref, got, atol=atol, rtol=rtol)
+    max_err = diff.max().item()
+    mean_err = diff.mean().item()
+    status = "PASS" if ok else "FAIL"
+    if log:
+        print(f"  {name:<28} {status}  max={max_err:.6f}  mean={mean_err:.6f}")
+    return ok
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Performance regression guard
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Baseline TFLOPS measured on gfx950/MI350 (fp16, M=1024, N=21568). A kernel must
+# stay within PERF_TOL below its baseline or the perf test fails (catches
+# regressions). Regenerate the numbers with:
+#   python amd-addmm-glu-opt_test.py
+# then copy the printed Summary table values here.
+PERF_TOL = 0.15  # allow 15% slack below baseline (run-to-run noise + minor drift)
+
+# key: (kernel, K) -> TFLOPS
+PERF_BASELINE_TFLOPS = {
+    ("tlx_baseline", 256): 237,
+    ("tlx_baseline", 512): 355,
+    ("tlx_baseline", 1024): 459,
+    ("tlx_simple_async", 256): 169,
+    ("tlx_simple_async", 512): 269,
+    ("tlx_simple_async", 1024): 349,
+    ("tlx_optimized_async", 256): 181,
+    ("tlx_optimized_async", 512): 279,
+    ("tlx_optimized_async", 1024): 406,
+    ("tlx_optimized", 256): 280,
+    ("tlx_optimized", 512): 442,
+    ("tlx_optimized", 1024): 597,
+    ("tlx_persistent", 256): 298,
+    ("tlx_persistent", 512): 449,
+    ("tlx_persistent", 1024): 613,
+}
+
+
+def measure_tflops(kernel_fn, M, N, K):
+    """Verify correctness then return achieved TFLOPS for one config."""
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+    bias = torch.randn(N, device=DEVICE, dtype=torch.float16)
+    y = torch.randn(M, N, device=DEVICE, dtype=torch.float16)
+    ref = pytorch_baseline(bias, a, b, y)
+    fn = lambda: kernel_fn(a, b, bias, y)
+    assert verify("", fn(), ref, log=False), "correctness check failed"
+    ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+    total_flops = 2.0 * M * N * K
+    return total_flops / ms * 1e-9
+
+
+@pytest.mark.parametrize("K", sorted(BEST_CONFIG))
+@pytest.mark.parametrize("kernel_name", list(KERNEL_REGISTRY))
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_addmm_glu_performance(kernel_name, K):
+    """Guard against perf regressions: achieved TFLOPS must stay within PERF_TOL
+    of the recorded gfx950 baseline (M=1024, N=21568, fp16)."""
+    baseline = PERF_BASELINE_TFLOPS[(kernel_name, K)]
+    floor = baseline * (1 - PERF_TOL)
+    got = measure_tflops(get_kernel(kernel_name), M, N, K)
+    print(f"  {kernel_name:20s} K={K:5d} {got:7.1f} TFLOPS (baseline {baseline}, floor {floor:.1f})")
+    assert got >= floor, (f"perf regression: {kernel_name} K={K} -> "
+                          f"{got:.1f} TFLOPS < floor {floor:.1f} (baseline {baseline}, tol {PERF_TOL:.0%})")
+
+
+def run_perf_test(args):
+    """CLI entry: run the perf guard over all baseline configs, print a report,
+    and return True iff every kernel is within PERF_TOL of its baseline."""
+    tol = args.perf_tol
+    all_ok = True
+    print(f"\nPerformance regression test (floor = baseline * (1 - {tol:.0%}))")
+    print("-" * 78)
+    for (kernel_name, K), baseline in sorted(PERF_BASELINE_TFLOPS.items()):
+        floor = baseline * (1 - tol)
+        try:
+            got = measure_tflops(get_kernel(kernel_name), M, N, K)
+        except Exception as e:
+            all_ok = False
+            print(f"  [FAIL] {kernel_name:20s} K={K:5d} -> ERROR ({e})")
+            continue
+        ok = got >= floor
+        all_ok &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] {kernel_name:20s} K={K:5d} "
+              f"{got:7.1f} TFLOPS (baseline {baseline}, floor {floor:.1f})")
+    print("-" * 78)
+    print("RESULT:", "PASS" if all_ok else "FAIL")
+    assert all_ok
+
+
+def print_summary_table(results, providers):
+    """Print a markdown-style summary table of benchmark results."""
+    rows = [(f"M={m} N={n} K={k}", results[(m, n, k)]) for (m, n, k) in sorted(results.keys())]
+
+    cfg_w = max(len("Config"), *(len(lbl) for lbl, _ in rows)) if rows else len("Config")
+    col_w = max(14, *(len(p) for p in providers))
+
+    hdr = f"| {'Config':<{cfg_w}} |" + "".join(f" {p:>{col_w}} |" for p in providers)
+    sep = f"|{'-' * (cfg_w + 2)}|" + "".join(f"{'-' * (col_w + 2)}|" for _ in providers)
+
+    print(f"\n{'=' * len(sep)}")
+    print("Summary (TFLOPS)   fp16")
+    print(f"{'=' * len(sep)}")
+    print(hdr)
+    print(sep)
+
+    for label, prov in rows:
+        vals = (f"{prov[p]['tflops']:>{col_w}.1f}" if p in prov else f"{'—':>{col_w}}" for p in providers)
+        print(f"| {label:<{cfg_w}} |" + "".join(f" {v} |" for v in vals))
+
+    print(f"{'=' * len(sep)}\n")
+
+
+def run_benchmark(args):
+    results = {}
+
+    for M in args.M:
+        for N in args.N:
+            for K in args.K:
+                torch.manual_seed(0)
+                a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+                b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+                bias = torch.randn(N, device=DEVICE, dtype=torch.float16)
+                y = torch.randn(M, N, device=DEVICE, dtype=torch.float16)
+
+                total_flops = 2.0 * M * N * K
+                ref = pytorch_baseline(bias, a, b, y)
+
+                key = (M, N, K)
+                results[key] = {}
+
+                # PyTorch reference: naive matmul + add, then GLU
+                pt_lambda = lambda: pytorch_baseline(bias, a, b, y)
+                ms = triton.testing.do_bench(pt_lambda, warmup=25, rep=100)
+                results[key]["PyTorch_naive"] = {"ms": ms, "tflops": total_flops / ms * 1e-9}
+
+                # Selected TLX kernels (verified against PyTorch reference)
+                for kernel_name in args.kernel:
+                    kernel_fn = get_kernel(kernel_name)
+                    try:
+                        k_lambda = lambda fn=kernel_fn: fn(a, b, bias, y)
+                        out = k_lambda()
+                        assert verify("", out, ref, log=False)
+                    except Exception as e:
+                        print(f"  {kernel_name:20s} M={M:5d} N={N:5d} K={K:5d} -> SKIPPED ({e})")
+                        continue
+                    ms = triton.testing.do_bench(k_lambda, warmup=25, rep=100)
+                    results[key][kernel_name] = {"ms": ms, "tflops": total_flops / ms * 1e-9}
+
+                # ROCBLAS reference: pure matmul (no add/GLU)
+                rb_lambda = lambda: torch.matmul(a, b)
+                ms = triton.testing.do_bench(rb_lambda, warmup=25, rep=100)
+                results[key]["ROCBLAS (matmul only)"] = {"ms": ms, "tflops": total_flops / ms * 1e-9}
+
+    providers = ["PyTorch_naive"] + list(args.kernel) + ["ROCBLAS (matmul only)"]
+    print_summary_table(results, providers)
+
+
+def parse_args():
+    k_choices = sorted(BEST_CONFIG)
+    kernel_choices = list(KERNEL_REGISTRY)
+    p = argparse.ArgumentParser(prog="AMD TLX Addmm+GLU")
+    p.add_argument("-M", type=int, nargs="+", default=[M], help="M (rows of A / output) sizes to benchmark")
+    p.add_argument("-N", type=int, nargs="+", default=[N], help="N (cols of B / output) sizes to benchmark")
+    p.add_argument("-K", type=int, nargs="+", default=k_choices, choices=k_choices,
+                   help="K (contraction) sizes to benchmark; only stored-config sizes are supported")
+    p.add_argument("--kernel", type=str, nargs="+", default=kernel_choices, choices=kernel_choices,
+                   help="Kernel variants to benchmark")
+    p.add_argument("--mode", choices=["benchmark", "perf_test"], default="benchmark",
+                   help="benchmark: print TFLOPS table; perf_test: assert TFLOPS within PERF_TOL of baseline")
+    p.add_argument("--perf-tol", dest="perf_tol", type=float, default=PERF_TOL,
+                   help="perf_test slack below baseline (e.g. 0.15 = allow 15%% regression)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.mode == "perf_test":
+        run_perf_test(args)
+    else:
+        run_benchmark(args)

--- a/third_party/tlx/tutorials/amd-fa-pipelined_test.py
+++ b/third_party/tlx/tutorials/amd-fa-pipelined_test.py
@@ -1,0 +1,1139 @@
+"""
+AMD Flash Attention Forward — Async DMA Kernel (CDNA4)
+============================================================
+
+Usage:
+    # Defaults: -b 1 -hq 64 -sq 1024 8192 16384 -d 64 128 -causal false --kernel async_simple
+    python amd-fa-pipelined_test.py
+
+    # Sweep sequence lengths and head dims
+    python amd-fa-pipelined_test.py -sq 512 1024 4096 -d 64 128
+
+    # Both causal modes, multiple batch sizes
+    python amd-fa-pipelined_test.py -b 1 2 -causal true false
+
+    # Multiple kernels
+    python amd-fa-pipelined_test.py --kernel async_simple --dtype fp16
+"""
+
+import argparse
+import math
+import pytest
+import torch
+import torch.nn.functional as F
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton._internal_testing import is_hip_cdna4
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# These kernels are gfx950/MI350 (CDNA4)-specific and do not lower on
+# gfx942/MI300, so the tests are gated to CDNA4 hardware.
+_requires_cdna4 = pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+
+
+@triton.jit
+def _assume_strides(
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+):
+    tl.assume(stride_qz >= 0)
+    tl.assume(stride_qh >= 0)
+    tl.assume(stride_qm > 0)
+    tl.assume(stride_qk >= 0)
+    tl.assume(stride_kz >= 0)
+    tl.assume(stride_kh >= 0)
+    tl.assume(stride_kn > 0)
+    tl.assume(stride_kk >= 0)
+    tl.assume(stride_vz >= 0)
+    tl.assume(stride_vh >= 0)
+    tl.assume(stride_vn > 0)
+    tl.assume(stride_vk >= 0)
+    tl.assume(stride_oz >= 0)
+    tl.assume(stride_oh >= 0)
+    tl.assume(stride_om > 0)
+    tl.assume(stride_ok >= 0)
+
+
+@triton.jit
+def _attn_fwd_async_simple(
+    Q,
+    K,
+    V,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    Z,
+    H,
+    N_CTX,
+    sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    _assume_strides(stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh, stride_kn, stride_kk, stride_vz,
+                    stride_vh, stride_vn, stride_vk, stride_oz, stride_oh, stride_om, stride_ok)
+
+    pid_m = tl.program_id(0)
+    pid_hz = tl.program_id(1)
+    off_z = pid_hz // H
+    off_h = pid_hz % H
+
+    q_off = off_z * stride_qz + off_h * stride_qh
+    k_off = off_z * stride_kz + off_h * stride_kh
+    v_off = off_z * stride_vz + off_h * stride_vh
+    o_off = off_z * stride_oz + off_h * stride_oh
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk, mask=offs_m[:, None] < N_CTX,
+                other=0.0)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    QK_SCALE = sm_scale * 1.44269504089
+
+    if IS_CAUSAL:
+        hi = min(N_CTX, (pid_m + 1) * BLOCK_M)
+    else:
+        hi = N_CTX
+
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, 1)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, 1)
+
+    k_base = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+    v_base = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
+
+    for start_n in tl.range(0, hi, BLOCK_N, num_stages=0):
+        kn = start_n + offs_n
+        k_mask = kn[:, None] < N_CTX
+        v_mask = kn[:, None] < N_CTX
+
+        tok_k = tlx.async_load(k_base + start_n * stride_kn, tlx.local_view(k_buf, 0), mask=k_mask)
+        tok_v = tlx.async_load(v_base + start_n * stride_vn, tlx.local_view(v_buf, 0), mask=v_mask)
+        tlx.async_load_commit_group([tok_k, tok_v])
+
+        wait_tok = tlx.async_load_wait_group(0)
+        # Transpose K at the memdesc level (metadata-only) so local_load lands
+        # directly in dot_op(opIdx=1) layout — skips the register-shuffle + LDS
+        # round-trip that `tl.dot(q, k_cur.T)` would otherwise emit.
+        kt_view = tlx.local_trans(tlx.local_view(k_buf, 0))
+        kt_cur = tlx.local_load(kt_view, token=wait_tok)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, 0), token=wait_tok)
+
+        qk = tl.dot(q, kt_cur)
+        if IS_CAUSAL:
+            qk = tl.where(offs_m[:, None] >= kn[None, :], qk, float("-inf"))
+        qk = tl.where(kn[None, :] < N_CTX, qk, float("-inf"))
+
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+        qk = qk * QK_SCALE - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        l_ij = tl.sum(p, 1)
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+        acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+
+    acc = acc / l_i[:, None]
+    o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+
+
+@triton.jit
+def _attn_fwd_async_prefetch(
+    Q,
+    K,
+    V,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    Z,
+    H,
+    N_CTX,
+    sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    """
+    Prefetch flash attention with explicit modulo-scheduled prologue,
+    hot loop (steady state), and epilogue.
+
+    Design notes:
+      * K and V are both double-buffered (2 LDS slots, alternating index
+        i%2).
+      * `local_trans` is applied to K so `local_load` lands directly in
+        dot-operand layout 1, skipping the per-iter ds_write+barrier+
+        ds_read shuffle that `tl.dot(q, k_cur.T)` would emit.
+    Prologue:
+    t = 0
+    [GLDS_KV]
+
+    Steady State (Hot Loop):
+    t = i               t = i+1
+    [LR_KV]
+    [QK, SM0, SM1, PV]  [GLDS_KV],
+    Epilogue:
+                        t = i+1
+                        [LR_KV]
+                        [QK (masked), SM0, SM1, PV]
+    """
+    _assume_strides(stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh, stride_kn, stride_kk, stride_vz,
+                    stride_vh, stride_vn, stride_vk, stride_oz, stride_oh, stride_om, stride_ok)
+
+    pid_m = tl.program_id(0)
+    pid_hz = tl.program_id(1)
+    off_z = pid_hz // H
+    off_h = pid_hz % H
+
+    q_off = off_z * stride_qz + off_h * stride_qh
+    k_off = off_z * stride_kz + off_h * stride_kh
+    v_off = off_z * stride_vz + off_h * stride_vh
+    o_off = off_z * stride_oz + off_h * stride_oh
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk, mask=offs_m[:, None] < N_CTX,
+                other=0.0)
+
+    QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
+
+    if IS_CAUSAL:
+        hi = min(N_CTX, (pid_m + 1) * BLOCK_M)
+    else:
+        hi = N_CTX
+
+    # K and V: 2 LDS slots each (double-buffered) -- avoids both the
+    # memdesc_trans alias race for K and any single-buf RAW hazards.
+    NUM_BUFFERS: tl.constexpr = 2
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, NUM_BUFFERS)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, NUM_BUFFERS)
+
+    k_ptrs = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+    v_ptrs = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
+
+    n_blocks = (hi + BLOCK_N - 1) // BLOCK_N
+    n_main = tl.maximum(n_blocks - 1, 0)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    """
+    Prologue:
+    t = 0
+    [GLDS_KV]
+    """
+    tok_k0 = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0), mask=offs_n[:, None] < N_CTX)
+    tok_v0 = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0), mask=offs_n[:, None] < N_CTX)
+    tlx.async_load_commit_group([tok_k0, tok_v0])
+    """
+    Steady State (Hot Loop):
+    t = i               t = i+1
+    [LR_KV]
+    [QK, SM0, SM1, PV]  [GLDS_KV],
+    """
+    for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=0):
+        next_off = block_id + BLOCK_N
+        kn = block_id + offs_n
+        next_mask = (next_off + offs_n[:, None]) < N_CTX
+
+        i = block_id // BLOCK_N
+        slot_cur = i % 2
+        slot_nxt = (i + 1) % 2
+
+        # LR_KV_ti
+        wait_tok = tlx.async_load_wait_group(0)
+        kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_cur))
+        kt_cur = tlx.local_load(kt_view, token=wait_tok)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok)
+
+        # GLDS_KV_t(i+1), prefetch tile i+1 into the *other* slots.
+        tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, slot_nxt), mask=next_mask)
+        tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, slot_nxt), mask=next_mask)
+        tlx.async_load_commit_group([tok_k, tok_v])
+
+        # QK_ti
+        qk = tl.dot(q, kt_cur)
+        if IS_CAUSAL:
+            qk = tl.where(offs_m[:, None] >= kn[None, :], qk, float("-inf"))
+
+        # SM_ti
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+        p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
+        l_ij = tl.sum(p, 1)
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+
+        # PV_ti
+        acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+    """
+    Epilogue:
+    t = i+1
+    [LR_KV]
+    [QK (masked), SM0, SM1, PV]
+    """
+    # Consume tile n_main from slot (n_main % 2).
+    wait_tok = tlx.async_load_wait_group(0)
+    slot_last = n_main % 2
+    kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_last))
+    kt_cur = tlx.local_load(kt_view, token=wait_tok)
+    v_cur = tlx.local_load(tlx.local_view(v_buf, slot_last), token=wait_tok)
+
+    # QK_t(i+1) — with boundary + causal masking
+    kn_last = n_main * BLOCK_N + offs_n
+    qk = tl.dot(q, kt_cur)
+    qk = tl.where(kn_last[None, :] < N_CTX, qk, float("-inf"))
+    if IS_CAUSAL:
+        qk = tl.where(offs_m[:, None] >= kn_last[None, :], qk, float("-inf"))
+
+    # SM0_t(i+1)
+    m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+    p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
+    l_ij = tl.sum(p, 1)
+
+    # SM1_t(i+1)
+    alpha = tl.math.exp2(m_i - m_ij)
+    acc = acc * alpha[:, None]
+    l_i = l_i * alpha + l_ij
+    m_i = m_ij
+
+    # PV_t(i+1)
+    acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+
+    # Store output
+    acc = acc / l_i[:, None]
+    o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+
+
+@triton.jit
+def _async_prefetch_attn_tile(
+    pid_m,
+    q_off,
+    k_off,
+    v_off,
+    o_off,
+    Q,
+    K,
+    V,
+    Out,
+    k_buf,
+    v_buf,
+    stride_qm,
+    stride_qk,
+    stride_kn,
+    stride_kk,
+    stride_vn,
+    stride_vk,
+    stride_om,
+    stride_ok,
+    N_CTX_Q,
+    N_CTX_K,
+    DIAG_OFFSET,
+    QK_SCALE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    EVEN_N: tl.constexpr,
+):
+    """
+    Function to compute Compute one output m-tile — causal (peeled mask) or non-causal (full).
+    Using similar algorithm/optimizations to previous async_prefetch, but with additions of:
+
+    - Peeled last iteration of loop to have steady state not need masking or OOB check.
+    - Supports `q_len != kv_len` (cross-attention / decode). Query row `qpos`
+      attends key `kpos` iff `kpos <= qpos + DIAG_OFFSET`, where
+      `DIAG_OFFSET = kv_len - q_len` (bottom-right alignment).
+
+    """
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q = tl.load(Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk, mask=offs_m[:, None] < N_CTX_Q,
+                other=0.0)
+
+    if IS_CAUSAL:
+        # Largest key any query in this tile may attend, +1 (exclusive bound).
+        hi = min(N_CTX_K, (pid_m + 1) * BLOCK_M + DIAG_OFFSET)
+    else:
+        hi = N_CTX_K
+
+    k_ptrs = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+    v_ptrs = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
+
+    n_blocks = (hi + BLOCK_N - 1) // BLOCK_N
+    if IS_CAUSAL:
+        # Blocks fully below the diagonal for the *smallest* query row in the
+        # tile (conservative: any block we skip masking on is unmasked for every
+        # row). Reduces to (pid_m*BLOCK_M)//BLOCK_N when DIAG_OFFSET == 0.
+        n_unmasked = (pid_m * BLOCK_M + DIAG_OFFSET) // BLOCK_N
+        n_unmasked = tl.maximum(tl.minimum(n_unmasked, n_blocks), 0)
+    elif EVEN_N:
+        # No mask anywhere -> the whole range is the steady-state loop.
+        n_unmasked = n_blocks
+    else:
+        # Only the final ragged block needs a boundary mask.
+        n_unmasked = tl.maximum(n_blocks - 1, 0)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    # Prologue: prefetch block 0.
+    tok_k0 = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0), mask=offs_n[:, None] < N_CTX_K)
+    tok_v0 = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0), mask=offs_n[:, None] < N_CTX_K)
+    tlx.async_load_commit_group([tok_k0, tok_v0])
+    """
+    Unmasked steady-state loop
+    """
+    for block_id in tl.range(0, n_unmasked * BLOCK_N, BLOCK_N, num_stages=0):
+        next_off = block_id + BLOCK_N
+        i = block_id // BLOCK_N
+        slot_cur = i % 2
+        slot_nxt = (i + 1) % 2
+
+        wait_tok = tlx.async_load_wait_group(0)
+        kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_cur))
+        kt_cur = tlx.local_load(kt_view, token=wait_tok)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok)
+
+        next_mask = (next_off + offs_n[:, None]) < N_CTX_K
+        tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, slot_nxt), mask=next_mask)
+        tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, slot_nxt), mask=next_mask)
+        tlx.async_load_commit_group([tok_k, tok_v])
+
+        qk = tl.dot(q, kt_cur)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+        p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
+        l_ij = tl.sum(p, 1)
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+        acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+    """
+    Masked peeled epilogue
+    """
+    for block_id in tl.range(n_unmasked * BLOCK_N, n_blocks * BLOCK_N, BLOCK_N, num_stages=0):
+        next_off = block_id + BLOCK_N
+        kn = block_id + offs_n
+        i = block_id // BLOCK_N
+        slot_cur = i % 2
+        slot_nxt = (i + 1) % 2
+
+        wait_tok = tlx.async_load_wait_group(0)
+        kt_view = tlx.local_trans(tlx.local_view(k_buf, slot_cur))
+        kt_cur = tlx.local_load(kt_view, token=wait_tok)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok)
+
+        if next_off < hi:
+            next_mask = (next_off + offs_n[:, None]) < N_CTX_K
+            tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, slot_nxt), mask=next_mask)
+            tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, slot_nxt), mask=next_mask)
+            tlx.async_load_commit_group([tok_k, tok_v])
+
+        qk = tl.dot(q, kt_cur)
+        if IS_CAUSAL:
+            qk = tl.where(offs_m[:, None] + DIAG_OFFSET >= kn[None, :], qk, float("-inf"))
+        if not EVEN_N:
+            qk = tl.where(kn[None, :] < N_CTX_K, qk, float("-inf"))
+
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * QK_SCALE)
+        p = tl.math.exp2(qk * QK_SCALE - m_ij[:, None])
+        l_ij = tl.sum(p, 1)
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+        acc = tl.dot(p.to(v_cur.dtype), v_cur, acc)
+
+    acc = acc / l_i[:, None]
+    o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX_Q) & (offs_d[None, :] < HEAD_DIM))
+
+
+@triton.jit
+def _attn_fwd_persistent(
+    Q,
+    K,
+    V,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    Z,
+    H,
+    N_CTX_Q,
+    N_CTX_K,
+    DIAG_OFFSET,
+    sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    NUM_M_BLOCKS: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    EVEN_N: tl.constexpr,
+):
+    """
+    Persistent FA with these key features:
+    1. Aysnc prefetch work tile
+    2. XCD-pinned head-batch dim for improved L2 locality
+    3. zig-zag ordering of output/work tile for each workunit wihtin a WG,
+       for equal work distribution per WG and improved causal performance.
+
+    Ownership hierarchy (coarse -> fine), all derived from one flat `unit` index.
+    Examples use N=1024 causal defaults (BLOCK_M=256 -> 4 tiles/head, 64 heads,
+    8 XCDs, 32 programs/XCD, TILES_PER_UNIT=2 -> units_per_head=2, 16 units/XCD):
+
+    - XCD owns `heads_per_xcd` batch-heads (those with `hz % NUM_XCDS == xcd`),
+      i.e. a flat pile of `units = heads_per_xcd * units_per_head` work-units.
+        e.g. XCD 0 owns heads {0,8,16,...,56} -> 16 units.
+
+    - Local (one of the XCD's `NUM_LOCAL` workgroups) owns
+      a round-robin slice of that pile: units `local, local+NUM_LOCAL, ...`.
+        e.g. WG local=2 owns unit 2 (here 16 units < 32 programs, so local>=16 idle).
+
+    - Unit -> global work-unit id within the whole XCD; `bundle` = which work-unit within a head): `local_head = unit //
+      units_per_head` picks the head (global `pid_hz = xcd + local_head *
+      NUM_XCDS`), and `bundle = unit % units_per_head` picks the tile-group
+      within that head.
+        e.g. unit 2 -> local_head=1 -> head 8, bundle=0.
+
+    - Bundle owns `TILES_PER_UNIT` zig-zag tiles (causal: a {light, heavy} fold
+      pair of constant cost; non-causal: a single tile).
+        e.g. bundle 0 -> zig-zag {0,1} -> tiles {m0, m3} of head 8.
+
+    - Tile = `BLOCK_M` query rows of that head, streamed over its `BLOCK_N`
+      K-blocks (the inner `_async_prefetch_attn_tile` loop) to produce one output tile.
+        e.g. m0 -> rows 0..255, 4 K-blocks; m3 -> rows 768..1023, 16 (sum=20, flat).
+    """
+    _assume_strides(stride_qz, stride_qh, stride_qm, stride_qk, stride_kz, stride_kh, stride_kn, stride_kk, stride_vz,
+                    stride_vh, stride_vn, stride_vk, stride_oz, stride_oh, stride_om, stride_ok)
+
+    # Note since it is persistent, we only launch 1-dim of PIDs (NUM_SMs,).
+    pid = tl.program_id(0)
+    xcd = pid % NUM_XCDS
+    local = pid // NUM_XCDS
+    NUM_LOCAL: tl.constexpr = NUM_SMS // NUM_XCDS
+
+    NUM_BUFFERS: tl.constexpr = 2
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, NUM_BUFFERS)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, NUM_BUFFERS)
+
+    QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
+
+    # Causal: 2-tile {light, heavy} fold bundles (constant cost). Non-causal:
+    # 1-tile units (tiles are already equal-cost, so no bundling is needed).
+    TILES_PER_UNIT: tl.constexpr = 2 if IS_CAUSAL else 1
+
+    # We flattened head and batch dim into a single flat HZ work dim.
+    # Then, we pin specific HZ ids to a XCD for K/V L2 locality.
+    units_per_hz: tl.constexpr = (NUM_M_BLOCKS + TILES_PER_UNIT - 1) // TILES_PER_UNIT
+    hz_per_xcd = (Z * H + NUM_XCDS - 1) // NUM_XCDS
+    units = hz_per_xcd * units_per_hz
+    for unit in tl.range(local, units, NUM_LOCAL, num_stages=0):
+        local_hz = unit // units_per_hz  # which head-batch id (quotient)
+        bundle = unit % units_per_hz  # quer_seq/m tiles within head-batch id (remainder)
+        pid_hz = xcd + local_hz * NUM_XCDS  # global head-batch id.
+        if pid_hz < Z * H:
+            off_z = pid_hz // H
+            off_h = pid_hz % H
+            q_off = off_z * stride_qz + off_h * stride_qh
+            k_off = off_z * stride_kz + off_h * stride_kh
+            v_off = off_z * stride_vz + off_h * stride_vh
+            o_off = off_z * stride_oz + off_h * stride_oh
+
+            # Run the bundle's TILES_PER_UNIT consecutive zig-zag tiles.
+            # If causal and TILES_PER_UNIT=2, then head's m-tiles are walked
+            # as `0, N-1, 1, N-2, …`. This interleaves the lightest and heaviest
+            # causal tiles, making each WG do ~same amount of work.
+            for j in tl.static_range(TILES_PER_UNIT):
+                idx = bundle * TILES_PER_UNIT + j
+                if idx < NUM_M_BLOCKS:
+                    half = idx // 2
+                    pid_m = tl.where(idx % 2 == 0, half, NUM_M_BLOCKS - 1 - half)
+                    _async_prefetch_attn_tile(pid_m, q_off, k_off, v_off, o_off, Q, K, V, Out, k_buf, v_buf, stride_qm,
+                                              stride_qk, stride_kn, stride_kk, stride_vn, stride_vk, stride_om,
+                                              stride_ok, N_CTX_Q, N_CTX_K, DIAG_OFFSET, QK_SCALE=QK_SCALE,
+                                              BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM, IS_CAUSAL=IS_CAUSAL,
+                                              EVEN_N=EVEN_N)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Host wrapper
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def flash_attn_async_simple(q, k, v, sm_scale, causal=False, **kw):
+    """Launch with K in original BHND layout — stride_kk=1 avoids alignment issues."""
+    B, H, N_CTX, D = q.shape
+    o = torch.empty_like(q)
+
+    BLOCK_M = kw.pop("BLOCK_M", 256)
+    BLOCK_N = kw.pop("BLOCK_N", 64)
+    num_warps = kw.pop("num_warps", 4)
+
+    grid = (triton.cdiv(N_CTX, BLOCK_M), B * H)
+    _attn_fwd_async_simple[grid](
+        q,
+        k,
+        v,
+        o,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        o.stride(3),
+        B,
+        H,
+        N_CTX,
+        sm_scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        HEAD_DIM=D,
+        IS_CAUSAL=causal,
+        num_warps=num_warps,
+        **kw,
+    )
+    return o
+
+
+def flash_attn_async_prefetch(q, k, v, sm_scale, causal=False, **kw):
+    """Prefetch FA with modulo-scheduled prologue/hot-loop/epilogue."""
+    B, H, N_CTX, D = q.shape
+    o = torch.empty_like(q)
+
+    BLOCK_M = kw.pop("BLOCK_M", 256)
+    # BLOCK_N=128 wins at D=64 nocausal (more compute per barrier),
+    # but the diagonal masking cost overwhelms that for causal, and at
+    # D=128 it blows the 64KB LDS budget for double-buffered K+V.
+    BLOCK_N = kw.pop("BLOCK_N", 128 if (D <= 64 and not causal) else 64)
+    num_warps = kw.pop("num_warps", 4)
+
+    grid = (triton.cdiv(N_CTX, BLOCK_M), B * H)
+    _attn_fwd_async_prefetch[grid](
+        q,
+        k,
+        v,
+        o,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        o.stride(3),
+        B,
+        H,
+        N_CTX,
+        sm_scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        HEAD_DIM=D,
+        IS_CAUSAL=causal,
+        num_warps=num_warps,
+        **kw,
+    )
+    return o
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Kernel registry — add new kernel wrappers here
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def flash_attn_persistent(q, k, v, sm_scale, causal=False, **kw):
+    """persistent FA with workgroup scheduler who is persistent and have a zig-zag tile order.
+
+    FA with a workgroup scheduler who is persistent, XCD-grouped,
+    with constant-cost fold-bundling scheduler (zig-zag tile order + `TILES_PER_UNIT` bundle).
+    Causal uses 2-tile fold bundles non-causal uses 1-tile
+    units (tiles are already equal-cost). A program runs a *variable* number of
+    tiles, not a fixed 2.
+
+    Supports `q_len != kv_len` (cross-attention / decode): the causal diagonal is
+    anchored bottom-right via `DIAG_OFFSET = kv_len - q_len` (matching PyTorch
+    SDPA). Q heads and K/V heads must match (no GQA yet).
+
+    Falls back to the square baseline for partial-block N (`N % BLOCK_N != 0`) to
+    dodge the modulo-decode `iota_range` compiler crash (not perf-critical).
+    """
+    B, H, N_CTX_Q, D = q.shape
+    N_CTX_K = k.shape[2]
+    diag_offset = N_CTX_K - N_CTX_Q
+
+    BLOCK_M = kw.pop("BLOCK_M", 256)
+    # Peeled causal + non-causal both prefer BLOCK_N=128 at D<=64 (more compute
+    # per LDS barrier); D=128 must stay 64 for the double-buffered K+V LDS budget.
+    BLOCK_N = kw.pop("BLOCK_N", 128 if D <= 64 else 64)
+    num_warps = kw.pop("num_warps", 4)
+
+    if N_CTX_K % BLOCK_N != 0:
+        # Partial-block kv hits the modulo-decode iota_range compiler crash.
+        # The square baseline only handles q_len == kv_len, so require that here.
+        assert N_CTX_Q == N_CTX_K, ("persistent: partial-block kv_len with "
+                                    "q_len != kv_len is not supported "
+                                    f"(q_len={N_CTX_Q}, kv_len={N_CTX_K}, BLOCK_N={BLOCK_N})")
+        return flash_attn_async_prefetch(q, k, v, sm_scale, causal=causal, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+                                         num_warps=num_warps, **kw)
+
+    o = torch.empty_like(q)
+    num_m_blocks = triton.cdiv(N_CTX_Q, BLOCK_M)
+    num_xcds = kw.pop("NUM_XCDS", 8)
+    cu_count = torch.cuda.get_device_properties(q.device).multi_processor_count
+    num_sms = kw.pop("NUM_SMS", (cu_count // num_xcds) * num_xcds)
+    grid = (num_sms, )
+    _attn_fwd_persistent[grid](
+        q,
+        k,
+        v,
+        o,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        o.stride(3),
+        B,
+        H,
+        N_CTX_Q,
+        N_CTX_K,
+        diag_offset,
+        sm_scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        HEAD_DIM=D,
+        IS_CAUSAL=causal,
+        NUM_M_BLOCKS=num_m_blocks,
+        NUM_SMS=num_sms,
+        NUM_XCDS=num_xcds,
+        EVEN_N=(N_CTX_K % BLOCK_N == 0),
+        num_warps=num_warps,
+        **kw,
+    )
+    return o
+
+
+KERNEL_REGISTRY = {
+    "async_simple": flash_attn_async_simple,
+    "async_prefetch": flash_attn_async_prefetch,
+    "persistent": flash_attn_persistent,
+}
+
+
+def get_kernel(name):
+    if name not in KERNEL_REGISTRY:
+        raise ValueError(f"Unknown kernel: {name!r}. "
+                         f"Available: {list(KERNEL_REGISTRY.keys())}")
+    return KERNEL_REGISTRY[name]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Reference, verification, and Misc Utils
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def print_summary_table(results, kernel_names):
+    """Print a markdown-style summary table of benchmark results."""
+    providers = ["Torch SDPA"] + list(kernel_names)
+
+    rows = []
+    for key in sorted(results.keys()):
+        B, H, D, N, causal = key
+        rows.append((f"B={B}, H={H}, D={D}, N={N}, causal={causal}", results[key]))
+
+    cfg_w = max(len("Config"), *(len(lbl) for lbl, _ in rows)) if rows else len("Config")
+    col_w = max(14, *(len(p) for p in providers))
+
+    hdr = f"| {'Config':<{cfg_w}} |" + "".join(f" {p:>{col_w}} |" for p in providers)
+    sep = f"|{'-' * (cfg_w + 2)}|" + "".join(f"{'-' * (col_w + 2)}|" for _ in providers)
+
+    print(f"\n{'=' * len(sep)}")
+    print("Summary (TFLOPS)")
+    print(f"{'=' * len(sep)}")
+    print(hdr)
+    print(sep)
+
+    for label, prov in rows:
+        vals = (f"{prov[p]['tflops']:>{col_w}.1f}" if p in prov else f"{'—':>{col_w}}" for p in providers)
+        print(f"| {label:<{cfg_w}} |" + "".join(f" {v} |" for v in vals))
+
+    print(f"{'=' * len(sep)}\n")
+
+
+def ref_sdpa(q, k, v, sm_scale, causal=False):
+    return F.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=sm_scale)
+
+
+def verify(name, got, ref, atol=2e-2, rtol=2e-2, log=True):
+    diff = (got.float() - ref.float()).abs()
+    ok = torch.allclose(ref, got, atol=atol, rtol=rtol)
+    max_err = diff.max().item()
+    mean_err = diff.mean().item()
+    status = "PASS" if ok else "FAIL"
+    if log:
+        print(f"  {name:<28} {status}  max={max_err:.6f}  mean={mean_err:.6f}")
+    return ok
+
+
+def run_correctness_check(kernel_fn, dtype, causal, B=2, H=4, N=512, D=128):
+    torch.manual_seed(42)
+    q = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    k = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    v = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    sm = 1.0 / math.sqrt(D)
+    ref = ref_sdpa(q, k, v, sm, causal)
+    tag = f"causal={causal} N={N}"
+    out = kernel_fn(q, k, v, sm, causal)
+    return verify(f"{kernel_fn.__name__} [{tag}]", out, ref)
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["nocausal", "causal"])
+@pytest.mark.parametrize("n_test", [128, 192, 256, 500, 512, 1024])
+@pytest.mark.parametrize("kernel_name", list(KERNEL_REGISTRY.keys()))
+@_requires_cdna4
+def test_fa_correctness(kernel_name, causal, n_test, dtype=torch.bfloat16, D=128):
+    kernel_fn = get_kernel(kernel_name)
+    ok = run_correctness_check(kernel_fn, dtype, causal, B=1, H=4, N=n_test, D=D)
+    assert ok, f"Correctness failed: kernel={kernel_name} causal={causal} N={n_test}"
+
+
+def _ref_bottomright(q, k, v, sm, causal):
+    """Reference for q_len != kv_len: bottom-right causal alignment
+    (key j attends iff j <= i + (kv_len - q_len)) — the decode/KV-cache and
+    FlashAttention convention. Reduces to is_causal when q_len == kv_len."""
+    Lq, Lk = q.shape[2], k.shape[2]
+    if not causal:
+        return F.scaled_dot_product_attention(q, k, v, scale=sm)
+    i = torch.arange(Lq, device=q.device)[:, None]
+    j = torch.arange(Lk, device=q.device)[None, :]
+    bias = torch.zeros(Lq, Lk, device=q.device, dtype=q.dtype).masked_fill(~(j <= i + (Lk - Lq)), float("-inf"))
+    return F.scaled_dot_product_attention(q, k, v, attn_mask=bias, scale=sm)
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["nocausal", "causal"])
+@pytest.mark.parametrize("q_len,kv_len", [(256, 1024), (1024, 256), (1, 1024), (1024, 1024)],
+                         ids=["cross_qlt", "cross_qgt", "decode", "square"])
+@_requires_cdna4
+def test_fa_persistent_cross_attention(q_len, kv_len, causal, dtype=torch.bfloat16, D=128):
+    """persistent kernel with q_len != kv_len (cross-attention / decode)."""
+    torch.manual_seed(42)
+    B, H = 1, 8
+    q = torch.randn(B, H, q_len, D, device=DEVICE, dtype=dtype)
+    k = torch.randn(B, H, kv_len, D, device=DEVICE, dtype=dtype)
+    v = torch.randn(B, H, kv_len, D, device=DEVICE, dtype=dtype)
+    sm = 1.0 / math.sqrt(D)
+    ref = _ref_bottomright(q, k, v, sm, causal)
+    out = flash_attn_persistent(q, k, v, sm, causal)
+    valid = ~torch.isnan(ref.float())  # fully-masked rows (q_len > kv_len) are undefined
+    ok = torch.allclose(out.float()[valid], ref.float()[valid], atol=2e-2, rtol=2e-2)
+    assert ok, f"cross-attn failed: q_len={q_len} kv_len={kv_len} causal={causal}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Performance regression guard
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Baseline TFLOPS measured on gfx950/MI350 (bf16, H=64). A kernel must stay
+# within PERF_TOL below its baseline or the perf test fails (catches regressions).
+# Regenerate the numbers with (one run per (B, N) shape, so clocks stay warm):
+#   python amd-fa-pipelined_test.py -b 1 -hq 64 -sq 4096  -d 64 128 -causal true false --kernel async_simple async_prefetch persistent
+#   python amd-fa-pipelined_test.py -b 2 -hq 64 -sq 8192  -d 64 128 -causal true false --kernel async_simple async_prefetch persistent
+#   python amd-fa-pipelined_test.py -b 1 -hq 64 -sq 16384 -d 64 128 -causal true false --kernel async_simple async_prefetch persistent
+# then copy the printed Summary table values here.
+PERF_TOL = 0.15  # allow 15% slack below baseline (run-to-run noise + minor drift)
+
+# (B, N) shapes benchmarked (H=64). N=8192 uses B=2 to exercise a multi-batch shape.
+PERF_CONFIGS = [(1, 4096), (2, 8192), (1, 16384)]
+
+# key: (kernel, B, D, N, causal) -> TFLOPS
+PERF_BASELINE_TFLOPS = {
+    # B=1, N=4096
+    ("async_simple", 1, 64, 4096, False): 614,
+    ("async_simple", 1, 64, 4096, True): 344,
+    ("async_simple", 1, 128, 4096, False): 646,
+    ("async_simple", 1, 128, 4096, True): 341,
+    ("async_prefetch", 1, 64, 4096, False): 677,
+    ("async_prefetch", 1, 64, 4096, True): 334,
+    ("async_prefetch", 1, 128, 4096, False): 782,
+    ("async_prefetch", 1, 128, 4096, True): 447,
+    ("persistent", 1, 64, 4096, False): 695,
+    ("persistent", 1, 64, 4096, True): 620,
+    ("persistent", 1, 128, 4096, False): 828,
+    ("persistent", 1, 128, 4096, True): 697,
+    # B=2, N=8192
+    ("async_simple", 2, 64, 8192, False): 668,
+    ("async_simple", 2, 64, 8192, True): 380,
+    ("async_simple", 2, 128, 8192, False): 704,
+    ("async_simple", 2, 128, 8192, True): 372,
+    ("async_prefetch", 2, 64, 8192, False): 713,
+    ("async_prefetch", 2, 64, 8192, True): 358,
+    ("async_prefetch", 2, 128, 8192, False): 833,
+    ("async_prefetch", 2, 128, 8192, True): 472,
+    ("persistent", 2, 64, 8192, False): 726,
+    ("persistent", 2, 64, 8192, True): 694,
+    ("persistent", 2, 128, 8192, False): 879,
+    ("persistent", 2, 128, 8192, True): 794,
+    # B=1, N=16384
+    ("async_simple", 1, 64, 16384, False): 668,
+    ("async_simple", 1, 64, 16384, True): 432,
+    ("async_simple", 1, 128, 16384, False): 724,
+    ("async_simple", 1, 128, 16384, True): 475,
+    ("async_prefetch", 1, 64, 16384, False): 732,
+    ("async_prefetch", 1, 64, 16384, True): 439,
+    ("async_prefetch", 1, 128, 16384, False): 861,
+    ("async_prefetch", 1, 128, 16384, True): 544,
+    ("persistent", 1, 64, 16384, False): 744,
+    ("persistent", 1, 64, 16384, True): 741,
+    ("persistent", 1, 128, 16384, False): 894,
+    ("persistent", 1, 128, 16384, True): 837,
+}
+
+
+def measure_tflops(kernel_fn, B, H, N, D, causal, dtype=torch.bfloat16):
+    """Verify correctness then return achieved TFLOPS for one config."""
+    torch.manual_seed(42)
+    q = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    k = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    v = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+    sm = 1.0 / math.sqrt(D)
+    fn = lambda: kernel_fn(q, k, v, sm, causal)
+    assert verify("", fn(), ref_sdpa(q, k, v, sm, causal), log=False), "correctness check failed"
+    ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+    valid_el = N * (N + 1) // 2 if causal else N * N
+    total_flops = 2 * 2.0 * B * H * valid_el * D
+    return total_flops / ms * 1e-9
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["nocausal", "causal"])
+@pytest.mark.parametrize("B,N", PERF_CONFIGS, ids=[f"b{b}_n{n}" for b, n in PERF_CONFIGS])
+@pytest.mark.parametrize("D", [64, 128])
+@pytest.mark.parametrize("kernel_name", ["async_simple", "async_prefetch", "persistent"])
+@_requires_cdna4
+def test_fa_performance(kernel_name, D, B, N, causal):
+    """Guard against perf regressions: achieved TFLOPS must stay within PERF_TOL
+    of the recorded gfx950 baseline (H=64, bf16)."""
+    baseline = PERF_BASELINE_TFLOPS[(kernel_name, B, D, N, causal)]
+    floor = baseline * (1 - PERF_TOL)
+    got = measure_tflops(get_kernel(kernel_name), B, 64, N, D, causal)
+    print(f"  {kernel_name:14s} B={B} D={D:3d} N={N:5d} {'causal' if causal else 'nc':6s} "
+          f"{got:7.1f} TFLOPS (baseline {baseline}, floor {floor:.1f})")
+    assert got >= floor, (f"perf regression: {kernel_name} B={B} D={D} N={N} causal={causal} -> "
+                          f"{got:.1f} TFLOPS < floor {floor:.1f} (baseline {baseline}, tol {PERF_TOL:.0%})")
+
+
+def run_perf_test(args):
+    """CLI entry: run the perf guard over all baseline configs, print a report,
+    and assert every kernel is within PERF_TOL of its baseline."""
+    tol = args.perf_tol
+    all_ok = True
+    print(f"\nPerformance regression test (floor = baseline * (1 - {tol:.0%}))")
+    print("-" * 78)
+    for (kernel_name, B, D, N, causal), baseline in sorted(PERF_BASELINE_TFLOPS.items()):
+        floor = baseline * (1 - tol)
+        try:
+            got = measure_tflops(get_kernel(kernel_name), B, 64, N, D, causal)
+        except Exception as e:
+            all_ok = False
+            print(f"  [FAIL] {kernel_name:14s} B={B} D={D:3d} N={N:5d} "
+                  f"{'causal' if causal else 'nc':6s} -> ERROR ({e})")
+            continue
+        ok = got >= floor
+        all_ok &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] {kernel_name:14s} B={B} D={D:3d} N={N:5d} "
+              f"{'causal' if causal else 'nc':6s} {got:7.1f} TFLOPS (baseline {baseline}, floor {floor:.1f})")
+    print("-" * 78)
+    print("RESULT:", "PASS" if all_ok else "FAIL")
+    assert all_ok
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Benchmark
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def run_benchmark(args):
+    causal_modes = [s.lower() in ("true", "1", "yes") for s in args.causal]
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16}[args.dtype]
+
+    results = {}
+
+    for kernel_name in args.kernel:
+        kernel_fn = get_kernel(kernel_name)
+        for B in args.b:
+            for H in args.hq:
+                for D in args.d:
+                    for N in args.sq:
+                        for causal in causal_modes:
+                            torch.manual_seed(42)
+                            q = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                            k = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                            v = torch.randn(B, H, N, D, device=DEVICE, dtype=dtype)
+                            sm = 1.0 / math.sqrt(D)
+
+                            if causal:
+                                valid_el = N * (N + 1) // 2
+                            else:
+                                valid_el = N * N
+                            total_flops = 2 * 2.0 * B * H * valid_el * D
+
+                            causal_str = "causal" if causal else "nc"
+                            ref_sdpa_lambda = lambda: F.scaled_dot_product_attention(
+                                q, k, v, is_causal=causal, scale=sm)
+
+                            try:
+                                tlx_sdpa_lambda = lambda: kernel_fn(q, k, v, sm, causal)
+                                ref_out = ref_sdpa_lambda()
+                                tlx_out = tlx_sdpa_lambda()
+                                assert verify("", tlx_out, ref_out, log=False)
+                            except Exception as e:
+                                print(f"  {kernel_name:20s} D={D} N={N:5d} {causal_str:6s} -> SKIPPED ({e})")
+                                continue
+
+                            key = (B, H, D, N, causal)
+                            if key not in results:
+                                results[key] = {}
+
+                            if "Torch SDPA" not in results[key]:
+                                ms = triton.testing.do_bench(ref_sdpa_lambda, warmup=25, rep=100)
+                                tflops = total_flops / ms * 1e-9
+                                results[key]["Torch SDPA"] = {"ms": ms, "tflops": tflops}
+
+                            ms = triton.testing.do_bench(tlx_sdpa_lambda, warmup=25, rep=100)
+                            tflops = total_flops / ms * 1e-9
+                            results[key][kernel_name] = {"ms": ms, "tflops": tflops}
+
+    print_summary_table(results, args.kernel)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def parse_args():
+    p = argparse.ArgumentParser(prog="AMD TLX FA Pipelined")
+    p.add_argument("-b", type=int, nargs="+", default=[1])
+    p.add_argument("-hq", type=int, nargs="+", default=[64])
+    p.add_argument("-sq", type=int, nargs="+", default=[1024, 8192, 16384])
+    p.add_argument("-d", type=int, nargs="+", default=[64, 128])
+    p.add_argument("-causal", type=str, nargs="+", default=["false"],
+                   help="Causal modes to benchmark (e.g. -causal true false)")
+    p.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16"])
+    p.add_argument("--kernel", type=str, nargs="+", default=["async_simple", "async_prefetch", "persistent"],
+                   help="Kernel variants to benchmark")
+    p.add_argument("--mode", choices=["benchmark", "perf_test"], default="benchmark",
+                   help="benchmark: print TFLOPS table; perf_test: assert TFLOPS within PERF_TOL of baseline")
+    p.add_argument("--perf-tol", dest="perf_tol", type=float, default=PERF_TOL,
+                   help="perf_test slack below baseline (e.g. 0.15 = allow 15%% regression)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.mode == "perf_test":
+        run_perf_test(args)
+    else:
+        run_benchmark(args)


### PR DESCRIPTION
Summary:

Backports `third_party/tlx/tutorials/amd-addmm-glu-opt_test.py` from upstream `214fd5e` ("[TLX][AMD] Add fused addmm + GLU tutorial kernel for gfx950 (#1690)"). Fused addmm + GLU (`out = x + x*y` where `x = A@B + bias`) for gfx950/MI350, fp16, M=1024 N=21568, with warp-pipelined async-copy and baseline kernels plus a perf-regression guard.

Adds the `py_tlx_amd_addmm-glu-opt` buck target (appended `addmm-glu-opt` to the AMD pipelined-test loop in `BUCK.template`, regenerated `BUCK`) and gates `test_addmm_glu_performance` with `is_hip_cdna4()`. The `tlx.warp_pipeline_stage` / `tlx.async_load` deps are already present in fbsource beta.

Reviewed By: wlei-llvm

Differential Revision: D109188034


