### PR TITLE
[AutoWS] Teach the loop pipeliner to predicate TMA reduce/scatter ops

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -295,7 +295,15 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     return op;
   }
   // Ops without a built-in pred operand: wrap in scf.if.
-  if (isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::TMAStoreTokenWaitOp>(op)) {
+  //
+  // The TMA "store" family (copy local->global, reduce, scatter) all write to
+  // global memory but have no mask/pred operand, so they cannot be masked in
+  // place. They must be predicated when the pipeliner peels prologue/epilogue
+  // iterations of a dynamic loop: executing a store/reduce/scatter for an
+  // iteration past the real trip count would corrupt the output (e.g. a
+  // spurious atomic add for a TMA reduce). Guard them with scf.if(pred).
+  if (isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp,
+          ttng::AsyncTMAScatterOp, ttng::TMAStoreTokenWaitOp>(op)) {
     rewriter.setInsertionPoint(op);
     bool hasResults = op->getNumResults() > 0;
     auto ifOp =

--- a/test/TritonGPU/loop-pipeline-expand.mlir
+++ b/test/TritonGPU/loop-pipeline-expand.mlir
@@ -96,3 +96,58 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Pipelining a loop with a TMA reduce (atomic add) requires the pipeliner to
+// predicate the reduce when it is cloned into a guarded iteration of a dynamic
+// loop. The reduce writes to global memory but has no mask/pred operand, so it
+// must be wrapped in an scf.if guard. Regression test for crash "pipeliner
+// doesn't know how to predicate this op" on ttng.async_tma_reduce.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tma_reduce_pipeline_predicate
+  tt.func public @tma_reduce_pipeline_predicate(%arg0: tensor<128x128xf32, #blocked>, %arg1: !tt.tensordesc<tensor<128x128xf32, #shared>>, %arg2: i32, %arg3: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
+    // CHECK: scf.if
+    // CHECK: ttng.async_tma_reduce
+    scf.for %arg4 = %c0_i32 to %arg3 step %arg2 : i32 {
+      %0 = arith.mulf %arg0, %cst {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked>
+      ttg.local_store %0, %buf {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
+      %1 = ttng.async_tma_reduce add, %arg1[%arg4, %c0_i32] %buf {loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x128xf32, #shared>>, !ttg.memdesc<128x128xf32, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %1 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.async.token
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Same as above but for a TMA scatter, which likewise has no pred operand and
+// must be wrapped in an scf.if guard when predicated by the pipeliner.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tma_scatter_pipeline_predicate
+  tt.func public @tma_scatter_pipeline_predicate(%arg0: tensor<8x128xf32, #blocked>, %arg1: !tt.tensordesc<tensor<1x128xf32, #shared>>, %arg2: i32, %arg3: i32, %arg5: tensor<8xi32, #blocked1>) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<2.000000e+00> : tensor<8x128xf32, #blocked>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<8x128xf32, #shared, #smem, mutable>
+    // CHECK: scf.if
+    // CHECK: ttng.async_tma_scatter
+    %acc = scf.for %arg4 = %c0_i32 to %arg3 step %arg2 iter_args(%a = %c0_i32) -> (i32) : i32 {
+      %0 = arith.mulf %arg0, %cst {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<8x128xf32, #blocked>
+      ttg.local_store %0, %buf {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<8x128xf32, #blocked> -> !ttg.memdesc<8x128xf32, #shared, #smem, mutable>
+      ttng.async_tma_scatter %arg1[%arg5, %arg4] %buf {loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<1x128xf32, #shared>>, tensor<8xi32, #blocked1>, i32, !ttg.memdesc<8x128xf32, #shared, #smem, mutable>
+      %next = arith.addi %a, %arg4 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : i32
+      scf.yield %next : i32
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
+    tt.return %acc : i32
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/MemoryLowering.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/MemoryLowering.md
@@ -133,6 +133,32 @@ maximize overlap with computation. See
 [TMA Store Wait Pipeline](TMAStoreWaitPipeline.md) for the full
 annotation → validation → reorder → lowering sequence.
 
+### Pipeliner Predication of TMA Store-Family Ops
+
+Once the store-family ops are lowered early, the generic loop pipeliner
+(`TritonGPUPipeline`) can pull them into a software-pipelined loop. When that
+loop is treated as a *dynamic* loop (the runtime trip count is not statically
+known to be ≥ the number of pipeline stages — true for essentially every
+Triton `i32` loop), the pipeliner peels prologue/epilogue iterations and must
+**predicate** any op it speculatively executes for an iteration that may be
+past the real trip count. For a store this is not optional: running it for a
+non-existent iteration corrupts the output (and for a TMA *reduce* / atomic add,
+double-counts via a spurious atomic).
+
+The TMA store-family ops — `AsyncTMACopyLocalToGlobalOp`, `AsyncTMAReduceOp`,
+and `AsyncTMAScatterOp` — write to global memory but have **no mask/pred
+operand**, so they cannot be masked in place like `tt.store` or
+`tt.atomic_rmw`. Instead, `predicateOp` (in
+`lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp`) guards each
+one by wrapping it in `scf.if(pred) { op }` (yielding `ub.poison` for the
+optional token in the else branch). The paired `TMAStoreTokenWaitOp` is
+predicated the same way. **All three store-family ops must appear in that
+`scf.if`-wrapping list**; a missing entry makes the pipeliner abort with
+`pipeliner doesn't know how to predicate this op` (this was the original gap
+for `AsyncTMAReduceOp`/`AsyncTMAScatterOp`). Lit coverage:
+`test/TritonGPU/loop-pipeline-expand.mlir`
+(`@tma_reduce_pipeline_predicate`, `@tma_scatter_pipeline_predicate`).
+
 ## 1D TMEM Allocation
 
 **File**: `TMEMAlloc1D.cpp`


### PR DESCRIPTION
The software pipeliner's predicateOp only knew how to scf.if-wrap the plain TMA store (async_tma_copy_local_to_global). async_tma_reduce and async_tma_scatter write to global memory but likewise have no mask/pred operand, and fell through to a fatal "pipeliner doesn't know how to predicate this op" error whenever they were pipelined into a predicated prologue/epilogue of a dynamic loop. This crashed the device-TMA Flash Attention backward kernel, whose dq gradient atomic-add lowers to async_tma_reduce. Predication is required for correctness here: a store/reduce run for an iteration past the real trip count would corrupt the output (a spurious atomic add for the reduce), so add both ops to the scf.if-wrapping path alongside the existing TMA store.

Found via trying to enable early_tma_store=True by default.

Authored with Claude.