### PR TITLE
[AutoWS][FA] Fix #1840 TMEMSubslice lowering crash on multibuffered TMEM (#1856)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -91,7 +91,18 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
 }
 
 uint32_t getTMemSubSliceOffset(MemDescType memDescType, int32_t nOffset) {
-  auto llInv = toLinearLayout(memDescType).pseudoinvert();
+  // The offset is computed in the *allocation*'s layout (the parent tile the
+  // subslice indexes into), so use getAllocShape() rather than the (possibly
+  // smaller) view shape. Strip multibuffering by taking only the trailing two
+  // dims: the column offset lives within a single 2D tile and the buffer index
+  // is carried by the base pointer. Without dropping the leading dim, a
+  // multibuffered (rank-3) memdesc trips the shape.size() == 2 assert in
+  // tensorMemoryToLinearLayout. (Equivalent to the original
+  // toLinearLayout(memDescType), which used
+  // getAllocShape().take_back(getRank()), except it keeps the inner 2 dims
+  // instead of all getRank() dims.)
+  auto shape = memDescType.getAllocShape().take_back(2);
+  auto llInv = toLinearLayout(shape, memDescType.getEncoding()).pseudoinvert();
   auto dimNames = llvm::to_vector(llInv.getInDimNames());
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   logicalOffsets.reserve(dimNames.size());


### PR DESCRIPTION
Summary:

getTMemSubSliceOffset called toLinearLayout() on the full source memdesc, which
for a multibuffered FA accumulator is rank-3 (e.g. memdesc<1x128x128xf32,
#tmem>). tensorMemoryToLinearLayout then aborts on assert(shape.size() == 2),
crashing ConvertTritonGPUToLLVM for the FA device-TMA kernels on Blackwell
(both _attn_fwd and the bwd reuse configs).

This is a regression from the #1840 cherry-pick bundle (PR #7777, "Lower
TMEMSubslice via LinearLayouts"): TMEMSubSliceOpConversion passes the source
type (rank-3, multibuffered) where upstream passes the rank-2 result type, so
the multibuffered case is newly exercised.

Strip the leading multibuffer dim before building the layout, mirroring the
sibling getTMemSubSliceShape: a subslice's column offset is within a single 2D
tile and the buffer index is carried by the base pointer, so the offset is
independent of multibuffering.

Reviewed By: agron911

Differential Revision: D109920344


