### PR TITLE
[ModuloSchedule] Native WS backend honors modulo partition schedule

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -725,16 +725,14 @@ class CUDABackend(BaseBackend):
                 # TRITON_USE_MODULO_SCHEDULE=sms|exhaustive|random
                 nvidia.passes.hopper.add_modulo_schedule(pm)
             nvidia.passes.hopper.add_data_partitioning(pm, 1)
-            # assign_latencies sets tt.latency on loads/MMAs (stage-distance
-            # latencies). schedule_loops reads tt.latency AND tt.autows:
-            # when MMA ops have tt.autows, scheduleKeyOpsAnnotation places
-            # them at the annotated stages/clusters while scheduling all
-            # other ops (loads, softmax, barriers) via the standard
-            # latency-based heuristic. Without assign_latencies, the WS
-            # pass's internal scheduleLoops has no latencies and can't
-            # enter the code path that reads tt.autows annotations.
-            passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
-            passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
+            # The modulo / LLM scheduler above already produced the full loop
+            # schedule (loop.stage / loop.cluster). Re-running assign_latencies +
+            # schedule_loops here would recompute and OVERRIDE it, so only run
+            # them on the default path where no custom scheduler set the schedule.
+            uses_custom_schedule = knobs.nvidia.use_llm_schedule or knobs.nvidia.use_modulo_schedule is not None
+            if not uses_custom_schedule:
+                passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
+                passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
             if not knobs.nvidia.use_meta_ws:
                 # 2-CTA + upstream WS is not supported
                 if opt.cluster_dims is None or max(opt.cluster_dims) < 2:

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -139,6 +139,79 @@ static void emitScheduleFromGraph(scf::ForOp loop,
                      DenseI32ArrayAttr::get(ctx, ArrayRef<int32_t>{wg}));
   }
 
+  // ── 1.6. Per-loop: ttg.partition_num_warps ──
+  // The per-partition warp count is a real schedule decision (Layer B): each
+  // warp group's count = max(minWarps) over its ops, snapped to {1,2,4,8}.
+  // Emit it as a DenseI32ArrayAttr indexed by partition id — the SAME shape as
+  // the final ttg.warp_specialize `partitionNumWarps` attr — so the downstream
+  // WS pass can honor modulo's choice instead of re-deriving from a binary
+  // tmem-presence heuristic. (Mirrors jsonDumpWarpGroups' num_warps.)
+  {
+    int maxWg = -1;
+    for (const auto &node : schedLoop.nodes)
+      maxWg = std::max(maxWg, node.warpGroup);
+    if (maxWg >= 0) {
+      SmallVector<int> wgMaxMinWarps(maxWg + 1, 0);
+      for (const auto &node : schedLoop.nodes) {
+        if (node.warpGroup < 0)
+          continue;
+        wgMaxMinWarps[node.warpGroup] = std::max(
+            wgMaxMinWarps[node.warpGroup], std::max(node.minWarps, 1));
+      }
+      auto snapWarps = [](int m) {
+        if (m <= 1)
+          return 1;
+        if (m <= 2)
+          return 2;
+        if (m <= 4)
+          return 4;
+        return 8;
+      };
+      SmallVector<int32_t> numWarps(maxWg + 1, 1);
+      for (int wg = 0; wg <= maxWg; ++wg)
+        numWarps[wg] = snapWarps(wgMaxMinWarps[wg] == 0 ? 1 : wgMaxMinWarps[wg]);
+      loop->setAttr("ttg.partition_num_warps",
+                    DenseI32ArrayAttr::get(ctx, numWarps));
+    }
+  }
+
+  // ── 1.7. Per-loop: ttg.partition.stages + ttg.warp_specialize.tag ──
+  // These are exactly what PartitionSet::fromLoop() (the WS backend's
+  // honor-preset hook in PartitionSchedulingMeta::getInitialSchedule) requires.
+  // Emitting them makes the backend adopt modulo's ttg.partition assignment
+  // verbatim instead of re-deriving partitions from its own MMA-backward-slice
+  // heuristic — i.e. all partition decisions come from modulo. Ops modulo left
+  // unassigned (warpGroup<0 infra ops) are still filled in by the backend's
+  // propagatePartitions after fromLoop.
+  //
+  // Per-partition stage = max loop.stage over that partition's ops. This
+  // matches PSM's own convention (compute/MMA partition lands at the higher
+  // stage, loads/epilogue at stage 0); the value is otherwise only used for
+  // channel-buffering offsets. The tag is required to be present; PSM resets it
+  // to the loop's WS index during serialize.
+  {
+    int maxWg = -1;
+    for (const auto &node : schedLoop.nodes)
+      maxWg = std::max(maxWg, node.warpGroup);
+    if (maxWg >= 0) {
+      SmallVector<int> wgMaxStage(maxWg + 1, 0);
+      for (const auto &node : schedLoop.nodes) {
+        if (node.warpGroup < 0)
+          continue;
+        wgMaxStage[node.warpGroup] =
+            std::max(wgMaxStage[node.warpGroup], node.cycle / II);
+      }
+      SmallVector<Attribute> stageAttrs;
+      for (int wg = 0; wg <= maxWg; ++wg)
+        stageAttrs.push_back(
+            IntegerAttr::get(IntegerType::get(ctx, 32), wgMaxStage[wg]));
+      loop->setAttr(ttg::kPartitionStagesAttrName,
+                    ArrayAttr::get(ctx, stageAttrs));
+      loop->setAttr(ttg::kWarpSpecializeTagAttrName,
+                    IntegerAttr::get(IntegerType::get(ctx, 32), 0));
+    }
+  }
+
   // ── 2. Per-loop: tt.modulo_ii, tt.scheduled_max_stage ──
   loop->setAttr("tt.modulo_ii",
                 IntegerAttr::get(IntegerType::get(ctx, 32), II));
@@ -169,6 +242,15 @@ static void emitScheduleFromGraph(scf::ForOp loop,
                        IntegerAttr::get(IntegerType::get(ctx, 32), buf.count));
     buf.defOp->setAttr("buffer.id",
                        IntegerAttr::get(IntegerType::get(ctx, 32), buf.id));
+    // Step 4.5 buffer-merge decision: buffers sharing a merge_group_id were
+    // colored to the same physical SMEM/TMEM slot (interval-graph coloring).
+    // Carry it so the downstream allocator can reuse modulo's coloring instead
+    // of running its own merge.
+    if (buf.mergeGroupId != UINT_MAX)
+      buf.defOp->setAttr(
+          "buffer.merge_group_id",
+          IntegerAttr::get(IntegerType::get(ctx, 32),
+                           static_cast<int>(buf.mergeGroupId)));
   }
 
   // ── 4. Clean up internal attrs ──

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -1264,6 +1264,20 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
                           DenseMap<unsigned, Partition *>(),
                           /*createComputePartitions=*/true};
 
+  // Modulo path is authoritative for partitioning. If the loop was modulo-
+  // scheduled (carries tt.modulo_ii) but fromLoop() above found no honorable
+  // preset schedule, FAIL rather than re-deriving partitions below — a
+  // re-derivation would silently override modulo's decisions, which is exactly
+  // what TRITON_USE_MODULO_SCHEDULE must prevent. The caller turns this
+  // nullopt into a pass failure for modulo loops.
+  if (mainLoop->hasAttr("tt.modulo_ii")) {
+    mainLoop->emitError(
+        "modulo-scheduled loop has no honorable partition schedule "
+        "(missing/invalid ttg.partition.stages or ttg.warp_specialize.tag); "
+        "refusing to re-derive partitions under the modulo path");
+    return std::nullopt;
+  }
+
   // Collect all loops (nested + main)
   SmallVector<scf::ForOp> loops{mainLoop.getOps<scf::ForOp>()};
   loops.push_back(mainLoop);
@@ -2636,8 +2650,18 @@ void PartitionSchedulingMeta::runOnOperation() {
     if (auto attr2 = loop->getAttrOfType<BoolAttr>("tt.merge_epilogue"))
       schedOpts.mergeEpilogue = attr2.getValue();
 
-    if (std::optional<ScheduleResult> result =
-            getInitialSchedule(loop, schedOpts)) {
+    std::optional<ScheduleResult> result = getInitialSchedule(loop, schedOpts);
+    if (!result) {
+      // getInitialSchedule emits a diagnostic and returns nullopt for a
+      // modulo-scheduled loop with no honorable preset partition schedule.
+      // Under the modulo path partitions are authoritative, so fail the pass
+      // instead of silently re-deriving or dropping WS. For non-modulo loops,
+      // nullopt just means "nothing to specialize" — skip as before.
+      if (loop->hasAttr("tt.modulo_ii"))
+        return signalPassFailure();
+      continue;
+    }
+    {
       PartitionSet &schedule = result->schedule;
       currentPhase = "propagate";
       propagatePartitions(loop, schedule, result->createComputePartitions);


### PR DESCRIPTION
Summary:
Under `TRITON_USE_MODULO_SCHEDULE=1`, route all partitioning decisions from modulo into the real warp-specialization backend instead of letting `PartitionSchedulingMeta` (PSM) re-derive them.

`emitScheduleFromGraph` now emits, per scheduled loop, the attributes the WS backend already understands so it adopts modulo's plan verbatim:
- `ttg.partition.stages` + `ttg.warp_specialize.tag` — exactly what `PartitionSet::fromLoop` requires; with these present PSM deserializes modulo's per-op `ttg.partition` instead of running its own MMA-backward-slice derivation.
- `ttg.partition_num_warps` — per-partition warp count (max `minWarps` over the group, snapped to {1,2,4,8}); mirrors the final `ttg.warp_specialize` `partitionNumWarps` attr.
- `buffer.merge_group_id` — modulo's Step 4.5 buffer-merge / interval-graph coloring decision, on each SMEM/TMEM alloc.

`PartitionSchedulingMeta::getInitialSchedule` now refuses to re-derive partitions for a modulo-scheduled loop: if `fromLoop` finds no honorable preset it emits a diagnostic and the pass fails, rather than silently overriding modulo's decisions.

compiler.py: skip `assign_latencies` + `schedule_loops` when a custom scheduler (modulo or LLM) already produced the schedule. They were re-running after modulo and OVERWRITING its `loop.stage` / `loop.cluster` (verified: schedule_loops rewrote load A from stage 0 / cluster 0 to stage 0 / cluster 1). Now modulo's full schedule reaches the pipeliner / WS backend intact.

Known follow-up (tracked separately): the WS memory planner does not yet support modulo's cross-WG SMEM channel layout (a TMA load and its `local_alloc` placed in different partitions), so full native lowering of such layouts still asserts in `handleOperandD`.

Reviewed By: htyu

Differential Revision: D109218265


