### PR TITLE
[autows-authoring] Document the epilogue-survival gotcha and the WS-validation partition-name nuance

### DIFF
--- a/.claude/skills/autows-authoring/SKILL.md
+++ b/.claude/skills/autows-authoring/SKILL.md
@@ -61,6 +61,18 @@ Related skills: `autows-testing` (run tests), `ir-debugging` (IR dumps),
    exclusively by Meta's WS passes. They do not exist in OSS Triton's
    `tl.range()` — see [OSS Fallback](#oss-triton-fallback) for how to gate them.
 
+5. **Compute the post-loop epilogue from the genuine MMA accumulator — never a
+   synthetic matmul.** The partition scheduler keeps a post-loop
+   reduction/gate/epilogue only if it sits in a real MMA's backward slice. If the
+   reduction is fed by a *synthetic* matmul inserted only to create an MMA (e.g.
+   `(x·x)@e0` to get a row-sum), the post-loop region belongs to no genuine MMA
+   and the scheduler **elides the entire epilogue**: the kernel still emits
+   `ttg.warp_specialize` and passes a structural WS check, but the `tl.sum` /
+   normalize / `tt.store` ops are all dropped and the output is unwritten garbage
+   (a silent correctness failure, not a compile error). Reduce or gate from the
+   real `A@B` accumulator instead. Confirm the WS TTGIR has a dedicated
+   `"epilogue"` Meta partition and that the store ops survive.
+
 ---
 
 ## Enabling AutoWS
@@ -406,6 +418,13 @@ def test_my_kernel():
    ```bash
    TRITON_USE_META_WS=1 python python/tutorials/test_hopper_fwd_autows_vs_tlx.py
    ```
+
+> **`ttg.warp_specialize` is necessary, not sufficient.** Its presence or count
+> alone does not prove a correct WS kernel — an elided epilogue (Key Authoring
+> Rule 5) leaves the op in the IR while the stores are gone. Prefer the **named
+> Meta partition list** as the reliable signal: a `"load"` / `"gemm"` /
+> `"computation"` set, plus a dedicated `"epilogue"` partition whenever the kernel
+> has a post-loop epilogue.
 
 ---
 


### PR DESCRIPTION
Summary:
From the `tritonbench_fb_b200` AutoWS coverage-run audits (A-1, confirmed run-wide in A-3): `triton_rms_norm` (K-1) hit `accuracy_failed` because its post-loop reduction epilogue was fed by a synthetic `(x·x)e0` MMA, so the partition scheduler — finding the epilogue in no genuine MMA's backward slice — elided the entire post-loop region; the kernel still emitted `ttg.warp_specialize` and passed a structural WS check but produced unwritten garbage. Add Key Authoring Rule 5 ("compute the post-loop epilogue from the genuine MMA accumulator, never a synthetic matmul"), which every one of the run's 24 epilogue-bearing successes follows, plus a callout that the presence/count of `ttg.warp_specialize` is necessary-but-not-sufficient — prefer the named Meta partition list (a dedicated `"epilogue"` partition) as the reliable proof.

Authored with Claude.

Differential Revision: D109333792


