### PR TITLE
[AutoWS] Harden reuse-group classification in code partitioning

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -91,7 +91,18 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
 }
 
 uint32_t getTMemSubSliceOffset(MemDescType memDescType, int32_t nOffset) {
-  auto llInv = toLinearLayout(memDescType).pseudoinvert();
+  // The offset is computed in the *allocation*'s layout (the parent tile the
+  // subslice indexes into), so use getAllocShape() rather than the (possibly
+  // smaller) view shape. Strip multibuffering by taking only the trailing two
+  // dims: the column offset lives within a single 2D tile and the buffer index
+  // is carried by the base pointer. Without dropping the leading dim, a
+  // multibuffered (rank-3) memdesc trips the shape.size() == 2 assert in
+  // tensorMemoryToLinearLayout. (Equivalent to the original
+  // toLinearLayout(memDescType), which used
+  // getAllocShape().take_back(getRank()), except it keeps the inner 2 dims
+  // instead of all getRank() dims.)
+  auto shape = memDescType.getAllocShape().take_back(2);
+  auto llInv = toLinearLayout(shape, memDescType.getEncoding()).pseudoinvert();
   auto dimNames = llvm::to_vector(llInv.getInDimNames());
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   logicalOffsets.reserve(dimNames.size());

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -696,15 +696,86 @@ static bool hasDependencyChain(Channel *A, Channel *B) {
   return false;
 }
 
+bool verifyReuseGroup1(ReuseGroup *group) {
+  // A1 (SMEM circular reuse): the channels share a single multi-buffered
+  // circular buffer and rely on accumCnt staggering, which is only well-defined
+  // when (a) the group is multi-buffered and (b) every producer/consumer of
+  // every logical buffer lives in one common basic block (the loop body).
+  if (group->channels.empty())
+    return false;
+  if (group->channels[0]->getNumBuffers() <= 1) {
+    LDBG("verifyReuseGroup1: group is single-buffered (numCopies <= 1)");
+    return false;
+  }
+  // Subtiled-region groups are not handled as A1 SMEM circular reuse: their
+  // producer/consumer ops legitimately live inside the SubtiledRegionOp
+  // per-tile block (a different basic block than the loop body), and their
+  // synchronization is provided by the subtiled-region lowering (per-tile
+  // barriers) rather than by A1 accumCnt staggering. The single-basic-block
+  // invariant below therefore does not apply, so skip them here instead of
+  // flagging them as ill-formed.
+  for (auto *ch : group->channels) {
+    for (Operation *op : {ch->getSrcOp(), ch->getDstOp()}) {
+      if (op && op->getParentOfType<ttng::SubtiledRegionOp>()) {
+        LDBG("verifyReuseGroup1: channel "
+             << ch->uniqID << " is inside a subtiled region; not an A1 group");
+        return true;
+      }
+    }
+  }
+  Block *commonBlock = nullptr;
+  for (auto *ch : group->channels) {
+    // getSrcOp()/getDstOp() (singular) are safe here: A1 groups are SMEM
+    // channels with a single producer/consumer each.
+    Operation *endpoints[] = {ch->getSrcOp(), ch->getDstOp()};
+    for (auto *op : endpoints) {
+      if (!op) {
+        LDBG("verifyReuseGroup1: channel " << ch->uniqID
+                                           << " missing producer/consumer");
+        return false;
+      }
+      if (!commonBlock) {
+        commonBlock = op->getBlock();
+      } else if (op->getBlock() != commonBlock) {
+        LDBG("verifyReuseGroup1: producer/consumer of channel "
+             << ch->uniqID << " not in the common basic block");
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// For a TMEM reuse group, return true iff the channels' column ranges
+// (`[buffer.offset, buffer.offset + numCols)`) overlap. Overlapping columns
+// mean the channels share the same physical TMEM space and reuse it across
+// time — a real reuse group needing synchronization (e.g. dp/dq, qk/dv).
+// Fully-disjoint columns are spatial packing, materialized by
+// replaceBufferReuse's column slice, and need no cross-channel sync.
+static bool tmemReuseGroupOverlaps(ReuseGroup *group) {
+  struct ColRange {
+    int64_t lo, hi;
+  };
+  SmallVector<ColRange> ranges;
+  for (auto *ch : group->channels) {
+    auto *allocOp = ch->getAllocOp();
+    if (!allocOp)
+      return false;
+    auto memDescType = cast<ttg::MemDescType>(allocOp->getResult(0).getType());
+    int64_t numCols = ttng::getTmemAllocSizes(memDescType).numCols;
+    int64_t off = 0;
+    if (auto a = allocOp->getAttrOfType<IntegerAttr>("buffer.offset"))
+      off = a.getInt();
+    ranges.push_back({off, off + numCols});
+  }
+  for (unsigned i = 0; i < ranges.size(); ++i)
+    for (unsigned j = i + 1; j < ranges.size(); ++j)
+      if (ranges[i].lo < ranges[j].hi && ranges[j].lo < ranges[i].hi)
+        return true;
+  return false;
+}
+
 bool verifyReuseGroup2(ReuseGroup *group) {
-  // TODO(reuse-group generalization): this handles exactly 2 channels at a
-  // single copy. Evaluate generalizing to reuse groups of size N (>2) and to
-  // multi-buffered groups (getNumBuffers() >= 2, e.g. the FA-fwd-persistent
-  // cross-stage QK/P reuse). A prior unused verifyReuseGroupN/orderReuseGroupN
-  // attempted the size-N axis but was dead code (and still assumed single
-  // copy), so it was removed; fold both axes here when a real
-  // N-channel/multi-copy case lands, with the reuse-WAR index/phase taken from
-  // the depth-aware getBufferIdxAndPhase.
   assert(group->channels.size() == 2 &&
          "verifyReuseGroup2 requires exactly 2 channels");
   auto *chA = group->channels[0];
@@ -714,27 +785,41 @@ bool verifyReuseGroup2(ReuseGroup *group) {
   if (chA->getNumBuffers() != 1 || chB->getNumBuffers() != 1)
     return false;
 
+  // TMEM real reuse requires BOTH:
+  //  (1) overlapping columns — the two channels occupy the same physical TMEM
+  //      space (disjoint columns are A4 spatial packing, handled by
+  //      replaceBufferReuse with no cross-channel sync), AND
+  //  (2) a consumer->producer dependency chain in either direction — proof the
+  //      two are temporally ordered (a real reuse), not concurrently live.
+  // Overlap alone would trust the planner's non-concurrency guarantee without
+  // verifying it; the chain confirms the reuse is real and gives
+  // `orderReuseGroup2` a reliable early/late ordering (rather than guessing via
+  // program order). This mirrors the SMEM path below.
+  if (chA->channelKind == DataChannelKind::TMEMPost &&
+      chB->channelKind == DataChannelKind::TMEMPost) {
+    if (!tmemReuseGroupOverlaps(group)) {
+      LDBG("verifyReuseGroup2: TMEM channels "
+           << chA->uniqID << "/" << chB->uniqID
+           << " disjoint columns (spatial packing, not a sync reuse group)");
+      return false;
+    }
+    bool chain = hasDependencyChain(chA, chB) || hasDependencyChain(chB, chA);
+    LDBG("verifyReuseGroup2: TMEM channels "
+         << chA->uniqID << "/" << chB->uniqID << " overlap=1 chain=" << chain);
+    return chain;
+  }
+
+  // SMEM (and other) real reuse: a consumer->producer dependency chain in
+  // either direction (e.g. qk/pp). The SMEM epilogue-subtile case (producers
+  // in the same block, no chain) is NOT handled here — it is the N-buffer
+  // path (verifyReuseGroupN).
   bool hasAtoB = hasDependencyChain(chA, chB);
   bool hasBtoA = hasDependencyChain(chB, chA);
   LDBG("verifyReuseGroup2: channel " << chA->uniqID << " -> channel "
                                      << chB->uniqID << ": " << hasAtoB);
   LDBG("verifyReuseGroup2: channel " << chB->uniqID << " -> channel "
                                      << chA->uniqID << ": " << hasBtoA);
-  if (!hasAtoB && !hasBtoA) {
-    // Fallback: check if producers are ordered in program order within
-    // the same block. Covers epilogue subtile stores that share a buffer
-    // but have producer/consumer in different partitions.
-    auto *srcA = chA->getSrcOp();
-    auto *srcB = chB->getSrcOp();
-    if (srcA && srcB && srcA->getBlock() == srcB->getBlock() &&
-        (appearsBefore(srcA, srcB) || appearsBefore(srcB, srcA))) {
-      LDBG("verifyReuseGroup2: fallback accepted, producers in same block");
-      return true;
-    }
-    LDBG("verifyReuseGroup2: no dependency chain between channels");
-    return false;
-  }
-  return true;
+  return hasAtoB || hasBtoA;
 }
 
 std::pair<Channel *, Channel *> orderReuseGroup2(ReuseGroup *group) {
@@ -748,10 +833,67 @@ std::pair<Channel *, Channel *> orderReuseGroup2(ReuseGroup *group) {
     return {chA, chB};
   if (hasDependencyChain(chB, chA))
     return {chB, chA};
-  // Fallback: order by producer program order.
-  if (appearsBefore(chA->getSrcOp(), chB->getSrcOp()))
-    return {chA, chB};
-  return {chB, chA};
+  // Unreachable for a verified group: verifyReuseGroup2 now requires a
+  // dependency chain in one direction (both for SMEM and overlapping TMEM), so
+  // a group reaching here is an overlapping-but-unordered (concurrently
+  // aliased) pair — a memory-planner contract violation that would otherwise
+  // yield a guessed (possibly wrong) barrier direction. Fail loudly instead.
+  llvm::report_fatal_error(
+      "orderReuseGroup2: reuse group has no dependency chain in either "
+      "direction (overlapping but temporally unordered reuse pair)");
+}
+
+bool verifyReuseGroupN(ReuseGroup *group) {
+  if (group->channels.size() < 2) {
+    LDBG("verifyReuseGroupN: need at least 2 channels, got "
+         << group->channels.size());
+    return false;
+  }
+  // The N-buffer (epilogue subtile) path is SMEM-only: it shares one circular
+  // SMEM buffer across N sub-tile stores. TMEM reuse is handled by
+  // verifyReuseGroup2 (overlap) + replaceBufferReuse (column packing).
+  // All channels must be SMEM, single-copy, with producers in the same block.
+  Block *commonBlock = nullptr;
+  for (auto *ch : group->channels) {
+    if (ch->channelKind != DataChannelKind::SMEMPost) {
+      LDBG("verifyReuseGroupN: channel " << ch->uniqID << " is not SMEM");
+      return false;
+    }
+    if (ch->getNumBuffers() != 1) {
+      LDBG("verifyReuseGroupN: channel " << ch->uniqID
+                                         << " has numBuffers != 1");
+      return false;
+    }
+    auto *producer = ch->getSrcOp();
+    if (!producer) {
+      LDBG("verifyReuseGroupN: channel " << ch->uniqID << " has no producer");
+      return false;
+    }
+    if (!commonBlock) {
+      commonBlock = producer->getBlock();
+    } else if (producer->getBlock() != commonBlock) {
+      LDBG("verifyReuseGroupN: producers are in different blocks");
+      return false;
+    }
+  }
+  return true;
+}
+
+SmallVector<Channel *> orderReuseGroupN(ReuseGroup *group) {
+  SmallVector<Channel *> ordered(group->channels.begin(),
+                                 group->channels.end());
+  // Sort by program order of producer ops. All producers are in the same
+  // block (verified by verifyReuseGroupN), so appearsBefore gives a total
+  // order.
+  llvm::sort(ordered, [](Channel *a, Channel *b) {
+    return appearsBefore(a->getSrcOp(), b->getSrcOp());
+  });
+  LLVM_DEBUG({
+    LDBG("orderReuseGroupN: ordered " << ordered.size() << " channels:");
+    for (unsigned i = 0; i < ordered.size(); i++)
+      LDBG("  [" << i << "] channel " << ordered[i]->uniqID);
+  });
+  return ordered;
 }
 
 bool needExplicitReuseWait(Channel *earlyChannel, Channel *lateChannel) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -337,6 +337,12 @@ void fuseTcgen05CommitBarriers(triton::FuncOp &funcOp);
 void doTMAStoreLowering(triton::FuncOp &funcOp);
 bool appearsBefore(Operation *A, Operation *B);
 
+// Verify that an A1 (SMEM circular reuse) group is well-formed:
+// - Multi-buffered (channels[0]->getNumBuffers() > 1).
+// - Every producer/consumer of every channel lives in one common basic block.
+// Returns true if valid, false otherwise.
+bool verifyReuseGroup1(ReuseGroup *group);
+
 // Verify that a 2-buffer reuse group is well-formed:
 // - Exactly 2 channels, each with a single copy (getNumBuffers() == 1).
 // - A dependency chain exists from one channel's consumer to the other's
@@ -349,6 +355,16 @@ bool verifyReuseGroup2(ReuseGroup *group);
 // chain from A's consumer to B's producer (A.consumer -> ... -> B.producer).
 // Returns {earlyChannel, lateChannel}.
 std::pair<Channel *, Channel *> orderReuseGroup2(ReuseGroup *group);
+
+// Verify that a reuse group with N channels (N >= 2) is well-formed:
+// - At least 2 channels, each with a single copy (getNumBuffers() == 1).
+// - All producers are in the same block (so program order gives a total order).
+bool verifyReuseGroupN(ReuseGroup *group);
+
+// For a verified N-channel reuse group, order channels by program order of
+// their producer ops (getSrcOp()). Returns a sorted vector where channels[0]
+// is earliest and channels[N-1] is latest in program order.
+SmallVector<Channel *> orderReuseGroupN(ReuseGroup *group);
 
 // Given ordered channels {early, late} in a reuse group, determine
 // whether we need to explicitly move late's producer_acquire to before early's

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3196,8 +3196,13 @@ void insertAsyncComm(
           // before overwriting it.
           earlyChannelForReuseSync = earlyChannel;
         }
-      } else if (group->channels.size() > 2) {
-        // N-buffer reuse group handling (N > 2).
+      } else if (group->channels.size() > 2 || verifyReuseGroupN(group)) {
+        // N-buffer reuse group handling: N > 2, or a 2-channel SMEM
+        // epilogue-subtile group admitted by verifyReuseGroupN (SMEM,
+        // single-copy, producers same block — also covers the 2-channel SMEM
+        // epilogue; the real-reuse 2-channel case went to A2 above). The body
+        // dispatches A6 whole-allocation-overwrite hub, then A3 same-block
+        // chain (and, after the 3-group fix commit, A5 cross-partition).
         bool allSingleCopy = llvm::all_of(group->channels, [](Channel *ch) {
           return ch->getNumBuffers() == 1;
         });
@@ -4926,6 +4931,26 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
       llvm::remove_if(orderedChannels,
                       [&](Channel *ch) { return mergedChannels.count(ch); }),
       orderedChannels.end());
+
+  // Condition checking for reuse groups (see ReuseGroups.md):
+  //  - A1 (SMEM circular reuse): a multi-buffered group must have numCopies > 1
+  //    and all producers/consumers of its logical buffers in one basic block,
+  //    otherwise the shared accumCnt staggering is ill-defined. The memory
+  //    planner has already committed to aliasing these buffers, so a violation
+  //    is a hard error rather than a silent fallback.
+  //  - A2 (2-buffer) / A3 (N-buffer) single-copy sync are verified at use in
+  //    insertAsyncComm (verifyReuseGroup2 / the inline N-buffer path).
+  for (unsigned i = 0; i < config.getGroupSize(); ++i) {
+    auto *group = config.getGroup(i);
+    if (group->channels.empty())
+      continue;
+    if (group->channels[0]->getNumBuffers() > 1 && !verifyReuseGroup1(group))
+      llvm::report_fatal_error(
+          "SMEM circular reuse group is ill-formed: a multi-buffered reuse "
+          "group requires all producers/consumers of its logical buffers to be "
+          "in the same basic block");
+  }
+
   appendAccumCntsForOps(asyncTaskTopOps, channels, regionsWithChannels,
                         &config);
   LLVM_DEBUG({

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/ReuseGroups.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/ReuseGroups.md
@@ -7,6 +7,25 @@ assigns them the same `buffer.id` so that downstream code partitioning replaces
 all but one allocation with views into a single representative buffer. This
 reduces SMEM and TMEM pressure without changing program semantics.
 
+## Reuse Categories (A1–A6)
+
+Code partitioning classifies each reuse group (channels sharing a `buffer.id`)
+by how it must be synchronized. These labels are used throughout this doc and in
+the `WSCodePartition.cpp` / `CodePartitionUtility.cpp` comments:
+
+| | Category | Mem | Shape | Predicate / handler |
+|---|---|---|---|---|
+| **A1** | SMEM circular reuse | SMEM | multi-buffered (`numCopies > 1`), all producers/consumers in one block; cycles channels through *time slots* of one circular buffer via `accumCnt` staggering | `verifyReuseGroup1` |
+| **A2** | 2-buffer real reuse | TMEM/SMEM | exactly 2 single-copy channels with **overlapping** reuse AND a consumer→producer dependency chain — TMEM (overlapping columns **and** chain) or SMEM (chain) | `verifyReuseGroup2` |
+| **A3** | N-buffer SMEM epilogue | SMEM | ≥2 single-copy channels sharing one circular buffer, stored/loaded sequentially, all producers in one block (epilogue subtiling) | `verifyReuseGroupN` + inline chain |
+| **A4** | TMEM column packing | TMEM | same `buffer.id`, **disjoint** columns (`buffer.offset`) — spatial packing, no cross-channel sync; materialized by `replaceBufferReuse`'s column slice | none (`tmemReuseGroupOverlaps` false) |
+| **A5** | Cross-partition reuse | TMEM | single-copy ≥3-channel group: a 2-channel **core** plus **extras** that elide via same-partition ordering | `verifyReuseGroupCrossPartition` |
+| **A6** | Whole-allocation-overwrite hub | TMEM | a `useC=false` owner overwrites the **whole** allocation, clobbering spatially-packed (distinct-`buffer.offset`) siblings; emits back-edges to those siblings | `isWholeAllocationOverwriteReuseOwner` |
+
+A1 uses temporal slot staggering (multi-buffered). A2/A3/A5/A6 are single-copy
+(`buffer.copy = 1`) and get explicit reuse barriers. A4 needs no synchronization
+(the columns are disjoint). Each category is detailed in its own section below.
+
 ## Requirements for Reuse
 
 Two channels can share a buffer when:
@@ -88,13 +107,20 @@ Reuse groups are formed in `doCodePartitionPost` (`WSCodePartition.cpp`):
 
 ### 1. Accumulation Counters
 
+> **SMEM-only.** Cross-group count accumulation applies **only to
+> multi-buffered SMEM circular reuse**. TMEM reuse groups do **not** accumulate
+> across the group — see [SMEM vs TMEM](#smem-vs-tmem-accumulation) below.
+
 When channels in a reuse group share a multi-buffered circular buffer, a shared
 **accumulation counter** (`accumCnt`) tracks which buffer slot to use. The
 counter is carried as a loop argument and incremented as channels are consumed.
 
 Key functions:
-- `needAccumCntForReuse` — returns true when a loop/if region contains at
-  least one src or dst op of the reuse group and the group is multi-buffered
+- `needAccumCntForReuse` — returns true when **the group is multi-buffered**
+  (`channels[0]->getNumBuffers() > 1`) **and** a loop/if region contains at
+  least one src or dst op of the reuse group. It short-circuits to `false` for
+  single-buffered groups (`CodePartitionUtility.cpp:346-348`), so no shared
+  `accumCnt` loop argument is created for them.
 - `getAccumForReuseGroup` — computes the `accumCnt` SSA value at a given
   operation by walking back through the channel list to find the nearest
   preceding region op, then arithmetically adding the remaining offset
@@ -103,6 +129,47 @@ Key functions:
   its slot within the shared circular buffer
 - `getReuseAccumArgIdx` — returns the position of a group's `accumCnt`
   argument within the region's full argument list
+
+#### Condition check (A1)
+
+Because the memory planner has already committed to aliasing a multi-buffered
+SMEM circular reuse group, code partitioning **validates** the A1 preconditions
+before emitting any `accumCnt` for it. After reuse-group formation (and before
+`appendAccumCntsForOps`), `doCodePartitionPost` calls `verifyReuseGroup1` on
+every multi-buffered group and `report_fatal_error`s if it fails:
+
+- **Multi-buffered** — `channels[0]->getNumBuffers() > 1` (this is also what
+  classifies the group as A1 rather than A2/A3).
+- **Common basic block** — every channel's producer (`getSrcOp()`) and consumer
+  (`getDstOp()`) live in one common block, so the shared `accumCnt` staggering
+  is well-defined.
+
+A violation is a hard error (not a silent fallback) because the buffers are
+already physically aliased; proceeding would emit incorrect synchronization.
+
+#### SMEM vs TMEM accumulation
+
+The `accumCnt` stagger is a **temporal** mechanism: it cycles the channels of a
+group through the *time slots* of one shared multi-buffered circular buffer.
+This is exactly how **SMEM circular reuse** works (the group is multi-buffered).
+
+**TMEM reuse does not use it.** TMEM column-packed reuse groups are
+**single-buffered** (`numBuffers == 1`); each accumulator is placed at its own
+**spatial column** via `buffer.offset` in `replaceBufferReuse`, not in a shared
+time slot. Consequently:
+
+1. `needAccumCntForReuse` returns `false` (single-buffered) → no shared
+   `accumCnt` loop argument is added for the group.
+2. The accumCnt/buffer-index path calls `channelInReuseGroup(channel, config)`
+   with the default `reuseBarrier=true`, which skips groups whose representative
+   has `numBuffers <= 1` → returns `-1`.
+3. With `reuseGroupIdx < 0`, `getBufferIdxAndPhase` takes the plain per-channel
+   branch — **no `+N` stagger across the group.**
+
+So `accumCnt` accumulation is exclusive to the SMEM circular-reuse path. TMEM
+reuse participates in reuse groups only for **spatial packing** (`buffer.offset`)
+and **barrier sharing** (looked up with `reuseBarrier=false`), never for
+cross-group count accumulation.
 
 ### 2. Token/Barrier Sharing
 
@@ -184,19 +251,55 @@ For a reuse group with 2 buffers A and B (`buffer.copy=1`):
 bool verifyReuseGroup2(ReuseGroup *group);
 ```
 
+`verifyReuseGroup2` recognizes only **real** 2-buffer reuse — two channels that
+share the same physical space and reuse it across time. The signal differs by
+memory kind:
+
+- **TMEM**: real reuse iff the two channels' **column ranges overlap**
+  (`[buffer.offset, buffer.offset + numCols)`) **and** there is a
+  consumer→producer **dependency chain** in either direction. Disjoint columns
+  are *spatial packing* (e.g. two independent accumulators side-by-side),
+  materialized by `replaceBufferReuse`'s column slice — they need no
+  cross-channel sync and are **not** treated as a reuse group here. Requiring
+  the chain in addition to overlap means the two accesses are provably
+  temporally ordered (a real reuse, not concurrently-live aliasing) and gives
+  `orderReuseGroup2` a reliable early/late ordering — the same standard SMEM
+  already meets.
+- **SMEM**: real reuse iff there is a consumer→producer **dependency chain** in
+  either direction (e.g. `qk/pp`).
+
+The SMEM **epilogue-subtile** case (producers in the same block, no dependency
+chain) is deliberately **not** handled here — it is the N-buffer path
+(`verifyReuseGroupN`). This split keeps `verifyReuseGroup2` strictly about
+overlapping-space reuse.
+
 Implementation:
 ```
 verifyReuseGroup2(group):
   assert group.channels.size() == 2
   A = group.channels[0], B = group.channels[1]
-  assert A.getNumBuffers() == 1 && B.getNumBuffers() == 1
 
-  // Check dependency chain: A.consumer → B.producer or B.consumer → A.producer
-  hasAtoB = isDependencyChain(A.dstOp, B.srcOp)
-  hasBtoA = isDependencyChain(B.dstOp, A.srcOp)
-  assert (hasAtoB || hasBtoA) // At least one direction
-  return true
+  // Only single-copy buffers are handled.
+  if A.getNumBuffers() != 1 || B.getNumBuffers() != 1:
+    return false
+
+  // TMEM: real reuse iff the column ranges overlap (same space) AND a
+  // consumer->producer dependency chain orders the two (real temporal reuse,
+  // not concurrent aliasing).
+  if A and B are both TMEM:
+    if not tmemReuseGroupOverlaps(group):
+      return false                                    // disjoint = spatial packing
+    return hasDependencyChain(A, B) || hasDependencyChain(B, A)
+
+  // SMEM: real reuse iff a consumer→producer dependency chain exists.
+  return hasDependencyChain(A, B) || hasDependencyChain(B, A)
 ```
+
+`hasDependencyChain(A, B)` walks the transitive users of `A.dstOp` looking for
+`B.srcOp`, and also treats same-block program order (`A.dstOp` before
+`B.srcOp`) as an implicit dependency. `tmemReuseGroupOverlaps` computes each
+channel's column interval from `getTmemAllocSizes(...).numCols` and
+`buffer.offset` and returns true if any two intervals intersect.
 
 #### `orderReuseGroup2`
 
@@ -211,9 +314,16 @@ Implementation:
 ```
 orderReuseGroup2(group):
   A = group.channels[0], B = group.channels[1]
-  if isDependencyChain(A.dstOp, B.srcOp):
+  if hasDependencyChain(A, B):    // A.consumer -> B.producer
     return {A, B}
-  return {B, A}
+  if hasDependencyChain(B, A):
+    return {B, A}
+  // Unreachable for a verified group: verifyReuseGroup2 now requires a chain in
+  // one direction (both SMEM and overlapping TMEM). A group with no chain is an
+  // overlapping-but-unordered (concurrently aliased) pair — a memory-planner
+  // contract violation — so fail loudly instead of guessing a barrier direction
+  // from program order.
+  report_fatal_error("orderReuseGroup2: reuse group has no dependency chain")
 ```
 
 #### `needExplicitReuseWait`
@@ -229,15 +339,14 @@ bool needExplicitReuseWait(Channel *earlyChannel, Channel *lateChannel);
 Implementation:
 ```
 needExplicitReuseWait(earlyChannel, lateChannel):
-  bConsumerOp = getUniqueActualConsumer(lateChannel.dstOp, consumerTaskId)
   aProducerOp = earlyChannel.srcOp
-
-  bConsumerTasks = getAsyncTaskIds(bConsumerOp)
-  aProducerTasks = getAsyncTaskIds(aProducerOp)
-
-  if bConsumerTasks and aProducerTasks share a common taskId:
-    if appearsBefore(aProducerOp, bConsumerOp):
-      return false  // No explicit wait needed (qk/pp case)
+  // Resolve through memdesc_trans etc. — there may be more than one.
+  for bConsumerOp in getActualConsumers(lateChannel.dstOp):
+    if getAsyncTaskIds(bConsumerOp) shares a taskId with getAsyncTaskIds(aProducerOp):
+      // Same partition: program order already serializes the release before
+      // the next acquire.
+      if aProducerOp, bConsumerOp in same block and appearsBefore(aProducerOp, bConsumerOp):
+        return false  // No explicit wait needed (qk/pp case)
 
   return true  // Need explicit wait (dp/dq case)
 ```
@@ -449,7 +558,13 @@ runtime validation is the FA-fwd-persistent dp kernel determinism check.
 | SMEM `buffer.id` assignment | `WSMemoryPlanner.cpp` | Assign `buffer.id` to SMEM allocs |
 | SMEM circular reuse (Phase 4) | `WSMemoryPlanner.cpp` | Form SMEM reuse pairs, maximize copies |
 | TMEM `applyAllocationState` | `WSMemoryPlanner.cpp` | Assign `buffer.id` + `buffer.offset` to TMEM allocs |
-| `verifyReuseGroup2` | `CodePartitionUtility.cpp` | Verify 2-buffer reuse group constraints |
+| `verifyReuseGroup1` | `CodePartitionUtility.cpp` | Verify A1 (SMEM circular reuse): multi-buffered + all producers/consumers in one block |
+| `verifyReuseGroup2` | `CodePartitionUtility.cpp` | Real 2-buffer reuse: TMEM (column overlap AND dependency chain), or SMEM (dependency chain) |
+| `tmemReuseGroupOverlaps` | `CodePartitionUtility.cpp` | True if a TMEM group's channel column ranges overlap (real reuse vs spatial packing) |
 | `orderReuseGroup2` | `CodePartitionUtility.cpp` | Determine early/late channel ordering |
 | `needExplicitReuseWait` | `CodePartitionUtility.cpp` | Check if explicit cross-channel wait is needed |
 | `isWholeAllocationOverwriteReuseOwner` | `CodePartitionUtility.cpp` | Detect a representative whose producer overwrites the whole allocation (needs back-edges to live packed siblings) |
+| `hasDependencyChain` | `CodePartitionUtility.cpp` | True if A's consumer reaches B's producer (transitive or program order) |
+| `verifyReuseGroupN` | `CodePartitionUtility.cpp` | **Live** gate for the SMEM epilogue path: SMEM, single-copy, producers same block, N ≥ 2 |
+| N-buffer sync (epilogue) | `WSCodePartition.cpp` (`insertAsyncComm`) | Inline chain + wrap-around `ProducerAcquireOp` insertion |
+| `orderReuseGroupN` | `CodePartitionUtility.cpp` | Producer-order sort helper — **still unused** (inline does its own sort) |


### PR DESCRIPTION
Summary:
Make code partitioning treat the memory planner's reuse groups as a contract:
classify each group by how it is actually synchronized, and identify real reuse
distinctly from spatial packing.

verifyReuseGroup2 now means real overlapping reuse only: for TMEM, real reuse is
detected by overlapping column ranges (tmemReuseGroupOverlaps); disjoint columns
are spatial packing handled by replaceBufferReuse. For SMEM it stays the
dependency-chain check. The "producers in the same block" epilogue fallback (and
a stray debug print) is removed from verifyReuseGroup2 and now lives only in
verifyReuseGroupN, which is scoped to SMEM and gates the epilogue path for N >= 2
channels. verifyReuseGroup1 + a validation loop in doCodePartitionPost
report_fatal_error when a multi-buffered (SMEM circular reuse) group does not
have all producers/consumers in one basic block.

ReuseGroups.md is updated to match.

Co-authored-by: Claude <claude@anthropic.com>

Reviewed By: njriasan

Differential Revision: D109337150


