### PR TITLE
[Backport][AMD][gfx9] Use asyncmark/wait_asyncmark for CDNA3/CDNA4 buffer_load_to_lds (#9883) (#1806)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -131,6 +131,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUConvertToBufferOps();
   mlir::registerTritonAMDGPULowerBarrierOps();
   mlir::registerTritonAMDGPUConvertToTensorOps();
+  mlir::registerTritonAMDGPUOptimizeBufferOpPtr();
   mlir::registerTritonAMDGPUInThreadTranspose();
   mlir::registerTritonAMDGPUCoalesceAsyncCopy();
   mlir::registerTritonAMDGPUCoalesceBufferOps();

--- a/python/src/passes.h
+++ b/python/src/passes.h
@@ -1,6 +1,11 @@
 #define ADD_PASS_WRAPPER_0(name, builder)                                      \
   m.def(name, [](mlir::PassManager &pm) { pm.addPass(builder()); })
 
+#define ADD_FUNC_PASS_WRAPPER_0(name, builder)                                 \
+  m.def(name, [](mlir::PassManager &pm) {                                      \
+    pm.addNestedPass<mlir::triton::FuncOp>(builder());                         \
+  });
+
 #define ADD_PASS_WRAPPER_1(name, builder, ty0)                                 \
   m.def(name,                                                                  \
         [](mlir::PassManager &pm, ty0 val0) { pm.addPass(builder(val0)); })

--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -16,7 +16,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     %ptr = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>, #blocked>
     %mask = tt.splat %maskVal : i1 -> tensor<64x1xi1, #blocked>
 
-    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
+    // COMMON: rocdl.global.load.async.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     // Check that store for 'other' has alias information set
     // COMMON: llvm.store {{.*}} {alias_scopes = [[[$LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     %0 = ttg.async_copy_global_to_local %ptr, %arg1 mask %mask other %other : tensor<64x1x!tt.ptr<f32>, #blocked> -> <64x1xf32, #shared, #smem, mutable>
@@ -41,7 +41,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %mask = tt.splat %maskVal : i1 -> tensor<8x64xi1, #blocked>
     %other = arith.constant dense<1.000000e+00> : tensor<8x64xf32, #blocked>
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     // Check that store for 'other' has alias information set
     // COMMON: llvm.store {{.*}} {alias_scopes = [[[$LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     %65 = amdg.buffer_load_to_local %arg1[%arg2] mask=%mask other=%other into %arg3 : <f32>[tensor<8x64xi32, #blocked>] tensor<8x64xf32, #blocked> -> <8x64xf32, #shared, #smem, mutable>
@@ -107,7 +107,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // We need the splat to allow the AxisAnalysis to work during lowering
     %ptr = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>, #blocked>
 
-    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
+    // COMMON: rocdl.global.load.async.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     %0 = ttg.async_copy_global_to_local %ptr, %arg1 : tensor<64x1x!tt.ptr<f32>, #blocked> -> <64x1xf32, #shared, #smem, mutable>
     %1 = ttg.async_commit_group tokens %0
 

--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -1,5 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s --check-prefix=GFX950
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --verify-diagnostics | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -11,9 +11,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
                                 %arg2: !ttg.memdesc<32x64xf32, #shared, #smem, mutable>) {
     // We need the splat to allow the AxisAnalysis to work during lowering
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>, #blocked>
-    // Each thread needs to load 8 elements and we load 1 (sizePerThread) per global.load.lds
-    // CHECK-COUNT-8: rocdl.global.load.lds
-    // CHECK-NOT: rocdl.global.load.lds
+    // Each thread needs to load 8 elements and we load 1 (sizePerThread) per load.
+    // CDNA3/CDNA4 use the async variant so LLVM tracks via asyncmark.
+    // CHECK-COUNT-8: rocdl.global.load.async.lds
+    // CHECK-NOT: rocdl.global.load.async.lds
     %2 = ttg.async_copy_global_to_local %1, %arg2 : tensor<32x64x!tt.ptr<f32>, #blocked> -> <32x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -31,9 +32,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
                                 %arg2: !ttg.memdesc<32x64xf32, #shared, #smem, mutable>) {
     // We need the splat to allow the AxisAnalysis to work during lowering
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>, #blocked>
-    // Each thread needs to load 8 elements and we load 1 () per global.load.lds
-    // CHECK-COUNT-8: rocdl.global.load.lds
-    // CHECK-NOT: rocdl.global.load.lds
+    // Each thread needs to load 8 elements and we load 1 () per load
+    // CHECK-COUNT-8: rocdl.global.load.async.lds
+    // CHECK-NOT: rocdl.global.load.async.lds
     %2 = ttg.async_copy_global_to_local %1, %arg2 : tensor<32x64x!tt.ptr<f32>, #blocked> -> <32x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -56,9 +57,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #blocked>
     %5 = tt.addptr %4, %3 : tensor<32x64x!tt.ptr<f16>, #blocked>, tensor<32x64xi32, #blocked>
 
-    // Each thread needs to load 8 elements and we load 2 (sizePerThread) per global.load.lds
-    // CHECK-COUNT-4: rocdl.global.load.lds
-    // CHECK-NOT: rocdl.global.load.lds
+    // Each thread needs to load 8 elements and we load 2 (sizePerThread) per load
+    // CHECK-COUNT-4: rocdl.global.load.async.lds
+    // CHECK-NOT: rocdl.global.load.async.lds
     %6 = ttg.async_copy_global_to_local %5, %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked> -> <32x64xf16, #shared, #smem, mutable>
     tt.return
   }
@@ -69,61 +70,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  // GFX950-LABEL: async_copy_vectorized_8xf16
-  tt.func public @async_copy_vectorized_8xf16(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                %arg1: i32 {tt.divisibility = 16 : i32},
-                                %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
-    // We need the index calculation so AxisAnalysis sees that we can vectorize the load
-    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %2 = tt.expand_dims %1 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
-    %3 = tt.broadcast %2 : tensor<1x64xi32, #blocked> -> tensor<32x64xi32, #blocked>
-    %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #blocked>
-    %5 = tt.addptr %4, %3 : tensor<32x64x!tt.ptr<f16>, #blocked>, tensor<32x64xi32, #blocked>
-
-    // Each thread needs to load 8 elements and we load 8 (sizePerThread) per global.load.lds
-    // GFX950: rocdl.global.load.lds
-    // GFX950-next: llvm.return
-
-    // GFX942 does not support vectorization > 4bytes
-    // expected-error@+1 {{failed to legalize operation 'ttg.async_copy_global_to_local' that was explicitly marked illegal}}
-    %6 = ttg.async_copy_global_to_local %5, %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked> -> <32x64xf16, #shared, #smem, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: async_wait
+  // GFX950-LABEL: async_wait
   tt.func public @async_wait(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                              %arg1: i32 {tt.divisibility = 16 : i32},
                              %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
-    // The waitcnt stores all counters in one i32 bits 15:14 and 3:0 store the vmcnt we have to wait on
-    // CHECK: rocdl.s.waitcnt -49168
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
-    amdg.async_wait {num_inst = 0 : i32}
-    // CHECK: rocdl.s.waitcnt -49167
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
-    amdg.async_wait {num_inst = 1 : i32}
-    // CHECK: rocdl.s.waitcnt -2
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
-    amdg.async_wait {num_inst = 62 : i32}
-    // CHECK: rocdl.s.waitcnt -1
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
-    amdg.async_wait {num_inst = 63 : i32}
-    // Check that we clamp values > 63
-    // CHECK: rocdl.s.waitcnt -1
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
-    amdg.async_wait {num_inst = 64 : i32}
+    // CDNA3/CDNA4 lower ttg.async_wait directly to wait_asyncmark.
+    // The commit group count is passed through without clamping since
+    // LLVM will compute the final waitcnt.
+    // CHECK: rocdl.wait.asyncmark 0
+    // GFX950: rocdl.wait.asyncmark 0
+    ttg.async_wait {num = 0 : i32}
+    // CHECK: rocdl.wait.asyncmark 1
+    // GFX950: rocdl.wait.asyncmark 1
+    ttg.async_wait {num = 1 : i32}
+    // CHECK: rocdl.wait.asyncmark 62
+    // GFX950: rocdl.wait.asyncmark 62
+    ttg.async_wait {num = 62 : i32}
+    // CHECK: rocdl.wait.asyncmark 63
+    // GFX950: rocdl.wait.asyncmark 63
+    ttg.async_wait {num = 63 : i32}
+    // No clamping — LLVM handles it based on instruction count
+    // CHECK: rocdl.wait.asyncmark 64
+    // GFX950: rocdl.wait.asyncmark 64
+    ttg.async_wait {num = 64 : i32}
     tt.return
   }
 }
@@ -133,13 +104,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: async_commit_group
+  // GFX950-LABEL: async_commit_group
   tt.func public @async_commit_group(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                                      %arg1: i32 {tt.divisibility = 16 : i32},
                                      %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
+    // CDNA3/CDNA4 emit asyncmark for async group tracking
+    // CHECK: rocdl.asyncmark
     // CHECK: llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT: llvm.return
+    // GFX950: rocdl.asyncmark
+    // GFX950: llvm.mlir.constant(0 : i32) : i32
+    // GFX950-NEXT: llvm.return
     ttg.async_commit_group
     tt.return
   }
@@ -179,25 +156,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Note that mask/other alignment is 1 so we need 4 conditionals
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -243,7 +220,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -251,7 +228,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -259,7 +236,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -267,7 +244,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -292,13 +269,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.sha
     // Each thread needs to load 1 element and we load 1 (sizePerThread) per global.load.lds
 
     // CHECK: llvm.getelementptr
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4, 0, 0
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 0
     %2 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = ca: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4, 0, 3
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 3
     %3 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cg: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4, 0, 17
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 17
     %4 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cv: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -313,7 +290,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK-LABEL: async_copy_contiguity_hint
   tt.func @async_copy_contiguity_hint(%v: tensor<256x!tt.ptr<f16>, #blocked>, %smem: !ttg.memdesc<256xf16, #shared1D, #smem, mutable>) {
     // Check we load 4 bytes at a time
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4
     %0 = ttg.async_copy_global_to_local %v, %smem {contiguity = 2 : i32} : tensor<256x!tt.ptr<f16>, #blocked> -> !ttg.memdesc<256xf16, #shared1D, #smem, mutable>
     tt.return
   }
@@ -332,7 +309,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>, #blocked>
     %2 = ttg.memdesc_subslice %arg2 [0, 0]  : !ttg.memdesc<32x128xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x64xf32, #shared, #smem, mutable, 32x128>
     // We slice in the fastest dim but each warp loads one row, therefore we can write coalesced into LDS
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     %3 = ttg.async_copy_global_to_local %1, %2 : tensor<32x64x!tt.ptr<f32>, #blocked> -> <32x64xf32, #shared, #smem, mutable, 32x128>
     tt.return
   }
@@ -351,7 +328,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %2 = ttg.memdesc_subslice %arg2 [0, 0]  : !ttg.memdesc<64x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable, 64x32>
     // We slice into the slowest dim which does not break coalesced writes into LDS
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     %3 = ttg.async_copy_global_to_local %1, %2 : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable, 64x32>
     tt.return
   }

--- a/test/Conversion/amd/async_ops_to_llvm_errors.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm_errors.mlir
@@ -1,0 +1,22 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --verify-diagnostics
+
+// GFX942 does not support vectorization > 4bytes for direct-to-LDS loads
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @async_copy_vectorized_8xf16_error(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                %arg1: i32 {tt.divisibility = 16 : i32},
+                                %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
+    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %2 = tt.expand_dims %1 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %3 = tt.broadcast %2 : tensor<1x64xi32, #blocked> -> tensor<32x64xi32, #blocked>
+    %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #blocked>
+    %5 = tt.addptr %4, %3 : tensor<32x64x!tt.ptr<f16>, #blocked>, tensor<32x64xi32, #blocked>
+
+    // expected-error@+1 {{failed to legalize operation 'ttg.async_copy_global_to_local' that was explicitly marked illegal}}
+    %6 = ttg.async_copy_global_to_local %5, %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked> -> <32x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -13,8 +13,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Each thread needs to load 8 elements and we load 1 (sizePerThread) per buffer load instruction
     // COMMON: rocdl.make.buffer.rsrc
     // COMMON-NOT: rocdl.make.buffer.rsrc
-    // COMMON-COUNT-8: rocdl.raw.ptr.buffer.load.lds
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON-COUNT-8: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -41,8 +41,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
     // Each thread needs to load 2 elements and we load 2 (sizePerThread) per buffer load instruction
     // COMMON: rocdl.make.buffer.rsrc
     // COMMON-NOT: rocdl.make.buffer.rsrc
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
   }
@@ -69,11 +69,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
     // Each thread needs to load 8 elements and we load 8 (sizePerThread) per buffer load instruction
     // GFX950: rocdl.make.buffer.rsrc
     // GFX950-NOT: rocdl.make.buffer.rsrc
-    // GFX950: rocdl.raw.ptr.buffer.load.lds
-    // GFX950-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX950: rocdl.raw.ptr.buffer.load.async.lds
+    // GFX950-NOT: rocdl.raw.ptr.buffer.load.async.lds
 
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
-    // GFX942-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
@@ -101,11 +101,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Each thread needs to load 8 elements and we load 8 (sizePerThread) per buffer load instruction
     // GFX950: rocdl.make.buffer.rsrc
     // GFX950-NOT: rocdl.make.buffer.rsrc
-    // GFX950: rocdl.raw.ptr.buffer.load.lds
-    // GFX950-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX950: rocdl.raw.ptr.buffer.load.async.lds
+    // GFX950-NOT: rocdl.raw.ptr.buffer.load.async.lds
 
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
-    // GFX942-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<256x8xi32, #blocked>]  -> <256x8xf16, #shared, #smem, mutable>
     tt.return
@@ -146,7 +146,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Each thread needs to load 4 elements and we load 1 (sizePerThread) per buffer load instruction
     // Note that mask/other alignment is 1 so we need 4 conditionals
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
@@ -154,19 +154,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON: [[AND:%.*]] = llvm.and
     // COMMON: llvm.cond_br [[AND]]
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: _predicated_store
     // COMMON-NOT: llvm.cond_br
     // COMMON-NOT: llvm.store
@@ -191,15 +191,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // COMMON-NEXT: %[[IMM0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON-NEXT: %[[aux_ca:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON-NEXT: %[[IMM1:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // COMMON-NEXT: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, %[[VOFFSET]], %[[IMM1]], %[[IMM0]], %[[aux_ca]]
+    // COMMON-NEXT: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, %[[VOFFSET]], %[[IMM1]], %[[IMM0]], %[[aux_ca]]
     %1 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = ca into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: %[[aux_cg:.*]] = llvm.mlir.constant(3 : i32) : i32
-    // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
     %2 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cg into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: %[[aux_cv:.*]] = llvm.mlir.constant(17 : i32) : i32
-    // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
     %3 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cv into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
 
     tt.return
@@ -221,10 +221,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // COMMON: rocdl.make.buffer.rsrc
     // COMMON-NOT: rocdl.make.buffer.rsrc
     // COMMON: rocdl.ds_bpermute
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: rocdl.ds_bpermute
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : <f32>[tensor<16x64xi32, #blocked>] -> <16x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -266,31 +266,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON-NOT: rocdl.ds_bpermute
     // COMMON-NOT: rocdl.ballot
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: _predicated_store
 
     amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
@@ -318,11 +318,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
 
     // Each thread needs to load 8 elements and we load 8 (sizePerThread) per buffer load instruction
     // GFX950: rocdl.make.buffer.rsrc
-    // GFX950: rocdl.raw.ptr.buffer.load.lds
-    // GFX950-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX950: rocdl.raw.ptr.buffer.load.async.lds
+    // GFX950-NOT: rocdl.raw.ptr.buffer.load.async.lds
 
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
-    // GFX942-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
@@ -339,7 +339,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   tt.func @buffer_load_to_local_contiguity_hint(%ptr: !tt.ptr<f16>, %off: tensor<256xi32, #blocked>, %lds: !ttg.memdesc<256xf16, #shared1D, #smem, mutable>) {
     // Check we load 4 bytes
     // COMMON: %[[LOAD_BYTES:.*]] = llvm.mlir.constant(4 : i32) : i32
-    // COMMON: rocdl.raw.ptr.buffer.load.lds %{{.*}}, %{{.*}}, %[[LOAD_BYTES]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds %{{.*}}, %{{.*}}, %[[LOAD_BYTES]]
     %0 = amdg.buffer_load_to_local %ptr[%off] into %lds {contiguity = 2 : i32} : <f16>[tensor<256xi32, #blocked>] -> <256xf16, #shared1D, #smem, mutable>
     tt.return
   }

--- a/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
+++ b/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
@@ -1,0 +1,589 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx950" --tritonamdgpu-optimize-buffer-op-ptr| FileCheck %s --check-prefixes=CHECK
+
+// CHECK-LABEL: add_after_load
+// CHECK-DAG: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK-DAG: [[Y_OFFSET_CST:%.*]] = arith.constant dense<321>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, {{.*}}, [[X_BASE:%.*]] = {{.*}}, [[Y_BASE:%.*]] = {{.*}})
+// CHECK:   amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}} :
+// CHECK:   amdg.buffer_load [[Y_BASE]]{{\[}}[[Y_OFFSET_CST]]{{\]}} cacheModifier = cg :
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]], %c64_i32
+// CHECK:   [[NEXT_Y_BASE:%.*]] = tt.addptr [[Y_BASE]]
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]], [[NEXT_Y_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @add_after_load(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %stride: i32) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c1 = arith.constant 1 : index
+
+    %min_stride = arith.constant 1 : i32
+    %max_stride = arith.constant 1024 : i32
+    %0 = arith.cmpi sge, %stride, %min_stride : i32
+    llvm.intr.assume %0 : i1
+    %1 = arith.cmpi sle, %stride, %max_stride : i32
+    llvm.intr.assume %1 : i1
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %Yoffset_init = arith.constant dense<321> : tensor<64x32xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %y_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+
+    %tmp = arith.muli %stride, %c64_i32 : i32
+    %step = tt.splat %tmp : i32 -> tensor<64x32xi32, #blocked>
+    %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>) {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
+
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      %Yoffset_next = arith.addi %Yoffset, %step : tensor<64x32xi32, #blocked>
+      scf.yield %Xoffset_next, %Yoffset_next : tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: buffer_load_to_local
+// CHECK-DAG: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}}
+// CHECK:   amdg.buffer_load_to_local [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]], %c64_i32
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @buffer_load_to_local(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: add_before_load
+// CHECK-DAG: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]], %c64_i32
+// CHECK:   amdg.buffer_load [[NEXT_X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @add_before_load(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: isolated_pattern_nested_loop1
+// CHECK: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for
+// CHECK:   scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:     amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:     [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]]
+// CHECK:     scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @isolated_pattern_nested_loop1(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    %c1 = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    scf.for %idx_outer = %c0 to %c32 step %c1 iter_args() -> () {
+      %for_inner = scf.for %idx_innter = %c0 to %c32 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+        %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+        ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+        %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+        scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+      }
+      scf.yield
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: isolated_pattern_nested_loop2
+// CHECK: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:   scf.for
+// CHECK:     amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]]
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @isolated_pattern_nested_loop2(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for_outer = scf.for %idx_outer = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      scf.for %idx_inner = %c0 to %c128 step %c1 iter_args() -> () {
+        %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+        ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+        scf.yield
+      }
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: convert_with_base_ptr_optimization
+// CHECK: [[X_OFFSET_CST:%.*]] = arith.constant dense<123>
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[X_BASE:%.*]] = {{.*}})
+// CHECK:   amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}}
+// CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]]
+// CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @convert_with_base_ptr_optimization(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+    %x_base = tt.splat %X : !tt.ptr<f16> -> tensor<16x64x!tt.ptr<f16>, #blocked>
+    %offsets_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx_outer = %c0 to %c128 step %c1 iter_args(%offsets = %offsets_init) -> (tensor<16x64xi32, #blocked>) {
+      %X_ptr = tt.addptr %x_base, %offsets : tensor<16x64x!tt.ptr<f16>, #blocked>, tensor<16x64xi32, #blocked>
+      %x = tt.load %X_ptr : tensor<16x64x!tt.ptr<f16>, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %offsets_next = arith.addi %offsets, %step : tensor<16x64xi32, #blocked>
+      scf.yield %offsets_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: dynamic_base_negative
+// CHECK:   [[X_BASE:%.*]] = tt.addptr
+// CHECK:   amdg.buffer_load [[X_BASE]]
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @dynamic_base_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
+      %x_base = tt.addptr %X, %idx : !tt.ptr<f16>, i32
+      %x = amdg.buffer_load %x_base[%Xoffset] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: non_uniform_step_negative
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @non_uniform_step_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %step : tensor<16x64xi32, #blocked>) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: offsets_possible_overflow_negative
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @offsets_possible_overflow_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %step_scalar : i32) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %step = tt.splat %step_scalar: i32 -> tensor<16x64xi32, #blocked>
+    %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: two_parallel_addi_negative
+// CHECK-NOT: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @two_parallel_addi_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c128 = arith.constant 128 : i32
+    %c1 = arith.constant 1 : i32
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Xoffset_dummy = %Xoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>) : i32 {
+      %Xoffset_decoy = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_decoy] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next, %Xoffset_decoy : tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Check case with three buffer ops in a loop, first and third are optimized, second is rejected because step is not uniform
+// CHECK-LABEL: mixed_optimized_rejected_optimized
+// CHECK-DAG: [[X_OFFSET:%.*]] = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+// CHECK-DAG: [[Y_OFFSET_INIT:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+// CHECK-DAG: [[Z_OFFSET:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+// CHECK: scf.for {{.*}} iter_args({{%.*}}[[Y_OFFSET:%.*]] = [[Y_OFFSET_INIT]]
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mixed_optimized_rejected_optimized(
+        %X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Z: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}
+      ) attributes {noinline = false} {
+    %Xstep = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %Ystep_slice = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %Ystep_2d = tt.expand_dims %Ystep_slice {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %Ystep = tt.broadcast %Ystep_2d : tensor<1x32xi32, #blocked> -> tensor<64x32xi32, #blocked>
+    %Zstep = arith.constant dense<256> : tensor<32x32xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %Yoffset_init = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+    %Zoffset_init = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %y_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+    %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+    %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+      ttg.local_store %z, %z_dummy_buffer : tensor<32x32xf16, #blocked> -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+      %Xoffset_next = arith.addi %Xoffset, %Xstep : tensor<16x64xi32, #blocked>
+      %Yoffset_next = arith.addi %Yoffset, %Ystep : tensor<64x32xi32, #blocked>
+      %Zoffset_next = arith.addi %Zoffset, %Zstep : tensor<32x32xi32, #blocked>
+      scf.yield %Xoffset_next, %Yoffset_next, %Zoffset_next : tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Check case with three buffer ops in a loop, only second one is optimized
+// CHECK-LABEL: mixed_rejected_optimized_rejected
+// CHECK-DAG: [[X_OFFSET_INIT:%.*]] = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+// CHECK-DAG: [[Y_OFFSET:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+// CHECK-DAG: [[Z_OFFSET_INIT:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+// CHECK: scf.for {{.*}} iter_args([[X_OFFSET:%.*]] = [[X_OFFSET_INIT]], {{.*}}[[Z_OFFSET:%.*]] = [[Z_OFFSET_INIT]]
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mixed_rejected_optimized_rejected(
+        %X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Z: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+        %Xstride: i32,
+        %Zstride: i32
+      ) attributes {noinline = false} {
+    %Xstep = tt.splat %Xstride: i32 -> tensor<16x64xi32, #blocked>
+    %Ystep = arith.constant dense<128> : tensor<64x32xi32, #blocked>
+    %Zstep = tt.splat %Zstride : i32 -> tensor<32x32xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %Yoffset_init = arith.constant dense<456> : tensor<64x32xi32, #blocked>
+    %Zoffset_init = arith.constant dense<789> : tensor<32x32xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %y_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+    %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+    %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
+      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : tensor<32x32xf16, #blocked>
+
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
+      ttg.local_store %z, %z_dummy_buffer : tensor<32x32xf16, #blocked> -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
+
+      %Xoffset_next = arith.addi %Xoffset, %Xstep : tensor<16x64xi32, #blocked>
+      %Yoffset_next = arith.addi %Yoffset, %Ystep : tensor<64x32xi32, #blocked>
+      %Zoffset_next = arith.addi %Zoffset, %Zstep : tensor<32x32xi32, #blocked>
+      scf.yield %Xoffset_next, %Yoffset_next, %Zoffset_next : tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_offset_uses
+// CHECK: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_offset_uses(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %offset_step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %offset_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+    %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      ttg.local_store %Xoffset, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %offset_step : tensor<16x64xi32, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      ttg.local_store %Xoffset_next, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    ttg.local_store %for, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_offset_uses_over_multiple_loops
+// CHECK: scf.for
+// CHECK:   tt.addptr
+// CHECK:   scf.for
+// CHECK:     tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_offset_uses_over_multiple_loops(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %Y: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %offset_step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 32 : index
+    %iter_step = arith.constant 1 : index
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+    %offset_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
+    %for1 = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset1 = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %Xoffset_next1 = arith.addi %Xoffset1, %offset_step : tensor<16x64xi32, #blocked>
+
+      %for2 = scf.for %idx2 = %iter_first to %iter_last step %iter_step iter_args(%Xoffset2 = %Xoffset_next1) -> (tensor<16x64xi32, #blocked>) {
+        %Xoffset_next2 = arith.addi %Xoffset2, %offset_step : tensor<16x64xi32, #blocked>
+        %x2 = amdg.buffer_load %X[%Xoffset_next2] : tensor<16x64xf16, #blocked>
+        ttg.local_store %x2, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+        scf.yield %Xoffset_next2 : tensor<16x64xi32, #blocked>
+      }
+
+      %x1 = amdg.buffer_load %X[%Xoffset_next1] : tensor<16x64xf16, #blocked>
+      ttg.local_store %x1, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next1 : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_addi_in_sequence_negative
+// CHECK-NOT:  tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_addi_in_sequence_negative(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst1 = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %cst2 = arith.constant dense<128> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+    %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+      %Xoffset_tmp = arith.addi %Xoffset, %cst1 : tensor<16x64xi32, #blocked>
+      %Xoffset_next = arith.addi %Xoffset_tmp, %cst2 : tensor<16x64xi32, #blocked>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_buffer_loads_on_one_addi
+// CHECK-COUNT-2: tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_buffer_loads_on_one_addi(%X: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<16x64xi32, #blocked>
+    %iter_first = arith.constant 0 : index
+    %iter_last = arith.constant 128 : index
+    %iter_step = arith.constant 1 : index
+
+    %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
+
+    %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+
+    %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
+      %x1 = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
+      %x2 = amdg.buffer_load_to_local %X[%Xoffset_next] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: messed_add_chain_negative
+// CHECK-NOT:  tt.addptr
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @messed_add_chain_negative(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) -> tensor<256xi32, #blocked> attributes {noinline = false} {
+    %zero = arith.constant dense<0> : tensor<256xi32, #blocked>
+    %iter_first = arith.constant 0 : i32
+    %iter_last = arith.constant 15 : i32
+    %iter_step = arith.constant 1 : i32
+
+    %for:2 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%arg1 = %zero, %arg2 = %zero) -> (tensor<256xi32, #blocked>, tensor<256xi32, #blocked>) : i32 {
+      %data = amdg.buffer_load %arg0[%arg1] : tensor<256xi32, #blocked>
+      scf.yield %arg2, %data : tensor<256xi32, #blocked>, tensor<256xi32, #blocked>
+    }
+    tt.return %for#1 : tensor<256xi32, #blocked>
+  }
+}

--- a/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx950 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx1250 | FileCheck %s
 
 // The number in SSA symbolic names represents the number of generated async load operation at assembly level a ttg.async_copy_global_to_local will generate, which is counted by this pass.
 // For example `ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst ..` will generate two global_load_async_to_lds_b128 assembly instruction
@@ -25,11 +25,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     // CHECK: amdg.async_wait {num_inst = 0
     ttg.async_wait {num = 0 : i32}
+    // 1 outstanding commit group (2nd): 2 instructions
     // CHECK: amdg.async_wait {num_inst = 2
     ttg.async_wait {num = 1 : i32}
-    // Check we stop at function boundary
+    // 2 outstanding commit groups: 2 + 1 = 3 instructions
     // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 2 : i32}
+    // Only 2 commit groups exist, stop at function boundary
     // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 3 : i32}
 
@@ -47,10 +49,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emit 1 instruction
     ttg.async_copy_global_to_local %ptr1Inst, %memDesc1Inst : tensor<64x16x!tt.ptr<f16>, #blocked> -> <64x16xf16, #shared, #smem, mutable>
 
-    // We expect 1 because the async copy above has not been committed yet
+    // No commit groups found, walk to function boundary: 1 instruction
     // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 0 : i32}
-    // -1 can be used to wait on all, even non committed async ops
+    // -1 means wait on all — immediate stop → conservative 0
     // CHECK: amdg.async_wait {num_inst = 0
     ttg.async_wait {num = -1 : i32}
 
@@ -216,6 +218,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_commit_group
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
+    // 3 outstanding commit groups, each ptr2Inst emits 2 instr → 6
     // CHECK: amdg.async_wait {num_inst = 6
     ttg.async_wait {num = 3: i32}
 

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx950 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx1250 | FileCheck %s
 
 // Simple case without any branching
 
@@ -17,10 +17,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the second async_copy => waitcnt 2
+    // Wait on token %1: 2 instructions outstanding (second async_copy emits 2)
     // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
+    // Wait on token %3: 0 instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -44,11 +44,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ttg.async_commit_group tokens %0
     // Emits 2 direct to lds instructions
     %2 = amdg.buffer_load_to_local %arg2[%arg3] into %arg5 : <f16>[tensor<16x256xi32, #blocked1>]  -> <16x256xf16, #shared1, #smem, mutable>
-    // Do not wait on the second buffer_load_to_local => waitcnt 2
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %3 = ttg.async_commit_group tokens %2
+    // Wait on token %1: 2 instructions outstanding (second buffer_load emits 2)
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %4 = ttg.async_wait %1 {num = 0 : i32}
-    // No buffer_load_to_local in between => waitcnt 0
+    // Wait on token %3: 0 instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %5 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -74,10 +74,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the second async_copy => waitcnt 2
+    // Wait on token %3: 0 instructions outstanding (nothing after %3)
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %9 = ttg.async_wait %3 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
+    // Wait on token %1: 2 instructions outstanding (second async_copy emits 2)
     // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %10 = ttg.async_wait %1 {num = 0 : i32}
     tt.return
@@ -105,8 +105,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     %4 = tt.load %arg3 : tensor<128x16x!tt.ptr<f16>, #blocked>
 
+    // Wait on token %1: 2 instructions outstanding (tt.load ignored, second async_copy emits 2)
     // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
+    // Wait on token %3: 0 instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -134,6 +136,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
     %8:2 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %3) -> (!ttg.async.token, !ttg.async.token)  : i32 {
+      // min over tokens: %arg16 has 0 outstanding → overall 0
       // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 0
       %10 = ttg.async_wait %arg15, %arg16 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -173,6 +176,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      // 2 loads per buffer: first emits 1, second emits 2 → 3 per iteration
       // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
       %10 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -212,12 +216,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token) : i32 {
       %103 = scf.if %cond -> (!ttg.async.token) {
-        // We wait on both tokens so we interleave with one iteration => 3
         // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
       } else {
-        // We only wait on the token of the first load so we can interleave one more load => 3 + 2
         // CHECK: amdg.async_wait {{.*}} {num_inst = 5
         %token2 = ttg.async_wait %arg15 {num = 1 : i32}
         scf.yield %token2 : !ttg.async.token
@@ -262,7 +264,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %103 = scf.if %cond -> (!ttg.async.token) {
         %cond_load = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
         %cond_load_commit = ttg.async_commit_group tokens %cond_load
-        // We wait on both tokens (3) and additionally we should count the load inside our block (+2) => 5
         // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 5
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
@@ -306,7 +307,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-      // The then block contains 3 instructions and the else 1 so we expect the count to be 3 (1 + 2) because there are also 2 instructions outside the scf.if in the loop body
       // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
       %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
 
@@ -349,7 +349,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
-    // Dynamic iteration count so we should not count its body
+    // Dynamic iteration count
     %30 = scf.for %arg21 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
       // CHECK: amdg.async_wait {{.*}} {num_inst = 0
       %31 = ttg.async_wait %arg30 {num = 1 : i32}
@@ -383,7 +383,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
-    // Loop with 4 iterations => 4 instructions
     %30 = scf.for %arg21 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
       // CHECK: amdg.async_wait {{.*}} {num_inst = 0
       %31 = ttg.async_wait %arg30 {num = 1 : i32}
@@ -442,10 +441,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the second async_copy => waitcnt 2
+    // Wait on token %1: 2 store instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
+    // Wait on token %3: 0 outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -469,10 +468,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the store => waitcnt 2
+    // Wait on token %1: 2 store instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
+    // Wait on token %3: 0 outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -504,11 +503,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %5 = ttg.async_copy_global_to_local %ptr, %memDesc : tensor<128x8x!tt.ptr<f16>, #blocked> -> <128x8xf16, #shared, #smem, mutable>
     %51 = ttg.async_commit_group tokens %4, %5
 
-    // Check that we do not take other load types into account (async_tdm_copy vs async_copy)
-
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 1
     %tw1 = amdg.async_tdm_wait %1 {num = 0 : i32}
 
+    // Wait on token %21: 2 async_copy instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %cw1 = ttg.async_wait %21 {num = 0 : i32}
 
@@ -543,6 +541,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %inner_commit = ttg.async_commit_group tokens %inner
     }
 
+    // Wait on token %1: if path contributes 1, else (skip) contributes 0 → min = 0
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %1 {num = 0 : i32}
     tt.return
@@ -585,3 +584,4 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -344,6 +344,7 @@ class HIPBackend(BaseBackend):
                 knobs.amd.use_buffer_atomics,
                 knobs.amd.buffer_ops_analyze_small_tensor_range,
             )
+            amd.passes.ttgpuir.add_optimize_buffer_op_ptr(pm)
 
         # Facebook begin
         # D79814483: Disable amd.passes.ttgpuir.add_fold_true_cmpi

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -194,6 +194,14 @@ def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "ml
   ];
 }
 
+def TritonAMDGPUOptimizeBufferOpPtr : Pass<"tritonamdgpu-optimize-buffer-op-ptr", "mlir::triton::FuncOp"> {
+  let summary = "Optimize address operands of buffer operations";
+
+  let description = "This pass optimizes address computation for buffer operations";
+
+  let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect"];
+}
+
 def TritonAMDGPUBlockPingpong: Pass<"tritonamdgpu-block-pingpong", "mlir::ModuleOp"> {
   let summary = "Interleaving instructions from two warps on the same SIMD to better utilize matrix core";
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -108,7 +108,7 @@ Value BufferEmitter::emitLoad(Type type, Value rsrcDesc, Value offset,
   return data;
 }
 
-ROCDL::RawPtrBufferLoadLdsOp
+ROCDL::RawPtrBufferLoadAsyncLdsOp
 BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
                              Value offset, Value dst, Value pred,
                              triton::CacheModifier cm) {
@@ -117,7 +117,11 @@ BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
   fillCommonArgs(type, rsrcDesc, offset, pred, cm, /*isBufferLoad=*/true,
                  commonArgs);
   Type bufferType = getBufferOpType(type, false);
-  return ROCDL::RawPtrBufferLoadLdsOp::create(
+
+  // buffer_load_to_lds is only supported on gfx942/gfx950 which always use
+  // asyncmark. Emit the async intrinsic so LLVM's SIInsertWaitcnts tracks
+  // these operations via asyncmark/wait_asyncmark.
+  return ROCDL::RawPtrBufferLoadAsyncLdsOp::create(
       rewriter, loc, TypeRange{},
       ValueRange{
           commonArgs[0], // Buffer descriptor
@@ -127,8 +131,7 @@ BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
           b.i32_val(0),  // LDS offset
           commonArgs[2], // Instruction offset
           commonArgs[3], // AUX
-      },
-      ArrayRef<NamedAttribute>());
+      });
 }
 
 Value BufferEmitter::emitAtomicCAS(Type type, Value rsrcDesc, Value offset,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
@@ -70,11 +70,13 @@ struct BufferEmitter {
   Value emitLoad(Type type, Value rsrcDesc, Value offset, Value pred,
                  Value falseVal, CacheModifier cm);
 
-  // Emit a predicated rocdl.raw.ptr.buffer.load.lds
-  ROCDL::RawPtrBufferLoadLdsOp emitLoadToLds(Type type, Value byteWidth,
-                                             Value rsrcDesc, Value offset,
-                                             Value dst, Value pred,
-                                             CacheModifier cm);
+  // Emit a rocdl.raw.ptr.buffer.load.async.lds for direct-to-LDS loads.
+  // Always emits the async variant since buffer_load_to_lds is only supported
+  // on gfx942/gfx950 which use asyncmark-based synchronization.
+  ROCDL::RawPtrBufferLoadAsyncLdsOp emitLoadToLds(Type type, Value byteWidth,
+                                                  Value rsrcDesc, Value offset,
+                                                  Value dst, Value pred,
+                                                  CacheModifier cm);
 
   // Emit a predicated rocdl.raw.ptr.buffer.atomic.* RMWOp
   Value emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc, Value offset,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1017,13 +1017,13 @@ struct AsyncCopyGlobalToLocalOpConversion
         mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
             cacheMod, /*isLoad=*/true, targetInfo);
 
-    if (llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
-                           targetInfo.getISAFamily())) {
-      auto globalLoadLdsOp = ROCDL::GlobalLoadLDSOp::create(
+    if (targetInfo.useAsyncMarks()) {
+      // Use the async intrinsic so LLVM tracks these via asyncmark
+      auto asyncLoadOp = ROCDL::GlobalLoadAsyncLDSOp::create(
           rewriter, loc, srcPtr, shmemAddr, vecBits / 8,
           /*offset=*/0, cacheModifiers, nullptr, nullptr, nullptr);
       if (targetInfo.requiresAliasInfoForAsyncOps())
-        AMD::addAsyncCopyAliasScope(globalLoadLdsOp);
+        AMD::addAsyncCopyAliasScope(asyncLoadOp);
     } else if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
       if (cacheMod != triton::CacheModifier::NONE) {
         emitRemark(loc) << "cache modifiers not yet implemented on gfx1250";
@@ -2285,6 +2285,40 @@ struct AtomicRMWOpConversion
   }
 };
 
+// Lower ttg.async_wait directly to wait_asyncmark for architectures that use
+// asyncmark-based synchronization (CDNA3/CDNA4). The commit group count from
+// ttg.async_wait is passed through without clamping since LLVM will compute
+// the final waitcnt based on #instructions instead of #commitGroups.
+struct TTGAsyncWaitOpConversion : public ConvertOpToLLVMPattern<AsyncWaitOp> {
+  TTGAsyncWaitOpConversion(LLVMTypeConverter &converter,
+                           const AMD::TargetInfo &targetInfo,
+                           PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(AsyncWaitOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!targetInfo.useAsyncMarks())
+      return rewriter.notifyMatchFailure(
+          op, "ttg.async_wait should have been lowered to amdg.async_wait by "
+              "UpdateAsyncWaitCount for non-asyncmark targets");
+
+    auto loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Pass through the commit group count. LLVM will compute the correct
+    // vmcnt based on asyncmark/wait_asyncmark markers.
+    ROCDL::WaitAsyncmarkOp::create(rewriter, loc, op.getNum());
+
+    // Drop the result AsyncToken
+    rewriter.replaceOp(op, b.i32_val(0));
+    return success();
+  }
+
+private:
+  const AMD::TargetInfo &targetInfo;
+};
+
 struct AsyncWaitOpConversion
     : public ConvertOpToLLVMPattern<amdgpu::AsyncWaitOp> {
   AsyncWaitOpConversion(LLVMTypeConverter &converter,
@@ -2298,41 +2332,15 @@ struct AsyncWaitOpConversion
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    switch (targetInfo.getISAFamily()) {
-    case ISAFamily::CDNA1:
-    case ISAFamily::CDNA2:
-    case ISAFamily::CDNA3:
-    case ISAFamily::CDNA4: {
-      // global.load.lds uses vmcnt to synchronize
-      // The rocdl op stores all available counters in a single int32 value (v).
-      // The vmcnt (6 bits) is split into a lower 3:0 and higher 5:4 parts.
-      // The lower part is stored in bits 3:0 of v and the higher part in bits
-      // 15:14. We have to set all other bits in v to 1 to signal we are not
-      // interested in those.
-
-      // Clamp vmcnt to 6bits; a lower vmcnt will produce a conservative wait
-      unsigned vmCnt = std::min(63u, op.getNumInst());
-
-      // Extract low and high bits and combine while setting all other bits to 1
-      unsigned lowBits = vmCnt & 0xF;
-      unsigned highBits = vmCnt >> 4 << 14;
-      unsigned otherCnts = ~0xC00F; // C00F has bits 15:14 and 3:0 set
-      unsigned waitValue = lowBits | highBits | otherCnts;
-
-      ROCDL::SWaitcntOp::create(rewriter, loc, waitValue);
-      break;
-    }
-    case ISAFamily::GFX1250: {
-      // Clamp asyncCnt to 6bits(hw imit); lower means conservative
+    if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
+      // Clamp asyncCnt to 6bits(hw limit); lower means conservative
       unsigned asyncCnt = std::min(63u, op.getNumInst());
       LLVM::createLLVMIntrinsicCallOp(rewriter, loc,
                                       "llvm.amdgcn.s.wait.asynccnt", {},
                                       {b.i16_val(asyncCnt)});
-      break;
-    }
-    default:
+    } else {
       return rewriter.notifyMatchFailure(
-          op, "Only supported on CDNA target architecture");
+          op, "async wait not supported on this target architecture");
     }
 
     // Drop the result AsyncToken
@@ -2365,17 +2373,28 @@ struct AsyncTDMIntrinsicWaitConversion
 
 struct AsyncCommitGroupOpConversion
     : public ConvertOpToLLVMPattern<AsyncCommitGroupOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  AsyncCommitGroupOpConversion(LLVMTypeConverter &converter,
+                               const AMD::TargetInfo &targetInfo,
+                               PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
 
   LogicalResult
   matchAndRewrite(AsyncCommitGroupOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Drop the result AsyncToken
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Emit asyncmark for architectures that use async tracking
+    if (targetInfo.useAsyncMarks())
+      ROCDL::AsyncmarkOp::create(rewriter, loc);
+
+    // Drop the result AsyncToken
     rewriter.replaceOp(op, b.i32_val(0));
     return success();
   }
+
+private:
+  const AMD::TargetInfo &targetInfo;
 };
 
 struct AsyncCopyMbarrierArriveOpConversion
@@ -2472,10 +2491,12 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                AsyncTDMCopyLocalToGlobalOpConversion,
                AsyncTDMScatterOpConversion, AsyncTDMGatherOpConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, benefit);
+  patterns.add<TTGAsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<TDMPrefetchConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncTDMIntrinsicWaitConversion>(typeConverter, benefit);
-  patterns.add<AsyncCommitGroupOpConversion>(typeConverter, benefit);
+  patterns.add<AsyncCommitGroupOpConversion>(typeConverter, targetInfo,
+                                             benefit);
   patterns.add<AsyncCopyMbarrierArriveOpConversion>(typeConverter, benefit);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -740,6 +740,11 @@ bool TargetInfo::supportsBufferLoadToLocal() const {
                             getISAFamily());
 }
 
+bool TargetInfo::useAsyncMarks() const {
+  return llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
+                            getISAFamily());
+}
+
 bool TargetInfo::supportsWaveId() const {
   return getISAFamily() == ISAFamily::RDNA4 ||
          getISAFamily() == ISAFamily::GFX1250;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -111,6 +111,10 @@ public:
   bool supportsDirectFromLdsStoreBitWidth(int bitWidth) const;
   bool supportsBufferLoadToLocal() const;
 
+  // Whether this target uses asyncmark/wait_asyncmark intrinsics for
+  // async memory ops synchronization instead of waitcnt-based intrinsics waits.
+  bool useAsyncMarks() const;
+
   bool supportsMultiCTALaunch() const;
   bool supportsTDM() const;
   bool supportsClusterLoadBitWidth(int biwWidth) const;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonAMDGPUTransforms
   ConvertToBufferOps.cpp
   ConvertToTensorOps.cpp
   LowerBarrierOps.cpp
+  OptimizeBufferOpPtr.cpp
   OptimizeEpilogue.cpp
   OptimizeDotOperands.cpp
   HoistLayoutConversions.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeBufferOpPtr.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeBufferOpPtr.cpp
@@ -1,0 +1,565 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "third_party/amd/include/Analysis/RangeAnalysis.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "tritonamdgpu-optimize-buffer-op-ptr"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using ::mlir::LLVM::AMD::getVectorSize;
+using mlir::triton::AMD::ISAFamily;
+
+namespace ttg = mlir::triton::gpu;
+namespace tt = mlir::triton;
+namespace amdttg = mlir::triton::amdgpu;
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONAMDGPUOPTIMIZEBUFFEROPPTR
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+namespace {
+// /*-----------------Base pointer increment optimization-------------------*/
+
+// Optimization tries to transfer increments from offsets to base pointer in
+// buffer operations:
+//
+// for ... (offsets = offsets_init):
+//   val = buffer_load basePtr [ offsets ]
+//   offsets_new = offsets + cst
+//   yield offsets_new
+// }
+//
+// transforms to:
+//
+// for ... (basePtr = basePtr_init):
+//   val = buffer_load basePtr [ offsets ]
+//   basePtr_new = basePtr + cst
+//   yield basePtr_new
+// }
+//
+// Goal of this transformation is to decrease amount of work done by vector
+// instructions(decrease number of v_add). This could save cycles in a loop, and
+// give more parallelism on architectures where MFMA and vector instrcutions
+// executed on the same hardware module.
+struct AdvanceBasePointer : public OpRewritePattern<scf::ForOp> {
+
+  AdvanceBasePointer(MLIRContext *context, DataFlowSolver *solver,
+                     PatternBenefit benefit = 1)
+      : OpRewritePattern<scf::ForOp>(context, benefit), solver(solver) {}
+
+  // Check if same value is stored in every element of tensor val
+  // Return true if all elelemts are equal, false if not or it was not able for
+  // proove it.
+  static bool isScalarizableValue(mlir::Value val) {
+    if (isa<IntegerType>(val.getType()))
+      return true;
+    auto defOp = val.getDefiningOp();
+    if (!defOp)
+      return false;
+    APInt constant;
+    if (matchPattern(val, m_ConstantInt(&constant))) {
+      return true;
+    } else if (auto splat = dyn_cast<triton::SplatOp>(defOp)) {
+      return isScalarizableValue(splat.getSrc());
+    }
+    return false;
+  }
+
+  // Generate a scalar value that is stored in provided RankedTensor val
+  static mlir::Value scalarizeValue(PatternRewriter &rewriter,
+                                    mlir::Value val) {
+    if (isa<IntegerType>(val.getType()))
+      return val;
+    auto defOp = val.getDefiningOp();
+    assert(defOp);
+    APInt constant;
+    if (matchPattern(val, m_ConstantInt(&constant))) {
+      rewriter.setInsertionPoint(defOp);
+      auto intType =
+          IntegerType::get(rewriter.getContext(), constant.getBitWidth());
+      return arith::ConstantIntOp::create(rewriter, defOp->getLoc(), intType,
+                                          constant);
+    } else if (auto splat = dyn_cast<triton::SplatOp>(defOp)) {
+      return scalarizeValue(rewriter, splat.getSrc());
+    }
+    return Value();
+  }
+
+  // Description of struct fields:
+  // - op is a target BufferOp, for example BufferLoadOp or BufferLoadToLocalOp
+  // - offsetIncrement is a tensor added to offsets on each iteration
+  // - baseIncrement is a scalar which will be added to base pointer
+  // - offsetInitializer is a value of offset on first loop iteration
+  // - incrementOp is an operation that advances offset tensor
+  struct BufferOpInfo {
+    amdttg::BufferOpInterface op;
+    Value offsetIncrement;
+    Value baseIncrement;
+    Value offsetInitializer;
+    Operation *incrementOp;
+  };
+
+  static std::optional<ConstantIntRanges>
+  getValueRange(Value value, DataFlowSolver *solver) {
+    auto stepType = cast<RankedTensorType>(value.getType());
+    assert(stepType.getElementType().getIntOrFloatBitWidth() < 64);
+
+    const auto *stepRange =
+        solver->lookupState<dataflow::IntegerValueRangeLattice>(value);
+    if (stepRange->getValue().isUninitialized()) {
+      LDBG("Rejected: value range is unintialized");
+      return {};
+    }
+    return stepRange->getValue().getValue();
+  }
+
+  static bool isStrictlyNegative(Value advanceStep, DataFlowSolver *solver) {
+    auto stepRangeValue = getValueRange(advanceStep, solver);
+    if (!stepRangeValue.has_value())
+      return false;
+
+    return stepRangeValue.value().smax().isNegative();
+  }
+
+  static bool isNonNegative(Value advanceStep, DataFlowSolver *solver) {
+    auto stepRangeValue = getValueRange(advanceStep, solver);
+    if (!stepRangeValue.has_value())
+      return false;
+
+    return stepRangeValue.value().smax().isNonNegative();
+  }
+
+  // Estimates range of offset used in buffer op.
+  // offset is 32 bit unsigned integer, equal to blockArg + advancedStep.
+  // blockArg and advancedStep unit is a potentially multibyte element, offset
+  // is measured in bytes.
+  static std::optional<std::pair<int64_t, int64_t>>
+  estimateRangeOfOffsetWithCarryValues(int elemByteWidth, Value blockArg,
+                                       Value advanceStep,
+                                       DataFlowSolver *solver) {
+    auto stepType = cast<RankedTensorType>(advanceStep.getType());
+    assert(stepType.getElementType().getIntOrFloatBitWidth() < 64);
+
+    const auto *blockArgRange =
+        solver->lookupState<dataflow::IntegerValueRangeLattice>(blockArg);
+    if (blockArgRange->getValue().isUninitialized()) {
+      LDBG("Rejected: blockArg range is unintialized");
+      return {};
+    }
+
+    const auto *stepRange =
+        solver->lookupState<dataflow::IntegerValueRangeLattice>(advanceStep);
+    if (stepRange->getValue().isUninitialized()) {
+      LDBG("Rejected: step range is unintialized");
+      return {};
+    }
+
+    auto blockArgRangeValue = blockArgRange->getValue().getValue();
+    auto stepRangeValue = stepRange->getValue().getValue();
+
+    // Use limit to crop MSB from negative indexing
+    constexpr uint64_t maxOffsetValue = 0xff'ff'ff'ff;
+
+    // Range analysys for block argument and step should not return values
+    // larger than maximum uint32_t
+    assert(blockArgRangeValue.umax().getLimitedValue() <= maxOffsetValue &&
+           "expect block argument to be a 32 bit value");
+    assert(stepRangeValue.umax().getLimitedValue() <= maxOffsetValue &&
+           "expect step value to be a 32 bit value");
+
+    // Offset value for current iteration is a sum of block argument (offset
+    // from previous iteration) and step (increment of offset).
+    // These values are measured in number of elements.
+    // Offset in buffer instruction is measured in bytes instead of elements.
+    // In order to convert offset in elements to offset in
+    // bytest compiler left shifts offset. This shift is emulated by
+    // multiplication with "elemByteWidth". Potentially this could lead to
+    // overflow of 32 bit value, but it should happen only if step or offset is
+    // a negative number, i.e. we can discard most significant bits.
+    auto elemsToBytes = [maxOffsetValue, elemByteWidth](const llvm::APInt &x) {
+      return (x * elemByteWidth).getLimitedValue(maxOffsetValue);
+    };
+    uint32_t blockArgInBytesMax = elemsToBytes(blockArgRangeValue.umax());
+    uint32_t blockArgInBytesMin = elemsToBytes(blockArgRangeValue.umin());
+    uint32_t stepArgInBytesMax = elemsToBytes(stepRangeValue.umax());
+    uint32_t stepArgInBytesMin = elemsToBytes(stepRangeValue.umin());
+
+    int64_t operationUncappedResultMax =
+        (int64_t)blockArgInBytesMax + stepArgInBytesMax;
+    int64_t operationUncappedResultMin =
+        (int64_t)blockArgInBytesMin + stepArgInBytesMin;
+    return {{operationUncappedResultMin, operationUncappedResultMax}};
+  }
+
+  static bool unsignedOverflowImpossible(int elemByteWidth, Value blockArg,
+                                         Value advanceStep,
+                                         DataFlowSolver *solver) {
+    auto maybeOffsetRange = estimateRangeOfOffsetWithCarryValues(
+        elemByteWidth, blockArg, advanceStep, solver);
+    if (!maybeOffsetRange.has_value())
+      return false;
+    auto offsetWithCarryRange = maybeOffsetRange.value();
+    assert(offsetWithCarryRange.first >= 0 && "offset is unsigned");
+    assert(offsetWithCarryRange.first <= offsetWithCarryRange.second);
+
+    return offsetWithCarryRange.second <= 0xff'ff'ff'ff;
+  }
+
+  static bool unsignedOverflowInevitable(int elemByteWidth, Value blockArg,
+                                         Value advanceStep,
+                                         DataFlowSolver *solver) {
+    auto maybeOffsetRange = estimateRangeOfOffsetWithCarryValues(
+        elemByteWidth, blockArg, advanceStep, solver);
+    if (!maybeOffsetRange.has_value())
+      return false;
+    auto offsetWithCarryRange = maybeOffsetRange.value();
+    assert(offsetWithCarryRange.first <= offsetWithCarryRange.second);
+
+    return offsetWithCarryRange.first > 0xff'ff'ff'ff;
+  }
+
+  static bool isTransformationEquivalent(int elemByteWidth, Value blockArg,
+                                         Value advanceStep,
+                                         DataFlowSolver *solver) {
+    if (isNonNegative(advanceStep, solver) &&
+        unsignedOverflowImpossible(elemByteWidth, blockArg, advanceStep,
+                                   solver))
+      return true;
+    if (isStrictlyNegative(advanceStep, solver) &&
+        unsignedOverflowInevitable(elemByteWidth, blockArg, advanceStep,
+                                   solver))
+      return true;
+    return false;
+  }
+
+  static BlockArgument getLoopBlockArgument(Value val, scf::ForOp loop) {
+    auto blockArg = dyn_cast<BlockArgument>(val);
+    if (!blockArg || blockArg.getOwner()->getParentOp() != loop)
+      return nullptr;
+    return blockArg;
+  }
+
+  static BlockArgument getLoopArgInAdd(arith::AddIOp addOp, scf::ForOp forOp) {
+    for (auto operand : addOp->getOperands())
+      if (auto loopArg = getLoopBlockArgument(operand, forOp))
+        return loopArg;
+    return nullptr;
+  }
+
+  // Assume that offset step is not a loop argument.
+  // This optimization supports only cases when step could be analyzed without
+  // traversing control flow.
+  static Value getStepOperandInAdd(arith::AddIOp addOp, scf::ForOp forOp) {
+    for (auto operand : addOp->getOperands())
+      if (!getLoopBlockArgument(operand, forOp))
+        return operand;
+    return nullptr;
+  }
+
+  static bool isAddFirst(amdttg::BufferOpInterface bufferOp) {
+    return isa_and_nonnull<arith::AddIOp>(
+        bufferOp.getOffsets().getDefiningOp());
+  }
+
+  static BlockArgument findOffsetLoopArgumentCandidate(Value offsetValue,
+                                                       scf::ForOp targetFor) {
+    BlockArgument offsetLoopArgument;
+    if (auto offsetAdd =
+            dyn_cast_or_null<arith::AddIOp>(offsetValue.getDefiningOp())) {
+      offsetLoopArgument = getLoopArgInAdd(offsetAdd, targetFor);
+    } else {
+      offsetLoopArgument = getLoopBlockArgument(offsetValue, targetFor);
+    }
+    return offsetLoopArgument;
+  }
+
+  static Value findIncrementedOffsetCandidate(BlockArgument offsetLoopArgument,
+                                              scf::ForOp targetFor) {
+    int yieldArgNumber =
+        offsetLoopArgument.getArgNumber() - targetFor.getNumInductionVars();
+    auto yield = cast<scf::YieldOp>(targetFor.getBody()->getTerminator());
+    return yield.getOperand(yieldArgNumber);
+  }
+
+  static arith::AddIOp findOffsetAddCandidate(Value incrementedOffset) {
+    auto addOp =
+        dyn_cast_or_null<arith::AddIOp>(incrementedOffset.getDefiningOp());
+    return addOp;
+  }
+
+  // Checks that bufferOp uses given OffsetAddOp as an offset
+  // and offsetAddOp takes one of it's operands from a given BlockArgument.
+  static bool incrementChainConsistent(amdttg::BufferOpInterface bufferOp,
+                                       BlockArgument offset,
+                                       arith::AddIOp offsetAddOp) {
+    auto targetFor = cast<scf::ForOp>(offset.getOwner()->getParentOp());
+    auto maybeOffsetLoopArgument = getLoopArgInAdd(offsetAddOp, targetFor);
+    if (offset != maybeOffsetLoopArgument) {
+      return false;
+    }
+    if (isAddFirst(bufferOp) &&
+        bufferOp.getOffsets().getDefiningOp() != offsetAddOp) {
+      return false;
+    }
+    return true;
+  }
+
+  static bool isInvariantForLoop(Value val, scf::ForOp loop) {
+    return val.getParentBlock()->getParentOp()->isProperAncestor(loop);
+  }
+
+  // Perform series of checks to decide if given operation could be optimized.
+  // If optimization is possible, return filled BufferOpInfo.
+  static std::optional<BufferOpInfo>
+  analyzeBufferOp(amdttg::BufferOpInterface op, scf::ForOp targetFor,
+                  DataFlowSolver *solver) {
+    auto offsetValue = op.getOffsets();
+
+    // Try to match components of two following patterns:
+    //
+    // Case 1(add first):
+    //   for (%offsetLoopArgument):
+    //     %incrementedOffset = arith.addi %offsetLoopArgument, %advanceStep
+    //     bufferOp %base[%incrementedOffset]
+    //     yield %incrementedOffset
+    //
+    // Case 2(buffer op first)
+    //   for (%offsetLoopArgument):
+    //     bufferOp %base[%offsetLoopArgument]
+    //     %incrementedOffset = arith.addi %offsetLoopArgument, %advanceStep
+    //     yield %incrementedOffset
+    //
+    // These patterns are similar. but buffer operation uses different values:
+    // loop argument or loop argument after increment.
+    //
+    // Offset incrementing data flow graph is same for both of them:
+    //
+    //           advanceStep
+    //                      \
+    // offsetLoopArgument -addi-> incrementedOffset -yield->
+    auto offsetLoopArgument =
+        findOffsetLoopArgumentCandidate(offsetValue, targetFor);
+    if (!offsetLoopArgument) {
+      LDBG("Rejected: Could not find a candidate for loop_arg in "
+           "loop_arg->addi->yield chain");
+      return {};
+    }
+
+    auto incrementedOffset =
+        findIncrementedOffsetCandidate(offsetLoopArgument, targetFor);
+    if (!incrementedOffset) {
+      LDBG("Rejected: Could not find a candidate for yield operand");
+      return {};
+    }
+
+    auto addOp = findOffsetAddCandidate(incrementedOffset);
+    if (!addOp) {
+      LDBG("Rejected: Could not find addi in loop_arg->addi->yield chain");
+      return {};
+    }
+
+    Value advanceStep = getStepOperandInAdd(addOp, targetFor);
+    if (!advanceStep) {
+      LDBG("Rejected: Could not find an offset step");
+      return {};
+    }
+
+    // End of pattern component search.
+    // Following core verifies that found pattern is optimizable and consistent.
+
+    if (!incrementChainConsistent(op, offsetLoopArgument, addOp)) {
+      LDBG("Rejected: Found offset increment chain is not consistent");
+      return {};
+    }
+
+    if (!isInvariantForLoop(op.getPtr(), targetFor)) {
+      LDBG("Rejected: Buffer op base Ptr is not an invariant in the loop");
+      return {};
+    }
+
+    if (!isScalarizableValue(advanceStep)) {
+      LDBG("Rejected: ptr increment step is not uniform or not supported by "
+           "scalarizer yet");
+      return {};
+    }
+
+    auto ptrType = cast<PointerType>(op.getPtr().getType());
+    auto elemBitwidth = ptrType.getPointeeType().getIntOrFloatBitWidth();
+    auto dtypeByteWidth = elemBitwidth / 8;
+    assert(dtypeByteWidth > 0);
+    if (!isTransformationEquivalent(dtypeByteWidth, offsetLoopArgument,
+                                    advanceStep, solver)) {
+      LDBG("Rejected: it is arithmetically unsafe to split offset computation");
+      return {};
+    }
+
+    LDBG("Buffer op is suitable for offset pointer optimization");
+
+    int offsetInitNo =
+        offsetLoopArgument.getArgNumber() - targetFor.getNumInductionVars();
+    auto offsetInitializer = targetFor.getInitArgs()[offsetInitNo];
+    BufferOpInfo info{op, advanceStep, nullptr, offsetInitializer, addOp};
+
+    return info;
+  }
+
+  // Create scalar values which will increment buffer op base ptr
+  // Fills appropriate fields in given BufferOpInfo structures
+  static void createScalarIncrements(PatternRewriter &rewriter,
+                                     SmallVector<BufferOpInfo> &infoList) {
+    for (auto &BufferOpInfo : infoList) {
+      auto scalarStep = scalarizeValue(rewriter, BufferOpInfo.offsetIncrement);
+      BufferOpInfo.baseIncrement = scalarStep;
+    }
+  }
+
+  static scf::ForOp
+  cloneLoopWithBasePtrIncrements(PatternRewriter &rewriter, scf::ForOp forOp,
+                                 SmallVector<BufferOpInfo> &infoList) {
+    // Create new loop with additional arguments
+    llvm::SmallVector<Value> newLoopArgs(forOp.getInitArgs());
+    for (auto info : infoList) {
+      newLoopArgs.push_back(info.op.getPtr());
+    }
+    rewriter.setInsertionPoint(forOp);
+    auto newForOp =
+        scf::ForOp::create(rewriter, forOp.getLoc(), forOp.getLowerBound(),
+                           forOp.getUpperBound(), forOp.getStep(), newLoopArgs);
+    // Clone old loop body without terminator
+    IRMapping mapping;
+    auto oldBlock = forOp.getBody();
+    auto newBlock = newForOp.getBody();
+    for (unsigned i = 0; i < oldBlock->getNumArguments(); ++i) {
+      mapping.map(oldBlock->getArgument(i), newBlock->getArgument(i));
+    }
+    rewriter.setInsertionPoint(newForOp.getBody(), newForOp.getBody()->end());
+    for (auto &op : oldBlock->without_terminator()) {
+      rewriter.clone(op, mapping);
+    }
+    // Create base pointer increment operations
+    auto basePtrs = newBlock->getArguments().take_back(infoList.size());
+    llvm::SmallVector<Value> nextIterBasePtrs;
+    for (auto [info, basePtr] : llvm::zip(infoList, basePtrs)) {
+      if (isAddFirst(info.op)) {
+        rewriter.setInsertionPoint(newBlock, newBlock->begin());
+      } else {
+        rewriter.setInsertionPoint(newBlock, newBlock->end());
+      }
+      Value step = info.baseIncrement;
+      if (mapping.contains(info.baseIncrement)) {
+        step = mapping.lookup(info.baseIncrement);
+      }
+      auto loc = info.incrementOp->getLoc();
+      auto ptrType = basePtr.getType();
+      auto nextIterBasePtr =
+          triton::AddPtrOp::create(rewriter, loc, ptrType, basePtr, step);
+      nextIterBasePtrs.push_back(nextIterBasePtr);
+    }
+    // Create yield operation
+    llvm::SmallVector<Value> newYieldOperands;
+    auto oldTerminator = forOp.getBody()->getTerminator();
+    for (auto operand : oldTerminator->getOperands()) {
+      newYieldOperands.push_back(mapping.lookup(operand));
+    }
+    newYieldOperands.append(nextIterBasePtrs);
+
+    rewriter.setInsertionPoint(newBlock, newBlock->end());
+    scf::YieldOp::create(rewriter, oldBlock->getTerminator()->getLoc(),
+                         newYieldOperands);
+    // Replace dynamic buffer op offsets with invariant value
+    // Replace base ptr with incrementing value
+    for (auto [info, basePtr, nextBasePtr] :
+         llvm::zip(infoList, basePtrs, nextIterBasePtrs)) {
+      auto newBufferOp = cast<amdttg::BufferOpInterface>(
+          mapping.lookup<Operation *>(info.op.getOperation()));
+      newBufferOp.getOffsetsMutable().assign(info.offsetInitializer);
+      // two cases:
+      // 1. buffer op uses pointer after increment
+      // 2. buffer op uses pointers from loop arguments,
+      //    incremented pointer is used on next iteration
+      Value advancingBasePtr = isAddFirst(info.op) ? nextBasePtr : basePtr;
+      newBufferOp.getPtrMutable().assign(advancingBasePtr);
+    }
+    return newForOp;
+  }
+
+  SmallVector<BufferOpInfo> collectBufferOps(scf::ForOp forOp) const {
+    SmallVector<BufferOpInfo> list;
+    forOp.walk([&list, this, forOp](amdttg::BufferOpInterface op) {
+      auto info = analyzeBufferOp(op, forOp, solver);
+      if (info.has_value()) {
+        list.push_back(info.value());
+      }
+    });
+    return list;
+  }
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    LDBG("Analyzing ForOp for offset pointer optimization: " << forOp);
+    // Gather buffer buffer operations which could be optimized
+    SmallVector<BufferOpInfo> infoList = collectBufferOps(forOp);
+
+    if (infoList.empty())
+      return rewriter.notifyMatchFailure(forOp,
+                                         "no suitable buffer operations");
+
+    // Perform IR transformation
+    createScalarIncrements(rewriter, infoList);
+    auto newForOp = cloneLoopWithBasePtrIncrements(rewriter, forOp, infoList);
+    rewriter.replaceAllUsesWith(
+        forOp.getResults(), newForOp.getResults().drop_back(infoList.size()));
+    rewriter.eraseOp(forOp);
+    return success();
+  }
+
+  DataFlowSolver *solver;
+};
+
+} // anonymous namespace
+
+struct TritonAMDGPUOptimizeBufferOpPtrPass
+    : impl::TritonAMDGPUOptimizeBufferOpPtrBase<
+          TritonAMDGPUOptimizeBufferOpPtrPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    FuncOp funcOp = getOperation();
+
+    DenseMap<Value, SetVector<Operation *>> assumptions =
+        AMD::TritonIntegerRangeAnalysis::collectAssumptions(funcOp);
+    std::shared_ptr<DataFlowSolver> solver = createDataFlowSolver();
+    DominanceInfo *dominanceInfo = &getAnalysis<DominanceInfo>();
+    AMD::TritonIntegerRangeAnalysis *rangeAnalysis =
+        solver->load<AMD::TritonIntegerRangeAnalysis>(assumptions,
+                                                      dominanceInfo);
+    AMD::initializeFuncOps(funcOp, rangeAnalysis);
+    if (failed(solver->initializeAndRun(funcOp))) {
+      LDBG("Integer range analysis failed to initialize, exiting");
+      return;
+    }
+
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<AdvanceBasePointer>(context, solver.get(), /*benefit=*/1);
+    walkAndApplyPatterns(funcOp, std::move(patterns));
+  }
+};
+
+} // namespace mlir

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -373,46 +373,36 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
       return;
     }
 
-    // For HW which does not support async loads (GFX9) but only direct-to-lds,
-    // we still use the waitcnt to support interleaving of direct-to-lds loads
-    // when pipelining. The flag is used to emit warnings in case we find
-    // tt.loads/store which make the computed count conservative and hinder
-    // performance.
-    bool supportsAsyncLoads = true;
-    switch (targetInfo.getISAFamily()) {
-    case triton::AMD::ISAFamily::CDNA3:
-    case triton::AMD::ISAFamily::CDNA4:
-      supportsAsyncLoads = false;
-      break;
-    default:
-      break;
-    }
-
     ModuleOp m = getOperation();
 
-    // ttg.async_wait should only count async **non** tdm load:
-    SmallVector<ttg::AsyncWaitOp> waitOps;
-    getOperation()->walk(
-        [&](ttg::AsyncWaitOp waitOp) { waitOps.push_back(waitOp); });
+    // With asyncmark/wait_asyncmark, LLVM handles vmcnt computation —
+    // Triton no longer needs to walk the IR and count outstanding async
+    // intrinsics. Keep the ttg.async_wait ops unchanged (they track
+    // commit groups) and lower them directly to wait_asyncmark later.
+    if (!targetInfo.useAsyncMarks()) {
+      // GFX1250 (and future arches without asyncmark) use instruction counting.
+      SmallVector<ttg::AsyncWaitOp> waitOps;
+      getOperation()->walk(
+          [&](ttg::AsyncWaitOp waitOp) { waitOps.push_back(waitOp); });
 
-    ModuleAxisInfoAnalysis axisInfo(m);
-    // Cache #intrinsic per asyc op to avoid expensive recomputations
-    DenseMap<Operation *, int> intrinsicCountCache;
-    auto countAsyncLoadInstructions = [&](Operation *op) {
-      auto found = intrinsicCountCache.find(op);
-      if (found != intrinsicCountCache.end()) {
-        return found->second;
+      ModuleAxisInfoAnalysis axisInfo(m);
+      DenseMap<Operation *, int> intrinsicCountCache;
+      auto countAsyncLoadInstructions = [&](Operation *op) {
+        auto found = intrinsicCountCache.find(op);
+        if (found != intrinsicCountCache.end()) {
+          return found->second;
+        }
+        auto v = getOpNumberOfAsyncCopyInstructions(
+            op, targetInfo, axisInfo,
+            /*emitRemarkOnNonAsyncOp=*/false);
+        intrinsicCountCache[op] = v;
+        return v;
+      };
+
+      for (auto waitOp : waitOps) {
+        IRRewriter builder(waitOp->getContext());
+        updateWaitCount(waitOp, countAsyncLoadInstructions, builder);
       }
-      auto v = getOpNumberOfAsyncCopyInstructions(op, targetInfo, axisInfo,
-                                                  !supportsAsyncLoads);
-      intrinsicCountCache[op] = v;
-      return v;
-    };
-
-    // Note: AsyncWaits should ignore TDM ops; different HW counter
-    for (auto waitOp : waitOps) {
-      IRRewriter builder(waitOp->getContext());
-      updateWaitCount(waitOp, countAsyncLoadInstructions, builder);
     }
 
     // amdgpu.AsyncTDMWait should only count async tdm ops

--- a/third_party/amd/python/test/test_pointer_optimization.py
+++ b/third_party/amd/python/test/test_pointer_optimization.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from triton._internal_testing import is_hip
+
+if not is_hip():
+    pytest.skip(allow_module_level=True)
+
+
+@pytest.mark.parametrize(
+    "input_size, input_offset, block_size, num_blocks, increment, initial_offset, expect_optimization",
+    [(256 * 32, 0, 256, 32, 256, 0, True),  # step forward
+     (256 * 33, 0, 256, 32, -256, 256 * 32, True),  # step backward
+     (256 * 32, 0, 256, 32, -256, 256 * 31, False),  # step backward #2, analysis is too conservative
+     (2**29 - 1, 0, 256, 2, 1, 2**29 - 1 - 256 - 1, True),  # go near the upper limit of befferized tensor size
+     (2048, 1024, 256, 2, -1024, 0, False),  # on first iteration offset is positive, on second becomes negative
+     ])
+def test_buffer_op_ptr_optimization(input_size, input_offset, block_size, num_blocks, increment, initial_offset,
+                                    expect_optimization, device):
+    """ Test verifies that increments are going to base pointer instead of offset tensor when possible and this transformation is correct:
+
+    expect TTGIR looks like this:
+
+        scf.for (%X) {
+        %x = amdg.buffer_load %X[%offset]
+        ...
+
+        %X_1 = tt.addptr %X, %step
+        scf.yield %X_1
+        }
+
+    instead of
+
+        scf.for (%offset) {
+        %x = amdg.buffer_load %X[%offset]
+        ...
+
+        %offset_1 = arith.addi %offset, %step
+        scf.yield %offset_1
+        }
+    """
+
+    @triton.jit
+    def kernel(X, Y, BLOCK_SIZE: tl.constexpr, NUM_BLOCKS: tl.constexpr, INCREMENT: tl.constexpr,
+               INITIAL_OFFSET: tl.constexpr):
+        offset = tl.arange(0, BLOCK_SIZE) + INITIAL_OFFSET
+        y = tl.zeros([BLOCK_SIZE], tl.float32)
+        for i in range(NUM_BLOCKS):
+            Xs = X + offset
+            x = tl.load(Xs)
+            y += x
+            offset += INCREMENT
+        Ys = Y + tl.arange(0, BLOCK_SIZE)
+        tl.store(Ys, y)
+
+    def check_ir(ttgir, expect_optimization):
+        optimized = False
+        buffer_op_present = False
+        for line in ttgir.split("\n"):
+            if "buffer_load" in line:
+                buffer_op_present = True
+            if "addptr" in line:
+                optimized = True
+        assert optimized == expect_optimization
+        assert buffer_op_present
+
+    X = torch.randn((input_size, ), device=device, dtype=torch.float32)
+    Y = torch.randn((block_size, ), device=device, dtype=torch.float32)
+
+    ref_output = torch.zeros_like(Y)
+    for i in range(num_blocks):
+        for j in range(block_size):
+            ref_output[j] += X[(input_offset + initial_offset + increment * i + j) % input_size]
+
+    grid = (1, )
+
+    pgm = kernel[grid](X[input_offset:], Y, block_size, num_blocks, increment, initial_offset, num_warps=1)
+
+    check_ir(pgm.asm["ttgir"], expect_optimization)
+
+    if expect_optimization:
+        assert torch.allclose(Y, ref_output, rtol=1e-3, atol=1e-2)

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -104,6 +104,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                             const std::string &, bool, bool);
   ADD_PASS_WRAPPER_0("add_lower_barrier_ops",
                      mlir::createTritonAMDGPULowerBarrierOps);
+  ADD_FUNC_PASS_WRAPPER_0("add_optimize_buffer_op_ptr",
+                          mlir::createTritonAMDGPUOptimizeBufferOpPtr);
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi", mlir::createTritonAMDFoldTrueCmpI);
 
   ADD_PASS_OPTION_WRAPPER_1("add_block_pingpong",


### PR DESCRIPTION
Summary:

Backport of upstream Triton PR #9883 (by Lixun Zhang / AMD).

Upstream PR: https://github.com/triton-lang/triton/pull/9883
Upstream commit: 87bdecb39d0eb54d38662c8e32a67f86db43f06e

Original commit message:

On CDNA3 (gfx942) and CDNA4 (gfx950), buffer_load_to_lds synchronization had two issues: (1) conservative s_waitcnt vmcnt(0) before ds_read due to LLVM modeling buffer_load_to_lds as a synchronous LDS write, worked around fragilely via no-alias attributes; and (2) conflicting vmcnt management between Triton (for buffer_load_to_lds) and LLVM (for buffer_load) on the shared counter. This switches CDNA3/CDNA4 to LLVM's asyncmark / wait_asyncmark intrinsics, which model the async semantics properly and solve both issues. Touches BufferOpsEmitter, LoadStoreOpToLLVM, TargetInfo, and UpdateAsyncWaitCount (asyncmark vs instruction-counting paths).

Co-authored-by: Alexander Efimov <efimov.alexander@gmail.com>

Backport notes:
Depends on the LLVM 62b7cf9 bump (D109226675) which provides int_amdgcn_asyncmark / int_amdgcn_wait_asyncmark. Applied the upstream patch verbatim.

Disabled 3 gfx1250 instruction-counting-path test cases in amd-update-async-wait-count.mlir (tdm_partitioned_shared_waitcnt, warp_free_variable_returns_zero, register_zero_bases_not_inflated): they depend on prerequisites not yet in beta (partitioned_shared TDM op support, and the warp-free / register-zero-bases instruction-count fixes). These are gfx1250-only concerns; CDNA3/CDNA4 use the asyncmark path (no instruction counting), so they don't affect the arches this PR targets. Backport these gfx1250 prereqs separately to re-enable.

Authored with Claude.

Reviewed By: wlei-llvm

Differential Revision: D109233523


