### PR TITLE
[triton][Cherry-pick][AMD] Optimize address increments for buffer loads in loops (#8464) (#1805)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -131,6 +131,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUConvertToBufferOps();
   mlir::registerTritonAMDGPULowerBarrierOps();
   mlir::registerTritonAMDGPUConvertToTensorOps();
+  mlir::registerTritonAMDGPUOptimizeBufferOpPtr();
   mlir::registerTritonAMDGPUInThreadTranspose();
   mlir::registerTritonAMDGPUCoalesceAsyncCopy();
   mlir::registerTritonAMDGPUCoalesceBufferOps();

--- a/python/src/passes.h
+++ b/python/src/passes.h
@@ -1,6 +1,11 @@
 #define ADD_PASS_WRAPPER_0(name, builder)                                      \
   m.def(name, [](mlir::PassManager &pm) { pm.addPass(builder()); })
 
+#define ADD_FUNC_PASS_WRAPPER_0(name, builder)                                 \
+  m.def(name, [](mlir::PassManager &pm) {                                      \
+    pm.addNestedPass<mlir::triton::FuncOp>(builder());                         \
+  });
+
 #define ADD_PASS_WRAPPER_1(name, builder, ty0)                                 \
   m.def(name,                                                                  \
         [](mlir::PassManager &pm, ty0 val0) { pm.addPass(builder(val0)); })

--- a/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
+++ b/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
@@ -1,0 +1,589 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx950" --tritonamdgpu-optimize-buffer-op-ptr| FileCheck %s --check-prefixes=CHECK
+
+// CHECK-LABEL: add_after_load
+// CHECK-DAG: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK-DAG: [[Y_OFFSET_CST:%.*]] = arith.constant dense<321>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, {{.*}}, [[X_BASE:%.*]] = {{.*}}, [[Y_BASE:%.*]] = {{.*}})
+// CHECK:   amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}} :
+// CHECK:   amdg.buffer_load [[Y_BASE]]{{\[}}[[Y_OFFSET_CST]]{{\]}} cacheModifier = cg :
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]], %c64_i32
+// CHECK:   [[NEXT_Y_BASE:%.*]] = tt.addptr [[Y_BASE]]
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]], [[NEXT_Y_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @add_after_load(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %stride: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c1 = arith.constant 1 : index
+
+    %min_stride = arith.constant 1 : i32
+    %max_stride = arith.constant 1024 : i32
+    %0 = arith.cmpi sge, %stride, %min_stride : i32
+    llvm.intr.assume %0 : i1
+    %1 = arith.cmpi sle, %stride, %max_stride : i32
+    llvm.intr.assume %1 : i1
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %Yoffset_init = arith.constant dense<321> : tensor<64x32xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %y_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+
+    %tmp = arith.muli %stride, %c64_i32 : i32
+    %step = tt.splat %tmp : i32 -> tensor<64x32xi32, #blocked>
+    %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>) {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
+
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      %Yoffset_next = arith.addi %Yoffset, %step : tensor<64x32xi32, #blocked>
+      scf.yield %Xoffset_next, %Yoffset_next : tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: buffer_load_to_local
+// CHECK-DAG: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}}
+// CHECK:   amdg.buffer_load_to_local [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]], %c64_i32
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @buffer_load_to_local(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: add_before_load
+// CHECK-DAG: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]], %c64_i32
+// CHECK:   amdg.buffer_load [[NEXT_X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @add_before_load(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: isolated_pattern_nested_loop1
+// CHECK: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for
+// CHECK:   scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:     amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:     [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]]
+// CHECK:     scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @isolated_pattern_nested_loop1(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    %c1 = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    scf.for %idx_outer = %c0 to %c32 step %c1 iter_args() -> () {
+      %for_inner = scf.for %idx_innter = %c0 to %c32 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+        %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+        ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+        %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+        scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+      }
+      scf.yield
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: isolated_pattern_nested_loop2
+// CHECK: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:   scf.for
+// CHECK:     amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]]
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @isolated_pattern_nested_loop2(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for_outer = scf.for %idx_outer = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      scf.for %idx_inner = %c0 to %c128 step %c1 iter_args() -> () {
+        %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+        ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+        scf.yield
+      }
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: convert_with_base_ptr_optimization
+// CHECK: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:   amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]]
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @convert_with_base_ptr_optimization(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+    %x_base = tt.splat %X : !tt.ptr<f16> -> tensor<16x64x!tt.ptr<f16>, #blocked>
+    %offsets_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx_outer = %c0 to %c128 step %c1 iter_args(%offsets = %offsets_init) -> (tensor<16x64xi32, #blocked>) {
+      %X_ptr = tt.addptr %x_base, %offsets : tensor<16x64x!tt.ptr<f16>, #blocked>, tensor<16x64xi32, #blocked>
+      %x = tt.load %X_ptr : tensor<16x64x!tt.ptr<f16>, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %offsets_next = arith.addi %offsets, %step : tensor<16x64xi32, #blocked>
+      scf.yield %offsets_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: dynamic_base_negative
+// CHECK:   [[X_BASE:%.*]] = tt.addptr
+// CHECK:   amdg.buffer_load [[X_BASE]]
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @dynamic_base_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
+      %x_base = tt.addptr %X, %idx : !tt.ptr<f16>, i32
+      %x = amdg.buffer_load %x_base[%Xoffset] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: non_uniform_step_negative
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @non_uniform_step_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %step : tensor<16x64xi32, #blocked>) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: offsets_possible_overflow_negative
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @offsets_possible_overflow_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %step_scalar : i32) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %step = tt.splat %step_scalar: i32 -> tensor<16x64xi32, #blocked>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: two_parallel_addi_negative
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @two_parallel_addi_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Xoffset_dummy = %Xoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>) : i32 {
+      %Xoffset_decoy = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_decoy] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next, %Xoffset_decoy : tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Check case with three buffer ops in a loop, first and third are optimized, second is rejected because step is not uniform
+// CHECK-LABEL: mixed_optimized_rejected_optimized
+// CHECK-DAG: [[X_OFFSET:%.*]] = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+// CHECK-DAG: [[Y_OFFSET_INIT:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+// CHECK-DAG: [[Z_OFFSET:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+// CHECK: scf.for {{.*}} iter_args({{%.*}}[[Y_OFFSET:%.*]] = [[Y_OFFSET_INIT]]
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mixed_optimized_rejected_optimized(
+        %X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Z: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}
+      ) attributes {noinline = false} {
+    %Xstep = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %Ystep_slice = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %Ystep_2d = tt.expand_dims %Ystep_slice {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %Ystep = tt.broadcast %Ystep_2d : tensor<1x32xi32, #blocked> -> tensor<64x32xi32, #blocked>
+    %Zstep = arith.constant dense<256> : tensor<32x32xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %Yoffset_init = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+    %Zoffset_init = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %y_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+    %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+    %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+      ttg.local_store %z, %z_dummy_buffer : tensor<32x32xf16, #blocked> -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+      %Xoffset_next = arith.addi %Xoffset, %Xstep : tensor<16x64xi32, #blocked>
+      %Yoffset_next = arith.addi %Yoffset, %Ystep : tensor<64x32xi32, #blocked>
+      %Zoffset_next = arith.addi %Zoffset, %Zstep : tensor<32x32xi32, #blocked>
+      scf.yield %Xoffset_next, %Yoffset_next, %Zoffset_next : tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Check case with three buffer ops in a loop, only second one is optimized
+// CHECK-LABEL: mixed_rejected_optimized_rejected
+// CHECK-DAG: [[X_OFFSET_INIT:%.*]] = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+// CHECK-DAG: [[Y_OFFSET:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+// CHECK-DAG: [[Z_OFFSET_INIT:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+// CHECK: scf.for {{.*}} iter_args([[X_OFFSET:%.*]] = [[X_OFFSET_INIT]], {{.*}}[[Z_OFFSET:%.*]] = [[Z_OFFSET_INIT]]
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mixed_rejected_optimized_rejected(
+        %X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Z: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Xstride: i32,
+        %Zstride: i32
+      ) attributes {noinline = false} {
+    %Xstep = tt.splat %Xstride: i32 -> tensor<16x64xi32, #blocked>
+    %Ystep = arith.constant dense<128> : tensor<64x32xi32, #blocked>
+    %Zstep = tt.splat %Zstride : i32 -> tensor<32x32xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %Yoffset_init = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+    %Zoffset_init = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %y_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+    %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+    %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+      ttg.local_store %z, %z_dummy_buffer : tensor<32x32xf16, #blocked> -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+      %Xoffset_next = arith.addi %Xoffset, %Xstep : tensor<16x64xi32, #blocked>
+      %Yoffset_next = arith.addi %Yoffset, %Ystep : tensor<64x32xi32, #blocked>
+      %Zoffset_next = arith.addi %Zoffset, %Zstep : tensor<32x32xi32, #blocked>
+      scf.yield %Xoffset_next, %Yoffset_next, %Zoffset_next : tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_offset_uses
+// CHECK: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_offset_uses(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %offset_step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %offset_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      ttg.local_store %Xoffset, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %offset_step : tensor<16x64xi32, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %Xoffset_next, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    ttg.local_store %for, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_offset_uses_over_multiple_loops
+// CHECK: scf.for
+// CHECK:   tt.addptr
+// CHECK:   scf.for
+// CHECK:     tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_offset_uses_over_multiple_loops(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %offset_step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 32 : index
+    %iter_step = arith.constant 1 : index
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %offset_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+    %for1 = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset1 = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %Xoffset_next1 = arith.addi %Xoffset1, %offset_step : tensor<16x64xi32, #blocked>
+
+      %for2 = scf.for %idx2 = %iter_first to %iter_last step %iter_step iter_args(%Xoffset2 = %Xoffset_next1) -> (tensor<16x64xi32, #blocked>) {
+        %Xoffset_next2 = arith.addi %Xoffset2, %offset_step : tensor<16x64xi32, #blocked>
+        %x2 = amdg.buffer_load %X[%Xoffset_next2] : tensor<16x64xf16, #blocked>
+        ttg.local_store %x2, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+        scf.yield %Xoffset_next2 : tensor<16x64xi32, #blocked>
+      }
+
+      %x1 = amdg.buffer_load %X[%Xoffset_next1] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x1, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next1 : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_addi_in_sequence_negative
+// CHECK-NOT:  tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_addi_in_sequence_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst1 = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %cst2 = arith.constant dense<128> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+    %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+      %Xoffset_tmp = arith.addi %Xoffset, %cst1 : tensor<16x64xi32, #blocked>
+      %Xoffset_next = arith.addi %Xoffset_tmp, %cst2 : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_buffer_loads_on_one_addi
+// CHECK-COUNT-2: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_buffer_loads_on_one_addi(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+    %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %x1 = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      %x2 = amdg.buffer_load_to_local %X[%Xoffset_next] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: messed_add_chain_negative
+// CHECK-NOT:  tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @messed_add_chain_negative(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) -> tensor<256xi32, #blocked> attributes {noinline = false} {
+    %zero = arith.constant dense<0> : tensor<256xi32, #blocked>
+    %iter_first = arith.constant 0 : i32
+    %iter_last = arith.constant 15 : i32
+    %iter_step = arith.constant 1 : i32
+
+    %for:2 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%arg1 = %zero, %arg2 = %zero) -> (tensor<256xi32, #blocked>, tensor<256xi32, #blocked>) : i32 {
+      %data = amdg.buffer_load %arg0[%arg1] : tensor<256xi32, #blocked>
+      scf.yield %arg2, %data : tensor<256xi32, #blocked>, tensor<256xi32, #blocked>
+    }
+    tt.return %for#1 : tensor<256xi32, #blocked>
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -344,6 +344,7 @@ class HIPBackend(BaseBackend):
                 knobs.amd.use_buffer_atomics,
                 knobs.amd.buffer_ops_analyze_small_tensor_range,
             )
+            amd.passes.ttgpuir.add_optimize_buffer_op_ptr(pm)
 
         # Facebook begin
         # D79814483: Disable amd.passes.ttgpuir.add_fold_true_cmpi

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -194,6 +194,14 @@ def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "ml
   ];
 }
 
+def TritonAMDGPUOptimizeBufferOpPtr : Pass<"tritonamdgpu-optimize-buffer-op-ptr", "mlir::triton::FuncOp"> {
+  let summary = "Optimize address operands of buffer operations";
+
+  let description = "This pass optimizes address computation for buffer operations";
+
+  let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect"];
+}
+
 def TritonAMDGPUBlockPingpong: Pass<"tritonamdgpu-block-pingpong", "mlir::ModuleOp"> {
   let summary = "Interleaving instructions from two warps on the same SIMD to better utilize matrix core";
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonAMDGPUTransforms
   ConvertToBufferOps.cpp
   ConvertToTensorOps.cpp
   LowerBarrierOps.cpp
+  OptimizeBufferOpPtr.cpp
   OptimizeEpilogue.cpp
   OptimizeDotOperands.cpp
   HoistLayoutConversions.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeBufferOpPtr.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeBufferOpPtr.cpp
@@ -1,0 +1,565 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "third_party/amd/include/Analysis/RangeAnalysis.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "tritonamdgpu-optimize-buffer-op-ptr"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using ::mlir::LLVM::AMD::getVectorSize;
+using mlir::triton::AMD::ISAFamily;
+
+namespace ttg = mlir::triton::gpu;
+namespace tt = mlir::triton;
+namespace amdttg = mlir::triton::amdgpu;
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONAMDGPUOPTIMIZEBUFFEROPPTR
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+namespace {
+// /*-----------------Base pointer increment optimization-------------------*/
+
+// Optimization tries to transfer increments from offsets to base pointer in
+// buffer operations:
+//
+// for ... (offsets = offsets_init):
+//   val = buffer_load basePtr [ offsets ]
+//   offsets_new = offsets + cst
+//   yield offsets_new
+// }
+//
+// transforms to:
+//
+// for ... (basePtr = basePtr_init):
+//   val = buffer_load basePtr [ offsets ]
+//   basePtr_new = basePtr + cst
+//   yield basePtr_new
+// }
+//
+// Goal of this transformation is to decrease amount of work done by vector
+// instructions(decrease number of v_add). This could save cycles in a loop, and
+// give more parallelism on architectures where MFMA and vector instrcutions
+// executed on the same hardware module.
+struct AdvanceBasePointer : public OpRewritePattern<scf::ForOp> {
+
+  AdvanceBasePointer(MLIRContext *context, DataFlowSolver *solver,
+                     PatternBenefit benefit = 1)
+      : OpRewritePattern<scf::ForOp>(context, benefit), solver(solver) {}
+
+  // Check if same value is stored in every element of tensor val
+  // Return true if all elelemts are equal, false if not or it was not able for
+  // proove it.
+  static bool isScalarizableValue(mlir::Value val) {
+    if (isa<IntegerType>(val.getType()))
+      return true;
+    auto defOp = val.getDefiningOp();
+    if (!defOp)
+      return false;
+    APInt constant;
+    if (matchPattern(val, m_ConstantInt(&constant))) {
+      return true;
+    } else if (auto splat = dyn_cast<triton::SplatOp>(defOp)) {
+      return isScalarizableValue(splat.getSrc());
+    }
+    return false;
+  }
+
+  // Generate a scalar value that is stored in provided RankedTensor val
+  static mlir::Value scalarizeValue(PatternRewriter &rewriter,
+                                    mlir::Value val) {
+    if (isa<IntegerType>(val.getType()))
+      return val;
+    auto defOp = val.getDefiningOp();
+    assert(defOp);
+    APInt constant;
+    if (matchPattern(val, m_ConstantInt(&constant))) {
+      rewriter.setInsertionPoint(defOp);
+      auto intType =
+          IntegerType::get(rewriter.getContext(), constant.getBitWidth());
+      return arith::ConstantIntOp::create(rewriter, defOp->getLoc(), intType,
+                                          constant);
+    } else if (auto splat = dyn_cast<triton::SplatOp>(defOp)) {
+      return scalarizeValue(rewriter, splat.getSrc());
+    }
+    return Value();
+  }
+
+  // Description of struct fields:
+  // - op is a target BufferOp, for example BufferLoadOp or BufferLoadToLocalOp
+  // - offsetIncrement is a tensor added to offsets on each iteration
+  // - baseIncrement is a scalar which will be added to base pointer
+  // - offsetInitializer is a value of offset on first loop iteration
+  // - incrementOp is an operation that advances offset tensor
+  struct BufferOpInfo {
+    amdttg::BufferOpInterface op;
+    Value offsetIncrement;
+    Value baseIncrement;
+    Value offsetInitializer;
+    Operation *incrementOp;
+  };
+
+  static std::optional<ConstantIntRanges>
+  getValueRange(Value value, DataFlowSolver *solver) {
+    auto stepType = cast<RankedTensorType>(value.getType());
+    assert(stepType.getElementType().getIntOrFloatBitWidth() < 64);
+
+    const auto *stepRange =
+        solver->lookupState<dataflow::IntegerValueRangeLattice>(value);
+    if (stepRange->getValue().isUninitialized()) {
+      LDBG("Rejected: value range is unintialized");
+      return {};
+    }
+    return stepRange->getValue().getValue();
+  }
+
+  static bool isStrictlyNegative(Value advanceStep, DataFlowSolver *solver) {
+    auto stepRangeValue = getValueRange(advanceStep, solver);
+    if (!stepRangeValue.has_value())
+      return false;
+
+    return stepRangeValue.value().smax().isNegative();
+  }
+
+  static bool isNonNegative(Value advanceStep, DataFlowSolver *solver) {
+    auto stepRangeValue = getValueRange(advanceStep, solver);
+    if (!stepRangeValue.has_value())
+      return false;
+
+    return stepRangeValue.value().smax().isNonNegative();
+  }
+
+  // Estimates range of offset used in buffer op.
+  // offset is 32 bit unsigned integer, equal to blockArg + advancedStep.
+  // blockArg and advancedStep unit is a potentially multibyte element, offset
+  // is measured in bytes.
+  static std::optional<std::pair<int64_t, int64_t>>
+  estimateRangeOfOffsetWithCarryValues(int elemByteWidth, Value blockArg,
+                                       Value advanceStep,
+                                       DataFlowSolver *solver) {
+    auto stepType = cast<RankedTensorType>(advanceStep.getType());
+    assert(stepType.getElementType().getIntOrFloatBitWidth() < 64);
+
+    const auto *blockArgRange =
+        solver->lookupState<dataflow::IntegerValueRangeLattice>(blockArg);
+    if (blockArgRange->getValue().isUninitialized()) {
+      LDBG("Rejected: blockArg range is unintialized");
+      return {};
+    }
+
+    const auto *stepRange =
+        solver->lookupState<dataflow::IntegerValueRangeLattice>(advanceStep);
+    if (stepRange->getValue().isUninitialized()) {
+      LDBG("Rejected: step range is unintialized");
+      return {};
+    }
+
+    auto blockArgRangeValue = blockArgRange->getValue().getValue();
+    auto stepRangeValue = stepRange->getValue().getValue();
+
+    // Use limit to crop MSB from negative indexing
+    constexpr uint64_t maxOffsetValue = 0xff'ff'ff'ff;
+
+    // Range analysys for block argument and step should not return values
+    // larger than maximum uint32_t
+    assert(blockArgRangeValue.umax().getLimitedValue() <= maxOffsetValue &&
+           "expect block argument to be a 32 bit value");
+    assert(stepRangeValue.umax().getLimitedValue() <= maxOffsetValue &&
+           "expect step value to be a 32 bit value");
+
+    // Offset value for current iteration is a sum of block argument (offset
+    // from previous iteration) and step (increment of offset).
+    // These values are measured in number of elements.
+    // Offset in buffer instruction is measured in bytes instead of elements.
+    // In order to convert offset in elements to offset in
+    // bytest compiler left shifts offset. This shift is emulated by
+    // multiplication with "elemByteWidth". Potentially this could lead to
+    // overflow of 32 bit value, but it should happen only if step or offset is
+    // a negative number, i.e. we can discard most significant bits.
+    auto elemsToBytes = [maxOffsetValue, elemByteWidth](const llvm::APInt &x) {
+      return (x * elemByteWidth).getLimitedValue(maxOffsetValue);
+    };
+    uint32_t blockArgInBytesMax = elemsToBytes(blockArgRangeValue.umax());
+    uint32_t blockArgInBytesMin = elemsToBytes(blockArgRangeValue.umin());
+    uint32_t stepArgInBytesMax = elemsToBytes(stepRangeValue.umax());
+    uint32_t stepArgInBytesMin = elemsToBytes(stepRangeValue.umin());
+
+    int64_t operationUncappedResultMax =
+        (int64_t)blockArgInBytesMax + stepArgInBytesMax;
+    int64_t operationUncappedResultMin =
+        (int64_t)blockArgInBytesMin + stepArgInBytesMin;
+    return {{operationUncappedResultMin, operationUncappedResultMax}};
+  }
+
+  static bool unsignedOverflowImpossible(int elemByteWidth, Value blockArg,
+                                         Value advanceStep,
+                                         DataFlowSolver *solver) {
+    auto maybeOffsetRange = estimateRangeOfOffsetWithCarryValues(
+        elemByteWidth, blockArg, advanceStep, solver);
+    if (!maybeOffsetRange.has_value())
+      return false;
+    auto offsetWithCarryRange = maybeOffsetRange.value();
+    assert(offsetWithCarryRange.first >= 0 && "offset is unsigned");
+    assert(offsetWithCarryRange.first <= offsetWithCarryRange.second);
+
+    return offsetWithCarryRange.second <= 0xff'ff'ff'ff;
+  }
+
+  static bool unsignedOverflowInevitable(int elemByteWidth, Value blockArg,
+                                         Value advanceStep,
+                                         DataFlowSolver *solver) {
+    auto maybeOffsetRange = estimateRangeOfOffsetWithCarryValues(
+        elemByteWidth, blockArg, advanceStep, solver);
+    if (!maybeOffsetRange.has_value())
+      return false;
+    auto offsetWithCarryRange = maybeOffsetRange.value();
+    assert(offsetWithCarryRange.first <= offsetWithCarryRange.second);
+
+    return offsetWithCarryRange.first > 0xff'ff'ff'ff;
+  }
+
+  static bool isTransformationEquivalent(int elemByteWidth, Value blockArg,
+                                         Value advanceStep,
+                                         DataFlowSolver *solver) {
+    if (isNonNegative(advanceStep, solver) &&
+        unsignedOverflowImpossible(elemByteWidth, blockArg, advanceStep,
+                                   solver))
+      return true;
+    if (isStrictlyNegative(advanceStep, solver) &&
+        unsignedOverflowInevitable(elemByteWidth, blockArg, advanceStep,
+                                   solver))
+      return true;
+    return false;
+  }
+
+  static BlockArgument getLoopBlockArgument(Value val, scf::ForOp loop) {
+    auto blockArg = dyn_cast<BlockArgument>(val);
+    if (!blockArg || blockArg.getOwner()->getParentOp() != loop)
+      return nullptr;
+    return blockArg;
+  }
+
+  static BlockArgument getLoopArgInAdd(arith::AddIOp addOp, scf::ForOp forOp) {
+    for (auto operand : addOp->getOperands())
+      if (auto loopArg = getLoopBlockArgument(operand, forOp))
+        return loopArg;
+    return nullptr;
+  }
+
+  // Assume that offset step is not a loop argument.
+  // This optimization supports only cases when step could be analyzed without
+  // traversing control flow.
+  static Value getStepOperandInAdd(arith::AddIOp addOp, scf::ForOp forOp) {
+    for (auto operand : addOp->getOperands())
+      if (!getLoopBlockArgument(operand, forOp))
+        return operand;
+    return nullptr;
+  }
+
+  static bool isAddFirst(amdttg::BufferOpInterface bufferOp) {
+    return isa_and_nonnull<arith::AddIOp>(
+        bufferOp.getOffsets().getDefiningOp());
+  }
+
+  static BlockArgument findOffsetLoopArgumentCandidate(Value offsetValue,
+                                                       scf::ForOp targetFor) {
+    BlockArgument offsetLoopArgument;
+    if (auto offsetAdd =
+            dyn_cast_or_null<arith::AddIOp>(offsetValue.getDefiningOp())) {
+      offsetLoopArgument = getLoopArgInAdd(offsetAdd, targetFor);
+    } else {
+      offsetLoopArgument = getLoopBlockArgument(offsetValue, targetFor);
+    }
+    return offsetLoopArgument;
+  }
+
+  static Value findIncrementedOffsetCandidate(BlockArgument offsetLoopArgument,
+                                              scf::ForOp targetFor) {
+    int yieldArgNumber =
+        offsetLoopArgument.getArgNumber() - targetFor.getNumInductionVars();
+    auto yield = cast<scf::YieldOp>(targetFor.getBody()->getTerminator());
+    return yield.getOperand(yieldArgNumber);
+  }
+
+  static arith::AddIOp findOffsetAddCandidate(Value incrementedOffset) {
+    auto addOp =
+        dyn_cast_or_null<arith::AddIOp>(incrementedOffset.getDefiningOp());
+    return addOp;
+  }
+
+  // Checks that bufferOp uses given OffsetAddOp as an offset
+  // and offsetAddOp takes one of it's operands from a given BlockArgument.
+  static bool incrementChainConsistent(amdttg::BufferOpInterface bufferOp,
+                                       BlockArgument offset,
+                                       arith::AddIOp offsetAddOp) {
+    auto targetFor = cast<scf::ForOp>(offset.getOwner()->getParentOp());
+    auto maybeOffsetLoopArgument = getLoopArgInAdd(offsetAddOp, targetFor);
+    if (offset != maybeOffsetLoopArgument) {
+      return false;
+    }
+    if (isAddFirst(bufferOp) &&
+        bufferOp.getOffsets().getDefiningOp() != offsetAddOp) {
+      return false;
+    }
+    return true;
+  }
+
+  static bool isInvariantForLoop(Value val, scf::ForOp loop) {
+    return val.getParentBlock()->getParentOp()->isProperAncestor(loop);
+  }
+
+  // Perform series of checks to decide if given operation could be optimized.
+  // If optimization is possible, return filled BufferOpInfo.
+  static std::optional<BufferOpInfo>
+  analyzeBufferOp(amdttg::BufferOpInterface op, scf::ForOp targetFor,
+                  DataFlowSolver *solver) {
+    auto offsetValue = op.getOffsets();
+
+    // Try to match components of two following patterns:
+    //
+    // Case 1(add first):
+    //   for (%offsetLoopArgument):
+    //     %incrementedOffset = arith.addi %offsetLoopArgument, %advanceStep
+    //     bufferOp %base[%incrementedOffset]
+    //     yield %incrementedOffset
+    //
+    // Case 2(buffer op first)
+    //   for (%offsetLoopArgument):
+    //     bufferOp %base[%offsetLoopArgument]
+    //     %incrementedOffset = arith.addi %offsetLoopArgument, %advanceStep
+    //     yield %incrementedOffset
+    //
+    // These patterns are similar. but buffer operation uses different values:
+    // loop argument or loop argument after increment.
+    //
+    // Offset incrementing data flow graph is same for both of them:
+    //
+    //           advanceStep
+    //                      \
+    // offsetLoopArgument -addi-> incrementedOffset -yield->
+    auto offsetLoopArgument =
+        findOffsetLoopArgumentCandidate(offsetValue, targetFor);
+    if (!offsetLoopArgument) {
+      LDBG("Rejected: Could not find a candidate for loop_arg in "
+           "loop_arg->addi->yield chain");
+      return {};
+    }
+
+    auto incrementedOffset =
+        findIncrementedOffsetCandidate(offsetLoopArgument, targetFor);
+    if (!incrementedOffset) {
+      LDBG("Rejected: Could not find a candidate for yield operand");
+      return {};
+    }
+
+    auto addOp = findOffsetAddCandidate(incrementedOffset);
+    if (!addOp) {
+      LDBG("Rejected: Could not find addi in loop_arg->addi->yield chain");
+      return {};
+    }
+
+    Value advanceStep = getStepOperandInAdd(addOp, targetFor);
+    if (!advanceStep) {
+      LDBG("Rejected: Could not find an offset step");
+      return {};
+    }
+
+    // End of pattern component search.
+    // Following core verifies that found pattern is optimizable and consistent.
+
+    if (!incrementChainConsistent(op, offsetLoopArgument, addOp)) {
+      LDBG("Rejected: Found offset increment chain is not consistent");
+      return {};
+    }
+
+    if (!isInvariantForLoop(op.getPtr(), targetFor)) {
+      LDBG("Rejected: Buffer op base Ptr is not an invariant in the loop");
+      return {};
+    }
+
+    if (!isScalarizableValue(advanceStep)) {
+      LDBG("Rejected: ptr increment step is not uniform or not supported by "
+           "scalarizer yet");
+      return {};
+    }
+
+    auto ptrType = cast<PointerType>(op.getPtr().getType());
+    auto elemBitwidth = ptrType.getPointeeType().getIntOrFloatBitWidth();
+    auto dtypeByteWidth = elemBitwidth / 8;
+    assert(dtypeByteWidth > 0);
+    if (!isTransformationEquivalent(dtypeByteWidth, offsetLoopArgument,
+                                    advanceStep, solver)) {
+      LDBG("Rejected: it is arithmetically unsafe to split offset computation");
+      return {};
+    }
+
+    LDBG("Buffer op is suitable for offset pointer optimization");
+
+    int offsetInitNo =
+        offsetLoopArgument.getArgNumber() - targetFor.getNumInductionVars();
+    auto offsetInitializer = targetFor.getInitArgs()[offsetInitNo];
+    BufferOpInfo info{op, advanceStep, nullptr, offsetInitializer, addOp};
+
+    return info;
+  }
+
+  // Create scalar values which will increment buffer op base ptr
+  // Fills appropriate fields in given BufferOpInfo structures
+  static void createScalarIncrements(PatternRewriter &rewriter,
+                                     SmallVector<BufferOpInfo> &infoList) {
+    for (auto &BufferOpInfo : infoList) {
+      auto scalarStep = scalarizeValue(rewriter, BufferOpInfo.offsetIncrement);
+      BufferOpInfo.baseIncrement = scalarStep;
+    }
+  }
+
+  static scf::ForOp
+  cloneLoopWithBasePtrIncrements(PatternRewriter &rewriter, scf::ForOp forOp,
+                                 SmallVector<BufferOpInfo> &infoList) {
+    // Create new loop with additional arguments
+    llvm::SmallVector<Value> newLoopArgs(forOp.getInitArgs());
+    for (auto info : infoList) {
+      newLoopArgs.push_back(info.op.getPtr());
+    }
+    rewriter.setInsertionPoint(forOp);
+    auto newForOp =
+        scf::ForOp::create(rewriter, forOp.getLoc(), forOp.getLowerBound(),
+                           forOp.getUpperBound(), forOp.getStep(), newLoopArgs);
+    // Clone old loop body without terminator
+    IRMapping mapping;
+    auto oldBlock = forOp.getBody();
+    auto newBlock = newForOp.getBody();
+    for (unsigned i = 0; i < oldBlock->getNumArguments(); ++i) {
+      mapping.map(oldBlock->getArgument(i), newBlock->getArgument(i));
+    }
+    rewriter.setInsertionPoint(newForOp.getBody(), newForOp.getBody()->end());
+    for (auto &op : oldBlock->without_terminator()) {
+      rewriter.clone(op, mapping);
+    }
+    // Create base pointer increment operations
+    auto basePtrs = newBlock->getArguments().take_back(infoList.size());
+    llvm::SmallVector<Value> nextIterBasePtrs;
+    for (auto [info, basePtr] : llvm::zip(infoList, basePtrs)) {
+      if (isAddFirst(info.op)) {
+        rewriter.setInsertionPoint(newBlock, newBlock->begin());
+      } else {
+        rewriter.setInsertionPoint(newBlock, newBlock->end());
+      }
+      Value step = info.baseIncrement;
+      if (mapping.contains(info.baseIncrement)) {
+        step = mapping.lookup(info.baseIncrement);
+      }
+      auto loc = info.incrementOp->getLoc();
+      auto ptrType = basePtr.getType();
+      auto nextIterBasePtr =
+          triton::AddPtrOp::create(rewriter, loc, ptrType, basePtr, step);
+      nextIterBasePtrs.push_back(nextIterBasePtr);
+    }
+    // Create yield operation
+    llvm::SmallVector<Value> newYieldOperands;
+    auto oldTerminator = forOp.getBody()->getTerminator();
+    for (auto operand : oldTerminator->getOperands()) {
+      newYieldOperands.push_back(mapping.lookup(operand));
+    }
+    newYieldOperands.append(nextIterBasePtrs);
+
+    rewriter.setInsertionPoint(newBlock, newBlock->end());
+    scf::YieldOp::create(rewriter, oldBlock->getTerminator()->getLoc(),
+                         newYieldOperands);
+    // Replace dynamic buffer op offsets with invariant value
+    // Replace base ptr with incrementing value
+    for (auto [info, basePtr, nextBasePtr] :
+         llvm::zip(infoList, basePtrs, nextIterBasePtrs)) {
+      auto newBufferOp = cast<amdttg::BufferOpInterface>(
+          mapping.lookup<Operation *>(info.op.getOperation()));
+      newBufferOp.getOffsetsMutable().assign(info.offsetInitializer);
+      // two cases:
+      // 1. buffer op uses pointer after increment
+      // 2. buffer op uses pointers from loop arguments,
+      //    incremented pointer is used on next iteration
+      Value advancingBasePtr = isAddFirst(info.op) ? nextBasePtr : basePtr;
+      newBufferOp.getPtrMutable().assign(advancingBasePtr);
+    }
+    return newForOp;
+  }
+
+  SmallVector<BufferOpInfo> collectBufferOps(scf::ForOp forOp) const {
+    SmallVector<BufferOpInfo> list;
+    forOp.walk([&list, this, forOp](amdttg::BufferOpInterface op) {
+      auto info = analyzeBufferOp(op, forOp, solver);
+      if (info.has_value()) {
+        list.push_back(info.value());
+      }
+    });
+    return list;
+  }
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    LDBG("Analyzing ForOp for offset pointer optimization: " << forOp);
+    // Gather buffer buffer operations which could be optimized
+    SmallVector<BufferOpInfo> infoList = collectBufferOps(forOp);
+
+    if (infoList.empty())
+      return rewriter.notifyMatchFailure(forOp,
+                                         "no suitable buffer operations");
+
+    // Perform IR transformation
+    createScalarIncrements(rewriter, infoList);
+    auto newForOp = cloneLoopWithBasePtrIncrements(rewriter, forOp, infoList);
+    rewriter.replaceAllUsesWith(
+        forOp.getResults(), newForOp.getResults().drop_back(infoList.size()));
+    rewriter.eraseOp(forOp);
+    return success();
+  }
+
+  DataFlowSolver *solver;
+};
+
+} // anonymous namespace
+
+struct TritonAMDGPUOptimizeBufferOpPtrPass
+    : impl::TritonAMDGPUOptimizeBufferOpPtrBase<
+          TritonAMDGPUOptimizeBufferOpPtrPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    FuncOp funcOp = getOperation();
+
+    DenseMap<Value, SetVector<Operation *>> assumptions =
+        AMD::TritonIntegerRangeAnalysis::collectAssumptions(funcOp);
+    std::shared_ptr<DataFlowSolver> solver = createDataFlowSolver();
+    DominanceInfo *dominanceInfo = &getAnalysis<DominanceInfo>();
+    AMD::TritonIntegerRangeAnalysis *rangeAnalysis =
+        solver->load<AMD::TritonIntegerRangeAnalysis>(assumptions,
+                                                      dominanceInfo);
+    AMD::initializeFuncOps(funcOp, rangeAnalysis);
+    if (failed(solver->initializeAndRun(funcOp))) {
+      LDBG("Integer range analysis failed to initialize, exiting");
+      return;
+    }
+
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<AdvanceBasePointer>(context, solver.get(), /*benefit=*/1);
+    walkAndApplyPatterns(funcOp, std::move(patterns));
+  }
+};
+
+} // namespace mlir

--- a/third_party/amd/python/test/test_pointer_optimization.py
+++ b/third_party/amd/python/test/test_pointer_optimization.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from triton._internal_testing import is_hip
+
+if not is_hip():
+    pytest.skip(allow_module_level=True)
+
+
+@pytest.mark.parametrize(
+    "input_size, input_offset, block_size, num_blocks, increment, initial_offset, expect_optimization",
+    [(256 * 32, 0, 256, 32, 256, 0, True),  # step forward
+     (256 * 33, 0, 256, 32, -256, 256 * 32, True),  # step backward
+     (256 * 32, 0, 256, 32, -256, 256 * 31, False),  # step backward #2, analysis is too conservative
+     (2**29 - 1, 0, 256, 2, 1, 2**29 - 1 - 256 - 1, True),  # go near the upper limit of befferized tensor size
+     (2048, 1024, 256, 2, -1024, 0, False),  # on first iteration offset is positive, on second becomes negative
+     ])
+def test_buffer_op_ptr_optimization(input_size, input_offset, block_size, num_blocks, increment, initial_offset,
+                                    expect_optimization, device):
+    """ Test verifies that increments are going to base pointer instead of offset tensor when possible and this transformation is correct:
+
+    expect TTGIR looks like this:
+
+        scf.for (%X) {
+        %x = amdg.buffer_load %X[%offset]
+        ...
+
+        %X_1 = tt.addptr %X, %step
+        scf.yield %X_1
+        }
+
+    instead of
+
+        scf.for (%offset) {
+        %x = amdg.buffer_load %X[%offset]
+        ...
+
+        %offset_1 = arith.addi %offset, %step
+        scf.yield %offset_1
+        }
+    """
+
+    @triton.jit
+    def kernel(X, Y, BLOCK_SIZE: tl.constexpr, NUM_BLOCKS: tl.constexpr, INCREMENT: tl.constexpr,
+               INITIAL_OFFSET: tl.constexpr):
+        offset = tl.arange(0, BLOCK_SIZE) + INITIAL_OFFSET
+        y = tl.zeros([BLOCK_SIZE], tl.float32)
+        for i in range(NUM_BLOCKS):
+            Xs = X + offset
+            x = tl.load(Xs)
+            y += x
+            offset += INCREMENT
+        Ys = Y + tl.arange(0, BLOCK_SIZE)
+        tl.store(Ys, y)
+
+    def check_ir(ttgir, expect_optimization):
+        optimized = False
+        buffer_op_present = False
+        for line in ttgir.split("\n"):
+            if "buffer_load" in line:
+                buffer_op_present = True
+            if "addptr" in line:
+                optimized = True
+        assert optimized == expect_optimization
+        assert buffer_op_present
+
+    X = torch.randn((input_size, ), device=device, dtype=torch.float32)
+    Y = torch.randn((block_size, ), device=device, dtype=torch.float32)
+
+    ref_output = torch.zeros_like(Y)
+    for i in range(num_blocks):
+        for j in range(block_size):
+            ref_output[j] += X[(input_offset + initial_offset + increment * i + j) % input_size]
+
+    grid = (1, )
+
+    pgm = kernel[grid](X[input_offset:], Y, block_size, num_blocks, increment, initial_offset, num_warps=1)
+
+    check_ir(pgm.asm["ttgir"], expect_optimization)
+
+    if expect_optimization:
+        assert torch.allclose(Y, ref_output, rtol=1e-3, atol=1e-2)

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -104,6 +104,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                             const std::string &, bool, bool);
   ADD_PASS_WRAPPER_0("add_lower_barrier_ops",
                      mlir::createTritonAMDGPULowerBarrierOps);
+  ADD_FUNC_PASS_WRAPPER_0("add_optimize_buffer_op_ptr",
+                          mlir::createTritonAMDGPUOptimizeBufferOpPtr);
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi", mlir::createTritonAMDFoldTrueCmpI);
 
   ADD_PASS_OPTION_WRAPPER_1("add_block_pingpong",


### PR DESCRIPTION
Summary:

Backport of upstream Triton PR #8464 (by Aleksandr Efimov / AMD).

Upstream PR: https://github.com/triton-lang/triton/pull/8464
Upstream commit: 3e26d31928af967b494e4cb2cbf1aab9ade89f73

Original commit message:

This PR transfers address computation from offsets in buffer loads to base pointers, which reuses amount of required computations and lowers register pressure.

Adds the AMD-specific pass tritonamdgpu-optimize-buffer-op-ptr (third_party/amd/lib/TritonAMDGPUTransforms/OptimizeBufferOpPtr.cpp, Passes.td), registers it (RegisterTritonDialects.h, triton_amd.cc, python/src/passes.h), and wires it into the HIPBackend pipeline (third_party/amd/backend/compiler.py).

Co-authored-by: Alexander Efimov <efimov.alexander@gmail.com>

Backport notes:
Applied the upstream patch verbatim; regenerated BUCK (buck run fbcode//triton/tools/reactor:reactor -- buckify triton beta) to pick up the new OptimizeBufferOpPtr.cpp source and pass registration. Stacked on the LLVM 62b7cf9 bump (D109226675).

Authored with Claude.

Reviewed By: wlei-llvm

Differential Revision: D109232104


