### PR TITLE
[TLX][AMD] Port rotated 4-cluster FA pipeline to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1225,6 +1225,8 @@ Currently consumed only by the scaled-WMMA pattern (gfx1250). Regular
 
 [Persistent Flash Attention fwd — XCD zig-zag, cross-attention / decode](third_party/tlx/tutorials/amd_fa_persistent.py)
 
+[Rotated 4-cluster Flash Attention fwd](third_party/tlx/tutorials/amd_fa_cluster.py)
+
 [Fused addmm + GLU (Gated Linear Unit: out = x + x*y, x = A@B + bias)](third_party/tlx/tutorials/amd_addmm_glu.py)
 
 [IKBO Flash Attention (In-Kernel Broadcast Optimization, candidate/user broadcast)](third_party/tlx/tutorials/ikbo/ikbo_fa_triton.py)
@@ -1287,7 +1289,10 @@ gfx950 / CDNA4:
 
 `third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_amd_gemm_perf.py [--version {warp_pipeline|pipelined}]`
 
-`third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_amd_fa_perf.py [--version {simple|prefetch|persistent}]`
+`third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_amd_fa_perf.py [--version {simple|prefetch|persistent|cluster}]`
+
+Without `--version`, AMD FA perf runs `simple`, `prefetch`, and `persistent`; select
+`cluster` explicitly because it is D=128-only.
 
 `third_party/tlx/denoise.sh python third_party/tlx/tutorials/testing/test_amd_addmm_glu_perf.py [--version {tlx_baseline|tlx_simple_async|tlx_optimized_async|tlx_optimized|tlx_persistent}]`
 

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -648,7 +648,7 @@ void init_triton_llvm(py::module &&m) {
       "optimize_module",
       [](llvm::Module *mod, const llvm::OptimizationLevel &opt,
          std::string arch, std::string features, std::vector<std::string> flags,
-         bool enable_fp_fusion) {
+         bool enable_fp_fusion, bool disable_vector_combine) {
         if (mlir::triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))
           return;
         // Check to see if we are passing a list of flags to disable
@@ -679,11 +679,24 @@ void init_triton_llvm(py::module &&m) {
         PassInstrumentationCallbacks passInstrCb;
         StandardInstrumentations standardInstr(mod->getContext(),
                                                /*DebugLogging*/ true);
+        bool enablePassInstrumentation = false;
+        if (disable_vector_combine) {
+          // VectorCombinePass::name() returns the C++ class name, not the
+          // registry name "vector-combine".
+          const StringRef kVectorCombinePassName = "VectorCombinePass";
+          passInstrCb.registerShouldRunOptionalPassCallback(
+              [kVectorCombinePassName](StringRef passName, Any) {
+                return passName != kVectorCombinePassName;
+              });
+          enablePassInstrumentation = true;
+        }
         if (mlir::triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
           setLLVMOption<bool>("print-after-all", true);
           standardInstr.registerCallbacks(passInstrCb, &mam);
-          instrCbPtr = &passInstrCb;
+          enablePassInstrumentation = true;
         }
+        if (enablePassInstrumentation)
+          instrCbPtr = &passInstrCb;
 
         PipelineTuningOptions tuningOptions;
         tuningOptions.LoopUnrolling = true;
@@ -768,6 +781,7 @@ void init_triton_llvm(py::module &&m) {
       py::arg("arch") = "", py::arg("features") = "",
       py::arg("flags") = std::vector<std::string>{},
       py::arg("enable_fp_fusion") = false,
+      py::arg("disable_vector_combine") = false,
       py::call_guard<py::gil_scoped_release>());
 
   m.def(

--- a/test/TritonGPU/amd/accelerate-amd-matmul-chain-dot.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-chain-dot.mlir
@@ -183,3 +183,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+
+// -----
+
+// Cross-iteration chain-dot: in pipelined FA the QK dot result is yielded and
+// consumed as operand A of the PV dot on the next iteration.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dotOp0 = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dotOp1 = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+// CHECK-GFX950-LABEL: cross_iter_chain_dot_fa
+// CHECK-GFX950: tt.dot {{.*}} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>> -> tensor<128x128xf32, #mma>
+// CHECK-GFX950: tt.dot {{.*}} -> tensor<128x64xf32, #mma>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @cross_iter_chain_dot_fa(
+      %q: tensor<128x128xf16, #dotOp0>,
+      %k: tensor<128x64xf16, #dotOp1>,
+      %v: tensor<64x128xf16, #dotOp1>,
+      %acc_init: tensor<128x128xf32, #blocked>,
+      %p_init: tensor<128x64xf16, #dotOp0>,
+      %lb: index, %ub: index, %step: index) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #blocked>
+    %result:2 = scf.for %iv = %lb to %ub step %step
+        iter_args(%acc = %acc_init, %p_prev = %p_init) -> (tensor<128x128xf32, #blocked>, tensor<128x64xf16, #dotOp0>) {
+      %pv = tt.dot %p_prev, %v, %acc : tensor<128x64xf16, #dotOp0> * tensor<64x128xf16, #dotOp1> -> tensor<128x128xf32, #blocked>
+      %qk = tt.dot %q, %k, %cst : tensor<128x128xf16, #dotOp0> * tensor<128x64xf16, #dotOp1> -> tensor<128x64xf32, #blocked>
+      %qk_f16 = arith.truncf %qk : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+      %p_next = ttg.convert_layout %qk_f16 : tensor<128x64xf16, #blocked> -> tensor<128x64xf16, #dotOp0>
+      scf.yield %pv, %p_next : tensor<128x128xf32, #blocked>, tensor<128x64xf16, #dotOp0>
+    }
+    tt.return %result#0 : tensor<128x128xf32, #blocked>
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -498,7 +498,7 @@ class HIPBackend(BaseBackend):
             if len(paths) > 0:
                 llvm.link_extern_libs(llvm_mod, paths)
 
-        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, "", [], options.enable_fp_fusion)
+        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, "", [], options.enable_fp_fusion, True)
 
         # Architectures with architected SGPRs store the workgroup id in ttmp9 (X) and ttmp7 (Y[15:0], Z[31:16]).
         # These attributes are used to determine if Z should be masked out when loading Y. They are inferred during

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -5,6 +5,7 @@
 #include "TritonAMDGPUToLLVM/TargetUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/PatternMatch.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -692,6 +693,20 @@ bool canLoadDirectToLDS(const triton::AMD::TargetInfo &targetInfo,
   return true;
 }
 
+// For a region iter arg of an scf.for, return the yield operand that feeds it
+// on the back-edge. Returns {} if the parent isn't scf.for or the arg is the
+// induction variable.
+static Value resolveLoopBackedge(BlockArgument bbArg) {
+  auto forOp = dyn_cast<scf::ForOp>(bbArg.getOwner()->getParentOp());
+  if (!forOp)
+    return {};
+  auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  int iterArgIdx = bbArg.getArgNumber() - forOp.getNumInductionVars();
+  if (iterArgIdx < 0 || iterArgIdx >= (int)yieldOp.getNumOperands())
+    return {};
+  return yieldOp.getOperand(iterArgIdx);
+}
+
 bool isChainDotHead(tt::DotOpInterface dotOp, unsigned opIdx) {
   auto isInSameRegion = [&dotOp](Operation *op) {
     return op->getParentRegion() == dotOp->getParentRegion();
@@ -710,6 +725,37 @@ bool isChainDotHead(tt::DotOpInterface dotOp, unsigned opIdx) {
       }
     }
   }
+
+  // Cross-iteration: for each op in the forward slice (including dotOp itself)
+  // that is consumed by a scf.yield, resolve to the corresponding iter arg and
+  // check that iter arg's forward slice for a dot.
+  fwdSlices.insert(dotOp);
+  for (Operation *op : fwdSlices) {
+    for (Value result : op->getResults()) {
+      for (OpOperand &use : result.getUses()) {
+        auto yieldOp = dyn_cast<scf::YieldOp>(use.getOwner());
+        if (!yieldOp)
+          continue;
+        auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp());
+        if (!forOp)
+          continue;
+        BlockArgument nextIterArg =
+            forOp.getRegionIterArg(use.getOperandNumber());
+        SetVector<Operation *> argFwdSlices;
+        getForwardSlice(nextIterArg, &argFwdSlices, fwdOpt);
+        for (Operation *argOp : argFwdSlices) {
+          auto dOp = dyn_cast<tt::DotOpInterface>(argOp);
+          if (!dOp || dOp == dotOp)
+            continue;
+          Value dotOperand = (opIdx == 0) ? dOp.getA() : dOp.getB();
+          if (dotOperand == nextIterArg ||
+              (dotOperand.getDefiningOp() &&
+               argFwdSlices.contains(dotOperand.getDefiningOp())))
+            return true;
+        }
+      }
+    }
+  }
   return false;
 }
 
@@ -722,13 +768,44 @@ bool isChainDotTail(tt::DotOpInterface dotOp) {
   bwdOpt.filter = isInSameRegion;
   SetVector<Operation *> bwdSlices;
   Operation *opA = dotOp.getA().getDefiningOp();
-  if (!opA)
-    return false;
-  (void)getBackwardSlice(opA, &bwdSlices, bwdOpt);
-  if (llvm::find_if(bwdSlices, [](Operation *op) {
-        return isa<tt::DotOpInterface>(op);
-      }) != bwdSlices.end())
-    return true;
+  if (opA) {
+    (void)getBackwardSlice(opA, &bwdSlices, bwdOpt);
+    if (llvm::find_if(bwdSlices, [](Operation *op) {
+          return isa<tt::DotOpInterface>(op);
+        }) != bwdSlices.end())
+      return true;
+  }
+
+  // Cross-iteration: if operand A (or its backward slice) touches a block
+  // arg, resolve via the yield back-edge and check the backward slice of
+  // the yielded value for a dot (mirrors the intra-iteration check above).
+  SmallVector<BlockArgument, 4> bbArgs;
+  if (auto bbArg = dyn_cast<BlockArgument>(dotOp.getA())) {
+    bbArgs.push_back(bbArg);
+  } else if (opA) {
+    bwdSlices.insert(opA);
+    for (Operation *sliceOp : bwdSlices)
+      for (Value operand : sliceOp->getOperands())
+        if (auto bbArg = dyn_cast<BlockArgument>(operand))
+          bbArgs.push_back(bbArg);
+  }
+
+  for (BlockArgument bbArg : bbArgs) {
+    Value yieldVal = resolveLoopBackedge(bbArg);
+    if (!yieldVal)
+      continue;
+    Operation *yieldDef = yieldVal.getDefiningOp();
+    if (!yieldDef)
+      continue;
+    SetVector<Operation *> yieldBwdSlices;
+    (void)getBackwardSlice(yieldDef, &yieldBwdSlices, bwdOpt);
+    yieldBwdSlices.insert(yieldDef);
+    if (llvm::find_if(yieldBwdSlices, [&dotOp](Operation *op) {
+          return isa<tt::DotOpInterface>(op) && op != dotOp;
+        }) != yieldBwdSlices.end())
+      return true;
+  }
+
   return false;
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -111,12 +111,10 @@ bool canLoadDirectToLDS(const triton::AMD::TargetInfo &targetInfo,
                         RankedTensorType srcTy, Attribute dstEnc,
                         ArrayRef<int64_t> dstAllocShape, unsigned &vectorSize);
 
-// Check if the result of this tl.dot is used as opA or opB of another tl.dot
-// in the same region
+// Check if the result of this tl.dot is used as opA or opB of another tl.dot.
 bool isChainDotHead(mlir::triton::DotOpInterface dotOp, unsigned opIdx = 0);
 
-// Check if the opA of this tl.dot is the result of another tl.dot
-// in the same region
+// Check if the opA of this tl.dot is the result of another tl.dot.
 bool isChainDotTail(mlir::triton::DotOpInterface dotOp);
 
 // Software implementation of converting an 8-element vector of MXFP4 elements

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -2302,11 +2302,12 @@ enumerateClusterPartitions(int numClusters) {
 ///  - tcgen05 MMA (→TMEM) and TMEM copies operate on memdesc and yield an async
 ///    token / no value — never a register tensor. EXCLUDED explicitly so a
 ///    future tensor-typed result can't be miscounted.
-///  - Pointer-element tensors (`!tt.ptr<...>`) must not be split across WGs (the
+///  - Pointer-element tensors (`!tt.ptr<...>`) must not be split across WGs
+///  (the
 ///    partition scheduler can't form a pointer cross-WG channel), so they never
 ///    incur a register round-trip. EXCLUDED. See partition-scheduler-bugs.md.
-/// Net: only genuine register compute chains (the FA softmax `subf→exp2`) count;
-/// GEMM/wgrad cross-WG edges (all load/MMA) score zero.
+/// Net: only genuine register compute chains (the FA softmax `subf→exp2`)
+/// count; GEMM/wgrad cross-WG edges (all load/MMA) score zero.
 static bool isRegisterComputeValue(Operation *op) {
   if (!op || op->getNumResults() == 0)
     return false;
@@ -2367,10 +2368,10 @@ constexpr int kCrossWGRoundTripLatency = 500;
 /// resident, not a register hand-off, and (being unavoidable) are present in
 /// every candidate anyway. Net: zero for GEMM/LayerNorm/wgrad partitions; only
 /// a CUDA-chain cut (FA softmax) pays.
-static void accumulateCrossWGRoundTrip(
-    const ttg::ScheduleLoop &loop,
-    const llvm::SmallDenseMap<unsigned, int> &nodeToWg,
-    llvm::SmallDenseMap<int, int> &rtPerWg) {
+static void
+accumulateCrossWGRoundTrip(const ttg::ScheduleLoop &loop,
+                           const llvm::SmallDenseMap<unsigned, int> &nodeToWg,
+                           llvm::SmallDenseMap<int, int> &rtPerWg) {
   for (const auto &edge : loop.edges) {
     auto sIt = nodeToWg.find(edge.srcId);
     auto dIt = nodeToWg.find(edge.dstId);
@@ -4667,8 +4668,7 @@ struct ModuloSchedulePass
                   // Loops with their own candidate-k vary; loops with fewer
                   // candidates (a single fixed partition) clamp to their last
                   // one so they stay constant across variants.
-                  size_t idx =
-                      std::min(k, liveLoop.topPartitions.size() - 1);
+                  size_t idx = std::min(k, liveLoop.topPartitions.size() - 1);
                   finalizeLoopPartitionForDump(dstLoop,
                                                liveLoop.topPartitions[idx]);
                   if (idx < liveLoop.topPartitionCosts.size())

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -531,7 +531,7 @@ static bool getForwardSliceToPartition(Value v,
     auto onlyUsedByAtomicStore = [](Value v) {
       SetVector<Operation *> forwardSlice;
       getForwardSlice(v, &forwardSlice);
-      Operation *atomicStore;
+      Operation *atomicStore = nullptr;
       for (auto op : forwardSlice) {
         if (isa<AtomicRMWOp, DescriptorReduceOp>(op)) {
           atomicStore = op;

--- a/third_party/tlx/tutorials/amd_fa_cluster.py
+++ b/third_party/tlx/tutorials/amd_fa_cluster.py
@@ -1,0 +1,486 @@
+"""AMD CDNA4 Flash Attention forward with a rotated 4-cluster pipeline."""
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton.language.core import _aggregate as aggregate
+
+
+@triton.jit
+def _assume_strides(
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+):
+    tl.assume(stride_qz >= 0)
+    tl.assume(stride_qh >= 0)
+    tl.assume(stride_qm > 0)
+    tl.assume(stride_qk >= 0)
+    tl.assume(stride_kz >= 0)
+    tl.assume(stride_kh >= 0)
+    tl.assume(stride_kn > 0)
+    tl.assume(stride_kk >= 0)
+    tl.assume(stride_vz >= 0)
+    tl.assume(stride_vh >= 0)
+    tl.assume(stride_vn > 0)
+    tl.assume(stride_vk >= 0)
+    tl.assume(stride_oz >= 0)
+    tl.assume(stride_oh >= 0)
+    tl.assume(stride_om > 0)
+    tl.assume(stride_ok >= 0)
+
+
+@aggregate
+class SoftmaxState:
+    acc: tl.tensor
+    l_i: tl.tensor
+    m_i: tl.tensor
+
+    @triton.jit
+    def create(BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr):
+        return SoftmaxState(
+            tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32),
+            tl.full([BLOCK_M], 1.0, dtype=tl.float32),
+            tl.full([BLOCK_M], float("-inf"), dtype=tl.float32),
+        )
+
+    @triton.jit
+    def _nan_max_combine(a, b):
+        return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
+
+    @triton.jit
+    def _row_max(qk):
+        return tl.reduce(qk, 1, SoftmaxState._nan_max_combine)
+
+    @triton.jit
+    def vec1(
+        self,
+        qk,
+        start_n,
+        offs_m,
+        offs_n,
+        QK_SCALE: tl.constexpr,
+        DIAG_OFFSET: tl.constexpr,
+        MASK_STEPS: tl.constexpr,
+        IS_CAUSAL: tl.constexpr,
+    ):
+        if MASK_STEPS:
+            qk_sm = qk * QK_SCALE
+            if IS_CAUSAL:
+                kn = start_n + offs_n
+                qk_sm = tl.where(offs_m[:, None] + DIAG_OFFSET >= kn[None, :], qk_sm, float("-inf"))
+            m_ij = SoftmaxState._row_max(qk_sm)
+            m_new = tl.maximum(self.m_i, m_ij, propagate_nan=tl.PropagateNan.ALL)
+            p = tl.math.exp2(qk_sm - m_new[:, None])
+            alpha = tl.math.exp2(self.m_i - m_new)
+        else:
+            m_ij = SoftmaxState._row_max(qk) * QK_SCALE
+            m_new = tl.maximum(self.m_i, m_ij, propagate_nan=tl.PropagateNan.ALL)
+            p = tl.math.exp2(qk * QK_SCALE - m_new[:, None])
+            alpha = tl.math.exp2(self.m_i - m_new)
+        return SoftmaxState(self.acc, self.l_i, m_new), p, alpha
+
+    @triton.jit
+    def vec2(self, p, alpha, out_dtype: tl.constexpr):
+        l_ij = tl.sum(p, 1)
+        acc = self.acc * alpha[:, None]
+        l_i = self.l_i * alpha + l_ij
+        p_cast = p.to(out_dtype)
+        return SoftmaxState(acc, l_i, self.m_i), p_cast
+
+
+@triton.jit
+def _attn_inner_pipelined(
+    state,
+    q,
+    k_ptrs,
+    v_ptrs,
+    offs_m,
+    offs_n,
+    block_start,
+    block_end,
+    k_buf,
+    v_buf,
+    stride_kn,
+    stride_vn,
+    QK_SCALE: tl.constexpr,
+    DIAG_OFFSET: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BUF_DEPTH: tl.constexpr,
+    MASK_STEPS: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    # Prologue: prime the pipeline for output tile block_start.
+    b0 = block_start
+    tok_k0 = tlx.async_load(k_ptrs + b0 * BLOCK_N * stride_kn, tlx.local_view(k_buf, 0))
+    tok_v0 = tlx.async_load(v_ptrs + b0 * BLOCK_N * stride_vn, tlx.local_view(v_buf, 0))
+    tlx.async_load_commit_group([tok_k0])
+    tlx.async_load_commit_group([tok_v0])
+    tok_k1 = tlx.async_load(k_ptrs + (b0 + 1) * BLOCK_N * stride_kn, tlx.local_view(k_buf, 1))
+    tlx.async_load_commit_group([tok_k1])
+
+    wait0 = tlx.async_load_wait_group(2)
+    kt0 = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, 0)), token=wait0, relaxed=True)
+    qk = tl.dot(q, kt0)
+    state, p_c, alpha_c = state.vec1(
+        qk,
+        b0 * BLOCK_N,
+        offs_m,
+        offs_n,
+        QK_SCALE,
+        DIAG_OFFSET,
+        MASK_STEPS,
+        IS_CAUSAL,
+    )
+
+    tl.debug_barrier()
+    tok_k2 = tlx.async_load(k_ptrs + (b0 + 2) * BLOCK_N * stride_kn, tlx.local_view(k_buf, 0))
+    tlx.async_load_commit_group([tok_k2])
+    wait1 = tlx.async_load_wait_group(1)
+    kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, 1)), token=wait1, relaxed=True)
+    tok_v1 = tlx.async_load(v_ptrs + (b0 + 1) * BLOCK_N * stride_vn, tlx.local_view(v_buf, 1))
+    tlx.async_load_commit_group([tok_v1])
+
+    for block_n in tl.range(block_start, block_end - 3, num_stages=0):
+        cur_slot = (block_n - block_start) % BUF_DEPTH
+        nxt_slot = (block_n + 1 - block_start) % BUF_DEPTH
+        ack_n = (block_n + 3) * BLOCK_N
+        acv_n = (block_n + 2) * BLOCK_N
+        ahead_n = (block_n + 1) * BLOCK_N
+
+        with tlx.warp_pipeline_stage("dot1", priority=0):
+            qk = tl.dot(q, kt_dot)
+            state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+
+        tlx.async_load_wait_group(1)
+
+        with tlx.warp_pipeline_stage("mem1", priority=1):
+            v_dot = tlx.local_load(tlx.local_view(v_buf, cur_slot), relaxed=True)
+            tok_k = tlx.async_load(k_ptrs + ack_n * stride_kn, tlx.local_view(k_buf, nxt_slot))
+            tlx.async_load_commit_group([tok_k])
+
+        with tlx.warp_pipeline_stage("dot2", priority=0):
+            acc = tl.dot(p_dot, v_dot, state.acc)
+            state = SoftmaxState(acc, state.l_i, state.m_i)
+            state, p_c, alpha_c = state.vec1(
+                qk,
+                ahead_n,
+                offs_m,
+                offs_n,
+                QK_SCALE,
+                DIAG_OFFSET,
+                MASK_STEPS,
+                IS_CAUSAL,
+            )
+
+        tlx.async_load_wait_group(1)
+
+        with tlx.warp_pipeline_stage("mem2", priority=1):
+            kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, cur_slot)), relaxed=True)
+            tok_v = tlx.async_load(v_ptrs + acv_n * stride_vn, tlx.local_view(v_buf, cur_slot))
+            tlx.async_load_commit_group([tok_v])
+
+    # Drain the last three output tiles without out-of-bounds global prefetches.
+    nm3 = block_end - 3
+    nm2 = block_end - 2
+    nm1 = block_end - 1
+    s_nm3 = (nm3 - block_start) % BUF_DEPTH
+    s_nm2 = (nm2 - block_start) % BUF_DEPTH
+    s_nm1 = (nm1 - block_start) % BUF_DEPTH
+
+    qk = tl.dot(q, kt_dot)
+    tlx.async_load_wait_group(2)
+    v_dot = tlx.local_load(tlx.local_view(v_buf, s_nm3), relaxed=True)
+    state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+    acc = tl.dot(p_dot, v_dot, state.acc)
+    state = SoftmaxState(acc, state.l_i, state.m_i)
+    state, p_c, alpha_c = state.vec1(
+        qk,
+        nm2 * BLOCK_N,
+        offs_m,
+        offs_n,
+        QK_SCALE,
+        DIAG_OFFSET,
+        MASK_STEPS,
+        IS_CAUSAL,
+    )
+    tl.debug_barrier()
+    tok_vlast = tlx.async_load(v_ptrs + nm1 * BLOCK_N * stride_vn, tlx.local_view(v_buf, s_nm1))
+    tlx.async_load_commit_group([tok_vlast])
+    tlx.async_load_wait_group(2)
+    kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, s_nm1)), relaxed=True)
+
+    qk = tl.dot(q, kt_dot)
+    tlx.async_load_wait_group(1)
+    v_dot = tlx.local_load(tlx.local_view(v_buf, s_nm2), relaxed=True)
+    state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+    acc = tl.dot(p_dot, v_dot, state.acc)
+    state = SoftmaxState(acc, state.l_i, state.m_i)
+    state, p_c, alpha_c = state.vec1(
+        qk,
+        nm1 * BLOCK_N,
+        offs_m,
+        offs_n,
+        QK_SCALE,
+        DIAG_OFFSET,
+        MASK_STEPS,
+        IS_CAUSAL,
+    )
+
+    tlx.async_load_wait_group(0)
+    v_dot = tlx.local_load(tlx.local_view(v_buf, s_nm1), relaxed=True)
+    state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+    acc = tl.dot(p_dot, v_dot, state.acc)
+    state = SoftmaxState(acc, state.l_i, state.m_i)
+
+    return state
+
+
+@triton.jit
+def _attn_fwd_cluster_pipeline(
+    Q,
+    K,
+    V,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    N_CTX,
+    sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    _assume_strides(
+        stride_qz,
+        stride_qh,
+        stride_qm,
+        stride_qk,
+        stride_kz,
+        stride_kh,
+        stride_kn,
+        stride_kk,
+        stride_vz,
+        stride_vh,
+        stride_vn,
+        stride_vk,
+        stride_oz,
+        stride_oh,
+        stride_om,
+        stride_ok,
+    )
+
+    if IS_CAUSAL:
+        off_h = tl.program_id(0)
+        pid_m = tl.program_id(1)
+    else:
+        pid_m = tl.program_id(0)
+        off_h = tl.program_id(1)
+    off_z = tl.program_id(2)
+
+    q_off = off_z * stride_qz + off_h * stride_qh
+    k_off = off_z * stride_kz + off_h * stride_kh
+    v_off = off_z * stride_vz + off_h * stride_vh
+    o_off = off_z * stride_oz + off_h * stride_oh
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q = tl.load(
+        Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk,
+        mask=offs_m[:, None] < N_CTX,
+        other=0.0,
+    )
+
+    QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
+    DIAG_OFFSET: tl.constexpr = 0
+
+    state = SoftmaxState.create(BLOCK_M, HEAD_DIM)
+
+    BUF_DEPTH: tl.constexpr = 2
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, BUF_DEPTH)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, BUF_DEPTH)
+
+    k_ptrs = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+    v_ptrs = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
+
+    n_blocks = N_CTX // BLOCK_N
+
+    if IS_CAUSAL:
+        masked_blocks: tl.constexpr = BLOCK_M // BLOCK_N
+        causal_end = (pid_m + 1) * masked_blocks
+        n_full = causal_end - masked_blocks
+        if n_full > 0:
+            state = _attn_inner_pipelined(
+                state,
+                q,
+                k_ptrs,
+                v_ptrs,
+                offs_m,
+                offs_n,
+                0,
+                n_full,
+                k_buf,
+                v_buf,
+                stride_kn,
+                stride_vn,
+                QK_SCALE,
+                DIAG_OFFSET,
+                BLOCK_N,
+                BUF_DEPTH,
+                False,
+                True,
+            )
+        state = _attn_inner_pipelined(
+            state,
+            q,
+            k_ptrs,
+            v_ptrs,
+            offs_m,
+            offs_n,
+            n_full,
+            causal_end,
+            k_buf,
+            v_buf,
+            stride_kn,
+            stride_vn,
+            QK_SCALE,
+            DIAG_OFFSET,
+            BLOCK_N,
+            BUF_DEPTH,
+            True,
+            True,
+        )
+    else:
+        state = _attn_inner_pipelined(
+            state,
+            q,
+            k_ptrs,
+            v_ptrs,
+            offs_m,
+            offs_n,
+            0,
+            n_blocks,
+            k_buf,
+            v_buf,
+            stride_kn,
+            stride_vn,
+            QK_SCALE,
+            DIAG_OFFSET,
+            BLOCK_N,
+            BUF_DEPTH,
+            False,
+            False,
+        )
+
+    acc = state.acc / state.l_i[:, None]
+    o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+
+
+def _cluster_default_block_n(causal):
+    return 32 if causal else 64
+
+
+def _validate_inputs(q, k, v, causal, block_m, block_n, num_warps):
+    assert q.ndim == 4, f"cluster attention expects q to be 4D, got shape {tuple(q.shape)}"
+    B, H, N_CTX, D = q.shape
+    assert k.shape == (B, H, N_CTX, D), ("cluster attention supports square self-attention only: "
+                                         f"expected k shape {(B, H, N_CTX, D)}, got {tuple(k.shape)}")
+    assert v.shape == (B, H, N_CTX, D), ("cluster attention supports square self-attention only: "
+                                         f"expected v shape {(B, H, N_CTX, D)}, got {tuple(v.shape)}")
+    assert D == 128, f"cluster attention is validated only for D == 128, got {D}"
+    assert N_CTX % block_n == 0, f"cluster attention: N_CTX ({N_CTX}) must be a multiple of BLOCK_N ({block_n})"
+    assert N_CTX % block_m == 0, f"cluster attention: N_CTX ({N_CTX}) must be a multiple of BLOCK_M ({block_m})"
+
+    mfma_m = 32
+    assert block_m >= num_warps * mfma_m, (
+        f"cluster attention: BLOCK_M ({block_m}) must be >= num_warps ({num_warps}) * MFMA_M ({mfma_m})")
+    if causal:
+        assert block_m % block_n == 0, (
+            f"cluster attention causal: BLOCK_M ({block_m}) must be a multiple of BLOCK_N ({block_n})")
+        assert block_m // block_n >= 4, (
+            f"cluster attention causal: diagonal band BLOCK_M/BLOCK_N ({block_m // block_n}) must be >= 4 tiles")
+    else:
+        assert N_CTX // block_n >= 4, "cluster attention requires at least 4 K/V blocks"
+    return B, H, N_CTX, D
+
+
+def flash_attn_cluster_pipeline(q, k, v, sm_scale, causal=False, **kw):
+    mfma_m = 32
+    block_m = kw.pop("BLOCK_M", 256)
+    block_n = kw.pop("BLOCK_N", _cluster_default_block_n(causal))
+    num_warps = kw.pop("num_warps", min(8, max(1, block_m // mfma_m)))
+    waves_per_eu = kw.pop("waves_per_eu", 0 if causal else 2)
+    B, H, N_CTX, D = _validate_inputs(q, k, v, causal, block_m, block_n, num_warps)
+
+    o = torch.empty_like(q)
+    m_blocks = triton.cdiv(N_CTX, block_m)
+    grid = (H, m_blocks, B) if causal else (m_blocks, H, B)
+    _attn_fwd_cluster_pipeline[grid](
+        q,
+        k,
+        v,
+        o,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        o.stride(3),
+        N_CTX,
+        sm_scale,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        HEAD_DIM=D,
+        IS_CAUSAL=causal,
+        num_warps=num_warps,
+        waves_per_eu=waves_per_eu,
+        **kw,
+    )
+    return o
+
+
+def attention(q, k, v, sm_scale, causal, config=None):
+    config = {} if config is None else dict(config)
+    return flash_attn_cluster_pipeline(q, k, v, sm_scale, causal=causal, **config)

--- a/third_party/tlx/tutorials/amd_hstu_attn.py
+++ b/third_party/tlx/tutorials/amd_hstu_attn.py
@@ -5,9 +5,6 @@ import triton.language as tl
 import triton.language.extra.tlx as tlx
 import torch
 import torch.nn.functional as F
-import pytest
-import sys
-import argparse
 
 try:
     from triton.language.extra.libdevice import (

--- a/third_party/tlx/tutorials/testing/test_amd_fa_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_fa_perf.py
@@ -8,6 +8,8 @@ from triton.language.extra.tlx.tutorials.amd_fa_pipelined import (
     attention as _amd_fa_pipelined, )
 from triton.language.extra.tlx.tutorials.amd_fa_persistent import (
     attention as _amd_fa_persistent, )
+from triton.language.extra.tlx.tutorials.amd_fa_cluster import (
+    attention as _amd_fa_cluster, )
 
 from triton._internal_testing import is_hip
 
@@ -35,7 +37,10 @@ ATTENTION_METHODS = {
         }),
     "persistent":
     lambda q, k, v, sm_scale, causal: _amd_fa_persistent(q, k, v, sm_scale, causal),
+    "cluster":
+    lambda q, k, v, sm_scale, causal: _amd_fa_cluster(q, k, v, sm_scale, causal),
 }
+DEFAULT_ATTENTION_VERSIONS = ["simple", "prefetch", "persistent"]
 
 ref_lib = "SDPA"
 
@@ -43,11 +48,19 @@ ref_lib = "SDPA"
 def create_benchmark(versions):
     line_vals = [ref_lib.lower()] + versions
     line_names = [ref_lib] + versions
+    x_vals = [(1024, 128), (4096, 128), (8192, 128)] if "cluster" in versions else [
+        (1024, 64),
+        (4096, 64),
+        (8192, 64),
+        (1024, 128),
+        (4096, 128),
+        (8192, 128),
+    ]
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
             x_names=["N_CTX", "HEAD_DIM"],
-            x_vals=[(1024, 64), (4096, 64), (8192, 64), (1024, 128), (4096, 128), (8192, 128)],
+            x_vals=x_vals,
             line_arg="provider",
             line_vals=line_vals,
             line_names=line_names,
@@ -94,7 +107,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if is_hip():
-        versions = args.version if args.version else list(ATTENTION_METHODS.keys())
+        versions = args.version if args.version else DEFAULT_ATTENTION_VERSIONS
         print(f"Running benchmarks for: {versions}")
         benchmark = create_benchmark(versions)
         benchmark.run(print_data=True)

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -57,6 +57,8 @@ from triton.language.extra.tlx.tutorials.amd_fa_pipelined import (
     attention as _amd_fa_pipelined, )
 from triton.language.extra.tlx.tutorials.amd_fa_persistent import (
     attention as _amd_fa_persistent, )
+from triton.language.extra.tlx.tutorials.amd_fa_cluster import (
+    attention as _amd_fa_cluster, )
 from triton.language.extra.tlx.tutorials.amd_tdm_gemm_pipelined import (
     matmul as _amd_tdm_gemm_pipelined, )
 from triton.language.extra.tlx.tutorials.amd_gemm_warp_pipeline import (
@@ -1018,6 +1020,21 @@ def test_amd_fa_persistent_cross_attention(q_len, kv_len, causal):
     out = _amd_fa_persistent(q, k, v, sm, causal)
     valid = ~torch.isnan(ref.float())  # fully-masked rows (q_len > kv_len) are undefined
     torch.testing.assert_close(out.float()[valid], ref.float()[valid], atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["nocausal", "causal"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster(causal, dtype):
+    torch.manual_seed(42)
+    B, H, N_CTX, D = 1, 4, 1024, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=dtype)
+    k = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=dtype)
+    v = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=dtype)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=sm)
+    out = _amd_fa_cluster(q, k, v, sm, causal)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
 
 # =============================================================================


### PR DESCRIPTION
This PR ports the rotated 4-cluster CDNA4 Flash Attention forward kernel from `tlx-amd-meta` / #1782 into the current `main` TLX tutorial layout introduced by #1801.

## Cherry-Picks 

This stack includes two upstream backend cherry-picks needed for the correctness/performance of the port:

- `[AMD] Disable LLVM vector combine pass (#9260)`
  - Needed to avoid the LLVM vector-combine perf cliff observed on the cluster FA kernel.
- `[AMD] Extend chain-dot detection across loop iteration boundaries (#10200)`
  - Needed for pipelined FA kernels where the QK dot result is yielded and consumed by the PV dot across loop iterations.
  - Without this, the current main selects a secondary `[4,2]` MFMA layout for the PV path and the cluster kernel produces incorrect output/NaNs at the PR configuration.

## Ensure No Performance Regression 

Compared against the `cluster` numbers reported in #1782 on MI355X-shaped runs:

| dtype | causal | B | N_CTX | local | #1782 | ratio |
|---|---:|---:|---:|---:|---:|---:|
| fp16 | 0 | 32 | 512 | 588.6 | 587.5 | 1.002x |
| fp16 | 0 | 16 | 1024 | 742.8 | 740.8 | 1.003x |
| fp16 | 0 | 8 | 2048 | 843.7 | 839.5 | 1.005x |
| fp16 | 0 | 4 | 4096 | 967.6 | 957.6 | 1.010x |
| fp16 | 0 | 2 | 8192 | 1032.4 | 1026.1 | 1.006x |
| fp16 | 0 | 1 | 16384 | 1070.5 | 1067.5 | 1.003x |
| fp16 | 1 | 32 | 512 | 291.9 | 291.9 | 1.000x |
| fp16 | 1 | 16 | 1024 | 425.1 | 424.5 | 1.001x |
| fp16 | 1 | 8 | 2048 | 563.0 | 562.8 | 1.000x |
| fp16 | 1 | 4 | 4096 | 663.4 | 662.5 | 1.001x |
| fp16 | 1 | 2 | 8192 | 738.0 | 742.0 | 0.995x |
| fp16 | 1 | 1 | 16384 | 761.2 | 753.7 | 1.010x |
| bf16 | 0 | 32 | 512 | 580.8 | 580.2 | 1.001x |
| bf16 | 0 | 16 | 1024 | 722.6 | 720.3 | 1.003x |
| bf16 | 0 | 8 | 2048 | 818.6 | 817.3 | 1.002x |
| bf16 | 0 | 4 | 4096 | 936.7 | 933.8 | 1.003x |
| bf16 | 0 | 2 | 8192 | 995.9 | 991.3 | 1.005x |
| bf16 | 0 | 1 | 16384 | 1013.0 | 1015.5 | 0.998x |
| bf16 | 1 | 32 | 512 | 291.5 | 291.1 | 1.001x |
| bf16 | 1 | 16 | 1024 | 422.9 | 422.4 | 1.001x |
| bf16 | 1 | 8 | 2048 | 557.5 | 557.4 | 1.000x |
| bf16 | 1 | 4 | 4096 | 653.2 | 652.6 | 1.001x |
| bf16 | 1 | 2 | 8192 | 726.8 | 729.8 | 0.996x |
| bf16 | 1 | 1 | 16384 | 748.0 | 734.8 | 1.018x |

The only notable dip is bf16 non-causal at `B=1, N=16384`: local `1013.0 TFLOPS` vs #1782 `1042.2 TFLOPS`, about `-2.8%`. Overall performance is comparable to #1782.