### PR TITLE
 [AutoWS] Fix use-after-free and dominance error in SinkTMEMLoad (#1837)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -158,8 +158,17 @@ public:
     Value newToken = sinkValueRedefinition(rewriter, load.getDep(),
                                            load.getToken(), domOp->getBlock());
     if (newToken != load.getToken()) {
-      for (OpOperand *use : uses)
-        use->set(newToken);
+      // Iterate the live use list with make_early_inc_range: the OpOperand*
+      // captured above may dangle (sinkValueRedefinition can reallocate operand
+      // storage) and set() mutates the list. Skip uses newToken does not
+      // dominate -- when threaded out of an enclosing region it is that
+      // region's result, which does not dominate uses inside the region; those
+      // keep the original token, which still dominates them.
+      DominanceInfo postSinkDomInfo;
+      for (OpOperand &use :
+           llvm::make_early_inc_range(load.getToken().getUses()))
+        if (postSinkDomInfo.properlyDominates(newToken, use.getOwner()))
+          use.set(newToken);
     }
     return success();
   }

--- a/test/TritonGPU/hoist-tmem-alloc.mlir
+++ b/test/TritonGPU/hoist-tmem-alloc.mlir
@@ -393,3 +393,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %result1, %token2 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token
   }
 }
+
+// -----
+
+// Regression test for SinkTMEMLoad. The tmem_load's dep token is defined outside
+// an enclosing scf.if, so sinkValueRedefinition threads the token *out* of the if
+// and the redefined token becomes the if's own result, which does not dominate
+// uses inside the if. The in-if token use (%ld_tok, consumed by "token_user")
+// must therefore keep the original token. Redirecting it used to (a) deref an
+// OpOperand* invalidated by the threaded yield's operand-storage reallocation
+// (use-after-free, caught under ASAN) and (b) point the in-if use at the if
+// result -> `operand does not dominate this use` (deterministic verifier error
+// without the fix; "token_user" keeps a stable, non-reallocated operand so the
+// bad redirect lands).
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sink_tmem_load_through_if
+  // CHECK: scf.if
+  // The load is sunk below "barrier", and "token_user" keeps the load's own
+  // token (%[[LD_TOK]]) rather than the non-dominating scf.if result.
+  // CHECK: "barrier"
+  // CHECK: %{{.*}}, %[[LD_TOK:.*]] = ttng.tmem_load
+  // CHECK: "use"
+  // CHECK: "token_user"(%[[LD_TOK]])
+  tt.func public @sink_tmem_load_through_if(%mem: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg_tok: !ttg.async.token, %cnd: i1, %n: i32) -> !ttg.async.token {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %res = scf.for %i = %c0_i32 to %n step %c1_i32 iter_args(%tok = %arg_tok) -> (!ttg.async.token)  : i32 {
+      %if_tok = scf.if %cnd -> (!ttg.async.token) {
+        %ld, %ld_tok = ttng.tmem_load %mem[%tok] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        "barrier"() : () -> ()
+        "use"(%ld) : (tensor<128x128xf32, #blocked>) -> ()
+        "token_user"(%ld_tok) : (!ttg.async.token) -> ()
+        scf.yield %tok : !ttg.async.token
+      } else {
+        scf.yield %tok : !ttg.async.token
+      }
+      scf.yield %if_tok : !ttg.async.token
+    }
+    tt.return %res : !ttg.async.token
+  }
+}


### PR DESCRIPTION
Summary:
### Issue
`SinkTMEMLoad` (in `HoistTMEMAlloc`) sinks a tmem_load toward its result's users and rewires its dependency token. When the load sits inside an scf.if/scf.for but its incoming token is defined outside that region, sinkValueRedefinition rebuilds the load's output token as a new result of that region (so out-of-region users stay valid). The pass then had two bugs when repointing the token's uses to that new result:

  1. Use-after-free (UAF): rebuilding the token appends operands to the region's yields, reallocating their operand storage — but the pass wrote through OpOperand*  pointers snapshotted before that reallocation. It's latent in normal builds (the write lands on freed memory and is silently lost), but `MLIR_ENABLE_DUMP=1` churns the heap so the freed block is reused → corruption → crash in a later canonicalize. ASAN flags it directly.
  2. Dominance violation: it repointed token uses inside the region to the new region result, which doesn't dominate them (operand does not dominate this use).

### Fix
iterate the live use list with make_early_inc_range (no stale pointers — mirrors upstream [#6433](https://github.com/triton-lang/triton/pull/6433)'s fix for the sibling CombineTMEMLoadAndStore UAF), and only repoint uses the new token dominates; in-region uses keep the original token. 

This unblocks compiling DeepSeek-style blockwise scaled_mm (BlockWise1x128,BlockWise128x128) under `MLIR_ENABLE_DUMP=1`.


Test Plan:
New LIT regression test sink_tmem_load_through_if in test/TritonGPU/hoist-tmem-alloc.mlir: deterministically fails on the unfixed pass with error: operand does not dominate this use, passes with the fix. 

valgrind (memcheck) on the failing DeepSeek make_ttgir pipeline: 0 errors (was 47 invalid reads, free'd by sinkValueRedefinition / used at HoistTMEMAlloc.cpp).

```
  MLIR_ENABLE_DUMP=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm \
    --scaling-pair BlockWise1x128,BlockWise128x128 --m 4096 --n 4096 --k 4096 \
    --only triton_autows_fp8_gemm --metrics tflops
  - → compiles and runs (146 TFLOPS).
```

Differential Revision: D109758622

Pulled By: Sibylau


