### PR TITLE
[Triton][Frontend] Promote `_aggregate` to public (#10095) (#1822)

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -475,7 +475,7 @@ def test_unused_result():
     assert expected_err_msg == obtained_err_msg
 
 
-@tl.core._aggregate
+@triton.aggregate
 class Square:
     x: tl.tensor
 

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -26,7 +26,7 @@ def anchor(v):
     pass
 
 
-@tl.core._aggregate
+@triton.aggregate
 class Pair:
     first: tl.tensor
     second: tl.tensor
@@ -115,7 +115,7 @@ def test_jit_method():
     anchor(b)
 
 
-@tl.core._aggregate
+@triton.aggregate
 class TypeWithJitGetItem:
     value: tl.tensor
 
@@ -138,7 +138,7 @@ def test_jit_getitem():
     # CHECK: tt.return [[ARG0]]
 
 
-@tl.core._aggregate
+@triton.aggregate
 class TypeWithBuiltinInitializer:
     value: tl.tensor
 
@@ -158,7 +158,7 @@ def test_aggregate_initializers():
 
 def test_aggregate_auto_init_assigns_members():
 
-    @tl.core._aggregate
+    @triton.aggregate
     class State:
         x: tl.constexpr
         y: tl.constexpr
@@ -176,7 +176,7 @@ def test_aggregate_auto_init_with_tuples():
         x: tl.constexpr
         y: tl.constexpr
 
-    @tl.core._aggregate
+    @triton.aggregate
     class State:
         shape: tl.tuple
         strides: tl.tuple
@@ -197,7 +197,7 @@ def test_aggregate_auto_init_with_tuples():
 
 def test_aggregate_auto_init_respects_user_defined_init():
 
-    @tl.core._aggregate
+    @triton.aggregate
     class State:
         x: tl.constexpr
 
@@ -248,7 +248,7 @@ def test_call_in_loop():
         acc = accumulate(acc, i)
 
 
-@tl.core._aggregate
+@triton.aggregate
 class FunctionParent:
 
     @triton.jit
@@ -271,7 +271,7 @@ def test_function_name_mangling():
     FunctionParent.function_with_name()
 
 
-@tl.core._aggregate
+@triton.aggregate
 class AggregateWithConstexpr:
     a: tl.tensor
     b: tl.constexpr
@@ -304,7 +304,7 @@ def test_aggregate_with_constexpr():
     # CHECK: arith.addi %arg0, %cst : tensor<4xi32>
 
 
-@tl.core._aggregate
+@triton.aggregate
 class AggregateWithTuple:
     a: tl.tuple
 
@@ -389,7 +389,7 @@ def test_constexpr_getitem():
 @triton.constexpr_function
 def Box(T):
 
-    @tl.core._aggregate
+    @triton.aggregate
     class BoxImpl:
         value: T
 
@@ -495,7 +495,7 @@ def test_tuple_constexpr():
     run_parser(foo, args=(test, ))
 
 
-@tl.core._aggregate
+@triton.aggregate
 class AggregateWithConstexprFunction:
     val: tl.constexpr
     val_squared: tl.constexpr

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -28,9 +28,11 @@ from . import testing
 from . import tools
 
 must_use_result = language.core.must_use_result
+aggregate = language.core._aggregate
 
 __all__ = [
     "AsyncCompileMode",
+    "aggregate",
     "autotune",
     "cdiv",
     "CompilationError",
@@ -44,7 +46,6 @@ __all__ = [
     "JITFunction",
     "KernelInterface",
     "language",
-    "max_shared_mem",
     "MockTensor",
     "must_use_result",
     "next_power_of_2",


### PR DESCRIPTION
Summary:

Instead of the previous private name `triton.language.core._aggregate`, aggregates are now publicly available as `triton.aggregate` and `gluon.aggregate`.

The old spelling is also retained for backward compatibility.

Cherry-pick of upstream https://github.com/triton-lang/triton/pull/10095.

Reviewed By: dshi7

Differential Revision: D109611636


