### PR TITLE
[AutoWS] Fix register floor specification

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -48,11 +48,18 @@ static void padToMaxWarpGroups(WarpSpecializeOp op, int numExtraWarpGroups) {
   }
   op.setPartitionNumWarps(partitionNumWarps);
 
-  // Set the requested registers to low for the padded partitions that do
-  // nothing.
+  // Set the requested registers as low as legally possible for the padded
+  // partitions that do nothing. `nvvm.setmaxregister` requires the per-thread
+  // register count to be in [24, 256] (a multiple of 8) on all sm_90+ targets
+  // (Hopper and Blackwell), so 24 is the floor. Using a below-minimum value
+  // (e.g. 16) is only masked when a padding partition shares a warp group with
+  // a real partition requesting >= 24 (the warp group's request is the max over
+  // its members); when it does not, the illegal value reaches `setmaxregister`
+  // and lowering fails the verifier.
+  constexpr int32_t kMinLegalRegisters = 24;
   if (auto reqRegs = op.getRequestedRegisters()) {
     SmallVector<int32_t> newReqRegs(*reqRegs);
-    newReqRegs.append(paddingPartitionSizes.size(), 16);
+    newReqRegs.append(paddingPartitionSizes.size(), kMinLegalRegisters);
     op.setRequestedRegisters(newReqRegs);
   }
 

--- a/test/Conversion/allocate_warp_groups.mlir
+++ b/test/Conversion/allocate_warp_groups.mlir
@@ -143,3 +143,31 @@ tt.func @respect_user_start_ids() {
 }
 
 }
+
+// -----
+
+// Do-nothing padding partitions must request the legal setmaxregister floor
+// (24 on all sm_90+ targets), not a below-minimum value. If a padding partition
+// forms a warp group in which no partition requests >= 24, a below-floor value
+// reaches nvvm.setmaxregister and fails the verifier ("must be in between 24 to
+// 256"). Two 1-warp partitions (2 warps) are padded up to a full warp group (4
+// warps); the appended padding partition's request must be 24, not 16.
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+// CHECK-LABEL: tt.func @padding_register_floor
+tt.func @padding_register_floor() {
+  // CHECK: ttg.warp_specialize() attributes {actualRegisters = array<i32: {{[0-9]+}}, 24, 24, 24>, requestedRegisters = array<i32: 24, 24, 24>
+  ttg.warp_specialize() attributes {requestedRegisters = array<i32: 24, 24>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(1) {
+    ttg.warp_return
+  }
+  partition1() num_warps(1) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -89,8 +89,12 @@ private:
 
 static void createRegRealloc(TritonLLVMIRRewriter &b, int curRegs,
                              int adjRegs) {
-  curRegs = std::min(256, curRegs);
-  adjRegs = std::min(256, adjRegs);
+  // nvvm.setmaxregister requires the per-thread register count to be in the
+  // range [24, 256] (a multiple of 8). Clamp both ends: below-minimum requests
+  // (e.g. from a do-nothing padding partition) would otherwise emit an illegal
+  // setmaxregister and fail the verifier.
+  curRegs = std::clamp(curRegs, 24, 256);
+  adjRegs = std::clamp(adjRegs, 24, 256);
   // Round to a multiple of 8 (hardware requirement).
   adjRegs = adjRegs / 8 * 8;
   curRegs = curRegs / 8 * 8;


### PR DESCRIPTION
The register floor seems to be set at 16 when the actual minimum is 24. Encountered while debugging https://github.com/facebookexperimental/triton/pull/1879.