### PR TITLE
[triton][beta] Cherry-pick upstream reduction/layout bundle (#1877)

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -6,7 +6,6 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <limits>
 
@@ -28,7 +27,6 @@ unsigned getNumScratchElemsSwizzledCvt(const LinearLayout &srcLayout,
                                        int bitwidth, int numBanks = 32,
                                        gpu::LocalMemOpTile srcTile = {},
                                        gpu::LocalMemOpTile dstTile = {});
-
 unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
                                        RankedTensorType dstTy,
                                        int numBanks = 32,
@@ -151,6 +149,11 @@ public:
   /// Returns if the given buffer is a virtual buffer.
   bool isVirtualBuffer(BufferId bufferId) const {
     return bufferSet.at(bufferId).kind == BufferT::BufferKind::Virtual;
+  }
+
+  /// Returns if the given buffer is an explicit buffer.
+  bool isExplicitBuffer(BufferId bufferId) const {
+    return bufferSet.at(bufferId).kind == BufferT::BufferKind::Explicit;
   }
 
   /// Returns the size of total shared memory allocated

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -4,18 +4,26 @@
 #include "Allocation.h"
 
 #include "llvm/Support/raw_ostream.h"
+#include <functional>
 #include <set>
 #include <tuple>
 
 namespace mlir {
 
 class OpBuilder;
+struct AllocationSlice;
 
 /// Callback to allow backend to provide more information on whether a barrier
 /// is needed between two operations. Even though two operations access the same
 /// shared memory they may not require a barrier in between them.
 using MembarFilterFn =
-    std::function<bool(Operation *, Operation *, Allocation *)>;
+    std::function<bool(Operation *, Operation *, bool /*lhsIsRead*/,
+                       bool /*rhsIsRead*/, Allocation *)>;
+
+/// Slice-level filter to allow backends to ignore specific aliasing cases.
+using MembarSliceFilterFn =
+    std::function<bool(const AllocationSlice &, const AllocationSlice &,
+                       bool /*lhsIsRead*/, bool /*rhsIsRead*/, Allocation *)>;
 
 // Represents the access to a slice of an allocation
 // It contains information both on physical memory (the interval) and a
@@ -23,12 +31,14 @@ using MembarFilterFn =
 struct AllocationSlice {
 public:
   // Create allocation slice from a value, collecting subslice offsets
-  AllocationSlice(Value value, Interval<size_t> allocationInterval);
+  AllocationSlice(Value value, Interval<size_t> allocationInterval,
+                  Allocation::BufferId bufferId);
 
   // Builder for accesses that represent accesses to the whole
   // allocation (scratch buffers, ArriveBarrierOp, ..)
   AllocationSlice(Interval<size_t> interval)
-      : allocationInterval(interval), accessTy(nullptr) {}
+      : allocationInterval(interval), accessTy(nullptr),
+        bufferId(Allocation::InvalidBufferId) {}
 
   bool operator<(const AllocationSlice &other) const {
     return asTuple() < other.asTuple();
@@ -43,12 +53,26 @@ public:
   // Returns true if it can't prove the AllocationSlices are disjoint.
   bool intersects(const AllocationSlice &other) const;
 
+  Allocation::BufferId getBufferId() const { return bufferId; }
+
+  AllocationSlice translated(size_t offset,
+                             bool invalidateBufferId = false) const {
+    AllocationSlice shifted = *this;
+    shifted.allocationInterval = Interval<size_t>(
+        allocationInterval.start() + offset, allocationInterval.end() + offset);
+    if (invalidateBufferId)
+      shifted.bufferId = Allocation::InvalidBufferId;
+    return shifted;
+  }
+
   void print(raw_ostream &os) const;
 
 private:
-  std::tuple<Interval<size_t>, const void *, llvm::ArrayRef<int64_t>>
+  std::tuple<Interval<size_t>, Allocation::BufferId, const void *,
+             llvm::ArrayRef<int64_t>>
   asTuple() const {
-    return {allocationInterval, accessTy.getAsOpaquePointer(), subsliceOffsets};
+    return {allocationInterval, bufferId, accessTy.getAsOpaquePointer(),
+            subsliceOffsets};
   }
   // Offsets from subslice. Empty when offsets are unknown
   SmallVector<int64_t> subsliceOffsets;
@@ -56,6 +80,8 @@ private:
   Interval<size_t> allocationInterval;
   // Type of the memory descriptor for this access
   triton::gpu::MemDescType accessTy;
+  // Buffer id for partial sync on wait_barrier deps.
+  Allocation::BufferId bufferId;
 };
 
 struct BlockInfo {
@@ -103,15 +129,19 @@ struct BlockInfo {
 
   /// Returns true if Slices in two BlockInfo objects are intersected.
   bool isIntersected(const BlockInfo &other, MembarFilterFn filter,
-                     Allocation *allocation) const {
-    return /*RAW*/ isIntersected(syncWriteSlices, other.syncReadSlices, filter,
-                                 allocation) ||
+                     Allocation *allocation,
+                     MembarSliceFilterFn sliceFilter = nullptr) const {
+    return /*RAW*/ isIntersected(syncWriteSlices, other.syncReadSlices,
+                                 /*lhsIsRead=*/false, /*rhsIsRead=*/true,
+                                 filter, sliceFilter, allocation) ||
            /*WAR*/
-           isIntersected(syncReadSlices, other.syncWriteSlices, filter,
-                         allocation) ||
+           isIntersected(syncReadSlices, other.syncWriteSlices,
+                         /*lhsIsRead=*/true, /*rhsIsRead=*/false, filter,
+                         sliceFilter, allocation) ||
            /*WAW*/
-           isIntersected(syncWriteSlices, other.syncWriteSlices, filter,
-                         allocation);
+           isIntersected(syncWriteSlices, other.syncWriteSlices,
+                         /*lhsIsRead=*/false, /*rhsIsRead=*/false, filter,
+                         sliceFilter, allocation);
   }
 
   /// Clears the slices because a barrier is inserted.
@@ -130,14 +160,19 @@ struct BlockInfo {
 
 private:
   bool isIntersected(const SliceMapT &lhsSlices, const SliceMapT &rhsSlices,
-                     MembarFilterFn filter, Allocation *allocation) const {
+                     bool lhsIsRead, bool rhsIsRead, MembarFilterFn filter,
+                     MembarSliceFilterFn sliceFilter,
+                     Allocation *allocation) const {
     for (auto &lhs : lhsSlices)
       for (auto &rhs : rhsSlices)
         if (lhs.first.intersects(rhs.first))
-          for (auto lhsOp : lhs.second)
-            for (auto rhsOp : rhs.second)
-              if (!filter || !filter(lhsOp, rhsOp, allocation))
-                return true;
+          if (!sliceFilter || !sliceFilter(lhs.first, rhs.first, lhsIsRead,
+                                           rhsIsRead, allocation))
+            for (auto lhsOp : lhs.second)
+              for (auto rhsOp : rhs.second)
+                if (!filter ||
+                    !filter(lhsOp, rhsOp, lhsIsRead, rhsIsRead, allocation))
+                  return true;
     return false;
   }
 };
@@ -145,6 +180,26 @@ private:
 /// Returns true if `op` synchronizes local memory accesses for membar-style
 /// analyses.
 bool containsLocalBarrier(Operation *op);
+
+inline BlockInfo translateBlockInfoToCallsite(const BlockInfo &calleeBlockInfo,
+                                              size_t callOffset) {
+  BlockInfo translatedBlockInfo;
+  auto translateSlices = [&](const BlockInfo::SliceMapT &srcSlices,
+                             BlockInfo::SliceMapT &dstSlices) {
+    for (const auto &[slice, ops] : srcSlices) {
+      auto translatedSlice =
+          slice.translated(callOffset, /*invalidateBufferId=*/true);
+      auto &dstOps = dstSlices[translatedSlice];
+      dstOps.insert(ops.begin(), ops.end());
+    }
+  };
+
+  translateSlices(calleeBlockInfo.syncReadSlices,
+                  translatedBlockInfo.syncReadSlices);
+  translateSlices(calleeBlockInfo.syncWriteSlices,
+                  translatedBlockInfo.syncWriteSlices);
+  return translatedBlockInfo;
+}
 
 //===----------------------------------------------------------------------===//
 // Shared Memory Barrier Analysis

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -3,6 +3,7 @@
 
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -24,6 +25,22 @@ inline bool isZeroConst(Value v) {
 
 class ReduceOpHelper {
 public:
+  enum class InThreadVectorizeOpKind {
+    None,
+    AddF,
+    MulF,
+    MinNumF,
+    MaxNumF,
+    MinimumF,
+    MaximumF,
+    AddI,
+    MulI,
+    MinSI,
+    MaxSI,
+    MinUI,
+    MaxUI,
+  };
+
   explicit ReduceOpHelper(triton::ReduceOp op)
       : op(op.getOperation()), axis(op.getAxis()) {
     auto firstTy = cast<RankedTensorType>(op.getOperands()[0].getType());
@@ -56,6 +73,8 @@ public:
 
   unsigned getInterWarpSizeWithUniqueData();
 
+  bool isAssociative();
+
   unsigned getIntraWarpSizeWithUniqueData();
 
   // Number of register groups along the reduction axis that must be kept
@@ -65,7 +84,7 @@ public:
   // The shape of the shared memory space needed for the reduction.
   SmallVector<unsigned> getScratchRepShape();
 
-  SmallVector<unsigned> getOrderWithAxisAtBeginning();
+  bool isReduceWithinCTA();
 
   // Callback to allow backends to specify target-specific getter for scratch
   // elements.
@@ -76,9 +95,33 @@ public:
   unsigned
   getScratchSizeInBytes(GetNumScratchElemsFn numScratchElemsGetter = nullptr);
 
-  bool isReduceWithinCTA();
+  InThreadVectorizeOpKind
+  getInThreadVectorizeOpKind(unsigned axisPack,
+                             bool supportBitwidth16Elementwise,
+                             bool supportBitwidth32Elementwise);
 
-  bool isAssociative();
+  static Value createInThreadVectorizedCombineOp(OpBuilder &builder,
+                                                 Location loc,
+                                                 InThreadVectorizeOpKind kind,
+                                                 Value lhs, Value rhs);
+
+  static triton::ColumnAction
+  moveAxisBasesToFront(const triton::LinearLayout &layout, int axis,
+                       bool isVectorized = false);
+
+  static triton::LinearLayout reducedRegLaneLayout(RankedTensorType srcTy,
+                                                   int axis);
+
+  static triton::LinearLayout getInterLayout(const triton::LinearLayout &layout,
+                                             int axis);
+
+  static triton::LinearLayout
+  zeroBasesAlongDimAndReorder(const triton::LinearLayout &layout, int axis,
+                              StringAttr dim);
+
+  SmallVector<unsigned> getOrderWithAxisAtBeginning();
+
+  RankedTensorType getSrcTy() { return srcTy; }
 
 private:
   triton::ReduceOp op;
@@ -420,8 +463,8 @@ protected:
 // Create a basic DataFlowSolver with constant and dead code analysis included.
 std::unique_ptr<DataFlowSolver> createDataFlowSolver();
 
-bool isCvtWarpSync(const triton::LinearLayout &srcLayout,
-                   const triton::LinearLayout &dstLayout);
+bool isCvtDimSync(const triton::LinearLayout &srcLayout,
+                  const triton::LinearLayout &dstLayout, StringAttr dim);
 
 } // namespace mlir
 

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -21,6 +21,8 @@ public:
   // target address space
   virtual void barrier(Location loc, RewriterBase &rewriter,
                        triton::gpu::AddrSpace targets) const = 0;
+  // Emit a cluster-level barrier when supported. Defaults to CTA barrier.
+  virtual void clusterBarrier(Location loc, RewriterBase &rewriter) const = 0;
   // Insert a warp syncronization barrier that also guarantees local address
   // space visibility at warp level when supported by the backend.
   // Backends that do not support warp-level barriers should conservatively
@@ -106,6 +108,8 @@ public:
   virtual bool supportLdMatrix() const { return false; }
   virtual bool supportStMatrix() const { return false; }
   virtual bool supportLdStMatrixB8() const { return false; }
+  virtual bool supportBitwidth16Elementwise() const { return false; }
+  virtual bool supportBitwidth32Elementwise() const { return false; }
   virtual bool isCuda() const { return false; }
 
   // Returns the shared memory partition size in bytes. A value of 0 means

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -16,6 +16,8 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/MathExtras.h"
 
+#include <optional>
+
 #define DEBUG_TYPE "ttgpu_to_llvm"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
@@ -332,7 +334,7 @@ namespace triton {
 namespace gpu {
 
 std::pair<SmallVector<LocalMemOpTile>, SmallVector<LocalMemOpTile>>
-getSrcDstTiles(const TargetInfoBase &targetInfo, int bitwidth);
+getSrcDstTiles(const TargetInfoBase &targetInfo, int bitwidth, bool crossCTA);
 
 Type getFunctionType(Type resultType, ValueRange operands);
 
@@ -657,7 +659,8 @@ SmallVector<Value> lowerLdSt(
     RewriterBase &rewriter, const TargetInfoBase &targetInfo,
     std::optional<int> maybeMaxVecElems,
     std::function<SmallVector<Value>(RewriterBase &, Location, ArrayRef<Value>,
-                                     Value, int, VectorType)>
+                                     Value, int, VectorType,
+                                     std::optional<Value>)>
         lowerInst,
     std::optional<Value> barrierPtr = {});
 
@@ -725,10 +728,10 @@ void makeAllWarpGroupsIsolatedFromAbove(Operation *op);
 // Set the correct loop annotation on LLVM branch ops.
 void fixUpLoopAnnotation(ModuleOp mod);
 
-void transferWithinBlockSwizzling(triton::gpu::ConvertLayoutOp op, Value src,
-                                  const TargetInfoBase &targetInfo,
-                                  const LLVMTypeConverter *typeConverter,
-                                  RewriterBase &rewriter);
+void transferSwizzlingLocalMem(triton::gpu::ConvertLayoutOp op, Value src,
+                               const TargetInfoBase &targetInfo,
+                               const LLVMTypeConverter *typeConverter,
+                               RewriterBase &rewriter);
 
 SmallVector<Value> inlineRegionImpl(RewriterBase &rewriter, Region &region,
                                     ArrayRef<Value> args,

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
@@ -1,0 +1,19 @@
+#ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_
+#define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_
+
+#include "triton/Analysis/Allocation.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+/// Inserts cluster barriers (cluster_arrive + cluster_wait) using the provided
+/// shared-memory allocation analysis.
+void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
+                                int computeCapability);
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -98,8 +98,7 @@ static SmallVector<unsigned> getRepShapeForAtomic(Value result) {
 
 unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
   if (auto reduceOp = dyn_cast<ReduceOp>(op)) {
-    ReduceOpHelper helper(reduceOp);
-    return helper.getScratchSizeInBytes();
+    return ReduceOpHelper(reduceOp).getScratchSizeInBytes();
   }
   if (auto scanOp = dyn_cast<ScanOp>(op)) {
     ScanLoweringHelper helper(scanOp);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -47,8 +47,9 @@ static Interval<size_t> narrowIntervalForSubview(Value value,
 }
 
 AllocationSlice::AllocationSlice(Value value,
-                                 Interval<size_t> allocationInterval)
-    : allocationInterval(allocationInterval) {
+                                 Interval<size_t> allocationInterval,
+                                 Allocation::BufferId bufferId)
+    : allocationInterval(allocationInterval), bufferId(bufferId) {
   auto accessTy = cast<triton::gpu::MemDescType>(value.getType());
   this->accessTy = accessTy;
 
@@ -105,6 +106,9 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
 void AllocationSlice::print(raw_ostream &os) const {
   os << "interval=[" << allocationInterval.start() << ","
      << allocationInterval.end() << ")";
+
+  if (bufferId != Allocation::InvalidBufferId)
+    os << " buffer=" << bufferId;
 
   os << " offsets=[";
   if (!subsliceOffsets.empty()) {
@@ -314,8 +318,14 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     // Inter-function dependencies
     auto callOpInterface = dyn_cast<CallOpInterface>(op);
     if (auto callee =
-            dyn_cast<FunctionOpInterface>(callOpInterface.resolveCallable()))
-      curBlockInfo = funcBlockInfoMap->lookup(callee);
+            dyn_cast<FunctionOpInterface>(callOpInterface.resolveCallable())) {
+      auto calleeBlockInfo = funcBlockInfoMap->lookup(callee);
+      auto callBufferId = allocation->getBufferId(op);
+      size_t callOffset = 0;
+      if (callBufferId != Allocation::InvalidBufferId)
+        callOffset = allocation->getAllocatedInterval(callBufferId).start();
+      curBlockInfo = translateBlockInfoToCallsite(calleeBlockInfo, callOffset);
+    }
   } else {
     // Intra-function dependencies
     //
@@ -342,7 +352,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
                  allocation->getAllBufferIdsWithAliases(value)) {
               if (bufferId != Allocation::InvalidBufferId) {
                 auto interval = allocation->getAllocatedInterval(bufferId);
-                auto slice = AllocationSlice(value, interval);
+                auto slice = AllocationSlice(value, interval, bufferId);
 
                 if (isa<MemoryEffects::Write>(effectInstance.getEffect()))
                   curBlockInfo.syncWriteSlices[slice].insert(op);
@@ -380,7 +390,8 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
       auto dstTy = cast<RankedTensorType>(cvt.getType());
       auto srcLayout = triton::gpu::toLinearLayout(srcTy);
       auto dstLayout = triton::gpu::toLinearLayout(dstTy);
-      isWarpSync = mlir::isCvtWarpSync(srcLayout, dstLayout);
+      auto kWarp = StringAttr::get(op->getContext(), "warp");
+      isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
     }
 
     bool hasExplicitSharedDeps = !curBlockInfo.syncReadSlices.empty() ||

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -4,6 +4,8 @@
 
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Support/LLVM.h"
@@ -23,6 +25,25 @@ namespace mlir {
 
 using namespace triton;
 using namespace triton::gpu;
+
+static SmallVector<std::pair<StringAttr, int32_t>>
+inferOutDims(const LinearLayout::BasesT &bases,
+             ArrayRef<StringAttr> outDimNames) {
+  SmallVector<std::pair<StringAttr, int32_t>> outDims;
+  outDims.reserve(outDimNames.size());
+  for (StringAttr outDim : outDimNames)
+    outDims.emplace_back(outDim, 1);
+
+  for (const auto &entry : bases) {
+    const auto &inDimBases = entry.second;
+    for (const auto &basis : inDimBases) {
+      for (int i = 0; i < basis.size(); i++)
+        outDims[i].second =
+            std::max<int32_t>(outDims[i].second, llvm::NextPowerOf2(basis[i]));
+    }
+  }
+  return outDims;
+}
 
 SmallVector<unsigned> ReduceOpHelper::getOrderWithAxisAtBeginning() {
   auto order = toLinearEncoding(srcTy).getOrder();
@@ -161,13 +182,44 @@ SmallVector<unsigned> ReduceOpHelper::getScratchRepShape() {
 unsigned ReduceOpHelper::getScratchSizeInBytes(
     GetNumScratchElemsFn numScratchElemsGetter) {
   (void)numScratchElemsGetter;
-  auto smemShape = getScratchRepShape();
-  auto elems = product<unsigned>(smemShape);
-  unsigned bytesPerElem = 0;
-  for (const auto &ty : srcElementTypes) {
-    bytesPerElem += ceil<unsigned>(ty.getIntOrFloatBitWidth(), 8);
+  auto getLegacyScratchSize = [&]() {
+    auto smemShape = getScratchRepShape();
+    auto elems = product<unsigned>(smemShape);
+    unsigned bytesPerElem = 0;
+    for (const auto &ty : srcElementTypes) {
+      bytesPerElem += ceil<unsigned>(ty.getIntOrFloatBitWidth(), 8);
+    }
+    return bytesPerElem * elems;
+  };
+
+  auto kLane = StringAttr::get(op.getContext(), "lane");
+
+  auto isReduced = [axis = axis](const LinearLayout &layout) {
+    return layout.getOutDimSizes().begin()[axis] == 1;
+  };
+  auto regLl = reducedRegLaneLayout(srcTy, axis);
+  if (!isReduced(regLl))
+    return getLegacyScratchSize();
+
+  // All the inputs have the same layout so, since we order them from largest
+  // bitsize to smallest, and the first one is aligned, by induction, they are
+  // all aligned, so we don't need to align the byte numbers returned here.
+  unsigned bytesRegToTmp = 0;
+  while (!isReduced(regLl)) {
+    auto tmpLl = getInterLayout(regLl, axis);
+    // We take the maximum of the elements and multiply by the total bitwidth.
+    // We do this as otherwise it's quite tricky to find the correct
+    // BaseOffsets in the lowering.
+    int bytes = 0;
+    for (auto inputTy : op.getInputTypes()) {
+      auto nelem =
+          getNumScratchElemsSwizzledCvt(regLl, tmpLl, getBitwidth(inputTy));
+      bytes += nelem * (getBitwidth(inputTy) / 8);
+    }
+    bytesRegToTmp = std::max<unsigned>(bytesRegToTmp, bytes);
+    regLl = zeroBasesAlongDimAndReorder(tmpLl, axis, kLane);
   }
-  return bytesPerElem * elems;
+  return bytesRegToTmp;
 }
 
 bool ReduceOpHelper::isReduceWithinCTA() {
@@ -195,6 +247,278 @@ bool ReduceOpHelper::isAssociative() {
     return WalkResult::advance();
   });
   return !hasNoAssociativeOp;
+}
+
+ReduceOpHelper::InThreadVectorizeOpKind
+ReduceOpHelper::getInThreadVectorizeOpKind(unsigned axisPack,
+                                           bool supportBitwidth16Elementwise,
+                                           bool supportBitwidth32Elementwise) {
+  Operation *reduceOperation = op.getOperation();
+  if (axisPack < 4 || reduceOperation->getNumOperands() != 1 ||
+      reduceOperation->getNumResults() != 1)
+    return InThreadVectorizeOpKind::None;
+
+  assert(reduceOperation->getNumRegions() == 1 &&
+         "expected a single combine region");
+  Region &combineRegion = reduceOperation->getRegion(0);
+  Block &block = combineRegion.front();
+  if (block.getOperations().size() != 2)
+    return InThreadVectorizeOpKind::None;
+  Operation &combiner = block.front();
+
+  Type elemTy = srcElementTypes.front();
+  unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
+  if (bitwidth == 16 && !supportBitwidth16Elementwise)
+    return InThreadVectorizeOpKind::None;
+  if (bitwidth == 32 && !supportBitwidth32Elementwise)
+    return InThreadVectorizeOpKind::None;
+
+  bool is16Bit = bitwidth == 16;
+  bool isF32 = elemTy.isF32();
+  if (!is16Bit && !isF32)
+    return InThreadVectorizeOpKind::None;
+
+  if (isa<arith::AddFOp>(combiner)) {
+    return (is16Bit || isF32) ? InThreadVectorizeOpKind::AddF
+                              : InThreadVectorizeOpKind::None;
+  }
+  if (isa<arith::MulFOp>(combiner)) {
+    return (is16Bit || isF32) ? InThreadVectorizeOpKind::MulF
+                              : InThreadVectorizeOpKind::None;
+  }
+  if (isa<arith::MinNumFOp>(combiner)) {
+    return is16Bit ? InThreadVectorizeOpKind::MinNumF
+                   : InThreadVectorizeOpKind::None;
+  }
+  if (isa<arith::MaxNumFOp>(combiner)) {
+    return is16Bit ? InThreadVectorizeOpKind::MaxNumF
+                   : InThreadVectorizeOpKind::None;
+  }
+  if (isa<arith::MinimumFOp>(combiner)) {
+    return is16Bit ? InThreadVectorizeOpKind::MinimumF
+                   : InThreadVectorizeOpKind::None;
+  }
+  if (isa<arith::MaximumFOp>(combiner)) {
+    return is16Bit ? InThreadVectorizeOpKind::MaximumF
+                   : InThreadVectorizeOpKind::None;
+  }
+
+  if (!elemTy.isInteger(16))
+    return InThreadVectorizeOpKind::None;
+
+  if (isa<arith::AddIOp>(combiner)) {
+    return InThreadVectorizeOpKind::AddI;
+  }
+  if (isa<arith::MulIOp>(combiner)) {
+    return InThreadVectorizeOpKind::MulI;
+  }
+  if (isa<arith::MinSIOp>(combiner)) {
+    return InThreadVectorizeOpKind::MinSI;
+  }
+  if (isa<arith::MaxSIOp>(combiner)) {
+    return InThreadVectorizeOpKind::MaxSI;
+  }
+  if (isa<arith::MinUIOp>(combiner)) {
+    return InThreadVectorizeOpKind::MinUI;
+  }
+  if (isa<arith::MaxUIOp>(combiner)) {
+    return InThreadVectorizeOpKind::MaxUI;
+  }
+
+  return InThreadVectorizeOpKind::None;
+}
+
+Value ReduceOpHelper::createInThreadVectorizedCombineOp(
+    OpBuilder &builder, Location loc, InThreadVectorizeOpKind kind, Value lhs,
+    Value rhs) {
+  auto vecTy = lhs.getType();
+  Value result;
+  switch (kind) {
+  case InThreadVectorizeOpKind::AddF:
+    result = LLVM::FAddOp::create(builder, loc, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MulF:
+    result = LLVM::FMulOp::create(builder, loc, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MinNumF:
+    result = LLVM::MinNumOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MaxNumF:
+    result = LLVM::MaxNumOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MinimumF:
+    result = LLVM::MinimumOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MaximumF:
+    result = LLVM::MaximumOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::AddI:
+    result = LLVM::AddOp::create(builder, loc, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MulI:
+    result = LLVM::MulOp::create(builder, loc, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MinSI:
+    result = LLVM::SMinOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MaxSI:
+    result = LLVM::SMaxOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MinUI:
+    result = LLVM::UMinOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::MaxUI:
+    result = LLVM::UMaxOp::create(builder, loc, vecTy, lhs, rhs);
+    break;
+  case InThreadVectorizeOpKind::None:
+  default:
+    llvm::report_fatal_error("Unsupported in-thread vectorize op kind");
+  }
+  return result;
+}
+
+LinearLayout ReduceOpHelper::getInterLayout(const LinearLayout &layout,
+                                            int axis) {
+  auto *ctx = layout.getOutDimNames().begin()->getContext();
+  auto kLane = mlir::StringAttr::get(ctx, "lane");
+  auto kWarp = mlir::StringAttr::get(ctx, "warp");
+  auto kBlock = mlir::StringAttr::get(ctx, "block");
+  auto bases = layout.getBases();
+  auto &laneBases = bases[kLane];
+  auto &warpBases = bases[kWarp];
+  auto &blockBases = bases[kBlock];
+
+  auto collectAxisBases = [&](ArrayRef<std::vector<int32_t>> bases) {
+    SmallVector<unsigned> out;
+    for (unsigned i = 0; i < bases.size(); ++i) {
+      if (bases[i][axis] != 0)
+        out.push_back(i);
+    }
+    return out;
+  };
+
+  SmallVector<unsigned> warpAxisBases = collectAxisBases(warpBases);
+  SmallVector<unsigned> blockAxisBases = collectAxisBases(blockBases);
+
+  SmallVector<unsigned> zeroLaneBases;
+  for (unsigned i = 0; i < laneBases.size(); ++i) {
+    if (llvm::all_of(laneBases[i], [](int32_t v) { return v == 0; }))
+      zeroLaneBases.push_back(i);
+  }
+
+  auto totalAxisBases = warpAxisBases.size() + blockAxisBases.size();
+
+  // First try to place all warp/block axis bases into lane bases that are
+  // currently zero. If we can do this we will be able to perform the full
+  // reduction with just one convert_layout
+  if (zeroLaneBases.size() >= totalAxisBases) {
+    unsigned laneIdx = 0;
+    for (unsigned idx : warpAxisBases) {
+      std::swap(laneBases[zeroLaneBases[laneIdx]], warpBases[idx]);
+      ++laneIdx;
+    }
+    for (unsigned idx : blockAxisBases) {
+      std::swap(laneBases[zeroLaneBases[laneIdx]], blockBases[idx]);
+      ++laneIdx;
+    }
+    auto outDims = inferOutDims(bases, to_vector(layout.getOutDimNames()));
+    return LinearLayout(std::move(bases), std::move(outDims),
+                        /*requireSurjective=*/layout.isSurjective());
+  }
+
+  // If we can fit all the bases inside the lane dimension, we can perform the
+  // reduction with two convert_layouts
+  // The first cvt to move the relevant bases to the lane dimension
+  // The second to move all the bases we moved out of the lane dimension back to
+  // their original positions
+  if (warpAxisBases.size() + blockAxisBases.size() <= laneBases.size()) {
+    assert(totalAxisBases <= laneBases.size() &&
+           "unexpected lane base count for axis layout");
+    unsigned laneIdx = 0;
+    for (unsigned idx : warpAxisBases) {
+      std::swap(laneBases[laneIdx], warpBases[idx]);
+      ++laneIdx;
+    }
+    for (unsigned idx : blockAxisBases) {
+      std::swap(laneBases[laneIdx], blockBases[idx]);
+      ++laneIdx;
+    }
+    auto outDims = inferOutDims(bases, to_vector(layout.getOutDimNames()));
+    return LinearLayout(std::move(bases), std::move(outDims),
+                        /*requireSurjective=*/layout.isSurjective());
+  }
+
+  // Assumptions (easily relaxed if AMD needs it)
+  // We assume that
+  // max number of warps * max number of blocks <= (max number of lanes)^2
+  // We check this in logarithmic space (number of bases)
+  // This is true in nvidia as the max numbers are warps=64 ctas=16 so that
+  // 64 * 16 = 1024 = 32 * 32 = laneBases.size() * laneBases.size()
+  // This implies that, even if we have to perform 3 cvt_layouts, we can perform
+  // first one that does not cross CTAs, and then two that may cross CTAs
+  assert(blockBases.size() <= laneBases.size());
+  assert(warpBases.size() + blockBases.size() <= 2 * laneBases.size());
+
+  // Otherwise, fit as many warp bases as possible into the lane dimension
+  unsigned laneIdx = 0;
+  for (unsigned idx : warpAxisBases) {
+    std::swap(laneBases[laneIdx], warpBases[idx]);
+    ++laneIdx;
+    if (laneIdx >= laneBases.size())
+      break;
+  }
+
+  auto outDims = inferOutDims(bases, to_vector(layout.getOutDimNames()));
+  return LinearLayout(std::move(bases), std::move(outDims),
+                      /*requireSurjective=*/layout.isSurjective());
+}
+
+LinearLayout ReduceOpHelper::reducedRegLaneLayout(RankedTensorType srcTy,
+                                                  int axis) {
+  auto *ctx = srcTy.getContext();
+  auto kReg = StringAttr::get(ctx, "register");
+  auto reduced = toLinearLayout(srcTy);
+  reduced = actionRemoveBroadcastedRegs(reduced).apply(reduced);
+  reduced = moveAxisBasesToFront(reduced, axis).apply(reduced);
+  reduced = zeroBasesAlongDimAndReorder(reduced, axis, kReg);
+  reduced = actionRemoveBroadcastedRegs(reduced).apply(reduced);
+  return reduced;
+}
+
+LinearLayout
+ReduceOpHelper::zeroBasesAlongDimAndReorder(const LinearLayout &layout,
+                                            int axis, StringAttr dim) {
+  auto bases = layout.getBases();
+  for (auto &basis : bases[dim])
+    basis[axis] = 0;
+  auto outDims = inferOutDims(bases, to_vector(layout.getOutDimNames()));
+  return LinearLayout(std::move(bases), std::move(outDims),
+                      /*requireSurjective=*/false);
+}
+
+ColumnAction ReduceOpHelper::moveAxisBasesToFront(const LinearLayout &layout,
+                                                  int axis, bool isVectorized) {
+  auto *ctx = layout.getOutDimNames().begin()->getContext();
+  auto kReg = StringAttr::get(ctx, "register");
+  const auto &bases = layout.getBases().lookup(kReg);
+  if (bases.empty())
+    return ColumnAction::identity(kReg, bases.size());
+
+  // We keep the first basis where it is if it's vectorized to pack it without
+  // PRMT/MOV, and then we move the rest of the bases that don't move the axis
+  // to the front after it
+  SmallVector<size_t> perm;
+  if (isVectorized)
+    perm.push_back(0);
+  SmallVector<size_t> back;
+  for (size_t i = isVectorized ? 1 : 0; i < bases.size(); ++i) {
+    if (bases[i][axis] != 0)
+      perm.push_back(i);
+    else
+      back.push_back(i);
+  }
+  llvm::append_range(perm, back);
+  return ColumnAction(perm, kReg, bases.size());
 }
 
 ScanLoweringHelper::ScanLoweringHelper(triton::ScanOp op) : scanOp(op) {
@@ -1159,17 +1483,26 @@ std::unique_ptr<DataFlowSolver> createDataFlowSolver() {
   return solver;
 }
 
-bool isCvtWarpSync(const triton::LinearLayout &srcLayout,
-                   const triton::LinearLayout &dstLayout) {
-  // We can use warp.sync when the warp dimension in the convert is trival
-  // and there is no broadcasting at a warp level (otherwise reads may be
-  // wrong)
+bool isCvtDimSync(const triton::LinearLayout &srcLayout,
+                  const triton::LinearLayout &dstLayout, StringAttr dim) {
   auto *ctx = srcLayout.getInDimNames().begin()->getContext();
-  auto comp = dstLayout.invertAndCompose(srcLayout);
   auto kWarp = StringAttr::get(ctx, "warp");
-  return comp.isTrivialOver(kWarp) &&
-         srcLayout.getFreeVariableMasks()[kWarp] == 0 &&
-         dstLayout.getFreeVariableMasks()[kWarp] == 0;
-}
+  auto kBlock = StringAttr::get(ctx, "block");
+  assert((dim == kWarp || dim == kBlock) && "expected dim to be warp or block");
+  assert(srcLayout.hasInDim(dim) && dstLayout.hasInDim(dim) &&
+         "expected dim to be present in both layouts");
+  auto parentTrivial = true;
+  if (dim == kWarp) {
+    parentTrivial = isCvtDimSync(srcLayout, dstLayout, kBlock);
+  }
+  auto comp = dstLayout.invertAndCompose(srcLayout);
+  if (!parentTrivial || !comp.isTrivialOver(dim))
+    return false;
 
+  // Broadcasting across warps requires CTA-wide synchronization. A broadcast
+  // block basis does not move values between CTAs, so it remains CTA-local.
+  return dim == kBlock ||
+         (srcLayout.getFreeVariableMasks()[dim] == 0 &&
+          dstLayout.getFreeVariableMasks()[dim] == 0);
+}
 } // namespace mlir

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -4,6 +4,8 @@
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
+#include <optional>
+
 #include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -46,26 +48,20 @@ struct ConvertLayoutOpConversion
     LinearLayout srcLayout = toLinearLayout(srcTy);
     LinearLayout dstLayout = toLinearLayout(dstTy);
 
-    StringAttr kBlock = str_attr("block");
-    StringAttr kWarp = str_attr("warp");
-    StringAttr kLane = str_attr("lane");
-    StringAttr kRegister = str_attr("register");
+    auto kBlock = str_attr("block");
+    auto kWarp = str_attr("warp");
+    auto kLane = str_attr("lane");
+    auto kRegister = str_attr("register");
 
     auto dims = conversion.getInDimNames();
     bool alwaysUseWarpShuffle = cvtAlwaysUseWarpShuffle(op);
-    assert(!alwaysUseWarpShuffle || (!llvm::is_contained(dims, kBlock) &&
-                                     !llvm::is_contained(dims, kWarp)));
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));
-    if (llvm::is_contained(dims, kBlock)) {
-      // Case 1: Transfer between values in different CTAs.
-      //          This requires moving values through distributed shared memory.
-      return rewriter.notifyMatchFailure(
-          op, "NYI: Transfer between different CTAs");
-    } else if (llvm::is_contained(dims, kWarp)) {
-      // Case 2: Transfer between values in the same CTA, in which case we move
-      //         values through shared memory.
-      transferWithinBlockSwizzling(op, adaptor.getSrc(), rewriter);
+    if (llvm::is_contained(dims, kBlock) || llvm::is_contained(dims, kWarp)) {
+      assert(!alwaysUseWarpShuffle);
+      // Transfer between values in the same CTA, or across CTAs. We move values
+      // through (distributed) shared memory.
+      transferSwizzlingLocalMem(op, adaptor.getSrc(), rewriter);
       return success();
     } else if (llvm::is_contained(dims, kLane)) {
       // Case 3. Transfer between values in the same warp, in which case we try
@@ -74,7 +70,7 @@ struct ConvertLayoutOpConversion
       if (cvtNeedsWarpShuffle(srcTy, dstTy) || alwaysUseWarpShuffle)
         return transferWithinWarp(op, adaptor, rewriter);
 
-      transferWithinBlockSwizzling(op, adaptor.getSrc(), rewriter);
+      transferSwizzlingLocalMem(op, adaptor.getSrc(), rewriter);
       return success();
     } else if (llvm::is_contained(dims, kRegister)) {
       // Case 4. Transfer between values in the same thread, in which case we
@@ -114,7 +110,7 @@ struct ConvertLayoutOpConversion
                        ConversionPatternRewriter &rewriter) const {
     MLIRContext *ctx = op.getContext();
     auto loc = op.getLoc();
-    StringAttr kRegister = str_attr("register");
+    auto kRegister = str_attr("register");
     assert(!cvtNeedsSharedMemory(op.getSrc().getType(), op.getType()));
 
     auto srcTy = op.getSrc().getType();
@@ -233,7 +229,7 @@ struct ConvertLayoutOpConversion
     return outVals;
   }
 
-  SmallVector<Value> transferWithinBlockSwizzlingImpl(
+  SmallVector<Value> transferSwizzlingLocalMemImpl(
       Location loc, ConversionPatternRewriter &rewriter,
       const LinearLayout &srcLayout, const LinearLayout &dstLayout,
       ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase) const {
@@ -249,8 +245,8 @@ struct ConvertLayoutOpConversion
         return b.ptrtoint(llvmElemTyPtr, v).getResult();
       }));
       auto outVals =
-          transferWithinBlockSwizzlingImpl(loc, rewriter, srcLayout, dstLayout,
-                                           newInVals, llvmElemTyPtr, smemBase);
+          transferSwizzlingLocalMemImpl(loc, rewriter, srcLayout, dstLayout,
+                                        newInVals, llvmElemTyPtr, smemBase);
       for (auto &v : outVals) {
         v = b.inttoptr(llvmElemTy, v);
       }
@@ -263,7 +259,7 @@ struct ConvertLayoutOpConversion
       auto i8ElemTy = i8_ty;
       auto newInVals = llvm::to_vector(llvm::map_range(
           inVals, [&](Value v) { return b.zext(i8ElemTy, v).getResult(); }));
-      auto outVals = transferWithinBlockSwizzlingImpl(
+      auto outVals = transferSwizzlingLocalMemImpl(
           loc, rewriter, srcLayout, dstLayout, newInVals, i8ElemTy, smemBase);
       for (auto &v : outVals) {
         v = b.trunc(llvmElemTy, v);
@@ -276,15 +272,15 @@ struct ConvertLayoutOpConversion
     if (!removeBroadcastSrc.isIdentity()) {
       auto prmtSrc = removeBroadcastSrc.apply(srcLayout);
       auto newInVals = removeBroadcastSrc.apply(inVals);
-      return transferWithinBlockSwizzlingImpl(loc, rewriter, prmtSrc, dstLayout,
-                                              newInVals, llvmElemTy, smemBase);
+      return transferSwizzlingLocalMemImpl(loc, rewriter, prmtSrc, dstLayout,
+                                           newInVals, llvmElemTy, smemBase);
     }
 
     // Remove broadcasting in dst
     auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
     if (!removeBroadcastDst.isIdentity()) {
       auto prmtDst = removeBroadcastDst.apply(dstLayout);
-      auto outVals = transferWithinBlockSwizzlingImpl(
+      auto outVals = transferSwizzlingLocalMemImpl(
           loc, rewriter, srcLayout, prmtDst, inVals, llvmElemTy, smemBase);
       return broadcastAs(outVals, dstLayout);
     }
@@ -305,6 +301,8 @@ struct ConvertLayoutOpConversion
 
     // Extract reps from smem
     auto kReg = str_attr("register");
+    auto kWarp = str_attr("warp");
+    auto kBlock = str_attr("block");
     auto kReps = str_attr("reps");
     auto nReps = smem.getInDimSize(kReps);
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
@@ -326,8 +324,11 @@ struct ConvertLayoutOpConversion
     auto storeCvt = *divideRight(totalStoreCvt, reps);
     auto loadCvt = *divideRight(totalLoadCvt, reps);
     auto kOffset = str_attr("offset");
-    storeCvt = storeCvt.reshapeOuts({{kOffset, storeCvt.getTotalOutDimSize()}});
-    loadCvt = loadCvt.reshapeOuts({{kOffset, loadCvt.getTotalOutDimSize()}});
+    auto nBlock = storeCvt.getInDimSize(kBlock);
+    storeCvt = storeCvt.reshapeOuts(
+        {{kOffset, storeCvt.getTotalOutDimSize() / nBlock}, {kBlock, nBlock}});
+    loadCvt = loadCvt.reshapeOuts(
+        {{kOffset, loadCvt.getTotalOutDimSize() / nBlock}, {kBlock, nBlock}});
 
     auto tileSize = storeCvt.getInDimSize(kReg);
 
@@ -336,28 +337,30 @@ struct ConvertLayoutOpConversion
     auto affineOffset = b.i32_val(0);
     auto maskSpanAffineOffset = 0;
 
-    bool isWarpSync = mlir::isCvtWarpSync(srcLayout, dstLayout);
-    for (int i = 0; i < nReps; ++i) {
-      if (i > 0) {
-        if (isWarpSync) {
-          targetInfo.warpSync(loc, rewriter);
-        } else {
-          targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
-        }
+    bool isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
+    bool isBlockSync = mlir::isCvtDimSync(srcLayout, dstLayout, kBlock);
+    auto emitBarrier = [&]() {
+      if (isWarpSync) {
+        targetInfo.warpSync(loc, rewriter);
+      } else if (isBlockSync) {
+        targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+      } else {
+        targetInfo.clusterBarrier(loc, rewriter);
       }
+    };
+
+    for (int i = 0; i < nReps; ++i) {
+      if (i > 0)
+        emitBarrier();
       auto tileInVals =
           ArrayRef<Value>(permutedInVals).slice(i * tileSize, tileSize);
       // Store
       lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
                       /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
                       rewriter, targetInfo);
-      if (isWarpSync) {
-        targetInfo.warpSync(loc, rewriter);
-      } else {
-        targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
-      }
+      emitBarrier();
       // Load
-      SmallVector<Value> tileOutVals = lowerLdStShared(
+      auto tileOutVals = lowerLdStShared(
           loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},
           affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
       llvm::append_range(outVals, tileOutVals);
@@ -368,30 +371,21 @@ struct ConvertLayoutOpConversion
     return outVals;
   }
 
-  void transferWithinBlockSwizzling(ConvertLayoutOp op, Value src,
-                                    ConversionPatternRewriter &rewriter) const {
+  void transferSwizzlingLocalMem(ConvertLayoutOp op, Value src,
+                                 ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     auto *ctx = op.getContext();
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
-    // Remove the kBlock dimension from the layout as it's the identity in the
-    // cvt
     auto srcLayout = toLinearLayout(srcTy);
     auto dstLayout = toLinearLayout(dstTy);
-    auto kReg = str_attr("register");
-    auto kLane = str_attr("lane");
-    auto kWarp = str_attr("warp");
-    srcLayout = srcLayout.sublayout({kReg, kLane, kWarp},
-                                    to_vector(srcLayout.getOutDimNames()));
-    dstLayout = dstLayout.sublayout({kReg, kLane, kWarp},
-                                    to_vector(dstLayout.getOutDimNames()));
 
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
     auto smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto inVals = unpackLLElements(loc, src, rewriter);
-    auto outVals = transferWithinBlockSwizzlingImpl(
+    auto outVals = transferSwizzlingLocalMemImpl(
         loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase);
 
     Value result =
@@ -408,8 +402,8 @@ struct ConvertLayoutOpConversion
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
-    StringAttr kReg = str_attr("register");
-    StringAttr kLane = str_attr("lane");
+    auto kReg = str_attr("register");
+    auto kLane = str_attr("lane");
     auto elemTy = getTypeConverter()->convertType(srcTy.getElementType());
     int bitwidth = getIntOrFloatOrPtrBitWidth(elemTy);
 
@@ -566,8 +560,8 @@ struct ConvertLayoutOpConversion
       ArrayRef<TranspositionInfo> mixedTranspositions) const {
     auto *ctx = rewriter.getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    StringAttr kReg = str_attr("register");
-    StringAttr kLane = str_attr("lane");
+    auto kReg = str_attr("register");
+    auto kLane = str_attr("lane");
 
     SmallVector<Value> vals(inVals.begin(), inVals.end());
     int m = mixedTranspositions.size();

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -229,7 +229,7 @@ public:
       cvt = regLayout.invertAndCompose(sharedLayout);
     }
     auto kBlock = str_attr("block");
-    // NYI. We would need to emit a map.shared::cluster instruction.
+    // We could support it by removing this check if we ever want to
     if (!cvt.isTrivialOver({kBlock})) {
       return failure();
     }

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -1,8 +1,22 @@
 #include "ReduceScanCommon.h"
+
+#include <map>
+#include <memory>
+#include <numeric>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Support/LLVM.h"
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Tools/GenericSwizzling.h"
+#include "triton/Tools/LayoutUtils.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -26,6 +40,113 @@ public:
   LogicalResult
   matchAndRewrite(triton::ReduceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (isInnerTree(op))
+      return rewriteInnerTree(op, adaptor, rewriter);
+
+    ReduceOpHelper helper(op);
+    auto regLl = ReduceOpHelper::reducedRegLaneLayout(helper.getSrcTy(),
+                                                      op.getAxis());
+    auto kAxis = *(regLl.getOutDimNames().begin() + op.getAxis());
+    if (regLl.getOutDimSize(kAxis) != 1) {
+      return rewriteInnerTree(op, adaptor, rewriter);
+    }
+
+    return rewriteDefault(op, adaptor, rewriter);
+  }
+
+private:
+  const TargetInfoBase &targetInfo;
+
+  bool isInnerTree(triton::ReduceOp op) const {
+    auto attr = op.getReductionOrderingAttr();
+    return attr && attr.getValue() == "inner_tree";
+  }
+
+  LogicalResult rewriteDefault(triton::ReduceOp op, OpAdaptor adaptor,
+                               ConversionPatternRewriter &rewriter) const {
+    ReduceOpHelper helper(op);
+    Location loc = op->getLoc();
+    auto accs = unpackInputsByOperand(loc, op, adaptor, rewriter);
+    unsigned axis = op.getAxis();
+
+    auto *ctx = op.getContext();
+
+    // Remove block as we don't currently support it
+    LinearLayout regLl = triton::gpu::toLinearLayout(helper.getSrcTy());
+    // Remove broadcasting in registers as SliceLayout removes them
+    auto removeBroadcast = actionRemoveBroadcastedRegs(regLl);
+    if (!removeBroadcast.isIdentity()) {
+      regLl = removeBroadcast.apply(regLl);
+      for (auto &vals : accs)
+        vals = removeBroadcast.apply(vals);
+    }
+
+    std::tie(regLl, accs) =
+        reduceWithinWarps(op, std::move(regLl), std::move(accs), rewriter);
+
+    // reducedRegLaneLayout is used in the AllocationAnalysis to get the size
+    // of the scratch space.
+    assert(regLl ==
+           ReduceOpHelper::reducedRegLaneLayout(helper.getSrcTy(), axis));
+
+    // If we still need to reduce along warps / blocks:
+    // Create temporary layout for reduction within warps.
+    // By construction of tmpLl, we will iterate at most 2 times, as the maximum
+    // number of warp / block bases is 64 * 16 = 32 * 32
+    // That is, they fit in 2 rounds of warp reductions
+    // Even more, if we do two rounds, getInterLayout will make sure that the
+    // first one does not cross CTAs
+    auto kAxis = *(regLl.getOutDimNames().begin() + axis);
+    auto kBlock = StringAttr::get(ctx, "block");
+    bool lastCvtCrossesCTAs = false;
+    int i = 0;
+    while (regLl.getOutDimSize(kAxis) != 1) {
+      LinearLayout tmpLl = ReduceOpHelper::getInterLayout(regLl, axis);
+
+      // Emit a barrier if we are reusing the shmem.
+      if (i > 0)
+        sync(rewriter, loc, lastCvtCrossesCTAs);
+
+      accs = convertLayoutValues(loc, rewriter, op, regLl, tmpLl, accs);
+      lastCvtCrossesCTAs = !mlir::isCvtDimSync(regLl, tmpLl, kBlock);
+
+      std::tie(regLl, accs) =
+          reduceWithinWarps(op, std::move(tmpLl), std::move(accs), rewriter);
+      ++i;
+    }
+    assert(i <= 2 && "expected at most 2 rounds of warp reductions");
+
+    // Remove the axis dimension, which at this point is of size 1.
+    regLl = removeStandardDim(regLl, axis);
+
+    if (auto resultTy =
+            dyn_cast<RankedTensorType>(op.getResult()[0].getType())) {
+      auto outputLayout = triton::gpu::toLinearLayout(resultTy);
+      if (regLl != outputLayout) {
+        // Reuse the shmem.
+        sync(rewriter, loc, lastCvtCrossesCTAs);
+        accs =
+            convertLayoutValues(loc, rewriter, op, regLl, outputLayout, accs);
+      }
+    }
+
+    SmallVector<Value> results(op.getNumOperands());
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      if (auto resultTy =
+              dyn_cast<RankedTensorType>(op.getResult()[i].getType())) {
+        results[i] = packLLElements(loc, getTypeConverter(), accs[i], rewriter,
+                                    resultTy);
+      } else {
+        assert(accs[i].size() == 1 && "expected scalar reduce result");
+        results[i] = accs[i][0];
+      }
+    }
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+
+  LogicalResult rewriteInnerTree(triton::ReduceOp op, OpAdaptor adaptor,
+                                 ConversionPatternRewriter &rewriter) const {
     ReduceOpHelper helper(op);
     // Multi-CTA reduction pass generates tt.reduce on 1-element tensors
     // loaded from DSM buffers. These are within-CTA (each CTA has its own
@@ -89,14 +210,23 @@ public:
     return success();
   }
 
-private:
-  const TargetInfoBase &targetInfo;
-
-  bool isInnerTree(triton::ReduceOp op) const {
-    auto attr = op.getReductionOrderingAttr();
-    return attr && attr.getValue() == "inner_tree";
+  SmallVector<Value>
+  treeReduceBinary(Location loc, ConversionPatternRewriter &rewriter,
+                   Region &combineOp,
+                   SmallVector<SmallVector<Value>> values) const {
+    // The number of elements is always a power of two
+    assert(llvm::isPowerOf2_64(values.size()) && !values.empty());
+    while (values.size() > 1) {
+      SmallVector<SmallVector<Value>> next;
+      for (size_t i = 0; i + 1 < values.size(); i += 2) {
+        SmallVector<Value> acc = values[i];
+        accumulate(loc, rewriter, combineOp, acc, values[i + 1]);
+        next.push_back(std::move(acc));
+      }
+      values = std::move(next);
+    }
+    return values.front();
   }
-
   void accumulate(Location loc, ConversionPatternRewriter &rewriter,
                   Region &combineOp, SmallVector<Value> &acc, ValueRange cur,
                   Value pred = {}) const {
@@ -175,10 +305,249 @@ private:
     return srcValues;
   }
 
+  SmallVector<SmallVector<Value>>
+  unpackInputsByOperand(Location loc, triton::ReduceOp op, OpAdaptor adaptor,
+                        ConversionPatternRewriter &rewriter) const {
+    auto operands = adaptor.getOperands();
+    SmallVector<SmallVector<Value>> srcValues;
+    srcValues.reserve(op.getNumOperands());
+    for (unsigned i = 0; i < op.getNumOperands(); ++i)
+      srcValues.push_back(unpackLLElements(loc, operands[i], rewriter));
+    return srcValues;
+  }
+
   void sync(ConversionPatternRewriter &rewriter, Location loc,
-            triton::ReduceOp op) const {
+            bool crossCTA) const {
+    if (crossCTA) {
+      targetInfo.clusterBarrier(loc, rewriter);
+    } else {
+      targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+    }
+  }
+
+  void sync(ConversionPatternRewriter &rewriter, Location loc,
+            triton::ReduceOp) const {
+    targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+  }
+
+  SmallVector<Value> transferSwizzlingLocalMemImpl(
+      Location loc, ConversionPatternRewriter &rewriter,
+      const LinearLayout &srcLayout, const LinearLayout &dstLayout,
+      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase) const {
+    auto *ctx = rewriter.getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    b.barrier(triton::gpu::AddrSpace::Local);
+
+    if (isa<LLVM::LLVMPointerType>(llvmElemTy)) {
+      auto llvmElemTyPtr = i64_ty;
+      auto newInVals = llvm::to_vector(llvm::map_range(inVals, [&](Value v) {
+        return b.ptrtoint(llvmElemTyPtr, v).getResult();
+      }));
+      auto outVals =
+          transferSwizzlingLocalMemImpl(loc, rewriter, srcLayout, dstLayout,
+                                        newInVals, llvmElemTyPtr, smemBase);
+      for (auto &v : outVals)
+        v = b.inttoptr(llvmElemTy, v);
+      return outVals;
+    }
+
+    if (llvmElemTy.getIntOrFloatBitWidth() < 8) {
+      auto i8ElemTy = i8_ty;
+      auto newInVals = llvm::to_vector(llvm::map_range(
+          inVals, [&](Value v) { return b.zext(i8ElemTy, v).getResult(); }));
+      auto outVals = transferSwizzlingLocalMemImpl(
+          loc, rewriter, srcLayout, dstLayout, newInVals, i8ElemTy, smemBase);
+      for (auto &v : outVals)
+        v = b.trunc(llvmElemTy, v);
+      return outVals;
+    }
+
+    auto removeBroadcastSrc = actionRemoveBroadcastedRegs(srcLayout);
+    if (!removeBroadcastSrc.isIdentity()) {
+      auto prmtSrc = removeBroadcastSrc.apply(srcLayout);
+      auto newInVals = removeBroadcastSrc.apply(inVals);
+      return transferSwizzlingLocalMemImpl(loc, rewriter, prmtSrc, dstLayout,
+                                           newInVals, llvmElemTy, smemBase);
+    }
+
+    auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
+    if (!removeBroadcastDst.isIdentity()) {
+      auto prmtDst = removeBroadcastDst.apply(dstLayout);
+      auto outVals = transferSwizzlingLocalMemImpl(
+          loc, rewriter, srcLayout, prmtDst, inVals, llvmElemTy, smemBase);
+      return broadcastAs(outVals, dstLayout);
+    }
+
+    auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
+    auto smem = triton::gpu::optimalSwizzlingLdSt(srcLayout, dstLayout,
+                                                  bitwidth);
+
+    auto kReg = str_attr("register");
+    auto kWarp = str_attr("warp");
+    auto kBlock = str_attr("block");
+    auto kReps = str_attr("reps");
+    auto nReps = smem.getInDimSize(kReps);
+    auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
+
+    auto totalStoreCvt = srcLayout.invertAndCompose(smem);
+    auto totalLoadCvt = dstLayout.invertAndCompose(smem);
+
+    auto permStore = regPermForDivide(totalStoreCvt, reps, /*left=*/false)
+                         .value();
+    totalStoreCvt = permStore.apply(totalStoreCvt);
+    auto permutedInVals = permStore.apply(inVals);
+    auto permLoad = regPermForDivide(totalLoadCvt, reps, /*left=*/false)
+                        .value();
+    totalLoadCvt = permLoad.apply(totalLoadCvt);
+
+    auto storeCvt = *divideRight(totalStoreCvt, reps);
+    auto loadCvt = *divideRight(totalLoadCvt, reps);
+    auto kOffset = str_attr("offset");
+    auto nBlock = storeCvt.getInDimSize(kBlock);
+    storeCvt = storeCvt.reshapeOuts(
+        {{kOffset, storeCvt.getTotalOutDimSize() / nBlock}, {kBlock, nBlock}});
+    loadCvt = loadCvt.reshapeOuts(
+        {{kOffset, loadCvt.getTotalOutDimSize() / nBlock}, {kBlock, nBlock}});
+
+    auto tileSize = storeCvt.getInDimSize(kReg);
+
+    assert(permutedInVals.size() == tileSize * nReps);
+    SmallVector<Value> outVals;
+    auto affineOffset = b.i32_val(0);
+    auto maskSpanAffineOffset = 0;
+
+    bool isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
+    bool isBlockSync = mlir::isCvtDimSync(srcLayout, dstLayout, kBlock);
+    auto emitBarrier = [&]() {
+      if (isWarpSync) {
+        targetInfo.warpSync(loc, rewriter);
+      } else if (isBlockSync) {
+        targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+      } else {
+        targetInfo.clusterBarrier(loc, rewriter);
+      }
+    };
+
+    for (int i = 0; i < nReps; ++i) {
+      if (i > 0)
+        emitBarrier();
+      auto tileInVals =
+          ArrayRef<Value>(permutedInVals).slice(i * tileSize, tileSize);
+      lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
+                      /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
+                      rewriter, targetInfo);
+      emitBarrier();
+      auto tileOutVals = lowerLdStShared(
+          loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},
+          affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
+      llvm::append_range(outVals, tileOutVals);
+    }
+
+    outVals = permLoad.inverse().apply(outVals);
+    return outVals;
+  }
+
+  SmallVector<int64_t>
+  getSmemBaseOffsets(triton::ReduceOp op, const LinearLayout &srcLayout,
+                     const LinearLayout &dstLayout) const {
+    std::vector<unsigned> indices(op.getNumOperands());
+    std::iota(indices.begin(), indices.end(), 0);
+    llvm::stable_sort(indices, [&](unsigned lhs, unsigned rhs) {
+      return getBitwidth(op.getInputTypes()[lhs]) >
+             getBitwidth(op.getInputTypes()[rhs]);
+    });
+
+    SmallVector<int64_t> offsets(op.getNumOperands());
+    int64_t offset = 0;
+    for (unsigned idx : indices) {
+      offsets[idx] = offset;
+      auto inputTy = op.getInputTypes()[idx];
+      auto bytes = getNumScratchElemsSwizzledCvt(srcLayout, dstLayout,
+                                                 getBitwidth(inputTy)) *
+                   (getBitwidth(inputTy) / 8);
+      offset += bytes;
+    }
+    return offsets;
+  }
+
+  SmallVector<SmallVector<Value>>
+  convertLayoutValues(Location loc, ConversionPatternRewriter &rewriter,
+                      triton::ReduceOp op, const LinearLayout &srcLayout,
+                      const LinearLayout &dstLayout,
+                      const SmallVector<SmallVector<Value>> &inVals) const {
+    SmallVector<SmallVector<Value>> outVals(op.getNumOperands());
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto base =
+        LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
+    auto baseOffsets = getSmemBaseOffsets(op, srcLayout, dstLayout);
+
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      auto inputTy = cast<RankedTensorType>(op.getInputTypes()[i]);
+      auto llvmElemTy =
+          getTypeConverter()->convertType(inputTy.getElementType());
+      auto smemBase = b.gep(base.getType(), i8_ty, base,
+                            b.i32_val(baseOffsets[i]));
+      outVals[i] = transferSwizzlingLocalMemImpl(
+          loc, rewriter, srcLayout, dstLayout, inVals[i], llvmElemTy, smemBase);
+    }
+    return outVals;
+  }
+
+  void packVectorized(SmallVector<SmallVector<Value>> &accs,
+                      ConversionPatternRewriter &rewriter) const {
+    auto loc = accs.front().front().getLoc();
+    for (auto &acc : accs) {
+      SmallVector<Value> packedAcc;
+      for (unsigned reg = 0; reg < acc.size(); reg += 2) {
+        auto vector = packLLVector(loc, {acc[reg], acc[reg + 1]}, rewriter);
+        packedAcc.emplace_back(std::move(vector));
+      }
+      acc = std::move(packedAcc);
+    }
+  }
+
+  std::unique_ptr<Region> createVectorCombineRegion(
+      Location loc, Type elemTy,
+      ReduceOpHelper::InThreadVectorizeOpKind vectorizeKind,
+      ConversionPatternRewriter &rewriter) const {
+    if (vectorizeKind == ReduceOpHelper::InThreadVectorizeOpKind::None)
+      return nullptr;
+    MLIRContext *ctx = rewriter.getContext();
+    auto vecTy = vec_ty(elemTy, 2);
+
+    auto storage = std::make_unique<Region>();
+    auto *block = new Block();
+    storage->push_back(block);
+    block->addArgument(vecTy, loc);
+    block->addArgument(vecTy, loc);
+
+    OpBuilder builder(ctx);
+    builder.setInsertionPointToStart(block);
+    Value result = ReduceOpHelper::createInThreadVectorizedCombineOp(
+        builder, loc, vectorizeKind, block->getArgument(0),
+        block->getArgument(1));
+    triton::ReduceReturnOp::create(builder, loc, ValueRange{result});
+    return storage;
+  }
+
+  void unpackVectorized(Location loc, SmallVector<SmallVector<Value>> &accs,
+                        ConversionPatternRewriter &rewriter,
+                        Region *reduction) const {
+    for (auto &acc : accs) {
+      SmallVector<Value> unpacked;
+      for (Value val : acc) {
+        auto elems = unpackLLVector(loc, val, rewriter);
+        assert(elems.size() == 2 && "expected a 2-lane packed vector");
+        if (reduction) {
+          SmallVector<Value> cur = {elems[0]};
+          accumulate(loc, rewriter, *reduction, cur, {elems[1]});
+          unpacked.emplace_back(cur[0]);
+        } else {
+          unpacked.emplace_back(elems[0]);
+          unpacked.emplace_back(elems[1]);
+        }
+      }
+      acc = std::move(unpacked);
+    }
   }
 
   // Reduce along op axis for elements that are in the same thread. The
@@ -213,20 +582,25 @@ private:
           idx);
     }
 
-    if (!isInnerTree(op)) {
-      for (int idx : iterOrder) {
-        SmallVector<unsigned> key = offsets[idx];
-        key[axis] = 0;
-        bool isFirst = accs.find(key) == accs.end();
-        accumulate(op.getLoc(), rewriter, op.getCombineOp(), accs[key],
-                   srcValues[idx]);
-        if (isFirst)
-          indices[key] = srcIndices[idx];
+    if (isInnerTree(op)) {
+      for (auto &[key, group] : regGroups) {
+        llvm::sort(group, [&](int lhs, int rhs) {
+          return offsets[lhs][axis] < offsets[rhs][axis];
+        });
+
+        SmallVector<SmallVector<Value>> groupValues;
+        groupValues.reserve(group.size());
+        for (int idx : group)
+          groupValues.push_back(srcValues[idx]);
+
+        accs[key] = reduceValueSequence(op.getLoc(), op,
+                                        std::move(groupValues), rewriter);
+        indices[key] = srcIndices[group.front()];
       }
       return;
     }
 
-    for (auto &[key, group] : regGroups) {
+    auto reduceGroup = [&](SmallVector<int> &group) {
       llvm::sort(group, [&](int lhs, int rhs) {
         return offsets[lhs][axis] < offsets[rhs][axis];
       });
@@ -236,10 +610,140 @@ private:
       for (int idx : group)
         groupValues.push_back(srcValues[idx]);
 
-      accs[key] = reduceValueSequence(op.getLoc(), op, std::move(groupValues),
-                                      rewriter);
-      indices[key] = srcIndices[group.front()];
+      auto vectorizeKind = helper.getInThreadVectorizeOpKind(
+          groupValues.size(), targetInfo.supportBitwidth16Elementwise(),
+          targetInfo.supportBitwidth32Elementwise());
+      if (vectorizeKind == ReduceOpHelper::InThreadVectorizeOpKind::None)
+        return reduceValueSequence(op.getLoc(), op, std::move(groupValues),
+                                   rewriter);
+
+      unsigned numOperands = op.getNumOperands();
+      SmallVector<SmallVector<Value>> packedByOperand(numOperands);
+      for (auto &values : groupValues) {
+        for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+          packedByOperand[opIdx].push_back(values[opIdx]);
+      }
+      packVectorized(packedByOperand, rewriter);
+
+      SmallVector<SmallVector<Value>> packedValues;
+      for (unsigned i = 0; i < packedByOperand.front().size(); ++i) {
+        SmallVector<Value> values;
+        for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+          values.push_back(packedByOperand[opIdx][i]);
+        packedValues.push_back(std::move(values));
+      }
+
+      auto elemTy = operandType.getElementType();
+      auto vectorCombineRegion = createVectorCombineRegion(
+          op.getLoc(), elemTy, vectorizeKind, rewriter);
+      auto reduced =
+          treeReduceBinary(op.getLoc(), rewriter, *vectorCombineRegion,
+                           std::move(packedValues));
+
+      SmallVector<SmallVector<Value>> reducedByOperand(numOperands);
+      for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+        reducedByOperand[opIdx].push_back(reduced[opIdx]);
+      unpackVectorized(op.getLoc(), reducedByOperand, rewriter,
+                       &op.getCombineOp());
+
+      SmallVector<Value> result;
+      for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+        result.push_back(reducedByOperand[opIdx][0]);
+      return result;
+    };
+
+    for (auto &[groupKey, group] : regGroups) {
+      auto reduced = reduceGroup(group);
+      auto key = groupKey;
+      key[axis] = 0;
+      bool isFirst = accs.find(key) == accs.end();
+      if (isFirst) {
+        accs[key] = std::move(reduced);
+        indices[key] = srcIndices[group.front()];
+      } else {
+        accumulate(op.getLoc(), rewriter, op.getCombineOp(), accs[key],
+                   reduced);
+      }
     }
+  }
+
+  std::pair<LinearLayout, SmallVector<SmallVector<Value>>>
+  reduceWithinWarps(triton::ReduceOp op, LinearLayout layout,
+                    SmallVector<SmallVector<Value>> accs,
+                    ConversionPatternRewriter &rewriter) const {
+    auto *ctx = op.getContext();
+    auto loc = op.getLoc();
+    unsigned axis = op.getAxis();
+    auto kReg = str_attr("register");
+    auto linearAttr = triton::gpu::LinearEncodingAttr::get(ctx, layout);
+    auto basesPerDim = linearAttr.basesPerDim(kReg, /*skipBroadcast=*/true);
+    unsigned axisPack = basesPerDim[axis];
+    if (axisPack == 1) {
+      return {std::move(layout), std::move(accs)};
+    }
+
+    ReduceOpHelper helper(op);
+    auto vectorizeKind = helper.getInThreadVectorizeOpKind(
+        axisPack, targetInfo.supportBitwidth16Elementwise(),
+        targetInfo.supportBitwidth32Elementwise());
+    bool vectorize =
+        vectorizeKind != ReduceOpHelper::InThreadVectorizeOpKind::None;
+
+    // Bring the registers that move the axis to the front.
+    auto perm = ReduceOpHelper::moveAxisBasesToFront(layout, axis, vectorize);
+    if (!perm.isIdentity()) {
+      layout = perm.apply(layout);
+      for (auto &vals : accs)
+        vals = perm.apply(vals);
+    }
+
+    // Pack the inputs into vector values.
+    if (vectorize)
+      packVectorized(accs, rewriter);
+
+    // If we pack along the reduction axis we need to process half the
+    // registers.
+    const auto &regBases = layout.getBases().lookup(kReg);
+    bool packAlongAxis = vectorize && regBases.front()[axis] != 0;
+    if (packAlongAxis)
+      axisPack /= 2;
+
+    auto elemTy =
+        cast<RankedTensorType>(op.getOperandTypes().front()).getElementType();
+    std::unique_ptr<Region> vectorCombineRegion =
+        createVectorCombineRegion(loc, elemTy, vectorizeKind, rewriter);
+    Region &combineRegion =
+        vectorCombineRegion ? *vectorCombineRegion : op.getCombineOp();
+
+    unsigned numOperands = accs.size();
+    SmallVector<SmallVector<Value>> reduced(numOperands);
+    unsigned regs = accs.front().size();
+    for (unsigned regBase = 0; regBase < regs; regBase += axisPack) {
+      SmallVector<SmallVector<Value>> vals;
+      for (unsigned i = 0; i < axisPack; ++i) {
+        SmallVector<Value> cur(numOperands);
+        for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+          cur[opIdx] = accs[opIdx][regBase + i];
+        vals.push_back(std::move(cur));
+      }
+      auto acc =
+          treeReduceBinary(loc, rewriter, combineRegion, std::move(vals));
+      for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+        reduced[opIdx].push_back(acc[opIdx]);
+    }
+    accs = std::move(reduced);
+
+    // Reduce one last time via the scalar combine op if vector packing also
+    // packed along the reduction axis.
+    if (vectorize) {
+      Region *reduceAfterUnpacking =
+          packAlongAxis ? &op.getCombineOp() : nullptr;
+      unpackVectorized(loc, accs, rewriter, reduceAfterUnpacking);
+    }
+
+    layout = ReduceOpHelper::zeroBasesAlongDimAndReorder(layout, axis, kReg);
+    layout = actionRemoveBroadcastedRegs(layout).apply(layout);
+    return {std::move(layout), std::move(accs)};
   }
 
   // Apply warp reduction across the given number of contiguous lanes using op

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -40,7 +40,8 @@ namespace mlir {
 namespace triton::gpu {
 
 std::pair<SmallVector<LocalMemOpTile>, SmallVector<LocalMemOpTile>>
-getSrcDstTiles(const TargetInfoBase &targetInfo, int bitwidth) {
+getSrcDstTiles(const TargetInfoBase &targetInfo, int bitwidth,
+               bool crossCTALoads) {
   assert(bitwidth <= 128 && "bitwidth must be <= 128");
   assert(llvm::isPowerOf2_32(bitwidth) && "bitwidth must be a power of two");
   SmallVector<LocalMemOpTile> src;
@@ -58,7 +59,9 @@ getSrcDstTiles(const TargetInfoBase &targetInfo, int bitwidth) {
       if (targetInfo.supportStMatrix()) {
         src.push_back(ldstmatrix);
       }
-      if (targetInfo.supportLdMatrix()) {
+      // We do cross-CTA reads but in-CTA writes
+      // ldmatrix/stmatrix do not support cross-CTA transfers.
+      if (!crossCTALoads && targetInfo.supportLdMatrix()) {
         dst.push_back(ldstmatrix);
       }
     }
@@ -68,7 +71,7 @@ getSrcDstTiles(const TargetInfoBase &targetInfo, int bitwidth) {
       if (targetInfo.supportStMatrix()) {
         src.push_back(ldstmatrixtrans);
       }
-      if (targetInfo.supportLdMatrix()) {
+      if (!crossCTALoads && targetInfo.supportLdMatrix()) {
         dst.push_back(ldstmatrixtrans);
       }
     }
@@ -847,14 +850,16 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
 
   auto emitLdSt = [&](RewriterBase &rewriter, Location loc,
                       ArrayRef<Value> vals, Value shmemAddr, int idx,
-                      VectorType vecTy) -> SmallVector<Value> {
+                      VectorType vecTy,
+                      std::optional<Value> ctaId) -> SmallVector<Value> {
     auto length = vecTy.getNumElements();
+    std::optional<Value> targetCtaId = ctaId.has_value() ? ctaId : ctaRank;
     if (isStore) {
       Value valsVec =
           packLLVector(loc, ArrayRef<Value>(vals).slice(idx, length), rewriter);
 
       Value pred = b.true_val();
-      if (ctaRank.has_value()) {
+      if (targetCtaId.has_value()) {
         auto kLane = str_attr("lane");
         auto kWarp = str_attr("warp");
 
@@ -877,13 +882,13 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
         pred = b.and_(isRepLane, isRepWarp);
       }
 
-      targetInfo.storeDShared(rewriter, loc, shmemAddr, ctaRank, valsVec, pred,
-                              barrierPtr);
+      targetInfo.storeDShared(rewriter, loc, shmemAddr, targetCtaId, valsVec,
+                              pred, barrierPtr);
       return {};
     } else {
       assert(vals.empty());
       Value valsVec =
-          targetInfo.loadDShared(rewriter, loc, shmemAddr, std::nullopt, vecTy,
+          targetInfo.loadDShared(rewriter, loc, shmemAddr, targetCtaId, vecTy,
                                  /*pred=*/b.true_val(), localLoadOp);
       return unpackLLVector(loc, valsVec, rewriter);
     }
@@ -903,7 +908,8 @@ SmallVector<Value> lowerLdSt(
     RewriterBase &rewriter, const TargetInfoBase &targetInfo,
     std::optional<int> maybeMaxVecElems,
     std::function<SmallVector<Value>(RewriterBase &, Location, ArrayRef<Value>,
-                                     Value, int, VectorType)>
+                                     Value, int, VectorType,
+                                     std::optional<Value>)>
         lowerInst,
     std::optional<Value> barrierPtr) {
   assert(!smemBases.empty() && "smemBases cannot be empty");
@@ -914,6 +920,7 @@ SmallVector<Value> lowerLdSt(
   auto kReg = str_attr("register");
   auto kLane = str_attr("lane");
   auto kWarp = str_attr("warp");
+  auto kBlock = str_attr("block");
   auto kOffset = str_attr("offset");
   auto kPartition = str_attr("partition");
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
@@ -952,10 +959,11 @@ SmallVector<Value> lowerLdSt(
   auto quot = divideLeft(cvt, tile);
   assert(quot.has_value() && "cvt must be divisible by tile");
   LinearLayout reps = zerosLike(tile) * *quot;
-
+  assert(reps.hasInDim(kBlock));
   LinearLayout addrLayout =
       LinearLayout({{kLane, reps.getBases().lookup(kLane)},
-                    {kWarp, reps.getBases().lookup(kWarp)}},
+                    {kWarp, reps.getBases().lookup(kWarp)},
+                    {kBlock, reps.getBases().lookup(kBlock)}},
                    reps.getOutDims(), false);
   auto [nAdditive, permStrides] =
       actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
@@ -974,31 +982,60 @@ SmallVector<Value> lowerLdSt(
   // have to divide the computation by bitwdith / 8 and then lift this
   // shl, which often it's not able to do.
   auto i8Tile =
-      zerosLike(LinearLayout::identity1D(bitwidth / 8, kReg, kOffset));
+      LinearLayout::zeros1D(bitwidth / 8, kReg, kOffset, bitwidth / 8);
   auto i8AddrLayout = i8Tile * addrLayout;
 
-  auto regBaseI8 =
-      applyLinearLayout(
-          loc, rewriter, i8AddrLayout,
-          {{kReg, b.i32_val(0)}, {kLane, laneId}, {kWarp, warpId}})[0]
-          .second;
+  Value blockId = b.i32_val(0);
+  bool useBlockId =
+      reps.hasInDim(kBlock) &&
+      !reps.sublayoutIsZero({kBlock}, to_vector(reps.getOutDimNames()));
+  if (useBlockId) {
+    blockId = targetInfo.getClusterCTAId(rewriter, loc);
+  }
+
+  SmallVector<std::pair<StringAttr, Value>> addrInputs = {
+      {kReg, b.i32_val(0)}, {kLane, laneId}, {kWarp, warpId}};
+  if (i8AddrLayout.hasInDim(kBlock)) {
+    addrInputs.push_back({kBlock, blockId});
+  }
+  auto baseI8AndCTA =
+      applyLinearLayout(loc, rewriter, i8AddrLayout, addrInputs);
+  auto regBaseI8 = baseI8AndCTA[0].second;
+  Value targetCtaId;
+  if (useBlockId) {
+    targetCtaId = baseI8AndCTA[1].second;
+  }
 
   // It's fine that we don't compute the offset in bytes as affineOffset
   // will be folded into a constant
   auto affineOffsetI8 = b.mul(affineOffset, b.i32_val(bitwidth / 8));
   regBaseI8 = b.xor_(regBaseI8, affineOffsetI8);
+
   SmallVector<Value> outVals;
   auto vecTy = vec_ty(llvmElemTy, elemsPerVec);
   for (int i = 0; i < cvt.getInDimSize(kReg); i += nAdditive) {
-    auto regIdx = reps.apply({{kReg, i}, {kLane, 0}, {kWarp, 0}})[0].second;
-    auto regIdxI8 = regIdx * (bitwidth / 8);
+    SmallVector<std::pair<StringAttr, int32_t>> idxInputs = {
+        {kReg, i}, {kLane, 0}, {kWarp, 0}};
+    if (reps.hasInDim(kBlock)) {
+      idxInputs.push_back({kBlock, 0});
+    }
+    auto idxAndBlock = reps.apply(idxInputs);
+    auto regIdxI8 = idxAndBlock[0].second * (bitwidth / 8);
     Value offset = b.xor_(regBaseI8, b.i32_val(regIdxI8));
+    Value ctaOffset = b.i32_val(0);
+    if (useBlockId) {
+      ctaOffset = b.xor_(targetCtaId, b.i32_val(idxAndBlock[1].second));
+    }
     offset = applyPadding(loc, rewriter, offset, paddingShifts);
     for (int j = 0; j < nAdditive; j += elemsPerVec) {
       // all these constants will go as immediate values to LDS/STS
-      auto regIdxAdd =
-          reps.apply({{kReg, j}, {kLane, 0}, {kWarp, 0}})[0].second;
-      auto regIdxAddI8 = regIdxAdd * (bitwidth / 8);
+      SmallVector<std::pair<StringAttr, int32_t>> idxAddInputs = {
+          {kReg, j}, {kLane, 0}, {kWarp, 0}};
+      if (reps.hasInDim(kBlock)) {
+        idxAddInputs.push_back({kBlock, 0});
+      }
+      auto idxAndBlockAdd = reps.apply(idxAddInputs);
+      auto regIdxAddI8 = idxAndBlockAdd[0].second * (bitwidth / 8);
       // `actionAdditiveStrides` forces `regIdxAddI8` and `offset` to be bitwise
       // disjoint, so we can calculate their padding contributions separately.
       regIdxAddI8 = applyPadding(regIdxAddI8, paddingShifts);
@@ -1026,10 +1063,14 @@ SmallVector<Value> lowerLdSt(
                                  .second;
         smemBase = b.extract_element(basesVec, partitionIdx);
       }
+      std::optional<Value> innerCtaOffset;
+      if (useBlockId) {
+        innerCtaOffset = b.add(ctaOffset, b.i32_val(idxAndBlockAdd[1].second));
+      }
       auto vecAddr = b.gep(smemPtrTy, i8_ty, smemBase, innerOffset,
                            LLVM::GEPNoWrapFlags::inbounds);
-      llvm::append_range(outVals,
-                         lowerInst(rewriter, loc, vals, vecAddr, i + j, vecTy));
+      llvm::append_range(outVals, lowerInst(rewriter, loc, vals, vecAddr, i + j,
+                                            vecTy, innerCtaOffset));
     }
   }
 
@@ -1051,6 +1092,11 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
                SharedMemoryObject smemObj, RewriterBase &rewriter,
                const TargetInfoBase &targetInfo, Operation *localLoadOp,
                std::optional<Value> ctaRank, std::optional<Value> barrierPtr) {
+  auto kOffset = str_attr("offset");
+  auto kPartition = str_attr("partition");
+  assert(cvt.hasOutDim(kOffset));
+  assert(cvt.getNumOutDims() == 1 ||
+         (cvt.getNumOutDims() == 2 && cvt.hasOutDim(kPartition)));
 
   auto isStore = !valsArray.empty();
   // Remove broadcasting in the registers
@@ -1441,7 +1487,9 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
     auto [shape, allocShape] = shapes;
     for (int j = llvm::Log2_32(shape); j < llvm::Log2_32(allocShape); ++j) {
       logicalOffsets[dim].second = 1 << j;
-      ret |= invLl.apply(logicalOffsets)[0].second;
+      auto offsetAndBlock = invLl.apply(logicalOffsets);
+      ret |= offsetAndBlock[0].second;
+      assert(offsetAndBlock[1].second == 0);
     }
     // Reset the offset for the next dimension
     logicalOffsets[dim].second = 0;
@@ -2103,32 +2151,36 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
     return;
   }
 
+  // Yanky way of "composing with the associated contiguous shmem layout"
+  auto kOffset = str_attr("offset");
+  auto kBlock = str_attr("block");
   auto dstLayout = triton::gpu::toLinearLayout(tensorTy);
-  auto kReg = str_attr("register");
-  auto kLane = str_attr("lane");
-  auto kWarp = str_attr("warp");
-  dstLayout = dstLayout.sublayout({kReg, kLane, kWarp},
-                                  llvm::to_vector(dstLayout.getOutDimNames()));
-  dstLayout = dstLayout.reshapeOuts(
-      {{str_attr("offset"), dstLayout.getTotalOutDimSize()}});
+  auto dimOut = dstLayout.getTotalOutDimSize();
+  auto dimBlock = dstLayout.getInDimSize(kBlock);
+  // You should create a Shared linear layout with kBlock bases equal to the
+  // kBlock of dstLayout and then put all the other bases in order in the
+  // offsets.
+  assert(dimBlock == 1 && "NYI");
+  dstLayout = dstLayout.flattenOuts().reshapeOuts(
+      {{kOffset, dimOut / dimBlock}, {kBlock, dimBlock}});
   auto smemBase = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op);
 
   auto emitSt = [&](RewriterBase &rewriter, Location loc, ArrayRef<Value> vals,
-                    Value shmemAddr, int idx,
-                    VectorType vecTy) -> SmallVector<Value> {
+                    Value shmemAddr, int idx, VectorType vecTy,
+                    std::optional<Value> ctaId) -> SmallVector<Value> {
     auto length = vecTy.getNumElements();
     Value valsVec =
         packLLVector(loc, ArrayRef<Value>(vals).slice(idx, length), rewriter);
-    targetInfo.storeDShared(rewriter, loc, shmemAddr, std::nullopt, valsVec,
+    targetInfo.storeDShared(rewriter, loc, shmemAddr, ctaId, valsVec,
                             threadPred);
     return {};
   };
 
   auto emitLd = [&](RewriterBase &rewriter, Location loc, ArrayRef<Value> vals,
-                    Value shmemAddr, int idx,
-                    VectorType vecTy) -> SmallVector<Value> {
-    Value loadedVec = targetInfo.loadDShared(rewriter, loc, shmemAddr,
-                                             std::nullopt, vecTy, b.true_val());
+                    Value shmemAddr, int idx, VectorType vecTy,
+                    std::optional<Value> ctaId) -> SmallVector<Value> {
+    Value loadedVec = targetInfo.loadDShared(rewriter, loc, shmemAddr, ctaId,
+                                             vecTy, b.true_val());
     return unpackLLVector(loc, loadedVec, rewriter);
   };
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(TritonNvidiaGPUTransforms
+  ClusterBarrierInsertion.cpp
   CheckMatmulTwoCTAs.cpp
   CLCLowering.cpp
   ConSanNVIDIA.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -1,0 +1,194 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/Membar.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+namespace {
+
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
+  if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    if (!isRead)
+      return false;
+    auto srcTy = cvt.getSrc().getType();
+    auto dstTy = cvt.getType();
+    auto kBlock = StringAttr::get(op->getContext(), "block");
+    auto conversion = minimalCvtLayout(srcTy, dstTy);
+    return conversion.hasInDim(kBlock);
+  }
+  if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
+    if (!isRead)
+      return false;
+    auto srcTy = reduce.getInputTypes()[0];
+    auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
+    return splitNum[reduce.getAxis()] > 1;
+  }
+  if (auto mma = dyn_cast<ttng::TCGen5MMAOp>(op)) {
+    return mma.getTwoCtas();
+  } else if (auto mmaScaled = dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
+    // TODO: Change when we support scaled MMA with 2CTAs
+    assert(!ttng::getModuleTwoCTAs(op->getParentOfType<ModuleOp>()) &&
+           "Scaled MMA with 2CTAs not supported");
+    return false;
+  } else if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    return tma.getMulticast();
+  }
+  return false;
+}
+
+static bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
+                                       const AllocationSlice &rhsSlice,
+                                       bool /*lhsIsRead*/, bool /*rhsIsRead*/,
+                                       Allocation *allocation) {
+  auto bufferId = lhsSlice.getBufferId();
+  return bufferId != Allocation::InvalidBufferId &&
+         bufferId == rhsSlice.getBufferId() &&
+         allocation->isExplicitBuffer(bufferId);
+}
+
+class ClusterBarrierAnalysis : public MembarOrFenceAnalysis {
+public:
+  ClusterBarrierAnalysis() = default;
+  explicit ClusterBarrierAnalysis(Allocation *allocation, MembarFilterFn filter)
+      : MembarOrFenceAnalysis(allocation, filter) {}
+
+private:
+  void update(Operation *op, BlockInfo *blockInfo,
+              FuncBlockInfoMapT *funcBlockInfoMap, OpBuilder *builder) override;
+
+  void insertClusterBarrier(Operation *op, OpBuilder *builder);
+};
+
+void ClusterBarrierAnalysis::insertClusterBarrier(Operation *op,
+                                                  OpBuilder *builder) {
+  OpBuilder::InsertionGuard guard(*builder);
+  ttng::ClusterArriveOp::create(*builder, op->getLoc(), /*relaxed=*/false);
+  ttng::ClusterWaitOp::create(*builder, op->getLoc());
+}
+
+void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
+                                    FuncBlockInfoMapT *funcBlockInfoMap,
+                                    OpBuilder *builder) {
+  if (isa<ttng::ClusterWaitOp>(op)) {
+    blockInfo->sync();
+    return;
+  }
+
+  BlockInfo curBlockInfo;
+  auto scratchBufferId = Allocation::InvalidBufferId;
+  if (isa<triton::CallOp>(op)) {
+    auto callOpInterface = dyn_cast<CallOpInterface>(op);
+    if (auto callee =
+            dyn_cast<FunctionOpInterface>(callOpInterface.resolveCallable())) {
+      auto calleeBlockInfo = funcBlockInfoMap->lookup(callee);
+      auto callBufferId = allocation->getBufferId(op);
+      size_t callOffset = 0;
+      if (callBufferId != Allocation::InvalidBufferId)
+        callOffset = allocation->getAllocatedInterval(callBufferId).start();
+      curBlockInfo = translateBlockInfoToCallsite(calleeBlockInfo, callOffset);
+    }
+  } else {
+    if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
+      SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>>
+          effectInstances;
+      memEffects.getEffects(effectInstances);
+      for (auto effectInstance : effectInstances) {
+        if (auto value = effectInstance.getValue()) {
+          for (auto bufferId : allocation->getBufferIds(value)) {
+            if (bufferId != Allocation::InvalidBufferId) {
+              auto interval = allocation->getAllocatedInterval(bufferId);
+              auto slice = AllocationSlice(value, interval, bufferId);
+              if (isa<MemoryEffects::Write>(effectInstance.getEffect()))
+                curBlockInfo.syncWriteSlices[slice].insert(op);
+              else if (isa<MemoryEffects::Read>(effectInstance.getEffect()))
+                curBlockInfo.syncReadSlices[slice].insert(op);
+            }
+          }
+        }
+      }
+    }
+    scratchBufferId = allocation->getBufferId(op);
+  }
+
+  // Scratch buffer operations consist of a series of shared memory operations
+  // starting from a shared memory write, followed by a series of shared memory
+  // read/write operations, and ending with a shared memory read, i.e., shared
+  // memory write -> ... -> shared memory read.
+  if (scratchBufferId != Allocation::InvalidBufferId) {
+    if (!curBlockInfo.syncReadSlices.empty() ||
+        !curBlockInfo.syncWriteSlices.empty()) {
+      llvm::report_fatal_error(
+          "scratch buffer operations should not have any shared memory "
+          "dependencies");
+    }
+
+    auto interval = allocation->getAllocatedInterval(scratchBufferId);
+    auto scratchSlice = AllocationSlice(interval);
+    curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
+
+    auto insertClusterBarrierNeeded = blockInfo->isIntersected(
+        curBlockInfo, filter, allocation, isPreAllocAliasSliceFilter);
+    if (insertClusterBarrierNeeded) {
+      builder->setInsertionPoint(op);
+      insertClusterBarrier(op, builder);
+    }
+
+    // Clear prior distributed dependencies if we have inserted a cluster
+    // barrier, or if the scratch op itself performs a cluster-level sync.
+    bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
+    if (insertClusterBarrierNeeded || hasClusterSync)
+      blockInfo->sync();
+
+    curBlockInfo.syncReadSlices[scratchSlice].insert(op);
+  } else if (blockInfo->isIntersected(curBlockInfo, filter, allocation,
+                                      isPreAllocAliasSliceFilter)) {
+    builder->setInsertionPoint(op);
+    insertClusterBarrier(op, builder);
+    blockInfo->sync();
+  }
+
+  blockInfo->join(curBlockInfo);
+}
+
+} // namespace
+
+void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
+                                int computeCapability) {
+  ModuleOp mod = moduleAllocation.getModuleOp();
+  if (computeCapability < 90)
+    return;
+  if (ttg::TritonGPUDialect::getNumCTAs(mod) == 1)
+    return;
+
+  MembarFilterFn filterFn = [](Operation *lhs, Operation *rhs, bool lhsIsRead,
+                               bool rhsIsRead, Allocation * /*allocation*/) {
+    // Filter ops that do not touch distributed shared memory. Whether the
+    // aliasing was already present in TTGIR is handled per-allocation slice.
+    bool lhsDist = isDistributedMultiCTAOp(lhs, lhsIsRead);
+    bool rhsDist = isDistributedMultiCTAOp(rhs, rhsIsRead);
+    if (!lhsDist && !rhsDist)
+      return true;
+    return false;
+  };
+
+  ModuleMembarOrFenceAnalysis<ClusterBarrierAnalysis> analysis(
+      &moduleAllocation, filterFn);
+  analysis.run();
+}
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -1,6 +1,5 @@
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
@@ -93,7 +92,8 @@ bool ignoreOpForProxyFence(Operation *op) {
              triton::nvidia_gpu::InvalBarrierOp>(op);
 }
 
-bool filterFn(Operation *op, Operation *other, Allocation *allocation) {
+bool filterFn(Operation *op, Operation *other, bool /*opIsRead*/,
+              bool /*otherIsRead*/, Allocation *allocation) {
   return ignoreOpForProxyFence(other);
 }
 
@@ -150,7 +150,7 @@ void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
           for (auto bufferId : allocation->getAllBufferIdsWithAliases(value)) {
             if (bufferId != Allocation::InvalidBufferId) {
               auto interval = allocation->getAllocatedInterval(bufferId);
-              auto slice = AllocationSlice(value, interval);
+              auto slice = AllocationSlice(value, interval, bufferId);
 
               if (isAsyncProxyWrite(op) && value == getSmemDest(op)) {
                 proxyBlockInfo.syncWriteSlices[slice].insert(op);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -51,8 +51,8 @@ static TMemAccessKind getTMemAccessKind(Operation *op) {
   return TMemAccessKind::None;
 }
 
-static bool filterFn(Operation *lhs, Operation *rhs,
-                     Allocation * /*allocation*/) {
+static bool filterFn(Operation *lhs, Operation *rhs, bool /*lhsIsRead*/,
+                     bool /*rhsIsRead*/, Allocation * /*allocation*/) {
   TMemAccessKind lhsKind = getTMemAccessKind(lhs);
   TMemAccessKind rhsKind = getTMemAccessKind(rhs);
 

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -469,7 +469,7 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
       computeSegment(bankSrc, bankDst, nonZeroBlockBases, dim, lenSbasis);
 
   // The bank is the complement of the union of the vector and the start of the
-  // segments
+  // segments and the block bases
   SmallVector<int32_t> unionBasis;
   unionBasis.append(vbasis.begin(), vbasis.end());
   unionBasis.append(sbasis.begin(), sbasis.end());
@@ -552,6 +552,7 @@ getVecBasisLdSt(const LinearLayout &srcFlat, const LinearLayout &dstFlat,
   auto regDst = flatten(dstFlat, kReg);
   auto blockSrc = srcFlat.getBases().contains(kBlock) ? flatten(srcFlat, kBlock)
                                                       : SmallVector<int32_t>{};
+
   auto dim = srcFlat.getTotalOutDimSizeBits();
   SmallVector<int32_t> vbasis = intersectionBasis(regSrc, regDst, dim);
   // Restrict the vectorisation to the maximum we can use
@@ -782,6 +783,8 @@ optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   auto blockBases = srcFlat.getBases().contains(kBlock)
                         ? flatten(srcFlat, kBlock)
                         : SmallVector<int32_t>{};
+  auto blockSrcSet =
+      SetVector<int32_t>(llvm::from_range_t{}, blockBases);
   // Get the associated src/dst tiles for each instruction if they exist
   SmallVector<std::tuple<std::pair<int32_t, int32_t>, SmallVector<int32_t>,
                          SmallVector<int32_t>, SmallVector<int32_t>, int32_t>>
@@ -819,7 +822,8 @@ optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
     for (auto [instrs, vbasis, tileSrc, tileDst, leaveReps] : tiles) {
       auto smem =
           optimalSwizzling(srcFlat, dstFlat, bitwidth, vbasis, tileSrc, tileDst,
-                           blockBases, src.getOutDims(), leaveReps);
+                           blockSrcSet.getArrayRef(), src.getOutDims(),
+                           leaveReps);
       auto [read, write] = bankConflicts(tileSrc, tileDst, smem);
       smems.push_back({read + write, smem, {instrs.first, instrs.second}});
     }

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -45,9 +45,7 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
     return layout;
   }
   MLIRContext *ctx = shape.begin()->first.getContext();
-
   auto bases = layout.getBases();
-
   auto kRegister = StringAttr::get(ctx, "register");
   std::set<int32_t> broadcastedDims;
 
@@ -101,10 +99,8 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
     }
   }
   if (!broadcastRegisters) {
-    // Remove broadcasted registers
     std::vector<std::vector<int32_t>> newBasesRegister;
     for (auto [idx, basis] : llvm::enumerate(bases[kRegister])) {
-      // Remove if it's broadcasted
       if (broadcastedDims.find(idx) == broadcastedDims.end()) {
         newBasesRegister.push_back(std::move(basis));
       }
@@ -228,11 +224,7 @@ LinearLayout zerosLike(const LinearLayout &layout) {
     }
   }
 
-  SmallVector<std::pair<StringAttr, int32_t>> outDims;
-  for (auto outDim : layout.getOutDimNames()) {
-    outDims.emplace_back(outDim, layout.getOutDimSize(outDim));
-  }
-  return LinearLayout(std::move(bases), std::move(outDims),
+  return LinearLayout(std::move(bases), layout.getOutDims(),
                       /*requireSurjective=*/false);
 }
 
@@ -326,9 +318,10 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout) {
 std::pair<int64_t, ColumnAction>
 actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
                       uint64_t maskSpanOffsets) {
-  // We are looking to put at the front (after any zeros) any basis that does
-  // not intersect with any bit moved by any basis in kLane / kWarp
-  // and that is not moved by any affine offset
+  // General idea:
+  // We wan to swap an xor into an addition when computing the register offsets.
+  // We can do this if the output bits of this register are disjoint from those
+  // from lanes/warps/blocks or any affine offset (i.e., markSpanOffsets).
 
   // Note this function assumes that if any registers are used in the addrLayout
   // of the layout (as in ldmatrix/stmatrix) they will be the first non-zero
@@ -336,19 +329,18 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
   assert(layout.getNumInDims() != 0);
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
-  auto kLane = StringAttr::get(kReg.getContext(), "lane");
-  auto kWarp = StringAttr::get(kReg.getContext(), "warp");
-  assert(layout.getNumOutDims() == 1);
   uint32_t bits = maskSpanOffsets;
   llvm::SetVector<uint32_t> tileBases;
-  for (auto bases : llvm::make_second_range(addrLayout.getBases())) {
+  auto addrNamedBases = addrLayout.flattenOuts().getBases();
+  for (auto bases : llvm::make_second_range(addrNamedBases)) {
     for (auto basis : bases) {
       bits |= basis[0];
       tileBases.insert(basis[0]);
     }
   }
   SmallVector<size_t> front, back;
-  for (auto [idx, basis] : llvm::enumerate(layout.getBases().lookup(kReg))) {
+  auto layoutNamedBases = layout.flattenOuts().getBases();
+  for (auto [idx, basis] : llvm::enumerate(layoutNamedBases.lookup(kReg))) {
     if ((basis[0] & bits) == 0 || tileBases.contains(basis[0])) {
       front.push_back(idx);
     } else {

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -1036,9 +1036,9 @@ LinearLayout operator*(LinearLayout inner, LinearLayout outer) {
 
 bool LinearLayout::isTrivialOver(ArrayRef<StringAttr> dimNames) const {
   for (StringAttr dim : dimNames) {
-    if (!llvm::is_contained(getInDimNames(), dim) &&
-        !llvm::is_contained(getOutDimNames(), dim)) {
-      return false;
+    if (!hasInDim(dim) || !hasOutDim(dim)) {
+      llvm::report_fatal_error(
+          ("dim " + dim.str() + " must be present in the layout").c_str());
     }
   }
 
@@ -1070,6 +1070,10 @@ bool LinearLayout::isTrivialOver(ArrayRef<StringAttr> dimNames) const {
 
 std::optional<LinearLayout>
 LinearLayout::quotient(ArrayRef<StringAttr> dimNames) const {
+  if (llvm::any_of(dimNames,
+                   [this](StringAttr dim) { return !hasInDim(dim); })) {
+    return std::nullopt;
+  }
   if (!isTrivialOver(dimNames)) {
     return std::nullopt;
   }

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -161,7 +161,66 @@ def test_scan_blocked_broadcast_layout_multiblock(device):
     y = torch.empty_like(x)
     scan_kernel[(1, )](x, y, M, 1, src_layout, 0, num_warps=2)
 
-    torch.testing.assert_close(y, torch.cumsum(x, dim=0))
+
+def _funky_reduce_layouts():
+
+    def ilog2(x):
+        return x.bit_length() - 1
+
+    # Broadcasting here and there and bases in a weird order
+    layouts = [
+        # Funky layout where the warp bases fit in the lane bases
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[0, 8], [1, 0], [0, 0], [2, 0], [4, 0], [8, 0], [16, 0]],
+            lane_bases=[[0, 1], [0, 0], [64, 0], [0, 2], [0, 4]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[32, 0], [0, 16]],
+            block_bases=[],
+            shape=[128, 32],
+        ),
+        # Another funky layout for good measure
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1, 0], [2, 0]],
+            lane_bases=[[0, 1], [4, 0], [0, 2], [8, 0], [0, 4]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[16, 0], [32, 0]],
+            block_bases=[],
+            shape=[64, 8],
+        ),
+        # Funky layout where warp bases do *not* fit in the lane bases
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1, 0], [2, 0]],
+            lane_bases=[[0, 1], [4, 0], [0, 2], [8, 0], [0, 4]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[16, 0], [32, 0], [64, 0]],
+            block_bases=[],
+            shape=[128, 8],
+        ),
+        # Basic funky layout with block bases. They fit in the lane bases
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1, 0], [2, 0]],
+            lane_bases=[[0, 1], [4, 0], [0, 2], [8, 0], [0, 0]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[16, 0], [32, 0]],
+            block_bases=[[64, 0]],
+            shape=[128, 4],
+        ),
+        # Funky layout with two convert_layouts with block_bases
+        ttgl.DistributedLinearLayout(
+            reg_bases=[],
+            lane_bases=[[0, 1], [0, 4], [0, 2], [1, 0], [0, 0]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[4, 0], [8, 0]],
+            block_bases=[[2, 0]],
+            shape=[16, 8],
+        ),
+        # Three convert_layouts
+        ttgl.DistributedLinearLayout(
+            reg_bases=[],
+            lane_bases=[[0, 1], [0, 4], [0, 2], [1, 0], [0, 0]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[4, 0], [8, 0], [16, 0], [128, 0], [512, 0]],
+            block_bases=[[2, 0], [32, 0], [64, 0], [256, 0]],
+            shape=[1024, 8],
+        ),
+    ]
+    for axis in [0, 1]:
+        for layout in layouts:
+            yield (layout, axis)
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
@@ -196,8 +255,52 @@ def _reduce_linear_layouts():
                 shape=[64, 128],
             )
         ]
-    else:
-        raise RuntimeError(f"Unsupported THREADS_PER_WARP: {THREADS_PER_WARP}")
+
+
+@pytest.mark.parametrize("src_layout, axis", list(_funky_reduce_layouts()))
+def test_reduce_funky_layout(src_layout, axis, device):
+    shape = tuple(src_layout.shape)
+    num_warps = 2**len(src_layout.warp_bases)
+    num_ctas = 2**len(src_layout.block_bases)
+
+    # TODO: Remove this once AMD supports num_ctas > 1
+    if num_ctas > 1 and not is_hopper_or_newer():
+        pytest.skip("num_ctas > 1 requires NVIDIA SM90+ (Hopper)")
+    # PTXAS BUGGGG
+    if shape == (16, 8) and axis == 0:
+        pytest.skip("PTXAS BUGGGG")
+
+    @gluon.jit
+    def kernel(
+        x_ptr,
+        y_ptr,
+        shape: ttgl.constexpr,
+        axis: ttgl.constexpr,
+        layout: ttgl.constexpr,
+    ):
+        x_offs_m = ttgl.arange(0, shape[0], layout=ttgl.SliceLayout(1, layout))[:, None]
+        x_offs_n = ttgl.arange(0, shape[1], layout=ttgl.SliceLayout(0, layout))[None, :]
+        x = ttgl.load(x_ptr + x_offs_m * shape[1] + x_offs_n)
+        y = ttgl.reduce(x, axis=axis, combine_fn=_combine)
+        y_offs = ttgl.arange(0, shape[1 - axis])
+        ttgl.store(y_ptr + y_offs, y)
+
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=torch.float32, device=device)
+    y = torch.empty((shape[1 - axis], ), dtype=torch.float32, device=device)
+    pm = kernel[(1, )](x, y, shape, axis, src_layout, num_warps=num_warps, num_ctas=num_ctas)
+
+    torch.testing.assert_close(y, torch.sum(x, dim=axis))
+
+    def bases_along_axis(bases, axis):
+        return sum(basis[axis] != 0 for basis in bases)
+
+    axis_warps = bases_along_axis(src_layout.warp_bases, axis)
+    axis_blocks = bases_along_axis(src_layout.block_bases, axis)
+
+    # warp-sync
+    if is_cuda() and axis_warps + axis_blocks == 0:
+        assert pm.asm["ptx"].count("bar.sync") == 0
 
 
 def _reduce_layouts():

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3242,6 +3242,8 @@ def _add_reduction_docstr(
         docstr = """
     Returns the {name} of all elements in the :code:`input` tensor along the provided :code:`axis`
 
+    The reduction operation should be associative and commutative.
+
     :param input: the input values
     :type input: Tensor
     :param axis: the dimension along which the reduction should be done. If None, reduce all dimensions

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1232,3 +1232,42 @@ module attributes {ttg.target = "cuda:90", "ttg.num-warps" = 8 : i32} {
     tt.return
   }
 }
+
+// -----
+
+#blockedLarge = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#sharedLarge = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#blockedCallSrc = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mmaCall = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#blockedCallDst = #ttg.dot_op<{opIdx = 0, parent = #mmaCall, kWidth = 2}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func private @callee_call_offset_membar() -> tensor<128x32xf16, #blockedCallDst> {
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    tt.return %cvt : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  // The call's virtual buffer is offset by the large allocation. The
+  // subsequent scratch op should alias at the same offset and require a membar.
+  // CHECK-LABEL: @caller_call_offset_membar
+  // CHECK: tt.call @callee_call_offset_membar{{.*}}allocation.offset = [[CALL_OFFSET:[1-9][0-9]*]]
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttg.convert_layout{{.*}}allocation.offset = [[CALL_OFFSET]]
+  tt.func @caller_call_offset_membar() -> tensor<128x32xf16, #blockedCallDst> {
+    %large = arith.constant dense<0> : tensor<65536xi8, #blockedLarge>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<65536xi8, #sharedLarge, #smem, mutable>
+    ttg.local_store %large, %buf : tensor<65536xi8, #blockedLarge> -> !ttg.memdesc<65536xi8, #sharedLarge, #smem, mutable>
+
+    %call = tt.call @callee_call_offset_membar() : () -> tensor<128x32xf16, #blockedCallDst>
+
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    %sum = arith.addf %call, %cvt : tensor<128x32xf16, #blockedCallDst>
+
+    %ld = ttg.local_load %buf : !ttg.memdesc<65536xi8, #sharedLarge, #smem, mutable> -> tensor<65536xi8, #blockedLarge>
+    ttg.local_dealloc %buf : !ttg.memdesc<65536xi8, #sharedLarge, #smem, mutable>
+    tt.return %sum : tensor<128x32xf16, #blockedCallDst>
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1860,6 +1860,40 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 }
 
 // -----
+// CHECK-LABEL: @reduce_vec8_axisonly
+// CHECK-COUNT-7: llvm.fadd {{.*}} : f16
+// CHECK-NOT: llvm.fadd {{.*}} : vector<2xf16>
+// CHECK: llvm.return
+#blocked_vec8_axisonly = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reduce_vec8_axisonly(%arg0: tensor<1x8xf16, #blocked_vec8_axisonly>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f16, %b: f16):
+      %c = arith.addf %a, %b : f16
+      tt.reduce.return %c : f16
+    }) : (tensor<1x8xf16, #blocked_vec8_axisonly>) -> tensor<1xf16, #ttg.slice<{dim = 1, parent = #blocked_vec8_axisonly}>>
+    tt.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @reduce_vec8_firstbasis_nonaxis
+// CHECK-COUNT-14: llvm.fadd {{.*}} : f16
+// CHECK-NOT: llvm.fadd {{.*}} : vector<2xf16>
+// CHECK: llvm.return
+#blocked_vec8_firstbasis_nonaxis = #ttg.blocked<{sizePerThread = [2, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reduce_vec8_firstbasis_nonaxis(%arg0: tensor<64x8xf16, #blocked_vec8_firstbasis_nonaxis>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f16, %b: f16):
+      %c = arith.addf %a, %b : f16
+      tt.reduce.return %c : f16
+    }) : (tensor<64x8xf16, #blocked_vec8_firstbasis_nonaxis>) -> tensor<64xf16, #ttg.slice<{dim = 1, parent = #blocked_vec8_firstbasis_nonaxis}>>
+    tt.return
+  }
+}
+
+// -----
 #blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 2], order = [1, 0]}>
 #slice = #ttg.slice<{dim = 1, parent = #blocked}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
@@ -1874,7 +1908,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
     tt.return
   }
 }
-
 
 // -----
 

--- a/test/Conversion/tritongpu_to_ptx.mlir
+++ b/test/Conversion/tritongpu_to_ptx.mlir
@@ -1,8 +1,13 @@
 // RUN: triton-opt %s --allocate-shared-memory-nv='compute-capability=90 ptx-version=83' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | opt -O3 -S | llc -mtriple nvptx64-nvidia-cuda -mcpu=sm_90 -mattr=+ptx83 | FileCheck --check-prefixes CHECK,SM90 --dump-input-context=20 %s
 // RUN: triton-opt %s --allocate-shared-memory-nv='compute-capability=80 ptx-version=83' --convert-triton-gpu-to-llvm='compute-capability=80 ptx-version=83' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | opt -O3 -S | llc -mtriple nvptx64-nvidia-cuda -mcpu=sm_80 -mattr=+ptx83 | FileCheck --check-prefixes CHECK,SM80 --dump-input-context=20 %s
+// RUN: triton-opt %s --allocate-shared-memory-nv='compute-capability=100 ptx-version=87' --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=87' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | opt -O3 -S | llc -mtriple nvptx64-nvidia-cuda -mcpu=sm_100 -mattr=+ptx87 | FileCheck --check-prefixes CHECK,SM100 --dump-input-context=20 %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm='compute-capability=80 ptx-version=83' -cse | FileCheck --check-prefix=VEC80 --dump-input-context=20 %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' -cse | FileCheck --check-prefix=VEC90 --dump-input-context=20 %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=87' -cse | FileCheck --check-prefix=VEC100 --dump-input-context=20 %s
 
 
 #blocked = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
+#blocked_reduce = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @add_bf16(%ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg0: tensor<256xbf16, #blocked>, %arg1: tensor<256xbf16, #blocked>) {
     // CHECK-LABEL: add_bf16
@@ -81,6 +86,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
     %2 = tt.splat %ptr : !tt.ptr<f16> -> tensor<256x!tt.ptr<f16>, #blocked>
     %3 = tt.addptr %2, %1 : tensor<256x!tt.ptr<f16>, #blocked>, tensor<256xi32, #blocked>
     tt.store %3, %0 : tensor<256x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: reduce_f16_store
+  // SM80-NOT: add.rn.f16x2
+  // SM90: add.rn.f16x2
+  // SM100: add.rn.f16x2
+  // VEC80-LABEL: llvm.func @reduce_f16_store
+  // VEC80-NOT: llvm.fadd {{.*}} : vector<2xf16>
+  // VEC90-LABEL: llvm.func @reduce_f16_store
+  // VEC90: llvm.fadd {{.*}} : vector<2xf16>
+  // VEC100-LABEL: llvm.func @reduce_f16_store
+  // VEC100: llvm.fadd {{.*}} : vector<2xf16>
+  tt.func public @reduce_f16_store(%out: !tt.ptr<f16>, %arg0: tensor<1x256xf16, #blocked_reduce>) {
+    %r = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f16, %b: f16):
+      %sum = arith.addf %a, %b : f16
+      tt.reduce.return %sum : f16
+    }) {allocation.offset = 0 : i32} : (tensor<1x256xf16, #blocked_reduce>) -> tensor<1xf16, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    %ptr = tt.splat %out : !tt.ptr<f16> -> tensor<1x!tt.ptr<f16>, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.store %ptr, %r : tensor<1x!tt.ptr<f16>, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+
+  // CHECK-LABEL: reduce_f32_store
+  // VEC80-LABEL: llvm.func @reduce_f32_store
+  // VEC80-NOT: llvm.fadd {{.*}} : vector<2xf32>
+  // VEC90-LABEL: llvm.func @reduce_f32_store
+  // VEC90-NOT: llvm.fadd {{.*}} : vector<2xf32>
+  // VEC100-LABEL: llvm.func @reduce_f32_store
+  // VEC100: llvm.fadd {{.*}} : vector<2xf32>
+  tt.func public @reduce_f32_store(%out: !tt.ptr<f32>, %arg0: tensor<1x256xf32, #blocked_reduce>) {
+    %r = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %sum = arith.addf %a, %b : f32
+      tt.reduce.return %sum : f32
+    }) {allocation.offset = 0 : i32} : (tensor<1x256xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    %ptr = tt.splat %out : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.store %ptr, %r : tensor<1x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
     tt.return
   }
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -596,8 +596,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c256_i32 = arith.constant 256 : i32
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
-    // CHECK: st.shared.b32
-    // CHECK: bar.warp.sync
     // CHECK: tensormap.replace.tile.global_address.shared::cta.b1024.b64 [ $0 + 0 ], $1;
     // CHECK: tensormap.replace.tile.rank.shared::cta.b1024.b32 [ $0 + 0 ], 0x0;
     // CHECK: tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [ $0 + 0 ], 0x0, $1;
@@ -622,8 +620,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
     %c1024_i64 = arith.constant 1024 : i64
-    // CHECK: st.shared.b32
-    // CHECK: bar.warp.sync
     // CHECK: tensormap.replace.tile.global_address.shared::cta.b1024.b64 [ $0 + 0 ], $1;
     // CHECK: tensormap.replace.tile.rank.shared::cta.b1024.b32 [ $0 + 0 ], 0x1;
     // CHECK: tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [ $0 + 0 ], 0x0, $1;

--- a/test/TritonNvidiaGPU/async_remote_shmem_copy.mlir
+++ b/test/TritonNvidiaGPU/async_remote_shmem_copy.mlir
@@ -12,8 +12,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     %src = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
     %dst = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: nvvm.mapa
-    // CHECK: nvvm.mapa
+    // CHECK: mapa.shared::cluster.u32
+    // CHECK: mapa.shared::cluster.u32
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att{{.*}}cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes
     ttg.async_remote_shmem_copy %src, rank %arg0, %dst barrier %bar : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> barrier_ty !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
@@ -38,7 +38,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // The subslice at [128, 0] adds an offset to the base pointer.
     // Verify GEP (offset computation) appears before mapa for the dst.
     // CHECK: llvm.getelementptr
-    // CHECK: nvvm.mapa
+    // CHECK: mapa.shared::cluster.u32
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att{{.*}}cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes
     ttg.async_remote_shmem_copy %src, rank %arg0, %dst barrier %bar : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64> barrier_ty !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return

--- a/test/TritonNvidiaGPU/async_remote_shmem_store.mlir
+++ b/test/TritonNvidiaGPU/async_remote_shmem_store.mlir
@@ -17,8 +17,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // CHECK: %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: ttg.async_remote_shmem_store %arg0, rank %arg1, %0 barrier %1 : tensor<1x1xf32, #blocked> -> !ttg.memdesc<1x1xf32, #shared, #smem, mutable> barrier_ty !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK-LLVM: nvvm.mapa
-    // CHECK-LLVM: nvvm.mapa
+    // CHECK-LLVM: mapa.shared::cluster.u32
+    // CHECK-LLVM: mapa.shared::cluster.u32
     // CHECK-LLVM: llvm.inline_asm has_side_effects asm_dialect = att{{.*}}st.async.shared::cluster.mbarrier::complete_tx::bytes
     ttg.async_remote_shmem_store %arg0, rank %arg1, %0 barrier %1 : tensor<1x1xf32, #blocked> -> !ttg.memdesc<1x1xf32, #shared, #smem, mutable> barrier_ty !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
@@ -40,7 +40,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // CHECK: %0 = ttg.local_alloc : () -> !ttg.memdesc<1x1xf32, #shared, #smem, mutable>
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x1xf32, #shared, #smem, mutable>
     // CHECK: ttg.remote_shmem_store %arg0, rank %arg1, %0 : tensor<1x1xf32, #blocked> -> !ttg.memdesc<1x1xf32, #shared, #smem, mutable>
-    // CHECK-LLVM: nvvm.mapa
+    // CHECK-LLVM: mapa.shared::cluster.u32
     // CHECK-LLVM-NOT: llvm.inline_asm{{.*}}st.async.shared::cluster.mbarrier
     ttg.remote_shmem_store %arg0, rank %arg1, %0 : tensor<1x1xf32, #blocked> -> !ttg.memdesc<1x1xf32, #shared, #smem, mutable>
     tt.return

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -1,0 +1,567 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-tma-lowering --allocate-shared-memory -test-print-membar | FileCheck --dump-input=fail --dump-input-context=30 %s
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedSplitN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @convert_layout_cluster_barrier
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttg.local_alloc
+  tt.func @convert_layout_cluster_barrier() -> tensor<256x128xf16, #blockedSplitM> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSplitM> -> tensor<256x128xf16, #blockedSplitN>
+    %buf = ttg.local_alloc %cvt : (tensor<256x128xf16, #blockedSplitN>) -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    ttg.local_store %cvt, %buf : tensor<256x128xf16, #blockedSplitN> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSplitM>
+    tt.return %ld : tensor<256x128xf16, #blockedSplitM>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blocked}>
+#slice1 = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // First reduction does not cross CTAs; second one does.
+  // There should be no cluster barrier between them as tt.reduce always syncs internally before touching distributed shared memory.
+  // but there should be a local barrier after the reduction that touches distributed shared memory
+  // CHECK-LABEL: @reduce_nocross_then_cross
+  // CHECK: "tt.reduce"{{.*}}axis = 0
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: "tt.reduce"{{.*}}axis = 1
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: ttg.barrier local
+  // CHECK: "tt.reduce"{{.*}}axis = 0
+  tt.func @reduce_nocross_then_cross(%t1: tensor<256x128xf16, #blocked>, %t2: tensor<256x128xf16, #blocked>) -> (tensor<128xf16, #slice0>, tensor<256xf16, #slice1>, tensor<128xf16, #slice0>) {
+    %red_nc = "tt.reduce"(%t1) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blocked>) -> tensor<128xf16, #slice0>
+
+    %red_c = "tt.reduce"(%t1) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 1 : i32} : (tensor<256x128xf16, #blocked>) -> tensor<256xf16, #slice1>
+
+    %red_nc2 = "tt.reduce"(%t2) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blocked>) -> tensor<128xf16, #slice0>
+
+    tt.return %red_nc, %red_c, %red_nc2 : tensor<128xf16, #slice0>, tensor<256xf16, #slice1>, tensor<128xf16, #slice0>
+  }
+}
+
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @reduce_cluster_barrier
+  // CHECK: "tt.reduce"
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttg.local_alloc
+  tt.func @reduce_cluster_barrier() -> tensor<128xf16, #slice0> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %red = "tt.reduce"(%cst) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
+    %buf = ttg.local_alloc %red : (tensor<128xf16, #slice0>) -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    ttg.local_store %red, %buf : tensor<128xf16, #slice0> -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<128xf16, #shared1d, #smem, mutable> -> tensor<128xf16, #slice0>
+    tt.return %ld : tensor<128xf16, #slice0>
+  }
+}
+
+// -----
+
+#sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 2], order = [0, 1], CGALayout = [[1, 0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // TODO: Improve the heuristics so that we don't emit a cluster_arrive/wait when num-ctas == 2!
+  // A wait with explicit deps proves the inputs are no longer in use whenever num-ctas == 2 but
+  // we currently emit a cluster barrier
+  // CHECK-LABEL: @mma_v5_two_ctas_wait_barrier_no_cluster
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttng.wait_barrier
+  // CHECK: ttng.cluster_arrive
+  // CHECK: ttng.cluster_wait
+  // CHECK: ttg.local_store
+  // CHECK: tt.return
+  tt.func @mma_v5_two_ctas_wait_barrier_no_cluster() -> tensor<256x32xf16, #blocked> {
+    %a = ttg.local_alloc : () -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x32xf16, #blocked>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.tc_gen5_mma %a, %b, %acc, %true, %true, %barrier[%true] {is_async, two_ctas} :
+       !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>,
+       !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>,
+       !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %a, %b :
+      !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>,
+      !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %a : !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    ttg.local_dealloc %b : !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    ttg.local_store %cst, %buf : tensor<256x32xf16, #blocked> -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable> -> tensor<256x32xf16, #blocked>
+    tt.return %ld : tensor<256x32xf16, #blocked>
+  }
+}
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
+#shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // We make sure we generate cluster barriers when we touch distributed shared memory in a loop.
+  // TODO: A better codegen would be:
+  // for {
+  //   reduce
+  //   cluster_arrive
+  //   cluster_wait
+  // }
+  // local_alloc
+  // but not even the membar allocation pass generates this pattern
+  // An even better codegen would be the above + predicate on the last iteration
+  // and come out of the for loop analysis with a read dependency on the last reduce
+
+  // CHECK-LABEL: @scf_for_reduce_cluster_barrier
+  // CHECK: scf.for
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: tt.reduce
+  // CHECK: scf.yield
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttg.local_alloc
+  tt.func @scf_for_reduce_cluster_barrier() -> tensor<128xf16, #slice0> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %init = arith.constant dense<0.000000e+00> : tensor<128xf16, #slice0>
+    %loop_res = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> (tensor<128xf16, #slice0>) {
+      %red = "tt.reduce"(%cst) ({
+      ^bb0(%lhs: f16, %rhs: f16):
+        %add = arith.addf %lhs, %rhs : f16
+        tt.reduce.return %add : f16
+      }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
+      scf.yield %red : tensor<128xf16, #slice0>
+    }
+    %buf = ttg.local_alloc %loop_res : (tensor<128xf16, #slice0>) -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    ttg.local_store %loop_res, %buf : tensor<128xf16, #slice0> -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<128xf16, #shared1d, #smem, mutable> -> tensor<128xf16, #slice0>
+    tt.return %ld : tensor<128xf16, #slice0>
+  }
+}
+
+// -----
+
+#blockedSrc = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedDst = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0]]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA when the layouts don't cross CTAs
+  // CHECK-LABEL: @no_cluster_convert_block_trivial
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_convert_block_trivial() -> tensor<256x128xf16, #blockedSrc> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSrc>
+    %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSrc> -> tensor<256x128xf16, #blockedDst>
+    %buf = ttg.local_alloc %cvt : (tensor<256x128xf16, #blockedDst>) -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    ttg.local_store %cvt, %buf : tensor<256x128xf16, #blockedDst> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSrc>
+    tt.return %ld : tensor<256x128xf16, #blockedSrc>
+  }
+}
+
+// -----
+
+#blockedTmaSrc = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedTmaDst = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#nvmmaTma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEncTma = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Non-distributed convert_layout followed by multicast TMA should still
+  // insert a cluster barrier before the TMA.
+  // TODO: There is a world where we can do better:
+  // 1. We emit the relaxed = false cluster_arrive/wait pair automatically
+  // 2. We realise that we can avoid emitting it there as there is a cluster barrier after the convert_layout
+  // CHECK-LABEL: @convert_layout_trivial_then_tma_multicast_cluster_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttg.convert_layout
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  tt.func @convert_layout_trivial_then_tma_multicast_cluster_barrier(%input: tensor<64x128xf16, #blockedTmaSrc>, %desc: !tt.tensordesc<64x128xf16, #nvmmaTma>) -> tensor<64x128xf16, #blockedTmaDst> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    %cvt = ttg.convert_layout %input : tensor<64x128xf16, #blockedTmaSrc> -> tensor<64x128xf16, #blockedTmaDst>
+    %dst = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %dst, %barrier, %true {multicast} :
+        !tt.tensordesc<64x128xf16, #nvmmaTma>, !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %dst :
+        !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>,
+        !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttg.local_dealloc %dst : !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
+    tt.return %cvt : tensor<64x128xf16, #blockedTmaDst>
+  }
+}
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#slice1 = #ttg.slice<{dim = 1, parent = #blockedSplitM}>
+#shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA reduce when the axis is not split
+  // CHECK-LABEL: @no_cluster_reduce_unsplit_axis
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_reduce_unsplit_axis() -> tensor<256xf16, #slice1> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %red = "tt.reduce"(%cst) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 1 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<256xf16, #slice1>
+    %buf = ttg.local_alloc %red : (tensor<256xf16, #slice1>) -> !ttg.memdesc<256xf16, #shared1d, #smem, mutable>
+    ttg.local_store %red, %buf : tensor<256xf16, #slice1> -> !ttg.memdesc<256xf16, #shared1d, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256xf16, #shared1d, #smem, mutable> -> tensor<256xf16, #slice1>
+    tt.return %ld : tensor<256xf16, #slice1>
+  }
+}
+
+// -----
+
+#sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 2], order = [0, 1], CGALayout = [[0, 0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1, CGALayout = [[0, 1]]>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA MMA when the twoCTAs is not set
+  // CHECK-LABEL: @no_cluster_mma_without_two_ctas
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_mma_without_two_ctas() -> tensor<128x16xf16, #blocked> {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf16, #blocked>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.tc_gen5_mma %a, %b, %acc, %true, %true, %barrier[%true] {is_async} :
+       !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>,
+       !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>,
+       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %a, %b :
+      !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>,
+      !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %a : !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    ttg.local_dealloc %b : !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    ttg.local_store %cst, %buf : tensor<128x16xf16, #blocked> -> !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable> -> tensor<128x16xf16, #blocked>
+    tt.return %ld : tensor<128x16xf16, #blocked>
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA TMA when the multicast is not set
+  // CHECK-LABEL: @no_cluster_tma_without_multicast
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_tma_without_multicast(%desc: !tt.tensordesc<64x128xf16, #nvmma>) -> tensor<64x128xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf16, #blocked>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buf, %barrier, %true :
+      !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %buf :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_dealloc %buf : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    %buf2 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_store %cst, %buf2 : tensor<64x128xf16, #blocked> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %ld = ttg.local_load %buf2 : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    tt.return %ld : tensor<64x128xf16, #blocked>
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Wait included to model the end of the async lifetime. No extra cluster
+  // barriers should appear after the wait when reusing the same alloc.
+  // CHECK-LABEL: @no_cluster_when_same_allocation
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttng.wait_barrier
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_when_same_allocation(%desc: !tt.tensordesc<64x128xf16, #nvmma>) -> tensor<64x128xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf16, #blocked>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buf, %barrier, %true {multicast} :
+      !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %buf :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_store %cst, %buf : tensor<64x128xf16, #blocked> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    tt.return %ld : tensor<64x128xf16, #blocked>
+  }
+}
+
+// -----
+
+#sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1]]}>
+#barrierTMA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#barrierMMA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // Exact TTGIR shape for:
+  // test_tma_mma_shared_inputs[True-True-ctas_per_cga1-reps0-warps2]
+  // with smem allocations outside the loop.
+  // If we fully manage the shared memory and the allocator does not create any new aliases,
+  // then we shouldn't emit any cluster barriers
+  // CHECK-LABEL: @example_matmul
+  // CHECK: ttg.local_alloc
+  // CHECK: ttg.local_alloc
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.init_barrier
+  // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: scf.for
+  // CHECK: ttng.barrier_expect
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttng.wait_barrier
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttng.tc_gen5_mma
+  // CHECK: ttng.wait_barrier
+  tt.func @example_matmul(%a_desc: !tt.tensordesc<256x16xf16, #sharedA>, %b_desc: !tt.tensordesc<16x64xf16, #sharedB>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %c16 = arith.constant 16 : i32
+    %c0_idx = arith.constant 0 : index
+    %c4_idx = arith.constant 4 : index
+    %c1_idx = arith.constant 1 : index
+    %smem_a = ttg.local_alloc : () -> !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>
+    %smem_b = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+    %bTMA = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+    %bMMA = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    ttng.init_barrier %bTMA, 1 : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+    ttng.init_barrier %bMMA, 1 : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    %acc_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    %phase_init = arith.constant 0 : i32
+    %phase_tma = scf.for %k = %c0_idx to %c4_idx step %c1_idx iter_args(%phase = %phase_init) -> (i32) {
+      %k_i32 = arith.index_cast %k : index to i32
+      ttng.barrier_expect %bTMA, 5120, %true : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+      %offs = arith.muli %k_i32, %c16 : i32
+      ttng.async_tma_copy_global_to_local %a_desc[%c0, %offs] %smem_a, %bTMA, %true {multicast} :
+        !tt.tensordesc<256x16xf16, #sharedA>, !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable> -> !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>
+      ttng.async_tma_copy_global_to_local %b_desc[%offs, %c0] %smem_b, %bTMA, %true {multicast} :
+        !tt.tensordesc<16x64xf16, #sharedB>, !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable> -> !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+      ttng.wait_barrier %bTMA, %phase, %true deps %smem_a, %smem_b :
+        !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>,
+        !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>,
+        !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+      %next_phase = arith.xori %phase, %c1 : i32
+      %use_acc = arith.cmpi ne, %k_i32, %c0 : i32
+      %mma_tok = ttng.tc_gen5_mma %smem_a, %smem_b, %acc_tmem[], %use_acc, %true, %bMMA[%true] {is_async, two_ctas, multicast} :
+         !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>,
+         !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>,
+         !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+         !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+      ttng.wait_barrier %bMMA, %phase, %true deps %smem_a, %smem_b :
+        !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>,
+        !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>,
+        !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+      scf.yield %next_phase : i32
+    }
+    ttg.local_dealloc %bTMA : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+    ttg.local_dealloc %bMMA : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    ttg.local_dealloc %smem_a : !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>
+    ttg.local_dealloc %smem_b : !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // The wait just waits on the first CTA, so there should be a barrier in between
+  // CHECK-LABEL: @cluster_barrier_between_lifetimes_same_offset
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttg.local_alloc
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK: ttng.wait_barrier
+  // CHECK: ttg.local_dealloc
+  // CHECK: ttg.local_alloc
+  // CHECK-NEXT: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  tt.func @cluster_barrier_between_lifetimes_same_offset(%desc: !tt.tensordesc<64x128xf16, #nvmma>) -> tensor<64x128xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    // a lifetime start
+    %a = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %a, %barrier, %true {multicast} :
+      !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %a :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %t = ttg.local_load %a : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    ttg.local_dealloc %a : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    // a lifetime end
+
+    // b lifetime start
+    %b = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %b, %barrier, %true {multicast} :
+      !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %b :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %t2 = ttg.local_load %b : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    ttg.local_dealloc %b : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    // b lifetime end
+
+    tt.return %t2 : tensor<64x128xf16, #blocked>
+  }
+}

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(TritonTestAnalysis
   TestMembar.cpp
   TestPrintNesting.cpp
 )
-target_link_libraries(TritonTestAnalysis PUBLIC MLIRPass TritonAnalysis)
+target_link_libraries(TritonTestAnalysis PUBLIC MLIRPass TritonAnalysis TritonNvidiaGPUTransforms)
 target_compile_options(TritonTestAnalysis PRIVATE ${TRITON_DISABLE_EH_RTTI_FLAGS})

--- a/test/lib/Analysis/TestMembar.cpp
+++ b/test/lib/Analysis/TestMembar.cpp
@@ -1,12 +1,13 @@
 #include "../third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.h"
+#include "third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-// NOTE: ClusterBarrierInsertion.h is intentionally omitted -- beta does not
-// carry the TritonNvidiaGPU ClusterBarrierInsertion transform/header.
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 
 using namespace mlir;
 
@@ -29,8 +30,18 @@ struct TestMembarPass
   void runOnOperation() override {
     Operation *operation = getOperation();
     ModuleOp moduleOp = cast<ModuleOp>(operation);
-    // Print all ops after membar pass
     ModuleAllocation allocation(moduleOp);
+    if (moduleOp->hasAttr("ttg.target")) {
+      int computeCapability = getNVIDIAComputeCapability(moduleOp);
+      int ptxVersion = computeCapability;
+      triton::NVIDIA::TargetInfo targetInfo(computeCapability, ptxVersion);
+      allocation = ModuleAllocation(
+          moduleOp,
+          triton::nvidia_gpu::getNvidiaAllocationAnalysisScratchSizeFn(
+              targetInfo));
+      triton::nvidia_gpu::runClusterBarrierInsertion(allocation,
+                                                     computeCapability);
+    }
     ModuleMembarAnalysis membarPass(&allocation,
                                     mlir::triton::NVIDIA::canSkipBarSync);
     membarPass.run();

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -26,7 +26,8 @@ namespace mlir::triton::AMD {
 //      # Requires ttg.barrier but filter will prevent it
 //     %4 = AsyncCopyGlobalToLocal %ptr_2 %tile_a
 //     scf.yield
-bool membarFilter(Operation *op1, Operation *op2, Allocation *allocation);
+bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,
+                  bool op2IsRead, Allocation *allocation);
 } // namespace mlir::triton::AMD
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -72,7 +72,7 @@ static BlockInfo buildBlockInfoFromBlock(Block *block, Allocation *allocation) {
         if (bufId == Allocation::InvalidBufferId)
           continue;
         auto interval = allocation->getAllocatedInterval(bufId);
-        auto slice = AllocationSlice(v, interval);
+        auto slice = AllocationSlice(v, interval, bufId);
         if (isa<MemoryEffects::Write>(eff.getEffect()))
           info.syncWriteSlices[slice].insert(op);
         else if (isa<MemoryEffects::Read>(eff.getEffect()))

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -469,9 +469,6 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
                                    : "direct from lds stores do not support "
                                      "non-trivial block dimension");
     }
-    cvt = cvt.sublayout(
-        {str_attr("register"), str_attr("lane"), str_attr("warp")},
-        {str_attr("offset")});
 
     // Multicast is only supported for loads
     Value ctaMulticastMask;
@@ -495,7 +492,9 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
 
     auto lowerInstForwardMulticastMask =
         [&](RewriterBase &rewriter, Location loc, ArrayRef<Value> vals,
-            Value shmemAddr, int idx, VectorType vecTy) {
+            Value shmemAddr, int idx, VectorType vecTy,
+            std::optional<Value> ctaId) {
+          assert(!ctaId.has_value() && "NYI");
           return lowerInst(rewriter, loc, vals, shmemAddr, idx, vecTy,
                            ctaMulticastMask);
         };
@@ -506,7 +505,8 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
       laneId = b.i32_val(0);
     }
 
-    lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemObj.getBase(), paddingShifts,
+    SmallVector<Value> smemBases = {smemObj.getBase()};
+    lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemBases, paddingShifts,
               affineOffset, maskSpanAffineOffset, laneId, warpId, rewriter,
               targetInfo, vec, lowerInstForwardMulticastMask);
     return success();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -64,7 +64,8 @@ bool filterLDSMemoryBarriersDependencies(Operation *op1, Operation *op2) {
 }
 } // namespace
 
-bool membarFilter(Operation *op1, Operation *op2, Allocation *allocation) {
+bool membarFilter(Operation *op1, Operation *op2, bool /*op1IsRead*/,
+                  bool /*op2IsRead*/, Allocation *allocation) {
   return (filterAsyncLocalLoadsDependencies(op1, op2, allocation) ||
           filterLDSMemoryBarriersDependencies(op1, op2));
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -426,6 +426,7 @@ private:
     auto kReg = str_attr("register");
     auto kLane = str_attr("lane");
     auto kWarp = str_attr("warp");
+    auto kBlock = str_attr("block");
     auto kOffset = str_attr("offset");
     auto dstTy = cast<RankedTensorType>(op.getType());
     auto srcTy = cast<MemDescType>(op.getSrc().getType());
@@ -480,10 +481,12 @@ private:
     if (elemsPerVec != ldsTransLoadParams->tileSize)
       return failure();
 
-    cvt = cvt.sublayout({kReg, kLane, kWarp}, {kOffset});
+    assert(cvt.isTrivialOver({kBlock}) && "NYI");
     auto lowerInst = [&](RewriterBase &rewriter, Location loc,
                          ArrayRef<Value> inVals, Value vecAddr, int idx,
-                         VectorType vTy) -> SmallVector<Value> {
+                         VectorType vTy,
+                         std::optional<Value> ctaId) -> SmallVector<Value> {
+      assert(!ctaId.has_value() && "NYI");
       auto numElemsI32 = (vTy.getNumElements() * bitWidth / 32);
       auto vTyI32 = VectorType::get(numElemsI32, i32_ty);
       Value dsReadTr =

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -1,4 +1,5 @@
 #include "TargetInfo.h"
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "TritonAMDGPUToLLVM/GCNAsmFormat.h"
 #include "TritonAMDGPUToLLVM/TargetUtils.h"
 #include "Utility.h"
@@ -140,6 +141,11 @@ void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
                          triton::gpu::AddrSpace targets) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   b.barrier(targets);
+}
+
+void TargetInfo::clusterBarrier(Location loc, RewriterBase &rewriter) const {
+  triton::amdgpu::ClusterBarrierArriveOp::create(rewriter, loc);
+  triton::amdgpu::ClusterBarrierWaitOp::create(rewriter, loc);
 }
 
 void TargetInfo::warpSync(Location loc, RewriterBase &rewriter) const {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -37,6 +37,7 @@ public:
 
   void barrier(Location loc, RewriterBase &rewriter,
                triton::gpu::AddrSpace targets) const override;
+  void clusterBarrier(Location loc, RewriterBase &rewriter) const override;
 
   void warpSync(Location loc, RewriterBase &rewriter) const override;
 

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h
@@ -10,8 +10,8 @@ namespace NVIDIA {
 
 /// Return true if we can skip a barrier synchronization between two operations
 /// even if they access the same shared memory.
-bool canSkipBarSync(Operation *before, Operation *after,
-                    Allocation *allocation);
+bool canSkipBarSync(Operation *before, Operation *after, bool beforeIsRead,
+                    bool afterIsRead, Allocation *allocation);
 } // namespace NVIDIA
 } // namespace triton
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
@@ -56,11 +56,18 @@ static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   srcLayout = actionRemoveBroadcastedRegs(srcLayout).apply(srcLayout);
   dstLayout = actionRemoveBroadcastedRegs(dstLayout).apply(dstLayout);
   auto bitwidth = getBitwidth(srcTy);
-  auto [srcTiles, dstTiles] = gpu::getSrcDstTiles(targetInfo, bitwidth);
+  auto kBlock = StringAttr::get(ctx, "block");
+  bool crossCTA =
+      !dstLayout.invertAndCompose(srcLayout).isTrivialOver({kBlock});
+  auto [srcTiles, dstTiles] =
+      gpu::getSrcDstTiles(targetInfo, bitwidth, crossCTA);
   auto [smem, _] = triton::gpu::optimalSwizzling(srcLayout, dstLayout, srcTiles,
                                                  dstTiles, bitwidth);
   auto reps = smem.getInDimSize(StringAttr::get(ctx, "reps"));
-  return smem.getTotalOutDimSizeProduct() / reps;
+  // The smem has the same cta layout as the srcLayout, so we use that instead
+  // We remove the number of elements that are duplicated in the cta layout
+  auto nBlocks = product(triton::gpu::getCTASplitNum(srcTy.getEncoding()));
+  return smem.getTotalOutDimSizeProduct() / (reps * nBlocks);
 }
 
 std::function<unsigned(Operation *)>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -31,9 +31,6 @@ struct ConvertLayoutOpSwizzlingConversion
   LogicalResult
   matchAndRewrite(ConvertLayoutOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    MLIRContext *ctx = op.getContext();
-
-    const auto &shape = op.getType().getShape();
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
@@ -45,23 +42,10 @@ struct ConvertLayoutOpSwizzlingConversion
     LinearLayout srcLayout = toLinearLayout(srcTy);
     LinearLayout dstLayout = toLinearLayout(dstTy);
 
-    StringAttr kBlock = str_attr("block");
-    StringAttr kWarp = str_attr("warp");
-    StringAttr kLane = str_attr("lane");
-    StringAttr kReg = str_attr("register");
-
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));
-    auto dims = conversion.getInDimNames();
-    if (!llvm::is_contained(dims, kBlock) && !cvtAlwaysUseWarpShuffle(op) &&
-        cvtNeedsSharedMemory(srcTy, dstTy)) {
+    if (!cvtAlwaysUseWarpShuffle(op) && cvtNeedsSharedMemory(srcTy, dstTy)) {
       auto loc = op.getLoc();
-      // Remove the kBlock dimension from the layout as it's the identity in the
-      // cvt
-      srcLayout = srcLayout.sublayout({kReg, kLane, kWarp},
-                                      to_vector(srcLayout.getOutDimNames()));
-      dstLayout = dstLayout.sublayout({kReg, kLane, kWarp},
-                                      to_vector(dstLayout.getOutDimNames()));
 
       auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
       auto smemBase = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo,
@@ -137,13 +121,18 @@ struct ConvertLayoutOpSwizzlingConversion
     // At this point we have a type that's at least 8-bit
     // and we don't have broadcasting in the registers
     auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
-    auto [srcTiles, dstTiles] = getSrcDstTiles(targetInfo, bitwidth);
+    auto kBlock = str_attr("block");
+    bool crossCTA =
+        !dstLayout.invertAndCompose(srcLayout).isTrivialOver({kBlock});
+    auto [srcTiles, dstTiles] = getSrcDstTiles(targetInfo, bitwidth, crossCTA);
     auto [smem, instr] =
         optimalSwizzling(srcLayout, dstLayout, srcTiles, dstTiles, bitwidth);
     auto [idxSrc, idxDst] = instr;
 
     // Extract reps from smem
     auto kReg = str_attr("register");
+    auto kLane = str_attr("lane");
+    auto kWarp = str_attr("warp");
     auto kReps = str_attr("reps");
     auto nReps = smem.getInDimSize(kReps);
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
@@ -165,8 +154,16 @@ struct ConvertLayoutOpSwizzlingConversion
     auto storeCvt = *divideRight(totalStoreCvt, reps);
     auto loadCvt = *divideRight(totalLoadCvt, reps);
     auto kOffset = str_attr("offset");
-    storeCvt = storeCvt.reshapeOuts({{kOffset, storeCvt.getTotalOutDimSize()}});
-    loadCvt = loadCvt.reshapeOuts({{kOffset, loadCvt.getTotalOutDimSize()}});
+    auto nBlock = storeCvt.getInDimSize(kBlock);
+    storeCvt = storeCvt.reshapeOuts(
+        {{kOffset, storeCvt.getTotalOutDimSize() / nBlock}, {kBlock, nBlock}});
+    loadCvt = loadCvt.reshapeOuts(
+        {{kOffset, loadCvt.getTotalOutDimSize() / nBlock}, {kBlock, nBlock}});
+
+    // We never do cross-CTA writes by construction. We may do cross-CTA reads,
+    // but in that case we lower to ld.shared/st.shared
+    assert(storeCvt.isTrivialOver({kBlock}));
+    assert(loadCvt.isTrivialOver({kBlock}) || idxDst == 0);
 
     auto tileSize = storeCvt.getInDimSize(kReg);
 
@@ -174,16 +171,25 @@ struct ConvertLayoutOpSwizzlingConversion
     SmallVector<Value> outVals;
     auto affineOffset = b.i32_val(0);
     auto maskSpanAffineOffset = 0;
-    bool isWarpSync = mlir::isCvtWarpSync(srcLayout, dstLayout);
-    for (int i = 0; i < nReps; ++i) {
-      if (i > 0) {
-        if (isWarpSync) {
-          targetInfo.warpSync(loc, rewriter);
-        } else {
-          targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
-        }
+    bool isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
+    bool isBlockSync = mlir::isCvtDimSync(srcLayout, dstLayout, kBlock);
+    auto emitBarrier = [&]() {
+      if (isWarpSync) {
+        targetInfo.warpSync(loc, rewriter);
+      } else if (isBlockSync) {
+        targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+      } else {
+        targetInfo.clusterBarrier(loc, rewriter);
       }
-
+    };
+    auto dropBlock = [&](const LinearLayout &cvt) {
+      SmallVector<StringAttr> inDims = {kReg, kLane, kWarp};
+      SmallVector<StringAttr> outDims = {kOffset};
+      return cvt.sublayout(inDims, outDims);
+    };
+    for (int i = 0; i < nReps; ++i) {
+      if (i > 0)
+        emitBarrier();
       auto tileInVals =
           to_vector(ArrayRef(permutedInVals).slice(i * tileSize, tileSize));
       // Store
@@ -195,16 +201,13 @@ struct ConvertLayoutOpSwizzlingConversion
       } else {
         assert(idxSrc == 1 || idxSrc == 2);
         bool transpose = idxSrc == 2;
+        auto storeCvtNoBlock = dropBlock(storeCvt);
         auto result = lowerLdStMatrix(
-            loc, storeCvt, transpose, tileInVals, smemBase, affineOffset,
+            loc, storeCvtNoBlock, transpose, tileInVals, smemBase, affineOffset,
             maskSpanAffineOffset, llvmElemTy, rewriter, targetInfo);
         assert(succeeded(result));
       }
-      if (isWarpSync) {
-        targetInfo.warpSync(loc, rewriter);
-      } else {
-        targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
-      }
+      emitBarrier();
       // Load
       SmallVector<Value> tileOutVals;
       // idxDst 0: ld.shared, idxDst 1: ldmatrix, idxDst 2: ldmatrix.trans
@@ -215,8 +218,9 @@ struct ConvertLayoutOpSwizzlingConversion
       } else {
         assert(idxDst == 1 || idxDst == 2);
         bool transpose = idxDst == 2;
+        auto loadCvtNoBlock = dropBlock(loadCvt);
         auto result = lowerLdStMatrix(
-            loc, loadCvt, transpose, tileOutVals, smemBase, affineOffset,
+            loc, loadCvtNoBlock, transpose, tileOutVals, smemBase, affineOffset,
             maskSpanAffineOffset, llvmElemTy, rewriter, targetInfo);
         assert(succeeded(result));
       }
@@ -227,127 +231,29 @@ struct ConvertLayoutOpSwizzlingConversion
     outVals = permLoad.inverse().apply(outVals);
     return outVals;
   }
-};
-
-struct ConvertLayoutOpConversion
-    : public ConvertOpToLLVMPattern<triton::gpu::ConvertLayoutOp> {
-public:
-  ConvertLayoutOpConversion(const LLVMTypeConverter &typeConverter,
-                            const NVIDIA::TargetInfo &targetInfo,
-                            PatternBenefit benefit = 1)
-      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
-  }
 
   LogicalResult
-  matchAndRewrite(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    RankedTensorType srcTy = op.getSrc().getType();
-    RankedTensorType dstTy = op.getType();
-    Attribute srcLayout = srcTy.getEncoding();
-    Attribute dstLayout = dstTy.getEncoding();
-    if (isa<MmaEncodingTrait, BlockedEncodingAttr, SliceEncodingAttr>(
-            srcLayout) &&
-        isa<MmaEncodingTrait, BlockedEncodingAttr, SliceEncodingAttr>(
-            dstLayout)) {
-      if (shouldUseDistSmem(srcLayout, dstLayout))
-        return lowerDistToDistWithDistSmem(op, adaptor, rewriter, targetInfo);
-    }
-
-    return failure();
-  }
-
-private:
-  LogicalResult
-  lowerDistToDistWithDistSmem(triton::gpu::ConvertLayoutOp op,
-                              OpAdaptor adaptor,
-                              ConversionPatternRewriter &rewriter,
-                              const NVIDIA::TargetInfo &targetInfo) const {
-    MLIRContext *ctx = rewriter.getContext();
+  transferWithinBlockSwizzling(ConvertLayoutOp op, Value src,
+                               ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto typeConverter = getTypeConverter();
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
-    auto srcLayout = srcTy.getEncoding();
-    auto dstLayout = dstTy.getEncoding();
-    auto srcShapePerCTA = getShapePerCTA(srcTy);
-    auto srcCTAsPerCGA = triton::gpu::getCTAsPerCGA(srcLayout);
-    auto srcCTAOrder = triton::gpu::getCTAOrder(srcLayout);
-    unsigned rank = srcShapePerCTA.size();
 
-    auto llvmElemTy = typeConverter->convertType(dstTy.getElementType());
-    auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
+    auto srcLayout = toLinearLayout(srcTy);
+    auto dstLayout = toLinearLayout(dstTy);
 
-    Value smemBase =
+    auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
+    auto smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
-    smemBase = b.bitcast(smemBase, elemPtrTy);
-    auto smemShape = convertType<unsigned, int64_t>(srcShapePerCTA);
+    auto inVals = unpackLLElements(loc, src, rewriter);
+    auto outVals = transferWithinBlockSwizzling(
+        loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase);
 
-    // Store to local shared memory
-    {
-      auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-      auto inIndices = emitIndices(loc, rewriter, targetInfo, srcLayout, srcTy,
-                                   /*withCTAOffset*/ false);
-
-      assert(inIndices.size() == inVals.size() &&
-             "Unexpected number of indices emitted");
-
-      for (unsigned i = 0; i < inIndices.size(); ++i) {
-        Value offset = LLVM::linearize(rewriter, loc, inIndices[i], smemShape);
-        Value ptr = b.gep(elemPtrTy, llvmElemTy, smemBase, offset);
-        b.store(inVals[i], ptr);
-      }
-    }
-
-    // Cluster barrier
-    triton::nvidia_gpu::ClusterArriveOp::create(rewriter, loc, false);
-    triton::nvidia_gpu::ClusterWaitOp::create(rewriter, loc);
-
-    // Load from remote shared memory
-    {
-      SmallVector<Value> srcShapePerCTACache;
-      for (unsigned i = 0; i < rank; ++i)
-        srcShapePerCTACache.push_back(b.i32_val(srcShapePerCTA[i]));
-
-      SmallVector<Value> outVals;
-      auto outIndices = emitIndices(loc, rewriter, targetInfo, dstLayout, dstTy,
-                                    /*withCTAOffset*/ true);
-
-      for (unsigned i = 0; i < outIndices.size(); ++i) {
-        auto coord = outIndices[i];
-        assert(coord.size() == rank && "Unexpected rank of index emitted");
-
-        SmallVector<Value> multiDimCTAId, localCoord;
-        for (unsigned d = 0; d < rank; ++d) {
-          multiDimCTAId.push_back(b.udiv(coord[d], srcShapePerCTACache[d]));
-          localCoord.push_back(b.urem(coord[d], srcShapePerCTACache[d]));
-        }
-
-        Value remoteCTAId = LLVM::linearize(rewriter, loc, multiDimCTAId,
-                                            srcCTAsPerCGA, srcCTAOrder);
-        Value localOffset =
-            LLVM::linearize(rewriter, loc, localCoord, smemShape);
-
-        Value ptr = b.gep(elemPtrTy, llvmElemTy, smemBase, localOffset);
-        outVals.push_back(targetInfo.loadDShared(rewriter, loc, ptr,
-                                                 remoteCTAId, llvmElemTy,
-                                                 /*pred=*/b.true_val()));
-      }
-
-      Value result =
-          packLLElements(loc, typeConverter, outVals, rewriter, dstTy);
-      rewriter.replaceOp(op, result);
-    }
-
-    // Cluster barrier
-    triton::nvidia_gpu::ClusterArriveOp::create(rewriter, loc, false);
-    triton::nvidia_gpu::ClusterWaitOp::create(rewriter, loc);
-
+    Value result =
+        packLLElements(loc, getTypeConverter(), outVals, rewriter, dstTy);
+    rewriter.replaceOp(op, result);
     return success();
   }
-
-private:
-  const NVIDIA::TargetInfo &targetInfo;
 };
 
 } // namespace
@@ -355,10 +261,10 @@ private:
 void mlir::triton::NVIDIA::populateConvertLayoutOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, const TargetInfo &targetInfo,
     RewritePatternSet &patterns, PatternBenefit benefit) {
-  // Give this convertLayoutOpConversion a higher benefit as it only matches
-  // optimized or cross CTA cases
-  patterns.add<ConvertLayoutOpConversion, ConvertLayoutOpSwizzlingConversion>(
-      typeConverter, targetInfo, benefit.getBenefit() + 1);
+  // Give this convertLayoutOpSwizzlingConversion a higher benefit as it
+  // matches optimized ldmatrix/stmatrix cases
+  patterns.add<ConvertLayoutOpSwizzlingConversion>(typeConverter, targetInfo,
+                                                   benefit.getBenefit() + 1);
   mlir::triton::populateConvertLayoutOpToLLVMPatterns(typeConverter, targetInfo,
                                                       patterns, benefit);
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1150,7 +1150,9 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto emitCpAsync = [&b, threadPred, ptrTy, hasMask = bool(llMask)](
                            RewriterBase &rewriter, Location loc,
                            ArrayRef<Value> vals, Value shmemAddr, int startIdx,
-                           VectorType vecTy) -> SmallVector<Value> {
+                           VectorType vecTy,
+                           std::optional<Value> ctaId) -> SmallVector<Value> {
+      assert(!ctaId.has_value() && "cp.async does not support cross-cta loads");
       assert(isa<VectorType>(vecTy));
       auto *ctx = rewriter.getContext();
       auto elemTy = vecTy.getElementType();
@@ -1206,13 +1208,11 @@ struct AsyncCopyGlobalToLocalOpConversion
       return emitError(loc,
                        "cp.async does not support non-trivial block dimension");
     }
-    cvt = cvt.sublayout(
-        {str_attr("register"), str_attr("lane"), str_attr("warp")},
-        {str_attr("offset")});
     auto affineOffset = smemObj.getShmemOffset(loc, rewriter, dstTy);
     auto maskSpanAffineOffset = SharedMemoryObject::getMaskSpanOffsets(dstTy);
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-    lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemObj.getBase(),
+    SmallVector<Value> smemBases = {smemObj.getBase()};
+    lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemBases,
               /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset, laneId,
               warpId, rewriter, targetInfo, maxVec, emitCpAsync);
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -175,6 +175,7 @@ LogicalResult lowerLdStMatrix(
   }
   auto cvt = activeRegLayout.invertAndCompose(memLayout);
   auto kBlock = StringAttr::get(loc.getContext(), "block");
+  // ldmatrix/stmatrix does not support shared::cluster
   auto maybeSublayout = cvt.quotient({kBlock});
   if (!maybeSublayout) {
     return failure();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/NVPTXAddrSpace.h"
 
@@ -153,19 +154,42 @@ void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
   b.barrier(targets);
 }
 
+void TargetInfo::clusterBarrier(Location loc, RewriterBase &rewriter) const {
+  triton::nvidia_gpu::ClusterArriveOp::create(rewriter, loc, /*relaxed=*/false);
+  triton::nvidia_gpu::ClusterWaitOp::create(rewriter, loc);
+}
+
 void TargetInfo::warpSync(Location loc, RewriterBase &rewriter) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   NVVM::SyncWarpOp::create(rewriter, loc, b.i32_val(0xffffffff));
 }
 
+static bool isConstantTruePred(Value pred) {
+  if (auto constOp = pred.getDefiningOp<LLVM::ConstantOp>()) {
+    return cast<IntegerAttr>(constOp.getValue()).getInt() == -1;
+  }
+  return false;
+}
+
 static Value mapa(RewriterBase &rewriter, Location loc, Value ptr, Value ctaid,
                   Value pred) {
+  auto *ctx = rewriter.getContext();
+  auto clusterPtrTy = ptr_ty(ctx, /*addrspace=*/7);
+  if (isConstantTruePred(pred)) {
+    return NVVM::MapaOp::create(rewriter, loc, clusterPtrTy, ptr, ctaid);
+  }
+
+  PTXBuilder builder;
   auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
-  assert(ptrTy.getAddressSpace() == llvm::NVPTXAS::ADDRESS_SPACE_SHARED &&
-         "Invalid src llvm addr space for mapa");
-  MLIRContext *ctx = rewriter.getContext();
-  auto dsmPtrTy = ptr_ty(ctx, llvm::NVPTXAS::ADDRESS_SPACE_SHARED_CLUSTER);
-  return NVVM::MapaOp::create(rewriter, loc, dsmPtrTy, ptr, ctaid);
+  assert(ptrTy.getAddressSpace() == 3);
+
+  auto &mapaInstr = *builder.create("mapa");
+  mapaInstr.o("shared::cluster.u32");
+  auto *dstOpr = builder.newOperand("=r");
+  auto *ptrOpr = builder.newOperand(ptr, "r");
+  auto *ctaidOpr = builder.newOperand(ctaid, "r");
+  mapaInstr(dstOpr, ptrOpr, ctaidOpr).predicate(pred, "b");
+  return builder.launch(rewriter, loc, clusterPtrTy, /*hasSideEffect=*/false);
 }
 
 static std::string getConstraintForBitwidth(unsigned bitwidth) {
@@ -180,13 +204,6 @@ static std::string getConstraintForBitwidth(unsigned bitwidth) {
   default:
     llvm_unreachable("unsupported bitwidth");
   }
-}
-
-static bool isConstantTruePred(Value pred) {
-  if (auto constOp = pred.getDefiningOp<LLVM::ConstantOp>()) {
-    return cast<IntegerAttr>(constOp.getValue()).getInt() == -1;
-  }
-  return false;
 }
 
 void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
@@ -444,7 +461,7 @@ Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
 
   PTXBuilder builder;
   auto ld = builder.create("ld")
-                ->o("shared::cta", ctaId.has_value())
+                ->o("shared::cluster", ctaId.has_value())
                 .o("shared", !ctaId.has_value())
                 .v(vec, /*predicate=*/vec > 1)
                 .b(elemBitwidth);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -20,6 +20,7 @@ public:
 
   void barrier(Location loc, RewriterBase &rewriter,
                triton::gpu::AddrSpace targets) const override;
+  void clusterBarrier(Location loc, RewriterBase &rewriter) const override;
 
   void warpSync(Location loc, RewriterBase &rewriter) const override;
 
@@ -44,6 +45,12 @@ public:
   }
   bool supportLdStMatrixB8() const override {
     return targetFeatures.supportLdStMatrixB8();
+  }
+  bool supportBitwidth16Elementwise() const override {
+    return targetFeatures.supportBitwidth16Elementwise();
+  }
+  bool supportBitwidth32Elementwise() const override {
+    return targetFeatures.supportBitwidth32Elementwise();
   }
 
   Value shuffleXor(RewriterBase &rewriter, Location loc, Value val,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -18,6 +18,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 
 #include "Allocation.h"
 #include "PatternTritonGPUOpToLLVM.h"
@@ -99,6 +100,8 @@ struct ConvertTritonGPUToLLVM
     ModuleAllocation allocation(
         mod, mlir::triton::nvidia_gpu::getNvidiaAllocationAnalysisScratchSizeFn(
                  targetInfo));
+    mlir::triton::nvidia_gpu::runClusterBarrierInsertion(allocation,
+                                                         computeCapability);
     ModuleMembarAnalysis membarPass(&allocation, canSkipBarSync);
     membarPass.run();
     if (failed(maybeInsertClusterSync(mod))) {
@@ -507,6 +510,7 @@ createConvertTritonGPUToLLVMPass(int32_t computeCapability,
 }
 
 bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,
+                            bool /*beforeIsRead*/, bool /*afterIsRead*/,
                             Allocation *allocation) {
   // These mbarrier ops are single threaded, so are always synchronized wrt.
   // each other.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -227,7 +227,6 @@ LogicalResult lowerLdStMatrix(
   auto kReg = S("register");
   auto kLane = S("lane");
   auto kWarp = S("warp");
-  auto kBlock = S("block");
   auto kOffset = S("offset");
   auto kAddr = S("addr");
   auto smemPtrTy = ptr_ty(ctx, 3);
@@ -237,9 +236,6 @@ LogicalResult lowerLdStMatrix(
   if ((!transpose && bitwidth > 32) ||
       (transpose && !(bitwidth == 16 ||
                       (bitwidth == 8 && targetInfo.supportLdStMatrixB8()))))
-    return failure();
-  // Inter block stmatrix is not supported
-  if (cvt.hasInDim(kBlock))
     return failure();
 
   // Map onto offsets (contiguous part) and addr (non-contiguous part)

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -313,7 +313,8 @@ TEST_F(SwizzleTest, Test128x128Float8Transpose) {
   LinearLayout matrix(
       {{S("register"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {1, 0}, {2, 0}}},
        {S("lane"), {{0, 16}, {0, 32}, {0, 64}, {4, 0}, {8, 0}}},
-       {S("warp"), {{16, 0}, {32, 0}, {64, 0}}}},
+       {S("warp"), {{16, 0}, {32, 0}, {64, 0}}},
+       {S("block"), {}}},
       {{S("dim0"), 128}, {S("dim1"), 128}}, /*requireSurjective=*/true);
   auto matrix_t = transposeLinearLayout(matrix, {1, 0});
 
@@ -327,12 +328,14 @@ TEST_F(SwizzleTest, Test16x16Bf16BlockedMma) {
   // 16×16 bf16 MMA
   LinearLayout blocked({{S("register"), {{0, 1}, {0, 2}, {0, 4}}},
                         {S("lane"), {{0, 8}, {1, 0}, {2, 0}, {4, 0}, {8, 0}}},
-                        {S("warp"), {}}},
+                        {S("warp"), {}},
+                        {S("block"), {}}},
                        {{S("dim0"), 16}, {S("dim1"), 16}},
                        /*requireSurjective=*/true);
   LinearLayout mma({{S("register"), {{0, 1}, {8, 0}, {0, 8}}},
                     {S("lane"), {{0, 2}, {0, 4}, {1, 0}, {2, 0}, {4, 0}}},
-                    {S("warp"), {}}},
+                    {S("warp"), {}},
+                    {S("block"), {}}},
                    {{S("dim0"), 16}, {S("dim1"), 16}},
                    /*requireSurjective=*/true);
 
@@ -348,13 +351,15 @@ TEST_F(SwizzleTest, Test16x256U4Mma) {
       {{S("register"),
         {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {4, 0}, {8, 0}}},
        {S("lane"), {{0, 32}, {0, 64}, {0, 128}, {1, 0}, {2, 0}}},
-       {S("warp"), {}}},
+       {S("warp"), {}},
+       {S("block"), {}}},
       {{S("dim0"), 16}, {S("dim1"), 256}}, /*requireSurjective=*/true);
   LinearLayout mma(
       {{S("register"),
         {{0, 1}, {0, 2}, {0, 4}, {8, 0}, {0, 32}, {0, 64}, {0, 128}}},
        {S("lane"), {{0, 8}, {0, 16}, {1, 0}, {2, 0}, {4, 0}}},
-       {S("warp"), {}}},
+       {S("warp"), {}},
+       {S("block"), {}}},
       {{S("dim0"), 16}, {S("dim1"), 256}}, /*requireSurjective=*/true);
 
   auto smem = optimalSwizzlingLdSt(blocked, mma, /*bitwidth=*/4);
@@ -367,12 +372,14 @@ TEST_F(SwizzleTest, Test32x16F32Transpose) {
   // 32×16 f32 transpose
   LinearLayout matrix({{S("register"), {{4, 0}, {8, 0}, {16, 0}}},
                        {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {1, 0}}},
-                       {S("warp"), {{2, 0}}}},
+                       {S("warp"), {{2, 0}}},
+                       {S("block"), {}}},
                       {{S("dim0"), 32}, {S("dim1"), 16}},
                       /*requireSurjective=*/true);
   LinearLayout matrix_t({{S("register"), {{0, 2}, {0, 4}, {0, 8}}},
                          {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}}},
-                         {S("warp"), {{0, 1}}}},
+                         {S("warp"), {{0, 1}}},
+                         {S("block"), {}}},
                         {{S("dim0"), 32}, {S("dim1"), 16}},
                         /*requireSurjective=*/true);
   auto smem = optimalSwizzlingLdSt(matrix, matrix_t, /*bitwidth=*/32);
@@ -385,13 +392,15 @@ TEST_F(SwizzleTest, Test128x128F16Transpose) {
   LinearLayout matrix(
       {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {0, 32}, {0, 64}}},
        {S("lane"), {{8, 0}, {16, 0}, {32, 0}, {64, 0}, {0, 1}}},
-       {S("warp"), {{0, 2}, {0, 4}, {0, 8}, {0, 16}}}},
+       {S("warp"), {{0, 2}, {0, 4}, {0, 8}, {0, 16}}},
+       {S("block"), {}}},
       {{S("dim0"), 128}, {S("dim1"), 128}},
       /*requireSurjective=*/true);
   LinearLayout matrix_t(
       {{S("register"), {{0, 1}, {0, 2}, {0, 4}, {32, 0}, {64, 0}}},
        {S("lane"), {{0, 8}, {0, 16}, {0, 32}, {0, 64}, {1, 0}}},
-       {S("warp"), {{2, 0}, {4, 0}, {8, 0}, {16, 0}}}},
+       {S("warp"), {{2, 0}, {4, 0}, {8, 0}, {16, 0}}},
+       {S("block"), {}}},
       {{S("dim0"), 128}, {S("dim1"), 128}},
       /*requireSurjective=*/true);
   auto smem = optimalSwizzlingLdSt(matrix, matrix_t, /*bitwidth=*/16);


### PR DESCRIPTION
Summary:

**Context:**
D109373532 v1 was accepted as the conflict-baseline version of this upstream Triton reactor bundle. This commit recreates that payload as one resolved, buildable diff owned by this stack so the landing path does not depend on publishing another version of the accepted baseline diff.

**Motivation:**
The upstream bundle touches layout conversion, reduction lowering, membar analysis, load/store lowering, and related tests. Keeping the upstream changes plus the beta-specific conflict resolutions in one fresh diff simplifies review and landing while preserving the original backport metadata.

**This diff:**
- Cherry-picks upstream Triton PRs #9220, #9221, #9317, #9318, and #9327 into `third-party/triton/beta/triton`.
- Keeps beta's special local-barrier handling in Membar analysis.
- Preserves beta's `inner_tree` reduction behavior as a separate `ReduceOpToLLVM` path while using the upstream reduction lowering whenever `inner_tree` is not selected.
- Keeps the helper support needed for `inner_tree` while otherwise aligning Utility and Allocation handling with the upstream implementation.
- Applies upstream ConvertLayout handling in the generic and NVIDIA lowerings.
- Resolves `python/test/gluon/test_lowerings.py` by selecting the upstream test options.
- Carries the accepted v1 reactor backport metadata from D109373532.

Upstream PRs:
https://github.com/triton-lang/triton/pull/9220
https://github.com/triton-lang/triton/pull/9221
https://github.com/triton-lang/triton/pull/9317
https://github.com/triton-lang/triton/pull/9318
https://github.com/triton-lang/triton/pull/9327

***Do not remove the following lines from this commit***
Reactor Backport Revision: b5e3800aec693eed012da1574c0e95edb20655eb
Reactor Backport Revision: bb75a870803727d80bb1900a59b26500f18fec16
Reactor Backport Revision: c155e4a5084cca4e95332a573e1af3284667fd17
Reactor Backport Revision: 05fc47ffacf0523ad043e81d77198ab21fd23f23
Reactor Backport Revision: 03d956b49fc7df83254aebd9848bd1697d6351ec

Reviewed By: dshi7

Differential Revision: D109662150
