### PR TITLE
 Fix build error of ctaSplitNum => cgaLayout (#1862)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -2656,7 +2656,7 @@ bool visit_make_tensordesc_args(PyObject *arg, PyObject *sig,
 
   Py_ssize_t arg_len = PySequence_Fast_GET_SIZE(arg_fast.ptr());
   Py_ssize_t sig_len = PyTuple_GET_SIZE(sig);
-  assert(sig_len == arg_len || !"Invalid signature");
+  assert(sig_len == arg_len && "Invalid signature");
   Py_ssize_t len = arg_len;
 
   for (Py_ssize_t i = 0; i < len; ++i) {

--- a/python/test/unit/language/test_amd_warp_pipeline.py
+++ b/python/test/unit/language/test_amd_warp_pipeline.py
@@ -6,11 +6,7 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-
-
-def is_hip():
-    return triton.runtime.driver.active.get_current_target().backend == "hip"
-
+from triton._internal_testing import is_hip
 
 # --- Runtime test: simple GEMM with warp pipeline ---
 

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -515,7 +515,7 @@ def matmul_kernel_persistent_scatter(a_ptr, b_ptr, c_ptr,  #
         c_desc.scatter(c, offs_am + tl.arange(0, BLOCK_SIZE_M), offs_bn)
 
 
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] != 10,
+@pytest.mark.skipif(not (is_cuda() and torch.cuda.get_device_capability()[0] == 10),
                     reason="TMA Scatter only works on cloud Blackwell Chips")
 def test_scatter_pipeline(device):
 

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -479,9 +479,7 @@ class CudaLauncher(object):
             if size > 0:
                 grid_size = gridX * gridY * gridZ
                 alloc_size = grid_size * self.num_ctas * size
-                return active_driver.allocate_default_profile_scratch(
-                    alloc_size, align, stream
-                )
+                return active_driver.allocate_default_profile_scratch(alloc_size, align, stream)
             return None
 
         global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
@@ -492,9 +490,7 @@ class CudaLauncher(object):
                 _allocation._profile_allocator,
             )
         else:
-            profile_scratch = allocate_default_profile_scratch(
-                self.profile_scratch_size, self.profile_scratch_align
-            )
+            profile_scratch = allocate_default_profile_scratch(self.profile_scratch_size, self.profile_scratch_align)
 
         self.launch(
             gridX,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -861,8 +861,9 @@ SmallVector<Channel *> orderReuseGroupChain(ReuseGroup *group) {
         edge[i][j] = true;
         ++indeg[j];
       }
-  // Kahn's algorithm requiring a unique zero-in-degree node at each step, so the
-  // chain order is unambiguous (true for a real reuse cycle like dpT->dsT->dq).
+  // Kahn's algorithm requiring a unique zero-in-degree node at each step, so
+  // the chain order is unambiguous (true for a real reuse cycle like
+  // dpT->dsT->dq).
   SmallVector<Channel *> ordered;
   SmallVector<bool> used(n, false);
   for (unsigned step = 0; step < n; ++step) {
@@ -1009,10 +1010,10 @@ bool verifyReuseGroupCrossPartition(ReuseGroup *group) {
   // see "one block"), but the cross-partition writers need explicit reuse
   // barriers — a same-partition program-order elision is unsound for them.
   //
-  // Realized case: FA-bwd `_BWD_DOT_ATTRS_TMEM` {dpT, dsT, dq} on one buffer.id:
-  // dpT (gemm) -> dsT (computation tmem_store) -> dq (gemm). The computation
-  // writer dsT needs a cross-iteration WAR against dq, which the A3 single-wrap
-  // omits (it raced across the persistent outer loop).
+  // Realized case: FA-bwd `_BWD_DOT_ATTRS_TMEM` {dpT, dsT, dq} on one
+  // buffer.id: dpT (gemm) -> dsT (computation tmem_store) -> dq (gemm). The
+  // computation writer dsT needs a cross-iteration WAR against dq, which the A3
+  // single-wrap omits (it raced across the persistent outer loop).
   if (group->channels.size() <= 2)
     return false;
   for (auto *ch : group->channels) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1421,8 +1421,7 @@ void createTokenPost(
           LDBG("createTokenPost Fix1: non-rep channel "
                << channel->uniqID
                << " allocated gen5 consumer barrier for task "
-               << consumerAsyncTaskId
-               << " (rep channel " << repChannel->uniqID
+               << consumerAsyncTaskId << " (rep channel " << repChannel->uniqID
                << " did not cover this task)");
         }
 
@@ -1432,8 +1431,7 @@ void createTokenPost(
              << channel->uniqID
              << " shares CommChannel from representative channel "
              << repChannel->uniqID << " ("
-             << commChannel.consumerBarriers.size()
-             << " consumer barriers)");
+             << commChannel.consumerBarriers.size() << " consumer barriers)");
         continue;
       }
     }
@@ -3226,16 +3224,16 @@ void insertAsyncComm(
         });
         // A6 (whole-allocation-overwrite hub) targets SPATIAL PACKING: siblings
         // packed at DISTINCT `buffer.offset`s within the owner's columns (e.g.
-        // FA-fwd alpha/m_ij/l_i0 at offsets 64/65/66 inside the QK accumulator).
-        // A group whose channels all share the SAME offset is full-overlap
-        // TEMPORAL reuse (e.g. FA-bwd {dpT,dq,dsT}, all offset 0) and must NOT
-        // be routed to A6 even when it has a useC=false owner — it needs the
-        // same-block reuse chain (A3) / cross-partition (A5) barrier below, or
-        // dq's async overwrite races dk's async read of dsT. (Column-range
-        // overlap can't distinguish them — the owner spans the packed siblings'
-        // columns in both cases; and block-based verifyReuseGroupCrossPartition
-        // is unusable here since partitions are still async_task_id tags in one
-        // block.)
+        // FA-fwd alpha/m_ij/l_i0 at offsets 64/65/66 inside the QK
+        // accumulator). A group whose channels all share the SAME offset is
+        // full-overlap TEMPORAL reuse (e.g. FA-bwd {dpT,dq,dsT}, all offset 0)
+        // and must NOT be routed to A6 even when it has a useC=false owner — it
+        // needs the same-block reuse chain (A3) / cross-partition (A5) barrier
+        // below, or dq's async overwrite races dk's async read of dsT.
+        // (Column-range overlap can't distinguish them — the owner spans the
+        // packed siblings' columns in both cases; and block-based
+        // verifyReuseGroupCrossPartition is unusable here since partitions are
+        // still async_task_id tags in one block.)
         llvm::DenseSet<int64_t> bufferOffsets;
         for (auto *ch : group->channels) {
           int64_t off = 0;
@@ -3323,8 +3321,7 @@ void insertAsyncComm(
             return ch->channelKind == DataChannelKind::TMEM ||
                    ch->channelKind == DataChannelKind::TMEMPost;
           });
-          if (isTmemGroup && !isSpatialPacking &&
-              group->channels.size() >= 3 &&
+          if (isTmemGroup && !isSpatialPacking && group->channels.size() >= 3 &&
               orderReuseGroupChain(group).empty()) {
             llvm::report_fatal_error(
                 "TMEM reuse group with >= 3 buffers has no unique "
@@ -3332,38 +3329,43 @@ void insertAsyncComm(
                 "consumers are not totally ordered, so a correct reuse barrier "
                 "cannot be emitted (this would otherwise deadlock or "
                 "miscompile). Order the slot's writers/readers into a chain - "
-                "e.g. ensure dk reads dsT before dq overwrites the shared slot.");
+                "e.g. ensure dk reads dsT before dq overwrites the shared "
+                "slot.");
           }
           if (verifyReuseGroupCrossPartition(group)) {
             // A5: cross-partition dependency-chain reuse (e.g. FA-bwd
             // {dpT,dsT,dq}). Producers span >1 partition but share one block at
-            // this code-partition stage. DECOUPLED from the A3 same-block chain:
-            // it emits no per-consecutive wrap-around barriers. Two ingredients:
+            // this code-partition stage. DECOUPLED from the A3 same-block
+            // chain: it emits no per-consecutive wrap-around barriers. Two
+            // ingredients:
             //
-            //  (1) Ordering dpT -> dsT -> dq is *enforced by inherent edges*, so
+            //  (1) Ordering dpT -> dsT -> dq is *enforced by inherent edges*,
+            //  so
             //      the shared TMEM slot is written/read strictly in that order
             //      within a tile:
-            //        - dpT -> dsT is a data dependency (dsT is computed from dpT
+            //        - dpT -> dsT is a data dependency (dsT is computed from
+            //        dpT
             //          in the computation partition: read dpT, then store dsT),
             //          so dsT's write necessarily follows dpT's read.
-            //        - dsT -> dq is gemm-partition program order within the same
+            //        - dsT -> dq is gemm-partition program order within the
+            //        same
             //          SWP stage: the dk MMA reads dsT before the dq MMA
-            //          overwrites the slot, and consecutive tcgen05 MMAs execute
-            //          in issue order, so dq's write necessarily follows dsT's
-            //          read.
+            //          overwrites the slot, and consecutive tcgen05 MMAs
+            //          execute in issue order, so dq's write necessarily
+            //          follows dsT's read.
             //      No explicit barrier is needed for these middle edges.
             //
             //  (2) The only non-inherent edge is the cross-iteration WAR: the
             //      NEXT tile's first write (dpT) must wait for the PREVIOUS
-            //      tile's last read (dq) before reusing the slot. This is emitted
-            //      exactly like the 2-buffer A2 case, applied to the chain
-            //      ENDPOINTS — early = first buffer (dpT), late = last buffer
-            //      (dq): relocate the late channel's producer_acquire ahead of
-            //      the early channel's producer so the shared slot's empty
-            //      barrier (flipped by dq's consumer release) gates the dpT
-            //      overwrite; and record the early channel so the late writer
-            //      also intra-waits the early reader (subsumed by program order,
-            //      kept for parity with A2).
+            //      tile's last read (dq) before reusing the slot. This is
+            //      emitted exactly like the 2-buffer A2 case, applied to the
+            //      chain ENDPOINTS — early = first buffer (dpT), late = last
+            //      buffer (dq): relocate the late channel's producer_acquire
+            //      ahead of the early channel's producer so the shared slot's
+            //      empty barrier (flipped by dq's consumer release) gates the
+            //      dpT overwrite; and record the early channel so the late
+            //      writer also intra-waits the early reader (subsumed by
+            //      program order, kept for parity with A2).
             SmallVector<Channel *> ordered = orderReuseGroupChain(group);
             if (ordered.size() == group->channels.size()) {
               Channel *firstCh = ordered.front(); // dpT
@@ -5146,11 +5148,9 @@ void mergeStagingReuseIntoHost(triton::FuncOp funcOp,
           cast<ttg::MemDescType>(stagingAlloc.getResult().getType());
       builder.setInsertionPointAfter(insertAnchor);
       auto stagingView = ttg::MemDescReinterpretOp::create(
-          builder, stagingAlloc.getLoc(), stagingTy,
-          backingAlloc.getResult());
-      for (StringRef name :
-           {"buffer.id", "buffer.copy", "buffer.idx_in_group",
-            "allocation.shareGroup", "async_task_id"}) {
+          builder, stagingAlloc.getLoc(), stagingTy, backingAlloc.getResult());
+      for (StringRef name : {"buffer.id", "buffer.copy", "buffer.idx_in_group",
+                             "allocation.shareGroup", "async_task_id"}) {
         if (auto a = stagingAlloc->getAttr(name))
           stagingView->setAttr(name, a);
       }
@@ -5374,8 +5374,7 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
   funcOp.walk([&](ttg::LocalAllocOp allocOp) {
     auto reuseAttr =
         allocOp->getAttrOfType<IntegerAttr>("allocation.reuseTarget");
-    auto stagingAttr =
-        allocOp->getAttrOfType<IntegerAttr>("buffer.tmaStaging");
+    auto stagingAttr = allocOp->getAttrOfType<IntegerAttr>("buffer.tmaStaging");
     if (!reuseAttr || !stagingAttr)
       return;
     // Find the first local_store user.
@@ -5396,7 +5395,7 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
          << reuseAttr.getInt() << " firstStore found");
   });
   LDBG("Step 4.5: collected " << stagingReuseInfos.size()
-       << " staging reuse entries");
+                              << " staging reuse entries");
 
   // Step 5: Create buffers. An array of buffers for each channel.
   DenseMap<Channel *, Value> bufferMap =
@@ -5452,7 +5451,7 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
       auto targetIt = bufferIdToChannel.find(info.targetBufferId);
       if (targetIt == bufferIdToChannel.end()) {
         LDBG("Step 7.5: target buffer.id=" << info.targetBufferId
-             << " — channel not found, skipping");
+                                           << " — channel not found, skipping");
         continue;
       }
       Channel *targetChannel = targetIt->second;
@@ -5460,7 +5459,7 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
       if (targetTokenIt == tokenMap.end() ||
           targetTokenIt->second.tokens.empty()) {
         LDBG("Step 7.5: target channel " << targetChannel->uniqID
-             << " has no tokens, skipping");
+                                         << " has no tokens, skipping");
         continue;
       }
 
@@ -5470,8 +5469,7 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
       auto asyncTaskIds = getAsyncTaskIds(firstStore);
       builder.setAsynTaskIdsFromArray(asyncTaskIds);
 
-      for (const auto &[taskId, tokenValue] :
-           targetTokenIt->second.tokens) {
+      for (const auto &[taskId, tokenValue] : targetTokenIt->second.tokens) {
         Value bufIdx = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
             firstStore->getLoc(), 0, 32);
         Value phase = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
@@ -5488,7 +5486,7 @@ void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers) {
       }
     }
     LDBG("Step 7.5: processed " << stagingReuseInfos.size()
-         << " staging reuse entries");
+                                << " staging reuse entries");
   }
 
   // Step 8: add async communication ops (ProducerAcquire etc). Also lower

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -842,11 +842,11 @@ static std::string getLocName(Operation *op) {
 
 /// Priority levels for SMEM multi-buffering candidates.
 enum class WSBufferPriority {
-  P0_InnermostTMA = 0,    // innermost loop + TMA channel
-  P1_InnermostNonTMA,     // innermost loop, non-TMA
-  P2_InnerTMAStaging,     // TMA staging buffer inside the innermost loop (e.g. dq)
-  P3_OuterTMAStaging,     // TMA staging buffer outside loops (e.g. dk, dv)
-  P4_Other,               // outside loop / non-innermost (regular epilogue)
+  P0_InnermostTMA = 0, // innermost loop + TMA channel
+  P1_InnermostNonTMA,  // innermost loop, non-TMA
+  P2_InnerTMAStaging,  // TMA staging buffer inside the innermost loop (e.g. dq)
+  P3_OuterTMAStaging,  // TMA staging buffer outside loops (e.g. dk, dv)
+  P4_Other,            // outside loop / non-innermost (regular epilogue)
 };
 
 /// A wrapper around one ttg.local_alloc op for the new SMEM allocation.
@@ -867,8 +867,7 @@ struct WSBuffer {
       0; // 0=normal, 1=TMA store staging, 2=TMA reduce staging
   bool isAllocated =
       false; // Has dedicated SMEM; false = reuses another buffer.
-  int reuseTargetBufferId =
-      -1; // bufferId of the reuse target, -1 = no reuse.
+  int reuseTargetBufferId = -1; // bufferId of the reuse target, -1 = no reuse.
 };
 
 static unsigned
@@ -1427,11 +1426,10 @@ static void increaseFusedEpilogueCopies(SmallVector<WSBuffer> &wsBuffers,
     return false;
   };
 
-  LDBG("Phase 4.5: enter \u2014 numBuffers=" << numBuffers
-                                        << " smemBudget=" << smemBudget
-                                        << " totalBuffers=" << wsBuffers.size()
-                                        << " currentTotalSmem="
-                                        << computeTotalSmem(wsBuffers));
+  LDBG("Phase 4.5: enter \u2014 numBuffers="
+       << numBuffers << " smemBudget=" << smemBudget
+       << " totalBuffers=" << wsBuffers.size()
+       << " currentTotalSmem=" << computeTotalSmem(wsBuffers));
 
   // Collect eligible groups by bufferId and remember each group's priority.
   DenseMap<unsigned, SmallVector<unsigned>> epilogueGroups;
@@ -1442,9 +1440,8 @@ static void increaseFusedEpilogueCopies(SmallVector<WSBuffer> &wsBuffers,
     if (buf.isPinned) {
       ++skippedPinned;
       LDBG("Phase 4.5: skip WSBuffer["
-           << i << "] bufferId=" << buf.bufferId
-           << " \u2014 isPinned (copies=" << buf.numCopies
-           << ", tmaStaging=" << buf.tmaStaging << ")");
+           << i << "] bufferId=" << buf.bufferId << " \u2014 isPinned (copies="
+           << buf.numCopies << ", tmaStaging=" << buf.tmaStaging << ")");
       continue;
     }
     if (!isEligible(buf.priority)) {
@@ -1452,18 +1449,16 @@ static void increaseFusedEpilogueCopies(SmallVector<WSBuffer> &wsBuffers,
       LDBG("Phase 4.5: skip WSBuffer["
            << i << "] bufferId=" << buf.bufferId << " \u2014 priority="
            << static_cast<int>(buf.priority) << " (not eligible)"
-           << " copies=" << buf.numCopies
-           << " tmaStaging=" << buf.tmaStaging);
+           << " copies=" << buf.numCopies << " tmaStaging=" << buf.tmaStaging);
       continue;
     }
     epilogueGroups[buf.bufferId].push_back(i);
     groupPriority[buf.bufferId] = buf.priority;
   }
 
-  LDBG("Phase 4.5: collected " << epilogueGroups.size()
-                               << " eligible groups (skippedPinned="
-                               << skippedPinned << " skippedPriority="
-                               << skippedPriority << ")");
+  LDBG("Phase 4.5: collected "
+       << epilogueGroups.size() << " eligible groups (skippedPinned="
+       << skippedPinned << " skippedPriority=" << skippedPriority << ")");
 
   // Walk tiers in priority order, and within each tier sort by bufferId for
   // determinism (DenseMap iteration is otherwise non-deterministic).
@@ -1473,7 +1468,8 @@ static void increaseFusedEpilogueCopies(SmallVector<WSBuffer> &wsBuffers,
       if (groupPriority.lookup(kv.first) == pri)
         ids.push_back(kv.first);
     llvm::sort(ids);
-    LDBG("Phase 4.5: tier=P" << static_cast<int>(pri) << " groups=" << ids.size());
+    LDBG("Phase 4.5: tier=P" << static_cast<int>(pri)
+                             << " groups=" << ids.size());
 
     for (unsigned bufferId : ids) {
       auto &indices = epilogueGroups[bufferId];
@@ -1504,16 +1500,15 @@ static void increaseFusedEpilogueCopies(SmallVector<WSBuffer> &wsBuffers,
       LDBG("Phase 4.5:   bufferId="
            << bufferId << " priority=P" << static_cast<int>(pri)
            << " groupSize=" << indices.size() << " perAllocSize=" << firstSize
-           << " tmaStaging=" << firstTmaStaging
-           << " currentCopies=" << currentCopies
-           << " anyCrossStage=" << anyCrossStage
+           << " tmaStaging=" << firstTmaStaging << " currentCopies="
+           << currentCopies << " anyCrossStage=" << anyCrossStage
            << " \u2014 will try bumping to numBuffers=" << numBuffers);
 
       if (currentCopies >= numBuffers) {
-        LDBG("Phase 4.5:   bufferId="
-             << bufferId << " currentCopies=" << currentCopies
-             << " already >= numBuffers=" << numBuffers
-             << " \u2014 no room to bump");
+        LDBG("Phase 4.5:   bufferId=" << bufferId
+                                      << " currentCopies=" << currentCopies
+                                      << " already >= numBuffers=" << numBuffers
+                                      << " \u2014 no room to bump");
         continue;
       }
 
@@ -1528,17 +1523,17 @@ static void increaseFusedEpilogueCopies(SmallVector<WSBuffer> &wsBuffers,
 
         unsigned totalSmem = computeTotalSmem(wsBuffers);
         if (totalSmem <= smemBudget) {
-          LDBG("Phase 4.5:     bufferId="
-               << bufferId << " copies=" << tryCopies
-               << " totalSmem=" << totalSmem << " \u2264 " << smemBudget
-               << " \u2014 kept");
+          LDBG("Phase 4.5:     bufferId=" << bufferId << " copies=" << tryCopies
+                                          << " totalSmem=" << totalSmem
+                                          << " \u2264 " << smemBudget
+                                          << " \u2014 kept");
           tryCopies++;
         } else {
           for (unsigned k = 0; k < indices.size(); ++k)
             wsBuffers[indices[k]].numCopies = saved[k];
           LDBG("Phase 4.5:     bufferId="
-               << bufferId << " copies=" << tryCopies << " totalSmem="
-               << totalSmem << " > " << smemBudget
+               << bufferId << " copies=" << tryCopies
+               << " totalSmem=" << totalSmem << " > " << smemBudget
                << " \u2014 budget exhausted, reverted to copies=" << saved[0]);
           break;
         }
@@ -1858,9 +1853,8 @@ static unsigned allocateSmemBuffers(
     if (buf.isPinned)
       continue;
     if (buf.tmaStaging > 0) {
-      buf.priority = buf.isInnermost
-                         ? WSBufferPriority::P2_InnerTMAStaging
-                         : WSBufferPriority::P3_OuterTMAStaging;
+      buf.priority = buf.isInnermost ? WSBufferPriority::P2_InnerTMAStaging
+                                     : WSBufferPriority::P3_OuterTMAStaging;
     } else if (buf.isInnermost && buf.isTMA) {
       buf.priority = WSBufferPriority::P0_InnermostTMA;
     } else if (buf.isInnermost) {
@@ -2188,9 +2182,10 @@ static unsigned allocateSmemBuffers(
       }
       std::string bufName = getLocName(buf.allocOp);
       auto diag = buf.allocOp->emitRemark()
-          << "SMEM buffer \"" << bufName << "\" (buffer.id=" << buf.bufferId
-          << ", " << buf.sizeBytes << "B) reuses \""
-          << targetName << "\" (buffer.id=" << buf.reuseTargetBufferId << ")";
+                  << "SMEM buffer \"" << bufName
+                  << "\" (buffer.id=" << buf.bufferId << ", " << buf.sizeBytes
+                  << "B) reuses \"" << targetName
+                  << "\" (buffer.id=" << buf.reuseTargetBufferId << ")";
     }
     if (buf.tmaStaging > 0) {
       buf.allocOp->setAttr("buffer.tmaStaging",
@@ -2446,9 +2441,8 @@ private:
     Attribute tensorMemorySpace = ttng::TensorMemorySpaceAttr::get(ctx);
     Type elemType = scaleType.getElementType();
     ttg::CGAEncodingAttr cgaLayout = ttg::getCGALayout(scaleType.getEncoding());
-    auto ctaSplitNum = cgaLayout.getCTASplitNum();
-    auto scaleEncoding = ttng::TensorMemoryScalesEncodingAttr::get(
-        ctx, ctaSplitNum[0], ctaSplitNum[1]);
+    auto scaleEncoding =
+        ttng::TensorMemoryScalesEncodingAttr::get(ctx, cgaLayout);
     SmallVector<int64_t> shape = {
         rows, ceil<int64_t>(product(scaleType.getShape()), rows)};
     auto futureType =


### PR DESCRIPTION
Summary:
The upstream API changed TensorMemoryScalesEncodingAttr::get to take a CGAEncodingAttr directly instead of two CTASplitM/CTASplitN ints.

Fix formatter in same PR too


Reviewed By: njriasan, xuzhao9

Differential Revision: D110057531

Pulled By: dshi7


