### PR TITLE
Support multi-consumer TMA load buffers

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_code_partition_post_tma_multi_consumer_alloc.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_post_tma_multi_consumer_alloc.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition='num-buffers=2 post-channel-creation=1' | FileCheck %s
+
+// Regression test for a post-allocated TMA load whose SMEM tile feeds multiple
+// consumers. The memory planner can materialize one local_store/local_alloc
+// pair per consumer even when both allocs map to the same physical buffer.
+// Code partitioning should merge those stores before TMA lowering so the
+// descriptor load becomes one async TMA copy instead of tripping the
+// single-local-store invariant in optimizeTMALoads.
+
+// CHECK-LABEL: @post_tma_load_multi_consumer_allocs
+// CHECK-COUNT-1: ttng.async_tma_copy_global_to_local
+// CHECK: ttng.wait_barrier {{.*}}async_task_id = array<i32: 1>
+// CHECK: ttg.local_load {{.*}}async_task_id = array<i32: 1>
+// CHECK: ttng.wait_barrier {{.*}}async_task_id = array<i32: 2>
+// CHECK: ttg.local_load {{.*}}async_task_id = array<i32: 2>
+// CHECK-NOT: tt.descriptor_load
+// CHECK: tt.return
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @post_tma_load_multi_consumer_allocs(%desc: !tt.tensordesc<tensor<128x64xf16, #shared>>, %out0: !tt.ptr<f16>, %out1: !tt.ptr<f16>) attributes {noinline = false} {
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %ptrs0 = tt.splat %out0 {async_task_id = array<i32: 1>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptrs1 = tt.splat %out1 {async_task_id = array<i32: 2>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %tile = tt.descriptor_load %desc[%c0, %c0] {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+    %alloc0 = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %alloc1 = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.local_store %tile, %alloc0 {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.local_store %tile, %alloc1 {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %loaded0 = ttg.local_load %alloc0 {async_task_id = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked>
+    %loaded1 = ttg.local_load %alloc1 {async_task_id = array<i32: 2>} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked>
+    %consumer0 = arith.addf %loaded0, %loaded0 {async_task_id = array<i32: 1>} : tensor<128x64xf16, #blocked>
+    %consumer1 = arith.subf %loaded1, %loaded1 {async_task_id = array<i32: 2>} : tensor<128x64xf16, #blocked>
+    tt.store %ptrs0, %consumer0 {async_task_id = array<i32: 1>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    tt.store %ptrs1, %consumer1 {async_task_id = array<i32: 2>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3587,7 +3587,7 @@ void insertAsyncComm(
 
     for (const auto &token : commChannel.tokens) {
       // Use token for producer acquire and consumer release.
-      if (commChannel.consumerBarriers.empty()) {
+      if (!commChannel.consumerBarriers.count(token.first)) {
         // Insert ProducerAcquireOp before the producer.
         auto producerAcquirePoint =
             getSameLevelOp(headConsumer, tmaHeadProducer);
@@ -3889,7 +3889,7 @@ void insertAsyncComm(
 
       // Insert ConsumerReleaseOp, if consumer is not a TCGen5MMAOp. For
       // TCGen5MMAOp, TCGen5MMAOp lowering will handle the ConsumerReleaseOp.
-      if (commChannel.consumerBarriers.empty()) {
+      if (!commChannel.consumerBarriers.count(token.first)) {
         auto consumerReleasePoint =
             consumerReleaseHeuristic(tailProducer, tailConsumer, token.first);
         auto subtiled = getEnclosingSubtiledRegionTile(consumerReleasePoint);
@@ -4266,6 +4266,93 @@ static void mergeDuplicateLocalAllocs(triton::FuncOp &funcOp) {
   }
 }
 
+static bool haveSameIntegerAttr(Operation *a, Operation *b,
+                                StringRef attrName) {
+  auto attrA = a->getAttrOfType<IntegerAttr>(attrName);
+  auto attrB = b->getAttrOfType<IntegerAttr>(attrName);
+  if (!attrA || !attrB)
+    return attrA == attrB;
+  return attrA.getInt() == attrB.getInt();
+}
+
+static bool canShareTMALoadBuffer(ttg::LocalAllocOp a, ttg::LocalAllocOp b) {
+  if (a.getType() != b.getType())
+    return false;
+  auto bufferIdA = a->getAttrOfType<IntegerAttr>("buffer.id");
+  auto bufferIdB = b->getAttrOfType<IntegerAttr>("buffer.id");
+  if (!bufferIdA || !bufferIdB || bufferIdA.getInt() != bufferIdB.getInt())
+    return false;
+  return haveSameIntegerAttr(a, b, "buffer.offset") &&
+         haveSameIntegerAttr(a, b, "buffer.copy");
+}
+
+static void mergeDuplicateTMALoadLocalStores(triton::FuncOp &funcOp) {
+  SmallVector<tt::DescriptorLoadOp> tmaLoads;
+  funcOp.walk([&](tt::DescriptorLoadOp loadOp) { tmaLoads.push_back(loadOp); });
+
+  for (auto loadOp : tmaLoads) {
+    SmallVector<ttg::LocalStoreOp> localStores;
+    for (Operation *user : loadOp->getUsers()) {
+      auto storeOp = dyn_cast<ttg::LocalStoreOp>(user);
+      if (!storeOp)
+        continue;
+      if (storeOp.getSrc() != loadOp.getResult())
+        continue;
+      auto allocOp = storeOp.getDst().getDefiningOp<ttg::LocalAllocOp>();
+      if (!allocOp)
+        continue;
+      localStores.push_back(storeOp);
+    }
+
+    if (localStores.size() < 2)
+      continue;
+
+    llvm::sort(localStores, [](ttg::LocalStoreOp a, ttg::LocalStoreOp b) {
+      return appearsBefore(a.getOperation(), b.getOperation());
+    });
+
+    SmallPtrSet<Operation *, 8> erasedStores;
+    for (unsigned i = 0; i < localStores.size(); ++i) {
+      auto canonicalStore = localStores[i];
+      if (erasedStores.contains(canonicalStore.getOperation()))
+        continue;
+      auto canonicalAlloc =
+          canonicalStore.getDst().getDefiningOp<ttg::LocalAllocOp>();
+      if (!canonicalAlloc)
+        continue;
+
+      for (unsigned j = i + 1; j < localStores.size(); ++j) {
+        auto duplicateStore = localStores[j];
+        if (erasedStores.contains(duplicateStore.getOperation()))
+          continue;
+        auto duplicateAlloc =
+            duplicateStore.getDst().getDefiningOp<ttg::LocalAllocOp>();
+        if (!duplicateAlloc)
+          continue;
+        if (!canShareTMALoadBuffer(canonicalAlloc, duplicateAlloc))
+          continue;
+
+        LLVM_DEBUG({
+          LDBG("mergeDuplicateTMALoadLocalStores: merging duplicate store for "
+               "descriptor load");
+          loadOp->dump();
+          LDBG("  canonical alloc:");
+          canonicalAlloc->dump();
+          LDBG("  duplicate alloc:");
+          duplicateAlloc->dump();
+        });
+
+        duplicateAlloc.getResult().replaceAllUsesWith(
+            canonicalAlloc.getResult());
+        erasedStores.insert(duplicateStore.getOperation());
+        duplicateStore.erase();
+        if (duplicateAlloc->use_empty())
+          duplicateAlloc.erase();
+      }
+    }
+  }
+}
+
 // Remove redundant TMEM zeroing stores.
 // When a TMEMAllocOp is used as operand D of a TCGen5MMAOp with
 // useAccumulator=false (on the first iteration), any preceding
@@ -4537,6 +4624,9 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
 }
 
 void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
+  // Merge duplicate TMA-load local stores before post-channel discovery.
+  mergeDuplicateTMALoadLocalStores(funcOp);
+
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;
   collectPostChannels(channelsOrigin, funcOp);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
@@ -49,6 +49,14 @@ Step 11: replaceBufferReuse        — rewrite non-representative allocs
 Step 12: specializeRegion          — clone ops into WarpSpecializeOp regions
 ```
 
+Before channel discovery, the post-allocated path also merges duplicate
+`descriptor_load -> local_store -> local_alloc` chains when memory planning has
+assigned the local allocs the same physical `buffer.id`, layout, offset, and
+copy count. This represents one TMA-loaded SMEM tile with multiple consumers,
+for example an A tile consumed by both scalar normalization math and a gen5 MMA.
+After merging, channel discovery sees one producer-side store and multiple
+consumer uses of the same SMEM buffer.
+
 ## `doBufferAllocation` — Pre-pass
 
 **Function**: `doBufferAllocation(funcOp)`
@@ -171,6 +179,12 @@ Creates synchronization tokens for each channel group:
 - Results are stored in a `CommChannel` struct per channel, containing
   `tokens` (per consumer task ID), optional `producerBarrier` (for TMA/gen5),
   and optional `consumerBarriers` (for gen5 inline barriers).
+
+Channels can mix gen5 and non-gen5 consumers. In that case, gen5 consumers use
+their inline completion barrier while non-gen5 consumers still get token-based
+producer acquire and consumer release operations. Synchronization insertion must
+therefore check `consumerBarriers` per consumer task ID rather than treating the
+whole channel as all-gen5 or all-token-based.
 
 ## Synchronization Insertion
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/MemoryLowering.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/MemoryLowering.md
@@ -97,6 +97,13 @@ loads for the same MMA), they are fused onto a single barrier:
 4. **Multiple copies, one wait**: Each `AsyncTMACopyGlobalToLocalOp` references
    the shared barrier. The consumer issues a single `WaitBarrierOp`.
 
+In the post-allocated path, the inverse shape is also supported after code
+partitioning merges duplicate `ttg.local_store` ops for the same TMA descriptor
+load: one TMA descriptor load can feed one SMEM allocation with multiple
+consumers. Memory lowering emits a single `AsyncTMACopyGlobalToLocalOp` for
+that allocation, creates wait barriers for each consumer task, and removes the
+now-redundant high-level descriptor load and producer-side local store.
+
 See [Barrier Fusion](BarrierFusion.md) for more details.
 
 ## TMA Store Lowering


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1832

Post-allocation AutoWS can materialize duplicate local_store/local_alloc chains for a single descriptor_load when the same physical SMEM tile feeds both scalar math and gen5 MMA. Merge those local stores before post-channel discovery, and make synchronization insertion handle mixed gen5 and token consumers per task. This lets memory lowering emit one async TMA load for the shared allocation while preserving per-consumer waits.

Authored with Claude.