### PR TITLE
[triton] Fix pre-commit code-formatting violations across the repo

### DIFF
--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -584,4 +584,3 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
-

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -34,7 +34,8 @@ static ttg::CGAEncodingAttr makeCGALayout(mlir::MLIRContext *ctx,
                                           llvm::ArrayRef<unsigned> CTASplitNum,
                                           llvm::ArrayRef<unsigned> CTAOrder) {
   unsigned rank = CTAsPerCGA.size();
-  bool isSingleCTA = llvm::all_of(CTAsPerCGA, [](unsigned c) { return c == 1; });
+  bool isSingleCTA =
+      llvm::all_of(CTAsPerCGA, [](unsigned c) { return c == 1; });
   if (isSingleCTA)
     return ttg::CGAEncodingAttr::get1CTALayout(ctx, rank);
   return ttg::CGAEncodingAttr::fromSplitParams(ctx, CTAsPerCGA, CTASplitNum,
@@ -185,8 +186,8 @@ void init_triton_tlx_ir(py::module &&m) {
              assert(order.size() == CTASplitNum.size() && "shape mismatch");
              assert(order.size() == CTAOrder.size() && "shape mismatch");
              auto context = self.getBuilder().getContext();
-             auto CTALayout = makeCGALayout(
-                 context, CTAsPerCGA, CTASplitNum, CTAOrder);
+             auto CTALayout =
+                 makeCGALayout(context, CTAsPerCGA, CTASplitNum, CTAOrder);
              return mlir::cast<Attribute>(ttg::SwizzledSharedEncodingAttr::get(
                  context, vectorSize, perPhase, maxPhase, order, CTALayout));
            })
@@ -205,8 +206,8 @@ void init_triton_tlx_ir(py::module &&m) {
              intervalPads.reserve(intervals.size());
              for (auto [i, p] : llvm::zip(intervals, paddings))
                intervalPads.emplace_back(i, p);
-             auto CTALayout = makeCGALayout(
-                 context, CTAsPerCGA, CTASplitNum, CTAOrder);
+             auto CTALayout =
+                 makeCGALayout(context, CTAsPerCGA, CTASplitNum, CTAOrder);
              return mlir::cast<Attribute>(ttg::PaddedSharedEncodingAttr::get(
                  context, intervalPads, order, shape, CTALayout));
            })
@@ -241,8 +242,8 @@ void init_triton_tlx_ir(py::module &&m) {
              /* Validation logic for user defined layout encoding end */
 
              auto context = self.getBuilder().getContext();
-             auto CTALayout = makeCGALayout(
-                 context, CTAsPerCGA, CTASplitNum, CTAOrder);
+             auto CTALayout =
+                 makeCGALayout(context, CTAsPerCGA, CTASplitNum, CTAOrder);
              if (swizzled) {
                return mlir::cast<Attribute>(ttg::NVMMASharedEncodingAttr::get(
                    context, shape, order, CTALayout, elemType, fp4Padded));
@@ -274,8 +275,8 @@ void init_triton_tlx_ir(py::module &&m) {
              SmallVector<unsigned, 2> CTAsPerCGA = {1, 1};
              SmallVector<unsigned, 2> CTASplitNum = {1, 1};
              SmallVector<unsigned, 2> CTAOrder = {1, 0};
-             auto CTALayout = makeCGALayout(
-                 context, CTAsPerCGA, CTASplitNum, CTAOrder);
+             auto CTALayout =
+                 makeCGALayout(context, CTAsPerCGA, CTASplitNum, CTAOrder);
              return tlx::wrapNoVerifyLayout(mlir::cast<Attribute>(
                  ttg::NvidiaMmaEncodingAttr::get(context, versionMajor,
                                                  versionMinor, warpsPerCTA,


### PR DESCRIPTION
Summary:
The facebookexperimental/triton OSS `Integration Tests / pre-commit (code formatting)` job runs `pre-commit run --all-files` over the entire repository, so it fails on any unformatted file regardless of whether the diff under test touches it. Several files (synced from internal, where formatting differs from the OSS hook config) were unformatted on master, turning the check red for unrelated diffs.

Reformatted the offending files with the exact hook-pinned tools — `yapf` 0.43.0, `ruff` 0.9.1, and `clang-format` 19.1.6 — using the in-repo `pyproject.toml` and `.clang-format` settings:

- `yapf`: `python/triton/knobs.py`, `third_party/amd/backend/compiler.py`, `third_party/tlx/tutorials/blackwell-multi-cta-layernorm_test.py`
- `clang-format`: `third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp`, `third_party/tlx/dialect/triton_tlx.cc`
- `ruff`: `python/test/unit/language/test_line_info.py` (removes the unused `is_hip` import, F401)
- `end-of-file-fixer`: `test/TritonGPU/amd/amd-update-async-wait-count.mlir` (strips an extra trailing blank line)

Everything is a pure whitespace/line-wrapping reformat except the single unused-import removal.

Reviewed By: FindHao

Differential Revision: D109496823


