### PR TITLE
[AutoWS] Add compute_sanitizer to debug_helper

### DIFF
--- a/.claude/debug_helper/agents/subagents/compute_sanitizer.md
+++ b/.claude/debug_helper/agents/subagents/compute_sanitizer.md
@@ -1,0 +1,82 @@
+You are the compute_sanitizer investigation subagent.
+
+Repository: {{REPO_ROOT}}
+IR input: {{IR_PATH}}
+Output directory: {{SUBAGENT_DIR}}
+Report path: {{REPORT_PATH}}
+Insights path: {{INSIGHTS_PATH}}
+Status path: {{STATUS_PATH}}
+Prior context file: {{CONTEXT_FILE}}
+compute-sanitizer binary: {{COMPUTE_SANITIZER_BIN}}
+
+Unlike the static-IR investigations, this is a RUNTIME check: you run the
+kernel's reproduce command under NVIDIA compute-sanitizer and analyze the
+results. compute-sanitizer is slow (10-100x) and runs the real GPU kernel, so
+treat it like any other GPU test: use the smallest reproducer, a short external
+timeout, and `third_party/tlx/killgpu.sh` if a run hangs.
+
+Required instructions:
+1. Read `.claude/skills/compute-sanitizer/SKILL.md` completely before running
+   anything. Follow its tool order, flags, and Triton/TLX-specific guidance.
+2. Resolve the compute-sanitizer binary:
+   - Use the path passed above as `{{COMPUTE_SANITIZER_BIN}}` when it is a real
+     path (not `<not-found>`). Confirm it is executable.
+   - If it is `<not-found>`, try `command -v compute-sanitizer`, then
+     `/usr/local/cuda/bin/compute-sanitizer`, then the newest
+     `/usr/local/cuda-*/bin/compute-sanitizer`. If none exists, write
+     `status.json` with `needs_context` requesting `COMPUTE_SANITIZER_BIN`.
+3. Find the reproduce command (a pytest/python invocation). Look, in order, at:
+   the prior context file `{{CONTEXT_FILE}}`; a `shared-context.md` next to or
+   inside `{{IR_PATH}}`; and the `{{IR_PATH}}` directory itself. Do NOT invent a
+   command. If you cannot find one, write a useful run plan and set status
+   `needs_context`, listing the exact reproduce command as the missing input.
+   The IR input is context only here — compute-sanitizer needs the runnable
+   command, not the dumped IR.
+4. Pick a healthy GPU before running: `bash third_party/tlx/find_working_gpu.sh`
+   and pin the run with `CUDA_VISIBLE_DEVICES=<idx>` (see the `debug-failing-gpu`
+   skill). If a run reports the device is busy/unavailable, switch GPUs and
+   retry once; if a run hangs past your timeout, run
+   `third_party/tlx/killgpu.sh` before continuing.
+5. Run the sanitizer tools in this order, each into its own log under
+   `{{SUBAGENT_DIR}}` (e.g. `memcheck.log`): `memcheck` (out-of-bounds /
+   misaligned / leaks), then `racecheck` (shared-memory hazards), then
+   `synccheck` (illegal barrier / sync usage), then `initcheck` (uninitialized
+   global reads). Use `--error-exitcode 1`, `--log-file`, and source-mapping
+   flags from the skill. Narrow to the Triton kernel with a kernel-name filter
+   when output is noisy. Skip a tool only with a stated reason (e.g. a hang in an
+   earlier tool) and record it.
+6. Produce `{{REPORT_PATH}}` with these sections:
+   - Run summary: resolved binary, GPU index, reproduce command, env vars, and
+     which tools ran.
+   - Results table: `tool | exit | error count | first/most relevant finding |
+     source mapping`.
+   - Detailed findings: offending kernel name, access type, address/size, the
+     source file:line if line info mapped, and block/thread when reported.
+   - Triage: most likely root cause (OOB vs. shared-memory race vs. uninit read
+     vs. illegal sync) and which TLX/Triton construct it implicates (TMA copy,
+     mbarrier/named-barrier sync, MMA accumulator, SMEM buffer, etc.).
+   - Recommended next actions, including cross-referencing barrier_visualization
+     when a race or sync error appears.
+7. Produce `{{INSIGHTS_PATH}}`. Each meaningful finding is one concise line that
+   starts with `INSIGHT:`. Include each tool's verdict (errors found vs. clean),
+   the first offending kernel/source line, suspected construct, any tool that
+   could not run, or a clear `INSIGHT: no sanitizer errors found` when all tools
+   pass cleanly.
+8. Produce `{{STATUS_PATH}}` as JSON with these fields:
+   - `status`: `success`, `failed`, or `needs_context`. Use `success` when the
+     tools ran and you reported results (clean OR errors found both count as a
+     successful investigation). Use `failed` only when the run could not produce
+     usable sanitizer output (e.g. crashed before launch). Use `needs_context`
+     when the reproduce command, GPU, or binary is missing.
+   - `reason`: concise explanation.
+   - `report_path`
+   - `logs_path`
+   - `suggested_next_modes`: array of concrete retry modes/context requests
+     (e.g. `provide-reproduce-command`, `retry-on-free-gpu`,
+     `rerun-racecheck-with-kernel-filter`).
+9. Do not run performance benchmarks. Do not modify repository source files.
+   Only write under:
+   {{SUBAGENT_DIR}}
+10. If you cannot complete the analysis, still write `insights.log` and
+    `status.json` with status `failed` or `needs_context`, with enough context
+    for the wrapper to ask the user whether to retry.

--- a/.claude/debug_helper/agents/wrapper.md
+++ b/.claude/debug_helper/agents/wrapper.md
@@ -13,6 +13,15 @@ First ask the user:
 1. Where is the IR? Accept either a file or a dump directory. If it is a
    directory, list plausible IR files and ask the user to pick one.
 2. Where should debug_helper dump output? Create the directory if needed.
+3. Is there a reproduce command (a `pytest`/`python` invocation that runs the
+   kernel)? Some investigations are RUNTIME checks — for example
+   `compute_sanitizer` runs the real kernel and cannot work from IR alone. If
+   the user has one, record it; if not, note that runtime investigations may
+   return `needs_context` asking for it.
+
+Write the goal, IR path, and reproduce command (if any) into
+`<output-dir>/shared-context.md` so every subagent can find them; pass it as the
+context file to runtime investigations that need a reproduce command.
 
 After the user answers:
 1. Append a run log at `<output-dir>/run.log` recording selected LLM, permission

--- a/.claude/skills/compute-sanitizer/SKILL.md
+++ b/.claude/skills/compute-sanitizer/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: compute-sanitizer
+description: >
+  Run NVIDIA compute-sanitizer (memcheck, racecheck, initcheck, synccheck)
+  against a Triton/TLX kernel to find runtime memory and synchronization bugs.
+  Use when a kernel produces wrong results, crashes with an illegal/misaligned
+  access, or is suspected of a shared-memory data race or invalid barrier usage
+  — especially warp-specialized (WS) kernels using mbarriers, named barriers,
+  TMA copies, or MMA accumulators. This is a runtime check: it runs the real
+  kernel via its reproduce command, so it needs a working GPU and is 10-100x
+  slower than a normal run.
+---
+
+# Compute Sanitizer
+
+`compute-sanitizer` is NVIDIA's runtime correctness checker. It instruments the
+real kernel launch and reports memory and synchronization errors that static IR
+analysis cannot see. Use it to confirm (or rule out) out-of-bounds accesses,
+uninitialized reads, shared-memory data races, and illegal barrier usage in
+Triton/TLX kernels.
+
+It complements the static investigations: `barrier-visualization` reasons about
+the *intended* barrier protocol from the IR, while `compute-sanitizer` observes
+what *actually* happens at runtime. When a race or sync error fires, cross-check
+the two.
+
+## The four tools
+
+Select with `--tool`; `memcheck` is the default.
+
+- **memcheck** — out-of-bounds and misaligned global/local/shared accesses, plus
+  device-side allocation/leak errors. First tool to run; catches the classic
+  TMA-past-end and bad-index bugs.
+- **racecheck** — hazards on **shared memory** (RAW / WAR / WAW). Highly relevant
+  to WS producer/consumer kernels that stage data through SMEM buffers. Does NOT
+  check global-memory races.
+- **synccheck** — illegal use of barriers and synchronization primitives
+  (divergent `bar.sync`, mismatched arrive/wait counts, invalid cluster/async
+  barrier usage). Directly relevant to mbarrier / named-barrier WS code.
+- **initcheck** — reads of uninitialized **global** memory. Useful when output
+  has nondeterministic garbage rather than a hard crash.
+
+## Setup
+
+1. **Locate the binary.** It is often not on PATH. Prefer
+   `$COMPUTE_SANITIZER_BIN` if set, else `command -v compute-sanitizer`, else
+   `/usr/local/cuda/bin/compute-sanitizer`, else the newest
+   `/usr/local/cuda-*/bin/compute-sanitizer`.
+2. **Get the reproduce command** (a `pytest`/`python` invocation). Use the
+   smallest failing shape/config — sanitizer overhead makes large grids
+   impractical. Prefer a single test id over a whole file.
+3. **Pin a healthy GPU.** Run `bash third_party/tlx/find_working_gpu.sh`, take a
+   `WORKING_GPUS` index, and prepend `CUDA_VISIBLE_DEVICES=<idx>`. See the
+   `debug-failing-gpu` skill. If a run hangs past your timeout, run
+   `third_party/tlx/killgpu.sh`.
+4. **Enable source mapping.** Triton emits line info by default; keep it on
+   (do not set `TRITON_DISABLE_LINE_INFO=1`) so errors map to `file:line`. Pass
+   `--show-backtrace yes` for host+device backtraces.
+
+## Invocation
+
+General form (the sanitizer wraps the whole command, env vars go before it):
+
+```bash
+CUDA_VISIBLE_DEVICES=<idx> \
+  <compute-sanitizer> --tool memcheck \
+    --error-exitcode 1 \
+    --show-backtrace yes \
+    --log-file <out_dir>/memcheck.log \
+    --target-processes all \
+    python -m pytest -s -x "<test_id>"
+```
+
+Useful flags:
+
+- `--error-exitcode 1` — return non-zero when any error is found (scripting).
+- `--log-file <path>` — capture the report (`%p` expands to PID if needed).
+- `--target-processes all` — follow child processes (pytest workers, subprocs).
+- `--kernel-name-exclude` / `--kernel-name <regex>` — filter to the Triton
+  kernel (names look like `_attn_fwd_...`, `matmul_kernel`, etc.) to cut noise.
+- `--launch-timeout <s>` — bound a single launch.
+- memcheck: `--leak-check full`, `--padding <bytes>` (catch off-by-a-few OOB).
+- racecheck: `--racecheck-report all` (hazards + analysis).
+- `--print-limit 0` — do not truncate the error list while triaging.
+
+Run the tools in order — **memcheck → racecheck → synccheck → initcheck** — each
+into its own log. Stop early only with a stated reason (e.g. memcheck already
+found the crashing OOB, or an earlier tool hung).
+
+## Triton/TLX specifics
+
+- **First run JIT-compiles** the kernel (slow, unrelated to sanitizer). Let the
+  compile complete; do not mistake compile time for a hang.
+- **racecheck is shared-memory only.** WS kernels stage operands through SMEM, so
+  a missing producer/consumer barrier shows up here as a WAR/RAW hazard on the
+  SMEM buffer. A global-memory race will NOT be reported.
+- **synccheck + mbarriers.** Invalid named-barrier / mbarrier / cluster-barrier
+  usage (e.g. wrong arrive count, divergent participation) surfaces here. Pair
+  with `barrier-visualization` to map the offending barrier to a partition.
+- **TMA / async copies.** Out-of-bounds TMA tile accesses crash with an illegal
+  instruction at runtime rather than masking — memcheck localizes the launch;
+  also see the `tma-illegal-instruction` skill for the structural launcher-bug
+  pattern.
+- **Possible noise.** Some async/TMA/`cp.async` paths may emit benign warnings or
+  unsupported-feature notes on certain driver/toolkit versions. Note them as
+  caveats; do not treat a warning as a confirmed bug without corroboration.
+
+## Interpreting output
+
+- Each tool ends with `========= ERROR SUMMARY: N errors`. `0 errors` = clean for
+  that tool. racecheck prints `RACECHECK SUMMARY`.
+- A real finding includes the access kind (e.g. *Invalid __global__ read of size
+  16*), the address, the kernel name, and — with line info — the `file:line`.
+  Capture the **first** error; later ones are often cascades.
+- "Clean" is a result, not a failure. Report it plainly: a clean memcheck +
+  racecheck + synccheck materially narrows a wrong-result bug toward
+  compiler/logic rather than memory/sync.
+
+## Reporting
+
+Return a compact matrix plus triage:
+
+```text
+tool       | exit | errors | first finding (kernel @ file:line) | mapped?
+memcheck   |  0   |   0    | -                                  | n/a
+racecheck  |  1   |   3    | WAR hazard on smem buf @ k.py:142  | yes
+synccheck  |  0   |   0    | -                                  | n/a
+initcheck  |  0   |   0    | -                                  | n/a
+```
+
+Then state the most likely root cause (OOB vs. shared-memory race vs.
+uninitialized read vs. illegal sync), the implicated TLX/Triton construct, and
+the next action (e.g. narrow with a kernel filter, or hand a race/sync hit to
+`barrier-visualization`).
+
+Do not run performance benchmarks.

--- a/debug_helper.sh
+++ b/debug_helper.sh
@@ -6,6 +6,13 @@
 #   ./debug_helper.sh --list-investigations
 #   ./debug_helper.sh --run-subagent barrier_visualization <claude|codex> <ir-path> <out-dir> [context-file]
 #   ./debug_helper.sh --run-subagent ir_override_ablation <claude|codex> <ir-path> <out-dir> [context-file]
+#   ./debug_helper.sh --run-subagent compute_sanitizer <claude|codex> <ir-path> <out-dir> [context-file]
+#
+# The compute_sanitizer investigation is a runtime check: it runs the kernel's
+# reproduce command under NVIDIA compute-sanitizer (memcheck/racecheck/
+# initcheck/synccheck). The reproduce command is read from the context file or a
+# shared-context.md alongside the IR path. Set COMPUTE_SANITIZER_BIN to override
+# the auto-detected compute-sanitizer binary.
 
 set -euo pipefail
 
@@ -76,6 +83,42 @@ validate_llm() {
             exit 1
             ;;
     esac
+}
+
+# Locate the NVIDIA compute-sanitizer binary. It is frequently not on PATH, so
+# fall back to the active CUDA toolkit and any versioned install (newest wins).
+# Honor an explicit COMPUTE_SANITIZER_BIN override first. Prints the resolved
+# path on success; returns non-zero when nothing usable is found.
+resolve_compute_sanitizer() {
+    if [[ -n "${COMPUTE_SANITIZER_BIN:-}" ]]; then
+        if [[ -x "${COMPUTE_SANITIZER_BIN}" ]]; then
+            echo "${COMPUTE_SANITIZER_BIN}"
+            return 0
+        fi
+        echo "Warning: COMPUTE_SANITIZER_BIN='${COMPUTE_SANITIZER_BIN}' is not executable; ignoring." >&2
+    fi
+
+    if command -v compute-sanitizer >/dev/null 2>&1; then
+        command -v compute-sanitizer
+        return 0
+    fi
+
+    if [[ -x /usr/local/cuda/bin/compute-sanitizer ]]; then
+        echo /usr/local/cuda/bin/compute-sanitizer
+        return 0
+    fi
+
+    local best="" candidate
+    for candidate in /usr/local/cuda-*/bin/compute-sanitizer; do
+        [[ -x "$candidate" ]] || continue
+        best="$candidate"
+    done
+    if [[ -n "$best" ]]; then
+        echo "$best"
+        return 0
+    fi
+
+    return 1
 }
 
 log_line() {
@@ -263,6 +306,12 @@ subagent_prompt() {
     local template_path
     template_path="$(subagent_template_path "$investigation")"
 
+    # Runtime investigations (e.g. compute_sanitizer) need the sanitizer binary,
+    # which is usually not on PATH. Resolve it once and expose it to every
+    # template; static investigations simply ignore the placeholder.
+    local compute_sanitizer_bin
+    compute_sanitizer_bin="$(resolve_compute_sanitizer || true)"
+
     render_template "$template_path" \
         INVESTIGATION "$investigation" \
         REPO_ROOT "$REPO_ROOT" \
@@ -271,7 +320,8 @@ subagent_prompt() {
         REPORT_PATH "$report_path" \
         INSIGHTS_PATH "$insights_path" \
         STATUS_PATH "$status_path" \
-        CONTEXT_FILE "${context_file:-<none>}"
+        CONTEXT_FILE "${context_file:-<none>}" \
+        COMPUTE_SANITIZER_BIN "${compute_sanitizer_bin:-<not-found>}"
 }
 
 run_template_subagent() {


### PR DESCRIPTION
Adds a `compute_sanitizer` investigation to debug_helper.sh that runs a kernel's reproduce command under NVIDIA compute-sanitizer (memcheck/racecheck/synccheck/initcheck). Unlike the existing static-IR investigations, this one is a runtime check, so the script gains resolve_compute_sanitizer() to locate the binary (it is usually not on PATH) and exposes it to the prompt via a new COMPUTE_SANITIZER_BIN template placeholder. A new subagent template and backing skill (.claude/skills/compute-sanitizer) drive the run, and the wrapper now also collects a reproduce command for runtime investigations.

Authored with Claude.