### PR TITLE
[tlx][sched2tlx] Add DDG JSON dumps for example cases

### DIFF
--- a/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/ddg.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/ddg.json
@@ -1,0 +1,283 @@
+{
+  "schema_version": "ddg-0.1",
+  "config": {"schedule_algo": "rau", "smem_budget_bytes": 233472, "tmem_budget_bytes": 262144},
+  "kernel": {
+    "name": "gemm_kernel",
+    "args": [
+      {"name": "A", "type": "*f16"},
+      {"name": "B", "type": "*f16"},
+      {"name": "C", "type": "*f16"},
+      {"name": "M", "type": "i32"},
+      {"name": "N", "type": "i32"},
+      {"name": "K", "type": "i32"},
+      {"name": "stride_am", "type": "i32"},
+      {"name": "stride_ak", "type": "i32"},
+      {"name": "stride_bk", "type": "i32"},
+      {"name": "stride_bn", "type": "i32"},
+      {"name": "stride_cm", "type": "i32"},
+      {"name": "stride_cn", "type": "i32"}
+    ]
+  },
+  "ops": {
+    "op_88510686050096": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686050352": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": -1}
+    },
+    "op_88510686050608": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i64"],
+      "attributes": {"value": 1}
+    },
+    "op_88510686051120": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 128}
+    },
+    "op_88510686051376": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 64}
+    },
+    "op_88510686051504": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686052016": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
+    },
+    "op_88510686052272": {
+      "kind": "tt.get_program_id",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 0}
+    },
+    "op_88510686052528": {
+      "kind": "tt.get_program_id",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 1}
+    },
+    "op_88785563950288": {
+      "kind": "arith.extsi",
+      "scope": "function",
+      "operands": [{"arg": "stride_am"}],
+      "result_types": ["i64"],
+      "attributes": {}
+    },
+    "op_89197880816464": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "A"}, {"arg": "M"}, {"arg": "K"}, {"op": "op_88785563950288"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_88785563950480": {
+      "kind": "arith.extsi",
+      "scope": "function",
+      "operands": [{"arg": "stride_bk"}],
+      "result_types": ["i64"],
+      "attributes": {}
+    },
+    "op_89197880816848": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "B"}, {"arg": "K"}, {"arg": "N"}, {"op": "op_88785563950480"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_88991722426960": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88510686052272"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722427200": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88510686052528"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88716844710912": {
+      "kind": "ttng.tmem_alloc",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
+      "attributes": {}
+    },
+    "op_89129161510032": {
+      "kind": "ttng.tmem_store",
+      "scope": "function",
+      "operands": [{"op": "op_88716844710912", "result": 0}, {"op": "op_88716844710912", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {}
+    },
+    "op_89129161510672": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89197880816464"}, {"op": "op_88991722426960"}, {"iv": 0}],
+      "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 0, "loop.stage": 0, "ttg.partition": [0]}
+    },
+    "op_88854283423264": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161510672"}],
+      "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 0, "loop.cluster": 2, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [2]}
+    },
+    "op_89129161510992": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89197880816848"}, {"iv": 0}, {"op": "op_88991722427200"}],
+      "result_types": ["tensor<64x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [1]}
+    },
+    "op_88854283423472": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161510992"}],
+      "result_types": ["!ttg.memdesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 1, "loop.cluster": 0, "loop.stage": 1, "tt.num_buffers": 2, "ttg.partition": [2]}
+    },
+    "op_89266600419024": {
+      "kind": "ttng.tc_gen5_mma",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283423264"}, {"op": "op_88854283423472"}, {"op": "op_88716844710912", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 1, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [2]}
+    },
+    "op_88854283423664": {
+      "kind": "scf.yield",
+      "scope": "loop:0",
+      "operands": [{"const": -1, "type": "i1"}, {"op": "op_89266600419024"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_89197880817248": {
+      "kind": "scf.for",
+      "scope": "function",
+      "operands": [{"const": 0, "type": "i32"}, {"arg": "K"}, {"const": 64, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_89129161510032"}],
+      "result_types": ["i1", "!ttg.async.token"],
+      "attributes": {"tt.modulo_ii": 559, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "tt.warp_specialize": "unit"}
+    },
+    "op_89129161511328": {
+      "kind": "ttng.tmem_load",
+      "scope": "function",
+      "operands": [{"op": "op_88716844710912", "result": 0}, {"op": "op_89197880817248", "result": 1}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
+      "attributes": {"resultSegmentSizes": [1, 1, 0]}
+    },
+    "op_88785563950864": {
+      "kind": "arith.extsi",
+      "scope": "function",
+      "operands": [{"arg": "stride_cm"}],
+      "result_types": ["i64"],
+      "attributes": {}
+    },
+    "op_89197880817616": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "C"}, {"arg": "M"}, {"arg": "N"}, {"op": "op_88785563950864"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<128x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_88991722436080": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88510686052272"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722436320": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88510686052528"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88854283423888": {
+      "kind": "arith.truncf",
+      "scope": "function",
+      "operands": [{"op": "op_89129161511328", "result": 0}],
+      "result_types": ["tensor<128x128xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {}
+    },
+    "op_88785563951056": {
+      "kind": "ttg.convert_layout",
+      "scope": "function",
+      "operands": [{"op": "op_88854283423888"}],
+      "result_types": ["tensor<128x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {}
+    },
+    "op_89129161511616": {
+      "kind": "tt.descriptor_store",
+      "scope": "function",
+      "operands": [{"op": "op_89197880817616"}, {"op": "op_88785563951056"}, {"op": "op_88991722436080"}, {"op": "op_88991722436320"}],
+      "result_types": [],
+      "attributes": {"reduce_kind": 0}
+    },
+    "op_88441966583344": {
+      "kind": "tt.return",
+      "scope": "function",
+      "operands": [],
+      "result_types": [],
+      "attributes": {}
+    }
+  },
+  "loops": [
+    {
+      "loop_id": 0,
+      "is_outer": false,
+      "trip_count": 4,
+      "trip_count_estimated": true,
+      "induction_var": {"name": "iv", "type": "i32"},
+      "lower_bound": {"const": 0, "type": "i32"},
+      "upper_bound": {"arg": "K"},
+      "step": {"const": 64, "type": "i32"},
+      "min_ii": 559, "res_mii": 559, "rec_mii": 559,
+      "ddg": {
+        "nodes": [
+          {"id": 0, "op_ref": "op_89129161510672", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 556, "self_latency": 30, "occupancy": 96, "min_warps": 1, "is_super_node": false},
+          {"id": 1, "op_ref": "op_88854283423264", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 2, "op_ref": "op_89129161510992", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 556, "self_latency": 30, "occupancy": 96, "min_warps": 1, "is_super_node": false},
+          {"id": 3, "op_ref": "op_88854283423472", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 4, "op_ref": "op_89266600419024", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "latency": 559, "self_latency": 30, "occupancy": 559, "min_warps": 1, "is_super_node": false}
+        ],
+        "edges": [
+          {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 556},
+          {"src": 2, "dst": 3, "kind": "data", "distance": 0, "latency": 556},
+          {"src": 1, "dst": 4, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 3, "dst": 4, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 4, "dst": 4, "kind": "loop_carried", "distance": 1, "latency": 559}
+        ]
+      }
+    }
+  ]
+}

--- a/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/ddg.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/ddg.json
@@ -1,0 +1,439 @@
+{
+  "schema_version": "ddg-0.1",
+  "config": {"schedule_algo": "rau", "smem_budget_bytes": 233472, "tmem_budget_bytes": 262144},
+  "kernel": {
+    "name": "matmul_kernel_tma_persistent_simple",
+    "args": [
+      {"name": "a_desc", "type": "!tt.tensordesc<tensor<256x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"},
+      {"name": "a_desc_0", "type": "i32"},
+      {"name": "a_desc_1", "type": "i32"},
+      {"name": "a_desc_2", "type": "i64"},
+      {"name": "a_desc_3", "type": "i64"},
+      {"name": "b_desc", "type": "!tt.tensordesc<tensor<256x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"},
+      {"name": "b_desc_0", "type": "i32"},
+      {"name": "b_desc_1", "type": "i32"},
+      {"name": "b_desc_2", "type": "i64"},
+      {"name": "b_desc_3", "type": "i64"},
+      {"name": "c_desc", "type": "!tt.tensordesc<tensor<256x256xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"},
+      {"name": "c_desc_0", "type": "i32"},
+      {"name": "c_desc_1", "type": "i32"},
+      {"name": "c_desc_2", "type": "i64"},
+      {"name": "c_desc_3", "type": "i64"},
+      {"name": "M", "type": "i32"},
+      {"name": "N", "type": "i32"},
+      {"name": "K", "type": "i32"}
+    ]
+  },
+  "ops": {
+    "op_88510686050096": {
+      "kind": "ub.poison",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {"value": "#ub.poison"}
+    },
+    "op_88510686050352": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686050608": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": -1}
+    },
+    "op_88510686051120": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 148}
+    },
+    "op_88510686051376": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 256}
+    },
+    "op_88510686051632": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 64}
+    },
+    "op_88510686051760": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686052016": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 1}
+    },
+    "op_88510686052400": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 255}
+    },
+    "op_88510686052656": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 63}
+    },
+    "op_88510686053168": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<256x256xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"value": "dense<0.000000e+00> : tensor<256x256xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
+    },
+    "op_88510686053296": {
+      "kind": "tt.get_program_id",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 0}
+    },
+    "op_88991722424800": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"arg": "M"}, {"const": 255, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722425040": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722424800"}, {"const": 256, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_88991722425280": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"arg": "N"}, {"const": 255, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722425520": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722425280"}, {"const": 256, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_88991722425760": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"arg": "K"}, {"const": 63, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722426000": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722425760"}, {"const": 64, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_88991722426240": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88991722425040"}, {"op": "op_88991722425520"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722426480": {
+      "kind": "arith.subi",
+      "scope": "function",
+      "operands": [{"op": "op_88510686053296"}, {"const": 148, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722426720": {
+      "kind": "arith.divsi",
+      "scope": "loop:1",
+      "operands": [{"iv": 1}, {"op": "op_88991722425520"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 4, "loop.stage": 0}
+    },
+    "op_88923002949776": {
+      "kind": "arith.remsi",
+      "scope": "loop:1",
+      "operands": [{"iv": 1}, {"op": "op_88991722425520"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 5, "loop.stage": 0}
+    },
+    "op_88991722426960": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722426720"}, {"const": 256, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 8, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722427200": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88923002949776"}, {"const": 256, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 9, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88510686054832": {
+      "kind": "ttng.tmem_alloc",
+      "scope": "loop:1",
+      "operands": [],
+      "result_types": ["!ttg.memdesc<256x256xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>, #ttng.tensor_memory, mutable>"],
+      "attributes": {"buffer.id": 0, "loop.cluster": 0, "loop.stage": 0, "tt.num_buffers": 1, "ttg.partition": [3]}
+    },
+    "op_88991722430784": {
+      "kind": "ttng.tmem_store",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88510686054832"}, {"const": 0, "type": "tensor<256x256xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "result_types": [],
+      "attributes": {"loop.cluster": 10, "loop.stage": 0, "ttg.partition": [3]}
+    },
+    "op_88991722431040": {
+      "kind": "arith.muli",
+      "scope": "loop:0",
+      "operands": [{"iv": 0}, {"const": 64, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_89129161515472": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"arg": "a_desc"}, {"op": "op_88991722426960"}, {"op": "op_88991722431040"}],
+      "result_types": ["tensor<256x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [0]}
+    },
+    "op_88854283423264": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161515472"}],
+      "result_types": ["!ttg.memdesc<256x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 0, "loop.cluster": 0, "loop.stage": 1, "tt.num_buffers": 2, "ttg.partition": [2]}
+    },
+    "op_89129161515792": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"arg": "b_desc"}, {"op": "op_88991722427200"}, {"op": "op_88991722431040"}],
+      "result_types": ["tensor<256x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 2, "loop.stage": 0, "ttg.partition": [1]}
+    },
+    "op_88854283423472": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161515792"}],
+      "result_types": ["!ttg.memdesc<256x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 1, "loop.cluster": 1, "loop.stage": 1, "tt.num_buffers": 2, "ttg.partition": [2]}
+    },
+    "op_88854283423680": {
+      "kind": "ttg.memdesc_trans",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283423472"}],
+      "result_types": ["!ttg.memdesc<64x256xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"loop.cluster": 1, "loop.stage": 1, "order": [1, 0], "ttg.partition": [2]}
+    },
+    "op_89197880816832": {
+      "kind": "ttng.tc_gen5_mma",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283423264"}, {"op": "op_88854283423680"}, {"op": "op_88510686054832"}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
+      "result_types": [],
+      "attributes": {"loop.cluster": 1, "loop.stage": 1, "operandSegmentSizes": [1, 1, 1, 0, 1, 1, 0, 0], "ttg.partition": [2]}
+    },
+    "op_88854283423872": {
+      "kind": "scf.yield",
+      "scope": "loop:0",
+      "operands": [{"const": -1, "type": "i1"}, {"op": "op_88510686050096"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_89197880817248": {
+      "kind": "scf.for",
+      "scope": "loop:1",
+      "operands": [{"const": 0, "type": "i32"}, {"op": "op_88991722426000"}, {"const": 1, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_88510686050096"}],
+      "result_types": ["i1", "!ttg.async.token"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 0, "tt.modulo_ii": 559, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "ttg.partition": [3]}
+    },
+    "op_88991722431760": {
+      "kind": "arith.addi",
+      "scope": "loop:1",
+      "operands": [{"iter_arg": {"loop": 1, "idx": 0}}, {"const": 148, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 1, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [0]}
+    },
+    "op_88991722432000": {
+      "kind": "arith.divsi",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722431760"}, {"op": "op_88991722425520"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 2, "loop.stage": 0, "ttg.partition": [0]}
+    },
+    "op_88923002950224": {
+      "kind": "arith.remsi",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722431760"}, {"op": "op_88991722425520"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 3, "loop.stage": 0, "ttg.partition": [0]}
+    },
+    "op_88991722432720": {
+      "kind": "ttng.tmem_load",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88510686054832"}],
+      "result_types": ["tensor<256x256xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 11, "loop.stage": 0, "resultSegmentSizes": [1, 0, 0], "ttg.partition": [3]}
+    },
+    "op_88854283424096": {
+      "kind": "arith.truncf",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722432720"}],
+      "result_types": ["tensor<256x256xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 1, "ttg.partition": [3]}
+    },
+    "op_88991722432960": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722432000"}, {"const": 256, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 6, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [0]}
+    },
+    "op_88991722433200": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88923002950224"}, {"const": 256, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 7, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [0]}
+    },
+    "op_88785563952208": {
+      "kind": "ttg.convert_layout",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88854283424096"}],
+      "result_types": ["tensor<256x256xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"loop.cluster": 1, "loop.stage": 1, "ttg.partition": [3]}
+    },
+    "op_89129161517376": {
+      "kind": "tt.descriptor_store",
+      "scope": "loop:1",
+      "operands": [{"arg": "c_desc"}, {"op": "op_88785563952208"}, {"op": "op_88991722432960"}, {"op": "op_88991722433200"}],
+      "result_types": [],
+      "attributes": {"buffer.id": 1, "loop.cluster": 2, "loop.stage": 1, "reduce_kind": 0, "tt.num_buffers": 1, "ttg.partition": [0]}
+    },
+    "op_88716844709296": {
+      "kind": "scf.yield",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722431760"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_89129161517712": {
+      "kind": "scf.for",
+      "scope": "function",
+      "operands": [{"op": "op_88510686053296"}, {"op": "op_88991722426240"}, {"const": 148, "type": "i32"}, {"op": "op_88991722426480"}],
+      "result_types": ["i32"],
+      "attributes": {"tt.modulo_ii": 20016, "tt.num_stages": 1, "tt.scheduled_max_stage": 1, "tt.warp_specialize": "unit"}
+    },
+    "op_88441966584688": {
+      "kind": "tt.return",
+      "scope": "function",
+      "operands": [],
+      "result_types": [],
+      "attributes": {}
+    }
+  },
+  "loops": [
+    {
+      "loop_id": 0,
+      "is_outer": false,
+      "trip_count": 4,
+      "trip_count_estimated": true,
+      "induction_var": {"name": "iv", "type": "i32"},
+      "lower_bound": {"const": 0, "type": "i32"},
+      "upper_bound": {"op": "op_88991722426000"},
+      "step": {"const": 1, "type": "i32"},
+      "min_ii": 559, "res_mii": 559, "rec_mii": 0,
+      "ddg": {
+        "nodes": [
+          {"id": 0, "op_ref": "op_88991722431040", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 1, "op_ref": "op_89129161515472", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 652, "self_latency": 30, "occupancy": 192, "min_warps": 1, "is_super_node": false},
+          {"id": 2, "op_ref": "op_88854283423264", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 3, "op_ref": "op_89129161515792", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 652, "self_latency": 30, "occupancy": 192, "min_warps": 1, "is_super_node": false},
+          {"id": 4, "op_ref": "op_88854283423472", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 5, "op_ref": "op_88854283423680", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 6, "op_ref": "op_89197880816832", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "latency": 559, "self_latency": 30, "occupancy": 559, "min_warps": 1, "is_super_node": false}
+        ],
+        "edges": [
+          {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 1, "dst": 2, "kind": "data", "distance": 0, "latency": 652},
+          {"src": 0, "dst": 3, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 3, "dst": 4, "kind": "data", "distance": 0, "latency": 652},
+          {"src": 4, "dst": 5, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 2, "dst": 6, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 5, "dst": 6, "kind": "data", "distance": 0, "latency": 0}
+        ]
+      }
+    },
+    {
+      "loop_id": 1,
+      "is_outer": true,
+      "trip_count": 4,
+      "trip_count_estimated": true,
+      "induction_var": {"name": "iv", "type": "i32"},
+      "lower_bound": {"op": "op_88510686053296"},
+      "upper_bound": {"op": "op_88991722426240"},
+      "step": {"const": 148, "type": "i32"},
+      "min_ii": 17888, "res_mii": 6786, "rec_mii": 1,
+      "ddg": {
+        "nodes": [
+          {"id": 0, "op_ref": "op_88991722426720", "op_kind": "arith.divsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 1, "op_ref": "op_88923002949776", "op_kind": "arith.remsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 2, "op_ref": "op_88991722426960", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 3, "op_ref": "op_88991722427200", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 4, "op_ref": "op_88510686054832", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 5, "op_ref": "op_88991722430784", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "latency": 384, "self_latency": 192, "occupancy": 192, "min_warps": 4, "is_super_node": false},
+          {"id": 6, "op_ref": "op_89197880817248", "op_kind": "scf.for", "pipeline": "NONE", "latency": 17888, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": true, "inner_ii": 559, "prologue_latency": 559},
+          {"id": 7, "op_ref": "op_88991722431760", "op_kind": "arith.addi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 8, "op_ref": "op_88991722432000", "op_kind": "arith.divsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 9, "op_ref": "op_88923002950224", "op_kind": "arith.remsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 10, "op_ref": "op_88991722432720", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "latency": 2128, "self_latency": 1024, "occupancy": 1024, "min_warps": 4, "is_super_node": false},
+          {"id": 11, "op_ref": "op_88854283424096", "op_kind": "arith.truncf", "pipeline": "CUDA", "latency": 420, "self_latency": 256, "occupancy": 256, "min_warps": 4, "is_super_node": false},
+          {"id": 12, "op_ref": "op_88991722432960", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 13, "op_ref": "op_88991722433200", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 14, "op_ref": "op_88785563952208", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "latency": 420, "self_latency": 420, "occupancy": 420, "min_warps": 4, "is_super_node": false},
+          {"id": 15, "op_ref": "op_89129161517376", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "latency": 6786, "self_latency": 30, "occupancy": 6786, "min_warps": 1, "is_super_node": false}
+        ],
+        "edges": [
+          {"src": 0, "dst": 2, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 1, "dst": 3, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 4, "dst": 5, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 7, "dst": 8, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 7, "dst": 9, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 4, "dst": 10, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 10, "dst": 11, "kind": "data", "distance": 0, "latency": 2128},
+          {"src": 8, "dst": 12, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 9, "dst": 13, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 11, "dst": 14, "kind": "data", "distance": 0, "latency": 420},
+          {"src": 14, "dst": 15, "kind": "data", "distance": 0, "latency": 420},
+          {"src": 12, "dst": 15, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 13, "dst": 15, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 6, "dst": 10, "kind": "data", "distance": 0, "latency": 17888},
+          {"src": 7, "dst": 7, "kind": "loop_carried", "distance": 1, "latency": 1}
+        ]
+      }
+    }
+  ]
+}

--- a/third_party/tlx/tools/sched2tlx/examples/case3_FA/ddg.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case3_FA/ddg.json
@@ -1,0 +1,718 @@
+{
+  "schema_version": "ddg-0.1",
+  "config": {"schedule_algo": "rau", "smem_budget_bytes": 233472, "tmem_budget_bytes": 262144},
+  "kernel": {
+    "name": "fa_fwd_kernel_nows",
+    "args": [
+      {"name": "Q", "type": "*bf16"},
+      {"name": "K", "type": "*bf16"},
+      {"name": "V", "type": "*bf16"},
+      {"name": "Out", "type": "*bf16"},
+      {"name": "M_lse", "type": "*f32"},
+      {"name": "sm_scale", "type": "f32"},
+      {"name": "H", "type": "i32"},
+      {"name": "N_CTX", "type": "i32"}
+    ]
+  },
+  "ops": {
+    "op_88510686052144": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686052400": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": -1}
+    },
+    "op_88510686052656": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 128}
+    },
+    "op_88510686052784": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 64}
+    },
+    "op_88510686052912": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i64"],
+      "attributes": {"value": 128}
+    },
+    "op_88510686053168": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i64"],
+      "attributes": {"value": 1}
+    },
+    "op_88510686053296": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686053552": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["f32"],
+      "attributes": {"value": "1.44269502 : f32"}
+    },
+    "op_88510686053680": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 1}
+    },
+    "op_88510686054320": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"value": "dense<1.000000e+00> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}
+    },
+    "op_88510686054704": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"value": "dense<0xFF800000> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}
+    },
+    "op_88510686055216": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
+    },
+    "op_88510686055344": {
+      "kind": "tt.get_program_id",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 0}
+    },
+    "op_88510686055600": {
+      "kind": "tt.get_program_id",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 1}
+    },
+    "op_88991722426960": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88510686055600"}, {"arg": "N_CTX"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722427200": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88510686055344"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722427440": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722426960"}, {"op": "op_88991722427200"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722427680": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"arg": "N_CTX"}, {"const": 64, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_88991722427920": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"arg": "H"}, {"arg": "N_CTX"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_89197880816464": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "Q"}, {"op": "op_88991722427920"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_89197880816848": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "K"}, {"op": "op_88991722427920"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_89197880817232": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "V"}, {"op": "op_88991722427920"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_89197880817616": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "Out"}, {"op": "op_88991722427920"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_89129161511952": {
+      "kind": "tt.descriptor_load",
+      "scope": "function",
+      "operands": [{"op": "op_89197880816464"}, {"op": "op_88991722427440"}, {"const": 0, "type": "i32"}],
+      "result_types": ["tensor<128x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1}
+    },
+    "op_88854283424720": {
+      "kind": "ttg.local_alloc",
+      "scope": "function",
+      "operands": [{"op": "op_89129161511952"}],
+      "result_types": ["!ttg.memdesc<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {}
+    },
+    "op_88991722428160": {
+      "kind": "arith.mulf",
+      "scope": "function",
+      "operands": [{"arg": "sm_scale"}, {"const": 1.4427, "type": "f32"}],
+      "result_types": ["f32"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88785563952592": {
+      "kind": "tt.splat",
+      "scope": "function",
+      "operands": [{"op": "op_88991722428160"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {}
+    },
+    "op_88785563952784": {
+      "kind": "tt.splat",
+      "scope": "function",
+      "operands": [{"op": "op_88991722428160"}],
+      "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {}
+    },
+    "op_88716844711968": {
+      "kind": "ttng.tmem_alloc",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["!ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
+      "attributes": {}
+    },
+    "op_88716844712848": {
+      "kind": "ttng.tmem_alloc",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
+      "attributes": {}
+    },
+    "op_89129161512272": {
+      "kind": "ttng.tmem_store",
+      "scope": "function",
+      "operands": [{"op": "op_88716844712848", "result": 0}, {"op": "op_88716844712848", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {}
+    },
+    "op_88991722438000": {
+      "kind": "arith.muli",
+      "scope": "loop:0",
+      "operands": [{"iv": 0}, {"const": 64, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722438240": {
+      "kind": "arith.addi",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722426960"}, {"op": "op_88991722438000"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 1, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_89129161512912": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89197880816848"}, {"op": "op_88991722438240"}, {"const": 0, "type": "i32"}],
+      "result_types": ["tensor<64x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 2, "loop.stage": 0, "ttg.partition": [0]}
+    },
+    "op_89129161513232": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89197880817232"}, {"op": "op_88991722438240"}, {"const": 0, "type": "i32"}],
+      "result_types": ["tensor<64x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 3, "loop.stage": 0, "ttg.partition": [1]}
+    },
+    "op_88854283427424": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161513232"}],
+      "result_types": ["!ttg.memdesc<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 0, "loop.cluster": 6, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [4]}
+    },
+    "op_88854283427632": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161512912"}],
+      "result_types": ["!ttg.memdesc<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 1, "loop.cluster": 5, "loop.stage": 0, "tt.num_buffers": 1, "ttg.partition": [2]}
+    },
+    "op_88854283427840": {
+      "kind": "ttg.memdesc_trans",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283427632"}],
+      "result_types": ["!ttg.memdesc<128x64xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"loop.cluster": 5, "loop.stage": 0, "order": [1, 0], "ttg.partition": [2]}
+    },
+    "op_89266600419024": {
+      "kind": "ttng.tc_gen5_mma",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283424720"}, {"op": "op_88854283427840"}, {"op": "op_88716844711968", "result": 0}, {"iter_arg": {"loop": 0, "idx": 3}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {"loop.cluster": 5, "loop.stage": 0, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [2]}
+    },
+    "op_89129161513568": {
+      "kind": "ttng.tmem_load",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88716844711968", "result": 0}, {"op": "op_89266600419024"}],
+      "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [5]}
+    },
+    "op_88991722439440": {
+      "kind": "arith.maxnumf",
+      "scope": "loop:0",
+      "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
+      "result_types": ["f32"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88716844712992": {
+      "kind": "tt.reduce.return",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722439440"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_88991722439680": {
+      "kind": "tt.reduce",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161513568", "result": 0}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 2, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88991722439920": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722439680"}, {"op": "op_88785563952592"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 3, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88991722440160": {
+      "kind": "arith.maxnumf",
+      "scope": "loop:0",
+      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_88991722439920"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 4, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88991722440400": {
+      "kind": "arith.subf",
+      "scope": "loop:0",
+      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_88991722440160"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 6, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88854283428880": {
+      "kind": "math.exp2",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722440400"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 8, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88991722440640": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161513568", "result": 0}, {"op": "op_88785563952784"}],
+      "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 1, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88854283429088": {
+      "kind": "tt.expand_dims",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722440160"}],
+      "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 5, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88785563953360": {
+      "kind": "tt.broadcast",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283429088"}],
+      "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 5, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88991722440880": {
+      "kind": "arith.subf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722440640"}, {"op": "op_88785563953360"}],
+      "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 5, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88854283429296": {
+      "kind": "math.exp2",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722440880"}],
+      "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 7, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88991722441120": {
+      "kind": "arith.addf",
+      "scope": "loop:0",
+      "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
+      "result_types": ["f32"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88716844713168": {
+      "kind": "tt.reduce.return",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722441120"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_88991722441360": {
+      "kind": "tt.reduce",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283429296"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 14, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88854283429504": {
+      "kind": "tt.expand_dims",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283428880"}],
+      "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 9, "loop.stage": 1, "ttg.partition": [3]}
+    },
+    "op_88785563953552": {
+      "kind": "ttg.convert_layout",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283429504"}],
+      "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 9, "loop.stage": 1, "ttg.partition": [3]}
+    },
+    "op_88785563953744": {
+      "kind": "tt.broadcast",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88785563953552"}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 9, "loop.stage": 1, "ttg.partition": [3]}
+    },
+    "op_89129161514528": {
+      "kind": "ttng.tmem_load",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88716844712848", "result": 0}, {"iter_arg": {"loop": 0, "idx": 4}}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
+      "attributes": {"loop.cluster": 4, "loop.stage": 0, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [3]}
+    },
+    "op_88991722442560": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161514528", "result": 0}, {"op": "op_88785563953744"}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 10, "loop.stage": 1, "ttg.partition": [3]}
+    },
+    "op_88854283429712": {
+      "kind": "arith.truncf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283429296"}],
+      "result_types": ["tensor<128x64xbf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 13, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88785563953936": {
+      "kind": "ttng.tmem_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283429712"}],
+      "result_types": ["!ttg.memdesc<128x64xbf16, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory>"],
+      "attributes": {"buffer.id": 2, "loop.cluster": 16, "loop.stage": 1, "tt.num_buffers": 1, "ttg.partition": [4]}
+    },
+    "op_89129161514832": {
+      "kind": "ttng.tmem_store",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88716844712848", "result": 0}, {"op": "op_89129161514528", "result": 1}, {"op": "op_88991722442560"}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {"loop.cluster": 12, "loop.stage": 1, "ttg.partition": [3]}
+    },
+    "op_89266600419472": {
+      "kind": "ttng.tc_gen5_mma",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88785563953936"}, {"op": "op_88854283427424"}, {"op": "op_88716844712848", "result": 0}, {"op": "op_89129161514832"}, {"iter_arg": {"loop": 0, "idx": 2}}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {"loop.cluster": 16, "loop.stage": 1, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [4]}
+    },
+    "op_88991722445680": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"iter_arg": {"loop": 0, "idx": 1}}, {"op": "op_88854283428880"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 11, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_88991722445920": {
+      "kind": "arith.addf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722445680"}, {"op": "op_88991722441360"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 15, "loop.stage": 1, "ttg.partition": [5]}
+    },
+    "op_89129161515136": {
+      "kind": "scf.yield",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722440160"}, {"op": "op_88991722445920"}, {"const": -1, "type": "i1"}, {"op": "op_89129161513568", "result": 1}, {"op": "op_89266600419472"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_89335319787152": {
+      "kind": "scf.for",
+      "scope": "function",
+      "operands": [{"const": 0, "type": "i32"}, {"op": "op_88991722427680"}, {"const": 1, "type": "i32"}, {"const": "-inf", "type": "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}, {"const": 1, "type": "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}, {"const": 0, "type": "i1"}, {"op": "op_88716844711968", "result": 1}, {"op": "op_89129161512272"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>", "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>", "i1", "!ttg.async.token", "!ttg.async.token"],
+      "attributes": {"tt.modulo_ii": 1459, "tt.num_stages": 2, "tt.scheduled_max_stage": 1}
+    },
+    "op_89129161515488": {
+      "kind": "ttng.tmem_load",
+      "scope": "function",
+      "operands": [{"op": "op_88716844712848", "result": 0}, {"op": "op_89335319787152", "result": 4}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
+      "attributes": {"resultSegmentSizes": [1, 1, 0]}
+    },
+    "op_88854283430752": {
+      "kind": "tt.expand_dims",
+      "scope": "function",
+      "operands": [{"op": "op_89335319787152", "result": 1}],
+      "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"axis": 1}
+    },
+    "op_88785563954128": {
+      "kind": "ttg.convert_layout",
+      "scope": "function",
+      "operands": [{"op": "op_88854283430752"}],
+      "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {}
+    },
+    "op_88785563954320": {
+      "kind": "tt.broadcast",
+      "scope": "function",
+      "operands": [{"op": "op_88785563954128"}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {}
+    },
+    "op_88991722447120": {
+      "kind": "arith.divf",
+      "scope": "function",
+      "operands": [{"op": "op_89129161515488", "result": 0}, {"op": "op_88785563954320"}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88854283430960": {
+      "kind": "arith.truncf",
+      "scope": "function",
+      "operands": [{"op": "op_88991722447120"}],
+      "result_types": ["tensor<128x128xbf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {}
+    },
+    "op_88785563954512": {
+      "kind": "ttg.convert_layout",
+      "scope": "function",
+      "operands": [{"op": "op_88854283430960"}],
+      "result_types": ["tensor<128x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {}
+    },
+    "op_89129161515776": {
+      "kind": "tt.descriptor_store",
+      "scope": "function",
+      "operands": [{"op": "op_89197880817616"}, {"op": "op_88785563954512"}, {"op": "op_88991722427440"}, {"const": 0, "type": "i32"}],
+      "result_types": [],
+      "attributes": {"reduce_kind": 0}
+    },
+    "op_88510686061872": {
+      "kind": "tt.make_range",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
+      "attributes": {"end": 128, "start": 0}
+    },
+    "op_88785563954704": {
+      "kind": "tt.splat",
+      "scope": "function",
+      "operands": [{"op": "op_88991722427200"}],
+      "result_types": ["tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
+      "attributes": {}
+    },
+    "op_88991722447360": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"op": "op_88785563954704"}, {"op": "op_88510686061872"}],
+      "result_types": ["tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88923002949328": {
+      "kind": "tt.addptr",
+      "scope": "function",
+      "operands": [{"arg": "M_lse"}, {"op": "op_88991722426960"}],
+      "result_types": ["!tt.ptr<f32>"],
+      "attributes": {}
+    },
+    "op_88785563954896": {
+      "kind": "tt.splat",
+      "scope": "function",
+      "operands": [{"op": "op_88923002949328"}],
+      "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
+      "attributes": {}
+    },
+    "op_88923002949552": {
+      "kind": "tt.addptr",
+      "scope": "function",
+      "operands": [{"op": "op_88785563954896"}, {"op": "op_88991722447360"}],
+      "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
+      "attributes": {}
+    },
+    "op_88854283431168": {
+      "kind": "math.log2",
+      "scope": "function",
+      "operands": [{"op": "op_89335319787152", "result": 1}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88991722447600": {
+      "kind": "arith.addf",
+      "scope": "function",
+      "operands": [{"op": "op_89335319787152", "result": 0}, {"op": "op_88854283431168"}],
+      "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88785563955088": {
+      "kind": "ttg.convert_layout",
+      "scope": "function",
+      "operands": [{"op": "op_88991722447600"}],
+      "result_types": ["tensor<128xf32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
+      "attributes": {}
+    },
+    "op_88991722447824": {
+      "kind": "tt.store",
+      "scope": "function",
+      "operands": [{"op": "op_88923002949552"}, {"op": "op_88785563955088"}],
+      "result_types": [],
+      "attributes": {"boundaryCheck": [], "cache": 1, "evict": 1}
+    },
+    "op_88441966590064": {
+      "kind": "tt.return",
+      "scope": "function",
+      "operands": [],
+      "result_types": [],
+      "attributes": {}
+    }
+  },
+  "loops": [
+    {
+      "loop_id": 0,
+      "is_outer": false,
+      "trip_count": 4,
+      "trip_count_estimated": true,
+      "induction_var": {"name": "iv", "type": "i32"},
+      "lower_bound": {"const": 0, "type": "i32"},
+      "upper_bound": {"op": "op_88991722427680"},
+      "step": {"const": 1, "type": "i32"},
+      "min_ii": 1459, "res_mii": 1459, "rec_mii": 1325,
+      "ddg": {
+        "nodes": [
+          {"id": 0, "op_ref": "op_88991722438000", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 1, "op_ref": "op_88991722438240", "op_kind": "arith.addi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 2, "op_ref": "op_89129161512912", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 556, "self_latency": 30, "occupancy": 96, "min_warps": 1, "is_super_node": false},
+          {"id": 3, "op_ref": "op_89129161513232", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 556, "self_latency": 30, "occupancy": 96, "min_warps": 1, "is_super_node": false},
+          {"id": 4, "op_ref": "op_88854283427424", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 5, "op_ref": "op_88854283427632", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 6, "op_ref": "op_88854283427840", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 7, "op_ref": "op_89266600419024", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "latency": 900, "self_latency": 30, "occupancy": 900, "min_warps": 1, "is_super_node": false},
+          {"id": 8, "op_ref": "op_89129161513568", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "latency": 266, "self_latency": 128, "occupancy": 128, "min_warps": 4, "is_super_node": false},
+          {"id": 9, "op_ref": "op_88991722439680", "op_kind": "tt.reduce", "pipeline": "CUDA", "latency": 3, "self_latency": 2, "occupancy": 2, "min_warps": 4, "is_super_node": false},
+          {"id": 10, "op_ref": "op_88991722439920", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 4, "is_super_node": false},
+          {"id": 11, "op_ref": "op_88991722440160", "op_kind": "arith.maxnumf", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 4, "is_super_node": false},
+          {"id": 12, "op_ref": "op_88991722440400", "op_kind": "arith.subf", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 4, "is_super_node": false},
+          {"id": 13, "op_ref": "op_88854283428880", "op_kind": "math.exp2", "pipeline": "SFU", "latency": 8, "self_latency": 1, "occupancy": 1, "min_warps": 4, "is_super_node": false},
+          {"id": 14, "op_ref": "op_88991722440640", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 69, "self_latency": 64, "occupancy": 64, "min_warps": 4, "is_super_node": false},
+          {"id": 15, "op_ref": "op_88854283429088", "op_kind": "tt.expand_dims", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 16, "op_ref": "op_88785563953360", "op_kind": "tt.broadcast", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 17, "op_ref": "op_88991722440880", "op_kind": "arith.subf", "pipeline": "CUDA", "latency": 65, "self_latency": 64, "occupancy": 64, "min_warps": 4, "is_super_node": false},
+          {"id": 18, "op_ref": "op_88854283429296", "op_kind": "math.exp2", "pipeline": "SFU", "latency": 570, "self_latency": 64, "occupancy": 64, "min_warps": 4, "is_super_node": false},
+          {"id": 19, "op_ref": "op_88991722441360", "op_kind": "tt.reduce", "pipeline": "CUDA", "latency": 13, "self_latency": 4, "occupancy": 4, "min_warps": 4, "is_super_node": false},
+          {"id": 20, "op_ref": "op_88854283429504", "op_kind": "tt.expand_dims", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 21, "op_ref": "op_88785563953552", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 22, "op_ref": "op_88785563953744", "op_kind": "tt.broadcast", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 23, "op_ref": "op_89129161514528", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "latency": 532, "self_latency": 256, "occupancy": 256, "min_warps": 4, "is_super_node": false},
+          {"id": 24, "op_ref": "op_88991722442560", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 138, "self_latency": 128, "occupancy": 128, "min_warps": 4, "is_super_node": false},
+          {"id": 25, "op_ref": "op_88854283429712", "op_kind": "arith.truncf", "pipeline": "CUDA", "latency": 52, "self_latency": 32, "occupancy": 32, "min_warps": 4, "is_super_node": false},
+          {"id": 26, "op_ref": "op_88785563953936", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 27, "op_ref": "op_89129161514832", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "latency": 96, "self_latency": 48, "occupancy": 48, "min_warps": 4, "is_super_node": false},
+          {"id": 28, "op_ref": "op_89266600419472", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "latency": 559, "self_latency": 30, "occupancy": 559, "min_warps": 1, "is_super_node": false},
+          {"id": 29, "op_ref": "op_88991722445680", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 4, "is_super_node": false},
+          {"id": 30, "op_ref": "op_88991722445920", "op_kind": "arith.addf", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 4, "is_super_node": false}
+        ],
+        "edges": [
+          {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 1, "dst": 2, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 1, "dst": 3, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 3, "dst": 4, "kind": "data", "distance": 0, "latency": 556},
+          {"src": 2, "dst": 5, "kind": "data", "distance": 0, "latency": 556},
+          {"src": 5, "dst": 6, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 6, "dst": 7, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 7, "dst": 8, "kind": "data", "distance": 0, "latency": 900},
+          {"src": 8, "dst": 9, "kind": "data", "distance": 0, "latency": 266},
+          {"src": 9, "dst": 10, "kind": "data", "distance": 0, "latency": 3},
+          {"src": 10, "dst": 11, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 11, "dst": 12, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 12, "dst": 13, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 8, "dst": 14, "kind": "data", "distance": 0, "latency": 266},
+          {"src": 11, "dst": 15, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 15, "dst": 16, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 14, "dst": 17, "kind": "data", "distance": 0, "latency": 69},
+          {"src": 16, "dst": 17, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 17, "dst": 18, "kind": "data", "distance": 0, "latency": 65},
+          {"src": 18, "dst": 19, "kind": "data", "distance": 0, "latency": 570},
+          {"src": 13, "dst": 20, "kind": "data", "distance": 0, "latency": 8},
+          {"src": 20, "dst": 21, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 21, "dst": 22, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 23, "dst": 24, "kind": "data", "distance": 0, "latency": 532},
+          {"src": 22, "dst": 24, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 18, "dst": 25, "kind": "data", "distance": 0, "latency": 570},
+          {"src": 25, "dst": 26, "kind": "data", "distance": 0, "latency": 52},
+          {"src": 23, "dst": 27, "kind": "data", "distance": 0, "latency": 532},
+          {"src": 24, "dst": 27, "kind": "data", "distance": 0, "latency": 138},
+          {"src": 26, "dst": 28, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 4, "dst": 28, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 27, "dst": 28, "kind": "data", "distance": 0, "latency": 96},
+          {"src": 13, "dst": 29, "kind": "data", "distance": 0, "latency": 8},
+          {"src": 29, "dst": 30, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 19, "dst": 30, "kind": "data", "distance": 0, "latency": 13},
+          {"src": 11, "dst": 11, "kind": "loop_carried", "distance": 1, "latency": 1},
+          {"src": 11, "dst": 12, "kind": "loop_carried", "distance": 1, "latency": 1},
+          {"src": 30, "dst": 29, "kind": "loop_carried", "distance": 1, "latency": 1},
+          {"src": 8, "dst": 7, "kind": "loop_carried", "distance": 1, "latency": 266},
+          {"src": 28, "dst": 23, "kind": "loop_carried", "distance": 1, "latency": 559}
+        ]
+      }
+    }
+  ]
+}

--- a/third_party/tlx/tools/sched2tlx/examples/case5_addmm_bias/ddg.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case5_addmm_bias/ddg.json
@@ -1,0 +1,454 @@
+{
+  "schema_version": "ddg-0.1",
+  "config": {"schedule_algo": "rau", "smem_budget_bytes": 233472, "tmem_budget_bytes": 262144},
+  "kernel": {
+    "name": "addmm_persistent_2d_bias",
+    "args": [
+      {"name": "arg0", "type": "!tt.tensordesc<tensor<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"},
+      {"name": "arg1", "type": "!tt.tensordesc<tensor<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"},
+      {"name": "arg2", "type": "!tt.tensordesc<tensor<128x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"},
+      {"name": "arg3", "type": "!tt.tensordesc<tensor<128x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"},
+      {"name": "arg4", "type": "i32"},
+      {"name": "arg5", "type": "i32"},
+      {"name": "arg6", "type": "i32"}
+    ]
+  },
+  "ops": {
+    "op_88510686050096": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686050224": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i1"],
+      "attributes": {"value": -1}
+    },
+    "op_88510686050480": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 148}
+    },
+    "op_88510686050608": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 128}
+    },
+    "op_88510686050736": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 64}
+    },
+    "op_88510686050864": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686050992": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 1}
+    },
+    "op_88510686051248": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 127}
+    },
+    "op_88510686051376": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 63}
+    },
+    "op_88510686051632": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
+    },
+    "op_88510686051760": {
+      "kind": "tt.get_program_id",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 0}
+    },
+    "op_88991722426240": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"arg": "arg4"}, {"const": 127, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722426480": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722426240"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_88991722426720": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"arg": "arg5"}, {"const": 127, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722426960": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722426720"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_88991722427200": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"arg": "arg6"}, {"const": 63, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722427440": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722427200"}, {"const": 64, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_88991722427680": {
+      "kind": "arith.muli",
+      "scope": "function",
+      "operands": [{"op": "op_88991722426480"}, {"op": "op_88991722426960"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722427920": {
+      "kind": "arith.subi",
+      "scope": "function",
+      "operands": [{"op": "op_88510686051760"}, {"const": 148, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722428160": {
+      "kind": "arith.divsi",
+      "scope": "loop:1",
+      "operands": [{"iv": 1}, {"op": "op_88991722426960"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 6, "loop.stage": 0}
+    },
+    "op_88923002949776": {
+      "kind": "arith.remsi",
+      "scope": "loop:1",
+      "operands": [{"iv": 1}, {"op": "op_88991722426960"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 7, "loop.stage": 0}
+    },
+    "op_88991722428400": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722428160"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 8, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722428640": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88923002949776"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 9, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88716844711088": {
+      "kind": "ttng.tmem_alloc",
+      "scope": "loop:1",
+      "operands": [],
+      "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
+      "attributes": {"buffer.id": 0, "loop.cluster": 0, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [2]}
+    },
+    "op_89129161510352": {
+      "kind": "ttng.tmem_store",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88716844711088", "result": 0}, {"op": "op_88716844711088", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [2]}
+    },
+    "op_88991722435600": {
+      "kind": "arith.muli",
+      "scope": "loop:0",
+      "operands": [{"iv": 0}, {"const": 64, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_89129161510992": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"arg": "arg0"}, {"op": "op_88991722428400"}, {"op": "op_88991722435600"}],
+      "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [0]}
+    },
+    "op_88854283422640": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161510992"}],
+      "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 0, "loop.cluster": 3, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [2]}
+    },
+    "op_89129161511312": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"arg": "arg1"}, {"op": "op_88991722435600"}, {"op": "op_88991722428640"}],
+      "result_types": ["tensor<64x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 2, "loop.stage": 0, "ttg.partition": [1]}
+    },
+    "op_88854283422848": {
+      "kind": "ttg.local_alloc",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161511312"}],
+      "result_types": ["!ttg.memdesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
+      "attributes": {"buffer.id": 1, "loop.cluster": 0, "loop.stage": 1, "tt.num_buffers": 2, "ttg.partition": [2]}
+    },
+    "op_89266600418576": {
+      "kind": "ttng.tc_gen5_mma",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283422640"}, {"op": "op_88854283422848"}, {"op": "op_88716844711088", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
+      "result_types": ["!ttg.async.token"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 1, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [2]}
+    },
+    "op_88854283423040": {
+      "kind": "scf.yield",
+      "scope": "loop:0",
+      "operands": [{"const": -1, "type": "i1"}, {"op": "op_89266600418576"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_89197880816480": {
+      "kind": "scf.for",
+      "scope": "loop:1",
+      "operands": [{"const": 0, "type": "i32"}, {"op": "op_88991722427440"}, {"const": 1, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_89129161510352"}],
+      "result_types": ["i1", "!ttg.async.token"],
+      "attributes": {"loop.cluster": 10, "loop.stage": 0, "tt.modulo_ii": 559, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722436800": {
+      "kind": "arith.addi",
+      "scope": "loop:1",
+      "operands": [{"iter_arg": {"loop": 1, "idx": 0}}, {"const": 148, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 1, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [2]}
+    },
+    "op_88991722437040": {
+      "kind": "arith.divsi",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722436800"}, {"op": "op_88991722426960"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 2, "loop.stage": 0, "ttg.partition": [2]}
+    },
+    "op_88923002950000": {
+      "kind": "arith.remsi",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722436800"}, {"op": "op_88991722426960"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 3, "loop.stage": 0, "ttg.partition": [2]}
+    },
+    "op_88991722437280": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722437040"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 4, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [2]}
+    },
+    "op_88991722437520": {
+      "kind": "arith.muli",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88923002950000"}, {"const": 128, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 5, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [2]}
+    },
+    "op_89129161511632": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:1",
+      "operands": [{"arg": "arg2"}, {"op": "op_88991722437280"}, {"op": "op_88991722437520"}],
+      "result_types": ["tensor<128x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 6, "loop.stage": 0, "ttg.partition": [2]}
+    },
+    "op_88854283423264": {
+      "kind": "arith.extf",
+      "scope": "loop:1",
+      "operands": [{"op": "op_89129161511632"}],
+      "result_types": ["tensor<128x128xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"loop.cluster": 11, "loop.stage": 0, "ttg.partition": [2]}
+    },
+    "op_88785563950288": {
+      "kind": "ttg.convert_layout",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88854283423264"}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 12, "loop.stage": 0, "ttg.partition": [2]}
+    },
+    "op_89129161511968": {
+      "kind": "ttng.tmem_load",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88716844711088", "result": 0}, {"op": "op_89197880816480", "result": 1}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [2]}
+    },
+    "op_88991722438720": {
+      "kind": "arith.addf",
+      "scope": "loop:1",
+      "operands": [{"op": "op_89129161511968", "result": 0}, {"op": "op_88785563950288"}],
+      "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 1, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88854283423472": {
+      "kind": "arith.truncf",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722438720"}],
+      "result_types": ["tensor<128x128xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
+      "attributes": {"loop.cluster": 2, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88785563950480": {
+      "kind": "ttg.convert_layout",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88854283423472"}],
+      "result_types": ["tensor<128x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
+      "attributes": {"loop.cluster": 3, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_89129161512256": {
+      "kind": "tt.descriptor_store",
+      "scope": "loop:1",
+      "operands": [{"arg": "arg3"}, {"op": "op_88785563950480"}, {"op": "op_88991722437280"}, {"op": "op_88991722437520"}],
+      "result_types": [],
+      "attributes": {"buffer.id": 1, "loop.cluster": 4, "loop.stage": 1, "reduce_kind": 0, "tt.num_buffers": 1, "ttg.partition": [2]}
+    },
+    "op_88716844711232": {
+      "kind": "scf.yield",
+      "scope": "loop:1",
+      "operands": [{"op": "op_88991722436800"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_89129161512592": {
+      "kind": "scf.for",
+      "scope": "function",
+      "operands": [{"op": "op_88510686051760"}, {"op": "op_88991722427680"}, {"const": 148, "type": "i32"}, {"op": "op_88991722427920"}],
+      "result_types": ["i32"],
+      "attributes": {"tt.modulo_ii": 17888, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "tt.warp_specialize": "unit"}
+    },
+    "op_88441966584912": {
+      "kind": "tt.return",
+      "scope": "function",
+      "operands": [],
+      "result_types": [],
+      "attributes": {}
+    }
+  },
+  "loops": [
+    {
+      "loop_id": 0,
+      "is_outer": false,
+      "trip_count": 4,
+      "trip_count_estimated": true,
+      "induction_var": {"name": "iv", "type": "i32"},
+      "lower_bound": {"const": 0, "type": "i32"},
+      "upper_bound": {"op": "op_88991722427440"},
+      "step": {"const": 1, "type": "i32"},
+      "min_ii": 559, "res_mii": 559, "rec_mii": 559,
+      "ddg": {
+        "nodes": [
+          {"id": 0, "op_ref": "op_88991722435600", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 1, "op_ref": "op_89129161510992", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 556, "self_latency": 30, "occupancy": 96, "min_warps": 1, "is_super_node": false},
+          {"id": 2, "op_ref": "op_88854283422640", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 3, "op_ref": "op_89129161511312", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 556, "self_latency": 30, "occupancy": 96, "min_warps": 1, "is_super_node": false},
+          {"id": 4, "op_ref": "op_88854283422848", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 5, "op_ref": "op_89266600418576", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "latency": 559, "self_latency": 30, "occupancy": 559, "min_warps": 1, "is_super_node": false}
+        ],
+        "edges": [
+          {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 1, "dst": 2, "kind": "data", "distance": 0, "latency": 556},
+          {"src": 0, "dst": 3, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 3, "dst": 4, "kind": "data", "distance": 0, "latency": 556},
+          {"src": 2, "dst": 5, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 4, "dst": 5, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 5, "dst": 5, "kind": "loop_carried", "distance": 1, "latency": 559}
+        ]
+      }
+    },
+    {
+      "loop_id": 1,
+      "is_outer": true,
+      "trip_count": 4,
+      "trip_count_estimated": true,
+      "induction_var": {"name": "iv", "type": "i32"},
+      "lower_bound": {"op": "op_88510686051760"},
+      "upper_bound": {"op": "op_88991722427680"},
+      "step": {"const": 148, "type": "i32"},
+      "min_ii": 17888, "res_mii": 1986, "rec_mii": 1,
+      "ddg": {
+        "nodes": [
+          {"id": 0, "op_ref": "op_88991722428160", "op_kind": "arith.divsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 1, "op_ref": "op_88923002949776", "op_kind": "arith.remsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 2, "op_ref": "op_88991722428400", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 3, "op_ref": "op_88991722428640", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 4, "op_ref": "op_88716844711088", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": false},
+          {"id": 5, "op_ref": "op_89129161510352", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "latency": 96, "self_latency": 48, "occupancy": 48, "min_warps": 4, "is_super_node": false},
+          {"id": 6, "op_ref": "op_89197880816480", "op_kind": "scf.for", "pipeline": "NONE", "latency": 17888, "self_latency": 0, "occupancy": 0, "min_warps": 1, "is_super_node": true, "inner_ii": 559, "prologue_latency": 559},
+          {"id": 7, "op_ref": "op_88991722436800", "op_kind": "arith.addi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 8, "op_ref": "op_88991722437040", "op_kind": "arith.divsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 9, "op_ref": "op_88923002950000", "op_kind": "arith.remsi", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 10, "op_ref": "op_88991722437280", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 11, "op_ref": "op_88991722437520", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 12, "op_ref": "op_89129161511632", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 652, "self_latency": 30, "occupancy": 192, "min_warps": 1, "is_super_node": false},
+          {"id": 13, "op_ref": "op_88854283423264", "op_kind": "arith.extf", "pipeline": "CUDA", "latency": 105, "self_latency": 64, "occupancy": 64, "min_warps": 4, "is_super_node": false},
+          {"id": 14, "op_ref": "op_88785563950288", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "latency": 105, "self_latency": 105, "occupancy": 105, "min_warps": 4, "is_super_node": false},
+          {"id": 15, "op_ref": "op_89129161511968", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "latency": 532, "self_latency": 256, "occupancy": 256, "min_warps": 4, "is_super_node": false},
+          {"id": 16, "op_ref": "op_88991722438720", "op_kind": "arith.addf", "pipeline": "CUDA", "latency": 130, "self_latency": 128, "occupancy": 128, "min_warps": 4, "is_super_node": false},
+          {"id": 17, "op_ref": "op_88854283423472", "op_kind": "arith.truncf", "pipeline": "CUDA", "latency": 105, "self_latency": 64, "occupancy": 64, "min_warps": 4, "is_super_node": false},
+          {"id": 18, "op_ref": "op_88785563950480", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "latency": 105, "self_latency": 105, "occupancy": 105, "min_warps": 4, "is_super_node": false},
+          {"id": 19, "op_ref": "op_89129161512256", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "latency": 1794, "self_latency": 30, "occupancy": 1794, "min_warps": 1, "is_super_node": false}
+        ],
+        "edges": [
+          {"src": 0, "dst": 2, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 1, "dst": 3, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 4, "dst": 5, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 4, "dst": 5, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 5, "dst": 6, "kind": "data", "distance": 0, "latency": 96},
+          {"src": 7, "dst": 8, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 7, "dst": 9, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 8, "dst": 10, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 9, "dst": 11, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 10, "dst": 12, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 11, "dst": 12, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 12, "dst": 13, "kind": "data", "distance": 0, "latency": 652},
+          {"src": 13, "dst": 14, "kind": "data", "distance": 0, "latency": 105},
+          {"src": 4, "dst": 15, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 6, "dst": 15, "kind": "data", "distance": 0, "latency": 17888},
+          {"src": 15, "dst": 16, "kind": "data", "distance": 0, "latency": 532},
+          {"src": 14, "dst": 16, "kind": "data", "distance": 0, "latency": 105},
+          {"src": 16, "dst": 17, "kind": "data", "distance": 0, "latency": 130},
+          {"src": 17, "dst": 18, "kind": "data", "distance": 0, "latency": 105},
+          {"src": 18, "dst": 19, "kind": "data", "distance": 0, "latency": 105},
+          {"src": 10, "dst": 19, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 11, "dst": 19, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 6, "dst": 15, "kind": "data", "distance": 0, "latency": 17888},
+          {"src": 7, "dst": 7, "kind": "loop_carried", "distance": 1, "latency": 1}
+        ]
+      }
+    }
+  ]
+}

--- a/third_party/tlx/tools/sched2tlx/examples/case6_layernorm/ddg.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case6_layernorm/ddg.json
@@ -1,0 +1,493 @@
+{
+  "schema_version": "ddg-0.1",
+  "config": {"schedule_algo": "rau", "smem_budget_bytes": 233472, "tmem_budget_bytes": 262144},
+  "kernel": {
+    "name": "layernorm_fwd_nows",
+    "args": [
+      {"name": "X", "type": "*f16"},
+      {"name": "W", "type": "*f16"},
+      {"name": "B", "type": "*f16"},
+      {"name": "Y", "type": "*f16"},
+      {"name": "M", "type": "i32"},
+      {"name": "eps", "type": "f32"}
+    ]
+  },
+  "ops": {
+    "op_88510686047792": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 512}
+    },
+    "op_88510686048048": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i64"],
+      "attributes": {"value": 512}
+    },
+    "op_88510686048176": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i64"],
+      "attributes": {"value": 1}
+    },
+    "op_88510686048304": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 8}
+    },
+    "op_88510686048560": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 0}
+    },
+    "op_88510686048688": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"value": 7}
+    },
+    "op_88510686049328": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"value": "dense<1.000000e+00> : tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}
+    },
+    "op_88510686049584": {
+      "kind": "arith.constant",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"value": "dense<5.120000e+02> : tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}
+    },
+    "op_88510686049712": {
+      "kind": "tt.get_program_id",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 0}
+    },
+    "op_88510686049968": {
+      "kind": "tt.get_num_programs",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["i32"],
+      "attributes": {"axis": 0}
+    },
+    "op_88991722424800": {
+      "kind": "arith.addi",
+      "scope": "function",
+      "operands": [{"arg": "M"}, {"const": 7, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_88991722425040": {
+      "kind": "arith.divsi",
+      "scope": "function",
+      "operands": [{"op": "op_88991722424800"}, {"const": 8, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {}
+    },
+    "op_89197880816080": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "X"}, {"arg": "M"}, {"const": 512, "type": "i32"}, {"const": 512, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<8x512xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_89197880816464": {
+      "kind": "tt.make_tensor_descriptor",
+      "scope": "function",
+      "operands": [{"arg": "Y"}, {"arg": "M"}, {"const": 512, "type": "i32"}, {"const": 512, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<tensor<8x512xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
+    },
+    "op_88510686051888": {
+      "kind": "tt.make_range",
+      "scope": "function",
+      "operands": [],
+      "result_types": ["tensor<512xi32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"end": 512, "start": 0}
+    },
+    "op_88785563947600": {
+      "kind": "tt.splat",
+      "scope": "function",
+      "operands": [{"arg": "W"}],
+      "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {}
+    },
+    "op_88923002949776": {
+      "kind": "tt.addptr",
+      "scope": "function",
+      "operands": [{"op": "op_88785563947600"}, {"op": "op_88510686051888"}],
+      "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {}
+    },
+    "op_89060441856080": {
+      "kind": "tt.load",
+      "scope": "function",
+      "operands": [{"op": "op_88923002949776"}],
+      "result_types": ["tensor<512xf16, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"boundaryCheck": [], "cache": 1, "evict": 1, "isVolatile": 0, "operandSegmentSizes": [1, 0, 0]}
+    },
+    "op_88785563947792": {
+      "kind": "tt.splat",
+      "scope": "function",
+      "operands": [{"arg": "B"}],
+      "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {}
+    },
+    "op_88923002950000": {
+      "kind": "tt.addptr",
+      "scope": "function",
+      "operands": [{"op": "op_88785563947792"}, {"op": "op_88510686051888"}],
+      "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {}
+    },
+    "op_89060441856336": {
+      "kind": "tt.load",
+      "scope": "function",
+      "operands": [{"op": "op_88923002950000"}],
+      "result_types": ["tensor<512xf16, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"boundaryCheck": [], "cache": 1, "evict": 1, "isVolatile": 0, "operandSegmentSizes": [1, 0, 0]}
+    },
+    "op_88785563947984": {
+      "kind": "tt.splat",
+      "scope": "function",
+      "operands": [{"arg": "eps"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {}
+    },
+    "op_88854283422848": {
+      "kind": "tt.expand_dims",
+      "scope": "function",
+      "operands": [{"op": "op_89060441856080"}],
+      "result_types": ["tensor<1x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"axis": 0}
+    },
+    "op_88854283423056": {
+      "kind": "arith.extf",
+      "scope": "function",
+      "operands": [{"op": "op_88854283422848"}],
+      "result_types": ["tensor<1x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {}
+    },
+    "op_88785563948176": {
+      "kind": "tt.broadcast",
+      "scope": "function",
+      "operands": [{"op": "op_88854283423056"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {}
+    },
+    "op_88854283423264": {
+      "kind": "tt.expand_dims",
+      "scope": "function",
+      "operands": [{"op": "op_89060441856336"}],
+      "result_types": ["tensor<1x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"axis": 0}
+    },
+    "op_88854283423472": {
+      "kind": "arith.extf",
+      "scope": "function",
+      "operands": [{"op": "op_88854283423264"}],
+      "result_types": ["tensor<1x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {}
+    },
+    "op_88785563948368": {
+      "kind": "tt.broadcast",
+      "scope": "function",
+      "operands": [{"op": "op_88854283423472"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {}
+    },
+    "op_88991722425280": {
+      "kind": "arith.muli",
+      "scope": "loop:0",
+      "operands": [{"iv": 0}, {"const": 8, "type": "i32"}],
+      "result_types": ["i32"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
+    },
+    "op_89129161507792": {
+      "kind": "tt.descriptor_load",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89197880816080"}, {"op": "op_88991722425280"}, {"const": 0, "type": "i32"}],
+      "result_types": ["tensor<8x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [0]}
+    },
+    "op_88854283423680": {
+      "kind": "arith.extf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89129161507792"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"loop.cluster": 0, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722425520": {
+      "kind": "arith.addf",
+      "scope": "loop:0",
+      "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
+      "result_types": ["f32"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88716844698560": {
+      "kind": "tt.reduce.return",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722425520"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_88991722425760": {
+      "kind": "tt.reduce",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283423680"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 2, "loop.stage": 1, "reduction_ordering": "unordered", "ttg.partition": [2]}
+    },
+    "op_88991722426000": {
+      "kind": "arith.divf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722425760"}, {"const": 512, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 3, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722426240": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283423680"}, {"op": "op_88854283423680"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 1, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722426480": {
+      "kind": "arith.addf",
+      "scope": "loop:0",
+      "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
+      "result_types": ["f32"],
+      "attributes": {"fastmath": "#arith.fastmath<none>"}
+    },
+    "op_88716844698736": {
+      "kind": "tt.reduce.return",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722426480"}],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_88991722426720": {
+      "kind": "tt.reduce",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722426240"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 5, "loop.stage": 1, "reduction_ordering": "unordered", "ttg.partition": [2]}
+    },
+    "op_88991722426960": {
+      "kind": "arith.divf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722426720"}, {"const": 512, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 6, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722427200": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722426000"}, {"op": "op_88991722426000"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 7, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722427440": {
+      "kind": "arith.subf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722426960"}, {"op": "op_88991722427200"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 8, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722427680": {
+      "kind": "arith.addf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722427440"}, {"op": "op_88785563947984"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 9, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88854283423888": {
+      "kind": "math.sqrt",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722427680"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 9, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722427920": {
+      "kind": "arith.divf",
+      "scope": "loop:0",
+      "operands": [{"const": 1, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}, {"op": "op_88854283423888"}],
+      "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 10, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88854283424096": {
+      "kind": "tt.expand_dims",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722426000"}],
+      "result_types": ["tensor<8x1xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 3, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88785563948560": {
+      "kind": "tt.broadcast",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283424096"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"loop.cluster": 3, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722428160": {
+      "kind": "arith.subf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283423680"}, {"op": "op_88785563948560"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 4, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88854283424304": {
+      "kind": "tt.expand_dims",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722427920"}],
+      "result_types": ["tensor<8x1xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"axis": 1, "loop.cluster": 10, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88785563948752": {
+      "kind": "tt.broadcast",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88854283424304"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"loop.cluster": 10, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722428400": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722428160"}, {"op": "op_88785563948752"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 11, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722428640": {
+      "kind": "arith.mulf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722428400"}, {"op": "op_88785563948176"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 12, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88991722428880": {
+      "kind": "arith.addf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722428640"}, {"op": "op_88785563948368"}],
+      "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 13, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_88854283424512": {
+      "kind": "arith.truncf",
+      "scope": "loop:0",
+      "operands": [{"op": "op_88991722428880"}],
+      "result_types": ["tensor<8x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
+      "attributes": {"loop.cluster": 14, "loop.stage": 1, "ttg.partition": [2]}
+    },
+    "op_89129161508736": {
+      "kind": "tt.descriptor_store",
+      "scope": "loop:0",
+      "operands": [{"op": "op_89197880816464"}, {"op": "op_88854283424512"}, {"op": "op_88991722425280"}, {"const": 0, "type": "i32"}],
+      "result_types": [],
+      "attributes": {"buffer.id": 0, "loop.cluster": 15, "loop.stage": 1, "reduce_kind": 0, "tt.num_buffers": 1, "ttg.partition": [1]}
+    },
+    "op_88441966585248": {
+      "kind": "scf.yield",
+      "scope": "loop:0",
+      "operands": [],
+      "result_types": [],
+      "attributes": {}
+    },
+    "op_89129161509056": {
+      "kind": "scf.for",
+      "scope": "function",
+      "operands": [{"op": "op_88510686049712"}, {"op": "op_88991722425040"}, {"op": "op_88510686049968"}],
+      "result_types": [],
+      "attributes": {"tt.modulo_ii": 594, "tt.num_stages": 2, "tt.scheduled_max_stage": 1}
+    },
+    "op_88441966585472": {
+      "kind": "tt.return",
+      "scope": "function",
+      "operands": [],
+      "result_types": [],
+      "attributes": {}
+    }
+  },
+  "loops": [
+    {
+      "loop_id": 0,
+      "is_outer": false,
+      "trip_count": 4,
+      "trip_count_estimated": true,
+      "induction_var": {"name": "iv", "type": "i32"},
+      "lower_bound": {"op": "op_88510686049712"},
+      "upper_bound": {"op": "op_88991722425040"},
+      "step": {"op": "op_88510686049968"},
+      "min_ii": 594, "res_mii": 594, "rec_mii": 0,
+      "ddg": {
+        "nodes": [
+          {"id": 0, "op_ref": "op_88991722425280", "op_kind": "arith.muli", "pipeline": "CUDA", "latency": 1, "self_latency": 1, "occupancy": 1, "min_warps": 1, "is_super_node": false},
+          {"id": 1, "op_ref": "op_89129161507792", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "latency": 748, "self_latency": 30, "occupancy": 48, "min_warps": 1, "is_super_node": false},
+          {"id": 2, "op_ref": "op_88854283423680", "op_kind": "arith.extf", "pipeline": "CUDA", "latency": 26, "self_latency": 16, "occupancy": 16, "min_warps": 4, "is_super_node": false},
+          {"id": 3, "op_ref": "op_88991722425760", "op_kind": "tt.reduce", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 4, "op_ref": "op_88991722426000", "op_kind": "arith.divf", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 5, "op_ref": "op_88991722426240", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 34, "self_latency": 32, "occupancy": 32, "min_warps": 4, "is_super_node": false},
+          {"id": 6, "op_ref": "op_88991722426720", "op_kind": "tt.reduce", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 7, "op_ref": "op_88991722426960", "op_kind": "arith.divf", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 8, "op_ref": "op_88991722427200", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 9, "op_ref": "op_88991722427440", "op_kind": "arith.subf", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 10, "op_ref": "op_88991722427680", "op_kind": "arith.addf", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 11, "op_ref": "op_88854283423888", "op_kind": "math.sqrt", "pipeline": "SFU", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 12, "op_ref": "op_88991722427920", "op_kind": "arith.divf", "pipeline": "CUDA", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 13, "op_ref": "op_88854283424096", "op_kind": "tt.expand_dims", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 14, "op_ref": "op_88785563948560", "op_kind": "tt.broadcast", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 15, "op_ref": "op_88991722428160", "op_kind": "arith.subf", "pipeline": "CUDA", "latency": 32, "self_latency": 32, "occupancy": 32, "min_warps": 4, "is_super_node": false},
+          {"id": 16, "op_ref": "op_88854283424304", "op_kind": "tt.expand_dims", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 17, "op_ref": "op_88785563948752", "op_kind": "tt.broadcast", "pipeline": "NONE", "latency": 0, "self_latency": 0, "occupancy": 0, "min_warps": 4, "is_super_node": false},
+          {"id": 18, "op_ref": "op_88991722428400", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 34, "self_latency": 32, "occupancy": 32, "min_warps": 4, "is_super_node": false},
+          {"id": 19, "op_ref": "op_88991722428640", "op_kind": "arith.mulf", "pipeline": "CUDA", "latency": 34, "self_latency": 32, "occupancy": 32, "min_warps": 4, "is_super_node": false},
+          {"id": 20, "op_ref": "op_88991722428880", "op_kind": "arith.addf", "pipeline": "CUDA", "latency": 32, "self_latency": 32, "occupancy": 32, "min_warps": 4, "is_super_node": false},
+          {"id": 21, "op_ref": "op_88854283424512", "op_kind": "arith.truncf", "pipeline": "CUDA", "latency": 26, "self_latency": 16, "occupancy": 16, "min_warps": 4, "is_super_node": false},
+          {"id": 22, "op_ref": "op_89129161508736", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "latency": 546, "self_latency": 30, "occupancy": 546, "min_warps": 1, "is_super_node": false}
+        ],
+        "edges": [
+          {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},
+          {"src": 1, "dst": 2, "kind": "data", "distance": 0, "latency": 748},
+          {"src": 2, "dst": 3, "kind": "data", "distance": 0, "latency": 26},
+          {"src": 3, "dst": 4, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 2, "dst": 5, "kind": "data", "distance": 0, "latency": 26},
+          {"src": 2, "dst": 5, "kind": "data", "distance": 0, "latency": 26},
+          {"src": 5, "dst": 6, "kind": "data", "distance": 0, "latency": 34},
+          {"src": 6, "dst": 7, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 4, "dst": 8, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 4, "dst": 8, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 7, "dst": 9, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 8, "dst": 9, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 9, "dst": 10, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 10, "dst": 11, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 11, "dst": 12, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 4, "dst": 13, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 13, "dst": 14, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 2, "dst": 15, "kind": "data", "distance": 0, "latency": 26},
+          {"src": 14, "dst": 15, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 12, "dst": 16, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 16, "dst": 17, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 15, "dst": 18, "kind": "data", "distance": 0, "latency": 32},
+          {"src": 17, "dst": 18, "kind": "data", "distance": 0, "latency": 0},
+          {"src": 18, "dst": 19, "kind": "data", "distance": 0, "latency": 34},
+          {"src": 19, "dst": 20, "kind": "data", "distance": 0, "latency": 34},
+          {"src": 20, "dst": 21, "kind": "data", "distance": 0, "latency": 32},
+          {"src": 21, "dst": 22, "kind": "data", "distance": 0, "latency": 26},
+          {"src": 0, "dst": 22, "kind": "data", "distance": 0, "latency": 1}
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Summary:
Generate `ddg.json` (modulo scheduler Data Dependence Graph, schema `ddg-0.1`) for each sched2tlx example case from its `pre_modulo.ttgir` via `TRITON_MODULO_DUMP_DDG` (added in D108942541), capturing the solver-input layer alongside the existing `schedule_graph.json`. Split out of D109476374, which retains the `generating_ddg_json.md` / `ddg_validation_harness.md` docs.

Authored with Claude.

Reviewed By: wlei-llvm

Differential Revision: D109489077


