### PR TITLE
 [AutoWS] Support dynamic persistent GEMM in AutoWS (#1879)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -163,14 +163,29 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
   // Because the partition region is isolated from above, we could in theory
   // compile it to PTX and read the number of registers that got allocated.
   SmallVector<unsigned> maxTensorRegs;
+  // Whether a partition contains any tensor at all (including single-element
+  // ones). This gates layout relayout when the warp count changes, and is kept
+  // separate from the register-budget estimate below: a single-element tensor
+  // (e.g. the scalar broadcast AutoWS synthesizes for a dynamic-persistent tile
+  // id) must be relayouted if its partition's warps change, but must NOT
+  // reclassify an otherwise non-tensor partition into the tensor register
+  // class.
+  SmallVector<bool> partitionHasTensor;
   for (Region *partition : wsOp.getPartitionRegions()) {
     unsigned &tensorRegs = maxTensorRegs.emplace_back(0);
+    bool &hasTensor = partitionHasTensor.emplace_back(false);
 
     partition->walk([&](Operation *op) {
       for (Type type :
            llvm::concat<Type>(op->getOperandTypes(), op->getResultTypes())) {
-        if (auto tensor = dyn_cast<RankedTensorType>(type))
+        if (auto tensor = dyn_cast<RankedTensorType>(type)) {
+          hasTensor = true;
+          // A single-element tensor is logically a scalar and carries no
+          // meaningful tensor register footprint, so ignore it for the budget.
+          if (tensor.getNumElements() <= 1)
+            continue;
           tensorRegs = std::max(tensorRegs, getTensorNumI32Regs(tensor));
+        }
       }
     });
     // Assume that the largest tensor accounts for half of the registers used
@@ -293,9 +308,10 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
   int maxRegAutoWS = hasMax ? maxRegAttr.getInt() : -1;
 
   SmallVector<int32_t> estRegUsage(partitionNumWarps.size());
-  for (auto [partition, newNumWarps, prevNumWarps, tensorRegs, estRegs] :
-       llvm::zip(wsOp.getPartitionRegions(), partitionNumWarps,
-                 wsOp.getPartitionNumWarps(), maxTensorRegs, estRegUsage)) {
+  for (auto [partition, newNumWarps, prevNumWarps, tensorRegs, hasTensor,
+             estRegs] : llvm::zip(wsOp.getPartitionRegions(), partitionNumWarps,
+                                  wsOp.getPartitionNumWarps(), maxTensorRegs,
+                                  partitionHasTensor, estRegUsage)) {
     // When both min and max are provided, use the current heuristic.
     // When only min is provided (the default), tensor partitions get -1
     // (sentinel for "split leftover evenly") while non-tensor partitions
@@ -303,9 +319,10 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
     estRegs = hasMax ? (tensorRegs ? maxRegAutoWS : minRegAutoWS)
                      : (tensorRegs ? -1 : minRegAutoWS);
 
-    // Layouts need to be reassigned if the number of warps changed and there
-    // are tensor computations.
-    if (newNumWarps == prevNumWarps || !tensorRegs)
+    // Layouts need to be reassigned if the number of warps changed and the
+    // partition contains any tensor (even a single-element broadcast tensor,
+    // which is excluded from tensorRegs above but still needs relayout).
+    if (newNumWarps == prevNumWarps || !hasTensor)
       continue;
     // We need to reassign layouts.
     if (failed(relayoutWarps(axisInfo, partition, prevNumWarps, newNumWarps,

--- a/python/src/passes.h
+++ b/python/src/passes.h
@@ -52,3 +52,10 @@
                  ty3 val3, ty4 val4, ty5 val5) {                               \
     pm.addPass(builder({val0, val1, val2, val3, val4, val5}));                 \
   })
+
+#define ADD_PASS_OPTION_WRAPPER_7(name, builder, ty0, ty1, ty2, ty3, ty4, ty5, \
+                                  ty6)                                         \
+  m.def(name, [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2,          \
+                 ty3 val3, ty4 val4, ty5 val5, ty6 val6) {                     \
+    pm.addPass(builder({val0, val1, val2, val3, val4, val5, val6}));           \
+  })

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -215,6 +215,64 @@ def matmul_kernel_tma_static_persistent_ws_while(
 
 
 # ============================================================================
+# Kernel 2c: matmul_kernel_tma_dynamic_persistent_ws_while
+# Dynamic (work-stealing) persistent TMA matmul whose persistent outer loop is a
+# while loop. Each CTA starts at its program id, then grabs the next tile from a
+# global counter via atomic_add (no constant per-CTA increment), so tiles are
+# distributed dynamically rather than statically strided by NUM_SMS.
+# ============================================================================
+@triton.jit
+def matmul_kernel_tma_dynamic_persistent_ws_while(
+    a_desc,
+    b_desc,
+    c_desc,
+    tile_counter,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    dtype = tl.float16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    # Each CTA seeds its first tile with its program id; subsequent tiles are
+    # claimed dynamically from the shared counter (initialized to NUM_SMS).
+    tile_id = start_pid
+
+    while tile_id < num_tiles:
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in tl.range(k_tiles, warp_specialize=True):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        acc_slices = _split_n_2D(accumulator, EPILOGUE_SUBTILE)
+        slice_size: tl.constexpr = BLOCK_SIZE_N // EPILOGUE_SUBTILE
+        for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
+            c_desc.store(
+                [offs_am, offs_bn + slice_id * slice_size],
+                acc_slices[slice_id].to(dtype),
+            )
+        # Dynamically claim the next tile (work stealing): no constant increment.
+        tile_id = tl.atomic_add(tile_counter, 1)
+
+
+# ============================================================================
 # Kernel 3: matmul_kernel_descriptor_persistent - Device-side TMA descriptors
 # Uses warp_specialize with flatten in outer tile loop
 # ============================================================================
@@ -663,7 +721,7 @@ def test_tutorial09_matmul_tma_persistent_warp_specialize(
 # ============================================================================
 # Test 2b: Static persistent matmul with a while-loop outer loop
 # ============================================================================
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
 def test_tutorial09_matmul_tma_static_persistent_while_loop_warp_specialize(EPILOGUE_SUBTILE):
     """Test a static persistent matmul whose persistent outer loop is a while loop."""
@@ -721,9 +779,86 @@ def test_tutorial09_matmul_tma_static_persistent_while_loop_warp_specialize(EPIL
         ttgir = kernel.asm["ttgir"]
         assert "scf.while" in ttgir, "Expected persistent outer loop to lower to scf.while"
         assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
-        assert "ttng.tc_gen5_mma" in ttgir, "Expected Blackwell MMA instruction"
+        # Blackwell lowers to tcgen5 MMA; Hopper lowers to wgmma (warp_group_dot).
+        assert ("ttng.tc_gen5_mma" in ttgir or "ttng.warp_group_dot" in ttgir), "Expected an MMA instruction"
         assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
         assert "ttng.clc_" not in ttgir, "Expected static persistent scheduling, not CLC"
+
+        ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
+        torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
+
+
+# ============================================================================
+# Test 2c: Dynamic (work-stealing) persistent matmul with a while-loop outer loop
+# ============================================================================
+@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
+@pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
+def test_tutorial09_matmul_tma_dynamic_persistent_while_loop_warp_specialize(EPILOGUE_SUBTILE):
+    """Dynamic persistent matmul: the while-loop tile id is claimed via atomic_add."""
+    M, N, K = 2048, 2048, 256
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 128
+    BLOCK_SIZE_K = 64
+    GROUP_SIZE_M = 8
+    num_stages = 3
+    num_warps = 4
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+
+        dtype = torch.float16
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        device = "cuda"
+
+        torch.manual_seed(42)
+        A = torch.randn((M, K), dtype=dtype, device=device)
+        B = torch.randn((N, K), dtype=dtype, device=device)
+        C = torch.empty((M, N), dtype=dtype, device=device)
+        # Shared work counter: CTAs claim initial tiles 0..NUM_SMS-1 by program id,
+        # then atomically claim NUM_SMS, NUM_SMS+1, ... so the counter starts at
+        # NUM_SMS.
+        tile_counter = torch.full((1, ), NUM_SMS, dtype=torch.int32, device=device)
+
+        def alloc_fn(size, align, stream):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        a_desc = TensorDescriptor(A, A.shape, A.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        b_desc = TensorDescriptor(B, B.shape, B.stride(), [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor(C, C.shape, C.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_N // EPILOGUE_SUBTILE])
+
+        grid = lambda META: (min(
+            NUM_SMS,
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        ), )
+
+        kernel = matmul_kernel_tma_dynamic_persistent_ws_while[grid](
+            a_desc,
+            b_desc,
+            c_desc,
+            tile_counter,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
+            NUM_SMS=NUM_SMS,
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+
+        ttgir = kernel.asm["ttgir"]
+        assert "scf.while" in ttgir, "Expected persistent outer loop to lower to scf.while"
+        assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
+        # Blackwell lowers to tcgen5 MMA; Hopper lowers to wgmma (warp_group_dot).
+        assert ("ttng.tc_gen5_mma" in ttgir or "ttng.warp_group_dot" in ttgir), "Expected an MMA instruction"
+        assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
+        assert "atomic" in ttgir, "Expected an atomic op driving the dynamic tile id"
+        assert "ttng.clc_" not in ttgir, "Expected dynamic atomic scheduling, not CLC"
 
         ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
         torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -554,6 +554,9 @@ class nvidia_knobs(base_knobs):
     libdevice_path: env_opt_str = env_opt_str("TRITON_LIBDEVICE_PATH")
     libcuda_path: env_opt_str = env_opt_str("TRITON_LIBCUDA_PATH")
     use_meta_ws: env_bool = env_bool("TRITON_USE_META_WS")
+    # Number of buffers for the dynamic-persistent tile-id broadcast channel
+    # (cross-partition run-once atomic support). 1 = single-stage.
+    ws_tile_prefetch_depth: env_int = env_int("TRITON_WS_TILE_PREFETCH_DEPTH", 1)
     use_modulo_schedule: env_opt_str = env_opt_str("TRITON_USE_MODULO_SCHEDULE")
     use_llm_schedule: env_bool = env_bool("TRITON_USE_LLM_SCHEDULE")
     disable_wsbarrier_reorder: env_bool = env_bool("TRITON_DISABLE_WSBARRIER_REORDER")

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject.mlir
@@ -1,0 +1,88 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s
+
+// Case 3 (graceful reject): the persistent scf.while's tile counter is claimed
+// by a NON-scalar (scatter) tt.atomic_rmw replicated across partitions. AutoWS
+// cannot broadcast a data-dependent scatter, so it must bail out of warp
+// specialization and leave a plain, compilable (non-WS) kernel: no
+// ttg.warp_specialize op and no leftover partition ids / async_task_ids.
+
+// CHECK-LABEL: @reject_scatter_atomic
+// CHECK-NOT: ttg.warp_specialize
+// CHECK-NOT: async_task_id
+// CHECK-NOT: ttg.partition
+// The unsupported atomic itself is preserved (kernel still compiles).
+// CHECK: tt.atomic_rmw
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#b1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reject_scatter_atomic(%arg0: !tt.tensordesc<tensor<128x64xf16, #shared>>, %arg5: !tt.tensordesc<tensor<128x64xf16, #shared>>, %arg10: !tt.tensordesc<tensor<128x128xf16, #shared>>, %arg15: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg16, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg17, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg18, %c63_i32 : i32
+    %6 = arith.divsi %5, %c64_i32 : i32
+    %7 = arith.muli %2, %4 : i32
+    %8 = arith.muli %4, %c8_i32 : i32
+    %9 = scf.while (%arg19 = %0) : (i32) -> i32 {
+      %10 = arith.cmpi slt, %arg19, %7 : i32
+      scf.condition(%10) %arg19 : i32
+    } do {
+    ^bb0(%arg19: i32):
+      %10 = arith.divsi %arg19, %8 : i32
+      %11 = arith.muli %10, %c8_i32 : i32
+      %12 = arith.subi %2, %11 : i32
+      %13 = arith.minsi %12, %c8_i32 : i32
+      %14 = arith.remsi %arg19, %13 : i32
+      %15 = arith.addi %11, %14 : i32
+      %16 = arith.remsi %arg19, %8 : i32
+      %17 = arith.divsi %16, %13 : i32
+      %18 = arith.muli %15, %c128_i32 : i32
+      %19 = arith.muli %17, %c128_i32 : i32
+      %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %20 = ttng.tmem_store %cst, %result[%token], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %21:2 = scf.for %arg20 = %c0_i32 to %6 step %c1_i32 iter_args(%arg21 = %false, %arg22 = %20) -> (i1, !ttg.async.token)  : i32 {
+        %27 = arith.muli %arg20, %c64_i32 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
+        %28 = tt.descriptor_load %arg0[%18, %27] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+        %29 = ttg.local_alloc %28 {loop.cluster = 0 : i32, loop.stage = 2 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %30 = tt.descriptor_load %arg5[%19, %27] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+        %31 = ttg.local_alloc %30 {loop.cluster = 0 : i32, loop.stage = 2 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %32 = ttg.memdesc_trans %31 {loop.cluster = 0 : i32, loop.stage = 2 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+        %33 = ttng.tc_gen5_mma %29, %32, %result[%arg22], %arg21, %true {loop.cluster = 0 : i32, loop.stage = 2 : i32, tt.self_latency = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %true, %33 : i1, !ttg.async.token
+      } {tt.scheduled_max_stage = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm", "load"], ttg.warp_specialize.tag = 0 : i32}
+      %result_0, %token_1 = ttng.tmem_load %result[%21#1] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %22 = arith.truncf %result_0 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+      %23 = ttg.convert_layout %22 {ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<128x128xf16, #blocked1>
+      %24 = ttg.local_alloc %23 {ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %25 = ttng.async_tma_copy_local_to_global %arg10[%18, %19] %24 {ttg.partition = array<i32: 0>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %25   {ttg.partition = array<i32: 0>} : !ttg.async.token
+      // Scatter atomic: non-scalar (tensor of pointers) -> unsupported -> reject.
+      %pt = tt.splat %arg15 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>, #b1>
+      %vt = tt.splat %c1_i32 : i32 -> tensor<1xi32, #b1>
+      %mt = tt.splat %true : i1 -> tensor<1xi1, #b1>
+      %scatter = tt.atomic_rmw add, acq_rel, gpu, %pt, %vt, %mt : (tensor<1x!tt.ptr<i32>, #b1>, tensor<1xi32, #b1>, tensor<1xi1, #b1>) -> tensor<1xi32, #b1>
+      %next_tile = tt.unsplat %scatter : tensor<1xi32, #b1>
+      scf.yield %next_tile : i32
+    }
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_transform.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_transform.mlir
@@ -1,0 +1,96 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448 tile-prefetch-depth=2" | FileCheck %s --check-prefix=DEPTH2
+
+// Case 2 (transform): a dynamic-persistent matmul whose persistent scf.while
+// claims its next tile via a scalar, loop-carried tt.atomic_rmw replicated to
+// every partition. AutoWS must run the atomic ONCE (in the load/owner
+// partition) and broadcast its result to every partition through an SMEM slot
+// (splat -> local_store -> local_load -> tt.unsplat), instead of cloning the
+// side-effecting atomic into all three partitions (which would make each warp
+// group claim a different tile and deadlock).
+
+// CHECK-LABEL: @matmul_kernel_tma_dynamic_persistent_ws_while
+// CHECK: ttg.warp_specialize
+// The atomic is not cloned per partition: exactly one tt.atomic_rmw survives,
+// tagged with a single owner partition, and its scalar result is broadcast.
+// CHECK-COUNT-1: tt.atomic_rmw
+// CHECK-NOT: tt.atomic_rmw
+// CHECK: tt.unsplat
+
+// tile-prefetch-depth=2 multi-buffers the tile-id broadcast channel: the
+// single-element broadcast slot is pinned to a 2-deep SMEM buffer
+// (memdesc<2x1xi32>), letting the owner publish tile ids ahead of the slower
+// consumer partitions. Warp specialization and the run-once atomic broadcast
+// (tt.unsplat) are otherwise unchanged.
+// DEPTH2: memdesc<2x1xi32
+// DEPTH2: ttg.warp_specialize
+// DEPTH2-COUNT-1: tt.atomic_rmw
+// DEPTH2: tt.unsplat
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel_tma_dynamic_persistent_ws_while(%arg0: !tt.tensordesc<tensor<128x64xf16, #shared>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<tensor<128x64xf16, #shared>>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<tensor<128x128xf16, #shared>>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg16, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg17, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg18, %c63_i32 : i32
+    %6 = arith.divsi %5, %c64_i32 : i32
+    %7 = arith.muli %2, %4 : i32
+    %8 = arith.muli %4, %c8_i32 : i32
+    %9 = scf.while (%arg19 = %0) : (i32) -> i32 {
+      %10 = arith.cmpi slt, %arg19, %7 : i32
+      scf.condition(%10) %arg19 : i32
+    } do {
+    ^bb0(%arg19: i32):
+      %10 = arith.divsi %arg19, %8 : i32
+      %11 = arith.muli %10, %c8_i32 : i32
+      %12 = arith.subi %2, %11 : i32
+      %13 = arith.minsi %12, %c8_i32 : i32
+      %14 = arith.remsi %arg19, %13 : i32
+      %15 = arith.addi %11, %14 : i32
+      %16 = arith.remsi %arg19, %8 : i32
+      %17 = arith.divsi %16, %13 : i32
+      %18 = arith.muli %15, %c128_i32 : i32
+      %19 = arith.muli %17, %c128_i32 : i32
+      %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %20 = ttng.tmem_store %cst, %result[%token], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %21:2 = scf.for %arg20 = %c0_i32 to %6 step %c1_i32 iter_args(%arg21 = %false, %arg22 = %20) -> (i1, !ttg.async.token)  : i32 {
+        %27 = arith.muli %arg20, %c64_i32 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
+        %28 = tt.descriptor_load %arg0[%18, %27] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+        %29 = ttg.local_alloc %28 {loop.cluster = 0 : i32, loop.stage = 2 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %30 = tt.descriptor_load %arg5[%19, %27] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>
+        %31 = ttg.local_alloc %30 {loop.cluster = 0 : i32, loop.stage = 2 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %32 = ttg.memdesc_trans %31 {loop.cluster = 0 : i32, loop.stage = 2 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+        %33 = ttng.tc_gen5_mma %29, %32, %result[%arg22], %arg21, %true {loop.cluster = 0 : i32, loop.stage = 2 : i32, tt.self_latency = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %true, %33 : i1, !ttg.async.token
+      } {tt.scheduled_max_stage = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm", "load"], ttg.warp_specialize.tag = 0 : i32}
+      %result_0, %token_1 = ttng.tmem_load %result[%21#1] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %22 = arith.truncf %result_0 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+      %23 = ttg.convert_layout %22 {ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<128x128xf16, #blocked1>
+      %24 = ttg.local_alloc %23 {ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %25 = ttng.async_tma_copy_local_to_global %arg10[%18, %19] %24 {ttg.partition = array<i32: 0>} : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %25   {ttg.partition = array<i32: 0>} : !ttg.async.token
+      %26 = tt.atomic_rmw add, acq_rel, gpu, %arg15, %c1_i32, %true : (!tt.ptr<i32>, i32, i1) -> i32
+      scf.yield %26 : i32
+    }
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -732,6 +732,7 @@ class CUDABackend(BaseBackend):
                 dump_enabled,
                 smem_budget,
                 generate_subtiled,
+                knobs.nvidia.ws_tile_prefetch_depth,
             )
             if not knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
@@ -782,6 +783,7 @@ class CUDABackend(BaseBackend):
                     dump_enabled,
                     smem_budget,
                     generate_subtiled,
+                    knobs.nvidia.ws_tile_prefetch_depth,
                 )
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_optimize_partition_warps(pm)

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -34,7 +34,11 @@ def NVGPUWarpSpecialization : Pass<"nvgpu-warp-specialization", "mlir::ModuleOp"
              "SMEM budget in bytes (0 = auto-detect from target)">,
     Option<"generateSubtiledRegion", "generate-subtiled-region",
              "bool", /*default*/"false",
-             "Generate SubtiledRegionOp from epilogue split patterns">
+             "Generate SubtiledRegionOp from epilogue split patterns">,
+    Option<"tilePrefetchDepth", "tile-prefetch-depth",
+             "int32_t", /*default*/"1",
+             "Number of buffers for the dynamic-persistent tile-id broadcast "
+             "channel (cross-partition run-once atomic support)">
     ];
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_triton_library(NVHopperTransforms
   MultiCTAReduction.cpp
   WarpSpecialization.cpp
   WarpSpecialization/CodePartitionUtility.cpp
+  WarpSpecialization/WSAtomicBroadcast.cpp
   WarpSpecialization/PingPong.cpp
   WarpSpecialization/TaskIdPropagation.cpp
   WarpSpecialization/TMEMAlloc1D.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -41,6 +41,9 @@ static LogicalResult cleanupWarpSpecializedLoops(Operation *op) {
 }
 
 int doTaskIdPropagate(triton::FuncOp &funcOp);
+// Cross-partition run-once atomic support. Returns failure() when an atomic
+// forces a graceful warp-specialization reject (kernel already de-specialized).
+LogicalResult doAtomicBroadcast(triton::FuncOp funcOp, int tilePrefetchDepth);
 LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
                               StringRef readDecisionFile = "",
                               StringRef writeDecisionFile = "",
@@ -114,12 +117,23 @@ public:
   // regions as WS regions and crashes when sibling ops in an scf.if/else aren't
   // tagged. Stripping everything ensures downstream sees a plain (non-WS) loop.
   void removeWarpSpecializeAttr(triton::FuncOp funcOp) {
-    funcOp->walk([&](scf::ForOp forOp) {
-      forOp->removeAttr(mlir::triton::kWarpSpecializeAttrName);
-      forOp->removeAttr(mlir::triton::gpu::kPartitionStagesAttrName);
-      forOp->removeAttr(mlir::triton::gpu::kWarpSpecializeTagAttrName);
-    });
+    auto stripLoop = [](Operation *loop) {
+      loop->removeAttr(mlir::triton::kWarpSpecializeAttrName);
+      loop->removeAttr(mlir::triton::gpu::kPartitionStagesAttrName);
+      loop->removeAttr(mlir::triton::gpu::kWarpSpecializeTagAttrName);
+      loop->removeAttr(kPartitionTypesAttrName);
+    };
+    funcOp->walk([&](scf::ForOp forOp) { stripLoop(forOp); });
+    funcOp->walk([&](scf::WhileOp whileOp) { stripLoop(whileOp); });
     funcOp->walk([&](Operation *op) {
+      // Strip both the partition id (`ttg.partition`) and the task id
+      // (`async_task_id`). The task id is only present once `doTaskIdPropagate`
+      // has run (e.g. the atomic-broadcast reject path bails after
+      // propagation); for the earlier bail-outs it simply does not exist yet
+      // and this is a no-op. Leaving either behind produces a half-tagged state
+      // that the downstream `tritongpu-pipeline` pass mis-treats as a WS
+      // region. Use the shared helper so the attr name lives in one place.
+      removeAsyncTaskIds(op);
       op->removeAttr(mlir::triton::gpu::kPartitionAttrName);
       op->removeAttr(mlir::triton::gpu::kPartitionOutputsAttrName);
     });
@@ -184,6 +198,27 @@ public:
     if (dumpIntermediateSteps) {
       llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
                       "doTaskIdPropagate\n";
+      moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
+      llvm::dbgs() << "\n\n\n";
+    }
+
+    // Cross-partition run-once atomic support: classify each side-effecting
+    // atomic and either pass it through (single-partition), transform it into a
+    // run-once + SMEM broadcast (all-partition scalar loop-carried counter), or
+    // gracefully bail out of warp specialization (unsupported shape). On a
+    // reject we strip all WS metadata via removeWarpSpecializeAttr (which now
+    // also clears the `async_task_id`s that doTaskIdPropagate materialized
+    // above) so downstream sees a plain, compilable non-WS kernel. The
+    // broadcast channel depth comes from the `tile-prefetch-depth` pass option
+    // (a Python knob), not an env var.
+    if (failed(doAtomicBroadcast(funcOp, tilePrefetchDepth))) {
+      LDBG("Atomic broadcast rejected warp specialization. Skipping.");
+      removeWarpSpecializeAttr(funcOp);
+      return;
+    }
+    if (dumpIntermediateSteps) {
+      llvm::dbgs() << "// -----// WarpSpec internal IR Dump After: "
+                      "doAtomicBroadcast\n";
       moduleOp.print(llvm::dbgs(), getOpPrintingFlagsWithLoc());
       llvm::dbgs() << "\n\n\n";
     }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -15,6 +15,17 @@ namespace mlir {
 
 namespace tt = mlir::triton;
 
+// Discardable i32 attribute stamped by WSAtomicBroadcast on the
+// dynamic-persistent tile-id broadcast slot's `local_alloc` to request a
+// specific multi-buffer depth (tile prefetch depth). `allocateSmemBuffers`
+// (WSMemoryPlanner) pins the buffer's copy count to this value so the requested
+// depth is honored end-to-end (buffer shape + accumCnt-driven slot/phase),
+// rather than leaving this non-innermost broadcast channel single-buffered.
+// Defined here so the producer (WSAtomicBroadcast) and the consumer
+// (WSMemoryPlanner) share one source of truth for the name.
+constexpr llvm::StringLiteral kAtomicBroadcastCopiesAttrName =
+    "ttg.atomic_broadcast_copies";
+
 enum class DataChannelKind : int {
   SMEM = 0,
   TMEM = 1,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
@@ -1,0 +1,298 @@
+//===- WSAtomicBroadcast.cpp - Cross-partition run-once atomic support ----===//
+//
+// Support for a side-effecting, loop-carried `tt.atomic_rmw` that appears in a
+// dynamic (work-stealing) persistent kernel's `scf.while` loop, e.g.
+//
+//     tile_id = start_pid
+//     while tile_id < num_tiles:
+//         ... compute tile ...
+//         tile_id = tl.atomic_add(tile_counter, 1)   // claim next tile
+//
+// Under AutoWS the persistent `scf.while` is cloned once per partition. Cloning
+// is correct for the *pure* static update (`tile_id += NUM_SMS`) but wrong for
+// the *side-effecting, non-deterministic* atomic: task-id propagation assigns
+// the atomic (whose result is the loop-carried value used by every partition)
+// to *all* partitions, so each warp group bumps the counter independently, the
+// partitions diverge onto different tiles, and their producer/consumer barriers
+// never match -> runtime deadlock.
+//
+// This pass runs immediately after `doTaskIdPropagate`. For each
+// `tt.atomic_rmw` it classifies the op into one of three cases (see the design
+// doc `docs/CrossPartitionAtomicSupport.md`):
+//
+//   1. Single-partition atomic  -> pass through unchanged (identity).
+//   2. All-partition, scalar, loop-carried atomic (the dynamic tile counter)
+//      -> transform: execute the atomic once in the producer/load partition and
+//      broadcast the scalar result to every partition through an SMEM slot
+//      guarded by a full/empty mbarrier handshake, so all partitions' while
+//      conditions agree on the same tile id.
+//   3. Anything else -> gracefully reject warp specialization (leave the kernel
+//      unspecialized-but-compilable, never crash).
+//
+//===----------------------------------------------------------------------===//
+
+#include "CodePartitionUtility.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Partition.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+
+namespace mlir {
+
+#define DEBUG_TYPE "nvgpu-ws-atomic-broadcast"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace {
+
+enum class AtomicWSCase {
+  PassThrough, // case 1: mapped to a single partition
+  Transform,   // case 2: all-partition, scalar, loop-carried counter
+  Reject       // case 3: unsupported shape -> bail out of WS
+};
+
+// The full set of partitions the kernel is being specialized into. Derived from
+// the union of task ids on the enclosing persistent loop.
+static SmallVector<AsyncTaskId> getAllPartitions(scf::WhileOp whileOp) {
+  return getAsyncTaskIds(whileOp.getOperation());
+}
+
+// Return the enclosing persistent `scf.while` whose after-region terminator
+// (`scf.yield`) directly forwards `result` as a loop-carried value, or nullptr.
+// This is what makes the atomic result "loop-carried": its value drives the
+// next iteration's `scf.condition` in every partition.
+static scf::WhileOp getLoopCarryingWhile(Value result) {
+  for (OpOperand &use : result.getUses()) {
+    auto yield = dyn_cast<scf::YieldOp>(use.getOwner());
+    if (!yield)
+      continue;
+    if (auto whileOp = dyn_cast<scf::WhileOp>(yield->getParentOp()))
+      return whileOp;
+  }
+  return nullptr;
+}
+
+// A scalar atomic has neither a tensor result nor a tensor (scatter) address.
+static bool isScalarAtomic(tt::AtomicRMWOp atomicOp) {
+  if (isa<RankedTensorType>(atomicOp.getResult().getType()))
+    return false;
+  if (isa<RankedTensorType>(atomicOp.getPtr().getType()))
+    return false;
+  return true;
+}
+
+static AtomicWSCase classifyAtomic(tt::AtomicRMWOp atomicOp,
+                                   scf::WhileOp &carryingWhileOut) {
+  SmallVector<AsyncTaskId> taskIds = getAsyncTaskIds(atomicOp.getOperation());
+
+  // Case 1: mapped to exactly one partition -> no cross-partition concern.
+  if (taskIds.size() <= 1)
+    return AtomicWSCase::PassThrough;
+
+  // Case 2 requires a scalar atomic whose result is the loop-carried value of
+  // an enclosing persistent `scf.while`, replicated to *every* partition.
+  if (!isScalarAtomic(atomicOp)) {
+    LDBG("reject: non-scalar / scatter atomic replicated across partitions");
+    return AtomicWSCase::Reject;
+  }
+  scf::WhileOp whileOp = getLoopCarryingWhile(atomicOp.getResult());
+  if (!whileOp) {
+    LDBG("reject: replicated scalar atomic is not while-loop-carried");
+    return AtomicWSCase::Reject;
+  }
+  SmallVector<AsyncTaskId> allParts = getAllPartitions(whileOp);
+  if (taskIds.size() != allParts.size()) {
+    LDBG("reject: atomic replicated to a strict subset of partitions");
+    return AtomicWSCase::Reject;
+  }
+  carryingWhileOut = whileOp;
+  return AtomicWSCase::Transform;
+}
+
+// Owner of the run-once atomic = the producer / TMA-load partition already
+// assigned by PartitionSchedulingMeta. We locate it by the partition that owns
+// the loop's TMA loads. Falls back to the smallest partition id.
+static AsyncTaskId getOwnerPartition(scf::WhileOp whileOp,
+                                     ArrayRef<AsyncTaskId> allParts) {
+  AsyncTaskId owner = allParts.front();
+  bool found = false;
+  whileOp.getAfterBody()->walk([&](Operation *op) {
+    if (found)
+      return;
+    if (isa<tt::DescriptorLoadOp, ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+      auto ids = getAsyncTaskIds(op);
+      if (ids.size() == 1) {
+        owner = ids[0];
+        found = true;
+      }
+    }
+  });
+  return owner;
+}
+
+// Transform a case-2 atomic (see file header). `depth` (>= 1) is the
+// tile-prefetch depth: the number of buffer slots the broadcast channel is
+// multi-buffered with. depth == 1 is the single-stage broadcast; depth > 1 lets
+// the owner/producer claim and publish up to `depth` tile ids ahead of the
+// slower consumer partitions (e.g. the epilogue), so the persistent loop does
+// not serialize on the tile-id handoff.
+//
+// Rather than hand-synthesizing barriers, we install only the *data path*: run
+// the atomic once in the owner partition, splat its scalar result into a 1-CTA
+// SMEM slot, and read it back (+ tt.unsplat) in every partition, rewiring the
+// while's loop-carried tile id to the broadcast value. The producer→consumer
+// synchronization is left to `doCodePartitionPost`, which already turns a
+// cross-partition `local_store`→`local_load` into (N) SMEM channels with the
+// correct full/empty mbarriers and phase — i.e. the broadcast is expressed in
+// terms of an existing, tested AutoWS channel rather than a bespoke handshake.
+// Multi-buffering (depth) is likewise delegated: we stamp the requested count
+// on the slot alloc and the memory planner pins the channel to it.
+static LogicalResult transformAtomic(triton::FuncOp funcOp,
+                                     tt::AtomicRMWOp atomicOp,
+                                     scf::WhileOp whileOp, int depth) {
+  MLIRContext *ctx = funcOp.getContext();
+  SmallVector<AsyncTaskId> allParts = getAllPartitions(whileOp);
+  AsyncTaskId owner = getOwnerPartition(whileOp, allParts);
+  Location loc = atomicOp.getLoc();
+
+  // The atomic result must be the loop-carried yield operand we rewrite. The
+  // tile-id pattern forwards the atomic to exactly one carried value, so stop
+  // at the first match: rewiring only the last occurrence would leave any other
+  // operand referencing the raw atomic, which is now retagged to the owner
+  // partition alone and no longer produced in the others.
+  Value atomicRes = atomicOp.getResult();
+  auto yieldOp = whileOp.getYieldOp();
+  int yieldIdx = -1;
+  for (auto [i, v] : llvm::enumerate(yieldOp.getOperands()))
+    if (v == atomicRes) {
+      yieldIdx = i;
+      break;
+    }
+  if (yieldIdx < 0)
+    return failure();
+
+  // Function-scope SMEM slot holding the claimed scalar (becomes a WS capture).
+  // The per-slot shape is a single element; the channel machinery prepends the
+  // buffer count (numBuffers) when it multi-buffers this channel. For depth > 1
+  // we stamp the requested count on the alloc (kAtomicBroadcastCopiesAttrName)
+  // so the memory planner pins this otherwise non-innermost broadcast channel
+  // to `depth` buffers; the accumCnt already threaded through the persistent
+  // scf.while then rotates the slot/phase across iterations.
+  OpBuilder fb(funcOp);
+  fb.setInsertionPointToStart(&funcOp.getBody().front());
+  Attribute smem = ttg::SharedMemorySpaceAttr::get(ctx);
+  auto numCTAs = ttg::lookupNumCTAs(funcOp);
+  auto cga = ttg::CGAEncodingAttr::get1DLayout(ctx, numCTAs);
+  auto slotEnc = ttg::SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, cga);
+  auto elemTy = atomicRes.getType();
+  auto slotTy = ttg::MemDescType::get({1}, elemTy, slotEnc, smem,
+                                      /*mutableMemory=*/true);
+  auto slotOp = ttg::LocalAllocOp::create(
+      fb, NameLoc::get(StringAttr::get(ctx, "atomic_bcast_slot"), loc), slotTy,
+      Value());
+  if (depth > 1)
+    slotOp->setAttr(kAtomicBroadcastCopiesAttrName,
+                    fb.getI32IntegerAttr(depth));
+  Value slot = slotOp;
+
+  // Single-element tensor for the scalar round-trip: splat -> local_store ->
+  // local_load -> tt.unsplat. The default blocked layout mirrors the
+  // scalar-load pipelining pattern (LowerLoops.cpp). Single-element tensors are
+  // excluded from partition register-budget classification
+  // (OptimizePartitionWarps), so this does not reclassify an otherwise
+  // non-tensor partition.
+  int numWarps = ttg::lookupNumWarps(funcOp);
+  int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(
+      funcOp->getParentOfType<ModuleOp>());
+  auto bcastLayout = ttg::getDefaultBlockedEncoding(ctx, {1}, numWarps,
+                                                    threadsPerWarp, numCTAs);
+  auto bcastTy = RankedTensorType::get({1}, elemTy, bcastLayout);
+
+  OpBuilderWithAsyncTaskIds b(ctx);
+
+  // Owner: run the atomic once, then publish its result into the slot.
+  setAsyncTaskIds(atomicOp, {owner});
+  b.setAsynTaskIdsFromArray({owner});
+  b.setInsertionPointAfter(atomicOp);
+  Value splat = b.createWithAsyncTaskIds<tt::SplatOp>(loc, bcastTy, atomicRes)
+                    .getResult();
+  b.createWithAsyncTaskIds<ttg::LocalStoreOp>(loc, splat, slot);
+
+  // Every partition: read the broadcast value back and unsplat to a scalar.
+  b.setAsynTaskIdsFromArray(allParts);
+  Value loaded =
+      b.createWithAsyncTaskIds<ttg::LocalLoadOp>(loc, bcastTy, slot, Value())
+          .getResult();
+  Value bcastScalar =
+      b.createWithAsyncTaskIds<tt::UnsplatOp>(loc, elemTy, loaded).getResult();
+
+  // Rewire the loop-carried tile id to the broadcast value; the atomic now
+  // feeds only the slot store, so it is cloned into the owner partition alone.
+  yieldOp->setOperand(yieldIdx, bcastScalar);
+  return success();
+}
+
+} // namespace
+
+// Entry point: classify and (where applicable) transform every `tt.atomic_rmw`.
+// Returns failure() when an atomic forces a graceful warp-specialization
+// reject. The caller is responsible for stripping WS metadata (via
+// removeWarpSpecializeAttr, which clears both the partition ids and the
+// async_task_ids) so the kernel is left unspecialized-but-compilable; this
+// keeps a single source of truth for the reject teardown shared with the other
+// AutoWS bail-outs.
+LogicalResult doAtomicBroadcast(triton::FuncOp funcOp, int tilePrefetchDepth) {
+  SmallVector<tt::AtomicRMWOp> atomics;
+  funcOp.walk([&](tt::AtomicRMWOp op) { atomics.push_back(op); });
+
+  // Phase 1: classify every atomic *before* mutating any of them. A Reject
+  // aborts the whole pass, and the reject teardown (removeWarpSpecializeAttr)
+  // only strips WS attributes -- it does not undo an already-applied broadcast
+  // transform. Classifying up front keeps the pass transactional: a later
+  // Reject can never leave an earlier atomic half-transformed with dangling
+  // SMEM broadcast plumbing and a rewired yield.
+  SmallVector<std::pair<tt::AtomicRMWOp, scf::WhileOp>> toTransform;
+  for (auto atomicOp : atomics) {
+    scf::WhileOp whileOp;
+    switch (classifyAtomic(atomicOp, whileOp)) {
+    case AtomicWSCase::PassThrough:
+      continue;
+    case AtomicWSCase::Reject:
+      LDBG("Warp specialization does not support this atomic shape. Skipping.");
+      return failure();
+    case AtomicWSCase::Transform:
+      toTransform.emplace_back(atomicOp, whileOp);
+      continue;
+    }
+  }
+
+  // `tile-prefetch-depth` is the broadcast channel's multi-buffer depth (>= 1);
+  // see transformAtomic. A nonsensical value is clamped to the single-stage
+  // default rather than silently mis-sizing the buffer.
+  int depth = tilePrefetchDepth;
+  if (depth < 1) {
+    if (!toTransform.empty())
+      toTransform.front().first.emitWarning()
+          << "tile-prefetch-depth=" << tilePrefetchDepth
+          << " is invalid; using a single-stage (depth 1) broadcast channel";
+    depth = 1;
+  }
+
+  // Phase 2: every collected atomic is transformable; apply the broadcast.
+  for (auto &[atomicOp, whileOp] : toTransform) {
+    if (failed(transformAtomic(funcOp, atomicOp, whileOp, depth))) {
+      LDBG("atomic broadcast transform failed; skipping WS.");
+      return failure();
+    }
+  }
+  return success();
+}
+
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3591,9 +3591,14 @@ void insertAsyncComm(
                            kv.second.front()->getNumBuffers(),
                            regionsWithChannels, bufferIdx, phase, config,
                            reuseGrp, masterChannel);
-    } else if (auto forOp = headProducer->getParentOfType<scf::ForOp>()) {
+    } else if (headProducer->getParentOfType<scf::ForOp>() ||
+               headProducer->getParentOfType<scf::WhileOp>()) {
       // headProducer can be local_store but bufferIdx will be used
-      // by tmaLoad as well.
+      // by tmaLoad as well. A producer directly in a persistent scf.while
+      // after region (e.g. the dynamic-persistent tile-id broadcast slot)
+      // also needs the accumCnt-derived buffer index/phase so the mbarrier
+      // parity toggles across persistent iterations; getBufferIdxAndPhase ->
+      // getAccumCount resolves the counter from the while's after-region args.
       if (producerAcquireForChannelLoop) {
         builder.setInsertionPoint(producerAcquireForChannelLoop);
       } else {
@@ -3608,7 +3613,7 @@ void insertAsyncComm(
                            regionsWithChannels, bufferIdx, phase, config,
                            reuseGrp, masterChannel);
     } else {
-      // Producer is not in a ForOp, create phase and bufferIdx here.
+      // Producer is truly outside any loop, create phase and bufferIdx here.
       bufferIdx = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
           headProducer->getLoc(), 0, 32);
       phase = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -1772,6 +1772,18 @@ static unsigned allocateSmemBuffers(
       buf.isPinned = true;
       LDBG("Phase 1: WSBuffer pinned by annotation: bufferId="
            << buf.bufferId << " numCopies=" << buf.numCopies);
+    } else if (auto copies = alloc->getAttrOfType<IntegerAttr>(
+                   kAtomicBroadcastCopiesAttrName)) {
+      // Cross-partition atomic broadcast slot (dynamic-persistent tile id):
+      // WSAtomicBroadcast stamped the requested tile-prefetch depth on the
+      // alloc. Pin the buffer to it so the planner honors the depth exactly and
+      // accounts for the extra copies against the SMEM budget, instead of
+      // leaving this non-innermost (P4_Other) channel single-buffered.
+      buf.numCopies = copies.getInt();
+      buf.minCopies = copies.getInt();
+      buf.isPinned = true;
+      LDBG("Phase 1: WSBuffer pinned by atomic-broadcast depth: numCopies="
+           << buf.numCopies);
     }
 
     // Detect TMA staging buffers: allocs whose users include

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
@@ -174,6 +174,86 @@ token (`getDep()`) to its result token (`getToken()`) so the accumulator
 dependency chain skips the removed store; forwarding the wrong operand leaves the
 store un-erased and reintroduces the cross-tile race.
 
+## Persistent `scf.while` Loops
+
+A static persistent kernel's outer loop may be an `scf.while` instead of an
+`scf.for` (e.g. `while tile_id < num_tiles:` with `tile_id += NUM_SMS`). The
+accumulation counters must still be carried across persistent iterations so
+buffer indices and mbarrier phases stay in phase, exactly as for the `scf.for`
+persistent case. Without this, every persistent iteration would restart the
+counter at 0 while the hardware mbarrier phases keep advancing, producing a
+runtime deadlock, and the buffer-index lookup would mis-resolve to a non-integer
+loop-carried value (e.g. a tensor accumulator), crashing in `cast<IntegerType>`.
+
+The `scf.while` is threaded analogously to `scf.for` (`createNewWhileWrapper` /
+`createNewWhileLoop`):
+
+1. Each accumCnt is added as an `i64` to the **init operands**, the **before**
+   block args, and the **after** block args.
+2. The `scf.condition` op **forwards** the before-region accumCnt args into the
+   after region (and the while results).
+3. The after-region `scf.yield` yields the next accumCnt value back, so it flows
+   to the next iteration's before args.
+
+Two kinds of counters can live on a persistent while:
+
+- **Nested-loop counter** — for the inner warp-specialized `scf.for` (e.g. the
+  A/B TMA load channel). Seeded from the while's after-region arg; the inner
+  loop yields its final value back.
+- **Direct counter** — for a channel whose producer/consumer lives directly in
+  the while's after region (e.g. the accumulator/epilogue channel). Like a
+  channel directly in an `scf.for`, it advances by one per persistent iteration.
+
+For ops directly in the after region, `getAccumCount` resolves the counter from
+the while's after-region arguments (no enclosing `scf.for`). In
+`createBufferPost`, operandD/TMEM users (and other channel users) that live
+directly in the after region must use `getBufferIdxAndPhase(builder, user, ...)`
+so their buffer slot rotates with the while-carried counter — matching the
+writer's slot — rather than the truly-outside-loop fallback (which would pin the
+slot to 0 and race across persistent iterations).
+
+`scf.while` regions are registered in `regionsWithChannels`
+(`collectRegionsWithChannels` / `collectRegionsWithChannelsPost`), counted by
+`getAccumCnts` / `getAccumCntsPreOrder`, and indexed by `getAccumArgIdx` the same
+way `scf.for`/`scf.if` are.
+
+### Reuse groups directly in a persistent `scf.while`
+
+A subtiled epilogue (`EPILOGUE_SUBTILE > 1`) emits several TMA stores that share
+one multi-buffered staging buffer — a **reuse group** whose channels live
+directly in the while's after region (a *second* channel directly in the while,
+in addition to the operand-D accumulator). Reuse groups get their own appended
+accumCnt, after the per-region counters. The while path mirrors the `scf.for`
+reuse handling end-to-end:
+
+- `createNewWhileWrapper` appends a reuse-group counter to `initialAccums`
+  (seeded via `getAccumForReuseGroup`, which is a constant 0 for the outermost
+  while) and wires its yield with the staggered next value.
+- `getReuseChannels`, `needAccumCntForReuse`, and `getAccumForReuseGroup` accept
+  `scf::WhileOp` (iterating / indexing the after region).
+- `getStaggeredAccumCnt` finds the enclosing loop as `scf::ForOp` **or**
+  `scf::WhileOp` — using `getParentOfType<scf::ForOp>()` alone is null for an op
+  in the while's after region and would crash `getReuseChannels`.
+
+Missing any of these makes the per-channel accumCnt index run past the counters
+actually threaded into the while (an out-of-bounds after-region argument /
+non-integer accumCnt), the same failure class the `getAccumCount` `isIntOrIndex`
+assertion guards against.
+
+### Redundant accumulator zero-store removal
+
+`removeRedundantTmemZeroStores` (`WSCodePartition.cpp`) drops the explicit
+`tmem_store 0` that initializes the accumulator when the MMA already zeroes it
+via `useAccumulator=false` on the first iteration. Without this, the zero-store
+becomes a *cross-partition* channel (epilogue zeroes, gemm reads) that, in a
+persistent loop, races/hangs across tiles. It must recognize the persistent
+outer loop as an `scf.while` (not only `scf.for`) — the zero-store lives directly
+in the while's after region, so its enclosing loop is found via
+`getParentOfType<scf::WhileOp>()`. The erase step forwards the store's input dep
+token (`getDep()`) to its result token (`getToken()`) so the accumulator
+dependency chain skips the removed store; forwarding the wrong operand leaves the
+store un-erased and reintroduces the cross-tile race.
+
 ## Interaction with Reuse Groups
 
 When channels share a reuse group (same `buffer.id`), they share a single

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CrossPartitionAtomicSupport.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CrossPartitionAtomicSupport.md
@@ -1,0 +1,134 @@
+# Cross-Partition Run-Once Atomic Support (Dynamic Persistent)
+
+**Files**: `WSAtomicBroadcast.cpp` (the pass), `WarpSpecialization.cpp`
+(pipeline wiring), with supporting fixes in `WSCodePartition.cpp` and
+`lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp`.
+
+## Problem
+
+A dynamic (work-stealing) persistent kernel claims its next tile from a global
+counter inside a persistent `scf.while`:
+
+```python
+tile_id = tl.program_id(0)
+while tile_id < num_tiles:
+    ... compute tile ...
+    tile_id = tl.atomic_add(tile_counter, 1)   # claim next tile
+```
+
+AutoWS clones the persistent `scf.while` once per partition. That is correct for
+the *pure* static update (`tile_id += NUM_SMS`) but **wrong** for the
+side-effecting `tl.atomic_add`: task-id propagation assigns the atomic (whose
+result is the loop-carried value used by every partition) to **all** partitions,
+so each warp group bumps the counter independently, diverges onto a different
+tile, and the producer/consumer barriers never match → **runtime deadlock**.
+
+## Pass: `doAtomicBroadcast`
+
+Runs in `WarpSpecialization.cpp::runOnFuncOp` immediately **after**
+`doTaskIdPropagate` (so partitions are materialized as `async_task_id`) and
+before `doBufferAllocation`. For each `tt.atomic_rmw` it classifies into one of
+three cases:
+
+| Case | Condition | Action |
+|------|-----------|--------|
+| **1. Pass-through** | mapped to a single partition | leave unchanged |
+| **2. Transform** | scalar, mapped to *every* partition, and its result is the loop-carried value of an enclosing persistent `scf.while` | run once + broadcast (below) |
+| **3. Reject** | any other shape (non-scalar/scatter, strict-subset replication, or not loop-carried) | bail out of WS gracefully |
+
+### Case 2 — transform
+
+`transformAtomic` installs only the **data path** and lets the existing AutoWS
+channel machinery provide synchronization:
+
+1. Retag the atomic to the **owner** partition alone (the TMA-load/producer
+   partition, located via the loop's `tt.descriptor_load` /
+   `async_tma_copy_global_to_local`).
+2. In the owner: `tt.splat` the scalar result into a single-element SMEM slot
+   (`ttg.local_alloc` at function scope) via `ttg.local_store`.
+3. In every partition: `ttg.local_load` the slot and `tt.unsplat` back to a
+   scalar.
+4. Rewire the `scf.while`'s loop-carried tile id to the broadcast (unsplat)
+   value, so the atomic now feeds only the slot store and is cloned into the
+   owner partition alone.
+
+The producer→consumer synchronization is **not** hand-synthesized. Because the
+`local_store` (owner) and `local_load` (all partitions) form an ordinary
+cross-partition SMEM dependency, `doCodePartitionPost` turns it into (N) SMEM
+channels with the correct full/empty mbarriers and phase — i.e. the broadcast is
+expressed in terms of an existing, tested AutoWS channel rather than a bespoke
+handshake.
+
+### Case 3 — graceful reject
+
+`doAtomicBroadcast` returns `failure()`. The caller then calls the canonical
+`removeWarpSpecializeAttr(funcOp)`, which strips **both** the partition ids
+(`ttg.partition`) and the task ids (`async_task_id`) from every op, plus the WS
+loop attributes (`tt.warp_specialize`, `ttg.partition.stages`,
+`ttg.partition.types`, `ttg.warp_specialize.tag`) from `scf.for`/`scf.while`
+loops. The kernel is left unspecialized-but-compilable (never a crash/assert).
+This is the same teardown used by the other AutoWS bail-outs (`numWarps < 4`,
+`scf.if` else-block); `removeWarpSpecializeAttr` clears `async_task_id` too
+because this reject runs *after* propagation, unlike the earlier bail-outs.
+
+## Two supporting fixes this feature required
+
+1. **`scf.while` phase for a direct channel producer** (`WSCodePartition.cpp`).
+   The broadcast channel's producer (`local_store`) lives directly in the
+   persistent `scf.while` after-region. The buffer-index/phase computation only
+   handled a producer inside an `scf.for`; a producer directly in a `scf.while`
+   fell back to a **constant phase**, so the channel's mbarrier parity did not
+   toggle across persistent iterations → deadlock. The fix routes a
+   `scf::WhileOp`-parented producer through `getBufferIdxAndPhase` (which, via
+   `getAccumCount`, resolves the counter from the while's after-region args),
+   exactly as for `scf.for`.
+
+2. **Single-element tensors excluded from register-class estimation**
+   (`OptimizePartitionWarps.cpp`). The scalar round-trips through SMEM as a
+   single-element `tensor<1xi32>`. Counting it would flip an otherwise
+   non-tensor partition into the "tensor" register class (request `-1` instead
+   of the fixed minimum), which shifts warp-group register budgeting. The fix
+   ignores single-element tensors for the register estimate while still
+   relayouting them when a partition's warp count changes.
+
+## Tunable: broadcast depth
+
+The broadcast-channel depth is a compile-time knob, not an env var:
+
+- Python: `knobs.nvidia.ws_tile_prefetch_depth` (default 1).
+- Threaded to the `nvgpu-warp-specialization` pass as the `tile-prefetch-depth`
+  option (`Passes.td` → `triton_nvidia.cc` → `compiler.py`).
+
+`depth` is the number of buffer slots the tile-id broadcast channel is
+multi-buffered with. Depth 1 is the single-stage broadcast (producer and
+consumers move in lockstep on the tile id). For `depth > 1`, `transformAtomic`
+stamps the requested count (`kAtomicBroadcastCopiesAttrName`, defined in
+`CodePartitionUtility.h`) on the broadcast slot's `local_alloc`, and the memory
+planner (`allocateSmemBuffers`, phase 1) **pins** that buffer to `depth` copies —
+so the otherwise non-innermost (`P4_Other`) broadcast channel is not left
+single-buffered. The alloc becomes shape `{depth, 1}` and the accumCnt already
+threaded through the persistent `scf.while` rotates the slot/phase across
+iterations, exactly as for any other multi-buffered while-region channel. This
+lets the owner/producer claim and publish up to `depth` tile ids ahead of the
+slower consumer partitions (e.g. the epilogue), so the persistent loop does not
+serialize on the tile-id handoff.
+
+No explicit drain-on-exit is required: the terminating tile id (the first claim
+`>= num_tiles`) flows through the *same* broadcast channel and must be loaded by
+every partition to evaluate its own `while` condition, so the producer's store
+count and each consumer's load count stay balanced across the loop exit
+regardless of `depth` — the multi-buffer only adds bounded run-ahead
+backpressure, never an unconsumed slot. A nonsensical `depth < 1` is clamped to
+1 with a warning.
+
+## Tests
+
+- E2E: `test_tutorial09_matmul_tma_dynamic_persistent_while_loop_warp_specialize`
+  (un-xfailed; runs on Hopper or Blackwell) asserts correctness for
+  `EPILOGUE_SUBTILE ∈ {1,2,4}`; verified at `TRITON_WS_TILE_PREFETCH_DEPTH` 1, 2,
+  and 3.
+- LIT: `test/Hopper/WarpSpecialization/ws_atomic_broadcast_transform.mlir`
+  (case 2 — exactly one atomic + broadcast; second RUN line checks
+  `tile-prefetch-depth=2` multi-buffers the slot to `memdesc<2x1xi32>`) and
+  `ws_atomic_broadcast_reject.mlir` (case 3 — no WS / no partition ids / no task
+  ids left, atomic preserved).

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -15,6 +15,7 @@ orchestrates sub-passes as function calls within a single monolithic pass:
 ```
 doTaskPartition          (Hopper only; skipped on Blackwell)
   → doTaskIdPropagate
+  → doAtomicBroadcast    (cross-partition run-once atomic support)
   → doDataPartition      (via nvgpu-ws-data-partition when requested)
   → doPingPongPrep       (optional, if pingpongAutoWS is set)
   → doBufferAllocation
@@ -68,6 +69,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `WSTaskPartition.cpp` | `doTaskPartition` | Assigns `async_task_id` to anchor ops (loads, dots, stores) — Hopper only |
 | `TaskIdPropagation.cpp` | — | `TaskIdBackwardPropagation` sparse dataflow analysis |
 | `WSTaskIdPropagate.cpp` | `doTaskIdPropagate` | Runs analysis and materializes task IDs |
+| `WSAtomicBroadcast.cpp` | `doAtomicBroadcast` | Cross-partition run-once atomic support: run a dynamic-persistent tile-id `atomic_add` once and broadcast it (or gracefully reject unsupported atomics). See [CrossPartitionAtomicSupport.md](CrossPartitionAtomicSupport.md) |
 | `WSDataPartition.cpp` | `doDataPartition` / `nvgpu-ws-data-partition` | Splits ops along M/N dimensions across warp groups |
 | `PingPong.cpp` | `doPingPongPrep` / `doPingPongSync` | Named barrier insertion for ping-pong scheduling |
 | `WSCodePartition.cpp` | `doBufferAllocation` | Channel discovery and SMEM/TMEM allocation hoisting (pre-pass) |
@@ -114,6 +116,7 @@ recognizes the `scf.while` outer loop (same doc).
 ## Further Reading
 
 - [Task Partitioning & ID Propagation](TaskPartitionAndPropagation.md) — how ops are assigned to partitions
+- [Cross-Partition Run-Once Atomic Support](CrossPartitionAtomicSupport.md) — dynamic-persistent tile-id `atomic_add` broadcast
 - [Data Partitioning](DataPartition.md) — splitting tensor dimensions across consumer warp groups
 - [Code Partitioning](CodePartition.md) — channel discovery, buffer creation, sync insertion
 - [Code Specialization](CodeSpecialization.md) — how ops are cloned into WarpSpecializeOp regions

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -204,9 +204,9 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
 
 void init_triton_hopper_passes(py::module &&m) {
   // Meta's autoWS
-  ADD_PASS_OPTION_WRAPPER_6("add_hopper_warpspec",
+  ADD_PASS_OPTION_WRAPPER_7("add_hopper_warpspec",
                             mlir::createNVGPUWarpSpecialization, int, int, bool,
-                            bool, int, bool);
+                            bool, int, bool, int);
   ADD_PASS_OPTION_WRAPPER_1("add_data_partitioning",
                             mlir::createNVGPUWSDataPartition, int);
   ADD_PASS_WRAPPER_0("add_tma_store_lowering",

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -660,9 +660,13 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
         _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
         post_grid = (N_CTX // PRE_BLOCK, Z * H)
         _blackwell_fa_bwd_dq_postprocess[post_grid](
-            dq_accum, dq, N_CTX,
-            BLK=_blk, HALF_HD=HEAD_DIM // 2,
-            BLOCK_M=PRE_BLOCK, HEAD_DIM=HEAD_DIM,
+            dq_accum,
+            dq,
+            N_CTX,
+            BLK=_blk,
+            HALF_HD=HEAD_DIM // 2,
+            BLOCK_M=PRE_BLOCK,
+            HEAD_DIM=HEAD_DIM,
         )
 
         torch.testing.assert_close(dv, ref_dv, atol=1e-2, rtol=0)


### PR DESCRIPTION
Summary:
Adds support for a dynamic persistent GEMM in AutoWS. In this schedule we author a kernel that looks roughly like this:

```
tile_id = tl.program_id(0)
while tile_id < num_tiles: # Tile is legal
   ...
   tile_id = tl.atomic_add(tile_counter, 1)   # claim next tile
```

This structure is logically equivalent to CLC, except that it doesn't leverage the actual blackwell hardware features. However, this use case provides a simple example of how to support CLC in AutoWS. The fundamental issue is that in AutoWS `tile_id = tl.atomic_add(tile_counter, 1)` needs to be computed by exactly 1 partition. The algorithm roughly handles this as follows:

1. When a `atomic_add` is mapped to every partition (we exit AutoWS if its not entirely 1 partition or every partition) we rewrite this logically as an `atomic_add` assigned to a single partition and an SMEM store + load to broadcast to every partition.
2. The `atomic_add` is by default assigned to the load partition. The logic here is that to ensure we keep all partitions busy we want which partition should finish first to get the next tile fetch (this should normally be the producer). In many cases (GEMM is actually 1 example) we could also give it its own partition, but I don't believe this is worth the complexity at this time.
3. The channels are generated via the regular AutoWS buffer path. In particular we expose `TRITON_WS_TILE_PREFETCH_DEPTH` to allow multi-buffering the tile_id counter. The logic here is that we can trade off accurately we "dynamically fetch the next work" with ensure we don't bubble waiting for a tile. In practice I expect we only ever need this to be 1 and we can remove it if this proves accurate.

Conceptually it should be possible to recycle this same structure for generating the actual CLC implementation. The only fundamental differences should be: 1) Selecting the frontend API and 2) Possible extension to the (X, Y, Z) format (which may require/warrant pruning in the store if some dimension is dead.

The plan for PRs is roughly this:

Support static persistent GEMM with a while loop
Support dynamic persistent GEMM with a while loop (here)
Support CLC APIs for Triton.
Support CLC GEMM with a while loop
Attention support (probably several PRs).


Depends on https://github.com/facebookexperimental/triton/pull/1735


Reviewed By: manman-ren

Differential Revision: D110282925

Pulled By: njriasan


