### PR TITLE
[triton] Move launch.h to the nvidia backend dir (#1816)

### DIFF
--- a/python/test/unit/runtime/test_launch_kernel_core.py
+++ b/python/test/unit/runtime/test_launch_kernel_core.py
@@ -1,5 +1,5 @@
 """Tests that the JIT variadic launcher (driver.c::launchKernel) routes through
-the shared data-driven core ``triton_launch_kernel`` in ``triton/runtime/launch.h``.
+the shared data-driven core ``triton_launch_kernel`` in ``nvidia/backend/launch.h``.
 
 The default launch path (no ``TRITON_USE_C_DISPATCHER``) goes through
 ``kernel.run() -> CudaLauncher -> launchKernel``. To make these tests robust

--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -253,14 +253,14 @@ def test_launcher_src_exists():
 
 
 def test_launcher_src_includes_launch_h():
-    """Generated C source should include triton/runtime/launch.h."""
+    """Generated C source should include nvidia/backend/launch.h."""
     compiled = _compile_kernel(
         add_kernel,
         signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
         constexprs={"BLOCK": 1024},
     )
     src = compiled.asm["launcher_src"]
-    assert '#include "triton/runtime/launch.h"' in src
+    assert '#include "nvidia/backend/launch.h"' in src
 
 
 def test_launcher_src_no_python_h():
@@ -433,7 +433,7 @@ def test_launcher_src_compiles_with_gcc():
         # triton_include path resolution in buck link-tree environments.
         from pathlib import Path
         launch_h_content = Path(launch_h).read_text()
-        test_src = src.replace('#include "triton/runtime/launch.h"', launch_h_content)
+        test_src = src.replace('#include "nvidia/backend/launch.h"', launch_h_content)
         f.write(test_src)
         f.flush()
         try:

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -400,7 +400,7 @@ class CUDABackend(BaseBackend):
     def make_launcher_src(self, metadata, src):
         """Generate a standalone C launcher source from Level 0 metadata.
 
-        The generated C file includes ``triton/runtime/launch.h`` and implements
+        The generated C file includes ``nvidia/backend/launch.h`` and implements
         a single entry point ``triton_launch_<kernel>()`` that sets up
         CUlaunchConfig with compile-time-known parameters baked in as constants,
         builds the kernel parameter array, and calls ``cuLaunchKernelEx``.
@@ -469,7 +469,7 @@ class CUDABackend(BaseBackend):
         lines.append(f"/* Kernel: {kernel_name} */")
         lines.append(f"/* ABI version: {launch_meta['abi_version']} */")
         lines.append("")
-        lines.append('#include "triton/runtime/launch.h"')
+        lines.append('#include "nvidia/backend/launch.h"')
         lines.append("")
 
         # ---- Args struct ----

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -11,7 +11,7 @@
 
 /* Shared, Python-free data-driven launch core (params[]/TMA/attrs/launch).
  * The same core is used by TritonCC / AOT-T via make_launcher_src. */
-#include "triton/runtime/launch.h"
+#include "nvidia/backend/launch.h"
 
 typedef struct {
   PyObject_HEAD;

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -19,19 +19,15 @@ from triton.backends.driver import (
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dirs = [os.path.join(dirname, "include")]
-# Path(s) to the shared data-driven launcher core. driver.c is compiled via a
-# fixed Remote-Execution command that ignores include_dirs, so we inline this
-# header into the driver.c source at build time (see CudaUtils.__init__) rather
-# than relying on an -I path.
-#
-# The first candidate (backend/launch.h) is a vendored copy that ships with the
-# nvidia backend resources (the BUCK glob packages it next to driver.py), so it
-# is present in packaged/buck builds. The second is the canonical source used by
-# C/C++ consumers (cc_library triton_launch_h). Keep the two in sync; the
-# canonical is python/triton/runtime/launch.h.
+# Path to the shared data-driven launcher core. It lives in the nvidia backend
+# dir (next to driver.c / driver.py) and is the canonical source for C/C++
+# consumers (cc_library triton_launch_h). driver.c is compiled via a fixed
+# Remote-Execution command that ignores include_dirs, so we inline this header
+# into the driver.c source at build time (see CudaUtils.__init__) rather than
+# relying on an -I path. In both source and packaged/buck builds the header
+# sits next to this file.
 _launch_h_candidates = [
     os.path.join(dirname, "launch.h"),
-    os.path.join(dirname, "..", "..", "..", "python", "triton", "runtime", "launch.h"),
 ]
 libdevice_dir = os.path.join(dirname, "lib")
 libraries = ["libcuda.so.1"]
@@ -130,7 +126,7 @@ class CudaUtils(object):
         if launch_h_path is None:
             raise FileNotFoundError(f"launch.h not found in any of: {_launch_h_candidates}")
         launch_h_src = Path(launch_h_path).read_text()
-        include_marker = '#include "triton/runtime/launch.h"'
+        include_marker = '#include "nvidia/backend/launch.h"'
         if include_marker not in driver_src:
             raise RuntimeError(f"driver.c must contain the marker {include_marker!r} for "
                                "launch.h inlining, but it was not found")

--- a/third_party/nvidia/backend/launch.h
+++ b/third_party/nvidia/backend/launch.h
@@ -1,5 +1,5 @@
 /*
- * triton/runtime/launch.h — Minimal runtime header for Triton standalone
+ * nvidia/backend/launch.h — Minimal runtime header for Triton standalone
  * launchers.
  *
  * This header provides everything a compiler-generated launcher needs to call


### PR DESCRIPTION
Summary:

The shared launch core launch.h is CUDA/NVGPU-only (CUresult, cuLaunchKernelEx,
CUtensorMap, CUDA_VERSION) but lived in the backend-agnostic
python/triton/runtime/. Move it next to the nvidia backend at
third_party/nvidia/backend/launch.h and switch the logical include to
nvidia/backend/launch.h across every consumer: the JIT driver.c (+ driver.py
inlining marker), TritonCC/AOT-T make_launcher_src + AOT-T codegen, and the
AOT-T extension builder vendor copy. The triton_launch_h cc_library now exports
it from third_party (includes=[third_party]); the nvidia_files genrule picks it
up via the existing third_party/nvidia/backend glob (no separate copy). BUCK
regenerated from BUCK.template via reactor.

Addresses review feedback on D108692832 (hoy): a NVGPU-only launcher should live
in a target-specific folder.

Reviewed By: htyu

Differential Revision: D109508053
