### PR TITLE
[triton][beta] [Cherry-pick][BUNDLE] Cherry-pick 31 upstream(#9440 #9446 #9454 #9405 #9461 #9462 #9464 #9449 #9406 #9245 #9480 #9481 #9487 #9441 #9490 #9442 #9496 #9492 #9495 #9510 #9513 #9505 #9514 #9507 #9522 #9518 #9519 #9512 #9393 #9530...

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,6 @@ include Makefile
 include python/build_helpers.py
 include python/requirements.txt
 include python/test-requirements.txt
+global-exclude __pycache__
+global-exclude __pycache__/*
+global-exclude *.py[cod]

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -290,7 +290,8 @@ public:
       return failure();
     }
     // Keep the "partition" output dim (PartitionedSharedEncoding) so lowerLdSt
-    // can select the per-partition base pointer; lowerLdSt strips it afterwards.
+    // can select the per-partition base pointer; lowerLdSt strips it
+    // afterwards.
     SmallVector<StringAttr> ldStOutDims = {kOffset};
     auto kPartition = str_attr("partition");
     if (cvt.hasOutDim(kPartition))

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1449,12 +1449,7 @@ LinearLayout chooseScaledWmmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          CGAEncodingAttr cgaLayout) {
   using basisT = std::vector<std::vector<int32_t>>;
   unsigned rank = dotOperandShape.size();
-  SmallVector<int32_t> order;
-  if (rank == 3) {
-    order = {1, 0, 2};
-  } else {
-    order = {1, 0};
-  }
+  bool hasBatchDim = rank == 3;
   auto outDimNames = standardOutDimNames(ctx, rank);
 
   StringAttr kRegister = StringAttr::get(ctx, "register");
@@ -1468,8 +1463,8 @@ LinearLayout chooseScaledWmmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
   // - B: [K, N]
   // - aScale: [M, K / 32 or 16]
   // - bScale: [N, K / 32 or 16]
-  auto dimK = outDimNames[order[0]];
-  auto dimNonK = outDimNames[order[1]];
+  auto dimK = outDimNames[rank - 1];
+  auto dimNonK = outDimNames[rank - 2];
 
   // Each lane holds kWidth=4 consecutive values along the K dim.
   // The first 16 lanes are distributed along the nonK dim.
@@ -1480,13 +1475,23 @@ LinearLayout chooseScaledWmmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
       LinearLayout::identity1D(16, kLane, dimNonK) *
       LinearLayout::zeros1D(2, kLane, dimNonK);
 
-  unsigned mnDim = dotOperandIdx == 0 ? rank - 2 : rank - 1;
-
   // If the shape along the K dim is larger than kWidth, repeat this
   // pattern to fill the K dim.
   tileLayout *= LinearLayout::identity1D(kSize / scaleKWidth, kRegister, dimK);
 
+  if (hasBatchDim) {
+    tileLayout *= LinearLayout::identity1D(1, kRegister, outDimNames[0]);
+    tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[0]);
+  }
+
   if (dotOperandIdx == 1) {
+    // ctaLayout comes from the dot operand. For B in scaled dot,
+    // - the operand is ordered as [K, N]
+    // - the scale is ordered as [N, K / 32 or 16].
+    // Swap the last two dims of ctaLayout to match the tileLayout
+    SmallVector<int32_t> order = {1, 0};
+    if (hasBatchDim)
+      order = {0, 2, 1};
     ctaLayout = transposeLinearLayout(ctaLayout, order);
   }
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1108,10 +1108,12 @@ LogicalResult MemDescSubsliceOp::verify() {
   } else {
     ll = triton::gpu::toLinearLayout(srcTy);
   }
-  // NYI: We don't support non-trivial block dimension for now.
-  auto kBlock = mlir::StringAttr::get(getContext(), "block");
-  if (ll.getInDimSize(kBlock) != 1) {
-    return emitError("non-trivial block dimension not supported");
+
+  // If any block basis is fully broadcasted, multiple CTAs can alias the same
+  // output tile region. Subslice on such layouts is unsupported.
+  auto kBlock = mlir::StringAttr::get(ctx, "block");
+  if (ll.getFreeVariableMasks()[kBlock] != 0) {
+    return emitError("We don't support splitting with broadcasted CTA outputs");
   }
 
   auto llInv = ll.invert();
@@ -1124,9 +1126,15 @@ LogicalResult MemDescSubsliceOp::verify() {
     for (int dimSize = dstTy.getDimSize(dim); dimSize < srcTy.getDimSize(dim);
          dimSize *= 2) {
       namedOffsets[dim] = {kDim, dimSize};
-      if (!llvm::isPowerOf2_32(llInv.apply(namedOffsets)[0].second)) {
+      auto offsetAndBlock = llInv.apply(namedOffsets);
+      auto offset = offsetAndBlock[0];
+      auto block = offsetAndBlock[1];
+      if (!llvm::isPowerOf2_32(offset.second) && offset.second != 0) {
         return emitError(
             "We don't support splitting along the swizzling pattern");
+      }
+      if (block.second != 0) {
+        return emitError("We don't support splitting along CTA dimensions");
       }
     }
   }
@@ -1432,7 +1440,7 @@ LogicalResult WarpYieldOp::verify() {
 static size_t getSharedMemorySize(Type type) {
   if (isa<IntegerType, FloatType>(type))
     return llvm::divideCeil(type.getIntOrFloatBitWidth(), 8);
-  if (isa<PointerType, TensorDescType>(type))
+  if (isa<PointerType, TensorDescInterface>(type))
     return 8;
   if (auto desc = dyn_cast<MemDescType>(type)) {
     if (!isa<SharedMemorySpaceAttr,

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1373,42 +1373,32 @@ bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
     }
   }
 
-  // Compute single-use operations
-  DenseMap<Operation *, bool> isSingleUse;
-  std::function<bool(Operation *)> isOpSingleUse;
-  isOpSingleUse = [&](Operation *op) -> bool {
-    // lookup in memoization array:
-    auto it = isSingleUse.find(op);
-    if (it != isSingleUse.end()) {
-      return it->second;
+  // Determine which values used by operations outside the slice. We can use
+  // this to determine whether they will actually survive and therefore need to
+  // contribute to the cost.
+  SetVector<Value> nonSliceOnlyValues;
+
+  // Identify values that directly have uses outside the slice.
+  for (Value v : slice) {
+    for (auto &use : v.getUses()) {
+      auto *user = use.getOwner();
+      if (user == convertOp || sliceOps.contains(user))
+        continue;
+      nonSliceOnlyValues.insert(v);
+      break;
     }
+  }
 
-    bool singleUse = true;
-
-    for (Value result : op->getResults()) {
-      for (Operation *user : result.getUsers()) {
-        if (user == convertOp) {
-          continue;
-        }
-        if (sliceOps.contains(user)) {
-          if (!isOpSingleUse(user)) {
-            singleUse = false;
-            break;
-          }
-        } else {
-          singleUse = false;
-          break;
-        }
-      }
-      if (!singleUse) {
-        break;
-      }
+  // Expand the set to all transitive operands in the slice.
+  for (size_t i = 0; i < nonSliceOnlyValues.size(); ++i) {
+    Value v = nonSliceOnlyValues[i];
+    if (auto *op = v.getDefiningOp()) {
+      for (auto operand : op->getOperands())
+        if (slice.contains(operand))
+          nonSliceOnlyValues.insert(operand);
     }
-
-    // insert into memoization array:
-    isSingleUse[op] = singleUse;
-    return singleUse;
-  };
+    // TODO: Handle block arguments.
+  }
 
   int64_t convertLayoutCost = getConvertCost(convertOp.getSrc());
   int64_t rematerialisationCost = newCvtCost;
@@ -1416,11 +1406,16 @@ bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
   // Evaluate single-use status for every operation in slice
   for (Operation *op : sliceOps) {
     auto dialect = op->getDialect();
-    if (isOpSingleUse(op)) {
-      // when we rematerialise, this operation does not get duplicated
-      // so it does not contribute to our cost model:
+    // If all of the results of the op are only used within the slice, when we
+    // rematerialise, this operation does not get duplicated so it does not
+    // contribute to our cost model.
+    bool isOpUsedOutsideSlice = llvm::any_of(op->getResults(), [&](Value v) {
+      return nonSliceOnlyValues.contains(v);
+    });
+    if (!isOpUsedOutsideSlice)
       continue;
-    } else if (isa<arith::ConstantOp>(op)) {
+
+    if (isa<arith::ConstantOp>(op)) {
       // special-case: arith.constant has zero cost
       continue;
     } else if (isa<LoadOp>(op) || isa<LocalLoadOp>(op)) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -33,7 +33,8 @@ namespace {
 
 bool isAsyncProxyWrite(Operation *op) {
   return isa<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp,
-             triton::nvidia_gpu::AsyncTMAGatherOp>(op);
+             triton::nvidia_gpu::AsyncTMAGatherOp,
+             triton::nvidia_gpu::CLCTryCancelOp>(op);
 }
 
 Value getSmemDest(Operation *op) {
@@ -44,6 +45,9 @@ Value getSmemDest(Operation *op) {
   if (auto asyncTMAGatherOp =
           dyn_cast<triton::nvidia_gpu::AsyncTMAGatherOp>(op)) {
     return asyncTMAGatherOp.getResult();
+  }
+  if (auto clcTryCancelOp = dyn_cast<triton::nvidia_gpu::CLCTryCancelOp>(op)) {
+    return clcTryCancelOp.getResult();
   }
   return Value();
 }

--- a/python/examples/gluon/02-convolution.py
+++ b/python/examples/gluon/02-convolution.py
@@ -1,0 +1,615 @@
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+
+from triton.language.core import _aggregate as aggregate
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.nvidia.hopper import TensorDescriptor, TensorDescriptorIm2Col
+from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier
+from triton.experimental.gluon.language.nvidia.blackwell import (
+    TensorMemoryLayout,
+    allocate_tensor_memory,
+    tensor_memory_descriptor,
+    get_tmem_reg_layout,
+    tcgen05_mma,
+    tcgen05_commit,
+)
+
+# ===-----------------------------------------------------------------------===#
+# Utilities
+# ===-----------------------------------------------------------------------===#
+
+
+def is_cuda():
+    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+
+
+def is_blackwell():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 10
+
+
+def make_tensor_desc(x, shape, strides, block_shape):
+    layout = gl.NVMMASharedLayout.get_default_for(block_shape, gl.float16)
+    return TensorDescriptor(x, shape=shape, strides=strides, block_shape=block_shape, layout=layout)
+
+
+# ===-----------------------------------------------------------------------===#
+# Convolution Configuration
+# ===-----------------------------------------------------------------------===#
+
+# Convolution parameter naming convention:
+#   N   = batch size
+#   H,W = input spatial dims
+#   Ci  = input channels   (part of GEMM-K reduction: K_GEMM = R * S * Ci)
+#   Co  = output channels  (maps to GEMM-N dimension: N_GEMM = Co)
+#   R,S = filter height, width
+#
+# GEMM mapping:
+#   M_GEMM = N * out_h * out_w   (output spatial positions)
+#   N_GEMM = Co                  (output channels)
+#   K_GEMM = R * S * Ci          (reduction over filter x input channels)
+
+
+@aggregate
+class ConvConfig:
+    N: gl.tensor
+    H: gl.tensor
+    W: gl.tensor
+    Ci: gl.tensor
+    Co: gl.tensor
+    R: gl.tensor
+    S: gl.tensor
+    out_h: gl.tensor
+    out_w: gl.tensor
+    stride_h: gl.tensor
+    stride_w: gl.tensor
+    pad_h: gl.tensor
+    pad_w: gl.tensor
+    output_stride_n: gl.tensor
+    output_stride_h: gl.tensor
+    output_stride_w: gl.tensor
+    M_GEMM: gl.tensor
+
+    BLOCK_M: gl.constexpr
+    BLOCK_N: gl.constexpr
+    BLOCK_K: gl.constexpr
+    GROUP_SIZE_M: gl.constexpr
+    num_buffers: gl.constexpr
+    num_warps: gl.constexpr
+
+    @gluon.jit
+    def get_program(self, pid):
+        """Compute tile coordinates from program ID with grouped ordering."""
+        M_GEMM = self.M_GEMM
+        N_GEMM = self.Co
+
+        num_pid_m = gl.cdiv(M_GEMM, self.BLOCK_M)
+        num_pid_n = gl.cdiv(N_GEMM, self.BLOCK_N)
+        num_pid_in_group = self.GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * self.GROUP_SIZE_M
+        group_size_m = gl.minimum(num_pid_m - first_pid_m, self.GROUP_SIZE_M)
+        pid_m = first_pid_m + (pid % group_size_m)
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+        return ConvProgram(self, pid_m, pid_n)
+
+
+@aggregate
+class ConvProgram:
+    config: ConvConfig
+    pid_m: gl.tensor
+    pid_n: gl.tensor
+
+    @gluon.jit
+    def get_m_offsets(self):
+        """Decompose M-tile offset into (batch, out_y, out_x)."""
+        offs_m = self.pid_m * self.config.BLOCK_M
+        config = self.config
+        out_x = offs_m % config.out_w
+        out_y = (offs_m // config.out_w) % config.out_h
+        batch_id = (offs_m // config.out_w) // config.out_h
+        return batch_id, out_y, out_x
+
+
+# ===-----------------------------------------------------------------------===#
+# Partition Arguments
+# ===-----------------------------------------------------------------------===#
+
+
+@aggregate
+class PartitionArgs:
+    config: ConvConfig
+    in_desc: tma.tensor_descriptor_im2col
+    weight_desc: tma.tensor_descriptor
+    output_ptr: gl.tensor
+    a_bufs: gl.shared_memory_descriptor
+    b_bufs: gl.shared_memory_descriptor
+    load_empty_bars: gl.shared_memory_descriptor
+    load_ready_bars: gl.shared_memory_descriptor
+    acc_bufs: tensor_memory_descriptor
+    acc_empty_bars: gl.shared_memory_descriptor
+    acc_ready_bars: gl.shared_memory_descriptor
+
+
+# ===-----------------------------------------------------------------------===#
+# Warp-Specialized Partitions
+# ===-----------------------------------------------------------------------===#
+
+
+@gluon.jit
+def load_partition(p):
+    """Load partition: issues TMA copies for input (im2col) and weight tiles."""
+    config = p.config
+    BLOCK_N: gl.constexpr = config.BLOCK_N
+    BLOCK_K: gl.constexpr = config.BLOCK_K
+
+    pid = gl.program_id(axis=0)
+    prog = config.get_program(pid)
+    batch_id, out_y, out_x = prog.get_m_offsets()
+
+    num_buffers: gl.constexpr = p.a_bufs.type.shape[0]
+    # Allow Ci not divisible by BLOCK_K; TMA zero-fills out-of-bounds for the partial block.
+    ci_num_blocks = gl.cdiv(config.Ci, BLOCK_K)
+    num_rs = config.R * config.S
+    num_k_iter = num_rs * ci_num_blocks
+
+    for k_iter in range(num_k_iter):
+        index = k_iter % num_buffers
+        phase = k_iter // num_buffers & 1
+
+        # Decompose k_iter into (r, s, ci_block) indices.
+        # When Ci is not a multiple of BLOCK_K, the last iter_ci block is partial;
+        # we use the same indices (iter_ci * BLOCK_K, k_offset) and TMA zero-fills OOB.
+        iter_ci = k_iter // num_rs
+        remain_rs = k_iter % num_rs
+        iter_s = remain_rs % config.S
+        iter_r = remain_rs // config.S
+
+        # Wait for buffers to be consumed
+        mbarrier.wait(p.load_empty_bars.index(index), phase ^ 1)
+
+        # Set up ready barrier and issue both TMA copies
+        ready_bar = p.load_ready_bars.index(index)
+        mbarrier.expect(ready_bar, p.in_desc.block_type.nbytes + p.weight_desc.block_type.nbytes)
+
+        # Input tile via TMA im2col: channel offset iter_ci*BLOCK_K (OOB channels zero-filled)
+        tma.async_copy_global_to_shared_im2col(
+            p.in_desc,
+            [
+                batch_id, out_y * config.stride_h - config.pad_h, out_x * config.stride_w - config.pad_w,
+                iter_ci * BLOCK_K
+            ],
+            [iter_r.to(tl.int16), iter_s.to(tl.int16)],
+            ready_bar,
+            p.a_bufs.index(index),
+        )
+
+        # Weight tile: k_offset into (Co, R*S*Ci).  Use Ci (not ci_num_blocks*BLOCK_K) as
+        # the per-(r,s) stride so offsets stay aligned with the flat layout.  When the last
+        # ci block bleeds into the next (r,s) group, those weight elements are multiplied
+        # by zero-filled input channels, so the result is still correct.
+        k_offset = (iter_r * config.S + iter_s) * config.Ci + iter_ci * BLOCK_K
+        tma.async_copy_global_to_shared(
+            p.weight_desc,
+            [prog.pid_n * BLOCK_N, k_offset],
+            ready_bar,
+            p.b_bufs.index(index),
+        )
+
+
+@gluon.jit
+def mma_partition(p):
+    """MMA partition: performs tcgen05 matrix-multiply-accumulate operations."""
+    config = p.config
+    BLOCK_K: gl.constexpr = config.BLOCK_K
+
+    num_buffers: gl.constexpr = p.a_bufs.type.shape[0]
+    # Must match the load partition: R*S * ceil(Ci/BLOCK_K), not ceil(R*S*Ci / BLOCK_K).
+    num_k_iter = config.R * config.S * gl.cdiv(config.Ci, BLOCK_K)
+
+    # Wait for accumulator buffer
+    mbarrier.wait(p.acc_empty_bars.index(0), phase=1)
+    acc_buf = p.acc_bufs.index(0)
+    use_acc = False
+
+    for k_iter in range(num_k_iter):
+        index = k_iter % num_buffers
+        load_phase = k_iter // num_buffers & 1
+
+        # Wait for operands to be ready
+        mbarrier.wait(p.load_ready_bars.index(index), load_phase)
+
+        # MMA: A is [M, K], B in smem is [N, K] so permute to [K, N]
+        tcgen05_mma(p.a_bufs.index(index), p.b_bufs.index(index).permute((1, 0)), acc_buf, use_acc=use_acc)
+
+        # Signal that load buffers are consumed
+        tcgen05_commit(p.load_empty_bars.index(index))
+        use_acc = True
+
+    # Signal that accumulator is ready
+    tcgen05_commit(p.acc_ready_bars.index(0))
+
+
+@gluon.jit
+def epilogue_partition(p):
+    """Epilogue partition: loads accumulator from TMEM and stores to global memory."""
+    config = p.config
+    BLOCK_M: gl.constexpr = config.BLOCK_M
+    BLOCK_N: gl.constexpr = config.BLOCK_N
+    M_GEMM = config.M_GEMM
+    N_GEMM = config.Co
+    pid = gl.program_id(axis=0)
+    prog = config.get_program(pid)
+
+    # Register layouts
+    tmem_layout: gl.constexpr = TensorMemoryLayout(block=(128, BLOCK_N), col_stride=1)
+    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, config.num_warps)
+
+    # Wait for accumulator to be ready
+    mbarrier.wait(p.acc_ready_bars.index(0), phase=0)
+
+    # Load from TMEM and convert to fp16
+    acc = p.acc_bufs.index(0).load(acc_reg_layout)
+    result = gl.convert_layout(acc.to(gl.float16), gl.CoalescedLayout())
+
+    # Signal that accumulator is consumed
+    mbarrier.arrive(p.acc_empty_bars.index(0), count=1)
+
+    # Compute output addresses: decompose M offsets into (batch, out_y, out_x)
+    offs_m = prog.pid_m * BLOCK_M + gl.arange(0, BLOCK_M)
+    offs_n = prog.pid_n * BLOCK_N + gl.arange(0, BLOCK_N)
+
+    c_out_x = offs_m % config.out_w
+    c_out_y = (offs_m // config.out_w) % config.out_h
+    c_batch = (offs_m // config.out_w) // config.out_h
+
+    c_offsets = (c_batch[:, None] * config.output_stride_n + c_out_y[:, None] * config.output_stride_h +
+                 c_out_x[:, None] * config.output_stride_w + offs_n[None, :])
+    c_mask = (offs_m[:, None] < M_GEMM) & (offs_n[None, :] < N_GEMM)
+
+    gl.store(p.output_ptr + c_offsets, result, mask=c_mask)
+
+    # Clean up barriers
+    num_buffers: gl.constexpr = p.a_bufs.type.shape[0]
+    for i in gl.static_range(num_buffers):
+        mbarrier.invalidate(p.load_empty_bars.index(i))
+        mbarrier.invalidate(p.load_ready_bars.index(i))
+    mbarrier.invalidate(p.acc_empty_bars.index(0))
+    mbarrier.invalidate(p.acc_ready_bars.index(0))
+
+
+# ===-----------------------------------------------------------------------===#
+# Kernel Entry Point
+# ===-----------------------------------------------------------------------===#
+
+
+@gluon.jit(do_not_specialize=[
+    "N",
+    "H",
+    "W",
+    "R",
+    "S",
+    "pad_h",
+    "pad_w",
+])
+def conv2d_im2col_kernel(
+    in_desc,
+    weight_desc,
+    output,
+    N,
+    H,
+    W,
+    Ci,
+    Co,
+    R,
+    S,
+    out_h,
+    out_w,
+    output_stride_n,
+    output_stride_h,
+    output_stride_w,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    GROUP_SIZE_M: gl.constexpr,
+    num_buffers: gl.constexpr,
+    num_warps: gl.constexpr,
+):
+    """Warp-specialized implicit GEMM convolution kernel using TMA im2col.
+
+    GEMM dimensions:
+        M = N * out_h * out_w   (output spatial positions)
+        N = Co                  (output channels)
+        K = R * S * Ci          (reduction over filter x input channels)
+    """
+    M_GEMM = N * out_h * out_w
+    config = ConvConfig(
+        N,
+        H,
+        W,
+        Ci,
+        Co,
+        R,
+        S,
+        out_h,
+        out_w,
+        gl.to_tensor(stride_h),
+        gl.to_tensor(stride_w),
+        pad_h,
+        pad_w,
+        gl.to_tensor(output_stride_n),
+        gl.to_tensor(output_stride_h),
+        gl.to_tensor(output_stride_w),
+        M_GEMM,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+        GROUP_SIZE_M,
+        num_buffers,
+        num_warps,
+    )
+
+    # Allocate shared memory for multi-buffered loads
+    a_smem_layout: gl.constexpr = gl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_K], gl.float16)
+    b_smem_layout: gl.constexpr = gl.NVMMASharedLayout.get_default_for([BLOCK_N, BLOCK_K], gl.float16)
+
+    a_bufs = gl.allocate_shared_memory(gl.float16, [num_buffers, BLOCK_M, BLOCK_K], a_smem_layout)
+    b_bufs = gl.allocate_shared_memory(gl.float16, [num_buffers, BLOCK_N, BLOCK_K], b_smem_layout)
+
+    # Barriers for load pipeline
+    load_empty_bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    load_ready_bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    for i in gl.static_range(num_buffers):
+        mbarrier.init(load_empty_bars.index(i), count=1)
+        mbarrier.init(load_ready_bars.index(i), count=1)
+
+    # Allocate tensor memory for accumulator
+    tmem_layout: gl.constexpr = TensorMemoryLayout(block=(128, BLOCK_N), col_stride=1)
+    acc_bufs = allocate_tensor_memory(gl.float32, [1, BLOCK_M, BLOCK_N], tmem_layout)
+
+    # Barriers for accumulator pipeline
+    acc_empty_bars = gl.allocate_shared_memory(gl.int64, [1, 1], mbarrier.MBarrierLayout())
+    acc_ready_bars = gl.allocate_shared_memory(gl.int64, [1, 1], mbarrier.MBarrierLayout())
+    mbarrier.init(acc_empty_bars.index(0), count=1)
+    mbarrier.init(acc_ready_bars.index(0), count=1)
+
+    p = PartitionArgs(
+        config,
+        in_desc,
+        weight_desc,
+        output,
+        a_bufs,
+        b_bufs,
+        load_empty_bars,
+        load_ready_bars,
+        acc_bufs,
+        acc_empty_bars,
+        acc_ready_bars,
+    )
+
+    gl.warp_specialize([
+        (epilogue_partition, (p, )),
+        (mma_partition, (p, )),
+        (load_partition, (p, )),
+    ], [1, 1], [24, 24])
+
+
+# ===-----------------------------------------------------------------------===#
+# Host-Side Entry Point
+# ===-----------------------------------------------------------------------===#
+
+
+def conv2d_im2col(input_tensor, weight_tensor, stride=1, padding=0, num_buffers=2, num_warps=4):
+    """
+    Warp-specialized implicit GEMM convolution using TMA im2col.
+
+    Args:
+        input_tensor: (N, H, W, Ci) - NHWC layout
+        weight_tensor: (Co, R, S, Ci) - output channels first
+        stride: convolution stride (default: 1)
+        padding: convolution padding (default: 0)
+        num_buffers: number of pipeline buffers (default: 2)
+        num_warps: number of warps for MMA partition (default: 4)
+    """
+    N, H, W, Ci = input_tensor.shape
+    Co, R, S, Ci_w = weight_tensor.shape
+    assert Ci == Ci_w, "Input and weight channel dimensions must match"
+    if stride <= 0:
+        raise ValueError(f"stride must be positive, got {stride}")
+    if padding < 0:
+        raise ValueError(f"padding must be non-negative, got {padding}")
+
+    out_h = (H + 2 * padding - R) // stride + 1
+    out_w = (W + 2 * padding - S) // stride + 1
+    if out_h <= 0 or out_w <= 0:
+        raise ValueError("Invalid convolution geometry: computed output size "
+                         f"({out_h}, {out_w}) from H={H}, W={W}, R={R}, S={S}, "
+                         f"stride={stride}, padding={padding}.")
+
+    # Tile parameters for this kernel variant.
+    # Ci need not be divisible by BLOCK_K: the last channel block is partial and
+    # TMA zero-fills out-of-bounds, so the MMA result remains correct.
+    BLOCK_M = 256
+    BLOCK_N = 256
+    BLOCK_K = 64
+    GROUP_SIZE_M = 4
+
+    output = torch.empty((N, out_h, out_w, Co), device=input_tensor.device, dtype=torch.float16)
+
+    M_GEMM = N * out_h * out_w
+    N_GEMM = Co
+
+    grid = (triton.cdiv(M_GEMM, BLOCK_M) * triton.cdiv(N_GEMM, BLOCK_N), )
+
+    # TMA im2col descriptor for input: [N, H, W, Ci] in NHWC
+    #
+    # The pixel_box defines the access boundary per batch:
+    #   Lower = pixel_box_lower_corner + offsets
+    #   Upper = [H, W] + pixel_box_upper_corner + offsets
+    # With element_strides = [1, stride, stride, 1], TMA steps by `stride`
+    # in H/W between output pixels. The window must contain exactly out_h * out_w
+    # pixels per batch:
+    #   pixels_h = floor((window_h - 1) / stride) + 1 = out_h
+    #   => window_h = (out_h - 1) * stride + 1
+    #   => upper_h = (out_h - 1) * stride + 1 - H - padding
+    upper_h = (out_h - 1) * stride + 1 - H - padding
+    upper_w = (out_w - 1) * stride + 1 - W - padding
+
+    input_block_shape = [BLOCK_M, BLOCK_K]
+    input_layout = gl.NVMMASharedLayout.get_default_for(input_block_shape, gl.float16)
+    in_desc = TensorDescriptorIm2Col(
+        base=input_tensor,
+        shape=list(input_tensor.shape),
+        strides=list(input_tensor.stride()),
+        block_shape=input_block_shape,
+        layout=input_layout,
+        padding="zero",
+        element_strides=[1, stride, stride, 1],
+        pixel_box_lower_corner=[-padding, -padding],
+        pixel_box_upper_corner=[upper_h, upper_w],
+    )
+
+    # TMA tiled descriptor for weight: (Co, R*S*Ci) = (N_GEMM, K_GEMM)
+    weight_reshaped = weight_tensor.reshape(Co, R * S * Ci)
+    weight_block_shape = [BLOCK_N, BLOCK_K]
+    weight_layout = gl.NVMMASharedLayout.get_default_for(weight_block_shape, gl.float16)
+    weight_desc = TensorDescriptor.from_tensor(weight_reshaped, weight_block_shape, weight_layout)
+
+    conv2d_im2col_kernel[grid](
+        in_desc,
+        weight_desc,
+        output,
+        N,
+        H,
+        W,
+        Ci,
+        Co,
+        R,
+        S,
+        out_h,
+        out_w,
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        stride,
+        stride,
+        padding,
+        padding,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        num_buffers=num_buffers,
+        num_warps=num_warps,
+    )
+
+    return output
+
+
+# ===-----------------------------------------------------------------------===#
+# Unit Tests
+# ===-----------------------------------------------------------------------===#
+
+
+@pytest.mark.parametrize("N", [1, 128])
+@pytest.mark.parametrize("H,W", [(64, 64)])
+@pytest.mark.parametrize("Ci,Co", [(384, 384), (416, 416)])
+@pytest.mark.parametrize("R,S", [(3, 3), (4, 4), (5, 5)])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", [0, 1])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU (SM 10.x)")
+def test_op(N, H, W, Ci, Co, R, S, stride, padding):
+    torch.manual_seed(0)
+
+    x_nchw = torch.randn((N, Ci, H, W), device="cuda", dtype=torch.float16)
+    x_nhwc = x_nchw.permute(0, 2, 3, 1).contiguous()
+
+    w_nchw = torch.randn((Co, Ci, R, S), device="cuda", dtype=torch.float16)
+    w_nhwc = w_nchw.permute(0, 2, 3, 1).contiguous()  # (Co, R, S, Ci)
+
+    triton_out = conv2d_im2col(x_nhwc, w_nhwc, stride=stride, padding=padding)
+
+    torch_out = torch.nn.functional.conv2d(x_nchw, w_nchw, stride=stride, padding=padding)
+    torch_out = torch_out.permute(0, 2, 3, 1)  # NCHW -> NHWC
+
+    torch.testing.assert_close(triton_out, torch_out, atol=1e-2, rtol=1e-2)
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmarking
+# ===-----------------------------------------------------------------------===#
+
+BATCH = [128]
+CHANNELS = [(384, 384)]
+SPATIAL = [(64, 64)]
+FILTER = [(3, 3)]
+STRIDE = [1]
+PADDING = [1]
+
+bench_configs = []
+for N, (Ci, Co), (H, W), (R, S), stride_val, pad_val in [(N, ch, sp, f, s, p)
+                                                         for N in BATCH
+                                                         for ch in CHANNELS
+                                                         for sp in SPATIAL
+                                                         for f in FILTER
+                                                         for s in STRIDE
+                                                         for p in PADDING]:
+    config = triton.testing.Benchmark(
+        x_names=["num_buffers"],
+        x_vals=[2, 3],
+        line_arg="provider",
+        line_vals=["triton", "torch"],
+        line_names=["Triton", "PyTorch"],
+        styles=[("red", "-"), ("blue", "-")],
+        ylabel="TFLOPS",
+        plot_name=f"Conv2d N={N} Ci={Ci} Co={Co} H={H} W={W} R={R} S={S} stride={stride_val} pad={pad_val}",
+        args={
+            "N": N,
+            "H": H,
+            "W": W,
+            "Ci": Ci,
+            "Co": Co,
+            "R": R,
+            "S": S,
+            "stride_val": stride_val,
+            "pad_val": pad_val,
+        },
+    )
+    bench_configs.append(config)
+
+
+@triton.testing.perf_report(bench_configs)
+def bench(N, H, W, Ci, Co, R, S, stride_val, pad_val, num_buffers, provider):
+    torch.manual_seed(0)
+
+    x_nchw = torch.randn((N, Ci, H, W), device="cuda", dtype=torch.float16)
+    x_nhwc = x_nchw.permute(0, 2, 3, 1).contiguous()
+    w_nchw = torch.randn((Co, Ci, R, S), device="cuda", dtype=torch.float16)
+    w_nhwc = w_nchw.permute(0, 2, 3, 1).contiguous()
+
+    if provider == "triton":
+        fn = lambda: conv2d_im2col(x_nhwc, w_nhwc, stride=stride_val, padding=pad_val, num_buffers=num_buffers)
+    elif provider == "torch":
+        fn = lambda: torch.nn.functional.conv2d(x_nchw, w_nchw, stride=stride_val, padding=pad_val)
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")
+
+    ms = triton.testing.do_bench(fn)
+
+    out_h = (H + 2 * pad_val - R) // stride_val + 1
+    out_w = (W + 2 * pad_val - S) // stride_val + 1
+    flops = 2.0 * N * out_h * out_w * Co * Ci * R * S
+    return flops * 1e-12 / (ms * 1e-3)
+
+
+if __name__ == "__main__":
+    bench.run(save_path=".", print_data=True)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -125,9 +125,7 @@ def check_type_supported(dtype, device):
     """
     if device in ["cuda"]:
         cc = torch.cuda.get_device_capability()
-        if cc[0] < 8 and (
-            dtype is tl.bfloat16 or dtype == "bfloat16" or dtype is torch.bfloat16
-        ):
+        if cc[0] < 8 and (dtype is tl.bfloat16 or dtype == "bfloat16" or dtype is torch.bfloat16):
             pytest.skip("bfloat16 is only supported on NVGPU with cc >= 80")
         if cc[0] < 9 and dtype in {tl.float8e4nv, "float8e4nv", "float8_e4m3fn"}:
             pytest.skip("float8e4nv is only supported on NVGPU with cc >= 90")
@@ -158,7 +156,7 @@ def test_scalar_overflow(device):
         y = x + huge_int
 
     with pytest.raises(triton.TritonError, match="out of range"):
-        kernel[(1,)]()
+        kernel[(1, )]()
 
 
 # generic test functions
@@ -185,7 +183,7 @@ def _test_unary(dtype_x, expr, numpy_expr=None, device="cuda", num_ctas=1):
     # triton result
     x_tri = to_triton(x, device=device, dst_type=dtype_x)
     z_tri = to_triton(np.empty_like(x), device=device, dst_type=dtype_x)
-    kernel[(1,)](Z=z_tri, X=x_tri, SIZE=SIZE, num_warps=4, num_ctas=num_ctas)
+    kernel[(1, )](Z=z_tri, X=x_tri, SIZE=SIZE, num_warps=4, num_ctas=num_ctas)
     # compare
     np.testing.assert_allclose(z_ref, to_numpy(z_tri), rtol=0.01)
 
@@ -300,9 +298,7 @@ def _test_binary(
         if scalar_test:
             # We remove any explicit casting
             pattern = r"\.astype\(np\.\w+\)"
-            scalar_expr = (
-                expr if numpy_expr is None else re.sub(pattern, "", numpy_expr)
-            )
+            scalar_expr = (expr if numpy_expr is None else re.sub(pattern, "", numpy_expr))
             with promotion_numpy_2_0():
                 z_ref = eval(scalar_expr)
         else:
@@ -316,11 +312,9 @@ def _test_binary(
         x_tri = x if x_is_scalar else to_triton(x, device=device, dst_type=dtype_x)
         y_tri = y if y_is_scalar else to_triton(y, device=device, dst_type=dtype_y)
         z_tri = to_triton(np.empty(SIZE, dtype=z_ref.dtype), device=device)
-        kernel_fn[(1,)](z_tri, x_tri, y_tri, SIZE=SIZE, num_warps=4, num_ctas=num_ctas)
+        kernel_fn[(1, )](z_tri, x_tri, y_tri, SIZE=SIZE, num_warps=4, num_ctas=num_ctas)
         err_msg = f"{expr}, {kernel_fn.__name__}"
-        np.testing.assert_allclose(
-            z_ref, to_numpy(z_tri), err_msg=err_msg, atol=7e-3, rtol=0.01
-        )
+        np.testing.assert_allclose(z_ref, to_numpy(z_tri), err_msg=err_msg, atol=7e-3, rtol=0.01)
 
     def get_scalar(x, dtype, low, high, filter):
         # If dtype is int, don't choose a huge number for the scalar
@@ -333,9 +327,7 @@ def _test_binary(
             high_x = 7
             if high is not None:
                 high_x = min(high_x, high)
-            scalar = numpy_random(
-                (), dtype_str=dtype, rs=rs, low=low_x, high=high_x
-            ).item()
+            scalar = numpy_random((), dtype_str=dtype, rs=rs, low=low_x, high=high_x).item()
             if filter and filter(scalar):
                 #  https://xkcd.com/221/
                 scalar = 4
@@ -408,11 +400,7 @@ def test_dtype_codegen():
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
     expr = f"x {op} y"
-    np_expr_gen = (
-        (lambda x, y: f"{x} {op} {y}")
-        if op != "%"
-        else (lambda x, y: f"np.fmod({x}, {y})")
-    )
+    np_expr_gen = ((lambda x, y: f"{x} {op} {y}") if op != "%" else (lambda x, y: f"np.fmod({x}, {y})"))
 
     # Triton promotes 16-bit floating-point / and % to 32-bit because there
     # are no native div or FRem operations on float16. Since we have to
@@ -423,21 +411,11 @@ def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
             "float64",
         )
 
-    if op in ("/", "%") and (
-        promote_to_fp32(dtype_x, dtype_y) or promote_to_fp32(dtype_y, dtype_x)
-    ):
+    if op in ("/", "%") and (promote_to_fp32(dtype_x, dtype_y) or promote_to_fp32(dtype_y, dtype_x)):
         numpy_expr = np_expr_gen("x.astype(np.float32)", "y.astype(np.float32)")
-    elif (
-        dtype_x in uint_dtypes
-        and dtype_y in int_dtypes
-        and _bitwidth(dtype_x) >= _bitwidth(dtype_y)
-    ):
+    elif (dtype_x in uint_dtypes and dtype_y in int_dtypes and _bitwidth(dtype_x) >= _bitwidth(dtype_y)):
         numpy_expr = np_expr_gen(f"x.astype(np.{dtype_x})", f"y.astype(np.{dtype_x})")
-    elif (
-        dtype_y in uint_dtypes
-        and dtype_x in int_dtypes
-        and _bitwidth(dtype_y) >= _bitwidth(dtype_x)
-    ):
+    elif (dtype_y in uint_dtypes and dtype_x in int_dtypes and _bitwidth(dtype_y) >= _bitwidth(dtype_x)):
         numpy_expr = np_expr_gen(f"x.astype(np.{dtype_y})", f"y.astype(np.{dtype_y})")
     elif op == "%":
         # LLVM has 'numpy.fmod', not 'numpy.remainder', semantics on integer remainders.
@@ -445,43 +423,28 @@ def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
     else:
         numpy_expr = None
 
-    if op in ("%", "/") and (
-        (dtype_x in int_dtypes and dtype_y in uint_dtypes)
-        or (dtype_x in uint_dtypes and dtype_y in int_dtypes)
-    ):
+    if op in ("%", "/") and ((dtype_x in int_dtypes and dtype_y in uint_dtypes) or
+                             (dtype_x in uint_dtypes and dtype_y in int_dtypes)):
         with pytest.raises(
-            triton.TritonError,
-            match="Cannot use .* because they have different signedness",
+                triton.TritonError,
+                match="Cannot use .* because they have different signedness",
         ):
-            _test_binary(
-                dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas
-            )
+            _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas)
     else:
         # skip when bfloat16, as NumPy's ref performs the computation in float32
         # while Triton performs it in bfloat16
-        skip_scalar_test = (dtype_x == "bfloat16" and "float" in dtype_y) or (
-            op in ("/", "%") and dtype_x in ("float16", "bfloat16")
-        )
+        skip_scalar_test = (dtype_x == "bfloat16" and "float" in dtype_y) or (op in ("/", "%")
+                                                                              and dtype_x in ("float16", "bfloat16"))
         # can't divide by zero
-        not_zero = (
-            op in ("/", "%")
-            and dtype_x in integral_dtypes
-            and dtype_y in integral_dtypes
-        )
+        not_zero = (op in ("/", "%") and dtype_x in integral_dtypes and dtype_y in integral_dtypes)
         # can't represent -int(max)
-        not_minus_one = (
-            op in ("*", "/") and dtype_x in int_dtypes and dtype_y in int_dtypes
-        )
+        not_minus_one = (op in ("*", "/") and dtype_x in int_dtypes and dtype_y in int_dtypes)
         if not_zero or not_minus_one:
             filter_y = lambda y: not_zero * (y == 0) | not_minus_one * (y == -1)
         else:
             filter_y = None
 
-        if (
-            op == "%"
-            and dtype_x in integral_dtypes
-            and dtype_y in float_dtypes_with_bfloat16
-        ):
+        if (op == "%" and dtype_x in integral_dtypes and dtype_y in float_dtypes_with_bfloat16):
             x_low, x_high = _min_max_integral_mod_value(dtype_x, dtype_y)
         else:
             x_low, x_high = None, None
@@ -526,7 +489,9 @@ def test_addptr(dtype, order, device):
     x_tri = to_triton(x, dst_type=dtype, device=device)
     y_tri = to_triton(y, dst_type=dtype, device=device)
     y = x
-    kernel[1,](x_tri, y_tri, order, SIZE)
+    kernel[
+        1,
+    ](x_tri, y_tri, order, SIZE)
     np.testing.assert_allclose(y, to_numpy(y_tri))
 
 
@@ -587,7 +552,7 @@ def test_unsigned_name_mangling(device):
     x_tri = to_triton(x, device=device, dst_type=dtype_x)
     y_tri = to_triton(y, device=device, dst_type=dtype_y)
     actual = tuple(to_triton(np.empty_like(e), device=device) for e in expect)
-    kernel[(1,)](actual[0], actual[1], x_tri, y_tri, SIZE=SIZE, num_warps=4)
+    kernel[(1, )](actual[0], actual[1], x_tri, y_tri, SIZE=SIZE, num_warps=4)
 
     # Bitwise op, so expect exact equality
     assert (expect[0] == to_numpy(actual[0])).all()
@@ -609,17 +574,9 @@ def test_unsigned_name_mangling(device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_bitwise_op(dtype_x, dtype_y, op, num_ctas, device):
     expr = f"x {op} y"
-    if (
-        dtype_x in uint_dtypes
-        and dtype_y in int_dtypes
-        and _bitwidth(dtype_x) >= _bitwidth(dtype_y)
-    ):
+    if (dtype_x in uint_dtypes and dtype_y in int_dtypes and _bitwidth(dtype_x) >= _bitwidth(dtype_y)):
         numpy_expr = f"x.astype(np.{dtype_x}) {op} y.astype(np.{dtype_x})"
-    elif (
-        dtype_y in uint_dtypes
-        and dtype_x in int_dtypes
-        and _bitwidth(dtype_y) >= _bitwidth(dtype_x)
-    ):
+    elif (dtype_y in uint_dtypes and dtype_x in int_dtypes and _bitwidth(dtype_y) >= _bitwidth(dtype_x)):
         numpy_expr = f"x.astype(np.{dtype_y}) {op} y.astype(np.{dtype_y})"
     else:
         numpy_expr = None
@@ -635,19 +592,14 @@ def test_bitwise_op(dtype_x, dtype_y, op, num_ctas, device):
                 num_ctas=num_ctas,
             )
     else:
-        _test_binary(
-            dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas
-        )
+        _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas)
 
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype_x, dtype_y, op",
     [  #
-        (dtype_x, dtype_y, op)
-        for op in ["<<", ">>"]
-        for dtype_x in int_dtypes + uint_dtypes
-        for dtype_y in uint_dtypes
+        (dtype_x, dtype_y, op) for op in ["<<", ">>"] for dtype_x in int_dtypes + uint_dtypes for dtype_y in uint_dtypes
     ],
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
@@ -681,33 +633,18 @@ ops = ["==", "!=", ">", "<", ">=", "<="]
 @pytest.mark.parametrize(
     "dtype_x, dtype_y, op, mode_x, mode_y",
     # real
-    [
-        (dtype_x, dtype_y, op, "real", "real")
-        for op in ops
-        for dtype_x in dtypes
-        for dtype_y in dtypes
-    ]
+    [(dtype_x, dtype_y, op, "real", "real") for op in ops for dtype_x in dtypes for dtype_y in dtypes]
     # NaNs
-    + [
-        ("float32", "float32", op, mode_x, mode_y)
-        for op in ops
-        for mode_x, mode_y in [("nan", "real"), ("real", "nan"), ("nan", "nan")]
-    ],
+    + [("float32", "float32", op, mode_x, mode_y)
+       for op in ops
+       for mode_x, mode_y in [("nan", "real"), ("real", "nan"), ("nan", "nan")]],
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_compare_op(dtype_x, dtype_y, op, mode_x, mode_y, num_ctas, device):
     expr = f"x {op} y"
-    if (
-        dtype_x in uint_dtypes
-        and dtype_y in int_dtypes
-        and _bitwidth(dtype_x) >= _bitwidth(dtype_y)
-    ):
+    if (dtype_x in uint_dtypes and dtype_y in int_dtypes and _bitwidth(dtype_x) >= _bitwidth(dtype_y)):
         numpy_expr = f"x.astype(np.{dtype_x}) {op} y.astype(np.{dtype_x})"
-    elif (
-        dtype_y in uint_dtypes
-        and dtype_x in int_dtypes
-        and _bitwidth(dtype_y) >= _bitwidth(dtype_x)
-    ):
+    elif (dtype_y in uint_dtypes and dtype_x in int_dtypes and _bitwidth(dtype_y) >= _bitwidth(dtype_x)):
         numpy_expr = f"x.astype(np.{dtype_y}) {op} y.astype(np.{dtype_y})"
     else:
         numpy_expr = None
@@ -732,17 +669,13 @@ def test_broadcast(dtype, device):
     check_type_supported(dtype, device)
 
     @triton.jit
-    def broadcast_kernel(
-        x_ptr, y_ptr, y_broadcasted_ptr, M: tl.constexpr, N: tl.constexpr
-    ):
+    def broadcast_kernel(x_ptr, y_ptr, y_broadcasted_ptr, M: tl.constexpr, N: tl.constexpr):
         offset1 = tl.arange(0, M)
         offset2 = tl.arange(0, N)
         x = tl.load(x_ptr + N * offset1[:, None] + offset2[None, :])
         y = tl.load(y_ptr + offset2)
         _, y_broadcasted = tl.broadcast(x, y)
-        tl.store(
-            y_broadcasted_ptr + N * offset1[:, None] + offset2[None, :], y_broadcasted
-        )
+        tl.store(y_broadcasted_ptr + N * offset1[:, None] + offset2[None, :], y_broadcasted)
 
     M = 32
     N = 64
@@ -753,11 +686,9 @@ def test_broadcast(dtype, device):
 
     x_tri = to_triton(x, device=device, dst_type=dtype)
     y_tri = to_triton(y, device=device, dst_type=dtype)
-    y_broadcasted_tri = to_triton(
-        np.empty((M, N), dtype=y_broadcasted_np.dtype), device=device, dst_type=dtype
-    )
+    y_broadcasted_tri = to_triton(np.empty((M, N), dtype=y_broadcasted_np.dtype), device=device, dst_type=dtype)
 
-    broadcast_kernel[(1,)](x_tri, y_tri, y_broadcasted_tri, M=M, N=N)
+    broadcast_kernel[(1, )](x_tri, y_tri, y_broadcasted_tri, M=M, N=N)
     assert (y_broadcasted_np == to_numpy(y_broadcasted_tri)).all()
 
 
@@ -807,7 +738,7 @@ def test_slice(device):
         t = scalar[None, None]
         tl.static_assert(t.shape == [1, 1])
 
-    slice_kernel[(1,)](XBLOCK=32)
+    slice_kernel[(1, )](XBLOCK=32)
 
 
 # ------------------
@@ -824,7 +755,7 @@ def test_invalid_slice(device):
         dst[10:]
 
     with pytest.raises(triton.TritonError, match="unsupported tensor index"):
-        _kernel[(1,)](dst=dst)
+        _kernel[(1, )](dst=dst)
 
 
 # ----------------
@@ -875,7 +806,7 @@ def test_expand_dims(device):
 
     N = 32
     dummy_tensor = torch.empty((), device=device)
-    expand_dims_kernel[(1,)](dummy_tensor, N)
+    expand_dims_kernel[(1, )](dummy_tensor, N)
 
 
 @pytest.mark.interpreter
@@ -918,28 +849,24 @@ def test_expand_dims_error_cases(device):
     dummy_tensor = torch.empty((), device=device)
 
     with pytest.raises(triton.TritonError) as exc_info:
-        dim_out_of_range1[(1,)](dummy_tensor, N)
+        dim_out_of_range1[(1, )](dummy_tensor, N)
     assert "invalid axis -3" in str(exc_info.value.__cause__)
 
     with pytest.raises(triton.TritonError) as exc_info:
-        dim_out_of_range2[(1,)](dummy_tensor, N)
+        dim_out_of_range2[(1, )](dummy_tensor, N)
     assert "invalid axis 2" in str(exc_info.value.__cause__)
 
     with pytest.raises(triton.TritonError) as exc_info:
-        dim_out_of_range3[(1,)](dummy_tensor, N)
+        dim_out_of_range3[(1, )](dummy_tensor, N)
     assert "invalid axis 1" in str(exc_info.value.__cause__)
 
     with pytest.raises(triton.TritonError) as exc_info:
-        duplicate_dim1[(1,)](dummy_tensor, N)
-    assert re.search(
-        r"duplicate axes, normalized axes = \[0, 0\]", str(exc_info.value.__cause__)
-    )
+        duplicate_dim1[(1, )](dummy_tensor, N)
+    assert re.search(r"duplicate axes, normalized axes = \[0, 0\]", str(exc_info.value.__cause__))
 
     with pytest.raises(triton.TritonError) as exc_info:
-        duplicate_dim2[(1,)](dummy_tensor, N)
-    assert re.search(
-        r"duplicate axes, normalized axes = \[0, 0\]", str(exc_info.value.__cause__)
-    )
+        duplicate_dim2[(1, )](dummy_tensor, N)
+    assert re.search(r"duplicate axes, normalized axes = \[0, 0\]", str(exc_info.value.__cause__))
 
 
 # ----------------------------
@@ -954,10 +881,8 @@ def test_invalid_pid_axis(device):
         pid = tl.program_id(20)
 
     with pytest.raises(triton.TritonError) as exc_info:
-        _kernel[(1,)](dst)
-    assert re.search(
-        r"program_id axis must be 0, 1, or 2 but got 20", str(exc_info.value.__cause__)
-    )
+        _kernel[(1, )](dst)
+    assert re.search(r"program_id axis must be 0, 1, or 2 but got 20", str(exc_info.value.__cause__))
 
 
 # ---------------
@@ -1012,7 +937,7 @@ def test_where(dtype, num_ctas, device):
     y_tri = to_triton(y, device=device, dst_type=dtype)
     z_tri = to_triton(np.empty(SIZE, dtype=z.dtype), device=device, dst_type=dtype)
 
-    grid = lambda meta: (triton.cdiv(SIZE, meta["BLOCK_SIZE"]),)
+    grid = lambda meta: (triton.cdiv(SIZE, meta["BLOCK_SIZE"]), )
     where_kernel[grid](
         cond_tri,
         x_tri,
@@ -1071,12 +996,10 @@ def test_where_broadcast(num_ctas, device):
     z = np.where(mask, x, 0)
     cond_tri = to_triton(mask, device=device)
     x_tri = to_triton(x, device=device, dst_type=dtype)
-    z_tri = to_triton(
-        np.empty((SIZE, SIZE), dtype=z.dtype), device=device, dst_type=dtype
-    )
-    where_kernel[(1,)](cond_tri, x_tri, z_tri, SIZE)
+    z_tri = to_triton(np.empty((SIZE, SIZE), dtype=z.dtype), device=device, dst_type=dtype)
+    where_kernel[(1, )](cond_tri, x_tri, z_tri, SIZE)
     assert (z == to_numpy(z_tri)).all()
-    where_scalar_condition[(1,)](x_tri, z_tri, SIZE, num_ctas=num_ctas)
+    where_scalar_condition[(1, )](x_tri, z_tri, SIZE, num_ctas=num_ctas)
     z = np.where(0, x, 0)
     assert (z == to_numpy(z_tri)).all()
 
@@ -1089,8 +1012,7 @@ def test_where_broadcast(num_ctas, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype_x, expr",
-    [(dtype_x, " -x") for dtype_x in dtypes_with_bfloat16]
-    + [(dtype_x, " ~x") for dtype_x in int_dtypes],
+    [(dtype_x, " -x") for dtype_x in dtypes_with_bfloat16] + [(dtype_x, " ~x") for dtype_x in int_dtypes],
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_unary_op(dtype_x, expr, num_ctas, device):
@@ -1105,23 +1027,18 @@ def test_unary_op(dtype_x, expr, num_ctas, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype_x, expr, x",
-    [
-        (dtype_x, expr, x)
-        for dtype_x in ["float32", "float64"]
-        for expr in [
-            "exp",
-            "log",
-            "cos",
-            "sin",
-            "exp2",
-            "log2",
-            "sqrt",
-            "rsqrt",
-            "floor",
-            "ceil",
-        ]
-        for x in ["x", "3.0"]
-    ],
+    [(dtype_x, expr, x) for dtype_x in ["float32", "float64"] for expr in [
+        "exp",
+        "log",
+        "cos",
+        "sin",
+        "exp2",
+        "log2",
+        "sqrt",
+        "rsqrt",
+        "floor",
+        "ceil",
+    ] for x in ["x", "3.0"]],
 )
 def test_math_op(dtype_x, expr, x, device):
     np_expr = f"1.0 / np.sqrt({x})" if expr == "rsqrt" else f"np.{expr}({x})"
@@ -1145,7 +1062,7 @@ def test_math_erf_op(dtype, device):
     x = torch.randn(SIZE, dtype=torch_dtype, device=device)
     z_ref = torch.erf(x)
     z_tri = torch.zeros_like(x)
-    kernel[(1,)](z_tri, x, SIZE=SIZE, num_warps=4)
+    kernel[(1, )](z_tri, x, SIZE=SIZE, num_warps=4)
     torch.testing.assert_close(z_tri, z_ref)
 
 
@@ -1170,7 +1087,7 @@ def test_math_fma_op(dtype, device):
     w = torch.randn(SIZE, dtype=torch_dtype, device=device)
     z_ref = x * y + w
     z_tri = torch.zeros_like(x)
-    kernel[(1,)](z_tri, x, y, w, SIZE=SIZE, num_warps=4)
+    kernel[(1, )](z_tri, x, y, w, SIZE=SIZE, num_warps=4)
     torch.testing.assert_close(z_tri, z_ref)
 
 
@@ -1206,7 +1123,7 @@ def test_precise_math(expr_prec, expr_ref, num_ctas, device):
         tl.store(OUT + tl.arange(0, BLOCK), prec)
         tl.store(OUT_REF + tl.arange(0, BLOCK), ref)
 
-    shape = (128,)
+    shape = (128, )
     out = torch.zeros(shape, dtype=torch.float32, device=device)
     out_ref = torch.zeros(shape, dtype=torch.float32, device=device)
 
@@ -1221,7 +1138,7 @@ def test_precise_math(expr_prec, expr_ref, num_ctas, device):
 
     kernel = patch_kernel(kernel, {"PREC_CALC": expr_prec, "REF_CALC": expr_ref})
 
-    kernel[(1,)](x, y, out, out_ref, BLOCK=shape[0], num_ctas=num_ctas)
+    kernel[(1, )](x, y, out, out_ref, BLOCK=shape[0], num_ctas=num_ctas)
     assert torch.all(out == out_ref)  # bitwise exact
 
 
@@ -1262,7 +1179,7 @@ def test_abs_fp8(in_dtype, device):
     f8 = triton.reinterpret(f8_tensor, in_dtype)
     n_elements = f8_tensor.numel()
     out_f8 = torch.empty_like(f8_tensor)
-    abs_kernel[(1,)](f8, triton.reinterpret(out_f8, in_dtype), n_elements)
+    abs_kernel[(1, )](f8, triton.reinterpret(out_f8, in_dtype), n_elements)
 
     f32_tensor = convert_float_to_float32(f8_tensor, in_dtype)
     expect = f32_tensor.abs()
@@ -1301,7 +1218,7 @@ def test_shapes_as_params(device):
         a = tl.reshape(tl.arange(0, 64), 2, 4, 8, can_reorder=True)
         tl.static_assert(a.shape == [tl.constexpr(2), tl.constexpr(4), tl.constexpr(8)])
 
-    kernel[(1,)]()
+    kernel[(1, )]()
 
 
 # ----------------
@@ -1327,7 +1244,7 @@ def test_transpose(dtype_x, device):
     z_ref = x.T
     x_tri = to_triton(x, device=device, dst_type=dtype_x)
     z_tri = to_triton(np.empty_like(z_ref), device=device, dst_type=dtype_x)
-    kernel[(1,)](z_tri, x_tri, SIZE=SIZE)
+    kernel[(1, )](z_tri, x_tri, SIZE=SIZE)
     np.testing.assert_allclose(z_ref, to_numpy(z_tri))
 
 
@@ -1350,11 +1267,7 @@ def make_ptr_str(name, shape):
 # TODO: handle `%4 = ttg.convert_layout %3 : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>``
 @pytest.mark.parametrize(
     "expr, dtype_str",
-    [
-        (f"x[{s}]", d)
-        for s in ["None, :", ":, None", "None, :, :", ":, :, None"]
-        for d in ["int32", "uint32", "uint16"]
-    ],
+    [(f"x[{s}]", d) for s in ["None, :", ":, None", "None, :, :", ":, :, None"] for d in ["int32", "uint32", "uint16"]],
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_index1d(expr, dtype_str, num_ctas, device):
@@ -1393,13 +1306,13 @@ def test_index1d(expr, dtype_str, num_ctas, device):
     # triton result
     z_tri = to_triton(np.empty_like(z_ref), device=device)
     x_tri = to_triton(x, device=device)
-    kernel_match[(1,)](z_tri, x_tri, num_warps=1, SIZE=shape_x[0])
+    kernel_match[(1, )](z_tri, x_tri, num_warps=1, SIZE=shape_x[0])
     # compare
     assert (z_ref == to_numpy(z_tri)).all()
 
     def catch_compilation_error(kernel):
         try:
-            kernel[(1,)](z_tri, x_tri, num_warps=1, SIZE=shape_x[0], num_ctas=num_ctas)
+            kernel[(1, )](z_tri, x_tri, num_warps=1, SIZE=shape_x[0], num_ctas=num_ctas)
         except triton.CompilationError as e:
             np.testing.assert_(True)
         except BaseException:
@@ -1468,9 +1381,7 @@ def noinline_multi_values_fn(x, y, Z):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize(
-    "mode", ["simple", "call_graph", "shared", "dynamic", "multi_values"]
-)
+@pytest.mark.parametrize("mode", ["simple", "call_graph", "shared", "dynamic", "multi_values"])
 def test_noinline(mode, device):
 
     @triton.jit
@@ -1487,7 +1398,7 @@ def test_noinline(mode, device):
         z = torch.ones((16, 16), device=device, dtype=torch.float32)
     else:
         z = torch.tensor([0.0], device=device, dtype=torch.float32)
-    kernel[(1,)](x, y, z, num_warps=1)
+    kernel[(1, )](x, y, z, num_warps=1)
     if mode == "simple":
         assert torch.equal(z, x + y)
     elif mode == "call_graph" or mode == "dynamic" or mode == "multi_values":
@@ -1503,34 +1414,30 @@ def test_noinline(mode, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "op, dtype_x_str, mode, sem",
-    itertools.chain.from_iterable(
-        [
-            [
-                ("add", "bfloat16", mode, sem),
-                ("add", "float16", mode, sem),
-                ("add", "uint32", mode, sem),
-                ("add", "int32", mode, sem),
-                ("add", "float32", mode, sem),
-                ("add", "uint64", mode, sem),
-                ("add", "int64", mode, sem),
-                ("add", "float64", mode, sem),
-                ("max", "uint32", mode, sem),
-                ("max", "int32", mode, sem),
-                ("max", "float32", mode, sem),
-                ("max", "uint64", mode, sem),
-                ("max", "int64", mode, sem),
-                ("max", "float64", mode, sem),
-                ("min", "uint32", mode, sem),
-                ("min", "int32", mode, sem),
-                ("min", "float32", mode, sem),
-                ("min", "uint64", mode, sem),
-                ("min", "int64", mode, sem),
-                ("min", "float64", mode, sem),
-            ]
-            for mode in ["all_neg", "all_pos", "min_neg", "max_pos"]
-            for sem in [None, "acquire", "release", "acq_rel", "relaxed"]
-        ]
-    ),
+    itertools.chain.from_iterable([[
+        ("add", "bfloat16", mode, sem),
+        ("add", "float16", mode, sem),
+        ("add", "uint32", mode, sem),
+        ("add", "int32", mode, sem),
+        ("add", "float32", mode, sem),
+        ("add", "uint64", mode, sem),
+        ("add", "int64", mode, sem),
+        ("add", "float64", mode, sem),
+        ("max", "uint32", mode, sem),
+        ("max", "int32", mode, sem),
+        ("max", "float32", mode, sem),
+        ("max", "uint64", mode, sem),
+        ("max", "int64", mode, sem),
+        ("max", "float64", mode, sem),
+        ("min", "uint32", mode, sem),
+        ("min", "int32", mode, sem),
+        ("min", "float32", mode, sem),
+        ("min", "uint64", mode, sem),
+        ("min", "int64", mode, sem),
+        ("min", "float64", mode, sem),
+    ]
+                                   for mode in ["all_neg", "all_pos", "min_neg", "max_pos"]
+                                   for sem in [None, "acquire", "release", "acq_rel", "relaxed"]]),
 )
 def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
     check_type_supported(dtype_x_str, device)
@@ -1551,20 +1458,12 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
         tl.static_assert(old.dtype == x.dtype)
 
     sem_arg = sem if sem is None else f'"{sem}"'
-    kernel = patch_kernel(
-        kernel, {"GENERATE_TEST_HERE": f"tl.atomic_{op}(Z, x, sem={sem_arg})"}
-    )
+    kernel = patch_kernel(kernel, {"GENERATE_TEST_HERE": f"tl.atomic_{op}(Z, x, sem={sem_arg})"})
     numpy_op = {"add": np.sum, "max": np.max, "min": np.min}[op]
-    max_neutral = (
-        float("-inf")
-        if dtype_x_str in float_dtypes_with_bfloat16
-        else np.iinfo(getattr(np, dtype_x_str)).min
-    )
-    min_neutral = (
-        float("inf")
-        if dtype_x_str in float_dtypes_with_bfloat16
-        else np.iinfo(getattr(np, dtype_x_str)).max
-    )
+    max_neutral = (float("-inf")
+                   if dtype_x_str in float_dtypes_with_bfloat16 else np.iinfo(getattr(np, dtype_x_str)).min)
+    min_neutral = (float("inf")
+                   if dtype_x_str in float_dtypes_with_bfloat16 else np.iinfo(getattr(np, dtype_x_str)).max)
     neutral = {"add": 0, "max": max_neutral, "min": min_neutral}[op]
 
     # triton result
@@ -1577,10 +1476,10 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
     if mode == "all_pos":
         x = np.abs(x)
     if mode == "min_neg":
-        idx = rs.randint(n_programs, size=(1,)).item()
+        idx = rs.randint(n_programs, size=(1, )).item()
         x[idx] = -np.max(np.abs(x)) - 1
     if mode == "max_pos":
-        idx = rs.randint(n_programs, size=(1,)).item()
+        idx = rs.randint(n_programs, size=(1, )).item()
         x[idx] = np.max(np.abs(x)) + 1
     x_tri = to_triton(x, device=device, dst_type=dst_type)
 
@@ -1589,7 +1488,7 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
         device=device,
         dst_type=dst_type,
     )
-    h = kernel[(n_programs,)](x_tri, z_tri)
+    h = kernel[(n_programs, )](x_tri, z_tri)
     # torch result
     if dst_type == "bfloat16":
         z_ref = numpy_op(x).astype(getattr(np, dtype_x_str))
@@ -1628,33 +1527,29 @@ def test_atomic_rmw_predicate(num_ctas, device):
         if val < 64:
             tl.atomic_max(X, val)
 
-    x = torch.zeros((1,), device=device, dtype=torch.int32)
-    kernel[(4096,)](x, num_ctas=num_ctas)
+    x = torch.zeros((1, ), device=device, dtype=torch.int32)
+    kernel[(4096, )](x, num_ctas=num_ctas)
     assert x.item() == 63
 
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "shape, axis, num_ctas, dtype_x_str, check_return_val",
-    [
-        (shape, axis, num_ctas, dtype_x_str, check_return_val)
-        for shape in [(2, 2), (2, 8), (8, 2), (8, 8), (32, 32), (64, 64), (128, 128)]
-        for axis in [0, 1]
-        for num_ctas in num_ctas_list
-        for dtype_x_str in [
-            "bfloat16",
-            "float16",
-            "float32",
-            "uint64",
-            "int64",
-            "float64",
-        ]
-        for check_return_val in ([True, False] if is_hip() else [True])
-    ],
+    [(shape, axis, num_ctas, dtype_x_str, check_return_val)
+     for shape in [(2, 2), (2, 8), (8, 2), (8, 8), (32, 32), (64, 64), (128, 128)]
+     for axis in [0, 1]
+     for num_ctas in num_ctas_list
+     for dtype_x_str in [
+         "bfloat16",
+         "float16",
+         "float32",
+         "uint64",
+         "int64",
+         "float64",
+     ]
+     for check_return_val in ([True, False] if is_hip() else [True])],
 )
-def test_tensor_atomic_rmw(
-    shape, axis, num_ctas, dtype_x_str, check_return_val, device
-):
+def test_tensor_atomic_rmw(shape, axis, num_ctas, dtype_x_str, check_return_val, device):
     check_type_supported(dtype_x_str, device)
     shape0, shape1 = shape
     # triton kernel
@@ -1695,15 +1590,13 @@ def test_tensor_atomic_rmw(
 
     rs = RandomState(17)
     x = numpy_random((shape0, shape1), dtype_str=dtype_x_str, rs=rs)
-    z_shape = (shape0,) if axis == 1 else (shape1,)
+    z_shape = (shape0, ) if axis == 1 else (shape1, )
     z = numpy_random(z_shape, dtype_str=dtype_x_str, rs=rs)
     old = np.zeros(z_shape, dtype=z.dtype)
     # reference results
     if x.dtype == np.float16:
         # do the sum in float32 to reduce numerical variation
-        z_ref = z + np.sum(x.astype(np.float32), axis=axis, keepdims=False).astype(
-            x.dtype
-        )
+        z_ref = z + np.sum(x.astype(np.float32), axis=axis, keepdims=False).astype(x.dtype)
     else:
         z_ref = z + np.sum(x, axis=axis, keepdims=False)
     old_ref = np.copy(z)
@@ -1719,7 +1612,7 @@ def test_tensor_atomic_rmw(
             return tl.float16
         return None
 
-    kernel[(1,)](
+    kernel[(1, )](
         z_tri,
         x_tri,
         old_tri,
@@ -1750,12 +1643,10 @@ def test_tensor_atomic_rmw(
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "size, num_ctas, dtype_x_str",
-    [
-        (size, num_ctas, dtype_x_str)
-        for size in [2, 4, 8, 32, 64, 128]
-        for num_ctas in num_ctas_list
-        for dtype_x_str in ["bfloat16", "float16", "float32"]
-    ],
+    [(size, num_ctas, dtype_x_str)
+     for size in [2, 4, 8, 32, 64, 128]
+     for num_ctas in num_ctas_list
+     for dtype_x_str in ["bfloat16", "float16", "float32"]],
 )
 def test_tensor_atomic_add_non_exclusive_offset(size, num_ctas, dtype_x_str, device):
     check_type_supported(dtype_x_str, device)
@@ -1771,7 +1662,7 @@ def test_tensor_atomic_add_non_exclusive_offset(size, num_ctas, dtype_x_str, dev
     dtype = getattr(torch, dtype_x_str)
     x = torch.zeros(shape, dtype=dtype, device=device)
     val = torch.randn((size**2), dtype=dtype, device=device)
-    kernel[(1,)](x, val, size, num_warps=1, num_ctas=num_ctas)
+    kernel[(1, )](x, val, size, num_warps=1, num_ctas=num_ctas)
     ref = val[0::2] + val[1::2]
     torch.testing.assert_close(ref, x.reshape(math.prod(shape)))
 
@@ -1779,12 +1670,10 @@ def test_tensor_atomic_add_non_exclusive_offset(size, num_ctas, dtype_x_str, dev
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "size, num_ctas, dtype_x_str",
-    [
-        (size, num_ctas, dtype_x_str)
-        for size in [2, 4, 8, 32, 64, 128]
-        for num_ctas in num_ctas_list
-        for dtype_x_str in ["bfloat16", "float16", "float32"]
-    ],
+    [(size, num_ctas, dtype_x_str)
+     for size in [2, 4, 8, 32, 64, 128]
+     for num_ctas in num_ctas_list
+     for dtype_x_str in ["bfloat16", "float16", "float32"]],
 )
 def test_tensor_atomic_add_shift_1(size, num_ctas, dtype_x_str, device):
     check_type_supported(dtype_x_str, device)
@@ -1804,36 +1693,30 @@ def test_tensor_atomic_add_shift_1(size, num_ctas, dtype_x_str, device):
     x = torch.zeros(s, dtype=dtype, device=device)
     ref = torch.flatten(x)
     val = torch.randn(s, dtype=dtype, device=device)
-    kernel[(1,)](x, val, size, num_warps=1, num_ctas=num_ctas)
+    kernel[(1, )](x, val, size, num_warps=1, num_ctas=num_ctas)
     val = torch.flatten(val)
     ref[0:size] = val[0:size]
-    ref[1 : size + 1] += val[size : 2 * size]
+    ref[1:size + 1] += val[size:2 * size]
     torch.testing.assert_close(ref, torch.flatten(x))
 
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "shape, idx_order, mask_step, num_ctas, dtype_x_str",
-    [
-        (shape, idx_order, mask_step, num_ctas, dtype_x_str)
-        for shape in [(2, 2), (4, 4), (5, 5), (6, 6), (8, 8)]
-        for idx_order in ["increase", "decrease", "random_no_duplication", "random"]
-        for mask_step in range(1, 5)
-        for num_ctas in num_ctas_list
-        for dtype_x_str in ["bfloat16", "float16", "float32"]
-    ],
+    [(shape, idx_order, mask_step, num_ctas, dtype_x_str)
+     for shape in [(2, 2), (4, 4), (5, 5), (6, 6), (8, 8)]
+     for idx_order in ["increase", "decrease", "random_no_duplication", "random"]
+     for mask_step in range(1, 5)
+     for num_ctas in num_ctas_list
+     for dtype_x_str in ["bfloat16", "float16", "float32"]],
 )
-def test_tensor_atomic_add_access_patterns(
-    shape, idx_order, mask_step, num_ctas, dtype_x_str, device
-):
+def test_tensor_atomic_add_access_patterns(shape, idx_order, mask_step, num_ctas, dtype_x_str, device):
     check_type_supported(dtype_x_str, device)
     if is_interpreter():
         pytest.skip("not supported in the interpreter")
 
     @triton.jit
-    def kernel(
-        in_ptr, idx_ptr, out_ptr, shape0, shape1, mask_step, XBLOCK: tl.constexpr
-    ):
+    def kernel(in_ptr, idx_ptr, out_ptr, shape0, shape1, mask_step, XBLOCK: tl.constexpr):
         xoffset = tl.program_id(0) * XBLOCK
         x_idx = xoffset + tl.arange(0, XBLOCK)[:]
         mask = x_idx < shape0 * shape1
@@ -1846,13 +1729,9 @@ def test_tensor_atomic_add_access_patterns(
     shape0, shape1 = shape
     idx_row = torch.arange(0, shape1, device=device)
     if idx_order == "increase":
-        idx = torch.stack(
-            [idx_row.repeat_interleave(i + 1)[:shape1] for i in range(shape0)]
-        )
+        idx = torch.stack([idx_row.repeat_interleave(i + 1)[:shape1] for i in range(shape0)])
     if idx_order == "decrease":
-        idx = torch.stack(
-            [idx_row.flip(0).repeat_interleave(i + 1)[:shape1] for i in range(shape0)]
-        )
+        idx = torch.stack([idx_row.flip(0).repeat_interleave(i + 1)[:shape1] for i in range(shape0)])
     if idx_order == "random_no_duplication":
         idx = torch.stack([torch.randperm(shape1, device=device) for _ in idx_row])
     if idx_order == "random":
@@ -1871,7 +1750,7 @@ def test_tensor_atomic_add_access_patterns(
                 dst_ref[i][elem] += val[i][j]
             cnt += 1
 
-    kernel[(1,)](val, idx, dst, shape0, shape1, mask_step, 64, num_ctas=num_ctas)
+    kernel[(1, )](val, idx, dst, shape0, shape1, mask_step, 64, num_ctas=num_ctas)
 
     if dtype_x_str == "bfloat16":
         torch.testing.assert_close(dst_ref, dst, rtol=0.1, atol=0.1)
@@ -1895,7 +1774,7 @@ def test_tensor_atomic_rmw_block(num_ctas, device):
         tl.atomic_min(x, val)
 
     x = torch.ones((8, 8), device=device, dtype=torch.float32)
-    kernel[(2,)](x, shape[0], shape[1], num_ctas=num_ctas)
+    kernel[(2, )](x, shape[0], shape[1], num_ctas=num_ctas)
     assert torch.min(x).item() == 0.0
 
 
@@ -1910,22 +1789,22 @@ def test_atomic_cas(sem, num_ctas, dtype_str, device):
     # 1. make sure that atomic_cas changes the original value (Lock)
     @triton.jit
     def change_value(Lock, triton_dtype: tl.constexpr):
-        num0 = tl.full((1,), 0, dtype=triton_dtype).item()
-        num1 = tl.full((1,), 1, dtype=triton_dtype).item()
+        num0 = tl.full((1, ), 0, dtype=triton_dtype).item()
+        num1 = tl.full((1, ), 1, dtype=triton_dtype).item()
         tl.atomic_cas(Lock, num0, num1)
 
     torch_dtype = getattr(torch, dtype_str)
     triton_dtype = getattr(tl, dtype_str)
-    Lock = torch.zeros((1,), device=device, dtype=torch_dtype)
-    change_value[(1,)](Lock, triton_dtype)
+    Lock = torch.zeros((1, ), device=device, dtype=torch_dtype)
+    change_value[(1, )](Lock, triton_dtype)
 
     assert Lock[0] == 1
 
     # 2. only one block enters the critical section
     @triton.jit
     def serialized_add(data, Lock, triton_dtype: tl.constexpr, SEM: tl.constexpr):
-        num0 = tl.full((1,), 0, dtype=triton_dtype).item()
-        num1 = tl.full((1,), 1, dtype=triton_dtype).item()
+        num0 = tl.full((1, ), 0, dtype=triton_dtype).item()
+        num1 = tl.full((1, ), 1, dtype=triton_dtype).item()
 
         ptrs = data + tl.arange(0, 128)
         while tl.atomic_cas(Lock, num0, num1, SEM) == 1:
@@ -1940,12 +1819,10 @@ def test_atomic_cas(sem, num_ctas, dtype_str, device):
         # release lock
         tl.atomic_xchg(Lock, num0)
 
-    Lock = torch.zeros((1,), device=device, dtype=torch_dtype)
-    data = torch.zeros((128,), device=device, dtype=torch.float32)
-    ref = torch.full((128,), 2000.0)
-    h = serialized_add[(2000,)](
-        data, Lock, triton_dtype=triton_dtype, SEM=sem, num_ctas=num_ctas
-    )
+    Lock = torch.zeros((1, ), device=device, dtype=torch_dtype)
+    data = torch.zeros((128, ), device=device, dtype=torch.float32)
+    ref = torch.full((128, ), 2000.0)
+    h = serialized_add[(2000, )](data, Lock, triton_dtype=triton_dtype, SEM=sem, num_ctas=num_ctas)
     sem_str = "acq_rel" if sem is None else sem
     np.testing.assert_allclose(to_numpy(data), to_numpy(ref))
     if not is_cuda():
@@ -1957,33 +1834,29 @@ def test_atomic_cas(sem, num_ctas, dtype_str, device):
 @pytest.mark.parametrize("sem", [None, "acquire", "release", "acq_rel", "relaxed"])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 @pytest.mark.parametrize("size", [4, 128, 512, 1024])
-@pytest.mark.parametrize(
-    "dtype_str", ["bfloat16", "float16", "float32", "uint64", "int64", "float64"]
-)
+@pytest.mark.parametrize("dtype_str", ["bfloat16", "float16", "float32", "uint64", "int64", "float64"])
 def test_tensor_atomic_cas(sem, size, dtype_str, num_ctas, device):
     check_type_supported(dtype_str, device)
     if is_hip_cdna2():
         pytest.skip("Disabled due to being flaky on CDNA2")
 
     @triton.jit
-    def change_value(
-        X, BLOCK_SIZE: tl.constexpr, sem: tl.constexpr, dtype: tl.constexpr
-    ):
+    def change_value(X, BLOCK_SIZE: tl.constexpr, sem: tl.constexpr, dtype: tl.constexpr):
         pid = tl.program_id(axis=0)
         block_start = pid * BLOCK_SIZE
         offsets = block_start + tl.arange(0, BLOCK_SIZE)
-        t1 = tl.full((BLOCK_SIZE,), 0, dtype=dtype)
-        t2 = tl.full((BLOCK_SIZE,), 2, dtype=dtype)
+        t1 = tl.full((BLOCK_SIZE, ), 0, dtype=dtype)
+        t2 = tl.full((BLOCK_SIZE, ), 2, dtype=dtype)
         tl.atomic_cas(X + offsets, t1, t2, sem=sem)
 
     torch_dtype = getattr(torch, dtype_str)
-    X = torch.zeros((size,), device=device, dtype=torch_dtype)
+    X = torch.zeros((size, ), device=device, dtype=torch_dtype)
     X[1::2] = 1
     Y = X.clone()
     Y[0::2] = 2
 
     tl_dtype = getattr(tl, dtype_str)
-    change_value[(2,)](X, BLOCK_SIZE=size // 2, sem=sem, dtype=tl_dtype)
+    change_value[(2, )](X, BLOCK_SIZE=size // 2, sem=sem, dtype=tl_dtype)
     assert torch.equal(X, Y)
 
 
@@ -2004,14 +1877,10 @@ def test_load_scope_sem_coop_grid_cta_not_one(device):
         tl.store(ptrs, a)
 
     block_size = 128
-    data = torch.zeros((128,), device=device, dtype=torch.float32)
+    data = torch.zeros((128, ), device=device, dtype=torch.float32)
 
-    kernel_r[(2,)](
-        data, BLOCK_SIZE=block_size, num_ctas=4, launch_cooperative_grid=True
-    )
-    kernel_r[(2,)](
-        data, BLOCK_SIZE=block_size, num_ctas=4, launch_cooperative_grid=False
-    )
+    kernel_r[(2, )](data, BLOCK_SIZE=block_size, num_ctas=4, launch_cooperative_grid=True)
+    kernel_r[(2, )](data, BLOCK_SIZE=block_size, num_ctas=4, launch_cooperative_grid=False)
 
 
 @pytest.mark.interpreter
@@ -2027,15 +1896,11 @@ def test_load_scope_sem_coop_grid_cta_one(device):
         tl.store(ptrs, a)
 
     block_size = 128
-    data = torch.zeros((128,), device=device, dtype=torch.float32)
+    data = torch.zeros((128, ), device=device, dtype=torch.float32)
 
     # Should do nothing different for num_ctas=1 (with coop launch grid)
-    kernel_r[(2,)](
-        data, BLOCK_SIZE=block_size, num_ctas=1, launch_cooperative_grid=True
-    )
-    kernel_r[(2,)](
-        data, BLOCK_SIZE=block_size, num_ctas=1, launch_cooperative_grid=False
-    )
+    kernel_r[(2, )](data, BLOCK_SIZE=block_size, num_ctas=1, launch_cooperative_grid=True)
+    kernel_r[(2, )](data, BLOCK_SIZE=block_size, num_ctas=1, launch_cooperative_grid=False)
 
 
 @pytest.mark.interpreter
@@ -2050,22 +1915,16 @@ def test_atomic_min_max_neg_zero(device):
 
     N_PROG = 1
     dtype = torch.float32
-    out_min = torch.full(
-        [N_PROG], torch.finfo(torch.float32).max, device=device, dtype=dtype
-    )
-    out_max = torch.full(
-        [N_PROG], torch.finfo(torch.float32).min, device=device, dtype=dtype
-    )
+    out_min = torch.full([N_PROG], torch.finfo(torch.float32).max, device=device, dtype=dtype)
+    out_max = torch.full([N_PROG], torch.finfo(torch.float32).min, device=device, dtype=dtype)
     inp = torch.full([N_PROG], -0.0, device=device, dtype=dtype)
-    kernel[(N_PROG,)](inp, out_max, out_min)
+    kernel[(N_PROG, )](inp, out_max, out_min)
     torch.testing.assert_close(out_min, inp, atol=0, rtol=0)
     torch.testing.assert_close(out_max, inp, atol=0, rtol=0)
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize(
-    "dtype_str", ["float8_e4m3fn", "int8", "int16", "uint8", "uint16"]
-)
+@pytest.mark.parametrize("dtype_str", ["float8_e4m3fn", "int8", "int16", "uint8", "uint16"])
 def test_atomic_unsupported_type(dtype_str, device):
 
     @triton.jit
@@ -2073,10 +1932,10 @@ def test_atomic_unsupported_type(dtype_str, device):
         x = tl.load(I)
         tl.atomic_add(O, x)
 
-    I = torch.zeros((1,), device=device, dtype=getattr(torch, dtype_str))
-    O = torch.zeros((1,), device=device, dtype=getattr(torch, dtype_str))
+    I = torch.zeros((1, ), device=device, dtype=getattr(torch, dtype_str))
+    O = torch.zeros((1, ), device=device, dtype=getattr(torch, dtype_str))
     with pytest.raises(triton.TritonError):
-        kernel[(1,)](I, O)
+        kernel[(1, )](I, O)
 
 
 @pytest.mark.interpreter
@@ -2087,8 +1946,7 @@ def test_tensor_atomic_use_result(dtype_str, size, op, device):
     if is_hip():
         pytest.skip(
             "HIP is broken because (1) it doesn't support thread predicate in atomic cas, and (2) it doesn't support"
-            " atomic rmw with float16"
-        )
+            " atomic rmw with float16")
 
     @triton.jit
     def kernel(index_ptr, out_ptr, size: tl.constexpr, op: tl.constexpr):
@@ -2101,17 +1959,15 @@ def test_tensor_atomic_use_result(dtype_str, size, op, device):
         elif op == "cas":
             write_index = tl.atomic_cas(
                 index_ptr + tl.arange(0, size)[:, None],
-                cmp=tl.zeros((size,), dtype=index_ptr.dtype.element_ty)[:, None],
+                cmp=tl.zeros((size, ), dtype=index_ptr.dtype.element_ty)[:, None],
                 val=tl.arange(0, size).to(index_ptr.dtype.element_ty)[:, None],
                 sem="relaxed",
             )
-        tl.store(
-            out_ptr + write_index.to(tl.uint32) * size + tl.arange(0, size)[None, :], 5
-        )
+        tl.store(out_ptr + write_index.to(tl.uint32) * size + tl.arange(0, size)[None, :], 5)
 
     index = torch.arange(0, size, device=device).to(dtype=getattr(torch, dtype_str))
     out = torch.zeros((size, size), device=device, dtype=getattr(torch, dtype_str))
-    kernel[(1,)](index, out, size, op)
+    kernel[(1, )](index, out, size, op)
     assert (out == 5).all()
 
 
@@ -2123,75 +1979,46 @@ def test_tensor_atomic_use_result(dtype_str, size, op, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype_x, dtype_z, bitcast, size",
-    [(dtype_x, dtype_z, False, 1024) for dtype_x in dtypes for dtype_z in dtypes]
-    + [
+    [(dtype_x, dtype_z, False, 1024) for dtype_x in dtypes for dtype_z in dtypes] + [
         ("float32", "bfloat16", False, 1024),
         ("bfloat16", "float32", False, 1024),
         ("float32", "int32", True, 1024),
         ("float32", "bool", False, 1024),
         ("int8", "bfloat16", False, 1024),
-    ]
-    + [(f"uint{x}", f"int{x}", True, 1024) for x in [8, 16, 32, 64]]
-    + [(f"int{x}", f"uint{x}", True, 1024) for x in [8, 16, 32, 64]]
-    + (
-        (
-            [
-                (dtype_x, dtype_z, False, size)
-                for dtype_x in torch_float8_dtypes
-                for dtype_z in ["float16", "float32", "bfloat16"]
-                for size in [1024, 32]
-            ]  #
-            + [
-                (dtype_x, dtype_z, False, size)
-                for dtype_z in torch_float8_dtypes
-                for dtype_x in ["float16", "float32", "bfloat16"]
-                for size in [1024, 32]
-            ]
-        )
-        if torch.__version__ >= "2.1"
-        else []
-    ),
+    ] + [(f"uint{x}", f"int{x}", True, 1024) for x in [8, 16, 32, 64]] + [(f"int{x}", f"uint{x}", True, 1024)
+                                                                          for x in [8, 16, 32, 64]] +
+    (([(dtype_x, dtype_z, False, size)
+       for dtype_x in torch_float8_dtypes
+       for dtype_z in ["float16", "float32", "bfloat16"]
+       for size in [1024, 32]]  #
+      + [(dtype_x, dtype_z, False, size)
+         for dtype_z in torch_float8_dtypes
+         for dtype_x in ["float16", "float32", "bfloat16"]
+         for size in [1024, 32]]) if torch.__version__ >= "2.1" else []),
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
     # CUDA: bfloat16 on cc < 80 will not be tested
     # Interpreter: Only bfloat16 <-> float32 is supported
-    if not is_interpreter() or (
-        is_interpreter()
-        and not (
-            (dtype_z == "bfloat16" and dtype_x == "float32")
-            or (dtype_z == "float32" and dtype_x == "bfloat16")
-        )
-    ):
+    if not is_interpreter() or (is_interpreter() and not ((dtype_z == "bfloat16" and dtype_x == "float32") or
+                                                          (dtype_z == "float32" and dtype_x == "bfloat16"))):
         check_type_supported(dtype_x, device)
         check_type_supported(dtype_z, device)
 
     if is_hip():
-        if (
-            not is_hip_cdna3()
-            and not is_hip_cdna4()
-            and not is_hip_gfx1250()
-            and (dtype_x == "float8_e4m3fn" or dtype_z == "float8_e4m3fn")
-        ):
-            pytest.skip(
-                f"test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3/CDNA4 and above."
-            )
-        if (not (is_hip_cdna4() or is_hip_gfx1250())) and (
-            (dtype_x == "bfloat16" and dtype_z == "float8_e4m3fn")
-            or (dtype_x == "float8_e4m3fn" and dtype_z == "bfloat16")
-        ):
-            pytest.skip(
-                f"test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4 and above."
-            )
+        if (not is_hip_cdna3() and not is_hip_cdna4() and not is_hip_gfx1250()
+                and (dtype_x == "float8_e4m3fn" or dtype_z == "float8_e4m3fn")):
+            pytest.skip(f"test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3/CDNA4 and above.")
+        if (not (is_hip_cdna4() or is_hip_gfx1250())) and ((dtype_x == "bfloat16" and dtype_z == "float8_e4m3fn") or
+                                                           (dtype_x == "float8_e4m3fn" and dtype_z == "bfloat16")):
+            pytest.skip(f"test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4 and above.")
 
     torch.manual_seed(0)
     # This is tricky because numpy doesn't have bfloat, and torch doesn't have uints.
     if dtype_x.startswith("bfloat"):
         x_tri = torch.randn(size, dtype=getattr(torch, dtype_x), device=device)
     elif dtype_x.startswith("float8"):
-        x_tri = torch.randn(size, dtype=torch.half, device=device).to(
-            dtype=getattr(torch, dtype_x)
-        )
+        x_tri = torch.randn(size, dtype=torch.half, device=device).to(dtype=getattr(torch, dtype_x))
     else:
         x = numpy_random(size, dtype_str=dtype_x, low=-10, high=10) * 10
         # Triton clamps negative values to zero, while numpy wraps around
@@ -2238,18 +2065,14 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
     dtype_z_np = dtype_z if dtype_z != "bool" else "bool_"
     # triton result
     if dtype_z.startswith("bfloat"):
-        z_tri = torch.empty((size,), dtype=getattr(torch, dtype_z), device=device)
+        z_tri = torch.empty((size, ), dtype=getattr(torch, dtype_z), device=device)
     elif dtype_z.startswith("float8"):
-        z_tri = torch.empty((size,), dtype=torch.half, device=device).to(
-            dtype=getattr(torch, dtype_z)
-        )
+        z_tri = torch.empty((size, ), dtype=torch.half, device=device).to(dtype=getattr(torch, dtype_z))
     else:
-        z_tri = to_triton(
-            np.empty((size,), dtype=getattr(np, dtype_z_np)), device=device
-        )
+        z_tri = to_triton(np.empty((size, ), dtype=getattr(np, dtype_z_np)), device=device)
 
     dtype_z_tri = str_to_triton_dtype(dtype_z)
-    kernel[(1,)](
+    kernel[(1, )](
         x_tri,
         z_tri,
         TO_TYPE=dtype_z_tri,
@@ -2260,12 +2083,8 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
         num_ctas=num_ctas,
     )
     # torch result
-    if (
-        dtype_z.startswith("bfloat")
-        or dtype_x.startswith("bfloat")
-        or dtype_z.startswith("float8")
-        or dtype_x.startswith("float8")
-    ):
+    if (dtype_z.startswith("bfloat") or dtype_x.startswith("bfloat") or dtype_z.startswith("float8")
+            or dtype_x.startswith("float8")):
         assert bitcast is False
         z_ref = x_tri.to(z_tri.dtype)
         if dtype_z.startswith("float8") and device not in ["cuda"]:
@@ -2284,11 +2103,7 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype_str, num_warps",
-    [
-        (dtype_str, num_warps)
-        for dtype_str in int_dtypes + float_dtypes
-        for num_warps in [4, 8]
-    ],
+    [(dtype_str, num_warps) for dtype_str in int_dtypes + float_dtypes for num_warps in [4, 8]],
 )
 @pytest.mark.parametrize("can_reorder", [True, False])
 def test_cat(dtype_str, num_warps, can_reorder, device):
@@ -2305,8 +2120,8 @@ def test_cat(dtype_str, num_warps, can_reorder, device):
     x = torch.arange(0, 128, device=device).to(getattr(torch, dtype_str))
     y = torch.arange(-128, 0, device=device).to(getattr(torch, dtype_str))
     z_ref = torch.cat([x, y], dim=0)
-    z = torch.zeros((256,), dtype=getattr(torch, dtype_str), device=device)
-    kernel[(1,)](x, y, z, N=128, num_warps=num_warps, CAN_REORDER=can_reorder)
+    z = torch.zeros((256, ), dtype=getattr(torch, dtype_str), device=device)
+    kernel[(1, )](x, y, z, N=128, num_warps=num_warps, CAN_REORDER=can_reorder)
     assert z.sum() == z_ref.sum()
     if not can_reorder:
         torch.testing.assert_close(z, z_ref, atol=0, rtol=0)
@@ -2314,7 +2129,7 @@ def test_cat(dtype_str, num_warps, can_reorder, device):
     assert z.unique().size(0) == z.size(0)
 
 
-CAT_ND_SHAPES = ((128,), (16, 32), (8, 16, 4), (2, 4, 8, 16))
+CAT_ND_SHAPES = ((128, ), (16, 32), (8, 16, 4), (2, 4, 8, 16))
 CAT_ND_CASES = []
 for shape in CAT_ND_SHAPES:
     for dim in range(len(shape)):
@@ -2339,7 +2154,7 @@ def test_cat_nd(shape, dim, device):
     x_desc = TensorDescriptor.from_tensor(x, block_shape=shape)
     y_desc = TensorDescriptor.from_tensor(y, block_shape=shape)
     z_desc = TensorDescriptor.from_tensor(z, block_shape=z_ref.shape)
-    kernel[(1,)](x_desc, y_desc, z_desc, dim=dim, shape=shape)
+    kernel[(1, )](x_desc, y_desc, z_desc, dim=dim, shape=shape)
     torch.testing.assert_close(z, z_ref, atol=0, rtol=0)
 
 
@@ -2351,9 +2166,7 @@ def test_store_constant(num_ctas, dtype_str, constant_field, device):
     check_type_supported(dtype_str, device)
 
     @triton.jit
-    def kernel(
-        output_ptr, n_elements, BLOCK_SIZE: tl.constexpr, CONSTANT_FIELD: tl.constexpr
-    ):
+    def kernel(output_ptr, n_elements, BLOCK_SIZE: tl.constexpr, CONSTANT_FIELD: tl.constexpr):
         offsets = tl.program_id(axis=0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         if CONSTANT_FIELD == "value":
             value = 1
@@ -2368,7 +2181,7 @@ def test_store_constant(num_ctas, dtype_str, constant_field, device):
     ref = torch.ones([block_size], dtype=getattr(torch, dtype_str), device=device)
     output = torch.zeros([block_size], dtype=getattr(torch, dtype_str), device=device)
 
-    kernel[(1,)](
+    kernel[(1, )](
         output,
         block_size,
         BLOCK_SIZE=block_size,
@@ -2392,11 +2205,11 @@ def test_load_store_same_ptr(device):
         tl.store(in_out_ptr + pid, out)
 
     for _ in range(1000):
-        x = torch.ones((65536,), device=device, dtype=torch.float32)
+        x = torch.ones((65536, ), device=device, dtype=torch.float32)
         if is_hip():
-            kernel[(65536,)](x, num_warps=16)  # threads per Warp for ROCM is 64
+            kernel[(65536, )](x, num_warps=16)  # threads per Warp for ROCM is 64
         else:
-            kernel[(65536,)](x, num_warps=32)
+            kernel[(65536, )](x, num_warps=32)
         assert torch.all(x == 2)
 
 
@@ -2426,12 +2239,12 @@ def test_umulhi(dtype_str, device):
 
     rs = RandomState(17)
     N = 128
-    x = numpy_random((N,), dtype_str=dtype_str, rs=rs, low=0)
+    x = numpy_random((N, ), dtype_str=dtype_str, rs=rs, low=0)
     x_tri = to_triton(x, device=device)
-    y = numpy_random((N,), dtype_str=dtype_str, rs=rs, low=0)
+    y = numpy_random((N, ), dtype_str=dtype_str, rs=rs, low=0)
     y_tri = to_triton(y, device=device)
     z_tri = torch.zeros_like(x_tri)
-    kernel[(1,)](x_tri, y_tri, z_tri, N=N)
+    kernel[(1, )](x_tri, y_tri, z_tri, N=N)
 
     z_ref = umulhi32(x, y)
     np.testing.assert_equal(z_ref, to_numpy(z_tri))
@@ -2452,7 +2265,7 @@ def test_join(device):
     y = torch.arange(-128, 0, device=device).to(torch.int32)
     z_ref = torch.stack([x, y], dim=-1)
     z = torch.zeros_like(z_ref)
-    kernel[(1,)](x, y, z, N=128)
+    kernel[(1, )](x, y, z, N=128)
 
     np.testing.assert_equal(to_numpy(z_ref), to_numpy(z))
 
@@ -2471,7 +2284,7 @@ def test_join_scalars(device):
     x = torch.full([1], 42, device=device).to(torch.int32)
     y = torch.full([1], 100, device=device).to(torch.int32)
     z = torch.zeros([2], device=device)
-    kernel[(1,)](x, y, z)
+    kernel[(1, )](x, y, z)
 
     np.testing.assert_equal([42, 100], to_numpy(z))
 
@@ -2481,9 +2294,7 @@ def test_join_with_mma(device):
 
     @triton.jit
     def kernel(X, Z):
-        x = tl.load(
-            X + 16 * tl.arange(0, 32)[:, None] + tl.arange(0, 16)[None, :]
-        )  # (32,16)
+        x = tl.load(X + 16 * tl.arange(0, 32)[:, None] + tl.arange(0, 16)[None, :])  # (32,16)
         x2 = tl.join(x, 2 * x)  # (32,16,2)
         x3 = tl.reshape(x2, (32, 32))
         z = tl.dot(x3, x3)  # (32,32)
@@ -2493,7 +2304,7 @@ def test_join_with_mma(device):
     r = torch.stack([x, 2 * x], dim=-1).reshape((32, 32))
     z_ref = torch.matmul(r, r)
     z = torch.zeros_like(z_ref)
-    kernel[(1,)](x, z)
+    kernel[(1, )](x, z)
 
     torch.testing.assert_close(z, z_ref)
 
@@ -2511,7 +2322,7 @@ def test_interleave(device, debug):
     y = torch.arange(128, 256, device=device).to(torch.int32)
     z_ref = torch.stack([x, y], dim=-1).reshape(256)
     z = torch.zeros_like(z_ref)
-    kernel[(1,)](z, N=128)
+    kernel[(1, )](z, N=128)
 
     np.testing.assert_equal(to_numpy(z_ref), to_numpy(z))
 
@@ -2526,7 +2337,7 @@ def test_interleave_scalars(device):
         tl.store(Z + tl.arange(0, 2), z)
 
     z = torch.zeros(2, device=device)
-    kernel[(1,)](10, 20, z)
+    kernel[(1, )](10, 20, z)
 
     np.testing.assert_equal([10, 20], to_numpy(z))
 
@@ -2547,7 +2358,7 @@ def test_split(device):
     z1_ref, z2_ref = (x[:, 0], x[:, 1])
     z1 = torch.zeros_like(z1_ref)
     z2 = torch.zeros_like(z2_ref)
-    kernel[(1,)](x, z1, z2, N=256)
+    kernel[(1, )](x, z1, z2, N=256)
 
     np.testing.assert_equal(to_numpy(z1_ref), to_numpy(z1))
     np.testing.assert_equal(to_numpy(z2_ref), to_numpy(z2))
@@ -2573,7 +2384,7 @@ def test_split_to_scalar(device):
     z1_ref, z2_ref = (x[:, 0], x[:, 1])
     z1 = torch.zeros_like(z1_ref)
     z2 = torch.zeros_like(z2_ref)
-    kernel[(1,)](x, z1, z2)
+    kernel[(1, )](x, z1, z2)
 
     np.testing.assert_equal(to_numpy(z1_ref), to_numpy(z1))
     np.testing.assert_equal(to_numpy(z2_ref), to_numpy(z2))
@@ -2593,18 +2404,13 @@ def convert_float_to_float32(fp: torch.tensor, dtype=None):
     output = torch.where(
         exp == 0,
         # subnormal
-        ((-1.0) ** sign)
-        * (2.0 ** (1 - exp_bias))
-        * (frac / (2.0**dtype.fp_mantissa_width)),
+        ((-1.0)**sign) * (2.0**(1 - exp_bias)) * (frac / (2.0**dtype.fp_mantissa_width)),
         # normal
-        ((-1.0) ** sign)
-        * (2.0 ** (exp - exp_bias))
-        * (1.0 + frac / (2.0**dtype.fp_mantissa_width)),
+        ((-1.0)**sign) * (2.0**(exp - exp_bias)) * (1.0 + frac / (2.0**dtype.fp_mantissa_width)),
     ).float()
 
     extended_exp = (
-        (1 << (tl.float32.primitive_bitwidth - tl.float32.fp_mantissa_width - 1)) - 1
-    ) << tl.float32.fp_mantissa_width
+        (1 << (tl.float32.primitive_bitwidth - tl.float32.fp_mantissa_width - 1)) - 1) << tl.float32.fp_mantissa_width
     # special cases, exp is 0b11..1
     if dtype in [tl.float8e4nv, tl.float8e4b15]:
         # float8e4m3nv does not have infinities
@@ -2613,13 +2419,10 @@ def convert_float_to_float32(fp: torch.tensor, dtype=None):
     else:
         output = torch.where(
             exp == (1 << exp_width) - 1,
-            (
-                (sign << (tl.float32.primitive_bitwidth - 1))
-                | extended_exp
-                | (frac << (tl.float32.fp_mantissa_width - dtype.fp_mantissa_width))
-            ).view(  #
-                torch.float32
-            ),
+            ((sign << (tl.float32.primitive_bitwidth - 1))
+             | extended_exp
+             | (frac << (tl.float32.fp_mantissa_width - dtype.fp_mantissa_width))).view(  #
+                 torch.float32),
             output,
         )
     return output
@@ -2631,9 +2434,7 @@ def test_convert_float16_to_float32(in_dtype, device):
     """Tests that check convert_float_to_float32 function"""
     check_type_supported(in_dtype, device)
 
-    f16_input = torch.tensor(
-        range(-int(2 ** (16 - 1)), int(2 ** (16 - 1))), dtype=torch.int16
-    ).view(in_dtype)
+    f16_input = torch.tensor(range(-int(2**(16 - 1)), int(2**(16 - 1))), dtype=torch.int16).view(in_dtype)
     f32_output = convert_float_to_float32(f16_input)
 
     nan = f16_input.isnan()
@@ -2660,10 +2461,10 @@ def test_max_returns_zero(device):
         tl.store(Z, z)
 
     BLOCK = 128
-    x = torch.zeros((BLOCK,), device=device)
-    z = torch.ones((1,), device=device)
+    x = torch.zeros((BLOCK, ), device=device)
+    z = torch.ones((1, ), device=device)
 
-    kernel[(1,)](x, z, BLOCK=BLOCK)
+    kernel[(1, )](x, z, BLOCK=BLOCK)
     assert z[0] == 0
 
 
@@ -2703,10 +2504,10 @@ def test_max_min_with_nan(device):
 
     y = torch.ones(1, device=device)
 
-    max_kernel[(1,)](x, y, BLOCK_SIZE=BLOCK_SIZE)
+    max_kernel[(1, )](x, y, BLOCK_SIZE=BLOCK_SIZE)
     assert y[0] == float("inf")
 
-    min_kernel[(1,)](x, y, BLOCK_SIZE=BLOCK_SIZE)
+    min_kernel[(1, )](x, y, BLOCK_SIZE=BLOCK_SIZE)
     assert y[0] == float("-inf")
 
 
@@ -2720,9 +2521,7 @@ def get_reduced_dtype(dtype_str, op):
 
 def get_reduce_input(dtype_str, shape):
     # limit the range of integers so that reduce ops do not overflow
-    low = (
-        0 if dtype_str in uint_dtypes else -10 if dtype_str in integral_dtypes else None
-    )
+    low = (0 if dtype_str in uint_dtypes else -10 if dtype_str in integral_dtypes else None)
     high = 10 if dtype_str in integral_dtypes else None
     return numpy_random(shape, dtype_str=dtype_str, low=low, high=high)
 
@@ -2730,20 +2529,15 @@ def get_reduce_input(dtype_str, shape):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "op, dtype_str, shape",
-    [
-        (op, dtype, shape)
-        for op in [
-            "min",
-            "max",
-            "min-with-indices",
-            "max-with-indices",
-            "argmin-tie-break-left",
-            "argmax-tie-break-left",
-            "sum",
-        ]
-        for dtype in dtypes_with_bfloat16
-        for shape in [32, 64, 128, 512]
-    ],
+    [(op, dtype, shape) for op in [
+        "min",
+        "max",
+        "min-with-indices",
+        "max-with-indices",
+        "argmin-tie-break-left",
+        "argmax-tie-break-left",
+        "sum",
+    ] for dtype in dtypes_with_bfloat16 for shape in [32, 64, 128, 512]],
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_reduce1d(op, dtype_str, shape, num_ctas, device):
@@ -2765,7 +2559,7 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
         patch = f"z = tl.{op}(x, axis=0)"
     kernel = patch_kernel(kernel, {"GENERATE_TEST_HERE": patch})
     # input
-    x = get_reduce_input(dtype_str, (shape,))
+    x = get_reduce_input(dtype_str, (shape, ))
     numpy_op = {
         "sum": np.sum,
         "max": np.max,
@@ -2791,11 +2585,11 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
         z_ref = numpy_op(x).astype(getattr(np, z_dtype_str))
     # triton result
     z_tri = to_triton(
-        numpy_random((1,), dtype_str=z_dtype_str),
+        numpy_random((1, ), dtype_str=z_dtype_str),
         device=device,
         dst_type=z_tri_dtype_str,
     )
-    kernel[(1,)](x_tri, z_tri, BLOCK=shape, num_ctas=num_ctas)
+    kernel[(1, )](x_tri, z_tri, BLOCK=shape, num_ctas=num_ctas)
     z_tri = to_numpy(z_tri)
     # compare
     if op == "sum":
@@ -2810,12 +2604,10 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
 
 
 # TODO: [Qingyi] Fix argmin / argmax
-reduce_configs1 = [
-    (op, dtype, (1, 1024), axis, False)
-    for dtype in dtypes_with_bfloat16
-    for op in ["min", "max", "sum", "argmin", "argmax"]
-    for axis in [1]
-]
+reduce_configs1 = [(op, dtype, (1, 1024), axis, False)
+                   for dtype in dtypes_with_bfloat16
+                   for op in ["min", "max", "sum", "argmin", "argmax"]
+                   for axis in [1]]
 
 # shape (128, 256) and (32, 1024) are not enabled on sm86 because the required shared memory
 # exceeds the limit of 99KB
@@ -2825,51 +2617,33 @@ reduce2d_shapes = [(2, 32), (4, 32), (4, 128)]
 if is_cuda() and "V100" in torch.cuda.get_device_name(0):
     reduce2d_shapes += [(128, 256) and (32, 1024)]
 
-reduce_configs2 = [
-    (op, "float32", shape, axis, False)
-    for op in ["min", "max", "sum", "argmin", "argmax"]
-    for shape in reduce2d_shapes
-    for axis in [0, 1]
-] + [(op, "float32", [16, 32], None, False) for op in ["min", "max", "sum"]]
+reduce_configs2 = [(op, "float32", shape, axis, False)
+                   for op in ["min", "max", "sum", "argmin", "argmax"]
+                   for shape in reduce2d_shapes
+                   for axis in [0, 1]] + [(op, "float32", [16, 32], None, False) for op in ["min", "max", "sum"]]
 
 reduce3d_shapes = [(2, 32, 16), (32, 2, 16), (32, 16, 2)]
-reduce_configs3 = [
-    (op, "float32", shape, axis, False)
-    for op in ["min", "max", "sum", "argmin", "argmax"]
-    for shape in reduce3d_shapes
-    for axis in [0, 1, 2]
-]
+reduce_configs3 = [(op, "float32", shape, axis, False)
+                   for op in ["min", "max", "sum", "argmin", "argmax"]
+                   for shape in reduce3d_shapes
+                   for axis in [0, 1, 2]]
 invalid_config = [("sum", "float32", (32, 32), axis, False) for axis in [2, 3]]
 negative_config = [("sum", "float32", (32, 32), -1, False)]
-keep_dims_2d_configs = [
-    (op, "float32", (32, 32), axis, True)
-    for op in ["min", "max", "sum", "argmin", "argmax"]
-    for axis in [0, 1]
-] + [(op, "float32", (32, 32), None, True) for op in ["min", "max", "sum"]]
-keep_dims_3d_configs = [
-    (op, "float32", (32, 2, 16), axis, True)
-    for op in ["min", "max", "sum", "argmin", "argmax"]
-    for axis in [0, 1, 2]
-] + [(op, "float32", (32, 2, 16), None, True) for op in ["min", "max", "sum"]]
-reduce_bool = [
-    (op, "bool", shape, axis, False)
-    for op in ["xor_sum"]
-    for shape in reduce2d_shapes
-    for axis in [0, 1]
-]
+keep_dims_2d_configs = [(op, "float32", (32, 32), axis, True)
+                        for op in ["min", "max", "sum", "argmin", "argmax"]
+                        for axis in [0, 1]] + [(op, "float32", (32, 32), None, True) for op in ["min", "max", "sum"]]
+keep_dims_3d_configs = [(op, "float32", (32, 2, 16), axis, True)
+                        for op in ["min", "max", "sum", "argmin", "argmax"]
+                        for axis in [0, 1, 2]] + [(op, "float32", (32, 2, 16), None, True)
+                                                  for op in ["min", "max", "sum"]]
+reduce_bool = [(op, "bool", shape, axis, False) for op in ["xor_sum"] for shape in reduce2d_shapes for axis in [0, 1]]
 
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "op, dtype_str, shape, axis, keep_dims",
-    reduce_configs1
-    + reduce_configs2
-    + reduce_configs3
-    + invalid_config
-    + negative_config
-    + keep_dims_2d_configs
-    + keep_dims_3d_configs
-    + reduce_bool,
+    reduce_configs1 + reduce_configs2 + reduce_configs3 + invalid_config + negative_config + keep_dims_2d_configs +
+    keep_dims_3d_configs + reduce_bool,
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
@@ -2891,12 +2665,8 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
         range_n = tl.arange(0, BLOCK_N)
         range_k = tl.arange(0, BLOCK_K)
         if IS_3D:
-            x = tl.load(
-                X
-                + range_m[:, None, None] * BLOCK_N * BLOCK_K
-                + range_n[None, :, None] * BLOCK_K
-                + range_k[None, None, :]
-            )
+            x = tl.load(X + range_m[:, None, None] * BLOCK_N * BLOCK_K + range_n[None, :, None] * BLOCK_K +
+                        range_k[None, None, :])
         else:
             x = tl.load(X + range_m[:, None] * BLOCK_N + range_n[None, :])
         if USE_I1:
@@ -2924,9 +2694,7 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
             z_ptr = tl.expand_dims(z_ptr, axis=AXIS)
         tl.store(z_ptr, z)
 
-    kernel = patch_kernel(
-        kernel, {"GENERATE_TEST_HERE": f"tl.{op}(x, axis=AXIS, keep_dims=KEEP_DIMS)"}
-    )
+    kernel = patch_kernel(kernel, {"GENERATE_TEST_HERE": f"tl.{op}(x, axis=AXIS, keep_dims=KEEP_DIMS)"})
     # input
     x = get_reduce_input(dtype_str, shape)
     x_tri = to_triton(x, device=device)
@@ -2949,15 +2717,11 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
     if op not in ["argmin", "argmax"] and dtype_str == "bfloat16":
         z_dtype_str = "float32"
         z_tri_dtype_str = "bfloat16"
-        z_ref = numpy_op(x, axis=np_axis, keepdims=keep_dims).astype(
-            getattr(np, z_dtype_str)
-        )
+        z_ref = numpy_op(x, axis=np_axis, keepdims=keep_dims).astype(getattr(np, z_dtype_str))
         # trunc mantissa for a fair comparison of accuracy
         z_ref = (z_ref.view("uint32") & np.uint32(0xFFFF0000)).view("float32")
     else:
-        z_ref = numpy_op(x, axis=np_axis, keepdims=keep_dims).astype(
-            getattr(np, z_dtype_str)
-        )
+        z_ref = numpy_op(x, axis=np_axis, keepdims=keep_dims).astype(getattr(np, z_dtype_str))
 
     # triton result
     z_shape = z_ref.shape
@@ -2971,7 +2735,7 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
     USE_I1 = dtype_str == "bool"
     if axis is not None and axis >= len(shape):
         with pytest.raises(triton.TritonError):
-            kernel[(1,)](
+            kernel[(1, )](
                 x_tri,
                 z_tri,
                 BLOCK_M=shape[0],
@@ -2985,7 +2749,7 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
             )
         return
     else:
-        kernel[(1,)](
+        kernel[(1, )](
             x_tri,
             z_tri,
             BLOCK_M=shape[0],
@@ -3021,22 +2785,20 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
 
 scan2d_shapes = [(8, 32), (16, 32), (32, 16), (2, 1024), (1024, 2), (32, 32), (1, 1024)]
 
-scan_configs = [
-    (op, type, shape, axis, reverse, num_warps)
-    for num_warps in [4, 16]
-    for type in ["int32", "float32", "bfloat16"]
-    for axis in [1, 0]
-    for reverse in [True, False]
-    for shape in scan2d_shapes
-    for op in [
-        "cumsum",
-        "cumprod",
-        "get_first_element",
-        "linear_recurrence",
-        "cummax",
-        "roll",
-    ]
-]
+scan_configs = [(op, type, shape, axis, reverse, num_warps)
+                for num_warps in [4, 16]
+                for type in ["int32", "float32", "bfloat16"]
+                for axis in [1, 0]
+                for reverse in [True, False]
+                for shape in scan2d_shapes
+                for op in [
+                    "cumsum",
+                    "cumprod",
+                    "get_first_element",
+                    "linear_recurrence",
+                    "cummax",
+                    "roll",
+                ]]
 negative_config = [("cumsum", "float32", (32, 32), -1, False, 4)]
 
 
@@ -3061,26 +2823,24 @@ def test_sum_dtype(device):
         tl.store(out_ptr, x)
 
     out = torch.empty(1, dtype=torch.int32, device=device)
-    kernel_dtype[(1,)](out, init=1, in_dtype=tl.int1, out_dtype=None)
+    kernel_dtype[(1, )](out, init=1, in_dtype=tl.int1, out_dtype=None)
     assert out[0] == 32 * 32
 
-    kernel_dtype[(1,)](out, init=1, in_dtype=tl.int1, out_dtype=tl.int1)
+    kernel_dtype[(1, )](out, init=1, in_dtype=tl.int1, out_dtype=tl.int1)
     assert out[0] == 0
 
-    kernel_dtype[(1,)](out, init=7, in_dtype=tl.int8, out_dtype=tl.int8)
+    kernel_dtype[(1, )](out, init=7, in_dtype=tl.int8, out_dtype=tl.int8)
     assert out[0] == (7 * 32 * 32) % 256
 
-    kernel_dtype[(1,)](out, init=1, in_dtype=tl.int32, out_dtype=None)
+    kernel_dtype[(1, )](out, init=1, in_dtype=tl.int32, out_dtype=None)
     assert out[0] == 32 * 32
 
-    kernel_default_int[(1,)](out)
+    kernel_default_int[(1, )](out)
     assert out[0] == 32 * 32
 
     out = torch.empty(1, dtype=torch.bfloat16, device=device)
-    kernel_default_float[(1,)](out)
-    torch.testing.assert_close(
-        out[0], torch.tensor(32 * 32, dtype=torch.bfloat16, device=device)
-    )
+    kernel_default_float[(1, )](out)
+    torch.testing.assert_close(out[0], torch.tensor(32 * 32, dtype=torch.bfloat16, device=device))
 
 
 # trivial associative but not commutative function
@@ -3107,25 +2867,19 @@ def roll(a1, b1_last, b1_cur, a2, b2_last, b2_cur):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize(
-    "op, dtype_str, shape, axis, reverse, num_warps", scan_configs + negative_config
-)
+@pytest.mark.parametrize("op, dtype_str, shape, axis, reverse, num_warps", scan_configs + negative_config)
 def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     check_type_supported(dtype_str, device)
     if dtype_str == "bfloat16":
         if op == "cummax":
             pytest.skip("bfloat16 compare not supported before sm90")
         if op == "linear_recurrence":
-            pytest.skip(
-                "Skipping linear_recurrence scan on bfloat16 due to accuracy issues"
-            )
+            pytest.skip("Skipping linear_recurrence scan on bfloat16 due to accuracy issues")
     numpy_dtype_str = "float32" if dtype_str == "bfloat16" else dtype_str
 
     # triton kernel
     @triton.jit
-    def kernel(
-        X, Y, Z, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, AXIS: tl.constexpr
-    ):
+    def kernel(X, Y, Z, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, AXIS: tl.constexpr):
         range_m = tl.arange(0, BLOCK_M)
         range_n = tl.arange(0, BLOCK_N)
         x = tl.load(X + range_m[:, None] * BLOCK_N + range_n[None, :])
@@ -3141,9 +2895,7 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     elif op == "get_first_element":
         kernel = patch_kernel(
             kernel,
-            {
-                "GENERATE_TEST_HERE": f"z = tl.associative_scan(x, axis={axis}, combine_fn={op}, reverse={reverse})"
-            },
+            {"GENERATE_TEST_HERE": f"z = tl.associative_scan(x, axis={axis}, combine_fn={op}, reverse={reverse})"},
         )
     elif op == "cummax":
         rg = "range_m[:, None]" if axis == 0 else "range_n[None, :]"
@@ -3151,7 +2903,8 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
         kernel = patch_kernel(
             kernel,
             {
-                "GENERATE_TEST_HERE": f"_, z = tl.associative_scan((x, {rg}), axis={axis}, combine_fn={op}, reverse={reverse})"
+                "GENERATE_TEST_HERE":
+                f"_, z = tl.associative_scan((x, {rg}), axis={axis}, combine_fn={op}, reverse={reverse})"
             },
         )
     elif op == "roll":
@@ -3159,7 +2912,8 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
         kernel = patch_kernel(
             kernel,
             {
-                "GENERATE_TEST_HERE": f"_, z, _ = tl.associative_scan((1 + 0* x, 0 * x, x), axis={axis}, combine_fn={op}, reverse={reverse})"
+                "GENERATE_TEST_HERE":
+                f"_, z, _ = tl.associative_scan((1 + 0* x, 0 * x, x), axis={axis}, combine_fn={op}, reverse={reverse})"
             },
         )
     else:
@@ -3167,7 +2921,8 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
         kernel = patch_kernel(
             kernel,
             {
-                "GENERATE_TEST_HERE": f"_, z = tl.associative_scan((x, y), axis={axis}, combine_fn={op}, reverse={reverse})"
+                "GENERATE_TEST_HERE":
+                f"_, z = tl.associative_scan((x, y), axis={axis}, combine_fn={op}, reverse={reverse})"
             },
         )
     # input
@@ -3248,7 +3003,7 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     # triton result
     # we don't cast the `fp32 = bf16 op bf16` result to bfloat16 to alleviate accuracy issues
     z_tri = to_triton(z, device=device)
-    kernel[(1,)](
+    kernel[(1, )](
         x_tri,
         y_tri,
         z_tri,
@@ -3275,9 +3030,7 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize(
-    "M, N", [[2048, 2], [1024, 8], [1024, 128], [256, 512], [32, 512], [8, 512], [8, 2]]
-)
+@pytest.mark.parametrize("M, N", [[2048, 2], [1024, 8], [1024, 128], [256, 512], [32, 512], [8, 512], [8, 2]])
 def test_histogram(M, N, device):
 
     @triton.jit
@@ -3292,13 +3045,13 @@ def test_histogram(M, N, device):
         tl.store(z_ptr + offset2, z)
 
     torch.manual_seed(17)
-    x = torch.randint(0, N, (M,), device=device, dtype=torch.int32)
+    x = torch.randint(0, N, (M, ), device=device, dtype=torch.int32)
     z = torch.empty(N, dtype=torch.int32, device=device)
     # torch.histc does not work when the input type is not float and the device is CPU
     # https://github.com/pytorch/pytorch/issues/74236
     # This is a workload by converting the input to float
     z_torch = torch.histc(x.float(), bins=N, min=0, max=N - 1)
-    histogram_kernel[(1,)](x, z, M=M, N=N)
+    histogram_kernel[(1, )](x, z, M=M, N=N)
     assert (z_torch == z).all()
 
 
@@ -3315,10 +3068,8 @@ def test_histogram_silent_data_corruption(device):
     x = torch.ones(1, device=device, dtype=torch.int32)
     z = torch.ones(2, device=device, dtype=torch.int32)
 
-    histogram_kernel[(1,)](x, z)
-    assert (
-        z[1] == 1
-    ), f"Second element shouldn't be affected, expected_buffer=[1, 1], actual_buffer={z}"
+    histogram_kernel[(1, )](x, z)
+    assert (z[1] == 1), f"Second element shouldn't be affected, expected_buffer=[1, 1], actual_buffer={z}"
 
 
 # ------------------------
@@ -3327,9 +3078,7 @@ def test_histogram_silent_data_corruption(device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize(
-    "M, N", [[2048, 2], [1024, 8], [1024, 128], [256, 512], [32, 512], [8, 512], [8, 2]]
-)
+@pytest.mark.parametrize("M, N", [[2048, 2], [1024, 8], [1024, 128], [256, 512], [32, 512], [8, 512], [8, 2]])
 def test_histogram_mask(M, N, device):
 
     @triton.jit
@@ -3342,20 +3091,18 @@ def test_histogram_mask(M, N, device):
         tl.store(z_ptr + offset2, z)
 
     torch.manual_seed(17)
-    x1 = torch.randint(0, N, (M,), device=device, dtype=torch.int32)
+    x1 = torch.randint(0, N, (M, ), device=device, dtype=torch.int32)
     x = torch.cat((x1, x1), 0)
     z = torch.empty(N, dtype=torch.int32, device=device)
     # torch.histc does not work when the input type is not float and the device is CPU
     # https://github.com/pytorch/pytorch/issues/74236
     # This is a workload by converting the input to float
     z_torch = torch.histc(x1.float(), bins=N, min=0, max=N - 1)
-    histogram_kernel[(1,)](x, z, M=M, N=N)
+    histogram_kernel[(1, )](x, z, M=M, N=N)
     assert (z_torch == z).all()
 
 
-@pytest.mark.parametrize(
-    "M, N", [(1, 64), (2, 32), (4, 16), (8, 8), (16, 4), (32, 2), (64, 1)]
-)
+@pytest.mark.parametrize("M, N", [(1, 64), (2, 32), (4, 16), (8, 8), (16, 4), (32, 2), (64, 1)])
 def test_scan_1d(M, N, device):
 
     @triton.jit
@@ -3364,10 +3111,10 @@ def test_scan_1d(M, N, device):
         output = tl.cumsum(input).reshape([1, M]).broadcast_to([N, M])
         tl.store(out_ptr + tl.arange(0, M * N), output.reshape([M * N]))
 
-    x = torch.randint(-100, 100, (M,), dtype=torch.int32, device=device)
+    x = torch.randint(-100, 100, (M, ), dtype=torch.int32, device=device)
     output = torch.empty(M * N, dtype=torch.int32, device=device)
 
-    scan_kernel[(1,)](output, x, M, N)
+    scan_kernel[(1, )](output, x, M, N)
 
     ref = torch.cumsum(x, dim=0).reshape([1, M]).broadcast_to([N, M]).reshape([M * N])
     torch.testing.assert_close(ref.to(torch.int32), output, atol=0, rtol=0)
@@ -3409,18 +3156,15 @@ def test_optimize_thread_locality(op, BLOCK_N, N, num_pid_n, device):
         "max": np.max,
         "min": np.min,
     }[op]
-    kernel = patch_kernel(
-        kernel, {"ACCUMULATE_PATCH": reduce_patch, "INITIALIZE_PATCH": initialize_patch}
-    )
+    kernel = patch_kernel(kernel, {"ACCUMULATE_PATCH": reduce_patch, "INITIALIZE_PATCH": initialize_patch})
     torch.manual_seed(0)
     BLOCK_M = 32
     x = torch.randn((BLOCK_M, N), dtype=torch.float32, device=device)
     y = torch.randn((BLOCK_M, num_pid_n), dtype=torch.float32, device=device)
     h = kernel[(1, num_pid_n, 1)](x, y, N, BLOCK_M, BLOCK_N)
     if not is_interpreter():
-        assert (
-            h.asm["ttgir"].count('"tt.reduce"') == 2
-        ), "tt.reduce should be called twice, otherwise the optimization didn't work"
+        assert (h.asm["ttgir"].count('"tt.reduce"') == 2
+                ), "tt.reduce should be called twice, otherwise the optimization didn't work"
     y_ref = numpy_op(x.cpu().numpy(), axis=1, keepdims=True)
     y_tri = numpy_op(y.cpu().numpy(), axis=1, keepdims=True)
     np.testing.assert_allclose(y_tri, y_ref, rtol=0.01, atol=1e-3)
@@ -3441,28 +3185,20 @@ def test_no_rematerialization_op():
         loop_stages: tl.constexpr,
     ):
         tl.static_assert(DATA_LEN % BLOCK_SIZE == 0)
-        for curr_block_idx in tl.range(
-            0, DATA_LEN // BLOCK_SIZE, num_stages=loop_stages
-        ):
+        for curr_block_idx in tl.range(0, DATA_LEN // BLOCK_SIZE, num_stages=loop_stages):
             my_idxs = BLOCK_SIZE * curr_block_idx + tl.arange(0, BLOCK_SIZE)
-            values = tl.load(
-                input_data
-                + DATA_DIM * my_idxs[:, None]
-                + tl.arange(0, DATA_DIM)[None, :]
-            )
+            values = tl.load(input_data + DATA_DIM * my_idxs[:, None] + tl.arange(0, DATA_DIM)[None, :])
             accum = tl.sum(values, axis=-1).to(tl.float32)
             tl.store(sum_output + my_idxs, accum)
             sum_plus_0 = tl.full((1, 2), 0, tl.float32) + accum[:, None]
-            tl.store(
-                out_1 + my_idxs[:, None] * 2 + tl.arange(0, 2)[None, :], sum_plus_0
-            )
+            tl.store(out_1 + my_idxs[:, None] * 2 + tl.arange(0, 2)[None, :], sum_plus_0)
 
     device = "cuda"
     data_len = 32
     data_dim = 64
     torch.manual_seed(0)
     input_data = torch.randn((data_len, data_dim), dtype=torch.float32, device=device)
-    sum_output = torch.full((data_len,), -1, dtype=torch.float32, device=device)
+    sum_output = torch.full((data_len, ), -1, dtype=torch.float32, device=device)
     out_1 = torch.full((data_len, 2), -1, dtype=torch.float32, device=device)
     compiled_kernel = kernel.warmup(
         input_data=input_data,
@@ -3473,11 +3209,9 @@ def test_no_rematerialization_op():
         BLOCK_SIZE=16,
         num_warps=1,
         loop_stages=2,
-        grid=(1,),
+        grid=(1, ),
     )
-    assert (
-        compiled_kernel.asm["ttgir"].count('"tt.reduce"') == 1
-    ), "we shouldn't rematerialize tt.reduce"
+    assert (compiled_kernel.asm["ttgir"].count('"tt.reduce"') == 1), "we shouldn't rematerialize tt.reduce"
 
 
 @triton.jit
@@ -3508,7 +3242,7 @@ def test_generic_reduction(device):
         m2 = tl.zeros_like(x)
         weight = tl.full(x.shape, 1, x.dtype)
         # Test return a tuple and a single value
-        (sum0,) = tl.reduce((x,), 0, _sum_combine)
+        (sum0, ) = tl.reduce((x, ), 0, _sum_combine)
         sum1 = tl.reduce(x, 0, _sum_combine)
         # Test multiple values in a tuple
         (mean, m2, weight) = tl.reduce((mean, m2, weight), 0, _welford_combine)
@@ -3524,7 +3258,7 @@ def test_generic_reduction(device):
     sum0 = torch.empty((), device=device)
     sum1 = torch.empty((), device=device)
 
-    var_mean_kernel[(1,)](x, out_mean, out_var, sum0, sum1, BLOCK=SIZE)
+    var_mean_kernel[(1, )](x, out_mean, out_var, sum0, sum1, BLOCK=SIZE)
 
     expect_var, expect_mean = torch.var_mean(x, dim=0, correction=0)
     sum_ref = torch.sum(x)
@@ -3573,21 +3307,15 @@ def test_reduction_ordering_sum(BLOCK_M, device):
         tl.store(Z + offs_m, z)
 
     data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_data")
-    x_row = torch.load(
-        os.path.join(data_dir, "reduction_ordering_sum_input.pt"), weights_only=True
-    ).to(device)
-    reference = torch.load(
-        os.path.join(data_dir, "reduction_ordering_sum_ref.pt"), weights_only=True
-    ).to(device)
-    grid = (TOTAL_ROWS // BLOCK_M,)
+    x_row = torch.load(os.path.join(data_dir, "reduction_ordering_sum_input.pt"), weights_only=True).to(device)
+    reference = torch.load(os.path.join(data_dir, "reduction_ordering_sum_ref.pt"), weights_only=True).to(device)
+    grid = (TOTAL_ROWS // BLOCK_M, )
 
     for row_major in [True, False]:
         if row_major:
             x = x_row
         else:
-            x = torch.empty(
-                (BLOCK_N, TOTAL_ROWS), device=device, dtype=torch.float32
-            ).t()
+            x = torch.empty((BLOCK_N, TOTAL_ROWS), device=device, dtype=torch.float32).t()
             x.copy_(x_row)
 
         for nw in [1, 2, 4, 8]:
@@ -3602,10 +3330,8 @@ def test_reduction_ordering_sum(BLOCK_M, device):
                 ORDERING=tl.ReductionOrdering.INNER_TREE,
                 num_warps=nw,
             )
-            assert torch.equal(out, reference), (
-                f"INNER_TREE sum not bitwise equal to reference: "
-                f"num_warps={nw}, row_major={row_major}"
-            )
+            assert torch.equal(out, reference), (f"INNER_TREE sum not bitwise equal to reference: "
+                                                 f"num_warps={nw}, row_major={row_major}")
 
 
 @pytest.mark.parametrize("BLOCK_M", [1, 4, 16, 32])
@@ -3637,21 +3363,15 @@ def test_reduction_ordering_reduce_mul(BLOCK_M, device):
         tl.store(Z + offs_m, z)
 
     data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_data")
-    x_row = torch.load(
-        os.path.join(data_dir, "reduction_ordering_mul_input.pt"), weights_only=True
-    ).to(device)
-    reference = torch.load(
-        os.path.join(data_dir, "reduction_ordering_mul_ref.pt"), weights_only=True
-    ).to(device)
-    grid = (TOTAL_ROWS // BLOCK_M,)
+    x_row = torch.load(os.path.join(data_dir, "reduction_ordering_mul_input.pt"), weights_only=True).to(device)
+    reference = torch.load(os.path.join(data_dir, "reduction_ordering_mul_ref.pt"), weights_only=True).to(device)
+    grid = (TOTAL_ROWS // BLOCK_M, )
 
     for row_major in [True, False]:
         if row_major:
             x = x_row
         else:
-            x = torch.empty(
-                (BLOCK_N, TOTAL_ROWS), device=device, dtype=torch.float32
-            ).t()
+            x = torch.empty((BLOCK_N, TOTAL_ROWS), device=device, dtype=torch.float32).t()
             x.copy_(x_row)
 
         for nw in [1, 2, 4, 8]:
@@ -3666,10 +3386,8 @@ def test_reduction_ordering_reduce_mul(BLOCK_M, device):
                 ORDERING=tl.ReductionOrdering.INNER_TREE,
                 num_warps=nw,
             )
-            assert torch.equal(out, reference), (
-                f"INNER_TREE mul reduce not bitwise equal to reference: "
-                f"num_warps={nw}, row_major={row_major}"
-            )
+            assert torch.equal(out, reference), (f"INNER_TREE mul reduce not bitwise equal to reference: "
+                                                 f"num_warps={nw}, row_major={row_major}")
 
 
 @pytest.mark.parametrize("BLOCK_M", [1, 4, 16, 32])
@@ -3700,21 +3418,15 @@ def test_reduction_ordering_argmin(BLOCK_M, device):
         tl.store(Z + offs_m, z)
 
     data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_data")
-    x_row = torch.load(
-        os.path.join(data_dir, "reduction_ordering_argmin_input.pt"), weights_only=True
-    ).to(device)
-    reference = torch.load(
-        os.path.join(data_dir, "reduction_ordering_argmin_ref.pt"), weights_only=True
-    ).to(device)
-    grid = (TOTAL_ROWS // BLOCK_M,)
+    x_row = torch.load(os.path.join(data_dir, "reduction_ordering_argmin_input.pt"), weights_only=True).to(device)
+    reference = torch.load(os.path.join(data_dir, "reduction_ordering_argmin_ref.pt"), weights_only=True).to(device)
+    grid = (TOTAL_ROWS // BLOCK_M, )
 
     for row_major in [True, False]:
         if row_major:
             x = x_row
         else:
-            x = torch.empty(
-                (BLOCK_N, TOTAL_ROWS), device=device, dtype=torch.float32
-            ).t()
+            x = torch.empty((BLOCK_N, TOTAL_ROWS), device=device, dtype=torch.float32).t()
             x.copy_(x_row)
 
         for nw in [1, 2, 4, 8]:
@@ -3729,10 +3441,8 @@ def test_reduction_ordering_argmin(BLOCK_M, device):
                 ORDERING=tl.ReductionOrdering.INNER_TREE,
                 num_warps=nw,
             )
-            assert torch.equal(out, reference), (
-                f"INNER_TREE argmin not bitwise equal to reference: "
-                f"num_warps={nw}, row_major={row_major}"
-            )
+            assert torch.equal(out, reference), (f"INNER_TREE argmin not bitwise equal to reference: "
+                                                 f"num_warps={nw}, row_major={row_major}")
 
 
 @pytest.mark.parametrize("num_warps", [2, 4, 8])
@@ -3748,9 +3458,7 @@ def test_reduction_ordering_sum_multi_group(num_warps, device):
     BLOCK_N = 1024
 
     @triton.jit
-    def sum_kernel_1row(
-        X, Z, stride_row, stride_col, BLOCK_N: tl.constexpr, ORDERING: tl.constexpr
-    ):
+    def sum_kernel_1row(X, Z, stride_row, stride_col, BLOCK_N: tl.constexpr, ORDERING: tl.constexpr):
         pid = tl.program_id(0)
         offs_n = tl.arange(0, BLOCK_N)
         x = tl.load(X + pid * stride_row + offs_n * stride_col)
@@ -3759,7 +3467,7 @@ def test_reduction_ordering_sum_multi_group(num_warps, device):
 
     torch.manual_seed(42)
     x = torch.randn((TOTAL_ROWS, BLOCK_N), device=device, dtype=torch.float32)
-    grid = (TOTAL_ROWS,)
+    grid = (TOTAL_ROWS, )
 
     # Reference: num_warps=1 (K=1, no multi-group path)
     ref = torch.empty(TOTAL_ROWS, device=device, dtype=torch.float32)
@@ -3783,10 +3491,8 @@ def test_reduction_ordering_sum_multi_group(num_warps, device):
         ORDERING=tl.ReductionOrdering.INNER_TREE,
         num_warps=num_warps,
     )
-    assert torch.equal(out, ref), (
-        f"INNER_TREE sum K>1 not bitwise equal to K=1 reference: "
-        f"num_warps={num_warps}"
-    )
+    assert torch.equal(out, ref), (f"INNER_TREE sum K>1 not bitwise equal to K=1 reference: "
+                                   f"num_warps={num_warps}")
 
 
 @pytest.mark.parametrize("N, BLOCK_N", [(1296, 2048), (7776, 8192)])
@@ -3798,20 +3504,16 @@ def test_reduction_ordering_sum_masked_multi_reg_group(num_warps, N, BLOCK_N, de
     TOTAL_ROWS = 32
 
     @triton.jit
-    def sum_kernel_masked(
-        X, Z, stride_row, stride_col, N, BLOCK_N: tl.constexpr, ORDERING: tl.constexpr
-    ):
+    def sum_kernel_masked(X, Z, stride_row, stride_col, N, BLOCK_N: tl.constexpr, ORDERING: tl.constexpr):
         pid = tl.program_id(0)
         offs_n = tl.arange(0, BLOCK_N)
-        x = tl.load(
-            X + pid * stride_row + offs_n * stride_col, mask=offs_n < N, other=0.0
-        )
+        x = tl.load(X + pid * stride_row + offs_n * stride_col, mask=offs_n < N, other=0.0)
         z = tl.sum(x, axis=0, reduction_ordering=ORDERING)
         tl.store(Z + pid, z)
 
     torch.manual_seed(42)
     x = torch.randn((TOTAL_ROWS, N), device=device, dtype=torch.float16)
-    grid = (TOTAL_ROWS,)
+    grid = (TOTAL_ROWS, )
 
     ref = torch.empty(TOTAL_ROWS, device=device, dtype=torch.float32)
     sum_kernel_masked[grid](
@@ -3836,10 +3538,8 @@ def test_reduction_ordering_sum_masked_multi_reg_group(num_warps, N, BLOCK_N, de
         ORDERING=tl.ReductionOrdering.INNER_TREE,
         num_warps=num_warps,
     )
-    assert torch.equal(out, ref), (
-        f"INNER_TREE masked multi-group sum not bitwise equal to reference: "
-        f"num_warps={num_warps}"
-    )
+    assert torch.equal(out, ref), (f"INNER_TREE masked multi-group sum not bitwise equal to reference: "
+                                   f"num_warps={num_warps}")
 
 
 # ---------------
@@ -3850,20 +3550,16 @@ def test_reduction_ordering_sum_masked_multi_reg_group(num_warps, N, BLOCK_N, de
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype_str, shape, perm",
-    [
-        (dtype, shape, perm)
-        # TODO: bfloat16
-        for dtype in ["float8e4b15", "float16", "float32"]
-        for shape in [(64, 64), (128, 128)]
-        for perm in [(1, 0)]
-    ],
+    [(dtype, shape, perm)
+     # TODO: bfloat16
+     for dtype in ["float8e4b15", "float16", "float32"]
+     for shape in [(64, 64), (128, 128)]
+     for perm in [(1, 0)]],
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_permute(dtype_str, shape, perm, num_ctas, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
-    if dtype_str == "float8e4b15" and (
-        is_hip() or (is_cuda() and torch.cuda.get_device_capability() >= (9, 0))
-    ):
+    if dtype_str == "float8e4b15" and (is_hip() or (is_cuda() and torch.cuda.get_device_capability() >= (9, 0))):
         pytest.skip("float8e4b15 not supported on ROCm or CUDA >= 9.0")
 
     # triton kernel
@@ -3950,24 +3646,16 @@ def test_trans_2d(dtype_str, shape, perm, device):
         trans1: tl.constexpr,
         trans2: tl.constexpr,
     ):
-        in_offs = (
-            tl.arange(0, in_shape1)[:, None] * in_shape2
-            + tl.arange(0, in_shape2)[None, :]
-        )
-        ou_offs = (
-            tl.arange(0, ou_shape1)[:, None] * ou_shape2
-            + tl.arange(0, ou_shape2)[None, :]
-        )
+        in_offs = (tl.arange(0, in_shape1)[:, None] * in_shape2 + tl.arange(0, in_shape2)[None, :])
+        ou_offs = (tl.arange(0, ou_shape1)[:, None] * ou_shape2 + tl.arange(0, ou_shape2)[None, :])
         tl.store(Out + ou_offs, tl.permute(tl.load(In + in_offs), (trans1, trans2)))
 
-    input = torch.arange(
-        math.prod(shape), dtype=getattr(torch, dtype_str), device=device
-    ).reshape(shape)
+    input = torch.arange(math.prod(shape), dtype=getattr(torch, dtype_str), device=device).reshape(shape)
     expected = torch.permute(input, perm)
     # Don't do zeros_like -- that copies the layout, which we don't want.
     actual = torch.zeros(expected.shape, dtype=getattr(torch, dtype_str), device=device)
 
-    kernel[(1,)](input, actual, *shape, *[shape[i] for i in perm], *perm)
+    kernel[(1, )](input, actual, *shape, *[shape[i] for i in perm], *perm)
 
     np.testing.assert_equal(to_numpy(expected), to_numpy(actual))
 
@@ -4015,14 +3703,12 @@ def test_trans_4d(dtype_str, shape, perm, device, with_allocator):
         val = in_desc.load([0, 0, 0, 0]).permute((trans1, trans2, trans3, trans4))
         out_desc.store([0], val.reshape(out_desc.block_shape))
 
-    input = torch.arange(
-        math.prod(shape), dtype=getattr(torch, dtype_str), device=device
-    ).reshape(shape)
+    input = torch.arange(math.prod(shape), dtype=getattr(torch, dtype_str), device=device).reshape(shape)
     expected = torch.permute(input, perm)
     # Don't do zeros_like -- that copies the layout, which we don't want.
     actual = torch.zeros(expected.shape, dtype=getattr(torch, dtype_str), device=device)
 
-    kernel[(1,)](input, actual, *shape, *[shape[i] for i in perm], *perm, num_warps=8)
+    kernel[(1, )](input, actual, *shape, *[shape[i] for i in perm], *perm, num_warps=8)
 
     np.testing.assert_equal(to_numpy(expected), to_numpy(actual))
 
@@ -4034,148 +3720,127 @@ def test_trans_4d(dtype_str, shape, perm, device, with_allocator):
 
 def convert_fp8_to_fp32(x, device, dtype_str):
     if dtype_str == "float8e4nv":
-        return (
-            torch.tensor(x, device=device).view(torch.float8_e4m3fn).to(torch.float32)
-        )
+        return (torch.tensor(x, device=device).view(torch.float8_e4m3fn).to(torch.float32))
     elif dtype_str == "float8e5":
         return torch.tensor(x, device=device).view(torch.float8_e5m2).to(torch.float32)
     elif dtype_str == "float8e4b8":
-        return (
-            torch.tensor(x, device=device).view(torch.float8_e4m3fnuz).to(torch.float32)
-        )
+        return (torch.tensor(x, device=device).view(torch.float8_e4m3fnuz).to(torch.float32))
     elif dtype_str == "float8e5b16":
-        return (
-            torch.tensor(x, device=device).view(torch.float8_e5m2fnuz).to(torch.float32)
-        )
+        return (torch.tensor(x, device=device).view(torch.float8_e5m2fnuz).to(torch.float32))
     raise AssertionError("Unsupported float8 dtype")
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 def get_test_dot_base_cases():
-    return [
-        (
-            *shape,
-            4,
-            False,
-            False,
-            epilogue,
-            input_precision,
-            in_dtype,
-            out_dtype,
-            1,
-            None,
-        )
-        for shape in [(64, 64, 64), (32, 32, 32), (16, 16, 16)]
-        for epilogue in [
-            "none",
-            "trans",
-            "add-matrix",
-            "add-rows",
-            "add-cols",
-            "softmax",
-            "chain-dot",
-        ]
-        for input_precision in ["tf32", "tf32x3", "ieee", "bf16x3", "bf16x6"]
-        for in_dtype, out_dtype in [
-            ("float16", "float16"),
-            ("float16", "float32"),
-            ("float32", "float32"),
-            ("float64", "float64"),
-        ]
-        if not (input_precision != "ieee" and (in_dtype in ["float16"]))
-    ]
+    return [(
+        *shape,
+        4,
+        False,
+        False,
+        epilogue,
+        input_precision,
+        in_dtype,
+        out_dtype,
+        1,
+        None,
+    ) for shape in [(64, 64, 64), (32, 32, 32), (16, 16, 16)] for epilogue in [
+        "none",
+        "trans",
+        "add-matrix",
+        "add-rows",
+        "add-cols",
+        "softmax",
+        "chain-dot",
+    ] for input_precision in ["tf32", "tf32x3", "ieee", "bf16x3", "bf16x6"] for in_dtype, out_dtype in [
+        ("float16", "float16"),
+        ("float16", "float32"),
+        ("float32", "float32"),
+        ("float64", "float64"),
+    ] if not (input_precision != "ieee" and (in_dtype in ["float16"]))]
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 def get_test_dot_softmax():
-    return [
-        (
-            128,
-            128,
-            64,
-            8,
-            False,
-            False,
-            "softmax",
-            "ieee",
-            "float16",
-            "float32",
-            1,
-            None,
-        )
-    ]
+    return [(
+        128,
+        128,
+        64,
+        8,
+        False,
+        False,
+        "softmax",
+        "ieee",
+        "float16",
+        "float32",
+        1,
+        None,
+    )]
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 def get_test_dot_mixed_sizes_cases():
     available_kpack = [1, 2 if (is_hip() and not is_hip_cdna4()) else 1]
     available_precision = ["tf32" if is_cuda() else "ieee"]
-    return [
-        (
-            *shape_nw,
-            col_a,
-            col_b,
-            "none",
-            input_precision,
-            in_dtype,
-            out_dtype,
-            kpack,
-            None,
-        )
-        for shape_nw in [
-            [128, 256, 32, 8],
-            [128, 16, 32, 4],
-            [32, 128, 64, 4],
-            [128, 128, 64, 4],
-            [64, 128, 128, 4],
-            [32, 128, 64, 2],
-            [64, 64, 32, 4],
-            [32, 32, 128, 16],
-            [128, 128, 64, 2],
-            [64, 128, 128, 2],
-        ]
-        for input_precision in available_precision
-        for col_a in [True, False]
-        for col_b in [True, False]
-        for in_dtype, out_dtype in [
-            ("int8", "int8"),
-            ("float16", "float16"),
-            ("float16", "float32"),
-            ("float32", "float32"),
-        ]
-        for kpack in available_kpack
-    ]
+    return [(
+        *shape_nw,
+        col_a,
+        col_b,
+        "none",
+        input_precision,
+        in_dtype,
+        out_dtype,
+        kpack,
+        None,
+    )
+            for shape_nw in [
+                [128, 256, 32, 8],
+                [128, 16, 32, 4],
+                [32, 128, 64, 4],
+                [128, 128, 64, 4],
+                [64, 128, 128, 4],
+                [32, 128, 64, 2],
+                [64, 64, 32, 4],
+                [32, 32, 128, 16],
+                [128, 128, 64, 2],
+                [64, 128, 128, 2],
+            ]
+            for input_precision in available_precision
+            for col_a in [True, False]
+            for col_b in [True, False]
+            for in_dtype, out_dtype in [
+                ("int8", "int8"),
+                ("float16", "float16"),
+                ("float16", "float32"),
+                ("float32", "float32"),
+            ]
+            for kpack in available_kpack]
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #2370
 def get_test_dot_transposed_op_base_cases():
-    return [
-        (64, 64, 64, 4, col_a, col_b, "none", "ieee", "float32", "float32", 1, None)
-        for col_a in [True, False]
-        for col_b in [True, False]
-    ]
+    return [(64, 64, 64, 4, col_a, col_b, "none", "ieee", "float32", "float32", 1, None)
+            for col_a in [True, False]
+            for col_b in [True, False]]
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # Introduced in #2750
 def get_test_dot_h100_shortcut_cases():
-    return [
-        (
-            64,
-            64,
-            64,
-            4,
-            False,
-            False,
-            "chain-dot",
-            "ieee",
-            "bfloat16",
-            "float32",
-            1,
-            None,
-        )
-    ]
+    return [(
+        64,
+        64,
+        64,
+        4,
+        False,
+        False,
+        "chain-dot",
+        "ieee",
+        "bfloat16",
+        "float32",
+        1,
+        None,
+    )]
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
@@ -4192,23 +3857,20 @@ def get_test_dot_mfma_edge_cases():
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #3370
 def get_test_dot_fp8_output_cases():
-    return [
-        (
-            128,
-            128,
-            64,
-            4,
-            False,
-            False,
-            "chain-dot",
-            "ieee",
-            float8_type,
-            "float32",
-            1,
-            None,
-        )
-        for float8_type in ["float8e5", "float8e4nv"]
-    ]
+    return [(
+        128,
+        128,
+        64,
+        4,
+        False,
+        False,
+        "chain-dot",
+        "ieee",
+        float8_type,
+        "float32",
+        1,
+        None,
+    ) for float8_type in ["float8e5", "float8e4nv"]]
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
@@ -4216,25 +3878,23 @@ def get_test_dot_fp8_output_cases():
 def get_test_dot_small_k_mfma_cases():
     if not (is_hip_cdna() or is_hip_gfx1250()):
         return []
-    return [
-        (
-            32,
-            32,
-            k_size,
-            4,
-            False,
-            False,
-            "None",
-            "ieee",
-            in_dtype,
-            out_dtype,
-            1,
-            mma_nonk_size,
-        )
-        for k_size in [1, 2, 4, 8]
-        for in_dtype, out_dtype in [("float16", "float32"), ("int8", "int32")]
-        for mma_nonk_size in mma_nonk_sizes
-    ]
+    return [(
+        32,
+        32,
+        k_size,
+        4,
+        False,
+        False,
+        "None",
+        "ieee",
+        in_dtype,
+        out_dtype,
+        1,
+        mma_nonk_size,
+    )
+            for k_size in [1, 2, 4, 8]
+            for in_dtype, out_dtype in [("float16", "float32"), ("int8", "int32")]
+            for mma_nonk_size in mma_nonk_sizes]
 
 
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
@@ -4242,12 +3902,10 @@ def get_test_dot_small_k_mfma_cases():
 def get_test_dot_small_mn_mfma_cases():
     if not (is_hip_cdna() or is_hip_gfx1250()):
         return []
-    return [
-        (*shape_nw, False, False, epilogue, "ieee", in_dtype, out_dtype, 1, None)
-        for shape_nw in [(4, 64, 64, 1), (64, 4, 64, 1)]
-        for epilogue in ["none", "trans", "add-matrix", "add-rows", "add-cols"]
-        for in_dtype, out_dtype in [("float16", "float16"), ("float32", "float32")]
-    ]
+    return [(*shape_nw, False, False, epilogue, "ieee", in_dtype, out_dtype, 1, None)
+            for shape_nw in [(4, 64, 64, 1), (64, 4, 64, 1)]
+            for epilogue in ["none", "trans", "add-matrix", "add-rows", "add-cols"]
+            for in_dtype, out_dtype in [("float16", "float16"), ("float32", "float32")]]
 
 
 def get_test_dot_double_rate_cases():
@@ -4282,18 +3940,10 @@ def get_test_small_dots_cases():
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size",
-    get_test_dot_vdot2_cases()
-    + get_test_dot_double_rate_cases()
-    + get_test_dot_base_cases()
-    + get_test_dot_mixed_sizes_cases()
-    + get_test_dot_transposed_op_base_cases()
-    + get_test_dot_h100_shortcut_cases()
-    + get_test_dot_mfma_edge_cases()
-    + get_test_dot_fp8_output_cases()
-    + get_test_dot_small_k_mfma_cases()
-    + get_test_dot_small_mn_mfma_cases()
-    + get_test_dot_softmax()
-    + get_test_small_dots_cases(),
+    get_test_dot_vdot2_cases() + get_test_dot_double_rate_cases() + get_test_dot_base_cases() +
+    get_test_dot_mixed_sizes_cases() + get_test_dot_transposed_op_base_cases() + get_test_dot_h100_shortcut_cases() +
+    get_test_dot_mfma_edge_cases() + get_test_dot_fp8_output_cases() + get_test_dot_small_k_mfma_cases() +
+    get_test_dot_small_mn_mfma_cases() + get_test_dot_softmax() + get_test_small_dots_cases(),
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_dot(
@@ -4316,9 +3966,7 @@ def test_dot(
         if in_dtype == "bfloat16":
             pytest.skip("bfloat16 is not supported in the interpreter")
         if input_precision == "bf16x3" or input_precision == "bf16x6":
-            pytest.skip(
-                f"input_precision {input_precision} is not supported in the interpreter"
-            )
+            pytest.skip(f"input_precision {input_precision} is not supported in the interpreter")
     else:
         if not is_hip() and K < 16:
             pytest.skip("small dots are supported only on HIP at the moment")
@@ -4348,19 +3996,14 @@ def test_dot(
                 pytest.skip("Only IEEE precision is supported for float64 dot")
 
         if is_hip():
-            if in_dtype in ("float8e5", "float8e4nv") and not (
-                is_hip_gfx1250() or is_hip_cdna4() or is_hip_rdna4()
-            ):
+            if in_dtype in ("float8e5", "float8e4nv") and not (is_hip_gfx1250() or is_hip_cdna4() or is_hip_rdna4()):
                 pytest.skip(f"{in_dtype} only supported on CDNA4, RDNA4 and above")
             if in_dtype in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
                 pytest.skip(f"{in_dtype} only supported on CDNA3")
             if input_precision in ("bf16x3", "bf16x6") and is_hip_gfx1250():
                 pytest.skip(f"{input_precision} not fully supported on gfx1250")
-            if not (
-                (input_precision in ("bf16x3", "bf16x6"))
-                or (input_precision == "ieee")
-                or (input_precision == "tf32" and is_hip_cdna3())
-            ):
+            if not ((input_precision in ("bf16x3", "bf16x6")) or (input_precision == "ieee") or
+                    (input_precision == "tf32" and is_hip_cdna3())):
                 pytest.skip(f"{input_precision} not supported on HIP")
             if kpack == 2 and in_dtype == "int8" and K < 64:
                 pytest.skip("kpack too large for K")
@@ -4431,9 +4074,7 @@ def test_dot(
             z = num / den[:, None]
         if CHAIN_DOT:
             w = tl.load(Ws)
-            z = tl.dot(
-                z.to(w.dtype), w, input_precision=INPUT_PRECISION, out_dtype=out_dtype
-            )
+            z = tl.dot(z.to(w.dtype), w, input_precision=INPUT_PRECISION, out_dtype=out_dtype)
         tl.store(Zs, z)
 
     # input
@@ -4592,12 +4233,7 @@ def test_dot(
         else:
             assert "st.global.v4" in ptx
 
-    is_tcgen5 = (
-        (capability[0] == 10)
-        and (num_warps % 4) == 0
-        and (M % 64) == 0
-        and (N % 8) == 0
-    )
+    is_tcgen5 = ((capability[0] == 10) and (num_warps % 4) == 0 and (M % 64) == 0 and (N % 8) == 0)
 
     if in_dtype == "float32" and input_precision != "ieee":
         if is_tcgen5:
@@ -4619,9 +4255,7 @@ def test_dot(
         if is_tcgen5:
             assert re.search(r"tcgen05.mma.cta_group::1.kind::f16", ptx)
         elif capability[0] == 7 and capability[1] == 5:  # Turing
-            assert re.search(
-                r"mma.sync.aligned.m\d+n\d+k8(?:.row.col)?.f32.f16.f16", ptx
-            )
+            assert re.search(r"mma.sync.aligned.m\d+n\d+k8(?:.row.col)?.f32.f16.f16", ptx)
         else:
             assert re.search(
                 r"[mma|wgmma.mma_async].sync.aligned.m\d+n\d+k16(?:.row.col)?.f32.f16.f16",
@@ -4631,9 +4265,7 @@ def test_dot(
         if is_tcgen5:
             assert re.search(r"tcgen05.mma.cta_group::1.kind::f16", ptx)
         elif capability[0] == 7 and capability[1] == 5:  # Turing
-            assert re.search(
-                r"mma.sync.aligned.m\d+n\d+k8(?:.row.col)?.f16.f16.f16", ptx
-            )
+            assert re.search(r"mma.sync.aligned.m\d+n\d+k8(?:.row.col)?.f16.f16.f16", ptx)
         else:
             assert re.search(
                 r"[mma|wgmma.mma_async].sync.aligned.m\d+n\d+k16(?:.row.col)?.f16.f16.f16",
@@ -4643,10 +4275,8 @@ def test_dot(
         if capability[0] == 7 and capability[1] == 5:  # Turing
             assert "mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32" in ptx
         else:
-            assert (
-                "wgmma.mma_async.sync.aligned" in ptx
-                or "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32" in ptx
-            )
+            assert ("wgmma.mma_async.sync.aligned" in ptx
+                    or "mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32" in ptx)
     elif in_dtype == "float8e5" and out_dtype == tl.float32:
         if capability[0] == 9 and M >= 64 and N >= 8:
             assert "wgmma.mma_async.sync.aligned.m64n128k32.f32.e5m2.e5m2" in ptx
@@ -4657,28 +4287,22 @@ def test_dot(
             assert "wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3" in ptx
     if is_tcgen5 and epilogue == "softmax" and M >= 128:
         # check that there is no shared memory exchange in the softmax
-        pattern = (
-            r"tcgen05\.ld\.sync\.aligned\.16x32bx2\.x64\.b32"
-            r"(?:(?!st\.shared).)*"
-            r"cvt\.rn\.f16x2\.f32"
-        )
+        pattern = (r"tcgen05\.ld\.sync\.aligned\.16x32bx2\.x64\.b32"
+                   r"(?:(?!st\.shared).)*"
+                   r"cvt\.rn\.f16x2\.f32")
         assert re.search(pattern, ptx, flags=re.DOTALL)
 
 
 @pytest.mark.parametrize(
     "M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",
-    [
-        (M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)
-        for M, N, K in itertools.product([32, 64, 128], [32, 64, 128], [64, 128])
-        for col_a, col_b in itertools.product([True, False], repeat=2)
-        for rhs_scale in [False, True]
-        for mxfp_type in ["e2m1", "e4m3", "e5m2"]
-        for normal_type in ["e4m3", "e5m2", "bf16", "fp16"]
-        for mma in (mma_nonk_sizes if is_hip() else [16])
-        for kpack in (
-            [1, 2] if (is_hip() and not (is_hip_cdna4() or is_hip_gfx1250())) else [1]
-        )
-    ],
+    [(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)
+     for M, N, K in itertools.product([32, 64, 128], [32, 64, 128], [64, 128])
+     for col_a, col_b in itertools.product([True, False], repeat=2)
+     for rhs_scale in [False, True]
+     for mxfp_type in ["e2m1", "e4m3", "e5m2"]
+     for normal_type in ["e4m3", "e5m2", "bf16", "fp16"]
+     for mma in (mma_nonk_sizes if is_hip() else [16])
+     for kpack in ([1, 2] if (is_hip() and not (is_hip_cdna4() or is_hip_gfx1250())) else [1])],
 )
 def test_scaled_dot(
     M,
@@ -4702,25 +4326,13 @@ def test_scaled_dot(
         is_SM120 = cc >= (12, 0)
     if is_hip():
         if not (is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()):
-            pytest.skip(
-                "scaled_dot only implemented for HIP CDNA, RDNA3, RDNA4 and above"
-            )
+            pytest.skip("scaled_dot only implemented for HIP CDNA, RDNA3, RDNA4 and above")
         if "e4m3" in (mxfp_type, normal_type):
-            if not (
-                is_hip_cdna3()
-                or is_hip_cdna4()
-                or is_hip_rdna3()
-                or is_hip_rdna4()
-                or is_hip_gfx1250()
-            ):
+            if not (is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()):
                 pytest.skip(
                     f"scaled_dot({mxfp_type}, {normal_type}) only implemented for CDNA3, CDNA4, RDNA3, RDNA4, and above"
                 )
-        if (
-            mma == 16
-            and K == 64
-            and not (is_hip_rdna4() or is_hip_rdna3() or is_hip_gfx1250())
-        ):
+        if (mma == 16 and K == 64 and not (is_hip_rdna4() or is_hip_rdna3() or is_hip_gfx1250())):
             pytest.skip(f"K == {K} too small for mfma {mma} in scaled_dot")
 
     @triton.jit
@@ -4744,40 +4356,24 @@ def test_scaled_dot(
         DIV_FACTOR_B: tl.constexpr = 2 if type_b == "e2m1" else 1
         PACKED_BLOCK_K_A: tl.constexpr = BLOCK_K // DIV_FACTOR_A
         PACKED_BLOCK_K_B: tl.constexpr = BLOCK_K // DIV_FACTOR_B
-        a_ptr = (
-            a_base
-            + tl.arange(0, BLOCK_M)[:, None] * stride_a0
-            + tl.arange(0, PACKED_BLOCK_K_A)[None, :] * stride_a1
-        )
-        b_ptr = (
-            b_base
-            + tl.arange(0, PACKED_BLOCK_K_B)[:, None] * stride_b0
-            + tl.arange(0, BLOCK_N)[None, :] * stride_b1
-        )
+        a_ptr = (a_base + tl.arange(0, BLOCK_M)[:, None] * stride_a0 +
+                 tl.arange(0, PACKED_BLOCK_K_A)[None, :] * stride_a1)
+        b_ptr = (b_base + tl.arange(0, PACKED_BLOCK_K_B)[:, None] * stride_b0 +
+                 tl.arange(0, BLOCK_N)[None, :] * stride_b1)
 
         a = tl.load(a_ptr)
         b = tl.load(b_ptr)
         SCALE_BLOCK_K: tl.constexpr = BLOCK_K // 32
         if a_scale is not None:
-            scale_a_ptr = (
-                a_scale
-                + tl.arange(0, BLOCK_M)[:, None] * SCALE_BLOCK_K
-                + tl.arange(0, SCALE_BLOCK_K)[None, :]
-            )
+            scale_a_ptr = (a_scale + tl.arange(0, BLOCK_M)[:, None] * SCALE_BLOCK_K +
+                           tl.arange(0, SCALE_BLOCK_K)[None, :])
             a_scale = tl.load(scale_a_ptr)
         if b_scale is not None:
-            scale_b_ptr = (
-                b_scale
-                + tl.arange(0, BLOCK_N)[:, None] * SCALE_BLOCK_K
-                + tl.arange(0, SCALE_BLOCK_K)[None, :]
-            )
+            scale_b_ptr = (b_scale + tl.arange(0, BLOCK_N)[:, None] * SCALE_BLOCK_K +
+                           tl.arange(0, SCALE_BLOCK_K)[None, :])
             b_scale = tl.load(scale_b_ptr)
         c = tl.dot_scaled(a, a_scale, type_a, b, b_scale, type_b)
-        out_ptr = (
-            out
-            + tl.arange(0, BLOCK_M)[:, None] * BLOCK_N
-            + tl.arange(0, BLOCK_N)[None, :]
-        )
+        out_ptr = (out + tl.arange(0, BLOCK_M)[:, None] * BLOCK_N + tl.arange(0, BLOCK_N)[None, :])
         tl.store(out_ptr, c.to(tl.bfloat16))
 
     @triton.jit
@@ -4801,11 +4397,8 @@ def test_scaled_dot(
         LAST_DIM: tl.constexpr = 32 if is_fp8 else 16
         LOAD_SIZE: tl.constexpr = LAST_DIM * PARALLEL_DIM
 
-        offsets = (
-            tl.program_id(0) * LOAD_SIZE
-            + tl.arange(0, PARALLEL_DIM)[:, None] * LAST_DIM
-            + tl.arange(0, LAST_DIM)[None, :]
-        )
+        offsets = (tl.program_id(0) * LOAD_SIZE + tl.arange(0, PARALLEL_DIM)[:, None] * LAST_DIM +
+                   tl.arange(0, LAST_DIM)[None, :])
         x = tl.load(x_ptr + offsets, mask=offsets < N * LAST_DIM)
 
         offsets = tl.program_id(0) * PARALLEL_DIM + tl.arange(0, PARALLEL_DIM)[:, None]
@@ -4828,14 +4421,10 @@ def test_scaled_dot(
                 upcasted_x = x_f8.to(to_type)
                 # Preserve infs and nans. FIXME Fp8E5M2_to_Bf16 doesn't preserve them!
                 non_finite_mask: tl.constexpr = ((1 << e_bits) - 1) << m_bits
-                non_finite_mask_16bit: tl.constexpr = (
-                    (1 << to_e_bits) - 1
-                ) << to_m_bits
+                non_finite_mask_16bit: tl.constexpr = ((1 << to_e_bits) - 1) << to_m_bits
                 upcasted_x = tl.where(
                     x & non_finite_mask == non_finite_mask,
-                    (upcasted_x.to(tl.uint16, bitcast=True) | non_finite_mask_16bit).to(
-                        to_type, bitcast=True
-                    ),
+                    (upcasted_x.to(tl.uint16, bitcast=True) | non_finite_mask_16bit).to(to_type, bitcast=True),
                     upcasted_x,
                 )
             else:
@@ -4848,12 +4437,8 @@ def test_scaled_dot(
             # e2m1
             em0 = x & 0x7
             em1 = x & 0x70
-            x0 = (em0.to(tl.uint16) << (to_m_bits - 1)) | (
-                (x & 0x8).to(tl.uint16) << 12
-            )
-            x1 = (em1.to(tl.uint16) << (to_m_bits - 1 - 4)) | (
-                (x & 0x80).to(tl.uint16) << 8
-            )
+            x0 = (em0.to(tl.uint16) << (to_m_bits - 1)) | ((x & 0x8).to(tl.uint16) << 12)
+            x1 = (em1.to(tl.uint16) << (to_m_bits - 1 - 4)) | ((x & 0x80).to(tl.uint16) << 8)
             # Three cases:
             # 1) x is normal and non-zero: Correct bias
             x0 = tl.where((em0 & 0x6) != 0, x0 + ((to_bias - 1) << to_m_bits), x0)
@@ -4887,12 +4472,10 @@ def test_scaled_dot(
             if transposed:
                 v = v.mT.contiguous()
             v = v.contiguous()
-            v_upcast = v.new_empty(
-                scale.shape[:-1] + (32 * scale.shape[-1],), dtype=comp_dtype
-            )
+            v_upcast = v.new_empty(scale.shape[:-1] + (32 * scale.shape[-1], ), dtype=comp_dtype)
             N = v_upcast.numel()
             BLOCK_SIZE = 512
-            grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE,)
+            grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE, )
             comp_dtype = tl.float16 if comp_dtype == torch.float16 else tl.bfloat16
             mxfp_upcast_kernel[grid](
                 v,
@@ -4919,17 +4502,11 @@ def test_scaled_dot(
         class AccumulateInFp32:
 
             def __enter__(self):
-                self.prev_value = (
-                    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
-                )
-                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
-                    False
-                )
+                self.prev_value = (torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction)
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (False)
 
             def __exit__(self, exc_type, exc_val, exc_tb):
-                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
-                    self.prev_value
-                )
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (self.prev_value)
 
         with AccumulateInFp32():
             return torch.matmul(x_upcast, y_upcast)
@@ -4971,12 +4548,8 @@ def test_scaled_dot(
     y = make_arg((K // DIV_FACTOR_B, N), type_b, col_major=col_b)
 
     min_scale, max_scale = (0, 142) if comp_dtype == torch.bfloat16 else (124, 131)
-    scale_x = torch.randint(
-        min_scale, max_scale + 1, (M, K // 32), dtype=torch.uint8, device=device
-    )
-    scale_y = torch.randint(
-        min_scale, max_scale + 1, (N, K // 32), dtype=torch.uint8, device=device
-    )
+    scale_x = torch.randint(min_scale, max_scale + 1, (M, K // 32), dtype=torch.uint8, device=device)
+    scale_y = torch.randint(min_scale, max_scale + 1, (N, K // 32), dtype=torch.uint8, device=device)
     if rhs_scale:
         scale_x = None
     else:
@@ -4990,10 +4563,7 @@ def test_scaled_dot(
         if dtype == "e5m2" and comp_dtype == torch.float16:
             x = x & 0xB
         mask = 0x7C if dtype == "e5m2" else 0x7F
-        finite = (
-            torch.arange(x.numel(), device=device, dtype=torch.uint8).reshape_as(x)
-            % mask
-        )
+        finite = (torch.arange(x.numel(), device=device, dtype=torch.uint8).reshape_as(x) % mask)
         x_finite = torch.where(x & mask == mask, finite | (0x80 & x), x)
         x.copy_(x_finite)
         return x
@@ -5005,7 +4575,7 @@ def test_scaled_dot(
         kernel_kwargs["kpack"] = kpack
         kernel_kwargs["matrix_instr_nonkdim"] = mma
     z = x.new_empty((M, N), dtype=comp_dtype)
-    pgm = dot_scale_kernel[(1,)](
+    pgm = dot_scale_kernel[(1, )](
         x,
         *x.stride(),
         scale_x,
@@ -5042,13 +4612,10 @@ def test_scaled_dot(
             assert "ld.global.v4" in ptx
         if M * N // (num_warps * 32) >= 4:
             assert "st.global.v4" in ptx
-        assert (
-            re.search(
-                r"(mma|wgmma.mma_async).sync.aligned.m\d+n\d+k16(?:.row.col)?.f32.(f|bf)16.(f|bf)16",
-                ptx,
-            )
-            or "tcgen05.mma.cta_group::1.kind::f16" in ptx
-        )
+        assert (re.search(
+            r"(mma|wgmma.mma_async).sync.aligned.m\d+n\d+k16(?:.row.col)?.f32.(f|bf)16.(f|bf)16",
+            ptx,
+        ) or "tcgen05.mma.cta_group::1.kind::f16" in ptx)
     if is_hip_cdna4() and normal_type in ["bf16", "fp16"]:
         amdgcn = pgm.asm["amdgcn"]
         assert re.search(r"v_cvt_scalef32_pk_.*?(fp4|fp8|bf8).*?op_sel", amdgcn)
@@ -5057,48 +4624,39 @@ def test_scaled_dot(
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str",
-    [
-        (B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str)
-        for B in [1, 2, 4, 8]
-        for num_warps in [1, 2, 4, 8, 16]
-        for BLOCK_M, BLOCK_N in [(32, 32)]
-        for M, N, K in [(64, 64, 64), (32, 32, 32)]
-        for in_dtype_str, out_dtype_str in [
-            ("int8", "int8"),
-            ("float16", "float16"),
-            ("float16", "float32"),
-            ("float32", "float32"),
-            ("float64", "float64"),
-        ]
-    ]
-    +
+    [(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str)
+     for B in [1, 2, 4, 8]
+     for num_warps in [1, 2, 4, 8, 16]
+     for BLOCK_M, BLOCK_N in [(32, 32)]
+     for M, N, K in [(64, 64, 64), (32, 32, 32)]
+     for in_dtype_str, out_dtype_str in [
+         ("int8", "int8"),
+         ("float16", "float16"),
+         ("float16", "float32"),
+         ("float32", "float32"),
+         ("float64", "float64"),
+     ]] +
     # Large block sizes
     [(4, 4, 128, 128, 64, 64, 64, "float16", "float16")] +
     # Small block sizes
-    [
-        (B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str)
-        for B in [1, 2, 8]
-        for num_warps in [1, 2, 4]
-        for BLOCK_M, BLOCK_N in [(1, 32), (32, 2), (8, 8)]
-        for M, N, K in [(32, 32, 32)]
-        for in_dtype_str, out_dtype_str in [
-            ("float16", "float16"),
-            ("float32", "float32"),
-        ]
-    ],
+    [(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str)
+     for B in [1, 2, 8]
+     for num_warps in [1, 2, 4]
+     for BLOCK_M, BLOCK_N in [(1, 32), (32, 2), (8, 8)]
+     for M, N, K in [(32, 32, 32)]
+     for in_dtype_str, out_dtype_str in [
+         ("float16", "float16"),
+         ("float32", "float32"),
+     ]],
 )
-def test_dot3d(
-    B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str, device
-):
+def test_dot3d(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str, device):
     if is_hip():
         # hip does not support tf32 precision, so use ieee for all tests
         input_precision = "ieee"
         arch = triton.runtime.driver.active.get_current_target().arch
         if "gfx11" in arch or "gfx12" in arch:
             if in_dtype_str == "float32":
-                pytest.skip(
-                    f"{in_dtype_str} is not supported in WMMA dot, FMA does not support dot3d"
-                )
+                pytest.skip(f"{in_dtype_str} is not supported in WMMA dot, FMA does not support dot3d")
             if out_dtype_str == "float16":
                 pytest.skip(f"{out_dtype_str} has low precision in WMMA dot")
         if in_dtype_str == "float64":
@@ -5108,16 +4666,9 @@ def test_dot3d(
         if not is_interpreter() and (BLOCK_M < 16 or BLOCK_N < 16):
             pytest.skip("small dots are supported only on HIP at the moment")
 
-    shared_mem_accum = (
-        B * (BLOCK_M * K + K * BLOCK_N) * get_src_element_ty_size(in_dtype_str)
-    )
-    if (
-        not is_interpreter()
-        and triton.runtime.driver.active.utils.get_device_properties(
-            triton.runtime.driver.active.get_current_device()
-        )["max_shared_mem"]
-        < shared_mem_accum
-    ):
+    shared_mem_accum = (B * (BLOCK_M * K + K * BLOCK_N) * get_src_element_ty_size(in_dtype_str))
+    if (not is_interpreter() and triton.runtime.driver.active.utils.get_device_properties(
+            triton.runtime.driver.active.get_current_device())["max_shared_mem"] < shared_mem_accum):
         pytest.skip("Skipped due to insufficient shared memory on this GPU.")
 
     @triton.jit
@@ -5147,27 +4698,15 @@ def test_dot3d(
         offs_m = startm + tl.arange(0, BLOCK_M)
         offs_n = startn + tl.arange(0, BLOCK_N)
         offs_k = tl.arange(0, BLOCK_K)
-        q_ptrs = (
-            q_ptr
-            + offs_b[:, None, None] * stride_qb
-            + offs_m[None, :, None] * stride_qm
-            + offs_k[None, None, :] * stride_qk
-        )
-        k_ptrs = (
-            k_ptr
-            + offs_b[:, None, None] * stride_kb
-            + offs_k[None, :, None] * stride_kk
-            + offs_n[None, None, :] * stride_kn
-        )
+        q_ptrs = (q_ptr + offs_b[:, None, None] * stride_qb + offs_m[None, :, None] * stride_qm +
+                  offs_k[None, None, :] * stride_qk)
+        k_ptrs = (k_ptr + offs_b[:, None, None] * stride_kb + offs_k[None, :, None] * stride_kk +
+                  offs_n[None, None, :] * stride_kn)
         q = tl.load(q_ptrs)
         k = tl.load(k_ptrs)
         qk = tl.dot(q, k, input_precision=INPUT_PRECISION, out_dtype=out_dtype)
-        o_ptrs = (
-            o_ptr
-            + offs_b[:, None, None] * stride_ob
-            + offs_m[None, :, None] * stride_om
-            + offs_n[None, None, :] * stride_on
-        )
+        o_ptrs = (o_ptr + offs_b[:, None, None] * stride_ob + offs_m[None, :, None] * stride_om +
+                  offs_n[None, None, :] * stride_on)
         tl.store(o_ptrs, qk)
 
     if out_dtype_str == "int8":
@@ -5287,10 +4826,8 @@ def test_dot_mulbroadcasted(in_dtype, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize(
-    "dtype_str", int_dtypes + uint_dtypes + float_dtypes + ["bfloat16"]
-)
-@pytest.mark.parametrize("shape", [(), (1,), (128,)])
+@pytest.mark.parametrize("dtype_str", int_dtypes + uint_dtypes + float_dtypes + ["bfloat16"])
+@pytest.mark.parametrize("shape", [(), (1, ), (128, )])
 def test_full(dtype_str, shape, device):
     if dtype_str in uint_dtypes and not hasattr(torch, dtype_str):
         # PyTorch only has unsigned 8, but not 16, 32, or 64
@@ -5321,12 +4858,12 @@ def test_full(dtype_str, shape, device):
         },
     )
     out_static = torch.zeros((128), dtype=dtype, device=device)
-    kernel_static_patched[(1,)](out_static)
+    kernel_static_patched[(1, )](out_static)
     assert torch.all(out_static == 2)
 
     kernel_dynamic_patched = patch_kernel(kernel_dynamic, {"SHAPE": str(list(shape))})
     out_dynamic = torch.zeros((128), dtype=dtype, device=device)
-    kernel_dynamic_patched[(1,)](out_dynamic, 2, getattr(triton.language, dtype_str))
+    kernel_dynamic_patched[(1, )](out_dynamic, 2, getattr(triton.language, dtype_str))
     assert torch.all(out_dynamic == 2)
 
 
@@ -5353,8 +4890,8 @@ def test_constexpr(literal, dtype_str, device):
         tl.store(out_ptr.to(tl.pointer_type(val.dtype)), val)
 
     kernel_patched = patch_kernel(kernel, {"GENERATE_TEST_HERE": f"{literal}"})
-    out = torch.zeros((1,), dtype=torch.float32, device=device)
-    h = kernel_patched.warmup(out, grid=(1,))
+    out = torch.zeros((1, ), dtype=torch.float32, device=device)
+    h = kernel_patched.warmup(out, grid=(1, ))
     assert re.search(r"arith.constant .* : " + dtype_str, h.asm["ttir"]) is not None
 
 
@@ -5419,8 +4956,8 @@ def test_const(device, choose_const, constexpr, mode):
 """
 
     SIZE = 128
-    input = torch.randn((SIZE,), dtype=torch.float32, device=device)
-    output = torch.zeros((SIZE,), dtype=torch.float32, device=device)
+    input = torch.randn((SIZE, ), dtype=torch.float32, device=device)
+    output = torch.zeros((SIZE, ), dtype=torch.float32, device=device)
     patched_kernel = patch_kernel(
         kernel_constexpr if constexpr else kernel,
         {"LOSE_TAIL": LOSE_TAIL, "CONSTEXPR": ""},
@@ -5429,9 +4966,7 @@ def test_const(device, choose_const, constexpr, mode):
     expect_fail = (not constexpr and mode != "direct") or choose_const
     if expect_fail:
         with pytest.raises(triton.CompilationError) as exc_info:
-            patched_kernel.warmup(
-                input, output, output, choose_const, SIZE, SIZE, grid=(1,)
-            )
+            patched_kernel.warmup(input, output, output, choose_const, SIZE, SIZE, grid=(1, ))
         if constexpr:
             error = "Cannot store to a constant pointer"
         else:
@@ -5440,16 +4975,14 @@ def test_const(device, choose_const, constexpr, mode):
             elif mode == "if":
                 error = "Mismatched type for final_out"
             elif mode == "ternary":
-                error = (
-                    "Ternary expression with dynamic condition has inconsistent type"
-                )
+                error = ("Ternary expression with dynamic condition has inconsistent type")
             else:
                 assert mode == "direct" and choose_const
                 error = "Cannot store to a constant pointer"
         error_msg = exc_info.value.error_message or str(exc_info.value.__cause__)
         assert error in error_msg, "Wrong error message!"
     else:
-        patched_kernel[(1,)](input, output, output, choose_const, SIZE, SIZE)
+        patched_kernel[(1, )](input, output, output, choose_const, SIZE, SIZE)
         assert torch.all(input == output)
 
 
@@ -5465,14 +4998,12 @@ def test_dot_without_load(dtype_str, device):
         out_ptr = out + tl.arange(0, 32)[:, None] * 32 + tl.arange(0, 32)[None, :]
         tl.store(out_ptr, c)
 
-    kernel = patch_kernel(
-        _kernel, {"GENERATE_TEST_HERE": f"tl.full((32, 32), 1.0, tl.{dtype_str})"}
-    )
+    kernel = patch_kernel(_kernel, {"GENERATE_TEST_HERE": f"tl.full((32, 32), 1.0, tl.{dtype_str})"})
     a = torch.ones((32, 32), dtype=getattr(torch, dtype_str), device=device)
     b = torch.ones((32, 32), dtype=getattr(torch, dtype_str), device=device)
     out_ref = torch.matmul(a, b)
     out = torch.zeros((32, 32), dtype=getattr(torch, dtype_str), device=device)
-    kernel[(1,)](out)
+    kernel[(1, )](out)
     assert torch.all(out == out_ref)
 
 
@@ -5494,7 +5025,7 @@ def test_arange(start, num_ctas, device):
         val = tl.arange(START, END)
         tl.store(z + off, val)
 
-    _kernel[(1,)](z_tri, START=start, END=start + BLOCK, BLOCK=BLOCK, num_ctas=num_ctas)
+    _kernel[(1, )](z_tri, START=start, END=start + BLOCK, BLOCK=BLOCK, num_ctas=num_ctas)
     z_ref = torch.arange(start, BLOCK + start, dtype=torch.int32, device=device)
     np.testing.assert_allclose(to_numpy(z_tri), to_numpy(z_ref))
 
@@ -5507,13 +5038,11 @@ def test_arange(start, num_ctas, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype_str, size, size_diff, other",
-    [
-        (dtype_str, size, size_diff, other)
-        for dtype_str in torch_dtypes
-        for size in [128, 512]
-        for size_diff in [0, 1, 2, 3, 4]
-        for other in [0, 1]
-    ],
+    [(dtype_str, size, size_diff, other)
+     for dtype_str in torch_dtypes
+     for size in [128, 512]
+     for size_diff in [0, 1, 2, 3, 4]
+     for other in [0, 1]],
 )
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_masked_load(dtype_str, size, size_diff, other, num_ctas, device):
@@ -5523,12 +5052,12 @@ def test_masked_load(dtype_str, size, size_diff, other, num_ctas, device):
     input_size = size - size_diff
     output_size = size
     if dtype_str == "bool":
-        input = torch.randint(0, 2, (input_size,), dtype=dtype, device=device)
+        input = torch.randint(0, 2, (input_size, ), dtype=dtype, device=device)
     elif dtype_str in int_dtypes or dtype_str in uint_dtypes:
-        input = torch.randint(0, 127, (input_size,), dtype=dtype, device=device)
+        input = torch.randint(0, 127, (input_size, ), dtype=dtype, device=device)
     else:
         input = torch.rand(input_size, dtype=dtype, device=device)
-    output = torch.zeros((output_size,), dtype=dtype, device=device)
+    output = torch.zeros((output_size, ), dtype=dtype, device=device)
 
     @triton.jit
     def _kernel(in_ptr, out_ptr, in_size: tl.constexpr, out_size: tl.constexpr):
@@ -5540,14 +5069,10 @@ def test_masked_load(dtype_str, size, size_diff, other, num_ctas, device):
         tl.store(out_ptr + output_offsets, x)
 
     mask_str = f"mask=in_offsets < in_size, other={other}" if size_diff > 0 else "None"
-    kernel = patch_kernel(
-        _kernel, {"GENERATE_TEST_HERE": f"tl.load(in_ptr + in_offsets, {mask_str})"}
-    )
-    kernel[(1,)](input, output, input_size, output_size, num_ctas=num_ctas)
+    kernel = patch_kernel(_kernel, {"GENERATE_TEST_HERE": f"tl.load(in_ptr + in_offsets, {mask_str})"})
+    kernel[(1, )](input, output, input_size, output_size, num_ctas=num_ctas)
 
-    reference_out = torch.cat(
-        (input, torch.full((size_diff,), other, dtype=dtype, device=device))
-    )
+    reference_out = torch.cat((input, torch.full((size_diff, ), other, dtype=dtype, device=device)))
     torch.testing.assert_close(output, reference_out)
 
 
@@ -5559,23 +5084,21 @@ def test_masked_load_scalar(num_ctas, mask_val, other_val, device):
     input_val = 4.0
     size = 128
     dtype = torch.float32
-    input = torch.full((size,), input_val, dtype=dtype, device=device)
-    output = torch.zeros((size,), dtype=dtype, device=device)
+    input = torch.full((size, ), input_val, dtype=dtype, device=device)
+    output = torch.zeros((size, ), dtype=dtype, device=device)
 
     @triton.jit
-    def kernel(
-        in_ptr, out_ptr, size: tl.constexpr, mask: tl.constexpr, other: tl.constexpr
-    ):
+    def kernel(in_ptr, out_ptr, size: tl.constexpr, mask: tl.constexpr, other: tl.constexpr):
         offsets = tl.arange(0, size)
         x = tl.load(in_ptr + offsets, mask=mask, other=other)
         tl.store(out_ptr + offsets, x)
 
-    kernel[(1,)](input, output, size, mask_val, other_val, num_ctas=num_ctas)
+    kernel[(1, )](input, output, size, mask_val, other_val, num_ctas=num_ctas)
 
     if mask_val:
-        reference_out = torch.full((size,), input_val, dtype=dtype, device=device)
+        reference_out = torch.full((size, ), input_val, dtype=dtype, device=device)
     else:
-        reference_out = torch.full((size,), other_val, dtype=dtype, device=device)
+        reference_out = torch.full((size, ), other_val, dtype=dtype, device=device)
 
     torch.testing.assert_close(output, reference_out)
 
@@ -5628,7 +5151,7 @@ def test_masked_load_shared_memory(dtype, device):
         output_offsets = M_offsets[:, None] * out_stride + N_offsets[None, :]
         tl.store(output_ptr + output_offsets, o, mask=output_offsets < M * N)
 
-    pgm = _kernel[(1,)](
+    pgm = _kernel[(1, )](
         in1,
         in2,
         out,
@@ -5659,7 +5182,7 @@ def test_load_cache_modifier(cache, device):
         x = tl.load(src + offsets, cache_modifier=CACHE)
         tl.store(dst + offsets, x)
 
-    pgm = _kernel[(1,)](dst, src, CACHE=cache)
+    pgm = _kernel[(1, )](dst, src, CACHE=cache)
 
     if is_hip():
         target_arch = get_arch()
@@ -5669,12 +5192,8 @@ def test_load_cache_modifier(cache, device):
         amdgcn = pgm.asm["amdgcn"]
         cg_cache_modifier_str = "nt"
         cv_cache_modifier_str = "sc0 sc1"
-        buffer_load_line = [
-            line for line in amdgcn.splitlines() if "buffer_load" in line
-        ]
-        global_load_line = [
-            line for line in amdgcn.splitlines() if "global_load" in line
-        ]
+        buffer_load_line = [line for line in amdgcn.splitlines() if "buffer_load" in line]
+        global_load_line = [line for line in amdgcn.splitlines() if "global_load" in line]
         load_line = global_load_line[0] if global_load_line else buffer_load_line[0]
         if cache == "" or cache == ".ca":
             assert cg_cache_modifier_str not in load_line
@@ -5710,7 +5229,7 @@ def test_vectorization(N, num_ctas, device):
         x = tl.load(src + offsets, mask=offsets < N)
         tl.store(dst + offsets, x, mask=offsets < N)
 
-    pgm = _kernel[(1,)](dst, src, N=N, BLOCK_SIZE=block_size)
+    pgm = _kernel[(1, )](dst, src, N=N, BLOCK_SIZE=block_size)
 
     if not is_cuda():
         return
@@ -5739,7 +5258,7 @@ def test_vectorization_hints(has_hints, device):
         x = tl.load(src + offsets, mask=offsets < N)
         tl.store(dst + offsets, x, mask=offsets < N)
 
-    pgm = _kernel[(1,)](dst, src, off, N=1024, BLOCK_SIZE=src.shape[0], HINT=has_hints)
+    pgm = _kernel[(1, )](dst, src, off, N=1024, BLOCK_SIZE=src.shape[0], HINT=has_hints)
     if not is_cuda():
         return
 
@@ -5763,7 +5282,7 @@ def test_assume(device):
             tl.store(out_ptr + tl.program_id(0), current_size + 101024)
 
     output = torch.zeros(1024 // 128, device=device)
-    pgm = _kernel[(1024 // 128,)](output, N=1024, BLOCK_N=128)
+    pgm = _kernel[(1024 // 128, )](output, N=1024, BLOCK_N=128)
 
     if is_interpreter():
         return
@@ -5791,7 +5310,7 @@ def test_store_cache_modifier(cache, device):
         x = tl.load(src + offsets)
         tl.store(dst + offsets, x, cache_modifier=CACHE)
 
-    pgm = _kernel[(1,)](dst, src, CACHE=cache)
+    pgm = _kernel[(1, )](dst, src, CACHE=cache)
 
     if is_hip():
         target_arch = get_arch()
@@ -5801,12 +5320,8 @@ def test_store_cache_modifier(cache, device):
         amdgcn = pgm.asm["amdgcn"]
         cs_cache_modifier_str = "nt"
         wt_cache_modifier_str = "sc0 sc1"
-        buffer_store_line = [
-            line for line in amdgcn.splitlines() if "buffer_store" in line
-        ]
-        global_store_line = [
-            line for line in amdgcn.splitlines() if "global_store" in line
-        ]
+        buffer_store_line = [line for line in amdgcn.splitlines() if "buffer_store" in line]
+        global_store_line = [line for line in amdgcn.splitlines() if "global_store" in line]
         store_line = global_store_line[0] if global_store_line else buffer_store_line[0]
         if cache == "" or cache == ".cg":
             assert cs_cache_modifier_str not in store_line
@@ -5859,7 +5374,7 @@ def test_store_eviction_policy(eviction_policy, device):
         x = tl.load(src + offsets)
         tl.store(dst + offsets, x, eviction_policy=POLICY)
 
-    pgm = _kernel[(1,)](dst, src, POLICY=eviction_policy)
+    pgm = _kernel[(1, )](dst, src, POLICY=eviction_policy)
 
     if not is_cuda():
         return
@@ -5897,11 +5412,11 @@ def test_default(device):
         tl.store(ret0, _impl())
         tl.store(ret1, _impl(value))
 
-    _kernel[(1,)](ret0, ret1, value)
+    _kernel[(1, )](ret0, ret1, value)
     assert ret0.item() == 10
     assert ret1.item() == value
 
-    _kernel[(1,)](ret0, ret1)
+    _kernel[(1, )](ret0, ret1)
     assert ret0.item() == 10
     assert ret1.item() == 3
 
@@ -5922,9 +5437,9 @@ def test_pointer_arguments(device):
     x = torch.empty(1024, device=device.split("_")[0], pin_memory=pin_memory)
     if device == "cpu":
         with pytest.raises(ValueError):
-            kernel[(1,)](x)
+            kernel[(1, )](x)
     else:
-        kernel[(1,)](x)
+        kernel[(1, )](x)
 
 
 # --------------------
@@ -5952,13 +5467,7 @@ def test_value_specialization(value: int, value_type: str, device) -> None:
 
     def repr(specialization):
         ty = specialization.signature["value1"]
-        cst = "_".join(
-            [
-                k
-                for k, v in specialization.constants.items()
-                if isinstance(k, str) and v == 1
-            ]
-        )
+        cst = "_".join([k for k, v in specialization.constants.items() if isinstance(k, str) and v == 1])
         return f"kernel_{ty}_{cst}"
 
     @triton.jit(repr=repr)
@@ -5966,7 +5475,7 @@ def test_value_specialization(value: int, value_type: str, device) -> None:
         pass
 
     x = torch.tensor([3.14159], device=device)
-    h = kernel.warmup(value, 1, x, grid=(1,))
+    h = kernel.warmup(value, 1, x, grid=(1, ))
     assert "is_one" in h.name
     assert value_type in h.name
 
@@ -5985,9 +5494,9 @@ def test_value_specialization_overflow(value: int, overflow: bool, device) -> No
 
     if overflow:
         with pytest.raises(OverflowError):
-            kernel[(1,)](value, x)
+            kernel[(1, )](value, x)
     else:
-        kernel[(1,)](value, x)
+        kernel[(1, )](value, x)
 
 
 # ----------------
@@ -5996,9 +5505,7 @@ def test_value_specialization_overflow(value: int, overflow: bool, device) -> No
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize(
-    "op", ["+", "-", "*", "/", "%", "<", ">", "<<", ">>", "&", "^", "|"]
-)
+@pytest.mark.parametrize("op", ["+", "-", "*", "/", "%", "<", ">", "<<", ">>", "&", "^", "|"])
 @pytest.mark.parametrize("is_lhs_constexpr", [False, True])
 @pytest.mark.parametrize("is_rhs_constexpr", [True, False])
 def test_bin_op_constexpr(op, is_lhs_constexpr, is_rhs_constexpr, device):
@@ -6013,24 +5520,24 @@ def test_bin_op_constexpr(op, is_lhs_constexpr, is_rhs_constexpr, device):
     if op in ["<<", ">>", "&", "^", "|"]:  # int op
         x_str = "3" if is_lhs_constexpr else "x"
         y_str = "4" if is_rhs_constexpr else "y"
-        x = numpy_random((1,), dtype_str="int32")
+        x = numpy_random((1, ), dtype_str="int32")
 
         # NOTE: bitshifting beyond bitwidth can lead to undefined behavior
         if op in ["<<", ">>"]:
-            y = numpy_random((1,), dtype_str="int32", low=0, high=_bitwidth("int32"))
+            y = numpy_random((1, ), dtype_str="int32", low=0, high=_bitwidth("int32"))
         else:
-            y = numpy_random((1,), dtype_str="int32")
+            y = numpy_random((1, ), dtype_str="int32")
     else:
         x_str = "3.14" if is_lhs_constexpr else "x"
         y_str = "4.13" if is_rhs_constexpr else "y"
-        x = numpy_random((1,), dtype_str="float32")
-        y = numpy_random((1,), dtype_str="float32")
+        x = numpy_random((1, ), dtype_str="float32")
+        y = numpy_random((1, ), dtype_str="float32")
     kernel = patch_kernel(kernel, {"GENERATE_TEST_HERE": f"{x_str} {op} {y_str}"})
     z = np.array(eval(f"{x_str} {op} {y_str}"))
     x_tri = to_triton(x, device=device)
     y_tri = to_triton(y, device=device)
-    z_tri = to_triton(np.empty((1,), dtype=z.dtype), device=device)
-    kernel[(1,)](z_tri, x_tri, y_tri)
+    z_tri = to_triton(np.empty((1, ), dtype=z.dtype), device=device)
+    kernel[(1, )](z_tri, x_tri, y_tri)
     np.testing.assert_allclose(z, to_numpy(z_tri), rtol=1e-3)
 
 
@@ -6042,8 +5549,8 @@ def test_constexpr_shape(device):
         off = tl.arange(0, 128 + 128)
         tl.store(X + off, off)
 
-    x_tri = to_triton(np.empty((256,), dtype=np.int32), device=device)
-    kernel[(1,)](x_tri)
+    x_tri = to_triton(np.empty((256, ), dtype=np.int32), device=device)
+    kernel[(1, )](x_tri)
     np.testing.assert_equal(to_numpy(x_tri), np.arange(0, 256))
 
 
@@ -6056,15 +5563,15 @@ def test_constexpr_scalar_shape(device):
         val = off % (256 // s)
         tl.store(X + off, val)
 
-    x_tri = to_triton(np.empty((256,), dtype=np.int32), device=device)
-    kernel[(1,)](x_tri, 32)
+    x_tri = to_triton(np.empty((256, ), dtype=np.int32), device=device)
+    kernel[(1, )](x_tri, 32)
     np.testing.assert_equal(to_numpy(x_tri), np.arange(0, 256) % 8)
 
 
 reshape_list = [
-    ((64,), (8, 8)),
+    ((64, ), (8, 8)),
     ((2, 32), (16, 4)),
-    ((512,), (2, 2, 2, 2, 2, 2, 2, 2, 2)),
+    ((512, ), (2, 2, 2, 2, 2, 2, 2, 2, 2)),
     ((64, 32), (16, 8, 16)),
 ]
 
@@ -6092,7 +5599,7 @@ def test_reshape(formats, device):
     x_tri = to_triton(x, device=device)
     patched_kernel = generate_kernel(in_format, out_format)
     z_tri = to_triton(np.empty(out_format, dtype=np.int32), device=device)
-    patched_kernel[(1,)](z_tri, x_tri, out_format)
+    patched_kernel[(1, )](z_tri, x_tri, out_format)
     np.testing.assert_equal(z, to_numpy(z_tri))
 
 
@@ -6101,10 +5608,10 @@ def test_reshape_err(device):
     @triton.jit
     def kernel():
         x = tl.arange(0, 8 * 8)
-        y = tl.reshape(x, (8 * 4,))
+        y = tl.reshape(x, (8 * 4, ))
 
     with pytest.raises(triton.CompilationError) as exc_info:
-        kernel.warmup(grid=(1,))
+        kernel.warmup(grid=(1, ))
 
     assert "reshape" in str(exc_info.value)
 
@@ -6120,11 +5627,9 @@ def test_tma_load_block_shape_err(device):
     input = torch.empty((128, 128), dtype=torch.int32, device=device)
     errc = triton.CompilationError if not is_interpreter() else InterpreterError
     with pytest.raises(errc) as e:
-        kernel[(1,)](input)
+        kernel[(1, )](input)
 
-    assert "Descriptor block shape must have at least 16 bytes" in str(
-        e.value.__cause__
-    )
+    assert "Descriptor block shape must have at least 16 bytes" in str(e.value.__cause__)
 
 
 @pytest.mark.interpreter
@@ -6138,19 +5643,15 @@ def test_tma_store_block_shape_err(device):
     input = torch.empty((128, 128), dtype=torch.int16, device=device)
     errc = triton.CompilationError if not is_interpreter() else InterpreterError
     with pytest.raises(errc) as e:
-        kernel[(1,)](input)
+        kernel[(1, )](input)
 
-    assert "Descriptor block shape must have at least 16 bytes" in str(
-        e.value.__cause__
-    )
+    assert "Descriptor block shape must have at least 16 bytes" in str(e.value.__cause__)
 
 
 def test_trans_reshape(device, with_allocator):
 
     @triton.jit
-    def kernel(
-        in_base_ptr, out_base_ptr, IN_SHAPE0: tl.constexpr, IN_SHAPE1: tl.constexpr
-    ):
+    def kernel(in_base_ptr, out_base_ptr, IN_SHAPE0: tl.constexpr, IN_SHAPE1: tl.constexpr):
         in_block_ptr = tl.make_block_ptr(
             base=in_base_ptr,
             shape=(IN_SHAPE0, IN_SHAPE1),
@@ -6162,21 +5663,18 @@ def test_trans_reshape(device, with_allocator):
         x = tl.load(in_block_ptr)
         x = tl.reshape(x, (32, 4, 4, 2))
         x = tl.permute(x, (1, 2, 3, 0))
-        x = tl.reshape(x, (IN_SHAPE0 * IN_SHAPE1,))
+        x = tl.reshape(x, (IN_SHAPE0 * IN_SHAPE1, ))
         tl.store(out_base_ptr + tl.arange(0, IN_SHAPE0 * IN_SHAPE1), x)
 
     shape = (32, 32)
-    input = torch.arange(math.prod(shape), dtype=torch.int32, device=device).reshape(
-        shape
-    )
+    input = torch.arange(math.prod(shape), dtype=torch.int32, device=device).reshape(shape)
     expected = torch.permute(input, (1, 0))
     # Don't do zeros_like -- that copies the layout, which we don't want.
     actual = torch.zeros(expected.shape, dtype=torch.int32, device=device)
 
-    k = kernel[(1,)](input, actual, shape[0], shape[1])
-    assert (
-        k.asm["ttgir"].count("ttg.convert_layout") == 1
-    ), "Expected exactly one convert_layout op in the TTGIR after optimization"
+    k = kernel[(1, )](input, actual, shape[0], shape[1])
+    assert (k.asm["ttgir"].count("ttg.convert_layout") == 1
+            ), "Expected exactly one convert_layout op in the TTGIR after optimization"
 
     np.testing.assert_equal(to_numpy(expected), to_numpy(actual))
 
@@ -6221,11 +5719,11 @@ def test_call(type, num_ctas, device):
         vecmul_kernel(ptr, n_elements, num2, type)
 
     size = 1024
-    rand_val = numpy_random((size,), dtype_str="float32")
+    rand_val = numpy_random((size, ), dtype_str="float32")
     rand_val_tri = to_triton(rand_val, device=device)
     err_msg = ""
     try:
-        kernel[(size // 128,)](rand_val_tri, size, 3, 5, type, num_ctas=num_ctas)
+        kernel[(size // 128, )](rand_val_tri, size, 3, 5, type, num_ctas=num_ctas)
     except Exception as e:
         err_msg = str(e)
 
@@ -6280,11 +5778,7 @@ def test_if(if_type, device):
             val = 3.14 if pid % 2 == 0 else tl.load(XFalse)
             tl.store(Ret, val)
         elif IfType == "if_exp_dynamic_void":
-            (
-                tl.store(Ret, tl.load(XTrue))
-                if pid % 2 == 0
-                else tl.store(Ret, tl.load(XFalse))
-            )
+            (tl.store(Ret, tl.load(XTrue)) if pid % 2 == 0 else tl.store(Ret, tl.load(XFalse)))
         elif IfType == "if_exp_static":
             tl.store(Ret, tl.load(XTrue)) if BoolVar else tl.store(Ret, tl.load(XFalse))
         elif IfType == "if_and_dynamic":
@@ -6303,7 +5797,7 @@ def test_if(if_type, device):
     x_false = torch.tensor([1.51], dtype=torch.float32, device=device)
     ret = torch.zeros(1, dtype=torch.float32, device=device)
 
-    kernel[(1,)](cond, x_true, x_false, ret, if_type, True, 1)
+    kernel[(1, )](cond, x_true, x_false, ret, if_type, True, 1)
     assert torch.equal(ret, x_true)
 
 
@@ -6315,10 +5809,10 @@ def test_num_warps_pow2(device):
         pass
 
     with pytest.raises(AssertionError, match="must be a power of 2"):
-        _kernel.warmup(dst=dst, grid=(1,), num_warps=3)
-    _kernel.warmup(dst=dst, grid=(1,), num_warps=1)
-    _kernel.warmup(dst=dst, grid=(1,), num_warps=2)
-    _kernel.warmup(dst=dst, grid=(1,), num_warps=4)
+        _kernel.warmup(dst=dst, grid=(1, ), num_warps=3)
+    _kernel.warmup(dst=dst, grid=(1, ), num_warps=1)
+    _kernel.warmup(dst=dst, grid=(1, ), num_warps=2)
+    _kernel.warmup(dst=dst, grid=(1, ), num_warps=4)
 
 
 # -----------------------
@@ -6346,7 +5840,7 @@ def test_inline_asm(num_ctas, device):
         )
         tl.store(Z + tl.arange(0, BLOCK), z)
 
-    shape = (128,)
+    shape = (128, )
     rs = RandomState(17)
     x = numpy_random(shape, dtype_str="uint32", rs=rs)
     y = numpy_random(shape, dtype_str="uint32", rs=rs)
@@ -6354,7 +5848,7 @@ def test_inline_asm(num_ctas, device):
     y_tri = to_triton(y, device=device)
     n = 17
     z_tri = to_triton(numpy_random(shape, dtype_str="uint32", rs=rs), device=device)
-    kernel[(1,)](x_tri, y_tri, z_tri, n, BLOCK=shape[0], num_ctas=num_ctas)
+    kernel[(1, )](x_tri, y_tri, z_tri, n, BLOCK=shape[0], num_ctas=num_ctas)
     y_ref = (y << n) | (x >> (32 - n))
     # compare
     np.testing.assert_equal(y_ref, to_numpy(z_tri))
@@ -6382,12 +5876,12 @@ def test_inline_asm_packed(num_ctas, device):
         )
         tl.store(Y + tl.arange(0, BLOCK), y)
 
-    shape = (512,)
+    shape = (512, )
     rs = RandomState(17)
     x = numpy_random(shape, dtype_str="uint8", rs=rs)
     x_tri = to_triton(x, device=device)
     y_tri = to_triton(numpy_random(shape, dtype_str="uint8", rs=rs), device=device)
-    kernel[(1,)](x_tri, y_tri, BLOCK=shape[0], num_ctas=num_ctas)
+    kernel[(1, )](x_tri, y_tri, BLOCK=shape[0], num_ctas=num_ctas)
     y_ref = x << 3
     # compare
     np.testing.assert_equal(y_ref, to_numpy(y_tri))
@@ -6413,12 +5907,12 @@ def test_inline_asm_with_pointers(num_ctas, device):
             pack=1,
         )
 
-    shape = (512,)
+    shape = (512, )
     rs = RandomState(17)
     x = numpy_random(shape, dtype_str="uint8", rs=rs)
     x_tri = to_triton(x, device=device)
     y_tri = to_triton(numpy_random(shape, dtype_str="uint8", rs=rs), device=device)
-    kernel[(1,)](x_tri, y_tri, BLOCK=shape[0], num_ctas=num_ctas)
+    kernel[(1, )](x_tri, y_tri, BLOCK=shape[0], num_ctas=num_ctas)
     y_ref = x << 3
     # compare
     np.testing.assert_equal(y_ref, to_numpy(y_tri))
@@ -6444,8 +5938,7 @@ def test_inline_asm_multiple_outputs(device):
                 # 2 output registers: $0=C and $1=D.
                 "=r,=r,"
                 # 2 input registers: $2=A and $3=B.
-                "r,r"
-            ),
+                "r,r"),
             args=[a, b],
             dtype=(tl.uint32, tl.uint32),
             is_pure=True,
@@ -6454,7 +5947,7 @@ def test_inline_asm_multiple_outputs(device):
         tl.store(C + tl.arange(0, BLOCK), c)
         tl.store(D + tl.arange(0, BLOCK), d)
 
-    shape = (512,)
+    shape = (512, )
     rs = RandomState(17)
     A = numpy_random(shape, dtype_str="uint32", rs=rs)
     B = numpy_random(shape, dtype_str="uint32", rs=rs)
@@ -6462,7 +5955,7 @@ def test_inline_asm_multiple_outputs(device):
     B_tri = to_triton(B, device=device)
     C_tri = to_triton(numpy_random(shape, dtype_str="uint32", rs=rs), device=device)
     D_tri = to_triton(numpy_random(shape, dtype_str="uint32", rs=rs), device=device)
-    kernel[(1,)](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
+    kernel[(1, )](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
 
     C_ref = A - B
     D_ref = B - A
@@ -6517,8 +6010,7 @@ def test_inline_asm_packed_multiple_outputs(device):
                 #   $8=ai,
                 #   $9=b0, $10=b1, $11=b2, $12=b3.
                 # The four elements from `a` are all packed into one register.
-                "r,r,r,r,r"
-            ),
+                "r,r,r,r,r"),
             args=[a, b],
             dtype=(tl.int32, tl.float32),
             is_pure=True,
@@ -6527,7 +6019,7 @@ def test_inline_asm_packed_multiple_outputs(device):
         tl.store(C + tl.arange(0, BLOCK), c)
         tl.store(D + tl.arange(0, BLOCK), d)
 
-    shape = (512,)
+    shape = (512, )
     rs = RandomState(17)
     A = numpy_random(shape, dtype_str="uint8", rs=rs)
     B = numpy_random(shape, dtype_str="float32", rs=rs)
@@ -6535,7 +6027,7 @@ def test_inline_asm_packed_multiple_outputs(device):
     B_tri = to_triton(B, device=device)
     C_tri = to_triton(numpy_random(shape, dtype_str="int32", rs=rs), device=device)
     D_tri = to_triton(numpy_random(shape, dtype_str="float32", rs=rs), device=device)
-    kernel[(1,)](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
+    kernel[(1, )](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
 
     C_ref = A.astype(np.int32)
     D_ref = np.maximum(A.astype(np.float32), B)
@@ -6568,14 +6060,14 @@ def test_map_elementwise(num_ctas, device):
         z = tl.map_elementwise(compare, x, y)
         tl.store(Z + tl.arange(0, BLOCK), z)
 
-    shape = (128,)
+    shape = (128, )
     rs = RandomState(17)
     x = numpy_random(shape, dtype_str="int32", rs=rs)
     y = numpy_random(shape, dtype_str="int32", rs=rs)
     x_tri = to_triton(x, device=device)
     y_tri = to_triton(y, device=device)
     z_tri = to_triton(numpy_random(shape, dtype_str="int32", rs=rs), device=device)
-    kernel[(1,)](x_tri, y_tri, z_tri, BLOCK=shape[0], num_ctas=num_ctas)
+    kernel[(1, )](x_tri, y_tri, z_tri, BLOCK=shape[0], num_ctas=num_ctas)
     z_ref = (x > y).astype(int) - (y > x).astype(int)
     np.testing.assert_equal(z_ref, to_numpy(z_tri))
 
@@ -6596,7 +6088,7 @@ def test_map_elementwise_multiple_outputs(device):
         tl.store(C + tl.arange(0, BLOCK), c)
         tl.store(D + tl.arange(0, BLOCK), d)
 
-    shape = (512,)
+    shape = (512, )
     rs = RandomState(17)
     A = numpy_random(shape, dtype_str="uint32", rs=rs)
     B = numpy_random(shape, dtype_str="uint32", rs=rs)
@@ -6604,7 +6096,7 @@ def test_map_elementwise_multiple_outputs(device):
     B_tri = to_triton(B, device=device)
     C_tri = to_triton(numpy_random(shape, dtype_str="uint32", rs=rs), device=device)
     D_tri = to_triton(numpy_random(shape, dtype_str="uint32", rs=rs), device=device)
-    kernel[(1,)](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
+    kernel[(1, )](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
 
     C_ref = A // B
     D_ref = A % B
@@ -6629,7 +6121,7 @@ def test_map_elementwise_pack(device):
         tl.store(C + tl.arange(0, BLOCK), c)
         tl.store(D + tl.arange(0, BLOCK), d)
 
-    shape = (512,)
+    shape = (512, )
     rs = RandomState(17)
     A = numpy_random(shape, dtype_str="uint32", rs=rs)
     B = numpy_random(shape, dtype_str="uint32", rs=rs)
@@ -6637,7 +6129,7 @@ def test_map_elementwise_pack(device):
     B_tri = to_triton(B, device=device)
     C_tri = to_triton(numpy_random(shape, dtype_str="uint32", rs=rs), device=device)
     D_tri = to_triton(numpy_random(shape, dtype_str="uint32", rs=rs), device=device)
-    h = kernel[(1,)](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
+    h = kernel[(1, )](A_tri, B_tri, C_tri, D_tri, BLOCK=shape[0])
 
     C_ref = A // B
     D_ref = A % B
@@ -6676,8 +6168,8 @@ def test_for_iv(lo, hi, iv, device):
 
     lo = 2**35
     hi = 2**35 + 20
-    out = to_triton(np.zeros((1,), dtype=np.int64), device=device)
-    kernel[(1,)](out, lo, hi, iv)
+    out = to_triton(np.zeros((1, ), dtype=np.int64), device=device)
+    kernel[(1, )](out, lo, hi, iv)
     assert out[0] == sum(range(lo, hi, iv))
 
 
@@ -6692,17 +6184,17 @@ def test_if_else(device):
             val = tl.load(FalseVal)
         tl.store(Out, val)
 
-    out = to_triton(np.zeros((1,), dtype=np.int32), device=device)
-    true_val = to_triton(np.full((1,), 1, dtype=np.int32), device=device)
-    false_val = to_triton(np.full((1,), 2, dtype=np.int32), device=device)
-    cond = to_triton(np.zeros((1,), dtype=np.int32), device=device)
+    out = to_triton(np.zeros((1, ), dtype=np.int32), device=device)
+    true_val = to_triton(np.full((1, ), 1, dtype=np.int32), device=device)
+    false_val = to_triton(np.full((1, ), 2, dtype=np.int32), device=device)
+    cond = to_triton(np.zeros((1, ), dtype=np.int32), device=device)
     # True
     cond[0] = True
-    kernel[(1,)](cond, true_val, false_val, out)
+    kernel[(1, )](cond, true_val, false_val, out)
     assert to_numpy(out)[0] == true_val[0]
     # False
     cond[0] = False
-    kernel[(1,)](cond, true_val, false_val, out)
+    kernel[(1, )](cond, true_val, false_val, out)
     assert to_numpy(out)[0] == false_val[0]
 
 
@@ -6722,15 +6214,15 @@ def test_if_return(mode, device):
                 return
         tl.store(Out, 1)
 
-    out = to_triton(np.zeros((1,), dtype=np.int32), device=device)
-    exit_early = to_triton(np.zeros((1,), dtype=np.int32), device=device)
+    out = to_triton(np.zeros((1, ), dtype=np.int32), device=device)
+    exit_early = to_triton(np.zeros((1, ), dtype=np.int32), device=device)
     # exit early path taken
     exit_early[0] = 1
-    kernel[(1,)](exit_early, out, True, mode)
+    kernel[(1, )](exit_early, out, True, mode)
     assert to_numpy(out)[0] == 0
     # exit early path not taken
     exit_early[0] = 0
-    kernel[(1,)](exit_early, out, False, mode)
+    kernel[(1, )](exit_early, out, False, mode)
     assert to_numpy(out)[0] == 1
 
 
@@ -6839,8 +6331,8 @@ def test_if_call(call_type, device):
 
         tl.store(Out, o)
 
-    out = to_triton(np.zeros((1,), dtype=np.int32), device=device)
-    kernel[(1,)](out, call_type)
+    out = to_triton(np.zeros((1, ), dtype=np.int32), device=device)
+    kernel[(1, )](out, call_type)
     assert to_numpy(out)[0] == 1
 
 
@@ -6865,14 +6357,14 @@ def test_nested_if_else_return(_cond1, _cond2, _cond3, device):
                 val = tl.load(Val3)
         tl.store(Out, val)
 
-    out = to_triton(np.full((1,), -1, dtype=np.int32), device=device)
-    cond1 = to_triton(np.full((1,), _cond1, dtype=np.int32), device=device)
-    cond2 = to_triton(np.full((1,), _cond2, dtype=np.int32), device=device)
-    cond3 = to_triton(np.full((1,), _cond3, dtype=np.int32), device=device)
-    val1 = to_triton(np.full((1,), 1, dtype=np.int32), device=device)
-    val2 = to_triton(np.full((1,), 2, dtype=np.int32), device=device)
-    val3 = to_triton(np.full((1,), 3, dtype=np.int32), device=device)
-    kernel[(1,)](cond1, cond2, cond3, val1, val2, val3, out)
+    out = to_triton(np.full((1, ), -1, dtype=np.int32), device=device)
+    cond1 = to_triton(np.full((1, ), _cond1, dtype=np.int32), device=device)
+    cond2 = to_triton(np.full((1, ), _cond2, dtype=np.int32), device=device)
+    cond3 = to_triton(np.full((1, ), _cond3, dtype=np.int32), device=device)
+    val1 = to_triton(np.full((1, ), 1, dtype=np.int32), device=device)
+    val2 = to_triton(np.full((1, ), 2, dtype=np.int32), device=device)
+    val3 = to_triton(np.full((1, ), 3, dtype=np.int32), device=device)
+    kernel[(1, )](cond1, cond2, cond3, val1, val2, val3, out)
     targets = {
         (True, True, True): val1[0],
         (True, True, False): val1[0],
@@ -6902,13 +6394,13 @@ def test_while(device):
         tl.store(OutI, curr_i)
         tl.store(OutJ, j)
 
-    out_i = to_triton(np.zeros((1,), dtype=np.int32), device=device)
-    out_j = to_triton(np.zeros((1,), dtype=np.int32), device=device)
-    init_i = to_triton(np.full((1,), 1, dtype=np.int32), device=device)
-    out_init_i = to_triton(np.full((1,), 0, dtype=np.int32), device=device)
-    bound = to_triton(np.full((1,), 10, dtype=np.int32), device=device)
-    cut_off = to_triton(np.full((1,), 5, dtype=np.int32), device=device)
-    kernel[(1,)](init_i, bound, cut_off, out_i, out_init_i, out_j)
+    out_i = to_triton(np.zeros((1, ), dtype=np.int32), device=device)
+    out_j = to_triton(np.zeros((1, ), dtype=np.int32), device=device)
+    init_i = to_triton(np.full((1, ), 1, dtype=np.int32), device=device)
+    out_init_i = to_triton(np.full((1, ), 0, dtype=np.int32), device=device)
+    bound = to_triton(np.full((1, ), 10, dtype=np.int32), device=device)
+    cut_off = to_triton(np.full((1, ), 5, dtype=np.int32), device=device)
+    kernel[(1, )](init_i, bound, cut_off, out_i, out_init_i, out_j)
     assert out_init_i[0] == init_i[0]
     assert out_i[0] == init_i[0] + 1
     assert out_j[0] == bound[0]
@@ -6926,8 +6418,8 @@ def test_nested_while(device):
                 count = count - 2
 
     counter = torch.tensor([8], dtype=torch.int32, device=device)
-    data = torch.zeros((1,), device=device, dtype=torch.float32)
-    nested_while[(1,)](data, counter)
+    data = torch.zeros((1, ), device=device, dtype=torch.float32)
+    nested_while[(1, )](data, counter)
     assert data[0] == 40
 
 
@@ -6949,12 +6441,12 @@ def test_constexpr_if_return(device):
 
     sem = torch.zeros((), device=device, dtype=torch.int32)
     out = torch.empty((), device=device, dtype=torch.int32)
-    kernel[(1,)](sem, out, 1)
+    kernel[(1, )](sem, out, 1)
     assert out.item() == 0
 
     sem = torch.zeros((), device=device, dtype=torch.int32)
     out = torch.full((), fill_value=-1, device=device, dtype=torch.int32)
-    kernel[(4,)](sem, out, 4)
+    kernel[(4, )](sem, out, 4)
     assert out.item() >= 0
 
 
@@ -6965,11 +6457,8 @@ def test_constexpr_flattens():
 
 @pytest.mark.parametrize(
     "literal, tensor_ty",
-    [
-        (10, tl.int32),
-        (32.1, tl.float32),
-        ((5, 6, 7), None),  # tuples can't be lifted to tensors
-    ],
+    [(10, tl.int32), (32.1, tl.float32), ((5, 6, 7), None),  # tuples can't be lifted to tensors
+     ],
 )
 def test_constexpr_assignment(literal, tensor_ty):
     from triton.language.core import constexpr_type
@@ -6990,7 +6479,7 @@ def test_constexpr_assignment(literal, tensor_ty):
             tl.static_assert(assigned_variable.type == tensor_type)
 
     kernel_patched = patch_kernel(kernel, {"PATCHED": f"{literal}"})
-    kernel_patched[(1,)](literal, tensor_ty)
+    kernel_patched[(1, )](literal, tensor_ty)
 
 
 def test_constexpr_arg_str_attr():
@@ -6999,7 +6488,7 @@ def test_constexpr_arg_str_attr():
     def cst_str_attr(c_s_arg: tl.constexpr):
         pass
 
-    cst_str_attr.warmup("SD", grid=(1,))
+    cst_str_attr.warmup("SD", grid=(1, ))
 
 
 @triton.jit
@@ -7017,7 +6506,7 @@ def test_poison_return(device):
         tl.store(Out, return_poison(zero))
 
     a = torch.empty((), device=device, dtype=torch.int32)
-    h = kernel.warmup(a, grid=(1,))
+    h = kernel.warmup(a, grid=(1, ))
     assert "ub.poison" in h.asm["ttir"], h.asm["ttir"]
     # hip/xpu uses llvm.store, which in this case is removed by the optimizer
     if not (is_hip() or is_xpu()):
@@ -7040,8 +6529,8 @@ def test_num_threads(device):
         tl.store(Out + offs, 1)
 
     num_threads = 256
-    out = to_triton(np.zeros((num_threads,), dtype=np.int32), device=device)
-    kernel[(1,)](out, num_warps=num_threads // 32)
+    out = to_triton(np.zeros((num_threads, ), dtype=np.int32), device=device)
+    kernel[(1, )](out, num_warps=num_threads // 32)
     assert torch.sum(out) == 256
 
 
@@ -7060,13 +6549,13 @@ def test_globaltimer(device):
         tl.store(Out2, start)
         tl.store(Out2 + 1, end)
 
-    out1 = to_triton(np.zeros((128,), dtype=np.int64), device=device)
-    out2 = to_triton(np.zeros((2,), dtype=np.int64), device=device)
+    out1 = to_triton(np.zeros((128, ), dtype=np.int64), device=device)
+    out2 = to_triton(np.zeros((2, ), dtype=np.int64), device=device)
     if is_cuda():
         func = tl.extra.cuda.globaltimer
     else:
         func = tl.extra.hip.memrealtime
-    h = kernel[(1,)](out1, out2, func)
+    h = kernel[(1, )](out1, out2, func)
     assert out2[1] - out2[0] > 0
     if is_cuda():
         assert h.asm["ptx"].count("%globaltimer") == 2
@@ -7087,8 +6576,8 @@ def test_smid(device):
     def kernel(Out):
         tl.store(Out + tl.program_id(0), tl.extra.cuda.smid())
 
-    out = to_triton(np.zeros((1024,), dtype=np.int32), device=device)
-    h = kernel[(out.shape[0],)](out)
+    out = to_triton(np.zeros((1024, ), dtype=np.int32), device=device)
+    h = kernel[(out.shape[0], )](out)
     assert out.sort()[0].unique().shape[0] > 0
     assert h.asm["ptx"].count("%smid") == 1
 
@@ -7105,7 +6594,7 @@ def test_load_scalar_with_mask(device):
     Index = torch.tensor([0], dtype=torch.int32, device=device)
     Input = torch.tensor([0], dtype=torch.int32, device=device)
     Out = torch.empty_like(Index, device=device)
-    kernel[(1,)](Input, Index, Out, Index.numel())
+    kernel[(1, )](Input, Index, Out, Index.numel())
     assert Out.data[0] == 0
 
 
@@ -7157,7 +6646,7 @@ def test_ptx_cast(dtype_str, device):
     s0 = 4
     buf11 = -torch.ones((6 * s0, 197, 197), device=device, dtype=torch_dtype)
     buf14 = -torch.ones((s0, 6, 197, 197), device=device, dtype=torch_dtype)
-    kernel[(4728,)](buf11, buf14, 1182 * s0, 197, triton_dtype, 1, 256, num_warps=2)
+    kernel[(4728, )](buf11, buf14, 1182 * s0, 197, triton_dtype, 1, 256, num_warps=2)
     assert buf14.to(torch.float32).mean() == -2.0
 
 
@@ -7177,7 +6666,7 @@ def f8_to_f16(x, dtype):
         tl.store(Y + offs, x, mask=mask)
 
     ret = torch.empty(x.shape, dtype=torch.float16, device=x.device)
-    grid = lambda META: (triton.cdiv(x.numel(), META["BLOCK_SIZE"]),)
+    grid = lambda META: (triton.cdiv(x.numel(), META["BLOCK_SIZE"]), )
     dtype = getattr(tl, dtype)
     kernel[grid](ret, triton.reinterpret(x, dtype), ret.numel(), BLOCK_SIZE=1024)
     return ret
@@ -7185,23 +6674,14 @@ def f8_to_f16(x, dtype):
 
 @triton.jit
 def matmul_kernel(  #
-    a_ptr,
-    b_ptr,
-    c_ptr,  #
-    M,
-    N,
-    K,  #
-    stride_am,
-    stride_ak,  #
-    stride_bk,
-    stride_bn,  #
-    stride_cm,
-    stride_cn,  #
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,  #
-    low_precision_acc: tl.constexpr,  #
-    num_stages: tl.constexpr = 3,  #
+        a_ptr, b_ptr, c_ptr,  #
+        M, N, K,  #
+        stride_am, stride_ak,  #
+        stride_bk, stride_bn,  #
+        stride_cm, stride_cn,  #
+        BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,  #
+        low_precision_acc: tl.constexpr,  #
+        num_stages: tl.constexpr = 3,  #
 ):
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -7216,9 +6696,7 @@ def matmul_kernel(  #
     for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=num_stages):
         a = tl.load(a_ptrs)
         b = tl.load(b_ptrs)
-        accumulator = tl.dot(
-            a, b, acc=accumulator, max_num_imprecise_acc=low_precision_acc
-        )
+        accumulator = tl.dot(a, b, acc=accumulator, max_num_imprecise_acc=low_precision_acc)
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
     offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -7232,16 +6710,11 @@ def matmul_kernel(  #
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 256, 128), (64, 64, 64)])
 @pytest.mark.parametrize(
     "in_type_str",
-    (
-        ["float8e5", "float8e5b16", "float8e4b8", "float8e4nv"]
-        if is_hip()
-        else ["float8e5", "float8e4nv", "float8e4b15"]
-    ),
+    (["float8e5", "float8e5b16", "float8e4b8", "float8e4nv"]
+     if is_hip() else ["float8e5", "float8e4nv", "float8e4b15"]),
 )
 @pytest.mark.parametrize("low_precision_acc", [0, 32, 64, 128])
-def test_dot_max_num_imprecise_acc(
-    M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_str, low_precision_acc, device
-):
+def test_dot_max_num_imprecise_acc(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_str, low_precision_acc, device):
     num_stages = 3
     if is_cuda():
         cc = torch.cuda.get_device_capability()
@@ -7251,9 +6724,7 @@ def test_dot_max_num_imprecise_acc(
         num_stages = 2
         if in_type_str in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
             pytest.skip(f"{in_type_str} only supported on CDNA3")
-        if in_type_str in ("float8e5", "float8e4nv") and not (
-            is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
-        ):
+        if in_type_str in ("float8e5", "float8e4nv") and not (is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()):
             pytest.skip(f"{in_type_str} only supported on CDNA4, RDNA4 and above")
 
     check_type_supported(in_type_str, device)
@@ -7296,9 +6767,7 @@ def test_dot_max_num_imprecise_acc(
         torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)
     if is_hopper() and low_precision_acc > 0:
         # Hopper-specific workaround lower precision accumulator.
-        assert h.asm["ptx"].count("add.f32") == (BLOCK_M * BLOCK_N) // (
-            32 * num_warps
-        ) * (BLOCK_K // low_precision_acc)
+        assert h.asm["ptx"].count("add.f32") == (BLOCK_M * BLOCK_N) // (32 * num_warps) * (BLOCK_K // low_precision_acc)
 
 
 # -----------------------
@@ -7315,12 +6784,12 @@ def test_enable_fp_fusion(enable_fp_fusion, default_override, device, fresh_knob
         ptrs = data + tl.arange(0, 128)
         tl.store(ptrs, tl.load(ptrs) * 1.5 + 1.0)
 
-    data = torch.randn((128,), device=device, dtype=torch.float32)
+    data = torch.randn((128, ), device=device, dtype=torch.float32)
     if default_override:
         fresh_knobs.language.default_fp_fusion = enable_fp_fusion
-        h = mul_add.warmup(data, grid=(1,))
+        h = mul_add.warmup(data, grid=(1, ))
     else:
-        h = mul_add.warmup(data, grid=(1,), enable_fp_fusion=enable_fp_fusion)
+        h = mul_add.warmup(data, grid=(1, ), enable_fp_fusion=enable_fp_fusion)
 
     if not is_cuda():
         return
@@ -7342,8 +6811,8 @@ def test_enable_reflect_ftz(enable_reflect_ftz, device, fresh_knobs):
         ptrs = data + tl.arange(0, 128)
         tl.store(ptrs, tl.math.exp2(tl.load(ptrs)))
 
-    data = torch.full((128,), -127.0, device=device, dtype=torch.float32)
-    h = exp2.warmup(data, grid=(1,), enable_reflect_ftz=enable_reflect_ftz)
+    data = torch.full((128, ), -127.0, device=device, dtype=torch.float32)
+    h = exp2.warmup(data, grid=(1, ), enable_reflect_ftz=enable_reflect_ftz)
 
     found_ex2_ftz = re.search(r"ex2.approx.ftz.f32", h.asm["ptx"]) is not None
     assert found_ex2_ftz == enable_reflect_ftz
@@ -7354,9 +6823,7 @@ def test_enable_reflect_ftz(enable_reflect_ftz, device, fresh_knobs):
 # -----------------------
 
 
-@pytest.mark.parametrize(
-    "arch", ["sm70", "sm80", "sm90", "gfx942", "gfx950", "gfx1200"]
-)
+@pytest.mark.parametrize("arch", ["sm70", "sm80", "sm90", "gfx942", "gfx950", "gfx1200"])
 @pytest.mark.parametrize("env_var_override", [False, True])
 def test_override_arch(arch, env_var_override, device, fresh_knobs):
     if arch.startswith("sm") and not is_cuda():
@@ -7370,15 +6837,15 @@ def test_override_arch(arch, env_var_override, device, fresh_knobs):
         out_ptrs = out + tl.arange(0, 128)
         tl.store(out_ptrs, tl.load(in_ptrs) * 1.5 + 1.0)
 
-    data = torch.randn((128,), device=device, dtype=torch.float32)
+    data = torch.randn((128, ), device=device, dtype=torch.float32)
     out = torch.empty_like(data)
 
     if is_cuda():
         if env_var_override:
             fresh_knobs.runtime.override_arch = str(arch)
-            h = simple.warmup(data, out, grid=(1,))
+            h = simple.warmup(data, out, grid=(1, ))
         else:
-            h = simple.warmup(data, out, arch=arch, grid=(1,))
+            h = simple.warmup(data, out, arch=arch, grid=(1, ))
         ttgir_cc = re.search(r"cuda:(\d+)", h.asm["ttgir"])
         assert ttgir_cc.group(1) == arch[2:]
     elif is_hip():
@@ -7386,14 +6853,12 @@ def test_override_arch(arch, env_var_override, device, fresh_knobs):
         # them like CUDA side if the chip doesn't match. Here we just check generated ISA.
         if env_var_override:
             fresh_knobs.runtime.override_arch = str(arch)
-            h = simple.warmup(data, out, grid=(1,))
+            h = simple.warmup(data, out, grid=(1, ))
         else:
-            h = simple.warmup(data, out, arch=arch, grid=(1,))
+            h = simple.warmup(data, out, arch=arch, grid=(1, ))
         ttgir_gfx = re.search(r"hip:(\w+)", h.asm["ttgir"])
         ttgir_warp = re.search(r'"ttg.threads-per-warp" = (\d+)', h.asm["ttgir"])
-        amdgcn_gfx = re.search(
-            r'.amdgcn_target "amdgcn-amd-amdhsa--(\w+)"', h.asm["amdgcn"]
-        )
+        amdgcn_gfx = re.search(r'.amdgcn_target "amdgcn-amd-amdhsa--(\w+)"', h.asm["amdgcn"])
         assert ttgir_gfx.group(1) == arch
         assert int(ttgir_warp.group(1)) == (32 if arch == "gfx1200" else 64)
         assert amdgcn_gfx.group(1) == arch
@@ -7417,7 +6882,7 @@ def test_num_ctas_pre_sm90(device, fresh_knobs):
 
     fresh_knobs.runtime.override_arch = str(arch)
     with pytest.raises(ValueError, match=msg):
-        _kernel.warmup(src, grid=(1,), num_ctas=2)
+        _kernel.warmup(src, grid=(1, ), num_ctas=2)
 
 
 # -----------------------
@@ -7456,14 +6921,14 @@ def test_propagate_nan(dtype, propagate_nan, func, device):
         if func == "clamp" and mode == "B":
             # clamp does not guarantee propagation from 'min' and 'max' args
             continue
-        A = torch.randn((1,), device=device, dtype=getattr(torch, dtype))
+        A = torch.randn((1, ), device=device, dtype=getattr(torch, dtype))
         if mode == "A" or mode == "both":
             A[0] = torch.nan
-        B = torch.randn((1,), device=device, dtype=getattr(torch, dtype))
+        B = torch.randn((1, ), device=device, dtype=getattr(torch, dtype))
         if mode == "B" or mode == "both":
             B[0] = torch.nan
         C = torch.zeros_like(A, device=device, dtype=getattr(torch, dtype))
-        kernel[(1,)](A, B, C, propagate_nan, func)
+        kernel[(1, )](A, B, C, propagate_nan, func)
 
         if mode == "both" or propagate_nan == "ALL":
             assert torch.isnan(C[0])
@@ -7496,15 +6961,15 @@ def test_clamp(dtype, device):
 
     size = 128
 
-    x = torch.randn((size,), device=device, dtype=getattr(torch, dtype))
-    a = torch.randn((size,), device=device, dtype=getattr(torch, dtype))
-    b = torch.randn((size,), device=device, dtype=getattr(torch, dtype))
+    x = torch.randn((size, ), device=device, dtype=getattr(torch, dtype))
+    a = torch.randn((size, ), device=device, dtype=getattr(torch, dtype))
+    b = torch.randn((size, ), device=device, dtype=getattr(torch, dtype))
     _min = torch.min(a, b)
     _max = torch.max(a, b)
     out = torch.zeros_like(x, device=device, dtype=getattr(torch, dtype))
     ref = torch.zeros_like(x, device=device, dtype=getattr(torch, dtype))
 
-    kernel[(size,)](x, _min, _max, out, ref, x.numel(), BLOCK_SIZE=size)
+    kernel[(size, )](x, _min, _max, out, ref, x.numel(), BLOCK_SIZE=size)
 
     torch.testing.assert_close(out, ref)
 
@@ -7530,12 +6995,12 @@ def test_clamp_symmetric(dtype, device):
 
     size = 128
 
-    x = torch.randn((size,), device=device, dtype=getattr(torch, dtype))
-    limit = torch.randn((size,), device=device, dtype=getattr(torch, dtype)).abs()
+    x = torch.randn((size, ), device=device, dtype=getattr(torch, dtype))
+    limit = torch.randn((size, ), device=device, dtype=getattr(torch, dtype)).abs()
     out = torch.zeros_like(x, device=device, dtype=getattr(torch, dtype))
     ref = torch.zeros_like(x, device=device, dtype=getattr(torch, dtype))
 
-    kernel[(size,)](x, limit, out, ref, x.numel(), BLOCK_SIZE=size)
+    kernel[(size, )](x, limit, out, ref, x.numel(), BLOCK_SIZE=size)
 
     torch.testing.assert_close(out, ref)
 
@@ -7558,7 +7023,7 @@ def test_static_range(device):
     N = 100
     step = 7
     Out = torch.empty(1, dtype=torch.int32, device=device)
-    loop_kernel[(1,)](Out, N, step)
+    loop_kernel[(1, )](Out, N, step)
     Acc = torch.tensor([0], dtype=torch.int32, device=device)
     for i in range(0, N, step):
         Acc += i
@@ -7574,7 +7039,9 @@ def test_tl_range_num_stages(device):
     a = torch.randn((M, K), device=device, dtype=torch.float16)
     b = torch.randn((K, N), device=device, dtype=torch.float16)
     c = torch.empty((M, N), dtype=torch.float32, device=device)
-    pgm = matmul_kernel[1,](
+    pgm = matmul_kernel[
+        1,
+    ](
         a,
         b,
         c,
@@ -7620,7 +7087,7 @@ def test_tl_range_fuse(device):
 
     ub = 10
     out = torch.zeros((32, 32), dtype=torch.int32, device=device)
-    compiled_kernel = kernel[(1,)](ub, out)
+    compiled_kernel = kernel[(1, )](ub, out)
     assert "tt.flatten" in compiled_kernel.asm["ttir"]
     assert compiled_kernel.asm["ttgir"].count("scf.for") == 1
 
@@ -7650,12 +7117,12 @@ def test_tl_range_fuse_dependent(device):
     ub = 10
     out_i = torch.zeros(1024, dtype=torch.int32, device=device)
     out_j = torch.zeros(1024, dtype=torch.int32, device=device)
-    compiled_kernel = kernel[(1,)](ub, out_i, out_j)
+    compiled_kernel = kernel[(1, )](ub, out_i, out_j)
     assert "tt.flatten" in compiled_kernel.asm["ttir"]
     ttgir = compiled_kernel.asm["ttgir"]
-    ttgir = ttgir[ttgir.find("scf.for") :]
-    assert ttgir[: ttgir.find("}")].count("scf.for") == 1
-    ttgir = ttgir[ttgir.find("}") :]
+    ttgir = ttgir[ttgir.find("scf.for"):]
+    assert ttgir[:ttgir.find("}")].count("scf.for") == 1
+    ttgir = ttgir[ttgir.find("}"):]
     assert ttgir.count("scf.for") == 1
 
     ref_i = torch.zeros(1024, dtype=torch.int32, device=device)
@@ -7680,7 +7147,7 @@ def test_tl_range_option_none():
         for i in tl.range(0, ub, num_stages=None, loop_unroll_factor=None):
             print("i", i)
 
-    compiled_kernel = kernel.warmup(10, grid=(1,))
+    compiled_kernel = kernel.warmup(10, grid=(1, ))
     assert "num_stages" not in compiled_kernel.asm["ttir"]
     assert "loop_unroll_factor" not in compiled_kernel.asm["ttir"]
 
@@ -7706,13 +7173,13 @@ def test_disable_licm():
         for i in tl.range(0, n, disable_licm=True):
             print("i", i)
 
-    compiled_kernel1 = while_no_licm.warmup(10, grid=(1,))
+    compiled_kernel1 = while_no_licm.warmup(10, grid=(1, ))
     assert "llvm.licm.disable" in compiled_kernel1.asm["llir"]
 
-    compiled_kernel2 = while_default.warmup(10, grid=(1,))
+    compiled_kernel2 = while_default.warmup(10, grid=(1, ))
     assert "llvm.licm.disable" not in compiled_kernel2.asm["llir"]
 
-    compiled_kernel3 = for_no_licm.warmup(10, grid=(1,))
+    compiled_kernel3 = for_no_licm.warmup(10, grid=(1, ))
     assert "llvm.licm.disable" in compiled_kernel3.asm["llir"]
 
 
@@ -7739,7 +7206,7 @@ def test_maxnreg(device):
         maxnreg_noinline2(X)
 
     X = torch.empty(1, dtype=torch.int32, device=device)
-    k = kernel[(1,)](X, maxnreg=42)
+    k = kernel[(1, )](X, maxnreg=42)
 
     if not is_interpreter():
         # Ensure that .maxnreg is set on the kernel function (marked with .entry)
@@ -7757,31 +7224,31 @@ def test_temp_var_in_loop(device):
 
     @triton.jit
     def temp_in_loop(Z, N: tl.constexpr, BLOCK: tl.constexpr):
-        acc = tl.full((BLOCK,), 0, dtype=tl.int32)
+        acc = tl.full((BLOCK, ), 0, dtype=tl.int32)
         for i in range(N):
             if i == 0:
-                temp = tl.full((BLOCK,), 2, dtype=tl.int32)
+                temp = tl.full((BLOCK, ), 2, dtype=tl.int32)
                 acc = temp
             else:
-                acc += tl.full((BLOCK,), 1, dtype=tl.int32)
+                acc += tl.full((BLOCK, ), 1, dtype=tl.int32)
             # reuse the temp variable and make sure to check that it isn't creating incorrect IR.
-            temp = tl.full((BLOCK,), 1, dtype=tl.int32)
+            temp = tl.full((BLOCK, ), 1, dtype=tl.int32)
             acc += temp
         z = Z + tl.arange(0, BLOCK)
         tl.store(z, acc)
 
     N = 10
     BLOCK = 32
-    out = torch.empty((BLOCK,), dtype=torch.int32, device=device)
-    temp_in_loop[(1,)](out, N, BLOCK)
-    acc = torch.full((BLOCK,), 0, dtype=torch.int32, device=device)
+    out = torch.empty((BLOCK, ), dtype=torch.int32, device=device)
+    temp_in_loop[(1, )](out, N, BLOCK)
+    acc = torch.full((BLOCK, ), 0, dtype=torch.int32, device=device)
     for i in range(N):
         if i == 0:
-            temp = torch.full((BLOCK,), 2, dtype=torch.int32, device=device)
+            temp = torch.full((BLOCK, ), 2, dtype=torch.int32, device=device)
             acc = temp
         else:
-            acc += torch.full((BLOCK,), 1, dtype=torch.int32, device=device)
-        temp = torch.full((BLOCK,), 1, dtype=torch.int32, device=device)
+            acc += torch.full((BLOCK, ), 1, dtype=torch.int32, device=device)
+        temp = torch.full((BLOCK, ), 1, dtype=torch.int32, device=device)
         acc += temp
     assert (acc == out).all()
 
@@ -7790,7 +7257,7 @@ def test_temp_var_in_loop(device):
 def test_num_programs(device):
     # Assuming that the kernel is launched with a grid of (11, 21, 31)
     grid = (11, 21, 31)
-    input = torch.empty((3,), dtype=torch.int32, device=device)
+    input = torch.empty((3, ), dtype=torch.int32, device=device)
 
     @triton.jit
     def kernel(input):
@@ -7828,7 +7295,7 @@ def test_unroll_attr(device):
     # Try for all different loop unroll factors (compile-only):
     tmp = torch.empty(1, device=device)
     for unroll_factor in [1, 2, 4, 5, 8]:
-        h = _kernel.warmup(tmp, unroll_factor, grid=(1,))
+        h = _kernel.warmup(tmp, unroll_factor, grid=(1, ))
         check_loop_unroll_count(h.asm["ttir"], "tt.atomic_rmw", unroll_factor)
 
 
@@ -7857,7 +7324,7 @@ def test_side_effectful_reduction(device):
     X[:300] = 32
     X[300:] = 0
     Z = torch.zeros((), device="cuda", dtype=torch.int32)
-    sanitize_sum_kernel[(1,)](Z, X, BLOCK=BLOCK)
+    sanitize_sum_kernel[(1, )](Z, X, BLOCK=BLOCK)
     torch.testing.assert_close(Z, X.sum().to(torch.int32))
 
 
@@ -7875,9 +7342,7 @@ def test_side_effectful_reduction_2d(device, reduce_dim):
         reduce_dim: tl.constexpr,
         NON_REDUCE_DIM: tl.constexpr,
     ):
-        offsets = (
-            tl.arange(0, BLOCK_0)[:, None] * BLOCK_1 + tl.arange(0, BLOCK_1)[None, :]
-        )
+        offsets = (tl.arange(0, BLOCK_0)[:, None] * BLOCK_1 + tl.arange(0, BLOCK_1)[None, :])
         vals = tl.load(X + offsets)
         z = tl.reduce(vals, reduce_dim, sanitize_add)
         tl.store(Z + tl.arange(0, NON_REDUCE_DIM), z)
@@ -7888,7 +7353,7 @@ def test_side_effectful_reduction_2d(device, reduce_dim):
     torch.manual_seed(42)
     X = torch.randint(0, 10, [BLOCK_0, BLOCK_1], device="cuda", dtype=torch.int32)
     Z = torch.zeros([NON_REDUCE_DIM], device="cuda", dtype=torch.int32)
-    sanitize_sum_2d_kernel[(1,)](
+    sanitize_sum_2d_kernel[(1, )](
         Z,
         X,
         BLOCK_0=BLOCK_0,
@@ -7907,12 +7372,10 @@ def test_dtype(device):
         dtype_x: tl.constexpr = X.dtype.element_ty
         tl.static_assert(dtype_x == tl.int32)
         tl.static_assert(dtype_x == tl.constexpr(tl.int32))
-        tl.static_assert(
-            dtype_x == tl.int8 or (dtype_x == tl.int16 or dtype_x == tl.int32)
-        )
+        tl.static_assert(dtype_x == tl.int8 or (dtype_x == tl.int16 or dtype_x == tl.int32))
 
     X = torch.empty(1, dtype=torch.int32, device=device)
-    kernel[(1,)](X)
+    kernel[(1, )](X)
 
 
 def test_side_effectful_scan(device):
@@ -7931,7 +7394,7 @@ def test_side_effectful_scan(device):
     X[:300] = 32
     X[300:] = 0
     Z = torch.zeros_like(X)
-    sanitize_cumsum_kernel[(1,)](Z, X, BLOCK=BLOCK)
+    sanitize_cumsum_kernel[(1, )](Z, X, BLOCK=BLOCK)
     torch.testing.assert_close(Z, X.cumsum(0).to(torch.int32))
 
 
@@ -7973,11 +7436,9 @@ def test_chained_reductions(in_shape, perm, red_dims, device):
 
     input = torch.randint(0, 1000, in_shape, device=device, dtype=torch.int32)
     temp = torch.permute(input, perm).contiguous()
-    ref = torch.sum(
-        torch.sum(torch.sum(temp, dim=red_dims[0]), dim=red_dims[1]), dim=red_dims[2]
-    )
+    ref = torch.sum(torch.sum(torch.sum(temp, dim=red_dims[0]), dim=red_dims[1]), dim=red_dims[2])
     result = torch.empty_like(ref)
-    kernel[(1,)](
+    kernel[(1, )](
         input,
         result,
         input.shape[0],
@@ -8017,24 +7478,15 @@ def gather_test_kernel(
     out_stride0: tl.constexpr,
     out_stride1: tl.constexpr,
 ):
-    src_offs = (
-        tl.arange(0, src_dim0)[:, None] * src_stride0
-        + tl.arange(0, src_dim1)[None, :] * src_stride1
-    )
+    src_offs = (tl.arange(0, src_dim0)[:, None] * src_stride0 + tl.arange(0, src_dim1)[None, :] * src_stride1)
     src = tl.load(src_ptr + src_offs)
 
-    idx_offs = (
-        tl.arange(0, idx_dim0)[:, None] * idx_stride0
-        + tl.arange(0, idx_dim1)[None, :] * idx_stride1
-    )
+    idx_offs = (tl.arange(0, idx_dim0)[:, None] * idx_stride0 + tl.arange(0, idx_dim1)[None, :] * idx_stride1)
     idx = tl.load(idx_ptr + idx_offs)
 
     out = tl.gather(src, idx, axis)
 
-    out_offs = (
-        tl.arange(0, out_dim0)[:, None] * out_stride0
-        + tl.arange(0, out_dim1)[None, :] * out_stride1
-    )
+    out_offs = (tl.arange(0, out_dim0)[:, None] * out_stride0 + tl.arange(0, out_dim1)[None, :] * out_stride1)
     tl.store(out_ptr + out_offs, out)
 
 
@@ -8071,11 +7523,8 @@ def gather_test_kernel_1d(
     ],
 )
 def test_gather(src_shape, indices_shape, axis, device):
-    if (
-        (is_hip_cdna2() or is_hip_cdna3() or is_hip_rdna3() or is_hip_rdna4())
-        and src_shape == [128, 64]
-        and indices_shape == [256, 64]
-    ):
+    if ((is_hip_cdna2() or is_hip_cdna3() or is_hip_rdna3() or is_hip_rdna4()) and src_shape == [128, 64]
+            and indices_shape == [256, 64]):
         # This could be solved by reducing vectorization in general swizzling algorithm.
         # We will do this if any relevant workload suffers from large LDS consumption of the algorithm.
         pytest.skip("Not enough LDS.")
@@ -8084,7 +7533,7 @@ def test_gather(src_shape, indices_shape, axis, device):
         output = torch.empty(indices.shape, dtype=src.dtype, device=src.device)
 
         if len(src_shape) == 1:
-            gather_test_kernel_1d[(1,)](
+            gather_test_kernel_1d[(1, )](
                 src,
                 indices,
                 output,
@@ -8094,7 +7543,7 @@ def test_gather(src_shape, indices_shape, axis, device):
                 output.shape[0],
             )
         else:
-            gather_test_kernel[(1,)](
+            gather_test_kernel[(1, )](
                 src,
                 indices,
                 output,
@@ -8138,17 +7587,15 @@ def test_jit_function_arg(device):
     def square_kernel_jit_function(in_ptr, out_ptr, BLOCK_SIZE: tl.constexpr):
         offsets = tl.arange(0, BLOCK_SIZE)
         in_data = tl.load(in_ptr + offsets)
-        out_data = apply_binary_op(
-            in_data, mul_jit_function
-        )  # pass a JITFunction into another JITFunction
+        out_data = apply_binary_op(in_data, mul_jit_function)  # pass a JITFunction into another JITFunction
         tl.store(out_ptr + offsets, out_data)
 
     BLOCK_SIZE = 16
-    x = torch.full((BLOCK_SIZE,), 3.0, device=device)
-    out = torch.empty((BLOCK_SIZE,), device=device)
-    expect = torch.full((BLOCK_SIZE,), 9.0, dtype=x.dtype, device=device)
+    x = torch.full((BLOCK_SIZE, ), 3.0, device=device)
+    out = torch.empty((BLOCK_SIZE, ), device=device)
+    expect = torch.full((BLOCK_SIZE, ), 9.0, dtype=x.dtype, device=device)
 
-    square_kernel_jit_function[(1,)](x, out, BLOCK_SIZE)
+    square_kernel_jit_function[(1, )](x, out, BLOCK_SIZE)
 
     torch.testing.assert_close(out, expect)
 
@@ -8190,7 +7637,7 @@ def test_aliasing(device):
         triton.language.store(buffer, 1)
 
     buffer = torch.zeros(1, device=device)
-    aliasing_kernel[(1,)](buffer, buffer)
+    aliasing_kernel[(1, )](buffer, buffer)
     assert buffer[0] == 1
 
 
@@ -8291,17 +7738,15 @@ def test_indirect_store(dtype, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize(
     "dtype",
-    map(
-        tl.dtype, tl.dtype.SINT_TYPES + tl.dtype.UINT_TYPES + tl.dtype.STANDARD_FP_TYPES
-    ),
+    map(tl.dtype, tl.dtype.SINT_TYPES + tl.dtype.UINT_TYPES + tl.dtype.STANDARD_FP_TYPES),
 )
 def test_dtype_tensor(device, dtype):
 
     @triton.jit
     def dtype_tensor_kernel(dtype: tl.constexpr):
-        tensor = tl.zeros((1,), dtype)
+        tensor = tl.zeros((1, ), dtype)
 
-    dtype_tensor_kernel[(1,)](dtype)
+    dtype_tensor_kernel[(1, )](dtype)
 
 
 @pytest.mark.interpreter
@@ -8309,24 +7754,19 @@ def test_short_circuiting(device):
 
     @triton.jit
     def short_circuiting_kernel(x):
-        if (
-            (x is not None)
-            and hasattr(x, "dtype")
-            and isinstance(x.dtype, tl.pointer_type)
-            and (x.dtype.element_ty == tl.int32)
-            and (tl.load(x) > 42)
-        ):
+        if ((x is not None) and hasattr(x, "dtype") and isinstance(x.dtype, tl.pointer_type)
+                and (x.dtype.element_ty == tl.int32) and (tl.load(x) > 42)):
             tl.store(x, 42)
 
     def f(x):
-        short_circuiting_kernel[(1,)](x, num_warps=1)
+        short_circuiting_kernel[(1, )](x, num_warps=1)
 
     f(None)  # should succeed with NoneType
     f(1)  # should succeed with tl.constexpr type
     f(2)  # should succeed with integer type
 
     def g(y, dtype):
-        x = torch.full((1,), y, device=device, dtype=dtype)
+        x = torch.full((1, ), y, device=device, dtype=dtype)
         f(x)
         return x.item()
 
@@ -8338,9 +7778,7 @@ def test_short_circuiting(device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.filterwarnings(
-    "ignore:If conditional called with multidimensional Tensor*"
-)
+@pytest.mark.filterwarnings("ignore:If conditional called with multidimensional Tensor*")
 def test_unsplat(device):
 
     @triton.jit
@@ -8355,8 +7793,8 @@ def test_unsplat(device):
             tl.store(x, 42)
 
     def g(y, explicit):
-        x = torch.full((1,), y, device=device, dtype=torch.int32)
-        unsplat_kernel[(1,)](x, explicit, num_warps=1)
+        x = torch.full((1, ), y, device=device, dtype=torch.int32)
+        unsplat_kernel[(1, )](x, explicit, num_warps=1)
         return x.item()
 
     assert g(41, False) == 41
@@ -8370,12 +7808,12 @@ def test_cumsum_dtype(device):
 
     @triton.jit
     def kernel(Z):
-        x = tl.full((4,), True, dtype=tl.int1)
+        x = tl.full((4, ), True, dtype=tl.int1)
         z = tl.cumsum(x, axis=0)
         tl.store(Z + tl.arange(0, 4), z)
 
     z = torch.zeros(4, dtype=torch.int32, device=device)
-    kernel[(1,)](z)
+    kernel[(1, )](z)
     expected = torch.tensor([1, 2, 3, 4], dtype=torch.int32, device=device)
     assert torch.equal(z, expected)
 
@@ -8389,7 +7827,7 @@ def test_tensor_member(device):
         tl.device_assert(tl.abs(x) == x.abs())
         tl.device_assert(tl.sum(x) == x.sum())
 
-    kernel[(1,)]()
+    kernel[(1, )]()
 
 
 @pytest.mark.interpreter
@@ -8402,9 +7840,7 @@ def test_dot_multidim(rank, trans_a, trans_b, device):
         pytest.skip("bfloat16 is not supported in the interpreter")
 
     @triton.jit
-    def kernel(
-        X, Y, Z, RANK: tl.constexpr, TRANS_A: tl.constexpr, TRANS_B: tl.constexpr
-    ):
+    def kernel(X, Y, Z, RANK: tl.constexpr, TRANS_A: tl.constexpr, TRANS_B: tl.constexpr):
         x = tl.load(X + tl.arange(0, 256 << RANK)).reshape([2] * (RANK - 2) + [32, 32])
         y = tl.load(Y + tl.arange(0, 256 << RANK)).reshape([2] * (RANK - 2) + [32, 32])
         if TRANS_A:
@@ -8414,12 +7850,12 @@ def test_dot_multidim(rank, trans_a, trans_b, device):
         z = tl.dot(x, y)
         tl.store(Z + tl.arange(0, 256 << RANK), z.reshape([256 << RANK]))
 
-    shape = (2,) * (rank - 2) + (32, 32)
+    shape = (2, ) * (rank - 2) + (32, 32)
 
     a = torch.randint(-4, 5, shape, dtype=torch.bfloat16, device=device)
     b = torch.randint(-4, 5, shape, dtype=torch.bfloat16, device=device)
     c = torch.empty(shape, dtype=torch.float32, device=device)
-    kernel[(1,)](a, b, c, rank, trans_a, trans_b)
+    kernel[(1, )](a, b, c, rank, trans_a, trans_b)
 
     if trans_a:
         a = torch.transpose(a, -1, -2)
@@ -8438,21 +7874,19 @@ def test_libdevice_rint(dtype_str, device):
     size = 1000
     x0_np = np.random.uniform(iinfo32.min, iinfo32.max + 1, size)
     x1_np = np.random.uniform(iinfo64.min, iinfo64.max + 1, size)
-    x2_np = np.array(
-        [
-            -2.5,
-            -1.5,
-            -0.5,
-            -0.0,
-            0.0,
-            0.5,
-            1.5,
-            2.5,
-            float("inf"),
-            -float("inf"),
-            float("nan"),
-        ]
-    )
+    x2_np = np.array([
+        -2.5,
+        -1.5,
+        -0.5,
+        -0.0,
+        0.0,
+        0.5,
+        1.5,
+        2.5,
+        float("inf"),
+        -float("inf"),
+        float("nan"),
+    ])
     x_np = np.concat((x0_np, x1_np, x2_np))
     x_tri = to_triton(x_np, device=device, dst_type=dtype_str)
 
@@ -8468,8 +7902,6 @@ def test_libdevice_rint(dtype_str, device):
     res_out = torch.empty_like(x_tri)
     numel = x_tri.numel()
     BLOCK_SIZE = 512
-    rint_kernel[(triton.cdiv(numel, BLOCK_SIZE),)](res_out, x_tri, numel, BLOCK_SIZE)
+    rint_kernel[(triton.cdiv(numel, BLOCK_SIZE), )](res_out, x_tri, numel, BLOCK_SIZE)
     ref_out = np.rint(x_np)
-    np.testing.assert_allclose(
-        to_numpy(res_out), ref_out, rtol=0, atol=0, equal_nan=True
-    )
+    np.testing.assert_allclose(to_numpy(res_out), ref_out, rtol=0, atol=0, equal_nan=True)

--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -365,7 +365,7 @@ def link_aot_kernels(dir):
 
 def generate_matmul_test_data(dir, M, N, K):
     a = np.random.randn(M * K).astype(np.float16).reshape((M, K))
-    b = np.random.randn(M * K).astype(np.float16).reshape((K, N))
+    b = np.random.randn(N * K).astype(np.float16).reshape((K, N))
     a_path = os.path.join(dir, "a.csv")
     b_path = os.path.join(dir, "b.csv")
     c_path = os.path.join(dir, "c.csv")

--- a/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
@@ -1,6 +1,6 @@
 from ..._core import ir, builtin, _unwrap_if_constexpr
 from ..._semantic import _check
-from ..._layouts import BlockedLayout, SliceLayout
+from ..._layouts import DistributedLayout
 from ..cdna3 import _verify_buffer_ops
 
 __all__ = [
@@ -46,8 +46,7 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
     _check(ptr.type.is_block(), lambda: "expected ptr to be a tensor")
-    _check(isinstance(ptr.type.layout, (BlockedLayout, SliceLayout)),
-           lambda: "expected ptr type layout to be BlockedLayout or SliceLayout")
+    _check(isinstance(ptr.type.layout, DistributedLayout), lambda: "expected ptr type layout to be a DistributedLayout")
     _check(
         dest.shape == ptr.shape, lambda:
         f"expected dest shape to match pointer shape but got dest.shape = {dest.shape}, pointer.shape = {ptr.shape}")
@@ -102,8 +101,8 @@ def buffer_load_to_shared(dest, ptr, offsets, mask=None, other=None, cache_modif
         other (tensor or scalar, optional): Tensor or scalar providing default values for masked elements. Defaults to None.
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
-    _check(isinstance(offsets.type.layout, (BlockedLayout, SliceLayout)),
-           lambda: "expected offsets type layout to be BlockedLayout or SliceLayout")
+    _check(isinstance(offsets.type.layout, DistributedLayout),
+           lambda: "expected offsets type layout to be a DistributedLayout")
     _verify_buffer_ops(ptr, offsets, mask, other)
 
     mask = _unwrap_if_constexpr(mask)

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -92,7 +92,7 @@ def get_wmma_scale_layout(dot_operand_layout, shape):
     """
     op_idx = dot_operand_layout.operand_index
     parent = dot_operand_layout.parent
-    assert isinstance(parent, AMDWMMALayout), "Expected parent to be an instance of AMDMFMALayout"
+    assert isinstance(parent, AMDWMMALayout), "Expected parent to be an instance of AMDWMMALayout"
     mdim = parent.instr_shape[0]
     reg_bases = parent.reg_bases
     warp_bases = parent.warp_bases

--- a/python/triton/experimental/gluon/language/amd/gfx1250/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/async_copy.py
@@ -21,7 +21,7 @@ def global_to_shared(smem, pointer, mask=None, other=None, cache_modifier="", _s
     """
     _check(pointer.type.is_block(), lambda: "expected ptr to be a tensor")
     _check(isinstance(pointer.type.layout, DistributedLayout),
-           lambda: "expected ptr type layout to be BlockedLayout or SliceLayout")
+           lambda: "expected ptr type layout to be a DistributedLayout")
     _check(
         smem.shape == pointer.shape, lambda:
         f"expected smem shape to match pointer shape but got smem.shape = {smem.shape}, pointer.shape = {pointer.shape}"
@@ -54,7 +54,7 @@ def shared_to_global(pointer, smem, mask=None, cache_modifier="", _semantic=None
     """
     _check(pointer.type.is_block(), lambda: "expected ptr to be a tensor")
     _check(isinstance(pointer.type.layout, DistributedLayout),
-           lambda: "expected ptr type layout to be BlockedLayout or SliceLayout")
+           lambda: "expected ptr type layout to be a DistributedLayout")
     _check(
         smem.shape == pointer.shape, lambda:
         f"expected smem shape to match pointer shape but got smem.shape = {smem.shape}, pointer.shape = {pointer.shape}"

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -9,6 +9,7 @@ import triton.language as tl
 @triton.constexpr_function
 def get_scaled_dot_format_string(dtype: tl.dtype):
     mapping = {
+        tl.float32: "fp32",
         tl.float16: "fp16",
         tl.bfloat16: "bf16",
         tl.uint8: "e2m1",

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -20,7 +20,8 @@ from ._common import (
 
 @triton.jit
 def round_f32_to_tf32(x: tl.tensor):
-    ASM: tl.constexpr = "cvt.rna.tf32.f32 $0, $1;"
+    # use cvt.rn on Hopper+ to match the rounding of TMA.
+    ASM: tl.constexpr = "cvt.rn.tf32.f32 $0, $1;" if cuda_capability_geq(9, 0) else "cvt.rna.tf32.f32 $0, $1;"
     return tl.inline_asm_elementwise(ASM, "=r, r", [x], dtype=tl.float32, is_pure=True, pack=1)
 
 _matmul_repr = make_matmul_repr("_matmul", [0, 1, 2])

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -46,6 +46,12 @@ def _load_writeback_idx_and_mask(WriteBackIndx, writeback_size, offs, mask):
     return (offs, mask)
 
 
+@triton.jit
+def round_f32_to_tf32(x: tl.tensor):
+    ASM: tl.constexpr = "cvt.rn.tf32.f32 $0, $1;" if cuda_capability_geq(9, 0) else "cvt.rna.tf32.f32 $0, $1;"
+    return tl.inline_asm_elementwise(ASM, "=r, r", [x], dtype=tl.float32, is_pure=True, pack=1)
+
+
 _matmul_repr = make_matmul_repr("_p_matmul", [0, 1, 2])
 @triton.jit(do_not_specialize=["TOKENS_PER_EXPT_FOR_ANNOTATION"],
             repr=_matmul_repr, launch_metadata=matmul_launch_metadata)
@@ -312,7 +318,9 @@ def _p_matmul(
                         x = tl.load(XPtrs)
                 else:
                     x = tl.load(XPtrs, mask=mask_k[None, :], other=0.0)
-
+                if x.dtype == tl.float32 and ALLOW_TF32:
+                    # since data are not loaded from TMA we need to explicitly round to tf32.
+                    x = round_f32_to_tf32(x)
             # --- load x_scale ---
             x_format: tl.constexpr = get_scaled_dot_format_string(x.dtype)
             if is_x_microscaled:

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -248,7 +248,7 @@ def make_default_opt_flags_nvidia(
         is_persistent = True
     else:
         has_simple_epilogue = precision_config.max_num_imprecise_acc is None
-        is_persistent = supports_persistent and has_simple_epilogue and (tiles_per_sm >= 2.0 or lhs_dtype.bitwidth <= 8) and out_dtype.bitwidth < 32
+        is_persistent = supports_persistent and has_simple_epilogue and (tiles_per_sm >= 2.0 or lhs_dtype.bitwidth <= 8) and (out_dtype.bitwidth < 32 or lhs_dtype.bitwidth == 32 or rhs_dtype.bitwidth == 32)
         # TMA is slower for batched matmuls with small m/n/k.
         if m * n * k < 131072:
             is_persistent = False

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -2,7 +2,7 @@ import torch
 import triton
 from triton_kernels import target_info
 from triton_kernels.numerics_details.mxfp_details._downcast_to_mxfp import MXFP_BLOCK_SIZE
-from triton_kernels.tensor import FP4, Tensor, FP16, BF16
+from triton_kernels.tensor import FP4, FP16, FP32, BF16, Tensor
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout
 
@@ -143,7 +143,15 @@ def compute_num_stages(
         if x_transpose:
             smem_capacity -= block_m * block_k * (max(8, lhs_dtype.bitwidth) // 8)
 
+    # Persistent fp32 kernels need extra smem headroom (metadata/barriers/TMA state)
+    # that is not fully captured by the simple stage_size model above.
+    if is_persistent and (lhs_dtype == FP32 or rhs_dtype == FP32):
+        smem_capacity -= 32 * 1024
+    smem_capacity = max(smem_capacity, 0)
     num_stages = min(smem_capacity // int(stage_size), 4)
+    # Keep one stage of headroom for persistent fp32 to avoid launch-time OOR.
+    if is_persistent and (lhs_dtype == FP32 or rhs_dtype == FP32):
+        num_stages = min(num_stages, 3)
     if num_stages == 0:
         num_stages = 1
     return num_stages

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -91,28 +91,25 @@ class BlackwellActMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "added_leading_batch_dim", added_leading_batch_dim)
 
     def swizzle_data(self, data):
-        if self.mode == "batched":
-            padded_data = torch.nn.functional.pad(
-                data, (0, self.K_pad - self.K, 0, self.M_pad - self.M))  # value of padding on left, right, top, bottom
-            padded_data = padded_data.reshape(self.B, self.M_pad // 128, 4, 32, self.K_pad // 4, 4)
-            padded_data = padded_data.transpose(2, 4).contiguous()  # [1, M//128, K//4, 32, 4, 4]
-            padded_data = padded_data.view(1, self.B * self.M_pad // 128, self.K_pad // 4, 2, 256)
-        else:
-            # Objective is to pad the number of rows in each slice to be multiple of ALIGN_M
-            padded_data = pad_segments_triton(
-                data,
-                self.ragged_metadata,
-                self.ALIGN_M,
-                self.M_pad,
-                self.K,
-                self.K_pad,
-            )
+        if data.numel():
+            if self.mode == "batched":
+                # value of padding on left, right, top, bottom
+                data = torch.nn.functional.pad(data, (0, self.K_pad - self.K, 0, self.M_pad - self.M))
+            else:
+                # Objective is to pad the number of rows in each slice to be multiple of ALIGN_M
+                data = pad_segments_triton(
+                    data,
+                    self.ragged_metadata,
+                    self.ALIGN_M,
+                    self.M_pad,
+                    self.K,
+                    self.K_pad,
+                )
 
-            padded_data = padded_data.reshape(self.B, self.M_pad // 128, 4, 32, self.K_pad // 4, 4)
-            padded_data = padded_data.transpose(2, 4).contiguous()  # [1, M//128, K//4, 32, 4, 4]
-            padded_data = padded_data.view(1, self.B * self.M_pad // 128, self.K_pad // 4, 2, 256)
-
-        return padded_data
+        data = data.reshape(self.B, self.M_pad // 128, 4, 32, self.K_pad // 4, 4)
+        data = data.transpose(2, 4).contiguous()  # [1, M//128, K//4, 32, 4, 4]
+        data = data.view(1, self.B * self.M_pad // 128, self.K_pad // 4, 2, 256)
+        return data
 
     def unswizzle_data(self, data):
         data = data.reshape(self.B, self.M_pad // 128, self.K_pad // 4, 32, 4, 4)
@@ -154,7 +151,8 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "N_pad", (N + self.ALIGN_N - 1) // self.ALIGN_N * self.ALIGN_N)
 
     def swizzle_data(self, data):
-        data = torch.nn.functional.pad(data, (0, self.N_pad - self.N, 0, self.K_pad - self.K))
+        if data.numel():
+            data = torch.nn.functional.pad(data, (0, self.N_pad - self.N, 0, self.K_pad - self.K))
         data = data.transpose(-1, -2).contiguous()
         data = data.reshape(self.B, self.N_pad // self.ALIGN_N, self.ALIGN_N // 32, 32, self.K_pad // self.SWIZZLE_K,
                             self.SWIZZLE_K)

--- a/python/tutorials/gluon/13-conv-im2col.py
+++ b/python/tutorials/gluon/13-conv-im2col.py
@@ -1,0 +1,1245 @@
+"""
+TMA im2col mode and Convolution via Implicit GEMM
+===================================================
+
+This tutorial explains NVIDIA TMA's im2col mode and then applies it to an
+end-to-end convolution kernel.
+
+We cover:
+1) TMA im2col fundamentals on a 4-D NHWC tensor
+2) How TensorDescriptorIm2Col parameters control access boundaries
+3) Practical loading patterns (basic, padded, shifted-offset, multi-batch)
+4) How 2D convolution works (the sliding window)
+5) The im2col algorithm that reshapes convolution into GEMM
+6) A convolution kernel using TMA im2col + MMA (works on both Hopper and Blackwell)
+
+We re-use the MMA abstraction from ``07-persistence.py`` so that the same kernel
+runs on Hopper (WGMMA) and Blackwell (tcgen05 MMA) without code duplication.
+
+Prerequisites:
+  - ``04-tma.py``: TMA basics (tensor descriptors, async copies)
+  - ``05-wgmma.py``: Hopper warp-group MMA (WGMMA) basics
+  - ``06-tcgen05.py``: tcgen05 MMA for matrix multiplication on Blackwell
+  - ``07-persistence.py``: MMA abstraction (WGMMA / MMAv5) and persistent kernels
+
+Reference:
+https://docs.nvidia.com/cuda/parallel-thread-execution/#tensor-im2col-mode
+
+TMA im2col Mode Parameters:
+    The following descriptor fields and boundary rules are specific to
+    TensorDescriptorIm2Col in im2col mode.
+
+Block Shape:
+    block_shape = [pixelsPerColumn, channelsPerPixel]
+    - pixelsPerColumn: number of pixels from spatial dims [N, H, W]
+    - channelsPerPixel: number of channels per pixel from [C]
+
+TensorDescriptor Parameters:
+    - Input tensor: [N, H, W, C] in NHWC format
+    - pixel_box_lower_corner: [H_lo, W_lo] offset from (0, 0)
+    - pixel_box_upper_corner: [H_hi, W_hi] offset from [H - 1, W - 1]
+    - element_strides: [1, 1, 1, 1] for contiguous element access
+    - padding: "zero" or "nan" for out-of-bounds fills
+
+Access Boundary:
+    pixel_box_lower_corner, pixel_box_upper_corner, and offsets define the
+    spatial access window:
+    - Lower bound = pixel_box_lower_corner + offsets
+    - Upper bound = [H - 1, W - 1] + pixel_box_upper_corner + offsets
+    - Bounds are interpreted as closed (inclusive): [lower, upper]
+
+    The input tensor in global memory is NOT padded. When accessing outside
+    [0, 0] to [H-1, W-1], TMA fills with the padding value.
+
+async_copy_global_to_shared_im2col:
+    async_copy_global_to_shared_im2col(tensor_desc, coord, offsets, barrier, result)
+    - coord: [batch_idx, start_h, start_w, channel_start] start coords
+    - offsets: [h_offset, w_offset] spatial offsets (i16)
+
+    Starting position (the first pixel): (batch_idx, start_h + h_offset, start_w + w_offset, channel_start)
+"""
+
+import importlib
+import pytest
+import torch
+import triton
+import triton.language as tl
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+
+from triton.experimental.gluon.nvidia.hopper import TensorDescriptor, TensorDescriptorIm2Col
+from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
+
+t7 = importlib.import_module("07-persistence")
+
+if __name__ == "__main__" and not t7.is_hopper_or_newer():
+    raise RuntimeError("This tutorial requires Hopper or newer NVIDIA GPU")
+
+# %%
+# Tutorial Motivation
+# ===================
+#
+# Before diving into kernels, we first explain the concept of
+# **im2col convolution**: rewriting convolution as GEMM by flattening each
+# sliding-window patch into a row.
+#
+# Then we motivate why **TMA im2col mode** is helpful for this pattern:
+# it performs convolution-style address generation and padding handling in
+# hardware, so the kernel uses simpler indexing and can spend more resources on
+# MMA compute.
+#
+# %%
+# What is a 2D Convolution?
+# =======================
+#
+# A 2D convolution slides a small filter (kernel) across an input image and
+# computes a weighted sum at every position. For a single-channel example
+# with a 3x3 input and a 2x2 filter (stride=1, no padding), the output is 2x2:
+#
+# .. code-block:: text
+#
+#     Input (3x3):        Filter (2x2):       Output (2x2):
+#     +---+---+---+       +----+----+          +----+----+
+#     | a | b | c |       | w0 | w1 |          | y0 | y1 |
+#     +---+---+---+       +----+----+          +----+----+
+#     | d | e | f |       | w2 | w3 |          | y2 | y3 |
+#     +---+---+---+       +----+----+          +----+----+
+#     | g | h | i |
+#     +---+---+---+
+#
+# Each output element is the dot product of the filter with a region of the input:
+#
+# .. code-block:: text
+#
+#     y0 = a*w0 + b*w1 + d*w2 + e*w3
+#     y1 = b*w0 + c*w1 + e*w2 + f*w3
+#     y2 = d*w0 + e*w1 + g*w2 + h*w3
+#     y3 = e*w0 + f*w1 + h*w2 + i*w3
+#
+# With **multiple input channels** (Ci) and **multiple output channels** (Co):
+#
+# .. code-block:: text
+#
+#     y[n, oh, ow, co] = SUM over (r, s, ci) of:
+#         input[n, oh*stride + r - pad, ow*stride + s - pad, ci] * weight[co, r, s, ci]
+#
+# This nested summation over (r, s, ci) is the key insight for converting
+# convolution into matrix multiplication.
+#
+# %%
+# The im2col Algorithm
+# ====================
+#
+# **im2col** (image to column) rearranges the input so that convolution becomes
+# a standard matrix multiplication (GEMM). The idea is:
+#
+# 1. For each output position (n, oh, ow), extract the R x S x Ci input
+#    patch that the filter overlaps with.
+# 2. Flatten this patch into a single row of length ``R * S * Ci``.
+# 3. Stack all such rows into a matrix **A** of shape ``[M, K]``.
+# 4. Reshape the filter into a matrix **W** of shape ``[Co, K]``.
+# 5. The output is simply ``A @ W^T`` (a GEMM!).
+#
+# where ``M = N * out_h * out_w`` and ``K = R * S * Ci``.
+#
+# .. code-block:: text
+#
+#     Example: 3x3 input, 2x2 filter, stride=1, no padding => 2x2 output
+#
+#     Step 1: Extract patches for each output position
+#     -------------------------------------------------
+#     y0 at (0,0): patch = [a, b, d, e]
+#     y1 at (0,1): patch = [b, c, e, f]
+#     y2 at (1,0): patch = [d, e, g, h]
+#     y3 at (1,1): patch = [e, f, h, i]
+#
+#     Step 2: Stack patches into im2col matrix A (M=4, K=4)
+#     -----------------------------------------------------
+#              K = R*S*Ci = 4
+#              <------------->
+#          A = | a  b  d  e |  <- y0     ^
+#              | b  c  e  f |  <- y1     | M = 4
+#              | d  e  g  h |  <- y2     |
+#              | e  f  h  i |  <- y3     v
+#
+#     Note: overlapping patches share input elements (e.g., 'e' appears in all 4 rows).
+#
+#     Step 3: Reshape filter into weight matrix W (Co=1, K=4)
+#     -------------------------------------------------------
+#          W = | w0 w1 w2 w3 |
+#
+#     Step 4: Output = A @ W^T
+#     ------------------------
+#                        | w0 |     | y0 |
+#          A  @  W^T  =  | w1 |  =  | y1 |
+#          (4x4)(4x1)    | w2 |     | y2 |
+#                        | w3 |     | y3 |
+#                                   (4x1)
+#
+#     With Co output channels, W is (Co x K) and Output is (M x Co).
+#
+# Why TMA im2col mode is helpful for convolution:
+#   - In the matrix view above, each row of **A** is one output position's patch.
+#   - The indexing term ``oh*stride + r - pad`` / ``ow*stride + s - pad`` must be
+#     evaluated for every filter tap and channel block in the inner loop.
+#   - Software address generation and bounds handling increase integer ALU work
+#     and register pressure right where we want to maximize MMA throughput.
+#   - ``TensorDescriptorIm2Col`` encodes stride/padding/pixel-box once, and TMA
+#     hardware computes the gather addresses and out-of-bounds padding fills.
+#   - The kernel can focus on MMA scheduling while using simple ``coord`` +
+#     ``offsets`` loads, which is both cleaner and typically faster.
+#
+#   Example (multiple TMA im2col loads -> rows of A):
+#   .. code-block:: text
+#
+#       Use the same setup as above: 3x3 input, 2x2 filter, stride=1, pad=0.
+#
+#       Input (same symbols as the matrix example):
+#             W=0 W=1 W=2
+#       H=0    a   b   c
+#       H=1    d   e   f
+#       H=2    g   h   i
+#
+#       For each output position (oh, ow), TMA im2col uses:
+#         coord = [n, oh*stride - pad, ow*stride - pad, ci_blk]
+#
+#       Then one load is issued per filter offset (r, s):
+#         offsets=[0,0], [0,1], [1,0], [1,1]
+#
+#       (oh=0, ow=0), coord=[n,0,0,ci_blk] -> first column of A:
+#         [ a,
+#           b,
+#           d,
+#           e ]
+#       The width/channel dimension is Ci.
+#       (oh=0, ow=1), coord=[n,0,1,ci_blk] -> [b, c, e, f] = second column of A
+#       (oh=1, ow=0), coord=[n,1,0,ci_blk] -> [d, e, g, h] = third column of A
+#       (oh=1, ow=1), coord=[n,1,1,ci_blk] -> [e, f, h, i] = fourth column of A
+#       This is exactly the "image to column" idea: each output-position patch
+#       from the image is flattened and stored as one column of A.
+#
+#       Stacking these multiple loads across output positions forms A:
+#         | a  b  d  e |
+#         | b  c  e  f |
+#         | d  e  g  h |
+#         | e  f  h  i |
+#
+#       In the real kernel, this is executed in the K-loop as one
+#       async_copy_global_to_shared_im2col per (r, s, ci_block).
+#
+# %%
+# Shared Kernel for All Examples
+# ==============================
+#
+# All examples use the same kernel structure - only the TensorDescriptor
+# configuration and load coordinates differ.
+
+
+@gluon.jit
+def tma_im2col_kernel(in_desc, out_desc, coord_n: int, coord_h: int, coord_w: int, coord_c: int, offset_h: tl.constexpr,
+                      offset_w: tl.constexpr):
+    """Generic im2col kernel with configurable coordinates and offsets."""
+    smem = ttgl.allocate_shared_memory(in_desc.dtype, in_desc.block_shape, in_desc.layout)
+
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, in_desc.block_type.nbytes)
+
+    # TMA im2col load with specified coordinates and offsets
+    tma.async_copy_global_to_shared_im2col(
+        in_desc,
+        [coord_n, coord_h, coord_w, coord_c],
+        [offset_h, offset_w],
+        bar,
+        smem,
+    )
+
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+
+    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+    tma.store_wait(pendings=0)
+
+
+def run_tma_im2col(title, pixel_box_lower_corner, pixel_box_upper_corner, coord, offsets):
+    """
+    Shared function for all im2col examples.
+
+    Args:
+        title: Description to print
+        pixel_box_lower_corner: [H_lo, W_lo] lower boundary for TMA access
+        pixel_box_upper_corner: [H_hi, W_hi] upper boundary offset for TMA access
+        coord: [N, H, W, C] starting coordinates
+        offsets: [h_offset, w_offset] spatial offsets
+    """
+    # Create input tensor with values 1-16 and output tensor
+    inp = torch.arange(1, 17, device="cuda", dtype=torch.float32).unsqueeze(1).repeat(1, 32).reshape(1, 4, 4, 32)
+    out = torch.zeros(16, 32, device="cuda", dtype=torch.float32)
+
+    block_shape = [16, 32]
+    layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
+
+    in_desc = TensorDescriptorIm2Col.from_tensor(
+        inp,
+        block_shape,
+        layout,
+        padding="zero",
+        element_strides=[1, 1, 1, 1],
+        pixel_box_lower_corner=pixel_box_lower_corner,
+        pixel_box_upper_corner=pixel_box_upper_corner,
+    )
+    out_desc = TensorDescriptor.from_tensor(out, block_shape, layout)
+
+    tma_im2col_kernel[(1, )](in_desc, out_desc, *coord, *offsets, num_warps=1)
+
+    print(title)
+    print("\nLoaded data (pixel_id, value):")
+    for pixel_id in range(16):
+        value = int(out[pixel_id, 0].item())
+        print(f"  pixel {pixel_id:2d}: {value}")
+
+    return inp, out
+
+
+# %%
+# Example 1: Basic Loading (No Padding)
+# =====================================
+#
+# Load all 16 pixels (4x4 grid) from a [1, 4, 4, 32] tensor.
+# - coord = [0, 0, 0, 0], offsets = [0, 0]
+# - Access boundary: H in [0, 3], W in [0, 3] (original tensor)
+
+
+def run_tma_im2col_simple():
+    inp, out = run_tma_im2col(
+        title="Example 1: Basic loading (no padding)",
+        pixel_box_lower_corner=[0, 0],
+        pixel_box_upper_corner=[0, 0],
+        coord=[0, 0, 0, 0],
+        offsets=[0, 0],
+    )
+    torch.testing.assert_close(out, inp.reshape(16, 32), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not t7.is_hopper_or_newer(), reason="Requires Hopper")
+def test_tma_im2col_simple():
+    run_tma_im2col_simple()
+
+
+# %%
+# Example 1 Explanation:
+# ----------------------
+# Configuration:
+#   - pixel_box_lower_corner = [0, 0], pixel_box_upper_corner = [0, 0] (no padding)
+#   - coord = [0, 0, 0, 0], offsets = [0, 0]
+#   - Access boundary: H in [0, 3], W in [0, 3]
+#
+# Expected output:
+# ::
+#
+#     Loaded data: pixel 0->1, pixel 1->2, ..., pixel 15->16
+#
+#     Input [1, 4, 4, 32] spatial layout:     Output [16, 32] pixel order:
+#     Channel dimension is contiguous: each pixel stores 32 channels in order.
+#
+#     +----+----+----+----+                   pixel  0 = (H=0,W=0) -> value 1
+#     |  1 |  2 |  3 |  4 |  H=0              pixel  1 = (H=0,W=1) -> value 2
+#     +----+----+----+----+                   ...
+#     |  5 |  6 |  7 |  8 |  H=1              pixel 15 = (H=3,W=3) -> value 16
+#     +----+----+----+----+
+#     |  9 | 10 | 11 | 12 |  H=2
+#     +----+----+----+----+
+#     | 13 | 14 | 15 | 16 |  H=3
+#     +----+----+----+----+
+#       W=0  W=1  W=2  W=3
+
+if __name__ == "__main__":
+    run_tma_im2col_simple()
+    print("\n" + "=" * 50 + "\n")
+
+# %%
+# ```
+# Example 1: Basic loading (no padding)
+#
+# Loaded data (pixel_id, value):
+#   pixel  0: 1
+#   pixel  1: 2
+#   pixel  2: 3
+#   pixel  3: 4
+#   pixel  4: 5
+#   pixel  5: 6
+#   pixel  6: 7
+#   pixel  7: 8
+#   pixel  8: 9
+#   pixel  9: 10
+#   pixel 10: 11
+#   pixel 11: 12
+#   pixel 12: 13
+#   pixel 13: 14
+#   pixel 14: 15
+#   pixel 15: 16
+#
+# ==================================================
+# ```
+
+# %%
+# Example 2: Loading from Padded Region
+# =====================================
+#
+# With pixel_box_lower_corner=[-1,-1] and pixel_box_upper_corner=[-1,-1],
+# access boundary is H in [-1, 2], W in [-1, 2].
+# Negative coordinates are outside tensor -> filled with padding (0).
+
+
+def run_tma_im2col_padded():
+    _, out = run_tma_im2col(
+        title="Example 2: Loading from padded region",
+        pixel_box_lower_corner=[-1, -1],
+        pixel_box_upper_corner=[-1, -1],
+        coord=[0, -1, -1, 0],
+        offsets=[0, 0],
+    )
+    # Expected: row H=-1 all padded, then each row has W=-1 padded
+    expected = torch.tensor([0, 0, 0, 0, 0, 1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11], device="cuda", dtype=torch.float32)
+    torch.testing.assert_close(out[:, 0], expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not t7.is_hopper_or_newer(), reason="Requires Hopper")
+def test_tma_im2col_padded():
+    run_tma_im2col_padded()
+
+
+# %%
+# Example 2 Explanation:
+# ----------------------
+# Configuration:
+#   - pixel_box_lower_corner = [-1, -1], pixel_box_upper_corner = [-1, -1]
+#   - coord = [0, -1, -1, 0], offsets = [0, 0]
+#
+# Access Boundary with offsets=[0, 0]:
+#   - Lower = pixel_box_lower_corner + offsets = [-1, -1] + [0, 0]
+#   - Upper = [H - 1, W - 1] + pixel_box_upper_corner + offsets = [3, 3] + [-1, -1] + [0, 0]
+#   - Result: H in [-1, 2], W in [-1, 2]
+#   - Negative coordinates are outside tensor -> filled with padding (0)
+#
+# Expected output:
+# ::
+#
+#     pixel  0: 0  (H=-1, W=-1) padded     pixel  8: 0  (H=1, W=-1) padded
+#     pixel  1: 0  (H=-1, W=0)  padded     pixel  9: 5  (H=1, W=0)  actual
+#     pixel  2: 0  (H=-1, W=1)  padded     pixel 10: 6  (H=1, W=1)  actual
+#     pixel  3: 0  (H=-1, W=2)  padded     pixel 11: 7  (H=1, W=2)  actual
+#     pixel  4: 0  (H=0, W=-1)  padded     pixel 12: 0  (H=2, W=-1) padded
+#     pixel  5: 1  (H=0, W=0)   actual     pixel 13: 9  (H=2, W=0)  actual
+#     pixel  6: 2  (H=0, W=1)   actual     pixel 14: 10 (H=2, W=1)  actual
+#     pixel  7: 3  (H=0, W=2)   actual     pixel 15: 11 (H=2, W=2)  actual
+#
+# Visualization:
+# ::
+#
+#     Original 4x4 tensor:              Access boundary H in [-1,2], W in [-1,2]:
+#     Note: padded cells are not stored in global memory; TMA fills them on load.
+#
+#          W=0  W=1  W=2  W=3                 W=-1  W=0  W=1  W=2
+#         +----+----+----+----+              +----+----+----+----+
+#     H=0 |  1 |  2 |  3 |  4 |          H=-1|  0 |  0 |  0 |  0 | <- padded
+#         +----+----+----+----+              +----+----+----+----+
+#     H=1 |  5 |  6 |  7 |  8 |          H=0 |  0 |  1 |  2 |  3 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=2 |  9 | 10 | 11 | 12 |          H=1 |  0 |  5 |  6 |  7 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=3 | 13 | 14 | 15 | 16 |          H=2 |  0 |  9 | 10 | 11 |
+#         +----+----+----+----+              +----+----+----+----+
+#                                             ^
+#                                          padded (W<0)
+
+if __name__ == "__main__":
+    run_tma_im2col_padded()
+    print("\n" + "=" * 50 + "\n")
+
+# %%
+# ```
+# Example 2: Loading from padded region
+#
+# Loaded data (pixel_id, value):
+#   pixel  0: 0
+#   pixel  1: 0
+#   pixel  2: 0
+#   pixel  3: 0
+#   pixel  4: 0
+#   pixel  5: 1
+#   pixel  6: 2
+#   pixel  7: 3
+#   pixel  8: 0
+#   pixel  9: 5
+#   pixel 10: 6
+#   pixel 11: 7
+#   pixel 12: 0
+#   pixel 13: 9
+#   pixel 14: 10
+#   pixel 15: 11
+#
+# ==================================================
+# ```
+
+# %%
+# Example 3: Offset Shifts Access Boundary
+# ========================================
+#
+# Same TensorDescriptor as Example 2, but with offsets=[1, 1].
+# This shifts the access boundary from [-1, 2] to [0, 3], covering the original tensor.
+
+
+def run_tma_im2col_offset():
+    inp, out = run_tma_im2col(
+        title="Example 3: Offset shifts access to original tensor",
+        pixel_box_lower_corner=[-1, -1],
+        pixel_box_upper_corner=[-1, -1],
+        coord=[0, -1, -1, 0],
+        offsets=[1, 1],
+    )
+    # Offset shifts access to exactly the original tensor [0,3] x [0,3]
+    torch.testing.assert_close(out, inp.reshape(16, 32), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not t7.is_hopper_or_newer(), reason="Requires Hopper")
+def test_tma_im2col_offset():
+    run_tma_im2col_offset()
+
+
+# %%
+# Example 3 Explanation:
+# ----------------------
+# Configuration:
+#   - pixel_box_lower_corner = [-1, -1], pixel_box_upper_corner = [-1, -1]
+#   - coord = [0, -1, -1, 0], offsets = [1, 1]
+#
+# Access Boundary with offsets=[1, 1]:
+#   - Lower = pixel_box_lower_corner + offsets = [-1, -1] + [1, 1]
+#   - Upper = [H - 1, W - 1] + pixel_box_upper_corner + offsets = [3, 3] + [-1, -1] + [1, 1]
+#   - Result: H in [0, 3], W in [0, 3] -> exactly the original tensor
+#
+# Comparison (Example 2 vs Example 3):
+# ::
+#
+#     Example 2 (offsets=[0,0]):           Example 3 (offsets=[1,1]):
+#     Access H in [-1, 2], W in [-1, 2]    Access H in [0, 3], W in [0, 3]
+#
+#          W=-1  W=0  W=1  W=2                  W=0  W=1  W=2  W=3
+#         +----+----+----+----+              +----+----+----+----+
+#     H=-1|  0 |  0 |  0 |  0 |          H=0 |  1 |  2 |  3 |  4 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=0 |  0 |  1 |  2 |  3 |          H=1 |  5 |  6 |  7 |  8 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=1 |  0 |  5 |  6 |  7 |          H=2 |  9 | 10 | 11 | 12 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=2 |  0 |  9 | 10 | 11 |          H=3 | 13 | 14 | 15 | 16 |
+#         +----+----+----+----+              +----+----+----+----+
+#
+#     Key insight: offsets=[1,1] shifts the 4x4 access window from
+#     the padded region to exactly cover the original tensor data.
+
+if __name__ == "__main__":
+    run_tma_im2col_offset()
+    print("\n" + "=" * 50 + "\n")
+
+# %%
+# ```
+# Example 3: Offset shifts access to original tensor
+#
+# Loaded data (pixel_id, value):
+#   pixel  0: 1
+#   pixel  1: 2
+#   pixel  2: 3
+#   pixel  3: 4
+#   pixel  4: 5
+#   pixel  5: 6
+#   pixel  6: 7
+#   pixel  7: 8
+#   pixel  8: 9
+#   pixel  9: 10
+#   pixel 10: 11
+#   pixel 11: 12
+#   pixel 12: 13
+#   pixel 13: 14
+#   pixel 14: 15
+#   pixel 15: 16
+#
+# ==================================================
+# ```
+
+# %%
+# Example 4: Loading Across Multiple Batches
+# ==========================================
+#
+# This example shows loading pixels that span across multiple images (batches).
+# Input: [2, 4, 4, 32] - 2 batches of 4x4 images with 32 channels
+# Starting at coord=[0, 1, 3, 0] (batch 0, H=1, W=3) and loading 16 pixels
+# wraps from batch 0 into batch 1.
+
+
+def run_tma_im2col_multi_batch():
+    # Input: [2, 4, 4, 32] - 2 batches of 4x4 images (32 pixels total)
+    # Values 1-32 for easy tracking
+    inp = torch.arange(1, 33, device="cuda", dtype=torch.float32).unsqueeze(1).repeat(1, 32).reshape(2, 4, 4, 32)
+    out = torch.zeros(16, 32, device="cuda", dtype=torch.float32)
+
+    block_shape = [16, 32]  # load 16 pixels
+    layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
+
+    in_desc = TensorDescriptorIm2Col.from_tensor(
+        inp,
+        block_shape,
+        layout,
+        padding="zero",
+        element_strides=[1, 1, 1, 1],
+        pixel_box_lower_corner=[0, 0],
+        pixel_box_upper_corner=[0, 0],
+    )
+    out_desc = TensorDescriptor.from_tensor(out, block_shape, layout)
+
+    # coord=[0, 1, 3, 0] - start from batch 0, H=1, W=3, C=0
+    # This is pixel index 1*4 + 3 = 7 in batch 0
+    tma_im2col_kernel[(1, )](in_desc, out_desc, 0, 1, 3, 0, 0, 0, num_warps=1)
+
+    print("Example 4: Loading across multiple batches")
+    print("Input shape: [2, 4, 4, 32] (2 batches of 4x4 images)")
+    print("Starting at: batch=0, H=1, W=3 (pixel 8 in input)")
+    print("\nLoaded data (pixel_id, value):")
+    for pixel_id in range(16):
+        value = int(out[pixel_id, 0].item())
+        print(f"  pixel {pixel_id:2d}: value {value:2d}")
+
+    # Expected: values 8-16 from batch 0, then 17-23 from batch 1
+    expected = torch.tensor([8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23], device="cuda",
+                            dtype=torch.float32)
+    torch.testing.assert_close(out[:, 0], expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not t7.is_hopper_or_newer(), reason="Requires Hopper")
+def test_tma_im2col_multi_batch():
+    run_tma_im2col_multi_batch()
+
+
+# %%
+# Example 4 Explanation:
+# ----------------------
+# Configuration:
+#   - Input: [2, 4, 4, 32] - 2 batches of 4x4 images
+#   - block_shape = [16, 32] - load 16 pixels
+#   - coord = [0, 1, 3, 0] - start at batch 0, H=1, W=3
+#
+# Input layout (values 1-32):
+# ::
+#
+#     Batch 0 (4x4):                      Batch 1 (4x4):
+#     [x] = accessed pixel                 [x] = accessed pixel
+#
+#          W=0  W=1  W=2  W=3                  W=0  W=1  W=2  W=3
+#         +----+----+----+----+              +----+----+----+----+
+#     H=0 |  1 |  2 |  3 |  4 |          H=0 |[17]|[18]|[19]|[20]|
+#         +----+----+----+----+              +----+----+----+----+
+#     H=1 |  5 |  6 |  7 | [8]| <-start  H=1 |[21]|[22]|[23]| 24 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=2 |[ 9]|[10]|[11]|[12]|          H=2 | 25 | 26 | 27 | 28 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=3 |[13]|[14]|[15]|[16]|          H=3 | 29 | 30 | 31 | 32 |
+#         +----+----+----+----+              +----+----+----+----+
+#
+# Starting at (N=0, H=1, W=3), loading 16 pixels in row-major order:
+#   pixel  0: (N=0, H=1, W=3) -> value 8   (start position)
+#   pixel  1: (N=0, H=2, W=0) -> value 9
+#   pixel  2: (N=0, H=2, W=1) -> value 10
+#   pixel  3: (N=0, H=2, W=2) -> value 11
+#   pixel  4: (N=0, H=2, W=3) -> value 12
+#   pixel  5: (N=0, H=3, W=0) -> value 13
+#   pixel  6: (N=0, H=3, W=1) -> value 14
+#   pixel  7: (N=0, H=3, W=2) -> value 15
+#   pixel  8: (N=0, H=3, W=3) -> value 16  (last pixel in batch 0)
+#   pixel  9: (N=1, H=0, W=0) -> value 17  (wraps to batch 1)
+#   pixel 10: (N=1, H=0, W=1) -> value 18
+#   pixel 11: (N=1, H=0, W=2) -> value 19
+#   pixel 12: (N=1, H=0, W=3) -> value 20
+#   pixel 13: (N=1, H=1, W=0) -> value 21
+#   pixel 14: (N=1, H=1, W=1) -> value 22
+#   pixel 15: (N=1, H=1, W=2) -> value 23
+#
+# Key insight: Loading wraps from batch 0 into batch 1 seamlessly,
+# enabling efficient access patterns for convolution operations.
+
+if __name__ == "__main__":
+    run_tma_im2col_multi_batch()
+    print("\n" + "=" * 50 + "\n")
+
+# %%
+# ```
+# Example 4: Loading across multiple batches
+# Input shape: [2, 4, 4, 32] (2 batches of 4x4 images)
+# Starting at: batch=0, H=1, W=3 (pixel 8 in input)
+#
+# Loaded data (pixel_id, value):
+#   pixel  0: value  8
+#   pixel  1: value  9
+#   pixel  2: value 10
+#   pixel  3: value 11
+#   pixel  4: value 12
+#   pixel  5: value 13
+#   pixel  6: value 14
+#   pixel  7: value 15
+#   pixel  8: value 16
+#   pixel  9: value 17
+#   pixel 10: value 18
+#   pixel 11: value 19
+#   pixel 12: value 20
+#   pixel 13: value 21
+#   pixel 14: value 22
+#   pixel 15: value 23
+#
+# ==================================================
+# ```
+
+# %%
+# Example 5: Multi-Batch with Padded Access Boundary
+# ==================================================
+#
+# This example combines multi-batch loading with padding.
+# With pixel_box_lower_corner=[-1,-1] and pixel_box_upper_corner=[-1,-1],
+# the access boundary is H in [-1, 2], W in [-1, 2] per batch.
+# Starting at H=1, W=2 loads pixels that wrap across batches within
+# this constrained boundary.
+
+
+def run_tma_im2col_multi_batch_padded():
+    # Input: [2, 4, 4, 32] - 2 batches of 4x4 images (32 pixels total)
+    inp = torch.arange(1, 33, device="cuda", dtype=torch.float32).unsqueeze(1).repeat(1, 32).reshape(2, 4, 4, 32)
+    out = torch.zeros(16, 32, device="cuda", dtype=torch.float32)
+
+    block_shape = [16, 32]
+    layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
+
+    in_desc = TensorDescriptorIm2Col.from_tensor(
+        inp,
+        block_shape,
+        layout,
+        padding="zero",
+        element_strides=[1, 1, 1, 1],
+        pixel_box_lower_corner=[-1, -1],
+        pixel_box_upper_corner=[-1, -1],
+    )
+    out_desc = TensorDescriptor.from_tensor(out, block_shape, layout)
+
+    # coord=[0, 1, 2, 0] - start from batch 0, H=1, W=2, C=0
+    tma_im2col_kernel[(1, )](in_desc, out_desc, 0, 1, 2, 0, 0, 0, num_warps=1)
+
+    print("Example 5: Multi-batch with padded access boundary")
+    print("Input shape: [2, 4, 4, 32], pixel_box_lower_corner=[-1,-1], "
+          "pixel_box_upper_corner=[-1,-1]")
+    print("Access boundary per batch: H in [-1, 2], W in [-1, 2]")
+    print("Starting at: batch=0, H=1, W=2")
+    print("\nLoaded data (pixel_id, value):")
+    for pixel_id in range(16):
+        value = int(out[pixel_id, 0].item())
+        print(f"  pixel {pixel_id:2d}: {value}")
+
+    # Expected: 7, then padding + data pattern as described in documentation
+    expected = torch.tensor([7, 0, 9, 10, 11, 0, 0, 0, 0, 0, 17, 18, 19, 0, 21, 22], device="cuda", dtype=torch.float32)
+    torch.testing.assert_close(out[:, 0], expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not t7.is_hopper_or_newer(), reason="Requires Hopper")
+def test_tma_im2col_multi_batch_padded():
+    run_tma_im2col_multi_batch_padded()
+
+
+# %%
+# Example 5 Explanation:
+# ----------------------
+# Configuration:
+#   - Input: [2, 4, 4, 32] - 2 batches of 4x4 images
+#   - pixel_box_lower_corner = [-1, -1], pixel_box_upper_corner = [-1, -1]
+#   - Lower = pixel_box_lower_corner + offsets = [-1, -1] + [0, 0]
+#   - Upper = [H - 1, W - 1] + pixel_box_upper_corner + offsets = [3, 3] + [-1, -1] + [0, 0]
+#   - Access boundary per batch: H in [-1, 2], W in [-1, 2] (4x4 shifted region)
+#   - coord = [0, 1, 2, 0] - start at batch 0, H=1, W=2
+#
+# Access boundary visualization (per batch):
+# ::
+#
+#     Batch 0 - Original 4x4 tensor:     Batch 0 - Access boundary H in [-1,2], W in [-1,2]:
+#     [x] = accessed pixel                [x] = accessed pixel, [0] = accessed padding
+#
+#          W=0  W=1  W=2  W=3                 W=-1  W=0  W=1  W=2
+#         +----+----+----+----+              +----+----+----+----+
+#     H=0 |  1 |  2 |  3 |  4 |          H=-1|  0 |  0 |  0 |  0 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=1 |  5 |  6 | [7]|  8 |          H=0 |  0 |  1 |  2 |  3 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=2 | [9]|[10]|[11]| 12 |          H=1 |  0 |  5 |  6 | [7]| <-start
+#         +----+----+----+----+              +----+----+----+----+
+#     H=3 | 13 | 14 | 15 | 16 |          H=2 | [0]| [9]|[10]|[11]|
+#         +----+----+----+----+              +----+----+----+----+
+#
+#     Batch 1 - Original 4x4 tensor:     Batch 1 - Access boundary H in [-1,2], W in [-1,2]:
+#     [x] = accessed pixel                [x] = accessed pixel, [0] = accessed padding
+#
+#          W=0  W=1  W=2  W=3                 W=-1  W=0  W=1  W=2
+#         +----+----+----+----+              +----+----+----+----+
+#     H=0 |[17]|[18]|[19]| 20 |          H=-1| [0]| [0]| [0]| [0]| <- accessed padding
+#         +----+----+----+----+              +----+----+----+----+
+#     H=1 |[21]|[22]| 23 | 24 |          H=0 | [0]|[17]|[18]|[19]|
+#         +----+----+----+----+              +----+----+----+----+
+#     H=2 | 25 | 26 | 27 | 28 |          H=1 | [0]|[21]|[22]| 23 |
+#         +----+----+----+----+              +----+----+----+----+
+#     H=3 | 29 | 30 | 31 | 32 |          H=2 |  0 | 25 | 26 | 27 |
+#         +----+----+----+----+              +----+----+----+----+
+#
+# Starting at H=1, W=2 (value 7), loading 16 pixels within the boundary:
+#   pixel  0: (N=0, H=1, W=2) -> value 7   (start position)
+#   pixel  1: (N=0, H=2, W=-1) -> value 0  (padded, W=-1)
+#   pixel  2: (N=0, H=2, W=0) -> value 9
+#   pixel  3: (N=0, H=2, W=1) -> value 10
+#   pixel  4: (N=0, H=2, W=2) -> value 11
+#   pixel  5: (N=1, H=-1, W=-1) -> value 0 (wraps to batch 1, padded)
+#   pixel  6: (N=1, H=-1, W=0) -> value 0  (padded)
+#   pixel  7: (N=1, H=-1, W=1) -> value 0  (padded)
+#   pixel  8: (N=1, H=-1, W=2) -> value 0  (padded)
+#   pixel  9: (N=1, H=0, W=-1) -> value 0  (padded)
+#   pixel 10: (N=1, H=0, W=0) -> value 17
+#   pixel 11: (N=1, H=0, W=1) -> value 18
+#   pixel 12: (N=1, H=0, W=2) -> value 19
+#   pixel 13: (N=1, H=1, W=-1) -> value 0  (padded)
+#   pixel 14: (N=1, H=1, W=0) -> value 21
+#   pixel 15: (N=1, H=1, W=1) -> value 22
+#
+# Key insight: The access boundary constrains the 4x4 window per batch.
+# When wrapping to the next batch, the boundary resets and padded regions
+# (H=-1 or W=-1) are filled with zeros. This is useful for convolution
+# operations, where it allows seamlessly processing pixel data across
+# image boundaries in a single block.
+
+if __name__ == "__main__":
+    run_tma_im2col_multi_batch_padded()
+    print("\n" + "=" * 50 + "\n")
+
+# %%
+# ```
+# Example 5: Multi-batch with padded access boundary
+# Input shape: [2, 4, 4, 32], pixel_box_lower_corner=[-1,-1], pixel_box_upper_corner=[-1,-1]
+# Access boundary per batch: H in [-1, 2], W in [-1, 2]
+# Starting at: batch=0, H=1, W=2
+#
+# Loaded data (pixel_id, value):
+#   pixel  0: 7
+#   pixel  1: 0
+#   pixel  2: 9
+#   pixel  3: 10
+#   pixel  4: 11
+#   pixel  5: 0
+#   pixel  6: 0
+#   pixel  7: 0
+#   pixel  8: 0
+#   pixel  9: 0
+#   pixel 10: 17
+#   pixel 11: 18
+#   pixel 12: 19
+#   pixel 13: 0
+#   pixel 14: 21
+#   pixel 15: 22
+#
+# ==================================================
+# ```
+
+# %%
+# Implicit GEMM with TMA im2col
+# ==============================
+#
+# **Explicit im2col** physically constructs the matrix A in memory. This is
+# simple but wastes memory because overlapping patches duplicate input data.
+# For an R x S filter, each input element may be copied up to R * S times!
+#
+# **Implicit GEMM** avoids materializing A. During the GEMM K-loop, it computes
+# input addresses on the fly for each filter position ``(r, s)`` and channel
+# block. On Hopper+ GPUs, TMA provides a dedicated **im2col mode** that performs
+# this address generation in hardware. We configure one
+# ``TensorDescriptorIm2Col`` (see the launcher), and each TMA load receives a
+# filter offset ``[r, s]`` that selects which kernel position to gather. TMA
+# then handles output-position strides, zero-padding for out-of-bounds
+# accesses, and batch-boundary wrapping automatically, with no register-level
+# index arithmetic.
+#
+# Pseudocode:
+#
+# ```
+# # GEMM dimensions
+# M = N * out_h * out_w        # output spatial positions
+# N_gemm = Co                  # output channels
+# K = R * S * Ci               # reduction dimension
+#
+# for each M-tile (output positions):
+#     for each N-tile (output channels):
+#         acc = zeros(BLOCK_M, BLOCK_N)
+#
+#         for r in range(R):                  # filter height
+#             for s in range(S):              # filter width
+#                 for ci_block in range(Ci // BLOCK_K):
+#                     # Input tile via TMA im2col:
+#                     # input[batch, out_y*stride+r-pad, out_x*stride+s-pad, ci_block*BLOCK_K:...]
+#                     tma.async_copy_global_to_shared_im2col(...)
+#                     A_tile = a_smem         # [BLOCK_M, BLOCK_K]
+#
+#                     # Weight tile via standard TMA:
+#                     # weight[co_start:..., r, s, ci_block*BLOCK_K:...]
+#                     tma.async_copy_global_to_shared(...)
+#                     B_tile = b_smem         # [BLOCK_N, BLOCK_K]
+#
+#                     # Matrix multiply-accumulate (details omitted here)
+#                     acc += A_tile @ B_tile^T
+#
+#         # Store output tile via TMA
+#         tma.async_copy_shared_to_global(...)
+# ```
+#
+# Key insight: we never materialize the full im2col matrix; address generation
+# happens inside the K-loop via TMA im2col.
+#
+# %%
+# Gluon Kernel
+# ============
+#
+# The kernel below implements a single-buffered implicit GEMM convolution.
+# ``store_output_tile`` is factored out as a helper; everything else is
+# inline so the reader can follow the im2col algorithm top-to-bottom.
+#
+# ``MMAImpl`` (from ``07-persistence.py``) lets the same kernel run on Hopper
+# (WGMMA, accumulator in registers) and Blackwell (tcgen05, accumulator in
+# tensor memory) without any code changes.
+#
+# Convolution data layout convention for this section:
+#   - Input:  NHWC  ``[N, H, W, Ci]``
+#   - Weight: ``[Co, R, S, Ci]``  (output-channels first)
+#   - Output: NHWC  ``[N, out_h, out_w, Co]``
+
+
+@gluon.jit
+def decompose_m_offset(pid_m, BLOCK_M: ttgl.constexpr, out_h, out_w):
+    """Map M-tile index to (offs_m, batch, out_y, out_x) for TMA im2col coordinates."""
+    offs_m = pid_m * BLOCK_M
+    batch_id = offs_m // (out_h * out_w)
+    m_residual = offs_m % (out_h * out_w)
+    out_y = m_residual // out_w
+    out_x = m_residual % out_w
+    return offs_m, batch_id, out_y, out_x
+
+
+@gluon.jit
+def init_accumulator(in_desc, weight_desc, MMAImpl, dtype, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,
+                     num_warps: ttgl.constexpr):
+    """Allocate shared-memory tiles, MMA accumulator, and TMA barrier."""
+    a_smem = ttgl.allocate_shared_memory(dtype, in_desc.block_shape, in_desc.layout)
+    b_smem = ttgl.allocate_shared_memory(dtype, weight_desc.block_shape, weight_desc.layout)
+    mma = MMAImpl.initialize(dtype, BLOCK_M, BLOCK_N, num_warps)
+    tma_bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+    mbarrier.init(tma_bar, count=1)
+    return a_smem, b_smem, mma, tma_bar
+
+
+@gluon.jit
+def store_output_tile(mma, dtype, out_desc, offs_m, offs_n):
+    """Wait for the final MMA, downcast, and write the output tile via TMA."""
+    mma = mma.wait_num_outstanding(0)
+    acc, mma = mma.take_result()
+    c_smem = ttgl.allocate_shared_memory(dtype, out_desc.block_shape, out_desc.layout)
+    c_smem.store(acc.to(dtype))
+    fence_async_shared()
+    tma.async_copy_shared_to_global(out_desc, [offs_m, offs_n], c_smem)
+    tma.store_wait(pendings=0)
+
+
+@gluon.jit
+def conv2d_im2col_kernel(
+    in_desc,
+    weight_desc,
+    out_desc,
+    R,
+    S,
+    Ci,
+    out_h,
+    out_w,
+    pad_h,
+    pad_w,
+    stride_h: ttgl.constexpr,
+    stride_w: ttgl.constexpr,
+    MMAImpl: ttgl.constexpr,
+    BLOCK_M: ttgl.constexpr,
+    BLOCK_N: ttgl.constexpr,
+    BLOCK_K: ttgl.constexpr,
+    num_warps: ttgl.constexpr,
+):
+    """
+    Implicit GEMM convolution kernel using TMA im2col + MMA.
+    Works on both Hopper (WGMMA) and Blackwell (tcgen05) via MMAImpl.
+    """
+    dtype: ttgl.constexpr = in_desc.dtype
+
+    # for each M-tile / N-tile:
+    pid_m, pid_n = ttgl.program_id(0), ttgl.program_id(1)
+    offs_m, batch_id, out_y, out_x = decompose_m_offset(pid_m, BLOCK_M, out_h, out_w)
+
+    # acc = zeros(BLOCK_M, BLOCK_N)
+    a_smem, b_smem, mma, tma_bar = init_accumulator(in_desc, weight_desc, MMAImpl, dtype, BLOCK_M, BLOCK_N, num_warps)
+    phase = 0
+
+    # for r in range(R): for s in range(S): for ci_blk in range(ceil(Ci/BLOCK_K))
+    # When Ci is not a multiple of BLOCK_K, last channel block is partial; TMA zero-fills OOB.
+    ci_num_blocks = ttgl.cdiv(Ci, BLOCK_K)
+    total_k_iters = R * S * ci_num_blocks
+    for k_iter in range(total_k_iters):
+        ci_block, rs_idx = k_iter % ci_num_blocks, k_iter // ci_num_blocks
+        r, s = rs_idx // S, rs_idx % S
+
+        # A = load_input[batch, oh*stride+r-pad, ow*stride+s-pad, ci_blk*BLOCK_K:…]
+        # Equivalent TMA-im2col mapping:
+        #   coord   = [batch_id, out_y*stride_h-pad_h, out_x*stride_w-pad_w, ci_block*BLOCK_K]
+        #   offsets = [r, s]
+        # TMA applies offsets to the spatial coords, so start is:
+        #   [batch_id, out_y*stride_h-pad_h+r, out_x*stride_w-pad_w+s, ci_block*BLOCK_K]
+        mbarrier.expect(tma_bar, in_desc.block_type.nbytes + weight_desc.block_type.nbytes)
+        tma.async_copy_global_to_shared_im2col(
+            in_desc,
+            [batch_id, out_y * stride_h - pad_h, out_x * stride_w - pad_w, ci_block * BLOCK_K],
+            [r.to(tl.int16), s.to(tl.int16)],
+            tma_bar,
+            a_smem,
+        )
+        # B = load_weight[co_start:…, k_offset:k_offset+BLOCK_K].  Uses Ci (not
+        # ci_num_blocks*BLOCK_K) as the per-(r,s) stride so offsets stay aligned with the
+        # flat (Co, R*S*Ci) layout.  When the last ci block bleeds into the next (r,s)
+        # group, those weight elements are multiplied by zero-filled input channels (TMA
+        # zero-fills input channels past Ci), so the result is still correct.
+        k_offset = r * S * Ci + s * Ci + ci_block * BLOCK_K
+        tma.async_copy_global_to_shared(weight_desc, [pid_n * BLOCK_N, k_offset], tma_bar, b_smem)
+        mbarrier.wait(tma_bar, phase=phase)
+
+        # acc += A @ B^T
+        mma = mma.wait_num_outstanding(0)
+        mma = mma.issue_async_mma(a_smem, b_smem.permute((1, 0)))
+
+        phase ^= 1
+
+    mbarrier.invalidate(tma_bar)
+
+    # store output[...] = acc
+    store_output_tile(mma, dtype, out_desc, offs_m, pid_n * BLOCK_N)
+
+
+# %%
+# Host-Side Launcher
+# ==================
+#
+# The host side sets up TMA descriptors and launches the kernel.
+# The critical part is configuring the ``TensorDescriptorIm2Col`` with the
+# correct ``pixel_box``, ``element_strides``, and ``padding`` to match
+# the convolution parameters.
+#
+# ``t7.select_mma_impl()`` automatically picks the right MMA backend:
+# ``WGMMA`` on Hopper (SM 9.x) or ``MMAv5`` on Blackwell (SM 10.x).
+def conv2d_tma_im2col(input_nhwc, weight, stride=1, padding=0, BLOCK_M=64, BLOCK_N=64, BLOCK_K=64, num_warps=4):
+    """
+    2D convolution using TMA im2col + MMA (Hopper / Blackwell).
+
+    Args:
+        input_nhwc: [N, H, W, Ci] in NHWC format, float16
+        weight:     [Co, R, S, Ci] filter tensor, float16
+        stride:     convolution stride (default: 1)
+        padding:    convolution padding (default: 0)
+    """
+    MMAImpl = t7.select_mma_impl()
+    assert MMAImpl is not None, "conv2d_tma_im2col requires a Hopper or Blackwell GPU"
+
+    N, H, W, Ci = input_nhwc.shape
+    Co, R, S, Ci_w = weight.shape
+    assert Ci == Ci_w, "Channel mismatch"
+    assert stride > 0, f"stride must be positive, got {stride}"
+    assert padding >= 0, f"padding must be non-negative, got {padding}"
+    # Ci may be any positive value; when not divisible by BLOCK_K, last tile is partial (TMA zero-fills OOB).
+
+    out_h = (H + 2 * padding - R) // stride + 1
+    out_w = (W + 2 * padding - S) // stride + 1
+    assert out_h > 0 and out_w > 0, (f"Invalid convolution geometry: out_h={out_h}, out_w={out_w}, "
+                                     f"H={H}, W={W}, R={R}, S={S}, stride={stride}, padding={padding}")
+    M_GEMM = N * out_h * out_w
+    N_GEMM = Co
+
+    output = torch.empty(M_GEMM, Co, device=input_nhwc.device, dtype=input_nhwc.dtype)
+
+    # ── TMA im2col descriptor for input ──────────────────────────────────
+    # This configures TMA's hardware im2col mode on the [N, H, W, Ci]
+    # input tensor. Key parameters:
+    #
+    #   block_shape  = [BLOCK_M, BLOCK_K]
+    #       BLOCK_M output positions x BLOCK_K channels per async copy.
+    #
+    #   element_strides = [1, stride, stride, 1]
+    #       TMA steps by `stride` in H/W between consecutive output
+    #       positions, matching the convolution stride.
+    #
+    #   pixel_box_{lower,upper}_corner
+    #       Defines the spatial window that TMA traverses per batch.
+    #       The window must cover exactly out_h * out_w pixels:
+    #         window_h = (out_h - 1) * stride + 1
+    #         upper_h  = window_h - H - padding
+    #       Lower corner is [-padding, -padding].
+    #
+    #   padding = "zero"
+    #       Out-of-bounds reads (from conv padding) return 0 automatically.
+    #
+    upper_h = (out_h - 1) * stride + 1 - H - padding
+    upper_w = (out_w - 1) * stride + 1 - W - padding
+
+    input_block_shape = [BLOCK_M, BLOCK_K]
+    input_layout = ttgl.NVMMASharedLayout.get_default_for(input_block_shape, ttgl.float16)
+    in_desc = TensorDescriptorIm2Col.from_tensor(
+        input_nhwc,
+        input_block_shape,
+        input_layout,
+        padding="zero",
+        element_strides=[1, stride, stride, 1],
+        pixel_box_lower_corner=[-padding, -padding],
+        pixel_box_upper_corner=[upper_h, upper_w],
+    )
+
+    # ── TMA descriptor for weight ────────────────────────────────────────
+    # Reshape weight [Co, R, S, Ci] -> [Co, R*S*Ci] for standard 2D TMA
+    weight_2d = weight.reshape(Co, R * S * Ci)
+    weight_block_shape = [BLOCK_N, BLOCK_K]
+    weight_layout = ttgl.NVMMASharedLayout.get_default_for(weight_block_shape, ttgl.float16)
+    weight_desc = TensorDescriptor.from_tensor(weight_2d, weight_block_shape, weight_layout)
+
+    # ── TMA descriptor for output ────────────────────────────────────────
+    # Output is [M_GEMM, Co] (flattened spatial dims).
+    out_block_shape = [BLOCK_M, BLOCK_N]
+    out_layout = ttgl.NVMMASharedLayout.get_default_for(out_block_shape, ttgl.float16)
+    out_desc = TensorDescriptor.from_tensor(output, out_block_shape, out_layout)
+
+    # ── Launch kernel ────────────────────────────────────────────────────
+    grid = (triton.cdiv(M_GEMM, BLOCK_M), triton.cdiv(N_GEMM, BLOCK_N))
+    conv2d_im2col_kernel[grid](
+        in_desc,
+        weight_desc,
+        out_desc,
+        R,
+        S,
+        Ci,
+        out_h,
+        out_w,
+        padding,
+        padding,
+        stride,
+        stride,
+        MMAImpl=MMAImpl,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        num_warps=num_warps,
+    )
+    return output.reshape(N, out_h, out_w, Co)
+
+
+# %%
+# Testing
+# =======
+#
+# We compare our TMA im2col convolution against PyTorch's conv2d.
+
+
+@pytest.mark.parametrize("N", [1, 4])
+@pytest.mark.parametrize("H,W", [(16, 16)])
+@pytest.mark.parametrize("Ci,Co", [(64, 64), (96, 96)])
+@pytest.mark.parametrize("R,S", [(3, 3), (1, 1)])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", [0, 1])
+@pytest.mark.skipif(not t7.is_hopper_or_newer(), reason="Requires Hopper or newer GPU (SM 9.x+)")
+def test_conv2d_tma_im2col(N, H, W, Ci, Co, R, S, stride, padding):
+    torch.manual_seed(0)
+    x_nhwc = torch.randn(N, H, W, Ci, device="cuda", dtype=torch.float16)
+    w_co_r_s_ci = torch.randn(Co, R, S, Ci, device="cuda", dtype=torch.float16)
+
+    # Our kernel
+    triton_out = conv2d_tma_im2col(x_nhwc, w_co_r_s_ci, stride=stride, padding=padding)
+
+    # PyTorch reference (input NCHW, weight OIHW)
+    x_nchw = x_nhwc.permute(0, 3, 1, 2).contiguous()
+    w_oihw = w_co_r_s_ci.permute(0, 3, 1, 2).contiguous()
+    torch_out = torch.nn.functional.conv2d(x_nchw, w_oihw, stride=stride, padding=padding)
+    torch_out_nhwc = torch_out.permute(0, 2, 3, 1)
+    torch.testing.assert_close(triton_out, torch_out_nhwc, atol=1e-2, rtol=1e-2)
+
+
+# %%
+# Summary
+# =======
+#
+# In this tutorial we learned:
+#
+# 1. **TMA im2col fundamentals**: How ``TensorDescriptorIm2Col`` parameters
+#    (``pixel_box_lower_corner``, ``pixel_box_upper_corner``, ``element_strides``,
+#    ``padding``) control access boundaries on NHWC tensors, including padded
+#    regions, offset shifts, and multi-batch wrapping.
+#
+# 2. **Convolution as GEMM**: The im2col transformation converts convolution
+#    into a matrix multiplication by rearranging input patches into rows of
+#    a matrix.
+#
+# 3. **Implicit GEMM**: Instead of materializing the im2col matrix, we compute
+#    input addresses on-the-fly during the GEMM K-loop, saving memory.
+#
+# 4. **TMA im2col**: TMA hardware natively supports im2col address
+#    computation, eliminating register pressure from index arithmetic. We
+#    configure a ``TensorDescriptorIm2Col`` with convolution parameters
+#    (strides, padding, pixel box), and TMA handles the rest. This feature
+#    is available on both Hopper and Blackwell GPUs.
+#
+# 5. **Unified kernel via MMA abstraction**: By using the ``WGMMA`` / ``MMAv5``
+#    abstraction from ``07-persistence.py``, a single kernel implementation
+#    works on both Hopper and Blackwell. The abstraction handles:
+#
+#    - Accumulator allocation (registers on Hopper, tensor memory on Blackwell)
+#    - MMA barrier management
+#    - Async MMA issue and wait
+#
+#    The kernel itself only deals with TMA loads and the unified MMA API:
+#    ``initialize``, ``issue_async_mma``, ``wait_num_outstanding``, ``take_result``.
+#
+# For a production-quality implementation with warp specialization and
+# pipelining, see ``examples/gluon/02-convolution.py``.
+if __name__ == "__main__":
+    # Conv2d demo
+    torch.manual_seed(0)
+    N, H, W, Ci, Co, R, S = 4, 16, 16, 64, 64, 3, 3
+    stride, padding = 1, 1
+
+    x_nhwc = torch.randn(N, H, W, Ci, device="cuda", dtype=torch.float16)
+    w_co_r_s_ci = torch.randn(Co, R, S, Ci, device="cuda", dtype=torch.float16)
+
+    triton_out = conv2d_tma_im2col(x_nhwc, w_co_r_s_ci, stride=stride, padding=padding)
+
+    # Compare with PyTorch (input NCHW, weight OIHW)
+    x_nchw = x_nhwc.permute(0, 3, 1, 2).contiguous()
+    w_oihw = w_co_r_s_ci.permute(0, 3, 1, 2).contiguous()
+    torch_out = torch.nn.functional.conv2d(x_nchw, w_oihw, stride=stride, padding=padding)
+    torch_out_nhwc = torch_out.permute(0, 2, 3, 1)
+
+    max_err = (triton_out - torch_out_nhwc).abs().max().item()
+    print(f"Conv2d: N={N}, H={H}, W={W}, Ci={Ci}, Co={Co}, R={R}, S={S}, "
+          f"stride={stride}, pad={padding}")
+    print(f"Output shape: {list(triton_out.shape)}")
+    print(f"Max absolute error vs PyTorch: {max_err:.6f}")
+    print("PASSED!" if max_err < 0.02 else "FAILED!")
+
+# %%
+# ```
+# Conv2d: N=4, H=16, W=16, Ci=64, Co=64, R=3, S=3, stride=1, pad=1
+# Output shape: [4, 16, 16, 64]
+# Max absolute error vs PyTorch: 0.000000
+# PASSED!
+# ```

--- a/python/tutorials/gluon/conftest.py
+++ b/python/tutorials/gluon/conftest.py
@@ -3,6 +3,24 @@ import pytest
 
 @pytest.fixture
 def fresh_knobs():
+    """
+    Resets all knobs except ``build``, ``nvidia``, and ``amd`` (preserves
+    library paths needed to compile kernels).
+    """
+    from triton._internal_testing import _fresh_knobs_impl
+    fresh_function, reset_function = _fresh_knobs_impl(skipped_attr={"build", "nvidia", "amd"})
+    try:
+        yield fresh_function()
+    finally:
+        reset_function()
+
+
+@pytest.fixture
+def fresh_knobs_including_libraries():
+    """
+    Resets ALL knobs including ``build``, ``nvidia``, and ``amd``.
+    Use for tests that verify initial values of these knobs.
+    """
     from triton._internal_testing import _fresh_knobs_impl
     fresh_function, reset_function = _fresh_knobs_impl()
     try:

--- a/setup.py
+++ b/setup.py
@@ -847,6 +847,11 @@ setup(
     package_dir=dict(get_package_dirs()),
     entry_points=get_entry_points(),
     include_package_data=True,
+    exclude_package_data={"": [
+        "__pycache__",
+        "__pycache__/*",
+        "*.py[cod]",
+    ]},
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={
         "bdist_wheel": plugin_bdist_wheel,

--- a/test/Conversion/amd/convert_layout.mlir
+++ b/test/Conversion/amd/convert_layout.mlir
@@ -212,3 +212,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Regression test: convert_layout on tensor of pointers must not crash.
+#blocked4x4 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#linear4x4 = #ttg.linear<{register = [[1, 0], [2, 0], [0, 1], [0, 2]], lane = [[0, 4], [0, 8], [0, 16], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: convert_layout_pointer_element_no_crash
+  tt.func @convert_layout_pointer_element_no_crash(%arg0: tensor<32x32x!tt.ptr<i8>, #blocked4x4>) {
+    %0 = ttg.convert_layout %arg0 : tensor<32x32x!tt.ptr<i8>, #blocked4x4> -> tensor<32x32x!tt.ptr<i8>, #linear4x4>
+    tt.return
+  }
+}

--- a/test/Conversion/tma_to_llvm.mlir
+++ b/test/Conversion/tma_to_llvm.mlir
@@ -177,8 +177,8 @@ tt.func @tma_multicast(%desc: !tt.tensordesc<tensor<64x64xf16, #shared1>>,
   // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster [$1], [$2, {$3, $4}], [$5], $6;"
   ttng.async_tma_copy_global_to_local %desc[%off_m, %off_n] %buffer, %bar, %true, %target_cta_mask : !tt.tensordesc<tensor<64x64xf16, #shared1>>, !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared1, #smem, mutable>
 
-  // non multicast version
-  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];"
+  // non multicast version: non-cluster barrier (no CGALayout) -> shared::cta
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];"
   ttng.async_tma_copy_global_to_local %desc[%off_m, %off_n] %buffer, %bar, %true : !tt.tensordesc<tensor<64x64xf16, #shared1>>, !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared1, #smem, mutable>
 
   tt.return

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -136,6 +136,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @dot_reg_operand_A
   // Generate a wgmma where the first operand is a struct.
+  // CHECK: %[[A_MOV0:.*]] = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "mov.b32 $0, $1;", "=r,r" %{{.*}} : (i32) -> i32
+  // CHECK: %[[A_MOV1:.*]] = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "mov.b32 $0, $1;", "=r,r" %{{.*}} : (i32) -> i32
+  // CHECK: %[[A_MOV2:.*]] = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "mov.b32 $0, $1;", "=r,r" %{{.*}} : (i32) -> i32
+  // CHECK: %[[A_MOV3:.*]] = llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "mov.b32 $0, $1;", "=r,r" %{{.*}} : (i32) -> i32
+  // CHECK: nvvm.wgmma.fence.aligned
+  // CHECK: %[[A_PACK0:.*]] = llvm.insertvalue %[[A_MOV0]], %{{.*}}[0] : !llvm.struct<(i32, i32, i32, i32)>
+  // CHECK: %[[A_PACK1:.*]] = llvm.insertvalue %[[A_MOV1]], %[[A_PACK0]][1] : !llvm.struct<(i32, i32, i32, i32)>
+  // CHECK: %[[A_PACK2:.*]] = llvm.insertvalue %[[A_MOV2]], %[[A_PACK1]][2] : !llvm.struct<(i32, i32, i32, i32)>
+  // CHECK: %[[A_PACK3:.*]] = llvm.insertvalue %[[A_MOV3]], %[[A_PACK2]][3] : !llvm.struct<(i32, i32, i32, i32)>
+  // CHECK: nvg.wgmma %[[A_PACK3]], %{{.*}}
   // CHECK: nvg.wgmma {{.*}} : (!llvm.struct<(i32, i32, i32, i32)>, i64, i1) -> !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32)>
   // CHECK: nvg.wgmma_wait_group %{{.*}} {pendings = 0 : i32} : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32)>
   tt.func @dot_reg_operand_A(%a: tensor<128x64xf16, #mma>, %b: !ttg.memdesc<64x64xf16, #shared, #smem>) {

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -190,11 +190,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local
   // CHECK: elect.sync
-  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
   // CHECK-NOT: cp.async.bulk.tensor.2d.shared
   // CHECK: return
   tt.func @tma_copy_global_to_local(%tma: !tt.tensordesc<tensor<128x128xf32, #shared1>>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
     ttng.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.tensordesc<tensor<128x128xf32, #shared1>>, !ttg.memdesc<1xi64, #shared0, #smem> -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// TMA copy with barrier mask zero: barrier has no CGALayout -> shared::cta
+#shared0_cta = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tma_copy_barrier_mask_zero
+  // CHECK: cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK-NOT: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier
+  tt.func @tma_copy_barrier_mask_zero(%tma: !tt.tensordesc<tensor<128x128xf32, #shared1>>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0_cta, #smem>, %pred: i1) {
+    ttng.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.tensordesc<tensor<128x128xf32, #shared1>>, !ttg.memdesc<1xi64, #shared0_cta, #smem> -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// TMA copy with barrier mask non-zero: barrier has CGALayout
+#shared0_cluster = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#shared1_cga = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CGALayout = [[0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tma_copy_barrier_mask_nonzero
+  // Barrier pointer is modified when barrier mask != 0
+  // CHECK: llvm.ptrtoint
+  // CHECK: llvm.and
+  // CHECK: llvm.inttoptr
+  // TMA uses shared::cluster when barrier mask is non-zero
+  // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK-NOT: cp.async.bulk.tensor.2d.shared::cta.global.mbarrier
+  tt.func @tma_copy_barrier_mask_nonzero(%tma: !tt.tensordesc<tensor<128x128xf32, #shared1_cga>>, %alloc: !ttg.memdesc<128x128xf32, #shared1_cga, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0_cluster, #smem>, %pred: i1) {
+    ttng.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.tensordesc<tensor<128x128xf32, #shared1_cga>>, !ttg.memdesc<1xi64, #shared0_cluster, #smem> -> !ttg.memdesc<128x128xf32, #shared1_cga, #smem, mutable>
     tt.return
   }
 }
@@ -207,7 +244,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local_im2col
   // CHECK: elect.sync
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // CHECK-NOT: cp.async.bulk.tensor.4d.shared
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col(%tma: !ttng.tensordesc_im2col<tensor<16x64xf32, #shared1>>, %alloc: !ttg.memdesc<16x64xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
@@ -234,16 +271,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // Verify 4 TMA messages are generated with offsets computed via shift-left by 8 (multiply by 256)
   // CHECK-DAG: llvm.mlir.constant(8 : i32)
   // Message 1 (copyIdx=0): offset = 0 << 8 = 0
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // Message 2 (copyIdx=1): offset = 1 << 8 = 256
   // CHECK: llvm.mlir.constant(1 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // Message 3 (copyIdx=2): offset = 2 << 8 = 512
   // CHECK: llvm.mlir.constant(2 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // Message 4 (copyIdx=3): offset = 3 << 8 = 768
   // CHECK: llvm.mlir.constant(3 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col_multi_msg(%tma: !ttng.tensordesc_im2col<tensor<64x1024xf32, #shared2>>, %alloc: !ttg.memdesc<64x1024xf32, #shared2, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
     %off_w = arith.constant 1 : i16
@@ -269,16 +306,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // Verify 4 TMA messages are generated with offsets computed via shift-left by 6 (multiply by 64)
   // CHECK-DAG: llvm.mlir.constant(6 : i32)
   // Message 1 (copyIdx=0): offset = 0 << 6 = 0
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // Message 2 (copyIdx=1): offset = 1 << 6 = 64
   // CHECK: llvm.mlir.constant(1 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // Message 3 (copyIdx=2): offset = 2 << 6 = 128
   // CHECK: llvm.mlir.constant(2 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // Message 4 (copyIdx=3): offset = 3 << 6 = 192
   // CHECK: llvm.mlir.constant(3 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col_multi_msg_swizzle(%tma: !ttng.tensordesc_im2col<tensor<64x256xf16, #shared_swz>>, %alloc: !ttg.memdesc<64x256xf16, #shared_swz, #smem_swz, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0_swz, #smem_swz>, %pred: i1) {
     %off_w = arith.constant 1 : i16

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -376,3 +376,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// NOTE: A/B/C/D's CGA-layout are not necessarilly equal when num-ctas > 1
+//  - D and C's should have the same CGA-layout, in this case [[0, 1], [1, 0]]
+//  - A and B's CGA-layout is derived from D-CGA-layout by clearing the elements,
+//    corresponding to the K dim, in the bases to zero. Hence, one have layout
+//    [[0, 0] [1, ]], the other one has layout [[0, 1], [0, 0]]
+//
+// CHECK-DAG: #mma{{[0-9]}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 0\], \[1, 0\]\]}}
+// CHECK-DAG: #mma{{[0-9]}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 1\], \[0, 0\]\]}}
+// CHECK-LABEL: test_multi_ctas
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [1, 0]]}>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_multi_ctas(
+    %0: tensor<32x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %1: tensor<64x32xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %2: tensor<32x32x!tt.ptr<i32>, #blocked>) {
+    %3 = arith.constant dense<0> : tensor<32x32xi32, #blocked>
+    %4 = tt.dot %0, %1, %3 : tensor<32x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x32xi32, #blocked>
+    tt.store %2, %4 : tensor<32x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-pipeline-padded-layout-small-tile-gfx950.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-padded-layout-small-tile-gfx950.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-pipeline="use_async_copy=1" | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [32, 32, 16], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: pipeline_padded_layout_gfx950
+  // CHECK-NOT: ttg.padded_shared
+  tt.func @pipeline_padded_layout_gfx950(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    // CHECK: ttg.async_wait %{{.*}}
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x16xi32, #blocked>
+    %2 = tt.broadcast %1 : tensor<1x16xi32, #blocked> -> tensor<16x16xi32, #blocked>
+    %3 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #blocked>
+    %4 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #blocked>
+    %5 = tt.addptr %3, %2 : tensor<16x16x!tt.ptr<f16>, #blocked>, tensor<16x16xi32, #blocked>
+    %6 = tt.addptr %4, %2 : tensor<16x16x!tt.ptr<f16>, #blocked>, tensor<16x16xi32, #blocked>
+
+    %7 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<16x16xf32, #mma>)  : i32 {
+      %9 = tt.load %5 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<16x16x!tt.ptr<f16>, #blocked>
+      %10 = tt.load %6 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<16x16x!tt.ptr<f16>, #blocked>
+      %11 = ttg.convert_layout %9 : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+      %12 = ttg.convert_layout %10 : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %13 = tt.dot %11, %12, %arg4 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<16x16xf32, #mma>
+      scf.yield %13 : tensor<16x16xf32, #mma>
+    } {tt.scheduled_max_stage = 1 : i32}
+
+    tt.return
+  }
+}

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -1,12 +1,23 @@
 // RUN: triton-opt --split-input-file %s --verify-diagnostics
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32} {
+  tt.func public @subslice_non_broadcast_cga_dim(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
+      // expected-error @+1 {{CTA dimensions}}
+      %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<8x8xf32, #shared, #smem>
+      tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32} {
-  tt.func public @non_trivial_block(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
-      %zero = arith.constant 0 : i32
-      // expected-error @+1 {{non-trivial block}}
-      %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<8x8xf32, #shared, #smem>
+  tt.func public @subslice_broadcasted_cga_output(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
+      // expected-error @+1 {{broadcasted CTA outputs}}
+      %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<4x16xf32, #shared, #smem>
       tt.return
   }
 }
@@ -97,17 +108,16 @@ tt.func public @result_1d_to_1d(%arg0: !ttg.memdesc<8xf32, #shared, #smem>) {
     tt.return
 }
 
+
 // -----
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 16, order = [0, 1]}>
 #smem = #ttg.shared_memory
-tt.func public @subview_along_swizzling(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
-    %zero = arith.constant 0 : i32
+tt.func public @subview_along_swizzling_pattern(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
     // expected-error @+1 {{swizzling pattern}}
     %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<8x4xf32, #shared, #smem>
     tt.return
 }
-
 
 // -----
 

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -83,6 +83,35 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 // -----
 
+#shared_cga_01 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#shared_cga_10 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [4, 0]], block = [[2, 0]]}, alignment = 16>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @subslice_non_trivial_block_cga_01
+  tt.func @subslice_non_trivial_block_cga_01(%arg0: !ttg.memdesc<8x16xf32, #shared_cga_01, #smem>) {
+    // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
+    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_01, #smem> -> !ttg.memdesc<4x16xf32, #shared_cga_01, #smem>
+    tt.return
+  }
+
+  // CHECK-LABEL: @subslice_non_trivial_block_cga_10
+  tt.func @subslice_non_trivial_block_cga_10(%arg0: !ttg.memdesc<8x16xf32, #shared_cga_10, #smem>) {
+    // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
+    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_10, #smem> -> !ttg.memdesc<8x8xf32, #shared_cga_10, #smem>
+    tt.return
+  }
+
+  // CHECK-LABEL: @subview_split_on_cta_dim
+  tt.func @subview_split_on_cta_dim(%arg0: !ttg.memdesc<8x4xf32, #shared, #smem>) {
+    // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
+    %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x4xf32, #shared, #smem> -> !ttg.memdesc<4x4xf32, #shared, #smem, 8x4>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.padded_shared<[4:+4] {offset=[[1, 0], [2, 0], [0, 1], [0, 2]], block=[]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "gfx950", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -168,14 +168,27 @@ class HIPBackend(BaseBackend):
         if HIPBackend.instrumentation:
             HIPBackend.instrumentation.load_dialects(ctx)
 
+    # is_within_2gb() needs to check for a torch subobject and this var tracks torch
+    # availability state: None - not tested, True - torch is present. Anything else -
+    # no torch available. First call to is_within_2gb() checks torch availability
+    # and caches it.
+    _torch_available: None | bool = None
+
     @staticmethod
     def is_within_2gb(arg):
-        import torch
+        if HIPBackend._torch_available is None:
+            try:
+                import torch
+                HIPBackend._torch_available = True
+            except ImportError:
+                HIPBackend._torch_available = False
+        elif HIPBackend._torch_available:
+            import torch
 
         MAX_INT_32 = 2**31 - 1
         if hasattr(arg, "ptr_range"):
             return arg.ptr_range() <= MAX_INT_32
-        if isinstance(arg, torch.Tensor) and hasattr(arg, "untyped_storage"):
+        if HIPBackend._torch_available and isinstance(arg, torch.Tensor) and hasattr(arg, "untyped_storage"):
             return arg.untyped_storage().size() <= MAX_INT_32
         return False
 

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -368,7 +368,7 @@ def wrap_handle_tensordesc(launcher, signature, tensordesc_metadata):
 
     def inner(*args):
         base_args = args[:-1]
-        kernel_metadata = base_args[7]
+        kernel_metadata = base_args[8]
         kernel_args = args[-1]
 
         final_kernel_args = []

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -362,6 +362,8 @@ def BufferLoadToLocalOp : TT_AMDGPU_Op<"buffer_load_to_local", [
     );
     let results = (outs TTG_AsyncToken:$token);
 
+    let hasVerifier = 1;
+
     let assemblyFormat = [{
       $ptr `[` $offsets `]` (`mask` `=` $mask^)? (`other` `=` $other^)? (`stride` `=` $stride^)?
       oilist(`cacheModifier` `=` $cache) `into` $dest

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -196,7 +196,7 @@ LogicalResult ExtractSliceOp::verify() {
 // operations. When extract_slice is used to extract a portion that exactly
 // matches one of the original tensors concatenated by a concat operation, we
 // can eliminate extract_slice op and use the original tensor directly.
-struct CononicalizeExtractSliceAndConcat
+struct CanonicalizeExtractSliceAndConcat
     : public mlir::OpRewritePattern<amdgpu::ExtractSliceOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -249,7 +249,7 @@ struct CononicalizeExtractSliceAndConcat
 
 void ExtractSliceOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  patterns.add<CononicalizeExtractSliceAndConcat>(context);
+  patterns.add<CanonicalizeExtractSliceAndConcat>(context);
 }
 
 LogicalResult UpcastMXFPOp::verify() {
@@ -630,6 +630,23 @@ LogicalResult ConcatOp::verify() {
   }
 
   return success();
+}
+
+LogicalResult BufferLoadToLocalOp::verify() {
+  auto mod = getOperation()->getParentOfType<ModuleOp>();
+  if (!mod)
+    return success();
+
+  auto arch = mlir::getAMDArch(mod);
+  // buffer_load_to_local is supported only on CDNA3 (gfx942) and CDNA4
+  // (gfx950) -- i.e. AMD::TargetInfo::supportsBufferLoadToLocal() returns
+  // isaFamily in {CDNA3, CDNA4}. We check the arch string directly here rather
+  // than constructing AMD::TargetInfo (or calling deduceISAFamily): both live
+  // in the TritonAMDGPUToLLVM lowering library, which this IR dialect library
+  // (TritonAMDGPUIR) must not depend on.
+  if (!arch || *arch == "gfx942" || *arch == "gfx950")
+    return success();
+  return emitError() << "BufferLoadToLocal unsupported on target architecture";
 }
 
 LogicalResult LocalLoadPackedTransposedOp::verify() {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -739,7 +739,9 @@ public:
       return failure();
 
     // TODO: v_perm could be useful for fp16 tensors.
-    if (srcTy.getElementType().getIntOrFloatBitWidth() != 8)
+    auto elemTy = srcTy.getElementType();
+    int bitwidth = elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
+    if (bitwidth != 8)
       return failure();
 
     // If destination or source is smaller than one register, skip.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -269,6 +269,62 @@ cvtScalePkUpcastFromFp8(Location loc, ConversionPatternRewriter &rewriter,
   return ret;
 }
 
+// Convert Ocp Fp8/Bf8 to Fp16/Bf16/Fp32 on CDNA4
+template <typename ConvertOp>
+static SmallVector<Value>
+cvtScalePk8UpcastFromFp8(Location loc, ConversionPatternRewriter &rewriter,
+                         const SmallVector<Value> &v) {
+  assert(v.size() == 8);
+  const size_t inSize = v.size();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+  Type vInTy = nullptr;
+  Type resTy = nullptr;
+  Type vResTy = nullptr;
+
+  const size_t intVecSize = (inSize * i8_ty.getWidth()) / i32_ty.getWidth();
+  vInTy = vec_ty(i32_ty, intVecSize);
+
+  if constexpr ((std::is_same_v<ConvertOp, ROCDL::CvtPkScalePk8F32Fp8Op>) ||
+                (std::is_same_v<ConvertOp, ROCDL::CvtPkScalePk8F32Bf8Op>)) {
+    resTy = f32_ty;
+  } else if constexpr ((std::is_same_v<ConvertOp,
+                                       ROCDL::CvtPkScalePk8F16Bf8Op>) ||
+                       (std::is_same_v<ConvertOp,
+                                       ROCDL::CvtPkScalePk8F16Fp8Op>)) {
+    resTy = f16_ty;
+  } else if constexpr ((std::is_same_v<ConvertOp,
+                                       ROCDL::CvtPkScalePk8Bf16Bf8Op>) ||
+                       (std::is_same_v<ConvertOp,
+                                       ROCDL::CvtPkScalePk8Bf16Fp8Op>)) {
+    resTy = bf16_ty;
+  }
+  assert(resTy != nullptr);
+
+  vResTy = vec_ty(resTy, inSize);
+
+  auto vI8InTy = vec_ty(i8_ty, inSize);
+
+  Value vI8In = b.undef(vI8InTy);
+  SmallVector<Value, 8> idx;
+  for (size_t i = 0; i < inSize; ++i) {
+    idx.push_back(b.i32_val(i));
+    vI8In = b.insert_element(vI8InTy, vI8In, v[i], idx[i]);
+  }
+  auto vIn = b.bitcast(vI8In, vInTy);
+
+  Value scale = b.i32_val(127);
+  IntegerAttr opscale = rewriter.getI32IntegerAttr(0b1000);
+
+  auto result = ConvertOp::create(rewriter, loc, vResTy, vIn, scale, opscale);
+  SmallVector<Value> ret(inSize);
+  for (auto [i, value] : llvm::enumerate(ret)) {
+    value = b.extract_element(resTy, result, idx[i]);
+  }
+
+  return ret;
+}
+
 // Convert Fp16/Bf16/Fp32 to OCP Fp8/Bf8 on CDNA4
 template <typename ConvertOp>
 static SmallVector<Value>
@@ -315,6 +371,63 @@ cvtScalePk4DowncastToFp8(Location loc, ConversionPatternRewriter &rewriter,
     ret[i] = b.extract_element(i8_ty, fp8x4Vec, idx);
   }
   return ret;
+}
+
+template <typename ConvertOp>
+static SmallVector<Value>
+cvtScalePk8DowncastToFp8(Location loc, ConversionPatternRewriter &rewriter,
+                         const SmallVector<Value> &v) {
+  const size_t inSize = 8;
+  assert(v.size() == inSize);
+
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+  Type vFPInTy = nullptr;
+  if constexpr ((std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Fp8F32Op>) ||
+                (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Bf8F32Op>)) {
+    vFPInTy = vec_ty(f32_ty, inSize);
+  } else if constexpr ((std::is_same_v<ConvertOp,
+                                       ROCDL::CvtScaleF32Pk8Fp8F16Op>) ||
+                       (std::is_same_v<ConvertOp,
+                                       ROCDL::CvtScaleF32Pk8Bf8F16Op>)) {
+    vFPInTy = vec_ty(f16_ty, inSize);
+  } else if constexpr ((std::is_same_v<ConvertOp,
+                                       ROCDL::CvtScaleF32Pk8Fp8Bf16Op>) ||
+                       (std::is_same_v<ConvertOp,
+                                       ROCDL::CvtScaleF32Pk8Bf8Bf16Op>)) {
+    vFPInTy = vec_ty(bf16_ty, inSize);
+  }
+
+  Type vFPResTy = nullptr;
+  Type vFPOutTy = nullptr;
+  if constexpr ((std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Fp8F32Op>) ||
+                (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Bf8F32Op>) ||
+                (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Fp8F16Op>) ||
+                (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Bf8F16Op>) ||
+                (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Fp8Bf16Op>) ||
+                (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32Pk8Bf8Bf16Op>)) {
+    vFPResTy = vec_ty(i32_ty, 2);
+    vFPOutTy = vec_ty(i8_ty, inSize);
+  }
+
+  // make sure that all types were selected
+  assert(vFPInTy && vFPResTy && vFPOutTy);
+
+  // convert SmallVector to llvm vector
+  Value inVec = b.undef(vFPInTy);
+  for (size_t i = 0; i < inSize; ++i) {
+    inVec = b.insert_element(vFPInTy, inVec, v[i], b.i32_val(i));
+  }
+
+  auto resVec = ConvertOp::create(rewriter, loc, vFPResTy, inVec, b.f32_val(1));
+  auto outVec = b.bitcast(resVec, vFPOutTy);
+
+  // convert llvm vector to SmallVector
+  SmallVector<Value> result(inSize);
+  for (size_t i = 0; i < inSize; i++) {
+    result[i] = b.extract_element(i8_ty, outVec, b.i32_val(i));
+  }
+  return result;
 }
 
 static SmallVector<Value>
@@ -365,6 +478,9 @@ Fp16_to_Fp8E5M2_RTNE_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp16_to_Fp8E5M2_RTNE_HW(Location loc, ConversionPatternRewriter &rewriter,
                         const SmallVector<Value> &v) {
+  if (v.size() == 8)
+    return cvtScalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Bf8F16Op>(loc,
+                                                                   rewriter, v);
   assert(v.size() == 4);
   return cvtScalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8F16Op>(loc, rewriter,
                                                                 v);
@@ -591,6 +707,9 @@ Fp16_to_Fp8E4M3FN_RTNE_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp16_to_Fp8E4M3FN_RTNE_HW(Location loc, ConversionPatternRewriter &rewriter,
                           const SmallVector<Value> &v) {
+  if (v.size() == 8)
+    return cvtScalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Fp8F16Op>(loc,
+                                                                   rewriter, v);
   assert(v.size() == 4);
   return cvtScalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8F16Op>(loc, rewriter,
                                                                 v);
@@ -667,19 +786,27 @@ static SmallVector<Value> cvtPkFp32ToF8(Location loc,
   return ret;
 }
 
-// Convert OCP Fp8 to Fp32 on CDNA4
+// Convert OCP Fp8 to Fp32 on CDNA4+
 static SmallVector<Value> Fp8E4M3FN_to_Fp32(Location loc,
                                             ConversionPatternRewriter &rewriter,
                                             const SmallVector<Value> &v) {
+  if (v.size() == 8) {
+    return cvtScalePk8UpcastFromFp8<ROCDL::CvtPkScalePk8F32Fp8Op>(loc, rewriter,
+                                                                  v);
+  }
   assert(v.size() == 4);
   return cvtScalePkUpcastFromFp8<ROCDL::CvtScaleF32PkF32Fp8Op>(loc, rewriter,
                                                                v);
 }
 
-// Convert OCP Bf8 to Fp32 on CDNA4
+// Convert OCP Bf8 to Fp32 on CDNA4+
 static SmallVector<Value> Fp8E5M2_to_Fp32(Location loc,
                                           ConversionPatternRewriter &rewriter,
                                           const SmallVector<Value> &v) {
+  if (v.size() == 8) {
+    return cvtScalePk8UpcastFromFp8<ROCDL::CvtPkScalePk8F32Bf8Op>(loc, rewriter,
+                                                                  v);
+  }
   assert(v.size() == 4);
   return cvtScalePkUpcastFromFp8<ROCDL::CvtScaleF32PkF32Bf8Op>(loc, rewriter,
                                                                v);
@@ -700,6 +827,9 @@ Fp32_to_Fp8E4M3FN_RTNE_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp32_to_Fp8E4M3FN_RTNE_HW(Location loc, ConversionPatternRewriter &rewriter,
                           const SmallVector<Value> &v) {
+  if (v.size() == 8)
+    return cvtScalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Fp8F32Op>(loc,
+                                                                   rewriter, v);
   assert(v.size() == 4);
   return cvtScalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8F32Op>(loc, rewriter,
                                                                 v);
@@ -792,6 +922,9 @@ Fp32_to_Fp8E5M2_RTNE_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp32_to_Fp8E5M2_RTNE_HW(Location loc, ConversionPatternRewriter &rewriter,
                         const SmallVector<Value> &v) {
+  if (v.size() == 8)
+    return cvtScalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Bf8F32Op>(loc,
+                                                                   rewriter, v);
   assert(v.size() == 4);
   return cvtScalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8F32Op>(loc, rewriter,
                                                                 v);
@@ -851,7 +984,7 @@ static ConverterT Fp32_to_Fp8E4M3FNUZ(AMD::ISAFamily isaFamily) {
   return isCDNA4(isaFamily) ? Fp32_to_Fp8E4M3FNUZ_SW : Fp32_to_Fp8E4M3FNUZ_HW;
 }
 
-// Nanoo Bf8 -> Fp32 on CDNA3
+// Nanoo Bf8 -> Fp32 on CDNA3+
 static SmallVector<Value>
 Fp8E5M2FNUZ_to_Fp32(Location loc, ConversionPatternRewriter &rewriter,
                     const SmallVector<Value> &v) {
@@ -859,7 +992,7 @@ Fp8E5M2FNUZ_to_Fp32(Location loc, ConversionPatternRewriter &rewriter,
   return cvtPkF8ToFp32<ROCDL::CvtPkF32Bf8Op>(loc, rewriter, v);
 }
 
-// Nanoo Fp8 -> Fp32 on CDNA3
+// Nanoo Fp8 -> Fp32 on CDNA3+
 static SmallVector<Value>
 Fp8E4M3FNUZ_to_Fp32(Location loc, ConversionPatternRewriter &rewriter,
                     const SmallVector<Value> &v) {
@@ -948,13 +1081,18 @@ Fp8E4M3FN_to_Fp16_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp8E4M3FN_to_Fp16_HW(Location loc, ConversionPatternRewriter &rewriter,
                      const SmallVector<Value> &v) {
+  if (v.size() == 8) {
+    return cvtScalePk8UpcastFromFp8<ROCDL::CvtPkScalePk8F16Fp8Op>(loc, rewriter,
+                                                                  v);
+  }
   assert(v.size() == 4);
   return cvtScalePkUpcastFromFp8<ROCDL::CvtScaleF32PkF16Fp8Op>(loc, rewriter,
                                                                v);
 }
 
 ConverterT Fp8E4M3FN_to_Fp16(AMD::ISAFamily isaFamily) {
-  return isCDNA4(isaFamily) ? Fp8E4M3FN_to_Fp16_HW : Fp8E4M3FN_to_Fp16_SW;
+  return isCDNA4OrHigher(isaFamily) ? Fp8E4M3FN_to_Fp16_HW
+                                    : Fp8E4M3FN_to_Fp16_SW;
 }
 
 // Ocp Bf8->Fp16
@@ -989,13 +1127,17 @@ Fp8E5M2_to_Fp16_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp8E5M2_to_Fp16_HW(Location loc, ConversionPatternRewriter &rewriter,
                    const SmallVector<Value> &v) {
+  if (v.size() == 8) {
+    return cvtScalePk8UpcastFromFp8<ROCDL::CvtPkScalePk8F16Bf8Op>(loc, rewriter,
+                                                                  v);
+  }
   assert(v.size() == 4);
   return cvtScalePkUpcastFromFp8<ROCDL::CvtScaleF32PkF16Bf8Op>(loc, rewriter,
                                                                v);
 }
 
 ConverterT Fp8E5M2_to_Fp16(AMD::ISAFamily isaFamily) {
-  return isCDNA4(isaFamily) ? Fp8E5M2_to_Fp16_HW : Fp8E5M2_to_Fp16_SW;
+  return isCDNA4OrHigher(isaFamily) ? Fp8E5M2_to_Fp16_HW : Fp8E5M2_to_Fp16_SW;
 }
 
 static SmallVector<Value>
@@ -1107,7 +1249,7 @@ static SmallVector<Value> Fp32_to_F16_RTNE(Location loc,
                                            MultipleOperandsRange operands,
                                            AMD::ISAFamily isaFamily) {
   // For CDNA4 we can potentially use packed v_cvt_pk_[b]f16_f32 instructions.
-  if (isCDNA4(isaFamily)) {
+  if (isCDNA4OrHigher(isaFamily)) {
     SmallVector<Value> inVals;
     size_t numElem = std::min(size_t(2), operands.size());
     inVals.reserve(numElem);
@@ -1276,13 +1418,17 @@ Fp8E5M2_to_Bf16_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp8E5M2_to_Bf16_HW(Location loc, ConversionPatternRewriter &rewriter,
                    const SmallVector<Value> &v) {
+  if (v.size() == 8) {
+    return cvtScalePk8UpcastFromFp8<ROCDL::CvtPkScalePk8Bf16Bf8Op>(loc,
+                                                                   rewriter, v);
+  }
   assert(v.size() == 4);
   return cvtScalePkUpcastFromFp8<ROCDL::CvtScaleF32PkBf16Bf8Op>(loc, rewriter,
                                                                 v);
 }
 
 ConverterT Fp8E5M2_to_Bf16(AMD::ISAFamily isaFamily) {
-  return isCDNA4(isaFamily) ? Fp8E5M2_to_Bf16_HW : Fp8E5M2_to_Bf16_SW;
+  return isCDNA4OrHigher(isaFamily) ? Fp8E5M2_to_Bf16_HW : Fp8E5M2_to_Bf16_SW;
 }
 
 // Bf16 -> OCP Bf8
@@ -1365,6 +1511,9 @@ Bf16_to_Fp8E5M2_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Bf16_to_Fp8E5M2_HW(Location loc, ConversionPatternRewriter &rewriter,
                    const SmallVector<Value> &v) {
+  if (v.size() == 8)
+    return cvtScalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Bf8Bf16Op>(
+        loc, rewriter, v);
   assert(v.size() == 4);
   return cvtScalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8Bf16Op>(loc, rewriter,
                                                                  v);
@@ -1389,6 +1538,9 @@ Bf16_to_Fp8E4M3FN_RTNE_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Bf16_to_Fp8E4M3FN_RTNE_HW(Location loc, ConversionPatternRewriter &rewriter,
                           const SmallVector<Value> &v) {
+  if (v.size() == 8)
+    return cvtScalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Fp8Bf16Op>(
+        loc, rewriter, v);
   assert(v.size() == 4);
   return cvtScalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8Bf16Op>(loc, rewriter,
                                                                  v);
@@ -1409,13 +1561,18 @@ Fp8E4M3FN_to_Bf16_SW(Location loc, ConversionPatternRewriter &rewriter,
 static SmallVector<Value>
 Fp8E4M3FN_to_Bf16_HW(Location loc, ConversionPatternRewriter &rewriter,
                      const SmallVector<Value> &v) {
+  if (v.size() == 8) {
+    return cvtScalePk8UpcastFromFp8<ROCDL::CvtPkScalePk8Bf16Fp8Op>(loc,
+                                                                   rewriter, v);
+  }
   assert(v.size() == 4);
   return cvtScalePkUpcastFromFp8<ROCDL::CvtScaleF32PkBf16Fp8Op>(loc, rewriter,
                                                                 v);
 }
 
 ConverterT Fp8E4M3FN_to_Bf16(AMD::ISAFamily isaFamily) {
-  return isCDNA4(isaFamily) ? Fp8E4M3FN_to_Bf16_HW : Fp8E4M3FN_to_Bf16_SW;
+  return isCDNA4OrHigher(isaFamily) ? Fp8E4M3FN_to_Bf16_HW
+                                    : Fp8E4M3FN_to_Bf16_SW;
 }
 
 // fp8e4m3fnuz to bf16
@@ -1754,6 +1911,48 @@ struct FpToFpOpConversion
     return srcMap.lookup(key);
   }
 
+  int getNumElements(
+      Type srcElementType, Type dstElementType,
+      std::optional<::mlir::triton::RoundingMode> roundingMode) const {
+    const bool isRTZ = roundingMode == RoundingMode::RTZ;
+    const bool isRTNE = roundingMode == RoundingMode::RTNE;
+
+    // numElements = 2 for :
+    // fp32 -> fp16 with RTZ
+    // fp32/fp16 -> nanoo fp8/bf8 on non-CDNA3
+    if ((isa<Float32Type>(srcElementType) && isa<Float16Type>(dstElementType) &&
+         isRTZ) ||
+        (isa<Float32Type, Float16Type>(srcElementType) &&
+         isa<Float8E4M3FNUZType, Float8E5M2FNUZType>(dstElementType) &&
+         isaFamily != AMD::ISAFamily::CDNA3)) {
+      return 2;
+    }
+
+    // special upcast for CDNA4
+    // nanoo fp8 -> bf16 on CDNA4 (numElements = 2)
+    if ((isaFamily == AMD::ISAFamily::CDNA4) &&
+        isa<Float8E4M3FNUZType>(srcElementType) && dstElementType.isBF16()) {
+      return 2;
+    }
+
+    // special downcast cases for GFX1250+
+    if ((isaFamily == AMD::ISAFamily::GFX1250) &&
+        ((isa<Float32Type, Float16Type, BFloat16Type>(srcElementType))) &&
+        ((isa<Float8E4M3FNType, Float8E5M2Type>(dstElementType))) && isRTNE) {
+      return 8;
+    }
+
+    // special upcast cases for GFX1250+
+    if ((isaFamily == AMD::ISAFamily::GFX1250) &&
+        ((isa<Float8E5M2Type, Float8E4M3FNType>(srcElementType))) &&
+        ((isa<Float16Type, BFloat16Type, Float32Type>(dstElementType)))) {
+      return 8;
+    }
+
+    // return default value
+    return 4;
+  }
+
   SmallVector<Value> createDestOps(triton::FpToFpOp op, OpAdaptor adaptor,
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
@@ -1777,20 +1976,8 @@ struct FpToFpOpConversion
           convertFp32ToBf16(loc, rewriter, operands[0][0], RoundingMode::RTZ)};
     }
 
-    size_t numElements = 4;
-    // numElements = 2 for :
-    // fp32 -> fp16 with RTZ
-    // fp32/fp16 -> nanoo fp8/bf8 on non-CDNA3
-    // nanoo fp8 -> bf16 on CDNA4
-    if ((llvm::isa<Float32Type>(srcElementType) &&
-         llvm::isa<Float16Type>(dstElementType) &&
-         roundingMode == RoundingMode::RTZ) ||
-        (llvm::isa<Float32Type, Float16Type>(srcElementType) &&
-         llvm::isa<Float8E4M3FNUZType, Float8E5M2FNUZType>(dstElementType) &&
-         isaFamily != AMD::ISAFamily::CDNA3) ||
-        (llvm::isa<Float8E4M3FNUZType>(srcElementType) &&
-         dstElementType.isBF16() && isCDNA4(isaFamily)))
-      numElements = 2;
+    size_t numElements =
+        getNumElements(srcElementType, dstElementType, roundingMode);
 
     // fp32 -> fp8 with rtne can be done in two steps:
     // - fp32 -> fp16 with rtne and
@@ -1801,13 +1988,13 @@ struct FpToFpOpConversion
     // 3. fp32 -> ocp fp8/bf8 on non-CDNA4: has software support
     bool useFP16IntermediateSrc =
         srcElementType.isF32() && !dstElementType.isF16() &&
-        !(isCDNA4(isaFamily) &&
+        !(isCDNA4OrHigher(isaFamily) &&
           (llvm::isa<Float8E4M3FNType, Float8E4M3FNUZType, Float8E5M2Type,
                      Float8E5M2FNUZType>(dstElementType))) &&
         !(isaFamily == AMD::ISAFamily::CDNA3 &&
           (llvm::isa<Float8E4M3FNUZType, Float8E5M2FNUZType>(
               dstElementType))) &&
-        !(!isCDNA4(isaFamily) &&
+        !(!isCDNA4OrHigher(isaFamily) &&
           (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(dstElementType)));
 
     // fp8/bf8->f32, if neither nanoo fp8/bf8 on CDNA3 nor ocp fp8/bf8 on CDNA4,
@@ -1815,7 +2002,7 @@ struct FpToFpOpConversion
     bool isDstFP32 = dstElementType.isF32();
     bool useFP16IntermediateDst =
         (isDstFP32 &&
-         !(isCDNA4(isaFamily) &&
+         !(isCDNA4OrHigher(isaFamily) &&
            (llvm::isa<Float8E4M3FNType, Float8E5M2Type>(srcElementType))) &&
          !(isaFamily == AMD::ISAFamily::CDNA3 &&
            (llvm::isa<Float8E4M3FNUZType, Float8E5M2FNUZType>(
@@ -1823,6 +2010,7 @@ struct FpToFpOpConversion
 
     Type srcType = useFP16IntermediateSrc ? f16_ty : srcElementType;
     Type dstType = useFP16IntermediateDst ? f16_ty : dstElementType;
+
     SmallVector<Value> inVals;
     inVals.reserve(std::min(numElements, operands.size()));
     for (unsigned i = 0; i < std::min(numElements, operands.size()); i++) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -735,6 +735,11 @@ bool TargetInfo::supportsDirectFromLdsStoreBitWidth(int bitWidth) const {
   return false;
 }
 
+bool TargetInfo::supportsBufferLoadToLocal() const {
+  return llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
+                            getISAFamily());
+}
+
 bool TargetInfo::supportsWaveId() const {
   return getISAFamily() == ISAFamily::RDNA4 ||
          getISAFamily() == ISAFamily::GFX1250;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -109,6 +109,7 @@ public:
   bool requiresAliasInfoForAsyncOps() const;
   bool supportsDirectToLdsLoadBitWidth(int bitWidth) const;
   bool supportsDirectFromLdsStoreBitWidth(int bitWidth) const;
+  bool supportsBufferLoadToLocal() const;
 
   bool supportsMultiCTALaunch() const;
   bool supportsTDM() const;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -603,9 +603,7 @@ struct TritonAMDGPUConvertToBufferOpsPass
                  ConvertTritonStoreToBufferStore>(context, assumptions,
                                                   axisInfoAnalysis, solver,
                                                   this->analyzeSmallTensorOfst);
-    // BufferLoadToLds is only supported on CDNA3 and CDNA4
-    if (llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
-                           targetInfo.getISAFamily())) {
+    if (targetInfo.supportsBufferLoadToLocal()) {
       patterns
           .add<ConvertTritonLoadToBufferLoad<ttg::AsyncCopyGlobalToLocalOp>>(
               context, assumptions, axisInfoAnalysis, solver,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -215,6 +215,10 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
   constexpr unsigned vecSize = 8; // in favor of dwordX4
   unsigned contigLanes = contigDim / vecSize;
   unsigned wrap = std::min(contigDim, 128u) / padding;
+  // wrap == 0 means padding > contigDim, which is not a valid configuration
+  if (wrap == 0) {
+    return {};
+  }
   unsigned requiredDim = warpSize / contigLanes * wrap;
   if (nonContigDim < requiredDim) {
     return {};

--- a/third_party/amd/python/examples/gluon/mxfp_fa_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_fa_gfx1250.py
@@ -26,7 +26,7 @@ from triton.experimental.gluon.language.amd import warp_pipeline_stage
 from triton.experimental.gluon.language.amd.gfx1250 import wmma_scaled
 from triton.experimental.gluon.language.amd.gfx1250 import tdm
 from triton.experimental.gluon.language.amd.gfx1250 import buffer_load, buffer_store
-from triton.experimental.gluon.language.amd.gfx1250 import async_copy as cp
+from triton.experimental.gluon.language.amd.gfx1250 import get_wmma_scale_layout
 
 # Handle imports for both pytest (module context) and direct execution
 try:
@@ -40,8 +40,15 @@ except ImportError:
 
 
 @gluon.constexpr_function
-def get_padded_shared_layout(shape, transposed=False):
-    """ Get a padded shared layout without back conflict for a given tensor shape. """
+def get_shared_layout(shape, padding=False, transposed=False):
+    """Default shared memory layout for TDM.
+
+    When `padding=True`, use a padded shared memory layout to reduce LDS bank
+    conflicts.
+    """
+    if not padding:
+        return ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+
     _, inner_dim = shape
     ## Here we assume the elements in LDS is 8-bit (for mxfp4, 2 mxfp4
     ## are packed in 1 8-bit elements). Then 256 elements can occupy
@@ -68,34 +75,255 @@ def get_wmma_layout(shape, num_warps, packed=False, preshuffled=False, warp_axis
     warps_per_cta = [num_warps, 1] if warp_axis == 0 else [1, num_warps]
     tiles_per_warp = [1, 1]
 
+    # When use preshuffle, we should try to increase tiles_per_warp to 2 for each dimension if possible.
     if preshuffled:
-        if shape[1] > 16 * warps_per_cta[1]:
+        if 16 * warps_per_cta[1] < shape[1]:
             tiles_per_warp[1] = 2
-        if shape[0] > 16 * warps_per_cta[0]:
+        if 16 * warps_per_cta[0] < shape[0]:
             tiles_per_warp[0] = 2
 
+    # Translate tiles_per_warp to reg_bases for linear layout
     reg_bases = []
     if tiles_per_warp[1] > 1:
         reg_bases.append([0, 1])
     if tiles_per_warp[0] > 1:
         reg_bases.append([1, 0])
 
+    # Translate warps_per_cta to warp_bases for linear layout
     warp_bases = []
     warps_n = 1
     tiles_n = tiles_per_warp[1]
     while warps_n < warps_per_cta[1]:
-        warp_bases.append([0, tiles_n])
+        if tiles_n * 16 < shape[1]:
+            warp_bases.append([0, tiles_n])
+            tiles_n <<= 1
+        else:
+            warp_bases.append([0, 0])
         warps_n <<= 1
-        tiles_n <<= 1
     warps_m = 1
     tiles_m = tiles_per_warp[0]
     while warps_m < warps_per_cta[0]:
-        warp_bases.append([tiles_m, 0])
+        if tiles_m * 16 < shape[0]:
+            warp_bases.append([tiles_m, 0])
+            tiles_m <<= 1
+        else:
+            warp_bases.append([0, 0])
         warps_m <<= 1
-        tiles_m <<= 1
 
     instr_shape = [16, 16, 128] if not packed else [16, 16, 64]
     return ttgl.amd.AMDWMMALayout(3, True, warp_bases, reg_bases, instr_shape)
+
+
+@gluon.constexpr_function
+def get_store_layout(shape, num_warps):
+    """
+    The goal of this layout is to store contiguous data as much as possible.
+    Assume we are storing fp32 data. The inner dim is head_sz, which can be
+    either 128 or 64. For the normal wmma layout for a block of 16x16, we have
+    2 threads in a row, and each thread stores 8 elements. We can follow
+    the "2 threads in a row" manner, so that for head_sz=128, each thread
+    stores 64 elements / 256B; for head_sz=64, each thread stores 32 elements /
+    128B.
+    """
+    dim_outer, dim_inner = shape
+
+    # Ensure storing 4 contiguous elements = 128 bits
+    reg = [[0, 1], [0, 2]]
+    tile_inner = 4
+    # Distribute 16 lanes for outer dim to align with the wmma layout
+    lane = [[1, 0], [2, 0], [4, 0], [8, 0]]
+    tile_outer = 16
+    # Let each lane store half of inner dim.
+    assert tile_inner <= dim_inner // 2
+    while tile_inner < dim_inner // 2:
+        reg.append([0, tile_inner])
+        tile_inner <<= 1
+    # Let the other 16 lanes store the other half of inner dim.
+    lane.append([0, tile_inner])
+    # Distribute warps for outer dim.
+    warp = []
+    while 2**len(warp) < num_warps:
+        if tile_outer < dim_outer:
+            warp.append([tile_outer, 0])
+            tile_outer <<= 1
+        else:
+            warp.append([0, 0])
+    # Repeat the layout to cover the rest of outer dim.
+    while tile_outer < dim_outer:
+        reg.append([tile_outer, 0])
+        tile_outer <<= 1
+
+    return ttgl.DistributedLinearLayout(reg, lane, warp, [], shape)
+
+
+def preshuffle_kv_scale(x: torch.Tensor):
+    """ Preshuffle scales for scaled wmma instruction.
+    In scaled wmma instruction, scales takes following shapes in global memory:
+    - a_scale: [M, K // 32]
+    - b_scale: [N, K // 32]
+
+    To have vectorized memory access, it's better to store scales in a packed block scale layout. In this
+    layout, scales are stored contiguously in the shape of:
+    - a_scale: [M // 32 // 4, K // 32 // 4, 32, 4, 4]
+    - b_scale: [N // 32 // 4, K // 32 // 4, 32, 4, 4]
+
+    The output shape will be
+    - a_scale: [M // preshuffle_factor, K * preshuffle_factor]
+    - b_scale: [N // preshuffle_factor, K * preshuffle_factor]
+
+    In this way, we can load scales from global memory in a more vectorized way. Then inside the kernel, we
+    permute and reshape scales to canonical shapes required by scaled wmma.
+    """
+    *prefix, non_k, k = x.shape
+    preshuffle_factor = min(128, non_k)
+    scale_kwidth = 4 if k >= 4 else k
+    num_chunk_m = non_k // preshuffle_factor
+    num_chunk_k = k // scale_kwidth
+
+    batch = math.prod(prefix)
+    x = x.reshape(batch, non_k, k)
+
+    x = x.view(batch, num_chunk_m, 4, preshuffle_factor // 4, num_chunk_k, scale_kwidth)
+    x = x.permute(0, 1, 4, 3, 2, 5).contiguous()
+    x = x.view(batch, num_chunk_m, k * preshuffle_factor)
+
+    return x.view(*prefix, non_k // preshuffle_factor, k * preshuffle_factor)
+
+
+@gluon.jit
+def unshuffle_kv_scale(buffer, block_shape):
+    """ Unshuffle scales inside the kernel to restore the original shape. """
+    non_k_dim: ttgl.constexpr = block_shape[0]
+    k_dim: ttgl.constexpr = block_shape[1]
+    preshuffle_factor: ttgl.constexpr = 128 if non_k_dim >= 128 else non_k_dim
+    block_non_k: ttgl.constexpr = non_k_dim // preshuffle_factor
+    kwidth: ttgl.constexpr = 4 if k_dim >= 4 else k_dim
+    return (buffer  #
+            .reshape((block_non_k, k_dim // kwidth, preshuffle_factor // 4, 4, kwidth))  #
+            .permute((0, 3, 2, 1, 4))  #
+            .reshape((non_k_dim, k_dim)))
+
+
+@gluon.jit
+def initialize_kv_scale_mem(base, shape, block_shape, num_buffers=1):
+    """
+    Initialize the MemoryUnit for K or V scales. This is a specialized version of MemoryUnit for K or V scales. It
+    considers the preshuffle for K, V scales and will deduce the correct block shape accordingly.
+    """
+    preshuffle_factor: ttgl.constexpr = 128 if block_shape[0] >= 128 else block_shape[0]
+    return MemoryUnit.initialize(  #
+        base=base,  #
+        shape=[shape[0] // preshuffle_factor, shape[1] * preshuffle_factor],  #
+        block_shape=[block_shape[0] // preshuffle_factor, block_shape[1] * preshuffle_factor],  #
+        num_buffers=num_buffers)
+
+
+@gluon.jit
+def get_kv_scale_buffer(mem, buf, block_shape, slice=None):
+    """
+    Get the shared memory buffer for K or V scales. This function should be used in pair with `initialize_kv_scale_mem`
+    to get the correct shared memory buffer by reshaping the preshuffled data.
+    """
+    smem = mem.smem
+    buffer = smem.index(buf)
+    buffer = unshuffle_kv_scale(buffer, block_shape)
+    if slice is not None:
+        buffer = buffer.slice(slice * (block_shape[0] // 2), (block_shape[0] // 2))
+    return buffer
+
+
+def preshuffle_kv(x: torch.Tensor, block_shape: list[int], sub_axis: int | None = None):
+    """ Preshuffle operand for better TDM performance.
+
+    To get better performance from TDM, we need to make sure the inner-most dim of the target block is 256B.
+    For a given tensor `x` with shape [*, dim_outer, dim_inner], we will reshape it into
+    [*, dim_outer * dim_inner // 256, 256] from the host side, then restore it inside the kernel (`unshuffle_kv`).
+
+    When we do subtile for the operand (sub_axis is not None), depending on the sub_axis:
+    - When `sub_axis==0`, we are subtiling the outer dim, this works the same as no subtile case.
+    - When `sub_axis==1`, we are subtiling the inner dim, we need to first permute subtiles before reshaping.
+    """
+    block_dim_outer, block_dim_inner = block_shape
+
+    elem_bits = x.element_size() * 8
+    assert elem_bits == 8  # Only support 8-bit elements for now
+    elems = 256
+    *prefix, dim_outer, dim_inner = x.shape
+    assert block_dim_inner == dim_inner
+
+    if sub_axis == 0 or sub_axis is None:
+        x = x.contiguous().reshape(*prefix, dim_outer * dim_inner // elems, elems)
+        return x
+    else:
+        assert sub_axis == 1
+        batch = math.prod(prefix)
+        x = x.reshape(batch, dim_outer, dim_inner)
+
+        x = x.view(batch, dim_outer // block_dim_outer, block_dim_outer, 2, dim_inner // 2)
+        x = x.permute(0, 1, 3, 2, 4).contiguous()
+        x = x.reshape(*prefix, dim_outer * dim_inner // elems, elems)
+        return x
+
+
+@gluon.jit
+def unshuffle_kv(buffer, block_shape, sub_axis=None):
+    """
+    Unshuffle the operand's shared memory to restore the original shape. Use in pair with `preshuffle_kv`. The
+    `block_shape` and `sub_axis` should be the same as those used in `preshuffle_kv` to get the correct original
+    shape.
+    """
+    if sub_axis is None:
+        return buffer.reshape(block_shape)
+    elif sub_axis == 0:
+        return buffer.reshape([block_shape[0] // 2, block_shape[1]])
+    else:
+        return buffer.reshape([block_shape[0], block_shape[1] // 2])
+
+
+@gluon.jit
+def initialize_kv_mem(base, shape, block_shape, num_buffers=1, subtile=False):
+    """
+    Initialize the MemoryUnit for K or V. This is a specialized version of MemoryUnit for K or V. It considers the
+    preshuffle and subtile logic, and will deduce the correct block shape accordingly. After preshuffling, a block
+    is always subtiled along the outer dim (sub_axis=0).
+    """
+    elem_bits: ttgl.constexpr = base.dtype.element_ty.primitive_bitwidth
+    ttgl.static_assert(elem_bits == 8)  # Only support 8-bit elements for now
+    elems: ttgl.constexpr = 256
+    return MemoryUnit.initialize(  #
+        base=base,  #
+        shape=[shape[0] * shape[1] // elems, elems],  #
+        block_shape=[block_shape[0] * block_shape[1] // elems, elems],  #
+        padding=True,  #
+        num_buffers=num_buffers,  #
+        sub_axis=0 if subtile else None)
+
+
+@gluon.jit
+def get_kv_buffer(mem, sub_idx, buf, block_shape, sub_axis=None):
+    """
+    Get the shared memory buffer from K/V memory unit. This function should be used in pair with `initialize_kv_mem` to
+    get the correct shared memory shape.
+    """
+    smem = mem.smem
+    buffer = smem.index((buf * 2 + sub_idx) if sub_axis is not None else buf)
+    buffer = unshuffle_kv(buffer, block_shape, sub_axis)
+    return buffer
+
+
+@gluon.jit
+def split_n(x, n: ttgl.constexpr = 2):
+    """
+    Recursively split a 2D tensor along the N-dimension into `n` pieces.
+    """
+    layout: ttgl.constexpr = x.type.layout
+    if n == 1:
+        return (x, )
+    else:
+        a0, a1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
+        a0 = ttgl.convert_layout(a0, layout, assert_trivial=True)
+        a1 = ttgl.convert_layout(a1, layout, assert_trivial=True)
+        return (split_n(a0, n // 2) + split_n(a1, n // 2))
 
 
 @aggregate
@@ -132,38 +360,28 @@ class MemoryBlock:
 @aggregate
 class MemoryUnit:
     """
-    MemoryUnit abstracts the logic of transferring data from global memory to shared memory for 2D tensor.
-    It supports 2 methods:
+    MemoryUnit abstracts the logic of transferring data from global memory to shared memory for a 2D tensor via TDM.
+    To help iterate in a loop, MemoryUnit supports loads with an `idx` argument, where `idx` selects the `idx`-th
+    block along the `axis` dimension. This requires one dimension of the tensor shape to equal the block size, and
+    the block then slides along the other dimension. For example, for a tensor with shape [1024, 256] and block size
+    [256, 256], we automatically determine `axis=0`, and `idx=0` means loading [0:256, :].
 
-    - `issue_tdm_load`: issue an async load via TDM from global memory to shared memory.
-    - `issue_async_copy`: issue an async copy from global memory to shared memory.
-
-    To help use a MemoryUnit in a loop, it supports load with an `idx` argument, meaning loading the `idx`-th block
-    along the `axis` dimension. This requires the one dimension of the tensor shape equals to the block size, and we
-    will slide the block along the other dimension. For example, for a tensor with shape [1024, 256] and block size
-    [256, 256], we will automatically determine `axis=0`, and `idx=0` means loading [0:256, :].
-
-    MemoryUnit also supports split a block into 2 sub-tiles along the `sub_axis` axis. For example, for a tensor with
+    MemoryUnit also supports splitting a block into 2 subtiles along the `sub_axis` axis. For example, for a tensor
+    with
     shape [1024, 256] and block size [512, 256]:
-    - when `sub_axis=0`, we will split the block into 2 sub-tiles with shape [256, 256]
-    - when `sub_axis=1`, we will split the block into 2 sub-tiles with shape [512, 128]
-    When `sub_axis` is set to None, no sub-tiling is performed.
+    - when `sub_axis=0`, we will split the block into 2 subtiles with shape [256, 256]
+    - when `sub_axis=1`, we will split the block into 2 subtiles with shape [512, 128]
+    When `sub_axis` is set to None, no subtiling is performed.
     """
     smem: ttgl.shared_memory_descriptor
     desc: tdm.tensor_descriptor
-    block: MemoryBlock
-
-    strides: ttgl.constexpr
     axis: ttgl.constexpr
     sub_axis: ttgl.constexpr
 
     @gluon.constexpr_function
-    def __init__(self, smem, desc, block,  #
-                 strides, axis, sub_axis):
+    def __init__(self, smem, desc, axis, sub_axis):
         self.smem = smem
         self.desc = desc
-        self.block = block
-        self.strides = ttgl.constexpr(strides)
         self.axis = ttgl.constexpr(axis)
         self.sub_axis = ttgl.constexpr(sub_axis)
 
@@ -171,40 +389,32 @@ class MemoryUnit:
     def _compute_axis_offset(self, idx, sub_idx):
         axis: ttgl.constexpr = self.axis
         sub_axis: ttgl.constexpr = self.sub_axis
+        block_shape: ttgl.constexpr = self.desc.block_shape
 
         if sub_axis is None:
-            step: ttgl.constexpr = self.block.shape[axis]
+            step: ttgl.constexpr = block_shape[axis]
             off = [idx * step, 0] if axis == 0 else [0, idx * step]
         else:
-            step: ttgl.constexpr = self.block.shape[axis]
+            step: ttgl.constexpr = block_shape[axis]
             if sub_axis == axis:
                 step *= 2
             off = [idx * step, 0] if axis == 0 else [0, idx * step]
 
-            sub_step: ttgl.constexpr = self.block.shape[sub_axis]
+            sub_step: ttgl.constexpr = block_shape[sub_axis]
             off = [off[0] + sub_idx * sub_step, off[1]] if sub_axis == 0 else \
                   [off[0], off[1] + sub_idx * sub_step]
 
         return off
 
     @gluon.jit
-    def issue_tdm_load(self, idx, sub_idx=0, buf=0, pred=1):
+    def issue_load(self, idx, sub_idx=0, buf=0, pred=1):
         axis_off = self._compute_axis_offset(idx, sub_idx)
         num_subtile: ttgl.constexpr = 2 if self.sub_axis is not None else 1
         smem = self.smem.index(buf * num_subtile + sub_idx)
         tdm.async_load(self.desc, axis_off, smem, pred)
 
     @gluon.jit
-    def issue_async_copy(self, idx, sub_idx=0, buf=0):
-        axis_off = self._compute_axis_offset(idx, sub_idx)
-        off = axis_off[0] * self.strides[0] + axis_off[1] * self.strides[1]
-        num_subtile: ttgl.constexpr = 2 if self.sub_axis is not None else 1
-        smem = self.smem.index(buf * num_subtile + sub_idx)
-        cp.global_to_shared(smem, self.block.ptr + off + self.block.offs)
-        cp.commit_group()
-
-    @gluon.jit
-    def initialize(base, shape, block_shape, layout, padding=False, num_buffers=1, sub_axis=None):
+    def initialize(base, shape, block_shape, padding=False, num_buffers=1, sub_axis=None):
         ttgl.static_assert(len(block_shape) == 2 and len(shape) == 2)
 
         dtype: ttgl.constexpr = base.dtype.element_ty
@@ -220,10 +430,7 @@ class MemoryUnit:
         sub_block_n: ttgl.constexpr = block_shape[1] if sub_axis != 1 else block_shape[1] // 2
         num_subtile: ttgl.constexpr = 2 if sub_axis is not None else 1
 
-        if padding:
-            smem_layout: ttgl.constexpr = get_padded_shared_layout([sub_block_m, sub_block_n])
-        else:
-            smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+        smem_layout: ttgl.constexpr = get_shared_layout([sub_block_m, sub_block_n], padding=padding)
 
         desc = tdm.make_tensor_descriptor(  #
             base=base,  #
@@ -231,173 +438,12 @@ class MemoryUnit:
             strides=[shape[1], 1],  #
             block_shape=[sub_block_m, sub_block_n],  #
             layout=smem_layout)
-        block = MemoryBlock.initialize(  #
-            base=base,  #
-            shape=shape,  #
-            block_shape=[sub_block_m, sub_block_n],  #
-            layout=layout)
         smem = ttgl.allocate_shared_memory(  #
             dtype,  #
             [num_buffers * num_subtile] + [sub_block_m, sub_block_n],  #
             smem_layout)
 
-        return MemoryUnit(smem, desc, block, [shape[1], 1], axis, sub_axis)
-
-
-def preshuffle_scale(x: torch.Tensor, preshuffle_factor: int = 128):
-    """ Preshuffle scales for scaled wmma instruction.
-    In scaled wmma instruction, scales takes following shapes in global memory:
-    - a_scale: [M, K // 32]
-    - b_scale: [N, K // 32]
-
-    To have vectorized memory access, it's better to store scales in a packed block scale layout. In this
-    layout, scales are stored contiguously in the shape of:
-    - a_scale: [M // 32 // 4, K // 32 // 4, 32, 4, 4]
-    - b_scale: [N // 32 // 4, K // 32 // 4, 32, 4, 4]
-
-    The output shape will be
-    - a_scale: [M // preshuffle_factor, K * preshuffle_factor]
-    - b_scale: [N // preshuffle_factor, K * preshuffle_factor]
-
-    In this way, we can load scales from global memory in a more vectorized way. Then inside the kernel, we
-    permute and reshape scales to canonical shapes required by scaled wmma.
-    """
-    *prefix, non_k, k = x.shape
-    scale_kwidth = 4 if k >= 4 else k
-    num_chunk_m = non_k // preshuffle_factor
-    num_chunk_k = k // scale_kwidth
-
-    batch = 1
-    for d in prefix:
-        batch *= d
-    x = x.reshape(batch, non_k, k)
-
-    x = x.view(batch, num_chunk_m, 4, preshuffle_factor // 4, num_chunk_k, scale_kwidth)
-    x = x.permute(0, 1, 4, 3, 2, 5).contiguous()
-    x = x.view(batch, num_chunk_m, k * preshuffle_factor)
-
-    return x.view(*prefix, non_k // preshuffle_factor, k * preshuffle_factor)
-
-
-@gluon.jit
-def unshuffle_scale(buffer, non_k_dim, k_dim, preshuffle_factor=128):
-    """ Unshuffle scales inside the kernel to restore the original shape. """
-    block_non_k: ttgl.constexpr = non_k_dim // preshuffle_factor
-    kwidth: ttgl.constexpr = 4 if k_dim >= 4 else k_dim
-    return (buffer  #
-            .reshape((block_non_k, k_dim // kwidth, preshuffle_factor // 4, 4, kwidth))  #
-            .permute((0, 3, 2, 1, 4))  #
-            .reshape((non_k_dim, k_dim)))
-
-
-def preshuffle_operand(x: torch.Tensor, block_shape: list[int], sub_axis: int | None = None):
-    """ Preshuffle operand for better TDM performance.
-
-    To get better performance from TDM, we need to make sure the inner-most dim of the target block is 256B.
-    For a given tensor `x` with shape [*, dim_outer, dim_inner], we will reshape it into
-    [*, dim_outer * dim_inner // 256, 256] from the host side, then restore it inside the kernel (`unshuffle_operand`).
-
-    When we do subtile for the operand (sux_axis is not None), depending on the sub_axis:
-    - When `sub_axis==0`, we are subtiling the outer dim, this works the same as no subtile case.
-    - When `sub_axis==1`, we are subtiling the inner dim, we need to first permute subtiles before reshaping.
-    """
-    block_dim_outer, block_dim_inner = block_shape
-
-    elem_bits = x.element_size() * 8
-    assert elem_bits == 8  # Only support 8-bit elements for now
-    elems = 256
-    *prefix, dim_outer, dim_inner = x.shape
-    assert block_dim_inner == dim_inner
-
-    if sub_axis == 0 or sub_axis is None:
-        x = x.contiguous().reshape(*prefix, dim_outer * dim_inner // elems, elems)
-        return x
-    else:
-        assert sub_axis == 1
-        batch = 1
-        for d in prefix:
-            batch *= d
-        x = x.reshape(batch, dim_outer, dim_inner)
-
-        x = x.view(batch, dim_outer // block_dim_outer, block_dim_outer, 2, dim_inner // 2)
-        x = x.permute(0, 1, 3, 2, 4).contiguous()
-        x = x.reshape(*prefix, dim_outer * dim_inner // elems, elems)
-        return x
-
-
-@gluon.jit
-def unshuffle_operand(buffer, block_shape, sub_axis=None):
-    """
-    Unshuffle the operand's shared memory to restore the original shape. Use in pair with `preshuffle_operand`. The
-    `block_shape` and `sub_axis` should be the same as those used in `preshuffle_operand` to get the correct original
-    shape.
-    """
-    if sub_axis is None:
-        return buffer.reshape(block_shape)
-    elif sub_axis == 0:
-        return buffer.reshape([block_shape[0] // 2, block_shape[1]])
-    else:
-        return buffer.reshape([block_shape[0], block_shape[1] // 2])
-
-
-@gluon.jit
-def initialize_kv_mem(base, shape, block_shape, layout, num_buffers=1, subtile=False):
-    """
-    Initialize the MemoryUnit for K or V. This is a specialized version of MemoryUnit for K or V. It considers the
-    preshuffle and subtile logic, and will deduce the correct block shape accordingly. After preshuffling, a block
-    is always subtiled along the outer dim (sub_axis=0).
-    """
-    elem_bits: ttgl.constexpr = base.dtype.element_ty.primitive_bitwidth
-    ttgl.static_assert(elem_bits == 8)  # Only support 8-bit elements for now
-    elems: ttgl.constexpr = 256
-    return MemoryUnit.initialize(  #
-        base=base,  #
-        shape=[shape[0] * shape[1] // elems, elems],  #
-        block_shape=[block_shape[0] * block_shape[1] // elems, elems],  #
-        layout=layout,  #
-        padding=True,  #
-        num_buffers=num_buffers,  #
-        sub_axis=0 if subtile else None)
-
-
-@gluon.jit
-def get_kv_buffer(mem, sub_idx, buf, block_shape, sub_axis=None):
-    """
-    Get the shared memory buffer from K/V memory unit. This function should be used in pair with `initialize_kv_mem` to
-    get the correct shared memory shape.
-    """
-    smem = mem.smem
-    buffer = smem.index((buf * 2 + sub_idx) if sub_axis is not None else buf)
-    buffer = unshuffle_operand(buffer, block_shape, sub_axis)
-    return buffer
-
-
-@gluon.jit
-def initialize_kv_scale_mem(base, shape, block_shape, layout, num_buffers=1, preshuffle_factor=128):
-    """
-    Initialize the MemoryUnit for K or V scales. This is a specialized version of MemoryUnit for K or V scales. It
-    considers the preshuffle for K, V scales and will deduce the correct block shape accordingly.
-    """
-    return MemoryUnit.initialize(  #
-        base=base,  #
-        shape=[shape[0] // preshuffle_factor, shape[1] * preshuffle_factor],  #
-        block_shape=[block_shape[0] // preshuffle_factor, block_shape[1] * preshuffle_factor],  #
-        layout=layout,  #
-        num_buffers=num_buffers)
-
-
-@gluon.jit
-def get_kv_scale_buffer(mem, buf, block_shape, preshuffle_factor=128, slice=None):
-    """
-    Get the shared memory buffer for K or V scales. This function should be used in pair with `initialize_kv_scale_mem`
-    to get the correct shared memory buffer by reshaping the preshuffled data.
-    """
-    smem = mem.smem
-    buffer = smem.index(buf)
-    buffer = unshuffle_scale(buffer, block_shape[0], block_shape[1], preshuffle_factor)
-    if slice is not None:
-        buffer = buffer.slice(slice * (block_shape[0] // 2), (block_shape[0] // 2))
-    return buffer
+        return MemoryUnit(smem, desc, axis, sub_axis)
 
 
 @aggregate
@@ -412,12 +458,13 @@ class AttentionConfigBase:
     HEAD_SZ: ttgl.constexpr
     BLOCK_M: ttgl.constexpr
     BLOCK_N: ttgl.constexpr
+    SPLIT_K: ttgl.constexpr
     NUM_BUFFERS: ttgl.constexpr
     NUM_WARPS: ttgl.constexpr
 
     @gluon.constexpr_function
     def __init__(self, Q_TYPE, KV_TYPE, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ, BLOCK_M, BLOCK_N,
-                 NUM_BUFFERS, NUM_WARPS):
+                 SPLIT_K, NUM_BUFFERS, NUM_WARPS):
         self.Q_TYPE = ttgl.constexpr(Q_TYPE)
         self.P_TYPE = ttgl.constexpr(Q_TYPE)
         self.KV_TYPE = ttgl.constexpr(KV_TYPE)
@@ -428,6 +475,7 @@ class AttentionConfigBase:
         self.HEAD_SZ = ttgl.constexpr(HEAD_SZ)
         self.BLOCK_M = ttgl.constexpr(BLOCK_M)
         self.BLOCK_N = ttgl.constexpr(BLOCK_N)
+        self.SPLIT_K = ttgl.constexpr(SPLIT_K)
         self.NUM_BUFFERS = ttgl.constexpr(NUM_BUFFERS)
         self.NUM_WARPS = ttgl.constexpr(NUM_WARPS)
 
@@ -447,6 +495,7 @@ class GlobalScaledAttentionConfig:
     p_layout: ttgl.constexpr
     v_layout: ttgl.constexpr
     acc_layout: ttgl.constexpr
+    store_layout: ttgl.constexpr
 
     # Whether the layout convert between QK and P is trivial - no data movement. This can happen when we use
     # k_width=8 for P and V, which effectively makes QK and P have the same layout.
@@ -458,13 +507,13 @@ class GlobalScaledAttentionConfig:
 
     @gluon.constexpr_function
     def __init__(self, Q_TYPE, KV_TYPE, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ,  #
-                 BLOCK_M, BLOCK_N, SUBTILE, PINGPONG, WARP_REDUCE, P_K_WIDTH, NUM_BUFFERS, NUM_WARPS):
+                 BLOCK_M, BLOCK_N, SPLIT_K, SUBTILE, PINGPONG, WARP_REDUCE, P_K_WIDTH, NUM_BUFFERS, NUM_WARPS):
         assert Q_TYPE in ['e5m2', 'e4m3']
         assert KV_TYPE in ['e5m2', 'e4m3']
         assert P_K_WIDTH == 16 or P_K_WIDTH == 8
 
         self.base = AttentionConfigBase(Q_TYPE, KV_TYPE, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ, BLOCK_M,
-                                        BLOCK_N, NUM_BUFFERS, NUM_WARPS)
+                                        BLOCK_N, SPLIT_K, NUM_BUFFERS, NUM_WARPS)
 
         warp_axis = 0 if not WARP_REDUCE else 1
         wmma_shape = [BLOCK_M, min(BLOCK_N, HEAD_SZ)]
@@ -477,6 +526,7 @@ class GlobalScaledAttentionConfig:
         self.p_layout = ttgl.constexpr(ttgl.DotOperandLayout(0, wmma_layout, P_K_WIDTH))
         self.v_layout = ttgl.constexpr(ttgl.DotOperandLayout(1, wmma_layout, P_K_WIDTH))
         self.acc_layout = ttgl.constexpr(wmma_layout)
+        self.store_layout = ttgl.constexpr(get_store_layout([BLOCK_M, HEAD_SZ], NUM_WARPS))
 
         self.CONVERT_LAYOUT_TRIVIAL = ttgl.constexpr(True if P_K_WIDTH == 8 and not WARP_REDUCE else False)
         self.SUBTILE = ttgl.constexpr(SUBTILE)
@@ -493,7 +543,6 @@ class GlobalScaledAttentionProgram:
     k_scale: ttgl.tensor
     v_mem: MemoryUnit
     v_scale: ttgl.tensor
-    o_blk: MemoryBlock
     # TODO: sm_scale should be a constexpr but the current llvm can not properly
     # fuse v_fma for literal operands, so we are using tensor here to ensure
     # it is in a register. Change it back to constexpr once the llvm is fixed.
@@ -504,7 +553,6 @@ class GlobalScaledAttentionProgram:
                  q_blk, q_scale,  #
                  k_mem, k_scale,  #
                  v_mem, v_scale,  #
-                 o_blk,  #
                  sm_scale):
         self.cfg = cfg
         self.q_blk = q_blk
@@ -513,11 +561,10 @@ class GlobalScaledAttentionProgram:
         self.k_scale = k_scale
         self.v_mem = v_mem
         self.v_scale = v_scale
-        self.o_blk = o_blk
         self.sm_scale = sm_scale
 
     @gluon.jit
-    def initialize(cfg, q_ptr, q_scale, k_ptr, k_scale, v_ptr, v_scale, o_ptr, sm_scale):
+    def initialize(cfg, q_ptr, q_scale, k_ptr, k_scale, v_ptr, v_scale, sm_scale):
         ttgl.static_assert(isinstance(cfg, GlobalScaledAttentionConfig))
 
         SEQLEN_K: ttgl.constexpr = cfg.SEQLEN_K
@@ -527,12 +574,18 @@ class GlobalScaledAttentionProgram:
         NUM_K_HEADS: ttgl.constexpr = cfg.NUM_K_HEADS
         BLOCK_M: ttgl.constexpr = cfg.BLOCK_M
         BLOCK_N: ttgl.constexpr = cfg.BLOCK_N
+        SPLIT_K: ttgl.constexpr = cfg.SPLIT_K
         NUM_BUFFERS: ttgl.constexpr = cfg.NUM_BUFFERS
         SUBTILE: ttgl.constexpr = cfg.SUBTILE
 
         off_h = ttgl.program_id(0)
-        off_m = ttgl.program_id(1)
+        off_m = ttgl.program_id(1) // SPLIT_K
+        off_s = ttgl.program_id(1) % SPLIT_K
         off_z = ttgl.program_id(2)
+
+        ttgl.static_assert(SPLIT_K > 0)
+        ttgl.static_assert(SEQLEN_K % SPLIT_K == 0)
+        SEQLEN_K_SPLIT: ttgl.constexpr = SEQLEN_K // SPLIT_K
 
         if SEQLEN_Q == SEQLEN_K:
             GROUP_SZ: ttgl.constexpr = NUM_Q_HEADS // NUM_K_HEADS
@@ -550,11 +603,6 @@ class GlobalScaledAttentionProgram:
                 block_shape=[BLOCK_M, HEAD_SZ],  #
                 layout=cfg.q_layout)
 
-            o_blk = MemoryBlock.initialize(  #
-                o_ptr + q_off,  #
-                shape=[SEQLEN_Q, HEAD_SZ],  #
-                block_shape=[BLOCK_M, HEAD_SZ],  #
-                layout=cfg.acc_layout)
         else:
             GROUP_SZ: ttgl.constexpr = NUM_Q_HEADS // NUM_K_HEADS
             NUM_GROUPS: ttgl.constexpr = NUM_K_HEADS
@@ -572,28 +620,21 @@ class GlobalScaledAttentionProgram:
                 block_shape=[BLOCK_M, HEAD_SZ],  #
                 layout=cfg.q_layout)
 
-            o_off = q_off
-            o_blk = MemoryBlock.initialize(  #
-                o_ptr + o_off,  #
-                shape=[GROUP_SZ, HEAD_SZ],  #
-                block_shape=[BLOCK_M, HEAD_SZ],  #
-                layout=cfg.acc_layout)
-
-        k_off = SEQLEN_K * HEAD_SZ * (NUM_K_HEADS * off_z + off_hk)
+        k_off = SEQLEN_K * HEAD_SZ * (NUM_K_HEADS * off_z + off_hk) + \
+                SEQLEN_K_SPLIT * HEAD_SZ * off_s
         k_mem = initialize_kv_mem(  #
             base=k_ptr + k_off,  #
-            shape=[SEQLEN_K, HEAD_SZ],  #
+            shape=[SEQLEN_K_SPLIT, HEAD_SZ],  #
             block_shape=[BLOCK_N, HEAD_SZ],  #
-            layout=cfg.k_layout,  #
             num_buffers=NUM_BUFFERS,  #
             subtile=SUBTILE)
 
-        v_off = k_off
+        v_off = SEQLEN_K * HEAD_SZ * (NUM_K_HEADS * off_z + off_hk) + \
+                SEQLEN_K_SPLIT * HEAD_SZ * off_s
         v_mem = initialize_kv_mem(  #
             base=v_ptr + v_off,  #
-            shape=[SEQLEN_K, HEAD_SZ],  #
+            shape=[SEQLEN_K_SPLIT, HEAD_SZ],  #
             block_shape=[BLOCK_N, HEAD_SZ],  #
-            layout=cfg.v_layout,  #
             num_buffers=NUM_BUFFERS,  #
             subtile=SUBTILE)
 
@@ -602,7 +643,6 @@ class GlobalScaledAttentionProgram:
             q_blk, q_scale,  #
             k_mem, k_scale,  #
             v_mem, v_scale,  #
-            o_blk,  #
             sm_scale)
 
     @gluon.jit
@@ -613,11 +653,11 @@ class GlobalScaledAttentionProgram:
 
     @gluon.jit
     def issue_global_load_k(self, idx, sub_idx=0, buf=0, pred=1):
-        self.k_mem.issue_tdm_load(idx, sub_idx, buf, pred)
+        self.k_mem.issue_load(idx, sub_idx, buf, pred)
 
     @gluon.jit
     def issue_global_load_v(self, idx, sub_idx=0, buf=0, pred=1):
-        self.v_mem.issue_tdm_load(idx, sub_idx, buf, pred)
+        self.v_mem.issue_load(idx, sub_idx, buf, pred)
 
     @gluon.jit
     def shared_load_k(self, sub_idx=0, buf=0):
@@ -663,12 +703,6 @@ class GlobalScaledAttentionProgram:
         return p
 
     @gluon.jit
-    def store_output(self, acc):
-        o_blk = self.o_blk
-        o = acc.to(o_blk.dtype)
-        buffer_store(o, o_blk.ptr, o_blk.offs, o_blk.mask)
-
-    @gluon.jit
     def concat_subtile(self, x, y):
         cfg = self.cfg
         layout: ttgl.constexpr = cfg.acc_layout
@@ -700,14 +734,15 @@ class GlobalScaledAttentionProgram:
         acc = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ], 0.0, ttgl.float32, cfg.acc_layout)
 
         sm_scale = self.sm_scale
-        q_scale = self.q_scale
-        k_scale = self.k_scale
+        q_scale = self.q_scale.to(ttgl.uint8)
+        k_scale = self.k_scale.to(ttgl.uint8)
         p_scale = 0x7F
-        v_scale = self.v_scale
+        p_scale = p_scale.to(ttgl.uint8)
+        v_scale = self.v_scale.to(ttgl.uint8)
 
         q = self.global_load_q()
 
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end):
             self.issue_global_load_k(i)
 
@@ -736,8 +771,7 @@ class GlobalScaledAttentionProgram:
 
             acc = self.compute_pv(p, p_scale, v, v_scale, acc)
 
-        acc = acc / l_i[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
     @gluon.jit
     def fwd_pipeline(self):
@@ -749,10 +783,11 @@ class GlobalScaledAttentionProgram:
         acc = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ], 0.0, ttgl.float32, cfg.acc_layout)
 
         sm_scale = self.sm_scale
-        q_scale = self.q_scale
-        k_scale = self.k_scale
+        q_scale = self.q_scale.to(ttgl.uint8)
+        k_scale = self.k_scale.to(ttgl.uint8)
         p_scale = 0x7F
-        v_scale = self.v_scale
+        p_scale = p_scale.to(ttgl.uint8)
+        v_scale = self.v_scale.to(ttgl.uint8)
 
         q = self.global_load_q()
 
@@ -788,7 +823,7 @@ class GlobalScaledAttentionProgram:
         # TODO: Ideally we should unroll the loop by 2 to remove the buffer index
         # update, but our current codegen in llvm does not perform well. Re-enable
         # unroll when fixed.
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end - 2):
             a = i % 2
             b = 1 - a
@@ -850,10 +885,7 @@ class GlobalScaledAttentionProgram:
 
         acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ................. iter end-1
 
-        # write output
-        l_recip = 1 / l_i
-        acc = acc * l_recip[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
     @gluon.jit
     def fwd_pipeline_subtile(self):
@@ -866,10 +898,11 @@ class GlobalScaledAttentionProgram:
         acc1 = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ // 2], 0.0, ttgl.float32, cfg.acc_layout)
 
         sm_scale = self.sm_scale
-        q_scale = self.q_scale
-        k_scale = self.k_scale
+        q_scale = self.q_scale.to(ttgl.uint8)
+        k_scale = self.k_scale.to(ttgl.uint8)
         p_scale = 0x7F
-        v_scale = self.v_scale
+        p_scale = p_scale.to(ttgl.uint8)
+        v_scale = self.v_scale.to(ttgl.uint8)
 
         q = self.global_load_q()
 
@@ -907,7 +940,7 @@ class GlobalScaledAttentionProgram:
         p0 = ttgl.exp2(qk0_shifted)
         self.issue_global_load_k(2, sub_idx=1, buf=0)  # ...................... iter 2
 
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end - 2):
             a = i % 2
             b = 1 - a
@@ -1007,12 +1040,178 @@ class GlobalScaledAttentionProgram:
 
         # write output
         acc = self.concat_subtile(acc0, acc1)
-        l_recip = 1 / l_i
-        acc = acc * l_recip[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
     @gluon.jit
-    def fwd_pipeline_pingpong(self):
+    def fwd_pipeline_subtile_pingpong(self):
+        cfg = self.cfg
+
+        m_i = ttgl.full([cfg.BLOCK_M], float("-inf"), ttgl.float32, ttgl.SliceLayout(1, cfg.acc_layout))
+        l_i = ttgl.full([cfg.BLOCK_M], 1.0, ttgl.float32, ttgl.SliceLayout(1, cfg.acc_layout))
+        zero = ttgl.full([cfg.BLOCK_M, cfg.BLOCK_N // 2], 0.0, ttgl.float32, cfg.acc_layout)
+        acc0 = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ // 2], 0.0, ttgl.float32, cfg.acc_layout)
+        acc1 = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ // 2], 0.0, ttgl.float32, cfg.acc_layout)
+
+        sm_scale = self.sm_scale
+        q_scale = self.q_scale.to(ttgl.uint8)
+        k_scale = self.k_scale.to(ttgl.uint8)
+        p_scale = 0x7F
+        p_scale = p_scale.to(ttgl.uint8)
+        v_scale = self.v_scale.to(ttgl.uint8)
+
+        q = self.global_load_q()
+
+        # pipeline prologue, iter -3
+        self.issue_global_load_k(0, sub_idx=0, buf=0)  # ...................... iter 0
+
+        self.issue_global_load_k(0, sub_idx=1, buf=0)  # ...................... iter 0
+
+        # pipeline prologue, iter -2
+        self.issue_global_load_k(1, sub_idx=0, buf=1)  # ...................... iter 1
+
+        self.async_wait(2)
+        k0 = self.shared_load_k(sub_idx=0, buf=0)  # .......................... iter 0
+        self.issue_global_load_k(1, sub_idx=1, buf=1)  # ...................... iter 1
+
+        # pipeline prologue, iter -1
+        qk0 = self.compute_qk(q, q_scale, k0, k_scale, zero)  # ............... iter 0
+        self.async_wait(2)
+        k1 = self.shared_load_k(sub_idx=1, buf=0)  # .......................... iter 0
+        self.issue_global_load_v(0, sub_idx=0, buf=0)  # ...................... iter 0
+
+        qk1 = self.compute_qk(q, q_scale, k1, k_scale, zero)  # ............... iter 0
+        self.issue_global_load_v(0, sub_idx=1, buf=0)  # ...................... iter 0
+
+        qk = self.concat_subtile(qk0, qk1)  # ................................. iter 0
+        m = ttgl.max(qk, 1)
+        m_ij = ttgl.maximum(m_i, m)
+        m_ij_scaled = m_ij * sm_scale
+        self.issue_global_load_k(2, sub_idx=0, buf=0)  # ...................... iter 2
+
+        self.async_wait(4)
+        k0 = self.shared_load_k(sub_idx=0, buf=1)  # .......................... iter 1
+        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]  # ................ iter 0
+        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
+        p0 = ttgl.exp2(qk0_shifted)
+        self.issue_global_load_k(2, sub_idx=1, buf=0)  # ...................... iter 2
+
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
+        for i in range(0, end - 2):
+            a = i % 2
+            b = 1 - a
+            pred = i - end + 3
+            pred = (pred >> 31) & 1
+
+            with warp_pipeline_stage("compute0"):
+                qk0 = self.compute_qk(q, q_scale, k0, k_scale, zero)  # ....... iter i+1
+                p1 = ttgl.exp2(qk1_shifted)  # ................................ iter i
+                m_diff = m_i * sm_scale - m_ij_scaled
+                m_i = m_ij
+                alpha = ttgl.exp2(m_diff)
+                acc0 = acc0 * alpha[:, None]
+                acc1 = acc1 * alpha[:, None]
+
+            self.async_wait(4)
+            with warp_pipeline_stage("memory0"):
+                k1 = self.shared_load_k(sub_idx=1, buf=b)  # .................. iter i+1
+                self.issue_global_load_v(i + 1, sub_idx=0, buf=b)  # .......... iter i+1
+
+            with warp_pipeline_stage("compute1"):
+                qk1 = self.compute_qk(q, q_scale, k1, k_scale, zero)  # ....... iter i+1
+                p = self.concat_subtile(p0, p1)  # ............................ iter i
+                l_ij = ttgl.sum(p, 1)
+                l_i = l_i * alpha + l_ij
+                p = self.downcast_p(p)
+
+            self.async_wait(4)
+            with warp_pipeline_stage("memory1"):
+                v0 = self.shared_load_v(sub_idx=0, buf=a)  # .................. iter i
+                self.issue_global_load_v(i + 1, sub_idx=1, buf=b)  # .......... iter i+1
+
+            with warp_pipeline_stage("compute2"):
+                acc0 = self.compute_pv(p, p_scale, v0, v_scale, acc0)  # ...... iter i
+                qk = self.concat_subtile(qk0, qk1)  # ......................... iter i+1
+                m = ttgl.max(qk, 1)
+                m_ij = ttgl.maximum(m_i, m)
+                m_ij_scaled = m_ij * sm_scale
+
+            self.async_wait(4)
+            with warp_pipeline_stage("memory2"):
+                v1 = self.shared_load_v(sub_idx=1, buf=a)  # .................. iter i
+                self.issue_global_load_k(i + 3, sub_idx=0, buf=b, pred=pred)  # iter i+3
+
+            with warp_pipeline_stage("compute3"):
+                acc1 = self.compute_pv(p, p_scale, v1, v_scale, acc1)  # ...... iter i
+                qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]  # ........ iter i+1
+                qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
+                p0 = ttgl.exp2(qk0_shifted)
+
+            self.async_wait(4)
+            with warp_pipeline_stage("memory3"):
+                k0 = self.shared_load_k(sub_idx=0, buf=a)  # .................. iter i+2
+                self.issue_global_load_k(i + 3, sub_idx=1, buf=b, pred=pred)  # iter i+3
+
+        # pipeline epilogue iter end-2
+        self.issue_global_load_v(end - 1, sub_idx=0, buf=1)
+        self.issue_global_load_v(end - 1, sub_idx=1, buf=1)
+
+        p1 = ttgl.exp2(qk1_shifted)
+        m_diff = m_i * sm_scale - m_ij_scaled
+        m_i = m_ij
+        alpha = ttgl.exp2(m_diff)
+        acc0 = acc0 * alpha[:, None]
+        acc1 = acc1 * alpha[:, None]
+
+        p = self.concat_subtile(p0, p1)
+        l_ij = ttgl.sum(p, 1)
+        l_i = l_i * alpha + l_ij
+        p = self.downcast_p(p)
+
+        self.async_wait(2)
+        v0 = self.shared_load_v(sub_idx=0, buf=0)
+        v1 = self.shared_load_v(sub_idx=1, buf=0)
+
+        acc0 = self.compute_pv(p, p_scale, v0, v_scale, acc0)
+        acc1 = self.compute_pv(p, p_scale, v1, v_scale, acc1)
+
+        # pipeline epilogue iter end-1
+        qk0 = self.compute_qk(q, q_scale, k0, k_scale, zero)
+        k1 = self.shared_load_k(sub_idx=1, buf=1)
+        qk1 = self.compute_qk(q, q_scale, k1, k_scale, zero)
+
+        qk = self.concat_subtile(qk0, qk1)
+        m = ttgl.max(qk, 1)
+        m_ij = ttgl.maximum(m_i, m)
+        m_ij_scaled = m_ij * sm_scale
+
+        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
+        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
+        p0 = ttgl.exp2(qk0_shifted)
+
+        p1 = ttgl.exp2(qk1_shifted)
+        m_diff = m_i * sm_scale - m_ij_scaled
+        m_i = m_ij
+        alpha = ttgl.exp2(m_diff)
+        acc0 = acc0 * alpha[:, None]
+        acc1 = acc1 * alpha[:, None]
+
+        p = self.concat_subtile(p0, p1)
+        l_ij = ttgl.sum(p, 1)
+        l_i = l_i * alpha + l_ij
+        p = self.downcast_p(p)
+
+        self.async_wait(0)
+        v0 = self.shared_load_v(sub_idx=0, buf=1)
+        v1 = self.shared_load_v(sub_idx=1, buf=1)
+
+        acc0 = self.compute_pv(p, p_scale, v0, v_scale, acc0)
+        acc1 = self.compute_pv(p, p_scale, v1, v_scale, acc1)
+
+        acc = self.concat_subtile(acc0, acc1)
+        return acc, l_i, m_i
+
+    @gluon.jit
+    def fwd_pipeline_triplebuf(self):
         cfg = self.cfg
 
         m_i = ttgl.full([cfg.BLOCK_M], float("-inf"), ttgl.float32, ttgl.SliceLayout(1, cfg.acc_layout))
@@ -1021,124 +1220,114 @@ class GlobalScaledAttentionProgram:
         acc = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ], 0.0, ttgl.float32, cfg.acc_layout)
 
         sm_scale = self.sm_scale
-        q_scale = self.q_scale
-        k_scale = self.k_scale
+        q_scale = self.q_scale.to(ttgl.uint8)
+        k_scale = self.k_scale.to(ttgl.uint8)
         p_scale = 0x7F
-        v_scale = self.v_scale
+        p_scale = p_scale.to(ttgl.uint8)
+        v_scale = self.v_scale.to(ttgl.uint8)
 
         q = self.global_load_q()
 
-        # pipeline prologue, iter -3
+        # pipeline prologue, iter -4
         self.issue_global_load_k(0, buf=0)  # ................................. iter 0
 
-        # pipeline prologue, iter -2
+        # pipeline prologue, iter -3
         self.issue_global_load_k(1, buf=1)  # ................................. iter 1
 
-        self.async_wait(1)  # ................................................. iter 0
-        k = self.shared_load_k(buf=0)
+        # pipeline prologue, iter -2
         self.issue_global_load_v(0, buf=0)  # ................................. iter 0
+
+        self.async_wait(2)
+        self.issue_global_load_k(2, buf=2)  # ................................. iter 2
+        k = self.shared_load_k(buf=0)  # ...................................... iter 0
 
         # pipeline prologue, iter -1
         qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ................. iter 0
 
-        self.issue_global_load_k(2, buf=0)  # ................................. iter 2
+        self.issue_global_load_v(1, buf=1)  # ................................. iter 1
 
         m = ttgl.max(qk, 1)  # ................................................ iter 0
         m_ij = ttgl.maximum(m_i, m)
         m_ij_scaled = m_ij * sm_scale
-        qk0, qk1 = self.split_subtile(qk)
-        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
-        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
-        p0 = ttgl.exp2(qk0_shifted)
+        qk_shifted = qk * sm_scale - m_ij_scaled[:, None]
+        p = ttgl.exp2(qk_shifted)
         m_diff = m_i * sm_scale - m_ij_scaled
         alpha = ttgl.exp2(m_diff)
         m_i = m_ij
 
-        self.async_wait(2)  # ................................................. iter 0
-        k = self.shared_load_k(buf=1)
-        self.issue_global_load_v(1, buf=1)  # ................................. iter 1
+        self.async_wait(3)
+        self.issue_global_load_k(3, buf=0)  # ................................. iter 3
+        k = self.shared_load_k(buf=1)  # ...................................... iter 1
 
         # main loop from 0 to end-3
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end - 2):
-            a = i % 2
-            b = 1 - a
-            pred = i - end + 3
+            a = i % 3
+            b = (i + 1) % 3
+            c = (i + 2) % 3
+            pred = i - end + 4
             pred = (pred >> 31) & 1
 
-            with warp_pipeline_stage("stage0"):
-                qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ......... iter i+1
-                p1 = ttgl.exp2(qk1_shifted)  # ................................ iter i
-                p = self.concat_subtile(p0, p1)
-                l_ij = ttgl.sum(p, 1)
-                acc = acc * alpha[:, None]
-                l_i = l_i * alpha + l_ij
-                p = self.downcast_p(p)
+            qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ............. iter i+1
+            l_ij = ttgl.sum(p, 1)  # .......................................... iter i
+            acc = acc * alpha[:, None]
+            l_i = l_i * alpha + l_ij
+            p = self.downcast_p(p)
 
-            self.async_wait(2)
-            with warp_pipeline_stage("stage1"):
-                v = self.shared_load_v(buf=a)  # .............................. iter i
-                self.issue_global_load_k(i + 3, buf=b, pred=pred)  # .......... iter i+3
+            self.async_wait(3)
+            self.issue_global_load_v(i + 2, buf=c)  # ......................... iter i+2
+            v = self.shared_load_v(buf=a)  # .................................. iter i
 
-            with warp_pipeline_stage("stage2"):
-                acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ......... iter i
-                m = ttgl.max(qk, 1)  # ........................................ iter i+1
-                m_ij = ttgl.maximum(m_i, m)
-                m_ij_scaled = m_ij * sm_scale
-                qk0, qk1 = self.split_subtile(qk)
-                qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
-                qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
-                p0 = ttgl.exp2(qk0_shifted)
-                m_diff = m_i * sm_scale - m_ij_scaled
-                alpha = ttgl.exp2(m_diff)
-                m_i = m_ij
+            acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ............. iter i
+            m = ttgl.max(qk, 1)  # ............................................ iter i+1
+            m_ij = ttgl.maximum(m_i, m)
+            m_ij_scaled = m_ij * sm_scale
+            qk_shifted = qk * sm_scale - m_ij_scaled[:, None]
+            p = ttgl.exp2(qk_shifted)
+            m_diff = m_i * sm_scale - m_ij_scaled
+            alpha = ttgl.exp2(m_diff)
+            m_i = m_ij
 
-            self.async_wait(2)
-            with warp_pipeline_stage("stage3"):
-                k = self.shared_load_k(buf=a)  # .............................. iter i+2
-                self.issue_global_load_v(i + 2, buf=a)  # ..................... iter i+2
+            self.async_wait(3)
+            self.issue_global_load_k(i + 4, buf=b, pred=pred)  # .............. iter i+4
+            k = self.shared_load_k(buf=c)  # .................................. iter i+2
 
         # pipeline epilogue, iter end-2
+        a = (end - 1) % 3
+
         qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ................. iter end-1
-        p1 = ttgl.exp2(qk1_shifted)  # ........................................ iter end-2
-        p = self.concat_subtile(p0, p1)
-        l_ij = ttgl.sum(p, 1)
+        l_ij = ttgl.sum(p, 1)  # .............................................. iter end-2
         acc = acc * alpha[:, None]
         l_i = l_i * alpha + l_ij
         p = self.downcast_p(p)
 
-        self.async_wait(2)  # ................................................. iter end-2
-        v = self.shared_load_v(buf=0)
+        self.async_wait(1)
+        v = self.shared_load_v(buf=a)  # ...................................... iter end-2
 
         acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ................. iter end-2
         m = ttgl.max(qk, 1)  # ................................................ iter end-1
         m_ij = ttgl.maximum(m_i, m)
         m_ij_scaled = m_ij * sm_scale
-        qk0, qk1 = self.split_subtile(qk)
-        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
-        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
-        p0 = ttgl.exp2(qk0_shifted)
+        qk_shifted = qk * sm_scale - m_ij_scaled[:, None]
+        p = ttgl.exp2(qk_shifted)
         m_diff = m_i * sm_scale - m_ij_scaled
         alpha = ttgl.exp2(m_diff)
         m_i = m_ij
 
         # pipeline epilogue, iter end-1
-        p1 = ttgl.exp2(qk1_shifted)  # ........................................ iter end-1
-        p = self.concat_subtile(p0, p1)
+        a = (end - 1) % 3
+
         l_ij = ttgl.sum(p, 1)
         acc = acc * alpha[:, None]
         l_i = l_i * alpha + l_ij
         p = self.downcast_p(p)
 
-        self.async_wait(0)  # ................................................. iter end-1
-        v = self.shared_load_v(buf=1)
+        self.async_wait(0)
+        v = self.shared_load_v(buf=a)  # ...................................... iter end-1
 
         acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ................. iter end-1
 
-        # write output
-        l_recip = 1 / l_i
-        acc = acc * l_recip[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
 
 # ===-----------------------------------------------------------------------===#
@@ -1164,6 +1353,7 @@ class BlockScaledAttentionConfig:
     v_scale_layout: ttgl.constexpr
 
     acc_layout: ttgl.constexpr
+    store_layout: ttgl.constexpr
 
     # Whether to use per-block scaling for P; if False, use an uniform scale of 1.0.
     P_SCALING: ttgl.constexpr
@@ -1180,15 +1370,15 @@ class BlockScaledAttentionConfig:
 
     @gluon.constexpr_function
     def __init__(self, Q_TYPE, KV_TYPE, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ, P_SCALING,  #
-                 BLOCK_M, BLOCK_N, SUBTILE, PINGPONG, WARP_REDUCE, P_K_WIDTH, NUM_BUFFERS, NUM_WARPS):
+                 BLOCK_M, BLOCK_N, SPLIT_K, SUBTILE, PINGPONG, WARP_REDUCE, P_K_WIDTH, NUM_BUFFERS, NUM_WARPS):
         assert Q_TYPE in ['e5m2', 'e4m3']
         assert KV_TYPE in ['e5m2', 'e4m3', 'e2m1']
         assert P_K_WIDTH == 16 or (KV_TYPE != 'e2m1' and P_K_WIDTH == 8)
 
         KV_PACK_DIV: ttgl.constexpr = 2 if KV_TYPE == 'e2m1' else 1
         self.KV_PACK_DIV = ttgl.constexpr(KV_PACK_DIV)
-        self.base = AttentionConfigBase(Q_TYPE, KV_TYPE, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ, BLOCK_M,
-                                        BLOCK_N, NUM_BUFFERS, NUM_WARPS)
+        self.base = AttentionConfigBase(Q_TYPE, KV_TYPE, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ,  #
+                                        BLOCK_M, BLOCK_N, SPLIT_K, NUM_BUFFERS, NUM_WARPS)
 
         warp_axis = 0 if not WARP_REDUCE else 1
         wmma_shape = [BLOCK_M, min(BLOCK_N, HEAD_SZ)]
@@ -1209,16 +1399,13 @@ class BlockScaledAttentionConfig:
             self.v_layout = ttgl.constexpr(ttgl.DotOperandLayout(1, wmma_layout, k_width=P_K_WIDTH))
             self.CONVERT_LAYOUT_TRIVIAL = ttgl.constexpr(True if P_K_WIDTH == 8 and not WARP_REDUCE else False)
 
-        self.q_scale_layout = ttgl.constexpr(
-            ttgl.amd.gfx1250.get_wmma_scale_layout(self.q_layout, [BLOCK_M, HEAD_SZ // 32]))
-        self.k_scale_layout = ttgl.constexpr(
-            ttgl.amd.gfx1250.get_wmma_scale_layout(self.k_layout, [BLOCK_N, HEAD_SZ // 32]))
-        self.p_scale_layout = ttgl.constexpr(
-            ttgl.amd.gfx1250.get_wmma_scale_layout(self.p_layout, [BLOCK_M, BLOCK_N // 32]))
-        self.v_scale_layout = ttgl.constexpr(
-            ttgl.amd.gfx1250.get_wmma_scale_layout(self.v_layout, [HEAD_SZ, BLOCK_N // 32]))
+        self.q_scale_layout = ttgl.constexpr(get_wmma_scale_layout(self.q_layout, [BLOCK_M, HEAD_SZ // 32]))
+        self.k_scale_layout = ttgl.constexpr(get_wmma_scale_layout(self.k_layout, [BLOCK_N, HEAD_SZ // 32]))
+        self.p_scale_layout = ttgl.constexpr(get_wmma_scale_layout(self.p_layout, [BLOCK_M, BLOCK_N // 32]))
+        self.v_scale_layout = ttgl.constexpr(get_wmma_scale_layout(self.v_layout, [HEAD_SZ, BLOCK_N // 32]))
 
         self.acc_layout = ttgl.constexpr(wmma_layout)
+        self.store_layout = ttgl.constexpr(get_store_layout([BLOCK_M, HEAD_SZ], NUM_WARPS))
 
         self.P_SCALING = ttgl.constexpr(P_SCALING)
         self.SUBTILE = ttgl.constexpr(SUBTILE)
@@ -1235,7 +1422,6 @@ class BlockScaledAttentionProgram:
     k_scale_mem: MemoryUnit
     v_mem: MemoryUnit
     v_scale_mem: MemoryUnit
-    o_blk: MemoryBlock
     # TODO: sm_scale should be a constexpr but the current llvm can not properly
     # fuse v_fma for literal operands, so we are using tensor here to ensure
     # it is in a register. Change it back to constexpr once the llvm is fixed.
@@ -1246,7 +1432,6 @@ class BlockScaledAttentionProgram:
                  q_blk, q_scale_blk,  #
                  k_mem, k_scale_mem,  #
                  v_mem, v_scale_mem,  #
-                 o_blk,  #
                  sm_scale):
         self.cfg = cfg
         self.q_blk = q_blk
@@ -1255,11 +1440,10 @@ class BlockScaledAttentionProgram:
         self.k_scale_mem = k_scale_mem
         self.v_mem = v_mem
         self.v_scale_mem = v_scale_mem
-        self.o_blk = o_blk
         self.sm_scale = sm_scale
 
     @gluon.jit
-    def initialize(cfg, q_ptr, q_scale_ptr, k_ptr, k_scale_ptr, v_ptr, v_scale_ptr, o_ptr, sm_scale):
+    def initialize(cfg, q_ptr, q_scale_ptr, k_ptr, k_scale_ptr, v_ptr, v_scale_ptr, sm_scale):
         ttgl.static_assert(isinstance(cfg, BlockScaledAttentionConfig))
 
         SEQLEN_K: ttgl.constexpr = cfg.SEQLEN_K
@@ -1269,18 +1453,21 @@ class BlockScaledAttentionProgram:
         NUM_K_HEADS: ttgl.constexpr = cfg.NUM_K_HEADS
         BLOCK_M: ttgl.constexpr = cfg.BLOCK_M
         BLOCK_N: ttgl.constexpr = cfg.BLOCK_N
+        SPLIT_K: ttgl.constexpr = cfg.SPLIT_K
         NUM_BUFFERS: ttgl.constexpr = cfg.NUM_BUFFERS
         SUBTILE: ttgl.constexpr = cfg.SUBTILE
         KV_PACK_DIV: ttgl.constexpr = cfg.KV_PACK_DIV
 
         off_h = ttgl.program_id(0)
-        off_m = ttgl.program_id(1)
+        off_m = ttgl.program_id(1) // SPLIT_K
+        off_s = ttgl.program_id(1) % SPLIT_K
         off_z = ttgl.program_id(2)
 
-        if SEQLEN_Q == SEQLEN_K:
-            GROUP_SZ: ttgl.constexpr = NUM_Q_HEADS // NUM_K_HEADS
-            off_hk = off_h // GROUP_SZ
+        ttgl.static_assert(SPLIT_K > 0)
+        ttgl.static_assert(SEQLEN_K % SPLIT_K == 0)
+        SEQLEN_K_SPLIT: ttgl.constexpr = SEQLEN_K // SPLIT_K
 
+        if SEQLEN_Q == SEQLEN_K:
             # q_off =
             #   off_z * stride_z (NUM_Q_HEADS * SEQLEN_Q * HEAD_SZ) +
             #   off_h * stride_h (SEQLEN_Q * HEAD_SZ) +
@@ -1305,16 +1492,9 @@ class BlockScaledAttentionProgram:
                 block_shape=[BLOCK_M, HEAD_SZ // 32],  #
                 layout=cfg.q_scale_layout)
 
-            o_off = q_off
-            o_blk = MemoryBlock.initialize(  #
-                o_ptr + o_off,  #
-                shape=[SEQLEN_Q, HEAD_SZ],  #
-                block_shape=[BLOCK_M, HEAD_SZ],  #
-                layout=cfg.acc_layout)
         else:
             GROUP_SZ: ttgl.constexpr = NUM_Q_HEADS // NUM_K_HEADS
             NUM_GROUPS: ttgl.constexpr = NUM_K_HEADS
-            off_hk = off_h
 
             # q_off =
             #   off_z * stride_z (NUM_GROUPS * GROUP_SZ * HEAD_SZ) +
@@ -1340,54 +1520,49 @@ class BlockScaledAttentionProgram:
                 block_shape=[BLOCK_M, HEAD_SZ // 32],  #
                 layout=cfg.q_scale_layout)
 
-            o_off = q_off
-            o_blk = MemoryBlock.initialize(  #
-                o_ptr + o_off,  #
-                shape=[GROUP_SZ, HEAD_SZ],  #
-                block_shape=[BLOCK_M, HEAD_SZ],  #
-                layout=cfg.acc_layout)
-
-        k_off = SEQLEN_K * (HEAD_SZ // KV_PACK_DIV) * (NUM_K_HEADS * off_z + off_hk)
+        k_off = SEQLEN_K * (HEAD_SZ // KV_PACK_DIV) * (NUM_K_HEADS * off_z + off_h) + \
+                SEQLEN_K_SPLIT * (HEAD_SZ // KV_PACK_DIV) * off_s
         k_mem = initialize_kv_mem(  #
             base=k_ptr + k_off,  #
-            shape=[SEQLEN_K, HEAD_SZ // KV_PACK_DIV],  #
+            shape=[SEQLEN_K_SPLIT, HEAD_SZ // KV_PACK_DIV],  #
             block_shape=[BLOCK_N, HEAD_SZ // KV_PACK_DIV],  #
-            layout=cfg.k_layout,  #
             num_buffers=NUM_BUFFERS,  #
             subtile=SUBTILE)
 
-        k_scale_off = (SEQLEN_K) * (HEAD_SZ // 32) * (NUM_K_HEADS * off_z + off_hk)
+        k_scale_off = (SEQLEN_K) * (HEAD_SZ // 32) * (NUM_K_HEADS * off_z + off_h) + \
+                      SEQLEN_K_SPLIT * (HEAD_SZ // 32) * off_s
         k_scale_mem = initialize_kv_scale_mem(  #
             base=k_scale_ptr + k_scale_off,  #
-            shape=[SEQLEN_K, HEAD_SZ // 32],  #
+            shape=[SEQLEN_K_SPLIT, HEAD_SZ // 32],  #
             block_shape=[BLOCK_N, HEAD_SZ // 32],  #
-            layout=cfg.k_scale_layout,  #
             num_buffers=NUM_BUFFERS)
 
-        v_off = (SEQLEN_K // KV_PACK_DIV) * HEAD_SZ * (NUM_K_HEADS * off_z + off_hk)
+        v_off = (SEQLEN_K // KV_PACK_DIV) * HEAD_SZ * (NUM_K_HEADS * off_z + off_h) + \
+                (SEQLEN_K_SPLIT // KV_PACK_DIV) * HEAD_SZ * off_s
         v_mem = initialize_kv_mem(  #
             base=v_ptr + v_off,  #
-            shape=[SEQLEN_K // KV_PACK_DIV, HEAD_SZ],  #
+            shape=[SEQLEN_K_SPLIT // KV_PACK_DIV, HEAD_SZ],  #
             block_shape=[BLOCK_N // KV_PACK_DIV, HEAD_SZ],  #
-            layout=cfg.v_layout,  #
             num_buffers=NUM_BUFFERS,  #
             subtile=SUBTILE)
 
-        v_scale_off = (SEQLEN_K // 32) * (HEAD_SZ) * (NUM_K_HEADS * off_z + off_hk)
+        # NOTE: The actual shape for V scale after preshuffle is [1, SEQLEN_K // 32 * PRESHUFFLE_FACTOR], where the
+        # the `PRESHUFFLE_FACTOR` is determined by HEAD_SZ. When doing split-k, we need split the total length of
+        # `SEQLEN_K_SPLIT // 32 * PRESHUFFLE_FACTOR`, so we need to factor the `PRESHUFFLE_FACTOR` into the offset.
+        v_preshuffle_factor: ttgl.constexpr = HEAD_SZ
+        v_scale_off = (SEQLEN_K // 32) * (HEAD_SZ) * (NUM_K_HEADS * off_z + off_h) + \
+                      (SEQLEN_K_SPLIT // 32) * v_preshuffle_factor * off_s
         v_scale_mem = initialize_kv_scale_mem(  #
             base=v_scale_ptr + v_scale_off,  #
-            shape=[HEAD_SZ, SEQLEN_K // 32],  #
+            shape=[HEAD_SZ, SEQLEN_K_SPLIT // 32],  #
             block_shape=[HEAD_SZ, BLOCK_N // 32],  #
-            layout=cfg.v_scale_layout,  #
-            num_buffers=NUM_BUFFERS,  #
-            preshuffle_factor=128 if HEAD_SZ == 128 else 64)
+            num_buffers=NUM_BUFFERS)
 
         return BlockScaledAttentionProgram(  #
             cfg,  #
             q_blk, q_scale_blk,  #
             k_mem, k_scale_mem,  #
             v_mem, v_scale_mem,  #
-            o_blk,  #
             sm_scale)
 
     @gluon.jit
@@ -1404,19 +1579,19 @@ class BlockScaledAttentionProgram:
 
     @gluon.jit
     def issue_global_load_k(self, idx, sub_idx=0, buf=0, pred=1):
-        self.k_mem.issue_tdm_load(idx, sub_idx, buf, pred)
+        self.k_mem.issue_load(idx, sub_idx, buf, pred)
 
     @gluon.jit
     def issue_global_load_v(self, idx, sub_idx=0, buf=0, pred=1):
-        self.v_mem.issue_tdm_load(idx, sub_idx, buf, pred)
+        self.v_mem.issue_load(idx, sub_idx, buf, pred)
 
     @gluon.jit
     def issue_global_load_k_scale(self, idx, buf=0, pred=1):
-        self.k_scale_mem.issue_tdm_load(idx, buf=buf, pred=pred)
+        self.k_scale_mem.issue_load(idx, buf=buf, pred=pred)
 
     @gluon.jit
     def issue_global_load_v_scale(self, idx, buf=0, pred=1):
-        self.v_scale_mem.issue_tdm_load(idx, buf=buf, pred=pred)
+        self.v_scale_mem.issue_load(idx, buf=buf, pred=pred)
 
     @gluon.jit
     def shared_load_k(self, sub_idx=0, buf=0):
@@ -1454,8 +1629,7 @@ class BlockScaledAttentionProgram:
         cfg = self.cfg
 
         v_scale_buffer = get_kv_scale_buffer(self.v_scale_mem, buf,  #
-                                             [cfg.HEAD_SZ, cfg.BLOCK_N // 32],
-                                             preshuffle_factor=128 if cfg.HEAD_SZ == 128 else 64,  #
+                                             [cfg.HEAD_SZ, cfg.BLOCK_N // 32],  #
                                              slice=slice)
         v_scale = v_scale_buffer.load(cfg.v_scale_layout)
         return v_scale
@@ -1487,12 +1661,6 @@ class BlockScaledAttentionProgram:
         p = ttgl.convert_layout(p, cfg.p_layout, cfg.CONVERT_LAYOUT_TRIVIAL)
 
         return p, p_scale
-
-    @gluon.jit
-    def store_output(self, acc):
-        o_blk = self.o_blk
-        o = acc.to(o_blk.dtype)
-        buffer_store(o, o_blk.ptr, o_blk.offs, o_blk.mask)
 
     @gluon.jit
     def async_wait(self, count):
@@ -1565,7 +1733,7 @@ class BlockScaledAttentionProgram:
         q = self.global_load_q()
         q_scale = self.global_load_q_scale()
 
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end):
             self.issue_global_load_k(i)
             self.issue_global_load_k_scale(i)
@@ -1598,8 +1766,7 @@ class BlockScaledAttentionProgram:
 
             acc = self.compute_pv(p, p_scale, v, v_scale, acc)
 
-        acc = acc / l_i[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
     @gluon.jit
     def fwd_pipeline(self):
@@ -1653,7 +1820,7 @@ class BlockScaledAttentionProgram:
         # TODO: Ideally we should unroll the loop by 2 to remove the buffer index
         # update, but our current codegen in llvm does not perform well. Re-enable
         # unroll when fixed.
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end - 2):
             a = i % 2
             b = 1 - a
@@ -1721,10 +1888,7 @@ class BlockScaledAttentionProgram:
 
         acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ................. iter end-1
 
-        # write output
-        l_recip = 1 / l_i
-        acc = acc * l_recip[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
     @gluon.jit
     def fwd_pipeline_subtile(self):
@@ -1784,7 +1948,7 @@ class BlockScaledAttentionProgram:
         p0 = ttgl.exp2(qk0_shifted)
         self.issue_global_load_k(2, sub_idx=1, buf=0)  # ...................... iter 2
 
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end - 2):
             a = i % 2
             b = 1 - a
@@ -1899,12 +2063,193 @@ class BlockScaledAttentionProgram:
 
         # write output
         acc = self.concat_subtile(acc0, acc1)
-        l_recip = 1 / l_i
-        acc = acc * l_recip[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
     @gluon.jit
-    def fwd_pipeline_pingpong(self):
+    def fwd_pipeline_subtile_pingpong(self):
+        cfg = self.cfg
+
+        m_i = ttgl.full([cfg.BLOCK_M], float("-inf"), ttgl.float32, ttgl.SliceLayout(1, cfg.acc_layout))
+        l_i = ttgl.full([cfg.BLOCK_M], 1.0, ttgl.float32, ttgl.SliceLayout(1, cfg.acc_layout))
+        zero = ttgl.full([cfg.BLOCK_M, cfg.BLOCK_N // 2], 0.0, ttgl.float32, cfg.acc_layout)
+        acc0 = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ // 2], 0.0, ttgl.float32, cfg.acc_layout)
+        acc1 = ttgl.full([cfg.BLOCK_M, cfg.HEAD_SZ // 2], 0.0, ttgl.float32, cfg.acc_layout)
+        sm_scale = self.sm_scale
+
+        q = self.global_load_q()
+        q_scale = self.global_load_q_scale()
+
+        # pipeline prologue, iter -3
+        self.issue_global_load_k(0, sub_idx=0, buf=0)  # ...................... iter 0
+        self.issue_global_load_k_scale(0, buf=0)  # ........................... iter 0
+
+        self.issue_global_load_k(0, sub_idx=1, buf=0)  # ...................... iter 0
+
+        # pipeline prologue, iter -2
+        self.issue_global_load_k(1, sub_idx=0, buf=1)  # ...................... iter 1
+        self.issue_global_load_k_scale(1, buf=1)  # ........................... iter 1
+
+        self.async_wait(5)
+        k0 = self.shared_load_k(sub_idx=0, buf=0)  # .......................... iter 0
+        k0_scale = self.shared_load_k_scale(buf=0, slice=0)
+        k1_scale = self.shared_load_k_scale(buf=0, slice=1)
+        self.issue_global_load_k(1, sub_idx=1, buf=1)  # ...................... iter 1
+
+        # pipeline prologue, iter -1
+        qk0 = self.compute_qk(q, q_scale, k0, k0_scale, zero)  # .............. iter 0
+        self.async_wait(5)
+        k1 = self.shared_load_k(sub_idx=1, buf=0)  # .......................... iter 0
+        self.issue_global_load_v(0, sub_idx=0, buf=0)  # ...................... iter 0
+        self.issue_global_load_v_scale(0, buf=0)  # ........................... iter 0
+
+        qk1 = self.compute_qk(q, q_scale, k1, k1_scale, zero)  # .............. iter 0
+        self.issue_global_load_v(0, sub_idx=1, buf=0)  # ...................... iter 0
+
+        qk = self.concat_subtile(qk0, qk1)  # ................................. iter 0
+        m = ttgl.max(qk, 1)
+        m_ij = ttgl.maximum(m_i, m)
+        m_ij_scaled = m_ij * sm_scale
+        self.issue_global_load_k(2, sub_idx=0, buf=0)  # ...................... iter 2
+        self.issue_global_load_k_scale(2, buf=0)  # ........................... iter 2
+
+        self.async_wait(7)
+        k0 = self.shared_load_k(sub_idx=0, buf=1)  # .......................... iter 1
+        k0_scale = self.shared_load_k_scale(buf=1, slice=0)
+        k1_scale = self.shared_load_k_scale(buf=1, slice=1)
+        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]  # ................ iter 0
+        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
+        p0 = ttgl.exp2(qk0_shifted)
+        self.issue_global_load_k(2, sub_idx=1, buf=0)  # ...................... iter 2
+
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
+        for i in range(0, end - 2):
+            a = i % 2
+            b = 1 - a
+            pred = i - end + 3
+            pred = (pred >> 31) & 1
+
+            with warp_pipeline_stage("compute0"):
+                qk0 = self.compute_qk(q, q_scale, k0, k0_scale, zero)  # ...... iter i+1
+                p1 = ttgl.exp2(qk1_shifted)  # ................................ iter i
+                m_diff = m_i * sm_scale - m_ij_scaled
+                m_i = m_ij
+                alpha = ttgl.exp2(m_diff)
+                acc0 = acc0 * alpha[:, None]
+                acc1 = acc1 * alpha[:, None]
+
+            self.async_wait(7)
+            with warp_pipeline_stage("memory0"):
+                k1 = self.shared_load_k(sub_idx=1, buf=b)  # .................. iter i+1
+                self.issue_global_load_v(i + 1, sub_idx=0, buf=b)  # .......... iter i+1
+                self.issue_global_load_v_scale(i + 1, buf=b)  # ............... iter i+1
+
+            with warp_pipeline_stage("compute1"):
+                qk1 = self.compute_qk(q, q_scale, k1, k1_scale, zero)  # ...... iter i+1
+                p = self.concat_subtile(p0, p1)  # ............................ iter i
+                l_ij = ttgl.sum(p, 1)
+                l_i = l_i * alpha + l_ij
+                p, p_scale = self.downcast_p(p)
+
+            self.async_wait(7)
+            with warp_pipeline_stage("memory1"):
+                v0 = self.shared_load_v(sub_idx=0, buf=a)  # .................. iter i
+                v0_scale = self.shared_load_v_scale(buf=a, slice=0)  # ........ iter i
+                v1_scale = self.shared_load_v_scale(buf=a, slice=1)
+                self.issue_global_load_v(i + 1, sub_idx=1, buf=b)  # .......... iter i+1
+
+            with warp_pipeline_stage("compute2"):
+                acc0 = self.compute_pv(p, p_scale, v0, v0_scale, acc0)  # ..... iter i
+                qk = self.concat_subtile(qk0, qk1)  # ......................... iter i+1
+                m = ttgl.max(qk, 1)
+                m_ij = ttgl.maximum(m_i, m)
+                m_ij_scaled = m_ij * sm_scale
+
+            self.async_wait(7)
+            with warp_pipeline_stage("memory2"):
+                v1 = self.shared_load_v(sub_idx=1, buf=a)  # .................. iter i
+                self.issue_global_load_k(i + 3, sub_idx=0, buf=b, pred=pred)  # iter i+3
+                self.issue_global_load_k_scale(i + 3, buf=b, pred=pred)  # .... iter i+3
+
+            with warp_pipeline_stage("compute3"):
+                acc1 = self.compute_pv(p, p_scale, v1, v1_scale, acc1)  # ..... iter i
+                qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]  # ........ iter i+1
+                qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
+                p0 = ttgl.exp2(qk0_shifted)
+
+            self.async_wait(7)
+            with warp_pipeline_stage("memory3"):
+                k0 = self.shared_load_k(sub_idx=0, buf=a)  # .................. iter i+2
+                k0_scale = self.shared_load_k_scale(buf=a, slice=0)  # ........ iter i+2
+                k1_scale = self.shared_load_k_scale(buf=a, slice=1)
+                self.issue_global_load_k(i + 3, sub_idx=1, buf=b, pred=pred)  # iter i+3
+
+        # pipeline epilogue iter end-2
+        self.issue_global_load_v(end - 1, sub_idx=0, buf=1)
+        self.issue_global_load_v(end - 1, sub_idx=1, buf=1)
+        self.issue_global_load_v_scale(end - 1, buf=1)
+
+        p1 = ttgl.exp2(qk1_shifted)
+        m_diff = m_i * sm_scale - m_ij_scaled
+        m_i = m_ij
+        alpha = ttgl.exp2(m_diff)
+        acc0 = acc0 * alpha[:, None]
+        acc1 = acc1 * alpha[:, None]
+
+        p = self.concat_subtile(p0, p1)
+        l_ij = ttgl.sum(p, 1)
+        l_i = l_i * alpha + l_ij
+        p, p_scale = self.downcast_p(p)
+
+        self.async_wait(5)
+        v0 = self.shared_load_v(sub_idx=0, buf=0)
+        v1 = self.shared_load_v(sub_idx=1, buf=0)
+        v0_scale = self.shared_load_v_scale(buf=0, slice=0)
+        v1_scale = self.shared_load_v_scale(buf=0, slice=1)
+
+        acc0 = self.compute_pv(p, p_scale, v0, v0_scale, acc0)
+        acc1 = self.compute_pv(p, p_scale, v1, v1_scale, acc1)
+
+        # pipeline epilogue iter end-1
+        k1 = self.shared_load_k(sub_idx=1, buf=1)
+
+        qk0 = self.compute_qk(q, q_scale, k0, k0_scale, zero)
+        qk1 = self.compute_qk(q, q_scale, k1, k1_scale, zero)
+
+        qk = self.concat_subtile(qk0, qk1)
+        m = ttgl.max(qk, 1)
+        m_ij = ttgl.maximum(m_i, m)
+        m_ij_scaled = m_ij * sm_scale
+
+        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
+        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
+        p0 = ttgl.exp2(qk0_shifted)
+
+        p1 = ttgl.exp2(qk1_shifted)
+        m_diff = m_i * sm_scale - m_ij_scaled
+        m_i = m_ij
+        alpha = ttgl.exp2(m_diff)
+        acc0 = acc0 * alpha[:, None]
+        acc1 = acc1 * alpha[:, None]
+
+        p = self.concat_subtile(p0, p1)
+        l_ij = ttgl.sum(p, 1)
+        l_i = l_i * alpha + l_ij
+        p, p_scale = self.downcast_p(p)
+
+        self.async_wait(0)
+        v0 = self.shared_load_v(sub_idx=0, buf=1)
+        v1 = self.shared_load_v(sub_idx=1, buf=1)
+        v0_scale = self.shared_load_v_scale(buf=1, slice=0)
+        v1_scale = self.shared_load_v_scale(buf=1, slice=1)
+
+        acc0 = self.compute_pv(p, p_scale, v0, v0_scale, acc0)
+        acc1 = self.compute_pv(p, p_scale, v1, v1_scale, acc1)
+
+        acc = self.concat_subtile(acc0, acc1)
+        return acc, l_i, m_i
+
+    @gluon.jit
+    def fwd_pipeline_triplebuf(self):
         cfg = self.cfg
 
         m_i = ttgl.full([cfg.BLOCK_M], float("-inf"), ttgl.float32, ttgl.SliceLayout(1, cfg.acc_layout))
@@ -1916,133 +2261,120 @@ class BlockScaledAttentionProgram:
         q = self.global_load_q()
         q_scale = self.global_load_q_scale()
 
-        # pipeline prologue, iter -3
+        # pipeline prologue, iter -4
         self.issue_global_load_k(0, buf=0)  # ................................. iter 0
         self.issue_global_load_k_scale(0, buf=0)  # ........................... iter 0
 
-        # pipeline prologue, iter -2
+        # pipeline prologue, iter -3
         self.issue_global_load_k(1, buf=1)  # ................................. iter 1
         self.issue_global_load_k_scale(1, buf=1)  # ........................... iter 1
 
-        self.async_wait(2)  # ................................................. iter 0
-        k = self.shared_load_k(buf=0)
-        k_scale = self.shared_load_k_scale(buf=0)
+        # pipeline prologue, iter -2
         self.issue_global_load_v(0, buf=0)  # ................................. iter 0
         self.issue_global_load_v_scale(0, buf=0)  # ........................... iter 0
+
+        self.async_wait(4)
+        self.issue_global_load_k(2, buf=2)  # ................................. iter 2
+        self.issue_global_load_k_scale(2, buf=2)  # ........................... iter 2
+        k = self.shared_load_k(buf=0)  # ...................................... iter 0
+        k_scale = self.shared_load_k_scale(buf=0)
 
         # pipeline prologue, iter -1
         qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ................. iter 0
 
-        self.issue_global_load_k(2, buf=0)  # ................................. iter 2
-        self.issue_global_load_k_scale(2, buf=0)  # ........................... iter 2
+        self.issue_global_load_v(1, buf=1)  # ................................. iter 1
+        self.issue_global_load_v_scale(1, buf=1)  # ........................... iter 1
 
         m = ttgl.max(qk, 1)  # ................................................ iter 0
         m_ij = ttgl.maximum(m_i, m)
         m_ij_scaled = m_ij * sm_scale
-        qk0, qk1 = self.split_subtile(qk)
-        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
-        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
-        p0 = ttgl.exp2(qk0_shifted)
+        qk_shifted = qk * sm_scale - m_ij_scaled[:, None]
+        p = ttgl.exp2(qk_shifted)
         m_diff = m_i * sm_scale - m_ij_scaled
         alpha = ttgl.exp2(m_diff)
         m_i = m_ij
 
-        self.async_wait(4)  # ................................................. iter 0
-        k = self.shared_load_k(buf=1)
+        self.async_wait(6)
+        self.issue_global_load_k(3, buf=0)  # ................................. iter 3
+        self.issue_global_load_k_scale(3, buf=0)  # ........................... iter 3
+        k = self.shared_load_k(buf=1)  # ...................................... iter 1
         k_scale = self.shared_load_k_scale(buf=1)
-        self.issue_global_load_v(1, buf=1)  # ................................. iter 1
-        self.issue_global_load_v_scale(1, buf=1)  # ........................... iter 1
 
         # main loop from 0 to end-3
-        # TODO: Ideally we should unroll the loop by 2 to remove the buffer index
-        # update, but our current codegen in llvm does not perform well. Re-enable
-        # unroll when fixed.
-        end = ttgl.cdiv(cfg.SEQLEN_K, cfg.BLOCK_N)
+        end = ttgl.cdiv(cfg.SEQLEN_K // cfg.SPLIT_K, cfg.BLOCK_N)
         for i in range(0, end - 2):
-            a = i % 2
-            b = 1 - a
-            pred = i - end + 3
+            a = i % 3
+            b = (i + 1) % 3
+            c = (i + 2) % 3
+            pred = i - end + 4
             pred = (pred >> 31) & 1
 
-            with warp_pipeline_stage("stage0"):
-                qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ......... iter i+1
-                p1 = ttgl.exp2(qk1_shifted)  # ................................ iter i
-                p = self.concat_subtile(p0, p1)
-                l_ij = ttgl.sum(p, 1)
-                acc = acc * alpha[:, None]
-                l_i = l_i * alpha + l_ij
-                p, p_scale = self.downcast_p(p)
+            qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ............. iter i+1
+            l_ij = ttgl.sum(p, 1)  # .......................................... iter i
+            acc = acc * alpha[:, None]
+            l_i = l_i * alpha + l_ij
+            p, p_scale = self.downcast_p(p)
 
-            self.async_wait(4)
-            with warp_pipeline_stage("stage1"):
-                v = self.shared_load_v(buf=a)  # .............................. iter i
-                v_scale = self.shared_load_v_scale(buf=a)
-                self.issue_global_load_k(i + 3, buf=b, pred=pred)  # .......... iter i+3
-                self.issue_global_load_k_scale(i + 3, buf=b, pred=pred)
+            self.async_wait(6)
+            self.issue_global_load_v(i + 2, buf=c)  # ......................... iter i+2
+            self.issue_global_load_v_scale(i + 2, buf=c)  # ................... iter i+2
+            v = self.shared_load_v(buf=a)  # .................................. iter i
+            v_scale = self.shared_load_v_scale(buf=a)
 
-            with warp_pipeline_stage("stage2"):
-                acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ......... iter i
-                m = ttgl.max(qk, 1)  # ........................................ iter i+1
-                m_ij = ttgl.maximum(m_i, m)
-                m_ij_scaled = m_ij * sm_scale
-                qk0, qk1 = self.split_subtile(qk)
-                qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
-                qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
-                p0 = ttgl.exp2(qk0_shifted)
-                m_diff = m_i * sm_scale - m_ij_scaled
-                alpha = ttgl.exp2(m_diff)
-                m_i = m_ij
+            acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ............. iter i
+            m = ttgl.max(qk, 1)  # ............................................ iter i+1
+            m_ij = ttgl.maximum(m_i, m)
+            m_ij_scaled = m_ij * sm_scale
+            qk_shifted = qk * sm_scale - m_ij_scaled[:, None]
+            p = ttgl.exp2(qk_shifted)
+            m_diff = m_i * sm_scale - m_ij_scaled
+            alpha = ttgl.exp2(m_diff)
+            m_i = m_ij
 
-            self.async_wait(4)
-            with warp_pipeline_stage("stage3"):
-                k = self.shared_load_k(buf=a)  # .............................. iter i+2
-                k_scale = self.shared_load_k_scale(buf=a)
-                self.issue_global_load_v(i + 2, buf=a)  # ..................... iter i+2
-                self.issue_global_load_v_scale(i + 2, buf=a)
+            self.async_wait(6)
+            self.issue_global_load_k(i + 4, buf=b, pred=pred)  # .............. iter i+4
+            self.issue_global_load_k_scale(i + 4, buf=b, pred=pred)  # ........ iter i+4
+            k = self.shared_load_k(buf=c)  # .................................. iter i+2
+            k_scale = self.shared_load_k_scale(buf=c)
 
         # pipeline epilogue, iter end-2
+        a = (end - 2) % 3
+
         qk = self.compute_qk(q, q_scale, k, k_scale, zero)  # ................. iter end-1
-        p1 = ttgl.exp2(qk1_shifted)  # ........................................ iter end-2
-        p = self.concat_subtile(p0, p1)
-        l_ij = ttgl.sum(p, 1)
+        l_ij = ttgl.sum(p, 1)  # .............................................. iter end-2
         acc = acc * alpha[:, None]
         l_i = l_i * alpha + l_ij
         p, p_scale = self.downcast_p(p)
 
-        self.async_wait(4)  # ................................................. iter end-2
-        v = self.shared_load_v(buf=0)
-        v_scale = self.shared_load_v_scale(buf=0)
+        self.async_wait(2)
+        v = self.shared_load_v(buf=a)  # ...................................... iter end-2
+        v_scale = self.shared_load_v_scale(buf=a)
 
         acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ................. iter end-2
         m = ttgl.max(qk, 1)  # ................................................ iter end-1
         m_ij = ttgl.maximum(m_i, m)
         m_ij_scaled = m_ij * sm_scale
-        qk0, qk1 = self.split_subtile(qk)
-        qk0_shifted = qk0 * sm_scale - m_ij_scaled[:, None]
-        qk1_shifted = qk1 * sm_scale - m_ij_scaled[:, None]
-        p0 = ttgl.exp2(qk0_shifted)
+        qk_shifted = qk * sm_scale - m_ij_scaled[:, None]
+        p = ttgl.exp2(qk_shifted)
         m_diff = m_i * sm_scale - m_ij_scaled
         alpha = ttgl.exp2(m_diff)
         m_i = m_ij
 
         # pipeline epilogue, iter end-1
-        p1 = ttgl.exp2(qk1_shifted)  # ........................................ iter end-1
-        p = self.concat_subtile(p0, p1)
-        l_ij = ttgl.sum(p, 1)
+        a = (end - 1) % 3
+
+        l_ij = ttgl.sum(p, 1)  # .............................................. iter end-1
         acc = acc * alpha[:, None]
         l_i = l_i * alpha + l_ij
         p, p_scale = self.downcast_p(p)
 
-        self.async_wait(0)  # ................................................. iter end-1
-        v = self.shared_load_v(buf=1)
-        v_scale = self.shared_load_v_scale(buf=1)
+        self.async_wait(0)
+        v = self.shared_load_v(buf=a)  # ...................................... iter end-1
+        v_scale = self.shared_load_v_scale(buf=a)
 
         acc = self.compute_pv(p, p_scale, v, v_scale, acc)  # ................. iter end-1
 
-        # write output
-        l_recip = 1 / l_i
-        acc = acc * l_recip[:, None]
-        self.store_output(acc)
+        return acc, l_i, m_i
 
 
 # ===-----------------------------------------------------------------------===#
@@ -2051,10 +2383,101 @@ class BlockScaledAttentionProgram:
 
 
 @gluon.jit
+def store_output(  #
+        o_ptr, l_ptr, m_ptr,  #
+        acc, l_i, m_i,  #
+        cfg: ttgl.constexpr):
+    SEQLEN_K: ttgl.constexpr = cfg.SEQLEN_K
+    SEQLEN_Q: ttgl.constexpr = cfg.SEQLEN_Q
+    HEAD_SZ: ttgl.constexpr = cfg.HEAD_SZ
+    NUM_Q_HEADS: ttgl.constexpr = cfg.NUM_Q_HEADS
+    NUM_K_HEADS: ttgl.constexpr = cfg.NUM_K_HEADS
+    BLOCK_M: ttgl.constexpr = cfg.BLOCK_M
+    SPLIT_K: ttgl.constexpr = cfg.SPLIT_K
+
+    off_h = ttgl.program_id(0)
+    off_m = ttgl.program_id(1) // SPLIT_K
+    off_s = ttgl.program_id(1) % SPLIT_K
+    off_z = ttgl.program_id(2)
+
+    if SEQLEN_Q == SEQLEN_K:
+        ttgl.static_assert(SPLIT_K == 1)
+
+        # o_off =
+        #   off_z * stride_z (NUM_Q_HEADS * SEQLEN_Q * HEAD_SZ) +
+        #   off_h * stride_h (SEQLEN_Q * HEAD_SZ) +
+        #   off_m * stride_m (BLOCK_M * HEAD_SZ)
+        o_off = SEQLEN_Q * HEAD_SZ * (NUM_Q_HEADS * off_z + off_h) + \
+                BLOCK_M * HEAD_SZ * off_m
+        o_blk = MemoryBlock.initialize(  #
+            o_ptr + o_off,  #
+            shape=[SEQLEN_Q, HEAD_SZ],  #
+            block_shape=[BLOCK_M, HEAD_SZ],  #
+            layout=cfg.store_layout)
+
+        l_recip = 1 / l_i
+        acc = acc * l_recip[:, None]
+        o = acc.to(o_blk.dtype)
+        o = ttgl.convert_layout(o, cfg.store_layout)
+        buffer_store(o, o_blk.ptr, o_blk.offs, o_blk.mask)
+    else:
+        GROUP_SZ: ttgl.constexpr = NUM_Q_HEADS // NUM_K_HEADS
+        NUM_GROUPS: ttgl.constexpr = NUM_K_HEADS
+
+        if SPLIT_K == 1:
+            # o_off =
+            #   off_z * stride_z (NUM_GROUPS * GROUP_SZ * HEAD_SZ) +
+            #   off_h * stride_h (GROUP_SZ * HEAD_SZ) +
+            #   off_m * stride_m (BLOCK_M * HEAD_SZ)
+            o_off = GROUP_SZ * HEAD_SZ * (NUM_GROUPS * off_z + off_h) + \
+                    BLOCK_M * HEAD_SZ * off_m
+            o_blk = MemoryBlock.initialize(  #
+                o_ptr + o_off,  #
+                shape=[GROUP_SZ, HEAD_SZ],  #
+                block_shape=[BLOCK_M, HEAD_SZ],  #
+                layout=cfg.store_layout)
+
+            l_recip = 1 / l_i
+            acc = acc * l_recip[:, None]
+            o = acc.to(o_blk.dtype)
+            o = ttgl.convert_layout(o, cfg.store_layout)
+            buffer_store(o, o_blk.ptr, o_blk.offs, o_blk.mask)
+        else:
+            ttgl.static_assert(BLOCK_M == GROUP_SZ)
+            # o_off =
+            #   off_z * stride_z (NUM_GROUPS * SPLIT_K * GROUP_SZ * HEAD_SZ) +
+            #   off_h * stride_h (SPLIT_K * GROUP_SZ * HEAD_SZ) +
+            #   off_s * stride_s (BLOCK_M * HEAD_SZ)
+            o_off = SPLIT_K * GROUP_SZ * HEAD_SZ * (NUM_GROUPS * off_z + off_h) + \
+                    BLOCK_M * HEAD_SZ * off_s
+            o_blk = MemoryBlock.initialize(  #
+                o_ptr + o_off,  #
+                shape=[GROUP_SZ, HEAD_SZ],  #
+                block_shape=[BLOCK_M, HEAD_SZ],  #
+                layout=cfg.store_layout)
+
+            o = acc.to(o_ptr.dtype.element_ty)
+            o = ttgl.convert_layout(o, cfg.store_layout)
+            buffer_store(o, o_blk.ptr, o_blk.offs)
+
+            # l_off =
+            #   off_z * stride_z (NUM_GROUPS * GROUP_SZ * SPLIT_K) +
+            #   off_h * stride_h (GROUP_SZ * SPLIT_K) +
+            #   off_s * stride_s (1)
+            l_off = GROUP_SZ * SPLIT_K * (NUM_GROUPS * off_z + off_h) + off_s
+            l_offs = ttgl.arange(0, BLOCK_M, ttgl.SliceLayout(1, cfg.acc_layout))[:, None] * SPLIT_K
+            buffer_store(l_i[:, None], l_ptr + l_off, l_offs)
+
+            m_off = l_off
+            m_offs = l_offs
+            buffer_store(m_i[:, None], m_ptr + m_off, m_offs)
+
+
+@gluon.jit
 def mxfp_attn_fwd_kernel(  #
         q_ptr, k_ptr, v_ptr,  #
         q_scale_ptr, k_scale_ptr, v_scale_ptr,  #
-        o_ptr,  #
+        o_ptr, l_ptr, m_ptr,  #
         sm_scale,  #
         cfg: ttgl.constexpr):
 
@@ -2062,21 +2485,27 @@ def mxfp_attn_fwd_kernel(  #
     BLOCK_SCALING: ttgl.constexpr = isinstance(cfg, BlockScaledAttentionConfig)
     if not BLOCK_SCALING:
         pgm = GlobalScaledAttentionProgram.initialize(  #
-            cfg, q_ptr, q_scale_ptr, k_ptr, k_scale_ptr, v_ptr, v_scale_ptr, o_ptr, sm_scale)
+            cfg, q_ptr, q_scale_ptr, k_ptr, k_scale_ptr, v_ptr, v_scale_ptr, sm_scale)
     else:
         pgm = BlockScaledAttentionProgram.initialize(  #
-            cfg, q_ptr, q_scale_ptr, k_ptr, k_scale_ptr, v_ptr, v_scale_ptr, o_ptr, sm_scale)
+            cfg, q_ptr, q_scale_ptr, k_ptr, k_scale_ptr, v_ptr, v_scale_ptr, sm_scale)
 
     # Select the target schedule
     if cfg.NUM_BUFFERS == 1:
-        pgm.fwd_loop()
+        acc, l_i, m_i = pgm.fwd_loop()
     elif cfg.NUM_BUFFERS == 2:
         if cfg.SUBTILE:
-            pgm.fwd_pipeline_subtile()
-        elif cfg.PINGPONG:
-            pgm.fwd_pipeline_pingpong()
+            if cfg.PINGPONG:
+                acc, l_i, m_i = pgm.fwd_pipeline_subtile_pingpong()
+            else:
+                acc, l_i, m_i = pgm.fwd_pipeline_subtile()
         else:
-            pgm.fwd_pipeline()
+            acc, l_i, m_i = pgm.fwd_pipeline()
+    elif cfg.NUM_BUFFERS == 3:
+        ttgl.static_assert(not cfg.SUBTILE)
+        acc, l_i, m_i = pgm.fwd_pipeline_triplebuf()
+
+    store_output(o_ptr, l_ptr, m_ptr, acc, l_i, m_i, cfg)
 
 
 def get_attn_schedule(cfg):
@@ -2089,90 +2518,197 @@ def get_attn_schedule(cfg):
         return pgm.fwd_loop
     elif cfg.NUM_BUFFERS == 2:
         if cfg.SUBTILE:
-            return pgm.fwd_pipeline_subtile
-        elif cfg.PINGPONG:
-            return pgm.fwd_pipeline_pingpong
+            if cfg.PINGPONG:
+                return pgm.fwd_pipeline_subtile_pingpong
+            else:
+                return pgm.fwd_pipeline_subtile
         else:
             return pgm.fwd_pipeline
+    elif cfg.NUM_BUFFERS == 3:
+        assert not cfg.SUBTILE
+        return pgm.fwd_pipeline_triplebuf
 
 
-def get_attn_config(  #
-        q_type, kv_type, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz, block_scaling, p_scaling,  #
-        block_m, block_n, pipelined, num_warps):
+@gluon.jit
+def mxfp_attn_reduce_kernel(  #
+        o_ptr, l_ptr, m_ptr,  #
+        sm_scale,  #
+        cfg: ttgl.constexpr):
 
-    # When we have a large block_m for pipeline, we will subtile K/V to
-    # save registers
-    subtile = pipelined and block_m >= 256
-    # When pipelined, we need double buffer for K/V
-    num_buffers = 1 if not pipelined else 2
-    # When kv_type if mxfp8 (e4m3 or e5m2), we can use p_k_width of 8,
-    # which makes QK and P share the same layout.
-    p_k_width = 16 if kv_type == 'e2m1' else 8
-    # We can use pingpong schedule where there are 8 or more warps
-    pingpong = pipelined and num_warps >= 8
-    # TODO: Currently pingpong schedule will have register spill for
-    # block_m=256.
-    if block_m >= 256:
-        pingpong = False
-    # Disable warp reduce as it does not show performance benefit.
-    warp_reduce = False
+    SEQLEN_Q: ttgl.constexpr = cfg.SEQLEN_Q
+    NUM_Q_HEADS: ttgl.constexpr = cfg.NUM_Q_HEADS
+    NUM_K_HEADS: ttgl.constexpr = cfg.NUM_K_HEADS
+    HEAD_SZ: ttgl.constexpr = cfg.HEAD_SZ
+    BLOCK_M: ttgl.constexpr = cfg.BLOCK_M
+    SPLIT_K: ttgl.constexpr = cfg.SPLIT_K
+    GROUP_SZ: ttgl.constexpr = NUM_Q_HEADS // NUM_K_HEADS
+    NUM_GROUPS: ttgl.constexpr = NUM_K_HEADS
+    ttgl.static_assert(BLOCK_M == GROUP_SZ)
+    ttgl.static_assert(SPLIT_K > 1)
+    ttgl.static_assert(SEQLEN_Q == 1)
 
-    if block_scaling:
-        cfg = BlockScaledAttentionConfig(  #
-            q_type, kv_type, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz, p_scaling,  #
-            block_m, block_n, subtile, pingpong, warp_reduce, p_k_width, num_buffers, num_warps)
-    else:
-        cfg = GlobalScaledAttentionConfig(  #
-            q_type, kv_type, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz,  #
-            block_m, block_n, subtile, pingpong, warp_reduce, p_k_width, num_buffers, num_warps)
+    off_h = ttgl.program_id(0)
+    off_s = ttgl.program_id(1) % SPLIT_K
+    off_z = ttgl.program_id(2)
 
-    return cfg
+    acc_layout: ttgl.constexpr = get_store_layout([BLOCK_M, HEAD_SZ // SPLIT_K], cfg.NUM_WARPS)
+    smem_layout: ttgl.constexpr = get_shared_layout([BLOCK_M, HEAD_SZ // SPLIT_K])
+    dtype: ttgl.constexpr = o_ptr.dtype.element_ty
+
+    # l_off =
+    #   off_z * stride_z (NUM_GROUPS * GROUP_SZ * SPLIT_K) +
+    #   off_h * stride_h (GROUP_SZ * SPLIT_K)
+    l_off = GROUP_SZ * SPLIT_K * (NUM_GROUPS * off_z + off_h)
+    l_offs = ttgl.arange(0, BLOCK_M, ttgl.SliceLayout(1, acc_layout))[:, None] * SPLIT_K + \
+             ttgl.arange(0, SPLIT_K, ttgl.SliceLayout(0, acc_layout))[None, :]
+
+    m_off = l_off
+    m_offs = l_offs
+
+    l = buffer_load(l_ptr + l_off, l_offs)
+    m = buffer_load(m_ptr + m_off, m_offs)
+
+    # o_off =
+    #   off_z * stride_z (NUM_GROUPS * SPLIT_K * GROUP_SZ * HEAD_SZ) +
+    #   off_h * stride_h (SPLIT_K * GROUP_SZ * HEAD_SZ)
+    o_off = SPLIT_K * GROUP_SZ * HEAD_SZ * (NUM_GROUPS * off_z + off_h)
+    o_ptr = o_ptr + o_off
+    o_smem = ttgl.allocate_shared_memory(  #
+        dtype,  #
+        [SPLIT_K] + [BLOCK_M, HEAD_SZ // SPLIT_K],  #
+        smem_layout)
+    o_desc = tdm.make_tensor_descriptor(  #
+        base=o_ptr,  #
+        shape=[SPLIT_K * GROUP_SZ, HEAD_SZ],  #
+        strides=[HEAD_SZ, 1],  #
+        block_shape=[BLOCK_M, HEAD_SZ // SPLIT_K],  #
+        layout=smem_layout)
+
+    acc = ttgl.full([BLOCK_M, HEAD_SZ // SPLIT_K], 0, dtype, acc_layout)
+    for i in ttgl.static_range(SPLIT_K):
+        tdm.async_load(o_desc, [i * BLOCK_M, off_s * (HEAD_SZ // SPLIT_K)], o_smem.index(i))
+
+    m_ij = ttgl.max(m, 1)
+    m_ij_scaled = m_ij * sm_scale
+    m_diff = m * sm_scale - m_ij_scaled[:, None]
+    alpha = ttgl.exp2(m_diff)
+    alpha_s = split_n(alpha, SPLIT_K)
+    l_i = ttgl.sum(l * alpha, 1)
+
+    for i in ttgl.static_range(SPLIT_K):
+        tdm.async_wait(SPLIT_K - 1 - i)
+        o = o_smem.index(i).load(acc_layout)
+        acc += o * alpha_s[i]
+
+    l_recip = 1 / l_i
+    acc = acc * l_recip[:, None]
+
+    o_blk = MemoryBlock.initialize(  #
+        o_ptr + off_s * (HEAD_SZ // SPLIT_K),  #
+        shape=[GROUP_SZ, HEAD_SZ],  #
+        block_shape=[BLOCK_M, HEAD_SZ // SPLIT_K],  #
+        layout=acc_layout)
+    o = acc.to(o_blk.dtype)
+    buffer_store(o, o_blk.ptr, o_blk.offs)
 
 
 def attn_fwd(  #
         q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,  #
         q_scale: torch.Tensor | int, k_scale: torch.Tensor | int, v_scale: torch.Tensor | int,  #
         q_type: str, kv_type: str, block_scaling: bool, p_scaling: bool,  #
-        block_m: int, block_n: int, pipelined: bool, num_warps: int):
+        block_m: int, block_n: int, split_k: int, pipelined: bool, num_warps: int):
 
     batch, seqlen_q, num_q_heads, head_sz = q.shape
     _, seqlen_k, num_k_heads, _ = k.shape
-    dtype = torch.float32
+    out_dtype = torch.float32
     assert seqlen_q == 1 or seqlen_q == seqlen_k
     assert num_q_heads >= num_k_heads and num_q_heads % num_k_heads == 0
     assert head_sz in {64, 128}
-    if pipelined:
-        assert cdiv(seqlen_k, block_n) > 4
-
-    cfg = get_attn_config(  #
-        q_type, kv_type, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz, block_scaling, p_scaling,  #
-        block_m, block_n, pipelined, num_warps)
-    subtile = cfg.SUBTILE
+    assert block_n >= 128
+    assert block_m >= 16
+    assert seqlen_k % block_n == 0
+    assert split_k >= 1
+    assert seqlen_k % split_k == 0
+    assert seqlen_k >= block_n * split_k
+    assert (not pipelined) or cdiv(seqlen_k, block_n) > 4
     kv_pack_div = 2 if kv_type == 'e2m1' else 1
 
+    # When we have a large block_m for pipeline, we will subtile K/V to
+    # save registers
+    subtile = pipelined and block_m >= 256
+    # We can use pingpong schedule where there are 8 or more warps
+    pingpong = pipelined and num_warps >= 8
+    # Decide the number of buffers for pipeline
+    num_buffers = 1
+    if pipelined:
+        num_buffers = 2
+        # When block_m is small, the kernel becomes memory bound, and we need
+        # to increase the number of outstanding memory requests to improve
+        # memory utilization. This can be achieved by using triple buffering
+        # where one additional buffer can be used for an immediate memory
+        # request, without waiting for the data in the buffer to be consumed.
+        if block_m <= 64:
+            num_buffers = 3
+        group_sz = num_q_heads // num_k_heads
+        # For MHA decode, we are using a single wave per workgroup, and needs
+        # multiple workgroups to be scheduled on the same processor to achieve
+        # good occupancy. However, occupancy can be limited by the LDS size -
+        # which can roughly be computed by
+        # ```
+        # 2 * BLOCK_N * HEAD_SZ * NUM_BUFFERS / KV_PACK_DIV
+        # ```
+        # We only have 320KB per processor. For mxfp8 and head_sz=128,
+        # 1 workgroup needs 2 * 128 * 128 * 3 = 96KB, and 4 workgroups
+        # can use 384KB which exceeds the limit. So we will fallback to
+        # double buffering in this case.
+        if seqlen_q == 1 and group_sz == 1:
+            if num_warps == 1 and kv_type != 'e2m1' and head_sz == 128:
+                num_buffers = 2
+    # When kv_type is mxfp8 (e4m3 or e5m2), we can use p_k_width of 8,
+    # which makes QK and P share the same layout.
+    p_k_width = 16 if kv_type == 'e2m1' else 8
+    # Disable warp reduce as it does not show performance benefit.
+    warp_reduce = False
+
+    if block_scaling:
+        cfg = BlockScaledAttentionConfig(  #
+            q_type, kv_type, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz, p_scaling,  #
+            block_m, block_n, split_k, subtile, pingpong, warp_reduce, p_k_width, num_buffers, num_warps)
+    else:
+        cfg = GlobalScaledAttentionConfig(  #
+            q_type, kv_type, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz,  #
+            block_m, block_n, split_k, subtile, pingpong, warp_reduce, p_k_width, num_buffers, num_warps)
+
     if seqlen_q == seqlen_k:
+        assert split_k == 1
+        group_sz = num_q_heads // num_k_heads
+        assert group_sz == 1
         # q: [BATCH, NUM_Q_HEADS, SEQLEN_Q, HEAD_SZ]
         # k: [BATCH, NUM_K_HEADS, SEQLEN_K, HEAD_SZ]
         # v: [BATCH, NUM_K_HEADS, SEQLEN_K, HEAD_SZ]
         # o: [BATCH, NUM_Q_HEADS, SEQLEN_Q, HEAD_SZ]
         q = q.permute(0, 2, 1, 3).contiguous()
-        k = preshuffle_operand(k.permute(0, 2, 1, 3),  #
-                               block_shape=[block_n, head_sz // kv_pack_div],  #
-                               sub_axis=0 if subtile else None)
-        v = preshuffle_operand(v.permute(0, 2, 1, 3),  #
-                               block_shape=[block_n // kv_pack_div, head_sz],  #
-                               sub_axis=1 if subtile else None)
-        o = torch.zeros_like(q, dtype=dtype)
+        k = preshuffle_kv(k.permute(0, 2, 1, 3),  #
+                          block_shape=[block_n, head_sz // kv_pack_div],  #
+                          sub_axis=0 if subtile else None)
+        v = preshuffle_kv(v.permute(0, 2, 1, 3),  #
+                          block_shape=[block_n // kv_pack_div, head_sz],  #
+                          sub_axis=1 if subtile else None)
+        o = torch.zeros_like(q, dtype=out_dtype)
 
         # q_scale: [BATCH, NUM_Q_HEADS, SEQLEN_Q, HEAD_SZ / 32]
         # k_scale: [BATCH, NUM_K_HEADS, SEQLEN_K, HEAD_SZ / 32]
-        # v_scale: [BATCH, NUM_K_HEADS, HEAD_SZ / 32, SEQLEN_K]
+        # v_scale: [BATCH, NUM_K_HEADS, HEAD_SZ, SEQLEN_K / 32]
         if block_scaling:
             q_scale = q_scale.permute(0, 2, 1, 3).contiguous()
-            k_scale = preshuffle_scale(k_scale.permute(0, 2, 1, 3), preshuffle_factor=128)
-            v_scale = preshuffle_scale(v_scale.permute(0, 2, 3, 1), preshuffle_factor=128 if head_sz == 128 else 64)
+            k_scale = preshuffle_kv_scale(k_scale.permute(0, 2, 1, 3))
+            v_scale = preshuffle_kv_scale(v_scale.permute(0, 2, 3, 1))
 
         grid = (num_q_heads, cdiv(seqlen_q, block_m), batch)
+
+        l = torch.zeros((batch, num_q_heads, seqlen_q), dtype=out_dtype)
+        m = torch.zeros_like(l, dtype=out_dtype)
+
     else:
         group_sz = num_q_heads // num_k_heads
         num_groups = num_k_heads
@@ -2181,23 +2717,39 @@ def attn_fwd(  #
         # v: [BATCH, NUM_K_HEADS, SEQLEN_K, HEAD_SZ]
         # o: [BATCH, NUM_GROUPS, GROUP_SZ, HEAD_SZ]
         q = q.permute(0, 2, 1, 3).view(batch, num_groups, group_sz, head_sz).contiguous()
-        k = preshuffle_operand(k.permute(0, 2, 1, 3),  #
-                               block_shape=[block_n, head_sz // kv_pack_div],  #
-                               sub_axis=0 if subtile else None)
-        v = preshuffle_operand(v.permute(0, 2, 1, 3),  #
-                               block_shape=[block_n // kv_pack_div, head_sz],  #
-                               sub_axis=1 if subtile else None)
-        o = torch.zeros_like(q, dtype=dtype)
+        k = preshuffle_kv(k.permute(0, 2, 1, 3),  #
+                          block_shape=[block_n, head_sz // kv_pack_div],  #
+                          sub_axis=0 if subtile else None)
+        v = preshuffle_kv(v.permute(0, 2, 1, 3),  #
+                          block_shape=[block_n // kv_pack_div, head_sz],  #
+                          sub_axis=1 if subtile else None)
+        o = torch.zeros_like(q, dtype=out_dtype)
 
         # q_scale: [BATCH, NUM_GROUPS, GROUP_SZ, HEAD_SZ / 32]
         # k_scale: [BATCH, NUM_K_HEADS, SEQLEN_K, HEAD_SZ / 32]
-        # v_scale: [BATCH, NUM_K_HEADS, HEAD_SZ / 32, SEQLEN_K]
+        # v_scale: [BATCH, NUM_K_HEADS, HEAD_SZ, SEQLEN_K / 32]
         if block_scaling:
             q_scale = q_scale.permute(0, 2, 1, 3).view(batch, num_groups, group_sz, head_sz // 32).contiguous()
-            k_scale = preshuffle_scale(k_scale.permute(0, 2, 1, 3), preshuffle_factor=128)
-            v_scale = preshuffle_scale(v_scale.permute(0, 2, 3, 1), preshuffle_factor=128 if head_sz == 128 else 64)
+            k_scale = preshuffle_kv_scale(k_scale.permute(0, 2, 1, 3))
+            v_scale = preshuffle_kv_scale(v_scale.permute(0, 2, 3, 1))
 
         grid = (num_groups, cdiv(group_sz, block_m), batch)
+
+        l = torch.zeros((batch, num_groups, group_sz), dtype=out_dtype)
+        m = torch.zeros_like(l, dtype=out_dtype)
+
+        # When we have split_k > 1 we will create additional space for each k
+        # partitions for the partial reduction results, and launch a separate
+        # reduction kernel.
+        if split_k > 1:
+            assert block_m == group_sz
+            grid = (num_groups, split_k, batch)
+            # o: [BATCH, NUM_GROUPS, GROUP_SZ * SPLIT_K, HEAD_SZ]
+            # l: [BATCH, NUM_GROUPS, GROUP_SZ, SPLIT_K]
+            # m: [BATCH, NUM_GROUPS, GROUP_SZ, SPLIT_K]
+            o = o.repeat_interleave(split_k, dim=2)
+            l = torch.unsqueeze(l, dim=-1).repeat_interleave(split_k, dim=-1)
+            m = torch.zeros_like(l, dtype=out_dtype)
 
     q = q.cuda()
     k = k.cuda()
@@ -2208,16 +2760,27 @@ def attn_fwd(  #
         v_scale = v_scale.cuda()
     o = o.cuda()
 
+    l = l.cuda()
+    m = m.cuda()
+
     sm_scale = head_sz**(-0.5) * 1.4426950408889634  # 1 / ln(2)
-    args = [q, k, v, q_scale, k_scale, v_scale, o, sm_scale, cfg]
+    args = [q, k, v, q_scale, k_scale, v_scale, o, l, m, sm_scale, cfg]
     kwargs = {"num_warps": num_warps, "waves_per_eu": 1}
 
     kernel = mxfp_attn_fwd_kernel[grid](*args, **kwargs)
-    out = o.cpu()
+
+    if split_k == 1:
+        out = o.cpu()
+    else:
+        args = [o, l, m, sm_scale, cfg]
+        kwargs = {"num_warps": num_warps, "waves_per_eu": 1}
+        mxfp_attn_reduce_kernel[grid](*args, **kwargs)
+        out = o.cpu()[..., :group_sz, :]
+
     if seqlen_q == seqlen_k:
         out = out.permute(0, 2, 1, 3)
     else:
-        out = out.view(batch, num_q_heads, seqlen_q, head_sz).permute(0, 2, 1, 3)
+        out = out.reshape(batch, num_q_heads, seqlen_q, head_sz).permute(0, 2, 1, 3)
 
     return out, kernel, cfg
 
@@ -2378,15 +2941,17 @@ def get_source_mapping(amdgcn, cfg):
 
 
 def get_attn_fwd_configs():
-    # block_m,block_n,pipelined,num_warps
+    # block_m,block_n,split_k,pipelined,num_warps
     configs = {
-        "4warp_128x128_loop": [128, 128, False, 4],
-        "4warp_128x128_pipeline": [128, 128, True, 4],
-        "4warp_256x128_pipeline": [256, 128, True, 4],
-        "1warp_16x128_loop": [16, 128, False, 1],
-        "1warp_16x128_pipeline": [16, 128, True, 1],
-        "4warp_64x128_loop": [64, 128, False, 4],
-        "4warp_64x128_pipeline": [64, 128, True, 4],
+        "4warp_128x128_loop": [128, 128, 1, False, 4],
+        "4warp_128x128_pipeline": [128, 128, 1, True, 4],
+        "4warp_256x128_pipeline": [256, 128, 1, True, 4],
+        "8warp_256x128_pipeline": [256, 128, 1, True, 8],
+        "1warp_16x128_loop": [16, 128, 1, False, 1],
+        "1warp_16x128_pipeline": [16, 128, 1, True, 1],
+        "4warp_64x128_loop": [64, 128, 1, False, 4],
+        "4warp_64x128_pipeline": [64, 128, 1, True, 4],
+        "4warp_64x128_pipeline_split4": [64, 128, 4, True, 4],
     }
 
     return configs
@@ -2413,6 +2978,7 @@ def get_fwd_test_cases(block_scaling: bool):
             param.append((*test, *configs["4warp_128x128_loop"]))
             param.append((*test, *configs["4warp_128x128_pipeline"]))
             param.append((*test, *configs["4warp_256x128_pipeline"]))
+            param.append((*test, *configs["8warp_256x128_pipeline"]))
         else:
             assert seqlen_q == 1
             if num_q_heads == num_k_heads:
@@ -2424,15 +2990,18 @@ def get_fwd_test_cases(block_scaling: bool):
                 # MQA Decode
                 param.append((*test, *configs["4warp_64x128_loop"]))
                 param.append((*test, *configs["4warp_64x128_pipeline"]))
+                # Increase seqlen_k for split_k test
+                test[4] = 4096
+                param.append((*test, *configs["4warp_64x128_pipeline_split4"]))
     return param
 
 
 @pytest.mark.parametrize(
     "q_type,kv_type,batch,seqlen_q,seqlen_k,num_q_heads,num_k_heads,head_sz,"
-    "block_m,block_n,pipelined,num_warps",  #
+    "block_m,block_n,split_k,pipelined,num_warps",  #
     get_fwd_test_cases(True))
 def test_block_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz,  #
-                               block_m, block_n, pipelined, num_warps):
+                               block_m, block_n, split_k, pipelined, num_warps):
     torch.manual_seed(0)
 
     q, q_ref = create_operand(q_type, batch, seqlen_q, num_q_heads, head_sz)
@@ -2446,7 +3015,7 @@ def test_block_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_q
         q, k, v,  #
         q_scale, k_scale, v_scale,  #
         q_type, kv_type, True, False,  #
-        block_m, block_n, pipelined, num_warps)
+        block_m, block_n, split_k, pipelined, num_warps)
     o = o.to(torch.float32)
 
     o_ref = attn_fwd_ref(q_ref, k_ref, v_ref, q_scale_ref, k_scale_ref, v_scale_ref)
@@ -2497,7 +3066,8 @@ def test_block_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_q
             ds_load_instrs = [instr for instr in instrs if re.match(r'ds_load_', instr)]
             assert len(ds_load_instrs) > 0 and all(instr.startswith("ds_load_tr8_b64") for instr in ds_load_instrs)
             sources = [instr.split()[2] for instr in ds_load_instrs]
-            assert all(source == sources[0] for source in sources)
+            # TODO: For some cases, we can have generated code using 2 different source vgprs for address.
+            assert len(set(sources)) <= 2
         # check use v_permlane16_swap for convert layout
         if re.match(groups['convert_layout'], code):
             v_permlane_instrs = [instr for instr in instrs if re.match(r'v_permlane_*', instr)]
@@ -2509,10 +3079,10 @@ def test_block_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_q
 
 @pytest.mark.parametrize(
     "q_type,kv_type,batch,seqlen_q,seqlen_k,num_q_heads,num_k_heads,head_sz,"
-    "block_m,block_n,pipelined,num_warps",  #
+    "block_m,block_n,split_k,pipelined,num_warps",  #
     get_fwd_test_cases(False))
 def test_global_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz,  #
-                                block_m, block_n, pipelined, num_warps):
+                                block_m, block_n, split_k, pipelined, num_warps):
     torch.manual_seed(0)
 
     q, q_ref = create_operand(q_type, batch, seqlen_q, num_q_heads, head_sz)
@@ -2526,7 +3096,7 @@ def test_global_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_
         q, k, v,  #
         q_scale, k_scale, v_scale,  #
         q_type, kv_type, False, False,  #
-        block_m, block_n, pipelined, num_warps)
+        block_m, block_n, split_k, pipelined, num_warps)
     o = o.to(torch.float32)
 
     o_ref = attn_fwd_ref(q_ref, k_ref, v_ref, q_scale_ref, k_scale_ref, v_scale_ref)
@@ -2577,7 +3147,8 @@ def test_global_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_
             ds_load_instrs = [instr for instr in instrs if re.match(r'ds_load_', instr)]
             assert len(ds_load_instrs) > 0 and all(instr.startswith("ds_load_tr8_b64") for instr in ds_load_instrs)
             sources = [instr.split()[2] for instr in ds_load_instrs]
-            assert all(source == sources[0] for source in sources)
+            # TODO: For some cases, we can have generated code using 2 different source vgprs for address.
+            assert len(set(sources)) <= 2
         # check use v_permlane16_swap for convert layout
         if re.match(groups['convert_layout'], code):
             v_permlane_instrs = [instr for instr in instrs if re.match(r'v_permlane_*', instr)]
@@ -2588,7 +3159,7 @@ def test_global_scaled_attn_fwd(q_type, kv_type, batch, seqlen_q, seqlen_k, num_
 
 
 def run_attention(q_type, kv_type, batch, seqlen_q, seqlen_k, num_q_heads, num_k_heads, head_sz, scale_type,
-                  disable_p_scaling, block_m, block_n, pipelined, num_warps):
+                  disable_p_scaling, block_m, block_n, split_k, pipelined, num_warps):
     q, _ = create_operand(q_type, batch, seqlen_q, num_q_heads, head_sz)
     k, _ = create_operand(kv_type, batch, seqlen_k, num_k_heads, head_sz, pack_dim=3)
     v, _ = create_operand(kv_type, batch, seqlen_k, num_k_heads, head_sz, pack_dim=1)
@@ -2606,7 +3177,7 @@ def run_attention(q_type, kv_type, batch, seqlen_q, seqlen_k, num_q_heads, num_k
         q, k, v,  #
         q_scale, k_scale, v_scale,  #
         q_type, kv_type, scale_type == 'block', not disable_p_scaling,  #
-        block_m, block_n, pipelined, num_warps)
+        block_m, block_n, split_k, pipelined, num_warps)
     return kernel
 
 
@@ -2623,6 +3194,7 @@ if __name__ == "__main__":
     parser.add_argument("--head_sz", type=int, required=True)
     parser.add_argument("--block_m", type=int, required=True)
     parser.add_argument("--block_n", type=int, required=True)
+    parser.add_argument("--split_k", type=int, default=1)
     parser.add_argument(
         "--scale_type", type=str, choices=['block', 'global'], required=True,
         help="`block` = use block scaling where 32 elements share a scale; "

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -30,7 +30,6 @@ using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::NVIDIA;
 
-using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::MemDescType;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
@@ -296,6 +295,34 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
           llvm::SmallVector<Value> regA =
               loadReg(rewriter, loc, structA, (m * numRepK + k) * regASize,
                       regASize, startSequence);
+          // Emit "dummy" mov instructions for the register operand. The
+          // expectation is that there is a wait_group op before this WGMMA op
+          // which waits for the same WGMMA op issued in the previous iteration
+          // to finish. By inserting a mov instruction between such wait and the
+          // WGMMA, we can safely overlap transformations on the A operand with
+          // the previous-iteration WGMMA still in flight.
+          for (Value &regAVal : regA) {
+            OpBuilder::InsertionGuard guard(rewriter);
+            rewriter.setInsertionPoint(startSequence);
+            Type regTy = regAVal.getType();
+            if (!regTy.isIntOrFloat() || regTy.getIntOrFloatBitWidth() != 32) {
+              return mlir::emitError(loc, "unsupported WGMMA A register type ")
+                     << regTy;
+            }
+
+            Value movIn = regTy.isInteger(32)
+                              ? regAVal
+                              : tb.bitcast(regAVal, rewriter.getI32Type());
+
+            PTXBuilder ptxBuilder;
+            auto *dstOpr = ptxBuilder.newOperand("=r");
+            auto *srcOpr = ptxBuilder.newOperand(movIn, "r");
+            ptxBuilder.create("mov")->o("b32")(dstOpr, srcOpr);
+            Value movedReg =
+                ptxBuilder.launch(rewriter, loc, rewriter.getI32Type());
+            regAVal =
+                regTy.isInteger(32) ? movedReg : tb.bitcast(movedReg, regTy);
+          }
           auto regATy = LLVM::LLVMStructType::getLiteral(
               rewriter.getContext(),
               SmallVector<Type>(regA.size(), regA[0].getType()));

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1467,10 +1467,8 @@ struct AsyncTMACopyGlobalToLocalOpConversion
 
     uint32_t barrierMask =
         toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
-    // We emit a cluster-level barrier if we change the barrier and we don't
-    // multicast over that dimension (in which case that CTA would be predicated
-    // out)
-    bool clusterBarrier = barrierMask & ~maskCGABroadcast;
+    // We emit a cluster-level barrier when the barrier mask is set.
+    bool clusterBarrier = barrierMask != 0;
     if (clusterBarrier) {
       // This part is to support TMA into tcgen05.mma 2CTA mostly, i.e.,
       // barrierMask == 1
@@ -1512,12 +1510,18 @@ struct AsyncTMACopyGlobalToLocalOpConversion
           ptxBuilderTMA.newOperand(boxPred, "b"),
           ptxBuilderTMA.newOperand(shMemPtr, "r"),
           ptxBuilderTMA.newOperand(adaptor.getDesc(), "l")};
-      std::string tmaInst =
-          "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
-          "d.shared::cluster.global.mbarrier::complete_tx::bytes";
+      // The destination SMEM scope is cluster-level whenever the copy involves
+      // the cluster -- a cluster barrier (#9510), multicast, or a 2-CTA group;
+      // otherwise it is CTA-local. The barrier component keys on the barrier
+      // layout (not the SMEM layout), matching #9510.
+      auto multicastMask = op.getMulticastTargets();
+      bool clusterScope = clusterBarrier || multicast ||
+                          multicastMask != nullptr || op.getTwoCta();
+      std::string tmaInst = "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
+                            "d.shared::" + (clusterScope ? "cluster" : "cta") +
+                            ".global.mbarrier::complete_tx::bytes";
       if (op.getTwoCta())
         tmaInst += ".cta_group::2";
-      auto multicastMask = op.getMulticastTargets();
       if (multicastMask != nullptr)
         tmaInst += ".multicast::cluster";
       // Add L2 cache hint modifier if eviction policy is specified

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -117,7 +117,8 @@ proton.start(name="profile_name", context="shadow", backend="cupti", mode="pcsam
 #### Instrumentation
 
 The instrumentation backend allows for detailed, fine-grained profiling of intra-kernel behavior, generating trace or tree views similar to those produced by coarse-grained profiling.
-By default, if no `mode` is specified, Proton profiles kernel cycles, which may require shared memory or global memory (depends on `buffer-type`). If there is insufficient profiling memory capacity, profiling will abort and a warning will be displayed. Future releases will introduce additional instrumentation modes. See the [tutorial](tutorials/intra_kernel) for more detailed information and examples.
+By default, if no `mode` is specified, Proton profiles kernel cycles, which may require shared memory or global memory (depends on `buffer-type`). If there is insufficient profiling memory capacity, profiling will abort and a warning will be displayed. Future releases will introduce additional instrumentation modes. See the [tutorial](tutorials/intra_kernel) for more detailed information and examples. A video demo of the Tutorials from the 2025 Triton conference can be found here:
+https://youtu.be/PGUw2P55ZYM?si=EgsYeGzb9suBZSX5&t=984
 
 **Host-side usage:**
 
@@ -166,7 +167,7 @@ def kernel(...):
             gl.load(...)
 ```
 
-Advanced users can instrument either the `ttir` or `ttgir` intermediate representations for even finer-grained measurement. The relevant IR instructions are `proton.record start` and `proton.record end`. This can be combined with the environment variable `TRITON_KERNEL_OVERRIDE=1` for custom kernel overrides. For detailed steps, refer to the Triton [documentation](https://github.com/triton-lang/triton?tab=readme-ov-file#tips-for-hacking) under the **Kernel Override Steps** section. We have also assembled a [tutorial](tutorials/intra_kernel) that demonstrates how to use the IR-based instrumentation approach and the proton DSL approach.
+Advanced users can instrument either the `ttir` or `ttgir` intermediate representations for even finer-grained measurement. The relevant IR instructions are `proton.record start` and `proton.record end`. This can be combined with the environment variable `TRITON_KERNEL_OVERRIDE=1` for custom kernel overrides. For detailed steps, refer to the Triton [documentation](https://github.com/triton-lang/triton?tab=readme-ov-file#tips-for-hacking) under the **Kernel Override Steps** section. We have also assembled a [tutorial](tutorials/intra_kernel) that demonstrates how to use the IR-based instrumentation approach and the proton DSL approach. Video demo of the IR-based instrumentation approach can be found here:https://youtu.be/PGUw2P55ZYM?si=mBaHPud74EPAa7xt&t=1074
 
 ### Hook
 

--- a/third_party/proton/csrc/include/Data/TraceData.h
+++ b/third_party/proton/csrc/include/Data/TraceData.h
@@ -16,17 +16,11 @@ public:
 
   std::vector<uint8_t> toMsgPack(size_t phase) const override;
 
-  DataEntry addOp(const std::string &name) override;
-
   DataEntry addOp(size_t phase, size_t eventId,
                   const std::vector<Context> &contexts) override;
 
   void
   addMetrics(size_t scopeId,
-             const std::map<std::string, MetricValueType> &metrics) override;
-
-  void
-  addMetrics(size_t phase, size_t entryId,
              const std::map<std::string, MetricValueType> &metrics) override;
 
   class Trace;

--- a/third_party/proton/csrc/include/Data/TreeData.h
+++ b/third_party/proton/csrc/include/Data/TreeData.h
@@ -24,17 +24,11 @@ public:
 
   std::vector<uint8_t> toMsgPack(size_t phase) const override;
 
-  DataEntry addOp(const std::string &name) override;
-
   DataEntry addOp(size_t phase, size_t contextId,
                   const std::vector<Context> &contexts) override;
 
   void
   addMetrics(size_t scopeId,
-             const std::map<std::string, MetricValueType> &metrics) override;
-
-  void
-  addMetrics(size_t phase, size_t entryId,
              const std::map<std::string, MetricValueType> &metrics) override;
 
 protected:
@@ -48,8 +42,10 @@ private:
   // the background threads concurrently, so methods that access them should be
   // protected by a (shared) mutex.
   class Tree;
-  json buildHatchetJson(TreeData::Tree *tree) const;
-  std::vector<uint8_t> buildHatchetMsgPack(TreeData::Tree *tree) const;
+  json buildHatchetJson(TreeData::Tree *tree,
+                        TreeData::Tree *virtualTree) const;
+  std::vector<uint8_t> buildHatchetMsgPack(TreeData::Tree *tree,
+                                           TreeData::Tree *virtualTree) const;
 
   // Data
   void doDump(std::ostream &os, OutputFormat outputFormat,

--- a/third_party/proton/csrc/include/Profiler/Instrumentation/InstrumentationProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/Instrumentation/InstrumentationProfiler.h
@@ -69,7 +69,7 @@ private:
   std::map<uint64_t, std::string> functionNames;
   // functionId -> metadata
   std::map<uint64_t, InstrumentationMetadata> functionMetadata;
-  // data -> scopeId
+  // Active per-data entries for the current op.
   DataToEntryMap dataToEntryMap;
 };
 

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -4,6 +4,7 @@
 #include "nlohmann/json.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
@@ -49,8 +50,8 @@ public:
     size_t id = 0;
     size_t scopeId = Scope::DummyScopeId;
     size_t contextId = TraceContext::DummyId;
-    std::map<MetricKind, std::unique_ptr<Metric>> metrics = {};
-    std::map<std::string, FlexibleMetric> flexibleMetrics = {};
+    // Direct and linked metrics emitted for this trace event.
+    DataEntry::MetricSet metricSet{};
 
     const static inline size_t DummyId = std::numeric_limits<size_t>::max();
   };
@@ -102,7 +103,7 @@ public:
   }
 
   size_t addEvent(size_t contextId) {
-    traceEvents.emplace(nextEventId, TraceEvent(nextEventId, contextId));
+    traceEvents.try_emplace(nextEventId, nextEventId, contextId);
     return nextEventId++;
   }
 
@@ -147,46 +148,21 @@ void TraceData::exitScope(const Scope &scope) {
   scopeIdToEventId.erase(scope.scopeId);
 }
 
-DataEntry TraceData::addOp(const std::string &name) {
-  std::unique_lock<std::shared_mutex> lock(mutex);
-  auto *currentTrace = currentPhasePtrAs<Trace>();
-  std::vector<Context> contexts;
-  contexts = contextSource->getContexts();
-  if (!name.empty()) // not a placeholder event
-    contexts.emplace_back(name);
-  auto contextId = currentTrace->addContexts(contexts);
-  auto eventId = currentTrace->addEvent(contextId);
-  auto &event = currentTrace->getEvent(eventId);
-  return DataEntry(eventId, currentPhase.load(std::memory_order_relaxed),
-                   event.metrics);
-}
-
 DataEntry TraceData::addOp(size_t phase, size_t eventId,
                            const std::vector<Context> &contexts) {
-  auto lock = lockIfCurrentPhase(phase);
+  auto lock = lockIfCurrentOrVirtualPhase(phase);
   auto *trace = phasePtrAs<Trace>(phase);
-  // Add a new context under it and update the context
-  auto &event = trace->getEvent(eventId);
-  auto contextId = trace->addContexts(contexts, event.contextId);
-  auto newEventId = trace->addEvent(contextId);
-  auto &newEvent = trace->getEvent(newEventId);
-  return DataEntry(newEventId, phase, newEvent.metrics);
-}
-
-void TraceData::addMetrics(
-    size_t phase, size_t eventId,
-    const std::map<std::string, MetricValueType> &metrics) {
-  auto lock = lockIfCurrentPhase(phase);
-  auto *trace = phasePtrAs<Trace>(phase);
-  auto &event = trace->getEvent(eventId);
-  for (auto [metricName, metricValue] : metrics) {
-    if (event.flexibleMetrics.find(metricName) == event.flexibleMetrics.end()) {
-      event.flexibleMetrics.emplace(metricName,
-                                    FlexibleMetric(metricName, metricValue));
-    } else {
-      event.flexibleMetrics.at(metricName).updateValue(metricValue);
-    }
+  auto parentContextId = 0;
+  if (eventId == Data::kRootEntryId) {
+    parentContextId = Trace::TraceContext::RootId;
+  } else {
+    auto &event = trace->getEvent(eventId);
+    parentContextId = event.contextId;
   }
+  const auto contextId = trace->addContexts(contexts, parentContextId);
+  const auto newEventId = trace->addEvent(contextId);
+  auto &newEvent = trace->getEvent(newEventId);
+  return DataEntry(newEventId, phase, newEvent.metricSet);
 }
 
 void TraceData::addMetrics(
@@ -195,12 +171,13 @@ void TraceData::addMetrics(
   auto *currentTrace = currentPhasePtrAs<Trace>();
   auto eventId = scopeIdToEventId.at(scopeId);
   auto &event = currentTrace->getEvent(eventId);
+  auto &flexibleMetrics = event.metricSet.flexibleMetrics;
   for (auto [metricName, metricValue] : metrics) {
-    if (event.flexibleMetrics.find(metricName) == event.flexibleMetrics.end()) {
-      event.flexibleMetrics.emplace(metricName,
-                                    FlexibleMetric(metricName, metricValue));
+    if (flexibleMetrics.find(metricName) == flexibleMetrics.end()) {
+      flexibleMetrics.emplace(metricName,
+                              FlexibleMetric(metricName, metricValue));
     } else {
-      event.flexibleMetrics.at(metricName).updateValue(metricValue);
+      flexibleMetrics.at(metricName).updateValue(metricValue);
     }
   }
 }
@@ -224,15 +201,24 @@ namespace {
 // Structure to pair CycleMetric with its context for processing
 struct CycleMetricWithContext {
   const CycleMetric *cycleMetric;
-  uint32_t contextId;
+  // Full call path captured for this cycle metric event.
+  std::vector<Context> contexts;
 
-  CycleMetricWithContext(const CycleMetric *metric, uint32_t ctx)
-      : cycleMetric(metric), contextId(ctx) {}
+  CycleMetricWithContext(const CycleMetric *metric, std::vector<Context> ctx)
+      : cycleMetric(metric), contexts(std::move(ctx)) {}
+};
+
+struct KernelMetricWithContext {
+  const KernelMetric *kernelMetric;
+  // Full call path captured for this kernel metric event.
+  std::vector<Context> contexts;
+
+  KernelMetricWithContext(const KernelMetric *metric, std::vector<Context> ctx)
+      : kernelMetric(metric), contexts(std::move(ctx)) {}
 };
 
 std::vector<KernelTrace>
-convertToTimelineTrace(TraceData::Trace *trace,
-                       std::vector<CycleMetricWithContext> &cycleEvents) {
+convertToTimelineTrace(std::vector<CycleMetricWithContext> &cycleEvents) {
   std::vector<KernelTrace> results;
 
   auto getInt64Value = [](const CycleMetric *metric,
@@ -351,7 +337,7 @@ convertToTimelineTrace(TraceData::Trace *trace,
             break;
           }
 
-          auto scopeName = trace->getContexts(event.contextId).back().name;
+          auto scopeName = event.contexts.back().name;
           if (scopeNameToId.count(scopeName) == 0) {
             scopeIdToName[curScopeId] = scopeName;
             scopeNameToId[scopeName] = curScopeId;
@@ -378,7 +364,7 @@ convertToTimelineTrace(TraceData::Trace *trace,
     }
     std::vector<std::string> callStack;
     if (!sortedEvents.empty()) {
-      auto contexts = trace->getContexts(kernelEvent.contextId);
+      auto &contexts = kernelEvent.contexts;
       if (!contexts.empty()) {
         callStack.resize(contexts.size() - 1);
         std::transform(contexts.begin(), contexts.end() - 1, callStack.begin(),
@@ -396,26 +382,24 @@ convertToTimelineTrace(TraceData::Trace *trace,
   return results;
 }
 
-void dumpCycleMetricTrace(TraceData::Trace *trace,
-                          std::vector<CycleMetricWithContext> &cycleEvents,
+void dumpCycleMetricTrace(std::vector<CycleMetricWithContext> &cycleEvents,
                           std::ostream &os) {
-  auto timeline = convertToTimelineTrace(trace, cycleEvents);
+  auto timeline = convertToTimelineTrace(cycleEvents);
   auto writer = StreamChromeTraceWriter(timeline, "");
   writer.write(os);
 }
 
 void dumpKernelMetricTrace(
-    TraceData::Trace *trace, uint64_t minTimeStamp,
-    std::map<size_t, std::vector<const TraceData::Trace::TraceEvent *>>
+    uint64_t minTimeStamp,
+    const std::map<size_t, std::vector<KernelMetricWithContext>>
         &streamTraceEvents,
     std::ostream &os) {
   // for each streamId in ascending order, emit one JSON line
   for (auto const &[streamId, events] : streamTraceEvents) {
     json object = {{"displayTimeUnit", "us"}, {"traceEvents", json::array()}};
 
-    for (auto const *event : events) {
-      auto *kernelMetrics = static_cast<KernelMetric *>(
-          event->metrics.at(MetricKind::Kernel).get());
+    for (const auto &event : events) {
+      auto *kernelMetrics = event.kernelMetric;
       uint64_t startTimeNs =
           std::get<uint64_t>(kernelMetrics->getValue(KernelMetric::StartTime));
       uint64_t endTimeNs =
@@ -424,8 +408,7 @@ void dumpKernelMetricTrace(
       double ts = static_cast<double>(startTimeNs - minTimeStamp) / 1000;
       double dur = static_cast<double>(endTimeNs - startTimeNs) / 1000;
 
-      auto contextId = event->contextId;
-      auto contexts = trace->getContexts(contextId);
+      const auto &contexts = event.contexts;
 
       json element;
       element["name"] = contexts.back().name;
@@ -435,7 +418,7 @@ void dumpKernelMetricTrace(
       element["dur"] = dur;
       element["tid"] = streamId; // thread id = stream
       json callStack = json::array();
-      for (auto const &ctx : contexts) {
+      for (const auto &ctx : contexts) {
         callStack.push_back(ctx.name);
       }
       element["args"]["call_stack"] = std::move(callStack);
@@ -450,35 +433,75 @@ void dumpKernelMetricTrace(
 } // namespace
 
 void TraceData::dumpChromeTrace(std::ostream &os, size_t phase) const {
+  std::set<size_t> virtualTargetEntryIds;
+  tracePhases.withPtr(phase, [&](Trace *trace) {
+    for (const auto &[_, event] : trace->getEvents()) {
+      for (const auto &[targetEntryId, _] : event.metricSet.linkedMetrics) {
+        virtualTargetEntryIds.insert(targetEntryId);
+      }
+      for (const auto &[targetEntryId, _] :
+           event.metricSet.linkedFlexibleMetrics) {
+        virtualTargetEntryIds.insert(targetEntryId);
+      }
+    }
+  });
+
+  std::map<size_t, std::vector<Context>> targetIdToVirtualContexts;
+  if (!virtualTargetEntryIds.empty()) {
+    tracePhases.withPtr(Data::kVirtualPhase, [&](Trace *virtualTrace) {
+      for (auto targetEntryId : virtualTargetEntryIds) {
+        // Linked target ids are event ids, so resolve through the event first.
+        auto &targetEvent = virtualTrace->getEvent(targetEntryId);
+        auto contexts = virtualTrace->getContexts(targetEvent.contextId);
+        contexts.erase(contexts.begin());
+        targetIdToVirtualContexts.emplace(targetEntryId, std::move(contexts));
+      }
+    });
+  }
+
   tracePhases.withPtr(phase, [&](Trace *trace) {
     auto &events = trace->getEvents();
     // stream id -> trace event
-    std::map<size_t, std::vector<const Trace::TraceEvent *>> streamTraceEvents;
+    std::map<size_t, std::vector<KernelMetricWithContext>> streamTraceEvents;
     uint64_t minTimeStamp = std::numeric_limits<uint64_t>::max();
     bool hasKernelMetrics = false, hasCycleMetrics = false;
-    // Data structure for efficient cycle metrics conversion
-    std::map<uint64_t, int> kernelBlockNum;
     std::vector<CycleMetricWithContext> cycleEvents;
     cycleEvents.reserve(events.size());
-    for (auto &entry : events) {
-      auto &event = entry.second;
-      if (event.metrics.count(MetricKind::Kernel)) {
-        auto *kernelMetric = static_cast<KernelMetric *>(
-            event.metrics.at(MetricKind::Kernel).get());
-        auto streamId =
-            std::get<uint64_t>(kernelMetric->getValue(KernelMetric::StreamId));
-        streamTraceEvents[streamId].push_back(&event);
 
-        uint64_t startTime =
-            std::get<uint64_t>(kernelMetric->getValue(KernelMetric::StartTime));
-        minTimeStamp = std::min(minTimeStamp, startTime);
-        hasKernelMetrics = true;
-      }
-      if (event.metrics.count(MetricKind::Cycle)) {
-        auto *cycleMetric = static_cast<CycleMetric *>(
-            event.metrics.at(MetricKind::Cycle).get());
-        cycleEvents.emplace_back(cycleMetric, event.contextId);
-        hasCycleMetrics = true;
+    auto processMetricMaps =
+        [&](const std::map<MetricKind, std::unique_ptr<Metric>> &metrics,
+            const std::vector<Context> &contexts) {
+          if (auto kernelIt = metrics.find(MetricKind::Kernel);
+              kernelIt != metrics.end()) {
+            auto *kernelMetric =
+                static_cast<KernelMetric *>(kernelIt->second.get());
+            const auto streamId = std::get<uint64_t>(
+                kernelMetric->getValue(KernelMetric::StreamId));
+            streamTraceEvents[streamId].emplace_back(kernelMetric, contexts);
+            const auto startTime = std::get<uint64_t>(
+                kernelMetric->getValue(KernelMetric::StartTime));
+            minTimeStamp = std::min(minTimeStamp, startTime);
+            hasKernelMetrics = true;
+          }
+          if (auto cycleIt = metrics.find(MetricKind::Cycle);
+              cycleIt != metrics.end()) {
+            auto *cycleMetric =
+                static_cast<CycleMetric *>(cycleIt->second.get());
+            cycleEvents.emplace_back(cycleMetric, contexts);
+            hasCycleMetrics = true;
+          }
+        };
+
+    for (const auto &[_, event] : events) {
+      auto baseContexts = trace->getContexts(event.contextId);
+      processMetricMaps(event.metricSet.metrics, baseContexts);
+      for (const auto &[targetEntryId, linkedMetrics] :
+           event.metricSet.linkedMetrics) {
+        auto contexts = baseContexts;
+        auto &virtualContexts = targetIdToVirtualContexts[targetEntryId];
+        contexts.insert(contexts.end(), virtualContexts.begin(),
+                        virtualContexts.end());
+        processMetricMaps(linkedMetrics, contexts);
       }
 
       if (hasKernelMetrics && hasCycleMetrics) {
@@ -487,11 +510,11 @@ void TraceData::dumpChromeTrace(std::ostream &os, size_t phase) const {
     }
 
     if (hasCycleMetrics) {
-      dumpCycleMetricTrace(trace, cycleEvents, os);
+      dumpCycleMetricTrace(cycleEvents, os);
     }
 
     if (hasKernelMetrics) {
-      dumpKernelMetricTrace(trace, minTimeStamp, streamTraceEvents, os);
+      dumpKernelMetricTrace(minTimeStamp, streamTraceEvents, os);
     }
   });
 }

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -32,6 +32,61 @@ const std::array<std::string, static_cast<size_t>(DeviceType::COUNT)>
 
 constexpr size_t kMaxRegisteredDeviceIds = 32;
 
+struct MetricSummary {
+  // Whether we observed at least one kernel metric.
+  bool hasKernelMetric = false;
+  // Whether we observed at least one PC sampling metric.
+  bool hasPCSamplingMetric = false;
+  // Whether we observed at least one cycle metric.
+  bool hasCycleMetric = false;
+  // device_type -> bitmask of observed device ids.
+  std::array<uint32_t, static_cast<size_t>(DeviceType::COUNT)> deviceIdMasks{};
+
+  void updateDeviceIdMask(uint64_t deviceType, uint64_t deviceId) {
+    if (deviceType >= static_cast<uint64_t>(DeviceType::COUNT)) {
+      throw std::runtime_error("[PROTON] Invalid deviceType " +
+                               std::to_string(deviceType));
+    }
+    if (deviceId >= kMaxRegisteredDeviceIds) {
+      throw std::runtime_error("[PROTON] DeviceId " + std::to_string(deviceId) +
+                               " exceeds MaxRegisteredDeviceIds " +
+                               std::to_string(kMaxRegisteredDeviceIds) +
+                               " for deviceType " + std::to_string(deviceType));
+    }
+    deviceIdMasks[static_cast<size_t>(deviceType)] |=
+        (1u << static_cast<uint32_t>(deviceId));
+  }
+
+  void
+  observeMetrics(const std::map<MetricKind, std::unique_ptr<Metric>> &metrics) {
+    for (const auto &[metricKind, metric] : metrics) {
+      if (metricKind == MetricKind::Kernel) {
+        hasKernelMetric = true;
+        auto *kernelMetric = static_cast<KernelMetric *>(metric.get());
+        uint64_t deviceId =
+            std::get<uint64_t>(kernelMetric->getValue(KernelMetric::DeviceId));
+        uint64_t deviceType = std::get<uint64_t>(
+            kernelMetric->getValue(KernelMetric::DeviceType));
+        updateDeviceIdMask(deviceType, deviceId);
+      } else if (metricKind == MetricKind::PCSampling) {
+        hasPCSamplingMetric = true;
+      } else if (metricKind == MetricKind::Cycle) {
+        hasCycleMetric = true;
+        auto *cycleMetric = static_cast<CycleMetric *>(metric.get());
+        uint64_t deviceId =
+            std::get<uint64_t>(cycleMetric->getValue(CycleMetric::DeviceId));
+        uint64_t deviceType =
+            std::get<uint64_t>(cycleMetric->getValue(CycleMetric::DeviceType));
+        updateDeviceIdMask(deviceType, deviceId);
+      } else if (metricKind == MetricKind::Flexible) {
+        // Flexible metrics are tracked in a separate map.
+      } else {
+        throw std::runtime_error("MetricKind not supported");
+      }
+    }
+  }
+};
+
 } // namespace
 
 class TreeData::Tree {
@@ -66,8 +121,8 @@ public:
     size_t id = DummyId;
     std::vector<ChildEntry> children = {};
     std::unordered_map<std::string_view, size_t> childIndex = {};
-    std::map<MetricKind, std::unique_ptr<Metric>> metrics = {};
-    std::map<std::string, FlexibleMetric> flexibleMetrics = {};
+    // Direct and linked metrics associated with this tree node.
+    DataEntry::MetricSet metricSet{};
     friend class Tree;
   };
 
@@ -109,10 +164,10 @@ public:
   void upsertFlexibleMetric(size_t contextId,
                             const FlexibleMetric &flexibleMetric) {
     auto &node = treeNodeMap.at(contextId);
-    auto it = node.flexibleMetrics.find(flexibleMetric.getValueName(0));
-    if (it == node.flexibleMetrics.end()) {
-      node.flexibleMetrics.emplace(flexibleMetric.getValueName(0),
-                                   flexibleMetric);
+    auto &flexibleMetrics = node.metricSet.flexibleMetrics;
+    auto it = flexibleMetrics.find(flexibleMetric.getValueName(0));
+    if (it == flexibleMetrics.end()) {
+      flexibleMetrics.emplace(flexibleMetric.getValueName(0), flexibleMetric);
     } else {
       it->second.updateMetric(flexibleMetric);
     }
@@ -135,14 +190,26 @@ public:
     }
   }
 
-  template <typename FnT> void walkPostOrder(size_t contextId, FnT &&fn) {
-    for (const auto &child : getNode(contextId).children) {
-      walkPostOrder(child.id, fn);
-    }
-    fn(getNode(contextId));
-  }
-
   size_t size() const { return nextContextId; }
+
+  Tree structure() const {
+    Tree cloned;
+    cloned.nextContextId = nextContextId;
+
+    for (const auto &[id, node] : treeNodeMap) {
+      cloned.treeNodeMap.try_emplace(id, id, node.parentId, node.name);
+    }
+
+    for (const auto &[id, node] : treeNodeMap) {
+      auto &clonedNode = cloned.treeNodeMap.at(id);
+      clonedNode.children.reserve(node.children.size());
+      for (const auto &child : node.children) {
+        clonedNode.addChild(cloned.treeNodeMap[child.id].name, child.id);
+      }
+    }
+
+    return cloned;
+  }
 
 private:
   size_t nextContextId = TreeNode::RootId + 1;
@@ -150,26 +217,23 @@ private:
   std::unordered_map<size_t, TreeNode> treeNodeMap;
 };
 
-json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
+json TreeData::buildHatchetJson(TreeData::Tree *tree,
+                                TreeData::Tree *virtualTree) const {
   std::vector<json *> jsonNodes(tree->size(), nullptr);
   json output = json::array();
   output.push_back(json::object());
   jsonNodes[TreeData::Tree::TreeNode::RootId] = &(output.back());
-  bool hasKernelMetric = false;
-  bool hasPCSamplingMetric = false;
-  bool hasCycleMetric = false;
-  std::array<uint32_t, static_cast<size_t>(DeviceType::COUNT)> deviceIdMasks{};
-  tree->template walk<TreeData::Tree::WalkPolicy::PreOrder>(
-      [&](TreeData::Tree::TreeNode &treeNode) {
-        const auto contextName = treeNode.name;
-        auto contextId = treeNode.id;
-        json *jsonNode = jsonNodes[contextId];
-        (*jsonNode)["frame"] = {{"name", contextName}, {"type", "function"}};
-        (*jsonNode)["metrics"] = json::object();
-        auto &metricsJson = (*jsonNode)["metrics"];
-        for (auto &[metricKind, metric] : treeNode.metrics) {
+  MetricSummary metricSummary;
+  const std::map<MetricKind, std::unique_ptr<Metric>> emptyMetrics;
+  const std::map<std::string, FlexibleMetric> emptyFlexibleMetrics;
+  const auto &virtualRootNode = virtualTree->getNode(Tree::TreeNode::RootId);
+  auto appendMetrics =
+      [&](json &metricsJson,
+          const std::map<MetricKind, std::unique_ptr<Metric>> &metrics,
+          const std::map<std::string, FlexibleMetric> &flexibleMetrics) {
+        metricSummary.observeMetrics(metrics);
+        for (const auto &[metricKind, metric] : metrics) {
           if (metricKind == MetricKind::Kernel) {
-            hasKernelMetric = true;
             auto *kernelMetric = static_cast<KernelMetric *>(metric.get());
             uint64_t duration = std::get<uint64_t>(
                 kernelMetric->getValue(KernelMetric::Duration));
@@ -179,16 +243,6 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
                 kernelMetric->getValue(KernelMetric::DeviceId));
             uint64_t deviceType = std::get<uint64_t>(
                 kernelMetric->getValue(KernelMetric::DeviceType));
-            if (deviceId < kMaxRegisteredDeviceIds) {
-              deviceIdMasks[static_cast<size_t>(deviceType)] |=
-                  (1u << static_cast<uint32_t>(deviceId));
-            } else {
-              throw std::runtime_error(
-                  "[PROTON] DeviceId " + std::to_string(deviceId) +
-                  " exceeds MaxRegisteredDeviceIds " +
-                  std::to_string(kMaxRegisteredDeviceIds) + " for deviceType " +
-                  std::to_string(deviceType));
-            }
             const auto &deviceTypeName =
                 kDeviceTypeNames[static_cast<size_t>(deviceType)];
             const auto &durationName =
@@ -206,7 +260,6 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
             metricsJson[deviceIdName] = deviceIdStr;
             metricsJson[deviceTypeNameKey] = deviceTypeName;
           } else if (metricKind == MetricKind::PCSampling) {
-            hasPCSamplingMetric = true;
             auto *pcSamplingMetric =
                 static_cast<PCSamplingMetric *>(metric.get());
             for (size_t i = 0; i < PCSamplingMetric::Count; i++) {
@@ -215,7 +268,6 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
                          pcSamplingMetric->getValues()[i]);
             }
           } else if (metricKind == MetricKind::Cycle) {
-            hasCycleMetric = true;
             auto *cycleMetric = static_cast<CycleMetric *>(metric.get());
             uint64_t duration = std::get<uint64_t>(
                 cycleMetric->getValue(CycleMetric::Duration));
@@ -225,16 +277,6 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
                 cycleMetric->getValue(CycleMetric::DeviceId));
             uint64_t deviceType = std::get<uint64_t>(
                 cycleMetric->getValue(CycleMetric::DeviceType));
-            if (deviceId < kMaxRegisteredDeviceIds) {
-              deviceIdMasks[static_cast<size_t>(deviceType)] |=
-                  (1u << static_cast<uint32_t>(deviceId));
-            } else {
-              throw std::runtime_error(
-                  "[PROTON] DeviceId " + std::to_string(deviceId) +
-                  " exceeds MaxRegisteredDeviceIds " +
-                  std::to_string(kMaxRegisteredDeviceIds) + " for deviceType " +
-                  std::to_string(deviceType));
-            }
             const auto &durationName =
                 cycleMetric->getValueName(CycleMetric::Duration);
             const auto &normalizedDurationName =
@@ -256,7 +298,7 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
             throw std::runtime_error("MetricKind not supported");
           }
         }
-        for (auto &[_, flexibleMetric] : treeNode.flexibleMetrics) {
+        for (const auto &[_, flexibleMetric] : flexibleMetrics) {
           const auto &valueName = flexibleMetric.getValueName(0);
           std::visit(
               [&](auto &&v) {
@@ -281,31 +323,91 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
               },
               flexibleMetric.getValues()[0]);
         }
+      };
+
+  tree->template walk<TreeData::Tree::WalkPolicy::PreOrder>(
+      [&](TreeData::Tree::TreeNode &treeNode) {
+        const auto contextName = treeNode.name;
+        auto contextId = treeNode.id;
+        json *jsonNode = jsonNodes[contextId];
+        (*jsonNode)["frame"] = {{"name", contextName}, {"type", "function"}};
+        (*jsonNode)["metrics"] = json::object();
+        auto &metricsJson = (*jsonNode)["metrics"];
+        appendMetrics(metricsJson, treeNode.metricSet.metrics,
+                      treeNode.metricSet.flexibleMetrics);
         auto &childrenArray = (*jsonNode)["children"];
         childrenArray = json::array();
+        const bool hasLinkedTargets =
+            !treeNode.metricSet.linkedMetrics.empty() ||
+            !treeNode.metricSet.linkedFlexibleMetrics.empty();
         childrenArray.get_ref<json::array_t &>().reserve(
-            treeNode.children.size());
+            treeNode.children.size() +
+            (hasLinkedTargets ? virtualRootNode.children.size() : 0));
         for (const auto &child : treeNode.children) {
           childrenArray.push_back(json::object());
           jsonNodes[child.id] = &childrenArray.back();
         }
+        if (!hasLinkedTargets) {
+          return;
+        }
+        std::function<void(size_t, json &)> appendLinkedVirtualNode =
+            [&](size_t virtualNodeId, json &outNode) {
+              const auto &virtualNode = virtualTree->getNode(virtualNodeId);
+              const auto metricsIt =
+                  treeNode.metricSet.linkedMetrics.find(virtualNodeId);
+              const auto flexibleIt =
+                  treeNode.metricSet.linkedFlexibleMetrics.find(virtualNodeId);
+              outNode = json::object();
+              outNode["frame"] = {{"name", virtualNode.name},
+                                  {"type", "function"}};
+              outNode["metrics"] = json::object();
+              if (metricsIt != treeNode.metricSet.linkedMetrics.end() ||
+                  flexibleIt !=
+                      treeNode.metricSet.linkedFlexibleMetrics.end()) {
+                const auto &linkedMetrics =
+                    (metricsIt != treeNode.metricSet.linkedMetrics.end())
+                        ? metricsIt->second
+                        : emptyMetrics;
+                const auto &linkedFlexibleMetrics =
+                    (flexibleIt !=
+                     treeNode.metricSet.linkedFlexibleMetrics.end())
+                        ? flexibleIt->second
+                        : emptyFlexibleMetrics;
+                appendMetrics(outNode["metrics"], linkedMetrics,
+                              linkedFlexibleMetrics);
+              }
+              outNode["children"] = json::array();
+              auto &linkedChildren = outNode["children"];
+              linkedChildren.get_ref<json::array_t &>().reserve(
+                  virtualNode.children.size());
+              for (const auto &child : virtualNode.children) {
+                linkedChildren.push_back(json::object());
+                appendLinkedVirtualNode(child.id, linkedChildren.back());
+              }
+            };
+
+        for (const auto &virtualChild : virtualRootNode.children) {
+          json linkedRootChildNode;
+          appendLinkedVirtualNode(virtualChild.id, linkedRootChildNode);
+          childrenArray.push_back(std::move(linkedRootChildNode));
+        }
       });
 
-  if (hasKernelMetric) {
+  if (metricSummary.hasKernelMetric) {
     KernelMetric kernelMetric;
     output[TreeData::Tree::TreeNode::RootId]["metrics"]
           [kernelMetric.getValueName(KernelMetric::Invocations)] = 0;
     output[TreeData::Tree::TreeNode::RootId]["metrics"]
           [kernelMetric.getValueName(KernelMetric::Duration)] = 0;
   }
-  if (hasCycleMetric) {
+  if (metricSummary.hasCycleMetric) {
     CycleMetric cycleMetric;
     output[TreeData::Tree::TreeNode::RootId]["metrics"]
           [cycleMetric.getValueName(CycleMetric::Duration)] = 0;
     output[TreeData::Tree::TreeNode::RootId]["metrics"]
           [cycleMetric.getValueName(CycleMetric::NormalizedDuration)] = 0;
   }
-  if (hasPCSamplingMetric) {
+  if (metricSummary.hasPCSamplingMetric) {
     PCSamplingMetric pcSamplingMetric;
     for (size_t i = 0; i < PCSamplingMetric::Count; i++) {
       const auto &valueName = pcSamplingMetric.getValueName(i);
@@ -317,7 +419,7 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
   auto &deviceJson = output.back();
   for (size_t deviceType = 0;
        deviceType < static_cast<size_t>(DeviceType::COUNT); ++deviceType) {
-    auto mask = deviceIdMasks[deviceType];
+    auto mask = metricSummary.deviceIdMasks[deviceType];
     if (mask == 0) {
       continue;
     }
@@ -346,49 +448,23 @@ json TreeData::buildHatchetJson(TreeData::Tree *tree) const {
   return output;
 }
 
-std::vector<uint8_t> TreeData::buildHatchetMsgPack(TreeData::Tree *tree) const {
+std::vector<uint8_t>
+TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
+                              TreeData::Tree *virtualTree) const {
   MsgPackWriter writer;
   writer.reserve(16 * 1024 * 1024); // 16 MB
 
-  bool hasKernelMetric = false;
-  bool hasPCSamplingMetric = false;
-  bool hasCycleMetric = false;
-  std::array<uint32_t, static_cast<size_t>(DeviceType::COUNT)> deviceIdMasks{};
-
-  auto updateDeviceIdMask = [&](uint64_t deviceType, uint64_t deviceId) {
-    if (deviceId < kMaxRegisteredDeviceIds) {
-      deviceIdMasks[static_cast<size_t>(deviceType)] |=
-          (1u << static_cast<uint32_t>(deviceId));
-    } else {
-      throw std::runtime_error("[PROTON] DeviceId " + std::to_string(deviceId) +
-                               " exceeds MaxRegisteredDeviceIds " +
-                               std::to_string(kMaxRegisteredDeviceIds) +
-                               " for deviceType " + std::to_string(deviceType));
-    }
-  };
+  MetricSummary metricSummary;
+  const std::map<MetricKind, std::unique_ptr<Metric>> emptyMetrics;
+  const std::map<std::string, FlexibleMetric> emptyFlexibleMetrics;
+  const auto &virtualRootNode = virtualTree->getNode(Tree::TreeNode::RootId);
 
   tree->template walk<TreeData::Tree::WalkPolicy::PreOrder>(
       [&](TreeData::Tree::TreeNode &treeNode) {
-        for (auto &[metricKind, metric] : treeNode.metrics) {
-          if (metricKind == MetricKind::Kernel) {
-            hasKernelMetric = true;
-            auto *kernelMetric = static_cast<KernelMetric *>(metric.get());
-            uint64_t deviceId = std::get<uint64_t>(
-                kernelMetric->getValue(KernelMetric::DeviceId));
-            uint64_t deviceType = std::get<uint64_t>(
-                kernelMetric->getValue(KernelMetric::DeviceType));
-            updateDeviceIdMask(deviceType, deviceId);
-          } else if (metricKind == MetricKind::PCSampling) {
-            hasPCSamplingMetric = true;
-          } else if (metricKind == MetricKind::Cycle) {
-            hasCycleMetric = true;
-            auto *cycleMetric = static_cast<CycleMetric *>(metric.get());
-            uint64_t deviceId = std::get<uint64_t>(
-                cycleMetric->getValue(CycleMetric::DeviceId));
-            uint64_t deviceType = std::get<uint64_t>(
-                cycleMetric->getValue(CycleMetric::DeviceType));
-            updateDeviceIdMask(deviceType, deviceId);
-          }
+        metricSummary.observeMetrics(treeNode.metricSet.metrics);
+        for (const auto &[_, linkedMetrics] :
+             treeNode.metricSet.linkedMetrics) {
+          metricSummary.observeMetrics(linkedMetrics);
         }
       });
 
@@ -419,57 +495,92 @@ std::vector<uint8_t> TreeData::buildHatchetMsgPack(TreeData::Tree *tree) const {
       cycleMetricDurationName, cycleMetricNormalizedDurationName};
   std::set<std::string> cycleExclusiveValueNames = {cycleMetricDeviceIdName,
                                                     cycleMetricDeviceTypeName};
-  std::function<void(TreeData::Tree::TreeNode &)> packNode =
-      [&](TreeData::Tree::TreeNode &treeNode) {
-        writer.packMap(3);
+  const auto kernelInclusiveCount =
+      static_cast<uint32_t>(kernelInclusiveValueNames.size());
+  const auto kernelTotalCount = static_cast<uint32_t>(
+      kernelInclusiveValueNames.size() + kernelExclusiveValueNames.size());
+  const auto cycleInclusiveCount =
+      static_cast<uint32_t>(cycleInclusiveValueNames.size());
+  const auto cycleTotalCount = static_cast<uint32_t>(
+      cycleInclusiveValueNames.size() + cycleExclusiveValueNames.size());
 
-        writer.packStr("frame");
-        writer.packMap(2);
-        writer.packStr("name");
-        writer.packStr(treeNode.name);
-        writer.packStr("type");
-        writer.packStr("function");
+  auto packFlexibleMetricValue = [&](const MetricValueType &value) {
+    std::visit(
+        [&](auto &&v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, uint64_t>) {
+            writer.packUInt(v);
+          } else if constexpr (std::is_same_v<T, int64_t>) {
+            writer.packInt(v);
+          } else if constexpr (std::is_same_v<T, double>) {
+            writer.packDouble(v);
+          } else if constexpr (std::is_same_v<T, std::string>) {
+            writer.packStr(v);
+          } else if constexpr (std::is_same_v<T, std::vector<uint64_t>>) {
+            writer.packArray(static_cast<uint32_t>(v.size()));
+            for (auto value : v) {
+              writer.packUInt(value);
+            }
+          } else if constexpr (std::is_same_v<T, std::vector<int64_t>>) {
+            writer.packArray(static_cast<uint32_t>(v.size()));
+            for (auto value : v) {
+              writer.packInt(value);
+            }
+          } else if constexpr (std::is_same_v<T, std::vector<double>>) {
+            writer.packArray(static_cast<uint32_t>(v.size()));
+            for (auto value : v) {
+              writer.packDouble(value);
+            }
+          } else {
+            static_assert(sizeof(T) == 0, "Unsupported MetricValueType");
+          }
+        },
+        value);
+  };
 
-        writer.packStr("metrics");
-        uint32_t metricEntries = 0;
-        for (auto &[metricKind, metric] : treeNode.metrics) {
+  auto countMetricEntries =
+      [&](const std::map<MetricKind, std::unique_ptr<Metric>> &metrics,
+          const std::map<std::string, FlexibleMetric> &flexibleMetrics,
+          bool isRoot) -> uint32_t {
+    uint32_t metricEntries = static_cast<uint32_t>(flexibleMetrics.size());
+    for (const auto &[metricKind, _] : metrics) {
+      if (metricKind == MetricKind::Kernel) {
+        metricEntries += isRoot ? kernelInclusiveCount : kernelTotalCount;
+      } else if (metricKind == MetricKind::PCSampling) {
+        metricEntries += PCSamplingMetric::Count;
+      } else if (metricKind == MetricKind::Cycle) {
+        metricEntries += isRoot ? cycleInclusiveCount : cycleTotalCount;
+      } else if (metricKind == MetricKind::Flexible) {
+        // Flexible metrics are tracked in a separate map.
+      } else {
+        throw std::runtime_error("MetricKind not supported");
+      }
+    }
+    if (isRoot) {
+      if (metricSummary.hasKernelMetric &&
+          metrics.find(MetricKind::Kernel) == metrics.end()) {
+        metricEntries += kernelInclusiveCount;
+      }
+      if (metricSummary.hasPCSamplingMetric &&
+          metrics.find(MetricKind::PCSampling) == metrics.end()) {
+        metricEntries += PCSamplingMetric::Count;
+      }
+      if (metricSummary.hasCycleMetric &&
+          metrics.find(MetricKind::Cycle) == metrics.end()) {
+        metricEntries += cycleInclusiveCount;
+      }
+    }
+    return metricEntries;
+  };
+
+  auto packMetrics =
+      [&](const std::map<MetricKind, std::unique_ptr<Metric>> &metrics,
+          const std::map<std::string, FlexibleMetric> &flexibleMetrics,
+          bool isRoot) {
+        writer.packMap(countMetricEntries(metrics, flexibleMetrics, isRoot));
+        for (const auto &[metricKind, metric] : metrics) {
           if (metricKind == MetricKind::Kernel) {
-            metricEntries += (treeNode.id == TreeData::Tree::TreeNode::RootId)
-                                 ? kernelInclusiveValueNames.size()
-                                 : (kernelInclusiveValueNames.size() +
-                                    kernelExclusiveValueNames.size());
-          } else if (metricKind == MetricKind::PCSampling) {
-            metricEntries += PCSamplingMetric::Count;
-          } else if (metricKind == MetricKind::Cycle) {
-            metricEntries += (treeNode.id == TreeData::Tree::TreeNode::RootId)
-                                 ? cycleInclusiveValueNames.size()
-                                 : (cycleInclusiveValueNames.size() +
-                                    cycleExclusiveValueNames.size());
-          }
-        }
-        if (treeNode.id == TreeData::Tree::TreeNode::RootId) {
-          if (hasKernelMetric && treeNode.metrics.find(MetricKind::Kernel) ==
-                                     treeNode.metrics.end()) {
-            metricEntries +=
-                static_cast<uint32_t>(kernelInclusiveValueNames.size());
-          }
-          if (hasPCSamplingMetric &&
-              treeNode.metrics.find(MetricKind::PCSampling) ==
-                  treeNode.metrics.end()) {
-            metricEntries += PCSamplingMetric::Count;
-          }
-          if (hasCycleMetric && treeNode.metrics.find(MetricKind::Cycle) ==
-                                    treeNode.metrics.end()) {
-            metricEntries +=
-                static_cast<uint32_t>(cycleInclusiveValueNames.size());
-          }
-        }
-        metricEntries += static_cast<uint32_t>(treeNode.flexibleMetrics.size());
-        writer.packMap(metricEntries);
-
-        for (auto &[metricKind, metric] : treeNode.metrics) {
-          if (metricKind == MetricKind::Kernel) {
-            if (treeNode.id == TreeData::Tree::TreeNode::RootId) {
+            if (isRoot) {
               writer.packStr(kernelMetricDurationName);
               writer.packUInt(0);
               writer.packStr(kernelMetricInvocationsName);
@@ -502,7 +613,7 @@ std::vector<uint8_t> TreeData::buildHatchetMsgPack(TreeData::Tree *tree) const {
             for (size_t i = 0; i < PCSamplingMetric::Count; i++) {
               const auto &valueName = pcSamplingMetric->getValueName(i);
               writer.packStr(valueName);
-              if (treeNode.id == TreeData::Tree::TreeNode::RootId) {
+              if (isRoot) {
                 writer.packUInt(0);
               } else {
                 writer.packUInt(
@@ -510,7 +621,7 @@ std::vector<uint8_t> TreeData::buildHatchetMsgPack(TreeData::Tree *tree) const {
               }
             }
           } else if (metricKind == MetricKind::Cycle) {
-            if (treeNode.id == TreeData::Tree::TreeNode::RootId) {
+            if (isRoot) {
               writer.packStr(cycleMetricDurationName);
               writer.packUInt(0);
               writer.packStr(cycleMetricNormalizedDurationName);
@@ -536,56 +647,26 @@ std::vector<uint8_t> TreeData::buildHatchetMsgPack(TreeData::Tree *tree) const {
             writer.packStr(std::to_string(deviceId));
             writer.packStr(cycleMetricDeviceTypeName);
             writer.packStr(std::to_string(deviceType));
+          } else {
+            throw std::runtime_error("MetricKind not supported");
           }
         }
-
-        for (auto &[_, flexibleMetric] : treeNode.flexibleMetrics) {
+        for (const auto &[_, flexibleMetric] : flexibleMetrics) {
           const auto &valueName = flexibleMetric.getValueName(0);
           writer.packStr(valueName);
-          std::visit(
-              [&](auto &&v) {
-                using T = std::decay_t<decltype(v)>;
-                if constexpr (std::is_same_v<T, uint64_t>) {
-                  writer.packUInt(v);
-                } else if constexpr (std::is_same_v<T, int64_t>) {
-                  writer.packInt(v);
-                } else if constexpr (std::is_same_v<T, double>) {
-                  writer.packDouble(v);
-                } else if constexpr (std::is_same_v<T, std::string>) {
-                  writer.packStr(v);
-                } else if constexpr (std::is_same_v<T, std::vector<uint64_t>>) {
-                  writer.packArray(static_cast<uint32_t>(v.size()));
-                  for (auto value : v) {
-                    writer.packUInt(value);
-                  }
-                } else if constexpr (std::is_same_v<T, std::vector<int64_t>>) {
-                  writer.packArray(static_cast<uint32_t>(v.size()));
-                  for (auto value : v) {
-                    writer.packInt(value);
-                  }
-                } else if constexpr (std::is_same_v<T, std::vector<double>>) {
-                  writer.packArray(static_cast<uint32_t>(v.size()));
-                  for (auto value : v) {
-                    writer.packDouble(value);
-                  }
-                } else {
-                  static_assert(sizeof(T) == 0, "Unsupported MetricValueType");
-                }
-              },
-              flexibleMetric.getValues()[0]);
+          packFlexibleMetricValue(flexibleMetric.getValues()[0]);
         }
 
-        if (treeNode.id == TreeData::Tree::TreeNode::RootId) {
-          if (hasKernelMetric && treeNode.metrics.find(MetricKind::Kernel) ==
-                                     treeNode.metrics.end()) {
+        if (isRoot) {
+          if (metricSummary.hasKernelMetric &&
+              metrics.find(MetricKind::Kernel) == metrics.end()) {
             writer.packStr(kernelMetricDurationName);
             writer.packUInt(0);
             writer.packStr(kernelMetricInvocationsName);
             writer.packUInt(0);
           }
-          if (hasPCSamplingMetric &&
-              treeNode.metrics.find(MetricKind::PCSampling) ==
-                  treeNode.metrics.end()) {
+          if (metricSummary.hasPCSamplingMetric &&
+              metrics.find(MetricKind::PCSampling) == metrics.end()) {
             PCSamplingMetric pcSamplingMetric;
             for (size_t i = 0; i < PCSamplingMetric::Count; i++) {
               const auto &valueName = pcSamplingMetric.getValueName(i);
@@ -593,26 +674,98 @@ std::vector<uint8_t> TreeData::buildHatchetMsgPack(TreeData::Tree *tree) const {
               writer.packUInt(0);
             }
           }
-          if (hasCycleMetric && treeNode.metrics.find(MetricKind::Cycle) ==
-                                    treeNode.metrics.end()) {
+          if (metricSummary.hasCycleMetric &&
+              metrics.find(MetricKind::Cycle) == metrics.end()) {
             writer.packStr(cycleMetricDurationName);
             writer.packUInt(0);
             writer.packStr(cycleMetricNormalizedDurationName);
             writer.packUInt(0);
           }
         }
+      };
+  std::function<void(TreeData::Tree::TreeNode &)> packNode =
+      [&](TreeData::Tree::TreeNode &treeNode) {
+        writer.packMap(3);
 
+        writer.packStr("frame");
+        writer.packMap(2);
+        writer.packStr("name");
+        writer.packStr(treeNode.name);
+        writer.packStr("type");
+        writer.packStr("function");
+
+        writer.packStr("metrics");
+        packMetrics(treeNode.metricSet.metrics,
+                    treeNode.metricSet.flexibleMetrics,
+                    treeNode.id == TreeData::Tree::TreeNode::RootId);
+        const bool hasLinkedTargets =
+            !treeNode.metricSet.linkedMetrics.empty() ||
+            !treeNode.metricSet.linkedFlexibleMetrics.empty();
+
+        std::function<void(size_t)> packLinkedVirtualNode =
+            [&](size_t virtualNodeId) {
+              const auto &virtualNode = virtualTree->getNode(virtualNodeId);
+              writer.packMap(3);
+
+              writer.packStr("frame");
+              writer.packMap(2);
+              writer.packStr("name");
+              writer.packStr(virtualNode.name);
+              writer.packStr("type");
+              writer.packStr("function");
+
+              writer.packStr("metrics");
+              const auto metricsIt =
+                  treeNode.metricSet.linkedMetrics.find(virtualNodeId);
+              const auto flexibleIt =
+                  treeNode.metricSet.linkedFlexibleMetrics.find(virtualNodeId);
+              if (metricsIt != treeNode.metricSet.linkedMetrics.end() ||
+                  flexibleIt !=
+                      treeNode.metricSet.linkedFlexibleMetrics.end()) {
+                const auto &linkedMetrics =
+                    (metricsIt != treeNode.metricSet.linkedMetrics.end())
+                        ? metricsIt->second
+                        : emptyMetrics;
+                const auto &linkedFlexibleMetrics =
+                    (flexibleIt !=
+                     treeNode.metricSet.linkedFlexibleMetrics.end())
+                        ? flexibleIt->second
+                        : emptyFlexibleMetrics;
+                packMetrics(linkedMetrics, linkedFlexibleMetrics,
+                            /*isRoot=*/false);
+              } else {
+                writer.packMap(0);
+              }
+
+              writer.packStr("children");
+              writer.packArray(
+                  static_cast<uint32_t>(virtualNode.children.size()));
+              for (const auto &child : virtualNode.children) {
+                packLinkedVirtualNode(child.id);
+              }
+            };
+
+        uint32_t linkedChildCount =
+            hasLinkedTargets
+                ? static_cast<uint32_t>(virtualRootNode.children.size())
+                : 0;
         writer.packStr("children");
-        writer.packArray(static_cast<uint32_t>(treeNode.children.size()));
+        writer.packArray(static_cast<uint32_t>(treeNode.children.size()) +
+                         linkedChildCount);
         for (const auto &child : treeNode.children) {
           packNode(tree->getNode(child.id));
+        }
+        if (hasLinkedTargets) {
+          for (const auto &virtualChild : virtualRootNode.children) {
+            packLinkedVirtualNode(virtualChild.id);
+          }
         }
       };
 
   uint32_t deviceTypeEntries = 0;
   for (size_t deviceType = 0;
        deviceType < static_cast<size_t>(DeviceType::COUNT); ++deviceType) {
-    if (deviceIdMasks[deviceType] != 0) {
+    if (metricSummary.deviceIdMasks[deviceType] != 0) {
       ++deviceTypeEntries;
     }
   }
@@ -633,7 +786,7 @@ std::vector<uint8_t> TreeData::buildHatchetMsgPack(TreeData::Tree *tree) const {
   writer.packMap(deviceTypeEntries);
   for (size_t deviceType = 0;
        deviceType < static_cast<size_t>(DeviceType::COUNT); ++deviceType) {
-    auto mask = deviceIdMasks[deviceType];
+    auto mask = metricSummary.deviceIdMasks[deviceType];
     if (mask == 0) {
       continue;
     }
@@ -684,27 +837,16 @@ void TreeData::exitScope(const Scope &scope) {
   scopeIdToContextId.erase(scope.scopeId);
 }
 
-DataEntry TreeData::addOp(const std::string &name) {
-  std::unique_lock<std::shared_mutex> lock(mutex);
-  auto *currentTree = currentPhasePtrAs<Tree>();
-  std::vector<Context> contexts;
-  if (contextSource != nullptr)
-    contexts = contextSource->getContexts();
-  if (!name.empty())
-    contexts.emplace_back(name);
-  auto contextId = currentTree->addNode(contexts);
-  auto &node = currentTree->getNode(contextId);
-  return DataEntry(contextId, currentPhase.load(std::memory_order_relaxed),
-                   node.metrics);
-}
-
 DataEntry TreeData::addOp(size_t phase, size_t contextId,
                           const std::vector<Context> &contexts) {
-  auto lock = lockIfCurrentPhase(phase);
+  auto lock = lockIfCurrentOrVirtualPhase(phase);
+  if (contextId == Data::kRootEntryId) {
+    contextId = Tree::TreeNode::RootId;
+  }
   auto *tree = phasePtrAs<Tree>(phase);
   auto newContextId = tree->addNode(contexts, contextId);
   auto &node = tree->getNode(newContextId);
-  return DataEntry(newContextId, phase, node.metrics);
+  return DataEntry(newContextId, phase, node.metricSet);
 }
 
 void TreeData::addMetrics(
@@ -718,40 +860,39 @@ void TreeData::addMetrics(
   }
 }
 
-void TreeData::addMetrics(
-    size_t phase, size_t contextId,
-    const std::map<std::string, MetricValueType> &metrics) {
-  auto lock = lockIfCurrentPhase(phase);
-  auto *tree = phasePtrAs<Tree>(phase);
-  for (auto [metricName, metricValue] : metrics) {
-    tree->upsertFlexibleMetric(contextId,
-                               FlexibleMetric(metricName, metricValue));
-  }
-}
-
 void TreeData::dumpHatchet(std::ostream &os, size_t phase) const {
   treePhases.withPtr(phase, [&](Tree *tree) {
-    auto output = buildHatchetJson(tree);
-    os << std::endl << output.dump(4) << std::endl;
+    treePhases.withPtr(Data::kVirtualPhase, [&](Tree *virtualTree) {
+      auto output = buildHatchetJson(tree, virtualTree);
+      os << std::endl << output.dump(4) << std::endl;
+    });
   });
 }
 
 void TreeData::dumpHatchetMsgPack(std::ostream &os, size_t phase) const {
   treePhases.withPtr(phase, [&](Tree *tree) {
-    auto msgPack = buildHatchetMsgPack(tree);
-    os.write(reinterpret_cast<const char *>(msgPack.data()),
-             static_cast<std::streamsize>(msgPack.size()));
+    treePhases.withPtr(Data::kVirtualPhase, [&](Tree *virtualTree) {
+      auto msgPack = buildHatchetMsgPack(tree, virtualTree);
+      os.write(reinterpret_cast<const char *>(msgPack.data()),
+               static_cast<std::streamsize>(msgPack.size()));
+    });
   });
 }
 
 std::string TreeData::toJsonString(size_t phase) const {
-  return treePhases.withPtr(
-      phase, [&](Tree *tree) { return buildHatchetJson(tree).dump(); });
+  return treePhases.withPtr(phase, [&](Tree *tree) {
+    return treePhases.withPtr(Data::kVirtualPhase, [&](Tree *virtualTree) {
+      return buildHatchetJson(tree, virtualTree).dump();
+    });
+  });
 }
 
 std::vector<uint8_t> TreeData::toMsgPack(size_t phase) const {
-  return treePhases.withPtr(
-      phase, [&](Tree *tree) { return buildHatchetMsgPack(tree); });
+  return treePhases.withPtr(phase, [&](Tree *tree) {
+    return treePhases.withPtr(Data::kVirtualPhase, [&](Tree *virtualTree) {
+      return buildHatchetMsgPack(tree, virtualTree);
+    });
+  });
 }
 
 void TreeData::doDump(std::ostream &os, OutputFormat outputFormat,

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiPCSampling.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiPCSampling.cpp
@@ -354,7 +354,6 @@ void CuptiPCSampling::start(CUcontext context) {
 void CuptiPCSampling::processPCSamplingData(ConfigureData *configureData,
                                             const DataToEntryMap &dataToEntry) {
   auto *pcSamplingData = &configureData->pcSamplingData;
-  auto &profiler = CuptiProfiler::instance();
   // In the first round, we need to call getPCSamplingData to get the unsynced
   // data from the hardware buffer
   bool firstRound = true;
@@ -380,7 +379,8 @@ void CuptiPCSampling::processPCSamplingData(ConfigureData *configureData,
         if (!configureData->stallReasonIndexToMetricIndex.count(
                 stallReason->pcSamplingStallReasonIndex))
           throw std::runtime_error("[PROTON] Invalid stall reason index");
-        for (auto [data, entry] : dataToEntry) {
+        for (const auto &[data, baseEntry] : dataToEntry) {
+          auto entry = baseEntry;
           if (lineInfo.fileName.size())
             entry =
                 data->addOp(entry.phase, entry.id,

--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -235,9 +235,9 @@ void InstrumentationProfiler::exitInstrumentedOp(uint64_t streamId,
               auto normalizedDuration = static_cast<double>(duration) /
                                         (circularLayoutConfig->totalUnits *
                                          circularLayoutConfig->numBlocks);
-              for (auto [data, entry] : dataToEntryMap) {
-                auto kernelId = entry.id;
-                entry = data->addOp(entry.phase, kernelId, contexts);
+              for (const auto &[data, baseEntry] : dataToEntryMap) {
+                auto kernelId = baseEntry.id;
+                auto entry = data->addOp(baseEntry.phase, kernelId, contexts);
                 entry.upsertMetric(std::make_unique<CycleMetric>(
                     event.first->cycle, event.second->cycle, duration,
                     normalizedDuration, kernelId, functionName,
@@ -263,8 +263,9 @@ void InstrumentationProfiler::doAddMetrics(
       data->addMetrics(scopeId, scalarMetrics);
     }
   } else {
-    for (auto [data, entry] : dataToEntryMap) {
-      data->addMetrics(entry.phase, entry.id, scalarMetrics);
+    for (const auto &entryIt : dataToEntryMap) {
+      const auto &entry = entryIt.second;
+      entry.upsertFlexibleMetrics(scalarMetrics);
     }
   }
   // TODO(Keren): handle tensor metrics by making metricBuffer a member of the

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -149,6 +149,62 @@ def test_cudagraph(tmp_path: pathlib.Path, device: str):
                 assert child["children"][i]["children"][0]["metrics"]["time (ns)"] > 0
 
 
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports cudagraph replay")
+def test_cudagraph_not_captured_by_profiler(tmp_path: pathlib.Path, capfd, device: str):
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    @triton.jit
+    def foo(x, y, z):
+        tl.store(z, tl.load(y) + tl.load(x))
+
+    def fn():
+        a = torch.ones((2, 2), device=device)
+        b = torch.ones((2, 2), device=device)
+        c = a + b
+        foo[(1, )](a, b, c)
+
+    # Build/capture graph before profiler starts.
+    fn()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn()
+
+    temp_file = tmp_path / "test_cudagraph_not_captured_by_profiler.hatchet"
+    proton.start(str(temp_file.with_suffix("")), context="shadow")
+    with proton.scope("replay0"):
+        g.replay()
+    with proton.scope("replay1"):
+        g.replay()
+    proton.finalize()
+
+    captured = capfd.readouterr()
+    assert captured.err.count("Cannot find graph for graphExecId:") == 1
+    assert "start profiling before the graph is created" in captured.err
+
+    with temp_file.open() as f:
+        data = json.load(f)
+    replay0_frame = None
+    replay1_frame = None
+    for child in data[0]["children"]:
+        if child["frame"]["name"] == "replay0":
+            replay0_frame = child
+        elif child["frame"]["name"] == "replay1":
+            replay1_frame = child
+    assert replay0_frame is not None
+    assert replay1_frame is not None
+    assert len(replay0_frame["children"]) == 3
+    assert len(replay1_frame["children"]) == 3
+
+    def has_positive_time_metric(node):
+        if node["metrics"].get("time (ns)", 0) > 0:
+            return True
+        return any(has_positive_time_metric(child) for child in node["children"])
+
+    assert has_positive_time_metric(replay0_frame)
+    assert has_positive_time_metric(replay1_frame)
+
+
 @pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports cudagraph deactivation")
 def test_cudagraph_deactivate(tmp_path, device: str):
     stream = torch.cuda.Stream()
@@ -680,6 +736,113 @@ def test_multiple_sessions(tmp_path: pathlib.Path, device: str):
     scope0_count = int(data[0]["children"][0]["children"][0]["metrics"]["count"])
     scope1_count = int(data[0]["children"][1]["children"][0]["metrics"]["count"])
     assert scope0_count + scope1_count == 3
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+def test_multiple_sessions_cudagraph_metric_kernels(tmp_path: pathlib.Path, device: str):
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    foo_iters = 3
+    bar_iters = 2
+
+    def foo_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        x = args["x"]
+        # Tensor custom metric in graph capture mode launches metric kernels.
+        return {"name": "foo_with_metric", "sum_metric": x.sum()}
+
+    def bar_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        # Name-only metadata (no custom metric).
+        return {"name": "bar_without_metric"}
+
+    @triton.jit(launch_metadata=foo_metadata_fn)
+    def foo(x, y, z):
+        tl.store(z, tl.load(y) + tl.load(x))
+
+    @triton.jit(launch_metadata=bar_metadata_fn)
+    def bar(x, y, z):
+        tl.store(z, tl.load(y) - tl.load(x))
+
+    x = torch.ones((2, 2), device=device)
+    y = torch.ones((2, 2), device=device)
+    z = torch.empty_like(x)
+
+    # Compile kernels before profiling starts to reduce unrelated profile noise.
+    foo[(1, )](x, y, z)
+    bar[(1, )](x, y, z)
+
+    temp_file0 = tmp_path / "test_multiple_sessions_cudagraph_metric_kernels0.hatchet"
+    temp_file1 = tmp_path / "test_multiple_sessions_cudagraph_metric_kernels1.hatchet"
+    session_id0 = proton.start(str(temp_file0.with_suffix("")), context="shadow", hook="triton")
+    session_id1 = proton.start(str(temp_file1.with_suffix("")), context="shadow", hook="triton")
+
+    proton.deactivate(session_id1)
+
+    graph_foo = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph_foo):
+        for _ in range(foo_iters):
+            foo[(1, )](x, y, z)
+    with proton.scope("session0_replay"):
+        graph_foo.replay()
+
+    proton.deactivate(session_id0)
+    proton.activate(session_id1)
+
+    graph_bar = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph_bar):
+        for _ in range(bar_iters):
+            bar[(1, )](x, y, z)
+    with proton.scope("session1_replay"):
+        graph_bar.replay()
+
+    proton.finalize(session_id0)
+    proton.finalize(session_id1)
+
+    def get_frame_by_name(node, name: str):
+        queue = [node]
+        while queue:
+            cur = queue.pop(0)
+            if cur["frame"]["name"] == name:
+                return cur
+            queue.extend(cur["children"])
+        return None
+
+    def get_all_names(node):
+        names = set()
+        queue = [node]
+        while queue:
+            cur = queue.pop(0)
+            names.add(cur["frame"]["name"])
+            queue.extend(cur["children"])
+        return names
+
+    with temp_file0.open() as f:
+        data0 = json.load(f)
+    with temp_file1.open() as f:
+        data1 = json.load(f)
+
+    session0_replay_frame = get_frame_by_name(data0[0], "session0_replay")
+    session1_replay_frame = get_frame_by_name(data1[0], "session1_replay")
+    assert session0_replay_frame is not None
+    assert session1_replay_frame is not None
+
+    capture0 = session0_replay_frame["children"][0]
+    capture1 = session1_replay_frame["children"][0]
+
+    foo_frame0 = get_frame_by_name(capture0, "foo_with_metric")
+    bar_frame0 = get_frame_by_name(capture0, "bar_without_metric")
+    foo_frame1 = get_frame_by_name(capture1, "foo_with_metric")
+    bar_frame1 = get_frame_by_name(capture1, "bar_without_metric")
+
+    assert foo_frame0 is not None
+    assert bar_frame0 is None
+    assert foo_frame1 is None
+    assert bar_frame1 is not None
+
+    assert foo_frame0["metrics"]["sum_metric"] == float(foo_iters * x.numel())
+    assert int(foo_frame0["metrics"]["count"]) == foo_iters
+    assert "sum_metric" not in bar_frame1["metrics"]
+    assert int(bar_frame1["metrics"]["count"]) == bar_iters
 
 
 def test_trace(tmp_path: pathlib.Path, device: str):


### PR DESCRIPTION
Summary:
...#9545)

Bundle cherry-pick of 31 upstream Triton PR(s): #9440 #9446 #9454 #9405 #9461 #9462 #9464 #9449 #9406 #9245 #9480 #9481 #9487 #9441 #9490 #9442 #9496 #9492 #9495 #9510 #9513 #9505 #9514 #9507 #9522 #9518 #9519 #9512 #9393 #9530 #9545.

https://github.com/triton-lang/triton/pull/9440
https://github.com/triton-lang/triton/pull/9446
https://github.com/triton-lang/triton/pull/9454
https://github.com/triton-lang/triton/pull/9405
https://github.com/triton-lang/triton/pull/9461
https://github.com/triton-lang/triton/pull/9462
https://github.com/triton-lang/triton/pull/9464
https://github.com/triton-lang/triton/pull/9449
https://github.com/triton-lang/triton/pull/9406
https://github.com/triton-lang/triton/pull/9245
https://github.com/triton-lang/triton/pull/9480
https://github.com/triton-lang/triton/pull/9481
https://github.com/triton-lang/triton/pull/9487
https://github.com/triton-lang/triton/pull/9441
https://github.com/triton-lang/triton/pull/9490
https://github.com/triton-lang/triton/pull/9442
https://github.com/triton-lang/triton/pull/9074
https://github.com/triton-lang/triton/pull/9496
https://github.com/triton-lang/triton/pull/9492
https://github.com/triton-lang/triton/pull/9184
https://github.com/triton-lang/triton/pull/9495
https://github.com/triton-lang/triton/pull/9510
https://github.com/triton-lang/triton/pull/9513
https://github.com/triton-lang/triton/pull/9505
https://github.com/triton-lang/triton/pull/9514
https://github.com/triton-lang/triton/pull/9507
https://github.com/triton-lang/triton/pull/9522
https://github.com/triton-lang/triton/pull/9518
https://github.com/triton-lang/triton/pull/9519
https://github.com/triton-lang/triton/pull/9512
https://github.com/triton-lang/triton/pull/9393
https://github.com/triton-lang/triton/pull/9530
https://github.com/triton-lang/triton/pull/9545

Conflict Resolution:
- Dropped #9509 ([AMD] Enable supportBitwidth{16|32}Elementwise in TargetInfo). The reduction-codegen consumer that switch drives (upstream #9220) is intentionally absent from beta: beta uses its own opt-in INNER_TREE reduction path (reduction_ordering="inner_tree") engineered for bitwise-identical, num_warps-invariant results (guarded by scripts/njriasan/bitwise_equiv). In beta the supportBitwidth{16,32}Elementwise overrides were dead code (no consumers) and the accompanying test reduce_tree_vectorize.mlir asserted upstream packed vector<2xf16> behavior beta deliberately does not implement. Reverted the AMD TargetInfo overrides, the TargetInfoBase.h base virtuals, and removed the test.
- #9510 (Fix cluster barrier logic in Async TMA lowering): beta's AsyncTMACopyGlobalToLocal lowering hardcoded the destination SMEM scope to shared::cluster, so the #9510 test (tma_copy_barrier_mask_zero, expecting shared::cta) failed. Made the scope conditional in LoadStoreOpToLLVM.cpp -- cluster only when the copy involves the cluster (cluster barrier per #9510, multicast via op.getMulticastTargets(), the op.getMulticast() broadcast bool, or a 2-CTA group), else CTA-local. Updated the stale shared::cluster expectations on single-CTA non-cluster copies (regular + im2col in tritonnvidiagpu_to_llvm.mlir, the non-multicast copy in tma_to_llvm.mlir) to shared::cta; genuine cluster cases (mask_nonzero, cta_group::2, multicast) keep shared::cluster.
- #9449 ([AMD] Added hw FP upcast conversions for gfx1250): this PR was only partially applied in an earlier beta cherry-pick -- the Pk8 DOWNCAST path was dropped. getNumElements returns 8 for the gfx1250 f32/f16/bf16 -> f8E4M3FN/f8E5M2 RTNE downcast, but the downcast HW converters were pk4-only (assert v.size()==4), so the WMMA scaled-dot fp8 chained path (tritongpu_wmma_dot_scaled_to_llvm.mlir) crashed in Fp32_to_Fp8E5M2_RTNE_HW. Restored the missing cvtScalePk8DowncastToFp8 helper and added the v.size()==8 branch to all six downcast HW converters in ElementwiseOpToLLVM.cpp. Verified the failing lit test and the AMD fp8/cast/scaled lit suite pass.

Authored with Claude.

***Do not remove the following lines from this commit***
Reactor Backport Revision: 27bd20aa3270164d8f0983df9aa76967a575ec4c
Reactor Backport Revision: 2aebf4af8b6a6c6bed10a8743d6833af3089e4d1
Reactor Backport Revision: 3358991a6873ae398befe9770aa51a46a74ef7d6
Reactor Backport Revision: 5eef84552fe110bc897340fb49d3a963507e6ac1
Reactor Backport Revision: dbe4cbe28025fca09d6d92d6785fce53fc0b4e54
Reactor Backport Revision: 2ccb09ed14dad4a47a9489b46cbc72b1101d8cee
Reactor Backport Revision: ed6f1b7b152a26edb4cae226b110b640fc5eafcb
Reactor Backport Revision: f95bb15970d2ee36d86b836911af04973eeb1851
Reactor Backport Revision: c0ba2f1c2f6234683132369aea66aee0ad26524f
Reactor Backport Revision: c3b8d7ca83f16898bad9a19e75c90d5a2c6f2cb4
Reactor Backport Revision: e03f49c4ced2d1524c22dab99a5e3f217764bdb9
Reactor Backport Revision: 3610d0c0bd7a0389f809953e9906df0a35dcb388
Reactor Backport Revision: 6528ad59008ba61aecbd3d4ba5e59e66cb67f318
Reactor Backport Revision: 3a4f9d33246bbbc1164e410e64b0ec423c7a46b9
Reactor Backport Revision: 42950311a189e03e3ef53c0d740b6c98b8cf9a44
Reactor Backport Revision: fc26a7c98c263e6c0da71279efe5a52523186490
Reactor Backport Revision: 61250e7129302091753a18b7e15cd186608c662e
Reactor Backport Revision: f358d2c24baf07532d08111105513c826f1c4bc1
Reactor Backport Revision: f000045eaf7929cff9b2c2d8638a70473b55fd24
Reactor Backport Revision: 4b680e0cd8d378b4cf244a823094b7996d57485a
Reactor Backport Revision: b78c1c44208610c0c16894c69ecb4771d2ee9d1c
Reactor Backport Revision: 3f74afe4483d67c91fc427260c914a8eab22067d
Reactor Backport Revision: 0a0a57c315e0e83d51b37b86c14d1ba33d2009b8
Reactor Backport Revision: 3254b53d38e7c7a8d2518a170db590b2e2a440bb
Reactor Backport Revision: 813602f47b819ef4741f55a59a3812f1ffe96bc4
Reactor Backport Revision: ed24f4cff6cd4e9207d6d4eae2d09d87ca65a945
Reactor Backport Revision: f2070b3c13b75a1e1242ab3cc14155f0a5ce4bbe
Reactor Backport Revision: bf6ff76a77ec2764f69ca078019018b4c165e214
Reactor Backport Revision: f2895fae1b93bb3ab0e7ab44a3f68d24d88bdf48
Reactor Backport Revision: 15f9161545349b9f0bee8fdc237ddb3d7f6d1307
Reactor Backport Revision: 2868f7a90ac515627c098c47138c76e239ec2dd8

Reviewed By: dshi7

Differential Revision: D109056381
