### PR TITLE
[triton][beta] [Cherry-pick][BUNDLE] Cherry-pick 12 upstream commits (#9591, #9586, #9593, #9594, #9611, #9610, #9620, #9590, #9584, #9624, #9596, #9631) (#1848)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,33 +32,26 @@ test-cpp:
 
 .PHONY: test-unit
 test-unit: all
-	cd python/test/unit && $(PYTEST) --tb=short -s -n $(NUM_PROCS) --ignore=language/test_line_info.py \
-		--ignore=language/test_subprocess.py --ignore=test_debug.py --ignore=plugins/test_dialect_plugin.py --ignore=plugins/test_plugin.py
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/unit/language/test_subprocess.py
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/unit/test_debug.py --forked
-	$(PYTEST) --tb=short -s -n 6 python/triton_kernels/tests/
-	TRITON_DISABLE_LINE_INFO=0 $(PYTEST) --tb=short -s python/test/unit/language/test_line_info.py
+	cd python/test/unit && $(PYTEST) -n $(NUM_PROCS) --ignore-glob='plugins/*' --ignore=test_debug.py
+	$(PYTEST) -n $(NUM_PROCS) python/test/unit/test_debug.py
+	$(PYTEST) -n 6 python/triton_kernels/tests/
 	# Run attention separately to avoid out of gpu memory
-	$(PYTEST) --tb=short -vs python/tutorials/06-fused-attention.py
-	$(PYTEST) --tb=short -n $(NUM_PROCS) -vs python/tutorials/gluon
-	$(PYTEST) --tb=short -vs python/examples/gluon/01-attention-forward.py
+	$(PYTEST) python/tutorials/06-fused-attention.py
 	TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=python/triton/instrumentation/libGPUInstrumentationTestLib.so \
 		$(PYTEST) --capture=tee-sys -rfs -vvv python/test/unit/instrumentation/test_gpuhello.py
 	TRITON_PASS_PLUGIN_PATH=python/triton/plugins/libTritonPluginsTestLib.so \
 		$(PYTEST) -vvv python/test/unit/plugins/test_plugin.py
 	TRITON_PASS_PLUGIN_PATH=python/triton/plugins/libMLIRDialectPlugin.so \
-		$(PYTEST) -s -vvv python/test/unit/plugins/test_dialect_plugin.py
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/gluon
+		$(PYTEST) -vvv python/test/unit/plugins/test_dialect_plugin.py
 
 .PHONY: test-gluon
 test-gluon: all
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/gluon
-	$(PYTEST) --tb=short -vs python/examples/gluon/01-attention-forward.py
-	$(PYTEST) --tb=short -n $(NUM_PROCS) -vs python/tutorials/gluon
+	$(PYTEST) -n $(NUM_PROCS) python/test/gluon/ python/tutorials/gluon/
+	$(PYTEST) -n 2 python/examples/gluon/
 
 .PHONY: test-regression
 test-regression: all
-	$(PYTEST) --tb=short -s -n $(NUM_PROCS) python/test/regression
+	$(PYTEST) -n $(NUM_PROCS) python/test/regression
 
 .PHONY: test-microbenchmark
 test-microbenchmark: all
@@ -66,17 +59,17 @@ test-microbenchmark: all
 
 .PHONY: test-interpret
 test-interpret: all
-	cd python/test/unit && TRITON_INTERPRET=1 $(PYTEST) --tb=short -s -n 16 -m interpreter cuda language/test_core.py language/test_standard.py \
+	cd python/test/unit && TRITON_INTERPRET=1 $(PYTEST) -n 16 -m interpreter cuda language/test_core.py language/test_standard.py \
 		language/test_random.py language/test_block_pointer.py language/test_subprocess.py language/test_line_info.py \
 		language/test_tuple.py runtime/test_launch.py runtime/test_autotuner.py::test_kwargs[False] \
 		../../tutorials/06-fused-attention.py::test_op --device=cpu
 
 .PHONY: test-proton
 test-proton: all
-	$(PYTEST) --tb=short -s -n 8 third_party/proton/test --ignore=third_party/proton/test/test_override.py -k "not test_overhead and not test_hw_trace"
-	$(PYTEST) --tb=short -s third_party/proton/test/test_profile.py::test_hw_trace
-	$(PYTEST) --tb=short -s third_party/proton/test/test_override.py
-	$(PYTEST) --tb=short -s third_party/proton/test/test_instrumentation.py::test_overhead
+	$(PYTEST) -n 8 third_party/proton/test --ignore=third_party/proton/test/test_override.py -k "not test_overhead and not test_hw_trace"
+	$(PYTEST) third_party/proton/test/test_profile.py::test_hw_trace
+	$(PYTEST) third_party/proton/test/test_override.py
+	$(PYTEST) third_party/proton/test/test_instrumentation.py::test_overhead
 
 .PHONY: test-python
 test-python: test-unit test-regression test-interpret test-proton

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -93,10 +93,23 @@ public:
   // matching barrier phases.
   void createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b, int activeMask,
                                        Value pred, Operation *insertPoint);
+  // verifyBarrierCanInit: ensure the barrier is currently invalidated before
+  // initializing it again.
+  void createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b, Value mbar,
+                                      Operation *insertPoint);
+  // verifyBarrierInitialized: ensure the barrier has been initialized and not
+  // invalidated before it is used.
+  void createVerifyBarrierInitializedCall(ImplicitLocOpBuilder &b, Value mbar,
+                                          Value pred, Operation *insertPoint);
   // initBarrierState: Initialize the tracked barrier state to phase 0 and set
-  // both the initial and current arrival counts.
+  // both the initial and current arrival counts. A zero state denotes an
+  // invalidated/uninitialized barrier.
   void createInitBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                   int count, Operation *insertPoint);
+  // invalidateBarrierState: clear the tracked barrier lifecycle state and any
+  // waiting bits for the barrier.
+  void createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
+                                        Operation *insertPoint);
   // verifyBarrierArrive: Check that applying the arrive count would not drive
   // the tracked current count negative. Triggers an assertion on failure.
   void createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b, Value mbar,
@@ -145,6 +158,16 @@ public:
   void createTrackVisibleReadsCall(ImplicitLocOpBuilder &b, Value mbar,
                                    int thread, Value pred, MemType memType,
                                    Operation *insertPoint);
+  // clearBarrierWriteTracking: clear all write tracking associated with the
+  // given barrier row.
+  void createClearBarrierWriteTrackingCall(ImplicitLocOpBuilder &b, Value mbar,
+                                           Value pred, MemType memType,
+                                           Operation *insertPoint);
+  // clearBarrierReadTracking: clear all read tracking associated with the
+  // given barrier row.
+  void createClearBarrierReadTrackingCall(ImplicitLocOpBuilder &b, Value mbar,
+                                          Value pred, MemType memType,
+                                          Operation *insertPoint);
   // transferVisibleWrites: transfer write visibility tracked by a barrier to
   // all threads in threadMask.
   void createTransferVisibleWritesCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -8,6 +8,10 @@
 
 #include <array>
 
+namespace mlir::triton::gpu {
+class GlobalScratchAllocOp;
+}
+
 namespace mlir::triton::instrument {
 class FunctionBuilder;
 
@@ -29,6 +33,9 @@ Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
                                     Value tensor, RankedTensorType tensorType);
 Value createLoadScratchMemory(OpBuilder &b, Location loc, Value alloc,
                               RankedTensorType tensorType);
+gpu::GlobalScratchAllocOp
+createThirdPartyScratchAlloc(OpBuilder &b, Location loc, Type ptrType,
+                             int64_t sizeInBytes, int64_t alignment);
 Value expandOuterSlicedDim(OpBuilder &b, Location loc, Value tensor);
 RankedTensorType getIntTensorType(Region *region, ArrayRef<int64_t> shape,
                                   unsigned bitWidth);

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -63,6 +63,12 @@ llvm::DenseSet<Value> getBarrierOperands(Operation *op) {
   if (auto initBarrierOp = dyn_cast<ttng::InitBarrierOp>(op)) {
     return {initBarrierOp.getOperand()};
   }
+  if (auto waitBarrierOp = dyn_cast<ttng::WaitBarrierOp>(op)) {
+    return {waitBarrierOp.getAlloc()};
+  }
+  if (auto arriveBarrierOp = dyn_cast<ttng::ArriveBarrierOp>(op)) {
+    return {arriveBarrierOp.getAlloc()};
+  }
   if (auto barrierExpectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
     return {barrierExpectOp.getAlloc()};
   }
@@ -327,8 +333,8 @@ bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
           ttng::TMEMStoreOp, ttg::AsyncCopyGlobalToLocalOp,
           ttng::AsyncTMACopyGlobalToLocalOp, ttng::AsyncTMACopyLocalToGlobalOp,
           ttng::AsyncTMAGatherOp, ttng::AsyncTMAScatterOp, ttng::InitBarrierOp,
-          ttng::BarrierExpectOp, ttng::InvalBarrierOp, ttng::WaitBarrierOp>(
-          op)) {
+          ttng::BarrierExpectOp, ttng::InvalBarrierOp, ttng::WaitBarrierOp,
+          ttng::ArriveBarrierOp>(op)) {
     return true;
   }
   // Allocations with operands write to the memory.

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -129,17 +129,20 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
              << "bitwidth * colStride must be less than or equal to 32. Got "
              << bitwidth << " and " << enc.getColStride();
     }
-    shape = shape.take_back(2);
+    // Takes subslices into account and figures out whether we can construct
+    // the linear layout at all
     allocShape = allocShape.take_back(2);
     auto ctaSplit = enc.getCGALayout().getCTASplitNum();
+    auto blockN = std::min<int32_t>(enc.getBlockN(), shape.back());
     if (allocShape[0] < enc.getBlockM() * ctaSplit[0] ||
-        allocShape[1] < enc.getBlockN() * ctaSplit[1]) {
+        allocShape[1] < blockN * ctaSplit[1]) {
       return emitError() << "the allocation shape must be at least "
                          << enc.getBlockM() * ctaSplit[0] << "x"
-                         << enc.getBlockN() * ctaSplit[1] << ". Got "
-                         << allocShape;
+                         << blockN * ctaSplit[1] << ". Got " << allocShape;
     }
+    // Checks the layout of the allocation
     auto ll = toLinearLayout(allocShape, enc);
+    // Sanity check that the layout is of the right shape
     auto dims = standardOutDimNames(ctx, 2);
     if (ll.getOutDimSize(dims[0]) != allocShape[0] ||
         ll.getOutDimSize(dims[1]) != allocShape[1]) {

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -612,6 +612,103 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
       });
 }
 
+void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
+                                                     Value mbar,
+                                                     Operation *insertPoint) {
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when verifying barrier init");
+  assert(!auxData.barrierStates.empty() &&
+         "barrier states must exist when verifying barrier init");
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
+  auto barrierStatesType =
+      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
+  uint32_t length = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {mbarOffset, lengthVal, barriersVal,
+                             barrierStatesVal};
+  AssertInfo assertInfo{
+      "Barrier re-initialized without prior invalidation",
+      barrierStatesType.cloneWith(std::nullopt, b.getI1Type())};
+  createCallToCachedFunction(
+      b, "verify_barrier_can_init", args, assertInfo,
+      {barriersType, barrierStatesType},
+      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
+                                        Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value barriers = entryBlock->getArgument(2);
+        Value statesPtr = entryBlock->getArgument(3);
+
+        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
+                                                    barrierStatesType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
+        Value canInit =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
+        auto condType = cast<RankedTensorType>(canInit.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        canInit = arith::SelectOp::create(fb, mask, canInit, vTrue);
+        triton::ReturnOp::create(fb, canInit);
+      });
+}
+
+void FunctionBuilder::createVerifyBarrierInitializedCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint) {
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when verifying barrier use");
+  assert(!auxData.barrierStates.empty() &&
+         "barrier states must exist when verifying barrier use");
+  if (!pred) {
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  }
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
+  auto barrierStatesType =
+      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
+  uint32_t length = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {mbarOffset, lengthVal, pred, barriersVal,
+                             barrierStatesVal};
+  AssertInfo assertInfo{
+      "Barrier used before initialization or after invalidation",
+      barrierStatesType.cloneWith(std::nullopt, b.getI1Type())};
+  createCallToCachedFunction(
+      b, "verify_barrier_initialized", args, assertInfo,
+      {barriersType, barrierStatesType},
+      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
+                                        Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value statesPtr = entryBlock->getArgument(4);
+
+        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
+                                                    barrierStatesType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
+        Value initialized =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::ne, states, zero);
+        auto condType = cast<RankedTensorType>(initialized.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        initialized = arith::SelectOp::create(fb, mask, initialized, vTrue);
+        Value predicatedInitialized =
+            arith::SelectOp::create(fb, pred, initialized, vTrue);
+        triton::ReturnOp::create(fb, predicatedInitialized);
+      });
+}
+
 void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
                                                  Value mbar, int count,
                                                  Operation *insertPoint) {
@@ -668,6 +765,64 @@ void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
         Value updated = arith::SelectOp::create(fb, mask, newState, states);
         tti::createStoreScratchMemory(fb, fb.getLoc(), statesPtr, updated,
                                       barrierStatesType);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
+                                                       Value mbar,
+                                                       Operation *insertPoint) {
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when invalidating a barrier");
+  assert(!auxData.barrierStates.empty() &&
+         "barrier states must exist when invalidating a barrier");
+  assert(!auxData.waiting.empty() &&
+         "waiting state must exist when invalidating a barrier");
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
+  auto barrierStatesType =
+      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
+  Value waitingVal = auxData.waiting.at(insertPoint).value;
+  auto waitingType =
+      cast<RankedTensorType>(auxData.waiting.at(insertPoint).type);
+  uint32_t length = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {mbarOffset, lengthVal, barriersVal,
+                             barrierStatesVal, waitingVal};
+  createCallToCachedFunction(
+      b, "invalidate_barrier_state", args,
+      /*assertInfo=*/std::nullopt,
+      {barriersType, barrierStatesType, waitingType},
+      [barriersType, barrierStatesType, waitingType](ImplicitLocOpBuilder &fb,
+                                                     Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value barriers = entryBlock->getArgument(2);
+        Value statesPtr = entryBlock->getArgument(3);
+        Value waitingPtr = entryBlock->getArgument(4);
+
+        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
+                                                    barrierStatesType);
+        Value waiting = tti::createLoadScratchMemory(fb, fb.getLoc(),
+                                                     waitingPtr, waitingType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
+
+        Value zeroState =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
+        Value zeroWaiting =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, waitingType);
+        Value updatedStates =
+            arith::SelectOp::create(fb, mask, zeroState, states);
+        Value updatedWaiting =
+            arith::SelectOp::create(fb, mask, zeroWaiting, waiting);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), statesPtr, updatedStates,
+                                      barrierStatesType);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), waitingPtr,
+                                      updatedWaiting, waitingType);
         triton::ReturnOp::create(fb);
       });
 }
@@ -1282,6 +1437,120 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
             fb, barriersEqBar, readTrackingOrVisible, readTracking);
         tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
                                       newTracking, readTrackingType);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createClearBarrierWriteTrackingCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
+    Operation *insertPoint) {
+  if (auxData.writeTracking[(int)memType].empty()) {
+    return;
+  }
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when clearing barrier write tracking");
+  if (!pred) {
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  }
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value writeTrackingVal =
+      auxData.writeTracking[(int)memType].at(insertPoint).value;
+  auto writeTrackingType = cast<RankedTensorType>(
+      auxData.writeTracking[(int)memType].at(insertPoint).type);
+  uint32_t length = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {mbarOffset, lengthVal, pred, barriersVal,
+                             writeTrackingVal};
+  createCallToCachedFunction(
+      b, "clear_barrier_write_tracking", args,
+      /*assertInfo=*/std::nullopt,
+      {barriersType, writeTrackingType, (uint64_t)memType},
+      [barriersType, writeTrackingType](ImplicitLocOpBuilder &fb,
+                                        Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value writeTrackingPtr = entryBlock->getArgument(4);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value writeTracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        barriersEqBar = convertAndBroadcast(fb, barriersEqBar, /*dim=*/0,
+                                            writeTrackingType);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
+        Value updated =
+            arith::SelectOp::create(fb, barriersEqBar, zero, writeTracking);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
+                                      updated, writeTrackingType);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createClearBarrierReadTrackingCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
+    Operation *insertPoint) {
+  if (auxData.readTracking[(int)memType].empty()) {
+    return;
+  }
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when clearing barrier read tracking");
+  if (!pred) {
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  }
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value readTrackingVal =
+      auxData.readTracking[(int)memType].at(insertPoint).value;
+  auto readTrackingType = cast<RankedTensorType>(
+      auxData.readTracking[(int)memType].at(insertPoint).type);
+  uint32_t length = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {mbarOffset, lengthVal, pred, barriersVal,
+                             readTrackingVal};
+  createCallToCachedFunction(
+      b, "clear_barrier_read_tracking", args,
+      /*assertInfo=*/std::nullopt,
+      {barriersType, readTrackingType, (uint64_t)memType},
+      [barriersType, readTrackingType](ImplicitLocOpBuilder &fb,
+                                       Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value readTrackingPtr = entryBlock->getArgument(4);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value readTracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), readTrackingPtr, readTrackingType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        barriersEqBar =
+            convertAndBroadcast(fb, barriersEqBar, /*dim=*/0, readTrackingType);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
+        Value updated =
+            arith::SelectOp::create(fb, barriersEqBar, zero, readTracking);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr, updated,
+                                      readTrackingType);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -17,7 +17,7 @@
 // ------------------|---------|-----------------|------------
 // buffers           | tensor  | <B x i64>       | Base pointers of all (sub)buffers
 // barriers          | tensor  | <K x i64>       | Pointers to all individual mbarriers
-// barrierStates     | scratch | <K x i32>       | Packed barrier phase (bit 0) and arrival counts (bits[1..8] init, [9..16] current)
+// barrierStates     | scratch | <K x i32>       | Packed barrier phase (bit 0) and arrival counts (bits[1..8] init, [9..16] current); zero means invalid/uninitialized
 // waiting           | scratch | <K x i32>       | Two bits per thread: waiting flag bit (LSB), stored phase bit (bit 1)
 // writeVisibility   | scratch | <B x i64>       | Per-buffer thread-visibility bitmask (bit i => thread i visible)
 // readVisibility    | scratch | <B x T x i64>   | Per-buffer, per-thread visibility lanes (row-updated; values are bitmasks)
@@ -208,8 +208,22 @@ private:
         }
       }
       if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op)) {
+        funcBuilder.createVerifyBarrierCanInitCall(b, initOp.getAlloc(),
+                                                   initOp);
         funcBuilder.createInitBarrierStateCall(b, initOp.getAlloc(),
                                                initOp.getCount(), initOp);
+      }
+      if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op)) {
+        Value barrier = invalOp.getAlloc();
+        funcBuilder.createVerifyBarrierInitializedCall(b, barrier, nullptr,
+                                                       invalOp);
+        funcBuilder.createInvalidateBarrierStateCall(b, barrier, invalOp);
+        for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+          funcBuilder.createClearBarrierWriteTrackingCall(b, barrier, nullptr,
+                                                          memType, invalOp);
+          funcBuilder.createClearBarrierReadTrackingCall(b, barrier, nullptr,
+                                                         memType, invalOp);
+        }
       }
       if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op)) {
         // Pre-wait: mark waiting threads and check for deadlock.
@@ -219,6 +233,8 @@ private:
           b.setInsertionPoint(waitOp);
           auto pred = waitOp.getPred();
           auto barrier = waitOp.getAlloc();
+          funcBuilder.createVerifyBarrierInitializedCall(b, barrier, pred,
+                                                         waitOp);
           funcBuilder.createSetWaitingCall(b, barrier, baseThread,
                                            waitOp.getPhase(), pred, waitOp);
           funcBuilder.createCheckAllActiveWaitingCall(b, getActiveMask(op),
@@ -230,8 +246,8 @@ private:
         }
         // Post-wait: transfer visible writes and reads to all peer threads,
         // and clear waiting for this barrier
-        auto _barriers = auxData.barriers.at(op).value;
-        assert(!auxData.barriers.empty());
+        assert(!auxData.barriers.empty() &&
+               "barrier descriptors must exist when instrumenting wait");
         auto pred = waitOp.getPred();
         auto barrier = waitOp.getAlloc();
 
@@ -372,6 +388,8 @@ private:
     for (const auto &barrierInfo : opInfo->barriers) {
       Value barrier = barrierInfo.barrier;
       Value combinedPred = combinePredicates(barrierInfo.pred);
+      funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,
+                                                     op);
       // If the op has barriers, we treat it as a commit emitted for each
       // barrier.
       for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -197,6 +197,8 @@ LogicalResult WarpGroupDotWaitOp::verify() {
 LogicalResult InitBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
+  if (getCount() < 1)
+    return emitOpError("count must be greater than or equal to 1");
   return success();
 }
 
@@ -692,7 +694,10 @@ LogicalResult TCGen5MMAOp::verify() {
            << retType.getElementTypeBitWidth() << " but got "
            << retEnc.getColStride();
   // The maximum size of a MMA instruction is 128x256
-  if (retEnc.getBlockN() > 256)
+  auto ctaShape = getShapePerCTA(retEnc.getCGALayout().getCTASplitNum(),
+                                 retType.getShape());
+  auto instrSizeN = std::min<unsigned>(retEnc.getBlockN(), ctaShape[1]);
+  if (instrSizeN > 256)
     return emitOpError("The block size of the return operand must be less than "
                        "or equal to 256");
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -105,6 +105,11 @@ struct TCGen5MMAScaleSharedToTmemConversion
     MLIRContext *context = op->getContext();
     auto aScaleType = op.getAScale().getType();
     auto bScaleType = op.getBScale().getType();
+    if (aScaleType.getShape() != aScaleType.getAllocShape() ||
+        bScaleType.getShape() != bScaleType.getAllocShape()) {
+      op.emitError("subviews NYI");
+      return failure();
+    }
     int blockM = op.getBlockM();
     int blockN = op.getBlockN();
     bool anyChanged = false;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -273,8 +273,6 @@ public:
         tmemStoreOp.getDst().getType().getEncoding());
     if (!tmemEnc)
       return failure();
-    int M = tmemEnc.getBlockM();
-    int N = tmemEnc.getBlockN();
     int numWarps = ttg::lookupNumWarps(tmemStoreOp);
     // Compute the alternative layout.
     std::optional<LinearLayout> ll =
@@ -343,8 +341,6 @@ public:
         tmemLoadOp.getSrc().getType().getEncoding());
     if (!tmemEnc)
       return failure();
-    int M = tmemEnc.getBlockM();
-    int N = tmemEnc.getBlockN();
     int numWarps = ttg::lookupNumWarps(tmemLoadOp);
     auto oldType = tmemLoadOp.getType();
     auto memType = cast<gpu::MemDescType>(tmemLoadOp.getSrc().getType());

--- a/python/examples/gluon/01-attention-forward.py
+++ b/python/examples/gluon/01-attention-forward.py
@@ -14,8 +14,8 @@ from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared
 from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tensor_memory_descriptor,
+    tensor_memory_descriptor_type,
     tma,
     mbarrier,
     tcgen05_mma,
@@ -244,13 +244,18 @@ class AttentionConfig:
         self.p_tmem_layout = gl.constexpr(TensorMemoryLayout((qk_instr_shape[0], qk_instr_shape[1]), col_stride=1))
         o_splitn_tmem_layout: gl.constexpr = TensorMemoryLayout(
             (o_instr_shape[0], o_instr_shape[1] // self.SPLIT_D_FACTOR), col_stride=1)
+        qk_tmem_ty: gl.constexpr = tensor_memory_descriptor_type(gl.float32, self.qk_shape, self.qk_tmem_layout,
+                                                                 self.qk_shape)
+        o_splitn_tmem_ty: gl.constexpr = tensor_memory_descriptor_type(
+            gl.float32,
+            [self.o_shape[0], self.o_shape[1] // self.SPLIT_D_FACTOR],
+            o_splitn_tmem_layout,
+            self.o_shape,
+        )
 
-        self.qk_layout = gl.constexpr(
-            get_tmem_reg_layout(gl.float32, self.qk_shape, self.qk_tmem_layout, self.num_warps,
-                                instr_variant="32x32b_splitn"))
-        self.o_splitn_layout = gl.constexpr(
-            get_tmem_reg_layout(gl.float32, (self.o_shape[0], self.o_shape[1] // self.SPLIT_D_FACTOR),
-                                o_splitn_tmem_layout, self.num_warps))
+        self.qk_layout = gl.constexpr(qk_tmem_ty.get_reg_layout(num_warps=self.num_warps,
+                                                                instr_variant="32x32b_splitn"))
+        self.o_splitn_layout = gl.constexpr(o_splitn_tmem_ty.get_reg_layout(num_warps=self.num_warps))
         self.alpha_2d_layout = gl.constexpr(gl.BlockedLayout([1, 1], [32, 1], [self.num_warps, 1], [0, 1]))
 
         is_fp16 = self.dtype.value in [gl.float16, gl.bfloat16]
@@ -561,19 +566,17 @@ def _compute_and_store_exp2(config, qk, p_tmem):
 @gluon.jit
 def _subtiled_qk_load(config, s_tmem, use_tmem_red: gl.constexpr):
     SIZE: gl.constexpr = s_tmem.shape[1] // config.SPLIT_QK_LOAD_FACTOR
-    s = s_tmem.slice(0, SIZE)
-    layout: gl.constexpr = get_tmem_reg_layout(gl.float32, s.shape, s.layout, config.num_warps)
     qks = ()
     if use_tmem_red:
         red_total = None
         for i in gl.static_range(config.SPLIT_QK_LOAD_FACTOR):
-            vals, reds = s_tmem.slice(i * SIZE, SIZE).load_max(layout)
+            vals, reds = s_tmem.slice(i * SIZE, SIZE).load_max()
             red_total = reds if red_total is None else gl.maximum(red_total, reds)
             qks = qks + (vals, )
         return _join_n(qks), red_total
     else:
         for i in gl.static_range(config.SPLIT_QK_LOAD_FACTOR):
-            qks = qks + (s_tmem.slice(i * SIZE, SIZE).load(layout), )
+            qks = qks + (s_tmem.slice(i * SIZE, SIZE).load(), )
         return _join_n(qks), None
 
 

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -10,12 +10,12 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     allocate_tensor_memory,
     clc,
-    get_tmem_reg_layout,
     tcgen05_commit,
     tcgen05_mma,
+    tcgen05_mma_barrier_count,
     tensor_memory_descriptor,
 )
-from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
+from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.language.core import _aggregate as aggregate
 
@@ -37,6 +37,30 @@ def as_gl_dtype(torch_dtype):
     raise ValueError(f"Unsupported dtype for Gluon layout: {torch_dtype}")
 
 
+@gluon.constexpr_function
+def get_split_dim(cga_layout, dim):
+    return 1 << sum(b[dim] != 0 for b in cga_layout)
+
+
+def get_epilogue_size_n(block_m, block_n, cga_layout):
+    """
+    We can't split a layout along one of the first 4 warps
+    or along a CTA as each of these has their own address space.
+
+    It would be possible to split it if we use a smaller BLOCK_N
+    for both the TMA and MMA instructions but this is NYI.
+    """
+    # We can't split the layout along N as N on M=64 2CTA layouts
+    # the basis (0, TileN) is owned by the second warp basis!
+    if block_m == 64 and cga_layout:
+        return block_n
+    # We can't split the layout along N as the last basis along N
+    # is owned by a different CTA!
+    if get_split_dim(cga_layout, 1) > 1:
+        return block_n
+    return 32
+
+
 def matmul_get_configs(pre_hook=None):
     return [
         triton.Config(
@@ -48,23 +72,24 @@ def matmul_get_configs(pre_hook=None):
                 "GRID_TILE_WIDTH": grid_tile_width,
                 "STAGES": stages,
                 "ACC_STAGES": acc_stages,
-                "TWO_CTAS": two_cta,
-                "EPILOGUE_SIZE_N": epilogue_size_n,
+                "EPILOGUE_SIZE_N": get_epilogue_size_n(BM, BN, cga_layout),
+                "CGA_LAYOUT": cga_layout,
             },
             num_warps=4,
-            num_ctas=2 if two_cta else 1,
+            num_ctas=2**len(cga_layout),
             pre_hook=pre_hook,
         )
-        for BM in (128, )
-        for BN in (128, 256)
+        for BM in (64, 128)
+        for BN in (128, 256, 512)
         for BK in (64, 128)
         for minor_dim in (0, 1)
-        for grid_tile_width in (1, 4, 8, 12, 16)
+        for grid_tile_width in (4, 8, 16)
         for stages in (2, 4, 6)
-        for acc_stages in (2, 3, 4)
-        for epilogue_size_n in (32, 64)
-        for two_cta in (False, True)
-        if not (two_cta and BN > 128)
+        for acc_stages in (2, )
+        for cga_layout in ((), ((1, 0), ), ((1, 0), (2, 0)))
+        if BN // get_split_dim(cga_layout, 1) <= 256
+        # Trim some configs with too large a tile
+        if BN == 512 and len(cga_layout) == 0
     ]
 
 
@@ -73,34 +98,41 @@ def matmul_tma_set_block_size_hook(nargs):
     block_n = nargs["BLOCK_SIZE_N"]
     block_k = nargs["BLOCK_SIZE_K"]
     epilogue_size_n = nargs["EPILOGUE_SIZE_N"]
-    two_ctas = bool(nargs["TWO_CTAS"])
+    cga_layout = nargs["CGA_LAYOUT"]
 
-    tile_m = block_m * (2 if two_ctas else 1)
-    # Keeping this here because pallas does this, but in reality
-    # we should just multiply block_m by 2 if we want to compute
-    # the same number of elements per output tile
-    tile_n = block_n * (2 if two_ctas else 1)
+    tile_m = block_m * get_split_dim(cga_layout, 0)
     nargs["a_desc"].block_shape = [tile_m, block_k]
-    nargs["b_desc"].block_shape = [block_k, tile_n]
+    nargs["b_desc"].block_shape = [block_k, block_n]
     nargs["c_desc"].block_shape = [tile_m, epilogue_size_n]
 
-    if two_ctas:
-        cga_layouts = [[[1, 0]], [[0, 1]], [[1, 0]]]
-        for desc, cga_layout in zip(("a_desc", "b_desc", "c_desc"), cga_layouts):
-            nargs[desc].layout = gl.NVMMASharedLayout.get_default_for(
-                nargs[desc].block_shape,
-                as_gl_dtype(nargs[desc].base.dtype),
-                cga_layout=cga_layout,
-            )
-    else:
-        for desc in ("a_desc", "b_desc", "c_desc"):
-            nargs[desc].layout = gl.NVMMASharedLayout.get_default_for(
-                nargs[desc].block_shape,
-                as_gl_dtype(nargs[desc].base.dtype),
-            )
+    def get_cga_layout(layout, op_idx):
+        assert op_idx in (0, 1)
+        if not layout:
+            return layout
+
+        # 2CTA performs an outer product so bases are [1, 0] and [0, 1]
+        assert layout[0] == (1, 0)
+        first = (1, 0) if op_idx == 0 else (0, 1)
+
+        # Broadcast along K (the reduction dimension)
+        # We multiply by 2 for op_idx == 1, as we have added the (0, 1) basis.
+        def broadcast(b):
+            return (b[0], 0) if op_idx == 0 else (0, 2 * b[1])
+
+        return (first, *map(broadcast, layout[1:]))
+
+    cga_layout_a = get_cga_layout(cga_layout, 0)
+    cga_layout_b = get_cga_layout(cga_layout, 1)
+    cga_layout_c = cga_layout
+    for desc, cga_layout in zip(("a_desc", "b_desc", "c_desc"), (cga_layout_a, cga_layout_b, cga_layout_c)):
+        nargs[desc].layout = gl.NVMMASharedLayout.get_default_for(
+            nargs[desc].block_shape,
+            as_gl_dtype(nargs[desc].base.dtype),
+            cga_layout=cga_layout,
+        )
 
 
-# From Pallas.
+# From Pallas / CUTLASS
 @gluon.jit
 def _planar_snake(lin_idx, m_tiles, n_tiles, minor_dim: gl.constexpr, tile_width: gl.constexpr):
     major_size = n_tiles if minor_dim == 0 else m_tiles
@@ -140,12 +172,6 @@ class Counter:
     phase: gl.tensor
     num_barriers: gl.constexpr
 
-    @gluon.constexpr_function
-    def __init__(self, index, phase, num_barriers):
-        self.index = index
-        self.phase = phase
-        self.num_barriers = gl.constexpr(num_barriers)
-
     @gluon.jit
     def create(phase, num_barriers: gl.constexpr):
         return Counter(gl.to_tensor(0), gl.to_tensor(phase), num_barriers)
@@ -175,23 +201,6 @@ class ClcTileSchedulerConsumer:
     clc_consumed_bars: gl.shared_memory_descriptor
     counter: Counter
     consumed_counter: Counter
-
-    @gluon.constexpr_function
-    def __init__(self, has_work, tile_id, num_pid_m, num_pid_n, TILE_M, TILE_N, MINOR_DIM, GRID_TILE_WIDTH,
-                 clc_result_buffers, clc_barriers, clc_consumed_bars, counter, consumed_counter):
-        self.has_work = has_work
-        self.tile_id = tile_id
-        self.num_pid_m = num_pid_m
-        self.num_pid_n = num_pid_n
-        self.TILE_M = gl.constexpr(TILE_M)
-        self.TILE_N = gl.constexpr(TILE_N)
-        self.MINOR_DIM = gl.constexpr(MINOR_DIM)
-        self.GRID_TILE_WIDTH = gl.constexpr(GRID_TILE_WIDTH)
-        self.clc_result_buffers = clc_result_buffers
-        self.clc_barriers = clc_barriers
-        self.clc_consumed_bars = clc_consumed_bars
-        self.counter = counter
-        self.consumed_counter = consumed_counter
 
     @gluon.jit
     def initialize(M, N, TILE_M: gl.constexpr, TILE_N: gl.constexpr, MINOR_DIM: gl.constexpr,
@@ -276,28 +285,6 @@ class PartitionArgs:
     clc_consumed_bars: gl.shared_memory_descriptor
     MINOR_DIM: gl.constexpr
     GRID_TILE_WIDTH: gl.constexpr
-    TWO_CTAS: gl.constexpr
-
-    @gluon.constexpr_function
-    def __init__(self, a_desc, b_desc, c_desc, a_bufs, b_bufs, load_empty_bars, load_ready_bars, acc_bufs,
-                 acc_empty_bars, acc_ready_bars, clc_result_buffers, clc_barriers, clc_consumed_bars, MINOR_DIM,
-                 GRID_TILE_WIDTH, TWO_CTAS):
-        self.a_desc = a_desc
-        self.b_desc = b_desc
-        self.c_desc = c_desc
-        self.a_bufs = a_bufs
-        self.b_bufs = b_bufs
-        self.load_empty_bars = load_empty_bars
-        self.load_ready_bars = load_ready_bars
-        self.acc_bufs = acc_bufs
-        self.acc_empty_bars = acc_empty_bars
-        self.acc_ready_bars = acc_ready_bars
-        self.clc_result_buffers = clc_result_buffers
-        self.clc_barriers = clc_barriers
-        self.clc_consumed_bars = clc_consumed_bars
-        self.MINOR_DIM = gl.constexpr(MINOR_DIM)
-        self.GRID_TILE_WIDTH = gl.constexpr(GRID_TILE_WIDTH)
-        self.TWO_CTAS = gl.constexpr(TWO_CTAS)
 
     @gluon.jit
     def get_clc_consumer(self):
@@ -353,8 +340,8 @@ def matmul_load_partition(p):
             mbarrier.wait(p.load_empty_bars.index(state.index), state.phase, pred=pred)
             bar = p.load_ready_bars.index(state.index)
             mbarrier.expect(bar, p.a_desc.nbytes_per_cta + p.b_desc.nbytes_per_cta)
-            tma.async_copy_global_to_shared(p.a_desc, [off_m, k], bar, p.a_bufs.index(state.index))
-            tma.async_copy_global_to_shared(p.b_desc, [k, off_n], bar, p.b_bufs.index(state.index))
+            tma.async_copy_global_to_shared(p.a_desc, [off_m, k], bar, p.a_bufs.index(state.index), multicast=True)
+            tma.async_copy_global_to_shared(p.b_desc, [k, off_n], bar, p.b_bufs.index(state.index), multicast=True)
             state = state.next()
         scheduler = scheduler.step(i)
         i += 1
@@ -378,10 +365,10 @@ def matmul_mma_partition(p):
         for k in range(0, K, BLOCK_K):
             mbarrier.wait(p.load_ready_bars.index(load_state.index), load_state.phase)
             tcgen05_mma(p.a_bufs.index(load_state.index), p.b_bufs.index(load_state.index), acc_buf, use_acc=use_acc,
-                        mbarriers=[p.load_empty_bars.index(load_state.index)])
+                        multicast=True, mbarriers=[p.load_empty_bars.index(load_state.index)])
             load_state = load_state.next()
             use_acc = True
-        tcgen05_commit(p.acc_ready_bars.index(acc_state.index))
+        tcgen05_commit(p.acc_ready_bars.index(acc_state.index), descs=[p.a_bufs.index(0), p.b_bufs.index(0)])
         acc_state = acc_state.next()
         scheduler = scheduler.step(i)
         i += 1
@@ -411,16 +398,9 @@ def matmul_epilogue_partition(p):
         for s in gl.static_range(SUBTILE_FACTOR):
             acc_sub = acc_buf.slice(SPLIT_TILE_N * s, SPLIT_TILE_N)
             acc_smem = acc_smems.index(sub_acc_state.index)
-            acc = acc_sub.load(
-                get_tmem_reg_layout(
-                    gl.float32,
-                    (TILE_M, SPLIT_TILE_N),
-                    acc_sub.type.layout,
-                    gl.num_warps(),
-                )).to(dtype)
+            acc = acc_sub.load().to(dtype)
             tma.store_wait(pendings=1)
             acc_smem.store(acc)
-            fence_async_shared()
             tma.async_copy_shared_to_global(p.c_desc, [off_m, off_n + SPLIT_TILE_N * s], acc_smem)
             sub_acc_state = sub_acc_state.next()
         # Signal that the accumulator slot can be reused only after all stores are done.
@@ -445,29 +425,32 @@ def _matmul_kernel(
     GRID_TILE_WIDTH: gl.constexpr,
     STAGES: gl.constexpr,
     ACC_STAGES: gl.constexpr,
-    TWO_CTAS: gl.constexpr,
+    CGA_LAYOUT: gl.constexpr,
     EPILOGUE_SIZE_N: gl.constexpr,
 ):
     BLOCK_M: gl.constexpr = a_desc.block_shape[0]
     BLOCK_N: gl.constexpr = b_desc.block_shape[1]
+    TWO_CTAS: gl.constexpr = gl.num_ctas() > 1
+    N_PARTITIONS: gl.constexpr = 4
 
     dtype: gl.constexpr = a_desc.dtype
     a_bufs = gl.allocate_shared_memory(dtype, [STAGES] + a_desc.block_shape, a_desc.layout)
     b_bufs = gl.allocate_shared_memory(dtype, [STAGES] + b_desc.block_shape, b_desc.layout)
+    # Number of CTAs that will arrive on the barrier from a tcgen05_commit after an MMA instruction
+    mma_barrier_count: gl.constexpr = tcgen05_mma_barrier_count([a_bufs.index(0), b_bufs.index(0)], multicast=True)
 
     # Equiv. consumed_barrier. Barrier TCGEN05 MMA -> Load TMA
     load_empty_bars = mbarrier.allocate_mbarrier(batch=STAGES)
     # Equiv. ab_tma_barrier. Barrier Load TMA -> TCGEN05 MMA
     load_ready_bars = mbarrier.allocate_mbarrier(batch=STAGES, two_ctas=TWO_CTAS)
     for i in gl.static_range(STAGES):
-        # For multicast we could use tcgen05_mma_barrier_count
-        mbarrier.init(load_empty_bars.index(i), count=1)
+        mbarrier.init(load_empty_bars.index(i), count=mma_barrier_count)
         mbarrier.init(load_ready_bars.index(i), count=1)
 
     tmem_layout: gl.constexpr = TensorMemoryLayout(
-        [BLOCK_SIZE_M, BLOCK_N],
+        [BLOCK_SIZE_M, BLOCK_N // get_split_dim(CGA_LAYOUT, 1)],
         col_stride=1,
-        cta_split_num=(2, 1) if TWO_CTAS else None,
+        cga_layout=CGA_LAYOUT,
         two_ctas=TWO_CTAS,
     )
     acc_bufs = allocate_tensor_memory(gl.float32, [ACC_STAGES, BLOCK_M, BLOCK_N], tmem_layout)
@@ -477,20 +460,20 @@ def _matmul_kernel(
     acc_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(acc_empty_bars.index(i), count=1)
-        # For multicast we could use tcgen05_mma_barrier_count
-        mbarrier.init(acc_ready_bars.index(i), count=1)
+        mbarrier.init(acc_ready_bars.index(i), count=mma_barrier_count)
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     clc_consumed_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES, two_ctas=TWO_CTAS)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(clc_barriers.index(i), count=1)
-        mbarrier.init(clc_consumed_bars.index(i), count=3)
+        # Every partition but itself arrives on the barrier
+        mbarrier.init(clc_consumed_bars.index(i), count=N_PARTITIONS - 1)
 
     cga_layout: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
     clc_result_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 2],
                                                    gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout))
 
-    if TWO_CTAS:
+    if gl.num_ctas() > 1:
         mbarrier.sync_cluster_init()
     p = PartitionArgs(
         a_desc,
@@ -508,7 +491,6 @@ def _matmul_kernel(
         clc_consumed_bars,
         GRID_MINOR_DIM,
         GRID_TILE_WIDTH,
-        TWO_CTAS,
     )
 
     gl.warp_specialize([
@@ -530,29 +512,25 @@ def matmul_with_config(
     b,
     out=None,
     *,
-    block_size_m=128,
-    block_size_n=128,
-    block_size_k=64,
-    grid_minor_dim=0,
-    grid_tile_width=1,
-    stages=4,
-    acc_stages=2,
-    two_ctas=False,
-    epilogue_size_n=32,
+    block_size_m,
+    block_size_n,
+    block_size_k,
+    grid_minor_dim,
+    grid_tile_width,
+    stages,
+    acc_stages,
+    cga_layout,
+    epilogue_size_n,
 ):
-    if two_ctas and block_size_n > 128:
-        raise ValueError("two_ctas only supports BLOCK_SIZE_N <= 128")
+    if block_size_n // get_split_dim(cga_layout, 1) > 256:
+        raise ValueError(
+            f"cga_layout={list(cga_layout)} only supports BLOCK_SIZE_N <= {256 * get_split_dim(cga_layout, 1)}")
     M, K = a.shape
     K1, N = b.shape
     if K != K1:
         raise ValueError(f"incompatible shapes: {a.shape} and {b.shape}")
     if a.dtype != torch.float16 or b.dtype != torch.float16:
         raise ValueError("matmul only supports fp16 inputs")
-
-    tile_m = block_size_m * (2 if two_ctas else 1)
-    tile_n = block_size_n * (2 if two_ctas else 1)
-    if M % tile_m != 0 or N % tile_n != 0 or K % block_size_k != 0:
-        raise ValueError(f"Shape {(M, N, K)} incompatible with tile {(tile_m, tile_n, block_size_k)}")
 
     if out is None:
         c = torch.empty((M, N), device=a.device, dtype=a.dtype)
@@ -579,16 +557,13 @@ def matmul_with_config(
         "GRID_TILE_WIDTH": grid_tile_width,
         "STAGES": stages,
         "ACC_STAGES": acc_stages,
-        "TWO_CTAS": two_ctas,
+        "CGA_LAYOUT": cga_layout,
         "EPILOGUE_SIZE_N": epilogue_size_n,
     })
 
     def grid(meta):
-        tile_m = meta["BLOCK_SIZE_M"] * (2 if bool(meta["TWO_CTAS"]) else 1)
-        tile_n = meta["BLOCK_SIZE_N"] * (2 if bool(meta["TWO_CTAS"]) else 1)
-        block_k = meta["BLOCK_SIZE_K"]
-        if M % tile_m != 0 or N % tile_n != 0 or K % block_k != 0:
-            raise ValueError(f"Shape {(M, N, K)} incompatible with tile {(tile_m, tile_n, block_k)}")
+        tile_m = meta["BLOCK_SIZE_M"] * (2 if bool(meta["CGA_LAYOUT"]) else 1)
+        tile_n = meta["BLOCK_SIZE_N"]
         num_tiles = triton.cdiv(M, tile_m) * triton.cdiv(N, tile_n)
         return (num_tiles, )
 
@@ -606,10 +581,10 @@ def matmul_with_config(
         grid_tile_width,
         stages,
         acc_stages,
-        two_ctas,
+        cga_layout,
         epilogue_size_n,
         num_warps=4,
-        num_ctas=2 if two_ctas else 1,
+        num_ctas=2**len(cga_layout),
     )
     return c
 
@@ -630,11 +605,8 @@ def matmul(a, b):
     c_desc = TensorDescriptor.from_tensor(c, dummy_block, dummy_layout)
 
     def grid(meta):
-        tile_m = meta["BLOCK_SIZE_M"] * (2 if bool(meta["TWO_CTAS"]) else 1)
-        tile_n = meta["BLOCK_SIZE_N"] * (2 if bool(meta["TWO_CTAS"]) else 1)
-        block_k = meta["BLOCK_SIZE_K"]
-        if M % tile_m != 0 or N % tile_n != 0 or K % block_k != 0:
-            raise ValueError(f"Shape {(M, N, K)} incompatible with tile {(tile_m, tile_n, block_k)}")
+        tile_m = meta["BLOCK_SIZE_M"] * (2 if bool(meta["CGA_LAYOUT"]) else 1)
+        tile_n = meta["BLOCK_SIZE_N"]
         num_tiles = triton.cdiv(M, tile_m) * triton.cdiv(N, tile_n)
         return (num_tiles, )
 
@@ -642,91 +614,61 @@ def matmul(a, b):
     return c
 
 
+# Subset of matmul_get_configs
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize(
-    "grid_minor_dim,grid_tile_width,stages,block_size_n",
-    [
-        (0, 1, 2, 128),
-        (1, 8, 4, 128),
-        (0, 16, 2, 256),
-    ],
-)
-def test_matmul_single_cta_configs(grid_minor_dim, grid_tile_width, stages, block_size_n):
-    M, N, K = 512, 512, 256
+@pytest.mark.parametrize("BLOCK_SIZE_M", [64, 128])
+@pytest.mark.parametrize("BLOCK_SIZE_N", [128, 256])
+@pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
+@pytest.mark.parametrize("GRID_MINOR_DIM", [0, 1])
+@pytest.mark.parametrize("GRID_TILE_WIDTH", [8])
+@pytest.mark.parametrize("CGA_LAYOUT", [(), ((1, 0), ), ((1, 0), (2, 0))])
+@pytest.mark.parametrize("STAGES", [2, 4])
+@pytest.mark.parametrize("ACC_STAGES", [2])
+@pytest.mark.parametrize("EPILOGUE_SIZE_N", [32])
+@pytest.mark.parametrize("M, N, K", [(100, 200, 200)])
+def test_matmul_matches_torch(
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    GRID_MINOR_DIM,
+    GRID_TILE_WIDTH,
+    CGA_LAYOUT,
+    STAGES,
+    ACC_STAGES,
+    EPILOGUE_SIZE_N,
+):
+    # To support epilogue splitting we need to be able to split within a CTA
+    EPILOGUE_SIZE_N = get_epilogue_size_n(BLOCK_SIZE_M, BLOCK_SIZE_N, CGA_LAYOUT)
+
     torch.manual_seed(0)
     a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
     b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
     expected = torch.matmul(a, b)
-    actual = matmul_with_config(
-        a,
-        b,
-        block_size_m=128,
-        block_size_n=block_size_n,
-        block_size_k=64,
-        grid_minor_dim=grid_minor_dim,
-        grid_tile_width=grid_tile_width,
-        stages=stages,
-        two_ctas=False,
-        epilogue_size_n=32,
-    )
+    try:
+        actual = matmul_with_config(
+            a,
+            b,
+            block_size_m=BLOCK_SIZE_M,
+            block_size_n=BLOCK_SIZE_N,
+            block_size_k=BLOCK_SIZE_K,
+            grid_minor_dim=GRID_MINOR_DIM,
+            grid_tile_width=GRID_TILE_WIDTH,
+            stages=STAGES,
+            acc_stages=ACC_STAGES,
+            cga_layout=CGA_LAYOUT,
+            epilogue_size_n=EPILOGUE_SIZE_N,
+        )
+    except triton.OutOfResources:
+        pytest.skip("Out of resources")
     torch.testing.assert_close(expected, actual, atol=1e-1, rtol=1e-2)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize(
-    "grid_minor_dim,grid_tile_width,stages",
-    [
-        (1, 1, 2),
-        (1, 4, 4),
-        (0, 12, 6),
-        (0, 8, 4),
-    ],
-)
-def test_matmul_two_cta_configs(grid_minor_dim, grid_tile_width, stages):
-    M, N, K = 512, 512, 256
-    torch.manual_seed(0)
-    a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
-    b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
-    expected = torch.matmul(a, b)
-    actual = matmul_with_config(
-        a,
-        b,
-        block_size_m=128,
-        block_size_n=128,
-        block_size_k=64,
-        grid_minor_dim=grid_minor_dim,
-        grid_tile_width=grid_tile_width,
-        stages=stages,
-        two_ctas=True,
-        epilogue_size_n=32,
-    )
-    torch.testing.assert_close(expected, actual, atol=1e-1, rtol=1e-2)
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize(
-    "M,N,K",
-    [
-        (256, 256, 128),
-        (512, 256, 256),
-    ],
-)
-def test_matmul_autotuned_matches_torch(M, N, K):
-    torch.manual_seed(0)
-    a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
-    b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
-    expected = torch.matmul(a, b)
-    actual = matmul(a, b)
-    torch.testing.assert_close(expected, actual, atol=1e-1, rtol=1e-2)
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-def test_matmul_with_config_rejects_invalid_collective_config():
-    M, N, K = 512, 512, 256
-    a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
-    b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
-    with pytest.raises(ValueError, match="BLOCK_SIZE_N <= 128"):
-        _ = matmul_with_config(a, b, two_ctas=True, block_size_n=256)
+########################################################
+# Benchmarking
+########################################################
 
 
 def show_profile(profile_name):
@@ -759,13 +701,13 @@ def create_benchmark_tensors():
 def get_benchmark_kernel_config():
     return {
         "tile_m": 128,
-        "tile_n": 128,
+        "tile_n": 256,
         "tile_k": 64,
         "grid_minor_dim": 0,
         "grid_tile_width": 16,
         "stages": 6,
         "acc_stages": 2,
-        "collective": True,
+        "cga_layout": ((1, 0), ),
         "epilogue_tile_n": 32,
     }
 
@@ -790,7 +732,7 @@ def make_gluon_runner(a, b, c_triton, cfg, use_autotuned=False):
             grid_tile_width=cfg["grid_tile_width"],
             stages=cfg["stages"],
             acc_stages=cfg["acc_stages"],
-            two_ctas=cfg["collective"],
+            cga_layout=cfg["cga_layout"],
             epilogue_size_n=cfg["epilogue_tile_n"],
         )
 

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1117,8 +1117,8 @@ void init_gluon_ir(py::module &&m) {
   m.def(
       "compute_tmem_reg_layout",
       [](py::object elementTyObj, std::vector<int64_t> shape,
-         py::object layoutObj, unsigned numWarps,
-         const std::string &atomName) -> py::object {
+         std::vector<int64_t> allocShape, py::object layoutObj,
+         unsigned numWarps, const std::string &atomName) -> py::object {
         DialectRegistry registry;
         registry.insert<triton::TritonDialect, ttg::TritonGPUDialect,
                         ttng::TritonNvidiaGPUDialect, gluon::GluonDialect>();
@@ -1133,8 +1133,6 @@ void init_gluon_ir(py::module &&m) {
         auto elementType = elementTyObj.attr("to_ir")(builderObj).cast<Type>();
         auto layoutAttr =
             layoutObj.attr("_to_ir")(builderObj).cast<Attribute>();
-        auto allocShape = shape;
-
         auto ctx = builder.getContext();
         auto memDescTy = builder.getChecked<ttg::MemDescType>(
             shape, elementType, layoutAttr,

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -3,6 +3,7 @@ isort
 numpy
 pytest
 pytest-forked
+pytest-instafail
 pytest-xdist
 scipy>=1.7.1
 llnl-hatchet

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -6,7 +6,9 @@ import torch
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "interpreter: indicate whether interpreter supports the test")
+    # If pytest-sugar is not active, enable instafail
+    if not config.pluginmanager.hasplugin("sugar"):
+        config.option.instafail = True
 
 
 @pytest.fixture(autouse=True)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1,7 +1,6 @@
 import os
 import torch
 import pytest
-import triton
 from triton import knobs
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
@@ -12,7 +11,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import allocate_tensor_
 from triton._internal_testing import is_cuda
 import multiprocessing
 import tempfile
-from typing import Optional
 
 try:
     multiprocessing.set_start_method("spawn")
@@ -86,14 +84,7 @@ def failing_kernel(input):
     ampere.async_copy.wait_group(0)
 
 
-def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-    return torch.empty(size, device="cuda", dtype=torch.int8)
-
-
 def run_failing_kernel(device, enable_consan, mode):
-    # ConSan requires a global memory allocation
-    triton.set_allocator(alloc_fn)
-
     if enable_consan:
         if mode == "env":
             os.environ["TRITON_INSTRUMENTATION_MODE"] = "consan"
@@ -127,6 +118,17 @@ def test_cache_miss_env(device, monkeypatch):
     assert "device-side assert" in str(result.exc)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_consan_uses_profile_scratch(device, fresh_knobs):
+    with knobs.cache.scope(), knobs.runtime.scope():
+        knobs.cache.dir = tempfile.mkdtemp(prefix="triton-cache-")
+        fresh_knobs.compilation.instrumentation_mode = "consan"
+        input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+        compiled = failing_kernel.warmup(input, grid=(1, ))
+        assert compiled.metadata.profile_scratch_size > 0
+        assert compiled.metadata.global_scratch_size == 0
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_async_tma_kernel(FAILURE, device, run_wrapper, monkeypatch):
@@ -140,7 +142,6 @@ def test_async_tma_kernel(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input_desc, out, FAILURE: ttgl.constexpr):
@@ -182,7 +183,6 @@ def test_async_tma_kernel_2bufs_1bar(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(a_desc, b_desc, out, FAILURE: ttgl.constexpr):
@@ -232,7 +232,6 @@ def test_tma_interleave_kernel(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input_desc, out, FAILURE: ttgl.constexpr):
@@ -287,7 +286,6 @@ def test_async_copy(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input, FAILURE: ttgl.constexpr):
@@ -329,7 +327,6 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(output_desc, FAILURE: ttgl.constexpr):
@@ -374,7 +371,6 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input_desc, FAILURE: ttgl.constexpr, MEM_ACCESS_KIND: ttgl.constexpr):
@@ -434,7 +430,6 @@ def test_warpgroup_mma(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input, FAILURE: ttgl.constexpr):
@@ -474,7 +469,6 @@ def test_warpgroup_mma2(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input, FAILURE: ttgl.constexpr):
@@ -518,7 +512,6 @@ def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper, monkeypatch)
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input_desc, BUF_IDX: ttgl.constexpr, BAR_IDX: ttgl.constexpr):
@@ -572,7 +565,6 @@ def test_multibuffered_loop(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input_desc, FAILURE: ttgl.constexpr):
@@ -682,7 +674,6 @@ def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel(input_desc, FAILURE: ttgl.constexpr):
@@ -758,7 +749,6 @@ def test_ws_store_wait_load(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
@@ -809,7 +799,6 @@ def test_ws_load_wait_store(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
@@ -860,7 +849,6 @@ def test_ws_two_loads_two_bars(MISSING_BAR, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
@@ -921,7 +909,6 @@ def test_ws_two_loads_one_bar(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
@@ -982,7 +969,6 @@ def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper, monkeypatc
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
@@ -1061,7 +1047,6 @@ def test_ws_load_ordering(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
@@ -1123,7 +1108,6 @@ def test_ws_two_producers_two_consumers(MISSING_BAR, device, run_wrapper, monkey
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
@@ -1210,7 +1194,6 @@ def test_ws_different_warp_sizes(MISSING_BAR, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, MISSING_BAR: ttgl.constexpr):
@@ -1278,7 +1261,6 @@ def test_ws_async_copy_commits(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_prog(input, smem, FAILURE: ttgl.constexpr, blocked_layout: ttgl.constexpr, BASE: ttgl.constexpr):
@@ -1340,7 +1322,6 @@ def test_ws_async_copy_wait_visibility(FAILURE, device, run_wrapper, monkeypatch
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(input, smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
@@ -1391,7 +1372,6 @@ def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(smem, bar, FAILURE: ttgl.constexpr, blocked_layout: ttgl.constexpr, mma_layout: ttgl.constexpr):
@@ -1439,8 +1419,6 @@ def test_deadlock_two_partitions(device, run_wrapper, monkeypatch):
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
 
-    triton.set_allocator(alloc_fn)
-
     @gluon.jit
     def ws_default(bar):
         mbarrier.wait(bar.index(0), phase=0)
@@ -1472,7 +1450,6 @@ def test_deadlock_overarrival(device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def kernel():
@@ -1497,7 +1474,6 @@ def test_deadlock_underarrival(device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(bar):
@@ -1532,7 +1508,6 @@ def test_deadlock_different_phases(device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(bar):
@@ -1566,7 +1541,6 @@ def test_deadlock_exempt_when_tma_signals(device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(input_desc, smem, bar):
@@ -1608,7 +1582,6 @@ def test_barrier_underflow(device, run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def ws_default(bar):
@@ -1632,6 +1605,88 @@ def test_barrier_underflow(device, run_wrapper, monkeypatch):
     kernel[(1, )](num_warps=4)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("WITH_INVALIDATE", [False, True])
+def test_barrier_reinit_requires_invalidate(WITH_INVALIDATE, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_barrier_reinit_requires_invalidate, (WITH_INVALIDATE, device, False, monkeypatch))
+        if WITH_INVALIDATE:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        else:
+            assert "device-side assert" in str(result.exc)
+            assert "Barrier re-initialized without prior invalidation" in result.driver_stderr_output
+        return
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(WITH_INVALIDATE: ttgl.constexpr):
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        if WITH_INVALIDATE:
+            mbarrier.invalidate(bar.index(0))
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.invalidate(bar.index(0))
+
+    kernel[(1, )](WITH_INVALIDATE=WITH_INVALIDATE, num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("USE_KIND", ["wait", "arrive", "invalidate", "expect"])
+def test_barrier_use_without_init(USE_KIND, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_barrier_use_without_init, (USE_KIND, device, False, monkeypatch))
+        assert "device-side assert" in str(result.exc)
+        assert "Barrier used before initialization or after invalidation" in result.driver_stderr_output
+        return
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(USE_KIND: ttgl.constexpr):
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], mbarrier.MBarrierLayout())
+        if USE_KIND == "wait":
+            mbarrier.wait(bar.index(0), phase=0)
+        elif USE_KIND == "arrive":
+            mbarrier.arrive(bar.index(0), count=1)
+        elif USE_KIND == "invalidate":
+            mbarrier.invalidate(bar.index(0))
+        elif USE_KIND == "expect":
+            mbarrier.expect(bar.index(0), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+
+    kernel[(1, )](USE_KIND=USE_KIND, num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("USE_KIND", ["wait", "arrive", "expect"])
+def test_barrier_use_after_invalidate(USE_KIND, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_barrier_use_after_invalidate, (USE_KIND, device, False, monkeypatch))
+        assert "device-side assert" in str(result.exc)
+        assert "Barrier used before initialization or after invalidation" in result.driver_stderr_output
+        return
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(USE_KIND: ttgl.constexpr):
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.invalidate(bar.index(0))
+        if USE_KIND == "wait":
+            mbarrier.wait(bar.index(0), phase=0)
+        elif USE_KIND == "arrive":
+            mbarrier.arrive(bar.index(0), count=1)
+        elif USE_KIND == "expect":
+            mbarrier.expect(bar.index(0), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+
+    kernel[(1, )](USE_KIND=USE_KIND, num_warps=4)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("MISSING_BAR", [True, False])
 @pytest.mark.parametrize("OVERLAP", [True, False])
@@ -1650,7 +1705,6 @@ def test_aliasing_shared_visibility_outstanding_write(MISSING_BAR, OVERLAP, devi
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def writer(alias0: ttgl.constexpr, bar: ttgl.constexpr, OVERLAP: ttgl.constexpr, blocked_layout: ttgl.constexpr):
@@ -1702,7 +1756,6 @@ def test_aliasing_tensor_visibility_outstanding_read(FAILURE, device, run_wrappe
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def reader(alias0: ttgl.constexpr, smem: ttgl.constexpr, blocked_layout_read: ttgl.constexpr, bar: ttgl.constexpr):
@@ -1757,7 +1810,6 @@ def test_aliasing_commit_tracking(MISSING_WAIT, OVERLAP, device, run_wrapper, mo
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     @gluon.jit
     def producer(input, alias0, bar, MISSING_WAIT: ttgl.constexpr, OVERLAP: ttgl.constexpr,
@@ -1828,7 +1880,6 @@ def test_mma_read_async_copy_write(run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 128
     A = torch.randn((BLOCK_M, BLOCK_K), device="cuda", dtype=torch.float16)
@@ -1875,7 +1926,6 @@ def test_mma_read_local_alloc_write(run_wrapper, monkeypatch):
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
     knobs.refresh_knobs()
-    triton.set_allocator(alloc_fn)
 
     K = 512
     BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -33,7 +33,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_mma_barrier_count,
     tcgen05_mma,
     tcgen05_mma_scaled,
@@ -293,13 +292,7 @@ def tcgen05_mma_multicast_commit_kernel(a_desc, b_desc, out_ptrs, BLOCK_M: ttgl.
     mbarrier.wait(mma_bar, phase=0, deps=[smem_a, smem_b])
     mbarrier.invalidate(mma_bar)
 
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-        ttgl.float32,
-        (BLOCK_M, BLOCK_N),
-        acc_tmem_layout,
-        num_warps=ttgl.num_warps(),
-    )
-    out = acc_tmem.load(tmem_reg_layout)
+    out = acc_tmem.load()
     out = ttgl.convert_layout(out, blocked_c)
 
     out_offs_m = ttgl.arange(0, BLOCK_M)[:, None]
@@ -543,13 +536,7 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
         mbarrier.wait(mma_barrier, phase=0, deps=[smem_a, smem_b])
         mbarrier.invalidate(mma_barrier)
 
-        tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-            acc_dtype,
-            (M, N),
-            acc_layout,
-            num_warps=ttgl.num_warps(),
-        )
-        acc = acc_tmem.load(tmem_reg_layout)
+        acc = acc_tmem.load()
     else:
         acc = ttgl.zeros([M, N], dtype=acc_dtype, layout=acc_layout)
         acc = hopper.warpgroup_mma(smem_a, smem_b, acc, is_async=ASYNC)
@@ -653,13 +640,7 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexp
 
     if use_tcgen05:
         mbarrier.invalidate(mma_bar)
-        reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-            ttgl.float32,
-            (BLOCK_M, BLOCK_N),
-            acc_tmem_layout,
-            num_warps=ttgl.num_warps(),
-        )
-        acc = acc_tmem.load(reg_layout)
+        acc = acc_tmem.load()
 
     acc = ttgl.convert_layout(acc, block_layout_c)
     offs_m = ttgl.arange(0, BLOCK_M)[:, None]
@@ -1395,7 +1376,7 @@ def test_tmem_subslice_block_m_64():
         s_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=tmem_layout)
         o_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=tmem_layout)
 
-        layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (BLOCK_M, N), tmem_layout, num_warps=4)
+        layout: ttgl.constexpr = s_tmem.get_reg_layout()
 
         offsets = ttgl.arange(0, BLOCK_M)[:, None] * N + ttgl.arange(0, N)[None, :]
         offsets = ttgl.set_auto_layout(offsets, layout)
@@ -1404,21 +1385,20 @@ def test_tmem_subslice_block_m_64():
         s_tmem.store(s)
         o_tmem.store(s)
 
-        p_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), col_stride=1)
-        p_tmem = s_tmem.slice(0, N // 2)._reinterpret(ttgl.float16, [BLOCK_M, N], p_tmem_layout)
+        p_tmem = s_tmem.slice(0, N // 2)._reinterpret(ttgl.float16, [BLOCK_M, N], tmem_layout)
         p_tmem.store(ttgl.full((BLOCK_M, N), 0.0, dtype=ttgl.float16, layout=layout))
 
         d1_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, 2), col_stride=1)
-        d1_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (BLOCK_M, 2), d1_tmem_layout, num_warps=4)
 
         m_tmem = s_tmem.slice(N // 4, 2)._reinterpret(ttgl.float32, [BLOCK_M, 2], d1_tmem_layout)
+        d1_layout: ttgl.constexpr = m_tmem.get_reg_layout()
         m_tmem.store(ttgl.full((BLOCK_M, 2), 2.0, dtype=ttgl.float32, layout=d1_layout))
         l_tmem = s_tmem.slice(N // 4 + 2, 2)._reinterpret(ttgl.float32, [BLOCK_M, 2], d1_tmem_layout)
         l_tmem.store(ttgl.full((BLOCK_M, 2), 3.0, dtype=ttgl.float32, layout=d1_layout))
         a_tmem = s_tmem.slice(N // 4 + 4, 2)._reinterpret(ttgl.float32, [BLOCK_M, 2], d1_tmem_layout)
         a_tmem.store(ttgl.full((BLOCK_M, 2), 4.0, dtype=ttgl.float32, layout=d1_layout))
 
-        s = s_tmem.load(layout)
+        s = s_tmem.load()
 
         ttgl.store(out_ptr + offsets, s)
 
@@ -1476,8 +1456,10 @@ def test_block_m_64_mma():
 
         a_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), col_stride=1)
         acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), col_stride=1)
-        a_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float16, (BLOCK_M, N), a_tmem_layout, num_warps=4,
-                                                       instr_variant="32x32b_splitn")
+        al_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
+        ar_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
+        acc_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=acc_tmem_layout)
+        a_layout: ttgl.constexpr = al_tmem.get_reg_layout(instr_variant="32x32b_splitn")
         b_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [4, 1], [1, 0])
         a_offsets = ttgl.set_auto_layout(a_offsets, a_layout)
         b_offsets = ttgl.set_auto_layout(b_offsets, b_layout)
@@ -1485,10 +1467,6 @@ def test_block_m_64_mma():
         a = ttgl.load(a_ptr + a_offsets)
         b = ttgl.load(b_ptr + b_offsets)
         c = ttgl.load(c_ptr + a_offsets)
-
-        al_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
-        ar_tmem = allocate_tensor_memory(ttgl.float16, (BLOCK_M, N), layout=a_tmem_layout)
-        acc_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=acc_tmem_layout)
 
         a0, a1 = a.reshape((BLOCK_M, 2, N // 2)).permute(0, 2, 1).split()
 
@@ -1632,12 +1610,12 @@ def test_tmem_copy_no_scales(M, N, BLOCK_N, num_warps, swizzle):
             block=(128, BLOCK_N),
             col_stride=32 // in_ptr.dtype.element_ty.primitive_bitwidth,
         )
-        tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-            in_ptr.dtype.element_ty,
-            (M, N),
-            tmem_layout,
-            num_warps=num_warps,
+        tmem = allocate_tensor_memory(
+            element_ty=in_ptr.dtype.element_ty,
+            shape=[M, N],
+            layout=tmem_layout,
         )
+        tmem_reg_layout: ttgl.constexpr = tmem.get_reg_layout()
         offs_m = ttgl.arange(0, M, ttgl.SliceLayout(1, tmem_reg_layout))
         offs_n = ttgl.arange(0, N, ttgl.SliceLayout(0, tmem_reg_layout))
         offs = offs_m[:, None] * N + offs_n[None, :]
@@ -1648,17 +1626,12 @@ def test_tmem_copy_no_scales(M, N, BLOCK_N, num_warps, swizzle):
         smem = ttgl.allocate_shared_memory(in_ptr.dtype.element_ty, [M, N], layout=smem_layout)
 
         smem.store(input)
-        tmem = allocate_tensor_memory(
-            element_ty=in_ptr.dtype.element_ty,
-            shape=[M, N],
-            layout=tmem_layout,
-        )
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
         mbarrier.init(bar, count=1)
         tcgen05_copy(smem, tmem)
         tcgen05_commit(bar)
         mbarrier.wait(bar, phase=0)
-        output = tmem.load(tmem_reg_layout)
+        output = tmem.load()
         ttgl.store(out_ptr + offs, output)
 
     input = torch.arange(M * N, device="cuda").reshape(M, N).to(torch.int32)
@@ -2014,23 +1987,24 @@ def test_tcgen05_mma_scaled_minimal():
 
         # Accumulator in TMEM initialized to ones
         acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([M, N], col_stride=1)
-        tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (M, N), acc_tmem_layout, ttgl.num_warps())
+        acc_tmem = allocate_tensor_memory(ttgl.float32, [M, N], acc_tmem_layout)
+        tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
         acc_init = ttgl.zeros([M, N], ttgl.float32, layout=tmem_reg_layout)
-        acc_tmem = allocate_tensor_memory(ttgl.float32, [M, N], acc_tmem_layout, acc_init)
+        acc_tmem.store(acc_init)
 
         # Zero scales in TMEM
         scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
-        scale_reg_layout_m: ttgl.constexpr = get_tmem_reg_layout(ttgl.int8, (M, K // 32), scale_layout,
-                                                                 ttgl.num_warps())
-        scale_reg_layout_n: ttgl.constexpr = get_tmem_reg_layout(ttgl.int8, (N, K // 32), scale_layout,
-                                                                 ttgl.num_warps())
+        a_scale_tmem = allocate_tensor_memory(a_scale.dtype.element_ty, [M, K // 32], scale_layout)
+        b_scale_tmem = allocate_tensor_memory(b_scale.dtype.element_ty, [N, K // 32], scale_layout)
+        scale_reg_layout_m: ttgl.constexpr = a_scale_tmem.get_reg_layout()
+        scale_reg_layout_n: ttgl.constexpr = b_scale_tmem.get_reg_layout()
         scale_offs_k = ttgl.arange(0, (K // 32), layout=ttgl.SliceLayout(0, scale_reg_layout_m))[None, :]
         scale_offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, scale_reg_layout_m))[:, None]
         scale_offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(1, scale_reg_layout_n))[:, None]
         a_scale_init = ttgl.load(a_scale + scale_offs_m * (K // 32) + scale_offs_k)
         b_scale_init = ttgl.load(b_scale + scale_offs_n * (K // 32) + scale_offs_k)
-        a_scale_tmem = allocate_tensor_memory(ttgl.int8, [M, K // 32], scale_layout, a_scale_init)
-        b_scale_tmem = allocate_tensor_memory(ttgl.int8, [M, K // 32], scale_layout, b_scale_init)
+        a_scale_tmem.store(a_scale_init)
+        b_scale_tmem.store(b_scale_init)
 
         # Issue a single scaled MMA and commit
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
@@ -2040,7 +2014,7 @@ def test_tcgen05_mma_scaled_minimal():
         mbarrier.wait(bar, phase=0)
 
         # Load result from TMEM and store to global
-        out_reg = acc_tmem.load(tmem_reg_layout)
+        out_reg = acc_tmem.load()
         store_layout: ttgl.constexpr = reg_layout
         offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, store_layout))[:, None]
         offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, store_layout))[None, :]
@@ -4519,12 +4493,7 @@ def tmem_reduction_kernel(
     )
 
     # Get register layout for TMEM access
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(
-        in_ptr.dtype.element_ty,
-        (M, N),
-        tmem_layout,
-        num_warps=num_warps,
-    )
+    tmem_reg_layout: ttgl.constexpr = tmem.get_reg_layout()
 
     # Store input to TMEM
     input_data = ttgl.convert_layout(input_data, tmem_reg_layout)
@@ -4532,9 +4501,9 @@ def tmem_reduction_kernel(
 
     # Load from TMEM with reduction
     if RED_OP == "min":
-        output, reduced = tmem.load_min(tmem_reg_layout, abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
+        output, reduced = tmem.load_min(abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
     elif RED_OP == "max":
-        output, reduced = tmem.load_max(tmem_reg_layout, abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
+        output, reduced = tmem.load_max(abs=USE_ABS, propagate_nan=PROPAGATE_NAN)
 
     # Store full output
     output = ttgl.convert_layout(output, global_memory_layout)
@@ -4797,7 +4766,6 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
         a_scale = unswizzle_scales_shared_memory(a_scale_smem, BLOCK_M, BLOCK_K, VEC_SIZE)
         b_scale = unswizzle_scales_shared_memory(b_scale_smem, BLOCK_N, BLOCK_K, VEC_SIZE)
-        fence_async_shared()
         tcgen05_copy(a_scale, a_scale_tmem)
         tcgen05_copy(b_scale, b_scale_tmem)
 
@@ -4811,15 +4779,12 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
     mbarrier.invalidate(tma_bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (BLOCK_M, BLOCK_N), tmem_layout,
-                                                         ttgl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     if two_ctas:
         acc = ttgl.convert_layout(acc, block_layout_c)
     acc = acc.to(c_desc.dtype)
     acc_smem = ttgl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
-    fence_async_shared()
     tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
     tma.store_wait(0)
 

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1169,6 +1169,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 
 @gluon.jit
+def tmem_subslice_reg_layout_kernel():
+    layout: ttgl.constexpr = TensorMemoryLayout(block=[128, 256], col_stride=1, cga_layout=((1, 0), (2, 0)))
+    tmem = ttgl.nvidia.blackwell.allocate_tensor_memory(ttgl.float32, [2, 512, 256], layout)
+    sub = tmem.index(0).slice(0, 32)
+    _ = sub.load()
+
+
+def test_tmem_subslice_reg_layout_constexpr():
+    expecttest.assert_expected_inline(
+        anonymize_ir(
+            run_parser(
+                tmem_subslice_reg_layout_kernel,
+                *make_args(num_warps=4, num_ctas=4),
+                target=BLACKWELL_TARGET,
+            ).str_nodebug()), """\
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = [[128, 0], [256, 0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[1, 0], [2, 0]]>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tmem_subslice_reg_layout_kernel() attributes {noinline = false} {
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x512x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.memdesc_index %result[%c0_i32] : !ttg.memdesc<2x512x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<512x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_subslice %0 {N = 0 : i32} : !ttg.memdesc<512x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<512x32xf32, #tmem, #ttng.tensor_memory, mutable, 512x256>
+    %result_0 = ttng.tmem_load %1 : !ttg.memdesc<512x32xf32, #tmem, #ttng.tensor_memory, mutable, 512x256> -> tensor<512x32xf32, #linear>
+    tt.return
+  }
+}
+""")
+
+
+@filecheck_test
+@gluon.jit
+def test_tmem_reduction_default_layout_constexpr():
+    # CHECK-LABEL: @test_tmem_reduction_default_layout_constexpr
+    layout: ttgl.constexpr = TensorMemoryLayout(block=[128, 128], col_stride=1)
+    tmem = ttgl.nvidia.blackwell.allocate_tensor_memory(ttgl.float32, [128, 128], layout)
+    # CHECK: ttng.tmem_load {{.*}} {abs = true, redOp = #ttng.redOp<min>}
+    _ = tmem.load_min(abs=True)
+    # CHECK: ttng.tmem_load {{.*}} {NaN = true, redOp = #ttng.redOp<max>}
+    # CHECK-NOT: ttng.tmem_load
+    # CHECK: tt.return
+    _ = tmem.load_max(propagate_nan=tl.PropagateNan.ALL)
+
+
+@gluon.jit
 def smem_and_layout_user(smem, a: ttgl.constexpr):
     pass
 

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -555,3 +555,8 @@ def test_line_and_column_numbers(fresh_triton_cache):
 
     check_template = inspect.getsource(kernel_basic.fn)
     run_filecheck("placeholder", h.asm["ttir"], check_template)
+
+
+@pytest.fixture(autouse=True)
+def with_line_info(fresh_knobs):
+    fresh_knobs.compilation.disable_line_info = False

--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -146,6 +146,12 @@ class DriverBase(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def allocate_default_profile_scratch(self, size: int, alignment: int, stream):
+        """
+        Allocate profile scratch when no explicit profile allocator override was installed.
+        """
+        raise NotImplementedError
+
     def __init__(self) -> None:
         pass
 
@@ -167,3 +173,15 @@ class GPUDriver(DriverBase):
     # TODO: remove once TMA is cleaned up
     def assemble_tensormap_to_arg(self, tensormaps_info, args):
         return args
+
+    def allocate_default_profile_scratch(self, size: int, alignment: int, stream):
+        import torch
+        device = self.get_active_torch_device()
+        device_interface = self.get_device_interface()
+        if stream is None:
+            return torch.zeros(size, dtype=torch.int8, device=device)
+        launch_stream = device_interface.ExternalStream(stream, device=device)
+        with device_interface.stream(launch_stream):
+            scratch = torch.zeros(size, dtype=torch.int8, device=device)
+        scratch.record_stream(launch_stream)
+        return scratch

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -18,7 +18,7 @@ def _is_int_list(value):
     return isinstance(value, Sequence) and all(isinstance(i, int) for i in value)
 
 
-def _compute_tmem_reg_layout(element_ty, shape, layout, num_warps, instr_variant):
+def _compute_tmem_reg_layout(element_ty, shape, alloc_shape, layout, num_warps, instr_variant):
     _check(isinstance(instr_variant, str), lambda: "instr_variant must be a string")
     _check(instr_variant in ("32x32b", "16x64b", "16x128b", "16x256b", "16x32bx2", "32x32b_splitn"),
            lambda: f"unknown instr_variant: {instr_variant}")
@@ -29,6 +29,10 @@ def _compute_tmem_reg_layout(element_ty, shape, layout, num_warps, instr_variant
     _check(all(isinstance(dim, int) for dim in shape), lambda: f"shape entries must be ints but got {shape}")
     rank = len(shape)
     _check(rank == 2, lambda: "expected a 2D tensor")
+    alloc_shape = list(alloc_shape)
+    _check(all(isinstance(dim, int) for dim in alloc_shape),
+           lambda: f"alloc_shape entries must be ints but got {alloc_shape}")
+    _check(len(alloc_shape) >= rank, lambda: f"alloc_shape must have rank >= shape rank, got {alloc_shape} and {shape}")
 
     splitn = instr_variant == "32x32b_splitn"
     atom_variant = "32x32b" if splitn else instr_variant
@@ -36,6 +40,7 @@ def _compute_tmem_reg_layout(element_ty, shape, layout, num_warps, instr_variant
     layout_obj = compute_tmem_reg_layout(
         element_ty,
         shape,
+        alloc_shape,
         layout,
         num_warps,
         atom_variant,
@@ -65,10 +70,13 @@ def _compute_tmem_reg_layout(element_ty, shape, layout, num_warps, instr_variant
             for bases_str in ("lane_bases", "warp_bases"):
                 bases = getattr(layout_obj, bases_str)
                 for i, basis in enumerate(bases):
+                    # the first 4 warps have their own address space
+                    if bases_str == "warp_bases" and i < 2:
+                        continue
                     if basis == [0, N // 2]:
                         reg_bases[-1], bases[i] = bases[i], reg_bases[-1]
                         return layout_obj
-            assert False, f"splitn requires at least one basis of [0, N / 2]. Got {layout}"
+            assert False, f"splitn requires at least one basis of the form [0, N / 2] in lanes or warps[2:] bases. Got {layout}"
     return layout_obj
 
 

--- a/python/triton/runtime/_allocation.py
+++ b/python/triton/runtime/_allocation.py
@@ -62,3 +62,7 @@ def set_profile_allocator(allocator: Optional[Allocator]) -> None:
     that require additional global memory workspace.
     """
     _profile_allocator.set(allocator if allocator is not None else _NULL_ALLOCATOR)
+
+
+def has_profile_allocator() -> bool:
+    return not isinstance(_profile_allocator.get(), NullAllocator)

--- a/python/triton/tools/triton_to_gluon_translator/translator_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/translator_helpers.py
@@ -9,13 +9,12 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_commit,
     tcgen05_mma,
     tcgen05_mma_scaled,
 )
 from triton.experimental.gluon.language.nvidia.blackwell import tma as tma_blackwell
-from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
+from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
 from triton.language.core import _unwrap_if_constexpr
 
 
@@ -153,14 +152,13 @@ def tl_dot_blackwell(
     acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
     col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
     acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
-
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(acc_dtype, (M, N), acc_tmem_layout, ttgl.num_warps())
+    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
+    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
     if acc is not None:
         acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
     else:
         acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
-    acc_tmem = allocate_tensor_memory(acc_temp.dtype, [M, N], acc_tmem_layout, acc_temp)
-    fence_async_shared()
+    acc_tmem.store(acc_temp)
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     mbarrier.init(bar, count=1)
     tcgen05_mma(a_smem, b_smem, acc_tmem, use_acc=True)
@@ -169,7 +167,7 @@ def tl_dot_blackwell(
     mbarrier.invalidate(bar)
 
     # Load back from TMEM using a register layout and convert to acc layout
-    out = acc_tmem.load(tmem_reg_layout)
+    out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
     return out
@@ -464,32 +462,32 @@ def tl_dot_scaled_blackwell(
     acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
     col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
     acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
-    tmem_reg_layout: ttgl.constexpr = get_tmem_reg_layout(acc_dtype, (M, N), acc_tmem_layout, ttgl.num_warps())
+    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
+    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
     if acc is not None:
         acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
     else:
         acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
-    acc_tmem = allocate_tensor_memory(acc_temp.dtype, [M, N], acc_tmem_layout, acc_temp)
-    fence_async_shared()
+    acc_tmem.store(acc_temp)
 
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     mbarrier.init(bar, count=1)
     scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
-    scale_layout_reg_lhs: ttgl.constexpr = get_tmem_reg_layout(lhs_scale.dtype, lhs_scale.type.shape, scale_layout,
-                                                               ttgl.num_warps())
-    scale_layout_reg_rhs: ttgl.constexpr = get_tmem_reg_layout(rhs_scale.dtype, rhs_scale.type.shape, scale_layout,
-                                                               ttgl.num_warps())
+    a_scale_tmem = allocate_tensor_memory(lhs_scale.dtype, lhs_scale.shape, scale_layout)
+    b_scale_tmem = allocate_tensor_memory(rhs_scale.dtype, rhs_scale.shape, scale_layout)
+    scale_layout_reg_lhs: ttgl.constexpr = a_scale_tmem.get_reg_layout()
+    scale_layout_reg_rhs: ttgl.constexpr = b_scale_tmem.get_reg_layout()
     lhs_scale = ttgl.convert_layout(lhs_scale, scale_layout_reg_lhs)
     rhs_scale = ttgl.convert_layout(rhs_scale, scale_layout_reg_rhs)
-    a_scale_tmem = allocate_tensor_memory(lhs_scale.dtype, lhs_scale.shape, scale_layout, lhs_scale)
-    b_scale_tmem = allocate_tensor_memory(rhs_scale.dtype, rhs_scale.shape, scale_layout, rhs_scale)
+    a_scale_tmem.store(lhs_scale)
+    b_scale_tmem.store(rhs_scale)
 
     tcgen05_mma_scaled(a_smem, b_smem, acc_tmem, a_scale_tmem, b_scale_tmem, lhs_format, rhs_format, use_acc=True)
     tcgen05_commit(bar)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
     # Load back from TMEM using a register layout and convert to acc layout
-    out = acc_tmem.load(tmem_reg_layout)
+    out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
     return out
@@ -578,7 +576,6 @@ def tl_obj_scatter(obj, value, x_offsets, y_offset):
         desc = obj
         desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
         alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
-        fence_async_shared()
         x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
             0,
             ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
@@ -599,7 +596,6 @@ def tl_make_tensor_descriptor(base, shape, strides, block_shape, padding_option=
 @gluon.jit
 def tl_store_tensor_descriptor(desc, offsets, value):
     alloc = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout, value)
-    fence_async_shared()
     tma.async_copy_shared_to_global(desc, offsets, alloc)
     tma.store_wait(0)
     alloc._keep_alive()

--- a/python/tutorials/gluon/06-tcgen05.py
+++ b/python/tutorials/gluon/06-tcgen05.py
@@ -23,7 +23,6 @@ from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tma,
     mbarrier,
     tcgen05_mma,
@@ -116,17 +115,12 @@ def tmem_example_kernel(in_ptr, out_ptr, M: gl.constexpr, N: gl.constexpr, num_w
         layout=tmem_layout,
     )
 
-    # Get the register layout needed to access the tensor memory using a helper.
-    tmem_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        in_ptr.dtype.element_ty,
-        (M, N),
-        tmem_layout,
-        num_warps=num_warps,
-    )
+    # Get the register layout needed to access the tensor memory from the descriptor.
+    tmem_reg_layout: gl.constexpr = tmem.get_reg_layout()
 
     input = gl.convert_layout(input, tmem_reg_layout)
     tmem.store(input)
-    output = tmem.load(tmem_reg_layout)
+    output = tmem.load()
     output = gl.convert_layout(output, global_memory_layout)
 
     gl.store(out_ptr + offs, output)
@@ -188,12 +182,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
         col_stride=32 // d_desc.dtype.primitive_bitwidth,
     )
     acc_tmem = allocate_tensor_memory(d_desc.dtype, [M, N], acc_tmem_layout)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        d_desc.dtype,
-        (M, N),
-        acc_tmem_layout,
-        num_warps,
-    )
+    acc_reg_layout: gl.constexpr = acc_tmem.get_reg_layout()
     acc = c_smem.load(acc_reg_layout)
     acc_tmem.store(acc)
 
@@ -205,12 +194,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
         )
         lhs_tmem = allocate_tensor_memory(a_desc.dtype, [M, K], lhs_tmem_layout)
 
-        lhs_reg_layout: gl.constexpr = get_tmem_reg_layout(
-            a_desc.dtype,
-            (M, K),
-            lhs_tmem_layout,
-            num_warps,
-        )
+        lhs_reg_layout: gl.constexpr = lhs_tmem.get_reg_layout()
         lhs = a_smem.load(lhs_reg_layout)
         lhs_tmem.store(lhs)
         a = lhs_tmem
@@ -261,7 +245,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
     # way to zero the accumulator.
 
     d_smem = gl.allocate_shared_memory(d_desc.dtype, d_desc.block_type.shape, d_desc.layout)
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     d_smem.store(acc)
     fence_async_shared()
     tma.async_copy_shared_to_global(d_desc, [0, 0], d_smem)
@@ -362,13 +346,7 @@ def blocked_matmul_kernel(a_desc, b_desc, c_desc, TRANSPOSE_B: gl.constexpr, num
     mbarrier.invalidate(tma_bar)
     mbarrier.invalidate(mma_bar)
 
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        gl.float32,
-        (BLOCK_M, BLOCK_N),
-        tmem_layout,
-        num_warps,
-    )
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
 
     # Downcast accumulator and store tile of C.
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
@@ -585,13 +563,6 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
         tma.async_copy_global_to_shared(a_desc, [off_m + BLOCK_M, k], load_v_bar, v_bufs.index(load_index))
         k += BLOCK_K
 
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(
-        gl.float32,
-        (BLOCK_M, BLOCK_N),
-        tmem_layout,
-        num_warps,
-    )
-
     mma_index, mma_phase, mma_counter = get_and_increment(mma_counter)
     ub_bar = mma_ub_bars.index(mma_index)
     vb_bar = mma_vb_bars.index(mma_index)
@@ -617,14 +588,14 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
     # Wait UBN, UB epilogue
     mbarrier.wait(ub_bar, epilogue_phase)
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
-    ub = ub_tmem.load(acc_reg_layout)
+    ub = ub_tmem.load()
     c_smem.store(ub.to(dtype))
     fence_async_shared()
     tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
 
     # Wait VBN, VB epilogue
     mbarrier.wait(vb_bar, epilogue_phase)
-    vb = vb_tmem.load(acc_reg_layout)
+    vb = vb_tmem.load()
     tma.store_wait(pendings=0)
     c_smem.store(vb.to(dtype))
     fence_async_shared()

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -48,7 +48,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     tensor_memory_descriptor,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_mma,
     tcgen05_commit,
 )
@@ -130,7 +129,6 @@ class MMAv5:
     acc_tmem: tensor_memory_descriptor
     bar: gl.shared_memory_descriptor
     counter: gl.tensor
-    reg_layout: gl.constexpr
 
     @gluon.jit
     def initialize(dtype: gl.constexpr, BLOCK_M: gl.constexpr, BLOCK_N: gl.constexpr, num_warps: gl.constexpr):
@@ -138,14 +136,13 @@ class MMAv5:
         acc_tmem = allocate_tensor_memory(gl.float32, [BLOCK_M, BLOCK_N], layout)
         bar = gl.allocate_shared_memory(gl.int64, [1], mbarrier.MBarrierLayout())
         mbarrier.init(bar, count=1)
-        reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), layout, num_warps)
-        return MMAv5(gl.to_tensor(False), acc_tmem, bar, gl.to_tensor(0), reg_layout)
+        return MMAv5(gl.to_tensor(False), acc_tmem, bar, gl.to_tensor(0))
 
     @gluon.jit
     def issue_async_mma(self, a, b):
         tcgen05_mma(a, b, self.acc_tmem, use_acc=self.use_acc)
         tcgen05_commit(self.bar)
-        return MMAv5(gl.to_tensor(True), self.acc_tmem, self.bar, self.counter + 1, self.reg_layout)
+        return MMAv5(gl.to_tensor(True), self.acc_tmem, self.bar, self.counter + 1)
 
     @gluon.jit
     def wait_num_outstanding(self, num_outstanding: gl.constexpr):
@@ -154,8 +151,8 @@ class MMAv5:
 
     @gluon.jit
     def take_result(self):
-        next = MMAv5(gl.to_tensor(False), self.acc_tmem, self.bar, self.counter, self.reg_layout)
-        return self.acc_tmem.load(self.reg_layout), next
+        next = MMAv5(gl.to_tensor(False), self.acc_tmem, self.bar, self.counter)
+        return self.acc_tmem.load(), next
 
 
 def select_mma_impl():

--- a/python/tutorials/gluon/08-warp-specialization.py
+++ b/python/tutorials/gluon/08-warp-specialization.py
@@ -35,7 +35,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     tensor_memory_descriptor,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     tcgen05_mma,
     tcgen05_commit,
 )
@@ -510,13 +509,6 @@ def matmul_epilogue_partition(p, SchedulerImpl: gl.constexpr):
     acc_empty_bars = p.acc_empty_bars
     acc_ready_bars = p.acc_ready_bars
     acc_state = Counter.create(0, p.acc_empty_bars.shape[0])
-    acc_tmem_layout: gl.constexpr = TensorMemoryLayout([BLOCK_M, BLOCK_N], col_stride=1)
-    acc_layout: gl.constexpr = get_tmem_reg_layout(
-        dtype,
-        (BLOCK_M, BLOCK_N),
-        acc_tmem_layout,
-        p.num_warps,
-    )
     SPLIT_N: gl.constexpr = BLOCK_N // p.SUBTILE_FACTOR
     acc_smem = gl.allocate_shared_memory(dtype, [BLOCK_M, SPLIT_N], p.c_desc.layout)
 
@@ -529,7 +521,7 @@ def matmul_epilogue_partition(p, SchedulerImpl: gl.constexpr):
         # Wait for the accumulator. Since BLOCK_N=256, we need to interleave
         # the TMEM loads with the SMEM stores to avoid spilling.
         mbarrier.wait(acc_ready_bars.index(acc_state.index), acc_state.phase)
-        acc = p.acc_bufs.index(acc_state.index).load(acc_layout)
+        acc = p.acc_bufs.index(acc_state.index).load()
         acc_state = acc_state.next()
 
         accs = _split_n(acc, p.SUBTILE_FACTOR)

--- a/python/tutorials/gluon/11-tcgen05-mma-scaled.py
+++ b/python/tutorials/gluon/11-tcgen05-mma-scaled.py
@@ -74,7 +74,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
-    get_tmem_reg_layout,
     fence_async_shared,
     tensor_memory_descriptor,
     tcgen05_copy,
@@ -198,10 +197,8 @@ def simple_mma_scaled_kernel(a_desc, b_desc, c_desc, a_scale_ptr, a_scale_stride
 
         # We have to write the scales to tensor memory. Convert them into a the right
         # layout so we can write into tensor memory with layout `TensorMemoryScalesLayout`.
-        a_scale_layout: gl.constexpr = get_tmem_reg_layout(a_scale.dtype, a_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
-        b_scale_layout: gl.constexpr = get_tmem_reg_layout(b_scale.dtype, b_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
+        a_scale_layout: gl.constexpr = a_scale_tmem.get_reg_layout()
+        b_scale_layout: gl.constexpr = b_scale_tmem.get_reg_layout()
         a_scale = gl.convert_layout(a_scale, a_scale_layout)
         b_scale = gl.convert_layout(b_scale, b_scale_layout)
         a_scale_tmem.store(a_scale)
@@ -232,8 +229,7 @@ def simple_mma_scaled_kernel(a_desc, b_desc, c_desc, a_scale_ptr, a_scale_stride
     mbarrier.invalidate(mma_bar)
 
     # Load the accumulator tile from tensor memory and convert it to the output dtype.
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
 
     # Write the accumulator via TMA store.
@@ -513,10 +509,8 @@ def mma_scaled_contig_kernel(a_desc, b_desc, c_desc, a_scale_ptr, b_scale_ptr, V
         b_scale = b_scale.reshape(BLOCK_N, SCALE_BLOCK_K)
 
         # ======= Begin unchanged code from `simple_mma_scaled_kernel` =======
-        a_scale_layout: gl.constexpr = get_tmem_reg_layout(a_scale.dtype, a_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
-        b_scale_layout: gl.constexpr = get_tmem_reg_layout(b_scale.dtype, b_scale.type.shape, scale_layout,
-                                                           gl.num_warps())
+        a_scale_layout: gl.constexpr = a_scale_tmem.get_reg_layout()
+        b_scale_layout: gl.constexpr = b_scale_tmem.get_reg_layout()
         a_scale = gl.convert_layout(a_scale, a_scale_layout)
         b_scale = gl.convert_layout(b_scale, b_scale_layout)
         a_scale_tmem.store(a_scale)
@@ -533,8 +527,7 @@ def mma_scaled_contig_kernel(a_desc, b_desc, c_desc, a_scale_ptr, b_scale_ptr, V
 
     mbarrier.invalidate(bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
@@ -743,10 +736,8 @@ def mma_scaled_packed_block_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
         # which to load the scales from shared memory such that after unswizzling,
         # they have the right 2D layout for the store to TMEM. Instead, we will use
         # AutoLayout to let the compiler backwards propagate the layout.
-        a_scale_layout: gl.constexpr = get_tmem_reg_layout(a_scale_desc.dtype, [BLOCK_M, BLOCK_K // VEC_SIZE],
-                                                           scale_layout, gl.num_warps())
-        b_scale_layout: gl.constexpr = get_tmem_reg_layout(b_scale_desc.dtype, [BLOCK_N, BLOCK_K // VEC_SIZE],
-                                                           scale_layout, gl.num_warps())
+        a_scale_layout: gl.constexpr = a_scale_tmem.get_reg_layout()
+        b_scale_layout: gl.constexpr = b_scale_tmem.get_reg_layout()
 
         # Load the scales with AutoLayout. Subsequent operations, including the unswizzling,
         # will be generic over the layout.
@@ -775,8 +766,7 @@ def mma_scaled_packed_block_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
     mbarrier.invalidate(bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
@@ -1045,8 +1035,7 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
 
     mbarrier.invalidate(bar)
     mbarrier.invalidate(mma_bar)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
-    acc = acc_tmem.load(acc_reg_layout)
+    acc = acc_tmem.load()
     acc = acc.to(c_desc.dtype)
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
@@ -1246,7 +1235,6 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
     # of tensor memory, which leaves no room for the scales' tensor memory.
     num_acc_buffers: gl.constexpr = 2 if BLOCK_N < 256 else 1
     tmem_layout: gl.constexpr = TensorMemoryLayout([BLOCK_M, BLOCK_N], col_stride=1)
-    acc_reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), tmem_layout, gl.num_warps())
     acc_bufs = allocate_tensor_memory(gl.float32, [num_acc_buffers, BLOCK_M, BLOCK_N], tmem_layout)
     acc_idx = 0
 
@@ -1320,7 +1308,7 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
                                                     acc_bufs.index(acc_idx), use_acc=False, pred=has_next_tile)
         mbarrier.wait(mma_bars.index(mma_consumer.index), mma_consumer.phase)
         mma_consumer = mma_consumer.next()
-        acc = cur_acc_buf.load(acc_reg_layout)
+        acc = cur_acc_buf.load()
         if num_acc_buffers == 1:
             # Wait for all threads to finish loading from accumulator
             gl.barrier()
@@ -1405,15 +1393,13 @@ def mma_scaled_mma_partition(p):
 
 @gluon.jit
 def mma_scaled_epilogue_partition(p):
-    acc_layout: gl.constexpr = get_tmem_reg_layout(p.c_desc.dtype, (p.BLOCK_M, p.BLOCK_N), p.acc_bufs.type.layout,
-                                                   gl.num_warps())
     acc_state = t8.Counter.create(0, p.acc_empty_bars.shape[0])
     acc_smem = gl.allocate_shared_memory(p.c_desc.dtype, p.c_desc.block_type.shape, p.c_desc.layout)
     scheduler = p.SchedulerImpl.initialize(p.M, p.N, p.BLOCK_M, p.BLOCK_N)
     for idx in range(scheduler.get_num_tiles()):
         pid_m, pid_n = scheduler.get_tile(idx)
         mbarrier.wait(p.acc_ready_bars.index(acc_state.index), acc_state.phase)
-        acc = p.acc_bufs.index(acc_state.index).load(acc_layout)
+        acc = p.acc_bufs.index(acc_state.index).load()
         mbarrier.arrive(p.acc_empty_bars.index(acc_state.index), count=1)
         acc_state = acc_state.next()
 

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -1,10 +1,15 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s --check-prefix=GFX950
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx1250 | FileCheck %s --check-prefix=GFX1250
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32_scalar
+  // GFX1250-LABEL: atomic_add_f32_scalar
   tt.func @atomic_add_f32_scalar(%arg0 : !tt.ptr<f32>, %arg1 : i1, %arg2 : f32) {
+    // Scalar atomics should not have the compiler fence (no tensorTy)
+    // GFX1250-NOT: llvm.inline_asm
     // CHECK: llvm.cond_br
+    // GFX1250: llvm.cond_br
     // CHECK: llvm.atomicrmw
     // CHECK: llvm.store
     // CHECK: llvm.br
@@ -23,7 +28,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32
+  // GFX1250-LABEL: atomic_add_f32
   tt.func @atomic_add_f32(%arg0 : tensor<256x!tt.ptr<f32>, #blocked0>, %arg1 : tensor<256xi1, #blocked0>, %arg2 : tensor<256xf32, #blocked0>) {
+    // Tensor atomics on gfx1250 should have a compiler fence before the cond_br
+    // to prevent MachineSink from sinking LDS loads past barriers.
+    // GFX1250: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{memory}"
+    // GFX1250: llvm.cond_br
     // CHECK: llvm.cond_br
     // CHECK: llvm.atomicrmw
     // CHECK: llvm.atomicrmw

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -121,6 +121,34 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32} {
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_subslice_acc
+  // CHECK-DAG: %[[TMEM_SUBSLICE_OFFSET:.+]] = llvm.mlir.constant(64 : i32) : i32
+  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2{{.*}} : !llvm.ptr<3> to i32
+  // CHECK: %[[TMEM_SUBSLICE_BASE_INT:.+]] = llvm.add %[[TMEM_BASE]], %[[TMEM_SUBSLICE_OFFSET]] : i32
+  // CHECK: %[[TMEM_SUBSLICE_PTR:.+]] = llvm.inttoptr %[[TMEM_SUBSLICE_BASE_INT]] : i32 to !llvm.ptr<3>
+  // CHECK: %[[TMEM_SUBSLICE_BASE:.+]] = llvm.ptrtoint %[[TMEM_SUBSLICE_PTR]] : !llvm.ptr<3> to i32
+  // CHECK-COUNT-4: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_SUBSLICE_BASE]]
+  // CHECK-COUNT-4: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_SUBSLICE_BASE]]
+  tt.func @tc_gen5_mma_subslice_acc(%a: !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory>,
+                                    %b: !ttg.memdesc<64x64xf16, #shared1, #ttg.shared_memory>,
+                                    %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %sub = ttng.tmem_subslice %c {N = 64 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    ttng.tc_gen5_mma %a, %b, %sub, %false, %true :
+       !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<64x64xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
@@ -957,6 +985,24 @@ tt.func private @subslice_16x32bx2_interleaved_block4_offset(%arg0: !ttg.memdesc
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
   %0 = ttng.tmem_subslice %arg0 {N = 80 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
+}
+
+}
+
+// -----
+
+#bm128_bn256_cga = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[1, 0], [2, 0]]>
+#tmem = #ttng.tensor_memory
+
+module attributes {"ttg.target" = "cuda:100", "ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 4 : i32} {
+
+// CHECK-LABEL: @subslice_cga_allocshape_preserved
+tt.func private @subslice_cga_allocshape_preserved(%arg0: !ttg.memdesc<512x256xf32, #bm128_bn256_cga, #tmem>) -> !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256> {
+  // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(32 : i32)
+  // CHECK: [[PTR:%.*]] = llvm.ptrtoint
+  // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
+  %0 = ttng.tmem_subslice %arg0 {N = 32 : i32} : !ttg.memdesc<512x256xf32, #bm128_bn256_cga, #tmem> -> !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256>
+  tt.return %0 : !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256>
 }
 
 }

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
@@ -1378,3 +1378,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK-NEXT: ttg.barrier local
 // CHECK-NEXT: rocdl.sched.barrier
 // CHECK: scf.yield
+
+// -----
+
+// ---- amdg.async_wait recognized as a valid barrier between stages ----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @async_wait_between_stages(%n: index, %ptr: !tt.ptr<f32>) {
+    %c0  = arith.constant 0 : index
+    %c1  = arith.constant 1 : index
+    %v0  = arith.constant 0.0 : f32
+    %v1  = arith.constant 1.0 : f32
+
+    scf.for %i = %c0 to %n step %c1 {
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage1"}
+
+      // amdg.async_wait sits between stages and must be recognized as a barrier.
+      amdg.async_wait {num_inst = 0 : i32}
+
+      scf.execute_region {
+        tt.store %ptr, %v1 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage2"}
+
+      scf.yield
+    } {triton.warp_pipeline.pipelined_for}
+
+    tt.return
+  }
+}
+
+// The pass should succeed (not bail out) and produce barriers.
+// CHECK-LABEL: tt.func @async_wait_between_stages
+// CHECK: ttg.barrier local
+// CHECK: amdg.cond_barrier
+// CHECK: scf.for
+// CHECK-NOT: scf.execute_region
+// CHECK: rocdl.sched.barrier
+// CHECK: amdg.cond_barrier
+// CHECK: tt.return

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -12,16 +12,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @single_local_alloc() {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64, #[[BUFS_L]]>
 
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -42,16 +42,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @two_local_alloc() {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096], [{{.*}}], shared_mem : tensor<2xi64,
 
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T2xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1024 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1024 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T2x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T2x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T2x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -74,16 +74,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @three_local_alloc() {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096, 8192, 0], [{{.*}}], shared_mem : tensor<4xi64,
 
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2048 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2048 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -108,16 +108,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @three_sub_bufs() {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096, 8192, 0], [{{.*}}], shared_mem : tensor<4xi64,
 
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2048 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2048 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T4x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
@@ -139,7 +139,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: #[[READ_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
   // CHECK: @read_bars_alloc
   tt.func public @read_bars_alloc() {
-    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i8>
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T2x4xI8(%[[READ_BARS_G]], %c0_i8
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
@@ -182,27 +182,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @async_tma_copy_global_to_local(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // Model the async TMA completion mechanism: barrier_expect corresponds to
     // mbarrier.arrive.expect_tx and is what should update ConSan's barrier state.
     ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
@@ -234,30 +236,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %a_smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %b_smem = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // Two TMA copies contribute to a single expected transaction.
     ttng.barrier_expect %bar, 8192, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK: ttng.barrier_expect
 
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
-    // CHECK: ttng.async_tma_copy_global_to_local {{.*}}[{{.*}}, {{.*}}] {{.*}}, {{.*}}, {{.*}}
+    // CHECK: ttng.async_tma_copy_global_to_local
     ttng.async_tma_copy_global_to_local %a[%c0_i32, %c0_i32] %a_smem, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
-    // CHECK: ttng.async_tma_copy_global_to_local {{.*}}[{{.*}}, {{.*}}] {{.*}}, {{.*}}, {{.*}}
     ttng.async_tma_copy_global_to_local %b[%c0_i32, %c0_i32] %b_smem, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
-    // CHECK: tt.call @__triton_consan_set_waiting
-    // CHECK: tt.call @__triton_consan_check_all_active_waiting
-    // CHECK: ttng.wait_barrier
     ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
 
     // Consume results to prevent DCE / to keep realistic ordering.
@@ -382,6 +384,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @barrier_reinit_requires_invalidate
+  tt.func public @barrier_reinit_requires_invalidate() {
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32xi32, #shared1, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    %tmp = ttg.local_load %buf : !ttg.memdesc<32xi32, #shared1, #smem, mutable> -> tensor<32xi32>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_state
+    // CHECK: tt.call @__triton_consan_clear_barrier_write_tracking
+    // CHECK: tt.call @__triton_consan_clear_barrier_read_tracking
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -391,24 +418,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @wait_barrier(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64, #linear>
 
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64, #linear>
 
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK-DAG: tt.call @__triton_consan_set_waiting
     // CHECK-DAG: tt.call @__triton_consan_check_all_active_waiting
     // CHECK: ttng.wait_barrier
@@ -432,15 +461,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @arrive_barrier
   tt.func public @arrive_barrier(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32} : !tt.ptr<i32>
+    // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, third_party_allocation} : !tt.ptr<i32>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1xI32(%[[BSTATE_GLOB]], %c0_i32
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_track_visible_reads
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
@@ -448,6 +479,40 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tti.experimental_lock_release
     ttng.arrive_barrier %bar, 2, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @wait_barrier_without_init
+  tt.func public @wait_barrier_without_init() {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_set_waiting
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @arrive_barrier_without_init
+  tt.func public @arrive_barrier_without_init() {
+    %true = arith.constant true
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }
@@ -462,17 +527,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @tcgen5_mma
   tt.func public @tcgen5_mma(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
     // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_descriptors [0, 32768], [{{.*}}], shared_mem : tensor<2xi64
-    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1024 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1024 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], tensor_mem : tensor<1xi64
-    // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, third_party_allocation} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, third_party_allocation} : !tt.ptr<i8>
+    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
 
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
@@ -537,17 +602,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @tcgen5_mma_lhs_in_tmem
   tt.func public @tcgen5_mma_lhs_in_tmem(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
     // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_descriptors [32768], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_descriptors [0, 128], [{{.*}}], tensor_mem : tensor<2xi64
-    // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1024 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1024 : i32, third_party_allocation} : !tt.ptr<i64>
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, third_party_allocation} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, third_party_allocation} : !tt.ptr<i8>
+    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i64>
 
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
@@ -644,7 +709,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @async_copy_global_to_local
   tt.func public @async_copy_global_to_local(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
     // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x16xI8(%[[WRT_COMMITS_GLOB]], %c0_i8
 
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
@@ -675,12 +740,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @async_copy_global_to_local_with_barriers
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32} : !tt.ptr<i64>
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, third_party_allocation} : !tt.ptr<i8>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, third_party_allocation} : !tt.ptr<i64>
 
-    // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, third_party_allocation} : !tt.ptr<i8>
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
 
@@ -768,7 +833,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func public @warp_group_dot(%acc: tensor<128x128xf16, #mma>) {
     // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_descriptors [0, 32768], [{{.*}}], shared_mem : tensor<2xi64
 
-    // CHECK-DAG: %[[SM_WGMMA_WRITES_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_WGMMA_WRITES_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T2x16xI8(%[[SM_WGMMA_WRITES_GLOB]], %c0_i8
 
     // CHECK: tt.call @__triton_consan_verify_write_visibility
@@ -799,7 +864,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func public @warp_group_dot_sync(%acc: tensor<128x128xf16, #mma>) {
     // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_descriptors [0, 32768], [{{.*}}], shared_mem : tensor<2xi64
 
-    // CHECK-DAG: %[[SM_WGMMA_WRITES_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_WGMMA_WRITES_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T2x16xI8(%[[SM_WGMMA_WRITES_GLOB]], %c0_i8
 
     // CHECK: "before_dot"

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -111,3 +111,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: missing_proxy_fence_local_store_before_async_tma_copy_local_to_global
+  tt.func @missing_proxy_fence_local_store_before_async_tma_copy_local_to_global(%arg0: !tt.tensordesc<tensor<128x256xf32, #shared>>, %arg1: tensor<128x256xf32, #blocked>) {
+    // CHECK: ttng.async_tma_store_wait {pendings = 1 : i32}
+    // CHECK-NEXT: ttg.local_store
+    // CHECK-NEXT: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.async_tma_copy_local_to_global
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<128x256xf32, #shared, #smem, mutable>
+    ttng.async_tma_store_wait {pendings = 1 : i32}
+    ttg.local_store %arg1, %0 : tensor<128x256xf32, #blocked> -> !ttg.memdesc<128x256xf32, #shared, #smem, mutable>
+    ttng.async_tma_copy_local_to_global %arg0[%c0_i32, %c0_i32] %0 : !tt.tensordesc<tensor<128x256xf32, #shared>>, !ttg.memdesc<128x256xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: missing_proxy_fence_local_store_before_tmem_copy
+  tt.func @missing_proxy_fence_local_store_before_tmem_copy(%arg0: tensor<128x4xi8, #blocked>,
+      %arg1: !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>) {
+    // CHECK: ttg.local_store
+    // CHECK-NEXT: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.tmem_copy
+    %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>
+    ttg.local_store %arg0, %0 : tensor<128x4xi8, #blocked> -> !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>
+    ttng.tmem_copy %0, %arg1 : !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>, !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -66,6 +66,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @init_barrier_zero_count() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // expected-error @+1 {{count must be greater than or equal to 1}}
+    ttng.init_barrier %bar, 0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -343,6 +343,7 @@ class HIPLauncher(object):
 
     def __call__(self, gridX, gridY, gridZ, stream, function, kernel_metadata, launch_metadata, launch_enter_hook,
                  launch_exit_hook, *args):
+        active_driver = triton.runtime.driver.active
 
         def allocate_scratch(size, align, allocator):
             if size > 0:
@@ -352,9 +353,19 @@ class HIPLauncher(object):
                 return alloc_fn(alloc_size, align, stream)
             return None
 
+        def allocate_default_profile_scratch(size, align):
+            if size > 0:
+                grid_size = gridX * gridY * gridZ
+                alloc_size = grid_size * size
+                return active_driver.allocate_default_profile_scratch(alloc_size, align, stream)
+            return None
+
         global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
-        profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
-                                           _allocation._profile_allocator)
+        if _allocation.has_profile_allocator():
+            profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
+                                               _allocation._profile_allocator)
+        else:
+            profile_scratch = allocate_default_profile_scratch(self.profile_scratch_size, self.profile_scratch_align)
 
         self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, global_scratch,
                     profile_scratch, kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2211,6 +2211,51 @@ struct AtomicRMWOpConversion
                   loc, rewriter, targetInfo, op.getOperation()))
             : std::nullopt;
 
+    // Emit a compiler fence to prevent LLVM's MachineSink from sinking
+    // preceding LDS loads (e.g., from ConvertLayoutOps that feed into this
+    // atomic) past barriers introduced by the atomic lowering below.
+    //
+    // Root cause: MachineSink's isSafeToMove() only sets SawStore for
+    // instructions with mayStore(), not for UnmodeledSideEffects. AMDGPU
+    // barriers have UnmodeledSideEffects but not mayStore(), so loads can
+    // be sunk past them into successor blocks.
+    //
+    // When buffer atomics are not enabled for the target (see
+    // ConvertToBufferOps.cpp), this AtomicRMWOp lowering path is used instead.
+    // emitAtomicRMW() below creates a condBr that splits the current block to
+    // mask which threads execute the atomic. Without this fence, preceding LDS
+    // loads (from ConvertLayoutOps or reduce cross-warp communication) can be
+    // sunk past barriers in the successor blocks. On targets where buffer
+    // atomics ARE enabled (e.g., gfx950), LLVM replaces the condBr with buffer
+    // atomic OOB offset masking, eliminating the block split entirely and
+    // avoiding this issue.
+    //
+    // This inline asm has mayStore()=true via the "~{memory}" constraint,
+    // which sets SawStore in MachineSink's bottom-up walk, preventing any
+    // preceding loads from being sunk past this point.
+    //
+    // This is the only fence needed: emitAtomicRMW() is the only lowering
+    // pattern that creates a condBr splitting a block with preceding LDS
+    // loads where successor blocks contain barriers. If new lowering
+    // patterns with similar structure are added, they will need their own
+    // fence.
+    //
+    // This is a workaround for
+    // https://github.com/llvm/llvm-project/issues/181708.
+    if (tensorTy && targetInfo.getISAFamily() == ISAFamily::GFX1250) {
+      auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                                      LLVM::AsmDialect::AD_ATT);
+      auto asmTy = LLVM::LLVMVoidType::get(rewriter.getContext());
+      LLVM::InlineAsmOp::create(
+          rewriter, loc, asmTy,
+          /*operands=*/ValueRange{},
+          /*asm_string=*/"",
+          /*constraints=*/"~{memory}",
+          /*has_side_effects=*/true,
+          /*is_align_stack=*/false, LLVM::TailCallKind::None, asmDialectAttr,
+          /*operand_attrs=*/ArrayAttr::get(rewriter.getContext(), {}));
+    }
+
     SmallVector<Value> resultVals(elemsPerThread);
     for (size_t i = 0; i < elemsPerThread; i += vec) {
       // TODO: in case llMask is zero we can create only one branch for all

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -965,6 +965,12 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
                                         {kLane, laneId},
                                         {kWarp, warpId},
                                         {kBlock, ctaId}});
+
+  int cacheScope = 8; // (8) = L2 scope
+  int hintValue = cacheScope | static_cast<int>(isSpeculative);
+  Value hint = LLVM::ConstantOp::create(rewriter, loc, i32_ty,
+                                        rewriter.getI32IntegerAttr(hintValue));
+
   // Iterate over each register and emit a prefetch intrinsic
   SmallVector<Value> offsets(ll.getInDimSize(kRegister));
   for (int reg = 0; reg < ll.getInDimSize(kRegister); reg++) {
@@ -972,17 +978,16 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
         ll.apply({{kRegister, reg}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
 
     // XOR the base indices with the register specific indices
-    SmallVector<std::pair<StringAttr, Value>> indices;
+    SmallVector<Value> indices;
     for (auto [base, regIdx] : llvm::zip(baseIndices, regIndices)) {
       assert(base.first == regIdx.first);
       Value combined = b.xor_(base.second, b.i32_val(regIdx.second));
-      indices.emplace_back(base.first, combined);
+      indices.emplace_back(combined);
     }
 
     // Compute the local offset from tile ptr for this prefetch based on the
     // computed indices
-    Value localOffset =
-        dot64(to_vector(make_second_range(indices)), scaledStride);
+    Value localOffset = dot64(indices, scaledStride);
     auto prefetchPtr = b.gep(globalPtrTy, elementType, tilePtr, localOffset);
 
     // Mask the prefetch if the offset is out of bounds
@@ -1000,13 +1005,9 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
                            afterPrefetch);
 
     rewriter.setInsertionPointToStart(prefetchBlock);
-    int cache_scope = 8; // (8) = L2 scope
-    int speculative = isSpeculative;
-    int llvmTemporalHint = cache_scope | speculative;
-    Value scope = LLVM::ConstantOp::create(
-        rewriter, loc, i32_ty, rewriter.getI32IntegerAttr(llvmTemporalHint));
+
     LLVM::createLLVMIntrinsicCallOp(
-        rewriter, loc, "llvm.amdgcn.global.prefetch", {}, {prefetchPtr, scope});
+        rewriter, loc, "llvm.amdgcn.global.prefetch", {}, {prefetchPtr, hint});
 
     rewriter.setInsertionPointToEnd(prefetchBlock);
     LLVM::BrOp::create(rewriter, loc, afterPrefetch);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -513,19 +513,23 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
     triton::AMD::TargetInfo targetInfo(arch ? arch->str() : "");
 
     // Replace the old load with multi-buffered loads
-    if (useAsyncCopy && descLoadOp) {
+    if (descLoadOp) {
       loadToStreamOp[descLoadOp] =
           createTDMAsyncCopy(descLoadOp, alloc, extractIdx);
-    } else if (useAsyncCopy && canBeConvertedToAsyncLoad(
-                                   numBuffers, loadOp, info.sharedEncoding,
-                                   axisInfoAnalysis, targetInfo)) {
+      continue;
+    }
+
+    if (useAsyncCopy &&
+        canBeConvertedToAsyncLoad(numBuffers, loadOp, info.sharedEncoding,
+                                  axisInfoAnalysis, targetInfo)) {
       unsigned vec = axisInfoAnalysis.getContiguity(loadOp.getPtr());
       if (auto mask = loadOp.getMask())
         vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
       loadToStreamOp[loadOp] = createAsyncCopy(loadOp, alloc, extractIdx, vec);
-    } else {
-      loadToStreamOp[loadOp] = createStreamCopy(loadOp, alloc, extractIdx);
+      continue;
     }
+
+    loadToStreamOp[loadOp] = createStreamCopy(loadOp, alloc, extractIdx);
   }
 
   return loadToStreamOp;
@@ -776,7 +780,7 @@ void scheduleStreamOps(const LoadToStreamOpMap &loadToStreamOp,
 void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
                     tt::CoarseSchedule &schedule,
                     triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                    int numStages, bool useAsyncCopy, bool waitAtTail) {
+                    bool useAsyncCopy, bool waitAtTail) {
   LDBG("SingleDotSchedule::updateSchedule");
   Stages stages;
   Clusters clusters;
@@ -787,8 +791,8 @@ void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
   }
 
   int numBuffers = 1;
-  if (failed(initSchedule(maxDist, stages, numStages, numBuffers, useAsyncCopy,
-                          waitAtTail, clusters, schedule)))
+  if (failed(initSchedule(maxDist, stages, schedule.getNumStages(), numBuffers,
+                          useAsyncCopy, waitAtTail, clusters, schedule)))
     return;
 
   // Convert the loads into shared memory allocations and loads from them.
@@ -991,7 +995,7 @@ void lowerLoop(scf::ForOp forOp,
                                        axisInfoAnalysis, useAsyncCopy);
   } else {
     SingleDotSchedule::updateSchedule(forOp, loadToInfo, schedule,
-                                      axisInfoAnalysis, numStages, useAsyncCopy,
+                                      axisInfoAnalysis, useAsyncCopy,
                                       waitAtTail);
   }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -43,8 +43,8 @@ Operation *streamPredication(RewriterBase &rewriter, Operation *op,
   } else if (auto prefetchOp = dyn_cast<triton::amdgpu::TDMPrefetchOp>(op)) {
     rewriter.setInsertionPoint(prefetchOp);
     Value mask = arith::AndIOp::create(rewriter, prefetchOp->getLoc(),
-                                       copyOp.getPred(), pred);
-    copyOp.getPredMutable().assign(mask);
+                                       prefetchOp.getPred(), pred);
+    prefetchOp.getPredMutable().assign(mask);
     return op;
   } else if (auto waitOp = dyn_cast<triton::amdgpu::AsyncTDMWait>(op)) {
     return op;

--- a/third_party/amd/python/test/test_warp_pipeline_gfx9.py
+++ b/third_party/amd/python/test/test_warp_pipeline_gfx9.py
@@ -1,0 +1,40 @@
+import triton
+import triton.language as tl
+from triton.backends.compiler import GPUTarget
+from triton.experimental import gluon
+import triton.experimental.gluon.language as gl
+from triton.experimental.gluon.language.amd import warp_pipeline_stage
+
+NUM_WARPS = 4
+BLOCK = 128
+
+
+def _compile_gluon(fn, signature, constexprs, arch="gfx950"):
+    """Compile a Gluon kernel for gfx950 and return the compiled object."""
+    return triton.compile(src=gluon._runtime.GluonASTSource(fn, signature, constexprs),
+                          target=GPUTarget("hip", arch, 64), options={"num_warps": NUM_WARPS})
+
+
+@gluon.jit
+def pipeline_simple(A, B, BLOCK: gl.constexpr):
+    """Minimal 2-stage pipeline — baseline for s_setprio check."""
+    blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
+                                             warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
+    offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
+    offs = gl.program_id(0) * BLOCK + gl.arange(0, BLOCK, layout=offs_layout)
+
+    for i in tl.range(0, 4):
+        with warp_pipeline_stage("stage1", priority=1):
+            a = gl.load(A + offs)
+
+        with warp_pipeline_stage("stage2", priority=0):
+            gl.store(B + offs, a)
+
+
+def test_simple_pipeline_setprio():
+    """Baseline: a simple 2-stage pipeline emits s_setprio."""
+    signature = {"A": "*fp16", "B": "*fp16", "BLOCK": "constexpr"}
+    constexprs = {"BLOCK": BLOCK}
+    k = _compile_gluon(pipeline_simple, signature, constexprs)
+    amdgcn = k.asm["amdgcn"]
+    assert amdgcn.count("s_setprio") > 0, "Simple pipeline must emit s_setprio."

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -465,6 +465,8 @@ class CudaLauncher(object):
         *args,
     ):
 
+        active_driver = triton.runtime.driver.active
+
         def allocate_scratch(size, align, allocator):
             if size > 0:
                 grid_size = gridX * gridY * gridZ
@@ -473,12 +475,26 @@ class CudaLauncher(object):
                 return alloc_fn(alloc_size, align, stream)
             return None
 
+        def allocate_default_profile_scratch(size, align):
+            if size > 0:
+                grid_size = gridX * gridY * gridZ
+                alloc_size = grid_size * self.num_ctas * size
+                return active_driver.allocate_default_profile_scratch(
+                    alloc_size, align, stream
+                )
+            return None
+
         global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
-        profile_scratch = allocate_scratch(
-            self.profile_scratch_size,
-            self.profile_scratch_align,
-            _allocation._profile_allocator,
-        )
+        if _allocation.has_profile_allocator():
+            profile_scratch = allocate_scratch(
+                self.profile_scratch_size,
+                self.profile_scratch_align,
+                _allocation._profile_allocator,
+            )
+        else:
+            profile_scratch = allocate_default_profile_scratch(
+                self.profile_scratch_size, self.profile_scratch_align
+            )
 
         self.launch(
             gridX,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -1274,6 +1274,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
       int numWarps = mlir::triton::gpu::lookupNumWarps(op);
       builder.setInsertionPoint(op);
 
+      // TODO: This should probably be written as memdesc_subslice
       // calculate new tmem type.
       auto retType = cast<MemDescType>(tmemAllocOp.getType());
       SmallVector<int64_t> shape{retType.getShape().begin(),

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -23,6 +23,8 @@ DotOpMmaV5TmemLoader mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::build(
     Location loc, RewriterBase &rewriter, gpu::MemDescType memTy,
     Value tmemBase) {
   auto ctx = loc.getContext();
+  // We take the full layout even when it is a subview
+  // We'll just iterate the real shape when calling tmemLoad tho
   auto ll = toLinearLayout(memTy);
   auto layout = cast<ttng::TensorMemoryEncodingAttr>(memTy.getEncoding());
   auto bitwidth = memTy.getElementTypeBitWidth();
@@ -450,7 +452,8 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   auto tensorMemAttr =
       cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
   unsigned mmaSizeM = tensorMemAttr.getBlockM();
-  unsigned mmaSizeN = tensorMemAttr.getBlockN();
+  // Account for subslices
+  unsigned mmaSizeN = std::min<unsigned>(tensorMemAttr.getBlockN(), N);
   // Checked in the verifier
   assert(mmaSizeN <= 256 &&
          "The maximum size of an MMA instruction is 128x256");


### PR DESCRIPTION
Summary:

Folded bundle of 12 upstream OAI Triton commits cherry-picked into triton/beta. Tested as one diff via `reactor lab reactor-ci` (native A/B against trunk).

Note: upstream PR #9615 ([MultiCTA][Membar] Add fence + cluster relaxed automatically) was the 13th commit in this batch but is intentionally deferred. It depends on the `ClusterBarrierInsertion` pass and the reworked membar/cluster infrastructure introduced by the in-review (unlanded) backport bundle D109373532 (#9220 #9221 #9317 #9318 #9327). It will be re-cherry-picked once D109373532 lands; UPSTREAM_HASH remains at #9631 so #9615 stays pending.

Reactor-Bundle:
- [1] 32a009bc PR #9591 '[CONSAN] Support for detection of incorrect barrier re-initialization' — CLEAN
- [2] b1f9eaf8 PR #9586 '[AMD] Drop unused logic and fix prediction for L2 prefetch' — CLEAN
- [3] 7f9ba28c PR #9593 '[AMD] ConvertWarpPipeline: recognize AsyncWaitOp and fix bars alignment' — RESOLVED(ConvertWarpPipeline.cpp, amd-convert-warp-pipeline.mlir)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2394422021/  Resolution diff: https://www.internalfb.com/intern/paste/P2394429148/
- [4] c72bdad9 PR #9594 '[GLUON][BC Breaking] Infer automatically the register layout for tmem_load' — RESOLVED(dropped test_fpsan.py; beta lacks fpsan)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2394435782/
- [5] fb5c1971 PR #9611 '[BACKEND] Fix uses of blockN in subslices' — CLEAN
- [6] eb706474 PR #9610 '[FenceAsync] Add async read dependencies to the pass' — RESOLVED(ProxyFenceInsertion.cpp; beta already had all 3 parts)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2394438381/  Resolution diff: https://www.internalfb.com/intern/paste/P2394442445/
- [7] be51b08a PR #9620 '[Gluon] Improve multi-CTA matmul example + tests' — CLEAN
- [8] 4473e294 PR #9590 '[CI] Cleanup pytest usage' — RESOLVED(dropped .github/workflows/integration-tests-nvidia.yml; beta lacks it)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2394446681/
- [9] 756afc06 PR #9584 '[Examples] Add M=64 and multicta support in the test' — CLEAN
- [10] 1954693e PR #9624 '[AMD] Add fence to workaround MachineSink issue' — RESOLVED(tritongpu_to_llvm.mlir hybrid RUN lines)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2394447717/  Resolution diff: https://www.internalfb.com/intern/paste/P2394452319/
- [11] 05851861 PR #9596 'Add driver-provided default allocator for profile scratch' — RESOLVED(nvidia/backend/driver.py; dropped fpsan files)
      Raw conflicts: https://www.internalfb.com/intern/paste/P2394453566/  Resolution diff: https://www.internalfb.com/intern/paste/P2394458088/
- [12] 7c380030 PR #9631 '[AMD] Fix a crash in SWP.' — CLEAN

***Do not remove the following line from this commit***
Reactor Cherry-pick Revision: 7c3800308dcd85ebb5a0951ad200736121e5601d

Reviewed By: dshi7

Differential Revision: D109635521
